### PR TITLE
[WIP] Add support for creating objects in JS extensions + example

### DIFF
--- a/Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.js
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.js
@@ -1,0 +1,60 @@
+/**
+ * The PIXI.js renderer for the DummyRuntimeObject.
+ * 
+ * @class DummyRuntimeObjectPixiRenderer
+ * @constructor
+ * @param {gdjs.DummyRuntimeObject} runtimeObject The object to render
+ * @param {gdjs.RuntimeScene} runtimeScene The gdjs.RuntimeScene in which the object is
+ */
+gdjs.DummyRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene)
+{
+    this._object = runtimeObject; // Keep a reference to the object to read from it later.
+    
+    // Here we're going to create a dummy text as an example.
+    if ( this._text === undefined ) {
+        this._text = new PIXI.Text(runtimeObject.getText(), {align:"left"});
+    }
+
+    // You can also create a PIXI sprite or other PIXI object
+    // this._imageManager = runtimeScene.getGame().getImageManager();
+    // if ( this._sprite === undefined )
+    //     this._sprite = new PIXI.Sprite(this._imageManager.getInvalidPIXITexture());
+
+    this._text.anchor.x = 0.5;
+    this._text.anchor.y = 0.5;
+    runtimeScene.getLayer("").getRenderer().addRendererObject(this._text, runtimeObject.getZOrder());
+
+    this.updatePosition();
+};
+
+gdjs.DummyRuntimeObjectRenderer = gdjs.DummyRuntimeObjectPixiRenderer; //Register the class to let the engine use it.
+
+gdjs.DummyRuntimeObjectPixiRenderer.prototype.getRendererObject = function() {
+    // Mandatory, return the internal PIXI object used for your object:
+    return this._text;
+};
+
+gdjs.DummyRuntimeObjectPixiRenderer.prototype.ensureUpToDate = function() {
+    this.updatePosition();
+};
+
+gdjs.DummyRuntimeObjectPixiRenderer.prototype.updatePosition = function() {
+    this._text.position.x = this._object.x+this._text.width/2;
+    this._text.position.y = this._object.y+this._text.height/2;
+};
+
+gdjs.DummyRuntimeObjectPixiRenderer.prototype.updateAngle = function() {
+    this._text.rotation = gdjs.toRad(this._object.angle);
+};
+
+gdjs.DummyRuntimeObjectPixiRenderer.prototype.updateOpacity = function() {
+    this._text.alpha = this._object.opacity / 255;
+};
+
+gdjs.DummyRuntimeObjectPixiRenderer.prototype.getWidth = function() {
+    return this._text.width;
+};
+
+gdjs.DummyRuntimeObjectPixiRenderer.prototype.getHeight = function() {
+    return this._text.height;
+};

