### PR TITLE
Add links to documentation

### DIFF
--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -17,7 +17,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
                                _("Built-in camera extension"),
                                "Florian Rival",
                                "Open source (MIT License)")
-      .SetExtensionHelpPath("" /*TODO: Add a documentation page for this */);
+      .SetExtensionHelpPath("/interface/scene-editor/layers-and-cameras");
 
 #if defined(GD_IDE_ONLY)
   extension

--- a/Core/GDCore/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -29,7 +29,7 @@ BuiltinExtensionsImplementer::ImplementsCommonInstructionsExtension(
           _("Built-in extension providing standard events."),
           "Florian Rival",
           "Open source (MIT License)")
-      .SetExtensionHelpPath("" /*TODO: Add a documentation page for this */);
+      .SetExtensionHelpPath("/all-features/advanced-conditions");
 
 #if defined(GD_IDE_ONLY)
   extension

--- a/Core/GDCore/Extensions/Builtin/ExternalLayoutsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/ExternalLayoutsExtension.cpp
@@ -20,7 +20,7 @@ BuiltinExtensionsImplementer::ImplementsExternalLayoutsExtension(
             "external layouts"),
           "Florian Rival",
           "Open source (MIT License)")
-      .SetExtensionHelpPath("" /*TODO: Add a documentation page for this */);
+      .SetExtensionHelpPath("/interface/scene-editor/external-layouts");
 
 #if defined(GD_IDE_ONLY)
   extension

--- a/Core/GDCore/Extensions/Builtin/KeyboardExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/KeyboardExtension.cpp
@@ -18,7 +18,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsKeyboardExtension(
           _("Built-in extension that enables the use of a keyboard"),
           "Florian Rival",
           "Open source (MIT License)")
-      .SetExtensionHelpPath("" /*TODO: Add a documentation page for this */);
+      .SetExtensionHelpPath("/all-features/keyboard");
 
 #if defined(GD_IDE_ONLY)
   extension


### PR DESCRIPTION
Add the link to the documentation of layers and cameras

Edit: Link to documentation for external layouts has been added too (Used the same documentation as GD4) and both have been added as a sub page for scene editor :)