### PR TITLE
Add support for passing a behavior as parameter in an expression

### DIFF
--- a/Core/GDCore/Events/Parsers/ExpressionParser2.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.h
@@ -455,6 +455,8 @@ class GD_CORE_API ExpressionParser2 {
             parameters.push_back(Expression(type, objectName));
           } else if (gd::ParameterMetadata::IsObject(type)) {
             parameters.push_back(Expression(type));
+          } else if (gd::ParameterMetadata::IsBehavior(type)) {
+            parameters.push_back(ReadText()); // TODO
           } else {
             size_t parameterStartPosition = GetCurrentPosition();
             parameters.push_back(Expression("unknown"));


### PR DESCRIPTION
Checking what's the best way to support passing behaviors as parameters in expressions:
- either pass their names, implying the usage of the previous object: (`MyObject.DoSomething("MyBehavior")`)
- or pass a fully qualified "reference" to them: `MyObject.DoSomething(MyObject.MyBehavior)`.