### PR TITLE
Bring back Objectlist selection, new 'add instance of selected object'..

### DIFF
--- a/newIDE/app/src/ObjectsList/ObjectRow.js
+++ b/newIDE/app/src/ObjectsList/ObjectRow.js
@@ -151,11 +151,17 @@ class ThemableObjectRow extends React.Component {
         primaryText={label}
         leftIcon={<ListIcon src={this.props.getThumbnail(project, object)} />}
         rightIconButton={this._renderObjectMenu(object)}
-        onDoubleClick={(event) => {
+        onClick={() => {
+          if (!this.props.onObjectSelected) return;
+          if (this.props.editingName) return;
+          this.props.onObjectSelected(selected ? '' : objectName);
+        }}
+        onDoubleClick={event => {
           if (event.button !== LEFT_MOUSE_BUTTON) return;
           if (!this.props.onEdit) return;
           if (this.props.editingName) return;
 
+          this.props.onObjectSelected('');
           this.props.onEdit(object);
         }}
       />

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -121,8 +121,11 @@ class ObjectsList extends Component<*, *> {
               onAddNewObject={this.props.onAddNewObject}
               editingName={nameBeingEdited}
               getThumbnail={this.props.getThumbnail}
+              onObjectSelected={this.props.onObjectSelected}
               selected={
-                selectedObjectNames.indexOf(objectWithContext.object.getName()) !== -1
+                selectedObjectNames.indexOf(
+                  objectWithContext.object.getName()
+                ) !== -1
               }
             />
           );
@@ -366,11 +369,10 @@ export default class ObjectsListContainer extends React.Component<
     this.forceUpdateList();
   };
 
-  _onStartDraggingObject = ({index}: {index: number}) => {
+  _onStartDraggingObject = ({ index }: { index: number }) => {
     const { project, objectsContainer } = this.props;
 
-    const isInContainerObjectsList =
-      index < this.containerObjectsList.length;
+    const isInContainerObjectsList = index < this.containerObjectsList.length;
     if (isInContainerObjectsList) {
       this.props.onStartDraggingObject(objectsContainer.getObjectAt(index));
     } else {
@@ -453,6 +455,7 @@ export default class ObjectsListContainer extends React.Component<
                 renamedObjectWithScope={this.state.renamedObjectWithScope}
                 getThumbnail={this.props.getThumbnail}
                 selectedObjectNames={this.props.selectedObjectNames}
+                onObjectSelected={this.props.onObjectSelected}
                 onEditObject={this.props.onEditObject}
                 onCopyObject={this._copyObject}
                 onCutObject={this._cutObject}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -969,7 +969,8 @@ export default class SceneEditor extends Component {
               visible: this.state.selectedObjectNames.length > 0,
             },
             {
-              label: 'Edit Object',
+              label: 'Edit Object ' +
+              this.shortenedString(this.state.selectedObjectNames[0], 7),
               click: () => this.openObjectEditor(),
               visible: this.instancesSelection.hasSelectedInstances(),
             },

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -970,7 +970,7 @@ export default class SceneEditor extends Component {
             },
             {
               label: 'Edit Object ' +
-              this.shortenedString(this.state.selectedObjectNames[0], 7),
+              this.shortenedString(this.state.selectedObjectNames[0], 14),
               click: () => this.openObjectEditor(),
               visible: this.instancesSelection.hasSelectedInstances(),
             },

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -31,6 +31,7 @@ import EditorBar from '../UI/EditorBar';
 import InfoBar from '../UI/Messages/InfoBar';
 import ContextMenu from '../UI/Menu/ContextMenu';
 import { showWarningBox } from '../UI/Messages/MessageBox';
+import { shortenString } from '../Utils/StringHelpers';
 
 import {
   undo,
@@ -373,23 +374,13 @@ export default class SceneEditor extends Component {
   };
 
   _onAddInstanceUnderCursor = () => {
+    if (!this.state.selectedObjectNames.length) return;
     const objectSelected = this.state.selectedObjectNames[0];
     const cursorPosition = this.editor.getLastCursorPosition();
     this._addInstance(cursorPosition[0], cursorPosition[1], objectSelected);
     this.setState({
       selectedObjectNames: [objectSelected],
     });
-  };
-
-  shortenedString = (inputString: string, maxlength: number) => {
-    if (!inputString) {
-      return '';
-    }
-    let resultString = inputString;
-    if (resultString.length > maxlength) {
-      resultString = resultString.substring(0, maxlength) + '...';
-    }
-    return resultString;
   };
 
   _addInstance = (x, y, objectName) => {
@@ -905,7 +896,7 @@ export default class SceneEditor extends Component {
           />
         </Drawer>
         <InfoBar
-          message="Drag and Drop the object to the scene to add an instance."
+          message="Drag and Drop the object to the scene or use the right click menu to add an instance of it."
           show={!!this.state.selectedObjectNames.length}
         />
         <InfoBar
@@ -962,17 +953,21 @@ export default class SceneEditor extends Component {
           ref={contextMenu => (this.contextMenu = contextMenu)}
           buildMenuTemplate={() => [
             {
-              label:
-                'Add an Instance of ' +
-                this.shortenedString(this.state.selectedObjectNames[0], 7),
+              label: this.state.selectedObjectNames.length
+                ? 'Add an Instance of ' +
+                  shortenString(this.state.selectedObjectNames[0], 7)
+                : '',
               click: () => this._onAddInstanceUnderCursor(),
               visible: this.state.selectedObjectNames.length > 0,
             },
             {
-              label: 'Edit Object ' +
-              this.shortenedString(this.state.selectedObjectNames[0], 14),
-              click: () => this.openObjectEditor(),
-              visible: this.instancesSelection.hasSelectedInstances(),
+              label: this.state.selectedObjectNames.length
+                ? 'Edit Object ' +
+                  shortenString(this.state.selectedObjectNames[0], 14)
+                : '',
+              click: () =>
+                this.editObjectByName(this.state.selectedObjectNames[0]),
+              visible: this.state.selectedObjectNames.length > 0,
             },
             {
               label: 'Scene properties',

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -966,15 +966,12 @@ export default class SceneEditor extends Component {
                 'Add an Instance of ' +
                 this.shortenedString(this.state.selectedObjectNames[0], 7),
               click: () => this._onAddInstanceUnderCursor(),
-              visible:
-                // !this.instancesSelection.hasSelectedInstances() &&
-                this.state.selectedObjectNames.length > 0,
+              visible: this.state.selectedObjectNames.length > 0,
             },
             {
               label: 'Edit Object',
               click: () => this.openObjectEditor(),
-              visible:
-                this.instancesSelection.hasSelectedInstances(),
+              visible: this.instancesSelection.hasSelectedInstances(),
             },
             {
               label: 'Scene properties',

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -366,6 +366,32 @@ export default class SceneEditor extends Component {
     );
   };
 
+  _onObjectSelected = selectedObjectName => {
+    this.setState({
+      selectedObjectNames: [selectedObjectName],
+    });
+  };
+
+  _onAddInstanceUnderCursor = () => {
+    const objectSelected = this.state.selectedObjectNames[0];
+    const cursorPosition = this.editor.getLastCursorPosition();
+    this._addInstance(cursorPosition[0], cursorPosition[1], objectSelected);
+    this.setState({
+      selectedObjectNames: [objectSelected],
+    });
+  };
+
+  shortenedString = (inputString: string, maxlength: number) => {
+    if (!inputString) {
+      return '';
+    }
+    let resultString = inputString;
+    if (resultString.length > maxlength) {
+      resultString = resultString.substring(0, maxlength) + '...';
+    }
+    return resultString;
+  };
+
   _addInstance = (x, y, objectName) => {
     if (!objectName) return;
 
@@ -387,7 +413,9 @@ export default class SceneEditor extends Component {
 
   _onInstancesSelected = instances => {
     this.setState({
-      selectedObjectNames: uniq(instances.map(instance => instance.getObjectName())),
+      selectedObjectNames: uniq(
+        instances.map(instance => instance.getObjectName())
+      ),
     });
     this.forceUpdatePropertiesEditor();
     this.updateToolbar();
@@ -761,6 +789,7 @@ export default class SceneEditor extends Component {
             ) => {
               return this._canObjectUseNewName(objectWithContext, newName);
             }}
+            onObjectSelected={this._onObjectSelected}
             onRenameObject={this._onRenameObject}
             onObjectPasted={() => this.updateBehaviorsSharedData()}
             onStartDraggingObject={this._onStartDraggingObjectFromList}
@@ -933,9 +962,19 @@ export default class SceneEditor extends Component {
           ref={contextMenu => (this.contextMenu = contextMenu)}
           buildMenuTemplate={() => [
             {
+              label:
+                'Add an Instance of ' +
+                this.shortenedString(this.state.selectedObjectNames[0], 7),
+              click: () => this._onAddInstanceUnderCursor(),
+              visible:
+                // !this.instancesSelection.hasSelectedInstances() &&
+                this.state.selectedObjectNames.length > 0,
+            },
+            {
               label: 'Edit Object',
               click: () => this.openObjectEditor(),
-              enabled: this.instancesSelection.hasSelectedInstances(),
+              visible:
+                this.instancesSelection.hasSelectedInstances(),
             },
             {
               label: 'Scene properties',

--- a/newIDE/app/src/Utils/StringHelpers.js
+++ b/newIDE/app/src/Utils/StringHelpers.js
@@ -1,0 +1,3 @@
+export const shortenString = (str: string, maxLength: number) => {
+  return str.length > maxLength ? str.substring(0, maxLength) + '...' : str;
+};


### PR DESCRIPTION
..context sensitive menu command.

Treat first selected object as input for both edit object and add instance of commands

demo:
![addinstanceofgd](https://user-images.githubusercontent.com/6495061/45848409-388d6e80-bd26-11e8-87ce-426e8d08bd26.gif)

item visibility:
![addinstanceofmenuvisibility](https://user-images.githubusercontent.com/6495061/45848682-54dddb00-bd27-11e8-9149-c7a6fb7456da.gif)

Discussion:
https://github.com/4ian/GDevelop/issues/655

Why treat the first selected as target instead of disabling the menus when multiple are selected?
- So the menus are easier to discover
- So if multiple are selected,its clear which will be used by the command - the object name is also hinted in the menu items of the commands (useful for when user box selected overlapping )
