### PR TITLE
Fix missing Physics2Behaviour Functions

### DIFF
--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -1160,7 +1160,7 @@ module.exports = {
 
 	  aut
       .addExpression(
-        'LinearVelocityLength',
+        'LinearVelocity',
         t('Linear velocity'),
         t('Get the linear velocity of an object.'),
         t('Velocity'),

--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -1077,11 +1077,11 @@ module.exports = {
       .setManipulatedType('number')
       .setGetter('getLinearVelocityX');
 	
-	aut
+	  aut
       .addExpression(
         'LinearVelocityX',
-        t('Linear velocity X'),
-        t('Get an objects linear velocity on X.'),
+        t('Linear velocity on X axis'),
+        t('Get an objects linear velocity on X axis.'),
         t('Velocity'),
         'res/physics16.png'
       )
@@ -1090,7 +1090,7 @@ module.exports = {
       .getCodeExtraInformation()
       .setFunctionName('getLinearVelocityX');
     
-	aut
+	  aut
       .addCondition(
         'LinearVelocityY',
         t('Linear velocity Y'),
@@ -1127,11 +1127,11 @@ module.exports = {
       .setManipulatedType('number')
       .setGetter('getLinearVelocityY');
 	
-	aut
+	  aut
       .addExpression(
         'LinearVelocityY',
-        t('Linear velocity Y'),
-        t('Get an objects linear velocity on Y.'),
+        t('Linear velocity on Y axis'),
+        t('Get an objects linear velocity on Y axis.'),
         t('Velocity'),
         'res/physics16.png'
       )
@@ -1158,11 +1158,11 @@ module.exports = {
       .setFunctionName('getLinearVelocityLength')
       .setManipulatedType('number');
 
-	aut
+	  aut
       .addExpression(
         'LinearVelocityLength',
-        t('Linear velocity Length'),
-        t('Get an objects linear velocity length.'),
+        t('Linear velocity'),
+        t('Get the linear velocity of an object.'),
         t('Velocity'),
         'res/physics16.png'
       )
@@ -1208,11 +1208,11 @@ module.exports = {
       .setManipulatedType('number')
       .setGetter('getAngularVelocity');
 
-	aut
+	  aut
       .addExpression(
         'AngularVelocity',
         t('Angular velocity'),
-        t('Get an objects Angular velocity.'),
+        t('Get the angular velocity of an object.'),
         t('Velocity'),
         'res/physics16.png'
       )

--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -1081,7 +1081,7 @@ module.exports = {
       .addExpression(
         'LinearVelocityX',
         t('Linear velocity on X axis'),
-        t('Get an objects linear velocity on X axis.'),
+        t('Get the linear velocity of an object on X axis.'),
         t('Velocity'),
         'res/physics16.png'
       )
@@ -1131,7 +1131,7 @@ module.exports = {
       .addExpression(
         'LinearVelocityY',
         t('Linear velocity on Y axis'),
-        t('Get an objects linear velocity on Y axis.'),
+        t('Get the linear velocity of an object on Y axis.'),
         t('Velocity'),
         'res/physics16.png'
       )

--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -1076,8 +1076,8 @@ module.exports = {
       .setFunctionName('setLinearVelocityX')
       .setManipulatedType('number')
       .setGetter('getLinearVelocityX');
-	
-	  aut
+
+    aut
       .addExpression(
         'LinearVelocityX',
         t('Linear velocity on X axis'),
@@ -1089,8 +1089,8 @@ module.exports = {
       .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
       .getCodeExtraInformation()
       .setFunctionName('getLinearVelocityX');
-    
-	  aut
+
+    aut
       .addCondition(
         'LinearVelocityY',
         t('Linear velocity Y'),
@@ -1126,8 +1126,8 @@ module.exports = {
       .setFunctionName('setLinearVelocityY')
       .setManipulatedType('number')
       .setGetter('getLinearVelocityY');
-	
-	  aut
+
+    aut
       .addExpression(
         'LinearVelocityY',
         t('Linear velocity on Y axis'),
@@ -1138,8 +1138,8 @@ module.exports = {
       .addParameter('object', t('Object'), '', false)
       .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
       .getCodeExtraInformation()
-      .setFunctionName('getLinearVelocityY');  
-	  
+      .setFunctionName('getLinearVelocityY');
+
     aut
       .addCondition(
         'LinearVelocityLength',
@@ -1158,7 +1158,7 @@ module.exports = {
       .setFunctionName('getLinearVelocityLength')
       .setManipulatedType('number');
 
-	  aut
+    aut
       .addExpression(
         'LinearVelocity',
         t('Linear velocity'),
@@ -1169,8 +1169,8 @@ module.exports = {
       .addParameter('object', t('Object'), '', false)
       .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
       .getCodeExtraInformation()
-      .setFunctionName('getLinearVelocityLength');  
-	  
+      .setFunctionName('getLinearVelocityLength');
+
     aut
       .addCondition(
         'AngularVelocity',
@@ -1208,7 +1208,7 @@ module.exports = {
       .setManipulatedType('number')
       .setGetter('getAngularVelocity');
 
-	  aut
+    aut
       .addExpression(
         'AngularVelocity',
         t('Angular velocity'),
@@ -1219,8 +1219,8 @@ module.exports = {
       .addParameter('object', t('Object'), '', false)
       .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
       .getCodeExtraInformation()
-      .setFunctionName('getAngularVelocity');  
-	  
+      .setFunctionName('getAngularVelocity');
+
     // Forces and impulses
     aut
       .addAction(

--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -1076,8 +1076,21 @@ module.exports = {
       .setFunctionName('setLinearVelocityX')
       .setManipulatedType('number')
       .setGetter('getLinearVelocityX');
-
-    aut
+	
+	aut
+      .addExpression(
+        'LinearVelocityX',
+        t('Linear velocity X'),
+        t('Get an objects linear velocity on X.'),
+        t('Velocity'),
+        'res/physics16.png'
+      )
+      .addParameter('object', t('Object'), '', false)
+      .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
+      .getCodeExtraInformation()
+      .setFunctionName('getLinearVelocityX');
+    
+	aut
       .addCondition(
         'LinearVelocityY',
         t('Linear velocity Y'),
@@ -1113,7 +1126,20 @@ module.exports = {
       .setFunctionName('setLinearVelocityY')
       .setManipulatedType('number')
       .setGetter('getLinearVelocityY');
-
+	
+	aut
+      .addExpression(
+        'LinearVelocityY',
+        t('Linear velocity Y'),
+        t('Get an objects linear velocity on Y.'),
+        t('Velocity'),
+        'res/physics16.png'
+      )
+      .addParameter('object', t('Object'), '', false)
+      .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
+      .getCodeExtraInformation()
+      .setFunctionName('getLinearVelocityY');  
+	  
     aut
       .addCondition(
         'LinearVelocityLength',
@@ -1132,6 +1158,19 @@ module.exports = {
       .setFunctionName('getLinearVelocityLength')
       .setManipulatedType('number');
 
+	aut
+      .addExpression(
+        'LinearVelocityLength',
+        t('Linear velocity Length'),
+        t('Get an objects linear velocity length.'),
+        t('Velocity'),
+        'res/physics16.png'
+      )
+      .addParameter('object', t('Object'), '', false)
+      .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
+      .getCodeExtraInformation()
+      .setFunctionName('getLinearVelocityLength');  
+	  
     aut
       .addCondition(
         'AngularVelocity',
@@ -1169,6 +1208,19 @@ module.exports = {
       .setManipulatedType('number')
       .setGetter('getAngularVelocity');
 
+	aut
+      .addExpression(
+        'AngularVelocity',
+        t('Angular velocity'),
+        t('Get an objects Angular velocity.'),
+        t('Velocity'),
+        'res/physics16.png'
+      )
+      .addParameter('object', t('Object'), '', false)
+      .addParameter('behavior', t('Behavior'), 'Physics2Behavior')
+      .getCodeExtraInformation()
+      .setFunctionName('getAngularVelocity');  
+	  
     // Forces and impulses
     aut
       .addAction(


### PR DESCRIPTION
Add the missing expression functions  linearvelocityY, linearvelocityX, linearvelocityLength and also angularvelocity to Physics2Behaviour

This will probably not work, or it's luck!