### PR TITLE
add command to remove all missing resources - resourceManager issue #810

### DIFF
--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -1,4 +1,6 @@
 import ResourcesLoader from '../ResourcesLoader';
+import optionalRequire from '../Utils/OptionalRequire.js';
+const fs = optionalRequire('fs');
 
 export const createOrUpdateResource = (project, gdResource, resourceName) => {
   const resourcesManager = project.getResourcesManager();
@@ -15,4 +17,9 @@ export const getLocalResourceFullPath = (project, resourceName) => {
   let resourcePath = ResourcesLoader.getResourceFullUrl(project, resourceName);
   resourcePath = resourcePath.substring(7, resourcePath.lastIndexOf('?cache='));
   return resourcePath;
+};
+
+export const resourceHasValidPath = (project, resourceName) => {
+  const resourcePath = getLocalResourceFullPath(project, resourceName);
+  return fs.existsSync(resourcePath);
 };

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -7,7 +7,7 @@ import SearchBar from 'material-ui-search-bar';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import { filterResourcesList } from './EnumerateResources';
 import optionalRequire from '../Utils/OptionalRequire.js';
-import { createOrUpdateResource, getLocalResourceFullPath } from './ResourceUtils.js';
+import { createOrUpdateResource, getLocalResourceFullPath, resourceHasValidPath } from './ResourceUtils.js';
 import { type ResourceKind } from './ResourceSource.flow';
 
 const path = optionalRequire('path');
@@ -138,6 +138,18 @@ export default class ResourcesList extends React.Component<Props, State> {
     this.forceUpdate();
   };
 
+  _removeAllResourcesWithInvalidPath = () => {
+    const project = this.props.project;
+    const resourcesManager = project.getResourcesManager();
+    resourcesManager.getAllResourceNames().toJSArray().forEach(resourceName => {
+      if (!resourceHasValidPath(project, resourceName)) {
+        resourcesManager.removeResource(resourceName)
+        console.info("Removed due to invalid path: " + resourceName)
+      }
+    });
+    this.forceUpdate();
+  };
+
   _editName = (resource: ?gdResource) => {
     this.setState(
       {
@@ -229,21 +241,27 @@ export default class ResourcesList extends React.Component<Props, State> {
       },
       { type: 'separator' },
       {
-        label: 'Remove All Unused Images',
+        label: 'Remove Unused Images',
         click: () => {
           this._removeUnusedResources('image');
         },
       },
       {
-        label: 'Remove All Unused Audio',
+        label: 'Remove Unused Audio',
         click: () => {
           this._removeUnusedResources('audio');
         },
       },
       {
-        label: 'Remove All Unused Fonts',
+        label: 'Remove Unused Fonts',
         click: () => {
           this._removeUnusedResources('font');
+        },
+      },
+      {
+        label: 'Remove Resources with Invalid Path',
+        click: () => {
+          this._removeAllResourcesWithInvalidPath();
         },
       },
     ];


### PR DESCRIPTION
This adds a command to remove all resources that have a path to a file that no longer exists at that path.
This comes in handy when using placeholder sprites then deleting them

partially addressing issue #810 