### PR TITLE
Add filters conditions/actions in search bar for events

### DIFF
--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -97,9 +97,7 @@ export default class SearchPanel extends PureComponent<Props, State> {
       replaceText,
       matchCase,
       searchInActions,
-      searchInConditions,
-      searchInActions,
-      searchInConditions,
+      searchInConditions
     });
   };
 
@@ -158,7 +156,7 @@ export default class SearchPanel extends PureComponent<Props, State> {
                 checked={!this.state.matchCase}
                 onCheck={(e, checked) => this.setState({ matchCase: !checked })}
               />
-              <p>{'Filter by:'}</p>
+              <p><Trans>Filter by</Trans></p>
               <InlineCheckbox
                 label={<Trans>Conditions</Trans>}
                 checked={this.state.searchInConditions}

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -10,7 +10,6 @@ import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import IconButton from 'material-ui/IconButton';
 import InlineCheckbox from '../UI/InlineCheckbox';
-import { showMessageBox } from '../UI/Messages/MessageBox';
 import {
   type SearchInEventsInputs,
   type ReplaceInEventsInputs,
@@ -25,7 +24,6 @@ type Props = {|
   onGoToNextSearchResult: () => ?gdBaseEvent,
 |};
 type State = {|
-  searchDirty: boolean,
   searchText: string,
   replaceText: string,
   matchCase: boolean,
@@ -37,7 +35,6 @@ type State = {|
 export default class SearchPanel extends PureComponent<Props, State> {
   searchTextField: ?TextField;
   state = {
-    searchDirty: false,
     searchText: '',
     replaceText: '',
     matchCase: false,
@@ -67,14 +64,10 @@ export default class SearchPanel extends PureComponent<Props, State> {
       searchInActions,
       searchInConditions,
     });
-    this.setState({
-      searchDirty: false,
-    });
   };
 
   launchReplace = () => {
     const {
-      searchDirty,
       searchText,
       replaceText,
       searchInSelection,
@@ -82,12 +75,6 @@ export default class SearchPanel extends PureComponent<Props, State> {
       searchInActions,
       searchInConditions,
     } = this.state;
-    // if (searchDirty) {
-    //   showMessageBox(
-    //     'Click on Search first, inspect the results and then click on Replace to do the replacement(s).'
-    //   );
-    //   return;
-    // }
 
     this.launchSearch();
 
@@ -97,7 +84,7 @@ export default class SearchPanel extends PureComponent<Props, State> {
       replaceText,
       matchCase,
       searchInActions,
-      searchInConditions
+      searchInConditions,
     });
   };
 
@@ -119,9 +106,7 @@ export default class SearchPanel extends PureComponent<Props, State> {
                 (this.searchTextField = _searchTextField)
               }
               hintText={<Trans>Text to search</Trans>}
-              onChange={(e, searchText) =>
-                this.setState({ searchText, searchDirty: true })
-              }
+              onChange={(e, searchText) => this.setState({ searchText })}
               value={searchText}
               fullWidth
             />
@@ -156,7 +141,9 @@ export default class SearchPanel extends PureComponent<Props, State> {
                 checked={!this.state.matchCase}
                 onCheck={(e, checked) => this.setState({ matchCase: !checked })}
               />
-              <p><Trans>Filter by</Trans></p>
+              <p>
+                <Trans>Filter by</Trans>
+              </p>
               <InlineCheckbox
                 label={<Trans>Conditions</Trans>}
                 checked={this.state.searchInConditions}

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -29,6 +29,8 @@ type State = {|
   searchText: string,
   replaceText: string,
   matchCase: boolean,
+  searchInActions: boolean,
+  searchInConditions: boolean,
   searchInSelection: boolean,
 |};
 
@@ -39,6 +41,8 @@ export default class SearchPanel extends PureComponent<Props, State> {
     searchText: '',
     replaceText: '',
     matchCase: false,
+    searchInActions: true,
+    searchInConditions: true,
     searchInSelection: false,
   };
 
@@ -49,13 +53,19 @@ export default class SearchPanel extends PureComponent<Props, State> {
   };
 
   launchSearch = () => {
-    const { searchText, searchInSelection, matchCase } = this.state;
+    const {
+      searchText,
+      searchInSelection,
+      matchCase,
+      searchInActions,
+      searchInConditions,
+    } = this.state;
     this.props.onSearchInEvents({
       searchInSelection,
       searchText,
       matchCase,
-      searchInActions: true,
-      searchInConditions: true,
+      searchInActions,
+      searchInConditions,
     });
     this.setState({
       searchDirty: false,
@@ -69,21 +79,27 @@ export default class SearchPanel extends PureComponent<Props, State> {
       replaceText,
       searchInSelection,
       matchCase,
+      searchInActions,
+      searchInConditions,
     } = this.state;
-    if (searchDirty) {
-      showMessageBox(
-        'Click on Search first, inspect the results and then click on Replace to do the replacement(s).'
-      );
-      return;
-    }
+    // if (searchDirty) {
+    //   showMessageBox(
+    //     'Click on Search first, inspect the results and then click on Replace to do the replacement(s).'
+    //   );
+    //   return;
+    // }
+
+    this.launchSearch();
 
     this.props.onReplaceInEvents({
       searchInSelection,
       searchText,
       replaceText,
       matchCase,
-      searchInActions: true,
-      searchInConditions: true,
+      searchInActions,
+      searchInConditions,
+      searchInActions,
+      searchInConditions,
     });
   };
 
@@ -141,6 +157,21 @@ export default class SearchPanel extends PureComponent<Props, State> {
                 label={<Trans>Case insensitive</Trans>}
                 checked={!this.state.matchCase}
                 onCheck={(e, checked) => this.setState({ matchCase: !checked })}
+              />
+              <p>{'Filter by:'}</p>
+              <InlineCheckbox
+                label={<Trans>Conditions</Trans>}
+                checked={this.state.searchInConditions}
+                onCheck={(e, checked) =>
+                  this.setState({ searchInConditions: checked })
+                }
+              />
+              <InlineCheckbox
+                label={<Trans>Actions</Trans>}
+                checked={this.state.searchInActions}
+                onCheck={(e, checked) =>
+                  this.setState({ searchInActions: checked })
+                }
               />
               {/* <InlineCheckbox //TODO: Implement search/replace in selection
                 label={<Trans>Replace in selection</Trans>}


### PR DESCRIPTION
I had the idea earlier, I saw the card, I made the card 🤪

![image](https://user-images.githubusercontent.com/1670670/55249023-69a5a900-524b-11e9-8dda-e4cd833575e3.png)
It's tested and working with replace event too.
In this PR i've comment **searchDirty**, i find it counterproductive, i launch **search** at each **replace**  let me know about this i can remove my code.


[Card on Trello](https://trello.com/c/WwPJBT8K/121-add-support-for-searching-replacing-in-events-in-the-current-selection-and-or-restrict-to-only-actions-or-only-conditions)