### PR TITLE
Use content size on preview window

### DIFF
--- a/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
@@ -29,6 +29,7 @@ type State = {
   previewBrowserWindowConfig: ?{
     width: number,
     height: number,
+    useContentSize: boolean,
     title: string,
     backgroundColor: string,
   },
@@ -72,6 +73,7 @@ export default class LocalPreviewLauncher extends React.Component<
         previewBrowserWindowConfig: {
           width: project.getMainWindowDefaultWidth(),
           height: project.getMainWindowDefaultHeight(),
+          useContentSize: true,
           title: `Preview of ${project.getName()}`,
           backgroundColor: '#000000',
         },


### PR DESCRIPTION
Fixes that problem with the preview window having a different ratio than game size.

:warning: I've tested it and works, but edited the file directly in GitHub as the change was super simple, I have no flow here so if the flow is wrong you can fix it or close this to make your own commit :)