### PR TITLE
Prevent undefined vertices on physics

### DIFF
--- a/Extensions/Physics2Behavior/physics2runtimebehavior.js
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.js
@@ -273,10 +273,9 @@ gdjs.Physics2RuntimeBehavior.prototype.ownerRemovedFromScene = function() {
 };
 
 gdjs.Physics2RuntimeBehavior.getPolygon = function(verticesData) {
+  if (!verticesData) return null;
+
   var polygon = new gdjs.Polygon();
-
-  if (!verticesData) return polygon;
-
   var maxVertices = 8;
   for (
     var i = 0, len = verticesData.length;

--- a/Extensions/Physics2Behavior/physics2runtimebehavior.js
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.js
@@ -204,7 +204,10 @@ gdjs.Physics2RuntimeBehavior = function(runtimeScene, behaviorData, owner) {
   this.shapeOffsetX = behaviorData.content.shapeOffsetX;
   this.shapeOffsetY = behaviorData.content.shapeOffsetY;
   this.polygonOrigin = behaviorData.content.polygonOrigin;
-  this.polygon = this.shape === 'Polygon' ? gdjs.Physics2RuntimeBehavior.getPolygon(behaviorData.content.vertices) : null;
+  this.polygon =
+    this.shape === 'Polygon'
+      ? gdjs.Physics2RuntimeBehavior.getPolygon(behaviorData.content.vertices)
+      : null;
   this.density = behaviorData.content.density;
   this.friction = behaviorData.content.friction;
   this.restitution = behaviorData.content.restitution;
@@ -272,10 +275,14 @@ gdjs.Physics2RuntimeBehavior.prototype.ownerRemovedFromScene = function() {
 gdjs.Physics2RuntimeBehavior.getPolygon = function(verticesData) {
   var polygon = new gdjs.Polygon();
 
-  if(!verticesData) return polygon;
+  if (!verticesData) return polygon;
 
   var maxVertices = 8;
-  for (var i = 0, len = verticesData.length; i < Math.min(len, maxVertices); i++) {
+  for (
+    var i = 0, len = verticesData.length;
+    i < Math.min(len, maxVertices);
+    i++
+  ) {
     polygon.vertices.push([verticesData[i].x, verticesData[i].y]);
   }
   return polygon;
@@ -312,7 +319,7 @@ gdjs.Physics2RuntimeBehavior.prototype.createShape = function() {
   } else if (this.shape === 'Polygon') {
     shape = new Box2D.b2PolygonShape();
     // Not convex, fall back to a box
-    if (!this.polygon ||!this.polygon.isConvex()) {
+    if (!this.polygon || !this.polygon.isConvex()) {
       var width =
         (this.owner.getWidth() > 0 ? this.owner.getWidth() : 1) *
         this._sharedData.invScaleX;
@@ -324,15 +331,18 @@ gdjs.Physics2RuntimeBehavior.prototype.createShape = function() {
     } else {
       var originOffsetX = 0;
       var originOffsetY = 0;
-      if(this.polygonOrigin === "Origin"){
-        originOffsetX = (this.owner.getWidth() > 0 ? -this.owner.getWidth()/2 : 0)
-                        + (this.owner.getX() - this.owner.getDrawableX());
-        originOffsetY = (this.owner.getHeight() > 0 ? -this.owner.getHeight()/2 : 0)
-                        + (this.owner.getY() - this.owner.getDrawableY());
-      }
-      else if(this.polygonOrigin === "TopLeft"){
-        originOffsetX = this.owner.getWidth() > 0 ? -this.owner.getWidth()/2 : 0;
-        originOffsetY = this.owner.getHeight() > 0 ? -this.owner.getHeight()/2 : 0;
+      if (this.polygonOrigin === 'Origin') {
+        originOffsetX =
+          (this.owner.getWidth() > 0 ? -this.owner.getWidth() / 2 : 0) +
+          (this.owner.getX() - this.owner.getDrawableX());
+        originOffsetY =
+          (this.owner.getHeight() > 0 ? -this.owner.getHeight() / 2 : 0) +
+          (this.owner.getY() - this.owner.getDrawableY());
+      } else if (this.polygonOrigin === 'TopLeft') {
+        originOffsetX =
+          this.owner.getWidth() > 0 ? -this.owner.getWidth() / 2 : 0;
+        originOffsetY =
+          this.owner.getHeight() > 0 ? -this.owner.getHeight() / 2 : 0;
       }
       // Generate vertices if not done already
       if (!this._verticesBuffer) {
@@ -348,10 +358,12 @@ gdjs.Physics2RuntimeBehavior.prototype.createShape = function() {
       var offset = 0;
       for (var i = 0, len = this.polygon.vertices.length; i < len; i++) {
         Box2D.HEAPF32[(this._verticesBuffer + offset) >> 2] =
-          (this.polygon.vertices[i][0] * this.shapeScale + originOffsetX) * this._sharedData.invScaleX +
+          (this.polygon.vertices[i][0] * this.shapeScale + originOffsetX) *
+            this._sharedData.invScaleX +
           offsetX;
         Box2D.HEAPF32[(this._verticesBuffer + (offset + 4)) >> 2] =
-          (this.polygon.vertices[i][1] * this.shapeScale + originOffsetY) * this._sharedData.invScaleY +
+          (this.polygon.vertices[i][1] * this.shapeScale + originOffsetY) *
+            this._sharedData.invScaleY +
           offsetY;
         offset += 8;
       }

--- a/Extensions/Physics2Behavior/physics2runtimebehavior.js
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.js
@@ -204,7 +204,7 @@ gdjs.Physics2RuntimeBehavior = function(runtimeScene, behaviorData, owner) {
   this.shapeOffsetX = behaviorData.content.shapeOffsetX;
   this.shapeOffsetY = behaviorData.content.shapeOffsetY;
   this.polygonOrigin = behaviorData.content.polygonOrigin;
-  this.polygon = this.getPolygon(behaviorData.content.vertices);
+  this.polygon = this.shape === 'Polygon' ? gdjs.Physics2RuntimeBehavior.getPolygon(behaviorData.content.vertices) : null;
   this.density = behaviorData.content.density;
   this.friction = behaviorData.content.friction;
   this.restitution = behaviorData.content.restitution;
@@ -269,8 +269,11 @@ gdjs.Physics2RuntimeBehavior.prototype.ownerRemovedFromScene = function() {
   this.onDeActivate();
 };
 
-gdjs.Physics2RuntimeBehavior.prototype.getPolygon = function(verticesData) {
+gdjs.Physics2RuntimeBehavior.getPolygon = function(verticesData) {
   var polygon = new gdjs.Polygon();
+
+  if(!verticesData) return polygon;
+
   var maxVertices = 8;
   for (var i = 0, len = verticesData.length; i < Math.min(len, maxVertices); i++) {
     polygon.vertices.push([verticesData[i].x, verticesData[i].y]);
@@ -309,7 +312,7 @@ gdjs.Physics2RuntimeBehavior.prototype.createShape = function() {
   } else if (this.shape === 'Polygon') {
     shape = new Box2D.b2PolygonShape();
     // Not convex, fall back to a box
-    if (!this.polygon.isConvex()) {
+    if (!this.polygon ||!this.polygon.isConvex()) {
       var width =
         (this.owner.getWidth() > 0 ? this.owner.getWidth() : 1) *
         this._sharedData.invScaleX;


### PR DESCRIPTION
Sorry for that, so much polygon tests and it crashes when the shape is not a polygon :D

Now it will create the polygon if the shape is a polygon only, will prevent polygons with undefined vertices data, and even prevent undefined polygons when the shape is set as a polygon but somewhat a polygon is not created.