### PR TITLE
Show resource name on thumbnail hover

### DIFF
--- a/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
+++ b/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
@@ -49,6 +49,7 @@ const ThemableImageThumbnail = ({
 }) => {
   return (
     <div
+      title={resourceName}
       style={{
         ...styles.spriteThumbnail,
         borderColor: selected


### PR DESCRIPTION
This is a pull to show the resource's name when hovering on it's thumbnail
![showResourceNameOnHover](https://user-images.githubusercontent.com/6495061/55827469-275d5100-5b02-11e9-9c07-20a2a9d1bb8e.gif)

simple but useful

Was requested in the past
https://trello.com/c/Rrltmxda/168-display-name-of-the-resource-below-images-or-when-hovering-them