### PR TITLE
Avoid updates in project manager and tabs when they are not visible

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1027,6 +1027,7 @@ export default class MainFrame extends React.Component<Props, State> {
                 onOpenPlatformSpecificAssets={() =>
                   this.openPlatformSpecificAssets()}
                 onChangeSubscription={() => this.openSubscription(true)}
+                freezeUpdate={!projectManagerOpen}
               />
             )}
           </Drawer>

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -193,6 +193,7 @@ type Props = {|
   onAddExternalLayout: () => void,
   onOpenPlatformSpecificAssets: () => void,
   onChangeSubscription: () => void,
+  freezeUpdate: boolean,
 |};
 
 type State = {|
@@ -211,6 +212,14 @@ export default class ProjectManager extends React.Component<Props, State> {
     projectPropertiesDialogOpen: false,
     variablesEditorOpen: false,
   };
+
+  shouldComponentUpdate(nextProps: Props) {
+    // Rendering the component is (super) costly (~20ms) as it iterates over
+    // every project layouts/external layouts/external events, 
+    // so the prop freezeUpdate allow to ask the component to stop
+    // updating, for example when hidden.
+    return !nextProps.freezeUpdate;
+  }
 
   _onEditName = (kind: ?string, name: string) => {
     this.setState({

--- a/newIDE/app/src/UI/Tabs.js
+++ b/newIDE/app/src/UI/Tabs.js
@@ -21,20 +21,31 @@ const styles = {
 
 /**
  * This is to override the default material-ui tab template used to wrap the content of each tab element.
- * Instead of setting the "height" of hidden tabs to "0", we set "display" to "none" to avoid
+ * 2 changes (**please port them to your new implementation if you change the tabs**):
+ * 
+ * 1) Instead of setting the "height" of hidden tabs to "0", we set "display" to "none" to avoid
  * messing with components (in particular components where you can scroll: when collapsed because of height=0,
  * they will lose they scrolling position).
  * 
+ * 2) shouldComponentUpdate is used to avoid updating the content of a tab that is not selected.
+ * 
  * Rest of the implementation is the same.
  */
-const TabTemplate = ({ children, selected, style }) => {
-  const templateStyle = { ...styles.tabTemplateStyle, ...style };
-  if (!selected) {
-    templateStyle.display = 'none';
+class TabTemplate extends Component {
+  shouldComponentUpdate(nextProps) {
+    return this.props.selected || nextProps.selected;
   }
 
-  return <div style={templateStyle}>{children}</div>;
-};
+  render() {
+    const { children, selected, style } = this.props;
+    const templateStyle = { ...styles.tabTemplateStyle, ...style };
+    if (!selected) {
+      templateStyle.display = 'none';
+    }
+  
+    return <div style={templateStyle}>{children}</div>;
+  }
+}
 
 export class ThemableTabs extends Component {
   render() {


### PR DESCRIPTION
This avoids React updates in `ProjectManager` when it's closed, as well as in the other hidden tabs. Should be especially useful when lots of tabs opened to keep a user-perceived responsiveness when switching tabs.

Illustration the React profiler with components not updated in gray when switching tabs:

![image](https://user-images.githubusercontent.com/1280130/45787302-7c23a200-bc6c-11e8-8122-8dfb2811180d.png)
