### PR TITLE
Skinning (basicly) the "Link" event for the DefaultTheme and the Darktheme

### DIFF
--- a/newIDE/app/src/UI/Theme/DarkTheme/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/DarkTheme/EventsSheet.css
@@ -165,3 +165,16 @@
   width: '100%';
   box-sizing: 'border-box';
 }
+
+/**
+* Skinning the "Link" event
+*/
+.gd-events-sheet-dark-theme .large-selectable {
+  background: #505050;
+}
+.gd-events-sheet-dark-theme .large-selectable span {
+  color: rgb(209, 209, 209);
+}
+.gd-events-sheet-dark-theme .large-selectable .selectable {
+  color: #b77cff;
+}

--- a/newIDE/app/src/UI/Theme/DefaultTheme/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/DefaultTheme/EventsSheet.css
@@ -163,3 +163,13 @@
   width: '100%';
   box-sizing: 'border-box';
 }
+
+/**
+* Skinning the "Link" event
+*/
+.gd-events-sheet-default-theme .large-selectable {
+  background: #f1f2f2;
+}
+.gd-events-sheet-default-theme .large-selectable .selectable {
+  color: #3c4698;
+}


### PR DESCRIPTION
This is very basic skinning for the 2 themes and the "link" events. 

I added a color for the selectable class on the DefaultTheme (to make it look like similar to the others modifiable elements of events).
![image](https://user-images.githubusercontent.com/8144048/52088684-dc2c3c80-25ac-11e9-9ca4-1a3d157b78cf.png)

I added a background color, text color, and a color for the selectable class of the DarkTheme.
![image](https://user-images.githubusercontent.com/8144048/52088651-c0289b00-25ac-11e9-9dfa-fe62d604c29a.png)

First time i followed the readme to contribute to the newIDE, i have to admit : 
- installing node.js, cloning the repo was super easy
- identify the css files, classes, and modify it too
- but i've spent 2 hours to understand GitHub/Fork/Pull Requests ! Damn, i'm coming from subversion 🤣 
