### PR TITLE
Add a command to invert conditions to the event sheet context menu

### DIFF
--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -105,6 +105,19 @@ export const hasInstructionSelected = (selection: SelectionState): boolean => {
   return !!Object.keys(selection.selectedInstructions).length;
 };
 
+export const hasSelectedAtleastOneCondition = (
+  selection: SelectionState
+): boolean => {
+  let hasCondition = false;
+  for (var instructionContext of getSelectedInstructionsContexts(selection)) {
+    if (instructionContext.isCondition) {
+      hasCondition = true;
+      break;
+    }
+  }
+  return hasCondition;
+};
+
 export const hasInstructionsListSelected = (
   selection: SelectionState
 ): boolean => {
@@ -164,7 +177,8 @@ export const selectInstructionsList = (
   instructionsListContext: InstructionsListContext,
   multiSelection: boolean = false
 ): SelectionState => {
-  const instructionsList: gdInstructionsList = instructionsListContext.instrsList;
+  const instructionsList: gdInstructionsList =
+    instructionsListContext.instrsList;
   if (isInstructionsListSelected(selection, instructionsList)) return selection;
 
   const existingSelection = multiSelection ? selection : clearSelection();

--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -111,7 +111,6 @@ export const hasSelectedAtLeastOneCondition = (
   for (let instructionContext of getSelectedInstructionsContexts(selection)) {
     if (instructionContext.isCondition) {
       return true;
-      break;
     }
   }
   return false;

--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -105,17 +105,16 @@ export const hasInstructionSelected = (selection: SelectionState): boolean => {
   return !!Object.keys(selection.selectedInstructions).length;
 };
 
-export const hasSelectedAtleastOneCondition = (
+export const hasSelectedAtLeastOneCondition = (
   selection: SelectionState
 ): boolean => {
-  let hasCondition = false;
-  for (var instructionContext of getSelectedInstructionsContexts(selection)) {
+  for (let instructionContext of getSelectedInstructionsContexts(selection)) {
     if (instructionContext.isCondition) {
-      hasCondition = true;
+      return true;
       break;
     }
   }
-  return hasCondition;
+  return false;
 };
 
 export const hasInstructionsListSelected = (

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -32,7 +32,7 @@ import {
   hasSomethingSelected,
   hasEventSelected,
   hasInstructionSelected,
-  hasSelectedAtleastOneCondition,
+  hasSelectedAtLeastOneCondition,
   hasInstructionsListSelected,
   getSelectedEvents,
   getSelectedInstructions,
@@ -962,7 +962,7 @@ export default class EventsSheet extends React.Component<Props, State> {
                 {
                   label: 'Invert Condition',
                   click: () => this._invertSelectedConditions(),
-                  visible: hasSelectedAtleastOneCondition(this.state.selection),
+                  visible: hasSelectedAtLeastOneCondition(this.state.selection),
                 },
               ]}
             />

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -32,6 +32,7 @@ import {
   hasSomethingSelected,
   hasEventSelected,
   hasInstructionSelected,
+  hasSelectedAtleastOneCondition,
   hasInstructionsListSelected,
   getSelectedEvents,
   getSelectedInstructions,
@@ -55,7 +56,10 @@ import EventsSearcher, {
   type SearchInEventsInputs,
 } from './EventsSearcher';
 import { containsSubInstructions } from './ContainsSubInstruction';
-import { enumerateEventsMetadata, type EventMetadata } from './EnumerateEventsMetadata';
+import {
+  enumerateEventsMetadata,
+  type EventMetadata,
+} from './EnumerateEventsMetadata';
 const gd = global.gd;
 
 const CLIPBOARD_KIND = 'EventsAndInstructions';
@@ -616,6 +620,22 @@ export default class EventsSheet extends React.Component<Props, State> {
       this.pasteInstructions();
   };
 
+  _invertSelectedConditions = () => {
+    getSelectedInstructionsContexts(
+      this.state.selection
+    ).forEach(instructionContext => {
+      if (instructionContext.isCondition) {
+        instructionContext.instruction.setInverted(
+          !instructionContext.instruction.isInverted()
+        );
+      }
+    });
+
+    this._saveChangesToHistory(() => {
+      this._eventsTree.forceEventsUpdate();
+    });
+  };
+
   _saveChangesToHistory = (cb: ?Function) => {
     this.setState(
       {
@@ -938,6 +958,11 @@ export default class EventsSheet extends React.Component<Props, State> {
                   click: this.redo,
                   enabled: canRedo(this.state.history),
                   accelerator: 'CmdOrCtrl+Shift+Z',
+                },
+                {
+                  label: 'Invert Condition',
+                  click: () => this._invertSelectedConditions(),
+                  visible: hasSelectedAtleastOneCondition(this.state.selection),
                 },
               ]}
             />


### PR DESCRIPTION
It inverts all conditions inside a Selection. If the selection has no conditions, dont show the command in the menu (new function to check for that in the selection handler)

discussion here:
https://github.com/4ian/GDevelop/issues/685

Demo:
![invertconditionsgd](https://user-images.githubusercontent.com/6495061/46347034-122ed380-c642-11e8-8781-68854cc2fd32.gif)
