### PR TITLE
Add documentation link

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -641,7 +641,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 "res/actions/ecarter.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("objectList", _("Object"))
+      .AddParameter("objectList", _("Objects (won't move)"))
       .AddParameter("yesorno",
                     _("Ignore objects that are touching each other on their "
                       "edges, but are not overlapping (default: no)"),

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -18,7 +18,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                                _("Base object"),
                                "Florian Rival",
                                "Open source (MIT License)")
-      .SetExtensionHelpPath("/objects/base_object");
+      .SetExtensionHelpPath("/tutorials/basic-game-making-concepts/events");
 
   gd::ObjectMetadata& obj = extension.AddObject<gd::Object>(
       "", _("Base object"), _("Base object"), "res/objeticon24.png");
@@ -641,7 +641,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 "res/actions/ecarter.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("objectList", _("Objects"))
+      .AddParameter("objectList", _("Object"))
       .AddParameter("yesorno",
                     _("Ignore objects that are touching each other on their "
                       "edges, but are not overlapping (default: no)"),

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -18,7 +18,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                                _("Base object"),
                                "Florian Rival",
                                "Open source (MIT License)")
-      .SetExtensionHelpPath("/tutorials/basic-game-making-concepts/events");
+      .SetExtensionHelpPath("/objects/base_object/events");
 
   gd::ObjectMetadata& obj = extension.AddObject<gd::Object>(
       "", _("Base object"), _("Base object"), "res/objeticon24.png");


### PR DESCRIPTION
Added a separate documentation page for the conditions/actions of the extension. The other two pages can work as introduction to the features while the new page has a sole purpose of helping users with the conditions/actions.