### PR TITLE
Fix GDJS import bug during windows install

### DIFF
--- a/GDJS/scripts/CopyRuntimeToGD.bat
+++ b/GDJS/scripts/CopyRuntimeToGD.bat
@@ -5,10 +5,10 @@
 cd /d %~dp0
 
 set destDir=%1
-if "%destDir%"=="" set destDir="..\..\Binaries\Output\Release_Windows\JsPlatform\Runtime"
+if [%destDir%]==[] set destDir="..\..\Binaries\Output\Release_Windows\JsPlatform\Runtime"
 
 echo Copying GDJS and extensions runtime files (*.js) to %destDir%...
-xcopy "..\Runtime"\* "%destDir%"\* /S /E  /D /Y /Q
-xcopy "..\..\Extensions"\*.js "%destDir%\Extensions"\*.js /S /E  /D /Y /Q /EXCLUDE:FilesExcludedFromCopy
+xcopy "..\Runtime"\* %destDir%\* /S /E  /D /Y /Q
+xcopy "..\..\Extensions"\*.js %destDir%\Extensions\*.js /S /E  /D /Y /Q /EXCLUDE:FilesExcludedFromCopy
 
-echo ✅ Copied GDJS and extensions runtime files (*.js) to '%destDir%'.
+echo ✅ Copied GDJS and extensions runtime files (*.js) to %destDir%.

--- a/newIDE/app/scripts/import-GDJS-Runtime.js
+++ b/newIDE/app/scripts/import-GDJS-Runtime.js
@@ -7,10 +7,10 @@ var destFolder2 = path.join(process.cwd(), '..', 'node_modules', 'GDJS-for-web-a
 var gdjsScriptsFolder = '../../../GDJS/scripts';
 
 if (isWin) {
-  shell.exec('CopyRuntimeToGD.bat ' + destFolder, {
+  shell.exec('CopyRuntimeToGD.bat ' + "\"" + destFolder + "\"", {
     cwd: gdjsScriptsFolder,
   });
-  shell.exec('CopyRuntimeToGD.bat ' + destFolder2, {
+  shell.exec('CopyRuntimeToGD.bat ' + "\"" + destFolder2 + "\"", {
     cwd: gdjsScriptsFolder,
   });
 } else {


### PR DESCRIPTION
Fixed bug where if the working directory contained a space in Windows it would pass an incorrect argument and import GDJS to the wrong directory.

This Fixes:
#668 