### PR TITLE
Save as

### DIFF
--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -87,6 +87,7 @@ export const create = (authentification: Authentification) => {
                 />
               }
               onSaveProject={LocalProjectWriter.saveProject}
+              onSaveAsProject={LocalProjectWriter.saveAsProject}
               onAutoSaveProject={LocalProjectWriter.autoSaveProject}
               onChooseProject={LocalProjectOpener.chooseProjectFile}
               onReadFromPathOrURL={LocalProjectOpener.readProjectFile}

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -87,7 +87,7 @@ export const create = (authentification: Authentification) => {
                 />
               }
               onSaveProject={LocalProjectWriter.saveProject}
-              onSaveAsProject={LocalProjectWriter.saveAsProject}
+              onSaveProjectAs={LocalProjectWriter.saveProjectAs}
               onAutoSaveProject={LocalProjectWriter.autoSaveProject}
               onChooseProject={LocalProjectOpener.chooseProjectFile}
               onReadFromPathOrURL={LocalProjectOpener.readProjectFile}

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -82,6 +82,10 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
       event => this._editor && this._editor.save()
     );
     ipcRenderer.on(
+      ('main-menu-save-as': MainMenuEvent),
+      event => this._editor && this._editor.saveAs()
+    );
+    ipcRenderer.on(
       ('main-menu-close': MainMenuEvent),
       event => this._editor && this._editor.askToCloseProject(() => {})
     );
