### PR TITLE
Add more layer effects

### DIFF
--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -395,6 +395,21 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .MarkAsAdvanced();
 
   extension
+      .AddCondition(
+          "LayerEffectEnabled",
+          _("Layer effect is enabled"),
+          _("The effect on a layer is enabled"),
+          _("Effect _PARAM2_ on layer _PARAM1_ is enabled"),
+          _("Layers and cameras/Effects"),
+          "res/conditions/camera24.png",
+          "res/conditions/camera.png")
+      .AddCodeOnlyParameter("currentScene", "")
+      .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
+      .SetDefaultValue("\"\"")
+      .AddParameter("string", _("Effect"))
+      .MarkAsAdvanced();
+
+  extension
       .AddAction(
           "EnableLayerEffect",
           _("Enable layer effect"),

--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -395,6 +395,22 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .MarkAsAdvanced();
 
   extension
+      .AddAction(
+          "EnableLayerEffect",
+          _("Enable layer effect"),
+          _("Enable an effect on a layer"),
+          _("Enable effect _PARAM2_ on layer _PARAM1_: _PARAM3_"),
+          _("Layers and cameras/Effects"),
+          "res/conditions/camera24.png",
+          "res/conditions/camera.png")
+      .AddCodeOnlyParameter("currentScene", "")
+      .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
+      .SetDefaultValue("\"\"")
+      .AddParameter("string", _("Effect"))
+      .AddParameter("yesorno", _("Enable"), "", true)
+      .MarkAsAdvanced();
+
+  extension
       .AddCondition(
           "LayerTimeScale",
           _("Layer time scale"),

--- a/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
@@ -65,6 +65,8 @@ CameraExtension::CameraExtension() {
 
   GetAllActions()["SetLayerEffectParameter"].SetFunctionName(
       "gdjs.evtTools.camera.setLayerEffectParameter");
+  GetAllActions()["EnableLayerEffect"].SetFunctionName(
+      "gdjs.evtTools.camera.enableLayerEffect");
 
   GetAllConditions()["LayerTimeScale"].SetFunctionName(
       "gdjs.evtTools.camera.getLayerTimeScale");

--- a/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
@@ -67,6 +67,8 @@ CameraExtension::CameraExtension() {
       "gdjs.evtTools.camera.setLayerEffectParameter");
   GetAllActions()["EnableLayerEffect"].SetFunctionName(
       "gdjs.evtTools.camera.enableLayerEffect");
+  GetAllConditions()["LayerEffectEnabled"].SetFunctionName(
+      "gdjs.evtTools.camera.layerEffectEnabled");
 
   GetAllConditions()["LayerTimeScale"].SetFunctionName(
       "gdjs.evtTools.camera.getLayerTimeScale");

--- a/GDJS/Runtime/events-tools/cameratools.js
+++ b/GDJS/Runtime/events-tools/cameratools.js
@@ -129,24 +129,24 @@ gdjs.evtTools.camera.setLayerEffectParameter = function(runtimeScene, layer, eff
 }
 
 /**
- * Enable an effect.
- * @param {gdjs.RuntimeScene} runtimeScene The current scene
+ * Enable, or disable, an effect of a layer.
+ * @param {gdjs.RuntimeScene} runtimeScene The scene
  * @param {string} layer The name of the layer
  * @param {string} effect The name of the effect
- * @param {number} value The new value
+ * @param {boolean} enabled true to enable, false to disable.
  */
-gdjs.evtTools.camera.enableLayerEffect = function(runtimeScene, layer, effect, value) {
+gdjs.evtTools.camera.enableLayerEffect = function(runtimeScene, layer, effect, enabled) {
     if ( !runtimeScene.hasLayer(layer) ) { return; }
 
-    runtimeScene.getLayer(layer).enableEffect(effect, value);
+    runtimeScene.getLayer(layer).enableEffect(effect, enabled);
 }
 
 /**
- * Enable an effect.
- * @param {gdjs.RuntimeScene} runtimeScene The current scene
+ * Check if an effect is enabled.
+ * @param {gdjs.RuntimeScene} runtimeScene The scene
  * @param {string} layer The name of the layer
- * @param {string} filter The name of the effect
- * @return {boolean} Filter is enabled
+ * @param {string} effect The name of the effect
+ * @return {boolean} true if the effect is enabled, false otherwise.
  */
 gdjs.evtTools.camera.layerEffectEnabled = function(runtimeScene, layer, effect) {
     if ( !runtimeScene.hasLayer(layer) ) { return true; }

--- a/GDJS/Runtime/events-tools/cameratools.js
+++ b/GDJS/Runtime/events-tools/cameratools.js
@@ -128,6 +128,12 @@ gdjs.evtTools.camera.setLayerEffectParameter = function(runtimeScene, layer, eff
     return runtimeScene.getLayer(layer).setEffectParameter(effect, parameter, value);
 }
 
+gdjs.evtTools.camera.enableLayerEffect = function(runtimeScene, layer, effect, value) {
+    if ( !runtimeScene.hasLayer(layer) ) { return; }
+
+    return runtimeScene.getLayer(layer).enableEffect(effect, value);
+}
+
 gdjs.evtTools.camera.setLayerTimeScale = function(runtimeScene, layer, timeScale) {
     if ( !runtimeScene.hasLayer(layer) ) { return; }
     return runtimeScene.getLayer(layer).setTimeScale(timeScale);

--- a/GDJS/Runtime/events-tools/cameratools.js
+++ b/GDJS/Runtime/events-tools/cameratools.js
@@ -128,10 +128,30 @@ gdjs.evtTools.camera.setLayerEffectParameter = function(runtimeScene, layer, eff
     return runtimeScene.getLayer(layer).setEffectParameter(effect, parameter, value);
 }
 
+/**
+ * Enable an effect.
+ * @param {gdjs.RuntimeScene} runtimeScene The current scene
+ * @param {string} layer The name of the layer
+ * @param {string} effect The name of the effect
+ * @param {number} value The new value
+ */
 gdjs.evtTools.camera.enableLayerEffect = function(runtimeScene, layer, effect, value) {
     if ( !runtimeScene.hasLayer(layer) ) { return; }
 
-    return runtimeScene.getLayer(layer).enableEffect(effect, value);
+    runtimeScene.getLayer(layer).enableEffect(effect, value);
+}
+
+/**
+ * Enable an effect.
+ * @param {gdjs.RuntimeScene} runtimeScene The current scene
+ * @param {string} layer The name of the layer
+ * @param {string} filter The name of the effect
+ * @return {boolean} Filter is enabled
+ */
+gdjs.evtTools.camera.layerEffectEnabled = function(runtimeScene, layer, effect) {
+    if ( !runtimeScene.hasLayer(layer) ) { return 1; }
+
+    return runtimeScene.getLayer(layer).isEffectEnabled(effect);
 }
 
 gdjs.evtTools.camera.setLayerTimeScale = function(runtimeScene, layer, timeScale) {

--- a/GDJS/Runtime/events-tools/cameratools.js
+++ b/GDJS/Runtime/events-tools/cameratools.js
@@ -149,7 +149,7 @@ gdjs.evtTools.camera.enableLayerEffect = function(runtimeScene, layer, effect, v
  * @return {boolean} Filter is enabled
  */
 gdjs.evtTools.camera.layerEffectEnabled = function(runtimeScene, layer, effect) {
-    if ( !runtimeScene.hasLayer(layer) ) { return 1; }
+    if ( !runtimeScene.hasLayer(layer) ) { return true; }
 
     return runtimeScene.getLayer(layer).isEffectEnabled(effect);
 }

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -216,6 +216,10 @@ gdjs.Layer.prototype.setEffectParameter = function(name, parameterIndex, value) 
     return this._renderer.setEffectParameter(name, parameterIndex, value);
 };
 
+gdjs.Layer.prototype.enableEffect = function(name, value) {
+    return this._renderer.enableEffect(name, value);
+};
+
 gdjs.Layer.prototype.setEffectsDefaultParameters = function() {
     for (var i = 0; i < this._effects.length; ++i) {
         var effect = this._effects[i];

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -218,17 +218,17 @@ gdjs.Layer.prototype.setEffectParameter = function(name, parameterIndex, value) 
 
 /**
  * Enable or disable an effect.
- * @param {string} filter The name of the effect to enable or disable.
- * @param {boolean} value true to enable, false to disable
+ * @param {string} effect The name of the effect to enable or disable.
+ * @param {boolean} enable true to enable, false to disable
  */
-gdjs.Layer.prototype.enableEffect = function(name, value) {
-    this._renderer.enableEffect(name, value);
+gdjs.Layer.prototype.enableEffect = function(name, enable) {
+    this._renderer.enableEffect(name, enable);
 };
 
 /**
  * Check if an effect is enabled
- * @param {string} filter The name of the filter effect
- * @return {boolean} Filter is enabled
+ * @param {string} effect The name of the effect
+ * @return {boolean} true if the effect is enabled, false otherwise.
  */
 gdjs.Layer.prototype.isEffectEnabled = function(name) {
     return this._renderer.isEffectEnabled(name);

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -217,8 +217,8 @@ gdjs.Layer.prototype.setEffectParameter = function(name, parameterIndex, value) 
 };
 
 /**
- * Enable an effect.
- * @param {string} filter The name of the filter effect
+ * Enable or disable an effect.
+ * @param {string} filter The name of the effect to enable or disable.
  * @param {boolean} value true to enable, false to disable
  */
 gdjs.Layer.prototype.enableEffect = function(name, value) {
@@ -226,7 +226,7 @@ gdjs.Layer.prototype.enableEffect = function(name, value) {
 };
 
 /**
- * Enable an effect.
+ * Check if an effect is enabled
  * @param {string} filter The name of the filter effect
  * @return {boolean} Filter is enabled
  */

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -216,8 +216,22 @@ gdjs.Layer.prototype.setEffectParameter = function(name, parameterIndex, value) 
     return this._renderer.setEffectParameter(name, parameterIndex, value);
 };
 
+/**
+ * Enable an effect.
+ * @param {string} filter The name of the filter effect
+ * @param {boolean} value true to enable, false to disable
+ */
 gdjs.Layer.prototype.enableEffect = function(name, value) {
-    return this._renderer.enableEffect(name, value);
+    this._renderer.enableEffect(name, value);
+};
+
+/**
+ * Enable an effect.
+ * @param {string} filter The name of the filter effect
+ * @return {boolean} Filter is enabled
+ */
+gdjs.Layer.prototype.isEffectEnabled = function(name) {
+    return this._renderer.isEffectEnabled(name);
 };
 
 gdjs.Layer.prototype.setEffectsDefaultParameters = function() {

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -119,7 +119,7 @@ gdjs.LayerPixiRenderer.prototype.enableEffect = function (name, value) {
 };
 
 gdjs.LayerPixiRenderer.prototype.isEffectEnabled = function (name) {
-    if (!this._filters.hasOwnProperty(name)) return 1;
+    if (!this._filters.hasOwnProperty(name)) return false;
 
     var theFilter = this._filters[name];
     return gdjs.PixiFiltersTools.isEffectEnabled(theFilter.filter);

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -117,3 +117,10 @@ gdjs.LayerPixiRenderer.prototype.enableEffect = function (name, value) {
     var theFilter = this._filters[name];
     gdjs.PixiFiltersTools.enableEffect(theFilter.filter, value);
 };
+
+gdjs.LayerPixiRenderer.prototype.isEffectEnabled = function (name) {
+    if (!this._filters.hasOwnProperty(name)) return 1;
+
+    var theFilter = this._filters[name];
+    return gdjs.PixiFiltersTools.isEffectEnabled(theFilter.filter);
+};

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -109,4 +109,5 @@ gdjs.LayerPixiRenderer.prototype.setEffectParameter = function (name, parameterN
 
     var theFilter = this._filters[name];
     theFilter.updateParameter(theFilter.filter, parameterName, value);
+    //this._addFilters();
 };

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -110,3 +110,10 @@ gdjs.LayerPixiRenderer.prototype.setEffectParameter = function (name, parameterN
     var theFilter = this._filters[name];
     theFilter.updateParameter(theFilter.filter, parameterName, value);
 };
+
+gdjs.LayerPixiRenderer.prototype.enableEffect = function (name, value) {
+    if (!this._filters.hasOwnProperty(name)) return;
+
+    var theFilter = this._filters[name];
+    gdjs.PixiFiltersTools.enableEffect(theFilter.filter, value);
+};

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -109,5 +109,4 @@ gdjs.LayerPixiRenderer.prototype.setEffectParameter = function (name, parameterN
 
     var theFilter = this._filters[name];
     theFilter.updateParameter(theFilter.filter, parameterName, value);
-    //this._addFilters();
 };

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -96,6 +96,18 @@ gdjs.PixiFiltersTools._filters = {
             filter.alpha = value;
         },
     },
+    BlackAndWhite: {
+        makeFilter: function() {
+            var colorMatrix = new PIXI.filters.ColorMatrixFilter();
+            colorMatrix.blackAndWhite ();
+            return colorMatrix;
+        },
+        updateParameter: function(filter, parameterName, value) {
+            if (parameterName !== 'opacity') return;
+
+            filter.alpha = value;
+        },
+    },
 };
 
 gdjs.PixiFiltersTools.getFilter = function(filterName) {

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -111,6 +111,18 @@ gdjs.PixiFiltersTools._filters = {
             filter.alpha = gdjs.PixiFiltersTools.clampValue(value, 0, 1);
         },
     },
+    Brightness: {
+        makeFilter: function() {
+            var brightness = new PIXI.filters.ColorMatrixFilter();
+            brightness.brightness();
+            return brightness;
+        },
+        updateParameter: function(filter, parameterName, value) {
+            if (parameterName !== 'brightness') return;
+
+            filter.brightness(gdjs.PixiFiltersTools.clampValue(value, 0, 1));
+        },
+    },
     Noise: {
         makeFilter: function() {
             var noise = new PIXI.filters.NoiseFilter();
@@ -144,7 +156,7 @@ gdjs.PixiFiltersTools._filters = {
 
 /**
  * Enable an effect.
- * @param {string} filter The name of the filter effect
+ * @param {PIXI.Filter} filter The filter to enable or disable
  * @param {boolean} value Set to true to enable, false to disable
  */
 gdjs.PixiFiltersTools.enableEffect = function(filter, value) {
@@ -152,9 +164,9 @@ gdjs.PixiFiltersTools.enableEffect = function(filter, value) {
 }
 
 /**
- * Enable an effect.
- * @param {string} filter The name of the filter effect
- * @return {boolean} Filter is enabled
+ * Effect is enabled.
+ * @param {PIXI.Filter} filter The filter to be checked
+ * @return {boolean} true if the filter is enabled
  */
 gdjs.PixiFiltersTools.isEffectEnabled = function(filter) {
     return filter.enabled;

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -110,8 +110,8 @@ gdjs.PixiFiltersTools._filters = {
     },
     Noise: {
         makeFilter: function() {
-            var filter = new PIXI.filters.NoiseFilter();
-            return filter;
+            var noise = new PIXI.filters.NoiseFilter();
+            return noise;
         },
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'noise') return;

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -151,6 +151,15 @@ gdjs.PixiFiltersTools.enableEffect = function(filter, value) {
     filter.enabled = value;
 }
 
+/**
+ * Enable an effect.
+ * @param {string} filter The name of the filter effect
+ * @return {boolean} Filter is enabled
+ */
+gdjs.PixiFiltersTools.isEffectEnabled = function(filter) {
+    return filter.enabled;
+}
+
 gdjs.PixiFiltersTools.getFilter = function(filterName) {
     if (gdjs.PixiFiltersTools._filters.hasOwnProperty(filterName))
         return gdjs.PixiFiltersTools._filters[filterName];

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -142,6 +142,15 @@ gdjs.PixiFiltersTools._filters = {
     },
 };
 
+/**
+ * Enable an effect.
+ * @param {string} filter The name of the filter effect
+ * @param {boolean} value Set to true to enable, false to disable
+ */
+gdjs.PixiFiltersTools.enableEffect = function(filter, value) {
+    filter.enabled = value;
+}
+
 gdjs.PixiFiltersTools.getFilter = function(filterName) {
     if (gdjs.PixiFiltersTools._filters.hasOwnProperty(filterName))
         return gdjs.PixiFiltersTools._filters[filterName];

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -1,5 +1,8 @@
 gdjs.PixiFiltersTools = function() {};
 
+const clampValue = (value, min, max) => Math.max(min, Math.min(max, value));
+const clampKernelSize = value => ([5, 7, 9, 11, 13, 15].includes(value)) ? value : 5;
+
 gdjs.NightPixiFilter = function() {
   var vertexShader = null;
   var fragmentShader = [
@@ -70,7 +73,7 @@ gdjs.PixiFiltersTools._filters = {
             if (parameterName !== 'intensity' &&
                 parameterName !== 'opacity') return;
 
-            filter.uniforms[parameterName] = value;
+            filter.uniforms[parameterName] = clampValue(value, 0, 1);
         },
     },
     LightNight: {
@@ -81,7 +84,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'opacity') return;
 
-            filter.uniforms.opacity = value;
+            filter.uniforms.opacity = clampValue(value, 0, 1);
         },
     },
     Sepia: {
@@ -93,7 +96,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'opacity') return;
 
-            filter.alpha = value;
+            filter.alpha = clampValue(value, 0, 1);
         },
     },
     BlackAndWhite: {
@@ -105,7 +108,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'opacity') return;
 
-            filter.alpha = value;
+            filter.alpha = clampValue(value, 0, 1);
         },
     },
     Noise: {
@@ -116,7 +119,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'noise') return;
 
-            filter.noise = value;
+            filter.noise = clampValue(value, 0, 1);
         },
     },
     Blur: {
@@ -129,7 +132,11 @@ gdjs.PixiFiltersTools._filters = {
                 parameterName !== 'quality' &&
                 parameterName !== 'kernelSize' &&
                 parameterName !== 'resolution') return;
-
+            
+            if (parameterName === 'kernelSize'){
+                value = clampKernelSize(value);
+            }
+            
             filter[parameterName] = value;
         },
     },

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -99,13 +99,38 @@ gdjs.PixiFiltersTools._filters = {
     BlackAndWhite: {
         makeFilter: function() {
             var colorMatrix = new PIXI.filters.ColorMatrixFilter();
-            colorMatrix.blackAndWhite ();
+            colorMatrix.blackAndWhite();
             return colorMatrix;
         },
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'opacity') return;
 
             filter.alpha = value;
+        },
+    },
+    Noise: {
+        makeFilter: function() {
+            var filter = new PIXI.filters.NoiseFilter();
+            return filter;
+        },
+        updateParameter: function(filter, parameterName, value) {
+            if (parameterName !== 'noise') return;
+
+            filter.noise = value;
+        },
+    },
+    Blur: {
+        makeFilter: function() {
+            var blur = new PIXI.filters.BlurFilter();
+            return blur;
+        },
+        updateParameter: function(filter, parameterName, value) {
+            if (parameterName !== 'blur' &&
+                parameterName !== 'quality' &&
+                parameterName !== 'kernelSize' &&
+                parameterName !== 'resolution') return;
+
+            filter[parameterName] = value;
         },
     },
 };

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.js
@@ -1,7 +1,7 @@
 gdjs.PixiFiltersTools = function() {};
 
-const clampValue = (value, min, max) => Math.max(min, Math.min(max, value));
-const clampKernelSize = value => ([5, 7, 9, 11, 13, 15].includes(value)) ? value : 5;
+gdjs.PixiFiltersTools.clampValue = function(value, min, max) { return Math.max(min, Math.min(max, value)); };
+gdjs.PixiFiltersTools.clampKernelSize = function(value) { return (([5, 7, 9, 11, 13, 15].indexOf(value) !== -1) ? value : 5); };
 
 gdjs.NightPixiFilter = function() {
   var vertexShader = null;
@@ -73,7 +73,7 @@ gdjs.PixiFiltersTools._filters = {
             if (parameterName !== 'intensity' &&
                 parameterName !== 'opacity') return;
 
-            filter.uniforms[parameterName] = clampValue(value, 0, 1);
+            filter.uniforms[parameterName] = gdjs.PixiFiltersTools.clampValue(value, 0, 1);
         },
     },
     LightNight: {
@@ -84,7 +84,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'opacity') return;
 
-            filter.uniforms.opacity = clampValue(value, 0, 1);
+            filter.uniforms.opacity = gdjs.PixiFiltersTools.clampValue(value, 0, 1);
         },
     },
     Sepia: {
@@ -96,7 +96,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'opacity') return;
 
-            filter.alpha = clampValue(value, 0, 1);
+            filter.alpha = gdjs.PixiFiltersTools.clampValue(value, 0, 1);
         },
     },
     BlackAndWhite: {
@@ -108,7 +108,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'opacity') return;
 
-            filter.alpha = clampValue(value, 0, 1);
+            filter.alpha = gdjs.PixiFiltersTools.clampValue(value, 0, 1);
         },
     },
     Noise: {
@@ -119,7 +119,7 @@ gdjs.PixiFiltersTools._filters = {
         updateParameter: function(filter, parameterName, value) {
             if (parameterName !== 'noise') return;
 
-            filter.noise = clampValue(value, 0, 1);
+            filter.noise = gdjs.PixiFiltersTools.clampValue(value, 0, 1);
         },
     },
     Blur: {
@@ -134,7 +134,7 @@ gdjs.PixiFiltersTools._filters = {
                 parameterName !== 'resolution') return;
             
             if (parameterName === 'kernelSize'){
-                value = clampKernelSize(value);
+                value = gdjs.PixiFiltersTools.clampKernelSize(value);
             }
             
             filter[parameterName] = value;

--- a/newIDE/app/src/EffectsList/EffectDescription.js
+++ b/newIDE/app/src/EffectsList/EffectDescription.js
@@ -11,9 +11,6 @@ export type EffectDescription = {|
   parameterDefaultValues: Array<EffectDefaultValue>,
 |};
 
-const clampValue = value => Math.max(0, Math.min(1, value));
-const clampKernelSize = value => ([5, 7, 9, 11, 13, 15].includes(value)) ? value : 5;
-
 export const getAllEffectDescriptions = (
   i18n: I18nType
 ): Array<EffectDescription> => [
@@ -26,7 +23,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', newValue),
       },
     ],
     parameterDefaultValues: [
@@ -45,7 +42,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', newValue),
       },
     ],
     parameterDefaultValues: [
@@ -88,7 +85,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('kernelSize'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('kernelSize', clampKernelSize(newValue)),
+          effect.setParameter('kernelSize', newValue),
       },
     ],
     parameterDefaultValues: [
@@ -119,7 +116,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', newValue),
       },
       {
         name: 'intensity',
@@ -127,7 +124,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('intensity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('intensity', clampValue(newValue)),
+          effect.setParameter('intensity', newValue),
       },
     ],
     parameterDefaultValues: [
@@ -150,7 +147,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', newValue),
       },
     ],
     parameterDefaultValues: [
@@ -169,7 +166,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('noise'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('noise', clampValue(newValue)),
+          effect.setParameter('noise', newValue),
       },
     ],
     parameterDefaultValues: [

--- a/newIDE/app/src/EffectsList/EffectDescription.js
+++ b/newIDE/app/src/EffectsList/EffectDescription.js
@@ -26,7 +26,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', clampValue(newValue, 0, 1)),
       },
     ],
     parameterDefaultValues: [
@@ -45,13 +45,32 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', clampValue(newValue, 0, 1)),
       },
     ],
     parameterDefaultValues: [
       {
         name: 'opacity',
         value: 1,
+      },
+    ],
+  },
+  {
+    name: 'Brightness',
+    schema: [
+      {
+        name: 'brightness',
+        getLabel: () => 'brightness ' + i18n._(t`(between 0 and 1)`),
+        valueType: 'number',
+        getValue: (effect: gdEffect) => effect.getParameter('brightness'),
+        setValue: (effect: gdEffect, newValue: number) =>
+          effect.setParameter('brightness', clampValue(newValue, 0, 360)),
+      },
+    ],
+    parameterDefaultValues: [
+      {
+        name: 'brightness',
+        value: 0,
       },
     ],
   },
