### PR TITLE
Basic patch for #978

### DIFF
--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -136,15 +136,6 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
           value={this.state.windowTitle}
           onChange={(e, value) => this.setState({ windowTitle: value })}
         />
-        <ColorField
-          floatingLabelText={<Trans>Scene background color</Trans>}
-          fullWidth
-          disableAlpha
-          color={this.state.backgroundColor}
-          onChangeComplete={color =>
-            this.setState({ backgroundColor: color.rgb })
-          }
-        />
         <Checkbox
           checked={this.state.shouldStopSoundsOnStartup}
           label={<Trans>Stop musics and sounds on startup</Trans>}
@@ -152,6 +143,15 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
             this.setState({
               shouldStopSoundsOnStartup: check,
             })
+          }
+        />
+        <ColorField
+          floatingLabelText={<Trans>Scene background color</Trans>}
+          fullWidth
+          disableAlpha
+          color={this.state.backgroundColor}
+          onChangeComplete={color =>
+            this.setState({ backgroundColor: color.rgb })
           }
         />
         <RaisedButton


### PR DESCRIPTION
Just inverted the checkbox and the colorfield : now the colorpicker doesn't show up over the checkbox button, and so there is no more "dead zone"  to pick a color in the color picker on the scene editor.