### PR TITLE
Scene editor - add ''Edit Object" command to r.click menu and a 'Delete' command

### DIFF
--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -888,6 +888,10 @@ export default class SceneEditor extends Component {
               enabled: canRedo(this.state.history),
               accelerator: 'CmdOrCtrl+Shift+Z',
             },
+            {
+              label: 'Delete',
+              click: () => this.deleteSelection(),
+            },
           ]}
         />
       </div>

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -205,6 +205,12 @@ export default class SceneEditor extends Component {
     this.setState({ scenePropertiesDialogOpen: open });
   };
 
+  openObjectEditor = () => {
+    if(!this.instancesSelection.getSelectedInstances()[0]) {return};
+    const selectedObjectInstanceName = this.instancesSelection.getSelectedInstances()[0].getObjectName();
+    this.editObjectByName(selectedObjectInstanceName);
+  };
+
   editInstanceVariables = instance => {
     this.setState({ variablesEditedInstance: instance });
   };
@@ -842,6 +848,10 @@ export default class SceneEditor extends Component {
         <ContextMenu
           ref={contextMenu => (this.contextMenu = contextMenu)}
           buildMenuTemplate={() => [
+            {
+              label: 'Edit Object',
+              click: () => this.openObjectEditor(),
+            },
             {
               label: 'Scene properties',
               click: () => this.openSceneProperties(true),

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -206,9 +206,13 @@ export default class SceneEditor extends Component {
   };
 
   openObjectEditor = () => {
-    if(!this.instancesSelection.getSelectedInstances()[0]) {return};
-    const selectedObjectInstanceName = this.instancesSelection.getSelectedInstances()[0].getObjectName();
-    this.editObjectByName(selectedObjectInstanceName);
+    if (!this.instanceSelection.hasSelectedInstances()) {
+      return;
+    }
+    const selectedInstanceObjectName = this.instancesSelection
+      .getSelectedInstances()[0]
+      .getObjectName();
+    this.editObjectByName(selectedInstanceObjectName);
   };
 
   editInstanceVariables = instance => {


### PR DESCRIPTION
This will make it easier to edit a selected object in the instance editor, without having to find it in a long list of other objects

It also adds a 'Delete' command - for those who might not know the keyboard button for it 