### PR TITLE
add easier to remember command to update extensions

### DIFF
--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -85,7 +85,8 @@
     "analyze-flow-coverage": "flow-coverage-report",
     "analyze-source-map": "source-map-explorer build/static/js/main.*",
     "extract-all-translations": "node scripts/extract-all-translations.js",
-    "compile-translations": "node scripts/compile-translations.js"
+    "compile-translations": "node scripts/compile-translations.js",
+    "reload-extensions": "node scripts/import-GDJS-Runtime.js"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/newIDE/electron-app/package.json
+++ b/newIDE/electron-app/package.json
@@ -1,49 +1,50 @@
 {
-  "name": "gdevelop",
-  "productName": "GDevelop 5",
-  "description": "GDevelop 5 IDE running on the Electron runtime",
-  "version": "1.0.0",
-  "author": "Florian Rival",
-  "license": "MIT",
-  "homepage": "http://gdevelop-app.com",
-  "repository": "github:4ian/GDevelop",
-  "private": true,
-  "scripts": {
-    "postinstall": "cd app && npm install",
-    "app-build": "node scripts/app-build.js",
-    "build": "node scripts/build.js",
-    "electron-win": "node node_modules/electron/cli.js app",
-    "electron-linux": "./node_modules/electron/dist/electron app",
-    "electron-mac": "./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron app"
-  },
-  "build": {
-    "appId": "com.gdevelop-app.ide",
-    "extraResources": [
-      {
-        "from": "../app/resources/examples",
-        "to": "examples"
-      },
-      {
-        "from": "../app/resources/GDJS",
-        "to": "GDJS"
-      }
-    ],
-    "mac": {
-      "category": "public.app-category.developer-tools"
-    },
-    "publish": [
-      {
-        "provider": "github"
-      }
-    ]
-  },
-  "devDependencies": {
-    "electron": "3.0.9",
-    "electron-builder": "19.53.4",
-    "minimist": "^1.2.0",
-    "shelljs": "^0.7.7"
-  },
-  "dependencies": {
-    "electron-is": "^2.4.0"
-  }
+	"name": "gdevelop",
+	"productName": "GDevelop 5",
+	"description": "GDevelop 5 IDE running on the Electron runtime",
+	"version": "1.0.0",
+	"author": "Florian Rival",
+	"license": "MIT",
+	"homepage": "http://gdevelop-app.com",
+	"repository": "github:4ian/GDevelop",
+	"private": true,
+	"scripts": {
+		"postinstall": "cd app && npm install",
+		"app-build": "node scripts/app-build.js",
+		"build": "node scripts/build.js",
+		"electron-win": "node node_modules/electron/cli.js app",
+		"electron-linux": "./node_modules/electron/dist/electron app",
+		"electron-mac": "./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron app",
+		"reload-extensions": "cd ../app/scripts && node import-GDJS-Runtime.js"
+	},
+	"build": {
+		"appId": "com.gdevelop-app.ide",
+		"extraResources": [
+			{
+				"from": "../app/resources/examples",
+				"to": "examples"
+			},
+			{
+				"from": "../app/resources/GDJS",
+				"to": "GDJS"
+			}
+		],
+		"mac": {
+			"category": "public.app-category.developer-tools"
+		},
+		"publish": [
+			{
+				"provider": "github"
+			}
+		]
+	},
+	"devDependencies": {
+		"electron": "3.0.9",
+		"electron-builder": "19.53.4",
+		"minimist": "^1.2.0",
+		"shelljs": "^0.7.7"
+	},
+	"dependencies": {
+		"electron-is": "^2.4.0"
+	}
 }

--- a/newIDE/electron-app/package.json
+++ b/newIDE/electron-app/package.json
@@ -1,50 +1,50 @@
 {
-	"name": "gdevelop",
-	"productName": "GDevelop 5",
-	"description": "GDevelop 5 IDE running on the Electron runtime",
-	"version": "1.0.0",
-	"author": "Florian Rival",
-	"license": "MIT",
-	"homepage": "http://gdevelop-app.com",
-	"repository": "github:4ian/GDevelop",
-	"private": true,
-	"scripts": {
-		"postinstall": "cd app && npm install",
-		"app-build": "node scripts/app-build.js",
-		"build": "node scripts/build.js",
-		"electron-win": "node node_modules/electron/cli.js app",
-		"electron-linux": "./node_modules/electron/dist/electron app",
-		"electron-mac": "./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron app",
-		"reload-extensions": "cd ../app/scripts && node import-GDJS-Runtime.js"
-	},
-	"build": {
-		"appId": "com.gdevelop-app.ide",
-		"extraResources": [
-			{
-				"from": "../app/resources/examples",
-				"to": "examples"
-			},
-			{
-				"from": "../app/resources/GDJS",
-				"to": "GDJS"
-			}
-		],
-		"mac": {
-			"category": "public.app-category.developer-tools"
-		},
-		"publish": [
-			{
-				"provider": "github"
-			}
-		]
-	},
-	"devDependencies": {
-		"electron": "3.0.9",
-		"electron-builder": "19.53.4",
-		"minimist": "^1.2.0",
-		"shelljs": "^0.7.7"
-	},
-	"dependencies": {
-		"electron-is": "^2.4.0"
-	}
+  "name": "gdevelop",
+  "productName": "GDevelop 5",
+  "description": "GDevelop 5 IDE running on the Electron runtime",
+  "version": "1.0.0",
+  "author": "Florian Rival",
+  "license": "MIT",
+  "homepage": "http://gdevelop-app.com",
+  "repository": "github:4ian/GDevelop",
+  "private": true,
+  "scripts": {
+    "postinstall": "cd app && npm install",
+    "app-build": "node scripts/app-build.js",
+    "build": "node scripts/build.js",
+    "electron-win": "node node_modules/electron/cli.js app",
+    "electron-linux": "./node_modules/electron/dist/electron app",
+    "electron-mac": "./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron app",
+    "reload-extensions": "cd ../app/scripts && node import-GDJS-Runtime.js"
+  },
+  "build": {
+    "appId": "com.gdevelop-app.ide",
+    "extraResources": [
+      {
+        "from": "../app/resources/examples",
+        "to": "examples"
+      },
+      {
+        "from": "../app/resources/GDJS",
+        "to": "GDJS"
+      }
+    ],
+    "mac": {
+      "category": "public.app-category.developer-tools"
+    },
+    "publish": [
+      {
+        "provider": "github"
+      }
+    ]
+  },
+  "devDependencies": {
+    "electron": "3.0.9",
+    "electron-builder": "19.53.4",
+    "minimist": "^1.2.0",
+    "shelljs": "^0.7.7"
+  },
+  "dependencies": {
+    "electron-is": "^2.4.0"
+  }
 }


### PR DESCRIPTION
This adds a command to update extensions to package.json in app and electron-app

`npm run reload-extensions`

On one of the files vscode added different indentation. It is a bit annoying, because when I try to change it, it doesnt register it as a diff that can be added to staging.

I think this is caused by my prettier settings, but not sure why it did it to only of the two files