@@ -119,7 +138,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', clampValue(newValue, 0, 1)),
       },
       {
         name: 'intensity',
@@ -127,7 +146,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('intensity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('intensity', clampValue(newValue)),
+          effect.setParameter('intensity', clampValue(newValue, 0, 1)),
       },
     ],
     parameterDefaultValues: [
@@ -150,7 +169,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', clampValue(newValue)),
+          effect.setParameter('opacity', clampValue(newValue, 0, 1)),
       },
     ],
     parameterDefaultValues: [
@@ -169,7 +188,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('noise'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('noise', clampValue(newValue)),
+          effect.setParameter('noise', clampValue(newValue, 0, 1)),
       },
     ],
     parameterDefaultValues: [

--- a/newIDE/app/src/EffectsList/EffectDescription.js
+++ b/newIDE/app/src/EffectsList/EffectDescription.js
@@ -12,6 +12,7 @@ export type EffectDescription = {|
 |};
 
 const clampValue = value => Math.max(0, Math.min(1, value));
+const clampKernelSize = value => ([5, 7, 9, 11, 13, 15].includes(value)) ? value : 5;
 
 export const getAllEffectDescriptions = (
   i18n: I18nType
@@ -51,6 +52,61 @@ export const getAllEffectDescriptions = (
       {
         name: 'opacity',
         value: 1,
+      },
+    ],
+  },
+  {
+    name: 'Blur',
+    schema: [
+      {
+        name: 'blur',
+        getLabel: () => 'blur',
+        valueType: 'number',
+        getValue: (effect: gdEffect) => effect.getParameter('blur'),
+        setValue: (effect: gdEffect, newValue: number) =>
+          effect.setParameter('blur', newValue),
+      },
+      {
+        name: 'quality',
+        getLabel: () => 'quality ' + i18n._(t`(Number of render passes. High values cause lag.)`),
+        valueType: 'number',
+        getValue: (effect: gdEffect) => effect.getParameter('quality'),
+        setValue: (effect: gdEffect, newValue: number) =>
+          effect.setParameter('quality', newValue),
+      },
+      {
+        name: 'resolution',
+        getLabel: () => 'resolution',
+        valueType: 'number',
+        getValue: (effect: gdEffect) => effect.getParameter('resolution'),
+        setValue: (effect: gdEffect, newValue: number) =>
+          effect.setParameter('resolution', newValue),
+      },
+      {
+        name: 'kernelSize',
+        getLabel: () => 'kernelSize ' + i18n._(t`(one of these values: 5, 7, 9, 11, 13, 15)`),
+        valueType: 'number',
+        getValue: (effect: gdEffect) => effect.getParameter('kernelSize'),
+        setValue: (effect: gdEffect, newValue: number) =>
+          effect.setParameter('kernelSize', clampKernelSize(newValue)),
+      },
+    ],
+    parameterDefaultValues: [
+      {
+        name: 'blur',
+        value: 8,
+      },
+      {
+        name: 'quality',
+        value: 1,
+      },
+      {
+        name: 'resolution',
+        value: 2,
+      },
+      {
+        name: 'kernelSize',
+        value: 5,
       },
     ],
   },
@@ -101,6 +157,25 @@ export const getAllEffectDescriptions = (
       {
         name: 'opacity',
         value: 1,
+      },
+    ],
+  },
+  {
+    name: 'Noise',
+    schema: [
+      {
+        name: 'noise',
+        getLabel: () => 'noise ' + i18n._(t`(between 0 and 1)`),
+        valueType: 'number',
+        getValue: (effect: gdEffect) => effect.getParameter('noise'),
+        setValue: (effect: gdEffect, newValue: number) =>
+          effect.setParameter('noise', clampValue(newValue)),
+      },
+    ],
+    parameterDefaultValues: [
+      {
+        name: 'noise',
+        value: 0.5,
       },
     ],
   },

