### PR TITLE
Don't update frame when time between frames is 0

### DIFF
--- a/GDJS/Runtime/spriteruntimeobject.js
+++ b/GDJS/Runtime/spriteruntimeobject.js
@@ -239,7 +239,7 @@ gdjs.SpriteRuntimeObject.prototype.update = function(runtimeScene) {
         var elapsedTime = this.getElapsedTime(runtimeScene) / 1000;
         this._frameElapsedTime += this._animationPaused ? 0 : elapsedTime * this._animationSpeedScale;
 
-        if ( this._frameElapsedTime > direction.timeBetweenFrames ) {
+        if ( this._frameElapsedTime > direction.timeBetweenFrames && direction.timeBetweenFrames > 0 ) {
             var count = Math.floor(this._frameElapsedTime / direction.timeBetweenFrames);
             this._currentFrame += count;
             this._frameElapsedTime = this._frameElapsedTime-count*direction.timeBetweenFrames;


### PR DESCRIPTION
If the time between frames is set to 0 and the animation is set to loop the hitboxes never gets updated, there is a division by zero and hence other cool things around.
Zero or negative time between frames has no sense, maybe the IDE should prohibit them.