### PR TITLE
Do not give the focus to EventEditor when mouse is over it

### DIFF
--- a/IDE/EventsEditor.cpp
+++ b/IDE/EventsEditor.cpp
@@ -906,6 +906,11 @@ void EventsEditor::OneventsPanelLeftDClick(wxMouseEvent& event)
 
 void EventsEditor::OneventsPanelMouseMove(wxMouseEvent& event)
 {
+	#if !defined(__WXGTK__)
+	if (!liveEditingPanel->IsShown())
+		eventsPanel->SetFocus();
+	#endif
+
     //Column resizing
     if ( (event.GetX() >= conditionColumnWidth-2 && event.GetX() <= conditionColumnWidth+2) || isResizingColumns)
     {


### PR DESCRIPTION
This causes problems when using other editors. For instance, when renaming an object using the context menu : when you click on "Rename" (over the event editor, as the objects editor's context menu is sometime a bit out of the object editor), then the focus is immediately given back to the event editor before the user can edit the object's name. 