--- a/newIDE/app/src/EffectsList/EffectDescription.js
+++ b/newIDE/app/src/EffectsList/EffectDescription.js
@@ -36,6 +36,25 @@ export const getAllEffectDescriptions = (
     ],
   },
   {
+    name: 'BlackAndWhite',
+    schema: [
+      {
+        name: 'opacity',
+        getLabel: () => 'opacity ' + i18n._(t`(between 0 and 1)`),
+        valueType: 'number',
+        getValue: (effect: gdEffect) => effect.getParameter('opacity'),
+        setValue: (effect: gdEffect, newValue: number) =>
+          effect.setParameter('opacity', clampValue(newValue)),
+      },
+    ],
+    parameterDefaultValues: [
+      {
+        name: 'opacity',
+        value: 1,
+      },
+    ],
+  },
+  {
     name: 'Night',
     schema: [
       {

--- a/newIDE/app/src/EffectsList/EffectDescription.js
+++ b/newIDE/app/src/EffectsList/EffectDescription.js
@@ -11,6 +11,9 @@ export type EffectDescription = {|
   parameterDefaultValues: Array<EffectDefaultValue>,
 |};
 
+const clampValue = (value, min, max) => Math.max(min, Math.min(max, value));
+const clampKernelSize = value => ([5, 7, 9, 11, 13, 15].includes(value)) ? value : 5;
+
 export const getAllEffectDescriptions = (
   i18n: I18nType
 ): Array<EffectDescription> => [
@@ -23,7 +26,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', newValue),
+          effect.setParameter('opacity', clampValue(newValue)),
       },
     ],
     parameterDefaultValues: [
@@ -42,7 +45,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', newValue),
+          effect.setParameter('opacity', clampValue(newValue)),
       },
     ],
     parameterDefaultValues: [
@@ -85,7 +88,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('kernelSize'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('kernelSize', newValue),
+          effect.setParameter('kernelSize', clampKernelSize(newValue)),
       },
     ],
     parameterDefaultValues: [
@@ -116,7 +119,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', newValue),
+          effect.setParameter('opacity', clampValue(newValue)),
       },
       {
         name: 'intensity',
@@ -124,7 +127,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('intensity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('intensity', newValue),
+          effect.setParameter('intensity', clampValue(newValue)),
       },
     ],
     parameterDefaultValues: [
@@ -147,7 +150,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('opacity'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('opacity', newValue),
+          effect.setParameter('opacity', clampValue(newValue)),
       },
     ],
     parameterDefaultValues: [
@@ -166,7 +169,7 @@ export const getAllEffectDescriptions = (
         valueType: 'number',
         getValue: (effect: gdEffect) => effect.getParameter('noise'),
         setValue: (effect: gdEffect, newValue: number) =>
-          effect.setParameter('noise', newValue),
+          effect.setParameter('noise', clampValue(newValue)),
       },
     ],
     parameterDefaultValues: [


### PR DESCRIPTION
- [x] Add filters present in PIXI.filters
- [ ] Add filters present in external repo https://github.com/pixijs/pixi-filters
- [x] Add Action/Condition to enable/disable filters

Some effects like the displacement filter need a sprite to work, so I left it out for now. But it would be very cool to use an existing image ressource for that.

The pixi-filters has a bunch of nice effects but it is located in a different repository. Since it needs to be ES5 complient, how would I have to add the external JS file without using the `import` command? 

The pixi filters all have a property `enabled` that could theoretically be set the same way as the other filter parameters but I think it would be cleaner to create a separate action and condition for that.
I just don't know yet in which file I need to add that condition/action to appear in the events list.
