### PR TITLE
Update CircleCI configuration to build GDevelop.js too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,15 @@ jobs:
     steps:
       - checkout
 
-      # Install dependencies
+      # System dependencies (for Electron Builder and Emscripten)
+      - run:
+          name: Install dependencies for Emscripten
+          command: sudo apt install cmake
+
+      - run:
+          name: Install Emscripten (for GDevelop.js)
+          command: git clone https://github.com/juj/emsdk.git && cd emsdk && ./emsdk install sdk-1.37.37-64bit && ./emsdk activate sdk-1.37.37-64bit && cd ..
+
       - run:
           name: Install Wine for Electron builder
           command: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt install wine32
@@ -21,22 +29,36 @@ jobs:
           name: Install system dependencies for Electron builder
           command: sudo apt install icnsutils && sudo apt install graphicsmagick && sudo apt install rsync
 
-      # Download and cache npm dependencies
+      # Node.js dependencies
       - restore_cache:
           keys:
-            - gd-ide-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}
+            - gd-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}-{{ checksum "GDevelop.js/package.json" }}
             # fallback to using the latest cache if no exact match is found
-            - gd-ide-dependencies--
+            - gd-nodejs-dependencies---
 
-      - run: cd newIDE/app && npm install && cd ../electron-app && npm install
+      - run:
+          name: Install GDevelop.js dependencies and build it
+          command: cd GDevelop.js && sudo npm install -g grunt-cli && npm install && cd ..
+
+      - run:
+          name: Install GDevelop IDE dependencies
+          command: cd newIDE/app && npm install && cd ../electron-app && npm install
 
       - save_cache:
           paths:
-            - node_modules
-          key: gd-ide-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}
+            - newIDE/electron-app/node_modules
+            - newIDE/app/node_modules
+            - GDevelop.js/node_modules
+          key: gd-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}
 
-      # Build
-      - run: cd newIDE/electron-app && npm run build -- --mac --win --linux tar.gz --publish=never
+      # Build GDevelop IDE (including GDevelop.js)
+      - run:
+          name: Build GDevelop.js
+          command: cd GDevelop.js && source ../emsdk/emsdk_env.sh && npm run build && npm test && cd ..
+
+      - run:
+          name: Build GDevelop IDE
+          command: cd newIDE/electron-app && npm run build -- --mac --win --linux tar.gz --publish=never
 
       # Upload artifacts
       - run:


### PR DESCRIPTION
This adds CircleCI as a continuous integration/continuous deployment process. The idea is to have:

* **Semaphore CI** for very quick (<5 min) running of the *IDE and game engine typing/tests* (JavaScript only). 
  * Quick feedback is useful because most work is on the IDE and the game engine in JavaScript.
  * No build of GDevelop.js. This mimics the typical developer environment.
  * May have false negative (tests broken because of a old GDevelop.js if C++/bindings were modified) - but it's not a big deal - fast feedback is more important in 90% of cases :) 
* **Travis CI** for build/tests for the C++ codebase (native build), build/tests for GDevelop.js ("emscripten"), build/tests for the IDE (typing/tests).
  * This is longer (~25min) as it builds the whole C++ codebase both natively and for GDevelop.js
  * No false negative (if it's red, then something is definitely broken)
* **Circle CI** for build/tests of GDevelop.js, build of the IDE and the electron-app installer/binaries
  * Time is medium (~13min). This mimics creating a new version of GDevelop from an almost blank Linux installation. Later, this could be used to distribute nightly builds of GDevelop, for testing.
  * No false negative (if it's red, then something is definitely broken)

cc @blurymind @Bouh for your interest - no need to be familiar with all of this but can be useful to better understand what's going on :) 
I should maybe add this explanation somewhere in the docs.. in the meantime, hope this can be useful now or later for people to understand these continuous integrations.