### PR TITLE
fix unzipper failing to extract external editor under windows - due to path not normalized

### DIFF
--- a/newIDE/app/scripts/import-zipped-editor.js
+++ b/newIDE/app/scripts/import-zipped-editor.js
@@ -46,7 +46,7 @@ if (shell.test('-d', basePath)) {
           fs
             .createReadStream(zipFilePath)
             .pipe(unzipper.Extract({
-              path: '../public/external/' + editor
+              path: basePath
             }))
             .on('close', function () {
               shell.echo(

--- a/newIDE/app/scripts/import-zipped-editor.js
+++ b/newIDE/app/scripts/import-zipped-editor.js
@@ -7,12 +7,13 @@ var shell = require('shelljs');
 var https = require('follow-redirects').https;
 var fs = require('fs');
 var unzipper = require('unzipper');
-var process = require('process')
+var process = require('process');
+var path = require('path');
 
 const editor = process.argv[2];
 const gitRelease = process.argv[3];
 const gitUrl = 'https://github.com/4ian/GDevelop';
-const basePath = '../public/external/' + editor + '/' + editor + '-editor';
+const basePath = path.join('../public/external/', editor, editor + '-editor');
 const zipFilePath = basePath + '.zip';
 
 if (shell.test('-d', basePath)) {
@@ -46,7 +47,7 @@ if (shell.test('-d', basePath)) {
           fs
             .createReadStream(zipFilePath)
             .pipe(unzipper.Extract({
-              path: basePath
+              path: path.join('../public/external/',editor)
             }))
             .on('close', function () {
               shell.echo(


### PR DESCRIPTION
This fixes 
https://github.com/4ian/GDevelop/issues/1014

it looks like unzipper will fail to extract the file if the target path uses `/` instead of ` \\` under windows.
This results in both jfxr and piskel failing to unzip and therefor load under windows!

I am adding some path normalization in this pull, which fixes the issue

This issue was introduced after unzipper replaced unzip2
https://github.com/4ian/GDevelop/commit/1dba4bbda80ceafc26c848b70f4b7ad6c57c3c75