### PR TITLE
Resource manager choose file button

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -847,6 +847,8 @@ export default class MainFrame extends React.Component<Props, State> {
               }}
               isActive={isActive}
               ref={editorRef}
+              onChooseResource={this._onChooseResource}
+              resourceSources={this.props.resourceSources}
             />
           ),
           key: 'resources',

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1168,7 +1168,6 @@ export default class MainFrame extends React.Component<Props, State> {
             />
             {currentProject && (
               <ProjectManager
-                openProjectManager={this.openProjectManager}
                 project={currentProject}
                 onOpenExternalEvents={this.openExternalEvents}
                 onOpenLayout={this.openLayout}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1166,6 +1166,7 @@ export default class MainFrame extends React.Component<Props, State> {
             />
             {currentProject && (
               <ProjectManager
+                openProjectManager={this.openProjectManager}
                 project={currentProject}
                 onOpenExternalEvents={this.openExternalEvents}
                 onOpenLayout={this.openLayout}

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -576,7 +576,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                 src="res/ribbon_default/projectManager32.png"
               />
             }
-            initiallyOpen={true}
+            initiallyOpen={false}
             primaryTogglesNestedList={true}
             autoGenerateNestedIndicator={true}
             nestedItems={[

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -253,6 +253,7 @@ type Props = {|
   onChangeSubscription: () => void,
   eventsFunctionsExtensionsError: ?Error,
   onReloadEventsFunctionsExtensions: () => void,
+  openProjectManager?: boolean => void,
   freezeUpdate: boolean,
 |};
 
@@ -557,6 +558,7 @@ export default class ProjectManager extends React.Component<Props, State> {
       project,
       eventsFunctionsExtensionsError,
       onReloadEventsFunctionsExtensions,
+      openProjectManager,
     } = this.props;
     const { renamedItemKind, renamedItemName, searchText } = this.state;
 
@@ -622,7 +624,12 @@ export default class ProjectManager extends React.Component<Props, State> {
                     src="res/ribbon_default/image32.png"
                   />
                 }
-                onClick={() => this.props.onOpenResources()}
+                onClick={() => {
+                  this.props.onOpenResources();
+                  if (openProjectManager) {
+                    openProjectManager(false);
+                  }
+                }}
               />,
             ]}
           />

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -253,7 +253,6 @@ type Props = {|
   onChangeSubscription: () => void,
   eventsFunctionsExtensionsError: ?Error,
   onReloadEventsFunctionsExtensions: () => void,
-  openProjectManager?: boolean => void,
   freezeUpdate: boolean,
 |};
 
@@ -558,7 +557,6 @@ export default class ProjectManager extends React.Component<Props, State> {
       project,
       eventsFunctionsExtensionsError,
       onReloadEventsFunctionsExtensions,
-      openProjectManager,
     } = this.props;
     const { renamedItemKind, renamedItemName, searchText } = this.state;
 
@@ -626,9 +624,6 @@ export default class ProjectManager extends React.Component<Props, State> {
                 }
                 onClick={() => {
                   this.props.onOpenResources();
-                  if (openProjectManager) {
-                    openProjectManager(false);
-                  }
                 }}
               />,
             ]}

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -576,7 +576,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                 src="res/ribbon_default/projectManager32.png"
               />
             }
-            initiallyOpen={false}
+            initiallyOpen={true}
             primaryTogglesNestedList={true}
             autoGenerateNestedIndicator={true}
             nestedItems={[

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -6,8 +6,6 @@ import PropertiesEditor from '../../PropertiesEditor';
 import ResourcePreview from '../../ResourcesList/ResourcePreview';
 import ResourcesLoader from '../../ResourcesLoader';
 import propertiesMapToSchema from '../../PropertiesEditor/PropertiesMapToSchema';
-import FlatButton from 'material-ui/FlatButton';
-import { Column, Line } from '../../UI/Grid';
 
 import {
   type ResourceSource,
@@ -28,7 +26,7 @@ type Props = {|
   project: gdProject,
   resourcesLoader: typeof ResourcesLoader,
   resources: Array<gdResource>,
-  onUpdateProperties: () => void,
+  onResourcePathUpdated: () => void,
   resourceSources: Array<ResourceSource>,
   onChooseResource: ChooseResourceFunction,
 |};
@@ -48,10 +46,12 @@ export default class ResourcePropertiesEditor extends React.Component<
     },
     {
       name: 'File',
-      valueType: 'string',
+      valueType: 'string-with-button',
       getValue: (resource: gdResource) => resource.getFile(),
       setValue: (resource: gdResource, newValue: string) =>
         resource.setFile(newValue),
+      buttonLabel: 'Choose file',
+      onEditButtonClick: () => this._chooseResourcePath(),
     },
   ];
 
@@ -64,10 +64,10 @@ export default class ResourcePropertiesEditor extends React.Component<
     );
   }
 
-  _setResourcePath = () => {
+  _chooseResourcePath = () => {
     const {
       resources,
-      onUpdateProperties,
+      onResourcePathUpdated,
       onChooseResource,
       resourceSources,
     } = this.props;
@@ -81,7 +81,7 @@ export default class ResourcePropertiesEditor extends React.Component<
       resource.setFile(resources[0].getFile());
       resources.forEach(resource => resource.delete()); // Important, we are responsible for deleting the resources that were given to us. Otherwise we have a memory leak.
 
-      onUpdateProperties();
+      onResourcePathUpdated();
       this.forceUpdate();
     });
   };
