### PR TITLE
Fix "onOwnerRemovedFromScene" not always called and custom behaviors "onCreated"

### DIFF
--- a/Extensions/DraggableBehavior/draggableruntimebehavior.js
+++ b/Extensions/DraggableBehavior/draggableruntimebehavior.js
@@ -29,7 +29,7 @@ gdjs.DraggableRuntimeBehavior.prototype.onDeActivate = function() {
     this._endDrag();
 };
 
-gdjs.DraggableRuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
+gdjs.DraggableRuntimeBehavior.prototype.onDestroy = function() {
     this.onDeActivate();
 };
 

--- a/Extensions/ExampleJsExtension/dummyruntimeobject.js
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject.js
@@ -16,6 +16,9 @@ gdjs.DummyRuntimeObject = function(runtimeScene, objectData) {
   if (this._renderer)
     gdjs.DummyRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
   else this._renderer = new gdjs.DummyRuntimeObjectRenderer(this, runtimeScene);
+
+  // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+  this.onCreated();
 };
 
 gdjs.DummyRuntimeObject.prototype = Object.create(gdjs.RuntimeObject.prototype);

--- a/Extensions/ExampleJsExtension/dummyruntimeobject.js
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject.js
@@ -6,7 +6,7 @@
  * @extends RuntimeObject
  */
 gdjs.DummyRuntimeObject = function(runtimeScene, objectData) {
-  // Always call the base gdjs.RuntimeObject constructor.
+  // *ALWAYS* call the base gdjs.RuntimeObject constructor.
   gdjs.RuntimeObject.call(this, runtimeScene, objectData);
 
   // Load any required data from the object properties.

--- a/Extensions/Inventory/tests/inventorytools.spec.js
+++ b/Extensions/Inventory/tests/inventorytools.spec.js
@@ -1,6 +1,6 @@
 describe('Inventory', function() {
 	var runtimeGame = new gdjs.RuntimeGame({variables: [], properties: {windowWidth: 800, windowHeight: 600}});
-	var runtimeScene = new gdjs.RuntimeScene(runtimeGame, null);
+	var runtimeScene = new gdjs.RuntimeScene(runtimeGame);
 
 	gdjs.evtTools.inventory.add(runtimeScene, "MyInventory", "sword");
 	gdjs.evtTools.inventory.add(runtimeScene, "MyInventory", "sword");

--- a/Extensions/LinkedObjects/tests/linkedobjects.spec.js
+++ b/Extensions/LinkedObjects/tests/linkedobjects.spec.js
@@ -1,7 +1,7 @@
 
 describe('gdjs.LinksManager', function() {
 	var runtimeGame = new gdjs.RuntimeGame({variables: [], properties: {windowWidth: 800, windowHeight: 600}});
-	var runtimeScene = new gdjs.RuntimeScene(runtimeGame, null);
+	var runtimeScene = new gdjs.RuntimeScene(runtimeGame);
 	runtimeScene.loadFromScene({
 		layers:[{name:"", visibility: true}],
 		variables: [],

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-cocos-renderer.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-cocos-renderer.js
@@ -58,7 +58,7 @@ gdjs.PanelSpriteRuntimeObjectCocosRenderer.prototype._createTilingShaderAndUnifo
     }
 };
 
-gdjs.PanelSpriteRuntimeObjectCocosRenderer.prototype.onOwnerRemovedFromScene = function() {
+gdjs.PanelSpriteRuntimeObjectCocosRenderer.prototype.onDestroy = function() {
     if (this._centerSpriteShader && this._centerSpriteShader.shader)
         this._centerSpriteShader.shader.release();
     if (this._rightSpriteShader && this._rightSpriteShader.shader)

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
@@ -29,6 +29,9 @@ gdjs.PanelSpriteRuntimeObject = function(runtimeScene, objectData)
     else
         this._renderer = new gdjs.PanelSpriteRuntimeObjectRenderer(this, runtimeScene,
             objectData.texture, objectData.tiled);
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 
 gdjs.PanelSpriteRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );
@@ -38,11 +41,11 @@ gdjs.PanelSpriteRuntimeObject.prototype.getRendererObject = function() {
     return this._renderer.getRendererObject();
 };
 
-gdjs.PanelSpriteRuntimeObject.prototype.onDeletedFromScene = function(runtimeScene) {
-    gdjs.RuntimeObject.prototype.onDeletedFromScene.call(this, runtimeScene);
+gdjs.PanelSpriteRuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
+    gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
 
-    if (this._renderer.onOwnerRemovedFromScene) {
-        this._renderer.onOwnerRemovedFromScene();
+    if (this._renderer.onDestroy) {
+        this._renderer.onDestroy();
     }
 };
 

--- a/Extensions/ParticleSystem/particleemitterobject.js
+++ b/Extensions/ParticleSystem/particleemitterobject.js
@@ -51,6 +51,9 @@ gdjs.ParticleEmitterObject = function(runtimeScene, objectData){
     this._alphaDirty = true;
     this._textureDirty = true;
     this._flowDirty = true;
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 gdjs.ParticleEmitterObject.prototype = Object.create(gdjs.RuntimeObject.prototype);
 gdjs.ParticleEmitterObject.thisIsARuntimeObjectConstructor = "ParticleSystem::ParticleEmitter";
@@ -127,9 +130,9 @@ gdjs.ParticleEmitterObject.prototype.update = function(runtimeScene){
     }
 };
 
-gdjs.ParticleEmitterObject.prototype.onDeletedFromScene = function(runtimeScene){
+gdjs.ParticleEmitterObject.prototype.onDestroyFromScene = function(runtimeScene){
     this._renderer.destroy();
-    gdjs.RuntimeObject.prototype.onDeletedFromScene.call(this, runtimeScene);
+    gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
 };
 
 gdjs.ParticleEmitterObject.prototype.getEmitterForceMin = function(){

--- a/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.js
+++ b/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.js
@@ -104,7 +104,7 @@ gdjs.PathfindingObstacleRuntimeBehavior = function(runtimeScene, behaviorData, o
 gdjs.PathfindingObstacleRuntimeBehavior.prototype = Object.create( gdjs.RuntimeBehavior.prototype );
 gdjs.PathfindingObstacleRuntimeBehavior.thisIsARuntimeBehaviorConstructor = "PathfindingBehavior::PathfindingObstacleBehavior";
 
-gdjs.PathfindingObstacleRuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
+gdjs.PathfindingObstacleRuntimeBehavior.prototype.onDestroy = function() {
 	if ( this._manager && this._registeredInManager ) this._manager.removeObstacle(this);
 };
 

--- a/Extensions/Physics2Behavior/physics2runtimebehavior.js
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.js
@@ -268,7 +268,7 @@ gdjs.Physics2RuntimeBehavior.prototype.onDeActivate = function() {
   }
 };
 
-gdjs.Physics2RuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
+gdjs.Physics2RuntimeBehavior.prototype.onDestroy = function() {
   this.onDeActivate();
 };
 

--- a/Extensions/PhysicsBehavior/physicsruntimebehavior.js
+++ b/Extensions/PhysicsBehavior/physicsruntimebehavior.js
@@ -154,7 +154,7 @@ gdjs.PhysicsRuntimeBehavior.prototype.onDeActivate = function() {
 	}
 };
 
-gdjs.PhysicsRuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
+gdjs.PhysicsRuntimeBehavior.prototype.onDestroy = function() {
 	this.onDeActivate();
 };
 

--- a/Extensions/PlatformBehavior/platformruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformruntimebehavior.js
@@ -104,7 +104,7 @@ gdjs.PlatformRuntimeBehavior.LADDER = 2;
 gdjs.PlatformRuntimeBehavior.JUMPTHRU = 1;
 gdjs.PlatformRuntimeBehavior.NORMALPLAFTORM = 0;
 
-gdjs.PlatformRuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
+gdjs.PlatformRuntimeBehavior.prototype.onDestroy = function() {
 	if ( this._manager && this._registeredInManager ) this._manager.removePlatform(this);
 };
 

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -1,6 +1,6 @@
 describe('gdjs.PlatformerObjectRuntimeBehavior', function() {
 	var runtimeGame = new gdjs.RuntimeGame({variables: [], properties: {windowWidth: 800, windowHeight: 600}});
-	var runtimeScene = new gdjs.RuntimeScene(runtimeGame, null);
+	var runtimeScene = new gdjs.RuntimeScene(runtimeGame);
 	runtimeScene.loadFromScene({
 		layers: [{name: "", visibility: true}],
 		variables: [],
@@ -121,7 +121,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function() {
 
 describe('gdjs.PlatformerObjectRuntimeBehavior, rounded coordinates (moving platforms)', function() {
 	var runtimeGame = new gdjs.RuntimeGame({variables: [], properties: {windowWidth: 800, windowHeight: 600}});
-	var runtimeScene = new gdjs.RuntimeScene(runtimeGame, null);
+	var runtimeScene = new gdjs.RuntimeScene(runtimeGame);
 	runtimeScene.loadFromScene({
 		layers: [{name: "", visibility: true}],
 		variables: [],

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
@@ -25,6 +25,9 @@ gdjs.ShapePainterRuntimeObject = function(runtimeScene, objectData)
         gdjs.ShapePainterRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
     else
         this._renderer = new gdjs.ShapePainterRuntimeObjectRenderer(this, runtimeScene);
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 
 gdjs.ShapePainterRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );

--- a/Extensions/SkeletonObject/Gskeletonruntimeobject.js
+++ b/Extensions/SkeletonObject/Gskeletonruntimeobject.js
@@ -28,6 +28,9 @@ gdjs.SkeletonRuntimeObject = function(runtimeScene, objectData){
 
     this.manager = gdjs.SkeletonObjectsManager.getManager(runtimeScene);
     this.getSkeletonData(runtimeScene, objectData);
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 gdjs.SkeletonRuntimeObject.prototype = Object.create(gdjs.RuntimeObject.prototype);
 gdjs.SkeletonRuntimeObject.thisIsARuntimeObjectConstructor = "SkeletonObject::Skeleton";
@@ -330,7 +333,7 @@ gdjs.SkeletonRuntimeObject.prototype.setSlotZOrder = function(slotPath, z){
 gdjs.SkeletonRuntimeObject.prototype.isPointInsideSlot = function(slotPath, x, y){
     var hitBoxes = this.getPolygons(slotPath);
     if(!hitBoxes) return false;
-    
+
     for(var i = 0; i < this.hitBoxes.length; ++i) {
        if ( gdjs.Polygon.isPointInside(hitBoxes[i], x, y) )
             return true;
@@ -343,7 +346,7 @@ gdjs.SkeletonRuntimeObject.prototype.isPointInsideSlot = function(slotPath, x, y
 gdjs.SkeletonRuntimeObject.prototype.raycastSlot = function(slotPath, x, y, angle, dist, closest){
     var result = gdjs.Polygon.raycastTest._statics.result;
     result.collision = false;
-    
+
     var endX = x + dist*Math.cos(angle*Math.PI/180.0);
     var endY = y + dist*Math.sin(angle*Math.PI/180.0);
     var testSqDist = closest ? dist*dist : 0;
@@ -364,7 +367,7 @@ gdjs.SkeletonRuntimeObject.prototype.raycastSlot = function(slotPath, x, y, angl
             }
         }
     }
-    
+
     return result;
 };
 
@@ -433,7 +436,7 @@ gdjs.SkeletonRuntimeObject.prototype.getBone = function(bonePath){
     if(slot && slot.type === gdjs.sk.SLOT_ARMATURE && boneName in slot.childArmature.bonesMap){
         return slot.childArmature.bonesMap[boneName];
     }
-    
+
     return null;
 };
 

--- a/Extensions/TextEntryObject/textentryruntimeobject-cocos-renderer.js
+++ b/Extensions/TextEntryObject/textentryruntimeobject-cocos-renderer.js
@@ -12,7 +12,7 @@ gdjs.TextEntryRuntimeObjectCocosRenderer = function(runtimeObject, runtimeScene)
 
 gdjs.TextEntryRuntimeObjectRenderer = gdjs.TextEntryRuntimeObjectCocosRenderer; //Register the class to let the engine use it.
 
-gdjs.TextEntryRuntimeObjectCocosRenderer.prototype.onOwnerRemovedFromScene = function() {
+gdjs.TextEntryRuntimeObjectCocosRenderer.prototype.onDestroy = function() {
     this.activate(false);
 };
 

--- a/Extensions/TextEntryObject/textentryruntimeobject-pixi-renderer.js
+++ b/Extensions/TextEntryObject/textentryruntimeobject-pixi-renderer.js
@@ -50,7 +50,7 @@ gdjs.TextEntryRuntimeObjectPixiRenderer = function(runtimeObject)
 
 gdjs.TextEntryRuntimeObjectRenderer = gdjs.TextEntryRuntimeObjectPixiRenderer; //Register the class to let the engine use it.
 
-gdjs.TextEntryRuntimeObjectPixiRenderer.prototype.onOwnerRemovedFromScene = function() {
+gdjs.TextEntryRuntimeObjectPixiRenderer.prototype.onDestroy = function() {
     document.removeEventListener('keypress', this._pressHandler);
     document.removeEventListener('keyup', this._upHandler);
     document.removeEventListener('keydown', this._downHandler);

--- a/Extensions/TextEntryObject/textentryruntimeobject.js
+++ b/Extensions/TextEntryObject/textentryruntimeobject.js
@@ -20,16 +20,19 @@ gdjs.TextEntryRuntimeObject = function(runtimeScene, objectData)
         gdjs.TextEntryRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
     else
         this._renderer = new gdjs.TextEntryRuntimeObjectRenderer(this, runtimeScene);
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 
 gdjs.TextEntryRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );
 gdjs.TextEntryRuntimeObject.thisIsARuntimeObjectConstructor = "TextEntryObject::TextEntry";
 
-gdjs.TextEntryRuntimeObject.prototype.onDeletedFromScene = function(runtimeScene) {
-    gdjs.RuntimeObject.prototype.onDeletedFromScene.call(this, runtimeScene);
+gdjs.TextEntryRuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
+    gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
 
-    if (this._renderer.onOwnerRemovedFromScene) {
-        this._renderer.onOwnerRemovedFromScene();
+    if (this._renderer.onDestroy) {
+        this._renderer.onDestroy();
     }
 };
 

--- a/Extensions/TextObject/textruntimeobject.js
+++ b/Extensions/TextObject/textruntimeobject.js
@@ -44,6 +44,9 @@ gdjs.TextRuntimeObject = function(runtimeScene, objectData)
         gdjs.TextRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
     else
         this._renderer = new gdjs.TextRuntimeObjectRenderer(this, runtimeScene);
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 
 gdjs.TextRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );
@@ -206,7 +209,7 @@ gdjs.TextRuntimeObject.prototype.getHeight = function() {
  * Get scale of the text.
  */
 gdjs.TextRuntimeObject.prototype.getScale = function() {
-    return (Math.abs(this._scaleX)+Math.abs(this._scaleY))/2.0; 
+    return (Math.abs(this._scaleX)+Math.abs(this._scaleY))/2.0;
 };
 
 /**
@@ -413,7 +416,7 @@ gdjs.TextRuntimeObject.prototype.setGradient = function(strGradientType, strFirs
 
     this._gradientType = strGradientType;
 
-    this._useGradient = (this._gradient.length > 1) ? true : false; 
+    this._useGradient = (this._gradient.length > 1) ? true : false;
 
     this._renderer.updateStyle();
 };

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-cocos-renderer.js
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-cocos-renderer.js
@@ -23,7 +23,7 @@ gdjs.TiledSpriteRuntimeObjectCocosRenderer = function(runtimeObject, runtimeScen
 
 gdjs.TiledSpriteRuntimeObjectRenderer = gdjs.TiledSpriteRuntimeObjectCocosRenderer; //Register the class to let the engine use it.
 
-gdjs.TiledSpriteRuntimeObjectCocosRenderer.prototype.onOwnerRemovedFromScene = function() {
+gdjs.TiledSpriteRuntimeObjectCocosRenderer.prototype.onDestroy = function() {
     if (this._shader) this._shader.release();
 }
 

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.js
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.js
@@ -24,6 +24,9 @@ gdjs.TiledSpriteRuntimeObject = function(runtimeScene, objectData)
 
     this.setWidth(objectData.width);
     this.setHeight(objectData.height);
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 
 gdjs.TiledSpriteRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );
@@ -33,11 +36,11 @@ gdjs.TiledSpriteRuntimeObject.prototype.getRendererObject = function() {
     return this._renderer.getRendererObject();
 };
 
-gdjs.TiledSpriteRuntimeObject.prototype.onDeletedFromScene = function(runtimeScene) {
-    gdjs.RuntimeObject.prototype.onDeletedFromScene.call(this, runtimeScene);
+gdjs.TiledSpriteRuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
+    gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
 
-    if (this._renderer.onOwnerRemovedFromScene) {
-        this._renderer.onOwnerRemovedFromScene();
+    if (this._renderer.onDestroy) {
+        this._renderer.onDestroy();
     }
 };
 

--- a/Extensions/Video/videoruntimeobject-cocos-renderer.js
+++ b/Extensions/Video/videoruntimeobject-cocos-renderer.js
@@ -17,7 +17,7 @@ gdjs.VideoRuntimeObjectCocosRenderer.prototype.getRendererObject = function() {}
 /**
  * To be called when the object is removed from the scene: will pause the video.
  */
-gdjs.VideoRuntimeObjectCocosRenderer.prototype.onOwnerRemovedFromScene = function() {};
+gdjs.VideoRuntimeObjectCocosRenderer.prototype.onDestroy = function() {};
 
 gdjs.VideoRuntimeObjectCocosRenderer.prototype.ensureUpToDate = function() {};
 

--- a/Extensions/Video/videoruntimeobject-pixi-renderer.js
+++ b/Extensions/Video/videoruntimeobject-pixi-renderer.js
@@ -49,7 +49,7 @@ gdjs.VideoRuntimeObjectPixiRenderer.prototype.getRendererObject = function() {
 /**
  * To be called when the object is removed from the scene: will pause the video.
  */
-gdjs.VideoRuntimeObjectPixiRenderer.prototype.onOwnerRemovedFromScene = function() {
+gdjs.VideoRuntimeObjectPixiRenderer.prototype.onDestroy = function() {
   this.pause();
 };
 

--- a/Extensions/Video/videoruntimeobject.js
+++ b/Extensions/Video/videoruntimeobject.js
@@ -30,6 +30,9 @@ gdjs.VideoRuntimeObject = function(runtimeScene, objectData) {
   if (this._renderer)
     gdjs.VideoRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
   else this._renderer = new gdjs.VideoRuntimeObjectRenderer(this, runtimeScene);
+
+  // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+  this.onCreated();
 };
 
 gdjs.VideoRuntimeObject.prototype = Object.create(gdjs.RuntimeObject.prototype);
@@ -52,10 +55,10 @@ gdjs.VideoRuntimeObject.prototype.extraInitializationFromInitialInstance = funct
   }
 };
 
-gdjs.VideoRuntimeObject.prototype.onDeletedFromScene = function(runtimeScene) {
-  gdjs.RuntimeObject.prototype.onDeletedFromScene.call(this, runtimeScene);
+gdjs.VideoRuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
+  gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
 
-  this._renderer.onOwnerRemovedFromScene();
+  this._renderer.onDestroy();
 };
 
 gdjs.VideoRuntimeObject.prototype.update = function(runtimeScene) {

--- a/GDJS/GDJS/Events/CodeGeneration/BehaviorCodeGenerator.h
+++ b/GDJS/GDJS/Events/CodeGeneration/BehaviorCodeGenerator.h
@@ -56,6 +56,7 @@ class BehaviorCodeGenerator {
     return "_set" + propertyName;
   }
 
+
  private:
   gd::String GenerateRuntimeBehaviorTemplateCode(
       const gd::String& extensionName,
@@ -73,6 +74,9 @@ class BehaviorCodeGenerator {
   gd::String GenerateInitializePropertyFromDefaultValueCode(
       const gd::NamedPropertyDescriptor& property);
   gd::String GeneratePropertyValueCode(const gd::PropertyDescriptor& property);
+  gd::String GenerateBehaviorOnDestroyToDeprecatedOnOwnerRemovedFromScene(
+      const gd::EventsBasedBehavior& eventsBasedBehavior,
+      const gd::String& codeNamespace);
 
   gd::Project& project;
 };

--- a/GDJS/Runtime/runtimebehavior.js
+++ b/GDJS/Runtime/runtimebehavior.js
@@ -86,6 +86,15 @@ gdjs.RuntimeBehavior.prototype.activate = function(enable) {
 };
 
 /**
+ * Reimplement this to do extra work when the behavior is created (i.e: an
+ * object using it was created), after the object is fully initialized (so
+ * you can use `this.owner` without risk).
+ */
+gdjs.RuntimeBehavior.prototype.onCreated = function() {
+
+};
+
+/**
  * Return true if the behavior is activated
  */
 gdjs.RuntimeBehavior.prototype.activated = function() {
@@ -93,23 +102,22 @@ gdjs.RuntimeBehavior.prototype.activated = function() {
 };
 
 /**
- * Behaviors writers: Reimplement this method to do extra work
- * when the behavior is activated
+ * Reimplement this method to do extra work when the behavior is activated (after
+ * it has been deactivated, see `onDeActivate`).
  */
 gdjs.RuntimeBehavior.prototype.onActivate = function() {
 
 };
 
 /**
- * Behaviors writers: Reimplement this method to do extra work
- * when the behavior is deactivated
+ * Reimplement this method to do extra work when the behavior is deactivated.
  */
 gdjs.RuntimeBehavior.prototype.onDeActivate = function() {
 
 };
 
 /**
- * Behaviors writers: This method is called each tick before events are done.
+ * This method is called each tick before events are done.
  * @param {gdjs.RuntimeScene} runtimeScene The runtimeScene owning the object
  */
 gdjs.RuntimeBehavior.prototype.doStepPreEvents = function(runtimeScene) {
@@ -117,7 +125,7 @@ gdjs.RuntimeBehavior.prototype.doStepPreEvents = function(runtimeScene) {
 };
 
 /**
- * Behaviors writers: This method is called each tick after events are done.
+ * This method is called each tick after events are done.
  * @param {gdjs.RuntimeScene} runtimeScene The runtimeScene owning the object
  */
 gdjs.RuntimeBehavior.prototype.doStepPostEvents = function(runtimeScene) {
@@ -125,10 +133,10 @@ gdjs.RuntimeBehavior.prototype.doStepPostEvents = function(runtimeScene) {
 }
 
 /**
- * Behaviors writers: This method is called when the owner of the behavior
- * was removed from its scene and is about to be destroyed/reused later.
+ * This method is called when the owner of the behavior
+ * is being removed from the scene and is about to be destroyed/reused later,
  */
-gdjs.RuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
+gdjs.RuntimeBehavior.prototype.onDestroy = function() {
 
 }
 

--- a/GDJS/Runtime/runtimeobject.js
+++ b/GDJS/Runtime/runtimeobject.js
@@ -14,6 +14,9 @@
  * However, you should not be calling the constructor on an already existing object
  * which is not a RuntimeObject.
  *
+ * A `gdjs.RuntimeObject` should not be instanciated directly, always a child class
+ * (because gdjs.RuntimeObject don't call onCreated at the end of its constructor).
+ *
  * @memberof gdjs
  * @class RuntimeObject
  * @param {gdjs.RuntimeScene} runtimeScene The RuntimeScene owning the object.
@@ -101,6 +104,21 @@ gdjs.RuntimeObject.forcesGarbage = []; //Global container for unused forces, avo
 //Common members functions related to the object and its runtimeScene :
 
 /**
+ * To be called by the child classes in their constructor, at the very end.
+ * Notify the behaviors that they have been constructed (this must be done when
+ * the object is ready, otherwise behaviors can do operations on the object which
+ * could be not initialized yet).
+ *
+ * If you redefine this function, **make sure to call the original method**
+ * (`gdjs.RuntimeObject.prototype.onCreated.call(this);`).
+ */
+gdjs.RuntimeObject.prototype.onCreated = function() {
+    for(var i =0;i<this._behaviors.length;++i) {
+        this._behaviors[i].onCreated();
+    }
+}
+
+/**
  * Return the time elapsed since the last frame,
  * in milliseconds, for the object.
  *
@@ -133,8 +151,9 @@ gdjs.RuntimeObject.prototype.extraInitializationFromInitialInstance = function(i
 };
 
 /**
- * Remove an object from a scene.<br>
- * Extensions writers, do not change this method. Instead, redefine the onDeletedFromScene method.
+ * Remove an object from a scene.
+ *
+ * Do not change/redefine this method. Instead, redefine the onDestroyFromScene method.
  * @param {gdjs.RuntimeScene} runtimeScene The RuntimeScene owning the object.
  */
 gdjs.RuntimeObject.prototype.deleteFromScene = function(runtimeScene) {
@@ -145,13 +164,19 @@ gdjs.RuntimeObject.prototype.deleteFromScene = function(runtimeScene) {
 };
 
 /**
- * Called when the object is removed from its scene.
+ * Called when the object is destroyed (because it is removed from a scene or the scene
+ * is being unloaded). If you redefine this function, **make sure to call the original method**
+ * (`gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);`).
  *
- * @param {gdjs.RuntimeScene} runtimeScene The RuntimeScene owning the object.
+ * @param {gdjs.RuntimeScene} runtimeScene The scene owning the object.
  */
-gdjs.RuntimeObject.prototype.onDeletedFromScene = function(runtimeScene) {
+gdjs.RuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
     var theLayer = runtimeScene.getLayer(this.layer);
     theLayer.getRenderer().removeRendererObject(this.getRendererObject());
+
+    for(var j = 0, lenj = this._behaviors.length;j<lenj;++j) {
+        this._behaviors[j].onDestroy();
+    }
 };
 
 //Rendering:
@@ -716,8 +741,8 @@ gdjs.RuntimeObject.prototype.averageForceAngleIs = function(angle, toleranceInDe
 /**
  * Get the hit boxes for the object.<br>
  * The default implementation returns a basic bouding box based the size (getWidth and
- * getHeight) and the center point of the object (getCenterX and getCenterY). 
- * 
+ * getHeight) and the center point of the object (getCenterX and getCenterY).
+ *
  * You should probably redefine updateHitBoxes instead of this function.
  *
  * @return {Array} An array composed of polygon.
@@ -737,7 +762,7 @@ gdjs.RuntimeObject.prototype.getHitBoxes = function() {
 
 /**
  * Update the hit boxes for the object.
- * 
+ *
  * The default implementation set a basic bounding box based on the size (getWidth and
  * getHeight) and the center point of the object (getCenterX and getCenterY).
  * Result is cached until invalidated (by a position change, angle change...).
@@ -788,11 +813,11 @@ gdjs.RuntimeObject.prototype.updateHitBoxes = function() {
 
 /**
  * Get the AABB (axis aligned bounding box) for the object.
- * 
+ *
  * The default implementation uses either the position/size of the object (when angle is 0) or
  * hitboxes (when angle is not 0) to compute the bounding box.
  * Result is cached until invalidated (by a position change, angle change...).
- * 
+ *
  * You should probably redefine updateAABB instead of this function.
  *
  * @return {AABB} The bounding box (example: `{min: [10,5], max:[20,10]}`)
@@ -811,9 +836,9 @@ gdjs.RuntimeObject.prototype.getAABB = function() {
  * Get the AABB (axis aligned bounding box) to be used to determine if the object
  * is visible on screen. The gdjs.RuntimeScene will hide the renderer object if
  * the object is not visible on screen ("culling").
- * 
+ *
  * The default implementation uses the AABB returned by getAABB.
- * 
+ *
  * If `null` is returned, the object is assumed to be always visible.
  *
  * @return {?AABB} The bounding box (example: `{min: [10,5], max:[20,10]}`) or `null`.
@@ -824,10 +849,10 @@ gdjs.RuntimeObject.prototype.getVisibilityAABB = function() {
 
 /**
  * Update the AABB (axis aligned bounding box) for the object.
- * 
+ *
  * Default implementation uses either the position/size of the object (when angle is 0) or
  * hitboxes (when angle is not 0) to compute the bounding box.
- * 
+ *
  * You should not call this function by yourself, it is called when necessary by getAABB method.
  * However, you can redefine it if your object can have a faster implementation.
  */
@@ -848,8 +873,8 @@ gdjs.RuntimeObject.prototype.updateAABB = function() {
         for(var i = 0;i<this.hitBoxes.length;i++) {
             for(var j = 0;j<this.hitBoxes[i].vertices.length;j++) {
                 var vertex = this.hitBoxes[i].vertices[j];
-    
-                if (first) { 
+
+                if (first) {
                     this.aabb.min[0] = vertex[0];
                     this.aabb.max[0] = vertex[0];
                     this.aabb.min[1] = vertex[1];
@@ -888,9 +913,9 @@ gdjs.RuntimeObject.prototype.stepBehaviorsPostEvents = function(runtimeScene) {
 
 /**
  * Get a behavior from its name.
- * 
+ *
  * Be careful, the behavior must exists, no check is made on the name.
- * 
+ *
  * @param name {String} The behavior name.
  * @return {gdjs.RuntimeBehavior} The behavior with the given name, or undefined.
  */
@@ -1312,7 +1337,7 @@ gdjs.RuntimeObject.prototype.raycastTest = function(x, y, endX, endY, closest) {
 
     if ( diffX*diffX + diffY*diffY > sqBoundingR + sqDist + 2*Math.sqrt(sqDist*sqBoundingR) )
         return result;
-    
+
     var testSqDist = closest ? sqDist : 0;
 
     var hitBoxes = this.getHitBoxes();
@@ -1329,7 +1354,7 @@ gdjs.RuntimeObject.prototype.raycastTest = function(x, y, endX, endY, closest) {
             }
         }
     }
-    
+
     return result;
 };
 

--- a/GDJS/Runtime/runtimescene.js
+++ b/GDJS/Runtime/runtimescene.js
@@ -170,9 +170,18 @@ gdjs.RuntimeScene.prototype.unloadScene = function() {
 
     if (this._profiler) this.stopProfiler();
 
+    // Notify the objects they are being destroyed
+    this._constructListOfAllInstances();
+    for(var i = 0, len = this._allInstancesList.length;i<len;++i) {
+        var object = this._allInstancesList[i];
+        object.onDestroyFromScene(this);
+    }
+
+    // Notify the renderer
     if (this._renderer && this._renderer.onSceneUnloaded)
         this._renderer.onSceneUnloaded();
 
+    // Notify the global callbacks
     for(var i = 0;i < gdjs.callbacksRuntimeSceneUnloaded.length;++i) {
         gdjs.callbacksRuntimeSceneUnloaded[i](this);
     }
@@ -374,7 +383,7 @@ gdjs.RuntimeScene.prototype._cacheOrClearRemovedInstances = function() {
 };
 
 /**
- * Tool function filling _allObjectsList member with all the instances.
+ * Tool function filling _allInstancesList member with all the living object instances.
  * @private
  */
 gdjs.RuntimeScene.prototype._constructListOfAllInstances = function() {
@@ -565,10 +574,7 @@ gdjs.RuntimeScene.prototype.markObjectForDeletion = function(obj) {
     }
 
     //Notify the object it was removed from the scene
-    obj.onDeletedFromScene(this);
-    for(var j = 0, lenj = obj._behaviors.length;j<lenj;++j) {
-        obj._behaviors[j].onOwnerRemovedFromScene();
-    }
+    obj.onDestroyFromScene(this);
 
     //Call global callback
     for(var j = 0;j<gdjs.callbacksObjectDeletedFromScene.length;++j) {

--- a/GDJS/Runtime/spriteruntimeobject.js
+++ b/GDJS/Runtime/spriteruntimeobject.js
@@ -190,6 +190,9 @@ gdjs.SpriteRuntimeObject = function(runtimeScene, objectData)
         this._renderer = new gdjs.SpriteRuntimeObjectRenderer(this, runtimeScene);
 
     this._updateFrame();
+
+    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+    this.onCreated();
 };
 
 gdjs.SpriteRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );

--- a/GDJS/tests/karma.conf.js
+++ b/GDJS/tests/karma.conf.js
@@ -55,6 +55,9 @@ module.exports = function(config) {
       '../../Extensions/Inventory/inventory.js',
       '../../Extensions/Inventory/inventorytools.js',
 
+      // Test extensions:
+      './tests/Extensions/**.js',
+
       //All tests files:
       './tests/init.js',
       '../../Extensions/**/tests/**.spec.js',

--- a/GDJS/tests/tests/Extensions/testruntimebehavior.js
+++ b/GDJS/tests/tests/Extensions/testruntimebehavior.js
@@ -1,0 +1,36 @@
+/**
+ * A test behavior that set the varialbe of the object it's binded to according to lifecycle methods called.
+ *
+ * @class TestRuntimeBehavior
+ * @extends gdjs.RuntimeBehavior
+ * @constructor
+ */
+gdjs.TestRuntimeBehavior = function(runtimeScene, behaviorData, owner)
+{
+    gdjs.RuntimeBehavior.call(this, runtimeScene, behaviorData, owner);
+
+    this.owner.getVariables().get("lastState").setString('created'); // TODO: Move to onCreated
+};
+
+gdjs.TestRuntimeBehavior.prototype = Object.create( gdjs.RuntimeBehavior.prototype );
+gdjs.TestRuntimeBehavior.thisIsARuntimeBehaviorConstructor = "TestRuntimeBehavior::TestRuntimeBehavior";
+
+gdjs.TestRuntimeBehavior.prototype.onDeActivate = function() {
+    this.owner.getVariables().get("lastState").setString('deactivated');
+};
+
+gdjs.TestRuntimeBehavior.prototype.onActivate = function() {
+    this.owner.getVariables().get("lastState").setString('activated');
+};
+
+gdjs.TestRuntimeBehavior.prototype.doStepPreEvents = function(runtimeScene) {
+    this.owner.getVariables().get("lastState").setString('doStepPreEvents');
+};
+
+gdjs.TestRuntimeBehavior.prototype.doStepPostEvents = function(runtimeScene) {
+    this.owner.getVariables().get("lastState").setString('doStepPostEvents');
+};
+
+gdjs.TestRuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
+    this.owner.getVariables().get("lastState").setString('onOwnerRemovedFromScene');
+};

--- a/GDJS/tests/tests/Extensions/testruntimebehavior.js
+++ b/GDJS/tests/tests/Extensions/testruntimebehavior.js
@@ -8,12 +8,14 @@
 gdjs.TestRuntimeBehavior = function(runtimeScene, behaviorData, owner)
 {
     gdjs.RuntimeBehavior.call(this, runtimeScene, behaviorData, owner);
-
-    this.owner.getVariables().get("lastState").setString('created'); // TODO: Move to onCreated
 };
 
 gdjs.TestRuntimeBehavior.prototype = Object.create( gdjs.RuntimeBehavior.prototype );
-gdjs.TestRuntimeBehavior.thisIsARuntimeBehaviorConstructor = "TestRuntimeBehavior::TestRuntimeBehavior";
+gdjs.TestRuntimeBehavior.thisIsARuntimeBehaviorConstructor = "TestBehavior::TestBehavior";
+
+gdjs.TestRuntimeBehavior.prototype.onCreated = function() {
+    this.owner.getVariables().get("lastState").setString('created');
+};
 
 gdjs.TestRuntimeBehavior.prototype.onDeActivate = function() {
     this.owner.getVariables().get("lastState").setString('deactivated');
@@ -31,6 +33,6 @@ gdjs.TestRuntimeBehavior.prototype.doStepPostEvents = function(runtimeScene) {
     this.owner.getVariables().get("lastState").setString('doStepPostEvents');
 };
 
-gdjs.TestRuntimeBehavior.prototype.onOwnerRemovedFromScene = function() {
-    this.owner.getVariables().get("lastState").setString('onOwnerRemovedFromScene');
+gdjs.TestRuntimeBehavior.prototype.onDestroy = function() {
+    this.owner.getVariables().get("lastState").setString('onDestroy');
 };

--- a/GDJS/tests/tests/Extensions/testruntimeobject.js
+++ b/GDJS/tests/tests/Extensions/testruntimeobject.js
@@ -1,0 +1,24 @@
+/**
+ * A test object doing nothing. It's only used for testing: if you want
+ * an example to start a new object, take a look at gdjs.DummyRuntimeObject
+ * in the Extensions folder.
+ *
+ * @memberof gdjs
+ * @class TestRuntimeObject
+ * @extends RuntimeObject
+ */
+gdjs.TestRuntimeObject = function(runtimeScene, objectData) {
+  // *ALWAYS* call the base gdjs.RuntimeObject constructor.
+  gdjs.RuntimeObject.call(this, runtimeScene, objectData);
+
+  // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+  this.onCreated();
+};
+
+gdjs.TestRuntimeObject.prototype = Object.create(gdjs.RuntimeObject.prototype);
+gdjs.TestRuntimeObject.thisIsARuntimeObjectConstructor =
+  'TestObject::TestObject';
+
+gdjs.TestRuntimeObject.prototype.getRendererObject = function() {
+  return {};
+};

--- a/GDJS/tests/tests/runtimescene.js
+++ b/GDJS/tests/tests/runtimescene.js
@@ -1,0 +1,58 @@
+/**
+ * Test for gdjs.RuntimeBehavior
+ */
+
+describe('gdjs.RuntimeScene integration tests', function() {
+  describe('Object and behavior lifecycles (using ChangeTextTestRuntimeBehavior)', function () {
+    it('should properly create and destroy object, including the behaviors', function() {
+	    const runtimeGame = new gdjs.RuntimeGame({variables: [], properties: {windowWidth: 800, windowHeight: 600}});
+      const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
+      runtimeScene.loadFromScene({
+        layers:[{name:"", visibility: true}],
+        variables: [],
+        behaviorsSharedData: [],
+        objects: [{
+          type: '', // A gdjs.RuntimeObject
+          name: 'Object1',
+          behaviors: [
+            {
+              type: 'TestRuntimeBehavior::TestRuntimeBehavior',
+            },
+          ],
+        }],
+        instances: []
+      });
+
+      const object = runtimeScene.createObject('Object1');
+
+      // Check that the behavior was properly created
+      expect(
+        object
+          .getVariables()
+          .get('lastState')
+          .getAsString()
+      ).to.eql('created');
+
+      // Check that the behaviors are properly destroyed
+      runtimeScene.markObjectForDeletion(object);
+      expect(
+        object
+          .getVariables()
+          .get('lastState')
+          .getAsString()
+      ).to.eql('onOwnerRemovedFromScene');
+
+      const object2 = runtimeScene.createObject('Object1');
+
+      // Check that the behaviors are properly destroyed
+      // runtimeScene.unloadScene();
+      // expect(
+      //   object2
+      //     .getVariables()
+      //     .get('lastState')
+      //     .getAsString()
+      // ).to.eql('onOwnerRemovedFromScene');
+    });
+
+  });
+});

--- a/GDJS/tests/tests/runtimescene.js
+++ b/GDJS/tests/tests/runtimescene.js
@@ -1,9 +1,9 @@
 /**
- * Test for gdjs.RuntimeBehavior
+ * Test for gdjs.RuntimeScene
  */
 
 describe('gdjs.RuntimeScene integration tests', function() {
-  describe('Object and behavior lifecycles (using ChangeTextTestRuntimeBehavior)', function () {
+  describe('Object and behavior lifecycles (using TestObject and TestBehavior)', function () {
     it('should properly create and destroy object, including the behaviors', function() {
 	    const runtimeGame = new gdjs.RuntimeGame({variables: [], properties: {windowWidth: 800, windowHeight: 600}});
       const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
@@ -12,11 +12,11 @@ describe('gdjs.RuntimeScene integration tests', function() {
         variables: [],
         behaviorsSharedData: [],
         objects: [{
-          type: '', // A gdjs.RuntimeObject
+          type: 'TestObject::TestObject',
           name: 'Object1',
           behaviors: [
             {
-              type: 'TestRuntimeBehavior::TestRuntimeBehavior',
+              type: 'TestBehavior::TestBehavior',
             },
           ],
         }],
@@ -40,18 +40,18 @@ describe('gdjs.RuntimeScene integration tests', function() {
           .getVariables()
           .get('lastState')
           .getAsString()
-      ).to.eql('onOwnerRemovedFromScene');
+      ).to.eql('onDestroy');
 
       const object2 = runtimeScene.createObject('Object1');
 
       // Check that the behaviors are properly destroyed
-      // runtimeScene.unloadScene();
-      // expect(
-      //   object2
-      //     .getVariables()
-      //     .get('lastState')
-      //     .getAsString()
-      // ).to.eql('onOwnerRemovedFromScene');
+      runtimeScene.unloadScene();
+      expect(
+        object2
+          .getVariables()
+          .get('lastState')
+          .getAsString()
+      ).to.eql('onDestroy');
     });
 
   });

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
@@ -115,10 +115,12 @@ export default class BehaviorMethodSelectorDialog extends React.Component<
           />
           <MethodListItem
             icon={<Destroy style={styles.icon} />}
-            name={'onOwnerRemovedFromScene'}
-            disabled={eventsFunctions.hasEventsFunctionNamed(
-              'onOwnerRemovedFromScene'
-            )}
+            name={'onDestroy'}
+            disabled={
+              eventsFunctions.hasEventsFunctionNamed(
+                'onOwnerRemovedFromScene'
+              ) || eventsFunctions.hasEventsFunctionNamed('onDestroy')
+            }
             onChoose={onChoose}
             description={
               <Trans>

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -141,7 +141,10 @@ export const isBehaviorLifecycleFunction = (functionName: string) => {
       'onDeActivate',
       'doStepPreEvents',
       'doStepPostEvents',
+      'onDestroy',
+      // Compatibility with GD <= 5.0 beta 75
       'onOwnerRemovedFromScene',
+      // end of compatibility code
     ].indexOf(functionName) !== -1
   );
 };


### PR DESCRIPTION
* Rename onOwnerRemovedFromScene to onDestroy (because it can be now called when a scene is destroyed)
* Fix it being not called when a scene is destroyed (so behavior don't get a chance to clean up what they have created)
* Fix onCreated being called before the object is fully initialized (for custom behaviors or behaviors relying on an object type)
* Add tests for gdjs.RuntimeScene and object/behaviors creation/deletion.

Should fix issue in https://github.com/4ian/GDevelop-extensions/pull/15

The only "downside" to this implementation is the need for every object to called `this.onCreated`, but this should be clear as done in every object including the sample object for new extensions.