### PR TITLE
Add event, subevent and comment commands in event sheet right click menu

### DIFF
--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -776,7 +776,7 @@ export default class EventsSheet extends React.Component<Props, State> {
               searchResults={eventsSearchResultEvents}
               searchFocusOffset={searchFocusOffset}
               onEventMoved={this._onEventMoved}
-            />
+            /> 
             {this.state.showSearchPanel && (
               <SearchPanel
                 ref={searchPanel => (this._searchPanel = searchPanel)}
@@ -842,15 +842,27 @@ export default class EventsSheet extends React.Component<Props, State> {
                   enabled: Clipboard.has(CLIPBOARD_KIND),
                   accelerator: 'CmdOrCtrl+V',
                 },
-                { type: 'separator' },
-                {
-                  label: 'Toggle disabled',
-                  click: () => this.toggleDisabled(),
-                },
                 {
                   label: 'Delete',
                   click: () => this.deleteSelection(),
                   accelerator: 'Delete',
+                },
+                {
+                  label: 'Toggle disabled',
+                  click: () => this.toggleDisabled(),
+                },
+                { type: 'separator' },
+                {
+                  label: 'Add New Event Below',
+                  click: () => this.addNewEvent('BuiltinCommonInstructions::Standard'),
+                },
+                {
+                  label: 'Add Sub Event',
+                  click: () => this.addSubEvents(),
+                },
+                {
+                  label: 'Add Comment Below',
+                  click: () => this.addNewEvent('BuiltinCommonInstructions::Comment'),
                 },
                 { type: 'separator' },
                 {


### PR DESCRIPTION
This adds the basic new event commands to the context menu- making them easier to discover and faster to access with less mouse cursor travel distance

![menucommands](https://user-images.githubusercontent.com/6495061/46262788-15b94200-c4fe-11e8-9e59-40a6ecd1035d.png)

This partially addresses https://github.com/4ian/GDevelop/issues/666