### PR TITLE
Fix initial motors speed

### DIFF
--- a/Extensions/Physics2Behavior/physics2runtimebehavior.js
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.js
@@ -1508,7 +1508,7 @@ gdjs.Physics2RuntimeBehavior.prototype.addRevoluteJoint = function(
   jointDef.set_lowerAngle(gdjs.toRad(lowerAngle));
   jointDef.set_upperAngle(gdjs.toRad(upperAngle));
   jointDef.set_enableMotor(enableMotor);
-  jointDef.set_motorSpeed(motorSpeed);
+  jointDef.set_motorSpeed(gdjs.toRad(motorSpeed));
   jointDef.set_maxMotorTorque(maxMotorTorque >= 0 ? maxMotorTorque : 0);
   jointDef.set_collideConnected(false);
   // Create the joint and get the id
@@ -1577,7 +1577,7 @@ gdjs.Physics2RuntimeBehavior.prototype.addRevoluteJointBetweenTwoBodies = functi
   jointDef.set_lowerAngle(gdjs.toRad(lowerAngle));
   jointDef.set_upperAngle(gdjs.toRad(upperAngle));
   jointDef.set_enableMotor(enableMotor);
-  jointDef.set_motorSpeed(motorSpeed);
+  jointDef.set_motorSpeed(gdjs.toRad(motorSpeed));
   jointDef.set_maxMotorTorque(maxMotorTorque >= 0 ? maxMotorTorque : 0);
   jointDef.set_collideConnected(collideConnected);
   // Create the joint and get the id
@@ -1836,7 +1836,7 @@ gdjs.Physics2RuntimeBehavior.prototype.addPrismaticJoint = function(
     upperTranslation > 0 ? upperTranslation * this._sharedData.invScaleX : 0
   );
   jointDef.set_enableMotor(enableMotor);
-  jointDef.set_motorSpeed(motorSpeed);
+  jointDef.set_motorSpeed(motorSpeed * this._sharedData.invScaleX);
   jointDef.set_maxMotorForce(maxMotorForce);
   jointDef.set_collideConnected(collideConnected);
   // Create the joint and get the id
@@ -2502,7 +2502,7 @@ gdjs.Physics2RuntimeBehavior.prototype.addWheelJoint = function(
   jointDef.set_frequencyHz(frequency > 0 ? frequency : 1);
   jointDef.set_dampingRatio(dampingRatio >= 0 ? dampingRatio : 0);
   jointDef.set_enableMotor(enableMotor);
-  jointDef.set_motorSpeed(motorSpeed);
+  jointDef.set_motorSpeed(gdjs.toRad(motorSpeed));
   jointDef.set_maxMotorTorque(maxMotorTorque);
   jointDef.set_collideConnected(collideConnected);
   // Create the joint and get the id
@@ -2547,7 +2547,7 @@ gdjs.Physics2RuntimeBehavior.prototype.getWheelJointSpeed = function(jointId) {
   // Joint not found or has wrong type
   if (joint === null || joint.GetType() !== Box2D.e_wheelJoint) return 0;
   // Get the joint speed
-  return joint.GetJointSpeed() * this._sharedData.scaleX;
+  return gdjs.toDegrees(joint.GetJointSpeed());
 };
 
 gdjs.Physics2RuntimeBehavior.prototype.isWheelJointMotorEnabled = function(


### PR DESCRIPTION
All the joints with motor speed options were using "raw" box2d values, it doesn't affect the examples (already tested them) because the conditions and actions are fine, it's just on joint creation, sorry for that :)

Also checking it I noticed the wheel joint speed value was incorrect... it isn't a translation speed but a rotation... oops, in my defense the comments in Box2D sources (I've read the sources directly to do the extension) are wrong:
https://github.com/kripken/box2d.js/blob/de6186e2a80ec18f2ac923ff161d178f790c4b9f/Box2D_v2.3.1/Box2D/Dynamics/Joints/b2WheelJoint.h#L100-L101
I guess it's the magic of "usually", although the only motor speed in meters per second now is the prismatic.