### PR TITLE
Add zoom to ImagePreview and fix Physics2 behavior vertices edition

### DIFF
--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -72,10 +72,11 @@ module.exports = {
         return true;
       }
       if (propertyName === 'polygonOrigin') {
-        behaviorContent.getChild('polygonOrigin').setStringValue(newValue);
+        behaviorContent.addChild('polygonOrigin').setStringValue(newValue);
         return true;
       }
       if (propertyName === 'vertices') {
+        behaviorContent.addChild('vertices');
         behaviorContent.setChild('vertices', gd.Serializer.fromJSON(newValue));
         return true;
       }
@@ -203,7 +204,9 @@ module.exports = {
       behaviorProperties.set(
         'polygonOrigin',
         new gd.PropertyDescriptor(
-          behaviorContent.getChild('polygonOrigin').getStringValue() || 'Center'
+          behaviorContent.hasChild('polygonOrigin') ?
+            behaviorContent.getChild('polygonOrigin').getStringValue() :
+            'Center'
         )
           .setType('Choice')
           .setLabel('Polygon Origin')
@@ -214,7 +217,9 @@ module.exports = {
       behaviorProperties.set(
         'vertices',
         new gd.PropertyDescriptor(
-          gd.Serializer.toJSON(behaviorContent.getChild('vertices')) || '[]'
+          behaviorContent.hasChild('vertices') ?
+            gd.Serializer.toJSON(behaviorContent.getChild('vertices')) :
+            '[]'
         ).setLabel('Vertices')
       );
       behaviorProperties.set(

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -10,6 +10,7 @@ import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import ImagePreview from '../../../ResourcesList/ResourcePreview/ImagePreview';
 import ResourceSelector from '../../../ResourcesList/ResourceSelector';
 import ResourcesLoader from '../../../ResourcesLoader';
+import BackgroundText from '../../../UI/BackgroundText';
 import ShapePreview from './ShapePreview.js';
 import PolygonEditor from './PolygonEditor.js';
 import { type BehaviorEditorProps } from '../BehaviorEditorProps.flow';
@@ -18,8 +19,6 @@ type Props = BehaviorEditorProps;
 
 type State = {|
   image: string,
-  imageWidth: number,
-  imageHeight: number,
 |};
 
 function NumericProperty(props: {|
@@ -75,15 +74,6 @@ export default class Physics2Editor extends React.Component<Props, State> {
 
   state = {
     image: '',
-    imageWidth: 0,
-    imageHeight: 0,
-  };
-
-  _setImageSize = (width: number, height: number) => {
-    this.setState({
-      imageWidth: width,
-      imageHeight: height,
-    });
   };
 
   _isBitEnabled(bitsValue: number, pos: number) {
@@ -342,14 +332,17 @@ export default class Physics2Editor extends React.Component<Props, State> {
           />
         </Line>
         <Line>
-          <Column expand>
-            <Line>
-              <ImagePreview
-                resourceName={this.state.image}
-                project={this.props.project}
-                resourcesLoader={this.resourcesLoader}
-                onSize={this._setImageSize}
-              >
+          <div
+            style={{
+              width:
+                '100%' /* This div prevents ImagePreview to overflow outside the parent */,
+            }}
+          >
+            <ImagePreview
+              resourceName={this.state.image}
+              project={this.props.project}
+              resourcesLoader={this.resourcesLoader}
+              renderOverlay={({ imageWidth, imageHeight, imageZoomFactor }) => (
                 <ShapePreview
                   shape={properties.get('shape').getValue()}
                   dimensionA={parseFloat(
@@ -366,8 +359,9 @@ export default class Physics2Editor extends React.Component<Props, State> {
                   )}
                   polygonOrigin={properties.get('polygonOrigin').getValue()}
                   vertices={JSON.parse(properties.get('vertices').getValue())}
-                  width={this.state.imageWidth}
-                  height={this.state.imageHeight}
+                  width={imageWidth}
+                  height={imageHeight}
+                  zoomFactor={imageZoomFactor}
                   onMoveVertex={(index, newX, newY) => {
                     let vertices = JSON.parse(
                       properties.get('vertices').getValue()
@@ -383,26 +377,31 @@ export default class Physics2Editor extends React.Component<Props, State> {
                     this.forceUpdate();
                   }}
                 />
-              </ImagePreview>
-            </Line>
-            <Line>
-              <ResourceSelector
-                project={this.props.project}
-                resourceSources={this.props.resourceSources}
-                onChooseResource={this.props.onChooseResource}
-                resourceExternalEditors={this.props.resourceExternalEditors}
-                resourcesLoader={this.resourcesLoader}
-                resourceKind={'image'}
-                initialResourceName={''}
-                fullWidth={false}
-                onChange={resourceName => {
-                  this.setState({ image: resourceName });
-                  this.forceUpdate();
-                }}
-              />
-            </Line>
-          </Column>
-          {shape === 'Polygon' && (
+              )}
+            />
+          </div>
+        </Line>
+        <Line alignItems="center">
+          <ResourceSelector
+            project={this.props.project}
+            resourceSources={this.props.resourceSources}
+            onChooseResource={this.props.onChooseResource}
+            resourceExternalEditors={this.props.resourceExternalEditors}
+            resourcesLoader={this.resourcesLoader}
+            resourceKind={'image'}
+            initialResourceName={''}
+            fullWidth={false}
+            onChange={resourceName => {
+              this.setState({ image: resourceName });
+              this.forceUpdate();
+            }}
+          />
+          <BackgroundText>
+            An temporary image to help you visualize the shape/polygon
+          </BackgroundText>
+        </Line>
+        {shape === 'Polygon' && (
+          <Line>
             <PolygonEditor
               vertices={JSON.parse(properties.get('vertices').getValue())}
               onChangeVertexX={(newValue, index) => {
@@ -459,8 +458,8 @@ export default class Physics2Editor extends React.Component<Props, State> {
                 this.forceUpdate();
               }}
             />
-          )}
-        </Line>
+          </Line>
+        )}
         <Line>
           <Column expand>
             <NumericProperty

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -206,15 +206,19 @@ export default class CollisionMasksEditor extends Component {
           resourcesLoader={resourcesLoader}
           project={project}
           onSize={this._setCurrentSpriteSize}
-        >
-          {hasValidSprite && (
-            <CollisionMasksPreview
-              isDefaultBoundingBox={sprite.isCollisionMaskAutomatic()}
-              polygons={sprite.getCustomCollisionMask()}
-              onPolygonsUpdated={this._updateCollisionMasks}
-            />
-          )}
-        </ImagePreview>
+          renderOverlay={({ imageWidth, imageHeight, imageZoomFactor }) =>
+            hasValidSprite && (
+              <CollisionMasksPreview
+                imageWidth={imageWidth}
+                imageHeight={imageHeight}
+                imageZoomFactor={imageZoomFactor}
+                isDefaultBoundingBox={sprite.isCollisionMaskAutomatic()}
+                polygons={sprite.getCustomCollisionMask()}
+                onPolygonsUpdated={this._updateCollisionMasks}
+              />
+            )
+          }
+        />
         <Line>
           <Column expand>
             <SpriteSelector

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
@@ -21,6 +21,7 @@ type Props = {|
   pointsContainer: gdSprite, // Could potentially be generalized to other things than Sprite in the future.
   imageWidth: number,
   imageHeight: number,
+  imageZoomFactor: number,
   onPointsUpdated: () => void,
 |};
 
@@ -62,7 +63,6 @@ export default class PointsPreview extends React.Component<Props, State> {
    * Move a point with the mouse. A similar dragging implementation is done in
    * CollisionMasksPreview (but with svg elements).
    *
-   * If custom zoom is added, this should be adapted to properly set point coordinates.
    * TODO: This could be optimized by avoiding the forceUpdate (not sure if worth it though).
    */
   _onMouseMove = (event: any) => {
@@ -76,8 +76,8 @@ export default class PointsPreview extends React.Component<Props, State> {
     if (draggedPointKind === pointKindIdentifiers.CENTER) {
       this.props.pointsContainer.setDefaultCenterPoint(false);
     }
-    draggedPoint.setX(xOnContainer);
-    draggedPoint.setY(yOnContainer);
+    draggedPoint.setX(xOnContainer / this.props.imageZoomFactor);
+    draggedPoint.setY(yOnContainer / this.props.imageZoomFactor);
     this.forceUpdate();
   };
 
@@ -114,13 +114,18 @@ export default class PointsPreview extends React.Component<Props, State> {
   };
 
   render() {
-    const { pointsContainer, imageWidth, imageHeight } = this.props;
+    const {
+      pointsContainer,
+      imageWidth,
+      imageHeight,
+      imageZoomFactor,
+    } = this.props;
     const nonDefaultPoints = pointsContainer.getAllNonDefaultPoints();
     const points = mapVector(nonDefaultPoints, (point, i) =>
       this._renderPoint(
         point.getName(),
-        point.getX(),
-        point.getY(),
+        point.getX() * imageZoomFactor,
+        point.getY() * imageZoomFactor,
         pointKindIdentifiers.NORMAL,
         point
       )
@@ -140,15 +145,17 @@ export default class PointsPreview extends React.Component<Props, State> {
         {points}
         {this._renderPoint(
           'Origin',
-          originPoint.getX(),
-          originPoint.getY(),
+          originPoint.getX() * imageZoomFactor,
+          originPoint.getY() * imageZoomFactor,
           pointKindIdentifiers.ORIGIN,
           originPoint
         )}
         {this._renderPoint(
           'Center',
-          !automaticCenterPosition ? centerPoint.getX() : imageWidth / 2,
-          !automaticCenterPosition ? centerPoint.getY() : imageHeight / 2,
+          (!automaticCenterPosition ? centerPoint.getX() : imageWidth / 2) *
+            imageZoomFactor,
+          (!automaticCenterPosition ? centerPoint.getY() : imageHeight / 2) *
+            imageZoomFactor,
           pointKindIdentifiers.CENTER,
           centerPoint
         )}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
@@ -170,14 +170,18 @@ export default class PointsEditor extends Component {
           resourceName={hasValidSprite ? sprite.getImageName() : ''}
           resourcesLoader={resourcesLoader}
           project={project}
-        >
-          {hasValidSprite && (
-            <PointsPreview
-              pointsContainer={sprite}
-              onPointsUpdated={this._updatePoints}
-            />
-          )}
-        </ImagePreview>
+          renderOverlay={({ imageWidth, imageHeight, imageZoomFactor }) =>
+            hasValidSprite && (
+              <PointsPreview
+                imageWidth={imageWidth}
+                imageHeight={imageHeight}
+                imageZoomFactor={imageZoomFactor}
+                pointsContainer={sprite}
+                onPointsUpdated={this._updatePoints}
+              />
+            )
+          }
+        />
         <Line>
           <Column expand>
             <SpriteSelector

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -136,7 +136,7 @@ export default class ResourcePropertiesEditor extends React.Component<
     const { resources } = this.props;
 
     return (
-      <Background>
+      <Background maxWidth>
         {this._renderPreview()}
         {!resources || !resources.length
           ? this._renderEmpty()

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -1,32 +1,33 @@
 // @flow
 import { Trans } from '@lingui/macro';
-
+import IconButton from 'material-ui/IconButton';
+import Measure from 'react-measure';
 import * as React from 'react';
 import ResourcesLoader from '../../ResourcesLoader';
+import { Column } from '../../UI/Grid';
+import MiniToolbar from '../../UI/MiniToolbar';
+import ZoomIn from 'material-ui/svg-icons/action/zoom-in';
+import ZoomOut from 'material-ui/svg-icons/action/zoom-out';
+import ZoomOutMap from 'material-ui/svg-icons/maps/zoom-out-map';
 
 const MARGIN = 50;
+const MAX_ZOOM_FACTOR = 10;
+const MIN_ZOOM_FACTOR = 0.1;
 
 const styles = {
   imagePreviewContainer: {
     position: 'relative',
     display: 'inline-block',
     width: '100%',
-    textAlign: 'center',
     border: '#AAAAAA 1px solid',
     overflow: 'scroll',
     height: 200,
     background: 'url("res/transparentback.png") repeat',
   },
   spriteThumbnailImage: {
+    position: 'relative',
     pointerEvents: 'none',
     margin: MARGIN,
-  },
-  overlayContainer: {
-    textAlign: 'initial',
-    position: 'absolute',
-    top: MARGIN,
-    left: '50%',
-    transform: 'translate(-50%, 0)',
   },
   box: {
     border: '1px solid black',
@@ -38,7 +39,11 @@ type Props = {|
   resourceName: string,
   resourcePath?: string,
   resourcesLoader: typeof ResourcesLoader,
-  children?: any,
+  renderOverlay?: ({|
+    imageWidth: number,
+    imageHeight: number,
+    imageZoomFactor: number,
+  |}) => React.Node,
   style?: Object,
   onSize?: (number, number) => void,
 |};
@@ -48,6 +53,7 @@ type State = {|
   imageWidth: ?number,
   imageHeight: ?number,
   imageSource: ?string,
+  imageZoomFactor: number,
 |};
 
 /**
@@ -56,11 +62,13 @@ type State = {|
 export default class ImagePreview extends React.Component<Props, State> {
   _container: ?HTMLDivElement = null;
 
-  constructor(props: Props) {
-    super(props);
-
-    this.state = this._loadFrom(props);
-  }
+  state = {
+    errored: false,
+    imageWidth: null,
+    imageHeight: null,
+    imageZoomFactor: 1,
+    ...this._loadFrom(this.props),
+  };
 
   componentWillReceiveProps(newProps: Props) {
     if (
@@ -73,24 +81,15 @@ export default class ImagePreview extends React.Component<Props, State> {
     }
   }
 
-  _loadFrom(props: Props): State {
+  _loadFrom(props: Props): {| errored: boolean, imageSource: ?string |} {
     const { project, resourceName, resourcesLoader } = props;
     return {
       errored: false,
-      imageWidth: null,
-      imageHeight: null,
       imageSource: resourcesLoader.getResourceFullUrl(project, resourceName),
     };
   }
 
-  componentDidMount() {
-    if (this._container) {
-      this._container.scrollTop = MARGIN;
-      this._container.scrollLeft = MARGIN;
-    }
-  }
-
-  _handleError = () => {
+  _handleImageError = () => {
     this.setState({
       errored: true,
     });
@@ -99,8 +98,12 @@ export default class ImagePreview extends React.Component<Props, State> {
   _handleImageLoaded = (e: any) => {
     const imgElement = e.target;
 
-    const imageWidth = imgElement ? imgElement.clientWidth : 0;
-    const imageHeight = imgElement ? imgElement.clientHeight : 0;
+    const imageWidth = imgElement
+      ? imgElement.naturalWidth || imgElement.clientWidth
+      : 0;
+    const imageHeight = imgElement
+      ? imgElement.naturalHeight || imgElement.clientHeight
+      : 0;
     this.setState({
       imageWidth,
       imageHeight,
@@ -108,50 +111,138 @@ export default class ImagePreview extends React.Component<Props, State> {
     if (this.props.onSize) this.props.onSize(imageWidth, imageHeight);
   };
 
+  _zoomBy = (imageZoomFactorDelta: number) => {
+    this._zoomTo(this.state.imageZoomFactor + imageZoomFactorDelta);
+  };
+
+  _zoomTo = (imageZoomFactor: number) => {
+    this.setState(state => ({
+      imageZoomFactor: Math.min(
+        MAX_ZOOM_FACTOR,
+        Math.max(MIN_ZOOM_FACTOR, imageZoomFactor)
+      ),
+    }));
+  };
+
   render() {
-    const { resourceName, style, children } = this.props;
-
-    const { imageHeight, imageWidth, imageSource } = this.state;
-
-    const overlayStyle = {
-      ...styles.overlayContainer,
-      width: this.state.imageWidth,
-      height: this.state.imageHeight,
-    };
-    const canDisplayOverlays = !!imageWidth && !!imageHeight;
-
     return (
-      <div
-        style={{ ...styles.imagePreviewContainer, ...style }}
-        ref={container => (this._container = container)}
-      >
-        {!!this.state.errored && (
-          <p>
-            <Trans>Unable to load the image</Trans>
-          </p>
-        )}
-        {!this.state.errored && (
-          <img
-            style={styles.spriteThumbnailImage}
-            alt={resourceName}
-            src={imageSource}
-            onError={this._handleError}
-            onLoad={this._handleImageLoaded}
-            crossOrigin="anonymous"
-          />
-        )}
-        {canDisplayOverlays && children && (
-          <div style={{ ...overlayStyle, ...styles.box }} />
-        )}
-        {canDisplayOverlays && children && (
-          <div style={overlayStyle}>
-            {React.cloneElement(children, {
-              imageWidth,
-              imageHeight,
-            })}
-          </div>
-        )}
-      </div>
+      <Measure>
+        {dimensions => {
+          const containerWidth = dimensions.width;
+          const { resourceName, style, renderOverlay } = this.props;
+          const {
+            imageHeight,
+            imageWidth,
+            imageSource,
+            imageZoomFactor,
+          } = this.state;
+
+          const imageLoaded = !!imageWidth && !!imageHeight;
+
+          const imagePositionTop = 0;
+          const imagePositionLeft = Math.max(
+            0,
+            containerWidth / 2 -
+              ((imageWidth || 0) * imageZoomFactor) / 2 -
+              MARGIN
+          );
+
+          const imageStyle = {
+            ...styles.spriteThumbnailImage,
+            top: imagePositionTop,
+            left: imagePositionLeft,
+            width: imageWidth ? imageWidth * imageZoomFactor : undefined,
+            height: imageHeight ? imageHeight * imageZoomFactor : undefined,
+            visibility: imageLoaded ? undefined : 'hidden', // TODO: Loader
+          };
+
+          const overlayStyle = {
+            position: 'absolute',
+            top: imagePositionTop + MARGIN,
+            left: imagePositionLeft + MARGIN,
+            width: imageWidth ? imageWidth * imageZoomFactor : undefined,
+            height: imageHeight ? imageHeight * imageZoomFactor : undefined,
+            visibility: imageLoaded ? undefined : 'hidden', // TODO: Loader
+          };
+
+          return (
+            <Column expand noMargin>
+              <MiniToolbar>
+                <IconButton
+                  onClick={() => this._zoomBy(+0.2)}
+                  tooltip={
+                    <Trans>Zoom in (you can also use Ctrl + Mouse wheel)</Trans>
+                  }
+                  tooltipPosition="bottom-right"
+                >
+                  <ZoomIn />
+                </IconButton>
+                <IconButton
+                  onClick={() => this._zoomBy(-0.2)}
+                  tooltip={
+                    <Trans>
+                      Zoom out (you can also use Ctrl + Mouse wheel)
+                    </Trans>
+                  }
+                  tooltipPosition="bottom-right"
+                >
+                  <ZoomOut />
+                </IconButton>
+                <IconButton
+                  onClick={() => this._zoomTo(1)}
+                  tooltip={<Trans>Restore original size</Trans>}
+                  tooltipPosition="bottom-right"
+                >
+                  <ZoomOutMap />
+                </IconButton>
+              </MiniToolbar>
+              <div
+                style={{ ...styles.imagePreviewContainer, ...style }}
+                ref={container => (this._container = container)}
+                onWheel={event => {
+                  const { deltaY } = event;
+                  //TODO: Use KeyboardShortcuts
+                  if (event.metaKey || event.ctrlKey) {
+                    this._zoomBy(deltaY / 20);
+                    event.preventDefault();
+                    event.stopPropagation();
+                  } else {
+                    // Let the usual, native vertical or horizontal scrolling happen.
+                  }
+                }}
+              >
+                {!!this.state.errored && (
+                  <p>
+                    <Trans>Unable to load the image</Trans>
+                  </p>
+                )}
+                {!this.state.errored && (
+                  <img
+                    style={imageStyle}
+                    alt={resourceName}
+                    src={imageSource}
+                    onError={this._handleImageError}
+                    onLoad={this._handleImageLoaded}
+                    crossOrigin="anonymous"
+                  />
+                )}
+                {imageLoaded && renderOverlay && (
+                  <div style={{ ...overlayStyle, ...styles.box }} />
+                )}
+                {imageLoaded && renderOverlay && (
+                  <div style={overlayStyle}>
+                    {renderOverlay({
+                      imageWidth: imageWidth || 0,
+                      imageHeight: imageHeight || 0,
+                      imageZoomFactor,
+                    })}
+                  </div>
+                )}
+              </div>
+            </Column>
+          );
+        }}
+      </Measure>
     );
   }
 }

--- a/newIDE/app/src/ResourcesList/ResourcePreview/index.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/index.js
@@ -14,7 +14,6 @@ type Props = {|
   resourceName: string,
   resourcePath?: string,
   resourcesLoader: typeof ResourcesLoader,
-  children?: any,
   style?: Object,
   onSize?: (number, number) => void,
 |};
@@ -27,11 +26,7 @@ type State = {|
  * Display the right preview for any given resource of a project
  */
 export default class ResourcePreview extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = this._loadFrom(props);
-  }
+  state = this._loadFrom(this.props);
 
   componentWillReceiveProps(newProps: Props) {
     if (
@@ -65,7 +60,6 @@ export default class ResourcePreview extends React.Component<Props, State> {
             project={this.props.project}
             resourceName={this.props.resourceName}
             resourcesLoader={this.props.resourcesLoader}
-            children={this.props.children}
             style={this.props.style}
             onSize={this.props.onSize}
             resourcePath={this.props.resourcePath}

--- a/newIDE/app/src/UI/MiniToolbar.js
+++ b/newIDE/app/src/UI/MiniToolbar.js
@@ -4,8 +4,8 @@ import muiThemeable from 'material-ui/styles/muiThemeable';
 const style = {
   display: 'flex',
   alignItems: 'center',
-  paddingLeft: 16,
-  paddingRight: 16,
+  paddingLeft: 8,
+  paddingRight: 8,
 };
 
 class ThemableMiniToolbar extends Component {


### PR DESCRIPTION
* Refactor overlays (points, collision masks, physics shape preview) to be a render prop, better flow typing safety.
* Fix Physics2 polygon vertices edition (crash on some objects).
* Add cursor when hovering a vertex of a polygon.

Tested that zoom is properly working for points edition, collision masks edition, animation preview, resource preview and physics shape preview