### PR TITLE
Allow copy/pasting of actions and conditions & add paste button on hover

### DIFF
--- a/newIDE/app/src/EventsSheet/ClipboardKind.js
+++ b/newIDE/app/src/EventsSheet/ClipboardKind.js
@@ -1,0 +1,211 @@
+// @flow
+import Clipboard from '../Utils/Clipboard';
+import {
+  type SelectionState,
+  getSelectedEvents,
+  hasEventSelected,
+  getSelectedEventContexts,
+  hasInstructionSelected,
+  hasInstructionsListSelected,
+  getSelectedInstructionsContexts,
+  getSelectedInstructionsListsContexts,
+  type InstructionsListContext,
+} from './SelectionHandler';
+import {
+  serializeToJSObject,
+  unserializeFromJSObject,
+} from '../Utils/Serializer';
+const gd = global.gd;
+
+export const CLIPBOARD_KIND = 'EventsAndInstructions';
+
+export const hasClipboardEvents = () => {
+  return (
+    Clipboard.has(CLIPBOARD_KIND) &&
+    Clipboard.get(CLIPBOARD_KIND).eventsCount > 0
+  );
+};
+
+export const hasClipboardConditions = () => {
+  return (
+    Clipboard.has(CLIPBOARD_KIND) &&
+    Clipboard.get(CLIPBOARD_KIND).conditionsCount > 0
+  );
+};
+
+export const hasClipboardActions = () => {
+  return (
+    Clipboard.has(CLIPBOARD_KIND) &&
+    Clipboard.get(CLIPBOARD_KIND).actionsCount > 0
+  );
+};
+
+export const copySelectionToClipboard = (selection: SelectionState) => {
+  const eventsList = new gd.EventsList();
+  const actionsList = new gd.InstructionsList();
+  const conditionsList = new gd.InstructionsList();
+
+  getSelectedEvents(selection).forEach(event =>
+    eventsList.insertEvent(event, eventsList.getEventsCount())
+  );
+  getSelectedInstructionsContexts(selection).forEach(instructionContext => {
+    if (instructionContext.isCondition) {
+      conditionsList.insert(
+        instructionContext.instruction,
+        conditionsList.size()
+      );
+    } else {
+      actionsList.insert(instructionContext.instruction, actionsList.size());
+    }
+  });
+
+  Clipboard.set(CLIPBOARD_KIND, {
+    eventsList: serializeToJSObject(eventsList),
+    eventsCount: eventsList.getEventsCount(),
+    actionsList: serializeToJSObject(actionsList),
+    actionsCount: actionsList.size(),
+    conditionsList: serializeToJSObject(conditionsList),
+    conditionsCount: conditionsList.size(),
+  });
+
+  eventsList.delete();
+  actionsList.delete();
+  conditionsList.delete();
+};
+
+export const pasteEventsFromClipboardInSelection = (
+  project: gdProject,
+  selection: SelectionState
+): boolean => {
+  if (!hasEventSelected(selection) || !hasClipboardEvents()) return false;
+
+  const eventsList = new gd.EventsList();
+  unserializeFromJSObject(
+    eventsList,
+    Clipboard.get(CLIPBOARD_KIND).eventsList,
+    'unserializeFrom',
+    project
+  );
+  getSelectedEventContexts(selection).forEach(eventContext => {
+    eventContext.eventsList.insertEvents(
+      eventsList,
+      0,
+      eventsList.getEventsCount(),
+      eventContext.indexInList
+    );
+  });
+  eventsList.delete();
+
+  return true;
+};
+
+export const pasteInstructionsFromClipboardInSelection = (
+  project: gdProject,
+  selection: SelectionState
+): boolean => {
+  if (
+    (!hasInstructionSelected(selection) &&
+      !hasInstructionsListSelected(selection)) ||
+    (!hasClipboardConditions() && !hasClipboardActions())
+  )
+    return false;
+
+  const clipboardContent = Clipboard.get(CLIPBOARD_KIND);
+  const actionsList = new gd.InstructionsList();
+  const conditionsList = new gd.InstructionsList();
+  unserializeFromJSObject(
+    actionsList,
+    clipboardContent.actionsList,
+    'unserializeFrom',
+    project
+  );
+  unserializeFromJSObject(
+    conditionsList,
+    clipboardContent.conditionsList,
+    'unserializeFrom',
+    project
+  );
+  getSelectedInstructionsContexts(selection).forEach(instructionContext => {
+    if (instructionContext.isCondition) {
+      instructionContext.instrsList.insertInstructions(
+        conditionsList,
+        0,
+        conditionsList.size(),
+        instructionContext.indexInList
+      );
+    } else {
+      instructionContext.instrsList.insertInstructions(
+        actionsList,
+        0,
+        actionsList.size(),
+        instructionContext.indexInList
+      );
+    }
+  });
+  getSelectedInstructionsListsContexts(selection).forEach(
+    instructionsListContext => {
+      if (instructionsListContext.isCondition) {
+        instructionsListContext.instrsList.insertInstructions(
+          conditionsList,
+          0,
+          conditionsList.size(),
+          instructionsListContext.instrsList.size()
+        );
+      } else {
+        instructionsListContext.instrsList.insertInstructions(
+          actionsList,
+          0,
+          actionsList.size(),
+          instructionsListContext.instrsList.size()
+        );
+      }
+    }
+  );
+  conditionsList.delete();
+  actionsList.delete();
+
+  return true;
+};
+
+export const pasteInstructionsFromClipboardInInstructionsList = (
+  project: gdProject,
+  instructionsListContext: InstructionsListContext
+) => {
+  if (!hasClipboardConditions() && !hasClipboardActions()) return false;
+
+  const clipboardContent = Clipboard.get(CLIPBOARD_KIND);
+  const actionsList = new gd.InstructionsList();
+  const conditionsList = new gd.InstructionsList();
+  unserializeFromJSObject(
+    actionsList,
+    clipboardContent.actionsList,
+    'unserializeFrom',
+    project
+  );
+  unserializeFromJSObject(
+    conditionsList,
+    clipboardContent.conditionsList,
+    'unserializeFrom',
+    project
+  );
+
+  if (instructionsListContext.isCondition) {
+    instructionsListContext.instrsList.insertInstructions(
+      conditionsList,
+      0,
+      conditionsList.size(),
+      instructionsListContext.instrsList.size()
+    );
+  } else {
+    instructionsListContext.instrsList.insertInstructions(
+      actionsList,
+      0,
+      actionsList.size(),
+      instructionsListContext.instrsList.size()
+    );
+  }
+  conditionsList.delete();
+  actionsList.delete();
+
+  return true;
+};

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -68,13 +68,14 @@ type Props = {|
 
   // For potential sub-instructions list:
   selection: Object,
-  onAddNewSubInstruction: Function,
+  onAddNewSubInstruction: InstructionsListContext => void,
+  onPasteSubInstructions: InstructionsListContext => void,
   onMoveToSubInstruction: (destinationContext: InstructionContext) => void,
   onMoveToSubInstructionsList: (
     destinationContext: InstructionsListContext
   ) => void,
-  onSubInstructionClick: Function,
-  onSubInstructionDoubleClick: Function,
+  onSubInstructionClick: InstructionContext => void,
+  onSubInstructionDoubleClick: InstructionContext => void,
   onSubInstructionsListContextMenu: (
     x: number,
     y: number,
@@ -215,6 +216,7 @@ class Instruction extends React.Component<Props, *> {
               areConditions={this.props.isCondition}
               selection={this.props.selection}
               onAddNewInstruction={this.props.onAddNewSubInstruction}
+              onPasteInstructions={this.props.onPasteSubInstructions}
               onMoveToInstruction={this.props.onMoveToSubInstruction}
               onMoveToInstructionsList={this.props.onMoveToSubInstructionsList}
               onInstructionClick={this.props.onSubInstructionClick}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/EventRenderer.flow.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/EventRenderer.flow.js
@@ -18,7 +18,8 @@ export type EventRendererProps = {
 
   onUpdate: () => void,
   selected: boolean,
-  onAddNewInstruction: Function,
+  onAddNewInstruction: InstructionsListContext => void,
+  onPasteInstructions: InstructionsListContext => void,
   onMoveToInstruction: (destinationContext: InstructionContext) => void,
   onMoveToInstructionsList: (
     destinationContext: InstructionsListContext

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
@@ -87,6 +87,7 @@ export default class ForEachEvent extends React.Component<
             selection={this.props.selection}
             areConditions
             onAddNewInstruction={this.props.onAddNewInstruction}
+            onPasteInstructions={this.props.onPasteInstructions}
             onMoveToInstruction={this.props.onMoveToInstruction}
             onMoveToInstructionsList={this.props.onMoveToInstructionsList}
             onInstructionClick={this.props.onInstructionClick}
@@ -109,6 +110,7 @@ export default class ForEachEvent extends React.Component<
             selection={this.props.selection}
             areConditions={false}
             onAddNewInstruction={this.props.onAddNewInstruction}
+            onPasteInstructions={this.props.onPasteInstructions}
             onMoveToInstruction={this.props.onMoveToInstruction}
             onMoveToInstructionsList={this.props.onMoveToInstructionsList}
             onInstructionClick={this.props.onInstructionClick}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
@@ -87,6 +87,7 @@ export default class RepeatEvent extends React.Component<
             selection={this.props.selection}
             areConditions
             onAddNewInstruction={this.props.onAddNewInstruction}
+            onPasteInstructions={this.props.onPasteInstructions}
             onMoveToInstruction={this.props.onMoveToInstruction}
             onMoveToInstructionsList={this.props.onMoveToInstructionsList}
             onInstructionClick={this.props.onInstructionClick}
@@ -109,6 +110,7 @@ export default class RepeatEvent extends React.Component<
             selection={this.props.selection}
             areConditions={false}
             onAddNewInstruction={this.props.onAddNewInstruction}
+            onPasteInstructions={this.props.onPasteInstructions}
             onMoveToInstruction={this.props.onMoveToInstruction}
             onMoveToInstructionsList={this.props.onMoveToInstructionsList}
             onInstructionClick={this.props.onInstructionClick}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/StandardEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/StandardEvent.js
@@ -45,6 +45,7 @@ export default class StandardEvent extends React.Component<
           selection={this.props.selection}
           areConditions
           onAddNewInstruction={this.props.onAddNewInstruction}
+          onPasteInstructions={this.props.onPasteInstructions}
           onMoveToInstruction={this.props.onMoveToInstruction}
           onMoveToInstructionsList={this.props.onMoveToInstructionsList}
           onInstructionClick={this.props.onInstructionClick}
@@ -67,6 +68,7 @@ export default class StandardEvent extends React.Component<
           selection={this.props.selection}
           areConditions={false}
           onAddNewInstruction={this.props.onAddNewInstruction}
+          onPasteInstructions={this.props.onPasteInstructions}
           onMoveToInstruction={this.props.onMoveToInstruction}
           onMoveToInstructionsList={this.props.onMoveToInstructionsList}
           onInstructionClick={this.props.onInstructionClick}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
@@ -59,6 +59,7 @@ export default class ForEachEvent extends React.Component<
           selection={this.props.selection}
           areConditions
           onAddNewInstruction={this.props.onAddNewInstruction}
+          onPasteInstructions={this.props.onPasteInstructions}
           onMoveToInstruction={this.props.onMoveToInstruction}
           onMoveToInstructionsList={this.props.onMoveToInstructionsList}
           onInstructionClick={this.props.onInstructionClick}
@@ -85,6 +86,7 @@ export default class ForEachEvent extends React.Component<
             selection={this.props.selection}
             areConditions
             onAddNewInstruction={this.props.onAddNewInstruction}
+            onPasteInstructions={this.props.onPasteInstructions}
             onMoveToInstruction={this.props.onMoveToInstruction}
             onMoveToInstructionsList={this.props.onMoveToInstructionsList}
             onInstructionClick={this.props.onInstructionClick}
@@ -107,6 +109,7 @@ export default class ForEachEvent extends React.Component<
             selection={this.props.selection}
             areConditions={false}
             onAddNewInstruction={this.props.onAddNewInstruction}
+            onPasteInstructions={this.props.onPasteInstructions}
             onMoveToInstruction={this.props.onMoveToInstruction}
             onMoveToInstructionsList={this.props.onMoveToInstructionsList}
             onInstructionClick={this.props.onInstructionClick}

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -49,7 +49,8 @@ type EventsContainerProps = {|
   globalObjectsContainer: gdObjectsContainer,
   objectsContainer: gdObjectsContainer,
   selection: SelectionState,
-  onAddNewInstruction: Function,
+  onAddNewInstruction: InstructionsListContext => void,
+  onPasteInstructions: InstructionsListContext => void,
   onMoveToInstruction: (destinationContext: InstructionContext) => void,
   onMoveToInstructionsList: (
     destinationContext: InstructionsListContext
@@ -119,6 +120,7 @@ class EventContainer extends Component<EventsContainerProps, {||}> {
             leftIndentWidth={this.props.leftIndentWidth}
             onUpdate={this._onEventUpdated}
             onAddNewInstruction={this.props.onAddNewInstruction}
+            onPasteInstructions={this.props.onPasteInstructions}
             onMoveToInstruction={this.props.onMoveToInstruction}
             onMoveToInstructionsList={this.props.onMoveToInstructionsList}
             onInstructionClick={this.props.onInstructionClick}
@@ -162,7 +164,8 @@ type EventsTreeProps = {|
   globalObjectsContainer: gdObjectsContainer,
   objectsContainer: gdObjectsContainer,
   selection: SelectionState,
-  onAddNewInstruction: Function,
+  onAddNewInstruction: InstructionsListContext => void,
+  onPasteInstructions: InstructionsListContext => void,
   onMoveToInstruction: (destinationContext: InstructionContext) => void,
   onMoveToInstructionsList: (
     destinationContext: InstructionsListContext
@@ -399,6 +402,7 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
         selection={this.props.selection}
         leftIndentWidth={depth * indentWidth}
         onAddNewInstruction={this.props.onAddNewInstruction}
+        onPasteInstructions={this.props.onPasteInstructions}
         onMoveToInstruction={this.props.onMoveToInstruction}
         onMoveToInstructionsList={this.props.onMoveToInstructionsList}
         onInstructionClick={this.props.onInstructionClick}

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -1227,6 +1227,7 @@ storiesOf('EventsTree', module)
             objectsContainer={testLayout}
             selection={getInitialSelection()}
             onAddNewInstruction={action('add new instruction')}
+            onPasteInstructions={action('paste instructions')}
             onMoveToInstruction={action('move to instruction')}
             onMoveToInstructionsList={action('move instruction to list')}
             onInstructionClick={action('instruction click')}


### PR DESCRIPTION
* Display a paste button when hovering add condition or add action button,
if there are conditions or actions in the clipboard
* Allow to copy actions and conditions at the same time. Pasting will only
paste the proper actions or conditions.

Following a @Bouh idea :) Will hopefully make clearer that it's possible to paste on empty lists.
Also allow to copy conditions + actions and paste them at one or multiple places.