### PR TITLE
 Fix width images for patch note

### DIFF
--- a/newIDE/app/src/UI/Theme/DarkTheme/Markdown.css
+++ b/newIDE/app/src/UI/Theme/DarkTheme/Markdown.css
@@ -28,5 +28,5 @@
 }
 
 .gd-markdown-dark-theme img {
-  width: 100%;
+  max-width: 100%;
 }

--- a/newIDE/app/src/UI/Theme/DarkTheme/Markdown.css
+++ b/newIDE/app/src/UI/Theme/DarkTheme/Markdown.css
@@ -26,3 +26,7 @@
 .gd-markdown-dark-theme a {
   color: rgb(221, 221, 221);
 }
+
+.gd-markdown-dark-theme img {
+  width: 100%;
+}

--- a/newIDE/app/src/UI/Theme/DefaultTheme/Markdown.css
+++ b/newIDE/app/src/UI/Theme/DefaultTheme/Markdown.css
@@ -28,5 +28,5 @@
 }
 
 .gd-markdown-default-theme img {
-  width: 100%;
+  max-width: 100%;
 }

--- a/newIDE/app/src/UI/Theme/DefaultTheme/Markdown.css
+++ b/newIDE/app/src/UI/Theme/DefaultTheme/Markdown.css
@@ -26,3 +26,7 @@
 .gd-markdown-default-theme a {
   color: rgb(74, 176, 228);
 }
+
+.gd-markdown-default-theme img {
+  width: 100%;
+}


### PR DESCRIPTION
In patch note (like b70) images exceed the dialog container.
I've fixed this for default and dark themes.