### PR TITLE
No Grid Snap Keyboard Shortcut

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -11,8 +11,8 @@ export default class InstancesResizer {
     this.options = options;
   }
 
-  _roundXPosition(x) {
-    if (!this.options.snap || !this.options.grid || this.options.gridWidth <= 0)
+  _roundXPosition(x, noGridSnap) {
+    if (!this.options.snap || !this.options.grid || this.options.gridWidth <= 0 || noGridSnap)
       return Math.round(x);
 
     return (
@@ -22,12 +22,8 @@ export default class InstancesResizer {
     );
   }
 
-  _roundYPosition(y) {
-    if (
-      !this.options.snap ||
-      !this.options.grid ||
-      this.options.gridHeight <= 0
-    )
+  _roundYPosition(y, noGridSnap) {
+    if (!this.options.snap || !this.options.grid || this.options.gridHeight <= 0 || noGridSnap)
       return Math.round(y);
 
     return (
@@ -51,7 +47,7 @@ export default class InstancesResizer {
     return this.totalDeltaY;
   }
 
-  moveBy(instances, deltaX, deltaY, followAxis) {
+  moveBy(instances, deltaX, deltaY, followAxis, noGridSnap) {
     this.totalDeltaX += deltaX;
     this.totalDeltaY += deltaY;
 
@@ -68,12 +64,14 @@ export default class InstancesResizer {
 
       selectedInstance.setX(
         this._roundXPosition(
-          initialPosition.x + this._getMoveDeltaX(followAxis)
+          initialPosition.x + this._getMoveDeltaX(followAxis),
+          noGridSnap
         )
       );
       selectedInstance.setY(
         this._roundYPosition(
-          initialPosition.y + this._getMoveDeltaY(followAxis)
+          initialPosition.y + this._getMoveDeltaY(followAxis),
+          noGridSnap
         )
       );
     }

--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -1,8 +1,5 @@
 export default class InstancesMover {
-  constructor({
-    instanceMeasurer,
-    options
-  }) {
+  constructor({ instanceMeasurer, options }) {
     this.instanceMeasurer = instanceMeasurer;
     this.options = options;
     this.instancePositions = {};
@@ -15,23 +12,33 @@ export default class InstancesMover {
   }
 
   _roundXPosition(x, noGridSnap) {
-    if (!this.options.snap || !this.options.grid || this.options.gridWidth <= 0 || noGridSnap)
+    if (
+      !this.options.snap ||
+      !this.options.grid ||
+      this.options.gridWidth <= 0 ||
+      noGridSnap
+    )
       return Math.round(x);
 
     return (
       Math.round((x - this.options.gridOffsetX) / this.options.gridWidth) *
-      this.options.gridWidth +
+        this.options.gridWidth +
       this.options.gridOffsetX
     );
   }
 
   _roundYPosition(y, noGridSnap) {
-    if (!this.options.snap || !this.options.grid || this.options.gridHeight <= 0 || noGridSnap)
+    if (
+      !this.options.snap ||
+      !this.options.grid ||
+      this.options.gridHeight <= 0 ||
+      noGridSnap
+    )
       return Math.round(y);
 
     return (
       Math.round((y - this.options.gridOffsetY) / this.options.gridHeight) *
-      this.options.gridHeight +
+        this.options.gridHeight +
       this.options.gridOffsetY
     );
   }

--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -1,5 +1,8 @@
 export default class InstancesMover {
-  constructor({ instanceMeasurer, options }) {
+  constructor({
+    instanceMeasurer,
+    options
+  }) {
     this.instanceMeasurer = instanceMeasurer;
     this.options = options;
     this.instancePositions = {};

--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -1,4 +1,4 @@
-export default class InstancesResizer {
+export default class InstancesMover {
   constructor({ instanceMeasurer, options }) {
     this.instanceMeasurer = instanceMeasurer;
     this.options = options;
@@ -17,7 +17,7 @@ export default class InstancesResizer {
 
     return (
       Math.round((x - this.options.gridOffsetX) / this.options.gridWidth) *
-        this.options.gridWidth +
+      this.options.gridWidth +
       this.options.gridOffsetX
     );
   }
@@ -28,7 +28,7 @@ export default class InstancesResizer {
 
     return (
       Math.round((y - this.options.gridOffsetY) / this.options.gridHeight) *
-        this.options.gridHeight +
+      this.options.gridHeight +
       this.options.gridOffsetY
     );
   }

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -414,7 +414,8 @@ export default class InstancesEditorContainer extends Component {
       selectedInstances,
       sceneDeltaX,
       sceneDeltaY,
-      this.keyboardShortcuts.shouldFollowAxis()
+      this.keyboardShortcuts.shouldFollowAxis(),
+      this.keyboardShortcuts.shouldNotSnapToGrid()
     );
   };
 

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+import React, {
+  Component
+} from 'react';
 import gesture from 'pixi-simple-gesture';
 import KeyboardShortcuts from '../UI/KeyboardShortcuts';
 import SimpleDropTarget from '../Utils/DragDropHelpers/SimpleDropTarget';
@@ -16,7 +18,10 @@ import DropHandler from './DropHandler';
 import BackgroundColor from './BackgroundColor';
 import PIXI from 'pixi.js';
 import FpsLimiter from './FpsLimiter';
-import { startPIXITicker, stopPIXITicker } from '../Utils/PIXITicker';
+import {
+  startPIXITicker,
+  stopPIXITicker
+} from '../Utils/PIXITicker';
 
 export default class InstancesEditorContainer extends Component {
   constructor() {
@@ -542,13 +547,21 @@ export default class InstancesEditorContainer extends Component {
   render() {
     if (!this.props.project) return null;
 
-    return (
-      <SimpleDropTarget>
-        <div
-          ref={canvasArea => (this.canvasArea = canvasArea)}
-          style={{ flex: 1, position: 'absolute', overflow: 'hidden' }}
-        />
-      </SimpleDropTarget>
+    return ( <
+      SimpleDropTarget >
+      <
+      div ref = {
+        canvasArea => (this.canvasArea = canvasArea)
+      }
+      style = {
+        {
+          flex: 1,
+          position: 'absolute',
+          overflow: 'hidden'
+        }
+      }
+      /> <
+      /SimpleDropTarget>
     );
   }
 }

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -1,6 +1,4 @@
-import React, {
-  Component
-} from 'react';
+import React, { Component } from 'react';
 import gesture from 'pixi-simple-gesture';
 import KeyboardShortcuts from '../UI/KeyboardShortcuts';
 import SimpleDropTarget from '../Utils/DragDropHelpers/SimpleDropTarget';
@@ -18,10 +16,7 @@ import DropHandler from './DropHandler';
 import BackgroundColor from './BackgroundColor';
 import PIXI from 'pixi.js';
 import FpsLimiter from './FpsLimiter';
-import {
-  startPIXITicker,
-  stopPIXITicker
-} from '../Utils/PIXITicker';
+import { startPIXITicker, stopPIXITicker } from '../Utils/PIXITicker';
 
 export default class InstancesEditorContainer extends Component {
   constructor() {
@@ -306,7 +301,8 @@ export default class InstancesEditorContainer extends Component {
    * @param {string} objectName The name of the object for which instance must be re-rendered.
    */
   resetRenderersFor(objectName) {
-    if (this.instancesRenderer) this.instancesRenderer.resetRenderersFor(objectName);
+    if (this.instancesRenderer)
+      this.instancesRenderer.resetRenderersFor(objectName);
   }
 
   zoomBy(value) {
@@ -547,21 +543,17 @@ export default class InstancesEditorContainer extends Component {
   render() {
     if (!this.props.project) return null;
 
-    return ( <
-      SimpleDropTarget >
-      <
-      div ref = {
-        canvasArea => (this.canvasArea = canvasArea)
-      }
-      style = {
-        {
-          flex: 1,
-          position: 'absolute',
-          overflow: 'hidden'
-        }
-      }
-      /> <
-      /SimpleDropTarget>
+    return (
+      <SimpleDropTarget>
+        <div
+          ref={canvasArea => (this.canvasArea = canvasArea)}
+          style={{
+            flex: 1,
+            position: 'absolute',
+            overflow: 'hidden',
+          }}
+        />{' '}
+      </SimpleDropTarget>
     );
   }
 }

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -1,6 +1,4 @@
-import {
-  isMacLike
-} from '../../Utils/Platform';
+import { isMacLike } from '../../Utils/Platform';
 
 const CTRL_KEY = 17;
 const SHIFT_KEY = 16;
@@ -182,9 +180,9 @@ export default class KeyboardShortcuts {
 
     if (!isMacLike()) {
       if (evt.button === MID_MOUSE_BUTTON) {
-        this.mouseMidButtonPressed = true
+        this.mouseMidButtonPressed = true;
       } else {
-        this.mouseMidButtonPressed = false
+        this.mouseMidButtonPressed = false;
       }
     }
   };

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -1,4 +1,6 @@
-import { isMacLike } from '../../Utils/Platform';
+import {
+  isMacLike
+} from '../../Utils/Platform';
 
 const CTRL_KEY = 17;
 const SHIFT_KEY = 16;
@@ -179,9 +181,11 @@ export default class KeyboardShortcuts {
     if (!this.isFocused) return;
 
     if (!isMacLike()) {
-      if (evt.button === MID_MOUSE_BUTTON){
+      if (evt.button === MID_MOUSE_BUTTON) {
         this.mouseMidButtonPressed = true
-      } else {this.mouseMidButtonPressed = false}
+      } else {
+        this.mouseMidButtonPressed = false
+      }
     }
   };
 

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -65,6 +65,10 @@ export default class KeyboardShortcuts {
     return this.shiftPressed;
   }
 
+  shouldNotSnapToGrid() {
+    return this.altPressed;
+  }
+
   shouldResizeProportionally() {
     return this.shiftPressed;
   }


### PR DESCRIPTION
Press alt while moving an object with grid on and the item will not be forced to snap to the grid.