### PR TITLE
[WIP] Integrate SkeletonObject into GD5

### DIFF
--- a/Core/GDCore/Project/ResourcesManager.cpp
+++ b/Core/GDCore/Project/ResourcesManager.cpp
@@ -4,12 +4,12 @@
  * reserved. This project is released under the MIT License.
  */
 
+#include "GDCore/Project/ResourcesManager.h"
 #include <iostream>
 #include <map>
 #include "GDCore/CommonTools.h"
-#include "GDCore/Project/PropertyDescriptor.h"
 #include "GDCore/Project/Project.h"
-#include "GDCore/Project/ResourcesManager.h"
+#include "GDCore/Project/PropertyDescriptor.h"
 #include "GDCore/Serialization/Serializer.h"
 #include "GDCore/Serialization/SerializerElement.h"
 #include "GDCore/Tools/Localization.h"
@@ -553,13 +553,35 @@ void JsonResource::SetFile(const gd::String& newFile) {
 void JsonResource::UnserializeFrom(const SerializerElement& element) {
   SetUserAdded(element.GetBoolAttribute("userAdded"));
   SetFile(element.GetStringAttribute("file"));
+  DisablePreload(element.GetBoolAttribute("disablePreload", false));
 }
 
 #if defined(GD_IDE_ONLY)
 void JsonResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("userAdded", IsUserAdded());
   element.SetAttribute("file", GetFile());
+  element.SetAttribute("disablePreload", IsPreloadDisabled());
 }
+
+std::map<gd::String, gd::PropertyDescriptor> JsonResource::GetProperties(
+    gd::Project& project) const {
+  std::map<gd::String, gd::PropertyDescriptor> properties;
+  properties["disablePreload"]
+      .SetValue(disablePreload ? "true" : "false")
+      .SetType("Boolean")
+      .SetLabel(_("Disable preloading at game startup"));
+
+  return properties;
+}
+
+bool JsonResource::UpdateProperty(const gd::String& name,
+                                  const gd::String& value,
+                                  gd::Project& project) {
+  if (name == "disablePreload") disablePreload = value == "1";
+
+  return true;
+}
+
 #endif
 
 #if defined(GD_IDE_ONLY)

--- a/Core/GDCore/Project/ResourcesManager.h
+++ b/Core/GDCore/Project/ResourcesManager.h
@@ -5,6 +5,7 @@
  */
 #ifndef GDCORE_RESOURCESMANAGER_H
 #define GDCORE_RESOURCESMANAGER_H
+#include <map>
 #include <memory>
 #include <vector>
 #include "GDCore/String.h"

--- a/Core/GDCore/Project/ResourcesManager.h
+++ b/Core/GDCore/Project/ResourcesManager.h
@@ -13,7 +13,7 @@ class Project;
 class ResourceFolder;
 class SerializerElement;
 class PropertyDescriptor;
