### PR TITLE
Add rotate widget to Scene Editor instance selection

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesRotator.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRotator.js
@@ -13,7 +13,7 @@ export default class InstancesRotator {
     const angle =
       Math.atan2(this.totalDeltaY, this.totalDeltaX) * 180 / Math.PI +
       initialAngle;
-    return proportional ? Math.round(angle / 45) * 45 : angle;
+    return proportional ? Math.round(angle / 15) * 15 : angle;
   }
 
   rotateBy(instances, deltaX, deltaY, proportional) {

--- a/newIDE/app/src/InstancesEditor/InstancesRotator.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRotator.js
@@ -1,6 +1,5 @@
 export default class InstancesRotator {
-  constructor({ options }) {
-    this.options = options;
+  constructor() {
     this.instanceAngles = {};
     this.totalDeltaX = 0;
     this.totalDeltaY = 0;
@@ -10,13 +9,11 @@ export default class InstancesRotator {
     this.options = options;
   }
 
-  _getAngleDelta(proportional, initialAngle) {
-    let deg = Math.atan2(this.totalDeltaY, this.totalDeltaX) * 180 / Math.PI;
-    deg += initialAngle;
-    if (proportional) {
-      return (deg = Math.round(deg / 45) * 45);
-    }
-    return deg;
+  _getNewAngle(proportional: boolean, initialAngle: number) {
+    const angle =
+      Math.atan2(this.totalDeltaY, this.totalDeltaX) * 180 / Math.PI +
+      initialAngle;
+    return proportional ? Math.round(angle / 45) * 45 : angle;
   }
 
   rotateBy(instances, deltaX, deltaY, proportional) {
@@ -26,13 +23,12 @@ export default class InstancesRotator {
     for (let i = 0; i < instances.length; i++) {
       const selectedInstance = instances[i];
       let initialAngle = this.instanceAngles[selectedInstance.ptr];
-      if (!initialAngle) {
+      if (initialAngle === undefined) {
         initialAngle = this.instanceAngles[
           selectedInstance.ptr
         ] = selectedInstance.getAngle();
       }
-      let newAngle = this._getAngleDelta(proportional, initialAngle);
-      selectedInstance.setAngle(newAngle);
+      selectedInstance.setAngle(this._getNewAngle(proportional, initialAngle));
     }
   }
 

--- a/newIDE/app/src/InstancesEditor/InstancesRotator.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRotator.js
@@ -1,6 +1,5 @@
 export default class InstancesRotator {
-  constructor({ instanceMeasurer, options }) {
-    this.instanceMeasurer = instanceMeasurer;
+  constructor({ options }) {
     this.options = options;
     this.instanceAngles = {};
     this.totalDeltaX = 0;
@@ -32,7 +31,7 @@ export default class InstancesRotator {
           selectedInstance.ptr
         ] = selectedInstance.getAngle();
       }
-      let newAngle = this._getAngleDelta(proportional, initialAngle,{x:0,y:0});
+      let newAngle = this._getAngleDelta(proportional, initialAngle);
       selectedInstance.setAngle(newAngle);
     }
   }

--- a/newIDE/app/src/InstancesEditor/InstancesRotator.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRotator.js
@@ -1,0 +1,45 @@
+export default class InstancesRotator {
+  constructor({ instanceMeasurer, options }) {
+    this.instanceMeasurer = instanceMeasurer;
+    this.options = options;
+    this.instanceAngles = {};
+    this.totalDeltaX = 0;
+    this.totalDeltaY = 0;
+  }
+
+  setOptions(options) {
+    this.options = options;
+  }
+
+  _getAngleDelta(proportional, initialAngle) {
+    let deg = Math.atan2(this.totalDeltaY, this.totalDeltaX) * 180 / Math.PI;
+    deg += initialAngle;
+    if (proportional) {
+      return (deg = Math.round(deg / 45) * 45);
+    }
+    return deg;
+  }
+
+  rotateBy(instances, deltaX, deltaY, proportional) {
+    this.totalDeltaX += deltaX;
+    this.totalDeltaY += deltaY;
+
+    for (let i = 0; i < instances.length; i++) {
+      const selectedInstance = instances[i];
+      let initialAngle = this.instanceAngles[selectedInstance.ptr];
+      if (!initialAngle) {
+        initialAngle = this.instanceAngles[
+          selectedInstance.ptr
+        ] = selectedInstance.getAngle();
+      }
+      let newAngle = this._getAngleDelta(proportional, initialAngle,{x:0,y:0});
+      selectedInstance.setAngle(newAngle);
+    }
+  }
+
+  endRotate() {
+    this.instanceAngles = {};
+    this.totalDeltaX = 0;
+    this.totalDeltaY = 0;
+  }
+}

--- a/newIDE/app/src/InstancesEditor/InstancesRotator.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRotator.js
@@ -5,10 +5,6 @@ export default class InstancesRotator {
     this.totalDeltaY = 0;
   }
 
-  setOptions(options) {
-    this.options = options;
-  }
-
   _getNewAngle(proportional: boolean, initialAngle: number) {
     const angle =
       Math.atan2(this.totalDeltaY, this.totalDeltaX) * 180 / Math.PI +

--- a/newIDE/app/src/InstancesEditor/SelectedInstances.js
+++ b/newIDE/app/src/InstancesEditor/SelectedInstances.js
@@ -12,11 +12,15 @@ export default class InstancesSelection {
     instanceMeasurer,
     onResize,
     onResizeEnd,
+    onRotate,
+    onRotateEnd,
     toCanvasCoordinates,
   }) {
     this.instanceMeasurer = instanceMeasurer;
     this.onResize = onResize;
     this.onResizeEnd = onResizeEnd;
+    this.onRotate = onRotate;
+    this.onRotateEnd = onRotateEnd;
     this.toCanvasCoordinates = toCanvasCoordinates;
     this.instancesSelection = instancesSelection;
 
@@ -29,6 +33,7 @@ export default class InstancesSelection {
     this.resizeIcon = new PIXI.Sprite.fromImage('res/actions/direction.png');
     this.rightResizeButton = new PIXI.Graphics();
     this.bottomResizeButton = new PIXI.Graphics();
+    this.rotateButton = new PIXI.Graphics();
     this._makeButton(
       this.resizeButton,
       event => {
@@ -59,6 +64,16 @@ export default class InstancesSelection {
       },
       'ns-resize'
     );
+    this._makeButton(
+      this.rotateButton,
+      event => {
+        this.onRotate(event.deltaX, event.deltaY);
+      },
+      () => {
+        this.onRotateEnd();
+      },
+      'url("res/actions/rotate24.png"),auto'
+    );
   }
 
   _makeButton(objectButton, onMove, onEnd, cursor) {
@@ -75,7 +90,7 @@ export default class InstancesSelection {
     return this.pixiContainer;
   }
 
-  _renderButton(show, buttonObject, canvasPosition, size) {
+  _renderButton(show, buttonObject, canvasPosition, size, shape = 0) {
     buttonObject.clear();
     if (!show) {
       buttonObject.hitArea = new PIXI.Rectangle(0, 0, 0, 0);
@@ -85,7 +100,16 @@ export default class InstancesSelection {
     buttonObject.beginFill(0xffffff);
     buttonObject.lineStyle(1, 0x6868e8, 1);
     buttonObject.fillAlpha = 0.9;
-    buttonObject.drawRect(canvasPosition[0], canvasPosition[1], size, size);
+    if (shape === 0) {
+      buttonObject.drawRect(canvasPosition[0], canvasPosition[1], size, size);
+    } else {
+      buttonObject.drawCircle(
+        canvasPosition[0] + size / 2,
+        canvasPosition[1] + size / 2,
+        size / 2
+      );
+    }
+
     buttonObject.endFill();
     buttonObject.hitArea = new PIXI.Rectangle(
       canvasPosition[0],
@@ -163,6 +187,10 @@ export default class InstancesSelection {
     bottomResizeButtonPos[0] -= -smallButtonSize / 2;
     bottomResizeButtonPos[1] += buttonPadding;
 
+    const rotateButtonPos = this.toCanvasCoordinates(x1 + (x2 - x1) / 2, y1);
+    rotateButtonPos[0] -= -smallButtonSize / 2;
+    rotateButtonPos[1] -= buttonPadding * 3;
+
     this._renderButton(show, this.resizeButton, resizeButtonPos, buttonSize);
     this._renderButton(
       show,
@@ -175,6 +203,13 @@ export default class InstancesSelection {
       this.bottomResizeButton,
       bottomResizeButtonPos,
       smallButtonSize
+    );
+    this._renderButton(
+      show,
+      this.rotateButton,
+      rotateButtonPos,
+      smallButtonSize,
+      1
     );
   }
 }

--- a/newIDE/app/src/InstancesEditor/SelectedInstances.js
+++ b/newIDE/app/src/InstancesEditor/SelectedInstances.js
@@ -6,6 +6,9 @@ const buttonSize = 10;
 const smallButtonSize = 8;
 const buttonPadding = 5;
 
+const RECTANGLE_BUTTON_SHAPE = 0;
+const CIRCLE_BUTTON_SHAPE = 1;
+
 export default class InstancesSelection {
   constructor({
     instancesSelection,
@@ -90,7 +93,7 @@ export default class InstancesSelection {
     return this.pixiContainer;
   }
 
-  _renderButton(show, buttonObject, canvasPosition, size, shape = 0) {
+  _renderButton(show, buttonObject, canvasPosition, size, shape = RECTANGLE_BUTTON_SHAPE) {
     buttonObject.clear();
     if (!show) {
       buttonObject.hitArea = new PIXI.Rectangle(0, 0, 0, 0);
@@ -100,9 +103,9 @@ export default class InstancesSelection {
     buttonObject.beginFill(0xffffff);
     buttonObject.lineStyle(1, 0x6868e8, 1);
     buttonObject.fillAlpha = 0.9;
-    if (shape === 0) {
+    if (shape === RECTANGLE_BUTTON_SHAPE) {
       buttonObject.drawRect(canvasPosition[0], canvasPosition[1], size, size);
-    } else {
+    } else if (shape === CIRCLE_BUTTON_SHAPE) {
       buttonObject.drawCircle(
         canvasPosition[0] + size / 2,
         canvasPosition[1] + size / 2,
@@ -189,7 +192,7 @@ export default class InstancesSelection {
 
     const rotateButtonPos = this.toCanvasCoordinates(x1 + (x2 - x1) / 2, y1);
     rotateButtonPos[0] -= -smallButtonSize / 2;
-    rotateButtonPos[1] -= buttonPadding * 3;
+    rotateButtonPos[1] -= buttonPadding * 4;
 
     this._renderButton(show, this.resizeButton, resizeButtonPos, buttonSize);
     this._renderButton(

--- a/newIDE/app/src/InstancesEditor/SelectedInstances.js
+++ b/newIDE/app/src/InstancesEditor/SelectedInstances.js
@@ -212,7 +212,7 @@ export default class InstancesSelection {
       this.rotateButton,
       rotateButtonPos,
       smallButtonSize,
-      1
+      CIRCLE_BUTTON_SHAPE
     );
   }
 }

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -227,7 +227,6 @@ export default class InstancesEditorContainer extends Component {
       options: this.props.options,
     });
     this.instancesRotator = new InstancesRotator({
-      instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       options: this.props.options,
     });
     this.instancesMover = new InstancesMover({

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -287,7 +287,6 @@ export default class InstancesEditorContainer extends Component {
       this.grid.setOptions(nextProps.options);
       this.instancesMover.setOptions(nextProps.options);
       this.instancesResizer.setOptions(nextProps.options);
-      this.instancesRotator.setOptions(nextProps.options);
       this.windowMask.setOptions(nextProps.options);
       this.viewPosition.setOptions(nextProps.options);
     }

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -8,6 +8,7 @@ import SelectedInstances from './SelectedInstances';
 import HighlightedInstance from './HighlightedInstance';
 import SelectionRectangle from './SelectionRectangle';
 import InstancesResizer from './InstancesResizer';
+import InstancesRotator from './InstancesRotator';
 import InstancesMover from './InstancesMover';
 import Grid from './Grid';
 import WindowBorder from './WindowBorder';
@@ -212,6 +213,8 @@ export default class InstancesEditorContainer extends Component {
       instancesSelection: this.props.instancesSelection,
       onResize: this._onResize,
       onResizeEnd: this._onResizeEnd,
+      onRotate: this._onRotate,
+      onRotateEnd: this._onRotateEnd,
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       toCanvasCoordinates: this.viewPosition.toCanvasCoordinates,
     });
@@ -220,6 +223,10 @@ export default class InstancesEditorContainer extends Component {
       toCanvasCoordinates: this.viewPosition.toCanvasCoordinates,
     });
     this.instancesResizer = new InstancesResizer({
+      instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
+      options: this.props.options,
+    });
+    this.instancesRotator = new InstancesRotator({
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       options: this.props.options,
     });
@@ -283,6 +290,7 @@ export default class InstancesEditorContainer extends Component {
       this.grid.setOptions(nextProps.options);
       this.instancesMover.setOptions(nextProps.options);
       this.instancesResizer.setOptions(nextProps.options);
+      this.instancesRotator.setOptions(nextProps.options);
       this.windowMask.setOptions(nextProps.options);
       this.viewPosition.setOptions(nextProps.options);
     }
@@ -471,6 +479,26 @@ export default class InstancesEditorContainer extends Component {
 
     const selectedInstances = this.props.instancesSelection.getSelectedInstances();
     this.props.onInstancesResized(selectedInstances);
+  };
+
+  _onRotate = (deltaX, deltaY) => {
+    const sceneDeltaX = deltaX / this.getZoomFactor();
+    const sceneDeltaY = deltaY / this.getZoomFactor();
+
+    const selectedInstances = this.props.instancesSelection.getSelectedInstances();
+    this.instancesRotator.rotateBy(
+      selectedInstances,
+      sceneDeltaX,
+      sceneDeltaY,
+      this.keyboardShortcuts.shouldResizeProportionally()
+    );
+  };
+
+  _onRotateEnd = () => {
+    this.instancesRotator.endRotate();
+
+    const selectedInstances = this.props.instancesSelection.getSelectedInstances();
+    this.props.onInstancesRotated(selectedInstances);
   };
 
   _onDrop = (x, y, objectName) => {

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -226,9 +226,7 @@ export default class InstancesEditorContainer extends Component {
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       options: this.props.options,
     });
-    this.instancesRotator = new InstancesRotator({
-      options: this.props.options,
-    });
+    this.instancesRotator = new InstancesRotator();
     this.instancesMover = new InstancesMover({
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       options: this.props.options,

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -523,6 +523,15 @@ export default class SceneEditor extends React.Component<Props, State> {
     );
   };
 
+  _onInstancesRotated = (instances: Array<gdInitialInstance>) => {
+    this.setState(
+      {
+        history: saveToHistory(this.state.history, this.props.initialInstances),
+      },
+      () => this.forceUpdatePropertiesEditor()
+    );
+  };
+
   _onInstancesModified = (instances: Array<gdInitialInstance>) => {
     this.forceUpdate();
     //TODO: Save for redo with debounce (and cancel on unmount)
@@ -852,6 +861,7 @@ export default class SceneEditor extends React.Component<Props, State> {
           onInstancesSelected={this._onInstancesSelected}
           onInstancesMoved={this._onInstancesMoved}
           onInstancesResized={this._onInstancesResized}
+          onInstancesRotated={this._onInstancesRotated}
           onPointerUp={this._onPointerUpInstancesEditor}
           onPointerOver={this._onPointerOverInstancesEditor}
           onPointerOut={this._onPointerOutInstancesEditor}


### PR DESCRIPTION
For now it just rotates the instances without actually moving them.

Holding shift will snap rotation to 45 degree increments.
Demo:
![rotateinstances](https://user-images.githubusercontent.com/6495061/46584720-8ca28d80-ca5e-11e8-8401-238f95f75730.gif)
