### PR TITLE
Fix web online export

### DIFF
--- a/newIDE/electron-app/app/S3Upload.js
+++ b/newIDE/electron-app/app/S3Upload.js
@@ -51,7 +51,7 @@ module.exports = {
         async.series(
           allFiles.map((localFile, fileIndex) => callback => {
             const body = fs.createReadStream(localFile);
-            const filename = path.relative(localDir, localFile).replace(/\\/g,'/');;
+            const filename = path.relative(localDir, localFile).replace(/\\/g,'/');
             const fileExtension = path.extname(filename);
             awsS3Client
               .upload({

--- a/newIDE/electron-app/app/S3Upload.js
+++ b/newIDE/electron-app/app/S3Upload.js
@@ -51,6 +51,8 @@ module.exports = {
         async.series(
           allFiles.map((localFile, fileIndex) => callback => {
             const body = fs.createReadStream(localFile);
+            // Convert backslashs in paths to forward slash as they won't
+            // work in AWS urls.
             const filename = path.relative(localDir, localFile).replace(/\\/g,'/');
             const fileExtension = path.extname(filename);
             awsS3Client

--- a/newIDE/electron-app/app/S3Upload.js
+++ b/newIDE/electron-app/app/S3Upload.js
@@ -51,7 +51,7 @@ module.exports = {
         async.series(
           allFiles.map((localFile, fileIndex) => callback => {
             const body = fs.createReadStream(localFile);
-            const filename = path.relative(localDir, localFile);
+            const filename = path.relative(localDir, localFile).replace(/\\/g,'/');;
             const fileExtension = path.extname(filename);
             awsS3Client
               .upload({


### PR DESCRIPTION
This fix is for export to amazon service for the Web online export.
It's working on Win10, you should try on others OS before merging.

I've added logs and saw whats wrong in paths. Paths given to method was wrong and contain bad URL encoding, %5C instead backslash , but the file require classic slash /

So i've convert backslash to slash.
#956

http://gd-games.s3-website-eu-west-1.amazonaws.com/game-1564749083657/
Classic platformer game exported at 14h31 (French time)