### PR TITLE
Improve installDeps.sh

### DIFF
--- a/ExtLibs/installDeps.sh
+++ b/ExtLibs/installDeps.sh
@@ -1,7 +1,10 @@
 #Experimental script to download dependencies, build and install them
 #Only test on Ubuntu
+
+#Dependencies packages
 sudo apt-get install libgtk-3-dev libwebkitgtk-3.0-dev cmake p7zip-full libopenal-dev libjpeg-dev libglew-dev libudev-dev libxrandr-dev libsndfile1-dev libglu1-mesa-dev libfreetype6-dev
 
+#SFML
 wget http://www.compilgames.net/code/GameDevelopSDK/SFML.7z -O SFML.7z
 7za x SFML.7z
 
@@ -26,6 +29,7 @@ wget http://www.compilgames.net/code/GameDevelopSDK/boost_1_55_0.7z -O boost.7z
 7za x boost.7z
 mv boost_1_55_0 boost
 
+#wxWidgets
 wget https://sourceforge.net/projects/wxwindows/files/3.0.2/wxWidgets-3.0.2.tar.bz2 -O wxWidgets.tar.bz2
 tar jxf wxWidgets.tar.bz2
 


### PR DESCRIPTION
Put all package in a single command line.
Force the output filename (for downloads) to avoid problems when using the script multiple times.
Fixes for wxWidgets 3.0.2
