### PR TITLE
Fixed broken images for Shopify

### DIFF
--- a/Extensions/Shopify/JsExtension.cpp
+++ b/Extensions/Shopify/JsExtension.cpp
@@ -28,8 +28,8 @@ void DeclareShopifyExtension(gd::PlatformExtension& extension) {
             "products."),
           _("Initialize shop _PARAM1_ (domain: _PARAM2_, appId: _PARAM3_)"),
           _("Shopify"),
-          "JsPlatform/Extensions/Shopifyicon24.png",
-          "JsPlatform/Extensions/Shopifyicon16.png")
+          "JsPlatform/Extensions/shopifyicon24.png",
+          "JsPlatform/Extensions/shopifyicon16.png")
 
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("string", _("Shop name"))
@@ -48,8 +48,8 @@ void DeclareShopifyExtension(gd::PlatformExtension& extension) {
             "_PARAM4_) from shop _PARAM1_, and store it in _PARAM5_ (or "
             "_PARAM6_ in case of error)"),
           _("Shopify"),
-          "JsPlatform/Extensions/Shopifyicon24.png",
-          "JsPlatform/Extensions/Shopifyicon16.png")
+          "JsPlatform/Extensions/shopifyicon24.png",
+          "JsPlatform/Extensions/shopifyicon16.png")
 
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter(


### PR DESCRIPTION
The images in the beta and web version of "Shopify" category were broken, while the ones in the version built from source were not. I believe it was because of case-sensitivity and have fixed the same, even though I wasn't able to try it.