### PR TITLE
Animation preview - add fps input  to set animation playback speed, automatically convert to frame duration and back

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -40,7 +40,7 @@ export default class AnimationPreview extends Component<Props, State> {
     currentFrameIndex: 0,
     currentFrameElapsedTime: 0,
     paused: false,
-    fps: parseFloat((1/this.props.timeBetweenFrames).toFixed(0)),
+    fps: Math.round(1/this.props.timeBetweenFrames),
   };
 
   nextUpdate = null;
@@ -130,9 +130,12 @@ export default class AnimationPreview extends Component<Props, State> {
           <TextField
             value={fps}
             onChange={(e, text) => {
-              this.setState({fps: parseFloat(text)});
-              onChangeTimeBetweenFrames(parseFloat((1/text).toFixed(4)));
-              this.replay();
+              const fps = parseFloat(text);
+              if (fps > 0) {
+                this.setState({ fps });
+                onChangeTimeBetweenFrames(parseFloat((1/fps).toFixed(4)));
+                this.replay();
+              }
             }}
             id="direction-time-between-frames"
             type="number"
@@ -146,9 +149,12 @@ export default class AnimationPreview extends Component<Props, State> {
           <TextField
             value={timeBetweenFrames}
             onChange={(e, text) => {
-              onChangeTimeBetweenFrames(parseFloat(text));
-              this.setState({fps: parseFloat((1/text).toFixed(0))});
-              this.replay();
+              const time = parseFloat(text);
+              if (time > 0) {
+                this.setState({fps: Math.round(1/time)});
+                onChangeTimeBetweenFrames(time);  
+                this.replay();
+              }
             }}
             id="direction-time-between-frames"
             type="number"

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -140,6 +140,7 @@ export default class AnimationPreview extends Component<Props, State> {
             min={1}
             max={100}
             style={styles.timeField}
+            autoFocus={true}
           />
           <Timer style={styles.timeIcon} />
           <TextField
@@ -156,7 +157,6 @@ export default class AnimationPreview extends Component<Props, State> {
             min={0.01}
             max={5}
             style={styles.timeField}
-            autoFocus={true}
           />
           <FlatButton icon={<Replay />} label="Replay" onClick={this.replay} />
           <FlatButton

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -40,7 +40,7 @@ export default class AnimationPreview extends Component<Props, State> {
     currentFrameIndex: 0,
     currentFrameElapsedTime: 0,
     paused: false,
-    fps: (1/this.props.timeBetweenFrames).toFixed(0),
+    fps: parseFloat((1/this.props.timeBetweenFrames).toFixed(0)),
   };
 
   nextUpdate = null;
@@ -130,8 +130,8 @@ export default class AnimationPreview extends Component<Props, State> {
           <TextField
             value={fps}
             onChange={(e, text) => {
-              this.setState({fps:text})
-              onChangeTimeBetweenFrames((1/text).toFixed(4));
+              this.setState({fps: parseFloat(text)});
+              onChangeTimeBetweenFrames(parseFloat((1/text).toFixed(4)));
               this.replay();
             }}
             id="direction-time-between-frames"
@@ -146,8 +146,8 @@ export default class AnimationPreview extends Component<Props, State> {
           <TextField
             value={timeBetweenFrames}
             onChange={(e, text) => {
-              onChangeTimeBetweenFrames(text);
-              this.setState({fps:(1/text).toFixed(0)});
+              onChangeTimeBetweenFrames(parseFloat(text));
+              this.setState({fps: parseFloat((1/text).toFixed(0))});
               this.replay();
             }}
             id="direction-time-between-frames"

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -22,6 +22,7 @@ type State = {|
   currentFrameIndex: number,
   currentFrameElapsedTime: number,
   paused: boolean,
+  fps: number,
 |};
 
 const styles = {
@@ -39,6 +40,7 @@ export default class AnimationPreview extends Component<Props, State> {
     currentFrameIndex: 0,
     currentFrameElapsedTime: 0,
     paused: false,
+    fps: (1/this.props.timeBetweenFrames).toFixed(0),
   };
 
   nextUpdate = null;
@@ -108,7 +110,7 @@ export default class AnimationPreview extends Component<Props, State> {
       timeBetweenFrames,
       onChangeTimeBetweenFrames,
     } = this.props;
-    const { currentFrameIndex, paused } = this.state;
+    const { currentFrameIndex, paused, fps } = this.state;
 
     const hasValidSprite =
       currentFrameIndex < spritesContainer.getSpritesCount();
@@ -124,17 +126,33 @@ export default class AnimationPreview extends Component<Props, State> {
           project={project}
         />
         <Line noMargin alignItems="center">
+          <span style={styles.timeIcon}>FPS:</span>
+          <TextField
+            value={fps}
+            onChange={(e, text) => {
+              this.setState({fps:text})
+              onChangeTimeBetweenFrames((1/text).toFixed(4));
+              this.replay();
+            }}
+            id="direction-time-between-frames"
+            type="number"
+            step={1}
+            min={1}
+            max={100}
+            style={styles.timeField}
+          />
           <Timer style={styles.timeIcon} />
           <TextField
             value={timeBetweenFrames}
             onChange={(e, text) => {
               onChangeTimeBetweenFrames(text);
+              this.setState({fps:(1/text).toFixed(0)});
               this.replay();
             }}
             id="direction-time-between-frames"
             type="number"
-            step={0.01}
-            precision={1}
+            step={0.005}
+            precision={2}
             min={0.01}
             max={5}
             style={styles.timeField}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -40,7 +40,7 @@ export default class AnimationPreview extends Component<Props, State> {
     currentFrameIndex: 0,
     currentFrameElapsedTime: 0,
     paused: false,
-    fps: Math.round(1/this.props.timeBetweenFrames),
+    fps: Math.round(1 / this.props.timeBetweenFrames),
   };
 
   nextUpdate = null;
@@ -133,7 +133,7 @@ export default class AnimationPreview extends Component<Props, State> {
               const fps = parseFloat(text);
               if (fps > 0) {
                 this.setState({ fps });
-                onChangeTimeBetweenFrames(parseFloat((1/fps).toFixed(4)));
+                onChangeTimeBetweenFrames(parseFloat((1 / fps).toFixed(4)));
                 this.replay();
               }
             }}
@@ -151,8 +151,8 @@ export default class AnimationPreview extends Component<Props, State> {
             onChange={(e, text) => {
               const time = parseFloat(text);
               if (time > 0) {
-                this.setState({fps: Math.round(1/time)});
-                onChangeTimeBetweenFrames(time);  
+                this.setState({ fps: Math.round(1 / time) });
+                onChangeTimeBetweenFrames(time);
                 this.replay();
               }
             }}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -131,8 +131,8 @@ export default class DirectionTools extends Component<Props, State> {
           id="direction-time-between-frames"
           style={styles.timeField}
           type="number"
-          step={0.01}
-          precision={1}
+          step={0.005}
+          precision={2}
           min={0.01}
           max={5}
         />


### PR DESCRIPTION
This Adds an FPS input to animationPreview. Setting fps automatically computes and updates the frame duration, setting frame duration automatically computes and updates FPS.

Having the FPS as an option to set the animation speed should make the editor much more intuitive for artists and animators, since most creative software for creating animations uses FPS

demo:
![gdevelop-setfps](https://user-images.githubusercontent.com/6495061/50176767-2e184c00-02f8-11e9-9421-202b3df3cb1f.gif)
