### PR TITLE
Prevent repeated and aligned vertices

### DIFF
--- a/Extensions/Physics2Behavior/physics2runtimebehavior.js
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.js
@@ -290,7 +290,7 @@ gdjs.Physics2RuntimeBehavior.getPolygon = function(verticesData) {
 gdjs.Physics2RuntimeBehavior.isPolygonConvex = function(polygon) {
   if (!polygon.isConvex()) return false;
 
-  // Repeated vertices or all vertices aligned
+  // Check for repeated vertices or check if all vertices are aligned (would crash Box2D)
   var alignedX = true;
   var alignedY = true;
   for (i = 0; i < polygon.vertices.length - 1; ++i) {

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
@@ -30,10 +30,10 @@ type Props = {|
 export default class PolygonEditor extends React.Component<Props> {
   _isPolygonConvex(vertices: Array<Vertex>) {
     // Get edges
-    var edges = [];
-    var v1 = null;
-    var v2 = null;
-    for (var i = 0; i < vertices.length; i++) {
+    let edges = [];
+    let v1 = null;
+    let v2 = null;
+    for (let i = 0; i < vertices.length; i++) {
       v1 = vertices[i];
       if (i + 1 >= vertices.length) v2 = vertices[0];
       else v2 = vertices[i + 1];
@@ -46,31 +46,31 @@ export default class PolygonEditor extends React.Component<Props> {
     const zProductIsPositive =
       edges[0].x * edges[0 + 1].y - edges[0].y * edges[0 + 1].x > 0;
 
-    for (i = 1; i < edges.length - 1; ++i) {
-      var zCrossProduct =
+    for (let i = 1; i < edges.length - 1; ++i) {
+      let zCrossProduct =
         edges[i].x * edges[i + 1].y - edges[i].y * edges[i + 1].x;
-      var zCrossProductIsPositive = zCrossProduct > 0;
+      let zCrossProductIsPositive = zCrossProduct > 0;
       if (zCrossProductIsPositive !== zProductIsPositive) return false;
     }
 
-    var lastZCrossProduct =
+    let lastZCrossProduct =
       edges[edges.length - 1].x * edges[0].y -
       edges[edges.length - 1].y * edges[0].x;
-    var lastZCrossProductIsPositive = lastZCrossProduct > 0;
+    let lastZCrossProductIsPositive = lastZCrossProduct > 0;
     if (lastZCrossProductIsPositive !== zProductIsPositive) return false;
 
-    // Repeated vertices
-    for (i = 0; i < vertices.length - 1; ++i) {
-      for (var j = i + 1; j < vertices.length; ++j) {
+    // Check for repeated vertices (would crash Box2D during the game)
+    for (let i = 0; i < vertices.length - 1; ++i) {
+      for (let j = i + 1; j < vertices.length; ++j) {
         if (vertices[i].x === vertices[j].x && vertices[i].y === vertices[j].y)
           return false;
       }
     }
 
-    // All vertices aligned
-    var alignedX = true;
-    var alignedY = true;
-    for (i = 0; i < vertices.length - 1; ++i) {
+    // Check if all vertices are aligned (would crash Box2D during the game)
+    let alignedX = true;
+    let alignedY = true;
+    for (let i = 0; i < vertices.length - 1; ++i) {
       if (vertices[i].x !== vertices[i + 1].x) alignedX = false;
       if (vertices[i].y !== vertices[i + 1].y) alignedY = false;
     }


### PR DESCRIPTION
This fixes the two major crash cases:
Repeated vertices: If any vertex is repeated, the polygon is considered as degenerated / non-convex.
Aligned vertices: If all the vertices are aligned vertically or horizontally the polygon is also degenerated / non-convex.