### PR TITLE
Disable _invalidTexture assignment

### DIFF
--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.js
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.js
@@ -14,7 +14,7 @@
 gdjs.PixiImageManager = function(resources)
 {
     this._resources = resources;
-    this._invalidTexture = PIXI.Texture.fromImage("bunny.png"); //TODO
+    // this._invalidTexture = PIXI.Texture.fromImage("bunny.png"); //TODO
     this._loadedTextures = new Hashtable();
 };
 


### PR DESCRIPTION
This line is responsible for a 'bunny.png' 404 error in exported projects.