### PR TITLE
Fix bug with mono-bitmaps in TileMapObject

### DIFF
--- a/Extensions/TileMapObject/TileMapPanel.cpp
+++ b/Extensions/TileMapObject/TileMapPanel.cpp
@@ -155,7 +155,7 @@ void TileMapPanel::OnPaint(wxPaintEvent& event)
                 if(m_tilemap->GetTile(layer, col, row) == -1)
                     continue;
 
-                dc.DrawBitmap(m_tileset->GetTileBitmap(m_tilemap->GetTile(layer, col, row)), GetPositionOfTile(col, row).x, GetPositionOfTile(col, row).y);
+                dc.DrawBitmap(m_tileset->GetTileBitmap(m_tilemap->GetTile(layer, col, row)), GetPositionOfTile(col, row).x, GetPositionOfTile(col, row).y, true);
             }
         }
     }

--- a/Extensions/TileMapObject/TileSetPanel.cpp
+++ b/Extensions/TileMapObject/TileSetPanel.cpp
@@ -93,9 +93,8 @@ void TileSetPanel::OnPaint(wxPaintEvent& event)
         dc.SetBrush(gd::CommonBitmapManager::Get()->transparentBg);
         dc.DrawRectangle(minPos.x, minPos.y, width, height);
 
-
         //Draw the bitmap
-        dc.DrawBitmap(m_tileset->GetWxBitmap(), 0, 0, false);
+        dc.DrawBitmap(m_tileset->GetWxBitmap(), 0, 0, true);
 
         //Draw the lines
         dc.SetPen(wxPen(wxColor(128, 128, 128, 255), 1));

--- a/GDCpp/GDCpp/Polygon2d.cpp
+++ b/GDCpp/GDCpp/Polygon2d.cpp
@@ -5,5 +5,5 @@
  */
 
 #if !defined(GD_IDE_ONLY)
-#include "GDCore/BuiltinExtensions/SpriteExtension/Polygon.cpp"
+#include "GDCore/BuiltinExtensions/SpriteExtension/Polygon2d.cpp"
 #endif


### PR DESCRIPTION
Fix bug with mono-bitmaps in TileMapObject.
(I've also fixed the include in GDCpp/Polygon2d.cpp)