@@ -158,7 +162,7 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
         },
         {
           label: i18n._(t`Save as...`),
-          enabled: false, // TODO: Unimplemented for now
+          accelerator: 'CommandOrControl+Alt+S',
           onClickSendEvent: 'main-menu-save-as',
         },
         { type: 'separator' },

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1200,8 +1200,9 @@ class MainFrame extends React.Component<Props, State> {
       this._openSaveDialog();
     } else if (this.props.onSaveProjectAs) {
       this.props.onSaveProjectAs(currentProject).then(
-        () => {
-          this._showSnackMessage(i18n._(t`Project properly saved`));
+        saveDone => {
+          if (saveDone)
+            this._showSnackMessage(i18n._(t`Project properly saved`));
         },
         err => {
           showErrorBox(

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -125,6 +125,7 @@ type Props = {
   onChooseProject?: () => Promise<?string>,
   saveDialog?: React.Element<*>,
   onSaveProject?: gdProject => Promise<any>,
+  onSaveAsProject?: gdProject => Promise<any>,
   onAutoSaveProject?: (project: gdProject) => void,
   shouldOpenAutosave?: (
     filePath: string,
@@ -1188,6 +1189,34 @@ class MainFrame extends React.Component<Props, State> {
     }
   };
 
+  saveAs = () => {
+    console.log("save AS");
+    
+    saveUiSettings(this.state.editorTabs);
+
+    const { currentProject } = this.state;
+    if (!currentProject) return;
+    const { i18n } = this.props;
+
+    if (this.props.saveDialog) {
+      this._openSaveDialog();
+    } else if (this.props.onSaveProject) {
+      this.props.onSaveAsProject(currentProject).then(
+        () => {
+          this._showSnackMessage(i18n._(t`Project properly saved`));
+        },
+        err => {
+          showErrorBox(
+            i18n._(
+              t`Unable to save as the project! Please try again by choosing another location.`
+            ),
+            err
+          );
+        }
+      );
+    }
+  };
+
   askToCloseProject = (cb: ?Function) => {
     if (!this.state.currentProject) return;
     const { i18n } = this.props;
@@ -1440,6 +1469,7 @@ class MainFrame extends React.Component<Props, State> {
               }
               onRenameExternalEvents={this.renameExternalEvents}
               onSaveProject={this.save}
+              onSaveAsProject={this.saveAs}
               onCloseProject={this.askToCloseProject}
               onExportProject={this.openExportDialog}
               onOpenPreferences={() => this.openPreferences(true)}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -94,7 +94,6 @@ type State = {|
   exportDialogOpen: boolean,
   introDialogOpen: boolean,
   saveDialogOpen: boolean,
-  isSaveAs: boolean,
   genericDialogOpen: boolean,
   loadingProject: boolean,
   previewLoading: boolean,
@@ -126,7 +125,7 @@ type Props = {
   onChooseProject?: () => Promise<?string>,
   saveDialog?: React.Element<*>,
   onSaveProject?: gdProject => Promise<any>,
-  onSaveAsProject?: gdProject => Promise<any>,
+  onSaveProjectAs?: gdProject => Promise<any>,
   onAutoSaveProject?: (project: gdProject) => void,
   shouldOpenAutosave?: (
     filePath: string,
@@ -150,7 +149,6 @@ class MainFrame extends React.Component<Props, State> {
     exportDialogOpen: false,
     introDialogOpen: false,
     saveDialogOpen: false,
-    isSaveAs: false,
     genericDialogOpen: false,
     loadingProject: false,
     previewLoading: false,
@@ -1166,19 +1164,16 @@ class MainFrame extends React.Component<Props, State> {
   };
 
   save = () => {
-    this.setState({
-      isSaveAs: false,
-    });
     saveUiSettings(this.state.editorTabs);
 
-    const { currentProject, isSaveAs } = this.state;
+    const { currentProject } = this.state;
     if (!currentProject) return;
     const { i18n } = this.props;
 
     if (this.props.saveDialog) {
       this._openSaveDialog();
     } else if (this.props.onSaveProject) {
-      this.props.onSaveProject(currentProject, isSaveAs).then(
+      this.props.onSaveProject(currentProject).then(
         () => {
           this._showSnackMessage(i18n._(t`Project properly saved`));
         },
@@ -1195,19 +1190,16 @@ class MainFrame extends React.Component<Props, State> {
   };
 
   saveAs = () => {
-    this.setState({
-      isSaveAs: true,
-    });
     saveUiSettings(this.state.editorTabs);
 
-    const { currentProject, isSaveAs } = this.state;
+    const { currentProject } = this.state;
     if (!currentProject) return;
     const { i18n } = this.props;
 
     if (this.props.saveDialog) {
       this._openSaveDialog();
-    } else if (this.props.onSaveProject) {
-      this.props.onSaveProject(currentProject, isSaveAs).then(
+    } else if (this.props.onSaveProjectAs) {
+      this.props.onSaveProjectAs(currentProject).then(
         () => {
           this._showSnackMessage(i18n._(t`Project properly saved`));
         },
@@ -1475,7 +1467,6 @@ class MainFrame extends React.Component<Props, State> {
               }
               onRenameExternalEvents={this.renameExternalEvents}
               onSaveProject={this.save}
-              onSaveAsProject={this.saveAs}
               onCloseProject={this.askToCloseProject}
               onExportProject={this.openExportDialog}
               onOpenPreferences={() => this.openPreferences(true)}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -94,6 +94,7 @@ type State = {|
   exportDialogOpen: boolean,
   introDialogOpen: boolean,
   saveDialogOpen: boolean,
+  isSaveAs: boolean,
   genericDialogOpen: boolean,
   loadingProject: boolean,
   previewLoading: boolean,
@@ -149,6 +150,7 @@ class MainFrame extends React.Component<Props, State> {
     exportDialogOpen: false,
     introDialogOpen: false,
     saveDialogOpen: false,
+    isSaveAs: false,
     genericDialogOpen: false,
     loadingProject: false,
     previewLoading: false,
@@ -1164,16 +1166,19 @@ class MainFrame extends React.Component<Props, State> {
   };
 
   save = () => {
+    this.setState({
+      isSaveAs: false,
+    });
     saveUiSettings(this.state.editorTabs);
 
-    const { currentProject } = this.state;
+    const { currentProject, isSaveAs } = this.state;
     if (!currentProject) return;
     const { i18n } = this.props;
 
     if (this.props.saveDialog) {
       this._openSaveDialog();
     } else if (this.props.onSaveProject) {
-      this.props.onSaveProject(currentProject).then(
+      this.props.onSaveProject(currentProject, isSaveAs).then(
         () => {
           this._showSnackMessage(i18n._(t`Project properly saved`));
         },
@@ -1190,16 +1195,19 @@ class MainFrame extends React.Component<Props, State> {
   };
 
   saveAs = () => {
+    this.setState({
+      isSaveAs: true,
+    });
     saveUiSettings(this.state.editorTabs);
 
-    const { currentProject } = this.state;
+    const { currentProject, isSaveAs } = this.state;
     if (!currentProject) return;
     const { i18n } = this.props;
 
     if (this.props.saveDialog) {
       this._openSaveDialog();
-    } else if (this.props.onSaveAsProject) {
-      this.props.onSaveProject(currentProject, true).then(
+    } else if (this.props.onSaveProject) {
+      this.props.onSaveProject(currentProject, isSaveAs).then(
         () => {
           this._showSnackMessage(i18n._(t`Project properly saved`));
         },

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1190,8 +1190,6 @@ class MainFrame extends React.Component<Props, State> {
   };
 
   saveAs = () => {
-    console.log("save AS");
-    
     saveUiSettings(this.state.editorTabs);
 
     const { currentProject } = this.state;
@@ -1200,8 +1198,8 @@ class MainFrame extends React.Component<Props, State> {
 
     if (this.props.saveDialog) {
       this._openSaveDialog();
-    } else if (this.props.onSaveProject) {
-      this.props.onSaveAsProject(currentProject).then(
+    } else if (this.props.onSaveAsProject) {
+      this.props.onSaveProject(currentProject, true).then(
         () => {
           this._showSnackMessage(i18n._(t`Project properly saved`));
         },

--- a/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
@@ -123,10 +123,14 @@ export default class LocalProjectWriter {
       project,
       fileSystem,
       projectPath,
-      true,
-      false,
-      true
+      true, // Update the project with the new resource paths
+      false, // Don't move absolute files
+      true // Keep relative files folders structure.
     );
+
+    // Update the project with the new file path (resources have already been updated)
+    project.setProjectFile(filePath);
+
     return writeProjectFiles(project, filePath, projectPath).then(() => {
       return true; // Save was properly done
     });

--- a/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
@@ -96,7 +96,8 @@ export default class LocalProjectWriter {
       filters: [{ name: 'GDevelop 5 project', extensions: ['json'] }],
     };
 
-    const newProjectFolder = dialog.showSaveDialog(browserWindow, options);
+    const newFilepath = dialog.showSaveDialog(browserWindow, options);
+    const newProjectFolder = path.dirname(newFilepath);
 
     if (!filepath || filepath === '') {
       return Promise.reject('Filepath from dialog is empty');
@@ -136,7 +137,7 @@ export default class LocalProjectWriter {
           });
         })
       ).then(() => {
-        return writeJSONFile(serializedProjectObject, newProjectFolder).catch(
+        return writeJSONFile(serializedProjectObject, newFilepath).catch(
           err => {
             console.error('Unable to write the split project:', err);
             throw err;
@@ -144,12 +145,10 @@ export default class LocalProjectWriter {
         );
       });
     } else {
-      return writeJSONFile(serializedProjectObject, newProjectFolder).catch(
-        err => {
-          console.error('Unable to write the project:', err);
-          throw err;
-        }
-      );
+      return writeJSONFile(serializedProjectObject, newFilepath).catch(err => {
+        console.error('Unable to write the project:', err);
+        throw err;
+      });
     }
   };
 

--- a/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
@@ -130,7 +130,7 @@ export default class LocalProjectWriter {
         partialObjects.map(partialObject => {
           return writeJSONFile(
             partialObject.object,
-            path.join(projectPath, partialObject.reference) + '.json'
+            path.join(newProjectFolder, partialObject.reference) + '.json'
           ).catch(err => {
             console.error('Unable to write a partial file:', err);
             throw err;

--- a/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
@@ -90,34 +90,35 @@ export default class LocalProjectWriter {
     const filePath = project.getProjectFile();
     const projectPath = path.dirname(project.getProjectFile());
     if (!filePath) {
-      return Promise.reject('Unimplemented "Save as" feature');
+      return Promise.reject(
+        'Project file is empty, "Save as" should have been called?'
+      );
     }
 
     return writeProjectFiles(project, filePath, projectPath).then(() => {
-      return true;
+      return true; // Save was properly done
     });
   };
 
   static saveProjectAs = (project: gdProject): Promise<boolean> => {
-    let filePath = project.getProjectFile();
-    //const filenameWithExtension = path.basename(project.getProjectFile()) || 'game.json';
-    let projectPath = path.dirname(filePath);
+    const defaultPath = project.getProjectFile();
     const fileSystem = assignIn(new gd.AbstractFileSystemJS(), localFileSystem);
     const browserWindow = electron.remote.getCurrentWindow();
     const options = {
-      defaultPath: filePath,
+      defaultPath,
       filters: [{ name: 'GDevelop 5 project', extensions: ['json'] }],
     };
 
     if (!dialog) {
       return Promise.reject('Unsupported');
     }
-    filePath = dialog.showSaveDialog(browserWindow, options);
+    const filePath = dialog.showSaveDialog(browserWindow, options);
     if (!filePath) {
-      return Promise.reject(false);
+      return Promise.resolve(false); // Nothing was saved.
     }
-    projectPath = path.dirname(filePath);
+    const projectPath = path.dirname(filePath);
 
+    // TODO: Ideally, errors while copying resources should be reported.
     gd.ProjectResourcesCopier.copyAllResourcesTo(
       project,
       fileSystem,
@@ -127,7 +128,7 @@ export default class LocalProjectWriter {
       true
     );
     return writeProjectFiles(project, filePath, projectPath).then(() => {
-      return true;
+      return true; // Save was properly done
     });
   };
 

--- a/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalProjectWriter.js
@@ -16,15 +16,15 @@ const path = optionalRequire('path');
 const electron = optionalRequire('electron');
 const dialog = electron ? electron.remote.dialog : null;
 
-const writeJSONFile = (object: Object, filepath: string): Promise<void> => {
+const writeJSONFile = (object: Object, filePath: string): Promise<void> => {
   if (!fs) return Promise.reject(new Error('Filesystem is not supported.'));
 
   try {
     const content = JSON.stringify(object, null, 2);
-    return fs.ensureDir(path.dirname(filepath)).then(
+    return fs.ensureDir(path.dirname(filePath)).then(
       () =>
         new Promise((resolve, reject) => {
-          fs.writeFile(filepath, content, (err: ?Error) => {
+          fs.writeFile(filePath, content, (err: ?Error) => {
             if (err) {
               return reject(err);
             }
@@ -40,10 +40,9 @@ const writeJSONFile = (object: Object, filepath: string): Promise<void> => {
 
 const writeProjectFiles = (
   project: gdProject,
-  newFilepath: string,
-  newProjectFolder: string
+  filePath: string,
+  projectPath: string
 ): Promise<void> => {
-
   const serializedProjectObject = serializeToJSObject(project);
 
   if (project.isFolderProject()) {
@@ -66,20 +65,20 @@ const writeProjectFiles = (
       partialObjects.map(partialObject => {
         return writeJSONFile(
           partialObject.object,
-          path.join(newProjectFolder, partialObject.reference) + '.json'
+          path.join(projectPath, partialObject.reference) + '.json'
         ).catch(err => {
           console.error('Unable to write a partial file:', err);
           throw err;
         });
       })
     ).then(() => {
-      return writeJSONFile(serializedProjectObject, newFilepath).catch(err => {
+      return writeJSONFile(serializedProjectObject, filePath).catch(err => {
         console.error('Unable to write the split project:', err);
         throw err;
       });
     });
   } else {
-    return writeJSONFile(serializedProjectObject, newFilepath).catch(err => {
+    return writeJSONFile(serializedProjectObject, filePath).catch(err => {
       console.error('Unable to write the project:', err);
       throw err;
     });
@@ -87,83 +86,49 @@ const writeProjectFiles = (
 };
 
 export default class LocalProjectWriter {
-  static saveProject = (project: gdProject): Promise<void> => {
-    const filepath = project.getProjectFile();
+  static saveProject = (project: gdProject): Promise<boolean> => {
+    const filePath = project.getProjectFile();
     const projectPath = path.dirname(project.getProjectFile());
-    if (!filepath) {
+    if (!filePath) {
       return Promise.reject('Unimplemented "Save as" feature');
     }
-    const serializedProjectObject = serializeToJSObject(project);
-    if (project.isFolderProject()) {
-      const partialObjects = split(serializedProjectObject, {
-        pathSeparator: '/',
-        getArrayItemReferenceName: getSlugifiedUniqueNameFromProperty('name'),
-        shouldSplit: splitPaths(
-          new Set([
-            '/layouts/*',
-            '/externalLayouts/*',
-            '/externalEvents/*',
-            '/layouts/*',
-            '/eventsFunctionsExtensions/*',
-          ])
-        ),
-        isReferenceMagicPropertyName: '__REFERENCE_TO_SPLIT_OBJECT',
-      });
 
-      return Promise.all(
-        partialObjects.map(partialObject => {
-          return writeJSONFile(
-            partialObject.object,
-            path.join(projectPath, partialObject.reference) + '.json'
-          ).catch(err => {
-            console.error('Unable to write a partial file:', err);
-            throw err;
-          });
-        })
-      ).then(() => {
-        return writeJSONFile(serializedProjectObject, filepath).catch(err => {
-          console.error('Unable to write the split project:', err);
-          throw err;
-        });
-      });
-    } else {
-      return writeJSONFile(serializedProjectObject, filepath).catch(err => {
-        console.error('Unable to write the project:', err);
-        throw err;
-      });
-    }
+    return writeProjectFiles(project, filePath, projectPath).then(() => {
+      return true;
+    });
   };
 
-  static saveProjectAs = (project: gdProject): Promise<void> => {
-    const filepath = project.getProjectFile();
-    const filenameWithExtension = path.basename(project.getProjectFile()) || "game.json";
-    const projectPath = path.dirname(project.getProjectFile());
+  static saveProjectAs = (project: gdProject): Promise<boolean> => {
+    let filePath = project.getProjectFile();
+    //const filenameWithExtension = path.basename(project.getProjectFile()) || 'game.json';
+    let projectPath = path.dirname(filePath);
     const fileSystem = assignIn(new gd.AbstractFileSystemJS(), localFileSystem);
     const browserWindow = electron.remote.getCurrentWindow();
     const options = {
-    defaultPath: path.join(projectPath, filenameWithExtension),
-    filters: [{ name: 'GDevelop 5 project', extensions: ['json'] }],
+      defaultPath: filePath,
+      filters: [{ name: 'GDevelop 5 project', extensions: ['json'] }],
     };
 
     if (!dialog) {
-    return Promise.reject('Unsupported');
+      return Promise.reject('Unsupported');
     }
-    const newFilepath = dialog.showSaveDialog(browserWindow, options);
-    if (!newFilepath || newFilepath === '') {
-    return Promise.reject('Filepath from dialog is empty');
+    filePath = dialog.showSaveDialog(browserWindow, options);
+    if (!filePath) {
+      return Promise.reject(false);
     }
-    const newProjectFolder = path.dirname(newFilepath);
+    projectPath = path.dirname(filePath);
 
     gd.ProjectResourcesCopier.copyAllResourcesTo(
-    project,
-    fileSystem,
-    newProjectFolder,
-    true,
-    false,
-    true
+      project,
+      fileSystem,
+      projectPath,
+      true,
+      false,
+      true
     );
-
-    return writeProjectFiles(project, newFilepath, newProjectFolder);
+    return writeProjectFiles(project, filePath, projectPath).then(() => {
+      return true;
+    });
   };
 
   static autoSaveProject = (project: gdProject) => {


### PR DESCRIPTION
[Trello card](https://trello.com/c/jRAe3LV6/96-add-support-for-save-as)

It's tested and all case working, if we cancel the dialog nothing is save and promise is rejected.
At start i wished create  static method saveAsProject but lot of lines are same as  saveProject , then i've pimped this method.
Let me know :)

Edit: oh i miss to delete onSaveAsProject
`onSaveAsProject={this.saveAs}`
and other call, i will delete it for next commit, i wait review.