### PR TITLE
Add changeTimeBetweenFrames to animationPreview module - issue #809

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { Line, Column } from '../../../../UI/Grid';
 import ImagePreview from '../../../../ResourcesList/ResourcePreview/ImagePreview';
 import Replay from 'material-ui/svg-icons/av/replay';
 import PlayArrow from 'material-ui/svg-icons/av/play-arrow';
@@ -24,18 +25,13 @@ type State = {
 };
 
 const styles = {
-  container: {
-    paddingLeft: 12,
-    paddingRight: 12,
-    display: 'flex',
-    alignItems: 'center',
-  },
   timeField: {
     width: 75,
   },
   timeIcon: {
     paddingLeft: 6,
-    paddingRight: 6,
+    paddingRight: 8,
+    paddingTop: 6,
   },
 };
 
@@ -122,26 +118,38 @@ export default class AnimationPreview extends Component<Props, State> {
           resourcesLoader={resourcesLoader}
           project={project}
         />
-        <div style={styles.container}>
-          <Timer style={styles.timeIcon} />
-          <TextField
-            label="Time between frames"
-            value={timeBetweenFrames}
-            onChange={(e, text) => {onChangeTimeBetweenFrames(text); this.replay()}}
-            id="direction-time-between-frames"
-            style={styles.timeField}
-          />
-          <FlatButton
-            icon={<Replay />}
-            label="Replay"
-            onClick={this.replay}
-          />
-          <FlatButton
-            icon={paused ? <PlayArrow /> : <Pause />}
-            label={paused ? 'Play' : 'Pause'}
-            onClick={paused ? this.play : this.pause}
-          />
-        </div>
+        <Line>
+          <Column>
+            <Line noMargin>
+              <Timer style={styles.timeIcon} />
+              <TextField
+                label="Time between frames"
+                value={timeBetweenFrames}
+                onChange={(e, text) => {onChangeTimeBetweenFrames(text); this.replay()}}
+                id="direction-time-between-frames"
+                type="number"
+                step={0.01}
+                precision={1}
+                min={0.00}
+                max={5}
+              />
+            </Line>
+          </Column>
+          <Column>
+            <Line noMargin>
+              <FlatButton
+              icon={<Replay />}
+              label="Replay"
+              onClick={this.replay}
+              />
+              <FlatButton
+                icon={paused ? <PlayArrow /> : <Pause />}
+                label={paused ? 'Play' : 'Pause'}
+                onClick={paused ? this.play : this.pause}
+              />
+            </Line>
+          </Column>
+        </Line>
       </div>
     );
   }

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -133,6 +133,7 @@ export default class AnimationPreview extends Component<Props, State> {
                 min={0.00}
                 max={5}
                 style={styles.timeField}
+                autoFocus={true}
               />
             </Line>
           </Column>

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -27,12 +27,10 @@ type State = {
 const styles = {
   timeField: {
     width: 75,
-    bottom: 6,
   },
   timeIcon: {
     paddingLeft: 6,
     paddingRight: 8,
-    paddingTop: 6,
   },
 };
 
@@ -119,7 +117,7 @@ export default class AnimationPreview extends Component<Props, State> {
           resourcesLoader={resourcesLoader}
           project={project}
         />
-        <Line noMargin>
+        <Line noMargin alignItems="center">
           <Timer style={styles.timeIcon} />
           <TextField
             value={timeBetweenFrames}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
-import { Line, Column } from '../../../../UI/Grid';
+import { Line } from '../../../../UI/Grid';
 import ImagePreview from '../../../../ResourcesList/ResourcePreview/ImagePreview';
 import Replay from 'material-ui/svg-icons/av/replay';
 import PlayArrow from 'material-ui/svg-icons/av/play-arrow';
@@ -27,6 +27,7 @@ type State = {
 const styles = {
   timeField: {
     width: 75,
+    bottom: 6,
   },
   timeIcon: {
     paddingLeft: 6,

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -13,6 +13,8 @@ type Props = {
   spritesContainer: Object,
   resourcesLoader: Object,
   project: Object,
+  timeBetweenFrames: number,
+  onChangeTimeBetweenFrames: number => void,
 };
 
 type State = {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -128,7 +128,7 @@ export default class AnimationPreview extends Component<Props, State> {
             type="number"
             step={0.01}
             precision={1}
-            min={0.00}
+            min={0.01}
             max={5}
             style={styles.timeField}
             autoFocus={true}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -10,19 +10,19 @@ import Timer from 'material-ui/svg-icons/image/timer';
 import TextField from 'material-ui/TextField';
 import { FlatButton } from 'material-ui';
 
-type Props = {
+type Props = {|
   spritesContainer: Object,
   resourcesLoader: Object,
   project: Object,
   timeBetweenFrames: number,
   onChangeTimeBetweenFrames: number => void,
-};
+|};
 
-type State = {
+type State = {|
   currentFrameIndex: number,
   currentFrameElapsedTime: number,
   paused: boolean,
-};
+|};
 
 const styles = {
   timeField: {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -1,11 +1,12 @@
 // @flow
 
 import React, { Component } from 'react';
-import { Line, Column } from '../../../../UI/Grid';
 import ImagePreview from '../../../../ResourcesList/ResourcePreview/ImagePreview';
 import Replay from 'material-ui/svg-icons/av/replay';
 import PlayArrow from 'material-ui/svg-icons/av/play-arrow';
 import Pause from 'material-ui/svg-icons/av/pause';
+import Timer from 'material-ui/svg-icons/image/timer';
+import TextField from 'material-ui/TextField';
 import { FlatButton } from 'material-ui';
 
 type Props = {
@@ -18,6 +19,22 @@ type State = {
   currentFrameIndex: number,
   currentFrameElapsedTime: number,
   paused: boolean,
+};
+
+const styles = {
+  container: {
+    paddingLeft: 12,
+    paddingRight: 12,
+    display: 'flex',
+    alignItems: 'center',
+  },
+  timeField: {
+    width: 75,
+  },
+  timeIcon: {
+    paddingLeft: 6,
+    paddingRight: 6,
+  },
 };
 
 export default class AnimationPreview extends Component<Props, State> {
@@ -57,9 +74,8 @@ export default class AnimationPreview extends Component<Props, State> {
   _updateAnimation = () => {
     const animationSpeedScale = 1;
 
-    const { spritesContainer } = this.props;
+    const { spritesContainer, timeBetweenFrames } = this.props;
     const { currentFrameIndex, currentFrameElapsedTime, paused } = this.state;
-    const timeBetweenFrames = spritesContainer.getTimeBetweenFrames();
 
     const elapsedTime = 1 / 60;
     let newFrameIndex = currentFrameIndex;
@@ -88,7 +104,7 @@ export default class AnimationPreview extends Component<Props, State> {
   };
 
   render() {
-    const { spritesContainer, resourcesLoader, project } = this.props;
+    const { spritesContainer, resourcesLoader, project, timeBetweenFrames, onChangeTimeBetweenFrames } = this.props;
     const { currentFrameIndex, paused } = this.state;
 
     const hasValidSprite =
@@ -104,20 +120,26 @@ export default class AnimationPreview extends Component<Props, State> {
           resourcesLoader={resourcesLoader}
           project={project}
         />
-        <Line>
-          <Column expand>
-            <FlatButton
-              icon={<Replay />}
-              label="Replay"
-              onClick={this.replay}
-            />
-            <FlatButton
-              icon={paused ? <PlayArrow /> : <Pause />}
-              label={paused ? 'Play' : 'Pause'}
-              onClick={paused ? this.play : this.pause}
-            />
-          </Column>
-        </Line>
+        <div style={styles.container}>
+          <Timer style={styles.timeIcon} />
+          <TextField
+            label="Time between frames"
+            value={timeBetweenFrames}
+            onChange={(e, text) => {onChangeTimeBetweenFrames(text); this.replay()}}
+            id="direction-time-between-frames"
+            style={styles.timeField}
+          />
+          <FlatButton
+            icon={<Replay />}
+            label="Replay"
+            onClick={this.replay}
+          />
+          <FlatButton
+            icon={paused ? <PlayArrow /> : <Pause />}
+            label={paused ? 'Play' : 'Pause'}
+            onClick={paused ? this.play : this.pause}
+          />
+        </div>
       </div>
     );
   }

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -101,7 +101,13 @@ export default class AnimationPreview extends Component<Props, State> {
   };
 
   render() {
-    const { spritesContainer, resourcesLoader, project, timeBetweenFrames, onChangeTimeBetweenFrames } = this.props;
+    const {
+      spritesContainer,
+      resourcesLoader,
+      project,
+      timeBetweenFrames,
+      onChangeTimeBetweenFrames,
+    } = this.props;
     const { currentFrameIndex, paused } = this.state;
 
     const hasValidSprite =
@@ -121,7 +127,10 @@ export default class AnimationPreview extends Component<Props, State> {
           <Timer style={styles.timeIcon} />
           <TextField
             value={timeBetweenFrames}
-            onChange={(e, text) => {onChangeTimeBetweenFrames(text); this.replay()}}
+            onChange={(e, text) => {
+              onChangeTimeBetweenFrames(text);
+              this.replay();
+            }}
             id="direction-time-between-frames"
             type="number"
             step={0.01}
@@ -131,11 +140,7 @@ export default class AnimationPreview extends Component<Props, State> {
             style={styles.timeField}
             autoFocus={true}
           />
-          <FlatButton
-          icon={<Replay />}
-          label="Replay"
-          onClick={this.replay}
-          />
+          <FlatButton icon={<Replay />} label="Replay" onClick={this.replay} />
           <FlatButton
             icon={paused ? <PlayArrow /> : <Pause />}
             label={paused ? 'Play' : 'Pause'}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -118,39 +118,30 @@ export default class AnimationPreview extends Component<Props, State> {
           resourcesLoader={resourcesLoader}
           project={project}
         />
-        <Line>
-          <Column>
-            <Line noMargin>
-              <Timer style={styles.timeIcon} />
-              <TextField
-                label="Time between frames"
-                value={timeBetweenFrames}
-                onChange={(e, text) => {onChangeTimeBetweenFrames(text); this.replay()}}
-                id="direction-time-between-frames"
-                type="number"
-                step={0.01}
-                precision={1}
-                min={0.00}
-                max={5}
-                style={styles.timeField}
-                autoFocus={true}
-              />
-            </Line>
-          </Column>
-          <Column>
-            <Line noMargin>
-              <FlatButton
-              icon={<Replay />}
-              label="Replay"
-              onClick={this.replay}
-              />
-              <FlatButton
-                icon={paused ? <PlayArrow /> : <Pause />}
-                label={paused ? 'Play' : 'Pause'}
-                onClick={paused ? this.play : this.pause}
-              />
-            </Line>
-          </Column>
+        <Line noMargin>
+          <Timer style={styles.timeIcon} />
+          <TextField
+            value={timeBetweenFrames}
+            onChange={(e, text) => {onChangeTimeBetweenFrames(text); this.replay()}}
+            id="direction-time-between-frames"
+            type="number"
+            step={0.01}
+            precision={1}
+            min={0.00}
+            max={5}
+            style={styles.timeField}
+            autoFocus={true}
+          />
+          <FlatButton
+          icon={<Replay />}
+          label="Replay"
+          onClick={this.replay}
+          />
+          <FlatButton
+            icon={paused ? <PlayArrow /> : <Pause />}
+            label={paused ? 'Play' : 'Pause'}
+            onClick={paused ? this.play : this.pause}
+          />
         </Line>
       </div>
     );

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -132,6 +132,7 @@ export default class AnimationPreview extends Component<Props, State> {
                 precision={1}
                 min={0.00}
                 max={5}
+                style={styles.timeField}
               />
             </Line>
           </Column>

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -96,8 +96,8 @@ export default class DirectionTools extends Component<Props, State> {
       previewOpen: open,
     });
     if (!open) {
-      this.saveTimeBetweenFrames()
-    };
+      this.saveTimeBetweenFrames();
+    }
   };
 
   render() {
@@ -167,7 +167,8 @@ export default class DirectionTools extends Component<Props, State> {
               resourcesLoader={resourcesLoader}
               project={project}
               timeBetweenFrames={this.state.timeBetweenFrames}
-              onChangeTimeBetweenFrames={text => this.setState({ timeBetweenFrames: text })}
+              onChangeTimeBetweenFrames={text =>
+                this.setState({ timeBetweenFrames: text })}
             />
           </Dialog>
         )}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -95,6 +95,9 @@ export default class DirectionTools extends Component<Props, State> {
     this.setState({
       previewOpen: open,
     });
+    if (!open) {
+      this.saveTimeBetweenFrames()
+    };
   };
 
   render() {
@@ -163,7 +166,6 @@ export default class DirectionTools extends Component<Props, State> {
               spritesContainer={direction}
               resourcesLoader={resourcesLoader}
               project={project}
-              onBlur={() => this.saveTimeBetweenFrames()}
               timeBetweenFrames={this.state.timeBetweenFrames}
               onChangeTimeBetweenFrames={text => this.setState({ timeBetweenFrames: text })}
             />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -130,7 +130,7 @@ export default class DirectionTools extends Component<Props, State> {
           type="number"
           step={0.01}
           precision={1}
-          min={0.00}
+          min={0.01}
           max={5}
         />
         <span style={styles.spacer} />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -127,6 +127,11 @@ export default class DirectionTools extends Component<Props, State> {
           onBlur={() => this.saveTimeBetweenFrames()}
           id="direction-time-between-frames"
           style={styles.timeField}
+          type="number"
+          step={0.01}
+          precision={1}
+          min={0.00}
+          max={5}
         />
         <span style={styles.spacer} />
         <div style={styles.repeatContainer}>

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -143,7 +143,7 @@ export default class DirectionTools extends Component<Props, State> {
           <Dialog
             actions={
               <FlatButton
-                label="Close"
+                label="OK"
                 primary
                 onClick={() => this.openPreview(false)}
               />
@@ -158,6 +158,9 @@ export default class DirectionTools extends Component<Props, State> {
               spritesContainer={direction}
               resourcesLoader={resourcesLoader}
               project={project}
+              onBlur={() => this.saveTimeBetweenFrames()}
+              timeBetweenFrames={this.state.timeBetweenFrames}
+              onChangeTimeBetweenFrames={text => this.setState({ timeBetweenFrames: text })}
             />
           </Dialog>
         )}


### PR DESCRIPTION
This should partially address issue #809 

The pull adds the ability to set duration between frames directly in the animation previewer window and preview changes in real time before applying them:
![gd-setframerateinpreview](https://user-images.githubusercontent.com/6495061/50088625-6b4ae400-01fb-11e9-9553-7d18d3ec8d89.gif)

the current workflow to adjust animation speed is
1. change value
2. click to open preview
3. close preview to go back
4. select input again to adjust value
5. go back to step 2 to preview the change again

With my pull, you can still do the old way, but you can also do
1. Open preview
2. change value there and see changes immediately inside the preview
3. close preview to apply new value