### PR TITLE
new commands -locate/open/copy path of resource file - resource manager

### DIFF
--- a/newIDE/app/src/ResourcesList/LocalJfxrBridge.js
+++ b/newIDE/app/src/ResourcesList/LocalJfxrBridge.js
@@ -1,6 +1,6 @@
 import optionalRequire from '../Utils/OptionalRequire.js';
 import { type ExternalEditorOpenOptions } from './ResourceExternalEditor.flow';
-import { createOrUpdateResource } from './ResourceUtils.js';
+import { createOrUpdateResource, getLocalResourceFullPath } from './ResourceUtils.js';
 
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
@@ -19,14 +19,8 @@ export const openJfxr = ({
   extraOptions,
 }: ExternalEditorOpenOptions) => {
   if (!electron || !ipcRenderer) return;
-  const projectPath = path.dirname(project.getProjectFile());
-
-  let initialResourcePath = '';
-  initialResourcePath = resourcesLoader.getFullUrl(project, resourceNames[0]);
-  initialResourcePath = initialResourcePath.substring(
-    7,
-    initialResourcePath.lastIndexOf('?cache=')
-  );
+  const projectPath = path.dirname(project.getProjectFile(project, resourceNames[0]));
+  const initialResourcePath = getLocalResourceFullPath();
 
   const externalEditorData = {
     resourcePath: initialResourcePath,

--- a/newIDE/app/src/ResourcesList/LocalPiskelBridge.js
+++ b/newIDE/app/src/ResourcesList/LocalPiskelBridge.js
@@ -1,7 +1,7 @@
 // @flow
 import optionalRequire from '../Utils/OptionalRequire.js';
 import { type ExternalEditorOpenOptions } from './ResourceExternalEditor.flow';
-import { createOrUpdateResource } from './ResourceUtils.js';
+import { createOrUpdateResource, getLocalResourceFullPath } from './ResourceUtils.js';
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
@@ -22,17 +22,8 @@ export const openPiskel = ({
 }: ExternalEditorOpenOptions) => {
   if (!electron || !ipcRenderer) return;
 
-  const resources = resourceNames.map((resourceName, originalIndex) => {
-    let resourcePath = resourcesLoader.getResourceFullUrl(
-      project,
-      resourceName
-    );
-
-    //TODO: check if this is necessary or if resourcesLoader should be updated.
-    resourcePath = resourcePath.substring(
-      7,
-      resourcePath.lastIndexOf('?cache=')
-    );
+  const resources = resourceNames.map((resourceName, originalIndex) => { 
+    let resourcePath = getLocalResourceFullPath(project, resourceName);
     return {
       resourcePath,
       resourceName,

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -1,3 +1,5 @@
+import ResourcesLoader from '../ResourcesLoader';
+
 export const createOrUpdateResource = (project, gdResource, resourceName) => {
   const resourcesManager = project.getResourcesManager();
   if (resourcesManager.hasResource(resourceName)) {
@@ -7,4 +9,10 @@ export const createOrUpdateResource = (project, gdResource, resourceName) => {
   gdResource.setName(resourceName);
   resourcesManager.addResource(gdResource);
   gdResource.delete();
+};
+
+export const getLocalResourceFullPath = (project, resourceName) => {
+  let resourcePath = ResourcesLoader.getResourceFullUrl(project, resourceName);
+  resourcePath = resourcePath.substring(7, resourcePath.lastIndexOf('?cache='));
+  return resourcePath;
 };

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -12,7 +12,8 @@ import { type ResourceKind } from './ResourceSource.flow';
 
 const path = optionalRequire('path');
 const glob = optionalRequire('glob');
-const { shell, clipboard } = optionalRequire('electron')
+const electron = optionalRequire('electron');
+const hasElectron = electron ? true : false;
 
 const IMAGE_EXTENSIONS = 'png,jpg,jpeg,PNG,JPG,JPEG';
 const AUDIO_EXTENSIONS = 'wav,mp3,ogg,WAV,MP3,OGG';
@@ -88,17 +89,17 @@ export default class ResourcesList extends React.Component<Props, State> {
 
   _locateResourceFile = (resource: gdResource) => {
     const resourceFolderPath = path.dirname(getLocalResourceFullPath(this.props.project, resource.getFile()));
-    shell.openItem(resourceFolderPath);
+    electron.shell.openItem(resourceFolderPath);
   };
 
   _openResourceFile = (resource: gdResource) => {
     const resourceFilePath = getLocalResourceFullPath(this.props.project, resource.getFile());
-    shell.openItem(resourceFilePath);
+    electron.shell.openItem(resourceFilePath);
   };
 
   _copyResourceFilePath = (resource: gdResource) => {
     const resourceFilePath = getLocalResourceFullPath(this.props.project, resource.getFile());
-    clipboard.writeText(resourceFilePath);
+    electron.clipboard.writeText(resourceFilePath);
   };
   
   _scanForNewResources = (extensions: string, createResource: () => gdResource) => {
@@ -192,14 +193,17 @@ export default class ResourcesList extends React.Component<Props, State> {
       {
         label: 'Open File',
         click: () => this._openResourceFile(resource),
+        enabled: hasElectron,
       },
       {
         label: 'Locate File',
         click: () => this._locateResourceFile(resource),
+        enabled: hasElectron,
       },
       {
         label: 'Copy File Path',
         click: () => this._copyResourceFilePath(resource),
+        enabled: hasElectron,
       },
       { type: 'separator' },
       {
@@ -207,18 +211,21 @@ export default class ResourcesList extends React.Component<Props, State> {
         click: () => {
           this._scanForNewResources(IMAGE_EXTENSIONS, () => new gd.ImageResource());
         },
+        enabled: hasElectron,
       },
       {
         label: 'Scan for Audio',
         click: () => {
           this._scanForNewResources(AUDIO_EXTENSIONS, () => new gd.AudioResource());
         },
+        enabled: hasElectron,
       },
       {
         label: 'Scan for Fonts',
         click: () => {
           this._scanForNewResources(FONT_EXTENSIONS, () => new gd.FontResource());
         },
+        enabled: hasElectron,
       },
       { type: 'separator' },
       {

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -7,11 +7,12 @@ import SearchBar from 'material-ui-search-bar';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import { filterResourcesList } from './EnumerateResources';
 import optionalRequire from '../Utils/OptionalRequire.js';
-import { createOrUpdateResource } from './ResourceUtils.js';
+import { createOrUpdateResource, getLocalResourceFullPath } from './ResourceUtils.js';
 import { type ResourceKind } from './ResourceSource.flow';
 
 const path = optionalRequire('path');
 const glob = optionalRequire('glob');
+const { shell, clipboard } = optionalRequire('electron')
 
 const IMAGE_EXTENSIONS = 'png,jpg,jpeg,PNG,JPG,JPEG';
 const AUDIO_EXTENSIONS = 'wav,mp3,ogg,WAV,MP3,OGG';
@@ -85,6 +86,21 @@ export default class ResourcesList extends React.Component<Props, State> {
     this.props.onDeleteResource(resource);
   };
 
+  _locateResourceFile = (resource: gdResource) => {
+    const resourceFolderPath = path.dirname(getLocalResourceFullPath(this.props.project, resource.getFile()));
+    shell.openItem(resourceFolderPath);
+  };
+
+  _openResourceFile = (resource: gdResource) => {
+    const resourceFilePath = getLocalResourceFullPath(this.props.project, resource.getFile());
+    shell.openItem(resourceFilePath);
+  };
+
+  _copyResourceFilePath = (resource: gdResource) => {
+    const resourceFilePath = getLocalResourceFullPath(this.props.project, resource.getFile());
+    clipboard.writeText(resourceFilePath);
+  };
+  
   _scanForNewResources = (extensions: string, createResource: () => gdResource) => {
     const project = this.props.project;
     const resourcesManager = project.getResourcesManager();
@@ -171,6 +187,19 @@ export default class ResourcesList extends React.Component<Props, State> {
       {
         label: 'Remove',
         click: () => this._deleteResource(resource),
+      },
+      { type: 'separator' },
+      {
+        label: 'Open File',
+        click: () => this._openResourceFile(resource),
+      },
+      {
+        label: 'Locate File',
+        click: () => this._locateResourceFile(resource),
+      },
+      {
+        label: 'Copy File Path',
+        click: () => this._copyResourceFilePath(resource),
       },
       { type: 'separator' },
       {


### PR DESCRIPTION
This pull adds three new menu commands, which I believe will be useful to have in the resource manager:
- locate resource file - opens the folder where the resource is
- open resource file - opens the resource file with the default OS app
- copy path of resource file - copies the full path of where the resource is stored in the local file system

The pull also makes a little bit more of the code reusable - getting the path of the resource without a cache for example is now a utility function