### PR TITLE
Fix polygons point not moving in SpriteObjectEdition

### DIFF
--- a/Core/GDCore/BuiltinExtensions/SpriteExtension/Dialogs/SpriteObjectEditor.cpp
+++ b/Core/GDCore/BuiltinExtensions/SpriteExtension/Dialogs/SpriteObjectEditor.cpp
@@ -1483,7 +1483,7 @@ void SpriteObjectEditor::OnAddVerticeClick(wxCommandEvent& event)
 void SpriteObjectEditor::OnmaskTreeSelectionChanged(wxTreeListEvent& event)
 {
     wxTreeListItem selectedItem = maskTree->GetSelection();
-    if(polygonEditionHelper.IsMovingPoint())
+    if(polygonEditionHelper.IsMovingPoint()) //Do not select a point when we are currently moving another point
     	return;
     if ( maskTree->GetItemParent(selectedItem) == maskTree->GetRootItem() )
     {

--- a/Core/GDCore/IDE/Dialogs/PolygonEditionHelper.cpp
+++ b/Core/GDCore/IDE/Dialogs/PolygonEditionHelper.cpp
@@ -54,9 +54,6 @@ void PolygonEditionHelper::OnPaint(std::vector<Polygon2d> &mask, wxDC &dc, wxPoi
 
 void PolygonEditionHelper::OnMouseLeftDown(std::vector<Polygon2d> &mask, wxMouseEvent &event, wxPoint offset)
 {
-    if(movingPolygonPoint)
-        return;
-
     for (unsigned int i = 0;i<mask.size();++i)
     {
         for (unsigned int j = 0;j<mask[i].vertices.size();++j)


### PR DESCRIPTION
Fix polygons point not moving in SpriteObjectEdition (only under wxGTK).
The polygon treeview seemed to get selection change events while being updated when moving a point : it causes the point to be unselected.
