### PR TITLE
Fix performance issue in For Each generated code

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.cpp
@@ -24,8 +24,8 @@ void EventsCodeGenerationContext::InheritsFrom(
             parent_.objectsListsToBeDeclared.end(),
             std::inserter(alreadyDeclaredObjectsLists,
                           alreadyDeclaredObjectsLists.begin()));
-  std::copy(parent_.emptyObjectsListsToBeDeclared.begin(),
-            parent_.emptyObjectsListsToBeDeclared.end(),
+  std::copy(parent_.objectsListsWithoutPickingToBeDeclared.begin(),
+            parent_.objectsListsWithoutPickingToBeDeclared.end(),
             std::inserter(alreadyDeclaredObjectsLists,
                           alreadyDeclaredObjectsLists.begin()));
 
@@ -47,17 +47,18 @@ void EventsCodeGenerationContext::Reuse(
 
 void EventsCodeGenerationContext::ObjectsListNeeded(
     const gd::String& objectName) {
-  if (emptyObjectsListsToBeDeclared.find(objectName) ==
-      emptyObjectsListsToBeDeclared.end())
+  if (objectsListsWithoutPickingToBeDeclared.find(objectName) ==
+      objectsListsWithoutPickingToBeDeclared.end())
     objectsListsToBeDeclared.insert(objectName);
 
   depthOfLastUse[objectName] = GetContextDepth();
 }
-void EventsCodeGenerationContext::EmptyObjectsListNeeded(
+
+void EventsCodeGenerationContext::ObjectsListWithoutPickingNeeded(
     const gd::String& objectName) {
   if (objectsListsToBeDeclared.find(objectName) ==
       objectsListsToBeDeclared.end())
-    emptyObjectsListsToBeDeclared.insert(objectName);
+    objectsListsWithoutPickingToBeDeclared.insert(objectName);
 
   depthOfLastUse[objectName] = GetContextDepth();
 }
@@ -66,8 +67,8 @@ std::set<gd::String> EventsCodeGenerationContext::GetAllObjectsToBeDeclared()
     const {
   std::set<gd::String> allObjectListsToBeDeclared(
       objectsListsToBeDeclared.begin(), objectsListsToBeDeclared.end());
-  allObjectListsToBeDeclared.insert(emptyObjectsListsToBeDeclared.begin(),
-                                    emptyObjectsListsToBeDeclared.end());
+  allObjectListsToBeDeclared.insert(objectsListsWithoutPickingToBeDeclared.begin(),
+                                    objectsListsWithoutPickingToBeDeclared.end());
 
   return allObjectListsToBeDeclared;
 }

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.cpp
@@ -28,6 +28,10 @@ void EventsCodeGenerationContext::InheritsFrom(
             parent_.objectsListsWithoutPickingToBeDeclared.end(),
             std::inserter(alreadyDeclaredObjectsLists,
                           alreadyDeclaredObjectsLists.begin()));
+  std::copy(parent_.emptyObjectsListsToBeDeclared.begin(),
+            parent_.emptyObjectsListsToBeDeclared.end(),
+            std::inserter(alreadyDeclaredObjectsLists,
+                          alreadyDeclaredObjectsLists.begin()));
 
   depthOfLastUse = parent_.depthOfLastUse;
   customConditionDepth = parent_.customConditionDepth;
@@ -47,8 +51,7 @@ void EventsCodeGenerationContext::Reuse(
 
 void EventsCodeGenerationContext::ObjectsListNeeded(
     const gd::String& objectName) {
-  if (objectsListsWithoutPickingToBeDeclared.find(objectName) ==
-      objectsListsWithoutPickingToBeDeclared.end())
+  if (!IsToBeDeclared(objectName))
     objectsListsToBeDeclared.insert(objectName);
 
   depthOfLastUse[objectName] = GetContextDepth();
@@ -56,9 +59,16 @@ void EventsCodeGenerationContext::ObjectsListNeeded(
 
 void EventsCodeGenerationContext::ObjectsListWithoutPickingNeeded(
     const gd::String& objectName) {
-  if (objectsListsToBeDeclared.find(objectName) ==
-      objectsListsToBeDeclared.end())
+  if (!IsToBeDeclared(objectName))
     objectsListsWithoutPickingToBeDeclared.insert(objectName);
+
+  depthOfLastUse[objectName] = GetContextDepth();
+}
+
+void EventsCodeGenerationContext::EmptyObjectsListNeeded(
+    const gd::String& objectName) {
+  if (!IsToBeDeclared(objectName))
+    emptyObjectsListsToBeDeclared.insert(objectName);
 
   depthOfLastUse[objectName] = GetContextDepth();
 }
@@ -69,6 +79,8 @@ std::set<gd::String> EventsCodeGenerationContext::GetAllObjectsToBeDeclared()
       objectsListsToBeDeclared.begin(), objectsListsToBeDeclared.end());
   allObjectListsToBeDeclared.insert(objectsListsWithoutPickingToBeDeclared.begin(),
                                     objectsListsWithoutPickingToBeDeclared.end());
+  allObjectListsToBeDeclared.insert(emptyObjectsListsToBeDeclared.begin(),
+                                    emptyObjectsListsToBeDeclared.end());
 
   return allObjectListsToBeDeclared;
 }

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.h
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.h
@@ -5,7 +5,6 @@
  */
 #ifndef EVENTSCODEGENERATIONCONTEXT_H
 #define EVENTSCODEGENERATIONCONTEXT_H
-
 #include <map>
 #include <memory>
 #include <set>
@@ -21,7 +20,7 @@ namespace gd {
  * - The "current object", i.e the object being used by an action or a
  * condition.
  * - If conditions are being generated, the context keeps track of the depth of
- * the conditions ( see GetCurrentConditionDepth )
+ * the conditions (see GetCurrentConditionDepth)
  * - You can also get the context depth of the last use of an object list.
  */
 class GD_CORE_API EventsCodeGenerationContext {
@@ -106,21 +105,23 @@ class GD_CORE_API EventsCodeGenerationContext {
   const gd::String& GetCurrentObject() const { return currentObject; };
 
   /**
-   * \brief Call this when an instruction in the event need an object list.
+   * \brief Call this when an instruction in the event needs an objects list.
    *
    * The list will be filled with objects from the scene if it is the first time
-   * it is requested, unless there is already an object list with this name (
-   * i.e. ObjectAlreadyDeclared(objectName) returns true ).
+   * it is requested, unless there is already an object list with this name
+   * (i.e. `ObjectAlreadyDeclared(objectName)` returns true).
    */
   void ObjectsListNeeded(const gd::String& objectName);
 
   /**
-   * Call this when an instruction in the event need an object list.
-   * An empty event list will be declared, without filling it with objects from
-   * the scene. If there is already an object list with this name, no new list
+   * Call this when an instruction in the event needs an empty objects list
+   * or the one already declared, if any.
+   *
+   * An empty objects list will be declared, without filling it with objects from
+   * the scene. If there is already an objects list with this name, no new list
    * will be declared again.
    */
-  void EmptyObjectsListNeeded(const gd::String& objectName);
+  void ObjectsListWithoutPickingNeeded(const gd::String& objectName);
 
   /**
    * Return true if an object list has already been declared (or is going to be
@@ -152,11 +153,12 @@ class GD_CORE_API EventsCodeGenerationContext {
   };
 
   /**
-   * Return the objects lists which will be declared, but no filled, by the
-   * current context
+   * Return the objects lists which will be will be declared, without filling
+   * them with objects from the scene.
    */
-  const std::set<gd::String>& GetObjectsListsToBeDeclaredEmpty() const {
-    return emptyObjectsListsToBeDeclared;
+  const std::set<gd::String>& GetObjectsListsToBeDeclaredWithoutPicking()
+      const {
+    return objectsListsWithoutPickingToBeDeclared;
   };
 
   /**
@@ -214,9 +216,10 @@ class GD_CORE_API EventsCodeGenerationContext {
       objectsListsToBeDeclared;  ///< Objects lists that will be declared in
                                  ///< this context.
   std::set<gd::String>
-      emptyObjectsListsToBeDeclared;  ///< Objects lists that will be declared
-                                      ///< in this context, but not filled with
-                                      ///< scene's objects.
+      objectsListsWithoutPickingToBeDeclared;  ///< Objects lists that will be
+                                               ///< declared in this context,
+                                               ///< but not filled with scene's
+                                               ///< objects.
   std::map<gd::String, unsigned int>
       depthOfLastUse;  ///< The context depth when an object was last used.
   gd::String

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.h
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.h
@@ -117,11 +117,21 @@ class GD_CORE_API EventsCodeGenerationContext {
    * Call this when an instruction in the event needs an empty objects list
    * or the one already declared, if any.
    *
-   * An empty objects list will be declared, without filling it with objects from
-   * the scene. If there is already an objects list with this name, no new list
-   * will be declared again.
+   * An empty objects list will be declared, without filling it with objects
+   * from the scene. If there is already an objects list with this name, no new
+   * list will be declared again.
    */
   void ObjectsListWithoutPickingNeeded(const gd::String& objectName);
+
+  /**
+   * Call this when an instruction in the event needs an empty object list,
+   * even if one is already declared.
+   *
+   * An empty objects list will be declared, without filling it with objects
+   * from the scene. If there is already an object list with this name, it won't
+   * be used to initialize the new list, which will remain empty.
+   */
+  void EmptyObjectsListNeeded(const gd::String& objectName);
 
   /**
    * Return true if an object list has already been declared (or is going to be
@@ -159,6 +169,15 @@ class GD_CORE_API EventsCodeGenerationContext {
   const std::set<gd::String>& GetObjectsListsToBeDeclaredWithoutPicking()
       const {
     return objectsListsWithoutPickingToBeDeclared;
+  };
+
+  /**
+   * Return the objects lists which will be will be declared empty, without
+   * filling them with objects from the scene and without copying any previously
+   * declared objects list.
+   */
+  const std::set<gd::String>& GetObjectsListsToBeDeclaredEmpty() const {
+    return emptyObjectsListsToBeDeclared;
   };
 
   /**
@@ -209,6 +228,21 @@ class GD_CORE_API EventsCodeGenerationContext {
   size_t GetCurrentConditionDepth() const { return customConditionDepth; }
 
  private:
+  /**
+   * \brief Returns true if the given object is already going to be declared
+   * (either as a traditional objects list, or one without picking, or one
+   * empty).
+   *
+   */
+  bool IsToBeDeclared(const gd::String& objectName) {
+    return objectsListsToBeDeclared.find(objectName) !=
+               objectsListsToBeDeclared.end() ||
+           objectsListsWithoutPickingToBeDeclared.find(objectName) !=
+               objectsListsWithoutPickingToBeDeclared.end() ||
+           emptyObjectsListsToBeDeclared.find(objectName) !=
+               emptyObjectsListsToBeDeclared.end();
+  };
+
   std::set<gd::String>
       alreadyDeclaredObjectsLists;  ///< Objects lists already needed in a
                                     ///< parent context.
@@ -220,6 +254,12 @@ class GD_CORE_API EventsCodeGenerationContext {
                                                ///< declared in this context,
                                                ///< but not filled with scene's
                                                ///< objects.
+  std::set<gd::String>
+      emptyObjectsListsToBeDeclared;  ///< Objects lists that will be
+                                      ///< declared in this context,
+                                      ///< but not filled with scene's
+                                      ///< objects and not filled with any
+                                      ///< previously existing objects list.
   std::map<gd::String, unsigned int>
       depthOfLastUse;  ///< The context depth when an object was last used.
   gd::String

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -740,7 +740,7 @@ gd::String EventsCodeGenerator::GenerateObjectsDeclarationCode(
 
     declarationsCode += objectListDeclaration + "\n";
   }
-  for (auto object : context.GetObjectsListsToBeDeclaredEmpty()) {
+  for (auto object : context.GetObjectsListsToBeDeclaredWithoutPicking()) {
     gd::String objectListDeclaration = "";
     if (!context.ObjectAlreadyDeclared(object)) {
       objectListDeclaration = "std::vector<RuntimeObject*> " +

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -751,6 +751,18 @@ gd::String EventsCodeGenerator::GenerateObjectsDeclarationCode(
 
     declarationsCode += objectListDeclaration + "\n";
   }
+  for (auto object : context.GetObjectsListsToBeDeclaredEmpty()) {
+    gd::String objectListDeclaration = "";
+    if (!context.ObjectAlreadyDeclared(object)) {
+      objectListDeclaration = "std::vector<RuntimeObject*> " +
+                              GetObjectListName(object, context) + ";\n";
+      context.SetObjectDeclared(object);
+    } else
+      objectListDeclaration = "std::vector<RuntimeObject*> " +
+                              GetObjectListName(object, context) + ";\n";
+
+    declarationsCode += objectListDeclaration + "\n";
+  }
 
   return declarationsCode;
 }

--- a/Core/tests/EventsCodeGenerationContext.cpp
+++ b/Core/tests/EventsCodeGenerationContext.cpp
@@ -18,13 +18,13 @@
 TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
   /**
    * Generate a tree of contexts with declared objects as below:
-   *                   c1 -> c1.object1, c1.object2, c1.noPicking1 (empty list
+   *                   c1 -> c1.object1, c1.object2, c1.noPicking1 (no picking
    * request)
    *                  /  \
    *  c2.object1 <- c2   c3 -> c3.object1, c1.object2
    *               /  \
-   *              c4  c5 -> c5.object1, c5.noPicking1 (empty list request),
-   * c1.object2
+   *              c4  c5 -> c5.object1, c5.noPicking1 (no picking request),
+   * c1.object2, c5.empty1
    */
 
   unsigned int maxDepth = 0;
@@ -50,6 +50,7 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
   c5.ObjectsListWithoutPickingNeeded("c5.noPicking1");
   c5.ObjectsListNeeded("c5.object1");
   c5.ObjectsListNeeded("c1.object2");
+  c5.EmptyObjectsListNeeded("c5.empty1");
 
   SECTION("Parenting") {
     REQUIRE(c2.GetParentContext() == &c1);
@@ -100,8 +101,10 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
             std::set<gd::String>({"c5.object1", "c1.object2"}));
     REQUIRE(c5.GetObjectsListsToBeDeclaredWithoutPicking() ==
             std::set<gd::String>({"c5.noPicking1"}));
+    REQUIRE(c5.GetObjectsListsToBeDeclaredEmpty() ==
+            std::set<gd::String>({"c5.empty1"}));
     REQUIRE(c5.GetAllObjectsToBeDeclared() ==
-            std::set<gd::String>({"c5.object1", "c5.noPicking1", "c1.object2"}));
+            std::set<gd::String>({"c5.object1", "c5.noPicking1", "c1.object2", "c5.empty1"}));
   }
 
   SECTION("ObjectAlreadyDeclared") {
@@ -130,6 +133,7 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
     REQUIRE(c5.GetLastDepthObjectListWasNeeded("c1.object2") == 2);
     REQUIRE(c5.GetLastDepthObjectListWasNeeded("c2.object1") == 1);
     REQUIRE(c5.GetLastDepthObjectListWasNeeded("c5.object1") == 2);
+    REQUIRE(c5.GetLastDepthObjectListWasNeeded("c5.empty1") == 2);
   }
 
   SECTION("SetCurrentObject") {
@@ -145,12 +149,12 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
      * Generate a tree of contexts with declared objects as below:
      *                  ...
      *                   \
-     *                   c5 -> c5.object1, c5.noPicking1 (empty list request),
+     *                   c5 -> c5.object1, c5.noPicking1 (no picking request),
      * c1.object2
      *                  /
      *                c6  (reuse c5) -> c5.object1, c6.object3
      *               /
-     *              c7 -> c5.object1
+     *              c7 -> c5.object1, c5.empty1 (empty list request)
      */
     gd::EventsCodeGenerationContext c6;
     c6.Reuse(c5);
@@ -161,6 +165,7 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
     c7.InheritsFrom(c6);
     c7.ObjectsListNeeded("c5.object1");
     c7.ObjectsListNeeded("c6.object3");
+    c7.EmptyObjectsListNeeded("c5.empty1");
 
     // c6 is reusing c5 context so it has the same depth:
     REQUIRE(c6.GetParentContext() == &c5);
@@ -179,5 +184,6 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
     REQUIRE(c7.GetContextDepth() == 3);
     REQUIRE(c7.IsSameObjectsList("c5.object1", c6) == false);
     REQUIRE(c7.IsSameObjectsList("c6.object3", c6) == false);
+    REQUIRE(c7.IsSameObjectsList("c5.empty1", c5) == false);
   }
 }

--- a/Core/tests/EventsCodeGenerationContext.cpp
+++ b/Core/tests/EventsCodeGenerationContext.cpp
@@ -4,7 +4,7 @@
  * reserved. This project is released under the MIT License.
  */
 /**
- * @file Tests covering events of GDevelop Core.
+ * @file Tests covering events code generation context,
  */
 #include "GDCore/Events/CodeGeneration/EventsCodeGenerationContext.h"
 #include <memory>
@@ -18,12 +18,12 @@
 TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
   /**
    * Generate a tree of contexts with declared objects as below:
-   *                   c1 -> c1.object1, c1.object2, c1.empty1 (empty list
+   *                   c1 -> c1.object1, c1.object2, c1.noPicking1 (empty list
    * request)
    *                  /  \
    *  c2.object1 <- c2   c3 -> c3.object1, c1.object2
    *               /  \
-   *              c4  c5 -> c5.object1, c5.empty1 (empty list request),
+   *              c4  c5 -> c5.object1, c5.noPicking1 (empty list request),
    * c1.object2
    */
 
@@ -31,7 +31,7 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
   gd::EventsCodeGenerationContext c1(&maxDepth);
   c1.ObjectsListNeeded("c1.object1");
   c1.ObjectsListNeeded("c1.object2");
-  c1.EmptyObjectsListNeeded("c1.empty1");
+  c1.ObjectsListWithoutPickingNeeded("c1.noPicking1");
 
   gd::EventsCodeGenerationContext c2;
   c2.InheritsFrom(c1);
@@ -47,7 +47,7 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
 
   gd::EventsCodeGenerationContext c5;
   c5.InheritsFrom(c2);
-  c5.EmptyObjectsListNeeded("c5.empty1");
+  c5.ObjectsListWithoutPickingNeeded("c5.noPicking1");
   c5.ObjectsListNeeded("c5.object1");
   c5.ObjectsListNeeded("c1.object2");
 
@@ -72,36 +72,36 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
     REQUIRE(c1.GetObjectsListsAlreadyDeclared() == std::set<gd::String>());
     REQUIRE(c1.GetObjectsListsToBeDeclared() ==
             std::set<gd::String>({"c1.object1", "c1.object2"}));
-    REQUIRE(c1.GetObjectsListsToBeDeclaredEmpty() ==
-            std::set<gd::String>({"c1.empty1"}));
+    REQUIRE(c1.GetObjectsListsToBeDeclaredWithoutPicking() ==
+            std::set<gd::String>({"c1.noPicking1"}));
     REQUIRE(c1.GetAllObjectsToBeDeclared() ==
-            std::set<gd::String>({"c1.object1", "c1.object2", "c1.empty1"}));
+            std::set<gd::String>({"c1.object1", "c1.object2", "c1.noPicking1"}));
 
     REQUIRE(c2.GetObjectsListsAlreadyDeclared() ==
-            std::set<gd::String>({"c1.object1", "c1.object2", "c1.empty1"}));
+            std::set<gd::String>({"c1.object1", "c1.object2", "c1.noPicking1"}));
     REQUIRE(c2.GetObjectsListsToBeDeclared() ==
             std::set<gd::String>({"c2.object1"}));
-    REQUIRE(c2.GetObjectsListsToBeDeclaredEmpty() == std::set<gd::String>());
+    REQUIRE(c2.GetObjectsListsToBeDeclaredWithoutPicking() == std::set<gd::String>());
     REQUIRE(c2.GetAllObjectsToBeDeclared() ==
             std::set<gd::String>({"c2.object1"}));
 
     REQUIRE(c3.GetObjectsListsAlreadyDeclared() ==
-            std::set<gd::String>({"c1.object1", "c1.object2", "c1.empty1"}));
+            std::set<gd::String>({"c1.object1", "c1.object2", "c1.noPicking1"}));
     REQUIRE(c3.GetObjectsListsToBeDeclared() ==
             std::set<gd::String>({"c3.object1", "c1.object2"}));
-    REQUIRE(c3.GetObjectsListsToBeDeclaredEmpty() == std::set<gd::String>());
+    REQUIRE(c3.GetObjectsListsToBeDeclaredWithoutPicking() == std::set<gd::String>());
     REQUIRE(c3.GetAllObjectsToBeDeclared() ==
             std::set<gd::String>({"c3.object1", "c1.object2"}));
 
     REQUIRE(c5.GetObjectsListsAlreadyDeclared() ==
             std::set<gd::String>(
-                {"c1.object1", "c1.object2", "c1.empty1", "c2.object1"}));
+                {"c1.object1", "c1.object2", "c1.noPicking1", "c2.object1"}));
     REQUIRE(c5.GetObjectsListsToBeDeclared() ==
             std::set<gd::String>({"c5.object1", "c1.object2"}));
-    REQUIRE(c5.GetObjectsListsToBeDeclaredEmpty() ==
-            std::set<gd::String>({"c5.empty1"}));
+    REQUIRE(c5.GetObjectsListsToBeDeclaredWithoutPicking() ==
+            std::set<gd::String>({"c5.noPicking1"}));
     REQUIRE(c5.GetAllObjectsToBeDeclared() ==
-            std::set<gd::String>({"c5.object1", "c5.empty1", "c1.object2"}));
+            std::set<gd::String>({"c5.object1", "c5.noPicking1", "c1.object2"}));
   }
 
   SECTION("ObjectAlreadyDeclared") {
@@ -145,7 +145,7 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
      * Generate a tree of contexts with declared objects as below:
      *                  ...
      *                   \
-     *                   c5 -> c5.object1, c5.empty1 (empty list request),
+     *                   c5 -> c5.object1, c5.noPicking1 (empty list request),
      * c1.object2
      *                  /
      *                c6  (reuse c5) -> c5.object1, c6.object3
@@ -169,11 +169,11 @@ TEST_CASE("EventsCodeGenerationContext", "[common][events]") {
 
     // c6 reuse the objects lists from c5:
     REQUIRE(c6.IsSameObjectsList("c5.object1", c5) == true);
-    REQUIRE(c6.IsSameObjectsList("c5.empty1", c5) == true);
+    REQUIRE(c6.IsSameObjectsList("c5.noPicking1", c5) == true);
     REQUIRE(c6.GetLastDepthObjectListWasNeeded("c5.object1") ==
             c5.GetLastDepthObjectListWasNeeded("c5.object1"));
-    REQUIRE(c6.GetLastDepthObjectListWasNeeded("c5.empty1") ==
-            c5.GetLastDepthObjectListWasNeeded("c5.empty1"));
+    REQUIRE(c6.GetLastDepthObjectListWasNeeded("c5.noPicking1") ==
+            c5.GetLastDepthObjectListWasNeeded("c5.noPicking1"));
 
     REQUIRE(c7.GetParentContext() == &c6);
     REQUIRE(c7.GetContextDepth() == 3);

--- a/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -390,7 +390,7 @@ gd::String EventsCodeGenerator::GenerateObject(
 
     output += "runtimeContext->ClearObjectListsMap()";
     for (std::size_t i = 0; i < realObjects.size(); ++i) {
-      context.EmptyObjectsListNeeded(realObjects[i]);
+      context.ObjectsListWithoutPickingNeeded(realObjects[i]);
       output += ".AddObjectListToMap(\"" + ConvertToString(realObjects[i]) +
                 "\", " + ManObjListName(realObjects[i]) + ")";
     }

--- a/GDCpp/GDCpp/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -116,7 +116,7 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
               //"OR" condition must declare objects list, but without getting
               // the objects from the scene. Lists are either empty or come from
               // a parent event.
-              parentContext.EmptyObjectsListNeeded(*it);
+              parentContext.ObjectsListWithoutPickingNeeded(*it);
               // We need to duplicate the object lists : The "final" ones will
               // be filled with objects by conditions, but they will have no
               // incidence on further conditions, as conditions use "normal"

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -651,7 +651,7 @@ gd::String EventsCodeGenerator::GenerateObjectsDeclarationCode(
 
     declarationsCode += objectListDeclaration + "\n";
   }
-  for (auto object : context.GetObjectsListsToBeDeclaredEmpty()) {
+  for (auto object : context.GetObjectsListsToBeDeclaredWithoutPicking()) {
     gd::String objectListDeclaration = "";
     if (!context.ObjectAlreadyDeclared(object)) {
       objectListDeclaration =
@@ -826,7 +826,7 @@ gd::String EventsCodeGenerator::GenerateObject(
     std::vector<gd::String> realObjects =
         ExpandObjectsName(objectName, context);
     for (auto& objectName : realObjects)
-      context.EmptyObjectsListNeeded(objectName);
+      context.ObjectsListWithoutPickingNeeded(objectName);
 
     gd::String objectsMapName = declareMapOfObjects(realObjects, context);
     output = objectsMapName;

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -644,7 +644,7 @@ gd::String EventsCodeGenerator::GenerateObjectsDeclarationCode(
     if (!context.ObjectAlreadyDeclared(object)) {
       objectListDeclaration += GetObjectListName(object, context) +
                                ".createFrom(" +
-                               GenerateAllInstancesGetter(object) + ");";
+                               GenerateAllInstancesGetterCode(object) + ");";
       context.SetObjectDeclared(object);
     } else
       objectListDeclaration = declareObjectList(object, context);
@@ -662,11 +662,23 @@ gd::String EventsCodeGenerator::GenerateObjectsDeclarationCode(
 
     declarationsCode += objectListDeclaration + "\n";
   }
+  for (auto object : context.GetObjectsListsToBeDeclaredEmpty()) {
+    gd::String objectListDeclaration = "";
+    if (!context.ObjectAlreadyDeclared(object)) {
+      objectListDeclaration =
+          GetObjectListName(object, context) + ".length = 0;\n";
+      context.SetObjectDeclared(object);
+    } else
+      objectListDeclaration =
+          GetObjectListName(object, context) + ".length = 0;\n";
+
+    declarationsCode += objectListDeclaration + "\n";
+  }
 
   return declarationsCode;
 }
 
-gd::String EventsCodeGenerator::GenerateAllInstancesGetter(
+gd::String EventsCodeGenerator::GenerateAllInstancesGetterCode(
     gd::String& objectName) {
   if (HasProjectAndLayout()) {
     return "runtimeScene.getObjects(" + ConvertToStringExplicit(objectName) +

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
@@ -249,7 +249,7 @@ class EventsCodeGenerator : public gd::EventsCodeGenerator {
   virtual gd::String GenerateObjectsDeclarationCode(
       gd::EventsCodeGenerationContext& context);
 
-  virtual gd::String GenerateAllInstancesGetter(gd::String& objectName);
+  virtual gd::String GenerateAllInstancesGetterCode(gd::String& objectName);
 
   virtual gd::String GenerateProfilerSectionBegin(const gd::String& section);
   virtual gd::String GenerateProfilerSectionEnd(const gd::String& section);

--- a/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -191,7 +191,7 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
               //"OR" condition must declare objects list, but without getting
               // the objects from the scene. Lists are either empty or come from
               // a parent event.
-              parentContext.EmptyObjectsListNeeded(*it);
+              parentContext.ObjectsListWithoutPickingNeeded(*it);
               // We need to duplicate the object lists : The "final" ones will
               // be filled with objects by conditions, but they will have no
               // incidence on further conditions, as conditions use "normal"

--- a/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -341,8 +341,8 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
         gd::String outputCode;
         gd::WhileEvent& event = dynamic_cast<gd::WhileEvent&>(event_);
 
-        // Context is "reset" each time the event is repeated ( i.e. objects are
-        // picked again )
+        // Context is "reset" each time the event is repeated (i.e. objects are
+        // picked again)
         gd::EventsCodeGenerationContext context;
         context.InheritsFrom(parentContext);
         context.ForbidReuse();
@@ -414,8 +414,8 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
             gd::ExpressionCodeGenerator::GenerateExpressionCode(
                 codeGenerator, parentContext, "number", repeatNumberExpression);
 
-        // Context is "reset" each time the event is repeated ( i.e. objects are
-        // picked again )
+        // Context is "reset" each time the event is repeated (i.e. objects are
+        // picked again)
         gd::EventsCodeGenerationContext context;
         context.InheritsFrom(parentContext);
         context.ForbidReuse();
@@ -484,14 +484,14 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
         for (unsigned int i = 0; i < realObjects.size(); ++i)
           parentContext.ObjectsListNeeded(realObjects[i]);
 
-        // Context is "reset" each time the event is repeated ( i.e. objects are
-        // picked again )
+        // Context is "reset" each time the event is repeated (i.e. objects are
+        // picked again)
         gd::EventsCodeGenerationContext context;
         context.InheritsFrom(parentContext);
         context.ForbidReuse();
 
         for (unsigned int i = 0; i < realObjects.size(); ++i)
-          context.ObjectsListNeeded(realObjects[i]);
+          context.EmptyObjectsListNeeded(realObjects[i]);
 
         // Prepare conditions/actions codes
         gd::String conditionsCode = codeGenerator.GenerateConditionsListCode(
@@ -569,10 +569,13 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
                         " < " + forEachTotalCountVar + ";++" + forEachIndexVar +
                         ") {\n";
 
+        // Empty object lists declaration
         outputCode += objectDeclaration;
 
-        // Clear all concerned objects lists and keep only one object
+        // Pick one object
         if (realObjects.size() == 1) {
+          // We write a slighty more simple ( and optimized ) output code
+          // when only one object list is used.
           gd::String temporary = codeGenerator.GetCodeNamespaceAccessor() +
                                  "forEachTemporary" +
                                  gd::String::From(context.GetContextDepth());
@@ -581,22 +584,13 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
               temporary + " = " +
               codeGenerator.GetObjectListName(realObjects[0], parentContext) +
               "[" + forEachIndexVar + "];\n";
-          outputCode +=
-              codeGenerator.GetObjectListName(realObjects[0], context) +
-              ".length = 0;\n";
+
           outputCode +=
               codeGenerator.GetObjectListName(realObjects[0], context) +
               ".push(" + temporary + ");\n";
         } else {
-          // Declare all lists of concerned objects empty
-          for (unsigned int j = 0; j < realObjects.size(); ++j)
-            outputCode +=
-                codeGenerator.GetObjectListName(realObjects[j], context) +
-                ".length = 0;\n";
-
-          for (unsigned int i = 0; i < realObjects.size();
-               ++i)  // Pick then only one object
-          {
+          // Generate the code to pick only one object in the lists
+          for (unsigned int i = 0; i < realObjects.size(); ++i) {
             gd::String count;
             for (unsigned int j = 0; j <= i; ++j) {
               gd::String forEachCountVar =


### PR DESCRIPTION
Lists of objects were wrongly initialized, creating a useless performance hit. All the objects of the "for each" were copied into arrays, before being emptied. And this, for every single object in the for each loop. This was particularly bad when a lot of objects were picked by the for each (if we have N objects, complexity was N*N copies of the array).

This fix the issue and remove all the useless N*N complexity. (note that the C++ code generation was not affected, as the objects lists were manually declared in the code generation) by introducing a `EmptyObjectsListNeeded` function to get empty object lists directly (instead of first getting an objects list filled with objects, and then clear it).
(In the future, the C++ code generation could be reworked to use `EmptyObjectsListNeeded`, as it's clearer)

* Verified that generated code is correct (no more useless calls to `createFrom`)
* Verified that an example game with a for each and ~12000 objects is still at 60 fps.
* Verified that large games are still working.
