### PR TITLE
SFML offscreen rendering

### DIFF
--- a/Binaries/Output/Release_Windows/Examples/Basic platformer.gdg
+++ b/Binaries/Output/Release_Windows/Examples/Basic platformer.gdg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project firstLayout="">
-    <gdVersion build="84" major="3" minor="6" revision="0" />
-    <properties linuxExecutableFilename="" macExecutableFilename="" useExternalSourceFiles="false" winExecutableFilename="" winExecutableIconFile="">
+    <gdVersion build="94" major="4" minor="0" revision="0" />
+    <properties folderProject="false" linuxExecutableFilename="" macExecutableFilename="" packageName="" useExternalSourceFiles="false" winExecutableFilename="" winExecutableIconFile="">
         <name>Basic platformer</name>
         <author></author>
         <windowWidth>800</windowWidth>
@@ -31,7 +31,7 @@
             <extension name="BuiltinMathematicalTools" />
             <extension name="BuiltinExternalLayouts" />
             <extension name="TiledSpriteObject" />
-            <extension name="PlatformAutomatism" />
+            <extension name="PlatformBehavior" />
         </extensions>
         <platforms>
             <platform name="GDevelop C++ platform" />
@@ -71,7 +71,7 @@
     <variables />
     <layouts>
         <layout b="252" disableInputWhenNotFocused="true" mangledName="New_32scene" name="New scene" oglFOV="90.000000" oglZFar="500.000000" oglZNear="1.000000" r="201" standardSortMethod="true" stopSoundsOnStartup="true" title="" v="233">
-            <uiSettings associatedLayout="" grid="false" gridB="255" gridG="180" gridHeight="70" gridOffsetX="0" gridOffsetY="0" gridR="158" gridWidth="70" snap="true" windowMask="false" zoomFactor="0.764706" />
+            <uiSettings grid="false" gridB="255" gridG="180" gridHeight="70" gridOffsetX="0" gridOffsetY="0" gridR="158" gridWidth="70" snap="true" windowMask="false" zoomFactor="0.764706" />
             <objectsGroups />
             <variables />
             <instances>
@@ -102,7 +102,7 @@
                     <stringProperties />
                     <initialVariables />
                 </instance>
-                <instance angle="0.000000" customSize="false" height="0.000000" layer="" locked="false" name="Platform" width="0.000000" x="575.076965" y="268.769287" zOrder="1">
+                <instance angle="0.000000" customSize="false" height="0.000000" layer="" locked="false" name="Platform" width="0.000000" x="575.076965" y="270.076965" zOrder="1">
                     <numberProperties />
                     <stringProperties />
                     <initialVariables />
@@ -241,13 +241,13 @@
                 </instance>
             </instances>
             <objects>
-                <object name="Player" type="Sprite">
+                <object name="Player" type="Sprite" updateIfNotVisible="true">
                     <variables />
-                    <automatisms>
-                        <automatism acceleration="1500.000000" deceleration="1500.000000" gravity="1300.000000" ignoreDefaultControls="false" jumpSpeed="1000.000000" maxFallingSpeed="1000.000000" maxSpeed="250.000000" name="PlatformerObject" slopeMaxAngle="0.000000" type="PlatformAutomatism::PlatformerObjectAutomatism" />
-                    </automatisms>
+                    <behaviors>
+                        <behavior acceleration="1500.000000" canGrabPlatforms="false" deceleration="1500.000000" gravity="1300.000000" ignoreDefaultControls="false" jumpSpeed="1000.000000" maxFallingSpeed="1000.000000" maxSpeed="250.000000" name="PlatformerObject" slopeMaxAngle="0.000000" type="PlatformBehavior::PlatformerObjectBehavior" xGrabTolerance="10.000000" yGrabOffset="0.000000" />
+                    </behaviors>
                     <animations>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -268,7 +268,7 @@
                                 </direction>
                             </directions>
                         </animation>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -289,7 +289,7 @@
                                 </direction>
                             </directions>
                         </animation>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="true" timeBetweenFrames="0.050000">
                                     <sprites>
@@ -364,13 +364,13 @@
                         </animation>
                     </animations>
                 </object>
-                <object name="Platform" type="Sprite">
+                <object name="Platform" type="Sprite" updateIfNotVisible="true">
                     <variables />
-                    <automatisms>
-                        <automatism name="Platform" platformType="NormalPlatform" type="PlatformAutomatism::PlatformAutomatism" />
-                    </automatisms>
+                    <behaviors>
+                        <behavior canBeGrabbed="true" name="Platform" platformType="NormalPlatform" type="PlatformBehavior::PlatformBehavior" yGrabOffset="0.000000" />
+                    </behaviors>
                     <animations>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -391,7 +391,7 @@
                                 </direction>
                             </directions>
                         </animation>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -414,13 +414,13 @@
                         </animation>
                     </animations>
                 </object>
-                <object name="Jumpthru" type="Sprite">
+                <object name="Jumpthru" type="Sprite" updateIfNotVisible="true">
                     <variables />
-                    <automatisms>
-                        <automatism name="Platform" platformType="Jumpthru" type="PlatformAutomatism::PlatformAutomatism" />
-                    </automatisms>
+                    <behaviors>
+                        <behavior canBeGrabbed="true" name="Platform" platformType="Jumpthru" type="PlatformBehavior::PlatformBehavior" yGrabOffset="0.000000" />
+                    </behaviors>
                     <animations>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -445,23 +445,23 @@
                 </object>
                 <object height="70.000000" name="TiledGrassPlatform" texture="grassHalfMid.png" type="TiledSpriteObject::TiledSprite" width="70.000000">
                     <variables />
-                    <automatisms>
-                        <automatism name="Platform" platformType="NormalPlatform" type="PlatformAutomatism::PlatformAutomatism" />
-                    </automatisms>
+                    <behaviors>
+                        <behavior canBeGrabbed="true" name="Platform" platformType="NormalPlatform" type="PlatformBehavior::PlatformBehavior" yGrabOffset="0.000000" />
+                    </behaviors>
                 </object>
                 <object height="70.000000" name="TiledCastlePlatform" texture="castleCenter.png" type="TiledSpriteObject::TiledSprite" width="70.000000">
                     <variables />
-                    <automatisms>
-                        <automatism name="Platform" platformType="NormalPlatform" type="PlatformAutomatism::PlatformAutomatism" />
-                    </automatisms>
+                    <behaviors>
+                        <behavior canBeGrabbed="true" name="Platform" platformType="NormalPlatform" type="PlatformBehavior::PlatformBehavior" yGrabOffset="0.000000" />
+                    </behaviors>
                 </object>
-                <object name="MovingPlatform" type="Sprite">
+                <object name="MovingPlatform" type="Sprite" updateIfNotVisible="true">
                     <variables />
-                    <automatisms>
-                        <automatism name="Platform" platformType="Jumpthru" type="PlatformAutomatism::PlatformAutomatism" />
-                    </automatisms>
+                    <behaviors>
+                        <behavior canBeGrabbed="true" name="Platform" platformType="Jumpthru" type="PlatformBehavior::PlatformBehavior" yGrabOffset="0.000000" />
+                    </behaviors>
                     <animations>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -484,11 +484,11 @@
                         </animation>
                     </animations>
                 </object>
-                <object name="GoLeft" type="Sprite">
+                <object name="GoLeft" type="Sprite" updateIfNotVisible="true">
                     <variables />
-                    <automatisms />
+                    <behaviors />
                     <animations>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -511,11 +511,11 @@
                         </animation>
                     </animations>
                 </object>
-                <object name="GoRight" type="Sprite">
+                <object name="GoRight" type="Sprite" updateIfNotVisible="true">
                     <variables />
-                    <automatisms />
+                    <behaviors />
                     <animations>
-                        <animation useMultipleDirections="false">
+                        <animation name="" useMultipleDirections="false">
                             <directions>
                                 <direction looping="false" timeBetweenFrames="1.000000">
                                     <sprites>
@@ -540,9 +540,9 @@
                 </object>
                 <object height="70.000000" name="Ladder" texture="ladder_mid.png" type="TiledSpriteObject::TiledSprite" width="70.000000">
                     <variables />
-                    <automatisms>
-                        <automatism name="Platform" platformType="Ladder" type="PlatformAutomatism::PlatformAutomatism" />
-                    </automatisms>
+                    <behaviors>
+                        <behavior canBeGrabbed="true" name="Platform" platformType="Ladder" type="PlatformBehavior::PlatformBehavior" yGrabOffset="0.000000" />
+                    </behaviors>
                 </object>
             </objects>
             <events>
@@ -562,7 +562,7 @@
                     <type>BuiltinCommonInstructions::Standard</type>
                     <conditions>
                         <condition>
-                            <type inverted="false" value="PlatformAutomatism::IsJumping" />
+                            <type inverted="false" value="PlatformBehavior::IsJumping" />
                             <parameters>
                                 <parameter>Player</parameter>
                                 <parameter>PlatformerObject</parameter>
@@ -587,7 +587,7 @@
                     <type>BuiltinCommonInstructions::Standard</type>
                     <conditions>
                         <condition>
-                            <type inverted="false" value="PlatformAutomatism::IsFalling" />
+                            <type inverted="false" value="PlatformBehavior::IsFalling" />
                             <parameters>
                                 <parameter>Player</parameter>
                                 <parameter>PlatformerObject</parameter>
@@ -612,7 +612,7 @@
                     <type>BuiltinCommonInstructions::Standard</type>
                     <conditions>
                         <condition>
-                            <type inverted="false" value="PlatformAutomatism::IsOnFloor" />
+                            <type inverted="false" value="PlatformBehavior::IsOnFloor" />
                             <parameters>
                                 <parameter>Player</parameter>
                                 <parameter>PlatformerObject</parameter>
@@ -626,7 +626,7 @@
                             <type>BuiltinCommonInstructions::Standard</type>
                             <conditions>
                                 <condition>
-                                    <type inverted="true" value="PlatformAutomatism::IsMoving" />
+                                    <type inverted="true" value="PlatformBehavior::IsMoving" />
                                     <parameters>
                                         <parameter>Player</parameter>
                                         <parameter>PlatformerObject</parameter>
@@ -651,7 +651,7 @@
                             <type>BuiltinCommonInstructions::Standard</type>
                             <conditions>
                                 <condition>
-                                    <type inverted="false" value="PlatformAutomatism::IsMoving" />
+                                    <type inverted="false" value="PlatformBehavior::IsMoving" />
                                     <parameters>
                                         <parameter>Player</parameter>
                                         <parameter>PlatformerObject</parameter>
@@ -855,12 +855,13 @@
                     <cameras>
                         <camera defaultSize="true" defaultViewport="true" height="0.000000" viewportBottom="1.000000" viewportLeft="0.000000" viewportRight="1.000000" viewportTop="0.000000" width="0.000000" />
                     </cameras>
+                    <effects />
                 </layer>
             </layers>
