### PR TITLE
Fix JSON array parser separators

### DIFF
--- a/Core/GDCore/Serialization/Serializer.cpp
+++ b/Core/GDCore/Serialization/Serializer.cpp
@@ -461,7 +461,7 @@ size_t ParseJSONObject(const std::string& jsonStr,
   {
     std::string str;
     size_t endPos = pos;
-    const std::string separators = " \n,}";
+    const std::string separators = " \n,}]";
     while (endPos < jsonStr.length() &&
            separators.find_first_of(jsonStr[endPos]) == std::string::npos) {
       endPos++;


### PR DESCRIPTION
I think I've found the bug. After some try-and-error to catch the problem get that this string parses correctly:
`"{\"A\":[3,4,2 ],\"B\":7}"`
While this one doesn't:
`"{\"A\":[3,4,2],\"B\":7}"`

It's interesting how none of the tests show the problem, the parser warns about bad ending arrays but the resulting string is the same, for the last mixed:
`"{\"hello\": {\"world\": [{},[],3,\"4\"],\"world2\": [-1,\"-2\",{\"-3\": [-4]}]}}"`
Just adding a number inside the first empty array, changing the `\"4\"` by the number `4` or adding any other value at the end after the `[-4]` should result in fail.