### PR TITLE
New admob extension

### DIFF
--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -65,6 +65,7 @@ Project::Project()
       version("1.0.0"),
       packageName("com.example.gamename"),
       orientation("landscape"),
+      adMobAppId(""),
       folderProject(false),
 #endif
       windowWidth(800),
@@ -640,6 +641,7 @@ void Project::UnserializeFrom(const SerializerElement& element) {
   SetAuthor(propElement.GetChild("author", 0, "Auteur").GetValue().GetString());
   SetPackageName(propElement.GetStringAttribute("packageName"));
   SetOrientation(propElement.GetStringAttribute("orientation", "default"));
+  SetAdMobAppId(propElement.GetStringAttribute("adMobAppId", ""));
   SetFolderProject(propElement.GetBoolAttribute("folderProject"));
   SetProjectFile(propElement.GetStringAttribute("projectFile"));
   SetLastCompilationDirectory(propElement
@@ -916,6 +918,7 @@ void Project::SerializeTo(SerializerElement& element) const {
   propElement.SetAttribute("folderProject", folderProject);
   propElement.SetAttribute("packageName", packageName);
   propElement.SetAttribute("orientation", orientation);
+  propElement.SetAttribute("adMobAppId", adMobAppId);
   platformSpecificAssets.SerializeTo(
       propElement.AddChild("platformSpecificAssets"));
   loadingScreen.SerializeTo(propElement.AddChild("loadingScreen"));

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -1254,6 +1254,7 @@ void Project::Init(const gd::Project& game) {
   author = game.author;
   packageName = game.packageName;
   orientation = game.orientation;
+  adMobAppId = game.adMobAppId;
   folderProject = game.folderProject;
   latestCompilationDirectory = game.latestCompilationDirectory;
   platformSpecificAssets = game.platformSpecificAssets;

--- a/Core/GDCore/Project/Project.h
+++ b/Core/GDCore/Project/Project.h
@@ -117,6 +117,20 @@ class GD_CORE_API Project : public ObjectsContainer {
   const gd::String& GetOrientation() const { return orientation; }
 
   /**
+   * \brief Change the project AdMob application ID (needed
+   * to use the AdMob extension). This has no effect on desktop
+   * and web browsers.
+   */
+  void SetAdMobAppId(const gd::String& adMobAppId_) {
+    adMobAppId = adMobAppId_;
+  };
+
+   /**
+   * \brief Get the project AdMob application ID.
+   */
+  const gd::String& GetAdMobAppId() const { return adMobAppId; }
+
+  /**
    * Called when project file has changed.
    */
   void SetProjectFile(const gd::String& file) { gameFile = file; }
@@ -962,6 +976,7 @@ class GD_CORE_API Project : public ObjectsContainer {
   gd::String packageName;   ///< Game package name
   gd::String orientation;   ///< Lock game orientation (on mobile devices).
                             ///< "default", "landscape" or "portrait".
+  gd::String adMobAppId;   ///< AdMob application ID.
   bool
       folderProject;  ///< True if folder project, false if single file project.
   gd::String gameFile;                    ///< File of the game

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -17,7 +17,7 @@ module.exports = {
       "AdMob",
       t("AdMob"),
       t(
-        "Allow the game to display AdMob banner, intersticial and reward video ads"
+        "Allow the game to display AdMob banner, interstitial and reward video ads"
       ),
       "Franco Maciel",
       "MIT"

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -1,0 +1,143 @@
+/**
+ * This is a declaration of an extension for GDevelop 5.
+ *
+ * ℹ️ Run `node import-GDJS-Runtime.js` (in newIDE/app/scripts) if you make any change
+ * to this extension file or to any other *.js file that you reference inside.
+ *
+ * The file must be named "JsExtension.js", otherwise GDevelop won't load it.
+ * ⚠️ If you make a change and the extension is not loaded, open the developer console
+ * and search for any errors.
+ *
+ * More information on https://github.com/4ian/GDevelop/blob/master/newIDE/README-extensions.md
+ */
+module.exports = {
+  createExtension: function(t, gd) {
+    const extension = new gd.PlatformExtension();
+    extension.setExtensionInformation(
+      "AdMob",
+      t("AdMob"),
+      t(
+        "Allow the game to display AdMob banner, intersticial and reward video ads"
+      ),
+      "Franco Maciel",
+      "MIT"
+    );
+
+    extension
+      .addCondition(
+        "VideoLoading",
+        t("Video loading"),
+        t("Check if a reward video is currently loading."),
+        t("Reward video is loading"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isVideoLoading");
+
+    extension
+      .addCondition(
+        "VideoReady",
+        t("Video ready"),
+        t("Check if a reward video is ready to be displayed."),
+        t("Reward video is ready"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isVideoReady");
+
+    extension
+      .addCondition(
+        "VideoShowing",
+        t("Video showing"),
+        t("Check if there is a video being displayed."),
+        t("Reward video is showing"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isVideoShowing");
+
+    extension
+      .addCondition(
+        "VideoReward",
+        t("Video reward"),
+        t(
+          "Check if there is a video reward.\nYou can mark it as non-claimed yet, so you can check this reward in other events."
+        ),
+        t("Video reward given"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .addParameter("yesorno", t("Mark as claimed"), "", false)
+      .setDefaultValue("true")
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.existVideoReward");
+
+    extension
+      .addAction(
+        "LoadVideo",
+        t("Load video"),
+        t(
+          "Start loading a reward video, you can display it automatically when finish loading.\nIf test mode is set to true a test video will be displayed."
+        ),
+        t("Load reward video (show on load: _PARAM2_, test mode: _PARAM3_)"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .addParameter("string", t("Android reward video ID"), "", false)
+      .addParameter("string", t("iOS reward video ID"), "", false)
+      .addParameter("yesorno", t("Display on load complete?"), "", false)
+      .setDefaultValue("true")
+      .addParameter("yesorno", t("Test mode?"), "", false)
+      .setDefaultValue("true")
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.loadVideo");
+
+    extension
+      .addAction(
+        "ShowVideo",
+        t("Show video"),
+        t(
+          "Show the reward video, will work only when the video is fully loaded."
+        ),
+        t("Show reward video"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.showVideo");
+
+    extension
+      .addAction(
+        "ClaimReward",
+        t("Claim reward"),
+        t("Mark the video reward as claimed."),
+        t("Claim video reward"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.claimVideoReward");
+
+    return extension;
+  },
+  runExtensionSanityTests: function(gd, extension) {
+    return [];
+  }
+};

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -23,6 +23,224 @@ module.exports = {
       "MIT"
     );
 
+    // Banner
+    extension
+      .addCondition(
+        "BannerLoading",
+        t("Banner loading"),
+        t("Check if a banner is currently loading."),
+        t("Banner is loading"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isBannerLoading");
+
+    extension
+      .addCondition(
+        "BannerReady",
+        t("Banner ready"),
+        t("Check if a banner is ready to be displayed."),
+        t("Banner is ready"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isBannerReady");
+
+    extension
+      .addCondition(
+        "BannerShowing",
+        t("Banner showing"),
+        t("Check if there is a banner being displayed."),
+        t("Banner is showing"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isBannerShowing");
+
+    extension
+      .addCondition(
+        "BannerExists",
+        t("Banner exists"),
+        t("Check if there is a banner in memory (visible or hidden)."),
+        t("Banner exists"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.existBanner");
+
+    extension
+      .addAction(
+        "LoadBanner",
+        t("Load banner"),
+        t(
+          "Start loading a banner, you can display it automatically when finish loading.\nIf test mode is set to true a test banner will be displayed."
+        ),
+        t(
+          "Load banner (at top: _PARAM2_, overlap: _PARAM3_, show on load: _PARAM4_, test mode: _PARAM5_)"
+        ),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .addParameter("string", t("Android banner ID"), "", false)
+      .addParameter("string", t("iOS banner ID"), "", false)
+      .addParameter(
+        "yesorno",
+        t("Display at top? (bottom otherwise)"),
+        "",
+        false
+      )
+      .setDefaultValue("false")
+      .addParameter("yesorno", t("Overlap webview?"), "", false)
+      .setDefaultValue("true")
+      .addParameter("yesorno", t("Display on load complete?"), "", false)
+      .setDefaultValue("true")
+      .addParameter("yesorno", t("Test mode?"), "", false)
+      .setDefaultValue("true")
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.loadBanner");
+
+    extension
+      .addAction(
+        "ShowBanner",
+        t("Show banner"),
+        t("Show the banner, will work only when the banner is fully loaded."),
+        t("Show banner"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.showBanner");
+
+    extension
+      .addAction(
+        "HideBanner",
+        t("Hide banner"),
+        t(
+          "Hide the banner. You can show it again with the corresponding action."
+        ),
+        t("Hide banner"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.hideBanner");
+
+    extension
+      .addAction(
+        "RemoveBanner",
+        t("Remove banner"),
+        t(
+          "Remove the banner. You have to load another banner to show it again."
+        ),
+        t("Remove banner"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.removeBanner");
+
+    // Interstitial
+    extension
+      .addCondition(
+        "InterstitialLoading",
+        t("Interstitial loading"),
+        t("Check if an interstitial is currently loading."),
+        t("Interstitial is loading"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isInterstitialLoading");
+
+    extension
+      .addCondition(
+        "InterstitialReady",
+        t("Interstitial ready"),
+        t("Check if an interstitial is ready to be displayed."),
+        t("Interstitial is ready"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isInterstitialReady");
+
+    extension
+      .addCondition(
+        "InterstitialShowing",
+        t("Interstitial showing"),
+        t("Check if there is an interstitial being displayed."),
+        t("Interstitial is showing"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.isInterstitialShowing");
+
+    extension
+      .addAction(
+        "LoadInterstitial",
+        t("Load interstitial"),
+        t(
+          "Start loading an interstitial, you can display it automatically when finish loading.\nIf test mode is set to true a test interstitial will be displayed."
+        ),
+        t("Load interstitial (show on load: _PARAM2_, test mode: _PARAM3_)"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .addParameter("string", t("Android interstitial ID"), "", false)
+      .addParameter("string", t("iOS interstitial ID"), "", false)
+      .addParameter("yesorno", t("Display on load complete?"), "", false)
+      .setDefaultValue("true")
+      .addParameter("yesorno", t("Test mode?"), "", false)
+      .setDefaultValue("true")
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.loadInterstitial");
+
+    extension
+      .addAction(
+        "ShowInterstitial",
+        t("Show interstitial"),
+        t(
+          "Show the interstitial, will work only when the interstitial is fully loaded."
+        ),
+        t("Show interstitial"),
+        t("AdMob"),
+        "JsPlatform/Extensions/admobicon24.png",
+        "JsPlatform/Extensions/admobicon16.png"
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile("Extensions/AdMob/admobtools.js")
+      .setFunctionName("gdjs.adMob.showInterstitial");
+
+    // Reward video
     extension
       .addCondition(
         "VideoLoading",
@@ -55,7 +273,7 @@ module.exports = {
       .addCondition(
         "VideoShowing",
         t("Video showing"),
-        t("Check if there is a video being displayed."),
+        t("Check if there is a reward video being displayed."),
         t("Reward video is showing"),
         t("AdMob"),
         "JsPlatform/Extensions/admobicon24.png",

--- a/Extensions/AdMob/admobtools.js
+++ b/Extensions/AdMob/admobtools.js
@@ -5,12 +5,170 @@
  * @private
  */
 gdjs.adMob = {
+  // Banner
+  bannerLoading: false,
+  bannerReady: false,
+  bannerShowing: false,
+  bannerExists: false,
+  bannerAutoshow: false, // Needed because the banner event listeners bug
+  // Interstitial
+  interstitialLoading: false,
+  interstitialReady: false,
+  interstitialShowing: false,
+  // Reward video
   videoLoading: false,
   videoReady: false,
   videoShowing: false,
   videoReward: false
 };
 
+gdjs.adMob._getPlatformName = function() {
+  if (/(android)/i.test(navigator.userAgent)) {
+    return "android";
+  } else if (/(ipod|iphone|ipad)/i.test(navigator.userAgent)) {
+    return "ios";
+  } else {
+    return "windowsPhone";
+  }
+};
+
+// Banner
+gdjs.adMob.isBannerLoading = function() {
+  return gdjs.adMob.bannerLoading;
+};
+
+gdjs.adMob.isBannerReady = function() {
+  // This block is needed because the banner event listeners bug
+  if (gdjs.adMob.bannerAutoshow && gdjs.adMob.bannerReady) {
+    gdjs.adMob.bannerReady = false;
+    gdjs.adMob.bannerShowing = true;
+    gdjs.adMob.bannerExists = true;
+  }
+
+  return gdjs.adMob.bannerReady;
+};
+
+gdjs.adMob.isBannerShowing = function() {
+  // This block is needed because the banner event listeners bug
+  if (gdjs.adMob.bannerAutoshow && gdjs.adMob.bannerReady) {
+    gdjs.adMob.bannerReady = false;
+    gdjs.adMob.bannerShowing = true;
+    gdjs.adMob.bannerExists = true;
+  }
+
+  return gdjs.adMob.bannerShowing;
+};
+
+gdjs.adMob.existBanner = function() {
+  // This block is needed because the banner event listeners bug
+  if (gdjs.adMob.bannerAutoshow && gdjs.adMob.bannerReady) {
+    gdjs.adMob.bannerReady = false;
+    gdjs.adMob.bannerShowing = true;
+    gdjs.adMob.bannerExists = true;
+  }
+
+  return gdjs.adMob.bannerExists;
+};
+
+gdjs.adMob.loadBanner = function(
+  androidID,
+  iosID,
+  atTop,
+  overlap,
+  displayOnLoading,
+  testMode
+) {
+  if (typeof admob === "undefined") return;
+
+  admob.banner.config({
+    id: gdjs.adMob._getPlatformName() === "android" ? androidID : iosID, // Support Android & iOS
+    bannerAtTop: atTop,
+    overlap: overlap,
+    autoShow: displayOnLoading,
+    isTesting: testMode
+  });
+  admob.banner.prepare();
+
+  gdjs.adMob.bannerLoading = true;
+  gdjs.adMob.bannerReady = false;
+
+  // These lines are needed because the banner event listeners bug
+  gdjs.adMob.bannerAutoshow = displayOnLoading;
+  gdjs.adMob.bannerShowing = false;
+  gdjs.adMob.bannerExists = false;
+};
+
+gdjs.adMob.showBanner = function() {
+  if (typeof admob === "undefined") return;
+
+  // This block is needed because the banner event listeners bug
+  if (gdjs.adMob.bannerReady) {
+    gdjs.adMob.bannerReady = false;
+    gdjs.adMob.bannerExists = true;
+  }
+
+  if (gdjs.adMob.bannerExists) gdjs.adMob.bannerShowing = true;
+
+  admob.banner.show();
+};
+
+gdjs.adMob.hideBanner = function() {
+  if (typeof admob === "undefined") return;
+
+  if (gdjs.adMob.bannerExists) gdjs.adMob.bannerShowing = false;
+
+  admob.banner.hide();
+};
+
+gdjs.adMob.removeBanner = function() {
+  if (typeof admob === "undefined") return;
+
+  // These lines are needed because the banner event listeners bug
+  gdjs.adMob.bannerExists = false;
+  gdjs.adMob.bannerShowing = false;
+
+  admob.banner.remove();
+};
+
+// Interstitial
+gdjs.adMob.isInterstitialLoading = function() {
+  return gdjs.adMob.interstitialLoading;
+};
+
+gdjs.adMob.isInterstitialReady = function() {
+  return gdjs.adMob.interstitialReady;
+};
+
+gdjs.adMob.isInterstitialShowing = function() {
+  return gdjs.adMob.interstitialShowing;
+};
+
+gdjs.adMob.loadInterstitial = function(
+  androidID,
+  iosID,
+  displayOnLoading,
+  testMode
+) {
+  if (typeof admob === "undefined") return;
+
+  admob.interstitial.config({
+    id: gdjs.adMob._getPlatformName() === "android" ? androidID : iosID, // Support Android & iOS
+    autoShow: displayOnLoading,
+    isTesting: testMode
+  });
+  admob.interstitial.prepare();
+
+  gdjs.adMob.interstitialLoading = true;
+  gdjs.adMob.interstitialReady = false;
+};
+
+gdjs.adMob.showInterstitial = function() {
+  if (typeof admob === "undefined") return;
+
+  admob.interstitial.show();
+};
+
+// Reward video
 gdjs.adMob.isVideoLoading = function() {
   return gdjs.adMob.videoLoading;
 };
@@ -26,17 +184,8 @@ gdjs.adMob.isVideoShowing = function() {
 gdjs.adMob.existVideoReward = function(markAsClaimed) {
   var reward = gdjs.adMob.videoReward;
   if (markAsClaimed) gdjs.adMob.videoReward = false;
-  return reward;
-};
 
-gdjs.adMob._getPlatformName = function() {
-  if (/(android)/i.test(navigator.userAgent)) {
-    return "android";
-  } else if (/(ipod|iphone|ipad)/i.test(navigator.userAgent)) {
-    return "ios";
-  } else {
-    return "windowsPhone";
-  }
+  return reward;
 };
 
 gdjs.adMob.loadVideo = function(androidID, iosID, displayOnLoading, testMode) {
@@ -51,54 +200,132 @@ gdjs.adMob.loadVideo = function(androidID, iosID, displayOnLoading, testMode) {
 
   gdjs.adMob.videoLoading = true;
   gdjs.adMob.videoReady = false;
-
-  document.addEventListener(
-    "admob.rewardvideo.events.LOAD",
-    function() {
-      gdjs.adMob.videoReady = true;
-      gdjs.adMob.videoLoading = false;
-    },
-    false
-  );
-  document.addEventListener(
-    "admob.rewardvideo.events.LOAD_FAIL",
-    function() {
-      gdjs.adMob.videoLoading = false;
-    },
-    false
-  );
-  document.addEventListener(
-    "admob.rewardvideo.events.OPEN",
-    function() {
-      gdjs.adMob.videoShowing = true;
-      gdjs.adMob.videoReady = false;
-    },
-    false
-  );
-  document.addEventListener(
-    "admob.rewardvideo.events.CLOSE",
-    function() {
-      gdjs.adMob.videoShowing = false;
-    },
-    false
-  );
-  document.addEventListener(
-    "admob.rewardvideo.events.REWARD",
-    function() {
-      gdjs.adMob.videoReward = true;
-    },
-    false
-  );
 };
 
 gdjs.adMob.showVideo = function() {
   if (typeof admob === "undefined") return;
 
-  if (gdjs.adMob.videoReady && !gdjs.adMob.videoShowing) {
-    admob.rewardvideo.show();
-  }
+  admob.rewardvideo.show();
 };
 
 gdjs.adMob.claimVideoReward = function() {
   gdjs.adMob.videoReward = false;
 };
+
+// Banner event listeners
+document.addEventListener(
+  "admob.banner.events.LOAD",
+  function() {
+    gdjs.adMob.bannerReady = true;
+    gdjs.adMob.bannerLoading = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.banner.events.LOAD_FAIL",
+  function() {
+    gdjs.adMob.bannerLoading = false;
+  },
+  false
+);
+
+// BUG: These two never get called
+/*
+document.addEventListener(
+  "admob.banner.events.OPEN",
+  function() {
+    gdjs.adMob.bannerExists = true;
+    gdjs.adMob.bannerShowing = true;
+    gdjs.adMob.bannerReady = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.banner.events.CLOSE",
+  function() {
+    gdjs.adMob.bannerExists = false;
+    gdjs.adMob.bannerShowing = false;
+  },
+  false
+);
+*/
+
+// Interstitial event listeners
+document.addEventListener(
+  "admob.interstitial.events.LOAD",
+  function() {
+    gdjs.adMob.interstitialReady = true;
+    gdjs.adMob.interstitialLoading = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.interstitial.events.LOAD_FAIL",
+  function() {
+    gdjs.adMob.interstitialLoading = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.interstitial.events.OPEN",
+  function() {
+    gdjs.adMob.interstitialShowing = true;
+    gdjs.adMob.interstitialReady = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.interstitial.events.CLOSE",
+  function() {
+    gdjs.adMob.interstitialShowing = false;
+  },
+  false
+);
+
+// Reward video event listeners
+document.addEventListener(
+  "admob.rewardvideo.events.LOAD",
+  function() {
+    gdjs.adMob.videoReady = true;
+    gdjs.adMob.videoLoading = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.rewardvideo.events.LOAD_FAIL",
+  function() {
+    gdjs.adMob.videoLoading = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.rewardvideo.events.OPEN",
+  function() {
+    gdjs.adMob.videoShowing = true;
+    gdjs.adMob.videoReady = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.rewardvideo.events.CLOSE",
+  function() {
+    gdjs.adMob.videoShowing = false;
+  },
+  false
+);
+
+document.addEventListener(
+  "admob.rewardvideo.events.REWARD",
+  function() {
+    gdjs.adMob.videoReward = true;
+  },
+  false
+);

--- a/Extensions/AdMob/admobtools.js
+++ b/Extensions/AdMob/admobtools.js
@@ -1,0 +1,104 @@
+/**
+ * @memberof gdjs
+ * @class adMob
+ * @static
+ * @private
+ */
+gdjs.adMob = {
+  videoLoading: false,
+  videoReady: false,
+  videoShowing: false,
+  videoReward: false
+};
+
+gdjs.adMob.isVideoLoading = function() {
+  return gdjs.adMob.videoLoading;
+};
+
+gdjs.adMob.isVideoReady = function() {
+  return gdjs.adMob.videoReady;
+};
+
+gdjs.adMob.isVideoShowing = function() {
+  return gdjs.adMob.videoShowing;
+};
+
+gdjs.adMob.existVideoReward = function(markAsClaimed) {
+  var reward = gdjs.adMob.videoReward;
+  if (markAsClaimed) gdjs.adMob.videoReward = false;
+  return reward;
+};
+
+gdjs.adMob._getPlatformName = function() {
+  if (/(android)/i.test(navigator.userAgent)) {
+    return "android";
+  } else if (/(ipod|iphone|ipad)/i.test(navigator.userAgent)) {
+    return "ios";
+  } else {
+    return "windowsPhone";
+  }
+};
+
+gdjs.adMob.loadVideo = function(androidID, iosID, displayOnLoading, testMode) {
+  if (typeof admob === "undefined") return;
+
+  admob.rewardvideo.config({
+    id: gdjs.adMob._getPlatformName() === "android" ? androidID : iosID, // Support Android & iOS
+    autoShow: displayOnLoading,
+    isTesting: testMode
+  });
+  admob.rewardvideo.prepare();
+
+  gdjs.adMob.videoLoading = true;
+  gdjs.adMob.videoReady = false;
+
+  document.addEventListener(
+    "admob.rewardvideo.events.LOAD",
+    function() {
+      gdjs.adMob.videoReady = true;
+      gdjs.adMob.videoLoading = false;
+    },
+    false
+  );
+  document.addEventListener(
+    "admob.rewardvideo.events.LOAD_FAIL",
+    function() {
+      gdjs.adMob.videoLoading = false;
+    },
+    false
+  );
+  document.addEventListener(
+    "admob.rewardvideo.events.OPEN",
+    function() {
+      gdjs.adMob.videoShowing = true;
+      gdjs.adMob.videoReady = false;
+    },
+    false
+  );
+  document.addEventListener(
+    "admob.rewardvideo.events.CLOSE",
+    function() {
+      gdjs.adMob.videoShowing = false;
+    },
+    false
+  );
+  document.addEventListener(
+    "admob.rewardvideo.events.REWARD",
+    function() {
+      gdjs.adMob.videoReward = true;
+    },
+    false
+  );
+};
+
+gdjs.adMob.showVideo = function() {
+  if (typeof admob === "undefined") return;
+
+  if (gdjs.adMob.videoReady && !gdjs.adMob.videoShowing) {
+    admob.rewardvideo.show();
+  }
+};
+
+gdjs.adMob.claimVideoReward = function() {
+  gdjs.adMob.videoReward = false;
+};

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -229,6 +229,14 @@ bool ExporterHelper::ExportCordovaConfigFile(const gd::Project &project,
           .FindAndReplace("GDJS_ICON_IOS_100",
                           getIconFilename("ios", "icon-100"));
 
+  if(!project.GetAdMobAppId().empty()){
+    str = str.FindAndReplace("<!-- GDJS_ADMOB_APPLICATION_ID -->",
+            "<plugin name=\"cordova-admob-plus\" spec=\"~0.0.0\">"
+            "<variable name=\"ADMOB_APPLICATION_ID\" value=\"" + project.GetAdMobAppId() + "\" />"
+            "<variable name=\"PLAY_SERVICES_VERSION\" value=\"+\" />"
+            "</plugin>");
+  }
+
   if (!fs.WriteToFile(exportDir + "/config.xml", str)) {
     lastError = "Unable to write configuration file.";
     return false;

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -230,11 +230,10 @@ bool ExporterHelper::ExportCordovaConfigFile(const gd::Project &project,
                           getIconFilename("ios", "icon-100"));
 
   if(!project.GetAdMobAppId().empty()){
-    str = str.FindAndReplace("<!-- GDJS_ADMOB_APPLICATION_ID -->",
-            "<plugin name=\"cordova-admob-plus\" spec=\"~0.0.0\">"
-            "<variable name=\"ADMOB_APPLICATION_ID\" value=\"" + project.GetAdMobAppId() + "\" />"
-            "<variable name=\"PLAY_SERVICES_VERSION\" value=\"+\" />"
-            "</plugin>");
+    str = str.FindAndReplace("<!-- GDJS_ADMOB_PLUGIN_AND_APPLICATION_ID -->",
+            "<plugin name=\"cordova-plugin-admob-free\" spec=\"~0.21.0\">\n"
+            "\t\t<variable name=\"ADMOB_APP_ID\" value=\"" + project.GetAdMobAppId() + "\" />\n"
+            "\t</plugin>");
   }
 
   if (!fs.WriteToFile(exportDir + "/config.xml", str)) {

--- a/GDJS/Runtime/Cordova/config.xml
+++ b/GDJS/Runtime/Cordova/config.xml
@@ -55,5 +55,5 @@
     </platform>
     <preference name="orientation" value="GDJS_ORIENTATION" />
     <preference name="BackgroundColor" value="0xff000000"/>
-    <!-- GDJS_ADMOB_APPLICATION_ID -->
+    <!-- GDJS_ADMOB_PLUGIN_AND_APPLICATION_ID -->
 </widget>

--- a/GDJS/Runtime/Cordova/config.xml
+++ b/GDJS/Runtime/Cordova/config.xml
@@ -55,4 +55,5 @@
     </platform>
     <preference name="orientation" value="GDJS_ORIENTATION" />
     <preference name="BackgroundColor" value="0xff000000"/>
+    <!-- GDJS_ADMOB_APPLICATION_ID -->
 </widget>

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -26,6 +26,7 @@ type State = {|
   version: string,
   packageName: string,
   orientation: string,
+  adMobAppId: string,
   sizeOnStartupMode: string,
   showGDevelopSplash: boolean,
 |};
@@ -50,6 +51,7 @@ class ProjectPropertiesDialog extends React.Component<
       version: project.getVersion(),
       packageName: project.getPackageName(),
       orientation: project.getOrientation(),
+      adMobAppId: project.getAdMobAppId(),
       sizeOnStartupMode: project.getSizeOnStartupMode(),
       showGDevelopSplash: project.getLoadingScreen().isGDevelopSplashShown(),
     };
@@ -74,6 +76,7 @@ class ProjectPropertiesDialog extends React.Component<
       version,
       packageName,
       orientation,
+      adMobAppId,
       sizeOnStartupMode,
       showGDevelopSplash,
     } = this.state;
@@ -84,6 +87,7 @@ class ProjectPropertiesDialog extends React.Component<
     project.setVersion(version);
     project.setPackageName(packageName);
     project.setOrientation(orientation);
+    project.setAdMobAppId(adMobAppId);
     project.setSizeOnStartupMode(sizeOnStartupMode);
     project.getLoadingScreen().showGDevelopSplash(showGDevelopSplash);
 
@@ -114,6 +118,7 @@ class ProjectPropertiesDialog extends React.Component<
       version,
       packageName,
       orientation,
+      adMobAppId,
       sizeOnStartupMode,
       showGDevelopSplash,
     } = this.state;
@@ -204,6 +209,14 @@ class ProjectPropertiesDialog extends React.Component<
               primaryText="Change height to fit the screen"
             />
           </SelectField>
+          <SemiControlledTextField
+            floatingLabelText="AdMob application ID (for iOS and Android)"
+            fullWidth
+            hintText="ca-app-pub-XXXXXXXXXXXXXXXX/YYYYYYYYYY"
+            type="text"
+            value={adMobAppId}
+            onChange={value => this.setState({ adMobAppId: value })}
+          />
           <Checkbox
             label="Display GDevelop splash at startup (in exported game)"
             checked={showGDevelopSplash}


### PR DESCRIPTION
Work in progress, now it cordova should install the admob plugin automatically when adding a platform (android, ios).

@4ian As you can see, the admob application ID (now needed obligatorily) is a project property, because it has to be unique per project and we have to access it when exporting.
The exporter adds the plugin configuration, the version is hardcoded because it's required and this version works so far (plugins world changes fast so maybe it will need an update in the future) . With this extra configuration cordova downloads the plugin automatically when a platform is added.
Let me know what do you think, because I know it's not excellent, but the obligatory application ID changes the game.

Now I'll write it as a pure JS extensions, as suggested. And I was thinking about not using an "AdMob" object at all, but just conditions and actions, everything with ads seems to be singletons or something like that, there's just one admob.rewardvideo element for example.