### PR TITLE
Add 'other' new special events to eventSheet's context menu

### DIFF
--- a/newIDE/app/src/EventsSheet/EnumerateEventsMetadata.js
+++ b/newIDE/app/src/EventsSheet/EnumerateEventsMetadata.js
@@ -1,0 +1,28 @@
+import flatten from 'lodash/flatten';
+import { mapFor } from '../Utils/MapFor';
+const gd = global.gd;
+
+export const enumerateEventsMetadata = () => {
+  const allExtensions = gd
+    .asPlatform(gd.JsPlatform.get())
+    .getAllPlatformExtensions();
+
+  return flatten(
+    mapFor(0, allExtensions.size(), i => {
+      const extension = allExtensions.get(i);
+      const extensionEvents = extension.getAllEvents();
+
+      return extensionEvents
+        .keys()
+        .toJSArray()
+        .map(type => {
+          const metadata = extensionEvents.get(type);
+          return {
+            type,
+            fullName: metadata.getFullName(),
+            description: metadata.getDescription(),
+          };
+        });
+    })
+  );
+};

--- a/newIDE/app/src/EventsSheet/EnumerateEventsMetadata.js
+++ b/newIDE/app/src/EventsSheet/EnumerateEventsMetadata.js
@@ -1,8 +1,16 @@
+// @flow
+
 import flatten from 'lodash/flatten';
 import { mapFor } from '../Utils/MapFor';
 const gd = global.gd;
 