--- a/Extensions/ExampleJsExtension/dummyruntimeobject.js
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject.js
@@ -1,0 +1,108 @@
+/**
+ * A dummy object doing showing a text on screen
+ *
+ * @memberof gdjs
+ * @class DummyRuntimeObject
+ * @extends RuntimeObject
+ */
+gdjs.DummyRuntimeObject = function(runtimeScene, objectData) {
+  // Always call the base gdjs.RuntimeObject constructor.
+  gdjs.RuntimeObject.call(this, runtimeScene, objectData);
+
+  // Load any required data from the object properties.
+  this._property1 = objectData.content.property1;
+
+  // Create the renderer (see dummyruntimeobject-pixi-renderer.js)
+  if (this._renderer)
+    gdjs.DummyRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
+  else this._renderer = new gdjs.DummyRuntimeObjectRenderer(this, runtimeScene);
+};
+
+gdjs.DummyRuntimeObject.prototype = Object.create(gdjs.RuntimeObject.prototype);
+gdjs.DummyRuntimeObject.thisIsARuntimeObjectConstructor =
+  "MyDummyExtension::DummyObject"; //Replace by your extension + object name.
+
+gdjs.DummyRuntimeObject.prototype.getRendererObject = function() {
+  return this._renderer.getRendererObject();
+};
+
+/**
+ * Called once during the game loop, before events and rendering.
+ * @param {gdjs.RuntimeScene} runtimeScene The gdjs.RuntimeScene the object belongs to.
+ */
+gdjs.DummyRuntimeObject.prototype.update = function(runtimeScene) {
+  // This is an example: typically you want to make sure the renderer
+  // is up to date with the object.
+  this._renderer.ensureUpToDate();
+};
+
+/**
+ * Initialize the extra parameters that could be set for an instance.
+ * @private
+ */
+gdjs.DummyRuntimeObject.prototype.extraInitializationFromInitialInstance = function(
+  initialInstanceData
+) {
+  // For example:
+  // this.setSomething(initialInstanceData.something);
+};
+
+/**
+ * Update the object position.
+ * @private
+ */
+gdjs.DummyRuntimeObject.prototype._updatePosition = function() {
+  // This is an example: typically you want to tell the renderer to update
+  // the position of the object.
+  this._renderer.updatePosition();
+};
+
+/**
+ * Set object position on X axis.
+ */
+gdjs.DummyRuntimeObject.prototype.setX = function(x) {
+  gdjs.RuntimeObject.prototype.setX.call(this, x); // Always call the parent method first.
+  this._updatePosition();
+};
+
+/**
+ * Set object position on Y axis.
+ */
+gdjs.DummyRuntimeObject.prototype.setY = function(y) {
+  gdjs.RuntimeObject.prototype.setY.call(this, y); // Always call the parent method first.
+  this._updatePosition();
+};
+
+/**
+ * Set the angle of the object.
+ * @param {number} angle The new angle of the object
+ */
+gdjs.DummyRuntimeObject.prototype.setAngle = function(angle) {
+  gdjs.RuntimeObject.prototype.setAngle.call(this, angle); // Always call the parent method first.
+  this._renderer.updateAngle(); // Tell the renderer to update the rendered object
+};
+
+/**
+ * Set object opacity.
+ */
+gdjs.DummyRuntimeObject.prototype.setOpacity = function(opacity) {
+  if (opacity < 0) opacity = 0;
+  if (opacity > 255) opacity = 255;
+
+  this.opacity = opacity;
+  this._renderer.updateOpacity(); // Tell the renderer to update the rendered object
+};
+
+/**
+ * Get object opacity.
+ */
+gdjs.DummyRuntimeObject.prototype.getOpacity = function() {
+  return this.opacity;
+};
+
+/**
+ * Get the text that must be displayed by the dummy object.
+ */
+gdjs.DummyRuntimeObject.prototype.getText = function() {
+  return this._property1;
+};

--- a/newIDE/README-extensions.md
+++ b/newIDE/README-extensions.md
@@ -9,7 +9,7 @@ are provided by _extensions_. These extensions are composed of two parts:
 > Note that some GDevelop extensions are declared in C++, in files called `JsExtension.cpp`. If you want to edit them,
 > refer to the paragraph about them at the end.
 