-            <automatismsSharedData>
-                <automatismSharedData name="Platform" type="PlatformAutomatism::PlatformAutomatism" />
-                <automatismSharedData name="PlatformerObject" type="PlatformAutomatism::PlatformerObjectAutomatism" />
-            </automatismsSharedData>
+            <behaviorsSharedData>
+                <behaviorSharedData name="Platform" type="PlatformBehavior::PlatformBehavior" />
+                <behaviorSharedData name="PlatformerObject" type="PlatformBehavior::PlatformerObjectBehavior" />
+            </behaviorsSharedData>
         </layout>
     </layouts>
     <externalEvents />

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
@@ -121,15 +121,12 @@ LayoutEditorCanvas::LayoutEditorCanvas(wxWindow* parent, gd::Project & project_,
     smallButtonSize(gd::GUIContentScaleFactor::Get() > 1 ? 12 : 5),
     firstRefresh(true),
     isSelecting(false),
-    editing(true),
-    enableIdleEvents(true)
+    editing(true)
 {
 	//(*Initialize(LayoutEditorCanvas)
 	//*)
 
-	/*Connect(wxEVT_PAINT,(wxObjectEventFunction)&LayoutEditorCanvas::OnPaint);
-	Connect(wxEVT_ERASE_BACKGROUND,(wxObjectEventFunction)&LayoutEditorCanvas::OnEraseBackground);*/
-	Connect(wxEVT_IDLE,(wxObjectEventFunction)&LayoutEditorCanvas::OnIdle);
+
 	Connect(wxEVT_LEFT_DOWN,(wxObjectEventFunction)&LayoutEditorCanvas::OnLeftDown);
 	Connect(wxEVT_LEFT_UP,(wxObjectEventFunction)&LayoutEditorCanvas::OnLeftUp);
 	Connect(wxEVT_LEFT_DCLICK,(wxObjectEventFunction)&LayoutEditorCanvas::OnLeftDClick);
@@ -278,18 +275,6 @@ LayoutEditorCanvas::~LayoutEditorCanvas()
 {
 	//(*Destroy(LayoutEditorCanvas)
 	//*)
-}
-
-void LayoutEditorCanvas::OnIdle(wxIdleEvent & event)
-{
-    if(enableIdleEvents)
-    {
-        // Send a paint message when the control is idle, to ensure maximum framerate
-        OnUpdate();
-        #if defined(__WXGTK__)
-        event.RequestMore(); //On GTK, we need to specify that we want continuous idle events.
-        #endif
-    }
 }
 
 void LayoutEditorCanvas::AddAssociatedEditor(gd::LayoutEditorCanvasAssociatedEditor * editor)

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
@@ -52,7 +52,7 @@ using namespace std;
 namespace gd
 {
 
-BEGIN_EVENT_TABLE(LayoutEditorCanvas,wxPanel)
+BEGIN_EVENT_TABLE(LayoutEditorCanvas,wxControl)
 	//(*EventTable(LayoutEditorCanvas)
 	//*)
 END_EVENT_TABLE()
@@ -1133,7 +1133,7 @@ void LayoutEditorCanvas::OnKey( wxKeyEvent& evt )
 {
     if (!editing)
     {
-        evt.StopPropagation();
+        evt.Skip(); //To allow WxRenderingWindow to generate events from this
         return;
     }
 
@@ -1197,7 +1197,7 @@ void LayoutEditorCanvas::OnKeyUp( wxKeyEvent& evt )
 {
     if (!editing)
     {
-        evt.StopPropagation();
+        evt.Skip(); //To allow WxRenderingWindow to generate events from this
         return;
     }
 

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
@@ -100,6 +100,7 @@ wxRibbonButtonBar * LayoutEditorCanvas::modeRibbonBar = NULL;
 LayoutEditorCanvas::LayoutEditorCanvas(wxWindow* parent, gd::Project & project_,
     gd::Layout & layout_, gd::InitialInstancesContainer & instances_,
     LayoutEditorCanvasOptions & options_, gd::MainFrameWrapper & mainFrameWrapper_, gd::ExternalLayout * externalLayout_) :
+    WxRenderingWindow(parent),
     project(project_),
     layout(layout_),
     externalLayout(externalLayout_),
@@ -124,45 +125,10 @@ LayoutEditorCanvas::LayoutEditorCanvas(wxWindow* parent, gd::Project & project_,
     enableIdleEvents(true)
 {
 	//(*Initialize(LayoutEditorCanvas)
-	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxWANTS_CHARS, _T("wxID_ANY"));
 	//*)
 
-    //Initialization allowing to run SFML within the wxWidgets control.
-    //See also LayoutEditorCanvas::OnUpdate & co.
-    #ifdef __WXGTK__
-
-        // GTK implementation requires to go deeper to find the low-level X11 identifier of the widget
-        gtk_widget_realize(m_wxwindow); //Required to create the internal gtk window
-        gtk_widget_set_double_buffered(m_wxwindow, false);
-
-        GtkWidget* privHandle = m_wxwindow;
-        wxPizza * pizza = WX_PIZZA(privHandle);
-        GtkWidget * widget = GTK_WIDGET(pizza);
-
-        //Get the internal gtk window...
-        #if GTK_CHECK_VERSION(3, 0, 0)
-        GdkWindow* win = gtk_widget_get_window(widget);
-        #else
-        GdkWindow* win = widget->window;
-        #endif
-        XFlush(GDK_WINDOW_XDISPLAY(win));
-
-        //...and pass it to the sf::RenderWindow.
-        #if GTK_CHECK_VERSION(3, 0, 0)
-        sf::RenderWindow::create(GDK_WINDOW_XID(win), sf::ContextSettings(24, 8));
-        #else
-        sf::RenderWindow::create(GDK_WINDOW_XWINDOW(win), sf::ContextSettings(24, 8));
-        #endif
-
-    #else
-
-        // Tested under Windows XP only (should work with X11 and other Windows versions - no idea about MacOS)
-        sf::RenderWindow::create(static_cast<sf::WindowHandle>(GetHandle()), sf::ContextSettings(24, 8));
-
-    #endif
-
-	Connect(wxEVT_PAINT,(wxObjectEventFunction)&LayoutEditorCanvas::OnPaint);
-	Connect(wxEVT_ERASE_BACKGROUND,(wxObjectEventFunction)&LayoutEditorCanvas::OnEraseBackground);
+	/*Connect(wxEVT_PAINT,(wxObjectEventFunction)&LayoutEditorCanvas::OnPaint);
+	Connect(wxEVT_ERASE_BACKGROUND,(wxObjectEventFunction)&LayoutEditorCanvas::OnEraseBackground);*/
 	Connect(wxEVT_IDLE,(wxObjectEventFunction)&LayoutEditorCanvas::OnIdle);
 	Connect(wxEVT_LEFT_DOWN,(wxObjectEventFunction)&LayoutEditorCanvas::OnLeftDown);
 	Connect(wxEVT_LEFT_UP,(wxObjectEventFunction)&LayoutEditorCanvas::OnLeftUp);
@@ -302,7 +268,7 @@ LayoutEditorCanvas::LayoutEditorCanvas(wxWindow* parent, gd::Project & project_,
         }
     }
 
-    setFramerateLimit(30);
+    SetFramerateLimit(30);
     editionView.setCenter( (project.GetMainWindowDefaultWidth()/2),(project.GetMainWindowDefaultHeight()/2));
     RecreateRibbonToolbar();
     UpdateModeButtonsState();
@@ -319,21 +285,12 @@ void LayoutEditorCanvas::OnIdle(wxIdleEvent & event)
     if(enableIdleEvents)
     {
         // Send a paint message when the control is idle, to ensure maximum framerate
-        Refresh();
+        OnUpdate();
         #if defined(__WXGTK__)
         event.RequestMore(); //On GTK, we need to specify that we want continuous idle events.
         #endif
     }
 }
-
-void LayoutEditorCanvas::OnPaint(wxPaintEvent&)
-{
-    // Make sure the control is able to be repainted
-    wxPaintDC Dc(this);
-    OnUpdate();
-}
-
-void LayoutEditorCanvas::OnEraseBackground(wxEraseEvent&) {}
 
 void LayoutEditorCanvas::AddAssociatedEditor(gd::LayoutEditorCanvasAssociatedEditor * editor)
 {
@@ -746,7 +703,7 @@ void LayoutEditorCanvas::OnLeftDown( wxMouseEvent &event )
     //Check if there is a click on a gui element inside the layout
     for (std::size_t i = 0;i<guiElements.size();++i)
     {
-        if ( guiElements[i].area.Contains(wxPoint(sf::Mouse::getPosition(*this).x, sf::Mouse::getPosition(*this).y)) )
+        if ( guiElements[i].area.Contains(wxPoint(gd::WxRenderingWindow::GetMousePosition(*this).x, gd::WxRenderingWindow::GetMousePosition(*this).y)) )
         {
             OnGuiElementPressed(guiElements[i]);
             return ;
@@ -936,7 +893,7 @@ void LayoutEditorCanvas::OnLeftUp(wxMouseEvent &)
     //Check if there is a click released on a gui element inside the layout
     for (std::size_t i = 0;i<guiElements.size();++i)
     {
-        if ( guiElements[i].area.Contains(wxPoint(sf::Mouse::getPosition(*this).x, sf::Mouse::getPosition(*this).y)) )
+        if ( guiElements[i].area.Contains(wxPoint(gd::WxRenderingWindow::GetMousePosition(*this).x, gd::WxRenderingWindow::GetMousePosition(*this).y)) )
         {
             OnGuiElementReleased(guiElements[i]);
             return;
@@ -1098,7 +1055,7 @@ void LayoutEditorCanvas::OnMotion(wxMouseEvent &)
     {
         for ( auto & it : selectedInstances)
         {
-            float newAngle = atan2(sf::Mouse::getPosition(*this).y-angleButtonCenter.y, sf::Mouse::getPosition(*this).x-angleButtonCenter.x)*180/3.14159;
+            float newAngle = atan2(gd::WxRenderingWindow::GetMousePosition(*this).y-angleButtonCenter.y, gd::WxRenderingWindow::GetMousePosition(*this).x-angleButtonCenter.x)*180/3.14159;
             if (shiftPressed) newAngle = gd::Round(newAngle / 15.0) * 15.0;
             it.first->SetAngle(newAngle);
         }
@@ -1110,9 +1067,9 @@ void LayoutEditorCanvas::OnMotion(wxMouseEvent &)
         //Moving using middle click
         if ( isMovingView )
         {
-            float zoomFactor = static_cast<float>(getSize().x)/editionView.getSize().x;
+            float zoomFactor = static_cast<float>(GetSize().x)/editionView.getSize().x;
 
-            editionView.setCenter( movingViewStartPosition + (movingViewMouseStartPosition - sf::Vector2f(sf::Mouse::getPosition(*this)))/zoomFactor );
+            editionView.setCenter( movingViewStartPosition + (movingViewMouseStartPosition - sf::Vector2f(gd::WxRenderingWindow::GetMousePosition(*this)))/zoomFactor );
         }
 
         double mouseX = GetMouseXOnLayout();
@@ -1125,7 +1082,7 @@ void LayoutEditorCanvas::OnMotion(wxMouseEvent &)
         bool hoveringSomething = false;
         for (std::size_t i = 0;i<guiElements.size();++i)
         {
-            if ( guiElements[i].area.Contains(wxPoint(sf::Mouse::getPosition(*this).x, sf::Mouse::getPosition(*this).y)) ) {
+            if ( guiElements[i].area.Contains(wxPoint(gd::WxRenderingWindow::GetMousePosition(*this).x, gd::WxRenderingWindow::GetMousePosition(*this).y)) ) {
                 OnGuiElementHovered(guiElements[i]);
                 hoveringSomething = true;
             }
@@ -1166,8 +1123,8 @@ void LayoutEditorCanvas::OnMiddleDown(wxMouseEvent &)
 
     //User can move the view thanks to middle click
     isMovingView = true;
-    movingViewMouseStartPosition = sf::Vector2f(sf::Mouse::getPosition(*this));
-    movingViewStartPosition = getView().getCenter();
+    movingViewMouseStartPosition = sf::Vector2f(gd::WxRenderingWindow::GetMousePosition(*this));
+    movingViewStartPosition = GetRenderingTarget().getView().getCenter();
     SetCursor(wxCursor(wxCURSOR_SIZING));
 }
 
@@ -1446,12 +1403,12 @@ void LayoutEditorCanvas::OnFullScreenBtClick(wxCommandEvent & event)
 
 double LayoutEditorCanvas::GetMouseXOnLayout() const
 {
-    return mapPixelToCoords(sf::Mouse::getPosition(*this), editionView).x;
+    return GetRenderingTarget().mapPixelToCoords(gd::WxRenderingWindow::GetMousePosition(*this), editionView).x;
 }
 
 double LayoutEditorCanvas::GetMouseYOnLayout() const
 {
-    return mapPixelToCoords(sf::Mouse::getPosition(*this), editionView).y;
+    return GetRenderingTarget().mapPixelToCoords(gd::WxRenderingWindow::GetMousePosition(*this), editionView).y;
 }
 
 sf::Vector2f LayoutEditorCanvas::GetInitialInstanceSize(gd::InitialInstance & instance) const

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
@@ -674,6 +674,7 @@ void LayoutEditorCanvas::OnLeftDown( wxMouseEvent &event )
 {
     SetFocus();
 
+    event.Skip();
     if ( !editing ) return;
 
     if ( hasJustRightClicked )
@@ -738,6 +739,7 @@ void LayoutEditorCanvas::OnLeftDown( wxMouseEvent &event )
 
 void LayoutEditorCanvas::OnRightUp( wxMouseEvent &event )
 {
+    event.Skip();
     if ( !editing ) return;
 
 
@@ -856,8 +858,9 @@ private:
     std::set<gd::String> excludedLayers;
 };
 
-void LayoutEditorCanvas::OnLeftUp(wxMouseEvent &)
+void LayoutEditorCanvas::OnLeftUp(wxMouseEvent & event)
 {
+    event.Skip();
     if ( !editing ) return;
 
     if ( !currentDraggableBt.empty() ) //First check if we were dragging a button.
@@ -938,8 +941,9 @@ void LayoutEditorCanvas::OnLeftUp(wxMouseEvent &)
     }
 }
 
-void LayoutEditorCanvas::OnMotion(wxMouseEvent &)
+void LayoutEditorCanvas::OnMotion(wxMouseEvent & event)
 {
+    event.Skip();
     if (!editing) return;
 
     auto preserveWidthRatio = [this](gd::InitialInstance * instance) {
@@ -1102,8 +1106,9 @@ void LayoutEditorCanvas::OnMotion(wxMouseEvent &)
     }
 }
 
-void LayoutEditorCanvas::OnMiddleDown(wxMouseEvent &)
+void LayoutEditorCanvas::OnMiddleDown(wxMouseEvent & event)
 {
+    event.Skip();
     if ( !editing ) return;
 
     //User can move the view thanks to middle click
@@ -1115,6 +1120,7 @@ void LayoutEditorCanvas::OnMiddleDown(wxMouseEvent &)
 
 void LayoutEditorCanvas::OnMiddleUp(wxMouseEvent & event)
 {
+    event.Skip();
     if ( !editing ) return;
 
     isMovingView = false;
@@ -1123,6 +1129,7 @@ void LayoutEditorCanvas::OnMiddleUp(wxMouseEvent & event)
 
 void LayoutEditorCanvas::OnLeftDClick( wxMouseEvent &event )
 {
+    event.Skip();
     if ( !editing ) return;
 
     parentAuiManager->GetPane("PROPERTIES").Show();
@@ -1195,11 +1202,9 @@ void LayoutEditorCanvas::OnKey( wxKeyEvent& evt )
 
 void LayoutEditorCanvas::OnKeyUp( wxKeyEvent& evt )
 {
+    evt.Skip(); //To allow WxRenderingWindow to generate events from this
     if (!editing)
-    {
-        evt.Skip(); //To allow WxRenderingWindow to generate events from this
         return;
-    }
 
     if ( evt.GetKeyCode() == WXK_CONTROL )
         ctrlPressed = false;

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.h
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.h
@@ -20,6 +20,7 @@
 #include <wx/gdicmn.h>
 #include <wx/panel.h>
 #include "GDCore/Project/LayoutEditorPreviewer.h"
+#include "GDCore/Window/WxRenderingWindow.h"
 #include "GDCore/String.h"
 namespace gd { class MainFrameWrapper; }
 namespace gd { class InitialInstancesContainer; }
@@ -67,7 +68,7 @@ public:
  * \ingroup IDE
  * \ingroup IDE dialogs
  */
-class GD_CORE_API LayoutEditorCanvas: public wxPanel, public sf::RenderWindow
+class GD_CORE_API LayoutEditorCanvas: public gd::WxRenderingWindow
 {
     friend class InstancesRenderer;
 public:
@@ -349,8 +350,6 @@ protected:
 
     //Methods allowing to run SFML within the wxWidgets control
     virtual void OnUpdate();
-    virtual void OnPaint(wxPaintEvent& event);
-    virtual void OnEraseBackground(wxEraseEvent& event);
     virtual void OnIdle(wxIdleEvent&);
     //Changing the state of the editor
     virtual void OnPreviewBtClick( wxCommandEvent & event );

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.h
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.h
@@ -286,12 +286,6 @@ public:
      */
     void GoToEditingState();
 
-    /**
-     * \brief Enable or disable idle events. Disabling them avoid the scene to be constantly rendered.
-     * \note Used by the scene editor when the user switch to the event editor.
-     */
-    void EnableIdleEvents(bool enable = true) {enableIdleEvents = enable;};
-
     virtual sf::Vector2f GetInitialInstanceSize(gd::InitialInstance & instance) const;
     virtual sf::Vector2f GetInitialInstanceOrigin(gd::InitialInstance & instance) const;
 
@@ -349,8 +343,7 @@ protected:
     //*)
 
     //Methods allowing to run SFML within the wxWidgets control
-    virtual void OnUpdate();
-    virtual void OnIdle(wxIdleEvent&);
+    virtual void OnUpdate() override;
     //Changing the state of the editor
     virtual void OnPreviewBtClick( wxCommandEvent & event );
     virtual void OnPreviewDropDownBtClick( wxRibbonButtonBarEvent & event );
@@ -543,8 +536,6 @@ protected:
     //State
     bool editing; ///< True if the layout is being edited, false if a preview is running.
     std::shared_ptr<gd::LayoutEditorPreviewer> currentPreviewer; ///< The previewer being used to preview the layout.
-
-    bool enableIdleEvents;
 
     wxMenu contextMenu;
     wxMenu noObjectContextMenu;

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
@@ -687,7 +687,6 @@ void LayoutEditorCanvas::UpdateSize()
         double scaleFactor = GUIContentScaleFactor::Get();
 
         //Scene takes all the space available in edition mode.
-        WxRenderingWindow::SetSize(sf::Vector2u(width * scaleFactor, height * scaleFactor));
         wxWindowBase::SetPosition(wxPoint(0,0));
         wxWindowBase::SetSize(width * scaleFactor, height * scaleFactor);
 
@@ -696,7 +695,6 @@ void LayoutEditorCanvas::UpdateSize()
     else
     {
         //Scene has the size of the project's window size in preview mode.
-        WxRenderingWindow::SetSize(sf::Vector2u(project.GetMainWindowDefaultWidth(), project.GetMainWindowDefaultHeight()));
         wxWindowBase::SetClientSize(project.GetMainWindowDefaultWidth(), project.GetMainWindowDefaultHeight());
 
         //Scene is centered in preview mode

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
@@ -73,6 +73,10 @@ void LayoutEditorCanvas::OnUpdate()
             ReloadResources();
         }
 
+        //Empty the event queue
+        sf::Event dummyEvent;
+        while(PollEvent(dummyEvent));
+
         //Then display the layout
         RenderEdittime();
         if (vScrollbar && hScrollbar && !hScrollbar->HasFocus() && !vScrollbar->HasFocus())
@@ -601,6 +605,8 @@ void LayoutEditorCanvas::OnPreviewDropDownBtClick(wxRibbonButtonBarEvent& evt)
 
 void LayoutEditorCanvas::OnMouseWheel( wxMouseEvent &event )
 {
+    event.Skip(); //To allow WxRenderingWindow to generate events from this
+
     if (!editing) return;
 
     if ( ctrlPressed )

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
@@ -79,6 +79,8 @@ void LayoutEditorCanvas::OnUpdate()
             UpdateScrollbars();
 
     }
+
+    Display();
 }
 
 void LayoutEditorCanvas::DrawSelectionRectangleGuiElement(std::vector < std::shared_ptr<sf::Shape> > & target, const sf::FloatRect & rectangle )
@@ -319,7 +321,6 @@ void LayoutEditorCanvas::RenderEdittime()
 
     GetRenderingTarget().setView(editionView);
     GetRenderingTarget().popGLStates();
-    Display();
 }
 
 void LayoutEditorCanvas::RenderWindowMask()

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
@@ -689,6 +689,7 @@ void LayoutEditorCanvas::UpdateSize()
         //Scene takes all the space available in edition mode.
         wxWindowBase::SetPosition(wxPoint(0,0));
         wxWindowBase::SetSize(width * scaleFactor, height * scaleFactor);
+        WxRenderingWindow::SetSize(sf::Vector2u(width * scaleFactor, height * scaleFactor));
 
         UpdateViewAccordingToZoomFactor();
     }
@@ -700,6 +701,8 @@ void LayoutEditorCanvas::UpdateSize()
         //Scene is centered in preview mode
         wxWindowBase::SetPosition(wxPoint((parentControl->GetSize().GetWidth()-wxWindowBase::GetSize().GetX())/2,
                               (parentControl->GetSize().GetHeight()-wxWindowBase::GetSize().GetY())/2));
+
+        WxRenderingWindow::SetSize(sf::Vector2u(project.GetMainWindowDefaultWidth(), project.GetMainWindowDefaultHeight()));
     }
 }
 

--- a/Core/GDCore/Window/RenderingWindow.cpp
+++ b/Core/GDCore/Window/RenderingWindow.cpp
@@ -1,0 +1,28 @@
+#include "GDCore/Window/RenderingWindow.h"
+
+#include <SFML/Window/Mouse.hpp>
+
+namespace gd
+{
+
+sf::Vector2i RenderingWindow::GetMousePosition()
+{
+    return sf::Mouse::getPosition();
+}
+
+sf::Vector2i RenderingWindow::GetMousePosition(const RenderingWindow & window)
+{
+    return sf::Mouse::getPosition() - window.GetPosition();
+}
+
+void RenderingWindow::SetMousePosition(const sf::Vector2i & position)
+{
+    sf::Mouse::setPosition(position);
+}
+
+void RenderingWindow::SetMousePosition(const sf::Vector2i & position, const RenderingWindow & window)
+{
+    sf::Mouse::setPosition(position + window.GetPosition());
+}
+
+}

--- a/Core/GDCore/Window/RenderingWindow.h
+++ b/Core/GDCore/Window/RenderingWindow.h
@@ -1,0 +1,58 @@
+#ifndef GDCORE_RENDERINGWINDOW_H
+#define GDCORE_RENDERINGWINDOW_H
+
+#include <SFML/System/Vector2.hpp>
+
+#include "GDCore/String.h"
+
+namespace sf { class RenderTarget; }
+namespace sf { class Event; }
+
+namespace gd
+{
+
+class RenderingWindow
+{
+public:
+    RenderingWindow() {};
+    virtual ~RenderingWindow() {}
+
+    virtual const sf::RenderTarget & GetRenderingTarget() const = 0;
+    virtual sf::RenderTarget & GetRenderingTarget() = 0;
+
+    virtual void Display() = 0;
+
+    static sf::Vector2i GetMousePosition();
+    static sf::Vector2i GetMousePosition(const RenderingWindow & window);
+
+    static void SetMousePosition(const sf::Vector2i & position);
+    static void SetMousePosition(const sf::Vector2i & position, const RenderingWindow & window);
+
+    virtual void Close() = 0;
+
+    virtual bool PollEvent(sf::Event & event) = 0;
+
+    virtual sf::Vector2i GetPosition() const = 0;
+    virtual void SetPosition(const sf::Vector2i & pos) = 0;
+
+    virtual sf::Vector2u GetSize() const = 0;
+    virtual void SetSize(const sf::Vector2u & size) = 0;
+
+    virtual void SetFullScreen(bool fullscreen) = 0;
+
+    virtual void SetTitle(const gd::String & title) = 0;
+
+    virtual void SetVerticalSyncEnabled(bool enabled) = 0;
+
+    virtual void SetKeyRepeatEnabled(bool enabled) = 0;
+
+    virtual void SetFramerateLimit(unsigned int limit) = 0;
+
+    virtual void SetMouseCursorVisible(bool visible) = 0;
+
+    virtual bool SetActive(bool active = true) = 0;
+};
+
+}
+
+#endif

--- a/Core/GDCore/Window/RenderingWindow.h
+++ b/Core/GDCore/Window/RenderingWindow.h
@@ -1,6 +1,7 @@
 #ifndef GDCORE_RENDERINGWINDOW_H
 #define GDCORE_RENDERINGWINDOW_H
 
+#include <SFML/Graphics/Texture.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include "GDCore/String.h"
@@ -21,6 +22,8 @@ public:
     virtual sf::RenderTarget & GetRenderingTarget() = 0;
 
     virtual void Display() = 0;
+
+    virtual sf::Texture CaptureAsTexture() const = 0;
 
     static sf::Vector2i GetMousePosition();
     static sf::Vector2i GetMousePosition(const RenderingWindow & window);

--- a/Core/GDCore/Window/RenderingWindow.h
+++ b/Core/GDCore/Window/RenderingWindow.h
@@ -11,7 +11,7 @@ namespace sf { class Event; }
 namespace gd
 {
 
-class RenderingWindow
+class GD_CORE_API RenderingWindow
 {
 public:
     RenderingWindow() {};

--- a/Core/GDCore/Window/SFMLRenderingWindow.cpp
+++ b/Core/GDCore/Window/SFMLRenderingWindow.cpp
@@ -27,6 +27,15 @@ void SFMLRenderingWindow::Display()
     window.display();
 }
 
+sf::Texture SFMLRenderingWindow::CaptureAsTexture() const
+{
+    sf::Texture texture;
+    texture.create(window.getSize().x, window.getSize().y);
+    texture.update(window);
+
+    return texture;
+}
+
 void SFMLRenderingWindow::Close()
 {
     window.close();

--- a/Core/GDCore/Window/SFMLRenderingWindow.cpp
+++ b/Core/GDCore/Window/SFMLRenderingWindow.cpp
@@ -1,0 +1,107 @@
+#include "GDCore/Window/SFMLRenderingWindow.h"
+
+namespace gd
+{
+
+SFMLRenderingWindow::SFMLRenderingWindow(sf::VideoMode mode, const gd::String & title, sf::Uint32 style, const sf::ContextSettings & settings) :
+    window(mode, title, style, settings),
+    mode(mode),
+    title(title),
+    style(style)
+{
+
+}
+
+const sf::RenderTarget & SFMLRenderingWindow::GetRenderingTarget() const
+{
+    return window;
+}
+
+sf::RenderTarget & SFMLRenderingWindow::GetRenderingTarget()
+{
+    return window;
+}
+
+void SFMLRenderingWindow::Display()
+{
+    window.display();
+}
+
+void SFMLRenderingWindow::Close()
+{
+    window.close();
+}
+
+bool SFMLRenderingWindow::PollEvent(sf::Event & event)
+{
+    return window.pollEvent(event);
+}
+
+sf::Vector2i SFMLRenderingWindow::GetPosition() const
+{
+    return window.getPosition();
+}
+
+void SFMLRenderingWindow::SetPosition(const sf::Vector2i & pos)
+{
+    window.setPosition(pos);
+}
+
+sf::Vector2u SFMLRenderingWindow::GetSize() const
+{
+    return window.getSize();
+}
+
+void SFMLRenderingWindow::SetSize(const sf::Vector2u & size)
+{
+    window.setSize(size);
+}
+
+void SFMLRenderingWindow::SetFullScreen(bool fullscreen)
+{
+    sf::Uint32 newStyle = style;
+    if(fullscreen)
+        newStyle = newStyle | sf::Style::Fullscreen;
+    else
+        newStyle = newStyle & (~sf::Style::Fullscreen);
+
+    style = newStyle;
+    window.create(mode, title, newStyle, window.getSettings());
+}
+
+void SFMLRenderingWindow::SetTitle(const gd::String & title)
+{
+    window.setTitle(title);
+}
+
+void SFMLRenderingWindow::SetVerticalSyncEnabled(bool enabled)
+{
+    window.setVerticalSyncEnabled(enabled);
+}
+
+void SFMLRenderingWindow::SetKeyRepeatEnabled(bool enabled)
+{
+    window.setKeyRepeatEnabled(enabled);
+}
+
+void SFMLRenderingWindow::SetFramerateLimit(unsigned int limit)
+{
+    window.setFramerateLimit(limit);
+}
+
+void SFMLRenderingWindow::SetMouseCursorVisible(bool visible)
+{
+    window.setMouseCursorVisible(visible);
+}
+
+bool SFMLRenderingWindow::SetActive(bool active)
+{
+    window.setActive(active);
+}
+
+bool SFMLRenderingWindow::IsOpen() const
+{
+    return window.isOpen();
+}
+
+}

--- a/Core/GDCore/Window/SFMLRenderingWindow.h
+++ b/Core/GDCore/Window/SFMLRenderingWindow.h
@@ -18,6 +18,8 @@ public:
 
     virtual void Display();
 
+    virtual sf::Texture CaptureAsTexture() const;
+
     virtual void Close();
 
     virtual bool PollEvent(sf::Event & event);

--- a/Core/GDCore/Window/SFMLRenderingWindow.h
+++ b/Core/GDCore/Window/SFMLRenderingWindow.h
@@ -8,7 +8,7 @@
 namespace gd
 {
 
-class SFMLRenderingWindow : public RenderingWindow
+class GD_CORE_API SFMLRenderingWindow : public RenderingWindow
 {
 public:
     SFMLRenderingWindow(sf::VideoMode mode, const gd::String & title, sf::Uint32 style = sf::Style::Default, const sf::ContextSettings & settings = sf::ContextSettings());

--- a/Core/GDCore/Window/SFMLRenderingWindow.h
+++ b/Core/GDCore/Window/SFMLRenderingWindow.h
@@ -1,0 +1,57 @@
+#ifndef GDCORE_SFMLRENDERINGWINDOW_H
+#define GDCORE_SFMLRENDERINGWINDOW_H
+
+#include "GDCore/Window/RenderingWindow.h"
+
+#include <SFML/Graphics/RenderWindow.hpp>
+
+namespace gd
+{
+
+class SFMLRenderingWindow : public RenderingWindow
+{
+public:
+    SFMLRenderingWindow(sf::VideoMode mode, const gd::String & title, sf::Uint32 style = sf::Style::Default, const sf::ContextSettings & settings = sf::ContextSettings());
+
+    virtual const sf::RenderTarget & GetRenderingTarget() const;
+    virtual sf::RenderTarget & GetRenderingTarget();
+
+    virtual void Display();
+
+    virtual void Close();
+
+    virtual bool PollEvent(sf::Event & event);
+
+    virtual sf::Vector2i GetPosition() const;
+    virtual void SetPosition(const sf::Vector2i & pos);
+
+    virtual sf::Vector2u GetSize() const;
+    virtual void SetSize(const sf::Vector2u & size);
+
+    virtual void SetFullScreen(bool fullscreen);
+
+    virtual void SetTitle(const gd::String & title);
+
+    virtual void SetVerticalSyncEnabled(bool enabled);
+
+    virtual void SetKeyRepeatEnabled(bool enabled);
+
+    virtual void SetFramerateLimit(unsigned int limit);
+
+    virtual void SetMouseCursorVisible(bool visible);
+
+    virtual bool SetActive(bool active = true);
+
+    bool IsOpen() const;
+
+private:
+    sf::RenderWindow window;
+
+    sf::VideoMode mode;
+    gd::String title;
+    sf::Uint32 style;
+};
+
+}
+
+#endif

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -90,6 +90,9 @@ WxRenderingWindow::WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSi
     Bind(wxEVT_AUX2_DOWN, &WxRenderingWindow::OnMouseEvents, this);
     Bind(wxEVT_AUX2_UP, &WxRenderingWindow::OnMouseEvents, this);
     Bind(wxEVT_MOUSEWHEEL, &WxRenderingWindow::OnMouseEvents, this);
+    Bind(wxEVT_MOTION, &WxRenderingWindow::OnMouseEvents, this);
+    Bind(wxEVT_ENTER_WINDOW, &WxRenderingWindow::OnMouseEvents, this);
+    Bind(wxEVT_LEAVE_WINDOW, &WxRenderingWindow::OnMouseEvents, this);
 }
 
 const sf::RenderTarget & WxRenderingWindow::GetRenderingTarget() const
@@ -297,6 +300,26 @@ void WxRenderingWindow::OnMouseEvents(wxMouseEvent & event)
         deprecatedEvent.mouseWheel.x = GetMousePosition(*this).x;
         deprecatedEvent.mouseWheel.y = GetMousePosition(*this).y;
         eventsQueue.push(deprecatedEvent);
+    }
+    else if(event.Moving() || event.Dragging())
+    {
+        sf::Event mouseMovedEvent;
+        mouseMovedEvent.type = sf::Event::MouseMoved;
+        mouseMovedEvent.mouseMove.x = GetMousePosition(*this).x;
+        mouseMovedEvent.mouseMove.y = GetMousePosition(*this).y;
+        eventsQueue.push(mouseMovedEvent);
+    }
+    else if(event.Entering())
+    {
+        sf::Event mouseEnteredEvent;
+        mouseEnteredEvent.type = sf::Event::MouseEntered;
+        eventsQueue.push(mouseEnteredEvent);
+    }
+    else if(event.Leaving())
+    {
+        sf::Event mouseLeftEvent;
+        mouseLeftEvent.type = sf::Event::MouseLeft;
+        eventsQueue.push(mouseLeftEvent);
     }
 
     event.Skip();

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -336,10 +336,6 @@ std::map<int, sf::Keyboard::Key> & WxRenderingWindow::GetKeyMap()
 {
     if(!keysMapInitialized)
     {
-        /*keysMap[WXK_F1] = sf::Keyboard::F1;
-        keysMap[WXK_F2] = sf::Keyboard::F2;
-        keysMap['Z'] = sf::Keyboard::Z;*/
-
         keysMap[WXK_NONE] = sf::Keyboard::Unknown;
 
         keysMap['A'] = sf::Keyboard::A;

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -1,9 +1,9 @@
 #include "GDCore/Window/WxRenderingWindow.h"
 
+#if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
+
 #include <wx/dcbuffer.h>
 #include <wx/rawbmp.h>
-
-#if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 
 namespace
 {

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -114,7 +114,8 @@ sf::Vector2u WxRenderingWindow::GetSize() const
 
 void WxRenderingWindow::SetSize(const sf::Vector2u & size)
 {
-
+    texture.create(size.x, size.y, true);
+    ForceUpdate();
 }
 
 bool WxRenderingWindow::SetActive(bool active)
@@ -168,8 +169,7 @@ void WxRenderingWindow::OnIdle(wxIdleEvent & event)
 
 void WxRenderingWindow::OnSizeChanged(wxSizeEvent & event)
 {
-    texture.create(GetClientSize().GetWidth(), GetClientSize().GetHeight(), true);
-    ForceUpdate();
+    //Do nothing as it causes some troubles on Windows!
 }
 
 void WxRenderingWindow::ForceUpdate()

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -40,6 +40,11 @@ void WxRenderingWindow::Display()
     Refresh();
 }
 
+sf::Texture WxRenderingWindow::CaptureAsTexture() const
+{
+    return sf::Texture(texture.getTexture());
+}
+
 bool WxRenderingWindow::PollEvent(sf::Event & event)
 {
     return false;

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -57,6 +57,9 @@ namespace
 namespace gd
 {
 
+std::map<int, sf::Keyboard::Key> WxRenderingWindow::keysMap = std::map<int, sf::Keyboard::Key>();
+bool WxRenderingWindow::keysMapInitialized = false;
+
 WxRenderingWindow::WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSize, wxWindowID id, const wxPoint & pos, const wxSize & size, long style, const wxString & name) :
     wxControl(parent, id, pos, size, style|wxWANTS_CHARS|wxBORDER_NONE, wxDefaultValidator, name),
     idleEventEnabled(true),
@@ -71,6 +74,7 @@ WxRenderingWindow::WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSi
 	Bind(wxEVT_ERASE_BACKGROUND, &WxRenderingWindow::OnEraseBackground, this);
     Bind(wxEVT_IDLE, &WxRenderingWindow::OnIdle, this);
     Bind(wxEVT_SIZE, &WxRenderingWindow::OnSizeChanged, this);
+    Bind(wxEVT_KEY_DOWN, &WxRenderingWindow::OnKeyDown, this);
     Bind(wxEVT_CHAR, &WxRenderingWindow::OnCharEntered, this);
     Bind(wxEVT_MOUSEWHEEL, &WxRenderingWindow::OnMouseWheelScrolled, this);
 }
@@ -88,11 +92,6 @@ sf::RenderTarget & WxRenderingWindow::GetRenderingTarget()
 void WxRenderingWindow::Display()
 {
     texture.display();
-}
-
-sf::Texture WxRenderingWindow::CaptureAsTexture() const
-{
-    return sf::Texture(texture.getTexture());
 }
 
 sf::Texture WxRenderingWindow::CaptureAsTexture() const
@@ -186,6 +185,23 @@ void WxRenderingWindow::OnSizeChanged(wxSizeEvent & event)
     //Do nothing as it causes some troubles on Windows!
 }
 
+void WxRenderingWindow::OnKeyDown(wxKeyEvent & event)
+{
+    event.Skip();
+    if(event.GetKeyCode() == WXK_NONE || GetKeyMap().count(event.GetKeyCode()) == 0)
+        return;
+
+    sf::Event keyEvent;
+    keyEvent.type = sf::Event::KeyPressed;
+    keyEvent.key.code = GetKeyMap()[event.GetKeyCode()];
+    keyEvent.key.alt = event.AltDown();
+    keyEvent.key.control = event.ControlDown();
+    keyEvent.key.shift = event.ShiftDown();
+    keyEvent.key.system = event.MetaDown();
+
+    eventsQueue.push(keyEvent);
+}
+
 void WxRenderingWindow::OnCharEntered(wxKeyEvent & event)
 {
     if(event.GetUnicodeKey() != WXK_NONE)
@@ -196,6 +212,8 @@ void WxRenderingWindow::OnCharEntered(wxKeyEvent & event)
 
         eventsQueue.push(textEvent);
     }
+
+    event.Skip();
 }
 
 void WxRenderingWindow::OnMouseWheelScrolled(wxMouseEvent & event)
@@ -219,6 +237,8 @@ void WxRenderingWindow::OnMouseWheelScrolled(wxMouseEvent & event)
     deprecatedEvent.mouseWheel.x = GetMousePosition(*this).x;
     deprecatedEvent.mouseWheel.y = GetMousePosition(*this).y;
     eventsQueue.push(deprecatedEvent);
+
+    event.Skip();
 }
 
 void WxRenderingWindow::ForceUpdate()
@@ -226,6 +246,142 @@ void WxRenderingWindow::ForceUpdate()
     texture.clear(sf::Color(255, 255, 255, 255));
     hasRendered = true;
     wxWakeUpIdle();
+}
+
+std::map<int, sf::Keyboard::Key> & WxRenderingWindow::GetKeyMap()
+{
+    if(!keysMapInitialized)
+    {
+        /*keysMap[WXK_F1] = sf::Keyboard::F1;
+        keysMap[WXK_F2] = sf::Keyboard::F2;
+        keysMap['Z'] = sf::Keyboard::Z;*/
+
+        keysMap[WXK_NONE] = sf::Keyboard::Unknown;
+
+        keysMap['A'] = sf::Keyboard::A;
+        keysMap['B'] = sf::Keyboard::B;
+        keysMap['C'] = sf::Keyboard::C;
+        keysMap['D'] = sf::Keyboard::D;
+        keysMap['E'] = sf::Keyboard::E;
+        keysMap['F'] = sf::Keyboard::F;
+        keysMap['G'] = sf::Keyboard::G;
+        keysMap['H'] = sf::Keyboard::H;
+        keysMap['I'] = sf::Keyboard::I;
+        keysMap['J'] = sf::Keyboard::J;
+        keysMap['K'] = sf::Keyboard::K;
+        keysMap['L'] = sf::Keyboard::L;
+        keysMap['M'] = sf::Keyboard::M;
+        keysMap['N'] = sf::Keyboard::N;
+        keysMap['O'] = sf::Keyboard::O;
+        keysMap['P'] = sf::Keyboard::P;
+        keysMap['Q'] = sf::Keyboard::Q;
+        keysMap['R'] = sf::Keyboard::R;
+        keysMap['S'] = sf::Keyboard::S;
+        keysMap['T'] = sf::Keyboard::T;
+        keysMap['U'] = sf::Keyboard::U;
+        keysMap['V'] = sf::Keyboard::V;
+        keysMap['W'] = sf::Keyboard::W;
+        keysMap['X'] = sf::Keyboard::X;
+        keysMap['Y'] = sf::Keyboard::Y;
+        keysMap['Z'] = sf::Keyboard::Z;
+
+        keysMap['1'] = sf::Keyboard::Num1;
+        keysMap['2'] = sf::Keyboard::Num2;
+        keysMap['3'] = sf::Keyboard::Num3;
+        keysMap['4'] = sf::Keyboard::Num4;
+        keysMap['5'] = sf::Keyboard::Num5;
+        keysMap['6'] = sf::Keyboard::Num6;
+        keysMap['7'] = sf::Keyboard::Num7;
+        keysMap['8'] = sf::Keyboard::Num8;
+        keysMap['9'] = sf::Keyboard::Num9;
+        keysMap['0'] = sf::Keyboard::Num0;
+
+        keysMap[WXK_ESCAPE] = sf::Keyboard::Escape;
+
+        keysMap[WXK_RAW_CONTROL /* or WXK_CONTROL, depends on Mac OS X impl of SFML ? */] = sf::Keyboard::LControl;
+        keysMap[WXK_SHIFT] = sf::Keyboard::LShift;
+        keysMap[WXK_ALT] = sf::Keyboard::LAlt;
+        keysMap[WXK_RAW_CONTROL /* or WXK_CONTROL, depends on Mac OS X impl of SFML ? */] = sf::Keyboard::RControl;
+        keysMap[WXK_SHIFT] = sf::Keyboard::RShift;
+        keysMap[WXK_ALT] = sf::Keyboard::RAlt;
+        // Unfortunately, no ways to distinguish between left and right modifiers with wxWidgets' key codes
+
+        #if defined(WIN32)
+        keysMap[WXK_WINDOWS_LEFT] = sf::Keyboard::LSystem;
+        keysMap[WXK_WINDOWS_RIGHT] = sf::Keyboard::RSystem;
+        #elif defined(MACOS)
+        keysMap[WXK_CONTROL] = sf::Keyboard::LSystem;
+        keysMap[WXK_CONTROL] = sf::Keyboard::RSystem; // No way to know the side of this key too on MACOS
+        #endif
+        // The Windows/Command key doesn't work on Linux
+
+        keysMap[WXK_MENU] = sf::Keyboard::Menu;
+
+        keysMap['('] = sf::Keyboard::LBracket;
+        keysMap[')'] = sf::Keyboard::RBracket;
+        keysMap[';'] = sf::Keyboard::SemiColon;
+        keysMap[','] = sf::Keyboard::Comma;
+        keysMap['.'] = sf::Keyboard::Period;
+        keysMap['"'] = sf::Keyboard::Quote;
+        keysMap['/'] = sf::Keyboard::Slash;
+        keysMap['\\'] = sf::Keyboard::BackSlash;
+        keysMap['~'] = sf::Keyboard::Tilde;
+        keysMap['='] = sf::Keyboard::Equal;
+        keysMap['-'] = sf::Keyboard::Dash;
+
+        keysMap[WXK_SPACE] = sf::Keyboard::Space;
+        keysMap[WXK_RETURN] = sf::Keyboard::Return;
+        keysMap[WXK_BACK] = sf::Keyboard::BackSpace;
+        keysMap[WXK_TAB] = sf::Keyboard::Tab;
+
+        keysMap[WXK_PAGEUP] = sf::Keyboard::PageUp;
+        keysMap[WXK_PAGEDOWN] = sf::Keyboard::PageDown;
+        keysMap[WXK_END] = sf::Keyboard::End;
+        keysMap[WXK_HOME] = sf::Keyboard::Home;
+        keysMap[WXK_INSERT] = sf::Keyboard::Insert;
+        keysMap[WXK_DELETE] = sf::Keyboard::Delete;
+
+        keysMap[WXK_NUMPAD_ADD] = sf::Keyboard::Add;
+        keysMap[WXK_NUMPAD_SUBTRACT] = sf::Keyboard::Subtract;
+        keysMap[WXK_NUMPAD_MULTIPLY] = sf::Keyboard::Multiply;
+        keysMap[WXK_NUMPAD_DIVIDE] = sf::Keyboard::Divide;
+
+        keysMap[WXK_UP] = sf::Keyboard::Left;
+        keysMap[WXK_RIGHT] = sf::Keyboard::Right;
+        keysMap[WXK_UP] = sf::Keyboard::Up;
+        keysMap[WXK_DOWN] = sf::Keyboard::Down;
+
+        keysMap[WXK_NUMPAD0] = sf::Keyboard::Numpad0;
+        keysMap[WXK_NUMPAD1] = sf::Keyboard::Numpad1;
+        keysMap[WXK_NUMPAD2] = sf::Keyboard::Numpad2;
+        keysMap[WXK_NUMPAD3] = sf::Keyboard::Numpad3;
+        keysMap[WXK_NUMPAD4] = sf::Keyboard::Numpad4;
+        keysMap[WXK_NUMPAD5] = sf::Keyboard::Numpad5;
+        keysMap[WXK_NUMPAD6] = sf::Keyboard::Numpad6;
+        keysMap[WXK_NUMPAD7] = sf::Keyboard::Numpad7;
+        keysMap[WXK_NUMPAD8] = sf::Keyboard::Numpad8;
+        keysMap[WXK_NUMPAD9] = sf::Keyboard::Numpad9;
+
+        keysMap[WXK_F1] = sf::Keyboard::F1;
+        keysMap[WXK_F2] = sf::Keyboard::F2;
+        keysMap[WXK_F3] = sf::Keyboard::F3;
+        keysMap[WXK_F4] = sf::Keyboard::F4;
+        keysMap[WXK_F5] = sf::Keyboard::F5;
+        keysMap[WXK_F6] = sf::Keyboard::F6;
+        keysMap[WXK_F7] = sf::Keyboard::F7;
+        keysMap[WXK_F8] = sf::Keyboard::F8;
+        keysMap[WXK_F9] = sf::Keyboard::F9;
+        keysMap[WXK_F10] = sf::Keyboard::F10;
+        keysMap[WXK_F11] = sf::Keyboard::F11;
+        keysMap[WXK_F12] = sf::Keyboard::F12;
+        keysMap[WXK_F13] = sf::Keyboard::F13;
+        keysMap[WXK_F14] = sf::Keyboard::F14;
+        keysMap[WXK_F15] = sf::Keyboard::F15;
+
+        keysMap[WXK_PAUSE] = sf::Keyboard::Pause;
+    }
+
+    return keysMap;
 }
 
 }

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -1,0 +1,113 @@
+#include "GDCore/Window/WxRenderingWindow.h"
+
+#include <wx/dcbuffer.h>
+
+#if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
+
+namespace gd
+{
+
+WxRenderingWindow::WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSize, wxWindowID id, const wxPoint & pos, const wxSize & size, long style, const wxString & name) :
+    wxPanel(parent, id, pos, size, style|wxWANTS_CHARS, name)
+{
+    if(renderingSize == sf::Vector2u(-1, -1))
+        automaticSize = true;
+    else
+        automaticSize = false;
+
+    texture.create(
+        automaticSize ? size.GetWidth() : renderingSize.x,
+        automaticSize ? size.GetHeight() : renderingSize.y,
+        true);
+
+    Connect(wxEVT_PAINT, wxPaintEventHandler(WxRenderingWindow::OnPaint), NULL, this);
+	Connect(wxEVT_ERASE_BACKGROUND, (wxObjectEventFunction)& WxRenderingWindow::OnEraseBackground);
+}
+
+const sf::RenderTarget & WxRenderingWindow::GetRenderingTarget() const
+{
+    return texture;
+}
+
+sf::RenderTarget & WxRenderingWindow::GetRenderingTarget()
+{
+    return texture;
+}
+
+void WxRenderingWindow::Display()
+{
+    texture.display();
+    Refresh();
+}
+
+bool WxRenderingWindow::PollEvent(sf::Event & event)
+{
+    return false;
+}
+
+sf::Vector2i WxRenderingWindow::GetPosition() const
+{
+    return sf::Vector2i(
+        wxPanel::GetScreenPosition().x,
+        wxPanel::GetScreenPosition().y);
+}
+
+void WxRenderingWindow::SetPosition(const sf::Vector2i & pos)
+{
+    //Do nothing
+}
+
+sf::Vector2u WxRenderingWindow::GetSize() const
+{
+    return texture.getSize();
+}
+
+void WxRenderingWindow::SetSize(const sf::Vector2u & size)
+{
+    if(size == sf::Vector2u(-1, -1))
+    {
+        automaticSize = true;
+        texture.create(wxPanel::GetSize().GetWidth(), wxPanel::GetSize().GetHeight(), true);
+    }
+    else
+    {
+        automaticSize = false;
+        texture.create(size.x, size.y, true);
+    }
+}
+
+bool WxRenderingWindow::SetActive(bool active)
+{
+    texture.setActive(active);
+}
+
+void WxRenderingWindow::OnPaint(wxPaintEvent& event)
+{
+    wxAutoBufferedPaintDC dc(this);
+
+    sf::Image sfImage = texture.getTexture().copyToImage();
+    wxImage image(sfImage.getSize().x, sfImage.getSize().y, false);
+
+    for(std::size_t x = 0; x < sfImage.getSize().x; ++x)
+    {
+        for(std::size_t y = 0; y < sfImage.getSize().y; ++y)
+        {
+            sf::Color pixel = sfImage.getPixel(x, y);
+            image.SetRGB(x, y, pixel.r, pixel.g, pixel.b);
+            image.SetAlpha(x, y, pixel.a);
+        }
+    }
+
+    wxBitmap bitmap(image);
+
+    dc.DrawBitmap(bitmap, 0, 0, false);
+}
+
+void WxRenderingWindow::OnEraseBackground(wxEraseEvent& event)
+{
+
+}
+
+}
+
+#endif

--- a/Core/GDCore/Window/WxRenderingWindow.cpp
+++ b/Core/GDCore/Window/WxRenderingWindow.cpp
@@ -65,12 +65,12 @@ WxRenderingWindow::WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSi
 
     texture.create(size.GetWidth(), size.GetHeight(), true);
 
-    Bind(wxEVT_PAINT, WxRenderingWindow::OnPaint, this);
-	Bind(wxEVT_ERASE_BACKGROUND, WxRenderingWindow::OnEraseBackground, this);
-    Bind(wxEVT_IDLE, WxRenderingWindow::OnIdle, this);
-    Bind(wxEVT_SIZE, WxRenderingWindow::OnSizeChanged, this);
-    Bind(wxEVT_CHAR, WxRenderingWindow::OnCharEntered, this);
-    Bind(wxEVT_MOUSEWHEEL, WxRenderingWindow::OnMouseWheelScrolled, this);
+    Bind(wxEVT_PAINT, &WxRenderingWindow::OnPaint, this);
+	Bind(wxEVT_ERASE_BACKGROUND, &WxRenderingWindow::OnEraseBackground, this);
+    Bind(wxEVT_IDLE, &WxRenderingWindow::OnIdle, this);
+    Bind(wxEVT_SIZE, &WxRenderingWindow::OnSizeChanged, this);
+    Bind(wxEVT_CHAR, &WxRenderingWindow::OnCharEntered, this);
+    Bind(wxEVT_MOUSEWHEEL, &WxRenderingWindow::OnMouseWheelScrolled, this);
 }
 
 const sf::RenderTarget & WxRenderingWindow::GetRenderingTarget() const

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -64,6 +64,10 @@ private:
 
     virtual void OnIdle(wxIdleEvent & event);
 
+    virtual void OnSizeChanged(wxSizeEvent & event);
+
+    void ForceUpdate();
+
     sf::RenderTexture texture;
     bool idleEventEnabled;
 

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -1,0 +1,63 @@
+#ifndef GDCORE_WXRENDERINGWINDOW
+#define GDCORE_WXRENDERINGWINDOW
+
+#if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
+
+#include <wx/panel.h>
+#include <SFML/Graphics/RenderTexture.hpp>
+
+#include "GDCore/Window/RenderingWindow.h"
+
+namespace gd
+{
+
+class WxRenderingWindow : public wxPanel, public RenderingWindow
+{
+public:
+ 	WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSize = sf::Vector2u(-1, -1), wxWindowID id = wxID_ANY, const wxPoint & pos = wxDefaultPosition, const wxSize & size = wxDefaultSize, long style = wxWANTS_CHARS, const wxString & name = wxPanelNameStr);
+
+    virtual const sf::RenderTarget & GetRenderingTarget() const;
+    virtual sf::RenderTarget & GetRenderingTarget();
+
+    virtual void Display();
+
+    virtual void Close() {}
+
+    virtual bool PollEvent(sf::Event & event);
+
+    virtual sf::Vector2i GetPosition() const;
+    virtual void SetPosition(const sf::Vector2i & pos);
+
+    virtual sf::Vector2u GetSize() const;
+    virtual void SetSize(const sf::Vector2u & size);
+
+    virtual void SetFullScreen(bool fullscreen) {}
+
+    virtual void SetTitle(const gd::String & title) {}
+
+    virtual void SetVerticalSyncEnabled(bool enabled) {}
+
+    virtual void SetKeyRepeatEnabled(bool enabled) {}
+
+    virtual void SetFramerateLimit(unsigned int limit) {}
+
+    virtual void SetMouseCursorVisible(bool visible) {}
+
+    virtual bool SetActive(bool active = true);
+
+    bool IsOpen() const { return true; }
+
+    virtual void OnPaint(wxPaintEvent& event);
+    virtual void OnEraseBackground(wxEraseEvent& event);
+
+private:
+    sf::RenderTexture texture;
+
+    bool automaticSize;
+};
+
+}
+
+#endif
+
+#endif

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -11,7 +11,7 @@
 namespace gd
 {
 
-class WxRenderingWindow : public wxPanel, public RenderingWindow
+class GD_CORE_API WxRenderingWindow : public wxPanel, public RenderingWindow
 {
 public:
  	WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSize = sf::Vector2u(-1, -1), wxWindowID id = wxID_ANY, const wxPoint & pos = wxDefaultPosition, const wxSize & size = wxDefaultSize, long style = wxWANTS_CHARS, const wxString & name = wxPanelNameStr);

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -74,9 +74,11 @@ private:
 
     void OnKeyDown(wxKeyEvent & event);
 
+    void OnKeyUp(wxKeyEvent & event);
+
     void OnCharEntered(wxKeyEvent & event);
 
-    void OnMouseWheelScrolled(wxMouseEvent & event);
+    void OnMouseEvents(wxMouseEvent & event);
 
     void ForceUpdate();
 

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -3,12 +3,14 @@
 
 #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 
+#include <map>
 #include <queue>
 
 #include <wx/control.h>
 #include <wx/panel.h>
 #include <SFML/Graphics/RenderTexture.hpp>
 #include <SFML/Window/Event.hpp>
+#include <SFML/Window/Keyboard.hpp>
 
 #include "GDCore/Window/RenderingWindow.h"
 
@@ -70,6 +72,8 @@ private:
 
     virtual void OnSizeChanged(wxSizeEvent & event);
 
+    void OnKeyDown(wxKeyEvent & event);
+
     void OnCharEntered(wxKeyEvent & event);
 
     void OnMouseWheelScrolled(wxMouseEvent & event);
@@ -82,6 +86,11 @@ private:
     bool hasRendered; // Not to update more times than render
 
     std::queue<sf::Event> eventsQueue;
+
+    static std::map<int, sf::Keyboard::Key> & GetKeyMap();
+
+    static std::map<int, sf::Keyboard::Key> keysMap;
+    static bool keysMapInitialized;
 };
 
 }

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -21,6 +21,8 @@ public:
 
     virtual void Display();
 
+    virtual sf::Texture CaptureAsTexture() const;
+
     virtual void Close() {}
 
     virtual bool PollEvent(sf::Event & event);

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -3,15 +3,19 @@
 
 #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 
+#include <queue>
+
+#include <wx/control.h>
 #include <wx/panel.h>
 #include <SFML/Graphics/RenderTexture.hpp>
+#include <SFML/Window/Event.hpp>
 
 #include "GDCore/Window/RenderingWindow.h"
 
 namespace gd
 {
 
-class GD_CORE_API WxRenderingWindow : public wxPanel, public RenderingWindow
+class GD_CORE_API WxRenderingWindow : public wxControl, public RenderingWindow
 {
 public:
  	WxRenderingWindow(wxWindow * parent, sf::Vector2u renderingSize = sf::Vector2u(-1, -1), wxWindowID id = wxID_ANY, const wxPoint & pos = wxDefaultPosition, const wxSize & size = wxDefaultSize, long style = wxWANTS_CHARS, const wxString & name = wxPanelNameStr);
@@ -66,12 +70,18 @@ private:
 
     virtual void OnSizeChanged(wxSizeEvent & event);
 
+    void OnCharEntered(wxKeyEvent & event);
+
+    void OnMouseWheelScrolled(wxMouseEvent & event);
+
     void ForceUpdate();
 
     sf::RenderTexture texture;
     bool idleEventEnabled;
 
     bool hasRendered; // Not to update more times than render
+
+    std::queue<sf::Event> eventsQueue;
 };
 
 }

--- a/Core/GDCore/Window/WxRenderingWindow.h
+++ b/Core/GDCore/Window/WxRenderingWindow.h
@@ -49,13 +49,25 @@ public:
 
     bool IsOpen() const { return true; }
 
-    virtual void OnPaint(wxPaintEvent& event);
-    virtual void OnEraseBackground(wxEraseEvent& event);
+    /**
+     * \brief Enable or disable idle events. Disabling them avoid the panel to be constantly rendered.
+     */
+    void EnableIdleEvents(bool enable = true);
+
+protected:
+    virtual void OnUpdate() {}
 
 private:
-    sf::RenderTexture texture;
+    virtual void OnPaint(wxPaintEvent & event);
 
-    bool automaticSize;
+    virtual void OnEraseBackground(wxEraseEvent & event);
+
+    virtual void OnIdle(wxIdleEvent & event);
+
+    sf::RenderTexture texture;
+    bool idleEventEnabled;
+
+    bool hasRendered; // Not to update more times than render
 };
 
 }

--- a/Extensions/AnchorBehavior/AnchorBehavior.cpp
+++ b/Extensions/AnchorBehavior/AnchorBehavior.cpp
@@ -91,17 +91,17 @@ void AnchorBehavior::DoStepPostEvents(RuntimeScene & scene)
     {
         sf::Vector2u windowSize = m_relativeToOriginalWindowSize ?
             sf::Vector2u(scene.game->getWindowOriginalWidth(), scene.game->getWindowOriginalHeight()) :
-            scene.renderWindow->getSize();
+            scene.renderWindow->GetSize();
 
         //Calculate the distances from the window's bounds.
         sf::Vector2f topLeftPixel = mapCoordsToFloatPixel(
             sf::Vector2f(object->GetDrawableX(), object->GetDrawableY()),
-            *(scene.renderWindow),
+            scene.renderWindow->GetRenderingTarget(),
             firstCamera.GetSFMLView());
 
         sf::Vector2f bottomRightPixel = mapCoordsToFloatPixel(
             sf::Vector2f(object->GetDrawableX() + object->GetWidth(), object->GetDrawableY() + object->GetHeight()),
-            *(scene.renderWindow),
+            scene.renderWindow->GetRenderingTarget(),
             firstCamera.GetSFMLView());
 
         //Left edge
@@ -140,7 +140,7 @@ void AnchorBehavior::DoStepPostEvents(RuntimeScene & scene)
     }
     else
     {
-        sf::Vector2u windowSize = scene.renderWindow->getSize();
+        sf::Vector2u windowSize = scene.renderWindow->GetSize();
 
         //Move and resize the object if needed
         sf::Vector2f topLeftPixel;
@@ -178,8 +178,8 @@ void AnchorBehavior::DoStepPostEvents(RuntimeScene & scene)
         else if(m_bottomEdgeAnchor == ANCHOR_VERTICAL_PROPORTIONAL)
             bottomRightPixel.y = m_bottomEdgeDistance * static_cast<float>(windowSize.y);
 
-        sf::Vector2f topLeftCoord = mapFloatPixelToCoords(topLeftPixel, (*scene.renderWindow), firstCamera.GetSFMLView());
-        sf::Vector2f bottomRightCoord = mapFloatPixelToCoords(bottomRightPixel, (*scene.renderWindow), firstCamera.GetSFMLView());
+        sf::Vector2f topLeftCoord = mapFloatPixelToCoords(topLeftPixel, scene.renderWindow->GetRenderingTarget(), firstCamera.GetSFMLView());
+        sf::Vector2f bottomRightCoord = mapFloatPixelToCoords(bottomRightPixel, scene.renderWindow->GetRenderingTarget(), firstCamera.GetSFMLView());
 
         //Move and resize the object according to the anchors
         if(m_rightEdgeAnchor != ANCHOR_HORIZONTAL_NONE)

--- a/Extensions/DraggableBehavior/DraggableBehavior.cpp
+++ b/Extensions/DraggableBehavior/DraggableBehavior.cpp
@@ -33,7 +33,7 @@ void DraggableBehavior::DoStepPreEvents(RuntimeScene & scene)
         RuntimeLayer & theLayer = scene.GetRuntimeLayer(object->GetLayer());
         for (std::size_t cameraIndex = 0;cameraIndex < theLayer.GetCameraCount();++cameraIndex)
         {
-            sf::Vector2f mousePos = scene.renderWindow->mapPixelToCoords(
+            sf::Vector2f mousePos = scene.renderWindow->GetRenderingTarget().mapPixelToCoords(
                 scene.GetInputManager().GetMousePosition(), theLayer.GetCamera(cameraIndex).GetSFMLView());
 
             if ( object->GetDrawableX() <= mousePos.x
@@ -59,7 +59,7 @@ void DraggableBehavior::DoStepPreEvents(RuntimeScene & scene)
     //Being dragging ?
     if ( dragged ) {
         RuntimeLayer & theLayer = scene.GetRuntimeLayer(object->GetLayer());
-        sf::Vector2f mousePos = scene.renderWindow->mapPixelToCoords(
+        sf::Vector2f mousePos = scene.renderWindow->GetRenderingTarget().mapPixelToCoords(
             scene.GetInputManager().GetMousePosition(), theLayer.GetCamera(dragCameraIndex).GetSFMLView());
 
         object->SetX(mousePos.x-xOffset);

--- a/Extensions/PrimitiveDrawing/PrimitiveDrawingTools.cpp
+++ b/Extensions/PrimitiveDrawing/PrimitiveDrawingTools.cpp
@@ -34,7 +34,7 @@ void GD_EXTENSION_API CopyImageOnAnother( const gd::String & destName, const gd:
 
 void GD_EXTENSION_API CaptureScreen( RuntimeScene & scene, const gd::String & destFileName, const gd::String & destImageName )
 {
-    if ( !scene.renderWindow ) return;
+    /*if ( !scene.renderWindow ) return;
     sf::Image capture = scene.renderWindow->capture();
 
     if ( !destFileName.empty() ) capture.saveToFile(destFileName.ToLocale());
@@ -43,7 +43,7 @@ void GD_EXTENSION_API CaptureScreen( RuntimeScene & scene, const gd::String & de
         std::shared_ptr<SFMLTextureWrapper> sfmlTexture = scene.GetImageManager()->GetSFMLTexture(destImageName);
         sfmlTexture->image = capture;
         sfmlTexture->texture.loadFromImage(sfmlTexture->image); //Do not forget to update the associated texture
-    }
+    }*/
 }
 
 namespace

--- a/Extensions/PrimitiveDrawing/PrimitiveDrawingTools.cpp
+++ b/Extensions/PrimitiveDrawing/PrimitiveDrawingTools.cpp
@@ -34,16 +34,17 @@ void GD_EXTENSION_API CopyImageOnAnother( const gd::String & destName, const gd:
 
 void GD_EXTENSION_API CaptureScreen( RuntimeScene & scene, const gd::String & destFileName, const gd::String & destImageName )
 {
-    /*if ( !scene.renderWindow ) return;
-    sf::Image capture = scene.renderWindow->capture();
+    if ( !scene.renderWindow ) return;
+    sf::Texture capturedTexture = scene.renderWindow->CaptureAsTexture();
+    sf::Image capturedImage = capturedTexture.copyToImage();
 
-    if ( !destFileName.empty() ) capture.saveToFile(destFileName.ToLocale());
+    if ( !destFileName.empty() ) capturedImage.saveToFile(destFileName.ToLocale());
     if ( !destImageName.empty() && scene.GetImageManager()->HasLoadedSFMLTexture(destImageName) )
     {
         std::shared_ptr<SFMLTextureWrapper> sfmlTexture = scene.GetImageManager()->GetSFMLTexture(destImageName);
-        sfmlTexture->image = capture;
-        sfmlTexture->texture.loadFromImage(sfmlTexture->image); //Do not forget to update the associated texture
-    }*/
+        sfmlTexture->image = capturedImage;
+        sfmlTexture->texture = capturedTexture; //Do not forget to update the associated texture
+    }
 }
 
 namespace

--- a/GDCpp/GDCpp/Extensions/Builtin/MouseTools.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/MouseTools.cpp
@@ -2,36 +2,37 @@
 #include "GDCpp/Runtime/RuntimeScene.h"
 #include "GDCpp/Runtime/RuntimeLayer.h"
 #include "GDCpp/Runtime/RuntimeObjectsListsTools.h"
+#include "GDCpp/Runtime/Window/RenderingWindow.h"
 #include <SFML/Graphics.hpp>
 
 void GD_API CenterCursor( RuntimeScene & scene )
 {
-    sf::Mouse::setPosition(sf::Vector2i(scene.renderWindow->getSize().x/2, scene.renderWindow->getSize().y/2), *scene.renderWindow );
+    gd::RenderingWindow::SetMousePosition(sf::Vector2i(scene.renderWindow->GetSize().x/2, scene.renderWindow->GetSize().y/2), *scene.renderWindow );
 }
 
 void GD_API CenterCursorHorizontally( RuntimeScene & scene )
 {
-    sf::Mouse::setPosition(sf::Vector2i(scene.renderWindow->getSize().x/2, scene.GetInputManager().GetMousePosition().y ), *scene.renderWindow );
+    gd::RenderingWindow::SetMousePosition(sf::Vector2i(scene.renderWindow->GetSize().x/2, scene.GetInputManager().GetMousePosition().y ), *scene.renderWindow );
 }
 
 void GD_API CenterCursorVertically( RuntimeScene & scene )
 {
-    sf::Mouse::setPosition(sf::Vector2i(scene.GetInputManager().GetMousePosition().x, scene.renderWindow->getSize().y/2), *scene.renderWindow );
+    gd::RenderingWindow::SetMousePosition(sf::Vector2i(scene.GetInputManager().GetMousePosition().x, scene.renderWindow->GetSize().y/2), *scene.renderWindow );
 }
 
 void GD_API SetCursorPosition( RuntimeScene & scene, float newX, float newY )
 {
-    sf::Mouse::setPosition(sf::Vector2i(newX, newY), *scene.renderWindow );
+    gd::RenderingWindow::SetMousePosition(sf::Vector2i(newX, newY), *scene.renderWindow );
 }
 
 void GD_API HideCursor( RuntimeScene & scene )
 {
-    scene.renderWindow->setMouseCursorVisible(false);
+    scene.renderWindow->SetMouseCursorVisible(false);
 }
 
 void GD_API ShowCursor( RuntimeScene & scene )
 {
-    scene.renderWindow->setMouseCursorVisible(true);
+    scene.renderWindow->SetMouseCursorVisible(true);
 }
 
 double GD_API GetCursorXPosition( RuntimeScene & scene, const gd::String & layer, std::size_t camera )
@@ -41,7 +42,7 @@ double GD_API GetCursorXPosition( RuntimeScene & scene, const gd::String & layer
 
     //Get view, and compute mouse position
     const sf::View & view = scene.GetRuntimeLayer(layer).GetCamera(camera).GetSFMLView();
-    return scene.renderWindow->mapPixelToCoords(scene.GetInputManager().GetMousePosition(), view).x;
+    return scene.renderWindow->GetRenderingTarget().mapPixelToCoords(scene.GetInputManager().GetMousePosition(), view).x;
 }
 
 double GD_API GetCursorYPosition( RuntimeScene & scene, const gd::String & layer, std::size_t camera )
@@ -51,7 +52,7 @@ double GD_API GetCursorYPosition( RuntimeScene & scene, const gd::String & layer
 
     //Get view, and compute mouse position
     const sf::View & view = scene.GetRuntimeLayer(layer).GetCamera(camera).GetSFMLView();
-    return scene.renderWindow->mapPixelToCoords(scene.GetInputManager().GetMousePosition(), view).y;
+    return scene.renderWindow->GetRenderingTarget().mapPixelToCoords(scene.GetInputManager().GetMousePosition(), view).y;
 }
 
 bool GD_API MouseButtonPressed(RuntimeScene & scene, const gd::String & button)

--- a/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.cpp
@@ -7,6 +7,7 @@
 #include "GDCpp/Runtime/RuntimeScene.h"
 #include "GDCpp/Runtime/RuntimeObject.h"
 #include "GDCpp/Runtime/RuntimeLayer.h"
+#include "GDCpp/Runtime/Window/RenderingWindow.h"
 
 float GD_API GetCameraX(RuntimeScene & scene, const gd::String & layer, std::size_t camera)
 {
@@ -196,8 +197,8 @@ void GD_API ActDeleteCamera(RuntimeScene & scene, const gd::String & layerName, 
 void GD_API AddCamera( RuntimeScene & scene, const gd::String & layerName, float width, float height, float viewportLeft, float viewportTop, float viewportRight, float viewportBottom )
 {
     //Create the new view
-    const sf::RenderWindow * window = scene.renderWindow;
-    sf::View view = window ? window->getDefaultView() : sf::View();
+    const gd::RenderingWindow * window = scene.renderWindow;
+    sf::View view = window ? window->GetRenderingTarget().getDefaultView() : sf::View();
 
     //Setup the viewport and the view
     if ( viewportBottom != 0 && viewportLeft != 0 && viewportRight != 0 && viewportTop != 0) {

--- a/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneTools.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneTools.cpp
@@ -21,6 +21,7 @@
 #include "GDCpp/Runtime/profile.h"
 #include "GDCpp/Runtime/CommonTools.h"
 #include "GDCpp/Runtime/Project/Variable.h"
+#include "GDCpp/Runtime/Window/RenderingWindow.h"
 #include "GDCpp/Extensions/CppPlatform.h"
 
 gd::String GD_API GetSceneName(RuntimeScene & scene)
@@ -257,13 +258,14 @@ void GD_API SetWindowIcon(RuntimeScene & scene, const gd::String & imageName)
     if ( image == std::shared_ptr<SFMLTextureWrapper>() )
         return;
 
-    scene.renderWindow->setIcon(image->image.getSize().x, image->image.getSize().y, image->image.getPixelsPtr());
+    //TODO:
+    //scene.renderWindow->setIcon(image->image.getSize().x, image->image.getSize().y, image->image.getPixelsPtr());
 }
 
 void GD_API SetWindowTitle(RuntimeScene & scene, const gd::String & newName)
 {
     scene.SetWindowDefaultTitle( newName );
-    if (scene.renderWindow != NULL) scene.renderWindow->setTitle(scene.GetWindowDefaultTitle());
+    if (scene.renderWindow != NULL) scene.renderWindow->SetTitle(scene.GetWindowDefaultTitle());
 }
 
 const gd::String & GD_API GetWindowTitle(RuntimeScene & scene)
@@ -280,7 +282,9 @@ void GD_API SetWindowSize( RuntimeScene & scene, int windowWidth, int windowHeig
         scene.game->SetDefaultHeight( windowHeight );
     }
 
-    //Avoid recreating every tick a new window if the size has not changed!
+    scene.renderWindow->SetSize(sf::Vector2u(windowWidth, windowHeight));
+
+    /*//Avoid recreating every tick a new window if the size has not changed!
     if ( windowWidth == scene.renderWindow->getSize().x && windowHeight == scene.renderWindow->getSize().y )
         return;
 
@@ -288,29 +292,31 @@ void GD_API SetWindowSize( RuntimeScene & scene, int windowWidth, int windowHeig
     return; //The size of the window is always the same.
     #endif
 
-    scene.renderWindow->create(
+    scene.renderWindow->Create(
         sf::VideoMode( windowWidth, windowHeight, 32 ),
         scene.GetWindowDefaultTitle(),
         sf::Style::Close | (scene.RenderWindowIsFullScreen() ? sf::Style::Fullscreen : 0) );
-    scene.ChangeRenderWindow(scene.renderWindow);
+    scene.ChangeRenderWindow(scene.renderWindow);*/
     #endif
 }
 
 void GD_API SetFullScreen(RuntimeScene & scene, bool fullscreen, bool)
 {
     #if !defined(GD_IDE_ONLY)
-    if ( fullscreen && !scene.RenderWindowIsFullScreen() )
+    /*if ( fullscreen && !scene.RenderWindowIsFullScreen() )
     {
         scene.SetRenderWindowIsFullScreen();
-        scene.renderWindow->create( sf::VideoMode( scene.game->GetMainWindowDefaultWidth(), scene.game->GetMainWindowDefaultHeight(), 32 ), scene.GetWindowDefaultTitle(), sf::Style::Close | sf::Style::Fullscreen );
+        scene.renderWindow->Create( sf::VideoMode( scene.game->GetMainWindowDefaultWidth(), scene.game->GetMainWindowDefaultHeight(), 32 ), scene.GetWindowDefaultTitle(), sf::Style::Close | sf::Style::Fullscreen );
         scene.ChangeRenderWindow(scene.renderWindow);
     }
     else if ( !fullscreen && scene.RenderWindowIsFullScreen() )
     {
         scene.SetRenderWindowIsFullScreen(false);
-        scene.renderWindow->create( sf::VideoMode( scene.game->GetMainWindowDefaultWidth(), scene.game->GetMainWindowDefaultHeight(), 32 ), scene.GetWindowDefaultTitle(), sf::Style::Close );
+        scene.renderWindow->Create( sf::VideoMode( scene.game->GetMainWindowDefaultWidth(), scene.game->GetMainWindowDefaultHeight(), 32 ), scene.GetWindowDefaultTitle(), sf::Style::Close );
         scene.ChangeRenderWindow(scene.renderWindow);
-    }
+    }*/
+    scene.SetRenderWindowIsFullScreen(fullscreen);
+    scene.renderWindow->SetFullScreen(fullscreen);
     #endif
 }
 unsigned int GD_API GetSceneWindowWidth(RuntimeScene & scene)
@@ -319,7 +325,7 @@ unsigned int GD_API GetSceneWindowWidth(RuntimeScene & scene)
     return scene.game->GetMainWindowDefaultWidth();
     #else
     if ( scene.renderWindow != NULL )
-        return scene.renderWindow->getSize().x;
+        return scene.renderWindow->GetSize().x;
 
     return 0;
     #endif
@@ -331,7 +337,7 @@ unsigned int GD_API GetSceneWindowHeight(RuntimeScene & scene)
     return scene.game->GetMainWindowDefaultHeight();
     #else
     if ( scene.renderWindow != NULL )
-        return scene.renderWindow->getSize().y;
+        return scene.renderWindow->GetSize().y;
 
     return 0;
     #endif

--- a/GDCpp/GDCpp/IDE/Dialogs/CppLayoutPreviewer.cpp
+++ b/GDCpp/GDCpp/IDE/Dialogs/CppLayoutPreviewer.cpp
@@ -97,7 +97,7 @@ bool CppLayoutPreviewer::LaunchPreview( )
 
     playing = false;
 
-    editor.setFramerateLimit(editor.GetProject().GetMaximumFPS());
+    editor.SetFramerateLimit(editor.GetProject().GetMaximumFPS());
 
     if ( debugger ) debugger->Play();
 
@@ -156,8 +156,8 @@ void CppLayoutPreviewer::OnUpdate()
         bool changeRequested = previewScene.RenderAndStep();
         if (externalPreviewWindow && externalPreviewWindow->IsShown()) //Be sure that the editor is updated.
         {
-            editor.clear(sf::Color(255,255,255));
-            editor.display();
+            editor.GetRenderingTarget().clear(sf::Color(255,255,255));
+            editor.Display();
         }
 
         if (changeRequested)
@@ -266,7 +266,7 @@ void CppLayoutPreviewer::OnPreviewPlayBtClick( wxCommandEvent & event )
 }
 void CppLayoutPreviewer::OnPreviewPlayWindowBtClick( wxCommandEvent & event )
 {
-    PlayPreview();
+    /*PlayPreview();
 
     mainFrameWrapper.GetRibbonSceneEditorButtonBar()->EnableButton(idRibbonPlay, true);
     mainFrameWrapper.GetRibbonSceneEditorButtonBar()->EnableButton(idRibbonPause, true);
@@ -279,7 +279,7 @@ void CppLayoutPreviewer::OnPreviewPlayWindowBtClick( wxCommandEvent & event )
     externalPreviewWindow->Show(true);
 
     externalPreviewWindow->SetSizeOfRenderingZone(editor.GetProject().GetMainWindowDefaultWidth(), editor.GetProject().GetMainWindowDefaultHeight());
-    previewScene.ChangeRenderWindow(externalPreviewWindow->renderCanvas);
+    previewScene.ChangeRenderWindow(externalPreviewWindow->renderCanvas);*/
 }
 void CppLayoutPreviewer::ExternalWindowClosed()
 {
@@ -324,25 +324,25 @@ void CppLayoutPreviewer::RenderCompilationScreen()
 {
     //Ignore all events
     sf::Event event;
-    while ( editor.pollEvent( event ) )
+    while ( editor.PollEvent( event ) )
         ;
 
     //Render the screen
-    editor.clear(sf::Color(255,255,255));
+    editor.GetRenderingTarget().clear(sf::Color(255,255,255));
 
-    editor.pushGLStates();
-    editor.setView(sf::View(sf::Vector2f(editor.getSize().x/2, editor.getSize().y/2), sf::Vector2f(editor.getSize().x, editor.getSize().y)));
+    editor.GetRenderingTarget().pushGLStates();
+    editor.GetRenderingTarget().setView(sf::View(sf::Vector2f(editor.GetSize().x/2, editor.GetSize().y/2), sf::Vector2f(editor.GetSize().x, editor.GetSize().y)));
 
     reloadingIconSprite.setTexture(reloadingIconImage);
     reloadingIconSprite.setColor(sf::Color(255,255,255,128));
-    reloadingIconSprite.setPosition(editor.getSize().x/2-reloadingIconSprite.getLocalBounds().width/2, editor.getSize().y/2-reloadingIconSprite.getLocalBounds().height/2);
-    reloadingText.setPosition(editor.getSize().x/2-reloadingText.getLocalBounds().width/2, reloadingIconSprite.getPosition().y+reloadingIconSprite.getLocalBounds().height+10);
+    reloadingIconSprite.setPosition(editor.GetSize().x/2-reloadingIconSprite.getLocalBounds().width/2, editor.GetSize().y/2-reloadingIconSprite.getLocalBounds().height/2);
+    reloadingText.setPosition(editor.GetSize().x/2-reloadingText.getLocalBounds().width/2, reloadingIconSprite.getPosition().y+reloadingIconSprite.getLocalBounds().height+10);
 
-    editor.draw(reloadingIconSprite);
-    editor.draw(reloadingText);
+    editor.GetRenderingTarget().draw(reloadingIconSprite);
+    editor.GetRenderingTarget().draw(reloadingText);
 
-    editor.popGLStates();
-    editor.display();
+    editor.GetRenderingTarget().popGLStates();
+    editor.Display();
 }
 
 void CppLayoutPreviewer::SetParentAuiManager(wxAuiManager * manager)

--- a/GDCpp/GDCpp/Runtime/InputManager.cpp
+++ b/GDCpp/GDCpp/Runtime/InputManager.cpp
@@ -5,7 +5,11 @@
  */
 #include "InputManager.h"
 
-InputManager::InputManager(sf::Window * win) :
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/Keyboard.hpp>
+#include <SFML/Window/Mouse.hpp>
+
+InputManager::InputManager(gd::RenderingWindow * win) :
     window(win),
     lastPressedKey(0),
     keyWasPressed(false),
@@ -44,7 +48,7 @@ void InputManager::NextFrame()
             sf::Mouse::isButtonPressed(static_cast<sf::Mouse::Button>(it->second));
     }
 
-    if (window) mousePosition = sf::Mouse::getPosition(*window);
+    if (window) mousePosition = gd::RenderingWindow::GetMousePosition(*window);
     if (touchSimulateMouse && !touches.empty()) SimulateMousePressed(touches.begin()->second);
 }
 

--- a/GDCpp/GDCpp/Runtime/InputManager.h
+++ b/GDCpp/GDCpp/Runtime/InputManager.h
@@ -9,7 +9,7 @@
 #include <map>
 #include <string>
 #include <set>
-#include <SFML/Window.hpp>
+#include "GDCpp/Runtime/Window/RenderingWindow.h"
 #include "GDCpp/Runtime/String.h"
 
 /**
@@ -42,7 +42,7 @@ public:
     /**
      * @brief Constructor with a window to manage.
      */
-    InputManager(sf::Window * win);
+    InputManager(gd::RenderingWindow * win);
 
     /** \name Connection with window and events management
      */
@@ -50,7 +50,7 @@ public:
     /**
      * \brief Set the window managed by the input manager.
      */
-    InputManager & SetWindow(sf::Window * win) { window = win; return *this; }
+    InputManager & SetWindow(gd::RenderingWindow * win) { window = win; return *this; }
 
     /**
      * Set if the input must be disabled when window lose focus.
@@ -139,7 +139,7 @@ public:
     ///@}
 
 private:
-    sf::Window * window;
+    gd::RenderingWindow * window;
 
     int lastPressedKey; ///< SFML key code of the last pressed key.
     bool keyWasPressed; ///< True if a key was pressed during the last step.

--- a/GDCpp/GDCpp/Runtime/RuntimeObject.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeObject.cpp
@@ -13,6 +13,7 @@
 #include "GDCpp/Runtime/RuntimeScene.h"
 #include "GDCpp/Runtime/PolygonCollision.h"
 #include "GDCpp/Runtime/Polygon2d.h"
+#include "GDCpp/Runtime/Window/RenderingWindow.h"
 #include "GDCore/CommonTools.h"
 #include <SFML/System.hpp>
 #include <iostream>
@@ -576,7 +577,7 @@ bool RuntimeObject::CursorOnObject(RuntimeScene & scene, bool)
     {
         const auto & view = theLayer.GetCamera(cameraIndex).GetSFMLView();
 
-        sf::Vector2f mousePos = scene.renderWindow->mapPixelToCoords(
+        sf::Vector2f mousePos = scene.renderWindow->GetRenderingTarget().mapPixelToCoords(
             scene.GetInputManager().GetMousePosition(), view);
 
         if (insideObject(mousePos)) return true;
@@ -584,7 +585,7 @@ bool RuntimeObject::CursorOnObject(RuntimeScene & scene, bool)
         auto & touches = scene.GetInputManager().GetAllTouches();
         for(auto & it : touches)
         {
-            sf::Vector2f touchPos = scene.renderWindow->mapPixelToCoords(it.second, view);
+            sf::Vector2f touchPos = scene.renderWindow->GetRenderingTarget().mapPixelToCoords(it.second, view);
             if (insideObject(touchPos)) return true;
         }
     }

--- a/GDCpp/GDCpp/Runtime/RuntimeScene.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeScene.h
@@ -20,6 +20,7 @@
 #include "GDCpp/Runtime/BehaviorsRuntimeSharedDataHolder.h"
 namespace sf { class RenderWindow; }
 namespace sf { class Event; }
+namespace gd { class RenderingWindow; }
 namespace gd { class Project; }
 namespace gd { class Object; }
 namespace gd { class ImageManager; }
@@ -45,10 +46,10 @@ class BaseDebugger;
 class GD_API RuntimeScene : public Scene
 {
 public:
-    RuntimeScene(sf::RenderWindow * renderWindow_, RuntimeGame * game_);
+    RuntimeScene(gd::RenderingWindow * renderWindow_, RuntimeGame * game_);
     virtual ~RuntimeScene();
 
-    sf::RenderWindow *                      renderWindow; ///< Pointer to the render window used for display.
+    gd::RenderingWindow *                      renderWindow; ///< Pointer to the render window used for display.
     RuntimeGame *                           game; ///< Pointer to the game the scene is linked to.
     #if defined(GD_IDE_ONLY)
     BaseDebugger *                          debugger; ///< Pointer to the debugger. Can be NULL.
@@ -137,7 +138,7 @@ public:
     /**
      * \brief Change the window used for rendering the scene
      */
-    void ChangeRenderWindow(sf::RenderWindow * window);
+    void ChangeRenderWindow(gd::RenderingWindow * window);
 
     /**
      * \brief Check if scene is rendered full screen.

--- a/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.cpp
@@ -576,7 +576,7 @@ bool RuntimeSpriteObject::CursorOnObject(RuntimeScene & scene, bool accurate)
     {
         const auto & view = theLayer.GetCamera(cameraIndex).GetSFMLView();
 
-        sf::Vector2f mousePos = scene.renderWindow->mapPixelToCoords(
+        sf::Vector2f mousePos = scene.renderWindow->GetRenderingTarget().mapPixelToCoords(
             scene.GetInputManager().GetMousePosition(), view);
 
         if (insideObject(mousePos)) return true;
@@ -584,7 +584,7 @@ bool RuntimeSpriteObject::CursorOnObject(RuntimeScene & scene, bool accurate)
         auto & touches = scene.GetInputManager().GetAllTouches();
         for(auto & it : touches)
         {
-            sf::Vector2f touchPos = scene.renderWindow->mapPixelToCoords(it.second, view);
+            sf::Vector2f touchPos = scene.renderWindow->GetRenderingTarget().mapPixelToCoords(it.second, view);
             if (insideObject(touchPos)) return true;
         }
     }

--- a/GDCpp/GDCpp/Runtime/SceneStack.h
+++ b/GDCpp/GDCpp/Runtime/SceneStack.h
@@ -9,7 +9,7 @@
 #include <GDCpp/Runtime/String.h>
 class RuntimeGame;
 class RuntimeScene;
-namespace sf { class RenderWindow; }
+namespace gd { class RenderingWindow; }
 
 /**
  * A stack of RuntimeScene.
@@ -23,7 +23,7 @@ public:
 	 * \param window The sf::RenderWindow to be used to render the scenes.
 	 * \param codeLibraryName Filename to a shared library containing the code to execute for scenes.
 	 */
-	SceneStack(RuntimeGame & game_, sf::RenderWindow * window_) :
+	SceneStack(RuntimeGame & game_, gd::RenderingWindow * window_) :
 		game(game_),
 		window(window_)
 	{
@@ -76,7 +76,7 @@ public:
 
 private:
 	RuntimeGame & game;
-	sf::RenderWindow * window;
+	gd::RenderingWindow * window;
 	std::vector<std::unique_ptr<RuntimeScene>> stack;
 	std::function<void(gd::String)> errorCallback;
 	std::function<bool(RuntimeScene &)> loadCallback;

--- a/GDCpp/GDCpp/Runtime/Window/RenderingWindow.cpp
+++ b/GDCpp/GDCpp/Runtime/Window/RenderingWindow.cpp
@@ -1,0 +1,3 @@
+#if !defined(GD_IDE_ONLY)
+#include "GDCore/Window/RenderingWindow.cpp"
+#endif

--- a/GDCpp/GDCpp/Runtime/Window/RenderingWindow.h
+++ b/GDCpp/GDCpp/Runtime/Window/RenderingWindow.h
@@ -1,0 +1,1 @@
+#include "GDCore/Window/RenderingWindow.h"

--- a/GDCpp/GDCpp/Runtime/Window/SFMLRenderingWindow.cpp
+++ b/GDCpp/GDCpp/Runtime/Window/SFMLRenderingWindow.cpp
@@ -1,0 +1,3 @@
+#if !defined(GD_IDE_ONLY)
+#include "GDCore/Window/SFMLRenderingWindow.cpp"
+#endif

--- a/GDCpp/GDCpp/Runtime/Window/SFMLRenderingWindow.h
+++ b/GDCpp/GDCpp/Runtime/Window/SFMLRenderingWindow.h
@@ -1,0 +1,1 @@
+#include "GDCore/Window/SFMLRenderingWindow.h"

--- a/GDCpp/Runtime/main.cpp
+++ b/GDCpp/Runtime/main.cpp
@@ -32,6 +32,7 @@
 #include "GDCpp/Runtime/Serialization/SerializerElement.h"
 #include "GDCpp/Runtime/TinyXml/tinyxml.h"
 #include "GDCpp/Runtime/RuntimeGame.h"
+#include "GDCpp/Runtime/Window/SFMLRenderingWindow.h"
 #include "CompilationChecker.h"
 
 #include <stdlib.h>
@@ -172,14 +173,13 @@ int main( int argc, char *p_argv[] )
     game.GetImageManager()->LoadPermanentImages();
 
     //Create main window
-    sf::RenderWindow window;
 
     RuntimeGame runtimeGame;
     runtimeGame.LoadFromProject(game);
 
-    window.create(sf::VideoMode(game.GetMainWindowDefaultWidth(), game.GetMainWindowDefaultHeight(), 32),
+    gd::SFMLRenderingWindow window(sf::VideoMode(game.GetMainWindowDefaultWidth(), game.GetMainWindowDefaultHeight(), 32),
         "", sf::Style::Close, sf::ContextSettings(24, 8));
-    window.setActive(true);
+    window.SetActive(true);
 
     //Game main loop
     bool abort = false;


### PR DESCRIPTION
In the IDE, do the SFML rendering offscreen (thanks to a ```sf::RenderTexture```) and display it by drawing a ```wxBitmap``` on a ```wxControl``` (it manages focus, not like a ```wxPanel```).

**TODO list:**
 - [x] **Basic implementation**
 - [x] Adapt GDCpp and IDE to use it
 - [x] Generate all SFML events from wxWidgets events
   - [x] ```sf::TextEntered```
   - [x] ```sf::KeyPressed```
   - [x] ```sf::KeyReleased```
   - [x] ```sf::MouseButtonPressed```
   - [x] ```sf::MouseButtonReleased```
   - [x] ```sf::MouseMoved```
   - [x] ```sf::MouseWheelScrolled``` (and ```sf::MouseWheelMoved``` which is deprecated by the way and still used in GDevelop)
   - [x] ```sf::MouseEntered/Left```
 - [ ] Testing on Mac OS X @4ian 
 - [ ] Reenable preview in separate window feature