### PR TITLE
Update CommonConversionsExtension.cpp

### DIFF
--- a/Core/GDCore/Extensions/Builtin/CommonConversionsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CommonConversionsExtension.cpp
@@ -19,7 +19,7 @@ BuiltinExtensionsImplementer::ImplementsCommonConversionsExtension(
           _("Built-in extension providing standard conversions expressions."),
           "Florian Rival",
           "Open source (MIT License)")
-      .SetExtensionHelpPath("" /*TODO: Add a documentation page for this */);
+      .SetExtensionHelpPath("/all-features/common-conversions");
 
 #if defined(GD_IDE_ONLY)
 


### PR DESCRIPTION
* Added link to the documentation.
* Remove the "Number > Text (without scientific notation)" expression: The expression seemed to be outdated as beyond 1e+21, it returned numbers in scientific notation which is the same as the regular "Number > Text" expression.