-## Getting started
+## 1) Installation 💻
 
 To modify extensions, you need to have the development version of GDevelop running. Make sure to have [Git](https://git-scm.com/) and [Node.js](https://nodejs.org) installed. [Yarn](https://yarnpkg.com) is optional.
 
@@ -21,7 +21,7 @@ npm install #or yarn
 
 Refer to the [GDevelop IDE Readme](./README.md) for more information about the installation.
 
-## Development
+## 2) Development 🤓
 
 - First, run [GDevelop with Electron](https://github.com/4ian/GDevelop/blob/master/newIDE/README.md#development-of-the-standalone-app).
 
@@ -43,7 +43,7 @@ Refer to the [GDevelop IDE Readme](./README.md) for more information about the i
 
   > ⚠️ Always check the developer console after reloading GDevelop. If there is any error signaled, click on it to see what went wrong. You may have done a syntax error or mis-used an API.
 
-### Implement your feature for the game engine
+### 2.1) Implement your feature for the game engine 👾
 
 > ℹ️ Implement your extension in file called `extensionnametools.js` (for general functions), `objectnameruntimeobject.js` (for objects) or `behaviornameruntimebehavior.js` (for behaviors). See then the next section for declaring these files and the content of the extension to the IDE.
 
@@ -66,11 +66,13 @@ Read about [`gdjs.RuntimeBehavior`](file:///Users/florianrival/Projects/F/GD/doc
 
 #### How to create an object by extending `gdjs.RuntimeObject`
 
-> 👋 There is still no examples for objects, as declaring objects is not yet fully exposed to JavaScript extensions. Your help is welcome to expose this feature!
+See example in [dummyruntimeobject.js](../Extensions/ExampleJsExtension/dummyruntimeobject.js) (the object itself) and [dummyruntimeobject-pixi-renderer.js](../Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.js) (the renderer, using PIXI.js).
+
+You'll be interested in the constructor (to initialize things), `update` (called every frame) and the other methods. In the PIXI renderer, check the constructor (where PIXI objects are created). Other methods depend on the renderer.
 
 Read about [`gdjs.RuntimeObject`](file:///Users/florianrival/Projects/F/GD/docs/GDJS%20Runtime%20Documentation/gdjs.RuntimeObject.html), the base class inherited by all objects.
 
-### How to declare your extension to the IDE
+### 2.2) Declare your extension to the IDE 👋
 
 > ℹ️ Declaration must be done in a file called `JsExtension.js`. Your extension must be in Extensions folder, in its own directory.
 
@@ -102,17 +104,38 @@ Add a behavior using [`addBehavior`](http://4ian.github.io/GD-Documentation/GDCo
 - For the behavior, create a `new gd.BehaviorJsImplementation()` and define `updateProperty` and `getProperties`.
 - For the shared data (which are properties shared between all behaviors of the same type), if you don't have the need for it, just pass `new gd.BehaviorsSharedData()`. If you need shared data, create a `new gd.BehaviorSharedDataJsImplementation()` and define `updateProperty` and `getProperties`.
 
-> ⚠️ Like other functions to declare extensions, make sure that you've not forgotten to declare a function and that all arguments are correct. 
+> ⚠️ Like other functions to declare extensions, make sure that you've not forgotten to declare a function and that all arguments are correct.
 
 > 👉 See an example in the [example extension _JsExtension.js_ file](../Extensions/ExampleJsExtension/JsExtension.js).
 
 #### Declare objects
 
-> 👋 Declaring objects is not yet fully exposed to JavaScript extensions. Your help is welcome to expose this feature!
-
-Add an object using [`addObject`](http://4ian.github.io/GD-Documentation/GDCore%20Documentation/classgd_1_1_platform_extension.html#a554baca486909e8741e902133cceeec0). The last  parameter is the `gd.Object` representing the object:
+Add an object using [`addObject`](http://4ian.github.io/GD-Documentation/GDCore%20Documentation/classgd_1_1_platform_extension.html#a554baca486909e8741e902133cceeec0). The last parameter is the `gd.Object` representing the object:
 
 - Create a `new gd.ObjectJsImplementation()` and define `updateProperty` and `getProperties` (for the object properties) and `updateInitialInstanceProperty` and `getInitialInstanceProperties` (for the optional properties that are attached to each instance).
+
+> 👉 See an example in the [example extension _JsExtension.js_ file](../Extensions/ExampleJsExtension/JsExtension.js).
+
+> ℹ️ After doing this, you can actually see your object in GDevelop! Read the next sections to see how to add an editor and a renderer for instances on the scene editor.
+
+#### Declare object editor
+
+To add an editor to your object, implement the function `registerEditorConfigurations` in your extension module. For now, only a default editor, displaying the object properties, is supported:
+
+```js
+registerEditorConfigurations: function(objectsEditorService) {
+  objectsEditorService.registerEditorConfiguration(
+    "MyDummyExtension::DummyObject", // Replace by your extension and object type names.
+    objectsEditorService.getDefaultObjectJsImplementationPropertiesEditor()
+  );
+}
+```
+
+> 👉 See an example in the [example extension _JsExtension.js_ file](../Extensions/ExampleJsExtension/JsExtension.js).
+
+#### Declare the Pixi.js renderer for the instance of your object in the scene editor
+
+Finally, to have the instances of your object displayed properly on the scene editor, implement the function `registerInstanceRenderers` in your extension module. The function is passed an object called `objectsRenderingService`, containing [RenderedInstance](./app/src/ObjectsRendering/Renderers/RenderedInstance.js), the "base class" for instance renderers, and PIXI, which give you access to [Pixi.js rendering engine](https://github.com/pixijs/pixi.js), used in the editor to render the scene.
 
 > 👉 See an example in the [example extension _JsExtension.js_ file](../Extensions/ExampleJsExtension/JsExtension.js).
 
@@ -120,9 +143,7 @@ Add an object using [`addObject`](http://4ian.github.io/GD-Documentation/GDCore%
 
 > 👋 Declaring events is not yet exposed to JavaScript extensions. Your help is welcome to expose this feature!
 
-
-
-## Starting a new extension from scratch
+## 3) Starting a new extension from scratch 🚀
 
 If you want to start a new extension:
 
@@ -136,16 +157,22 @@ If you want to start a new extension:
   .setIncludeFile("Extensions/FacebookInstantGames/facebookinstantgamestools.js")
   ```
 
-## Current status and how to contribute
+## 4) How to contribute? 😎
 
-Declaring extensions in JavaScript is still new, and enhancements are possible to exploit the full potential of extensions:
+If you have ideas or are creating a new extension, your contribution is welcome!
 
-- [ ] Add support for objects and events
-- [ ] Document how to add custom icons
-- [ ] Add a button to reload extensions without reloading GDevelop IDE entirely.
-- [ ] Create a "watcher" script that automatically run `node import-GDJS-Runtime` anytime a change is made.
+- To submit your extension, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
-## Development of extensions declared in C++ (`JsExtension.cpp` or `Extension.cpp`)
+- Check the [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
+
+- A few enhancements are also possible to exploit the full potential of extensions:
+
+  - [ ] Add support for events
+  - [ ] Document how to add custom icons
+  - [ ] Add a button to reload extensions without reloading GDevelop IDE entirely.
+  - [ ] Create a "watcher" script that automatically run `node import-GDJS-Runtime` anytime a change is made.
+
+## 4) Note on the development of extensions declared in C++ (`JsExtension.cpp` or `Extension.cpp`)
 
 The majority of extensions are still declared in C++ for being compatible with GDevelop 4.
 Check the sources in [Extensions folder](https://github.com/4ian/GDevelop/tree/master/Extensions) and install [GDevelop.js](https://github.com/4ian/GDevelop.js). You'll then be able to make changes in C++ source files and have this reflected in the editor.

--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -141,6 +141,4 @@ The editor, the game engine and extensions are always in development. Your contr
 
 * To submit your changes, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
-* Before pushing your changes, make sure that your code is properly formatted. Run `npm run format` (or `yarn format`) in newIDE/app folder.
-
 * Finally, make sure that the tests pass (refer to this README and to the [game engine README](https://github.com/4ian/GDevelop/tree/master/GDJS)) for learning how to run tests.

--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -17,7 +17,9 @@ import browserResourceSources from './ResourcesList/BrowserResourceSources';
 import browserResourceExternalEditors from './ResourcesList/BrowserResourceExternalEditors';
 import BrowserS3PreviewLauncher from './Export/BrowserExporters/BrowserS3PreviewLauncher';
 import { getBrowserExporters } from './Export/BrowserExporters';
-import BrowserJsExtensionsLoader from './JsExtensionsLoader/BrowserJsExtensionsLoader';
+import makeExtensionsLoader from './JsExtensionsLoader/BrowserJsExtensionsLoader';
+import ObjectsEditorService from './ObjectEditor/ObjectsEditorService';
+import ObjectsRenderingService from './ObjectsRendering/ObjectsRenderingService';
 import { makeBrowserS3EventsFunctionWriter } from './EventsFunctionsExtensionsLoader/BrowserS3EventsFunctionWriter';
 
 export const create = (authentification: Authentification) => {
@@ -42,7 +44,11 @@ export const create = (authentification: Authentification) => {
       resourceSources={browserResourceSources}
       resourceExternalEditors={browserResourceExternalEditors}
       authentification={authentification}
-      extensionsLoader={new BrowserJsExtensionsLoader()}
+      extensionsLoader={makeExtensionsLoader({
+        objectsEditorService: ObjectsEditorService,
+        objectsRenderingService: ObjectsRenderingService,
+        filterExamples: !Window.isDev(),
+      })}
       initialPathsOrURLsToOpen={appArguments['_']}
       eventsFunctionWriter={makeBrowserS3EventsFunctionWriter()}
     />

--- a/newIDE/app/src/JsExtensionsLoader/LocalJsExtensionsLoader.js
+++ b/newIDE/app/src/JsExtensionsLoader/LocalJsExtensionsLoader.js
@@ -1,15 +1,36 @@
-// Note: this file does not use export/imports nor Flow to allow its usage from Node.js
+// @flow
+// Note: this file does not use export/imports and use Flow comments to allow its usage from Node.js
 
 const { loadExtension } = require('.');
 const optionalRequire = require('../Utils/OptionalRequire');
 const { findJsExtensionModules } = require('./LocalJsExtensionsFinder');
+
+/*flow-include
+import type {JsExtensionsLoader} from '.';
+import ObjectsEditorService from '../ObjectEditor/ObjectsEditorService';
+import ObjectsRenderingService from '../ObjectsRendering/ObjectsRenderingService';
+
+type MakeExtensionsLoaderArguments = {|
+  gd: any,
+  objectsEditorService: typeof ObjectsEditorService,
+  objectsRenderingService: typeof ObjectsRenderingService,
+  filterExamples: boolean,
+|};
+*/
 
 /**
  * Loader that will find all JS extensions declared in GDJS/Runtime/Extensions/xxx/JsExtension.js.
  * If you add a new extension and also want it to be available for the web-app version, add it in
  * BrowserJsExtensionsLoader.js
  */
-module.exports = function makeExtensionloader({ gd, filterExamples }) {
+module.exports = function makeExtensionsLoader(
+  {
+    gd,
+    objectsEditorService,
+    objectsRenderingService,
+    filterExamples,
+  } /*: MakeExtensionsLoaderArguments*/
+) /*: JsExtensionsLoader*/ {
   return {
     loadAllExtensions: () => {
       return findJsExtensionModules({ filterExamples }).then(
@@ -34,6 +55,28 @@ module.exports = function makeExtensionloader({ gd, filterExamples }) {
               }
 
               if (extensionModule) {
+                // Load any editor for objects, if we have somewhere where
+                // to register them.
+                if (
+                  objectsEditorService &&
+                  extensionModule.registerEditorConfigurations
+                ) {
+                  extensionModule.registerEditorConfigurations(
+                    objectsEditorService
+                  );
+                }
+
+                // Load any renderer for objects, if we have somewhere where
+                // to register them.
+                if (
+                  objectsRenderingService &&
+                  extensionModule.registerInstanceRenderers
+                ) {
+                  extensionModule.registerInstanceRenderers(
+                    objectsRenderingService
+                  );
+                }
+
                 return {
                   extensionModulePath,
                   result: loadExtension(

--- a/newIDE/app/src/JsExtensionsLoader/index.js
+++ b/newIDE/app/src/JsExtensionsLoader/index.js
@@ -1,34 +1,37 @@
-// Note: this file does not use export/imports nor Flow to allow its usage from Node.js
+// @flow
+// Note: this file does not use export/imports and use Flow comments to allow its usage from Node.js
 
 const some = require('lodash/some');
 const t = _ => _; //TODO: Implement support for i18n for extensions.
 
-// export type JsExtensionModule = {
-//   createExtension(t, gd): gdPlatformExtension,
-//   runExtensionSanityTests(extension: gdPlatformExtension): Array<string>,
-// };
+/*flow-include 
+export type JsExtensionModule = {
+  createExtension(t, gd: any): gdPlatformExtension,
+  runExtensionSanityTests(gd: any, extension: gdPlatformExtension): Array<string>,
+};
 
-// export type ExtensionLoadingResult = {
-//   error: boolean,
-//   message: string,
-//   dangerous?: boolean,
-//   rawError?: any,
-// };
+export type ExtensionLoadingResult = {
+  error: boolean,
+  message: string,
+  dangerous?: boolean,
+  rawError?: any,
+};
 
-// export interface JsExtensionsLoader {
-//   loadAllExtensions(): Promise<
-//     Array<{ extensionModulePath: string, result: ExtensionLoadingResult }>
-//   >,
-// }
+export interface JsExtensionsLoader {
+  loadAllExtensions(): Promise<
+    Array<{ extensionModulePath: string, result: ExtensionLoadingResult }>
+  >,
+}
+*/
 
 /**
  * Run extensions tests and check for any non-empty results.
  */
 const runExtensionSanityTests = (
-  gd,
+  gd /*: any */,
   extension /*: gdPlatformExtension*/,
   jsExtensionModule /*: JsExtensionModule*/
-) => /*: ExtensionLoadingResult*/ {
+) /*: ExtensionLoadingResult*/ => {
   if (!jsExtensionModule.runExtensionSanityTests) {
     return {
       error: true,
@@ -57,10 +60,10 @@ const runExtensionSanityTests = (
  * to contain a "createExtension" function returning a gd.PlatformExtension.
  */
 const loadExtension = (
-  gd,
+  gd /*: any */,
   platform /*: gdPlatform*/,
   jsExtensionModule /*: JsExtensionModule*/
-) => /*: ExtensionLoadingResult*/ {
+) /*: ExtensionLoadingResult*/ => {
   if (!jsExtensionModule.createExtension) {
     return {
       message:

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -18,8 +18,10 @@ import LocalProjectOpener from './ProjectsStorage/LocalProjectOpener';
 import LocalPreviewLauncher from './Export/LocalExporters/LocalPreviewLauncher';
 import { getLocalExporters } from './Export/LocalExporters';
 import ElectronEventsBridge from './MainFrame/ElectronEventsBridge';
-import makeExtensionloader from './JsExtensionsLoader/LocalJsExtensionsLoader';
+import makeExtensionsLoader from './JsExtensionsLoader/LocalJsExtensionsLoader';
 import { makeLocalEventsFunctionWriter } from './EventsFunctionsExtensionsLoader/LocalEventsFunctionWriter';
+import ObjectsEditorService from './ObjectEditor/ObjectsEditorService';
+import ObjectsRenderingService from './ObjectsRendering/ObjectsRenderingService';
 const gd = global.gd;
 
 export const create = (authentification: Authentification) => {
@@ -63,8 +65,10 @@ export const create = (authentification: Authentification) => {
           resourceSources={localResourceSources}
           resourceExternalEditors={localResourceExternalEditors}
           authentification={authentification}
-          extensionsLoader={makeExtensionloader({
+          extensionsLoader={makeExtensionsLoader({
             gd,
+            objectsEditorService: ObjectsEditorService,
+            objectsRenderingService: ObjectsRenderingService,
             filterExamples: !Window.isDev(),
           })}
           initialPathsOrURLsToOpen={appArguments['_']}

--- a/newIDE/app/src/ObjectEditor/Editors/ObjectPropertiesEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ObjectPropertiesEditor.js
@@ -1,0 +1,35 @@
+// @flow
+import * as React from 'react';
+import PropertiesEditor from '../../PropertiesEditor';
+import propertiesMapToSchema from '../../PropertiesEditor/PropertiesMapToSchema';
+import EmptyMessage from '../../UI/EmptyMessage';
+import { type EditorProps } from './EditorProps.flow';
+import { Column } from '../../UI/Grid';
+
+type Props = EditorProps;
+
+export default class ObjectPropertiesEditor extends React.Component<Props> {
+  render() {
+    const { object, project } = this.props;
+    const properties = object.getProperties(project);
+
+    const propertiesSchema = propertiesMapToSchema(
+      properties,
+      object => object.getProperties(project),
+      (object, name, value) => object.updateProperty(name, value, project)
+    );
+
+    return (
+      <Column>
+        {propertiesSchema.length ? (
+          <PropertiesEditor schema={propertiesSchema} instances={[object]} />
+        ) : (
+          <EmptyMessage>
+            There is nothing to configure for this object. You can still use
+            events to interact with the object.
+          </EmptyMessage>
+        )}
+      </Column>
+    );
+  }
+}

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -164,7 +164,7 @@ export default class ObjectEditorDialogContainer extends Component<*, *> {
     this.setState({
       dialogComponent: withSerializableObject(ObjectEditorDialog, {
         propName: 'object',
-        newObjectCreator: editorConfiguration.newObjectCreator,
+        newObjectCreator: () => editorConfiguration.createNewObject(object),
         useProjectToUnserialize: true,
       }),
       editorComponent: editorConfiguration.component,

--- a/newIDE/app/src/ObjectEditor/ObjectsEditorService.js
+++ b/newIDE/app/src/ObjectEditor/ObjectsEditorService.js
@@ -5,6 +5,7 @@ import SpriteEditor from './Editors/SpriteEditor';
 import EmptyEditor from './Editors/EmptyEditor';
 import ShapePainterEditor from './Editors/ShapePainterEditor';
 import ParticleEmitterEditor from './Editors/ParticleEmitterEditor';
+import ObjectPropertiesEditor from './Editors/ObjectPropertiesEditor';
 const gd = global.gd;
 
 /**
@@ -27,9 +28,9 @@ export default {
       );
       return;
     }
-    if (!editorConfiguration.newObjectCreator) {
+    if (!editorConfiguration.createNewObject) {
       console.warn(
-        `Tried to register editor configuration for object "${objectType}", but "newObjectCreator" property is not defined.`
+        `Tried to register editor configuration for object "${objectType}", but "createNewObject" property is not defined.`
       );
       return;
     }
@@ -40,55 +41,69 @@ export default {
       return;
     }
 
-    if (!this.editorConfigurations.hasOwnProperty(objectType)) {
+    if (this.editorConfigurations.hasOwnProperty(objectType)) {
       console.warn(
-        `Tried to register renderer for object "${objectType}", but an editor configuration already exists.`
+        `Tried to register editor configuration for object "${objectType}", but an editor configuration already exists.`
       );
       return;
     }
 
+    console.info(
+      `Properly registered editor configuration for object "${objectType}".`
+    );
     this.editorConfigurations[objectType] = editorConfiguration;
+  },
+  getDefaultObjectJsImplementationPropertiesEditor() {
+    return {
+      component: ObjectPropertiesEditor,
+      createNewObject: object =>
+        gd
+          .asObjectJsImplementation(object)
+          .clone()
+          .release(),
+      castToObjectType: object => gd.asObjectJsImplementation(object),
+    };
   },
   editorConfigurations: {
     Sprite: {
       component: SpriteEditor,
-      newObjectCreator: () => new gd.SpriteObject(''),
+      createNewObject: () => new gd.SpriteObject(''),
       castToObjectType: object => gd.asSpriteObject(object),
       helpPagePath: '/objects/sprite',
     },
     'TiledSpriteObject::TiledSprite': {
       component: TiledSpriteEditor,
-      newObjectCreator: () => new gd.TiledSpriteObject(''),
+      createNewObject: () => new gd.TiledSpriteObject(''),
       castToObjectType: object => gd.asTiledSpriteObject(object),
       helpPagePath: '/objects/tiled_sprite',
     },
     'PanelSpriteObject::PanelSprite': {
       component: PanelSpriteEditor,
-      newObjectCreator: () => new gd.PanelSpriteObject(''),
+      createNewObject: () => new gd.PanelSpriteObject(''),
       castToObjectType: object => gd.asPanelSpriteObject(object),
       helpPagePath: '/objects/panel_sprite',
     },
     'TextObject::Text': {
       component: TextEditor,
-      newObjectCreator: () => new gd.TextObject(''),
+      createNewObject: () => new gd.TextObject(''),
       castToObjectType: object => gd.asTextObject(object),
       helpPagePath: '/objects/text',
     },
     'PrimitiveDrawing::Drawer': {
       component: ShapePainterEditor,
-      newObjectCreator: () => new gd.ShapePainterObject(''),
+      createNewObject: () => new gd.ShapePainterObject(''),
       castToObjectType: object => gd.asShapePainterObject(object),
       helpPagePath: '/objects/shape_painter',
     },
     'TextEntryObject::TextEntry': {
       component: EmptyEditor,
-      newObjectCreator: () => new gd.TextEntryObject(''),
+      createNewObject: () => new gd.TextEntryObject(''),
       castToObjectType: object => gd.asTextEntryObject(object),
       helpPagePath: '/objects/text_entry',
     },
     'ParticleSystem::ParticleEmitter': {
       component: ParticleEmitterEditor,
-      newObjectCreator: () => new gd.ParticleEmitterObject(''),
+      createNewObject: () => new gd.ParticleEmitterObject(''),
       castToObjectType: object => gd.asParticleEmitterObject(object),
       helpPagePath: '/objects/particles_emitter',
     },

--- a/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
+++ b/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
@@ -8,6 +8,9 @@ import RenderedTextEntryInstance from './Renderers/RenderedTextEntryInstance';
 import RenderedParticleEmitterInstance from './Renderers/RenderedParticleEmitterInstance';
 import PixiResourcesLoader from './PixiResourcesLoader';
 import ResourcesLoader from '../ResourcesLoader';
+import RenderedInstance from './Renderers/RenderedInstance';
+import PIXI from 'pixi.js';
+const gd = global.gd;
 
 /**
  * A service containing functions that are called to render instances
@@ -78,13 +81,17 @@ export default {
       return;
     }
 
-    if (!this.renderers.hasOwnProperty(objectType)) {
+    if (this.renderers.hasOwnProperty(objectType)) {
       console.warn(
         `Tried to register renderer for object "${objectType}", but a renderer already exists.`
       );
       return;
     }
 
+    console.info(`Properly registered renderer for object "${objectType}".`);
     this.renderers[objectType] = renderer;
   },
+  gd, // Expose gd so that it can be used by renderers
+  PIXI, // Expose PIXI so that it can be used by renderers
+  RenderedInstance, // Expose the base class for renderers so that it can be used by renderers
 };

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
@@ -1,6 +1,6 @@
 /**
- * RenderedInstance represents the object associated to an instance
- * when it is rendered in a scene editor (see SceneAreaCtrl).
+ * RenderedInstance is the base class used for creating renderers of instances,
+ * which display on the scene editor, using Pixi.js, the instance of an object (see InstancesEditor).
  *
  * @class RenderedInstance
  * @constructor
@@ -20,7 +20,7 @@ function RenderedInstance(
   this._project = project;
   this._layout = layout;
   this._pixiResourcesLoader = pixiResourcesLoader;
-  this.wasUsed = true; //Used by SceneAreaCtrl to track rendered instance that are not used anymore.
+  this.wasUsed = true; //Used by InstancesRenderer to track rendered instance that are not used anymore.
 }
 
 /**


### PR DESCRIPTION
Still to do:

- [x] Allow the extension to specify a renderer for the IDE (should be doable to put this file inside the extension).
- [x] Display the property of the object in the object editor.
  - [x] Allow the extension to specify/register an editor, and provide a `createDefaultObjectJsImplementationEditor` function.
- [x] Check that the example runtime object is actually working (it's a simple text object showing "This is a dummy object", nothing fancy)
- [x] Add example of accessing to the properties
- [x] Check all the TODOs
- [x] Update README