### PR TITLE
Don't load ads if already loading/showing

### DIFF
--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -14,348 +14,348 @@ module.exports = {
   createExtension: function(t, gd) {
     const extension = new gd.PlatformExtension();
     extension.setExtensionInformation(
-      "AdMob",
-      t("AdMob"),
+      'AdMob',
+      t('AdMob'),
       t(
-        "Allow the game to display AdMob banner, interstitial and reward video ads"
+        'Allow the game to display AdMob banner, interstitial and reward video ads'
       ),
-      "Franco Maciel",
-      "MIT"
+      'Franco Maciel',
+      'MIT'
     );
 
     // Banner
     extension
       .addCondition(
-        "BannerLoading",
-        t("Banner loading"),
-        t("Check if a banner is currently loading."),
-        t("Banner is loading"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'BannerLoading',
+        t('Banner loading'),
+        t('Check if a banner is currently loading.'),
+        t('Banner is loading'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isBannerLoading");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isBannerLoading');
 
     extension
       .addCondition(
-        "BannerReady",
-        t("Banner ready"),
-        t("Check if a banner is ready to be displayed."),
-        t("Banner is ready"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'BannerReady',
+        t('Banner ready'),
+        t('Check if a banner is ready to be displayed.'),
+        t('Banner is ready'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isBannerReady");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isBannerReady');
 
     extension
       .addCondition(
-        "BannerShowing",
-        t("Banner showing"),
-        t("Check if there is a banner being displayed."),
-        t("Banner is showing"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'BannerShowing',
+        t('Banner showing'),
+        t('Check if there is a banner being displayed.'),
+        t('Banner is showing'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isBannerShowing");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isBannerShowing');
 
     extension
       .addCondition(
-        "BannerExists",
-        t("Banner exists"),
-        t("Check if there is a banner in memory (visible or hidden)."),
-        t("Banner exists"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'BannerExists',
+        t('Banner exists'),
+        t('Check if there is a banner in memory (visible or hidden).'),
+        t('Banner exists'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.existBanner");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.existBanner');
 
     extension
       .addAction(
-        "LoadBanner",
-        t("Load banner"),
+        'LoadBanner',
+        t('Load banner'),
         t(
-          "Start loading a banner, you can display it automatically when finish loading.\nIf test mode is set to true a test banner will be displayed."
+          'Start loading a banner, you can display it automatically when finish loading.\nIf test mode is set to true a test banner will be displayed.'
         ),
         t(
-          "Load banner (at top: _PARAM2_, overlap: _PARAM3_, show on load: _PARAM4_, test mode: _PARAM5_)"
+          'Load banner (at top: _PARAM2_, overlap: _PARAM3_, show on load: _PARAM4_, test mode: _PARAM5_)'
         ),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
-      .addParameter("string", t("Android banner ID"), "", false)
-      .addParameter("string", t("iOS banner ID"), "", false)
+      .addParameter('string', t('Android banner ID'), '', false)
+      .addParameter('string', t('iOS banner ID'), '', false)
       .addParameter(
-        "yesorno",
-        t("Display at top? (bottom otherwise)"),
-        "",
+        'yesorno',
+        t('Display at top? (bottom otherwise)'),
+        '',
         false
       )
-      .setDefaultValue("false")
-      .addParameter("yesorno", t("Overlap webview?"), "", false)
-      .setDefaultValue("true")
-      .addParameter("yesorno", t("Display on load complete?"), "", false)
-      .setDefaultValue("true")
-      .addParameter("yesorno", t("Test mode?"), "", false)
-      .setDefaultValue("true")
+      .setDefaultValue('false')
+      .addParameter('yesorno', t('Overlap webview?'), '', false)
+      .setDefaultValue('true')
+      .addParameter('yesorno', t('Display on load complete?'), '', false)
+      .setDefaultValue('true')
+      .addParameter('yesorno', t('Test mode?'), '', false)
+      .setDefaultValue('true')
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.loadBanner");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.loadBanner');
 
     extension
       .addAction(
-        "ShowBanner",
-        t("Show banner"),
-        t("Show the banner, will work only when the banner is fully loaded."),
-        t("Show banner"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'ShowBanner',
+        t('Show banner'),
+        t('Show the banner, will work only when the banner is fully loaded.'),
+        t('Show banner'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.showBanner");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.showBanner');
 
     extension
       .addAction(
-        "HideBanner",
-        t("Hide banner"),
+        'HideBanner',
+        t('Hide banner'),
         t(
-          "Hide the banner. You can show it again with the corresponding action."
+          'Hide the banner. You can show it again with the corresponding action.'
         ),
-        t("Hide banner"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('Hide banner'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.hideBanner");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.hideBanner');
 
     extension
       .addAction(
-        "RemoveBanner",
-        t("Remove banner"),
+        'RemoveBanner',
+        t('Remove banner'),
         t(
-          "Remove the banner. You have to load another banner to show it again."
+          'Remove the banner. You have to load another banner to show it again.'
         ),
-        t("Remove banner"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('Remove banner'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.removeBanner");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.removeBanner');
 
     // Interstitial
     extension
       .addCondition(
-        "InterstitialLoading",
-        t("Interstitial loading"),
-        t("Check if an interstitial is currently loading."),
-        t("Interstitial is loading"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'InterstitialLoading',
+        t('Interstitial loading'),
+        t('Check if an interstitial is currently loading.'),
+        t('Interstitial is loading'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isInterstitialLoading");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isInterstitialLoading');
 
     extension
       .addCondition(
-        "InterstitialReady",
-        t("Interstitial ready"),
-        t("Check if an interstitial is ready to be displayed."),
-        t("Interstitial is ready"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'InterstitialReady',
+        t('Interstitial ready'),
+        t('Check if an interstitial is ready to be displayed.'),
+        t('Interstitial is ready'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isInterstitialReady");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isInterstitialReady');
 
     extension
       .addCondition(
-        "InterstitialShowing",
-        t("Interstitial showing"),
-        t("Check if there is an interstitial being displayed."),
-        t("Interstitial is showing"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'InterstitialShowing',
+        t('Interstitial showing'),
+        t('Check if there is an interstitial being displayed.'),
+        t('Interstitial is showing'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isInterstitialShowing");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isInterstitialShowing');
 
     extension
       .addAction(
-        "LoadInterstitial",
-        t("Load interstitial"),
+        'LoadInterstitial',
+        t('Load interstitial'),
         t(
-          "Start loading an interstitial, you can display it automatically when finish loading.\nIf test mode is set to true a test interstitial will be displayed."
+          'Start loading an interstitial, you can display it automatically when finish loading.\nIf test mode is set to true a test interstitial will be displayed.'
         ),
-        t("Load interstitial (show on load: _PARAM2_, test mode: _PARAM3_)"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('Load interstitial (show on load: _PARAM2_, test mode: _PARAM3_)'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
-      .addParameter("string", t("Android interstitial ID"), "", false)
-      .addParameter("string", t("iOS interstitial ID"), "", false)
-      .addParameter("yesorno", t("Display on load complete?"), "", false)
-      .setDefaultValue("true")
-      .addParameter("yesorno", t("Test mode?"), "", false)
-      .setDefaultValue("true")
+      .addParameter('string', t('Android interstitial ID'), '', false)
+      .addParameter('string', t('iOS interstitial ID'), '', false)
+      .addParameter('yesorno', t('Display on load complete?'), '', false)
+      .setDefaultValue('true')
+      .addParameter('yesorno', t('Test mode?'), '', false)
+      .setDefaultValue('true')
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.loadInterstitial");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.loadInterstitial');
 
     extension
       .addAction(
-        "ShowInterstitial",
-        t("Show interstitial"),
+        'ShowInterstitial',
+        t('Show interstitial'),
         t(
-          "Show the interstitial, will work only when the interstitial is fully loaded."
+          'Show the interstitial, will work only when the interstitial is fully loaded.'
         ),
-        t("Show interstitial"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('Show interstitial'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.showInterstitial");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.showInterstitial');
 
     // Reward video
     extension
       .addCondition(
-        "VideoLoading",
-        t("Video loading"),
-        t("Check if a reward video is currently loading."),
-        t("Reward video is loading"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'VideoLoading',
+        t('Video loading'),
+        t('Check if a reward video is currently loading.'),
+        t('Reward video is loading'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isVideoLoading");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isVideoLoading');
 
     extension
       .addCondition(
-        "VideoReady",
-        t("Video ready"),
-        t("Check if a reward video is ready to be displayed."),
-        t("Reward video is ready"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'VideoReady',
+        t('Video ready'),
+        t('Check if a reward video is ready to be displayed.'),
+        t('Reward video is ready'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isVideoReady");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isVideoReady');
 
     extension
       .addCondition(
-        "VideoShowing",
-        t("Video showing"),
-        t("Check if there is a reward video being displayed."),
-        t("Reward video is showing"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'VideoShowing',
+        t('Video showing'),
+        t('Check if there is a reward video being displayed.'),
+        t('Reward video is showing'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.isVideoShowing");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.isVideoShowing');
 
     extension
       .addCondition(
-        "VideoReward",
-        t("Video reward"),
+        'VideoReward',
+        t('Video reward'),
         t(
-          "Check if there is a video reward.\nYou can mark it as non-claimed yet, so you can check this reward in other events."
+          'Check if there is a video reward.\nYou can mark it as non-claimed yet, so you can check this reward in other events.'
         ),
-        t("Video reward given"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('Video reward given'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
-      .addParameter("yesorno", t("Mark as claimed"), "", false)
-      .setDefaultValue("true")
+      .addParameter('yesorno', t('Mark as claimed'), '', false)
+      .setDefaultValue('true')
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.existVideoReward");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.existVideoReward');
 
     extension
       .addAction(
-        "LoadVideo",
-        t("Load video"),
+        'LoadVideo',
+        t('Load video'),
         t(
-          "Start loading a reward video, you can display it automatically when finish loading.\nIf test mode is set to true a test video will be displayed."
+          'Start loading a reward video, you can display it automatically when finish loading.\nIf test mode is set to true a test video will be displayed.'
         ),
-        t("Load reward video (show on load: _PARAM2_, test mode: _PARAM3_)"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('Load reward video (show on load: _PARAM2_, test mode: _PARAM3_)'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
-      .addParameter("string", t("Android reward video ID"), "", false)
-      .addParameter("string", t("iOS reward video ID"), "", false)
-      .addParameter("yesorno", t("Display on load complete?"), "", false)
-      .setDefaultValue("true")
-      .addParameter("yesorno", t("Test mode?"), "", false)
-      .setDefaultValue("true")
+      .addParameter('string', t('Android reward video ID'), '', false)
+      .addParameter('string', t('iOS reward video ID'), '', false)
+      .addParameter('yesorno', t('Display on load complete?'), '', false)
+      .setDefaultValue('true')
+      .addParameter('yesorno', t('Test mode?'), '', false)
+      .setDefaultValue('true')
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.loadVideo");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.loadVideo');
 
     extension
       .addAction(
-        "ShowVideo",
-        t("Show video"),
+        'ShowVideo',
+        t('Show video'),
         t(
-          "Show the reward video, will work only when the video is fully loaded."
+          'Show the reward video, will work only when the video is fully loaded.'
         ),
-        t("Show reward video"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        t('Show reward video'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.showVideo");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.showVideo');
 
     extension
       .addAction(
-        "ClaimReward",
-        t("Claim reward"),
-        t("Mark the video reward as claimed."),
-        t("Claim video reward"),
-        t("AdMob"),
-        "JsPlatform/Extensions/admobicon24.png",
-        "JsPlatform/Extensions/admobicon16.png"
+        'ClaimReward',
+        t('Claim reward'),
+        t('Mark the video reward as claimed.'),
+        t('Claim video reward'),
+        t('AdMob'),
+        'JsPlatform/Extensions/admobicon24.png',
+        'JsPlatform/Extensions/admobicon16.png'
       )
       .getCodeExtraInformation()
-      .setIncludeFile("Extensions/AdMob/admobtools.js")
-      .setFunctionName("gdjs.adMob.claimVideoReward");
+      .setIncludeFile('Extensions/AdMob/admobtools.js')
+      .setFunctionName('gdjs.adMob.claimVideoReward');
 
     return extension;
   },
   runExtensionSanityTests: function(gd, extension) {
     return [];
-  }
+  },
 };

--- a/Extensions/AdMob/admobtools.js
+++ b/Extensions/AdMob/admobtools.js
@@ -19,16 +19,16 @@ gdjs.adMob = {
   videoLoading: false,
   videoReady: false,
   videoShowing: false,
-  videoReward: false
+  videoReward: false,
 };
 
 gdjs.adMob._getPlatformName = function() {
   if (/(android)/i.test(navigator.userAgent)) {
-    return "android";
+    return 'android';
   } else if (/(ipod|iphone|ipad)/i.test(navigator.userAgent)) {
-    return "ios";
+    return 'ios';
   } else {
-    return "windowsPhone";
+    return 'windowsPhone';
   }
 };
 
@@ -78,14 +78,21 @@ gdjs.adMob.loadBanner = function(
   displayOnLoading,
   testMode
 ) {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
+
+  if (
+    gdjs.adMob.bannerLoading ||
+    gdjs.adMob.bannerReady ||
+    gdjs.adMob.bannerExists
+  )
+    return;
 
   admob.banner.config({
-    id: gdjs.adMob._getPlatformName() === "android" ? androidID : iosID, // Support Android & iOS
+    id: gdjs.adMob._getPlatformName() === 'android' ? androidID : iosID, // Support Android & iOS
     bannerAtTop: atTop,
     overlap: overlap,
     autoShow: displayOnLoading,
-    isTesting: testMode
+    isTesting: testMode,
   });
   admob.banner.prepare();
 
@@ -99,7 +106,7 @@ gdjs.adMob.loadBanner = function(
 };
 
 gdjs.adMob.showBanner = function() {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
 
   // This block is needed because the banner event listeners bug
   if (gdjs.adMob.bannerReady) {
@@ -113,7 +120,7 @@ gdjs.adMob.showBanner = function() {
 };
 
 gdjs.adMob.hideBanner = function() {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
 
   if (gdjs.adMob.bannerExists) gdjs.adMob.bannerShowing = false;
 
@@ -121,7 +128,7 @@ gdjs.adMob.hideBanner = function() {
 };
 
 gdjs.adMob.removeBanner = function() {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
 
   // These lines are needed because the banner event listeners bug
   gdjs.adMob.bannerExists = false;
@@ -149,12 +156,19 @@ gdjs.adMob.loadInterstitial = function(
   displayOnLoading,
   testMode
 ) {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
+
+  if (
+    gdjs.adMob.interstitialLoading ||
+    gdjs.adMob.interstitialReady ||
+    gdjs.adMob.interstitialShowing
+  )
+    return;
 
   admob.interstitial.config({
-    id: gdjs.adMob._getPlatformName() === "android" ? androidID : iosID, // Support Android & iOS
+    id: gdjs.adMob._getPlatformName() === 'android' ? androidID : iosID, // Support Android & iOS
     autoShow: displayOnLoading,
-    isTesting: testMode
+    isTesting: testMode,
   });
   admob.interstitial.prepare();
 
@@ -163,7 +177,7 @@ gdjs.adMob.loadInterstitial = function(
 };
 
 gdjs.adMob.showInterstitial = function() {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
 
   admob.interstitial.show();
 };
@@ -189,12 +203,19 @@ gdjs.adMob.existVideoReward = function(markAsClaimed) {
 };
 
 gdjs.adMob.loadVideo = function(androidID, iosID, displayOnLoading, testMode) {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
+
+  if (
+    gdjs.adMob.videoLoading ||
+    gdjs.adMob.videoReady ||
+    gdjs.adMob.videoShowing
+  )
+    return;
 
   admob.rewardvideo.config({
-    id: gdjs.adMob._getPlatformName() === "android" ? androidID : iosID, // Support Android & iOS
+    id: gdjs.adMob._getPlatformName() === 'android' ? androidID : iosID, // Support Android & iOS
     autoShow: displayOnLoading,
-    isTesting: testMode
+    isTesting: testMode,
   });
   admob.rewardvideo.prepare();
 
@@ -203,7 +224,7 @@ gdjs.adMob.loadVideo = function(androidID, iosID, displayOnLoading, testMode) {
 };
 
 gdjs.adMob.showVideo = function() {
-  if (typeof admob === "undefined") return;
+  if (typeof admob === 'undefined') return;
 
   admob.rewardvideo.show();
 };
@@ -214,7 +235,7 @@ gdjs.adMob.claimVideoReward = function() {
 
 // Banner event listeners
 document.addEventListener(
-  "admob.banner.events.LOAD",
+  'admob.banner.events.LOAD',
   function() {
     gdjs.adMob.bannerReady = true;
     gdjs.adMob.bannerLoading = false;
@@ -223,7 +244,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.banner.events.LOAD_FAIL",
+  'admob.banner.events.LOAD_FAIL',
   function() {
     gdjs.adMob.bannerLoading = false;
   },
@@ -254,7 +275,7 @@ document.addEventListener(
 
 // Interstitial event listeners
 document.addEventListener(
-  "admob.interstitial.events.LOAD",
+  'admob.interstitial.events.LOAD',
   function() {
     gdjs.adMob.interstitialReady = true;
     gdjs.adMob.interstitialLoading = false;
@@ -263,7 +284,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.interstitial.events.LOAD_FAIL",
+  'admob.interstitial.events.LOAD_FAIL',
   function() {
     gdjs.adMob.interstitialLoading = false;
   },
@@ -271,7 +292,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.interstitial.events.OPEN",
+  'admob.interstitial.events.OPEN',
   function() {
     gdjs.adMob.interstitialShowing = true;
     gdjs.adMob.interstitialReady = false;
@@ -280,7 +301,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.interstitial.events.CLOSE",
+  'admob.interstitial.events.CLOSE',
   function() {
     gdjs.adMob.interstitialShowing = false;
   },
@@ -289,7 +310,7 @@ document.addEventListener(
 
 // Reward video event listeners
 document.addEventListener(
-  "admob.rewardvideo.events.LOAD",
+  'admob.rewardvideo.events.LOAD',
   function() {
     gdjs.adMob.videoReady = true;
     gdjs.adMob.videoLoading = false;
@@ -298,7 +319,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.rewardvideo.events.LOAD_FAIL",
+  'admob.rewardvideo.events.LOAD_FAIL',
   function() {
     gdjs.adMob.videoLoading = false;
   },
@@ -306,7 +327,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.rewardvideo.events.OPEN",
+  'admob.rewardvideo.events.OPEN',
   function() {
     gdjs.adMob.videoShowing = true;
     gdjs.adMob.videoReady = false;
@@ -315,7 +336,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.rewardvideo.events.CLOSE",
+  'admob.rewardvideo.events.CLOSE',
   function() {
     gdjs.adMob.videoShowing = false;
   },
@@ -323,7 +344,7 @@ document.addEventListener(
 );
 
 document.addEventListener(
-  "admob.rewardvideo.events.REWARD",
+  'admob.rewardvideo.events.REWARD',
   function() {
     gdjs.adMob.videoReward = true;
   },


### PR DESCRIPTION
Fixes https://github.com/4ian/GDevelop/issues/815
Allows to load ads continuously, loads will be ignored if an ad of the same type is already loading, ready, or showing.

If you think it's ok and merge it, can you add a warning in the release notes too? because now you have to delete the previous ad to load a new one, that makes sense, though.

Also, I've run prettier on the files.