-export const enumerateEventsMetadata = () => {
+export type EventMetadata = {|
+  type: string,
+  fullName: string,
+  description: string,
+|};
+
+export const enumerateEventsMetadata = (): Array<EventMetadata> => {
   const allExtensions = gd
     .asPlatform(gd.JsPlatform.get())
     .getAllPlatformExtensions();

--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -4,37 +4,9 @@ import { ToolbarGroup } from 'material-ui/Toolbar';
 import ToolbarSeparator from '../UI/ToolbarSeparator';
 import ToolbarIcon from '../UI/ToolbarIcon';
 import IconMenu from '../UI/Menu/IconMenu';
-import { mapFor } from '../Utils/MapFor';
-import flatten from 'lodash/flatten';
 import { adaptAcceleratorString } from '../UI/AcceleratorString';
-const gd = global.gd;
 
 export class Toolbar extends PureComponent {
-  componentWillMount() {
-    const allExtensions = gd
-      .asPlatform(gd.JsPlatform.get())
-      .getAllPlatformExtensions();
-
-    this.allEventsMetadata = flatten(
-      mapFor(0, allExtensions.size(), i => {
-        const extension = allExtensions.get(i);
-        const extensionEvents = extension.getAllEvents();
-
-        return extensionEvents
-          .keys()
-          .toJSArray()
-          .map(type => {
-            const metadata = extensionEvents.get(type);
-            return {
-              type,
-              fullName: metadata.getFullName(),
-              description: metadata.getDescription(),
-            };
-          });
-      })
-    );
-  }
-
   render() {
     const { t } = this.props;
 
@@ -52,7 +24,9 @@ export class Toolbar extends PureComponent {
             iconButtonElement={
               <ToolbarIcon
                 src="res/ribbon_default/bug32.png"
-                tooltip={t('Advanced preview options (debugger, network preview...)')}
+                tooltip={t(
+                  'Advanced preview options (debugger, network preview...)'
+                )}
               />
             }
             buildMenuTemplate={() => [
@@ -66,8 +40,8 @@ export class Toolbar extends PureComponent {
                 click: () => this.props.onOpenDebugger(),
               },
             ]}
-          />)
-        }
+          />
+        )}
         {this.props.showPreviewButton && <ToolbarSeparator />}
         <ToolbarIcon
           onClick={this.props.onAddStandardEvent}
@@ -93,7 +67,7 @@ export class Toolbar extends PureComponent {
             />
           }
           buildMenuTemplate={() =>
-            this.allEventsMetadata.map(metadata => {
+            this.props.allEventsMetadata.map(metadata => {
               return {
                 label: metadata.fullName,
                 click: () => this.props.onAddEvent(metadata.type),
@@ -123,7 +97,9 @@ export class Toolbar extends PureComponent {
         <ToolbarIcon
           onClick={() => this.props.onToggleSearchPanel()}
           src="res/ribbon_default/search32.png"
-          tooltip={`${t('Search in events')} ${adaptAcceleratorString('CmdOrCtrl+F')}`}
+          tooltip={`${t('Search in events')} ${adaptAcceleratorString(
+            'CmdOrCtrl+F'
+          )}`}
         />
         {this.props.onOpenSettings && <ToolbarSeparator />}
         {this.props.onOpenSettings && (

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -776,7 +776,7 @@ export default class EventsSheet extends React.Component<Props, State> {
               searchResults={eventsSearchResultEvents}
               searchFocusOffset={searchFocusOffset}
               onEventMoved={this._onEventMoved}
-            />
+            /> 
             {this.state.showSearchPanel && (
               <SearchPanel
                 ref={searchPanel => (this._searchPanel = searchPanel)}
@@ -842,15 +842,27 @@ export default class EventsSheet extends React.Component<Props, State> {
                   enabled: Clipboard.has(CLIPBOARD_KIND),
                   accelerator: 'CmdOrCtrl+V',
                 },
-                { type: 'separator' },
-                {
-                  label: 'Toggle disabled',
-                  click: () => this.toggleDisabled(),
-                },
                 {
                   label: 'Delete',
                   click: () => this.deleteSelection(),
                   accelerator: 'Delete',
+                },
+                {
+                  label: 'Toggle disabled',
+                  click: () => this.toggleDisabled(),
+                },
+                { type: 'separator' },
+                {
+                  label: 'Add New Event Below',
+                  click: () => this.addNewEvent('BuiltinCommonInstructions::Standard'),
+                },
+                {
+                  label: 'Add Sub Event',
+                  click: () => this.addSubEvents(),
+                },
+                {
+                  label: 'Add Comment Below',
+                  click: () => this.addNewEvent('BuiltinCommonInstructions::Comment'),
                 },
                 { type: 'separator' },
                 {

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -127,6 +127,7 @@ export default class EventsSheet extends React.Component<Props, State> {
   eventContextMenu: ContextMenu;
   instructionContextMenu: ContextMenu;
   instructionsListContextMenu: ContextMenu;
+  allEventsMetadata: ContextMenu;
 
   constructor(props: Props) {
     super(props);

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -55,7 +55,7 @@ import EventsSearcher, {
   type SearchInEventsInputs,
 } from './EventsSearcher';
 import { containsSubInstructions } from './ContainsSubInstruction';
-import { enumerateEventsMetadata } from './EnumerateEventsMetadata';
+import { enumerateEventsMetadata, type EventMetadata } from './EnumerateEventsMetadata';
 const gd = global.gd;
 
 const CLIPBOARD_KIND = 'EventsAndInstructions';
@@ -109,11 +109,7 @@ type State = {|
   searchResults: ?Array<gdBaseEvent>,
   searchFocusOffset: ?number,
 
-  allEventsMetadata: Array<{
-    type: string,
-    fullName: string,
-    description: string,
-  }>,
+  allEventsMetadata: Array<EventMetadata>,
 |};
 
 const styles = {
@@ -165,7 +161,7 @@ export default class EventsSheet extends React.Component<Props, State> {
       searchResults: null,
       searchFocusOffset: null,
 
-      allEventsMetadata: [{ type: '', fullName: '', description: '' }],
+      allEventsMetadata: [],
     };
 
     this._keyboardShortcuts = new KeyboardShortcuts({

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -127,7 +127,7 @@ export default class EventsSheet extends React.Component<Props, State> {
   eventContextMenu: ContextMenu;
   instructionContextMenu: ContextMenu;
   instructionsListContextMenu: ContextMenu;
-  allEventsMetadata: ContextMenu;
+  allEventsMetadata: Array<{type: string, fullName: string, description: string}>;
 
   constructor(props: Props) {
     super(props);


### PR DESCRIPTION
This also moves other events menu array out of the toolbar class and into the eventSheet class. The toolbar class still gets it as a prop and still works as before

I thought that it is easier to manage and makes more sense to have it in the  event sheet rather than the toolbar :) 

This partially resolves #666 
![neweventmemugd](https://user-images.githubusercontent.com/6495061/46291602-d4b94000-c586-11e8-97dd-db7464b0f8ca.png)