### PR TITLE
Update material-ui imports

### DIFF
--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -22,6 +22,10 @@ const importsToReplace = [
     oldImport: 'material-ui/TextField',
     newImport: path.join(newIdeAppSrcPath, 'UI/TextField'),
   },
+  {
+    oldImport: 'material-ui/IconButton',
+    newImport: path.join(newIdeAppSrcPath, 'UI/IconButton'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -34,6 +34,10 @@ const importsToReplace = [
     oldImport: 'material-ui/MenuItem',
     newImport: path.join(newIdeAppSrcPath, 'UI/MenuItem'),
   },
+  {
+    oldImport: 'material-ui/Checkbox',
+    newImport: path.join(newIdeAppSrcPath, 'UI/Checkbox'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -14,6 +14,10 @@ const importsToReplace = [
     oldImport: 'material-ui/FlatButton',
     newImport: path.join(newIdeAppSrcPath, 'UI/FlatButton'),
   },
+  {
+    oldImport: 'material-ui/RaisedButton',
+    newImport: path.join(newIdeAppSrcPath, 'UI/RaisedButton'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -18,6 +18,10 @@ const importsToReplace = [
     oldImport: 'material-ui/RaisedButton',
     newImport: path.join(newIdeAppSrcPath, 'UI/RaisedButton'),
   },
+  {
+    oldImport: 'material-ui/TextField',
+    newImport: path.join(newIdeAppSrcPath, 'UI/TextField'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -1,0 +1,98 @@
+const shell = require('shelljs');
+const path = require('path');
+const fs = require('fs');
+const recursive = require('recursive-readdir');
+
+const newIdeAppSrcPath = path.join(__dirname, '../src');
+const verbose = true;
+const dryRun = true;
+
+const excludedPaths = ['UI', 'locales'];
+
+const importsToReplace = [
+  {
+    oldImport: 'material-ui/FlatButton',
+    newImport: path.join(newIdeAppSrcPath, 'UI/FlatButton'),
+  },
+];
+
+/**
+ * Replace an import by another.
+ */
+const replaceImport = (oldImport, newImport) => source => {
+  const regex = new RegExp(` from '${oldImport}';`, '');
+  return source.replace(regex, match => {
+    const replacement = ` from '${newImport}';`;
+
+    if (verbose)
+      console.log('Replace "' + match + '" by "' + replacement + '"');
+    return replacement;
+  });
+};
+
+const replaceImportsInFile = filePath =>
+  new Promise((resolve, reject) =>
+    fs.readFile(filePath, { encoding: 'utf8' }, (err, source) => {
+      if (err) return reject(err);
+
+      let newSource = source;
+      importsToReplace.forEach(({ oldImport, newImport }) => {
+        const newRelativeImport = path.relative(
+          path.dirname(filePath),
+          newImport
+        );
+
+        newSource = replaceImport(oldImport, newRelativeImport)(newSource);
+      });
+
+      if (source === newSource) {
+        return resolve({
+          filePath,
+          changed: false,
+        });
+      }
+
+      if (!dryRun) {
+        fs.writeFile(filePath, newSource, { encoding: 'utf8' }, err => {
+          if (err) {
+            shell.echo(`❌ Error while writing file ${filePath}: `, err);
+            return reject(err);
+          }
+
+          resolve({
+            filePath,
+            changed: true,
+          });
+        });
+      } else {
+        shell.echo('ℹ️  Would write ' + filePath);
+        resolve({
+          filePath,
+          changed: true,
+        });
+      }
+    })
+  );
+
+recursive(newIdeAppSrcPath, function(err, files) {
+  if (err) {
+    shell.echo(`❌ Error(s) occurred while reading files `, err);
+    shell.exit(1);
+  }
+
+  Promise.all(
+    files.map(filePath => {
+      if (excludedPaths.some(excludedPath => filePath.includes(excludedPath)))
+        return null;
+
+      return replaceImportsInFile(filePath);
+    })
+  ).then(results => {
+    if (dryRun) {
+      shell.echo(
+        `⚠️  This was a dry-run, set dryRun to false to do real changes.`
+      );
+      shell.exit(0);
+    }
+  });
+});

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -26,6 +26,14 @@ const importsToReplace = [
     oldImport: 'material-ui/IconButton',
     newImport: path.join(newIdeAppSrcPath, 'UI/IconButton'),
   },
+  {
+    oldImport: 'material-ui/SelectField',
+    newImport: path.join(newIdeAppSrcPath, 'UI/SelectField'),
+  },
+  {
+    oldImport: 'material-ui/MenuItem',
+    newImport: path.join(newIdeAppSrcPath, 'UI/MenuItem'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -42,6 +42,10 @@ const importsToReplace = [
     oldImport: 'material-ui/Table',
     newImport: path.join(newIdeAppSrcPath, 'UI/Table'),
   },
+  {
+    oldImport: 'material-ui/Toggle',
+    newImport: path.join(newIdeAppSrcPath, 'UI/Toggle'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -38,6 +38,10 @@ const importsToReplace = [
     oldImport: 'material-ui/Checkbox',
     newImport: path.join(newIdeAppSrcPath, 'UI/Checkbox'),
   },
+  {
+    oldImport: 'material-ui/Table',
+    newImport: path.join(newIdeAppSrcPath, 'UI/Table'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -46,6 +46,10 @@ const importsToReplace = [
     oldImport: 'material-ui/Toggle',
     newImport: path.join(newIdeAppSrcPath, 'UI/Toggle'),
   },
+  {
+    oldImport: 'material-ui/Tabs',
+    newImport: path.join(newIdeAppSrcPath, 'UI/Tabs'),
+  },
 ];
 
 /**

--- a/newIDE/app/scripts/codemod-replace-ui-components.js
+++ b/newIDE/app/scripts/codemod-replace-ui-components.js
@@ -50,6 +50,10 @@ const importsToReplace = [
     oldImport: 'material-ui/Tabs',
     newImport: path.join(newIdeAppSrcPath, 'UI/Tabs'),
   },
+  {
+    oldImport: 'material-ui/List',
+    newImport: path.join(newIdeAppSrcPath, 'UI/List'),
+  },
 ];
 
 /**

--- a/newIDE/app/src/BehaviorTypeSelector/index.js
+++ b/newIDE/app/src/BehaviorTypeSelector/index.js
@@ -1,8 +1,8 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import {
   type EnumeratedBehaviorMetadata,
   enumerateBehaviorsMetadata,
@@ -43,7 +43,7 @@ export default class BehaviorTypeSelector extends React.Component<
         floatingLabelText={<Trans>Behavior type</Trans>}
         floatingLabelFixed
         value={value}
-        onChange={(e, i, value) => {
+        onChange={(e, i, value: string) => {
           onChange(value);
         }}
         disabled={disabled}

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
@@ -10,7 +10,7 @@ import {
 } from 'material-ui/Table';
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import Warning from 'material-ui/svg-icons/alert/warning';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../UI/IconButton';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import Delete from 'material-ui/svg-icons/action/delete';
 

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
@@ -7,7 +7,7 @@ import {
   TableBody,
   TableHeader,
   TableHeaderColumn,
-} from 'material-ui/Table';
+} from '../../../UI/Table';
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import Warning from 'material-ui/svg-icons/alert/warning';
 import IconButton from '../../../UI/IconButton';

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import { Line, Column } from '../../../UI/Grid';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../../UI/Checkbox';
 import SelectField from '../../../UI/SelectField';
 import MenuItem from '../../../UI/MenuItem';
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -4,8 +4,8 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import { Line, Column } from '../../../UI/Grid';
 import Checkbox from 'material-ui/Checkbox';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../../UI/SelectField';
+import MenuItem from '../../../UI/MenuItem';
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import ImagePreview from '../../../ResourcesList/ResourcePreview/ImagePreview';
 import ResourceSelector from '../../../ResourcesList/ResourceSelector';
@@ -106,7 +106,7 @@ export default class Physics2Editor extends React.Component<Props, State> {
             floatingLabelText={properties.get('bodyType').getLabel()}
             floatingLabelFixed
             value={properties.get('bodyType').getValue()}
-            onChange={(e, index, newValue) => {
+            onChange={(e, index, newValue: string) => {
               behavior.updateProperty(
                 behaviorContent.getContent(),
                 'bodyType',
@@ -187,7 +187,7 @@ export default class Physics2Editor extends React.Component<Props, State> {
             floatingLabelText={properties.get('shape').getLabel()}
             floatingLabelFixed
             value={properties.get('shape').getValue()}
-            onChange={(e, index, newValue) => {
+            onChange={(e, index, newValue: string) => {
               behavior.updateProperty(
                 behaviorContent.getContent(),
                 'shape',
@@ -273,7 +273,7 @@ export default class Physics2Editor extends React.Component<Props, State> {
               floatingLabelText={properties.get('polygonOrigin').getLabel()}
               floatingLabelFixed
               value={properties.get('polygonOrigin').getValue()}
-              onChange={(e, index, newValue) => {
+              onChange={(e, index, newValue: string) => {
                 behavior.updateProperty(
                   behaviorContent.getContent(),
                   'polygonOrigin',

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -6,7 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
 import HelpButton from '../UI/HelpButton';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Subheader from 'material-ui/Subheader';
 import Avatar from 'material-ui/Avatar';
 import { Tabs, Tab } from 'material-ui/Tabs';

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -9,7 +9,7 @@ import HelpButton from '../UI/HelpButton';
 import FlatButton from '../UI/FlatButton';
 import Subheader from 'material-ui/Subheader';
 import Avatar from 'material-ui/Avatar';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../UI/Tabs';
 import { List, ListItem } from 'material-ui/List';
 import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -10,7 +10,7 @@ import FlatButton from '../UI/FlatButton';
 import Subheader from 'material-ui/Subheader';
 import Avatar from 'material-ui/Avatar';
 import { Tabs, Tab } from '../UI/Tabs';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
 import Create from 'material-ui/svg-icons/content/create';

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -13,7 +13,7 @@ import { getBehaviorHelpPagePath } from './BehaviorsHelpPagePaths';
 import BehaviorsEditorService from './BehaviorsEditorService';
 import { isNullPtr } from '../Utils/IsNullPtr';
 import { Column, Line } from '../UI/Grid';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 const gd = global.gd;
 
 const styles = {

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import TextField from '../UI/TextField';
 import Add from 'material-ui/svg-icons/content/add';
 import Delete from 'material-ui/svg-icons/action/delete';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
 import MiniToolbar from '../UI/MiniToolbar';
 import HelpIcon from '../UI/HelpIcon';

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import Add from 'material-ui/svg-icons/content/add';
 import Delete from 'material-ui/svg-icons/action/delete';
 import IconButton from 'material-ui/IconButton';

--- a/newIDE/app/src/CodeEditor/index.js
+++ b/newIDE/app/src/CodeEditor/index.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import { setupAutocompletions } from './LocalCodeEditorAutocompletions';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import { getAllThemes } from './Theme';
 

--- a/newIDE/app/src/CodeEditor/index.js
+++ b/newIDE/app/src/CodeEditor/index.js
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { setupAutocompletions } from './LocalCodeEditorAutocompletions';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import RaisedButton from '../UI/RaisedButton';
+import Text from '../UI/Text';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import { getAllThemes } from './Theme';
 
@@ -105,9 +106,9 @@ export class CodeEditor extends React.Component<Props, State> {
     if (error) {
       return (
         <React.Fragment>
-          <p>
+          <Text>
             <Trans>Unable to load the code editor</Trans>
-          </p>
+          </Text>
           <RaisedButton
             label={<Trans>Retry</Trans>}
             onClick={this.loadMonacoEditor}

--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -16,7 +16,7 @@ import {
 } from './GDJSInspectorDescriptions';
 import RawContentInspector from './Inspectors/RawContentInspector';
 import EmptyMessage from '../UI/EmptyMessage';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../UI/Checkbox';
 import Flash from 'material-ui/svg-icons/image/flash-on';
 import FlashOff from 'material-ui/svg-icons/image/flash-off';
 import HelpButton from '../UI/HelpButton';

--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import EditorMosaic, { MosaicWindow } from '../UI/EditorMosaic';
 import Background from '../UI/Background';
 import get from 'lodash/get';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 import InspectorsList from './InspectorsList';
 import {

--- a/newIDE/app/src/Debugger/DebuggerSelector.js
+++ b/newIDE/app/src/Debugger/DebuggerSelector.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import { Column } from '../UI/Grid';
 import { type DebuggerId } from '.';
 

--- a/newIDE/app/src/Debugger/Inspectors/RuntimeObjectInspector.js
+++ b/newIDE/app/src/Debugger/Inspectors/RuntimeObjectInspector.js
@@ -9,6 +9,7 @@ import {
   type CallFunction,
 } from '../GDJSInspectorDescriptions';
 import VariablesContainerInspector from './VariablesContainerInspector';
+import Text from '../../UI/Text';
 
 type Props = {|
   runtimeObject: GameData,
@@ -55,9 +56,9 @@ const handleEdit = (edit, { onCall, onEdit }: Props) => {
 
 export default (props: Props) => (
   <div style={styles.container}>
-    <p>
+    <Text>
       <Trans>General:</Trans>
-    </p>
+    </Text>
     <ReactJsonView
       collapsed={false}
       name={false}
@@ -69,9 +70,9 @@ export default (props: Props) => (
       groupArraysAfterLength={50}
       theme="monokai"
     />
-    <p>
+    <Text>
       <Trans>Instance variables:</Trans>
-    </p>
+    </Text>
     <VariablesContainerInspector
       variablesContainer={
         props.runtimeObject ? props.runtimeObject._variables : null

--- a/newIDE/app/src/Debugger/Inspectors/RuntimeSceneInspector.js
+++ b/newIDE/app/src/Debugger/Inspectors/RuntimeSceneInspector.js
@@ -10,7 +10,7 @@ import {
 } from '../GDJSInspectorDescriptions';
 import { Line } from '../../UI/Grid';
 import mapValues from 'lodash/mapValues';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import SemiControlledAutoComplete from '../../UI/SemiControlledAutoComplete';
 
 type Props = {|
@@ -152,9 +152,9 @@ export default class RuntimeSceneInspector extends React.Component<
             <RaisedButton
               label={<Trans>Create</Trans>}
               primary
-              onClick={() =>
-                onCall(['createObject'], [this.state.newObjectName])
-              }
+              onClick={() => {
+                onCall(['createObject'], [this.state.newObjectName]);
+              }}
             />
           </Line>
         )}

--- a/newIDE/app/src/Debugger/Inspectors/RuntimeSceneInspector.js
+++ b/newIDE/app/src/Debugger/Inspectors/RuntimeSceneInspector.js
@@ -12,6 +12,7 @@ import { Line } from '../../UI/Grid';
 import mapValues from 'lodash/mapValues';
 import RaisedButton from '../../UI/RaisedButton';
 import SemiControlledAutoComplete from '../../UI/SemiControlledAutoComplete';
+import Text from '../../UI/Text';
 
 type Props = {|
   runtimeScene: GameData,
@@ -112,9 +113,9 @@ export default class RuntimeSceneInspector extends React.Component<
 
     return (
       <div style={styles.container}>
-        <p>
+        <Text>
           <Trans>Layers:</Trans>
-        </p>
+        </Text>
         <ReactJsonView
           collapsed={false}
           name={false}
@@ -126,11 +127,11 @@ export default class RuntimeSceneInspector extends React.Component<
           groupArraysAfterLength={50}
           theme="monokai"
         />
-        <p>
+        <Text>
           <Trans>
             Create a new instance on the scene (will be at position 0;0):
           </Trans>
-        </p>
+        </Text>
         {runtimeScene._objects && runtimeScene._objects.items && (
           <Line noMargin alignItems="baseline">
             <SemiControlledAutoComplete

--- a/newIDE/app/src/Debugger/InspectorsList.js
+++ b/newIDE/app/src/Debugger/InspectorsList.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import get from 'lodash/get';
 import {
   type InspectorDescription,
@@ -36,7 +36,7 @@ export default class InspectorsList extends React.Component<Props, void> {
     gameData: GameData,
     getInspectorDescriptions: InspectorDescriptionsGetter,
     path: Array<string>
-  ): Array<React.Node> {
+  ): Array<React$Element<any> | null> {
     return getInspectorDescriptions(gameData).map(inspectorDescription => {
       if (!inspectorDescription) return null;
       const fullInspectorPath = path.concat(inspectorDescription.key);

--- a/newIDE/app/src/Debugger/Profiler/MeasuresTable.js
+++ b/newIDE/app/src/Debugger/Profiler/MeasuresTable.js
@@ -6,7 +6,7 @@ import { AutoSizer, Table, Column } from 'react-virtualized';
 import ThemeConsumer from '../../UI/Theme/ThemeConsumer';
 import flatMap from 'lodash/flatMap';
 import { type ProfilerMeasuresSection } from '..';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../UI/IconButton';
 import ExpandMore from 'material-ui/svg-icons/navigation/expand-more';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 

--- a/newIDE/app/src/Debugger/Profiler/index.js
+++ b/newIDE/app/src/Debugger/Profiler/index.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import MeasuresTable from './MeasuresTable';
 import { type ProfilerOutput } from '..';
 import EmptyMessage from '../../UI/EmptyMessage';

--- a/newIDE/app/src/Debugger/Profiler/index.js
+++ b/newIDE/app/src/Debugger/Profiler/index.js
@@ -9,6 +9,7 @@ import EmptyMessage from '../../UI/EmptyMessage';
 import { Line } from '../../UI/Grid';
 import Background from '../../UI/Background';
 import LinearProgress from 'material-ui/LinearProgress';
+import Text from '../../UI/Text';
 
 const styles = {
   tableContainer: {
@@ -31,11 +32,11 @@ export default class Profiler extends React.Component<Props, void> {
       <Background>
         <Line alignItems="center" justifyContent="center">
           {!profilingInProgress && profilerOutput && (
-            <p>
+            <Text>
               <Trans>
                 Last run collected on {profilerOutput.stats.framesCount} frames.
               </Trans>
-            </p>
+            </Text>
           )}
           {!profilingInProgress && profilerOutput && (
             <RaisedButton label={<Trans>Restart</Trans>} onClick={onStart} />

--- a/newIDE/app/src/Debugger/index.js
+++ b/newIDE/app/src/Debugger/index.js
@@ -6,6 +6,7 @@ import Toolbar from './Toolbar';
 import DebuggerContent from './DebuggerContent';
 import DebuggerSelector from './DebuggerSelector';
 import { Column } from '../UI/Grid';
+import Text from '../UI/Text';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import PlaceholderMessage from '../UI/PlaceholderMessage';
 import Background from '../UI/Background';
@@ -306,19 +307,19 @@ export default class Debugger extends React.Component<Props, State> {
         {!debuggerServerStarted && !debuggerServerError && (
           <PlaceholderMessage>
             <PlaceholderLoader />
-            <p>
+            <Text>
               <Trans>Debugger is starting...</Trans>
-            </p>
+            </Text>
           </PlaceholderMessage>
         )}
         {!debuggerServerStarted && debuggerServerError && (
           <PlaceholderMessage>
-            <p>
+            <Text>
               <Trans>
                 Unable to start the debugger server! Make sure that you are
                 authorized to run servers on this computer.
               </Trans>
-            </p>
+            </Text>
           </PlaceholderMessage>
         )}
         {debuggerServerStarted && (

--- a/newIDE/app/src/EffectsList/EffectsListDialog.js
+++ b/newIDE/app/src/EffectsList/EffectsListDialog.js
@@ -1,7 +1,7 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import EffectsList from './index';
 import HelpButton from '../UI/HelpButton';

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -8,7 +8,7 @@ import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import { mapFor } from '../Utils/MapFor';
 import RaisedButton from '../UI/RaisedButton';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
 import IconMenu from '../UI/Menu/IconMenu';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -7,7 +7,7 @@ import { Column, Line } from '../UI/Grid';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import { mapFor } from '../Utils/MapFor';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import IconButton from 'material-ui/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
 import IconMenu from '../UI/Menu/IconMenu';

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -4,8 +4,8 @@ import { t } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import * as React from 'react';
 import { Column, Line } from '../UI/Grid';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import { mapFor } from '../Utils/MapFor';
 import RaisedButton from '../UI/RaisedButton';
 import IconButton from '../UI/IconButton';
@@ -155,7 +155,7 @@ export default class EffectsList extends React.Component<Props, {||}> {
                       <Column expand>
                         <SelectField
                           value={effectName}
-                          onChange={(e, i, newEffectName) =>
+                          onChange={(e, i, newEffectName: string) =>
                             this._chooseEffectName(
                               allEffectDescriptions,
                               effect,

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
@@ -1,7 +1,7 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import EventsBasedBehaviorEditor from './index';
 import HelpButton from '../UI/HelpButton';

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -9,7 +9,7 @@ import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import { mapVector } from '../Utils/MapFor';
 import RaisedButton from '../UI/RaisedButton';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
 import IconMenu from '../UI/Menu/IconMenu';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -8,7 +8,7 @@ import { Column, Line } from '../UI/Grid';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import { mapVector } from '../Utils/MapFor';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import IconButton from 'material-ui/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
 import IconMenu from '../UI/Menu/IconMenu';

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -5,8 +5,8 @@ import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 import * as React from 'react';
 import { Column, Line } from '../UI/Grid';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import { mapVector } from '../Utils/MapFor';
 import RaisedButton from '../UI/RaisedButton';
 import IconButton from '../UI/IconButton';
@@ -195,7 +195,7 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                           <SelectField
                             floatingLabelText={<Trans>Type</Trans>}
                             value={property.getType()}
-                            onChange={(e, i, value) => {
+                            onChange={(e, i, value: string) => {
                               property.setType(value);
                               this.forceUpdate();
                               this.props.onPropertiesUpdated();

--- a/newIDE/app/src/EventsBasedBehaviorEditor/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/index.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import { Column, Spacer } from '../UI/Grid';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import ObjectTypeSelector from '../ObjectTypeSelector';

--- a/newIDE/app/src/EventsBasedBehaviorEditor/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/index.js
@@ -6,7 +6,7 @@ import TextField from '../UI/TextField';
 import { Column, Spacer } from '../UI/Grid';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import ObjectTypeSelector from '../ObjectTypeSelector';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../UI/Tabs';
 import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import AlertMessage from '../UI/AlertMessage';
 import EventsBasedBehaviorPropertiesEditor from './EventsBasedBehaviorPropertiesEditor';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Subheader from 'material-ui/Subheader';
 import { List, ListItem } from 'material-ui/List';
 import Dialog from '../UI/Dialog';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
 import Subheader from 'material-ui/Subheader';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import Dialog from '../UI/Dialog';
 import HelpButton from '../UI/HelpButton';
 import Create from '../UI/CustomSvgIcons/Behaviors/Create';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -9,7 +9,7 @@ import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import { mapVector } from '../../Utils/MapFor';
 import RaisedButton from '../../UI/RaisedButton';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../UI/IconButton';
 import EmptyMessage from '../../UI/EmptyMessage';
 import IconMenu from '../../UI/Menu/IconMenu';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -5,8 +5,8 @@ import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 import * as React from 'react';
 import { Column, Line, Spacer } from '../../UI/Grid';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../UI/SelectField';
+import MenuItem from '../../UI/MenuItem';
 import { mapVector } from '../../Utils/MapFor';
 import RaisedButton from '../../UI/RaisedButton';
 import IconButton from '../../UI/IconButton';
@@ -171,7 +171,7 @@ export default class EventsFunctionParametersEditor extends React.Component<
                             <SelectField
                               floatingLabelText={<Trans>Type</Trans>}
                               value={parameter.getType()}
-                              onChange={(e, i, value) => {
+                              onChange={(e, i, value: string) => {
                                 parameter.setType(value);
                                 this.forceUpdate();
                                 this.props.onParametersUpdated();

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -8,7 +8,7 @@ import { Column, Line, Spacer } from '../../UI/Grid';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import { mapVector } from '../../Utils/MapFor';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import IconButton from 'material-ui/IconButton';
 import EmptyMessage from '../../UI/EmptyMessage';
 import IconMenu from '../../UI/Menu/IconMenu';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -6,8 +6,8 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
 import { Column, Line, Spacer } from '../../UI/Grid';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../UI/SelectField';
+import MenuItem from '../../UI/MenuItem';
 import { mapVector } from '../../Utils/MapFor';
 import HelpButton from '../../UI/HelpButton';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
@@ -112,7 +112,7 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
                   value={type}
                   fullWidth
                   disabled={!!freezeEventsFunctionType}
-                  onChange={(e, i, value) => {
+                  onChange={(e, i, value: string) => {
                     eventsFunction.setFunctionType(value);
                     if (onConfigurationUpdated) onConfigurationUpdated();
                     this.forceUpdate();

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import ObjectGroupsListWithObjectGroupEditor from '../../ObjectGroupsList/ObjectGroupsListWithObjectGroupEditor';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../../UI/Tabs';
 import EventsFunctionParametersEditor from './EventsFunctionParametersEditor';
 import EventsFunctionPropertiesEditor from './EventsFunctionPropertiesEditor';
 import ScrollView from '../../UI/ScrollView';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import TextField from 'material-ui/TextField';
 import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
 import { Column, Line } from '../UI/Grid';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
 import { Column, Line } from '../UI/Grid';
 import Dialog from '../UI/Dialog';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
@@ -11,7 +11,7 @@ import HelpButton from '../UI/HelpButton';
 import EventsFunctionsExtensionsContext, {
   type EventsFunctionsExtensionsState,
 } from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import Window from '../Utils/Window';
 
 type Props = {|
@@ -217,12 +217,12 @@ export default class OptionsEditorDialog extends React.Component<Props, State> {
                         icon={<CloudUpload />}
                         primary
                         label={<Trans>Export to a file</Trans>}
-                        onClick={() =>
+                        onClick={() => {
                           exportExtension(
                             eventsFunctionsExtensionsState,
                             eventsFunctionsExtension
-                          )
-                        }
+                          );
+                        }}
                       />
                       <FlatButton
                         label={<Trans>Submit extension to the community</Trans>}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog.js
@@ -13,6 +13,7 @@ import EventsFunctionsExtensionsContext, {
 } from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
 import RaisedButton from '../UI/RaisedButton';
 import Window from '../Utils/Window';
+import Text from '../UI/Text';
 
 type Props = {|
   eventsFunctionsExtension: gdEventsFunctionsExtension,
@@ -203,14 +204,14 @@ export default class OptionsEditorDialog extends React.Component<Props, State> {
                 >
                   <Column expand>
                     <Line>
-                      <p>
+                      <Text>
                         <Trans>
                           You can export the extension to a file to easily
                           import it in another project. If your extension is
                           providing useful and reusable functions or behaviors,
                           consider sharing it with the GDevelop community!
                         </Trans>
-                      </p>
+                      </Text>
                     </Line>
                     <Line>
                       <RaisedButton

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -22,7 +22,7 @@ import {
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import BehaviorMethodSelectorDialog from './BehaviorMethodSelectorDialog';
 import { isBehaviorLifecycleFunction } from '../EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import { Line } from '../UI/Grid';
 import Divider from 'material-ui/Divider';
 const gd = global.gd;

--- a/newIDE/app/src/EventsSheet/EmptyEventsPlaceholder.js
+++ b/newIDE/app/src/EventsSheet/EmptyEventsPlaceholder.js
@@ -4,19 +4,20 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import PlaceholderMessage from '../UI/PlaceholderMessage';
 import HelpButton from '../UI/HelpButton';
+import Text from '../UI/Text';
 
 const EmptyEventsPlaceholder = () => (
   <PlaceholderMessage>
-    <p>
+    <Text>
       <Trans>
         There are no events here. Events are composed of conditions and actions.
       </Trans>
-    </p>
-    <p>
+    </Text>
+    <Text>
       <Trans>
         Add your first event using the first buttons of the toolbar.
       </Trans>
-    </p>
+    </Text>
     <HelpButton helpPagePath="/events" />
   </PlaceholderMessage>
 );

--- a/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 
 export type EventsContextResult = {|
   objectsNames: Array<string>,

--- a/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
@@ -4,6 +4,7 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
+import Text from '../UI/Text';
 
 export type EventsContextResult = {|
   objectsNames: Array<string>,
@@ -69,19 +70,19 @@ export default class EventsContextAnalyzerDialog extends React.Component<
 
     return (
       <Dialog actions={actions} open onRequestClose={onClose}>
-        <p>
+        <Text>
           <Trans>
             Objects or groups being directly referenced in the events:{' '}
             {eventsContextResult.objectOrGroupNames.join(', ')}
           </Trans>
-        </p>
-        <p>
+        </Text>
+        <Text>
           <Trans>
             All objects potentially used in events:{' '}
             {eventsContextResult.objectsNames.join(', ')}
           </Trans>
-        </p>
-        <p>
+        </Text>
+        <Text>
           <Trans>All behaviors being directly referenced in the events:</Trans>{' '}
           {Object.keys(eventsContextResult.objectOrGroupBehaviorNames).map(
             objectOrGroupName => {
@@ -96,7 +97,7 @@ export default class EventsContextAnalyzerDialog extends React.Component<
               );
             }
           )}
-        </p>
+        </Text>
       </Dialog>
     );
   }

--- a/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
@@ -60,6 +60,7 @@ export default class EventsContextAnalyzerDialog extends React.Component<
     const { onClose, eventsContextResult } = this.props;
     const actions = [
       <FlatButton
+        key="close"
         label={<Trans>Close</Trans>}
         primary={true}
         onClick={this.props.onClose}

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import { enumerateEventsFunctionsExtensions } from '../../ProjectManager/EnumerateProjectItems';
 import { Line, Column, Spacer } from '../../UI/Grid';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
@@ -7,8 +7,8 @@ import FlatButton from '../../UI/FlatButton';
 import { enumerateEventsFunctionsExtensions } from '../../ProjectManager/EnumerateProjectItems';
 import { Line, Column, Spacer } from '../../UI/Grid';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../UI/SelectField';
+import MenuItem from '../../UI/MenuItem';
 import Divider from 'material-ui/Divider';
 import {
   setupFunctionFromEvents,

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import classNames from 'classnames';
-import TextField from 'material-ui/TextField';
+import TextField from '../../../UI/TextField';
 import {
   largeSelectedArea,
   largeSelectableArea,

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent.js
@@ -6,7 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../UI/IconButton';
 import classNames from 'classnames';
 import {
   largeSelectedArea,

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component, type Node } from 'react';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import findIndex from 'lodash/findIndex';
 import {
   SortableTreeWithoutDndContext,
@@ -26,6 +25,7 @@ import ObjectsRenderingService from '../../ObjectsRendering/ObjectsRenderingServ
 // Import default style of react-sortable-tree and the override made for EventsSheet.
 import 'react-sortable-tree/style.css';
 import './style.css';
+import ThemeConsumer from '../../UI/Theme/ThemeConsumer';
 
 const getThumbnail = ObjectsRenderingService.getThumbnail.bind(
   ObjectsRenderingService
@@ -145,15 +145,18 @@ class EventContainer extends Component<EventsContainerProps, {||}> {
 
 const getNodeKey = ({ treeIndex }) => treeIndex;
 
-const ThemableSortableTree = ({ muiTheme, className, ...otherProps }) => (
-  <SortableTreeWithoutDndContext
-    className={`${eventsTree} ${
-      muiTheme.eventsSheetRootClassName
-    } ${className}`}
-    {...otherProps}
-  />
+const SortableTree = ({ className, ...otherProps }) => (
+  <ThemeConsumer>
+    {muiTheme => (
+      <SortableTreeWithoutDndContext
+        className={`${eventsTree} ${
+          muiTheme.eventsSheetRootClassName
+        } ${className}`}
+        {...otherProps}
+      />
+    )}
+  </ThemeConsumer>
 );
-const SortableTree = muiThemeable()(ThemableSortableTree);
 
 const noop = () => {};
 

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import InstructionEditor from './index.js';
 import {
   type ResourceSource,

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
@@ -59,11 +59,13 @@ export default class InstructionEditorDialog extends React.Component<
     } = this.props;
     const actions = [
       <FlatButton
+        key="cancel"
         label={<Trans>Cancel</Trans>}
         primary={false}
         onClick={onCancel}
       />,
       <FlatButton
+        key="ok"
         label={<Trans>Ok</Trans>}
         primary={true}
         keyboardFocused={false}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
-import { List, makeSelectable } from 'material-ui/List';
+import { SelectableList } from '../../../UI/List';
 import SearchBar from '../../../UI/SearchBar';
 import { type EnumeratedInstructionOrExpressionMetadata } from './EnumeratedInstructionOrExpressionMetadata.js';
 import { type InstructionOrExpressionTreeNode } from './CreateTree';
@@ -13,8 +13,6 @@ import EmptyMessage from '../../../UI/EmptyMessage';
 import ScrollView from '../../../UI/ScrollView';
 import { Column, Line } from '../../../UI/Grid';
 import { getInstructionListItemKey } from '../SelectorListItems/Keys';
-
-const SelectableList = makeSelectable(List);
 
 const styles = {
   searchBar: {

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -14,7 +14,7 @@ import {
   filterInstructionsList,
 } from './InstructionOrExpressionSelector/EnumerateInstructions';
 import { type EnumeratedInstructionOrExpressionMetadata } from './InstructionOrExpressionSelector/EnumeratedInstructionOrExpressionMetadata.js';
-import { List, makeSelectable } from 'material-ui/List';
+import { SelectableList } from '../../UI/List';
 import SearchBar from '../../UI/SearchBar';
 import ThemeConsumer from '../../UI/Theme/ThemeConsumer';
 import ScrollView from '../../UI/ScrollView';
@@ -46,8 +46,6 @@ const styles = {
     flexShrink: 0,
   },
 };
-
-const SelectableList = makeSelectable(List);
 
 export type TabName = 'objects' | 'free-instructions';
 

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -18,7 +18,7 @@ import { List, makeSelectable } from 'material-ui/List';
 import SearchBar from '../../UI/SearchBar';
 import ThemeConsumer from '../../UI/Theme/ThemeConsumer';
 import ScrollView from '../../UI/ScrollView';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../../UI/Tabs';
 import { Subheader } from 'material-ui';
 import {
   enumerateObjectsAndGroups,

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
@@ -20,7 +20,7 @@ import AlertMessage from '../../UI/AlertMessage';
 import { getExtraInstructionInformation } from '../../Hints';
 import { isAnEventFunctionMetadata } from '../../EventsFunctionsExtensionsLoader';
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../UI/IconButton';
 import { type EventsScope } from '../EventsScope.flow';
 const gd = global.gd;
 
@@ -245,7 +245,11 @@ export default class InstructionParametersEditor extends React.Component<
               />
               <p>{instructionMetadata.getDescription()}</p>
               {isAnEventFunctionMetadata(instructionMetadata) && (
-                <IconButton onClick={() => this._openExtension(i18n)}>
+                <IconButton
+                  onClick={() => {
+                    this._openExtension(i18n);
+                  }}
+                >
                   <OpenInNew />
                 </IconButton>
               )}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
@@ -5,7 +5,7 @@ import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
-import Toggle from 'material-ui/Toggle';
+import Toggle from '../../UI/Toggle';
 import { mapFor } from '../../Utils/MapFor';
 import EmptyMessage from '../../UI/EmptyMessage';
 import ParameterRenderingService from '../ParameterRenderingService';

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
@@ -22,6 +22,7 @@ import { isAnEventFunctionMetadata } from '../../EventsFunctionsExtensionsLoader
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';
 import IconButton from '../../UI/IconButton';
 import { type EventsScope } from '../EventsScope.flow';
+import Text from '../../UI/Text';
 const gd = global.gd;
 
 const styles = {
@@ -243,7 +244,7 @@ export default class InstructionParametersEditor extends React.Component<
                 alt=""
                 style={styles.icon}
               />
-              <p>{instructionMetadata.getDescription()}</p>
+              <Text>{instructionMetadata.getDescription()}</Text>
               {isAnEventFunctionMetadata(instructionMetadata) && (
                 <IconButton
                   onClick={() => {

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import {
   type ResourceSource,
   type ChooseResourceFunction,

--- a/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorGroupObjectsListItem.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorGroupObjectsListItem.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../../../UI/List';
 import ListIcon from '../../../UI/ListIcon';
 import type { GroupWithContext } from '../../../ObjectsList/EnumerateObjects';
 import { getObjectOrObjectGroupListItemKey } from './Keys';

--- a/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionOrExpressionListItem.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionOrExpressionListItem.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../../../UI/List';
 import ListIcon from '../../../UI/ListIcon';
 import { type EnumeratedInstructionOrExpressionMetadata } from '../InstructionOrExpressionSelector/EnumeratedInstructionOrExpressionMetadata.js';
 import { getInstructionListItemKey } from './Keys';

--- a/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionsTreeListItem.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionsTreeListItem.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../../../UI/List';
 import ListIcon from '../../../UI/ListIcon';
 import { type InstructionOrExpressionTreeNode } from '../InstructionOrExpressionSelector/CreateTree';
 import { type EnumeratedInstructionOrExpressionMetadata } from '../InstructionOrExpressionSelector/EnumeratedInstructionOrExpressionMetadata.js';
@@ -26,7 +26,7 @@ export const renderInstructionTree = ({
   onChoose,
   iconSize,
   useSubheaders,
-}: Props): Array<ListItem> => {
+}: Props): Array<React$Element<any> | null> => {
   return flatten(
     Object.keys(instructionTreeNode).map(key => {
       // In theory, we should have a way to distinguish

--- a/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorObjectListItem.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorObjectListItem.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../../../UI/List';
 import ListIcon from '../../../UI/ListIcon';
 import ObjectsRenderingService from '../../../ObjectsRendering/ObjectsRenderingService';
 import type { ObjectWithContext } from '../../../ObjectsList/EnumerateObjects';

--- a/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
@@ -1,7 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
-import AutoComplete from 'material-ui/AutoComplete';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
 import { getLastObjectParameterValue } from './ParameterMetadataTools';
 import SemiControlledAutoComplete from '../../UI/SemiControlledAutoComplete';
@@ -19,7 +18,7 @@ export default class BehaviorField extends React.Component<
   _description: ?string;
   _behaviorTypeAllowed: ?string;
   _behaviorNames: Array<string> = [];
-  _field: ?AutoComplete;
+  _field: ?SemiControlledAutoComplete;
 
   constructor(props: ParameterFieldProps) {
     super(props);

--- a/newIDE/app/src/EventsSheet/ParameterFields/ForceMultiplierField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ForceMultiplierField.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
 import React, { Component } from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { Line, Column } from '../../UI/Grid';
 import { makeNonBreakable } from '../../Utils/StringHelpers';
 import { type ParameterFieldProps } from './ParameterFieldCommons';

--- a/newIDE/app/src/EventsSheet/ParameterFields/ForceMultiplierField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ForceMultiplierField.js
@@ -9,6 +9,7 @@ import { type ParameterFieldProps } from './ParameterFieldCommons';
 import GenericExpressionField from './GenericExpressionField';
 import BackgroundText from '../../UI/BackgroundText';
 import { focusButton } from '../../UI/Button';
+import Text from '../../UI/Text';
 
 type State = {|
   showDeprecatedNumericValue: boolean,
@@ -44,13 +45,13 @@ export default class ForceMultiplierField extends Component<
             />
           </Column>
           <Column>
-            <p>
+            <Text>
               <Trans>
                 The force will only push the object during the time of one
                 frame. Typically used in an event with no conditions or with
                 conditions that stay valid for a certain amount of time.
               </Trans>
-            </p>
+            </Text>
           </Column>
         </Line>
         <Line expand alignItems="center">
@@ -62,14 +63,14 @@ export default class ForceMultiplierField extends Component<
             />
           </Column>
           <Column>
-            <p>
+            <Text>
               <Trans>
                 The force will push the object forever, unless you use the
                 action "Stop the object". Typically used in an event with
                 conditions that are only true once, or with a "Trigger Once"
                 condition.
               </Trans>
-            </p>
+            </Text>
           </Column>
         </Line>
         {showDeprecatedNumericValue && (

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import { type EventsScope } from '../../EventsScope.flow';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../UI/FlatButton';
 import ExpressionParametersEditor from './ExpressionParametersEditor';
 import Dialog from '../../../UI/Dialog';
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import Popover from 'material-ui/Popover';
 import Functions from 'material-ui/svg-icons/editor/functions';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../../UI/RaisedButton';
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import { mapVector } from '../../../Utils/MapFor';
 import ExpressionSelector from '../../InstructionEditor/InstructionOrExpressionSelector/ExpressionSelector';

--- a/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
@@ -1,8 +1,8 @@
 import { Trans } from '@lingui/macro';
 import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../UI/SelectField';
+import MenuItem from '../../UI/MenuItem';
 
 export default class RelationalOperatorField extends Component {
   focus() {}

--- a/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../UI/SelectField';
+import MenuItem from '../../UI/MenuItem';
 
 export default class OperatorField extends Component {
   focus() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/RelationalOperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/RelationalOperatorField.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../UI/SelectField';
+import MenuItem from '../../UI/MenuItem';
 
 export default class RelationalOperatorField extends Component {
   focus() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/TrueFalseField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/TrueFalseField.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
 import React, { Component } from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { Line, Column } from '../../UI/Grid';
 import {
   type ParameterFieldProps,

--- a/newIDE/app/src/EventsSheet/ParameterFields/TrueFalseField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/TrueFalseField.js
@@ -9,6 +9,7 @@ import {
   getParameterValueOrDefault,
 } from './ParameterFieldCommons';
 import { focusButton } from '../../UI/Button';
+import Text from '../../UI/Text';
 
 const styles = {
   button: {
@@ -39,7 +40,7 @@ export default class TrueFalseField extends Component<
 
     return (
       <Line>
-        <p style={styles.description}>{description}</p>
+        <Text style={styles.description}>{description}</Text>
         <Column noMargin>
           <RaisedButton
             style={styles.button}

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -1,7 +1,6 @@
 // @flow
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';
 import React, { Component } from 'react';
-import AutoComplete from 'material-ui/AutoComplete';
 import RaisedButton from '../../UI/RaisedButton';
 import { enumerateVariables } from './EnumerateVariables';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
@@ -26,7 +25,7 @@ type Props = {
 };
 
 export default class VariableField extends Component<Props, {||}> {
-  _field: ?AutoComplete;
+  _field: ?SemiControlledAutoComplete;
 
   focus() {
     if (this._field) this._field.focus();

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -2,7 +2,7 @@
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';
 import React, { Component } from 'react';
 import AutoComplete from 'material-ui/AutoComplete';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { enumerateVariables } from './EnumerateVariables';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
 import classNames from 'classnames';

--- a/newIDE/app/src/EventsSheet/ParameterFields/YesNoField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/YesNoField.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
 import React, { Component } from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { Line, Column } from '../../UI/Grid';
 import {
   type ParameterFieldProps,

--- a/newIDE/app/src/EventsSheet/ParameterFields/YesNoField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/YesNoField.js
@@ -9,6 +9,7 @@ import {
   getParameterValueOrDefault,
 } from './ParameterFieldCommons';
 import { focusButton } from '../../UI/Button';
+import Text from '../../UI/Text';
 
 const styles = {
   button: {
@@ -36,7 +37,7 @@ export default class YesNoField extends Component<ParameterFieldProps, void> {
 
     return (
       <Line>
-        <p style={styles.description}>{description}</p>
+        <Text style={styles.description}>{description}</Text>
         <Column noMargin>
           <RaisedButton
             style={styles.button}

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { PureComponent } from 'react';
 import Paper from 'material-ui/Paper';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import { Line, Column } from '../UI/Grid';
 import FlatButton from '../UI/FlatButton';
 import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import Paper from 'material-ui/Paper';
 import TextField from 'material-ui/TextField';
 import { Line, Column } from '../UI/Grid';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import IconButton from 'material-ui/IconButton';

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -8,7 +8,7 @@ import { Line, Column } from '../UI/Grid';
 import FlatButton from '../UI/FlatButton';
 import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import InlineCheckbox from '../UI/InlineCheckbox';
 import {
   type SearchInEventsInputs,
@@ -175,13 +175,17 @@ export default class SearchPanel extends PureComponent<Props, State> {
               </p>
               <IconButton
                 disabled={!resultsCount}
-                onClick={() => onGoToPreviousSearchResult()}
+                onClick={() => {
+                  onGoToPreviousSearchResult();
+                }}
               >
                 <ChevronLeft />
               </IconButton>
               <IconButton
                 disabled={!resultsCount}
-                onClick={() => onGoToNextSearchResult()}
+                onClick={() => {
+                  onGoToNextSearchResult();
+                }}
               >
                 <ChevronRight />
               </IconButton>

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { PureComponent } from 'react';
-import Paper from 'material-ui/Paper';
+import Background from '../UI/Background';
 import TextField from '../UI/TextField';
 import { Line, Column } from '../UI/Grid';
 import FlatButton from '../UI/FlatButton';
@@ -98,7 +98,7 @@ export default class SearchPanel extends PureComponent<Props, State> {
     const { searchText, replaceText, searchInSelection } = this.state;
 
     return (
-      <Paper>
+      <Background noFullHeight noExpand>
         <Column>
           <Line alignItems="baseline">
             <TextField
@@ -192,7 +192,7 @@ export default class SearchPanel extends PureComponent<Props, State> {
             </Line>
           </Line>
         </Column>
-      </Paper>
+      </Background>
     );
   }
 }

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -10,6 +10,7 @@ import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import IconButton from '../UI/IconButton';
 import InlineCheckbox from '../UI/InlineCheckbox';
+import Text from '../UI/Text';
 import {
   type SearchInEventsInputs,
   type ReplaceInEventsInputs,
@@ -141,9 +142,9 @@ export default class SearchPanel extends PureComponent<Props, State> {
                 checked={!this.state.matchCase}
                 onCheck={(e, checked) => this.setState({ matchCase: !checked })}
               />
-              <p>
+              <Text>
                 <Trans>Filter by</Trans>
-              </p>
+              </Text>
               <InlineCheckbox
                 label={<Trans>Conditions</Trans>}
                 checked={this.state.searchInConditions}
@@ -166,13 +167,13 @@ export default class SearchPanel extends PureComponent<Props, State> {
               /> */}
             </Line>
             <Line noMargin alignItems="center">
-              <p>
+              <Text>
                 {resultsCount === null || resultsCount === undefined
                   ? ''
                   : resultsCount !== 0
                   ? `${resultsCount} results`
                   : `No results`}
-              </p>
+              </Text>
               <IconButton
                 disabled={!resultsCount}
                 onClick={() => {

--- a/newIDE/app/src/Export/BrowserExporters/BrowserExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserExport.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { Column, Line } from '../../UI/Grid';
 import Window from '../../Utils/Window';
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserPreviewLinkDialog.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserPreviewLinkDialog.js
@@ -6,7 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import { showErrorBox } from '../../UI/Messages/MessageBox';
 import { Column, Line } from '../../UI/Grid';
 

--- a/newIDE/app/src/Export/Builds/BuildProgress.js
+++ b/newIDE/app/src/Export/Builds/BuildProgress.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import FlatButton from '../../UI/FlatButton';
 import { Spacer, Line } from '../../UI/Grid';
 import EmptyMessage from '../../UI/EmptyMessage';

--- a/newIDE/app/src/Export/Builds/BuildProgress.js
+++ b/newIDE/app/src/Export/Builds/BuildProgress.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import { Spacer, Line } from '../../UI/Grid';
 import EmptyMessage from '../../UI/EmptyMessage';
 import difference_in_seconds from 'date-fns/difference_in_seconds';

--- a/newIDE/app/src/Export/Builds/BuildProgress.js
+++ b/newIDE/app/src/Export/Builds/BuildProgress.js
@@ -6,6 +6,7 @@ import { Spacer, Line } from '../../UI/Grid';
 import EmptyMessage from '../../UI/EmptyMessage';
 import difference_in_seconds from 'date-fns/difference_in_seconds';
 import LinearProgress from 'material-ui/LinearProgress';
+import Text from '../../UI/Text';
 
 const buildTypesConfig = {
   'cordova-build': {
@@ -65,9 +66,9 @@ export default ({ build, onDownload }: Props) => {
   return build.status === 'error' ? (
     <React.Fragment>
       <Line alignItems="center">
-        <p>
+        <Text>
           <Trans>Something wrong happened :(</Trans>
-        </p>
+        </Text>
         <Spacer />
         <RaisedButton
           label={<Trans>See logs</Trans>}
@@ -93,13 +94,13 @@ export default ({ build, onDownload }: Props) => {
       />
       <Spacer />
       {estimatedRemainingTime > 0 ? (
-        <p>
+        <Text>
           <Trans>~{Math.round(estimatedRemainingTime / 60)} minutes.</Trans>
-        </p>
+        </Text>
       ) : (
-        <p>
+        <Text>
           <Trans>Should finish soon.</Trans>
-        </p>
+        </Text>
       )}
     </Line>
   ) : build.status === 'complete' ? (

--- a/newIDE/app/src/Export/Builds/BuildStepsProgress.js
+++ b/newIDE/app/src/Export/Builds/BuildStepsProgress.js
@@ -9,6 +9,7 @@ import { Line, Spacer } from '../../UI/Grid';
 import BuildProgress from './BuildProgress';
 import { type Build } from '../../Utils/GDevelopServices/Build';
 import EmptyMessage from '../../UI/EmptyMessage';
+import Text from '../../UI/Text';
 
 const styles = {
   stepper: { flex: 1 },
@@ -64,9 +65,9 @@ export default ({
         <Line alignItems="center">
           <CircularProgress size={20} />
           <Spacer />
-          <p>
+          <Text>
             <Trans>Export in progress...</Trans>
-          </p>
+          </Text>
         </Line>
       </StepContent>
     </Step>
@@ -74,19 +75,19 @@ export default ({
       <StepLabel>Upload to build service</StepLabel>
       <StepContent>
         {errored ? (
-          <p>
+          <Text>
             <Trans>
               Can't upload your game to the build service. Please check your
               internet connection or try again later.
             </Trans>
-          </p>
+          </Text>
         ) : exportStep === 'compress' ? (
           <Line alignItems="center">
             <CircularProgress size={20} />
             <Spacer />
-            <p>
+            <Text>
               <Trans>Compressing before upload...</Trans>
-            </p>
+            </Text>
           </Line>
         ) : (
           <Line alignItems="center" expand>
@@ -104,17 +105,17 @@ export default ({
       <StepLabel>Build and download</StepLabel>
       <StepContent>
         {errored && (
-          <p>
+          <Text>
             <Trans>
               Build could not start or errored. Please check your internet
               connection or try again later.
             </Trans>
-          </p>
+          </Text>
         )}
         {!build && !errored && (
-          <p>
+          <Text>
             <Trans>Build is starting...</Trans>
-          </p>
+          </Text>
         )}
         {build && <BuildProgress build={build} onDownload={onDownload} />}
         {showSeeAllMyBuildsExplanation && (

--- a/newIDE/app/src/Export/Builds/BuildsDialog.js
+++ b/newIDE/app/src/Export/Builds/BuildsDialog.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
 import HelpButton from '../../UI/HelpButton';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import Builds from '.';
 
 type Props = {|

--- a/newIDE/app/src/Export/Builds/BuildsList.js
+++ b/newIDE/app/src/Export/Builds/BuildsList.js
@@ -10,6 +10,7 @@ import PlaceholderLoader from '../../UI/PlaceholderLoader';
 import BuildProgress from './BuildProgress';
 import format from 'date-fns/format';
 import difference_in_calendar_days from 'date-fns/difference_in_calendar_days';
+import Text from '../../UI/Text';
 
 type Props = {|
   builds: ?Array<Build>,
@@ -54,10 +55,10 @@ export default ({ builds, onDownload }: Props) => {
 
               return (
                 <Paper style={styles.buildContainer} key={build.id}>
-                  <p>
+                  <Text>
                     {build.type} - Last updated on{' '}
                     {format(build.updatedAt, 'YYYY-MM-DD HH:mm:ss')}
-                  </p>
+                  </Text>
                   {!isOld && (
                     <BuildProgress
                       build={build}

--- a/newIDE/app/src/Export/ExportDialog.js
+++ b/newIDE/app/src/Export/ExportDialog.js
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
 import HelpButton from '../UI/HelpButton';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Subheader from 'material-ui/Subheader';
 import { List, ListItem } from 'material-ui/List';
 import Visibility from 'material-ui/svg-icons/action/visibility';

--- a/newIDE/app/src/Export/ExportDialog.js
+++ b/newIDE/app/src/Export/ExportDialog.js
@@ -4,7 +4,7 @@ import Dialog from '../UI/Dialog';
 import HelpButton from '../UI/HelpButton';
 import FlatButton from '../UI/FlatButton';
 import Subheader from 'material-ui/Subheader';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
 import BuildsDialog from './Builds/BuildsDialog';

--- a/newIDE/app/src/Export/LocalExporters/LocalCocos2dExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCocos2dExport.js
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import Toggle from 'material-ui/Toggle';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';

--- a/newIDE/app/src/Export/LocalExporters/LocalCocos2dExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCocos2dExport.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import Toggle from 'material-ui/Toggle';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';

--- a/newIDE/app/src/Export/LocalExporters/LocalCocos2dExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCocos2dExport.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
 import RaisedButton from '../../UI/RaisedButton';
-import Toggle from 'material-ui/Toggle';
+import Toggle from '../../UI/Toggle';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';
 import HelpButton from '../../UI/HelpButton';

--- a/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';

--- a/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';
 import { showErrorBox } from '../../UI/Messages/MessageBox';

--- a/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
@@ -19,6 +19,7 @@ import {
 import assignIn from 'lodash/assignIn';
 import optionalRequire from '../../Utils/OptionalRequire';
 import Window from '../../Utils/Window';
+import Text from '../../UI/Text';
 const electron = optionalRequire('electron');
 const shell = electron ? electron.shell : null;
 
@@ -114,15 +115,15 @@ class LocalCordovaExport extends Component<Props, State> {
       <Column noMargin>
         <Line>
           <Column noMargin>
-            <p>
+            <Text>
               This will export your game as a Cordova project. Cordova is a
               technology that enables HTML5 games to be packaged for <b>iOS</b>,{' '}
               <b>Android</b> and more.
-            </p>
-            <p>
+            </Text>
+            <Text>
               Third-party tools like <b>Adobe PhoneGap Build</b> allow game
               developers to bundle their games using Cordova.
-            </p>
+            </Text>
           </Column>
         </Line>
         <Line>
@@ -169,17 +170,17 @@ class LocalCordovaExport extends Component<Props, State> {
           modal
           open={this.state.exportFinishedDialogOpen}
         >
-          <p>
+          <Text>
             You can now compress and upload the game to <b>PhoneGap Build</b>{' '}
             which will compile it for you to an iOS and Android app.
-          </p>
-          <p>
+          </Text>
+          <Text>
             <Trans>
               You can also compile the game by yourself using Cordova
               command-line tool to iOS (XCode is required) or Android (Android
               SDK is required).
             </Trans>
-          </p>
+          </Text>
           <RaisedButton
             fullWidth
             primary

--- a/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';

--- a/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';
 import { showErrorBox } from '../../UI/Messages/MessageBox';

--- a/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
@@ -18,6 +18,7 @@ import {
 } from '../../ProjectManager/ProjectErrorsChecker';
 import assignIn from 'lodash/assignIn';
 import optionalRequire from '../../Utils/OptionalRequire';
+import Text from '../../UI/Text';
 const electron = optionalRequire('electron');
 const shell = electron ? electron.shell : null;
 
@@ -109,14 +110,14 @@ class LocalElectronExport extends Component<Props, State> {
       <Column noMargin>
         <Line>
           <Column noMargin>
-            <p>
+            <Text>
               <Trans>
                 This will export your game so that you can package it for
                 Windows, macOS or Linux. You will need to install third-party
                 tools (Node.js, Electron Builder) to package your game by
                 yourself.
               </Trans>
-            </p>
+            </Text>
           </Column>
         </Line>
         <Line>
@@ -163,13 +164,13 @@ class LocalElectronExport extends Component<Props, State> {
           modal
           open={this.state.exportFinishedDialogOpen}
         >
-          <p>
+          <Text>
             <Trans>
               The game was properly exported. You can now use Electron Builder
               (you need Node.js installed and to use the command-line to run it)
               to create an executable.
             </Trans>
-          </p>
+          </Text>
         </Dialog>
       </Column>
     );

--- a/newIDE/app/src/Export/LocalExporters/LocalExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalExport.js
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';
 import { showErrorBox } from '../../UI/Messages/MessageBox';

--- a/newIDE/app/src/Export/LocalExporters/LocalExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalExport.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../UI/Grid';

--- a/newIDE/app/src/Export/LocalExporters/LocalExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalExport.js
@@ -14,6 +14,7 @@ import optionalRequire from '../../Utils/OptionalRequire';
 import Window from '../../Utils/Window';
 import { getHelpLink } from '../../Utils/HelpLink';
 import AlertMessage from '../../UI/AlertMessage';
+import Text from '../../UI/Text';
 const electron = optionalRequire('electron');
 const shell = electron ? electron.shell : null;
 
@@ -136,11 +137,11 @@ export default class LocalExport extends Component {
           modal
           open={this.state.exportFinishedDialogOpen}
         >
-          <p>
+          <Text>
             <Trans>
               You can now upload the game to a web hosting to play to the game.
             </Trans>
-          </p>
+          </Text>
           <AlertMessage kind="warning">
             <Trans>
               Your game won't work if you open index.html on your computer. You

--- a/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/Progress.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/Progress.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Step, Stepper, StepLabel, StepContent } from 'material-ui/Stepper';
 import CircularProgress from 'material-ui/CircularProgress';
 import RaisedButton from 'material-ui/RaisedButton';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../UI/FlatButton';
 import { Line, Spacer } from '../../../UI/Grid';
 import { type LocalFacebookInstantGamesExportStep } from '.';
 

--- a/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/Progress.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/Progress.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import { Step, Stepper, StepLabel, StepContent } from 'material-ui/Stepper';
 import CircularProgress from 'material-ui/CircularProgress';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../../UI/RaisedButton';
 import FlatButton from '../../../UI/FlatButton';
 import { Line, Spacer } from '../../../UI/Grid';
 import { type LocalFacebookInstantGamesExportStep } from '.';

--- a/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/Progress.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/Progress.js
@@ -6,6 +6,7 @@ import { Step, Stepper, StepLabel, StepContent } from 'material-ui/Stepper';
 import CircularProgress from 'material-ui/CircularProgress';
 import RaisedButton from '../../../UI/RaisedButton';
 import FlatButton from '../../../UI/FlatButton';
+import Text from '../../../UI/Text';
 import { Line, Spacer } from '../../../UI/Grid';
 import { type LocalFacebookInstantGamesExportStep } from '.';
 
@@ -40,9 +41,9 @@ export default ({
         <Line alignItems="center">
           <CircularProgress size={20} />
           <Spacer />
-          <p>
+          <Text>
             <Trans>Export in progress...</Trans>
-          </p>
+          </Text>
         </Line>
       </StepContent>
     </Step>
@@ -50,19 +51,19 @@ export default ({
       <StepLabel>Upload to build service</StepLabel>
       <StepContent>
         {errored ? (
-          <p>
+          <Text>
             <Trans>
               Can't compress the game. Please check that you have rights to
               write on this computer.
             </Trans>
-          </p>
+          </Text>
         ) : (
           <Line alignItems="center">
             <CircularProgress size={20} />
             <Spacer />
-            <p>
+            <Text>
               <Trans>Compressing...</Trans>
-            </p>
+            </Text>
           </Line>
         )}
       </StepContent>

--- a/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport/index.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import assignIn from 'lodash/assignIn';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../../UI/RaisedButton';
 import { sendExportLaunched } from '../../../Utils/Analytics/EventSender';
 import { Column, Line, Spacer } from '../../../UI/Grid';
 import LocalFilePicker from '../../../UI/LocalFilePicker';

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport/index.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import assignIn from 'lodash/assignIn';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../../UI/RaisedButton';
 import { sendExportLaunched } from '../../../Utils/Analytics/EventSender';
 import {
   type Build,

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport/index.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import assignIn from 'lodash/assignIn';
 import RaisedButton from '../../../UI/RaisedButton';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../../UI/Checkbox';
 import { sendExportLaunched } from '../../../Utils/Analytics/EventSender';
 import {
   type Build,

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import assignIn from 'lodash/assignIn';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../../UI/RaisedButton';
 import Checkbox from 'material-ui/Checkbox';
 import { sendExportLaunched } from '../../../Utils/Analytics/EventSender';
 import {

--- a/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/LocalNetworkPreviewDialog.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/LocalNetworkPreviewDialog.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import Dialog from '../../../UI/Dialog';
 import FlatButton from '../../../UI/FlatButton';
-import TextField from 'material-ui/TextField';
+import TextField from '../../../UI/TextField';
 import { Line } from '../../../UI/Grid';
 import PlaceholderLoader from '../../../UI/PlaceholderLoader';
 

--- a/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/LocalNetworkPreviewDialog.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/LocalNetworkPreviewDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../UI/FlatButton';
 import TextField from 'material-ui/TextField';
 import { Line } from '../../../UI/Grid';
 import PlaceholderLoader from '../../../UI/PlaceholderLoader';

--- a/newIDE/app/src/Export/LocalExporters/LocalS3Export.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalS3Export.js
@@ -10,7 +10,7 @@ import { Column, Line, Spacer } from '../../UI/Grid';
 import LinearProgress from 'material-ui/LinearProgress';
 import { GDevelopHostingApi } from '../../Utils/GDevelopServices/ApiConfigs';
 import { makeTimestampedId } from '../../Utils/TimestampedId';
-import TextField from 'material-ui/TextField';
+import TextField from '../../UI/TextField';
 import { showErrorBox } from '../../UI/Messages/MessageBox';
 const os = optionalRequire('os');
 const electron = optionalRequire('electron');

--- a/newIDE/app/src/Export/LocalExporters/LocalS3Export.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalS3Export.js
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import axios from 'axios';
 import { sleep } from 'wait-promise';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
 import LocalExport from './LocalExport';
 import optionalRequire from '../../Utils/OptionalRequire';

--- a/newIDE/app/src/ExtensionsSearch/ExtensionInstallDialog.js
+++ b/newIDE/app/src/ExtensionsSearch/ExtensionInstallDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import {
   type ExtensionShortHeader,
   type ExtensionHeader,
@@ -18,7 +18,7 @@ type Props = {|
   extensionShortHeader: ExtensionShortHeader,
   isInstalling: boolean,
   onClose: () => void,
-  onInstall: (type: string, defaultName: string) => void,
+  onInstall: () => void,
   alreadyInstalled: boolean,
 |};
 type State = {|

--- a/newIDE/app/src/ExtensionsSearch/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/ExtensionsSearch/ExtensionsSearchDialog.js
@@ -5,7 +5,7 @@ import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import CloudDownload from 'material-ui/svg-icons/file/cloud-download';
 import ExtensionsSearch, { addSerializedExtensionToProject } from '.';
 import EventsFunctionsExtensionsContext, {
@@ -92,13 +92,13 @@ export default class ExtensionsSearchDialog extends Component<Props, {||}> {
                         icon={<CloudDownload />}
                         key="import"
                         label={<Trans>Import extension</Trans>}
-                        onClick={() =>
+                        onClick={() => {
                           importExtension(
                             i18n,
                             eventsFunctionsExtensionsState,
                             project
-                          )
-                        }
+                          );
+                        }}
                       />
                     ) : null,
                   ]}

--- a/newIDE/app/src/ExtensionsSearch/index.js
+++ b/newIDE/app/src/ExtensionsSearch/index.js
@@ -12,7 +12,7 @@ import {
   type SerializedExtension,
   getExtension,
 } from '../Utils/GDevelopServices/Extension';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import ExtensionInstallDialog from './ExtensionInstallDialog';
 import { unserializeFromJSObject } from '../Utils/Serializer';

--- a/newIDE/app/src/HelpFinder/DocSearchArea.js
+++ b/newIDE/app/src/HelpFinder/DocSearchArea.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import FlatButton from '../UI/FlatButton';
 import Window from '../Utils/Window';
 import { List, ListItem } from 'material-ui/List';

--- a/newIDE/app/src/HelpFinder/DocSearchArea.js
+++ b/newIDE/app/src/HelpFinder/DocSearchArea.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import TextField from 'material-ui/TextField';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Window from '../Utils/Window';
 import { List, ListItem } from 'material-ui/List';
 import { Column } from '../UI/Grid';

--- a/newIDE/app/src/HelpFinder/DocSearchArea.js
+++ b/newIDE/app/src/HelpFinder/DocSearchArea.js
@@ -9,6 +9,7 @@ import { List, ListItem } from '../UI/List';
 import { Column } from '../UI/Grid';
 import algoliasearch from 'algoliasearch/lite';
 import debounce from 'lodash/debounce';
+import Text from '../UI/Text';
 
 const styles = {
   dropdownMenuContainer: {
@@ -150,11 +151,11 @@ export default class DocSearchArea extends React.Component<Props, State> {
           </List>
         ) : (
           <React.Fragment>
-            <p>
+            <Text>
               <Trans>Examples:</Trans>
-            </p>
+            </Text>
             <Column expand>
-              <p>
+              <Text>
                 Coins in platformer
                 <br />
                 Export on Android
@@ -165,17 +166,17 @@ export default class DocSearchArea extends React.Component<Props, State> {
                 <br />
                 ...
                 <br />
-              </p>
+              </Text>
             </Column>
           </React.Fragment>
         )}
-        <p style={styles.poweredByText}>
+        <Text style={styles.poweredByText}>
           This search is powered by{' '}
           <FlatButton
             onClick={() => Window.openExternalURL('http://algolia.com/')}
             label={'Algolia'}
           />
-        </p>
+        </Text>
       </div>
     );
   }

--- a/newIDE/app/src/HelpFinder/DocSearchArea.js
+++ b/newIDE/app/src/HelpFinder/DocSearchArea.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import TextField from '../UI/TextField';
 import FlatButton from '../UI/FlatButton';
 import Window from '../Utils/Window';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import { Column } from '../UI/Grid';
 import algoliasearch from 'algoliasearch/lite';
 import debounce from 'lodash/debounce';

--- a/newIDE/app/src/HelpFinder/index.js
+++ b/newIDE/app/src/HelpFinder/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Window from '../Utils/Window';
 import DocSearchArea from './DocSearchArea';
 import debounce from 'lodash/debounce';

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -9,7 +9,7 @@ import propertiesMapToSchema from '../../PropertiesEditor/PropertiesMapToSchema'
 import { type Schema } from '../../PropertiesEditor';
 import VariablesList from '../../VariablesList';
 import getObjectByName from '../../Utils/GetObjectByName';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../UI/IconButton';
 import { Line, Column } from '../../UI/Grid';
 
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';

--- a/newIDE/app/src/LayersList/BackgroundColorRow.js
+++ b/newIDE/app/src/LayersList/BackgroundColorRow.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 
 import styles from './styles';
 import ThemeConsumer from '../UI/Theme/ThemeConsumer';

--- a/newIDE/app/src/LayersList/BackgroundColorRow.js
+++ b/newIDE/app/src/LayersList/BackgroundColorRow.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../UI/Table';
 import TextField from '../UI/TextField';
 
 import styles from './styles';

--- a/newIDE/app/src/LayersList/LayerRemoveDialog.js
+++ b/newIDE/app/src/LayersList/LayerRemoveDialog.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';

--- a/newIDE/app/src/LayersList/LayerRemoveDialog.js
+++ b/newIDE/app/src/LayersList/LayerRemoveDialog.js
@@ -2,8 +2,8 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import enumerateLayers from './EnumerateLayers';
 
 export default class VariablesEditorDialog extends Component {

--- a/newIDE/app/src/LayersList/LayerRemoveDialog.js
+++ b/newIDE/app/src/LayersList/LayerRemoveDialog.js
@@ -28,15 +28,18 @@ export default class VariablesEditorDialog extends Component {
 
     const actions = [
       <FlatButton
+        key="cancel"
         label={<Trans>Cancel</Trans>}
         keyboardFocused={true}
         onClick={() => this.props.onClose(false)}
       />,
       <FlatButton
+        key="remove"
         label={<Trans>Remove objects</Trans>}
         onClick={() => this.props.onClose(true, null)}
       />,
       <FlatButton
+        key="move"
         label={<Trans>Move objects</Trans>}
         primary={true}
         onClick={() => this.props.onClose(true, this.state.selectedLayer)}

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -9,7 +9,7 @@ import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
 import IconButton from 'material-ui/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import TextField from 'material-ui/TextField';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import DragHandle from '../UI/DragHandle';
 import styles from './styles';
 import ThemeConsumer from '../UI/Theme/ThemeConsumer';

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -8,7 +8,7 @@ import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
 import IconButton from 'material-ui/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import FlatButton from '../UI/FlatButton';
 import DragHandle from '../UI/DragHandle';
 import styles from './styles';

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -6,7 +6,7 @@ import { TableRow, TableRowColumn } from 'material-ui/Table';
 import InlineCheckbox from '../UI/InlineCheckbox';
 import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import TextField from '../UI/TextField';
 import FlatButton from '../UI/FlatButton';

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../UI/Table';
 import InlineCheckbox from '../UI/InlineCheckbox';
 import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';

--- a/newIDE/app/src/LayersList/index.js
+++ b/newIDE/app/src/LayersList/index.js
@@ -18,7 +18,7 @@ import EffectsListDialog from '../EffectsList/EffectsListDialog';
 import BackgroundColorRow from './BackgroundColorRow';
 import { Column, Line } from '../UI/Grid';
 import Add from 'material-ui/svg-icons/content/add';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 
 const SortableLayerRow = SortableElement(LayerRow);
 

--- a/newIDE/app/src/LayersList/index.js
+++ b/newIDE/app/src/LayersList/index.js
@@ -8,7 +8,7 @@ import {
   TableHeaderColumn,
   TableRow,
   TableRowColumn,
-} from 'material-ui/Table';
+} from '../UI/Table';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import { mapReverseFor } from '../Utils/MapFor';

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -8,7 +8,7 @@ import FlatButton from '../UI/FlatButton';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import { Column, Line } from '../UI/Grid';
 import Window from '../Utils/Window';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';
 import PreferencesContext from './Preferences/PreferencesContext';
 import {

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import React, { PureComponent } from 'react';
 import { List, ListItem } from 'material-ui/List';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import { Column, Line } from '../UI/Grid';
 import Window from '../Utils/Window';

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -173,10 +173,12 @@ export default class AboutDialog extends PureComponent<Props, *> {
                 <Tab label={<Trans>About GDevelop</Trans>} value="about">
                   <Column>
                     <Line>
-                      <Trans>
-                        GDevelop {getIDEVersion()} based on GDevelop.js{' '}
-                        {getGDCoreVersion()}
-                      </Trans>
+                      <Text>
+                        <Trans>
+                          GDevelop {getIDEVersion()} based on GDevelop.js{' '}
+                          {getGDCoreVersion()}
+                        </Trans>
+                      </Text>
                     </Line>
                     <Line>{updateStatusString}</Line>
                     <Line justifyContent="center">

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -9,6 +9,7 @@ import { Tabs, Tab } from '../UI/Tabs';
 import { Column, Line } from '../UI/Grid';
 import Window from '../Utils/Window';
 import IconButton from '../UI/IconButton';
+import Text from '../UI/Text';
 import OpenInNew from 'material-ui/svg-icons/action/open-in-new';
 import PreferencesContext from './Preferences/PreferencesContext';
 import {
@@ -197,14 +198,14 @@ export default class AboutDialog extends PureComponent<Props, *> {
                 </Tab>
                 <Tab label={<Trans>Contributors</Trans>} value="contributors">
                   <Column>
-                    <p>
+                    <Text>
                       <Trans>
                         GDevelop was created by Florian "4ian" Rival.
                       </Trans>
-                    </p>
-                    <p>
+                    </Text>
+                    <Text>
                       <Trans>Contributors, in no particular order:</Trans>
-                    </p>
+                    </Text>
                   </Column>
                   <List>
                     {contributors.map(contributor => (
@@ -230,13 +231,13 @@ export default class AboutDialog extends PureComponent<Props, *> {
                     ))}
                   </List>
                   <Column expand>
-                    <p>
+                    <Text>
                       <Trans>
                         Thanks to all users of GDevelop! There must be missing
                         tons of people, please send your name if you've
                         contributed and you're not listed.
                       </Trans>
-                    </p>
+                    </Text>
                     <Line alignItems="center" justifyContent="center">
                       <FlatButton
                         label={<Trans>Contribute to GDevelop</Trans>}

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { PureComponent } from 'react';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
 import { Tabs, Tab } from '../UI/Tabs';

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -139,11 +139,13 @@ export default class AboutDialog extends PureComponent<Props, *> {
       <Dialog
         actions={[
           <FlatButton
+            key="website"
             label={<Trans>GDevelop Website</Trans>}
             primary={false}
             onClick={() => Window.openExternalURL('http://gdevelop-app.com')}
           />,
           <FlatButton
+            key="close"
             label={<Trans>Close</Trans>}
             primary={false}
             onClick={onClose}

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import { List, ListItem } from 'material-ui/List';
 import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../UI/Tabs';
 import { Column, Line } from '../UI/Grid';
 import Window from '../Utils/Window';
 import IconButton from '../UI/IconButton';

--- a/newIDE/app/src/MainFrame/BrowserIntroDialog.js
+++ b/newIDE/app/src/MainFrame/BrowserIntroDialog.js
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
 import Window from '../Utils/Window';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 
 export default class BetaIntroDialog extends Component {
   _onOpenWebsite() {

--- a/newIDE/app/src/MainFrame/BrowserIntroDialog.js
+++ b/newIDE/app/src/MainFrame/BrowserIntroDialog.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
 import Window from '../Utils/Window';
 import FlatButton from '../UI/FlatButton';
+import Text from '../UI/Text';
 
 export default class BetaIntroDialog extends Component {
   _onOpenWebsite() {
@@ -29,22 +30,22 @@ export default class BetaIntroDialog extends Component {
     return (
       <Dialog actions={actions} open={open} onRequestClose={onClose}>
         <div>
-          <p>
+          <Text>
             <Trans>
               This is a version of GDevelop 5 that you can try online.
             </Trans>
-          </p>
-          <p>
+          </Text>
+          <Text>
             Choose a <b>new project to create</b> and then <b>open the scene</b>{' '}
             to make changes to the game. You can{' '}
             <b>launch a preview of your game</b> at any time!
-          </p>
-          <p>
+          </Text>
+          <Text>
             <Trans>
               Download the full version of GDevelop to create your own game
               without limits!
             </Trans>
-          </p>
+          </Text>
         </div>
       </Dialog>
     );

--- a/newIDE/app/src/MainFrame/BrowserIntroDialog.js
+++ b/newIDE/app/src/MainFrame/BrowserIntroDialog.js
@@ -13,11 +13,17 @@ export default class BetaIntroDialog extends Component {
     const { open, onClose } = this.props;
     const actions = [
       <FlatButton
+        key="download"
         label={<Trans>Download full GDevelop desktop version</Trans>}
         primary={false}
         onClick={this._onOpenWebsite}
       />,
-      <FlatButton label={<Trans>Ok</Trans>} primary={true} onClick={onClose} />,
+      <FlatButton
+        label={<Trans>Ok</Trans>}
+        primary={true}
+        onClick={onClose}
+        key="close"
+      />,
     ];
 
     return (

--- a/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
+++ b/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import Changelog from '.';
 
 type Props = {|

--- a/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
+++ b/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
@@ -5,6 +5,7 @@ import * as React from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
 import Changelog from '.';
+import Text from '../../UI/Text';
 
 type Props = {|
   open: boolean,
@@ -39,11 +40,11 @@ export default class ChangelogDialog extends React.Component<Props, State> {
         autoScrollBodyContent
         modal
       >
-        <p>
+        <Text>
           <Trans>
             GDevelop was upgraded to a new version! Check out the changes.
           </Trans>
-        </p>
+        </Text>
         <Changelog
           onUpdated={() => {
             this.forceUpdate(); /*Force update to ensure dialog is properly positionned*/

--- a/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
+++ b/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
@@ -23,6 +23,7 @@ export default class ChangelogDialog extends React.Component<Props, State> {
 
     const actions = [
       <FlatButton
+        key="close"
         label={<Trans>Close</Trans>}
         primary={true}
         onClick={onClose}

--- a/newIDE/app/src/MainFrame/Editors/ExternalEventsEditor.js
+++ b/newIDE/app/src/MainFrame/Editors/ExternalEventsEditor.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import React from 'react';
 import EventsSheet from '../../EventsSheet';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import { serializeToJSObject } from '../../Utils/Serializer';
 import PlaceholderMessage from '../../UI/PlaceholderMessage';
 import BaseEditor from './BaseEditor';

--- a/newIDE/app/src/MainFrame/Editors/ExternalLayoutEditor.js
+++ b/newIDE/app/src/MainFrame/Editors/ExternalLayoutEditor.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../UI/RaisedButton';
 import SceneEditor from '../../SceneEditor';
 import {
   serializeToJSObject,

--- a/newIDE/app/src/MainFrame/Editors/LayoutChooserDialog.js
+++ b/newIDE/app/src/MainFrame/Editors/LayoutChooserDialog.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 import Dialog from '../../UI/Dialog';
 import { mapFor } from '../../Utils/MapFor';

--- a/newIDE/app/src/MainFrame/Editors/LayoutChooserDialog.js
+++ b/newIDE/app/src/MainFrame/Editors/LayoutChooserDialog.js
@@ -4,6 +4,7 @@ import FlatButton from '../../UI/FlatButton';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 import Dialog from '../../UI/Dialog';
 import { mapFor } from '../../Utils/MapFor';
+import Text from '../../UI/Text';
 
 export default class LayoutChooserDialog extends Component {
   constructor(props) {
@@ -60,7 +61,7 @@ export default class LayoutChooserDialog extends Component {
         autoScrollBodyContent={true}
         contentStyle={{ width: '350px' }}
       >
-        {this.props.helpText && <p>{this.props.helpText}</p>}
+        {this.props.helpText && <Text>{this.props.helpText}</Text>}
         <RadioButtonGroup
           name="associated-layout"
           valueSelected={selectedLayoutName}

--- a/newIDE/app/src/MainFrame/Editors/LayoutChooserDialog.js
+++ b/newIDE/app/src/MainFrame/Editors/LayoutChooserDialog.js
@@ -30,11 +30,13 @@ export default class LayoutChooserDialog extends Component {
   render() {
     const actions = [
       <FlatButton
+        key="cancel"
         label={<Trans>Cancel</Trans>}
         primary={false}
         onClick={this.props.onClose}
       />,
       <FlatButton
+        key="choose"
         label={<Trans>Choose</Trans>}
         primary={true}
         keyboardFocused={true}

--- a/newIDE/app/src/MainFrame/Editors/StartPage/GDevelopLogo.js
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/GDevelopLogo.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import muiThemeable from 'material-ui/styles/muiThemeable';
+import ThemeConsumer from '../../../UI/Theme/ThemeConsumer';
 
 const styles = {
   logo: {
@@ -8,9 +8,10 @@ const styles = {
   },
 };
 
-const ThemableGDevelopLogo = ({ muiTheme }) => (
-  <img src={muiTheme.logo.src} alt="" style={styles.logo} />
+const GDevelopLogo = () => (
+  <ThemeConsumer>
+    {muiTheme => <img src={muiTheme.logo.src} alt="" style={styles.logo} />}
+  </ThemeConsumer>
 );
 
-const GDevelopLogo = muiThemeable()(ThemableGDevelopLogo);
 export default GDevelopLogo;

--- a/newIDE/app/src/MainFrame/Editors/StartPage/ScrollBackground.js
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/ScrollBackground.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import muiThemeable from 'material-ui/styles/muiThemeable';
+import ThemeConsumer from '../../../UI/Theme/ThemeConsumer';
 
 const styles = {
   scrollContainer: {
@@ -10,16 +10,23 @@ const styles = {
   },
 };
 
-const ThemableScrollBackground = ({ muiTheme, children }) => (
-  <div
-    style={{
-      ...styles.scrollContainer,
-      backgroundColor: muiTheme.palette.canvasColor,
-    }}
-  >
-    {children}
-  </div>
+type Props = {|
+  children: React.Node,
+|};
+
+const ScrollBackground = ({ children }: Props) => (
+  <ThemeConsumer>
+    {muiTheme => (
+      <div
+        style={{
+          ...styles.scrollContainer,
+          backgroundColor: muiTheme.palette.canvasColor,
+        }}
+      >
+        {children}
+      </div>
+    )}
+  </ThemeConsumer>
 );
 
-const ScrollBackground = muiThemeable()(ThemableScrollBackground);
 export default ScrollBackground;

--- a/newIDE/app/src/MainFrame/Editors/StartPage/StartPage.spec.js
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/StartPage.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import defaultTheme from '../../../UI/Theme/DefaultTheme';
 import StartPage from '.';
 import { I18nProvider } from '@lingui/react';
@@ -12,9 +12,9 @@ describe('StartPage', () => {
     const tree = renderer
       .create(
         <I18nProvider language="en">
-          <MuiThemeProvider muiTheme={defaultTheme}>
+          <V0MuiThemeProvider muiTheme={defaultTheme}>
             <StartPage project={null} />
-          </MuiThemeProvider>
+          </V0MuiThemeProvider>
         </I18nProvider>
       )
       .toJSON();
@@ -26,9 +26,9 @@ describe('StartPage', () => {
     const tree = renderer
       .create(
         <I18nProvider language="en">
-          <MuiThemeProvider muiTheme={defaultTheme}>
+          <V0MuiThemeProvider muiTheme={defaultTheme}>
             <StartPage project={project} />
-          </MuiThemeProvider>
+          </V0MuiThemeProvider>
         </I18nProvider>
       )
       .toJSON();

--- a/newIDE/app/src/MainFrame/Editors/StartPage/__snapshots__/StartPage.spec.js.snap
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/__snapshots__/StartPage.spec.js.snap
@@ -73,9 +73,9 @@ exports[`StartPage renders the start page with a project 1`] = `
               }
             }
           />
-          <Text>
+          <p>
             GDevelop is an easy-to-use game creator with no programming language to learn.
-          </Text>
+          </p>
         </div>
         <div
           style={

--- a/newIDE/app/src/MainFrame/Editors/StartPage/__snapshots__/StartPage.spec.js.snap
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/__snapshots__/StartPage.spec.js.snap
@@ -73,9 +73,9 @@ exports[`StartPage renders the start page with a project 1`] = `
               }
             }
           />
-          <p>
+          <Text>
             GDevelop is an easy-to-use game creator with no programming language to learn.
-          </p>
+          </Text>
         </div>
         <div
           style={

--- a/newIDE/app/src/MainFrame/Editors/StartPage/index.js
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/index.js
@@ -5,7 +5,7 @@ import { I18n } from '@lingui/react';
 import React from 'react';
 import FlatButton from '../../../UI/FlatButton';
 import Paper from 'material-ui/Paper';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../UI/IconButton';
 import Language from 'material-ui/svg-icons/action/language';
 import BaseEditor from '../BaseEditor';
 import Window from '../../../Utils/Window';

--- a/newIDE/app/src/MainFrame/Editors/StartPage/index.js
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/index.js
@@ -12,7 +12,7 @@ import Window from '../../../Utils/Window';
 import { Line } from '../../../UI/Grid';
 import GDevelopLogo from './GDevelopLogo';
 import ScrollBackground from './ScrollBackground';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../../UI/RaisedButton';
 
 const styles = {
   innerContainer: {

--- a/newIDE/app/src/MainFrame/Editors/StartPage/index.js
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 
 import React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../UI/FlatButton';
 import Paper from 'material-ui/Paper';
 import IconButton from 'material-ui/IconButton';
 import Language from 'material-ui/svg-icons/action/language';

--- a/newIDE/app/src/MainFrame/Editors/StartPage/index.js
+++ b/newIDE/app/src/MainFrame/Editors/StartPage/index.js
@@ -13,6 +13,7 @@ import { Line } from '../../../UI/Grid';
 import GDevelopLogo from './GDevelopLogo';
 import ScrollBackground from './ScrollBackground';
 import RaisedButton from '../../../UI/RaisedButton';
+import Text from '../../../UI/Text';
 
 const styles = {
   innerContainer: {
@@ -83,12 +84,12 @@ class StartPage extends BaseEditor {
                     }}
                   >
                     <GDevelopLogo />
-                    <p>
+                    <Text>
                       <Trans>
                         GDevelop is an easy-to-use game creator with no
                         programming language to learn.
                       </Trans>
-                    </p>
+                    </Text>
                   </Paper>
                   {!project && canOpen && (
                     <RaisedButton

--- a/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
@@ -2,9 +2,9 @@
 import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
+import SelectField from '../../UI/SelectField';
 import FlatButton from '../../UI/FlatButton';
-import MenuItem from 'material-ui/MenuItem';
+import MenuItem from '../../UI/MenuItem';
 import Dialog from '../../UI/Dialog';
 import { Column, Line } from '../../UI/Grid';
 import Window from '../../Utils/Window';
@@ -125,7 +125,7 @@ export default class LanguageDialog extends Component<Props, State> {
                           <Trans>Choose GDevelop language</Trans>
                         }
                         value={values.language}
-                        onChange={(e, i, value) => {
+                        onChange={(e, i, value: string) => {
                           setLanguage(value);
                           this.setState({
                             languageDidChange: true,

--- a/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import SelectField from 'material-ui/SelectField';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import MenuItem from 'material-ui/MenuItem';
 import Dialog from '../../UI/Dialog';
 import { Column, Line } from '../../UI/Grid';
@@ -87,7 +87,9 @@ export default class LanguageDialog extends Component<Props, State> {
                         )
                       }
                       primary={false}
-                      onClick={onClose}
+                      onClick={() => {
+                        onClose(false);
+                      }}
                       disabled={isLoadingLanguage}
                     />,
                   ]}

--- a/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
@@ -91,6 +91,7 @@ export default class LanguageDialog extends Component<Props, State> {
                         onClose(false);
                       }}
                       disabled={isLoadingLanguage}
+                      key="close"
                     />,
                   ]}
                   secondaryActions={[

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -2,9 +2,9 @@
 import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
+import SelectField from '../../UI/SelectField';
 import FlatButton from '../../UI/FlatButton';
-import MenuItem from 'material-ui/MenuItem';
+import MenuItem from '../../UI/MenuItem';
 import Toggle from 'material-ui/Toggle';
 import Dialog from '../../UI/Dialog';
 import EmptyMessage from '../../UI/EmptyMessage';
@@ -80,7 +80,7 @@ export default class PreferencesDialog extends Component<Props, State> {
                   <SelectField
                     floatingLabelText={<Trans>UI Theme</Trans>}
                     value={values.themeName}
-                    onChange={(e, i, value) => setThemeName(value)}
+                    onChange={(e, i, value: string) => setThemeName(value)}
                   >
                     {Object.keys(themes).map(themeName => (
                       <MenuItem
@@ -93,7 +93,7 @@ export default class PreferencesDialog extends Component<Props, State> {
                   <SelectField
                     floatingLabelText={<Trans>Code editor Theme</Trans>}
                     value={values.codeEditorThemeName}
-                    onChange={(e, i, value) => setCodeEditorThemeName(value)}
+                    onChange={(e, i, value: string) => setCodeEditorThemeName(value)}
                   >
                     {getAllThemes().map(codeEditorTheme => (
                       <MenuItem

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import SelectField from 'material-ui/SelectField';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../UI/FlatButton';
 import MenuItem from 'material-ui/MenuItem';
 import Toggle from 'material-ui/Toggle';
 import Dialog from '../../UI/Dialog';

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -93,7 +93,9 @@ export default class PreferencesDialog extends Component<Props, State> {
                   <SelectField
                     floatingLabelText={<Trans>Code editor Theme</Trans>}
                     value={values.codeEditorThemeName}
-                    onChange={(e, i, value: string) => setCodeEditorThemeName(value)}
+                    onChange={(e, i, value: string) =>
+                      setCodeEditorThemeName(value)
+                    }
                   >
                     {getAllThemes().map(codeEditorTheme => (
                       <MenuItem

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import SelectField from '../../UI/SelectField';
 import FlatButton from '../../UI/FlatButton';
 import MenuItem from '../../UI/MenuItem';
-import Toggle from 'material-ui/Toggle';
+import Toggle from '../../UI/Toggle';
 import Dialog from '../../UI/Dialog';
 import EmptyMessage from '../../UI/EmptyMessage';
 import { Column, Line } from '../../UI/Grid';

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -15,6 +15,7 @@ import Window from '../../Utils/Window';
 import PreferencesContext, {
   type AlertMessageIdentifier,
 } from './PreferencesContext';
+import Text from '../../UI/Text';
 
 type Props = {|
   open: boolean,
@@ -107,13 +108,13 @@ export default class PreferencesDialog extends Component<Props, State> {
                   </SelectField>
                 </Line>
                 <Line noMargin>
-                  <p>
+                  <Text>
                     You can contribute and create your own themes:{' '}
                     <FlatButton
                       label={<Trans>Learn more</Trans>}
                       onClick={this.createTheme}
                     />{' '}
-                  </p>
+                  </Text>
                 </Line>
                 <Line>
                   <Toggle
@@ -173,12 +174,12 @@ export default class PreferencesDialog extends Component<Props, State> {
                 <Line>
                   {dismissedAlertMessages.length ? (
                     <Column noMargin>
-                      <p>
+                      <Text>
                         <Trans>
                           You have dismissed some hints. Click to enable them
                           again:
                         </Trans>
-                      </p>
+                      </Text>
                       {dismissedAlertMessages.map(name => (
                         <FlatButton
                           label={name}

--- a/newIDE/app/src/MainFrame/Providers.js
+++ b/newIDE/app/src/MainFrame/Providers.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import DragDropContextProvider from '../Utils/DragDropHelpers/DragDropContextProvider';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { getTheme } from '../UI/Theme';
 import UserProfileProvider from '../Profile/UserProfileProvider';
 import Authentification from '../Utils/GDevelopServices/Authentification';
@@ -52,7 +52,7 @@ export default class Providers extends React.Component<Props, {||}> {
           <PreferencesContext.Consumer>
             {({ values }) => (
               <GDI18nProvider language={values.language}>
-                <MuiThemeProvider muiTheme={getTheme(values.themeName)}>
+                <V0MuiThemeProvider muiTheme={getTheme(values.themeName)}>
                   <UserProfileProvider authentification={authentification}>
                     <I18n update>
                       {({ i18n }) => (
@@ -75,7 +75,7 @@ export default class Providers extends React.Component<Props, {||}> {
                       )}
                     </I18n>
                   </UserProfileProvider>
-                </MuiThemeProvider>
+                </V0MuiThemeProvider>
               </GDI18nProvider>
             )}
           </PreferencesContext.Consumer>

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import './MainFrame.css';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import Drawer from 'material-ui/Drawer';
 import Snackbar from 'material-ui/Snackbar';
 import NavigationClose from 'material-ui/svg-icons/navigation/close';

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -19,7 +19,7 @@ import CloseConfirmDialog from '../UI/CloseConfirmDialog';
 import ProfileDialog from '../Profile/ProfileDialog';
 import Window from '../Utils/Window';
 import { showErrorBox } from '../UI/Messages/MessageBox';
-import { Tabs, Tab } from '../UI/Tabs';
+import { Tabs, Tab } from '../UI/ClosableTabs';
 import {
   getEditorTabsInitialState,
   openEditorTab,

--- a/newIDE/app/src/ObjectEditor/Editors/PanelSpriteEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/PanelSpriteEditor.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../UI/Checkbox';
 import { Line, Column } from '../../UI/Grid';
 import ResourceSelectorWithThumbnail from '../../ResourcesList/ResourceSelectorWithThumbnail';
 import { type EditorProps } from './EditorProps.flow';

--- a/newIDE/app/src/ObjectEditor/Editors/ParticleEmitterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ParticleEmitterEditor.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../UI/Checkbox';
 import SelectField from '../../UI/SelectField';
 import MenuItem from '../../UI/MenuItem';
 import { Line, Column } from '../../UI/Grid';

--- a/newIDE/app/src/ObjectEditor/Editors/ParticleEmitterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ParticleEmitterEditor.js
@@ -3,8 +3,8 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Checkbox from 'material-ui/Checkbox';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../UI/SelectField';
+import MenuItem from '../../UI/MenuItem';
 import { Line, Column } from '../../UI/Grid';
 import ColorField from '../../UI/ColorField';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
@@ -34,7 +34,7 @@ export default class ParticleEmitterEditor extends React.Component<
               fullWidth
               floatingLabelText={<Trans>Particles kind</Trans>}
               value={particleEmitterObject.getRendererType()}
-              onChange={(e, i, value) => {
+              onChange={(e, i, value: number) => {
                 particleEmitterObject.setRendererType(value);
                 if (value !== gd.ParticleEmitterObject.Quad) {
                   particleEmitterObject.setParticleTexture('');

--- a/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../UI/Checkbox';
 import { Line, Column, Spacer } from '../../UI/Grid';
 import ColorField from '../../UI/ColorField';
 import { type EditorProps } from './EditorProps.flow';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -8,7 +8,7 @@ import Replay from 'material-ui/svg-icons/av/replay';
 import PlayArrow from 'material-ui/svg-icons/av/play-arrow';
 import Pause from 'material-ui/svg-icons/av/pause';
 import Timer from 'material-ui/svg-icons/image/timer';
-import TextField from 'material-ui/TextField';
+import TextField from '../../../../UI/TextField';
 import { FlatButton } from 'material-ui';
 
 type Props = {|

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddPolygonRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddPolygonRow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
 import Add from 'material-ui/svg-icons/content/add';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../../UI/IconButton';
 import styles from './styles';
 
 const AddPolygonRow = ({ onAdd }) => (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddPolygonRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddPolygonRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../../../../UI/Table';
 import Add from 'material-ui/svg-icons/content/add';
 import IconButton from '../../../../UI/IconButton';
 import styles from './styles';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddVerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddVerticeRow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../../UI/IconButton';
 import styles from './styles';
 
 const AddVerticeRow = ({ onAdd }) => (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddVerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/AddVerticeRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../../../../UI/Table';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import IconButton from '../../../../UI/IconButton';
 import styles from './styles';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonRow.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonRow.js
@@ -2,44 +2,42 @@ import React from 'react';
 import { TableRow, TableRowColumn } from '../../../../UI/Table';
 import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';
+import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
 
-const ThemablePolygonRow = ({
-  onRemove,
-  isConvex,
-  verticesCount,
-  muiTheme,
-}) => {
+const PolygonRow = ({ onRemove, isConvex, verticesCount }) => {
   return (
-    <TableRow
-      style={{
-        backgroundColor: muiTheme.list.itemsBackgroundColor,
-      }}
-    >
-      <TableRowColumn style={styles.handleColumn}>
-        {/* <DragHandle /> Reordering polygons is not supported for now */}
-      </TableRowColumn>
-      {isConvex && (
-        <TableRowColumn>
-          {verticesCount === 3 && `Triangle`}
-          {verticesCount === 4 && `Quadrilateral`}
-          {verticesCount >= 5 && `Polygon with ${verticesCount} vertices`}
-        </TableRowColumn>
+    <ThemeConsumer>
+      {muiTheme => (
+        <TableRow
+          style={{
+            backgroundColor: muiTheme.list.itemsBackgroundColor,
+          }}
+        >
+          <TableRowColumn style={styles.handleColumn}>
+            {/* <DragHandle /> Reordering polygons is not supported for now */}
+          </TableRowColumn>
+          {isConvex && (
+            <TableRowColumn>
+              {verticesCount === 3 && `Triangle`}
+              {verticesCount === 4 && `Quadrilateral`}
+              {verticesCount >= 5 && `Polygon with ${verticesCount} vertices`}
+            </TableRowColumn>
+          )}
+          {!isConvex && <TableRowColumn>Polygon is not convex!</TableRowColumn>}
+          <TableRowColumn style={styles.coordinateColumn} />
+          <TableRowColumn style={styles.coordinateColumn} />
+          <TableRowColumn style={styles.toolColumn}>
+            {!!onRemove && (
+              <IconButton onClick={onRemove}>
+                <Delete />
+              </IconButton>
+            )}
+          </TableRowColumn>
+        </TableRow>
       )}
-      {!isConvex && <TableRowColumn>Polygon is not convex!</TableRowColumn>}
-      <TableRowColumn style={styles.coordinateColumn} />
-      <TableRowColumn style={styles.coordinateColumn} />
-      <TableRowColumn style={styles.toolColumn}>
-        {!!onRemove && (
-          <IconButton onClick={onRemove}>
-            <Delete />
-          </IconButton>
-        )}
-      </TableRowColumn>
-    </TableRow>
+    </ThemeConsumer>
   );
 };
 
-const PointRow = muiThemeable()(ThemablePolygonRow);
-export default PointRow;
+export default PolygonRow;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../../../../UI/Table';
 import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import muiThemeable from 'material-ui/styles/muiThemeable';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
@@ -8,7 +8,7 @@ import {
   TableHeaderColumn,
   TableRow,
   TableRowColumn,
-} from 'material-ui/Table';
+} from '../../../../UI/Table';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import { mapVector } from '../../../../Utils/MapFor';
 import styles from './styles';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
 import IconButton from 'material-ui/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
-import TextField from 'material-ui/TextField';
+import TextField from '../../../../UI/TextField';
 import Warning from 'material-ui/svg-icons/alert/warning';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import TextField from '../../../../UI/TextField';
 import Warning from 'material-ui/svg-icons/alert/warning';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../../../../UI/Table';
 import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import TextField from '../../../../UI/TextField';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -4,10 +4,10 @@ import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import TextField from '../../../../UI/TextField';
 import Warning from 'material-ui/svg-icons/alert/warning';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';
+import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
 
-const ThemableVerticeRow = ({
+const VerticeRow = ({
   hasWarning,
   canRemove,
   onRemove,
@@ -15,42 +15,48 @@ const ThemableVerticeRow = ({
   verticeY,
   onChangeVerticeX,
   onChangeVerticeY,
-  muiTheme,
 }) => (
-  <TableRow
-    style={{
-      backgroundColor: muiTheme.list.itemsBackgroundColor,
-    }}
-  >
-    <TableRowColumn style={styles.handleColumn}>
-      {/* <DragHandle /> Reordering vertices is not supported for now */}
-    </TableRowColumn>
-    <TableRowColumn>{hasWarning && <Warning />}</TableRowColumn>
-    <TableRowColumn style={styles.coordinateColumn}>
-      <TextField
-        value={verticeX}
-        type="number"
-        id="vertice-x"
-        onChange={(e, value) => onChangeVerticeX(parseFloat(value || 0, 10))}
-      />
-    </TableRowColumn>
-    <TableRowColumn style={styles.coordinateColumn}>
-      <TextField
-        value={verticeY}
-        type="number"
-        id="vertice-y"
-        onChange={(e, value) => onChangeVerticeY(parseFloat(value || 0, 10))}
-      />
-    </TableRowColumn>
-    <TableRowColumn style={styles.toolColumn}>
-      {!!onRemove && (
-        <IconButton onClick={onRemove} disabled={!canRemove}>
-          <Delete />
-        </IconButton>
-      )}
-    </TableRowColumn>
-  </TableRow>
+  <ThemeConsumer>
+    {muiTheme => (
+      <TableRow
+        style={{
+          backgroundColor: muiTheme.list.itemsBackgroundColor,
+        }}
+      >
+        <TableRowColumn style={styles.handleColumn}>
+          {/* <DragHandle /> Reordering vertices is not supported for now */}
+        </TableRowColumn>
+        <TableRowColumn>{hasWarning && <Warning />}</TableRowColumn>
+        <TableRowColumn style={styles.coordinateColumn}>
+          <TextField
+            value={verticeX}
+            type="number"
+            id="vertice-x"
+            onChange={(e, value) =>
+              onChangeVerticeX(parseFloat(value || 0, 10))
+            }
+          />
+        </TableRowColumn>
+        <TableRowColumn style={styles.coordinateColumn}>
+          <TextField
+            value={verticeY}
+            type="number"
+            id="vertice-y"
+            onChange={(e, value) =>
+              onChangeVerticeY(parseFloat(value || 0, 10))
+            }
+          />
+        </TableRowColumn>
+        <TableRowColumn style={styles.toolColumn}>
+          {!!onRemove && (
+            <IconButton onClick={onRemove} disabled={!canRemove}>
+              <Delete />
+            </IconButton>
+          )}
+        </TableRowColumn>
+      </TableRow>
+    )}
+  </ThemeConsumer>
 );
 
-const PointRow = muiThemeable()(ThemableVerticeRow);
-export default PointRow;
+export default VerticeRow;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../../UI/FlatButton';
 import EmptyMessage from '../../../../UI/EmptyMessage';
 import { Line, Column } from '../../../../UI/Grid';
 import { mapFor } from '../../../../Utils/MapFor';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Timer from 'material-ui/svg-icons/image/timer';
 import FlatButton from '../../../UI/FlatButton';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../../UI/Checkbox';
 import Repeat from 'material-ui/svg-icons/av/repeat';
 import Brush from 'material-ui/svg-icons/image/brush';
 import PlayArrow from 'material-ui/svg-icons/av/play-arrow';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -8,7 +8,7 @@ import Checkbox from 'material-ui/Checkbox';
 import Repeat from 'material-ui/svg-icons/av/repeat';
 import Brush from 'material-ui/svg-icons/image/brush';
 import PlayArrow from 'material-ui/svg-icons/av/play-arrow';
-import TextField from 'material-ui/TextField';
+import TextField from '../../../UI/TextField';
 import Dialog from '../../../UI/Dialog';
 import AnimationPreview from './AnimationPreview';
 import ResourcesLoader from '../../../ResourcesLoader';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import Timer from 'material-ui/svg-icons/image/timer';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../UI/FlatButton';
 import Checkbox from 'material-ui/Checkbox';
 import Repeat from 'material-ui/svg-icons/av/repeat';
 import Brush from 'material-ui/svg-icons/image/brush';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -156,6 +156,7 @@ export default class DirectionTools extends Component<Props, State> {
                 label={<Trans>OK</Trans>}
                 primary
                 onClick={() => this.openPreview(false)}
+                key="ok"
               />
             }
             autoScrollBodyContent

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/AddPointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/AddPointRow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
 import Add from 'material-ui/svg-icons/content/add';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../../UI/IconButton';
 import styles from './styles';
 
 const AddPointRow = ({ onAdd }) => (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/AddPointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/AddPointRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../../../../UI/Table';
 import Add from 'material-ui/svg-icons/content/add';
 import IconButton from '../../../../UI/IconButton';
 import styles from './styles';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -4,7 +4,7 @@ import { TableRow, TableRowColumn } from 'material-ui/Table';
 import IconButton from 'material-ui/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import ModeEdit from 'material-ui/svg-icons/editor/mode-edit';
-import TextField from 'material-ui/TextField';
+import TextField from '../../../../UI/TextField';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React from 'react';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import ModeEdit from 'material-ui/svg-icons/editor/mode-edit';
 import TextField from '../../../../UI/TextField';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React from 'react';
-import { TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableRow, TableRowColumn } from '../../../../UI/Table';
 import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import ModeEdit from 'material-ui/svg-icons/editor/mode-edit';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -5,10 +5,10 @@ import IconButton from '../../../../UI/IconButton';
 import Delete from 'material-ui/svg-icons/action/delete';
 import ModeEdit from 'material-ui/svg-icons/editor/mode-edit';
 import TextField from '../../../../UI/TextField';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';
+import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
 
-const ThemablePointRow = ({
+const PointRow = ({
   pointName,
   nameError,
   onBlur,
@@ -19,68 +19,74 @@ const ThemablePointRow = ({
   onChangePointY,
   onEdit,
   isAutomatic,
-  muiTheme,
 }) => (
-  <TableRow
-    style={{
-      backgroundColor: muiTheme.list.itemsBackgroundColor,
-    }}
-  >
-    <TableRowColumn style={styles.handleColumn}>
-      {/* <DragHandle /> Reordering point is not supported for now */}
-    </TableRowColumn>
-    <TableRowColumn>
-      <TextField
-        defaultValue={pointName || 'Base layer'}
-        id={pointName}
-        fullWidth
-        errorText={nameError ? 'This name is already taken' : undefined}
-        disabled={!onBlur}
-        onBlur={onBlur}
-      />
-    </TableRowColumn>
-    <TableRowColumn style={styles.coordinateColumn}>
-      {!isAutomatic ? (
-        <TextField
-          value={pointX}
-          type="number"
-          id="point-x"
-          onChange={(e, value) => onChangePointX(parseFloat(value || 0, 10))}
-        />
-      ) : (
-        <p>
-          <Trans>(auto)</Trans>
-        </p>
-      )}
-    </TableRowColumn>
-    <TableRowColumn style={styles.coordinateColumn}>
-      {!isAutomatic ? (
-        <TextField
-          value={pointY}
-          type="number"
-          id="point-y"
-          onChange={(e, value) => onChangePointY(parseFloat(value || 0, 10))}
-        />
-      ) : (
-        <p>
-          <Trans>(auto)</Trans>
-        </p>
-      )}
-    </TableRowColumn>
-    <TableRowColumn style={styles.toolColumn}>
-      {!!onRemove && (
-        <IconButton onClick={onRemove}>
-          <Delete />
-        </IconButton>
-      )}
-      {!!onEdit && (
-        <IconButton onClick={onEdit}>
-          <ModeEdit />
-        </IconButton>
-      )}
-    </TableRowColumn>
-  </TableRow>
+  <ThemeConsumer>
+    {muiTheme => (
+      <TableRow
+        style={{
+          backgroundColor: muiTheme.list.itemsBackgroundColor,
+        }}
+      >
+        <TableRowColumn style={styles.handleColumn}>
+          {/* <DragHandle /> Reordering point is not supported for now */}
+        </TableRowColumn>
+        <TableRowColumn>
+          <TextField
+            defaultValue={pointName || 'Base layer'}
+            id={pointName}
+            fullWidth
+            errorText={nameError ? 'This name is already taken' : undefined}
+            disabled={!onBlur}
+            onBlur={onBlur}
+          />
+        </TableRowColumn>
+        <TableRowColumn style={styles.coordinateColumn}>
+          {!isAutomatic ? (
+            <TextField
+              value={pointX}
+              type="number"
+              id="point-x"
+              onChange={(e, value) =>
+                onChangePointX(parseFloat(value || 0, 10))
+              }
+            />
+          ) : (
+            <p>
+              <Trans>(auto)</Trans>
+            </p>
+          )}
+        </TableRowColumn>
+        <TableRowColumn style={styles.coordinateColumn}>
+          {!isAutomatic ? (
+            <TextField
+              value={pointY}
+              type="number"
+              id="point-y"
+              onChange={(e, value) =>
+                onChangePointY(parseFloat(value || 0, 10))
+              }
+            />
+          ) : (
+            <p>
+              <Trans>(auto)</Trans>
+            </p>
+          )}
+        </TableRowColumn>
+        <TableRowColumn style={styles.toolColumn}>
+          {!!onRemove && (
+            <IconButton onClick={onRemove}>
+              <Delete />
+            </IconButton>
+          )}
+          {!!onEdit && (
+            <IconButton onClick={onEdit}>
+              <ModeEdit />
+            </IconButton>
+          )}
+        </TableRowColumn>
+      </TableRow>
+    )}
+  </ThemeConsumer>
 );
 
-const PointRow = muiThemeable()(ThemablePointRow);
 export default PointRow;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -7,6 +7,7 @@ import ModeEdit from 'material-ui/svg-icons/editor/mode-edit';
 import TextField from '../../../../UI/TextField';
 import styles from './styles';
 import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
+import Text from '../../../../UI/Text';
 
 const PointRow = ({
   pointName,
@@ -51,9 +52,9 @@ const PointRow = ({
               }
             />
           ) : (
-            <p>
+            <Text>
               <Trans>(auto)</Trans>
-            </p>
+            </Text>
           )}
         </TableRowColumn>
         <TableRowColumn style={styles.coordinateColumn}>
@@ -67,9 +68,9 @@ const PointRow = ({
               }
             />
           ) : (
-            <p>
+            <Text>
               <Trans>(auto)</Trans>
-            </p>
+            </Text>
           )}
         </TableRowColumn>
         <TableRowColumn style={styles.toolColumn}>

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -6,7 +6,7 @@ import {
   TableHeaderColumn,
   TableRow,
   TableRowColumn,
-} from 'material-ui/Table';
+} from '../../../../UI/Table';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import newNameGenerator from '../../../../Utils/NewNameGenerator';
 import { mapVector } from '../../../../Utils/MapFor';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -23,7 +23,7 @@ import {
 } from '../../../ResourcesList/ResourceSource.flow';
 import { type ResourceExternalEditor } from '../../../ResourcesList/ResourceExternalEditor.flow';
 import { applyResourceDefaults } from '../../../ResourcesList/ResourceUtils';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../UI/FlatButton';
 const gd = global.gd;
 const path = require('path');
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteSelector.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteSelector.js
@@ -2,8 +2,8 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../../../../UI/SelectField';
+import MenuItem from '../../../../UI/MenuItem';
 
 import Toggle from 'material-ui/Toggle';
 import { Line } from '../../../../UI/Grid';
@@ -73,7 +73,7 @@ export default class SpriteSelector extends React.Component<Props, void> {
           <SelectField
             floatingLabelText={<Trans>Animation</Trans>}
             value={this.props.animationIndex}
-            onChange={(e, i, value) => chooseAnimation(value)}
+            onChange={(e, i, value: number) => chooseAnimation(value)}
           >
             {mapFor(0, spriteObject.getAnimationsCount(), i => {
               const animation = spriteObject.getAnimation(i);
@@ -90,7 +90,7 @@ export default class SpriteSelector extends React.Component<Props, void> {
             <SelectField
               floatingLabelText={<Trans>Direction</Trans>}
               value={this.props.directionIndex}
-              onChange={(e, i, value) => chooseDirection(value)}
+              onChange={(e, i, value: number) => chooseDirection(value)}
             >
               {mapFor(0, animation.getDirectionsCount(), i => {
                 return (
@@ -103,7 +103,7 @@ export default class SpriteSelector extends React.Component<Props, void> {
             <SelectField
               floatingLabelText={<Trans>Frame</Trans>}
               value={this.props.spriteIndex}
-              onChange={(e, i, value) => chooseSprite(value)}
+              onChange={(e, i, value: number) => chooseSprite(value)}
             >
               {mapFor(0, direction.getSpritesCount(), i => {
                 return (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteSelector.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteSelector.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import SelectField from '../../../../UI/SelectField';
 import MenuItem from '../../../../UI/MenuItem';
 
-import Toggle from 'material-ui/Toggle';
+import Toggle from '../../../../UI/Toggle';
 import { Line } from '../../../../UI/Grid';
 import { mapFor } from '../../../../Utils/MapFor';
 import { getCurrentElements } from './SpriteObjectHelper';
@@ -25,7 +25,7 @@ type Props = {|
   sameForAllSprites: boolean,
 
   setSameForAllAnimations: boolean => void,
-  setSameForAllSprites: number => void,
+  setSameForAllSprites: boolean => void,
 
   setSameForAllAnimationsLabel: string,
   setSameForAllSpritesLabel: string,

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -2,7 +2,6 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import { GridList, GridTile } from 'material-ui/GridList';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import SpritesList from './SpritesList';
 import Add from 'material-ui/svg-icons/content/add';
@@ -114,7 +113,7 @@ class Animation extends React.Component<AnimationProps, void> {
 
     const animationName = animation.getName();
     return (
-      <GridTile>
+      <div>
         <MiniToolbar smallest>
           <DragHandle />
           <span style={styles.animationTitle}>
@@ -155,7 +154,7 @@ class Animation extends React.Component<AnimationProps, void> {
             />
           );
         })}
-      </GridTile>
+      </div>
     );
   }
 }
@@ -181,7 +180,7 @@ const SortableAnimationsList = SortableContainer(
     onReplaceDirection,
   }) => {
     return (
-      <GridList style={styles.gridList} cellHeight="auto" cols={1}>
+      <div style={styles.gridList}>
         {[
           ...mapFor(0, spriteObject.getAnimationsCount(), i => {
             const animation = spriteObject.getAnimation(i);
@@ -216,7 +215,7 @@ const SortableAnimationsList = SortableContainer(
             extraTools={extraBottomTools}
           />,
         ]}
-      </GridList>
+      </div>
     );
   }
 );

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -7,7 +7,7 @@ import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import SpritesList from './SpritesList';
 import Add from 'material-ui/svg-icons/content/add';
 import Delete from 'material-ui/svg-icons/action/delete';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../../UI/IconButton';
 import FlatButton from '../../../UI/FlatButton';
 import RaisedButton from '../../../UI/RaisedButton';
 import { mapFor } from '../../../Utils/MapFor';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -9,7 +9,7 @@ import Add from 'material-ui/svg-icons/content/add';
 import Delete from 'material-ui/svg-icons/action/delete';
 import IconButton from 'material-ui/IconButton';
 import FlatButton from '../../../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../../../UI/RaisedButton';
 import { mapFor } from '../../../Utils/MapFor';
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import Dialog from '../../../UI/Dialog';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -8,7 +8,7 @@ import SpritesList from './SpritesList';
 import Add from 'material-ui/svg-icons/content/add';
 import Delete from 'material-ui/svg-icons/action/delete';
 import IconButton from 'material-ui/IconButton';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../../../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import { mapFor } from '../../../Utils/MapFor';
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../UI/Checkbox';
 import { Line, Column } from '../../UI/Grid';
 import ColorPicker from '../../UI/ColorField/ColorPicker';
 import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -1,7 +1,7 @@
 // @flow weak
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import ObjectsEditorService from './ObjectsEditorService';
 import Dialog from '../UI/Dialog';
 import HelpButton from '../UI/HelpButton';

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -6,7 +6,7 @@ import ObjectsEditorService from './ObjectsEditorService';
 import Dialog from '../UI/Dialog';
 import HelpButton from '../UI/HelpButton';
 import BehaviorsEditor from '../BehaviorsEditor';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../UI/Tabs';
 import { withSerializableObject } from '../Utils/SerializableObjectEditorContainer';
 
 import { Column, Line } from '../UI/Grid';

--- a/newIDE/app/src/ObjectGroupEditor/ObjectGroupEditorDialog.js
+++ b/newIDE/app/src/ObjectGroupEditor/ObjectGroupEditorDialog.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import ObjectGroupEditor from '.';
 import Dialog from '../UI/Dialog';
 import { withSerializableObject } from '../Utils/SerializableObjectEditorContainer';

--- a/newIDE/app/src/ObjectGroupEditor/ObjectGroupEditorDialog.js
+++ b/newIDE/app/src/ObjectGroupEditor/ObjectGroupEditorDialog.js
@@ -13,11 +13,13 @@ export class ObjectGroupEditorDialog extends Component {
 
     const actions = [
       <FlatButton
+        key="cancel"
         label={<Trans>Cancel</Trans>}
         keyboardFocused
         onClick={this.props.onCancel}
       />,
       <FlatButton
+        key="apply"
         label={<Trans>Apply</Trans>}
         primary
         keyboardFocused

--- a/newIDE/app/src/ObjectGroupEditor/index.js
+++ b/newIDE/app/src/ObjectGroupEditor/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import { List, ListItem } from 'material-ui/List';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import Remove from 'material-ui/svg-icons/content/remove';
 import ObjectSelector from '../ObjectsList/ObjectSelector';
 import EmptyMessage from '../UI/EmptyMessage';

--- a/newIDE/app/src/ObjectGroupEditor/index.js
+++ b/newIDE/app/src/ObjectGroupEditor/index.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import IconButton from '../UI/IconButton';
 import Remove from 'material-ui/svg-icons/content/remove';
 import ObjectSelector from '../ObjectsList/ObjectSelector';

--- a/newIDE/app/src/ObjectGroupsList/GroupRow.js
+++ b/newIDE/app/src/ObjectGroupsList/GroupRow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ListItem } from 'material-ui/List';
 import IconMenu from '../UI/Menu/IconMenu';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import TextField from '../UI/TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import ThemeConsumer from '../UI/Theme/ThemeConsumer';

--- a/newIDE/app/src/ObjectGroupsList/GroupRow.js
+++ b/newIDE/app/src/ObjectGroupsList/GroupRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ListItem } from 'material-ui/List';
 import IconMenu from '../UI/Menu/IconMenu';
 import IconButton from 'material-ui/IconButton';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import ThemeConsumer from '../UI/Theme/ThemeConsumer';
 

--- a/newIDE/app/src/ObjectGroupsList/GroupRow.js
+++ b/newIDE/app/src/ObjectGroupsList/GroupRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../UI/List';
 import IconMenu from '../UI/Menu/IconMenu';
 import IconButton from '../UI/IconButton';
 import TextField from '../UI/TextField';

--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -6,7 +6,7 @@ import { AutoSizer, List } from 'react-virtualized';
 import Background from '../UI/Background';
 import SearchBar from '../UI/SearchBar';
 import GroupRow from './GroupRow';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../UI/List';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import { makeAddItem } from '../UI/ListCommonItem';

--- a/newIDE/app/src/ObjectTypeSelector/index.js
+++ b/newIDE/app/src/ObjectTypeSelector/index.js
@@ -2,8 +2,8 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import {
   enumerateObjectTypes,
   type EnumeratedObjectMetadata,
@@ -47,7 +47,7 @@ export default class ObjectTypeSelector extends React.Component<Props, State> {
         floatingLabelText={floatingLabelText || <Trans>Object type</Trans>}
         floatingLabelFixed
         value={value}
-        onChange={(e, i, value) => {
+        onChange={(e, i, value: string) => {
           onChange(value);
         }}
         disabled={disabled}

--- a/newIDE/app/src/ObjectsList/NewObjectDialog.js
+++ b/newIDE/app/src/ObjectsList/NewObjectDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Avatar from 'material-ui/Avatar';
 import Subheader from 'material-ui/Subheader';
 import { List, ListItem } from 'material-ui/List';

--- a/newIDE/app/src/ObjectsList/NewObjectDialog.js
+++ b/newIDE/app/src/ObjectsList/NewObjectDialog.js
@@ -5,7 +5,7 @@ import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
 import Avatar from 'material-ui/Avatar';
 import Subheader from 'material-ui/Subheader';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
 import {

--- a/newIDE/app/src/ObjectsList/ObjectRow.js
+++ b/newIDE/app/src/ObjectsList/ObjectRow.js
@@ -3,7 +3,7 @@ import { ListItem } from 'material-ui/List';
 import IconMenu from '../UI/Menu/IconMenu';
 import ListIcon from '../UI/ListIcon';
 import IconButton from 'material-ui/IconButton';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import Clipboard from '../Utils/Clipboard';
 import { CLIPBOARD_KIND } from './ClipboardKind';

--- a/newIDE/app/src/ObjectsList/ObjectRow.js
+++ b/newIDE/app/src/ObjectsList/ObjectRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ListItem } from 'material-ui/List';
 import IconMenu from '../UI/Menu/IconMenu';
 import ListIcon from '../UI/ListIcon';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import TextField from '../UI/TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import Clipboard from '../Utils/Clipboard';

--- a/newIDE/app/src/ObjectsList/ObjectRow.js
+++ b/newIDE/app/src/ObjectsList/ObjectRow.js
@@ -7,8 +7,8 @@ import TextField from '../UI/TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import Clipboard from '../Utils/Clipboard';
 import { CLIPBOARD_KIND } from './ClipboardKind';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import { buildTagsMenuTemplate, getTagsFromString } from '../Utils/TagsHelper';
+import ThemeConsumer from '../UI/Theme/ThemeConsumer';
 
 const LEFT_MOUSE_BUTTON = 0;
 
@@ -37,7 +37,7 @@ const getPasteLabel = isGlobalObject => {
     : 'Paste ' + clipboardObjectName;
 };
 
-class ThemableObjectRow extends React.Component {
+class ObjectRow extends React.Component {
   _renderObjectMenu(object) {
     return (
       <IconMenu
@@ -128,80 +128,80 @@ class ThemableObjectRow extends React.Component {
   };
 
   render() {
-    const {
-      project,
-      object,
-      selected,
-      isGlobalObject,
-      style,
-      muiTheme,
-    } = this.props;
-
-    const objectName = object.getName();
-    const label = this.props.editingName ? (
-      <TextField
-        id="rename-object-field"
-        ref={textField => (this.textField = textField)}
-        defaultValue={objectName}
-        onBlur={e => this.props.onRename(e.target.value)}
-        onKeyPress={event => {
-          if (event.charCode === 13) {
-            // enter key pressed
-            this.textField.blur();
-          }
-        }}
-        fullWidth
-        style={styles.textField}
-      />
-    ) : (
-      <div
-        style={{
-          ...styles.objectName,
-          color: selected ? muiTheme.listItem.selectedTextColor : undefined,
-          fontStyle: isGlobalObject ? 'italic' : undefined,
-          fontWeight: isGlobalObject ? 'bold' : 'normal',
-        }}
-      >
-        {objectName}
-      </div>
-    );
-
-    const itemStyle = {
-      borderBottom: `1px solid ${muiTheme.listItem.separatorColor}`,
-      backgroundColor: selected
-        ? muiTheme.listItem.selectedBackgroundColor
-        : undefined,
-    };
+    const { project, object, selected, isGlobalObject, style } = this.props;
 
     return (
-      <ListItem
-        style={{ ...itemStyle, ...style }}
-        onContextMenu={this._onContextMenu}
-        primaryText={label}
-        leftIcon={
-          <ListIcon
-            iconSize={32}
-            src={this.props.getThumbnail(project, object)}
-          />
-        }
-        rightIconButton={this._renderObjectMenu(object)}
-        onClick={() => {
-          if (!this.props.onObjectSelected) return;
-          if (this.props.editingName) return;
-          this.props.onObjectSelected(selected ? '' : objectName);
-        }}
-        onDoubleClick={event => {
-          if (event.button !== LEFT_MOUSE_BUTTON) return;
-          if (!this.props.onEdit) return;
-          if (this.props.editingName) return;
+      <ThemeConsumer>
+        {muiTheme => {
+          const objectName = object.getName();
+          const label = this.props.editingName ? (
+            <TextField
+              id="rename-object-field"
+              ref={textField => (this.textField = textField)}
+              defaultValue={objectName}
+              onBlur={e => this.props.onRename(e.target.value)}
+              onKeyPress={event => {
+                if (event.charCode === 13) {
+                  // enter key pressed
+                  this.textField.blur();
+                }
+              }}
+              fullWidth
+              style={styles.textField}
+            />
+          ) : (
+            <div
+              style={{
+                ...styles.objectName,
+                color: selected
+                  ? muiTheme.listItem.selectedTextColor
+                  : undefined,
+                fontStyle: isGlobalObject ? 'italic' : undefined,
+                fontWeight: isGlobalObject ? 'bold' : 'normal',
+              }}
+            >
+              {objectName}
+            </div>
+          );
 
-          this.props.onObjectSelected('');
-          this.props.onEdit(object);
+          const itemStyle = {
+            borderBottom: `1px solid ${muiTheme.listItem.separatorColor}`,
+            backgroundColor: selected
+              ? muiTheme.listItem.selectedBackgroundColor
+              : undefined,
+          };
+
+          return (
+            <ListItem
+              style={{ ...itemStyle, ...style }}
+              onContextMenu={this._onContextMenu}
+              primaryText={label}
+              leftIcon={
+                <ListIcon
+                  iconSize={32}
+                  src={this.props.getThumbnail(project, object)}
+                />
+              }
+              rightIconButton={this._renderObjectMenu(object)}
+              onClick={() => {
+                if (!this.props.onObjectSelected) return;
+                if (this.props.editingName) return;
+                this.props.onObjectSelected(selected ? '' : objectName);
+              }}
+              onDoubleClick={event => {
+                if (event.button !== LEFT_MOUSE_BUTTON) return;
+                if (!this.props.onEdit) return;
+                if (this.props.editingName) return;
+
+                this.props.onObjectSelected('');
+                this.props.onEdit(object);
+              }}
+            />
+          );
         }}
-      />
+      </ThemeConsumer>
     );
   }
 }
 
-const ObjectRow = muiThemeable()(ThemableObjectRow);
 export default ObjectRow;

--- a/newIDE/app/src/ObjectsList/ObjectRow.js
+++ b/newIDE/app/src/ObjectsList/ObjectRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../UI/List';
 import IconMenu from '../UI/Menu/IconMenu';
 import ListIcon from '../UI/ListIcon';
 import IconButton from '../UI/IconButton';

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import { AutoSizer, List } from 'react-virtualized';
-import { ListItem } from 'material-ui/List';
+import { ListItem } from '../UI/List';
 import Background from '../UI/Background';
 import SearchBar from '../UI/SearchBar';
 import ObjectRow from './ObjectRow';

--- a/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
+++ b/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import Dialog from '../UI/Dialog';
 import { Line } from '../UI/Grid';

--- a/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
+++ b/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import Dialog from '../UI/Dialog';
 import { Line } from '../UI/Grid';
 import ResourcesLoader from '../ResourcesLoader';

--- a/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
+++ b/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
@@ -16,6 +16,7 @@ import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEd
 import { resizeImage, isResizeSupported } from './ImageResizer';
 import { showErrorBox } from '../UI/Messages/MessageBox';
 import optionalRequire from '../Utils/OptionalRequire';
+import Text from '../UI/Text';
 const path = optionalRequire('path');
 const gd = global.gd;
 
@@ -253,17 +254,17 @@ export default class PlatformSpecificAssetsDialog extends React.Component<
               onClick={this._generateFromFile}
             />
           ) : (
-            <p>
+            <Text>
               <Trans>
                 Download GDevelop desktop version to generate the Android and
                 iOS icons of your game.
               </Trans>
-            </p>
+            </Text>
           )}
         </Line>
-        <p>
+        <Text>
           <Trans>Desktop (Windows, macOS and Linux) icon:</Trans>
-        </p>
+        </Text>
         {desktopSizes.map((size, index) => (
           <ResourceSelectorWithThumbnail
             key={size}
@@ -283,9 +284,9 @@ export default class PlatformSpecificAssetsDialog extends React.Component<
             }}
           />
         ))}
-        <p>
+        <Text>
           <Trans>Android icons:</Trans>
-        </p>
+        </Text>
         {androidSizes.map((size, index) => (
           <ResourceSelectorWithThumbnail
             key={size}
@@ -305,9 +306,9 @@ export default class PlatformSpecificAssetsDialog extends React.Component<
             }}
           />
         ))}
-        <p>
+        <Text>
           <Trans>iOS (iPhone and iPad) icons:</Trans>
-        </p>
+        </Text>
         {iosSizes.map((size, index) => (
           <ResourceSelectorWithThumbnail
             key={size}

--- a/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
+++ b/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
@@ -213,11 +213,13 @@ export default class PlatformSpecificAssetsDialog extends React.Component<
   render() {
     const actions = [
       <FlatButton
+        key="cancel"
         label={<Trans>Cancel</Trans>}
         primary={false}
         onClick={this.props.onClose}
       />,
       <FlatButton
+        key="apply"
         label={<Trans>Apply</Trans>}
         primary={true}
         keyboardFocused={true}

--- a/newIDE/app/src/Profile/CreateProfile.js
+++ b/newIDE/app/src/Profile/CreateProfile.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 

--- a/newIDE/app/src/Profile/CreateProfile.js
+++ b/newIDE/app/src/Profile/CreateProfile.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 
 const styles = {

--- a/newIDE/app/src/Profile/CreateProfile.js
+++ b/newIDE/app/src/Profile/CreateProfile.js
@@ -5,6 +5,7 @@ import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
 import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
+import Text from '../UI/Text';
 
 const styles = {
   orDivider: {
@@ -21,10 +22,10 @@ type Props = {
 export default ({ message, onLogin }: Props) => (
   <Column noMargin>
     <Line>
-      <p>
+      <Text>
         {message ||
           'You are not connected. Create an account and connect to access to GDevelop online services, like building your game for Android in one click!'}
-      </p>
+      </Text>
     </Line>
     <Line justifyContent="center" alignItems="center">
       <RaisedButton

--- a/newIDE/app/src/Profile/LimitDisplayer.js
+++ b/newIDE/app/src/Profile/LimitDisplayer.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 import { type Limit, type Subscription } from '../Utils/GDevelopServices/Usage';
 import PlaceholderLoader from '../UI/PlaceholderLoader';

--- a/newIDE/app/src/Profile/LimitDisplayer.js
+++ b/newIDE/app/src/Profile/LimitDisplayer.js
@@ -6,6 +6,7 @@ import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 import { type Limit, type Subscription } from '../Utils/GDevelopServices/Usage';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
+import Text from '../UI/Text';
 
 type Props = {|
   subscription: ?Subscription,
@@ -20,19 +21,19 @@ export default ({ subscription, limit, onChangeSubscription }: Props) => {
 
   return (
     <Column noMargin>
-      <p>
+      <Text>
         <Trans>
           You have {Math.max(limit.max - limit.current, 0)} remaining builds for
           today (out of {limit.max}).
         </Trans>
-      </p>
+      </Text>
       {hasSubscription && limit.limitReached && (
-        <p>
+        <Text>
           <Trans>
             Need more power? You can upgrade to a new plan to increase the
             limit!
           </Trans>
-        </p>
+        </Text>
       )}
       {hasSubscription && limit.limitReached && (
         <Line justifyContent="center" alignItems="center">
@@ -44,11 +45,11 @@ export default ({ subscription, limit, onChangeSubscription }: Props) => {
         </Line>
       )}
       {noSubscription && (
-        <p>
+        <Text>
           <Trans>
             You don't have a subscription. Get one to increase the limits!
           </Trans>
-        </p>
+        </Text>
       )}
       {noSubscription && (
         <Line justifyContent="center" alignItems="center">

--- a/newIDE/app/src/Profile/LoginDialog.js
+++ b/newIDE/app/src/Profile/LoginDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import Dialog from '../UI/Dialog';
 import { Column, Line, Spacer } from '../UI/Grid';

--- a/newIDE/app/src/Profile/LoginDialog.js
+++ b/newIDE/app/src/Profile/LoginDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import Dialog from '../UI/Dialog';
 import { Column, Line, Spacer } from '../UI/Grid';
 import TextField from 'material-ui/TextField/TextField';

--- a/newIDE/app/src/Profile/LoginDialog.js
+++ b/newIDE/app/src/Profile/LoginDialog.js
@@ -6,7 +6,7 @@ import FlatButton from '../UI/FlatButton';
 import RaisedButton from '../UI/RaisedButton';
 import Dialog from '../UI/Dialog';
 import { Column, Line, Spacer } from '../UI/Grid';
-import TextField from 'material-ui/TextField/TextField';
+import TextField from '../UI/TextField';
 import {
   type LoginForm,
   type LoginError,

--- a/newIDE/app/src/Profile/LoginDialog.js
+++ b/newIDE/app/src/Profile/LoginDialog.js
@@ -13,6 +13,7 @@ import {
 } from '../Utils/GDevelopServices/Authentification';
 import RightLoader from '../UI/RightLoader';
 import LeftLoader from '../UI/LeftLoader';
+import Text from '../UI/Text';
 
 type Props = {|
   open: boolean,
@@ -192,13 +193,13 @@ export default class LoginDialog extends Component<Props, State> {
           ]}
         >
           <Column noMargin>
-            <p>
+            <Text>
               <Trans>
                 You should have received an email containing instructions to
                 reset and set a new password. Once it's done, you can use your
                 new password in GDevelop.
               </Trans>
-            </p>
+            </Text>
           </Column>
         </Dialog>
       </Dialog>

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -7,6 +7,7 @@ import { Column, Line } from '../UI/Grid';
 import { type Profile } from '../Utils/GDevelopServices/Authentification';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import { getGravatarUrl } from '../UI/GravatarUrl';
+import Text from '../UI/Text';
 
 const styles = {
   title: {
@@ -28,11 +29,11 @@ export default ({ profile }: Props) =>
         <span style={styles.title}>You are connected as {profile.email}</span>
       </Line>
       <Line>
-        <p>
+        <Text>
           <Trans>
             An account allows you to access GDevelop services online.
           </Trans>
-        </p>
+        </Text>
       </Line>
     </Column>
   ) : (

--- a/newIDE/app/src/Profile/ProfileDialog.js
+++ b/newIDE/app/src/Profile/ProfileDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import Dialog from '../UI/Dialog';
 import { Column } from '../UI/Grid';

--- a/newIDE/app/src/Profile/ProfileDialog.js
+++ b/newIDE/app/src/Profile/ProfileDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../UI/Tabs';
 import Dialog from '../UI/Dialog';
 import { Column } from '../UI/Grid';
 import CreateProfile from './CreateProfile';

--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import Star from 'material-ui/svg-icons/toggle/star';

--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import Star from 'material-ui/svg-icons/toggle/star';
 import Favorite from 'material-ui/svg-icons/action/favorite';

--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -13,6 +13,7 @@ import {
   sendSubscriptionCheckDismiss,
 } from '../Utils/Analytics/EventSender';
 import { Trans } from '@lingui/macro';
+import Text from '../UI/Text';
 
 type Props = {|
   title: React.Node,
@@ -109,46 +110,46 @@ export class SubscriptionCheckDialog extends React.Component<
         <Column noMargin>
           <Line noMargin alignItems="center">
             {mode === 'try' ? (
-              <p>
+              <Text>
                 <Trans>
                   You can try this feature, but if you're using it regularly, we
                   ask you to get a subscription to GDevelop.
                 </Trans>
-              </p>
+              </Text>
             ) : (
-              <p>
+              <Text>
                 <Trans>
                   To use this feature, we ask you to get a subscription to
                   GDevelop.
                 </Trans>
-              </p>
+              </Text>
             )}
           </Line>
           <Line noMargin alignItems="center">
             <Star style={styles.icon} />
-            <p style={styles.iconText}>
+            <Text style={styles.iconText}>
               <Trans>
                 Having a subscription allows you to use the one-click export for
                 Android, Windows, macOS and Linux, launch live previews over
                 wifi, disable the GDevelop splashscreen during loading and more!
               </Trans>
-            </p>
+            </Text>
           </Line>
           <Line noMargin alignItems="center">
             <Favorite style={styles.icon} />
-            <p style={styles.iconText}>
+            <Text style={styles.iconText}>
               <Trans>
                 You're also supporting the development of GDevelop, an
                 open-source software! In the future, more online services will
                 be available for users with a subscription.
               </Trans>
-            </p>
+            </Text>
           </Line>
-          <p style={styles.thanksText}>
+          <Text style={styles.thanksText}>
             <b>
               <Trans>Thanks!</Trans>
             </b>
-          </p>
+          </Text>
         </Column>
       </Dialog>
     );

--- a/newIDE/app/src/Profile/SubscriptionDetails.js
+++ b/newIDE/app/src/Profile/SubscriptionDetails.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Column, Line } from '../UI/Grid';
 import { type Subscription } from '../Utils/GDevelopServices/Usage';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { Trans } from '@lingui/macro';
 
 type Props = {

--- a/newIDE/app/src/Profile/SubscriptionDetails.js
+++ b/newIDE/app/src/Profile/SubscriptionDetails.js
@@ -5,6 +5,7 @@ import { type Subscription } from '../Utils/GDevelopServices/Usage';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import RaisedButton from '../UI/RaisedButton';
 import { Trans } from '@lingui/macro';
+import Text from '../UI/Text';
 
 type Props = {
   subscription: ?Subscription,
@@ -15,13 +16,13 @@ export default ({ subscription, onChangeSubscription }: Props) =>
   subscription && subscription.planId ? (
     <Column>
       <Line>
-        <p>
+        <Text>
           <Trans>
             You are subscribed to {subscription.planId}. Congratulations! You
             have access to more online services, including building your game
             for Android, Windows, macOS and Linux in one click!
           </Trans>
-        </p>
+        </Text>
       </Line>
       <Line justifyContent="center">
         <RaisedButton
@@ -34,13 +35,13 @@ export default ({ subscription, onChangeSubscription }: Props) =>
   ) : subscription && !subscription.planId ? (
     <Column>
       <Line>
-        <p>
+        <Text>
           <Trans>
             If you don't have a subscription, consider getting one now. Accounts
             allow you to access all of the online services. With just one click,
             you can build your game for Android, Windows, macOS and Linux!
           </Trans>
-        </p>
+        </Text>
       </Line>
       <Line justifyContent="center">
         <RaisedButton

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -13,7 +13,7 @@ import {
   changeUserSubscription,
 } from '../Utils/GDevelopServices/Usage';
 import { StripeCheckoutConfig } from '../Utils/GDevelopServices/ApiConfigs';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import CheckCircle from 'material-ui/svg-icons/action/check-circle';
 import EmptyMessage from '../UI/EmptyMessage';
 import { showMessageBox, showErrorBox } from '../UI/Messages/MessageBox';

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import { Card, CardActions, CardHeader } from 'material-ui/Card';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import UserProfileContext, { UserProfile } from './UserProfileContext';
 import { Column, Line } from '../UI/Grid';

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -23,6 +23,7 @@ import {
   sendSubscriptionDialogShown,
   sendChoosePlanClicked,
 } from '../Utils/Analytics/EventSender';
+import Text from '../UI/Text';
 
 const styles = {
   descriptionText: {
@@ -177,14 +178,14 @@ export default class SubscriptionDialog extends Component<Props, State> {
           >
             <Column>
               <Line>
-                <p>
+                <Text>
                   <Trans>
                     Get a subscription to package your games for Android,
                     Windows, macOS and Linux, use live preview over wifi and
                     more. With a subscription, you're also supporting the
                     development of GDevelop, which is an open-source software.
                   </Trans>
-                </p>
+                </Text>
               </Line>
             </Column>
             {getSubscriptionPlans().map(plan => (
@@ -201,13 +202,13 @@ export default class SubscriptionDialog extends Component<Props, State> {
                   <Column key={index} expand>
                     <Line noMargin alignItems="center">
                       <CheckCircle style={styles.bulletIcon} />
-                      <p style={styles.bulletText}>{bulletText}</p>
+                      <Text style={styles.bulletText}>{bulletText}</Text>
                     </Line>
                   </Column>
                 ))}
-                <p style={styles.descriptionText}>
+                <Text style={styles.descriptionText}>
                   {plan.extraDescription || ''}
-                </p>
+                </Text>
                 <CardActions style={styles.actions}>
                   {userProfile.subscription &&
                   userProfile.subscription.planId === plan.planId ? (
@@ -250,13 +251,13 @@ export default class SubscriptionDialog extends Component<Props, State> {
             </Column>
             {!userProfile.authenticated && (
               <PlaceholderMessage>
-                <p>
+                <Text>
                   <Trans>
                     Create a GDevelop account to continue. It's free and you'll
                     be able to access to online services like one-click build
                     for Android:
                   </Trans>
-                </p>
+                </Text>
                 <RaisedButton
                   label={<Trans>Create my account</Trans>}
                   primary

--- a/newIDE/app/src/Profile/UsagesDetails.js
+++ b/newIDE/app/src/Profile/UsagesDetails.js
@@ -9,7 +9,7 @@ import {
   TableHeaderColumn,
   TableRow,
   TableRowColumn,
-} from 'material-ui/Table';
+} from '../UI/Table';
 import { type Usages } from '../Utils/GDevelopServices/Usage';
 import { Column, Line } from '../UI/Grid';
 import EmptyMessage from '../UI/EmptyMessage';

--- a/newIDE/app/src/ProjectCreation/BrowserExamples.js
+++ b/newIDE/app/src/ProjectCreation/BrowserExamples.js
@@ -121,11 +121,13 @@ export default class BrowserExamples extends Component {
   render() {
     return (
       <Column noMargin>
-        <Column>
-          <Text>
-            <Trans>Choose or search for an example to open:</Trans>
-          </Text>
-        </Column>
+        <Line>
+          <Column>
+            <Text>
+              <Trans>Choose or search for an example to open:</Trans>
+            </Text>
+          </Column>
+        </Line>
         <Line>
           <ExamplesList
             exampleNames={exampleNames}

--- a/newIDE/app/src/ProjectCreation/BrowserExamples.js
+++ b/newIDE/app/src/ProjectCreation/BrowserExamples.js
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';
+import Text from '../UI/Text';
 import ExamplesList from './ExamplesList';
 
 // This is the list of available examples in src/fixtures folder.
@@ -121,9 +122,9 @@ export default class BrowserExamples extends Component {
     return (
       <Column noMargin>
         <Column>
-          <p>
+          <Text>
             <Trans>Choose or search for an example to open:</Trans>
-          </p>
+          </Text>
         </Column>
         <Line>
           <ExamplesList

--- a/newIDE/app/src/ProjectCreation/BrowserStarters.js
+++ b/newIDE/app/src/ProjectCreation/BrowserStarters.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import { List, ListItem } from 'material-ui/List';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';
 import ListIcon from '../UI/ListIcon';

--- a/newIDE/app/src/ProjectCreation/BrowserStarters.js
+++ b/newIDE/app/src/ProjectCreation/BrowserStarters.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import RaisedButton from '../UI/RaisedButton';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';

--- a/newIDE/app/src/ProjectCreation/BrowserStarters.js
+++ b/newIDE/app/src/ProjectCreation/BrowserStarters.js
@@ -5,6 +5,7 @@ import RaisedButton from '../UI/RaisedButton';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';
 import ListIcon from '../UI/ListIcon';
+import Text from '../UI/Text';
 const gd = global.gd;
 
 export default class BrowserStarters extends Component {
@@ -13,9 +14,9 @@ export default class BrowserStarters extends Component {
       <Column noMargin>
         <Line>
           <Column>
-            <p>
+            <Text>
               <Trans>Choose a game to use as a starter:</Trans>
-            </p>
+            </Text>
           </Column>
         </Line>
         <Line>

--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import Tutorials from './Tutorials';
 

--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -50,6 +50,7 @@ export default class CreateProjectDialog extends React.Component<Props, State> {
         title={<Trans>Create a new game</Trans>}
         actions={[
           <FlatButton
+            key="close"
             label={<Trans>Close</Trans>}
             primary={false}
             onClick={onClose}

--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import { Tabs, Tab } from '../UI/Tabs';
 import Tutorials from './Tutorials';
 
 type State = {|

--- a/newIDE/app/src/ProjectCreation/ExamplesList.js
+++ b/newIDE/app/src/ProjectCreation/ExamplesList.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 import { List, ListItem } from 'material-ui/List';
 import PlaceholderLoader from '../UI/PlaceholderLoader';

--- a/newIDE/app/src/ProjectCreation/ExamplesList.js
+++ b/newIDE/app/src/ProjectCreation/ExamplesList.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import ExamplesSearchbar from './ExamplesSearchbar';
 import ExamplesInformation from './ExamplesInformation';

--- a/newIDE/app/src/ProjectCreation/ExamplesList.js
+++ b/newIDE/app/src/ProjectCreation/ExamplesList.js
@@ -5,6 +5,7 @@ import * as React from 'react';
 import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 import { List, ListItem } from '../UI/List';
+import Text from '../UI/Text';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import ExamplesSearchbar from './ExamplesSearchbar';
 import ExamplesInformation from './ExamplesInformation';
@@ -166,9 +167,9 @@ export default class LocalExamples extends React.Component<Props, State> {
             </List>
             {!!electron && (
               <Column expand>
-                <p>
+                <Text>
                   <Trans>Want to contribute to the examples?</Trans>
-                </p>
+                </Text>
                 <Line alignItems="center" justifyContent="center">
                   <RaisedButton
                     label={<Trans>Submit your example</Trans>}

--- a/newIDE/app/src/ProjectCreation/ExamplesSearchbar.js
+++ b/newIDE/app/src/ProjectCreation/ExamplesSearchbar.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { mapVector } from '../Utils/MapFor';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import SearchbarWithChips from '../UI/SearchbarWithChips';
 const gd = global.gd;
 

--- a/newIDE/app/src/ProjectCreation/LocalExamples.js
+++ b/newIDE/app/src/ProjectCreation/LocalExamples.js
@@ -6,6 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 import React, { Component } from 'react';
 import Divider from 'material-ui/Divider';
 import LocalFolderPicker from '../UI/LocalFolderPicker';
+import Text from '../UI/Text';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';
 import { findExamples } from './LocalExamplesFinder';
@@ -98,9 +99,9 @@ export default class LocalExamples extends Component<Props, State> {
         {({ i18n }) => (
           <Column noMargin>
             <Column>
-              <p>
+              <Text>
                 <Trans>Choose or search for an example to open:</Trans>
-              </p>
+              </Text>
             </Column>
             <Line>
               <ExamplesList

--- a/newIDE/app/src/ProjectCreation/LocalExamples.js
+++ b/newIDE/app/src/ProjectCreation/LocalExamples.js
@@ -98,11 +98,13 @@ export default class LocalExamples extends Component<Props, State> {
       <I18n>
         {({ i18n }) => (
           <Column noMargin>
-            <Column>
-              <Text>
-                <Trans>Choose or search for an example to open:</Trans>
-              </Text>
-            </Column>
+            <Line>
+              <Column>
+                <Text>
+                  <Trans>Choose or search for an example to open:</Trans>
+                </Text>
+              </Column>
+            </Line>
             <Line>
               <ExamplesList
                 exampleNames={this.state.exampleNames}

--- a/newIDE/app/src/ProjectCreation/LocalStarters.js
+++ b/newIDE/app/src/ProjectCreation/LocalStarters.js
@@ -4,7 +4,7 @@ import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 import React, { Component } from 'react';
 import Divider from 'material-ui/Divider';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import LocalFolderPicker from '../UI/LocalFolderPicker';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';

--- a/newIDE/app/src/ProjectCreation/LocalStarters.js
+++ b/newIDE/app/src/ProjectCreation/LocalStarters.js
@@ -8,7 +8,7 @@ import RaisedButton from '../UI/RaisedButton';
 import LocalFolderPicker from '../UI/LocalFolderPicker';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import { findExamples } from './LocalExamplesFinder';
 import optionalRequire from '../Utils/OptionalRequire.js';
 import { findEmptyPath } from './LocalPathFinder';

--- a/newIDE/app/src/ProjectCreation/LocalStarters.js
+++ b/newIDE/app/src/ProjectCreation/LocalStarters.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import Divider from 'material-ui/Divider';
 import RaisedButton from '../UI/RaisedButton';
 import LocalFolderPicker from '../UI/LocalFolderPicker';
+import Text from '../UI/Text';
 import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import { Column, Line } from '../UI/Grid';
 import { List, ListItem } from '../UI/List';
@@ -86,9 +87,9 @@ export default class LocalStarters extends Component<Props, State> {
           <Column noMargin>
             <Line>
               <Column>
-                <p>
+                <Text>
                   <Trans>Choose a game to use as a starter:</Trans>
-                </p>
+                </Text>
               </Column>
             </Line>
             <Line>

--- a/newIDE/app/src/ProjectCreation/Tutorials.js
+++ b/newIDE/app/src/ProjectCreation/Tutorials.js
@@ -4,7 +4,7 @@ import { Column, Line } from '../UI/Grid';
 import { sendTutorialOpened } from '../Utils/Analytics/EventSender';
 import Window from '../Utils/Window';
 import { getHelpLink } from '../Utils/HelpLink';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import { Subheader } from 'material-ui';
 
 export default class Tutorials extends PureComponent {

--- a/newIDE/app/src/ProjectCreation/Tutorials.js
+++ b/newIDE/app/src/ProjectCreation/Tutorials.js
@@ -5,6 +5,7 @@ import { sendTutorialOpened } from '../Utils/Analytics/EventSender';
 import Window from '../Utils/Window';
 import { getHelpLink } from '../Utils/HelpLink';
 import { List, ListItem } from '../UI/List';
+import Text from '../UI/Text';
 import { Subheader } from 'material-ui';
 
 export default class Tutorials extends PureComponent {
@@ -13,12 +14,12 @@ export default class Tutorials extends PureComponent {
       <Column noMargin>
         <Line>
           <Column>
-            <p>
+            <Text>
               <Trans>
                 Tutorials are available on GDevelop wiki. Choose a tutorial to
                 read:
               </Trans>
-            </p>
+            </Text>
           </Column>
         </Line>
         <Line>

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Checkbox from 'material-ui/Checkbox';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -4,8 +4,8 @@ import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
 import Checkbox from 'material-ui/Checkbox';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import Dialog from '../UI/Dialog';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import SubscriptionChecker from '../Profile/SubscriptionChecker';
@@ -35,7 +35,7 @@ type State = {|
   packageName: string,
   orientation: string,
   adMobAppId: string,
-  scaleMode: 'linear' | 'nearest',
+  scaleMode: string,
   sizeOnStartupMode: string,
   showGDevelopSplash: boolean,
   minFPS: number,
@@ -217,7 +217,7 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
             fullWidth
             floatingLabelText={<Trans>Project file type</Trans>}
             value={isFolderProject}
-            onChange={(e, i, value) =>
+            onChange={(e, i, value: boolean) =>
               this.setState({ isFolderProject: value })
             }
           >
@@ -318,7 +318,7 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
               <Trans>Device orientation (for iOS and Android)</Trans>
             }
             value={orientation}
-            onChange={(e, i, value) => this.setState({ orientation: value })}
+            onChange={(e, i, value: string) => this.setState({ orientation: value })}
           >
             <MenuItem
               value="default"
@@ -337,7 +337,7 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
             }
             floatingLabelFixed
             value={scaleMode}
-            onChange={(e, i, value) => this.setState({ scaleMode: value })}
+            onChange={(e, i, value: string) => this.setState({ scaleMode: value })}
           >
             <MenuItem
               value="linear"
@@ -374,7 +374,7 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
             floatingLabelText={<Trans>Fullscreen/game size mode</Trans>}
             floatingLabelFixed
             value={sizeOnStartupMode}
-            onChange={(e, i, value) =>
+            onChange={(e, i, value: string) =>
               this.setState({ sizeOnStartupMode: value })
             }
           >

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../UI/Checkbox';
 import SelectField from '../UI/SelectField';
 import MenuItem from '../UI/MenuItem';
 import Dialog from '../UI/Dialog';
@@ -318,7 +318,9 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
               <Trans>Device orientation (for iOS and Android)</Trans>
             }
             value={orientation}
-            onChange={(e, i, value: string) => this.setState({ orientation: value })}
+            onChange={(e, i, value: string) =>
+              this.setState({ orientation: value })
+            }
           >
             <MenuItem
               value="default"
@@ -337,7 +339,9 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
             }
             floatingLabelFixed
             value={scaleMode}
-            onChange={(e, i, value: string) => this.setState({ scaleMode: value })}
+            onChange={(e, i, value: string) =>
+              this.setState({ scaleMode: value })
+            }
           >
             <MenuItem
               value="linear"

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -8,7 +8,7 @@ import SearchBar from '../UI/SearchBar';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 import WarningIcon from 'material-ui/svg-icons/alert/warning';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import ListIcon from '../UI/ListIcon';
 import { makeAddItem, makeSearchItem } from '../UI/ListCommonItem';
 import Window from '../Utils/Window';

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import { List, ListItem } from 'material-ui/List';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import SearchBar from '../UI/SearchBar';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
@@ -201,7 +201,7 @@ class Item extends React.Component<ItemProps, {||}> {
         id="rename-item-field"
         ref={textField => (this.textField = textField)}
         defaultValue={this.props.primaryText}
-        onBlur={e => this.props.onRename(e.target.value)}
+        onBlur={e => this.props.onRename(e.currentTarget.value)}
         onKeyPress={event => {
           if (event.charCode === 13) {
             // enter key pressed

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import { List, ListItem } from 'material-ui/List';
+import { List, ListItem } from '../UI/List';
 import TextField from '../UI/TextField';
 import SearchBar from '../UI/SearchBar';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
@@ -64,7 +64,7 @@ type ProjectStructureItemProps = {|
   autoGenerateNestedIndicator: boolean,
   initiallyOpen: boolean,
   leftIcon: React$Element<any>,
-  nestedItems: Array<React$Element<any>>,
+  nestedItems: Array<React$Element<any> | null>,
   primaryText: React.Node,
   primaryTogglesNestedList: boolean,
   error?: ?Error,
@@ -72,35 +72,35 @@ type ProjectStructureItemProps = {|
   open?: boolean,
 |};
 
-const ProjectStructureItem = ({
-  onRefresh,
-  ...props
-}: ProjectStructureItemProps) => (
+const ProjectStructureItem = (props: ProjectStructureItemProps) => (
   <ThemeConsumer>
-    {muiTheme => (
-      <ListItem
-        style={{
-          backgroundColor: muiTheme.listItem.groupBackgroundColor,
-          borderBottom: `1px solid ${muiTheme.listItem.separatorColor}`,
-        }}
-        nestedListStyle={styles.projectStructureItemNestedList}
-        {...props}
-        leftIcon={props.error ? <WarningIcon /> : props.leftIcon}
-        rightIconButton={
-          props.error ? (
-            <IconButton
-              tooltip={`An error has occured in functions. Click to reload them.`}
-              tooltipPosition="bottom-left"
-              onClick={onRefresh}
-            >
-              <RefreshIcon />
-            </IconButton>
-          ) : (
-            undefined
-          )
-        }
-      />
-    )}
+    {muiTheme => {
+      const { error, leftIcon, onRefresh, ...otherProps } = props;
+      return (
+        <ListItem
+          style={{
+            backgroundColor: muiTheme.listItem.groupBackgroundColor,
+            borderBottom: `1px solid ${muiTheme.listItem.separatorColor}`,
+          }}
+          nestedListStyle={styles.projectStructureItemNestedList}
+          {...otherProps}
+          leftIcon={error ? <WarningIcon /> : leftIcon}
+          rightIconButton={
+            error ? (
+              <IconButton
+                tooltip={`An error has occured in functions. Click to reload them.`}
+                tooltipPosition="bottom-left"
+                onClick={onRefresh}
+              >
+                <RefreshIcon />
+              </IconButton>
+            ) : (
+              undefined
+            )
+          }
+        />
+      );
+    }}
   </ThemeConsumer>
 );
 

--- a/newIDE/app/src/ProjectsStorage/BrowserSaveDialog.js
+++ b/newIDE/app/src/ProjectsStorage/BrowserSaveDialog.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 import Window from '../Utils/Window';

--- a/newIDE/app/src/ProjectsStorage/BrowserSaveDialog.js
+++ b/newIDE/app/src/ProjectsStorage/BrowserSaveDialog.js
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { Column, Line } from '../UI/Grid';
 import Window from '../Utils/Window';
 import { serializeToJSObject } from '../Utils/Serializer';

--- a/newIDE/app/src/ProjectsStorage/BrowserSaveDialog.js
+++ b/newIDE/app/src/ProjectsStorage/BrowserSaveDialog.js
@@ -34,11 +34,13 @@ export default class BrowserSaveDialog extends Component {
 
     const actions = [
       <FlatButton
+        key="download"
         label={<Trans>Download GDevelop desktop version</Trans>}
         primary={false}
         onClick={() => Window.openExternalURL('http://gdevelop-app.com')}
       />,
       <FlatButton
+        key="close"
         label={<Trans>Close</Trans>}
         primary={false}
         onClick={onClose}

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -5,7 +5,7 @@ import InlineCheckbox from '../UI/InlineCheckbox';
 import ResourceSelector from '../ResourcesList/ResourceSelector';
 import ResourcesLoader from '../ResourcesLoader';
 import Subheader from 'material-ui/Subheader';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import Edit from 'material-ui/svg-icons/image/edit';

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -6,8 +6,8 @@ import ResourceSelector from '../ResourcesList/ResourceSelector';
 import ResourcesLoader from '../ResourcesLoader';
 import Subheader from 'material-ui/Subheader';
 import FlatButton from '../UI/FlatButton';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import SelectField from '../UI/SelectField';
+import MenuItem from '../UI/MenuItem';
 import Edit from 'material-ui/svg-icons/image/edit';
 import IconButton from '../UI/IconButton';
 import {
@@ -258,7 +258,7 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
           key={field.name}
           floatingLabelText={getFieldLabel(this.props.instances, field)}
           floatingLabelFixed
-          onChange={(event, index, newValue) => {
+          onChange={(event, index, newValue: string) => {
             this.props.instances.forEach(i =>
               setValue(i, parseFloat(newValue) || 0)
             );
@@ -270,7 +270,8 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
           {children}
         </SelectField>
       );
-    } else {
+    } else if (field.valueType === 'string') {
+      const { setValue } = field;
       return (
         <SelectField
           value={getFieldValue(
@@ -281,9 +282,9 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
           key={field.name}
           floatingLabelText={getFieldLabel(this.props.instances, field)}
           floatingLabelFixed
-          onChange={(event, index, newValue) => {
+          onChange={(event, index, newValue: string) => {
             this.props.instances.forEach(i =>
-              field.setValue(i, newValue || '')
+              setValue(i, newValue || '')
             );
             this._onInstancesModified(this.props.instances);
           }}

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -283,9 +283,7 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
           floatingLabelText={getFieldLabel(this.props.instances, field)}
           floatingLabelFixed
           onChange={(event, index, newValue: string) => {
-            this.props.instances.forEach(i =>
-              setValue(i, newValue || '')
-            );
+            this.props.instances.forEach(i => setValue(i, newValue || ''));
             this._onInstancesModified(this.props.instances);
           }}
           style={styles.field}

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -9,7 +9,7 @@ import FlatButton from '../UI/FlatButton';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import Edit from 'material-ui/svg-icons/image/edit';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import {
   type ResourceKind,
   type ResourceSource,

--- a/newIDE/app/src/ResourcesList/BrowserResourceSources.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceSources.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import ListIcon from '../UI/ListIcon';
 import { List, ListItem, makeSelectable } from 'material-ui/List';

--- a/newIDE/app/src/ResourcesList/BrowserResourceSources.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceSources.js
@@ -4,6 +4,7 @@ import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import ListIcon from '../UI/ListIcon';
 import { SelectableList, ListItem } from '../UI/List';
+import Text from '../UI/Text';
 const gd = global.gd;
 
 const styles = {
@@ -208,12 +209,12 @@ class GenericResourcesChooser extends Component {
         autoScrollBodyContent
       >
         <div style={styles.explanations}>
-          <p>
+          <Text>
             <Trans>
               Adding resources from Dropbox, Google Drive... is coming soon!
               Download GDevelop desktop version to use your own assets.
             </Trans>
-          </p>
+          </Text>
         </div>
         <SelectableList
           value={this.state.chosenResourceUrl}

--- a/newIDE/app/src/ResourcesList/BrowserResourceSources.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceSources.js
@@ -185,11 +185,13 @@ class GenericResourcesChooser extends Component {
 
     const actions = [
       <FlatButton
+        key="close"
         label={<Trans>Close</Trans>}
         primary={false}
         onClick={this._onClose}
       />,
       <FlatButton
+        key="choose"
         label={<Trans>Choose</Trans>}
         primary={false}
         disabled={!this.state.chosenResourceUrl}

--- a/newIDE/app/src/ResourcesList/BrowserResourceSources.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceSources.js
@@ -3,8 +3,7 @@ import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import ListIcon from '../UI/ListIcon';
-import { List, ListItem, makeSelectable } from 'material-ui/List';
-const SelectableList = makeSelectable(List);
+import { SelectableList, ListItem } from '../UI/List';
 const gd = global.gd;
 
 const styles = {

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -1,6 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../../UI/IconButton';
 import Measure from 'react-measure';
 import * as React from 'react';
 import ResourcesLoader from '../../ResourcesLoader';

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -9,6 +9,7 @@ import MiniToolbar from '../../UI/MiniToolbar';
 import ZoomIn from 'material-ui/svg-icons/action/zoom-in';
 import ZoomOut from 'material-ui/svg-icons/action/zoom-out';
 import ZoomOutMap from 'material-ui/svg-icons/maps/zoom-out-map';
+import Text from '../../UI/Text';
 
 const MARGIN = 50;
 const MAX_ZOOM_FACTOR = 10;
@@ -212,9 +213,9 @@ export default class ImagePreview extends React.Component<Props, State> {
                 }}
               >
                 {!!this.state.errored && (
-                  <p>
+                  <Text>
                     <Trans>Unable to load the image</Trans>
-                  </p>
+                  </Text>
                 )}
                 {!this.state.errored && (
                   <img

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import Add from 'material-ui/svg-icons/content/add';
 import Brush from 'material-ui/svg-icons/image/brush';
 import {

--- a/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
+++ b/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../../UI/Checkbox';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 
 const SPRITE_SIZE = 100;

--- a/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
+++ b/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Checkbox from '../../UI/Checkbox';
-import muiThemeable from 'material-ui/styles/muiThemeable';
+import ThemeConsumer from '../../UI/Theme/ThemeConsumer';
 
 const SPRITE_SIZE = 100;
 export const thumbnailContainerStyle = {
@@ -36,7 +36,7 @@ const styles = {
   },
 };
 
-const ThemableImageThumbnail = ({
+const ImageThumbnail = ({
   project,
   resourceName,
   resourcesLoader,
@@ -48,37 +48,40 @@ const ThemableImageThumbnail = ({
   muiTheme,
 }) => {
   return (
-    <div
-      title={resourceName}
-      style={{
-        ...styles.spriteThumbnail,
-        borderColor: selected
-          ? muiTheme.imageThumbnail.selectedBorderColor
-          : undefined,
-        ...style,
-      }}
-      onContextMenu={e => {
-        e.stopPropagation();
-        if (onContextMenu) onContextMenu(e.clientX, e.clientY);
-      }}
-    >
-      <img
-        style={styles.spriteThumbnailImage}
-        alt={resourceName}
-        src={resourcesLoader.getResourceFullUrl(project, resourceName)}
-        crossOrigin="anonymous"
-      />
-      {selectable && (
-        <div style={styles.checkboxContainer}>
-          <Checkbox
-            checked={selected}
-            onCheck={(e, check) => onSelect(check)}
+    <ThemeConsumer>
+      {muiTheme => (
+        <div
+          title={resourceName}
+          style={{
+            ...styles.spriteThumbnail,
+            borderColor: selected
+              ? muiTheme.imageThumbnail.selectedBorderColor
+              : undefined,
+            ...style,
+          }}
+          onContextMenu={e => {
+            e.stopPropagation();
+            if (onContextMenu) onContextMenu(e.clientX, e.clientY);
+          }}
+        >
+          <img
+            style={styles.spriteThumbnailImage}
+            alt={resourceName}
+            src={resourcesLoader.getResourceFullUrl(project, resourceName)}
+            crossOrigin="anonymous"
           />
+          {selectable && (
+            <div style={styles.checkboxContainer}>
+              <Checkbox
+                checked={selected}
+                onCheck={(e, check) => onSelect(check)}
+              />
+            </div>
+          )}
         </div>
       )}
-    </div>
+    </ThemeConsumer>
   );
 };
 
-const ImageThumbnail = muiThemeable()(ThemableImageThumbnail);
 export default ImageThumbnail;

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -4,7 +4,7 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
 import TextField from 'material-ui/TextField';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import Dialog from '../UI/Dialog';
 import ColorField from '../UI/ColorField';
 import EmptyMessage from '../UI/EmptyMessage';

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import Dialog from '../UI/Dialog';

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import RaisedButton from '../UI/RaisedButton';
 import Dialog from '../UI/Dialog';
 import ColorField from '../UI/ColorField';

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -11,7 +11,7 @@ import EmptyMessage from '../UI/EmptyMessage';
 import PropertiesEditor from '../PropertiesEditor';
 import propertiesMapToSchema from '../PropertiesEditor/PropertiesMapToSchema';
 import some from 'lodash/some';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../UI/Checkbox';
 import { isNullPtr } from '../Utils/IsNullPtr';
 const gd = global.gd;
 

--- a/newIDE/app/src/SceneEditor/SetupGridDialog.js
+++ b/newIDE/app/src/SceneEditor/SetupGridDialog.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import Dialog from '../UI/Dialog';
 
 export default class SetupGridDialog extends Component {

--- a/newIDE/app/src/SceneEditor/SetupGridDialog.js
+++ b/newIDE/app/src/SceneEditor/SetupGridDialog.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import TextField from 'material-ui/TextField';
 import Dialog from '../UI/Dialog';
 

--- a/newIDE/app/src/SceneEditor/SetupGridDialog.js
+++ b/newIDE/app/src/SceneEditor/SetupGridDialog.js
@@ -22,11 +22,13 @@ export default class SetupGridDialog extends Component {
   render() {
     const actions = [
       <FlatButton
+        key="cancel"
         label={<Trans>Cancel</Trans>}
         primary={false}
         onClick={this.props.onCancel}
       />,
       <FlatButton
+        key="apply"
         label={<Trans>Apply</Trans>}
         primary={true}
         keyboardFocused={true}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -30,7 +30,7 @@ import { passFullSize } from '../UI/FullSizeMeasurer';
 import { addScrollbars } from '../InstancesEditor/ScrollbarContainer';
 import { type PreviewOptions } from '../Export/PreviewLauncher.flow';
 import Drawer from 'material-ui/Drawer';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import NavigationClose from 'material-ui/svg-icons/navigation/close';
 import EditorMosaic, { MosaicWindow } from '../UI/EditorMosaic';
 import EditorBar, { editorBarHeight } from '../UI/EditorBar';

--- a/newIDE/app/src/UI/AlertMessage.js
+++ b/newIDE/app/src/UI/AlertMessage.js
@@ -7,6 +7,7 @@ import Info from 'material-ui/svg-icons/action/info';
 import Warning from 'material-ui/svg-icons/alert/warning';
 import { Line } from './Grid';
 import { FlatButton } from 'material-ui';
+import Text from './Text';
 
 const styles = {
   icon: { width: 28, height: 28, marginRight: 10, marginLeft: 10 },
@@ -28,7 +29,7 @@ const AlertMessage = ({ kind, children, onHide }: Props) => (
     <Line noMargin alignItems="center">
       {kind === 'info' && <Info style={styles.icon} />}
       {kind === 'warning' && <Warning style={styles.icon} />}
-      <p style={styles.content}>{children}</p>
+      <Text style={styles.content}>{children}</Text>
       {onHide && (
         <FlatButton label={<Trans>Hide</Trans>} onClick={() => onHide()} />
       )}

--- a/newIDE/app/src/UI/Background.js
+++ b/newIDE/app/src/UI/Background.js
@@ -4,7 +4,6 @@ import Paper from 'material-ui/Paper';
 
 const styles = {
   container: {
-    flex: 1,
     display: 'flex',
     flexDirection: 'column',
   },
@@ -18,6 +17,7 @@ type Props = {|
   maxWidth?: boolean,
   width?: number | string,
   noFullHeight?: boolean,
+  noExpand?: boolean,
 |};
 
 /**
@@ -33,6 +33,7 @@ const Background = (props: Props) => (
       ...styles.container,
       height: props.noFullHeight ? undefined : '100%',
       width: props.width ? props.width : undefined,
+      flex: props.noExpand ? undefined : 1,
       ...(props.maxWidth ? styles.maxWidth : undefined),
     }}
   >

--- a/newIDE/app/src/UI/Button.js
+++ b/newIDE/app/src/UI/Button.js
@@ -1,10 +1,9 @@
 // @flow
 import ReactDOM from 'react-dom';
-import MUIRaisedButton from 'material-ui/RaisedButton';
-import MUIFlatButton from 'material-ui/FlatButton';
 import FlatButton from './FlatButton';
+import RaisedButton from './RaisedButton';
 
-type Button = typeof MUIRaisedButton | typeof MUIFlatButton | typeof FlatButton;
+type Button = typeof RaisedButton | typeof FlatButton;
 
 // If you're searching for button components,
 // take a look at FlatButton or RaisedButton.

--- a/newIDE/app/src/UI/Button.js
+++ b/newIDE/app/src/UI/Button.js
@@ -1,9 +1,13 @@
 // @flow
 import ReactDOM from 'react-dom';
-import RaisedButton from 'material-ui/RaisedButton';
-import FlatButton from 'material-ui/FlatButton';
+import MUIRaisedButton from 'material-ui/RaisedButton';
+import MUIFlatButton from 'material-ui/FlatButton';
+import FlatButton from './FlatButton';
 
-type Button = typeof RaisedButton | typeof FlatButton;
+type Button = typeof MUIRaisedButton | typeof MUIFlatButton | typeof FlatButton;
+
+// If you're searching for button components,
+// take a look at FlatButton or RaisedButton.
 
 /**
  * Focus a button. This won't display the material-ui Ripple effect

--- a/newIDE/app/src/UI/Checkbox.js
+++ b/newIDE/app/src/UI/Checkbox.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react';
+import MUICheckbox from 'material-ui/Checkbox';
+
+// We support a subset of the props supported by Material-UI v0.x Checkbox
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  label?: ?React.Node,
+  checked: boolean,
+  onCheck?: (e: {||}, checked: boolean) => void,
+  checkedIcon?: React.Node,
+  uncheckedIcon?: React.Node,
+  disabled?: boolean,
+
+  style?: {|
+    display?: 'inline-block',
+    width?: number | 'auto',
+    marginRight?: number,
+  |},
+  labelStyle?: {|
+    width?: 'auto',
+    whiteSpace?: 'nowrap',
+  |},
+|};
+
+/**
+ * A text field based on Material-UI text field.
+ */
+export default class Checkbox extends React.Component<Props, {||}> {
+  render() {
+    return <MUICheckbox {...this.props} />;
+  }
+}

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -1,0 +1,174 @@
+import React, { Component } from 'react';
+import { Tabs as MaterialUITabs, Tab as MaterialUITab } from 'material-ui/Tabs';
+import Close from 'material-ui/svg-icons/navigation/close';
+import FlatButton from 'material-ui/FlatButton';
+import ThemeConsumer from './Theme/ThemeConsumer';
+
+const styles = {
+  tabsContainerStyle: {
+    maxWidth: '100%',
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  tabTemplateStyle: {
+    width: '100%',
+    position: 'relative',
+    textAlign: 'initial',
+    height: '100%',
+  },
+};
+
+/**
+ * This is to override the default material-ui tab template used to wrap the content of each tab element.
+ * 2 changes (**please port them to your new implementation if you change the tabs**):
+ *
+ * 1) Instead of setting the "height" of hidden tabs to "0", we set "display" to "none" to avoid
+ * messing with components (in particular components where you can scroll: when collapsed because of height=0,
+ * they will lose they scrolling position).
+ *
+ * 2) shouldComponentUpdate is used to avoid updating the content of a tab that is not selected.
+ *
+ * Rest of the implementation is the same.
+ */
+class TabTemplate extends Component {
+  shouldComponentUpdate(nextProps) {
+    return this.props.selected || nextProps.selected;
+  }
+
+  render() {
+    const { children, selected, style } = this.props;
+    const templateStyle = { ...styles.tabTemplateStyle, ...style };
+    if (!selected) {
+      templateStyle.display = 'none';
+    }
+
+    return <div style={templateStyle}>{children}</div>;
+  }
+}
+
+export class Tabs extends Component {
+  render() {
+    const { hideLabels, ...tabsProps } = this.props;
+
+    return (
+      <ThemeConsumer>
+        {muiTheme => {
+          const tabItemContainerStyle = {
+            maxWidth: '100%', // Tabs should take all width
+            flexShrink: 0, // Tabs height should never be reduced
+            overflowX: 'auto',
+            display: hideLabels ? 'none' : 'block',
+            backgroundColor: muiTheme.closableTabs.backgroundColor,
+          };
+
+          const contentContainerStyle = {
+            overflowY: 'hidden',
+            height: hideLabels
+              ? '100%'
+              : `calc(100% - ${muiTheme.closableTabs.height}px)`,
+          };
+
+          return (
+            <MaterialUITabs
+              style={styles.tabsContainerStyle}
+              tabTemplate={TabTemplate}
+              contentContainerStyle={contentContainerStyle}
+              tabItemContainerStyle={tabItemContainerStyle}
+              inkBarStyle={{ display: 'none' }}
+              {...tabsProps}
+            />
+          );
+        }}
+      </ThemeConsumer>
+    );
+  }
+}
+Tabs.muiName = 'Tabs';
+
+export class Tab extends Component {
+  static muiName = 'Tab';
+
+  render() {
+    const { selected, onClose, label, closable, ...tabProps } = this.props;
+
+    return (
+      <ThemeConsumer>
+        {muiTheme => {
+          const truncatedLabel = (
+            <span
+              style={{
+                width:
+                  muiTheme.closableTabs.width -
+                  muiTheme.closableTabs.closeButtonWidth * 1.5,
+                marginRight: muiTheme.closableTabs.closeButtonWidth,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {label}
+            </span>
+          );
+
+          return (
+            <span
+              style={{
+                position: 'relative',
+                width: muiTheme.closableTabs.width,
+                display: 'inline-block',
+              }}
+            >
+              <MaterialUITab
+                {...tabProps}
+                label={truncatedLabel}
+                selected={selected}
+                buttonStyle={{
+                  height: muiTheme.closableTabs.height,
+                  backgroundColor: selected
+                    ? muiTheme.closableTabs.selectedBackgroundColor
+                    : muiTheme.closableTabs.backgroundColor,
+                  color: selected
+                    ? muiTheme.closableTabs.selectedTextColor
+                    : muiTheme.closableTabs.textColor,
+                }}
+                style={{
+                  height: '100%',
+                  width: '100%',
+                }}
+              />
+              {closable && (
+                <FlatButton
+                  backgroundColor="transparent"
+                  hoverColor={muiTheme.selectedBackgroundColor}
+                  onClick={onClose}
+                  style={{
+                    position: 'absolute',
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    borderRadius: 0,
+                    width: muiTheme.closableTabs.closeButtonWidth,
+                    minWidth: muiTheme.closableTabs.closeButtonWidth,
+                  }}
+                  icon={
+                    <Close
+                      color={
+                        selected
+                          ? muiTheme.closableTabs.selectedTextColor
+                          : muiTheme.closableTabs.textColor
+                      }
+                      style={{
+                        width: muiTheme.closableTabs.height / 2,
+                        height: muiTheme.closableTabs.height / 2,
+                      }}
+                    />
+                  }
+                />
+              )}
+            </span>
+          );
+        }}
+      </ThemeConsumer>
+    );
+  }
+}

--- a/newIDE/app/src/UI/ColorField/index.js
+++ b/newIDE/app/src/UI/ColorField/index.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import TextField from 'material-ui/TextField';
+import TextField from '../TextField';
 import ColorPicker from './ColorPicker';
 
 const styles = {

--- a/newIDE/app/src/UI/Dialog/index.js
+++ b/newIDE/app/src/UI/Dialog/index.js
@@ -1,4 +1,5 @@
-import React from 'react';
+// @flow
+import * as React from 'react';
 import Dialog from 'material-ui/Dialog';
 
 const styles = {
@@ -16,11 +17,44 @@ const styles = {
   },
 };
 
+// We support a subset of the props supported by Material-UI v0.x Dialog
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  open?: boolean,
+  noMargin?: boolean,
+  title?: React.Node,
+  actions?: React.Node,
+  secondaryActions?: React.Node,
+
+  onRequestClose?: () => void,
+
+  modal?: boolean, // Force the user to use one of the actions in the Dialog. Clicking outside the Dialog will not trigger the onRequestClose.
+
+  children: React.Node, // The content of the dialog
+
+  // Style:
+  contentStyle?: {|
+    maxWidth?: string | number,
+    width?: string,
+  |},
+  titleStyle?: {| padding?: 0 |},
+  bodyStyle?: {|
+    padding?: 0,
+    display?: 'flex',
+    flexDirection?: 'row',
+    overflowX?: 'hidden',
+  |},
+
+  // Positioning:
+  autoScrollBodyContent?: boolean,
+  repositionOnUpdate?: boolean,
+|};
+
 /**
  * A enhanced material-ui Dialog that can have optional secondary actions
  * and no margins if required.
  */
-export default props => {
+export default (props: Props) => {
   const { secondaryActions, actions, noMargin, title, ...otherProps } = props;
   const dialogActions = secondaryActions
     ? [

--- a/newIDE/app/src/UI/EditTagsDialog.js
+++ b/newIDE/app/src/UI/EditTagsDialog.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Dialog from './Dialog';
 import { TextField } from 'material-ui';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from './FlatButton';
 import { Trans } from '@lingui/macro';
 import { type Tags, getTagsFromString } from '../Utils/TagsHelper';
 

--- a/newIDE/app/src/UI/EditorMosaic/CloseButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/CloseButton.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../IconButton';
 import Close from 'material-ui/svg-icons/navigation/close';
 import { MosaicWindowContext, MosaicContext } from 'react-mosaic-component';
 

--- a/newIDE/app/src/UI/EditorMosaic/TagsButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/TagsButton.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../IconButton';
 import FilterList from 'material-ui/svg-icons/content/filter-list';
 import IconMenu from '../Menu/IconMenu';
 

--- a/newIDE/app/src/UI/ErrorBoundary.js
+++ b/newIDE/app/src/UI/ErrorBoundary.js
@@ -6,7 +6,7 @@ import ReactErrorBoundary from 'react-error-boundary';
 import BugReport from 'material-ui/svg-icons/action/bug-report';
 import PlaceholderMessage from './PlaceholderMessage';
 import Divider from 'material-ui/Divider';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from './RaisedButton';
 import { sendErrorMessage } from '../Utils/Analytics/EventSender';
 import Window from '../Utils/Window';
 

--- a/newIDE/app/src/UI/ErrorBoundary.js
+++ b/newIDE/app/src/UI/ErrorBoundary.js
@@ -9,6 +9,7 @@ import Divider from 'material-ui/Divider';
 import RaisedButton from './RaisedButton';
 import { sendErrorMessage } from '../Utils/Analytics/EventSender';
 import Window from '../Utils/Window';
+import Text from './Text';
 
 const errorHandler = (error: Error, componentStack: string) => {
   console.error('Error catched by Boundary:', error, componentStack);
@@ -32,22 +33,22 @@ export const ErrorFallbackComponent = ({
   error: Error,
 }) => (
   <PlaceholderMessage>
-    <p style={styles.title}>
+    <Text style={styles.title}>
       <BugReport /> This editor encountered a problem.
-    </p>
+    </Text>
     <Divider />
-    <p>
+    <Text>
       Something wrong happened :(
       <br />
       Please <b>backup your game file</b> and save your game to ensure that you
       don't lose anything.
-    </p>
-    <p>
+    </Text>
+    <Text>
       The error was automatically reported.
       <br />
       To make sure it's fixed, you may report it on GitHub, the platform where
       GDevelop is developed:
-    </p>
+    </Text>
     <RaisedButton
       label={<Trans>Report the issue on GitHub</Trans>}
       onClick={() => {

--- a/newIDE/app/src/UI/FlatButton.js
+++ b/newIDE/app/src/UI/FlatButton.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+import FlatButton from 'material-ui/FlatButton';
+
+// We support a subset of the props supported by Material-UI v0.x FlatButton
+// They should be self descriptive.
+type Props = {|
+  label: React.Node,
+  onClick: ?() => void,
+  primary?: boolean,
+  disabled?: boolean,
+  keyboardFocused?: boolean,
+  fullWidth?: boolean,
+  icon?: React.Node,
+  style?: {|
+    marginLeft?: number,
+  |},
+  target?: '_blank',
+|};
+
+/**
+ * A "flat" button based on Material-UI button.
+ */
+export default React.forwardRef<Props, FlatButton>((props, ref) => (
+  <FlatButton {...props} ref={ref} />
+));

--- a/newIDE/app/src/UI/HelpButton/HelpButton.spec.js
+++ b/newIDE/app/src/UI/HelpButton/HelpButton.spec.js
@@ -1,16 +1,16 @@
 // @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import HelpButton from '.';
 
 describe('HelpButton', () => {
   it('renders the button linking to a help page', () => {
     const tree = renderer
       .create(
-        <MuiThemeProvider>
+        <V0MuiThemeProvider>
           <HelpButton helpPagePath="/objects/tiled_sprite" />
-        </MuiThemeProvider>
+        </V0MuiThemeProvider>
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
@@ -18,9 +18,9 @@ describe('HelpButton', () => {
   it('renders nothing if the helpPagePath is empty', () => {
     const tree = renderer
       .create(
-        <MuiThemeProvider>
+        <V0MuiThemeProvider>
           <HelpButton helpPagePath="" />
-        </MuiThemeProvider>
+        </V0MuiThemeProvider>
       )
       .toJSON();
     expect(tree).toMatchSnapshot();

--- a/newIDE/app/src/UI/HelpButton/index.js
+++ b/newIDE/app/src/UI/HelpButton/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../FlatButton';
 import HelpOutline from 'material-ui/svg-icons/action/help-outline';
 import Window from '../../Utils/Window';
 import { getHelpLink } from '../../Utils/HelpLink';

--- a/newIDE/app/src/UI/HelpIcon/HelpIcon.spec.js
+++ b/newIDE/app/src/UI/HelpIcon/HelpIcon.spec.js
@@ -1,16 +1,16 @@
 // @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import HelpIcon from '.';
 
 describe('HelpIcon', () => {
   it('renders the icon linking to a help page', () => {
     const tree = renderer
       .create(
-        <MuiThemeProvider>
+        <V0MuiThemeProvider>
           <HelpIcon helpPagePath="/objects/tiled_sprite" />
-        </MuiThemeProvider>
+        </V0MuiThemeProvider>
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
@@ -18,9 +18,9 @@ describe('HelpIcon', () => {
   it('renders nothing if the helpPagePath is empty', () => {
     const tree = renderer
       .create(
-        <MuiThemeProvider>
+        <V0MuiThemeProvider>
           <HelpIcon helpPagePath="" />
-        </MuiThemeProvider>
+        </V0MuiThemeProvider>
       )
       .toJSON();
     expect(tree).toMatchSnapshot();

--- a/newIDE/app/src/UI/HelpIcon/index.js
+++ b/newIDE/app/src/UI/HelpIcon/index.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import HelpOutline from 'material-ui/svg-icons/action/help-outline';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../IconButton';
 import { getHelpLink } from '../../Utils/HelpLink';
 import Window from '../../Utils/Window';
 

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react';
+import MUIIconButton from 'material-ui/IconButton';
+
+type IconProps =
+  | {|
+      children: React.Node,
+    |}
+  // Support a few specific icons from iconmoon-font.css
+  | {|
+      iconClassName: 'icon-twitter' | 'icon-facebook',
+    |};
+
+// We support a subset of the props supported by Material-UI v0.x IconButton
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  ...IconProps,
+  onClick?: () => void,
+  disabled?: boolean,
+
+  style?: {|
+    padding?: number,
+    width?: number,
+    height?: number,
+    transform?: string,
+    transition?: string,
+    opacity?: number,
+    marginRight?: number,
+  |},
+  iconStyle?: {|
+    marginLeft: number,
+    marginTop: number,
+    maxWidth: number,
+    maxHeight: number,
+    filter: ?string,
+  |},
+
+  tooltip?: React.Node,
+  tooltipPosition?: 'bottom-left' | 'bottom-right',
+|};
+
+/**
+ * A button showing just an icon, based on Material-UI icon button.
+ */
+export default class IconButton extends React.Component<Props, {||}> {
+  render() {
+    return <MUIIconButton {...this.props} />;
+  }
+}

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -43,6 +43,10 @@ type Props = {|
  * A button showing just an icon, based on Material-UI icon button.
  */
 export default class IconButton extends React.Component<Props, {||}> {
+  // Set muiName to let Material-UI's v0.x AppBar recognise
+  // the component (and apply proper color).
+  static muiName = 'IconButton';
+
   render() {
     return <MUIIconButton {...this.props} />;
   }

--- a/newIDE/app/src/UI/InlineCheckbox.js
+++ b/newIDE/app/src/UI/InlineCheckbox.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from './Checkbox';
 
 const styles = {
   root: {

--- a/newIDE/app/src/UI/List.js
+++ b/newIDE/app/src/UI/List.js
@@ -51,7 +51,7 @@ export class ListItem extends React.Component<ListItemProps, {||}> {
   // into ListItem props and assumes nestedItems is always an array.
   static defaultProps = {
     nestedItems: [],
-  }
+  };
 
   render() {
     return <MUIListItem {...this.props} />;

--- a/newIDE/app/src/UI/List.js
+++ b/newIDE/app/src/UI/List.js
@@ -1,0 +1,81 @@
+// @flow
+import * as React from 'react';
+import {
+  List as MUIList,
+  ListItem as MUIListItem,
+  makeSelectable,
+} from 'material-ui/List';
+
+// We support a subset of the props supported by Material-UI v0.x ListItem
+// They should be self descriptive - refer to Material UI docs otherwise.
+type ListItemProps = {|
+  onClick?: () => void,
+  primaryText: ?React.Node,
+  secondaryText?: React.Node,
+  value?: string,
+  primaryTogglesNestedList?: boolean,
+  autoGenerateNestedIndicator?: boolean,
+  nestedItems?: Array<React$Element<any> | null>,
+  open?: boolean,
+  initiallyOpen?: boolean,
+  disabled?: boolean,
+
+  nestedListStyle?: {|
+    padding: 0,
+  |},
+
+  style?: {|
+    backgroundColor?: string,
+    borderBottom?: string,
+    opacity?: number,
+  |},
+
+  onContextMenu?: () => void,
+
+  leftIcon?: React.Node,
+  leftAvatar?: React.Node,
+  rightIconButton?: ?React.Node,
+
+  secondaryTextLines?: number,
+|};
+
+/**
+ * A ListItem to be used in a List.
+ */
+export class ListItem extends React.Component<ListItemProps, {||}> {
+  // Set muiName to let Material-UI's v0.x List recognise
+  // the component.
+  static muiName = 'ListItem';
+
+  // Add default props because Material-UI's v0.x List does look
+  // into ListItem props and assumes nestedItems is always an array.
+  static defaultProps = {
+    nestedItems: [],
+  }
+
+  render() {
+    return <MUIListItem {...this.props} />;
+  }
+}
+
+// We support a subset of the props supported by Material-UI v0.x List
+// They should be self descriptive - refer to Material UI docs otherwise.
+type ListProps = {|
+  children: React.Node,
+  style?: {|
+    overflowY?: 'scroll',
+    flex?: 1,
+    padding?: number,
+  |},
+|};
+
+/**
+ * List based on Material-UI List.
+ */
+export class List extends React.Component<ListProps, {||}> {
+  render() {
+    return <MUIList {...this.props} />;
+  }
+}
+
+export const SelectableList = makeSelectable(MUIList);

--- a/newIDE/app/src/UI/ListCommonItem.js
+++ b/newIDE/app/src/UI/ListCommonItem.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import IconButton from 'material-ui/IconButton';
+import IconButton from './IconButton';
 import Add from 'material-ui/svg-icons/content/add';
 import Search from 'material-ui/svg-icons/action/search';
-import EmptyMessage from '../UI/EmptyMessage';
+import EmptyMessage from './EmptyMessage';
 // No i18n in this file
 
 const styles = {

--- a/newIDE/app/src/UI/ListIcon.js
+++ b/newIDE/app/src/UI/ListIcon.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { PureComponent } from 'react';
-import IconButton from 'material-ui/IconButton';
+import IconButton from './IconButton';
 import ThemeConsumer from './Theme/ThemeConsumer';
 // No i18n in this file
 

--- a/newIDE/app/src/UI/LocalFilePicker/index.js
+++ b/newIDE/app/src/UI/LocalFilePicker/index.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { PureComponent } from 'react';
-import TextField from 'material-ui/TextField';
+import TextField from '../TextField';
 import FlatButton from '../FlatButton';
 import optionalRequire from '../../Utils/OptionalRequire.js';
 const electron = optionalRequire('electron');

--- a/newIDE/app/src/UI/LocalFilePicker/index.js
+++ b/newIDE/app/src/UI/LocalFilePicker/index.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React, { PureComponent } from 'react';
 import TextField from 'material-ui/TextField';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../FlatButton';
 import optionalRequire from '../../Utils/OptionalRequire.js';
 const electron = optionalRequire('electron');
 const dialog = electron ? electron.remote.dialog : null;

--- a/newIDE/app/src/UI/LocalFolderPicker/index.js
+++ b/newIDE/app/src/UI/LocalFolderPicker/index.js
@@ -5,7 +5,7 @@ import { t } from '@lingui/macro';
 import { type I18n as I18nType } from '@lingui/core';
 
 import React, { PureComponent } from 'react';
-import TextField from 'material-ui/TextField';
+import TextField from '../TextField';
 import FlatButton from '../FlatButton';
 import optionalRequire from '../../Utils/OptionalRequire.js';
 const electron = optionalRequire('electron');

--- a/newIDE/app/src/UI/LocalFolderPicker/index.js
+++ b/newIDE/app/src/UI/LocalFolderPicker/index.js
@@ -6,7 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import React, { PureComponent } from 'react';
 import TextField from 'material-ui/TextField';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../FlatButton';
 import optionalRequire from '../../Utils/OptionalRequire.js';
 const electron = optionalRequire('electron');
 const dialog = electron ? electron.remote.dialog : null;

--- a/newIDE/app/src/UI/MenuItem.js
+++ b/newIDE/app/src/UI/MenuItem.js
@@ -1,0 +1,25 @@
+// @flow
+import * as React from 'react';
+import MUIMenuItem from 'material-ui/MenuItem';
+
+// We support a subset of the props supported by Material-UI v0.x MenuItem
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  value: string | number | boolean,
+  primaryText: React.Node,
+  fullWidth?: boolean,
+  disabled?: boolean,
+|};
+
+/**
+ * A menu item to be used with `SelectField`.
+ */
+export default class MenuItem extends React.Component<Props, {||}> {
+  // Set muiName to let Material-UI's v0.x SelectField recognise
+  // the component.
+  static muiName = 'MenuItem';
+
+  render() {
+    return <MUIMenuItem {...this.props} />;
+  }
+}

--- a/newIDE/app/src/UI/MiniToolbar.js
+++ b/newIDE/app/src/UI/MiniToolbar.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import ThemeConsumer from './Theme/ThemeConsumer';
+import Text from './Text';
 
 const style = {
   display: 'flex',
@@ -36,7 +37,7 @@ const toolbarTextStyle = {
 };
 
 export const MiniToolbarText = ({ children }) => (
-  <p style={toolbarTextStyle}>{children}</p>
+  <Text style={toolbarTextStyle}>{children}</Text>
 );
 
 export default MiniToolbar;

--- a/newIDE/app/src/UI/MiniToolbar.js
+++ b/newIDE/app/src/UI/MiniToolbar.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import muiThemeable from 'material-ui/styles/muiThemeable';
+import ThemeConsumer from './Theme/ThemeConsumer';
 
 const style = {
   display: 'flex',
@@ -8,21 +8,25 @@ const style = {
   paddingRight: 8,
 };
 
-class ThemableMiniToolbar extends Component {
+class MiniToolbar extends Component {
   render() {
-    const { muiTheme, justifyContent, smallest } = this.props;
+    const { justifyContent, smallest } = this.props;
 
     return (
-      <div
-        style={{
-          ...style,
-          height: smallest ? 34 : 48,
-          backgroundColor: muiTheme.toolbar.backgroundColor,
-          justifyContent,
-        }}
-      >
-        {this.props.children}
-      </div>
+      <ThemeConsumer>
+        {muiTheme => (
+          <div
+            style={{
+              ...style,
+              height: smallest ? 34 : 48,
+              backgroundColor: muiTheme.toolbar.backgroundColor,
+              justifyContent,
+            }}
+          >
+            {this.props.children}
+          </div>
+        )}
+      </ThemeConsumer>
     );
   }
 }
@@ -35,4 +39,4 @@ export const MiniToolbarText = ({ children }) => (
   <p style={toolbarTextStyle}>{children}</p>
 );
 
-export default muiThemeable()(ThemableMiniToolbar);
+export default MiniToolbar;

--- a/newIDE/app/src/UI/PlaceholderError.js
+++ b/newIDE/app/src/UI/PlaceholderError.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import { Column, Line } from './Grid';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from './RaisedButton';
 import EmptyMessage from './EmptyMessage';
 
 type Props = {|

--- a/newIDE/app/src/UI/RaisedButton.js
+++ b/newIDE/app/src/UI/RaisedButton.js
@@ -1,15 +1,14 @@
 // @flow
 import * as React from 'react';
-import MUIFlatButton from 'material-ui/FlatButton';
+import MUIRaisedButton from 'material-ui/RaisedButton';
 
-// We support a subset of the props supported by Material-UI v0.x FlatButton
+// We support a subset of the props supported by Material-UI v0.x RaisedButton
 // They should be self descriptive - refer to Material UI docs otherwise.
 type Props = {|
-  label: React.Node,
+  label?: React.Node,
   onClick: ?() => void,
   primary?: boolean,
   disabled?: boolean,
-  keyboardFocused?: boolean,
   fullWidth?: boolean,
   icon?: React.Node,
   style?: {|
@@ -19,14 +18,14 @@ type Props = {|
     marginRight?: number,
     margin?: number,
   |},
-  target?: '_blank',
+  labelPosition?: 'before',
 |};
 
 /**
- * A "flat" button based on Material-UI button.
+ * A raised button based on Material-UI button.
  */
-export default class FlatButton extends React.Component<Props, {||}> {
+export default class RaisedButton extends React.Component<Props, {||}> {
   render() {
-    return <MUIFlatButton {...this.props} />;
+    return <MUIRaisedButton {...this.props} />;
   }
 }

--- a/newIDE/app/src/UI/SearchBar.js
+++ b/newIDE/app/src/UI/SearchBar.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import IconButton from 'material-ui/IconButton';
-import TextField from 'material-ui/TextField';
+import TextField from './TextField';
 import Paper from 'material-ui/Paper';
 import Close from 'material-ui/svg-icons/navigation/close';
 import Search from 'material-ui/svg-icons/action/search';
@@ -126,7 +126,7 @@ export default class SearchBar extends React.Component<Props, State> {
     }
   };
 
-  handleInput = (e: { target: { value: string } }) => {
+  handleInput = (e: {| target: {| value: string |} |}) => {
     this.setState({ value: e.target.value });
     this.props.onChange && this.props.onChange(e.target.value);
   };

--- a/newIDE/app/src/UI/SearchBar.js
+++ b/newIDE/app/src/UI/SearchBar.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import IconButton from 'material-ui/IconButton';
+import IconButton from './IconButton';
 import TextField from './TextField';
 import Paper from 'material-ui/Paper';
 import Close from 'material-ui/svg-icons/navigation/close';

--- a/newIDE/app/src/UI/SearchbarWithChips.js
+++ b/newIDE/app/src/UI/SearchbarWithChips.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import Chip from 'material-ui/Chip';
-import TextField from 'material-ui/TextField';
 import { Column, Line } from '../UI/Grid';
 import randomColor from 'randomcolor';
 import SearchBar from '../UI/SearchBar';
@@ -34,10 +33,10 @@ const getChipColor = (tag: string) => {
 };
 
 export default class SearchbarWithChips extends Component<Props> {
-  _textField: ?TextField;
+  _searchBar: ?SearchBar;
 
   componentDidMount() {
-    if (this._textField) this._textField.focus();
+    if (this._searchBar) this._searchBar.focus();
   }
 
   render() {
@@ -58,7 +57,7 @@ export default class SearchbarWithChips extends Component<Props> {
           onChange={value => {
             onChange(value);
           }}
-          ref={textField => (this._textField = textField)}
+          ref={searchBar => (this._searchBar = searchBar)}
         />
         <Line>
           <Column>

--- a/newIDE/app/src/UI/SelectField.js
+++ b/newIDE/app/src/UI/SelectField.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react';
+import MUISelectField from 'material-ui/SelectField';
+
+type ValueProps =
+  | {|
+      value: string,
+      onChange?: (
+        event: {| target: {| value: string |} |},
+        index: number,
+        text: string
+      ) => void,
+    |}
+  | {|
+      value: number,
+      onChange?: (event: {||}, index: number, value: number) => void,
+    |}
+  | {|
+      value: boolean,
+      onChange?: (event: {||}, index: number, value: boolean) => void,
+    |};
+
+// We support a subset of the props supported by Material-UI v0.x SelectField
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  ...ValueProps,
+  fullWidth?: boolean,
+  children: React.Node,
+  disabled?: boolean,
+
+  style?: {
+    flex?: 1,
+    width?: 'auto',
+  },
+
+  floatingLabelText?: React.Node,
+  floatingLabelFixed?: boolean,
+  hintText?: React.Node,
+|};
+
+/**
+ * A select field based on Material-UI select field.
+ * To be used with `MenuItem`.
+ */
+export default class SelectField extends React.Component<Props, {||}> {
+  render() {
+    return <MUISelectField {...this.props} />;
+  }
+}

--- a/newIDE/app/src/UI/SemiControlledTextField.js
+++ b/newIDE/app/src/UI/SemiControlledTextField.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import TextField from 'material-ui/TextField';
+import TextField from './TextField';
 
 type State = {|
   focused: boolean,
@@ -58,7 +58,7 @@ export default class SemiControlledTextField extends React.Component<
     text: null,
   };
 
-  _field: ?any = null;
+  _field: ?TextField = null;
 
   focus() {
     if (this._field) this._field.focus();
@@ -79,8 +79,10 @@ export default class SemiControlledTextField extends React.Component<
     } = this.props;
 
     return (
+      // $FlowFixMe - not sure why Flow can't infer that we're using the "string version" of TextField.
       <TextField
         {...otherProps}
+        type="text"
         ref={field => (this._field = field)}
         value={this.state.focused ? this.state.text : value}
         onFocus={event => {

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
@@ -3,7 +3,7 @@ import { ListItem } from 'material-ui/List';
 import IconMenu from '../Menu/IconMenu';
 import ListIcon from '../ListIcon';
 import IconButton from 'material-ui/IconButton';
-import TextField from 'material-ui/TextField';
+import TextField from '../TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import { type Item } from '.';

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ListItem } from 'material-ui/List';
 import IconMenu from '../Menu/IconMenu';
 import ListIcon from '../ListIcon';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../IconButton';
 import TextField from '../TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import muiThemeable from 'material-ui/styles/muiThemeable';

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
@@ -5,8 +5,8 @@ import ListIcon from '../ListIcon';
 import IconButton from '../IconButton';
 import TextField from '../TextField';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import { type Item } from '.';
+import ThemeConsumer from '../Theme/ThemeConsumer';
 
 const styles = {
   itemName: {
@@ -31,7 +31,7 @@ type Props = {
   buildMenuTemplate: () => Array<any>,
 };
 
-class ThemableItemRow extends React.Component<Props, *> {
+class ItemRow extends React.Component<Props, *> {
   _renderItemMenu(item) {
     return (
       <IconMenu
@@ -59,78 +59,78 @@ class ThemableItemRow extends React.Component<Props, *> {
   };
 
   render() {
-    const {
-      item,
-      selected,
-      style,
-      getThumbnail,
-      errorStatus,
-      muiTheme,
-    } = this.props;
-
-    const itemName = item.getName();
-    const label = this.props.editingName ? (
-      <TextField
-        id="rename-item-field"
-        ref={textField => (this.textField = textField)}
-        defaultValue={itemName}
-        onBlur={e => this.props.onRename(e.target.value)}
-        onKeyPress={event => {
-          if (event.charCode === 13) {
-            // enter key pressed
-            this.textField.blur();
-          }
-        }}
-        fullWidth
-        style={styles.textField}
-      />
-    ) : (
-      <div
-        style={{
-          ...styles.itemName,
-          color: selected ? muiTheme.listItem.selectedTextColor : undefined,
-        }}
-      >
-        {itemName}
-      </div>
-    );
-
-    const itemStyle = {
-      borderBottom: `1px solid ${muiTheme.listItem.separatorColor}`,
-      backgroundColor: selected
-        ? errorStatus === ''
-          ? muiTheme.listItem.selectedBackgroundColor
-          : errorStatus === 'error'
-          ? muiTheme.listItem.selectedErrorBackgroundColor
-          : muiTheme.listItem.selectedWarningBackgroundColor
-        : undefined,
-      color:
-        errorStatus === ''
-          ? undefined
-          : errorStatus === 'error'
-          ? muiTheme.listItem.errorTextColor
-          : muiTheme.listItem.warningTextColor,
-    };
+    const { item, selected, style, getThumbnail, errorStatus } = this.props;
 
     return (
-      <ListItem
-        style={{ ...itemStyle, ...style }}
-        onContextMenu={this._onContextMenu}
-        primaryText={label}
-        leftIcon={
-          getThumbnail && <ListIcon iconSize={32} src={getThumbnail()} />
-        }
-        rightIconButton={this._renderItemMenu(item)}
-        onClick={() => {
-          if (!this.props.onItemSelected) return;
-          if (this.props.editingName) return;
+      <ThemeConsumer>
+        {muiTheme => {
+          const itemName = item.getName();
+          const label = this.props.editingName ? (
+            <TextField
+              id="rename-item-field"
+              ref={textField => (this.textField = textField)}
+              defaultValue={itemName}
+              onBlur={e => this.props.onRename(e.target.value)}
+              onKeyPress={event => {
+                if (event.charCode === 13) {
+                  // enter key pressed
+                  this.textField.blur();
+                }
+              }}
+              fullWidth
+              style={styles.textField}
+            />
+          ) : (
+            <div
+              style={{
+                ...styles.itemName,
+                color: selected
+                  ? muiTheme.listItem.selectedTextColor
+                  : undefined,
+              }}
+            >
+              {itemName}
+            </div>
+          );
 
-          this.props.onItemSelected(selected ? null : item);
+          const itemStyle = {
+            borderBottom: `1px solid ${muiTheme.listItem.separatorColor}`,
+            backgroundColor: selected
+              ? errorStatus === ''
+                ? muiTheme.listItem.selectedBackgroundColor
+                : errorStatus === 'error'
+                ? muiTheme.listItem.selectedErrorBackgroundColor
+                : muiTheme.listItem.selectedWarningBackgroundColor
+              : undefined,
+            color:
+              errorStatus === ''
+                ? undefined
+                : errorStatus === 'error'
+                ? muiTheme.listItem.errorTextColor
+                : muiTheme.listItem.warningTextColor,
+          };
+
+          return (
+            <ListItem
+              style={{ ...itemStyle, ...style }}
+              onContextMenu={this._onContextMenu}
+              primaryText={label}
+              leftIcon={
+                getThumbnail && <ListIcon iconSize={32} src={getThumbnail()} />
+              }
+              rightIconButton={this._renderItemMenu(item)}
+              onClick={() => {
+                if (!this.props.onItemSelected) return;
+                if (this.props.editingName) return;
+
+                this.props.onItemSelected(selected ? null : item);
+              }}
+            />
+          );
         }}
-      />
+      </ThemeConsumer>
     );
   }
 }
 
-const ItemRow = muiThemeable()(ThemableItemRow);
 export default ItemRow;

--- a/newIDE/app/src/UI/Table.js
+++ b/newIDE/app/src/UI/Table.js
@@ -1,0 +1,138 @@
+// @flow
+import * as React from 'react';
+import {
+  Table as MUITable,
+  TableBody as MUITableBody,
+  TableHeader as MUITableHeader,
+  TableHeaderColumn as MUITableHeaderColumn,
+  TableRow as MUITableRow,
+  TableRowColumn as MUITableRowColumn,
+} from 'material-ui/Table';
+
+// We support a subset of the props supported by Material-UI v0.x Table
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TableProps = {|
+  selectable?: boolean,
+  children: React.Node, // Should be TableHeader, TableBody or TableFooter
+|};
+
+/**
+ * A Table based on Material-UI Table.
+ */
+export class Table extends React.Component<TableProps, {||}> {
+  static muiName = 'Table';
+  render() {
+    return <MUITable {...this.props} />;
+  }
+}
+
+// We support a subset of the props supported by Material-UI v0.x TableBodyProps
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TableBodyProps = {|
+  displayRowCheckbox?: boolean,
+  deselectOnClickaway?: boolean,
+  showRowHover?: boolean,
+  children?: React.Node, // Should be TableRow
+|};
+
+/**
+ * A TableBody based on Material-UI TableBody.
+ */
+export class TableBody extends React.Component<TableBodyProps, {||}> {
+  // Set muiName to let Material-UI's v0.x Table recognise
+  // the component.
+  static muiName = 'TableBody';
+  render() {
+    return <MUITableBody {...this.props} />;
+  }
+}
+
+// We support a subset of the props supported by Material-UI v0.x TableHeaderProps
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TableHeaderProps = {|
+  adjustForCheckbox?: boolean,
+  displaySelectAll?: boolean,
+  children: React.Node, // Should be a TableRow
+|};
+
+/**
+ * A TableHeader based on Material-UI TableHeader.
+ */
+export class TableHeader extends React.Component<TableHeaderProps, {||}> {
+  // Set muiName to let Material-UI's v0.x Table recognise
+  // the component.
+  static muiName = 'TableHeader';
+  render() {
+    return <MUITableHeader {...this.props} />;
+  }
+}
+
+// We support a subset of the props supported by Material-UI v0.x TableHeaderColumnProps
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TableHeaderColumnProps = {|
+  children?: React.Node, // Text of the column
+  style?: {|
+    textAlign: 'left' | 'right',
+    paddingRight: number,
+  |},
+|};
+
+/**
+ * A TableHeaderColumn based on Material-UI TableHeaderColumn.
+ */
+export class TableHeaderColumn extends React.Component<
+  TableHeaderColumnProps,
+  {||}
+> {
+  // Set muiName to let Material-UI's v0.x TableHeader recognise
+  // the component.
+  static muiName = 'TableHeaderColumn';
+  render() {
+    return <MUITableHeaderColumn {...this.props} />;
+  }
+}
+
+// We support a subset of the props supported by Material-UI v0.x TableRow
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TableRowProps = {|
+  children: React.Node,
+  style?: {|
+    backgroundColor: string,
+  |},
+|};
+
+/**
+ * A TableRow based on Material-UI TableRow.
+ */
+export class TableRow extends React.Component<TableRowProps, {||}> {
+  // Set muiName to let Material-UI's v0.x TableBody recognise
+  // the component.
+  static muiName = 'TableRow';
+  render() {
+    return <MUITableRow {...this.props} />;
+  }
+}
+
+// We support a subset of the props supported by Material-UI v0.x TableRow
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TableRowColumnProps = {|
+  children?: React.Node, // Content for the cell
+  style?: {|
+    width?: number,
+    paddingLeft?: number,
+    paddingRight?: number,
+    textAlign?: string,
+  |},
+|};
+
+/**
+ * A TableRowColumn based on Material-UI TableRowColumn.
+ */
+export class TableRowColumn extends React.Component<TableRowColumnProps, {||}> {
+  // Set muiName to let Material-UI's v0.x TableBody recognise
+  // the component.
+  static muiName = 'TableRowColumn';
+  render() {
+    return <MUITableRowColumn {...this.props} />;
+  }
+}

--- a/newIDE/app/src/UI/Tabs.js
+++ b/newIDE/app/src/UI/Tabs.js
@@ -19,7 +19,7 @@ export class Tabs<TabName> extends React.Component<TabsProps<TabName>, {||}> {
   }
 }
 
-// We support a subset of the props supported by Material-UI v0.x Table
+// We support a subset of the props supported by Material-UI v0.x Tabs
 // They should be self descriptive - refer to Material UI docs otherwise.
 type TabProps = {|
   label: React.Node,
@@ -31,7 +31,7 @@ type TabProps = {|
  * A Tab based on Material-UI Tab.
  */
 export class Tab extends React.Component<TabProps, {||}> {
-  // Set muiName to let Material-UI's v0.x Table recognise
+  // Set muiName to let Material-UI's v0.x Tabs recognise
   // the component.
   static muiName = 'Tab';
   render() {

--- a/newIDE/app/src/UI/Tabs.js
+++ b/newIDE/app/src/UI/Tabs.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Tabs as MaterialUITabs, Tab as MaterialUITab } from 'material-ui/Tabs';
 import Close from 'material-ui/svg-icons/navigation/close';
 import FlatButton from 'material-ui/FlatButton';
-import muiThemeable from 'material-ui/styles/muiThemeable';
+import ThemeConsumer from './Theme/ThemeConsumer';
 
 const styles = {
   tabsContainerStyle: {
@@ -47,127 +47,128 @@ class TabTemplate extends Component {
   }
 }
 
-export class ThemableTabs extends Component {
+export class Tabs extends Component {
   render() {
-    const { muiTheme, hideLabels, ...tabsProps } = this.props;
-    const tabItemContainerStyle = {
-      maxWidth: '100%', // Tabs should take all width
-      flexShrink: 0, // Tabs height should never be reduced
-      overflowX: 'auto',
-      display: hideLabels ? 'none' : 'block',
-      backgroundColor: muiTheme.closableTabs.backgroundColor,
-    };
-
-    const contentContainerStyle = {
-      overflowY: 'hidden',
-      height: hideLabels
-        ? '100%'
-        : `calc(100% - ${muiTheme.closableTabs.height}px)`,
-    };
+    const { hideLabels, ...tabsProps } = this.props;
 
     return (
-      <MaterialUITabs
-        style={styles.tabsContainerStyle}
-        tabTemplate={TabTemplate}
-        contentContainerStyle={contentContainerStyle}
-        tabItemContainerStyle={tabItemContainerStyle}
-        inkBarStyle={{ display: 'none' }}
-        {...tabsProps}
-      />
+      <ThemeConsumer>
+        {muiTheme => {
+          const tabItemContainerStyle = {
+            maxWidth: '100%', // Tabs should take all width
+            flexShrink: 0, // Tabs height should never be reduced
+            overflowX: 'auto',
+            display: hideLabels ? 'none' : 'block',
+            backgroundColor: muiTheme.closableTabs.backgroundColor,
+          };
+
+          const contentContainerStyle = {
+            overflowY: 'hidden',
+            height: hideLabels
+              ? '100%'
+              : `calc(100% - ${muiTheme.closableTabs.height}px)`,
+          };
+
+          return (
+            <MaterialUITabs
+              style={styles.tabsContainerStyle}
+              tabTemplate={TabTemplate}
+              contentContainerStyle={contentContainerStyle}
+              tabItemContainerStyle={tabItemContainerStyle}
+              inkBarStyle={{ display: 'none' }}
+              {...tabsProps}
+            />
+          );
+        }}
+      </ThemeConsumer>
     );
   }
 }
-
-export const Tabs = muiThemeable()(ThemableTabs);
 Tabs.muiName = 'Tabs';
 
-class ThemableTab extends Component {
+export class Tab extends Component {
   static muiName = 'Tab';
 
   render() {
-    const {
-      muiTheme,
-      selected,
-      onClose,
-      label,
-      closable,
-      ...tabProps
-    } = this.props;
-
-    const truncatedLabel = (
-      <span
-        style={{
-          width:
-            muiTheme.closableTabs.width -
-            muiTheme.closableTabs.closeButtonWidth * 1.5,
-          marginRight: muiTheme.closableTabs.closeButtonWidth,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-        }}
-      >
-        {label}
-      </span>
-    );
+    const { selected, onClose, label, closable, ...tabProps } = this.props;
 
     return (
-      <span
-        style={{
-          position: 'relative',
-          width: muiTheme.closableTabs.width,
-          display: 'inline-block',
-        }}
-      >
-        <MaterialUITab
-          {...tabProps}
-          label={truncatedLabel}
-          selected={selected}
-          buttonStyle={{
-            height: muiTheme.closableTabs.height,
-            backgroundColor: selected
-              ? muiTheme.closableTabs.selectedBackgroundColor
-              : muiTheme.closableTabs.backgroundColor,
-            color: selected
-              ? muiTheme.closableTabs.selectedTextColor
-              : muiTheme.closableTabs.textColor,
-          }}
-          style={{
-            height: '100%',
-            width: '100%',
-          }}
-        />
-        {closable && (
-          <FlatButton
-            backgroundColor="transparent"
-            hoverColor={muiTheme.selectedBackgroundColor}
-            onClick={onClose}
-            style={{
-              position: 'absolute',
-              right: 0,
-              top: 0,
-              bottom: 0,
-              borderRadius: 0,
-              width: muiTheme.closableTabs.closeButtonWidth,
-              minWidth: muiTheme.closableTabs.closeButtonWidth,
-            }}
-            icon={
-              <Close
-                color={
-                  selected
+      <ThemeConsumer>
+        {muiTheme => {
+          const truncatedLabel = (
+            <span
+              style={{
+                width:
+                  muiTheme.closableTabs.width -
+                  muiTheme.closableTabs.closeButtonWidth * 1.5,
+                marginRight: muiTheme.closableTabs.closeButtonWidth,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {label}
+            </span>
+          );
+
+          return (
+            <span
+              style={{
+                position: 'relative',
+                width: muiTheme.closableTabs.width,
+                display: 'inline-block',
+              }}
+            >
+              <MaterialUITab
+                {...tabProps}
+                label={truncatedLabel}
+                selected={selected}
+                buttonStyle={{
+                  height: muiTheme.closableTabs.height,
+                  backgroundColor: selected
+                    ? muiTheme.closableTabs.selectedBackgroundColor
+                    : muiTheme.closableTabs.backgroundColor,
+                  color: selected
                     ? muiTheme.closableTabs.selectedTextColor
-                    : muiTheme.closableTabs.textColor
-                }
+                    : muiTheme.closableTabs.textColor,
+                }}
                 style={{
-                  width: muiTheme.closableTabs.height / 2,
-                  height: muiTheme.closableTabs.height / 2,
+                  height: '100%',
+                  width: '100%',
                 }}
               />
-            }
-          />
-        )}
-      </span>
+              {closable && (
+                <FlatButton
+                  backgroundColor="transparent"
+                  hoverColor={muiTheme.selectedBackgroundColor}
+                  onClick={onClose}
+                  style={{
+                    position: 'absolute',
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    borderRadius: 0,
+                    width: muiTheme.closableTabs.closeButtonWidth,
+                    minWidth: muiTheme.closableTabs.closeButtonWidth,
+                  }}
+                  icon={
+                    <Close
+                      color={
+                        selected
+                          ? muiTheme.closableTabs.selectedTextColor
+                          : muiTheme.closableTabs.textColor
+                      }
+                      style={{
+                        width: muiTheme.closableTabs.height / 2,
+                        height: muiTheme.closableTabs.height / 2,
+                      }}
+                    />
+                  }
+                />
+              )}
+            </span>
+          );
+        }}
+      </ThemeConsumer>
     );
   }
 }
-
-export const Tab = muiThemeable()(ThemableTab);
-Tab.muiName = 'Tab';

--- a/newIDE/app/src/UI/Tabs.js
+++ b/newIDE/app/src/UI/Tabs.js
@@ -1,174 +1,40 @@
-import React, { Component } from 'react';
-import { Tabs as MaterialUITabs, Tab as MaterialUITab } from 'material-ui/Tabs';
-import Close from 'material-ui/svg-icons/navigation/close';
-import FlatButton from 'material-ui/FlatButton';
-import ThemeConsumer from './Theme/ThemeConsumer';
+// @flow
+import * as React from 'react';
+import { Tabs as MUITabs, Tab as MUITab } from 'material-ui/Tabs';
 
-const styles = {
-  tabsContainerStyle: {
-    maxWidth: '100%',
-    flex: 1,
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  tabTemplateStyle: {
-    width: '100%',
-    position: 'relative',
-    textAlign: 'initial',
-    height: '100%',
-  },
-};
+// We support a subset of the props supported by Material-UI v0.x Tabs
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TabsProps<TabName> = {|
+  value?: TabName,
+  onChange: TabName => void,
+  children: React.Node, // Should be Tab
+|};
 
 /**
- * This is to override the default material-ui tab template used to wrap the content of each tab element.
- * 2 changes (**please port them to your new implementation if you change the tabs**):
- *
- * 1) Instead of setting the "height" of hidden tabs to "0", we set "display" to "none" to avoid
- * messing with components (in particular components where you can scroll: when collapsed because of height=0,
- * they will lose they scrolling position).
- *
- * 2) shouldComponentUpdate is used to avoid updating the content of a tab that is not selected.
- *
- * Rest of the implementation is the same.
+ * Tabs based on Material-UI Tabs.
  */
-class TabTemplate extends Component {
-  shouldComponentUpdate(nextProps) {
-    return this.props.selected || nextProps.selected;
-  }
-
+export class Tabs<TabName> extends React.Component<TabsProps<TabName>, {||}> {
   render() {
-    const { children, selected, style } = this.props;
-    const templateStyle = { ...styles.tabTemplateStyle, ...style };
-    if (!selected) {
-      templateStyle.display = 'none';
-    }
-
-    return <div style={templateStyle}>{children}</div>;
+    return <MUITabs {...this.props} />;
   }
 }
 
-export class Tabs extends Component {
-  render() {
-    const { hideLabels, ...tabsProps } = this.props;
+// We support a subset of the props supported by Material-UI v0.x Table
+// They should be self descriptive - refer to Material UI docs otherwise.
+type TabProps = {|
+  label: React.Node,
+  value: string,
+  children?: React.Node,
+|};
 
-    return (
-      <ThemeConsumer>
-        {muiTheme => {
-          const tabItemContainerStyle = {
-            maxWidth: '100%', // Tabs should take all width
-            flexShrink: 0, // Tabs height should never be reduced
-            overflowX: 'auto',
-            display: hideLabels ? 'none' : 'block',
-            backgroundColor: muiTheme.closableTabs.backgroundColor,
-          };
-
-          const contentContainerStyle = {
-            overflowY: 'hidden',
-            height: hideLabels
-              ? '100%'
-              : `calc(100% - ${muiTheme.closableTabs.height}px)`,
-          };
-
-          return (
-            <MaterialUITabs
-              style={styles.tabsContainerStyle}
-              tabTemplate={TabTemplate}
-              contentContainerStyle={contentContainerStyle}
-              tabItemContainerStyle={tabItemContainerStyle}
-              inkBarStyle={{ display: 'none' }}
-              {...tabsProps}
-            />
-          );
-        }}
-      </ThemeConsumer>
-    );
-  }
-}
-Tabs.muiName = 'Tabs';
-
-export class Tab extends Component {
+/**
+ * A Tab based on Material-UI Tab.
+ */
+export class Tab extends React.Component<TabProps, {||}> {
+  // Set muiName to let Material-UI's v0.x Table recognise
+  // the component.
   static muiName = 'Tab';
-
   render() {
-    const { selected, onClose, label, closable, ...tabProps } = this.props;
-
-    return (
-      <ThemeConsumer>
-        {muiTheme => {
-          const truncatedLabel = (
-            <span
-              style={{
-                width:
-                  muiTheme.closableTabs.width -
-                  muiTheme.closableTabs.closeButtonWidth * 1.5,
-                marginRight: muiTheme.closableTabs.closeButtonWidth,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {label}
-            </span>
-          );
-
-          return (
-            <span
-              style={{
-                position: 'relative',
-                width: muiTheme.closableTabs.width,
-                display: 'inline-block',
-              }}
-            >
-              <MaterialUITab
-                {...tabProps}
-                label={truncatedLabel}
-                selected={selected}
-                buttonStyle={{
-                  height: muiTheme.closableTabs.height,
-                  backgroundColor: selected
-                    ? muiTheme.closableTabs.selectedBackgroundColor
-                    : muiTheme.closableTabs.backgroundColor,
-                  color: selected
-                    ? muiTheme.closableTabs.selectedTextColor
-                    : muiTheme.closableTabs.textColor,
-                }}
-                style={{
-                  height: '100%',
-                  width: '100%',
-                }}
-              />
-              {closable && (
-                <FlatButton
-                  backgroundColor="transparent"
-                  hoverColor={muiTheme.selectedBackgroundColor}
-                  onClick={onClose}
-                  style={{
-                    position: 'absolute',
-                    right: 0,
-                    top: 0,
-                    bottom: 0,
-                    borderRadius: 0,
-                    width: muiTheme.closableTabs.closeButtonWidth,
-                    minWidth: muiTheme.closableTabs.closeButtonWidth,
-                  }}
-                  icon={
-                    <Close
-                      color={
-                        selected
-                          ? muiTheme.closableTabs.selectedTextColor
-                          : muiTheme.closableTabs.textColor
-                      }
-                      style={{
-                        width: muiTheme.closableTabs.height / 2,
-                        height: muiTheme.closableTabs.height / 2,
-                      }}
-                    />
-                  }
-                />
-              )}
-            </span>
-          );
-        }}
-      </ThemeConsumer>
-    );
+    return <MUITab {...this.props} />;
   }
 }

--- a/newIDE/app/src/UI/Text.js
+++ b/newIDE/app/src/UI/Text.js
@@ -30,4 +30,4 @@ type Props = {|
 // A Text to be displayed in the app. Prefer using this
 // than a `<p>`/`<span>` or `<div>` as this will help to maintain
 // consistency of text in the whole app.
-export default ({ children }: Props) => <p>{children}</p>;
+export default ({ children, style }: Props) => <p style={style}>{children}</p>;

--- a/newIDE/app/src/UI/Text.js
+++ b/newIDE/app/src/UI/Text.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react';
+
+type Props = {|
+  children: ?React.Node,
+  style?: {|
+    // Allow a larger text for titles
+    fontSize?: 24,
+
+    // Margins
+    marginLeft?: number,
+    marginRight?: number,
+    marginTop?: number,
+    marginBottom?: number,
+
+    // Allow to expand the text
+    flex?: 1,
+
+    // Allow to show the text inline
+    display?: 'inline-block',
+
+    // Right align
+    textAlign?: 'right',
+
+    // Styling
+    opacity?: 0.8,
+  |},
+|};
+
+// A Text to be displayed in the app. Prefer using this
+// than a `<p>`/`<span>` or `<div>` as this will help to maintain
+// consistency of text in the whole app.
+export default ({ children }: Props) => <p>{children}</p>;

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -1,0 +1,92 @@
+// @flow
+import * as React from 'react';
+import MUITextField from 'material-ui/TextField';
+
+type ValueProps =
+  // Support "text" and "password" type:
+  | {|
+      type?: 'text' | 'password',
+      value: string,
+      onChange?: (event: {| target: {| value: string |} |}, text: string) => void,
+    |}
+  // Support "number" type:
+  | {|
+      type: 'number',
+      value: number,
+      onChange?: (event: {||}, value: number) => void,
+    |}
+  // Support an "uncontrolled" field:
+  | {| defaultValue: string |}
+  // Support an empty field with just a hint text:
+  | {| hintText?: React.Node |};
+
+// We support a subset of the props supported by Material-UI v0.x TextField
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  ...ValueProps,
+  fullWidth?: boolean,
+  onFocus?: ({
+    currentTarget: {
+      value: string,
+    },
+    preventDefault: () => void,
+  }) => void,
+  onBlur?: ({
+    currentTarget: {
+      value: string,
+    },
+  }) => void,
+  onKeyPress?: (event: {| charCode: number, key: string |}) => void,
+  onKeyUp?: (event: {| charCode: number, key: string |}) => void,
+
+  disabled?: boolean,
+  errorText?: React.Node,
+  floatingLabelFixed?: boolean,
+  floatingLabelText?: React.Node,
+  fullWidth?: boolean,
+  hintText?: React.Node,
+  id?: string,
+  inputStyle?: Object,
+  precision?: number,
+  max?: number,
+  min?: number,
+  multiLine?: boolean,
+  name?: string,
+  step?: number,
+  style?: Object,
+  rows?: number,
+  rowsMax?: number,
+  autoFocus?: boolean,
+
+  underlineFocusStyle?: {| borderColor: string |},
+  underlineShow?: boolean,
+|};
+
+/**
+ * A text field based on Material-UI text field.
+ */
+export default class TextField extends React.Component<Props, {||}> {
+  _muiTextField = React.createRef<MUITextField>();
+
+  focus() {
+    if (this._muiTextField.current) {
+      this._muiTextField.current.focus();
+    }
+  }
+
+  blur() {
+    if (this._muiTextField.current) {
+      this._muiTextField.current.blur();
+    }
+  }
+
+  getInputNode() {
+    if (this._muiTextField.current) {
+      return this._muiTextField.current.getInputNode();
+    }
+  }
+
+  render() {
+    return <MUITextField {...this.props} ref={this._muiTextField} />;
+  }
+}

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -7,7 +7,10 @@ type ValueProps =
   | {|
       type?: 'text' | 'password',
       value: string,
-      onChange?: (event: {| target: {| value: string |} |}, text: string) => void,
+      onChange?: (
+        event: {| target: {| value: string |} |},
+        text: string
+      ) => void,
     |}
   // Support "number" type:
   | {|

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -26,8 +26,8 @@ type ValueProps =
 // We support a subset of the props supported by Material-UI v0.x TextField
 // They should be self descriptive - refer to Material UI docs otherwise.
 type Props = {|
+  // Value and change handling:
   ...ValueProps,
-  fullWidth?: boolean,
   onFocus?: ({
     currentTarget: {
       value: string,
@@ -46,21 +46,42 @@ type Props = {|
   errorText?: React.Node,
   floatingLabelFixed?: boolean,
   floatingLabelText?: React.Node,
-  fullWidth?: boolean,
+  name?: string,
   hintText?: React.Node,
   id?: string,
-  inputStyle?: Object,
+
+  // Keyboard focus:
+  autoFocus?: boolean,
+
+  // Number text field:
   precision?: number,
   max?: number,
   min?: number,
-  multiLine?: boolean,
-  name?: string,
   step?: number,
-  style?: Object,
+
+  // Support for multiline:
+  multiLine?: boolean,
   rows?: number,
   rowsMax?: number,
-  autoFocus?: boolean,
 
+  // Styling:
+  fullWidth?: boolean,
+  style?: {|
+    fontSize?: 18,
+    fontStyle?: 'normal' | 'italic',
+    width?: number | '100%',
+    flex?: 1,
+    top?: number,
+  |},
+  inputStyle?: {|
+    // Allow to customize color (replace by color prop?)
+    color?: string,
+    WebkitTextFillColor?: string,
+
+    // Allow to display monospaced font
+    fontFamily?: '"Lucida Console", Monaco, monospace',
+    lineHeight?: 1.4,
+  |},
   underlineFocusStyle?: {| borderColor: string |},
   underlineShow?: boolean,
 |};

--- a/newIDE/app/src/UI/Theme/ThemeConsumer.js
+++ b/newIDE/app/src/UI/Theme/ThemeConsumer.js
@@ -2,8 +2,6 @@ import muiThemeable from 'material-ui/styles/muiThemeable';
 
 /**
  * Expose the Material UI theme.
- * TODO: All components using muiThemeable HOC should be migrated to
- * use this component instead (will ease any future migration).
  */
 const ThemeConsumer = props => props.children(props.muiTheme);
 

--- a/newIDE/app/src/UI/Toggle.js
+++ b/newIDE/app/src/UI/Toggle.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+import MUIToggle from 'material-ui/Toggle';
+
+// We support a subset of the props supported by Material-UI v0.x Toggle
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  label?: ?React.Node,
+  toggled: boolean,
+  onToggle: (e: {||}, toggled: boolean) => void,
+  disabled?: boolean,
+  labelPosition: 'right',
+
+  style?: {|
+    marginTop?: number,
+  |},
+|};
+
+/**
+ * A text field based on Material-UI text field.
+ */
+export default class Toggle extends React.Component<Props, {||}> {
+  render() {
+    return <MUIToggle {...this.props} />;
+  }
+}

--- a/newIDE/app/src/UI/ToolbarIcon.js
+++ b/newIDE/app/src/UI/ToolbarIcon.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import IconButton from 'material-ui/IconButton';
+import IconButton from './IconButton';
 import ThemeConsumer from './Theme/ThemeConsumer';
 
 /**

--- a/newIDE/app/src/VariablesList/EditVariableRow.js
+++ b/newIDE/app/src/VariablesList/EditVariableRow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TreeTableRow, TreeTableCell } from '../UI/TreeTable';
 import Add from 'material-ui/svg-icons/content/add';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
 import ContentCopy from 'material-ui/svg-icons/content/content-copy';
 import ContentPaste from 'material-ui/svg-icons/content/content-paste';

--- a/newIDE/app/src/VariablesList/VariableRow.js
+++ b/newIDE/app/src/VariablesList/VariableRow.js
@@ -7,7 +7,7 @@ import SemiControlledTextField from '../UI/SemiControlledTextField';
 import Checkbox from 'material-ui/Checkbox';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import SubdirectoryArrowRight from 'material-ui/svg-icons/navigation/subdirectory-arrow-right';
-import TextField from 'material-ui/TextField';
+import TextField from '../UI/TextField';
 import IconButton from 'material-ui/IconButton';
 import Reset from 'material-ui/svg-icons/av/replay';
 import muiThemeable from 'material-ui/styles/muiThemeable';

--- a/newIDE/app/src/VariablesList/VariableRow.js
+++ b/newIDE/app/src/VariablesList/VariableRow.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { TreeTableRow, TreeTableCell } from '../UI/TreeTable';
 import DragHandle from '../UI/DragHandle';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox from '../UI/Checkbox';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import SubdirectoryArrowRight from 'material-ui/svg-icons/navigation/subdirectory-arrow-right';
 import TextField from '../UI/TextField';

--- a/newIDE/app/src/VariablesList/VariableRow.js
+++ b/newIDE/app/src/VariablesList/VariableRow.js
@@ -8,7 +8,7 @@ import Checkbox from 'material-ui/Checkbox';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import SubdirectoryArrowRight from 'material-ui/svg-icons/navigation/subdirectory-arrow-right';
 import TextField from '../UI/TextField';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '../UI/IconButton';
 import Reset from 'material-ui/svg-icons/av/replay';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';

--- a/newIDE/app/src/VariablesList/VariableRow.js
+++ b/newIDE/app/src/VariablesList/VariableRow.js
@@ -10,9 +10,9 @@ import SubdirectoryArrowRight from 'material-ui/svg-icons/navigation/subdirector
 import TextField from '../UI/TextField';
 import IconButton from '../UI/IconButton';
 import Reset from 'material-ui/svg-icons/av/replay';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import styles from './styles';
 import { type VariableOrigin } from './VariablesList.flow';
+import ThemeConsumer from '../UI/Theme/ThemeConsumer';
 
 //TODO: Refactor into TreeTable?
 const Indent = ({ width }) => (
@@ -34,7 +34,6 @@ type Props = {|
   onChangeValue: string => void,
   onResetToDefaultValue: () => void,
   children?: React.Node,
-  muiTheme: Object,
   showHandle: boolean,
   showSelectionCheckbox: boolean,
   isSelected: boolean,
@@ -42,7 +41,7 @@ type Props = {|
   origin: VariableOrigin,
 |};
 
-const ThemableVariableRow = ({
+const VariableRow = ({
   name,
   variable,
   depth,
@@ -53,7 +52,6 @@ const ThemableVariableRow = ({
   onChangeValue,
   onResetToDefaultValue,
   children,
-  muiTheme,
   showHandle,
   showSelectionCheckbox,
   isSelected,
@@ -143,16 +141,19 @@ const ThemableVariableRow = ({
   );
 
   return (
-    <div>
-      <TreeTableRow
-        style={{ backgroundColor: muiTheme.list.itemsBackgroundColor }}
-      >
-        {columns}
-      </TreeTableRow>
-      {children}
-    </div>
+    <ThemeConsumer>
+      {muiTheme => (
+        <div>
+          <TreeTableRow
+            style={{ backgroundColor: muiTheme.list.itemsBackgroundColor }}
+          >
+            {columns}
+          </TreeTableRow>
+          {children}
+        </div>
+      )}
+    </ThemeConsumer>
   );
 };
 
-const VariableRow = muiThemeable()(ThemableVariableRow);
 export default VariableRow;

--- a/newIDE/app/src/VariablesList/VariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/VariablesEditorDialog.js
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import FlatButton from 'material-ui/FlatButton';
+import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import { withSerializableObject } from '../Utils/SerializableObjectEditorContainer';
 import VariablesList from './index';

--- a/newIDE/app/src/VariablesList/index.js
+++ b/newIDE/app/src/VariablesList/index.js
@@ -1,11 +1,6 @@
 // @flow
 import * as React from 'react';
-import {
-  Table,
-  TableHeader,
-  TableHeaderColumn,
-  TableRow,
-} from 'material-ui/Table';
+import { Table, TableHeader, TableHeaderColumn, TableRow } from '../UI/Table';
 import flatten from 'lodash/flatten';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import { mapFor } from '../Utils/MapFor';

--- a/newIDE/app/src/stories/MuiDecorator.js
+++ b/newIDE/app/src/stories/MuiDecorator.js
@@ -1,11 +1,13 @@
 // @flow
 import React from 'react';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import defaultTheme from '../UI/Theme/DefaultTheme';
 import { type StoryDecorator } from '@storybook/react';
 
 const muiDecorator: StoryDecorator = (story, context) => (
-  <MuiThemeProvider muiTheme={defaultTheme}>{story(context)}</MuiThemeProvider>
+  <V0MuiThemeProvider muiTheme={defaultTheme}>
+    {story(context)}
+  </V0MuiThemeProvider>
 );
 
 export default muiDecorator;

--- a/newIDE/app/src/stories/SerializedObjectDisplay.js
+++ b/newIDE/app/src/stories/SerializedObjectDisplay.js
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import Paper from 'material-ui/Paper';
-import RaisedButton from 'material-ui/RaisedButton';
+import RaisedButton from '../UI/RaisedButton';
 import { serializeToJSObject } from '../Utils/Serializer';
 const gd = global.gd;
 

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -12,7 +12,7 @@ import HelpIcon from '../UI/HelpIcon';
 import StartPage from '../MainFrame/Editors/StartPage';
 import AboutDialog from '../MainFrame/AboutDialog';
 import CreateProjectDialog from '../ProjectCreation/CreateProjectDialog';
-import { Tabs, Tab } from '../UI/Tabs';
+import { Tabs, Tab } from '../UI/ClosableTabs';
 import DragHandle from '../UI/DragHandle';
 import Background from '../UI/Background';
 import HelpFinder from '../HelpFinder';


### PR DESCRIPTION
This replace the imports to various material-ui components by "facade" components in the UI folder.
This allow to type properly these UI components (could avoid a few silly bugs) and will make it: 
* Easier to upgrade to a new material-ui version
* Easier to change the design of the base components (buttons, text fields, etc...) in the whole app.

In the long term, only the "UI" folder should use `material-ui` components. The rest of the codebase should import all the necessary UI components from "UI" folder.