-}
+}  // namespace gd
 
 namespace gd {
 
@@ -82,7 +82,9 @@ class GD_CORE_API Resource {
    * \note Can be used by external editors to store extra information, for
    * example the configuration used to produce a sound.
    */
-  virtual void SetMetadata(const gd::String& metadata_) { metadata = metadata_; }
+  virtual void SetMetadata(const gd::String& metadata_) {
+    metadata = metadata_;
+  }
 
   /**
    * \brief Return the (optional) metadata associated to the resource
@@ -300,7 +302,7 @@ class GD_CORE_API VideoResource : public Resource {
  */
 class GD_CORE_API JsonResource : public Resource {
  public:
-  JsonResource() : Resource() { SetKind("json"); };
+  JsonResource() : Resource(), disablePreload(false) { SetKind("json"); };
   virtual ~JsonResource(){};
   virtual JsonResource* Clone() const override {
     return new JsonResource(*this);
@@ -311,12 +313,30 @@ class GD_CORE_API JsonResource : public Resource {
 
 #if defined(GD_IDE_ONLY)
   virtual bool UseFile() override { return true; }
+
+  std::map<gd::String, gd::PropertyDescriptor> GetProperties(
+      gd::Project& project) const override;
+  bool UpdateProperty(const gd::String& name,
+                      const gd::String& value,
+                      gd::Project& project) override;
+
   void SerializeTo(SerializerElement& element) const override;
 #endif
 
   void UnserializeFrom(const SerializerElement& element) override;
 
+  /**
+   * \brief Return true if the loading at game startup must be disabled
+   */
+  bool IsPreloadDisabled() const { return disablePreload; }
+
+  /**
+   * \brief Set if the json preload at game startup must be disabled
+   */
+  void DisablePreload(bool disable = true) { disablePreload = disable; }
+
  private:
+  bool disablePreload;  ///< If "true", don't load the JSON at game startup
   gd::String file;
 };
 
@@ -366,7 +386,8 @@ class GD_CORE_API ResourcesManager {
 
   /**
    * \brief Add an already constructed resource.
-   * \note A copy of the resource is made and stored inside the ResourcesManager.
+   * \note A copy of the resource is made and stored inside the
+   * ResourcesManager.
    */
   bool AddResource(const gd::Resource& resource);
 

--- a/Extensions/SkeletonObject/Bskeletonruntimeobject-cocos-renderer.js
+++ b/Extensions/SkeletonObject/Bskeletonruntimeobject-cocos-renderer.js
@@ -15,11 +15,25 @@ gdjs.sk.CocosDataLoader.prototype.getData = function(dataName){
     return cc.loader.getRes("res/"+dataName);
 };
 
+/**
+ * Load the textures from DragonBones data
+ * @param {gdjs.RuntimeScene} runtimeScene
+ * @param {Object} objectData
+ */
 gdjs.sk.CocosDataLoader.prototype.loadDragonBones = function(runtimeScene, objectData){
-    var textureData = this.getData(objectData.textureDataFilename);
+    var jsonManager = runtimeScene.getGame().getJsonManager();
+    if (!jsonManager.isJsonLoaded(objectData.textureDataFilename)) {
+        console.error("Tried to load DragonBones textures from \"" + objectData.textureDataFilename + "\" but this resource is not loaded.");
+        return;
+    }
+
+    var textureData = jsonManager.getLoadedJson(objectData.textureDataFilename);
     var texture = runtimeScene.getGame().getImageManager().getTexture(objectData.textureName);
-    if(!textureData || !texture._textureLoaded) return;
-    
+    if(!textureData || !texture._textureLoaded) {
+        console.error("Tried to load DragonBones textures from \"" + objectData.textureDataFilename + "\" resource but the texture or the texture data could not be loaded properly.");
+        return;
+    }
+
     for(var i=0; i<textureData.SubTexture.length; i++){
         var subTex = textureData.SubTexture[i];
         var frame = new cc.rect(subTex.x, subTex.y, subTex.width, subTex.height);
@@ -29,7 +43,7 @@ gdjs.sk.CocosDataLoader.prototype.loadDragonBones = function(runtimeScene, objec
         if (subTex.hasOwnProperty("frameHeight")){
             frame.height = subTex.frameHeight;
         }
-        
+
         this.textures[subTex.name] = {"texture": texture, "frame": frame};
     }
 };
@@ -98,7 +112,7 @@ gdjs.sk.SlotCocosRenderer.prototype.loadAsSprite = function(texture){
 };
 
 gdjs.sk.SlotCocosRenderer.prototype.loadAsMesh = function(texture, vertices, uvs, triangles){
-    // Meshes not supported, load as sprites 
+    // Meshes not supported, load as sprites
     this.loadAsSprite(texture);
 };
 

--- a/Extensions/SkeletonObject/Bskeletonruntimeobject-pixi-renderer.js
+++ b/Extensions/SkeletonObject/Bskeletonruntimeobject-pixi-renderer.js
@@ -11,18 +11,25 @@ gdjs.sk.PixiDataLoader = function()
 };
 gdjs.sk.DataLoader = gdjs.sk.PixiDataLoader;
 
-gdjs.sk.PixiDataLoader.prototype.getData = function(dataName){
-    if(PIXI.loader.resources[dataName]){
-        return PIXI.loader.resources[dataName].data;
-    }
-    return null;
-};
-
+/**
+ * Load the textures from DragonBones data
+ * @param {gdjs.RuntimeScene} runtimeScene
+ * @param {Object} objectData
+ */
 gdjs.sk.PixiDataLoader.prototype.loadDragonBones = function(runtimeScene, objectData){
-    var textureData = this.getData(objectData.textureDataFilename);
+    var jsonManager = runtimeScene.getGame().getJsonManager();
+    if (!jsonManager.isJsonLoaded(objectData.textureDataFilename)) {
+        console.error("Tried to load DragonBones textures from \"" + objectData.textureDataFilename + "\" but this resource is not loaded.");
+        return;
+    }
+
+    var textureData = jsonManager.getLoadedJson(objectData.textureDataFilename);
     var texture = runtimeScene.getGame().getImageManager().getPIXITexture(objectData.textureName);
-    if(!textureData || !texture.valid) return;
-    
+    if(!textureData || !texture.valid) {
+        console.error("Tried to load DragonBones textures from \"" + objectData.textureDataFilename + "\" resource but the texture or the texture data could not be loaded properly.");
+        return;
+    }
+
     for(var i=0; i<textureData.SubTexture.length; i++){
         var subTex = textureData.SubTexture[i];
         var frame = new PIXI.Rectangle(subTex.x, subTex.y, subTex.width, subTex.height);
@@ -37,7 +44,7 @@ gdjs.sk.PixiDataLoader.prototype.loadDragonBones = function(runtimeScene, object
         if(frame.y > texture.height) frame.y = 0;
         if(frame.x + frame.width > texture.width) frame.width = texture.width - frame.x;
         if(frame.y + frame.height > texture.height) frame.height = texture.height - frame.y;
-        
+
         this.textures[subTex.name] = new PIXI.Texture(texture.baseTexture, frame=frame);
     }
 };

--- a/Extensions/SkeletonObject/Extension.cpp
+++ b/Extensions/SkeletonObject/Extension.cpp
@@ -14,15 +14,14 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   extension.SetExtensionInformation(
       "SkeletonObject",
       _("Skeleton"),
-      _("Enables the use of animated skeleton objects.\nCurrently supported "
-        "formats:\n    *DragonBones"),
+      _("Enables the use of animated skeleton objects made with DragonBones."),
       "Franco Maciel",
       "Open source (MIT License)");
 
   gd::ObjectMetadata& obj = extension.AddObject<SkeletonObject>(
       "Skeleton",
       _("Skeleton"),
-      _("Object animated through bones"),
+      _("Object displayed using skeletal animation, powered by DragonBones. This object is experimental and searching for a maintainer."),
       "JsPlatform/Extensions/skeletonicon.png");
 
   // Object instructions

--- a/Extensions/SkeletonObject/Extension.cpp
+++ b/Extensions/SkeletonObject/Extension.cpp
@@ -11,17 +11,20 @@ This project is released under the MIT License.
 #include "SkeletonObject.h"
 
 void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
-  extension.SetExtensionInformation(
-      "SkeletonObject",
-      _("Skeleton"),
-      _("Enables the use of animated skeleton objects made with DragonBones."),
-      "Franco Maciel",
-      "Open source (MIT License)");
+  extension
+      .SetExtensionInformation("SkeletonObject",
+                               _("Skeleton"),
+                               _("Enables the use of animated skeleton objects "
+                                 "made with DragonBones."),
+                               "Franco Maciel",
+                               "Open source (MIT License)")
+      .SetExtensionHelpPath("/objects/skeleton");
 
   gd::ObjectMetadata& obj = extension.AddObject<SkeletonObject>(
       "Skeleton",
       _("Skeleton"),
-      _("Object displayed using skeletal animation, powered by DragonBones. This object is experimental and searching for a maintainer."),
+      _("Object displayed using skeletal animation, powered by DragonBones. "
+        "This object is experimental and searching for a maintainer."),
       "JsPlatform/Extensions/skeletonicon.png");
 
   // Object instructions

--- a/Extensions/SkeletonObject/Hskmanager.js
+++ b/Extensions/SkeletonObject/Hskmanager.js
@@ -26,14 +26,23 @@ gdjs.SkeletonObjectsManager.prototype.getSkeleton = function(runtimeScene, objec
     return this.loadedObjects[objectName];
 };
 
+/**
+ * Load the Skeleton data
+ * @param {gdjs.RuntimeScene} runtimeScene
+ * @param {Object} objectData
+ */
 gdjs.SkeletonObjectsManager.prototype.loadSkeleton = function(runtimeScene, objectData){
     var loader = new gdjs.sk.DataLoader();
-    var skeletalData = loader.getData(objectData.skeletalDataFilename);
     var skeleton = {"loader": loader,
                     "armatures": [],
                     "rootArmature": 0};
-    
-    if(!skeletalData) return skeleton;
+
+    var jsonManager = runtimeScene.getGame().getJsonManager();
+    var skeletalData = jsonManager.getLoadedJson(objectData.skeletalDataFilename);
+    if(!skeletalData) {
+        console.error("Tried to load a Skeleton file from \"" + objectData.skeletalDataFilename + "\" but this resource is not loaded.");
+        return skeleton;
+    }
 
     if(objectData.apiName === "DragonBones"){
         // Load sub-textures

--- a/Extensions/SkeletonObject/SkeletonObject.cpp
+++ b/Extensions/SkeletonObject/SkeletonObject.cpp
@@ -7,8 +7,8 @@ This project is released under the MIT License.
 
 #include "SkeletonObject.h"
 #include <SFML/Graphics.hpp>
-#include "GDCore/Project/PropertyDescriptor.h"
 #include "GDCore/IDE/Project/ArbitraryResourceWorker.h"
+#include "GDCore/Project/PropertyDescriptor.h"
 #include "GDCore/String.h"
 #include "GDCore/Tools/Localization.h"
 #include "GDCpp/Runtime/CommonTools.h"
@@ -52,10 +52,19 @@ void SkeletonObject::DoSerializeTo(gd::SerializerElement& element) const {
 std::map<gd::String, gd::PropertyDescriptor> SkeletonObject::GetProperties(
     gd::Project& project) const {
   std::map<gd::String, gd::PropertyDescriptor> properties;
-  properties[_("Skeletal data filename")].SetValue(skeletalDataFilename);
+  properties[_("Skeletal data filename")]
+      .SetValue(skeletalDataFilename)
+      .SetType("resource")
+      .AddExtraInfo("json");
   properties[_("Main armature name")].SetValue(rootArmatureName);
-  properties[_("Texture data filename")].SetValue(textureDataFilename);
-  properties[_("Texture")].SetValue(textureName);
+  properties[_("Texture data filename")]
+      .SetValue(textureDataFilename)
+      .SetType("resource")
+      .AddExtraInfo("json");
+  properties[_("Texture")]
+      .SetValue(textureName)
+      .SetType("resource")
+      .AddExtraInfo("image");
   properties[_("API")].SetValue(apiName).SetType("Choice").AddExtraInfo(
       "DragonBones");
   properties[_("Debug Polygons")]

--- a/GDJS/GDJS/Extensions/JsPlatform.cpp
+++ b/GDJS/GDJS/Extensions/JsPlatform.cpp
@@ -57,6 +57,7 @@ gd::PlatformExtension *CreateGDJSShopifyExtension();
 gd::PlatformExtension *CreateGDJSPathfindingBehaviorExtension();
 gd::PlatformExtension *CreateGDJSPhysicsBehaviorExtension();
 gd::PlatformExtension *CreateGDJSParticleSystemExtension();
+gd::PlatformExtension *CreateGDJSSkeletonObjectExtension();
 }
 #endif
 
@@ -163,6 +164,8 @@ void JsPlatform::ReloadBuiltinExtensions() {
   std::cout.flush();
   AddExtension(std::shared_ptr<gd::PlatformExtension>(
       CreateGDJSPhysicsBehaviorExtension()));
+  AddExtension(std::shared_ptr<gd::PlatformExtension>(
+      CreateGDJSSkeletonObjectExtension()));
   std::cout.flush();
 #endif
   std::cout << "done." << std::endl;

--- a/GDJS/Runtime/jsonmanager.js
+++ b/GDJS/Runtime/jsonmanager.js
@@ -18,6 +18,58 @@
  */
 gdjs.JsonManager = function(resources) {
   this._resources = resources;
+
+  /** @type Object.<string, Object> */
+  this._loadedJsons = {};
+};
+
+/**
+ * The callback called when a json is preloaded
+ * @callback JsonManagerOnProgressCallback
+ * @param {number} loaded The number of json files loaded so far
+ * @param {number} total The total number to be loaded
+ * @returns {undefined} Nothing
+ */
+
+/**
+ * The callback called when all jsons are preloaded
+ * @callback JsonManagerOnCompleteCallback
+ * @param {number} total The total number to be loaded
+ * @returns {undefined} Nothing
+ */
+
+/**
+ * Request all the json resources to be preloaded (unless they are marked as not preloaded).
+ *
+ * @param {JsonManagerOnProgressCallback} onProgress The function called after each json is loaded.
+ * @param {JsonManagerOnCompleteCallback} onComplete The function called when all jsons are loaded.
+ */
+gdjs.JsonManager.prototype.preloadJsons = function(onProgress, onComplete) {
+  var resources = this._resources;
+
+  var jsonResources = resources.filter(function(resource) {
+    return resource.kind === 'json' && !resource.disablePreload;
+  });
+  if (jsonResources.length === 0) return onComplete(jsonResources.length);
+
+  var loaded = 0;
+  /** @type JsonManagerRequestCallback */
+  var onLoad = function(error, jsonContent) {
+    if (error) {
+      console.error("Error while preloading a json resource:" + error);
+    }
+
+    loaded++;
+    if (loaded === jsonResources.length) {
+      return onComplete(jsonResources.length);
+    }
+
+    onProgress(loaded, jsonResources.length);
+  };
+
+  for (var i = 0; i < jsonResources.length; ++i) {
+    this.loadJson(jsonResources[i].name, onLoad);
+  }
 };
 
 /**
@@ -37,9 +89,9 @@ gdjs.JsonManager = function(resources) {
  * @param {JsonManagerRequestCallback} callback The callback function called when json is loaded (or an error occured).
  */
 gdjs.JsonManager.prototype.loadJson = function(resourceName, callback) {
-  var resource = this._resources.find(
-    resource => resource.kind === 'json' && resource.name === resourceName
-  );
+  var resource = this._resources.find(function(resource) {
+    return resource.kind === 'json' && resource.name === resourceName;
+  });
   if (!resource) {
     callback(
       new Error(
@@ -52,6 +104,7 @@ gdjs.JsonManager.prototype.loadJson = function(resourceName, callback) {
     return;
   }
 
+  var that = this;
   var xhr = new XMLHttpRequest();
   xhr.responseType = 'json';
   xhr.open('GET', resource.file);
@@ -64,6 +117,9 @@ gdjs.JsonManager.prototype.loadJson = function(resourceName, callback) {
       return;
     }
 
+    // Cache the result
+    that._loadedJsons[resourceName] = xhr.response;
+
     callback(null, xhr.response);
   };
   xhr.onerror = function() {
@@ -73,4 +129,12 @@ gdjs.JsonManager.prototype.loadJson = function(resourceName, callback) {
     callback(new Error('Request aborted'), null);
   };
   xhr.send();
+};
+
+gdjs.JsonManager.prototype.isJsonLoaded = function(resourceName) {
+  return !!this._loadedJsons[resourceName];
+};
+
+gdjs.JsonManager.prototype.getLoadedJson = function(resourceName) {
+  return this._loadedJsons[resourceName];
 };

--- a/GDJS/Runtime/jsonmanager.js
+++ b/GDJS/Runtime/jsonmanager.js
@@ -82,8 +82,8 @@ gdjs.JsonManager.prototype.preloadJsons = function(onProgress, onComplete) {
 
 /**
  * Request the json file from the given resource name.
- * When loaded, the `callback` is called with the error (null if none) and the loaded
- * json (string).
+ * This method is asynchronous. When loaded, the `callback` is called with the error
+ * (null if none) and the loaded json (a JS Object).
  *
  * @param {string} resourceName The resource pointing to the json file to load.
  * @param {JsonManagerRequestCallback} callback The callback function called when json is loaded (or an error occured).
@@ -131,10 +131,22 @@ gdjs.JsonManager.prototype.loadJson = function(resourceName, callback) {
   xhr.send();
 };
 
+/**
+ * Check if the given json resource was loaded (preloaded or loaded with `loadJson`).
+ * @param {string} resourceName The name of the json resource.
+ * @returns {boolean} true if the content of the json resource is loaded. false otherwise.
+ */
 gdjs.JsonManager.prototype.isJsonLoaded = function(resourceName) {
   return !!this._loadedJsons[resourceName];
 };
 
+/**
+ * Get the object for the given resource that is already loaded (preloaded or loaded with `loadJson`).
+ * If the resource is not loaded, `null` will be returned.
+ *
+ * @param {string} resourceName The name of the json resource.
+ * @returns {?Object} the content of the json resource, if loaded. `null` otherwise.
+ */
 gdjs.JsonManager.prototype.getLoadedJson = function(resourceName) {
-  return this._loadedJsons[resourceName];
+  return this._loadedJsons[resourceName] || null;
 };

--- a/GDJS/Runtime/runtimegame.js
+++ b/GDJS/Runtime/runtimegame.js
@@ -296,24 +296,42 @@ gdjs.RuntimeGame.prototype.loadAllAssets = function(
     function(texturesTotalCount) {
       that._soundManager.preloadAudio(
         function(count, total) {
-          loadingScreen.render(
-            Math.floor(((texturesTotalCount + count) / allAssetsTotal) * 100)
+          var percent = Math.floor(
+            ((texturesTotalCount + count) / allAssetsTotal) * 100
           );
+          loadingScreen.render(percent);
+          if (progressCallback) progressCallback(percent);
         },
         function(audioTotalCount) {
           that._fontManager.loadFonts(
             function(count, total) {
-              loadingScreen.render(
-                Math.floor(
-                  ((texturesTotalCount + audioTotalCount + count) /
-                    allAssetsTotal) *
-                    100
-                )
+              var percent = Math.floor(
+                ((texturesTotalCount + audioTotalCount + count) /
+                  allAssetsTotal) *
+                  100
               );
+              loadingScreen.render(percent);
+              if (progressCallback) progressCallback(percent);
             },
-            function() {
-              loadingScreen.unload();
-              callback();
+            function(fontTotalCount) {
+              that._jsonManager.preloadJsons(
+                function(count, total) {
+                  var percent = Math.floor(
+                    ((texturesTotalCount +
+                      audioTotalCount +
+                      fontTotalCount +
+                      count) /
+                      allAssetsTotal) *
+                      100
+                  );
+                  loadingScreen.render(percent);
+                  if (progressCallback) progressCallback(percent);
+                },
+                function() {
+                  loadingScreen.unload();
+                  callback();
+                }
+              );
             }
           );
         }

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2124,6 +2124,37 @@ interface TextEntryObject {
 };
 TextEntryObject implements gdObject;
 
+interface SkeletonObject {
+    void SkeletonObject([Const] DOMString name);
+
+    //Inherited from gdObject:
+    void SetName([Const] DOMString name);
+    [Const, Ref] DOMString GetName();
+    void SetType([Const] DOMString type);
+    [Const, Ref] DOMString GetType();
+    void SetTags([Const] DOMString tags);
+    [Const, Ref] DOMString GetTags();
+
+    [Value] MapStringPropertyDescriptor GetProperties([Ref] Project project);
+    boolean UpdateProperty([Const] DOMString name, [Const] DOMString value, [Ref] Project project);
+
+    [Value] MapStringPropertyDescriptor GetInitialInstanceProperties([Const, Ref] InitialInstance instance, [Ref] Project project, [Ref] Layout scene);
+    boolean UpdateInitialInstanceProperty([Ref] InitialInstance instance, [Const] DOMString name, [Const] DOMString value, [Ref] Project project, [Ref] Layout scene);
+
+    void ExposeResources([Ref] ArbitraryResourceWorker worker);
+
+    [Ref] VariablesContainer GetVariables();
+    [Value] VectorString GetAllBehaviorNames();
+    boolean HasBehaviorNamed([Const] DOMString name);
+    BehaviorContent AddNewBehavior([Ref] Project project, [Const] DOMString type, [Const] DOMString name);
+    [Ref] BehaviorContent GetBehavior([Const] DOMString name);
+    void RemoveBehavior([Const] DOMString name);
+    boolean RenameBehavior([Const] DOMString oldBame, [Const] DOMString name);
+
+    void SerializeTo([Ref] SerializerElement element);
+    void UnserializeFrom([Ref] Project project, [Const, Ref] SerializerElement element);
+};
+
 enum ParticleEmitterObject_RendererType {
   "ParticleEmitterObject::Point",
   "ParticleEmitterObject::Line",

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -71,6 +71,7 @@
 #include "../../Extensions/TextEntryObject/TextEntryObject.h"
 #include "../../Extensions/TextObject/TextObject.h"
 #include "../../Extensions/TiledSpriteObject/TiledSpriteObject.h"
+#include "../../Extensions/SkeletonObject/SkeletonObject.h"
 
 #include <GDJS/Events/Builtin/JsCodeEvent.h>
 #include <GDJS/Events/CodeGeneration/EventsCodeGenerator.h>

--- a/GDevelop.js/CMakeLists.txt
+++ b/GDevelop.js/CMakeLists.txt
@@ -99,3 +99,4 @@ target_link_libraries(GD PathfindingBehavior)
 target_link_libraries(GD PhysicsBehavior)
 # target_link_libraries(GD FacebookInstantGames) - Pure JS extension
 target_link_libraries(GD ParticleSystem)
+target_link_libraries(GD SkeletonObject)

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -827,11 +827,28 @@ describe('libGD.js', function() {
       resource.delete();
     });
     it('can have metadata', function() {
-      const resource = new gd.VideoResource();
+      const resource = new gd.JsonResource();
       expect(resource.getMetadata()).toBe('');
       resource.setMetadata(JSON.stringify({ hello: 'world' }));
       expect(resource.getMetadata()).toBe('{"hello":"world"}');
       resource.delete();
+    });
+
+    it('has disablePreload custom properties', function() {
+      const project = gd.ProjectHelper.createNewGDJSProject();
+      const resource = new gd.JsonResource();
+
+      const properties = resource.getProperties();
+      expect(properties.get('disablePreload').getValue()).toBe('false');
+
+      // Note: updateProperty expect the booleans in an usual "0" or "1" format.
+      resource.updateProperty('disablePreload', '1', project);
+
+      const updatedProperties = resource.getProperties();
+      expect(updatedProperties.get('disablePreload').getValue()).toBe('true');
+
+      resource.delete();
+      project.delete();
     });
   });
 

--- a/newIDE/app/src/Hints/index.js
+++ b/newIDE/app/src/Hints/index.js
@@ -35,6 +35,16 @@ export const getExtraObjectsInformation = (): {
       message: t`Video format supported can vary according to devices and browsers. For maximum compatibility, use H.264/mp4 file format (and AAC for audio).`,
     },
   ],
+  'SkeletonObject::Skeleton': [
+    {
+      kind: 'warning',
+      message: t`This object is experimental and not actively maintained. It might have bugs or incomplete support in GDevelop. A maintainer is searched to improve the object implementation and solve any issue. Your help is welcome!`,
+    },
+    {
+      kind: 'info',
+      message: t`Only use this object if you can contribute back to the source code or are able to remove/replace it from your game in a future version.`,
+    },
+  ],
 });
 
 export const getExtraInstructionInformation = (type: string): ?Hint => {

--- a/newIDE/app/src/Hints/index.js
+++ b/newIDE/app/src/Hints/index.js
@@ -15,6 +15,7 @@ export const getExperimentalObjects = (): {
   [string]: boolean,
 } => ({
   'Video::VideoObject': true,
+  'SkeletonObject::Skeleton': true,
 });
 
 export const getExtraObjectsInformation = (): {

--- a/newIDE/app/src/ObjectEditor/ObjectsEditorService.js
+++ b/newIDE/app/src/ObjectEditor/ObjectsEditorService.js
@@ -107,5 +107,11 @@ export default {
       castToObjectType: object => gd.asParticleEmitterObject(object),
       helpPagePath: '/objects/particles_emitter',
     },
+    'SkeletonObject::Skeleton': {
+      component: ObjectPropertiesEditor,
+      createNewObject: () => new gd.SkeletonObject(''),
+      castToObjectType: object => gd.castObject(object, gd.SkeletonObject),
+      helpPagePath: '/objects/skeleton',
+    },
   },
 };

--- a/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
+++ b/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
@@ -7,6 +7,7 @@ import RenderedTextInstance from './Renderers/RenderedTextInstance';
 import RenderedShapePainterInstance from './Renderers/RenderedShapePainterInstance';
 import RenderedTextEntryInstance from './Renderers/RenderedTextEntryInstance';
 import RenderedParticleEmitterInstance from './Renderers/RenderedParticleEmitterInstance';
+import RenderedSkeletonInstance from './Renderers/RenderedSkeletonInstance';
 import PixiResourcesLoader from './PixiResourcesLoader';
 import ResourcesLoader from '../ResourcesLoader';
 import RenderedInstance from './Renderers/RenderedInstance';
@@ -27,6 +28,7 @@ export default {
     'PrimitiveDrawing::Drawer': RenderedShapePainterInstance,
     'TextEntryObject::TextEntry': RenderedTextEntryInstance,
     'ParticleSystem::ParticleEmitter': RenderedParticleEmitterInstance,
+    'SkeletonObject::Skeleton': RenderedSkeletonInstance,
   },
   getThumbnail: function(project: gdProject, object: gdObject) {
     var objectType = object.getType();

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedSkeletonInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedSkeletonInstance.js
@@ -1,0 +1,2 @@
+import makeRenderer from './RenderedIconInstance';
+export default makeRenderer('JsPlatform/Extensions/skeletonicon24.png');


### PR DESCRIPTION
Integrate @Lizard-13 's SkeletonObject extension into GD5.
In the first step this will have to do without a graphical editor and only load an already existing animation.

ToDo:
- [x] Expose the existing Object/Conditions/Actions/Expressions into the GD5 IDE
- [x] Expose object editor in GD5 IDE
- [x] Add a way to load already existing animations
- [ ] ~~Add an instance renderer for the scene editor~~
- [x] Load animations using the official jsonResource via drop down list
- [x] Documentation / Wiki article
- [x] Fix broken extension icon
- [ ] Testing
- [ ] Example
- [x] Add property to disable preloading of JSON (by default, json will be loaded at the beginning)