@@ -97,24 +97,14 @@ export default class ResourcePropertiesEditor extends React.Component<
     );
 
     return (
-      <div key={resources.map(resource => '' + resource.ptr).join(';')}>
-        <Line expand alignItems="center" style={styles.propertiesContainer}>
-          <Column expand>
-            <PropertiesEditor
-              schema={this.schema.concat(resourceSchema)}
-              instances={resources}
-            />
-          </Column>
-          <Column>
-            <FlatButton
-              label="Choose File"
-              primary={false}
-              onClick={() => {
-                this._setResourcePath();
-              }}
-            />
-          </Column>
-        </Line>
+      <div
+        style={styles.propertiesContainer}
+        key={resources.map(resource => '' + resource.ptr).join(';')}
+      >
+        <PropertiesEditor
+          schema={this.schema.concat(resourceSchema)}
+          instances={resources}
+        />
       </div>
     );
   }

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -107,7 +107,7 @@ export default class ResourcePropertiesEditor extends React.Component<
           </Column>
           <Column>
             <FlatButton
-              label="Set File"
+              label="Choose File"
               primary={false}
               onClick={() => {
                 this._setResourcePath();

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -50,7 +50,6 @@ export default class ResourcePropertiesEditor extends React.Component<
       getValue: (resource: gdResource) => resource.getFile(),
       setValue: (resource: gdResource, newValue: string) =>
         resource.setFile(newValue),
-      buttonLabel: 'Choose file',
       onEditButtonClick: () => this._chooseResourcePath(),
     },
   ];

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -46,7 +46,7 @@ export default class ResourcePropertiesEditor extends React.Component<
     },
     {
       name: 'File',
-      valueType: 'string-with-button',
+      valueType: 'string',
       getValue: (resource: gdResource) => resource.getFile(),
       setValue: (resource: gdResource, newValue: string) =>
         resource.setFile(newValue),

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -136,7 +136,7 @@ export default class ResourcesEditor extends React.Component<Props, State> {
             ref={propertiesEditor =>
               (this._propertiesEditor = propertiesEditor)
             }
-            onUpdateProperties={() => {
+            onResourcePathUpdated={() => {
               if (this._resourcesList) {
                 this._resourcesList.checkMissingPaths();
               }

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -124,6 +124,11 @@ export default class ResourcesEditor extends React.Component<Props, State> {
             ref={propertiesEditor =>
               (this._propertiesEditor = propertiesEditor)
             }
+            onUpdateProperties={() => {
+              if (this._resourcesList) {
+                this._resourcesList.forceCheckMissingPaths();
+              }
+            }}
           />
         </MosaicWindow>
       ),

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -7,6 +7,11 @@ import EditorMosaic, { MosaicWindow } from '../UI/EditorMosaic';
 import InfoBar from '../UI/Messages/InfoBar';
 import ResourcesLoader from '../ResourcesLoader';
 
+import {
+  type ResourceSource,
+  type ChooseResourceFunction,
+} from '../ResourcesList/ResourceSource.flow';
+
 const styles = {
   container: {
     display: 'flex',
@@ -30,6 +35,8 @@ type Props = {
     newName: string,
     cb: (boolean) => void
   ) => void,
+  resourceSources: Array<ResourceSource>,
+  onChooseResource: ChooseResourceFunction,
 };
 
 export default class ResourcesEditor extends React.Component<Props, State> {
@@ -106,7 +113,12 @@ export default class ResourcesEditor extends React.Component<Props, State> {
   };
 
   render() {
-    const { project, onRenameResource } = this.props;
+    const {
+      project,
+      onRenameResource,
+      onChooseResource,
+      resourceSources,
+    } = this.props;
     const { selectedResource } = this.state;
 
     const editors = {
@@ -126,9 +138,11 @@ export default class ResourcesEditor extends React.Component<Props, State> {
             }
             onUpdateProperties={() => {
               if (this._resourcesList) {
-                this._resourcesList.forceCheckMissingPaths();
+                this._resourcesList.checkMissingPaths();
               }
             }}
+            onChooseResource={onChooseResource}
+            resourceSources={resourceSources}
           />
         </MosaicWindow>
       ),

--- a/newIDE/app/src/ResourcesList/LocalResourceSources.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceSources.js
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import optionalRequire from '../Utils/OptionalRequire.js';
-import {selectLocalResourcePath} from './ResourceUtils.js';
+import { selectLocalResourcePath } from './ResourceUtils.js';
 const path = optionalRequire('path');
 
 const gd = global.gd;
@@ -15,7 +15,6 @@ export default [
         project,
         multiSelections = true
       ): Promise<Array<any>> => {
-
         const options = {
           multiSelections,
           title: 'Choose an audio file',
@@ -28,9 +27,9 @@ export default [
             audioResource.setName(path.relative(projectPath, resourcePath));
 
             return audioResource;
-          }
+          },
         };
-        return selectLocalResourcePath(project, options)
+        return selectLocalResourcePath(project, options);
       };
 
       render() {
@@ -47,7 +46,6 @@ export default [
         project,
         multiSelections = true
       ): Promise<Array<any>> => {
-
         const options = {
           multiSelections,
           title: 'Choose an image',
@@ -60,9 +58,9 @@ export default [
             imageResource.setName(path.relative(projectPath, resourcePath));
 
             return imageResource;
-          }
+          },
         };
-        return selectLocalResourcePath(project, options)
+        return selectLocalResourcePath(project, options);
       };
 
       render() {
@@ -79,7 +77,6 @@ export default [
         project,
         multiSelections = true
       ): Promise<Array<any>> => {
-
         const options = {
           multiSelections,
           title: 'Choose a font file',
@@ -92,9 +89,9 @@ export default [
             fontResource.setName(path.relative(projectPath, resourcePath));
 
             return fontResource;
-          }
+          },
         };
-        return selectLocalResourcePath(project, options)
+        return selectLocalResourcePath(project, options);
       };
 
       render() {

--- a/newIDE/app/src/ResourcesList/LocalResourceSources.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceSources.js
@@ -2,8 +2,7 @@ import { Component } from 'react';
 import optionalRequire from '../Utils/OptionalRequire.js';
 import {selectLocalResourcePath} from './ResourceUtils.js';
 const path = optionalRequire('path');
-const electron = optionalRequire('electron');
-const dialog = electron ? electron.remote.dialog : null;
+
 const gd = global.gd;
 
 export default [

--- a/newIDE/app/src/ResourcesList/LocalResourceSources.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceSources.js
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import optionalRequire from '../Utils/OptionalRequire.js';
+import {selectLocalResourcePath} from './ResourceUtils.js';
 const path = optionalRequire('path');
 const electron = optionalRequire('electron');
 const dialog = electron ? electron.remote.dialog : null;
@@ -15,39 +16,22 @@ export default [
         project,
         multiSelections = true
       ): Promise<Array<any>> => {
-        return new Promise((resolve, reject) => {
-          if (!dialog) return reject('Not supported');
 
-          const properties = ['openFile'];
-          if (multiSelections) properties.push('multiSelections');
-          const projectPath = path.dirname(project.getProjectFile());
+        const options = {
+          multiSelections,
+          title: 'Choose an audio file',
+          name: 'Audio files',
+          extensions: ['wav', 'mp3', 'ogg'],
+          forEachPath: resourcePath => {
+            const audioResource = new gd.AudioResource();
+            const projectPath = path.dirname(project.getProjectFile());
+            audioResource.setFile(path.relative(projectPath, resourcePath));
+            audioResource.setName(path.relative(projectPath, resourcePath));
 
-          const browserWindow = electron.remote.getCurrentWindow();
-          dialog.showOpenDialog(
-            browserWindow,
-            {
-              title: 'Choose an audio file',
-              properties,
-              filters: [
-                { name: 'Audio files', extensions: ['wav', 'mp3', 'ogg'] },
-              ],
-              defaultPath: projectPath,
-            },
-            paths => {
-              if (!paths) return resolve([]);
-
-              const resources = paths.map(resourcePath => {
-                const audioResource = new gd.AudioResource();
-                const projectPath = path.dirname(project.getProjectFile());
-                audioResource.setFile(path.relative(projectPath, resourcePath));
-                audioResource.setName(path.relative(projectPath, resourcePath));
-
-                return audioResource;
-              }); // make reusable?
-              return resolve(resources);
-            }
-          );
-        });
+            return audioResource;
+          }
+        };
+        return selectLocalResourcePath(project, options)
       };
 
       render() {
@@ -64,37 +48,22 @@ export default [
         project,
         multiSelections = true
       ): Promise<Array<any>> => {
-        return new Promise((resolve, reject) => {
-          if (!dialog) return reject('Not supported');
 
-          const properties = ['openFile'];
-          if (multiSelections) properties.push('multiSelections');
-          const projectPath = path.dirname(project.getProjectFile());
+        const options = {
+          multiSelections,
+          title: 'Choose an image',
+          name: 'Image files',
+          extensions: ['png', 'jpg'],
+          forEachPath: resourcePath => {
+            const imageResource = new gd.ImageResource();
+            const projectPath = path.dirname(project.getProjectFile());
+            imageResource.setFile(path.relative(projectPath, resourcePath));
+            imageResource.setName(path.relative(projectPath, resourcePath));
 
-          const browserWindow = electron.remote.getCurrentWindow();
-          dialog.showOpenDialog(
-            browserWindow,
-            {
-              title: 'Choose an image',
-              properties,
-              filters: [{ name: 'Image files', extensions: ['png', 'jpg'] }],
-              defaultPath: projectPath,
-            },
-            paths => {
-              if (!paths) return resolve([]);
-
-              const resources = paths.map(resourcePath => {
-                const imageResource = new gd.ImageResource();
-                const projectPath = path.dirname(project.getProjectFile());
-                imageResource.setFile(path.relative(projectPath, resourcePath));
-                imageResource.setName(path.relative(projectPath, resourcePath));
-
-                return imageResource;
-              });
-              return resolve(resources);
-            }
-          );
-        });
+            return imageResource;
+          }
+        };
+        return selectLocalResourcePath(project, options)
       };
 
       render() {
@@ -111,37 +80,22 @@ export default [
         project,
         multiSelections = true
       ): Promise<Array<any>> => {
-        return new Promise((resolve, reject) => {
-          if (!dialog) return reject('Not supported');
 
-          const properties = ['openFile'];
-          if (multiSelections) properties.push('multiSelections');
-          const projectPath = path.dirname(project.getProjectFile());
+        const options = {
+          multiSelections,
+          title: 'Choose a font file',
+          name: 'Font files',
+          extensions: ['ttf'],
+          forEachPath: resourcePath => {
+            const fontResource = new gd.FontResource();
+            const projectPath = path.dirname(project.getProjectFile());
+            fontResource.setFile(path.relative(projectPath, resourcePath));
+            fontResource.setName(path.relative(projectPath, resourcePath));
 
-          const browserWindow = electron.remote.getCurrentWindow();
-          dialog.showOpenDialog(
-            browserWindow,
-            {
-              title: 'Choose a font file',
-              properties,
-              filters: [{ name: 'Font files', extensions: ['ttf'] }],
-              defaultPath: projectPath,
-            },
-            paths => {
-              if (!paths) return resolve([]);
-
-              const resources = paths.map(resourcePath => {
-                const fontResource = new gd.FontResource();
-                const projectPath = path.dirname(project.getProjectFile());
-                fontResource.setFile(path.relative(projectPath, resourcePath));
-                fontResource.setName(path.relative(projectPath, resourcePath));
-
-                return fontResource;
-              });
-              return resolve(resources);
-            }
-          );
-        });
+            return fontResource;
+          }
+        };
+        return selectLocalResourcePath(project, options)
       };
 
       render() {

--- a/newIDE/app/src/ResourcesList/LocalResourceSources.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceSources.js
@@ -43,7 +43,7 @@ export default [
                 audioResource.setName(path.relative(projectPath, resourcePath));
 
                 return audioResource;
-              });
+              }); // make reusable?
               return resolve(resources);
             }
           );

--- a/newIDE/app/src/ResourcesList/ResourcePreview/AudioPreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/AudioPreview.js
@@ -22,6 +22,7 @@ type Props = {|
   resourcesLoader: typeof ResourcesLoader,
   children?: any,
   style?: Object,
+  resourcePath?: string,
 |};
 
 /**

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -34,6 +34,7 @@ const styles = {
 type Props = {|
   project: gdProject,
   resourceName: string,
+  resourcePath?: string,
   resourcesLoader: typeof ResourcesLoader,
   children?: any,
   style?: Object,
@@ -63,7 +64,8 @@ export default class ImagePreview extends React.Component<Props, State> {
     if (
       newProps.resourceName !== this.props.resourceName ||
       newProps.project !== this.props.project ||
-      newProps.resourcesLoader !== this.props.resourcesLoader
+      newProps.resourcesLoader !== this.props.resourcesLoader ||
+      newProps.resourcePath !== this.props.resourcePath
     ) {
       this.setState(this._loadFrom(newProps));
     }

--- a/newIDE/app/src/ResourcesList/ResourcePreview/index.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/index.js
@@ -8,6 +8,7 @@ import AudioPreview from './AudioPreview';
 type Props = {|
   project: gdProject,
   resourceName: string,
+  resourcePath?: string,
   resourcesLoader: typeof ResourcesLoader,
   children?: any,
   style?: Object,
@@ -31,7 +32,8 @@ export default class ResourcePreview extends React.Component<Props, State> {
   componentWillReceiveProps(newProps: Props) {
     if (
       newProps.resourceName !== this.props.resourceName ||
-      newProps.project !== this.props.project
+      newProps.project !== this.props.project ||
+      newProps.resourcePath !== this.props.resourcePath
     ) {
       this.setState(this._loadFrom(newProps));
     }
@@ -62,6 +64,7 @@ export default class ResourcePreview extends React.Component<Props, State> {
             children={this.props.children}
             style={this.props.style}
             onSize={this.props.onSize}
+            resourcePath={this.props.resourcePath}
           />
         );
       case 'audio':
@@ -72,6 +75,7 @@ export default class ResourcePreview extends React.Component<Props, State> {
             resourcesLoader={this.props.resourcesLoader}
             children={this.props.children}
             style={this.props.style}
+            resourcePath={this.props.resourcePath}
           />
         );
       default:

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -1,9 +1,9 @@
 // @flow
 import ResourcesLoader from '../ResourcesLoader';
 import optionalRequire from '../Utils/OptionalRequire.js';
-const electron = optionalRequire('electron');
-const dialog = electron ? electron.remote.dialog : null;
-const path = optionalRequire('path');
+// const electron = optionalRequire('electron');
+// const dialog = electron ? electron.remote.dialog : null;
+// const path = optionalRequire('path');
 const fs = optionalRequire('fs');
 
 export const RESOURCE_EXTENSIONS = {
@@ -44,45 +44,45 @@ export const resourceHasValidPath = (
   return fs.existsSync(resourcePath);
 };
 
-export const selectLocalResourcePath = (
-  project: gdProject,
-  options: {
-    multiSelections: boolean,
-    title: string,
-    name: string,
-    extensions: Array<string>,
-    forEachPath: any,
-    callback?: ?() => any,
-  }
-) => {
-  return new Promise((resolve, reject) => {
-    if (!dialog) return reject('Not supported');
+// export const selectLocalResourcePath = (
+//   project: gdProject,
+//   options: {
+//     multiSelections: boolean,
+//     title: string,
+//     name: string,
+//     extensions: Array<string>,
+//     forEachPath: any,
+//     callback?: ?() => any,
+//   }
+// ) => {
+//   return new Promise((resolve, reject) => {
+//     if (!dialog) return reject('Not supported');
 
-    const properties = ['openFile'];
-    if (options.multiSelections) properties.push('multiSelections');
-    const projectPath = path.dirname(project.getProjectFile());
+//     const properties = ['openFile'];
+//     if (options.multiSelections) properties.push('multiSelections');
+//     const projectPath = path.dirname(project.getProjectFile());
 
-    const browserWindow = electron.remote.getCurrentWindow();
-    dialog.showOpenDialog(
-      browserWindow,
-      {
-        title: options.title,
-        properties,
-        filters: [{ name: options.name, extensions: options.extensions }],
-        defaultPath: projectPath,
-      },
-      paths => {
-        if (!paths) return resolve([]);
+//     const browserWindow = electron.remote.getCurrentWindow();
+//     dialog.showOpenDialog(
+//       browserWindow,
+//       {
+//         title: options.title,
+//         properties,
+//         filters: [{ name: options.name, extensions: options.extensions }],
+//         defaultPath: projectPath,
+//       },
+//       paths => {
+//         if (!paths) return resolve([]);
 
-        const resources = paths.map(resourcePath => {
-          return options.forEachPath(resourcePath);
-        });
+//         const resources = paths.map(resourcePath => {
+//           return options.forEachPath(resourcePath);
+//         });
 
-        if (options.callback) {
-          options.callback();
-        }
-        return resolve(resources);
-      }
-    );
-  });
-};
+//         if (options.callback) {
+//           options.callback();
+//         }
+//         return resolve(resources);
+//       }
+//     );
+//   });
+// };

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -38,7 +38,17 @@ export const resourceHasValidPath = (
   return fs.existsSync(resourcePath);
 };
 
-export const selectLocalResourcePath = (project, options) => {
+export const selectLocalResourcePath = (
+  project: gdProject,
+  options: {
+    multiSelections: boolean,
+    title: string,
+    name: string,
+    extensions: Array<string>,
+    forEachPath: any,
+    callback?: ?() => any,
+  }
+) => {
   return new Promise((resolve, reject) => {
     if (!dialog) return reject('Not supported');
 
@@ -64,7 +74,7 @@ export const selectLocalResourcePath = (project, options) => {
 
         if (options.callback) {
           options.callback();
-        }   
+        }
         return resolve(resources);
       }
     );

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -1,6 +1,9 @@
 // @flow
 import ResourcesLoader from '../ResourcesLoader';
 import optionalRequire from '../Utils/OptionalRequire.js';
+const electron = optionalRequire('electron');
+const dialog = electron ? electron.remote.dialog : null;
+const path = optionalRequire('path');
 const fs = optionalRequire('fs');
 
 export const createOrUpdateResource = (
@@ -33,4 +36,34 @@ export const resourceHasValidPath = (
 ) => {
   const resourcePath = getLocalResourceFullPath(project, resourceName);
   return fs.existsSync(resourcePath);
+};
+
+export const selectLocalResourcePath = (project, options) => {
+  return new Promise((resolve, reject) => {
+    if (!dialog) return reject('Not supported');
+
+    const properties = ['openFile'];
+    if (options.multiSelections) properties.push('multiSelections');
+    const projectPath = path.dirname(project.getProjectFile());
+
+    const browserWindow = electron.remote.getCurrentWindow();
+    dialog.showOpenDialog(
+      browserWindow,
+      {
+        title: options.title,
+        properties,
+        filters: [{ name: options.name, extensions: options.extensions }],
+        defaultPath: projectPath,
+      },
+      paths => {
+        if (!paths) return resolve([]);
+
+        const resources = paths.map(resourcePath => {
+          return options.forEachPath(resourcePath);
+        });
+        options.callback();
+        return resolve(resources);
+      }
+    );
+  });
 };

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -61,7 +61,10 @@ export const selectLocalResourcePath = (project, options) => {
         const resources = paths.map(resourcePath => {
           return options.forEachPath(resourcePath);
         });
-        options.callback();
+
+        if (options.callback) {
+          options.callback();
+        }   
         return resolve(resources);
       }
     );

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -1,9 +1,6 @@
 // @flow
 import ResourcesLoader from '../ResourcesLoader';
 import optionalRequire from '../Utils/OptionalRequire.js';
-// const electron = optionalRequire('electron');
-// const dialog = electron ? electron.remote.dialog : null;
-// const path = optionalRequire('path');
 const fs = optionalRequire('fs');
 
 export const RESOURCE_EXTENSIONS = {
@@ -43,46 +40,3 @@ export const resourceHasValidPath = (
   const resourcePath = getLocalResourceFullPath(project, resourceName);
   return fs.existsSync(resourcePath);
 };
-
-// export const selectLocalResourcePath = (
-//   project: gdProject,
-//   options: {
-//     multiSelections: boolean,
-//     title: string,
-//     name: string,
-//     extensions: Array<string>,
-//     forEachPath: any,
-//     callback?: ?() => any,
-//   }
-// ) => {
-//   return new Promise((resolve, reject) => {
-//     if (!dialog) return reject('Not supported');
-
-//     const properties = ['openFile'];
-//     if (options.multiSelections) properties.push('multiSelections');
-//     const projectPath = path.dirname(project.getProjectFile());
-
-//     const browserWindow = electron.remote.getCurrentWindow();
-//     dialog.showOpenDialog(
-//       browserWindow,
-//       {
-//         title: options.title,
-//         properties,
-//         filters: [{ name: options.name, extensions: options.extensions }],
-//         defaultPath: projectPath,
-//       },
-//       paths => {
-//         if (!paths) return resolve([]);
-
-//         const resources = paths.map(resourcePath => {
-//           return options.forEachPath(resourcePath);
-//         });
-
-//         if (options.callback) {
-//           options.callback();
-//         }
-//         return resolve(resources);
-//       }
-//     );
-//   });
-// };

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -6,6 +6,12 @@ const dialog = electron ? electron.remote.dialog : null;
 const path = optionalRequire('path');
 const fs = optionalRequire('fs');
 
+export const RESOURCE_EXTENSIONS = {
+  image: 'png,jpg,jpeg,PNG,JPG,JPEG',
+  audio: 'wav,mp3,ogg,WAV,MP3,OGG',
+  font: 'ttf,ttc,TTF,TTC',
+};
+
 export const createOrUpdateResource = (
   project: gdProject,
   gdResource: gdResource,

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -11,7 +11,7 @@ import {
   createOrUpdateResource,
   getLocalResourceFullPath,
   resourceHasValidPath,
-  selectLocalResourcePath,
+  RESOURCE_EXTENSIONS,
 } from './ResourceUtils.js';
 // import ResourcesLoader from '../ResourcesLoader';
 import { type ResourceKind } from './ResourceSource.flow';
@@ -20,12 +20,6 @@ const path = optionalRequire('path');
 const glob = optionalRequire('glob');
 const electron = optionalRequire('electron');
 const hasElectron = electron ? true : false;
-
-const RESOURCE_EXTENSIONS = {
-  image: 'png,jpg,jpeg,PNG,JPG,JPEG',
-  audio: 'wav,mp3,ogg,WAV,MP3,OGG',
-  font: 'ttf,ttc,TTF,TTC',
-};
 
 const gd = global.gd;
 
@@ -95,25 +89,6 @@ export default class ResourcesList extends React.Component<Props, State> {
 
   _deleteResource = (resource: gdResource) => {
     this.props.onDeleteResource(resource);
-  };
-
-  _setResourcePath = (resource: gdResource) => {
-    const { project } = this.props;
-    const projectPath = path.dirname(project.getProjectFile());
-    const options = {
-      multiSelections: false,
-      title: 'Choose a resource file',
-      name: 'Resource files',
-      extensions: RESOURCE_EXTENSIONS[resource.getKind()].split(','),
-      forEachPath: resourcePath => {
-        resource.setFile(path.relative(projectPath, resourcePath));
-      },
-      callback: () => {
-        this.forceCheckMissingPaths();
-        this.forceUpdateList();
-      },
-    };
-    selectLocalResourcePath(this.props.project, options);
   };
 
   _locateResourceFile = (resource: gdResource) => {
@@ -245,11 +220,6 @@ export default class ResourcesList extends React.Component<Props, State> {
         label: 'Remove',
         click: () => this._deleteResource(resource),
       },
-      {
-        label: 'Set Path',
-        click: () => this._setResourcePath(resource),
-        enabled: hasElectron,
-      },
       { type: 'separator' },
       {
         label: 'Open File',
@@ -338,6 +308,7 @@ export default class ResourcesList extends React.Component<Props, State> {
       );
     });
     this.setState({ resourcesWithMissingPath });
+    this.forceUpdateList();
   };
 
   componentDidMount() {

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -107,7 +107,6 @@ export default class ResourcesList extends React.Component<Props, State> {
       extensions: RESOURCE_EXTENSIONS[resource.getKind()].split(','),
       forEachPath: resourcePath => {
         resource.setFile(path.relative(projectPath, resourcePath))
-        // return resourcePath
       },
       callback: () => {
         this.forceCheckMissingPaths();

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -296,7 +296,7 @@ export default class ResourcesList extends React.Component<Props, State> {
     ];
   };
 
-  forceCheckMissingPaths = () => {
+  checkMissingPaths = () => {
     const { project } = this.props;
     const resourcesManager = project.getResourcesManager();
     const resourceNames = resourcesManager.getAllResourceNames().toJSArray();
@@ -312,7 +312,7 @@ export default class ResourcesList extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    this.forceCheckMissingPaths();
+    this.checkMissingPaths();
   }
 
   render() {

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -13,7 +13,6 @@ import {
   resourceHasValidPath,
   RESOURCE_EXTENSIONS,
 } from './ResourceUtils.js';
-// import ResourcesLoader from '../ResourcesLoader';
 import { type ResourceKind } from './ResourceSource.flow';
 
 const path = optionalRequire('path');

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -25,7 +25,7 @@ const RESOURCE_EXTENSIONS = {
   image: 'png,jpg,jpeg,PNG,JPG,JPEG',
   audio: 'wav,mp3,ogg,WAV,MP3,OGG',
   font: 'ttf,ttc,TTF,TTC',
-}
+};
 
 const gd = global.gd;
 
@@ -98,15 +98,15 @@ export default class ResourcesList extends React.Component<Props, State> {
   };
 
   _setResourcePath = (resource: gdResource) => {
-    const {project} = this.props
+    const { project } = this.props;
     const projectPath = path.dirname(project.getProjectFile());
     const options = {
       multiSelections: false,
-      title:'Choose a resource file',
+      title: 'Choose a resource file',
       name: 'Resource files',
       extensions: RESOURCE_EXTENSIONS[resource.getKind()].split(','),
       forEachPath: resourcePath => {
-        resource.setFile(path.relative(projectPath, resourcePath))
+        resource.setFile(path.relative(projectPath, resourcePath));
       },
       callback: () => {
         this.forceCheckMissingPaths();
@@ -341,8 +341,8 @@ export default class ResourcesList extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    this.forceCheckMissingPaths()
-  };
+    this.forceCheckMissingPaths();
+  }
 
   render() {
     const { project, selectedResource, onSelectResource } = this.props;


### PR DESCRIPTION
This adds a command to set the path of a resource, it also refactors some code to be more reusable

addresses one of the todos in #810
trello https://trello.com/c/nE095xiU/222-add-ability-to-set-file-on-resources-in-the-resource-manager

![gd-setpath](https://user-images.githubusercontent.com/6495061/50387588-eaf31a00-06f7-11e9-9121-3ba66ddafe68.gif)

Hope I haven't broken something with the refactor. It seems to work ok

One thing I can't get it to do yet:
- [x] trigger the file previewer to reload the new file
After setting it, you have to click on another one and select the one you have set again 
- [x] Add button to set path next to the filepath text field