### PR TITLE
Add support for creating instances by dropping objects from objects list

### DIFF
--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -37,7 +37,7 @@
     "prop-types": "^15.5.10",
     "randomcolor": "^0.5.3",
     "raven-js": "^3.19.1",
-    "react": "^16.2.0",
+    "react": "16.5.1",
     "react-color": "2.13.8",
     "react-dnd": "2.5.4",
     "react-dnd-html5-backend": "2.5.4",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -41,7 +41,7 @@
     "react-color": "2.13.8",
     "react-dnd": "2.5.4",
     "react-dnd-html5-backend": "2.5.4",
-    "react-dom": "^16.2.0",
+    "react-dom": "16.5.1",
     "react-error-boundary": "^1.2.0",
     "react-i18next": "6.2.0",
     "react-json-view": "^1.16.1",

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -18,6 +18,11 @@ import PIXI from 'pixi.js';
 import FpsLimiter from './FpsLimiter';
 import { startPIXITicker, stopPIXITicker } from '../Utils/PIXITicker';
 
+const styles = {
+  canvasArea: { flex: 1, position: 'absolute', overflow: 'hidden' },
+  dropCursor: { cursor: 'copy' },
+};
+
 export default class InstancesEditorContainer extends Component {
   constructor() {
     super();
@@ -48,6 +53,15 @@ export default class InstancesEditorContainer extends Component {
     });
     this.pixiRenderer.view.addEventListener('click', e => {
       this._onClick(e.offsetX, e.offsetY);
+    });
+    this.pixiRenderer.view.addEventListener('pointerup', event => {
+      this.props.onPointerUp();
+    });
+    this.pixiRenderer.view.addEventListener('pointerover', event => {
+      this.props.onPointerOver();
+    });
+    this.pixiRenderer.view.addEventListener('pointerout', event => {
+      this.props.onPointerOut();
     });
     this.pixiRenderer.view.onmousewheel = event => {
       if (this.keyboardShortcuts.shouldZoom()) {
@@ -548,9 +562,8 @@ export default class InstancesEditorContainer extends Component {
         <div
           ref={canvasArea => (this.canvasArea = canvasArea)}
           style={{
-            flex: 1,
-            position: 'absolute',
-            overflow: 'hidden',
+            ...styles.canvasArea,
+            ...(this.props.showDropCursor ? styles.dropCursor : undefined),
           }}
         />
       </SimpleDropTarget>

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -51,9 +51,6 @@ export default class InstancesEditorContainer extends Component {
 
       return false;
     });
-    this.pixiRenderer.view.addEventListener('click', e => {
-      this._onClick(e.offsetX, e.offsetY);
-    });
     this.pixiRenderer.view.addEventListener('pointerup', event => {
       this.props.onPointerUp();
     });
@@ -459,13 +456,6 @@ export default class InstancesEditorContainer extends Component {
 
     const selectedInstances = this.props.instancesSelection.getSelectedInstances();
     this.props.onInstancesResized(selectedInstances);
-  };
-
-  _onClick = (x, y) => {
-    const newPos = this.viewPosition.toSceneCoordinates(x, y);
-    if (this.props.onAddInstance) {
-      this.props.onAddInstance(newPos[0], newPos[1]);
-    }
   };
 
   _onDrop = (x, y, objectName) => {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -63,7 +63,7 @@ export default class CollisionMasksPreview extends React.Component<
    * If custom zoom is added, this should be adapted to properly set vertex coordinates.
    * TODO: This could be optimized by avoiding the forceUpdate (not sure if worth it though).
    */
-  _onMouseMove = (event: any) => {
+  _onPointerMove = (event: any) => {
     const { draggedVertex } = this.state;
     if (!draggedVertex) return;
 
@@ -117,7 +117,7 @@ export default class CollisionMasksPreview extends React.Component<
           const vertices = polygon.getVertices();
           return mapVector(vertices, (vertex, j) => (
             <circle
-              onMouseDown={event => this._onStartDragVertex(vertex)}
+              onPointerDown={event => this._onStartDragVertex(vertex)}
               key={`polygon-${i}-vertex-${j}`}
               fill="rgba(255,0,0,0.75)"
               strokeWidth={1}
@@ -137,8 +137,8 @@ export default class CollisionMasksPreview extends React.Component<
 
     return (
       <svg
-        onMouseMove={this._onMouseMove}
-        onMouseUp={this._onEndDragVertex}
+        onPointerMove={this._onPointerMove}
+        onPointerUp={this._onEndDragVertex}
         width={this.props.imageWidth}
         height={this.props.imageHeight}
         style={styles.svg}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
@@ -106,7 +106,7 @@ export default class PointsPreview extends React.Component<Props, State> {
         }}
         alt=""
         key={name}
-        onMouseDown={() => {
+        onPointerDown={() => {
           this._onStartDragPoint(point, kind);
         }}
       />
@@ -133,8 +133,8 @@ export default class PointsPreview extends React.Component<Props, State> {
     return (
       <div
         style={styles.container}
-        onMouseMove={this._onMouseMove}
-        onMouseUp={this._onEndDragPoint}
+        onPointerMove={this._onMouseMove}
+        onPointerUp={this._onEndDragPoint}
         ref={container => (this._container = container)}
       >
         {points}

--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -302,7 +302,7 @@ export default class GroupsListContainer extends React.Component<*, StateType> {
                 onSortEnd={({ oldIndex, newIndex }) =>
                   this._onMove(oldIndex, newIndex)}
                 helperClass="sortable-helper"
-                distance={30}
+                distance={20}
               />
             )}
           </AutoSizer>

--- a/newIDE/app/src/ObjectsList/ObjectRow.js
+++ b/newIDE/app/src/ObjectsList/ObjectRow.js
@@ -151,19 +151,12 @@ class ThemableObjectRow extends React.Component {
         primaryText={label}
         leftIcon={<ListIcon src={this.props.getThumbnail(project, object)} />}
         rightIconButton={this._renderObjectMenu(object)}
-        onClick={() => {
-          if (!this.props.onObjectSelected) return;
-          if (this.props.editingName) return;
-
-          this.props.onObjectSelected(selected ? '' : objectName);
-        }}
         onDoubleClick={(event) => {
           if (event.button !== LEFT_MOUSE_BUTTON) return;
           if (!this.props.onEdit) return;
           if (this.props.editingName) return;
 
           this.props.onEdit(object);
-          this.props.onObjectSelected('');
         }}
       />
     );

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -343,6 +343,8 @@ export default class ObjectsListContainer extends React.Component<
   };
 
   _move = (oldIndex: number, newIndex: number) => {
+    if (!this.props.canMoveObjects) return;
+
     const { project, objectsContainer } = this.props;
 
     const isInContainerObjectsList =
@@ -363,6 +365,20 @@ export default class ObjectsListContainer extends React.Component<
     }
 
     this.forceUpdateList();
+  };
+
+  _onStartDraggingObject = ({index}: {index: number}) => {
+    const { project, objectsContainer } = this.props;
+
+    const isInContainerObjectsList =
+      index < this.containerObjectsList.length;
+    if (isInContainerObjectsList) {
+      this.props.onStartDraggingObject(objectsContainer.getObjectAt(index));
+    } else {
+      const projectIndex = index - this.containerObjectsList.length;
+
+      this.props.onStartDraggingObject(project.getObjectAt(projectIndex));
+    }
   };
 
   _setAsGlobalObject = (objectWithContext: ObjectWithContext) => {
@@ -451,8 +467,11 @@ export default class ObjectsListContainer extends React.Component<
                 onEditVariables={this._editVariables}
                 onDelete={this._deleteObject}
                 onRename={this._rename}
-                onSortEnd={({ oldIndex, newIndex }) =>
-                  this._move(oldIndex, newIndex)}
+                onSortStart={this._onStartDraggingObject}
+                onSortEnd={({ oldIndex, newIndex }) => {
+                  this.props.onEndDraggingObject();
+                  this._move(oldIndex, newIndex);
+                }}
                 helperClass="sortable-helper"
                 distance={30}
               />

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -59,7 +59,7 @@ class ObjectsList extends Component<*, *> {
   }
 
   render() {
-    let { height, width, fullList, project, selectedObjectName } = this.props;
+    let { height, width, fullList, project, selectedObjectNames } = this.props;
 
     return (
       <List
@@ -122,9 +122,8 @@ class ObjectsList extends Component<*, *> {
               editingName={nameBeingEdited}
               getThumbnail={this.props.getThumbnail}
               selected={
-                objectWithContext.object.getName() === selectedObjectName
+                selectedObjectNames.indexOf(objectWithContext.object.getName()) !== -1
               }
-              onObjectSelected={this.props.onObjectSelected}
             />
           );
         }}
@@ -183,7 +182,7 @@ export default class ObjectsListContainer extends React.Component<
     )
       return true;
 
-    if (this.props.selectedObjectName !== nextProps.selectedObjectName)
+    if (this.props.selectedObjectNames !== nextProps.selectedObjectNames)
       return true;
 
     if (
@@ -453,8 +452,7 @@ export default class ObjectsListContainer extends React.Component<
                 height={height}
                 renamedObjectWithScope={this.state.renamedObjectWithScope}
                 getThumbnail={this.props.getThumbnail}
-                selectedObjectName={this.props.selectedObjectName}
-                onObjectSelected={this.props.onObjectSelected}
+                selectedObjectNames={this.props.selectedObjectNames}
                 onEditObject={this.props.onEditObject}
                 onCopyObject={this._copyObject}
                 onCutObject={this._cutObject}

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -471,7 +471,7 @@ export default class ObjectsListContainer extends React.Component<
                   this._move(oldIndex, newIndex);
                 }}
                 helperClass="sortable-helper"
-                distance={30}
+                distance={20}
               />
             )}
           </AutoSizer>

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -224,9 +224,9 @@ export default class ResourcesList extends React.Component<Props, State> {
                 onRename={this._rename}
                 onSortEnd={({ oldIndex, newIndex }) =>
                   this._move(oldIndex, newIndex)}
-                helperClass="sortable-helper"
-                distance={30}
                 buildMenuTemplate={this._renderResourceMenuTemplate}
+                helperClass="sortable-helper"
+                distance={20}
               />
             )}
           </AutoSizer>

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -82,6 +82,10 @@ export default class SceneEditor extends Component {
       selectedObjectName: null,
 
       editedGroup: null,
+      
+      // State for "drag'n'dropping" from the objects list to the instances editor:
+      objectDraggedFromList: null,
+      canDropDraggedObject: false,
 
       uiSettings: props.initialUiSettings,
       history: getHistoryInitialState(props.initialInstances, {
@@ -250,6 +254,75 @@ export default class SceneEditor extends Component {
       this.editObject(project.getObject(objectName));
   };
 
+  /**
+   * Called when an object is started to be dragged from the object list.
+   * See `_onPointerOverInstancesEditor`, `_onPointerOutInstancesEditor` and
+   * `_onPointerUpInstancesEditor` for the drag'n'drop workflow.
+   */
+  _onStartDraggingObjectFromList = object => {
+    // "Hijack" the name of the object that is dragged in the objects list.
+    // We'll then listen to "pointer over" events to see if the object
+    // is the dragged on the instances editor.
+    this.setState({
+      objectDraggedFromList: object,
+    });
+  };
+
+  _onEndDraggingObjectFromList = () => {
+    // If the dragged object is not being dropped on the instances editor,
+    // clear the dragged object so that we don't keep it the state (otherwise
+    // we could think later that a dragging is still occuring when cursor
+    // is over the instances editor).
+    if (!this.state.canDropDraggedObject) {
+      this.setState({
+        objectDraggedFromList: null,
+      });
+    }
+  }
+
+  _onPointerOverInstancesEditor = () => {
+    // If an object is dragged, and cursor is over the instances editor,
+    // mark in the state that we can drop an instance of this object.
+    if (this.state.objectDraggedFromList && !this.state.canDropDraggedObject) {
+      this.setState({
+        canDropDraggedObject: true,
+      });
+    }
+  };
+
+  _onPointerOutInstancesEditor = () => {
+    // If cursor is going out of the instances editor,
+    // mark in the state that we cannot drop an instance anymore.
+    if (this.state.canDropDraggedObject) {
+      this.setState({
+        canDropDraggedObject: false,
+      });
+    }
+  };
+
+  _onPointerUpInstancesEditor = () => {
+    if (this.state.canDropDraggedObject) {
+      if (this.editor && this.state.objectDraggedFromList) {
+        const cursorPosition = this.editor.getLastCursorPosition();
+        this._addInstance(
+          cursorPosition[0],
+          cursorPosition[1],
+          this.state.objectDraggedFromList.getName()
+        );
+      }
+      // Wait 30ms after dropping the object before reseting the canDropDraggedObject state boolean
+      // to ensure ObjectsList will be prevented to actually move object in the list.
+      setTimeout(
+        () =>
+          this.setState({
+            canDropDraggedObject: false,
+            objectDraggedFromList: null,
+          }),
+        30 // This value is very conservative, and timeout may not be needed at all
+      );
+    }
+  };
+
   editGroup = group => {
     this.setState({ editedGroup: group });
   };
@@ -299,7 +372,7 @@ export default class SceneEditor extends Component {
     });
   };
 
-  _onAddInstance = (x, y, objectName = '') => {
+  _addInstance = (x, y, objectName = '') => {
     const newInstanceObjectName = objectName || this.state.selectedObjectName;
     if (!newInstanceObjectName) return;
 
@@ -640,7 +713,7 @@ export default class SceneEditor extends Component {
           project={project}
           layout={layout}
           initialInstances={initialInstances}
-          onAddInstance={this._onAddInstance}
+          onAddInstance={this._addInstance}
           options={this.state.uiSettings}
           onChangeOptions={this.setUiSettings}
           instancesSelection={this.instancesSelection}
@@ -648,6 +721,9 @@ export default class SceneEditor extends Component {
           onInstancesSelected={this._onInstancesSelected}
           onInstancesMoved={this._onInstancesMoved}
           onInstancesResized={this._onInstancesResized}
+          onPointerUp={this._onPointerUpInstancesEditor}
+          onPointerOver={this._onPointerOverInstancesEditor}
+          onPointerOut={this._onPointerOutInstancesEditor}
           onContextMenu={this._onContextMenu}
           onCopy={() => this.copySelection({ useLastCursorPosition: true })}
           onCut={() => this.cutSelection({ useLastCursorPosition: true })}
@@ -656,6 +732,7 @@ export default class SceneEditor extends Component {
           onRedo={this.redo}
           onZoomOut={this.zoomOut}
           onZoomIn={this.zoomIn}
+          showDropCursor={this.state.canDropDraggedObject}
           wrappedEditorRef={editor => (this.editor = editor)}
           pauseRendering={!isActive}
         />
@@ -666,6 +743,10 @@ export default class SceneEditor extends Component {
           selectedObjectName={
             this.state
               .selectedObjectName /*Ensure MosaicWindow content is updated when selectedObjectName changes*/
+          }
+          canDropDraggedObject={
+            this.state
+              .canDropDraggedObject /*Ensure MosaicWindow content is updated when canDropDraggedObject changes*/
           }
         >
           <ObjectsList
@@ -686,6 +767,9 @@ export default class SceneEditor extends Component {
             }}
             onRenameObject={this._onRenameObject}
             onObjectPasted={() => this.updateBehaviorsSharedData()}
+            onStartDraggingObject={this._onStartDraggingObjectFromList}
+            onEndDraggingObject={this._onEndDraggingObjectFromList}
+            canMoveObjects={!this.state.canDropDraggedObject}
             ref={objectsList => (this._objectsList = objectsList)}
           />
         </MosaicWindow>

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -372,8 +372,7 @@ export default class SceneEditor extends Component {
     });
   };
 
-  _addInstance = (x, y, objectName = '') => {
-    // const newInstanceObjectName = objectName;
+  _addInstance = (x, y, objectName) => {
     if (!objectName) return;
 
     const instance = this.props.initialInstances.insertNewInitialInstance();
@@ -890,11 +889,11 @@ export default class SceneEditor extends Component {
           show={!!this.state.selectedObjectName}
         />
         <InfoBar
-          message="Objects panel is already opened: Use it to add and edit objects."
+          message="Objects panel is already opened: use it to add and edit objects."
           show={!!this.state.showObjectsListInfoBar}
         />
         <InfoBar
-          message="Properties panel is already opened"
+          message="Properties panel is already opened."
           show={!!this.state.showPropertiesInfoBar}
         />
         <SetupGridDialog

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-
+import uniq from 'lodash/uniq';
 import ObjectsList from '../ObjectsList';
 import ObjectGroupsList from '../ObjectGroupsList';
 import ObjectsRenderingService from '../ObjectsRendering/ObjectsRenderingService';
@@ -79,7 +79,7 @@ export default class SceneEditor extends Component {
       layerRemoved: null,
       editedObjectWithContext: { object: null, global: null },
       variablesEditedInstance: null,
-      selectedObjectName: null,
+      selectedObjectNames: [],
 
       editedGroup: null,
 
@@ -366,12 +366,6 @@ export default class SceneEditor extends Component {
     );
   };
 
-  _onObjectSelected = selectedObjectName => {
-    this.setState({
-      selectedObjectName,
-    });
-  };
-
   _addInstance = (x, y, objectName) => {
     if (!objectName) return;
 
@@ -384,7 +378,7 @@ export default class SceneEditor extends Component {
     instance.setZOrder(this.zOrderFinder.getHighestZOrder() + 1);
     this.setState(
       {
-        selectedObjectName: null,
+        selectedObjectNames: [],
         history: saveToHistory(this.state.history, this.props.initialInstances),
       },
       () => this.updateToolbar()
@@ -392,11 +386,9 @@ export default class SceneEditor extends Component {
   };
 
   _onInstancesSelected = instances => {
-    if (this.instancesSelection.hasSelectedInstances()) {
-      this.setState({
-        selectedObjectName: instances[0].getObjectName(),
-      });
-    }
+    this.setState({
+      selectedObjectNames: uniq(instances.map(instance => instance.getObjectName())),
+    });
     this.forceUpdatePropertiesEditor();
     this.updateToolbar();
   };
@@ -744,9 +736,9 @@ export default class SceneEditor extends Component {
       'objects-list': (
         <MosaicWindow
           title="Objects"
-          selectedObjectName={
+          selectedObjectNames={
             this.state
-              .selectedObjectName /*Ensure MosaicWindow content is updated when selectedObjectName changes*/
+              .selectedObjectNames /*Ensure MosaicWindow content is updated when selectedObjectNames changes*/
           }
           canDropDraggedObject={
             this.state
@@ -759,8 +751,7 @@ export default class SceneEditor extends Component {
             )}
             project={project}
             objectsContainer={layout}
-            selectedObjectName={this.state.selectedObjectName}
-            onObjectSelected={this._onObjectSelected}
+            selectedObjectNames={this.state.selectedObjectNames}
             onEditObject={this.props.onEditObject || this.editObject}
             onDeleteObject={this._onDeleteObject}
             canRenameObject={(
@@ -885,7 +876,7 @@ export default class SceneEditor extends Component {
         </Drawer>
         <InfoBar
           message="Drag and Drop the object to the scene to add an instance."
-          show={!!this.state.selectedObjectName}
+          show={!!this.state.selectedObjectNames.length}
         />
         <InfoBar
           message="Objects panel is already opened: use it to add and edit objects."

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -579,6 +579,7 @@ export default class SceneEditor extends Component {
 
     this.setState(
       {
+        selectedObjectNames: [],
         history: saveToHistory(this.state.history, this.props.initialInstances),
       },
       () => {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -82,7 +82,7 @@ export default class SceneEditor extends Component {
       selectedObjectName: null,
 
       editedGroup: null,
-      
+
       // State for "drag'n'dropping" from the objects list to the instances editor:
       objectDraggedFromList: null,
       canDropDraggedObject: false,
@@ -278,7 +278,7 @@ export default class SceneEditor extends Component {
         objectDraggedFromList: null,
       });
     }
-  }
+  };
 
   _onPointerOverInstancesEditor = () => {
     // If an object is dragged, and cursor is over the instances editor,
@@ -373,11 +373,11 @@ export default class SceneEditor extends Component {
   };
 
   _addInstance = (x, y, objectName = '') => {
-    const newInstanceObjectName = objectName || this.state.selectedObjectName;
-    if (!newInstanceObjectName) return;
+    // const newInstanceObjectName = objectName;
+    if (!objectName) return;
 
     const instance = this.props.initialInstances.insertNewInitialInstance();
-    instance.setObjectName(newInstanceObjectName);
+    instance.setObjectName(objectName);
     instance.setX(x);
     instance.setY(y);
 
@@ -393,6 +393,12 @@ export default class SceneEditor extends Component {
   };
 
   _onInstancesSelected = instances => {
+    if (!this.instancesSelection.hasSelectedInstances()) {
+      return;
+    }
+    this.setState({
+      selectedObjectName: instances[0].getObjectName(),
+    });
     this.forceUpdatePropertiesEditor();
     this.updateToolbar();
   };
@@ -880,7 +886,7 @@ export default class SceneEditor extends Component {
           />
         </Drawer>
         <InfoBar
-          message="Touch/click on the scene to add the object"
+          message="Drag and Drop the object to the scene to add an instance."
           show={!!this.state.selectedObjectName}
         />
         <InfoBar

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -392,12 +392,11 @@ export default class SceneEditor extends Component {
   };
 
   _onInstancesSelected = instances => {
-    if (!this.instancesSelection.hasSelectedInstances()) {
-      return;
+    if (this.instancesSelection.hasSelectedInstances()) {
+      this.setState({
+        selectedObjectName: instances[0].getObjectName(),
+      });
     }
-    this.setState({
-      selectedObjectName: instances[0].getObjectName(),
-    });
     this.forceUpdatePropertiesEditor();
     this.updateToolbar();
   };

--- a/newIDE/app/yarn.lock
+++ b/newIDE/app/yarn.lock
@@ -7109,14 +7109,14 @@ react@15.5.4:
     object-assign "^4.1.0"
     prop-types "^15.5.7"
 
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@16.5.1:
+  version "16.5.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.5.1.tgz#8cb8e9f8cdcb4bde41c9a138bfbf907e66132372"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.4.0"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -7559,6 +7559,12 @@ sax@1.2.1:
 sax@>=0.6.0, sax@^1.2.1, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+schedule@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.4.0.tgz#fa20cfd0bfbf91c47d02272fd7096780d3170bbb"
+  dependencies:
+    object-assign "^4.1.1"
 
 schema-utils@^0.3.0:
   version "0.3.0"

--- a/newIDE/app/yarn.lock
+++ b/newIDE/app/yarn.lock
@@ -6875,14 +6875,14 @@ react-dom@15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@16.5.1:
+  version "16.5.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.1.tgz#29d0c5a01ed3b6b4c14309aa91af6ec4eb4f292c"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.4.0"
 
 react-error-boundary@^1.2.0:
   version "1.2.0"

--- a/newIDE/electron-app/app/package-lock.json
+++ b/newIDE/electron-app/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gdevelop",
-  "version": "5.0.0-beta48",
+  "version": "5.0.0-beta52",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Add drag'n'drop from objects list.

* Should be more intuitive than selecting object then making one click.
* This will allow the blue selection background to be used for highlighting the object in https://github.com/4ian/GDevelop/pull/649
* Tested on Chrome and Firefox.

Ideally `SceneEditor/index.js` should be flow typed as it's becoming large and this could avoid regressions/mistakes.