### PR TITLE
Various adaptations for smaller screens

### DIFF
--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import EditorMosaic, { MosaicWindow } from '../UI/EditorMosaic';
+import EditorMosaic from '../UI/EditorMosaic';
 import Background from '../UI/Background';
 import get from 'lodash/get';
 import RaisedButton from '../UI/RaisedButton';
@@ -80,12 +80,11 @@ export default class DebuggerContent extends React.Component<Props, State> {
       <EditorMosaic
         ref={editors => (this._editors = editors)}
         editors={{
-          inspectors: (
-            <MosaicWindow
-              title={<Trans>Inspectors</Trans>}
-              toolbarControls={[]}
-              gameData={gameData}
-            >
+          inspectors: {
+            type: 'primary',
+            title: <Trans>Inspectors</Trans>,
+            toolbarControls: [],
+            renderEditor: () => (
               <Background>
                 <Column expand noMargin>
                   <Line justifyContent="center">
@@ -112,81 +111,81 @@ export default class DebuggerContent extends React.Component<Props, State> {
                   </Line>
                 </Column>
               </Background>
-            </MosaicWindow>
-          ),
-          'selected-inspector': (
-            <Column expand noMargin>
-              {' '}
-              {selectedInspector ? (
-                rawMode ? (
-                  <RawContentInspector
-                    gameData={get(gameData, selectedInspectorFullPath, null)}
-                    onEdit={(path, newValue) =>
-                      onEdit(selectedInspectorFullPath.concat(path), newValue)
-                    }
-                  />
-                ) : (
-                  selectedInspector.renderInspector(
-                    get(gameData, selectedInspectorFullPath, null),
-                    {
-                      onCall: (path, args) =>
-                        onCall(selectedInspectorFullPath.concat(path), args),
-                      onEdit: (path, newValue) =>
-                        onEdit(
-                          selectedInspectorFullPath.concat(path),
-                          newValue
-                        ),
-                    }
-                  ) || (
-                    <EmptyMessage>
-                      <Trans>
-                        No inspector, choose another element in the list or
-                        toggle the raw data view.
-                      </Trans>
-                    </EmptyMessage>
-                  )
-                )
-              ) : (
-                <EmptyMessage>
-                  {gameData
-                    ? 'Choose an element to inspect in the list'
-                    : 'Pause the game (from the toolbar) or hit refresh (on the left) to inspect the game'}
-                </EmptyMessage>
-              )}
-              <Column>
-                <Line justifyContent="space-between" alignItems="center">
-                  <HelpButton helpPagePath="/interface/debugger" />
-                  <div>
-                    <Checkbox
-                      checkedIcon={<Flash />}
-                      uncheckedIcon={<FlashOff />}
-                      checked={rawMode}
-                      onCheck={(e, enabled) =>
-                        this.setState({
-                          rawMode: enabled,
-                        })
+            ),
+          },
+          'selected-inspector': {
+            type: 'primary',
+            noTitleBar: true,
+            renderEditor: () => (
+              <Column expand noMargin>
+                {selectedInspector ? (
+                  rawMode ? (
+                    <RawContentInspector
+                      gameData={get(gameData, selectedInspectorFullPath, null)}
+                      onEdit={(path, newValue) =>
+                        onEdit(selectedInspectorFullPath.concat(path), newValue)
                       }
                     />
-                  </div>
-                </Line>
+                  ) : (
+                    selectedInspector.renderInspector(
+                      get(gameData, selectedInspectorFullPath, null),
+                      {
+                        onCall: (path, args) =>
+                          onCall(selectedInspectorFullPath.concat(path), args),
+                        onEdit: (path, newValue) =>
+                          onEdit(
+                            selectedInspectorFullPath.concat(path),
+                            newValue
+                          ),
+                      }
+                    ) || (
+                      <EmptyMessage>
+                        <Trans>
+                          No inspector, choose another element in the list or
+                          toggle the raw data view.
+                        </Trans>
+                      </EmptyMessage>
+                    )
+                  )
+                ) : (
+                  <EmptyMessage>
+                    {gameData
+                      ? 'Choose an element to inspect in the list'
+                      : 'Pause the game (from the toolbar) or hit refresh (on the left) to inspect the game'}
+                  </EmptyMessage>
+                )}
+                <Column>
+                  <Line justifyContent="space-between" alignItems="center">
+                    <HelpButton helpPagePath="/interface/debugger" />
+                    <div>
+                      <Checkbox
+                        checkedIcon={<Flash />}
+                        uncheckedIcon={<FlashOff />}
+                        checked={rawMode}
+                        onCheck={(e, enabled) =>
+                          this.setState({
+                            rawMode: enabled,
+                          })
+                        }
+                      />
+                    </div>
+                  </Line>
+                </Column>
               </Column>
-            </Column>
-          ),
-          profiler: (
-            <MosaicWindow
-              title={<Trans>Profiler</Trans>}
-              // Pass profilerOutput to force MosaicWindow update when profilerOutput is changed
-              profilerOutput={profilerOutput}
-              profilingInProgress={profilingInProgress}
-            >
+            ),
+          },
+          profiler: {
+            type: 'secondary',
+            title: <Trans>Profiler</Trans>,
+            renderEditor: () => (
               <Profiler
                 onStart={onStartProfiler}
                 onStop={onStopProfiler}
                 profilerOutput={profilerOutput}
                 profilingInProgress={profilingInProgress}
               />
-            </MosaicWindow>
-          ),
+            ),
+          },
         }}
         initialNodes={{
           direction: 'column',

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/ChooseEventsFunctionsExtensionEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/ChooseEventsFunctionsExtensionEditor.js
@@ -1,0 +1,59 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+import * as React from 'react';
+import Background from '../UI/Background';
+import { Column, Spacer } from '../UI/Grid';
+import Text from '../UI/Text';
+import RaisedButton from '../UI/RaisedButton';
+import FlatButton from '../UI/FlatButton';
+
+type Props = {|
+  eventsFunctionsExtension: gdEventsFunctionsExtension,
+  onEditFreeFunctions: () => void,
+  onEditBehaviors: () => void,
+  onEditExtensionOptions: () => void,
+|};
+
+export default (props: Props) => {
+  const eventsFunctionsCount = props.eventsFunctionsExtension.getEventsFunctionsCount();
+  const eventsBasedBehaviorsCount = props.eventsFunctionsExtension
+    .getEventsBasedBehaviors()
+    .getCount();
+
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <Background>
+          <Column>
+            <Text>
+              <Trans>
+                Extensions can provide functions (which can be actions,
+                conditions or expressions) or new behaviors.
+              </Trans>
+            </Text>
+            <RaisedButton
+              label={i18n._(
+                t`Edit functions (not attached to behaviors) (${eventsFunctionsCount})`
+              )}
+              onClick={props.onEditFreeFunctions}
+              primary
+            />
+            <Spacer />
+            <RaisedButton
+              label={i18n._(t`Edit behaviors (${eventsBasedBehaviorsCount})`)}
+              onClick={props.onEditBehaviors}
+              primary
+            />
+            <Spacer />
+            <FlatButton
+              label={<Trans>Edit extension options</Trans>}
+              onClick={props.onEditExtensionOptions}
+            />
+          </Column>
+        </Background>
+      )}
+    </I18n>
+  );
+};

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -6,7 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
 import EventsSheet from '../EventsSheet';
-import EditorMosaic, { MosaicWindow } from '../UI/EditorMosaic';
+import EditorMosaic from '../UI/EditorMosaic';
 import EmptyMessage from '../UI/EmptyMessage';
 import EventsFunctionConfigurationEditor from './EventsFunctionConfigurationEditor';
 import EventsFunctionsList from '../EventsFunctionsList';
@@ -438,11 +438,11 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
             <EditorMosaic
               ref={editors => (this._editors = editors)}
               editors={{
-                parameters: (
-                  <MosaicWindow
-                    title={<Trans>Function Configuration</Trans>}
-                    toolbarControls={[]}
-                  >
+                parameters: {
+                  type: 'primary',
+                  title: <Trans>Function Configuration</Trans>,
+                  toolbarControls: [],
+                  renderEditor: () => (
                     <Background>
                       {selectedEventsFunction &&
                       this._globalObjectsContainer &&
@@ -451,7 +451,9 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
                           project={project}
                           eventsFunction={selectedEventsFunction}
                           eventsBasedBehavior={selectedEventsBasedBehavior}
-                          globalObjectsContainer={this._globalObjectsContainer}
+                          globalObjectsContainer={
+                            this._globalObjectsContainer
+                          }
                           objectsContainer={this._objectsContainer}
                           helpPagePath={
                             !!selectedEventsBasedBehavior
@@ -475,182 +477,196 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
                         </EmptyMessage>
                       )}
                     </Background>
-                  </MosaicWindow>
-                ),
-                'events-sheet':
-                  selectedEventsFunction &&
-                  this._globalObjectsContainer &&
-                  this._objectsContainer ? (
-                    <EventsSheet
-                      key={selectedEventsFunction.ptr}
-                      ref={editor => (this.editor = editor)}
-                      project={project}
-                      scope={{
-                        layout: null,
-                        eventsFunctionsExtension,
-                        eventsBasedBehavior: selectedEventsBasedBehavior,
-                        eventsFunction: selectedEventsFunction,
-                      }}
-                      globalObjectsContainer={this._globalObjectsContainer}
-                      objectsContainer={this._objectsContainer}
-                      events={selectedEventsFunction.getEvents()}
-                      showPreviewButton={false}
-                      onPreview={options => {}}
-                      showNetworkPreviewButton={false}
-                      onOpenExternalEvents={() => {}}
-                      onOpenLayout={() => {}}
-                      resourceSources={this.props.resourceSources}
-                      onChooseResource={this.props.onChooseResource}
-                      resourceExternalEditors={
-                        this.props.resourceExternalEditors
-                      }
-                      openInstructionOrExpression={
-                        this.props.openInstructionOrExpression
-                      }
-                      setToolbar={this.props.setToolbar}
-                      onOpenDebugger={() => {}}
-                      onCreateEventsFunction={this.props.onCreateEventsFunction}
-                      onOpenSettings={this._editOptions} //TODO: Move this extra toolbar outside of EventsSheet toolbar
-                    />
-                  ) : (
-                    <Background>
-                      <EmptyMessage>
-                        <Trans>
-                          Choose a function, or a function of a behavior, to
-                          edit its events.
-                        </Trans>
-                      </EmptyMessage>
-                    </Background>
                   ),
-                'free-functions-list': (
-                  <MosaicWindow
-                    title={<Trans>Functions</Trans>}
-                    toolbarControls={[]}
-                    selectedEventsFunction={selectedEventsFunction}
-                  >
-                    <EventsFunctionsList
-                      project={project}
-                      eventsFunctionsContainer={eventsFunctionsExtension}
-                      selectedEventsFunction={selectedEventsFunction}
-                      onSelectEventsFunction={selectedEventsFunction =>
-                        this._selectEventsFunction(selectedEventsFunction, null)
-                      }
-                      onDeleteEventsFunction={this._onDeleteEventsFunction}
-                      canRename={() => true}
-                      onRenameEventsFunction={this._makeRenameFreeEventsFunction(
-                        i18n
-                      )}
-                      onAddEventsFunction={this._onAddFreeEventsFunction}
-                      onEventsFunctionAdded={() => {}}
-                      renderHeader={() => (
-                        <React.Fragment>
-                          <Line justifyContent="center">
-                            <FlatButton
-                              label={<Trans>Edit extension options</Trans>}
-                              primary
-                              onClick={() => this._editOptions()}
-                            />
-                          </Line>
-                          <Divider />
-                        </React.Fragment>
-                      )}
-                    />
-                  </MosaicWindow>
-                ),
-                'behavior-functions-list': selectedEventsBasedBehavior ? (
-                  <MosaicWindow
-                    title={<Trans>Behavior functions</Trans>}
-                    selectedEventsBasedBehavior={selectedEventsBasedBehavior}
-                    selectedEventsFunction={selectedEventsFunction}
-                  >
-                    <EventsFunctionsList
-                      project={project}
-                      eventsFunctionsContainer={selectedEventsBasedBehavior.getEventsFunctions()}
-                      selectedEventsFunction={selectedEventsFunction}
-                      onSelectEventsFunction={selectedEventsFunction =>
-                        this._selectEventsFunction(
-                          selectedEventsFunction,
-                          selectedEventsBasedBehavior
-                        )
-                      }
-                      onDeleteEventsFunction={this._onDeleteEventsFunction}
-                      canRename={(eventsFunction: gdEventsFunction) => {
-                        return !isBehaviorLifecycleFunction(
-                          eventsFunction.getName()
-                        );
-                      }}
-                      onRenameEventsFunction={(
-                        eventsFunction: gdEventsFunction,
-                        newName: string,
-                        done: boolean => void
-                      ) =>
-                        this._makeRenameBehaviorEventsFunction(i18n)(
-                          selectedEventsBasedBehavior,
-                          eventsFunction,
-                          newName,
-                          done
-                        )
-                      }
-                      onAddEventsFunction={this._onAddBehaviorEventsFunction}
-                      onEventsFunctionAdded={eventsFunction =>
-                        this._onBehaviorEventsFunctionAdded(
-                          selectedEventsBasedBehavior,
-                          eventsFunction
-                        )
-                      }
-                      renderHeader={() => (
-                        <React.Fragment>
-                          <Line justifyContent="center">
-                            <FlatButton
-                              label={<Trans>Edit behavior properties</Trans>}
-                              primary
-                              onClick={() =>
-                                this._editBehavior(selectedEventsBasedBehavior)
-                              }
-                            />
-                          </Line>
-                          <Divider />
-                        </React.Fragment>
-                      )}
-                    />
-                  </MosaicWindow>
-                ) : (
-                  <Background>
-                    <EmptyMessage>
-                      <Trans>
-                        Select a behavior to display the functions inside this
-                        behavior.
-                      </Trans>
-                    </EmptyMessage>
-                  </Background>
-                ),
+                },
+                'events-sheet': {
+                  type: 'primary',
+                  noTitleBar: true,
+                  renderEditor: () =>
+                    selectedEventsFunction &&
+                    this._globalObjectsContainer &&
+                    this._objectsContainer ? (
+                      <EventsSheet
+                        key={selectedEventsFunction.ptr}
+                        ref={editor => (this.editor = editor)}
+                        project={project}
+                        scope={{
+                          layout: null,
+                          eventsFunctionsExtension,
+                          eventsBasedBehavior: selectedEventsBasedBehavior,
+                          eventsFunction: selectedEventsFunction,
+                        }}
+                        globalObjectsContainer={this._globalObjectsContainer}
+                        objectsContainer={this._objectsContainer}
+                        events={selectedEventsFunction.getEvents()}
+                        showPreviewButton={false}
+                        onPreview={options => {}}
+                        showNetworkPreviewButton={false}
+                        onOpenExternalEvents={() => {}}
+                        onOpenLayout={() => {}}
+                        resourceSources={this.props.resourceSources}
+                        onChooseResource={this.props.onChooseResource}
+                        resourceExternalEditors={
+                          this.props.resourceExternalEditors
+                        }
+                        openInstructionOrExpression={
+                          this.props.openInstructionOrExpression
+                        }
+                        setToolbar={this.props.setToolbar}
+                        onOpenDebugger={() => {}}
+                        onCreateEventsFunction={
+                          this.props.onCreateEventsFunction
+                        }
+                        onOpenSettings={this._editOptions} //TODO: Move this extra toolbar outside of EventsSheet toolbar
+                      />
+                    ) : (
+                      <Background>
+                        <EmptyMessage>
+                          <Trans>
+                            Choose a function, or a function of a behavior, to
+                            edit its events.
+                          </Trans>
+                        </EmptyMessage>
+                      </Background>
+                    ),
+                },
+                'free-functions-list': {
+                  type: 'primary',
+                  title: <Trans>Functions</Trans>,
+                  toolbarControls: [],
+                  renderEditor: () => (
+                      <EventsFunctionsList
+                        project={project}
+                        eventsFunctionsContainer={eventsFunctionsExtension}
+                        selectedEventsFunction={selectedEventsFunction}
+                        onSelectEventsFunction={selectedEventsFunction =>
+                          this._selectEventsFunction(
+                            selectedEventsFunction,
+                            null
+                          )
+                        }
+                        onDeleteEventsFunction={this._onDeleteEventsFunction}
+                        canRename={() => true}
+                        onRenameEventsFunction={this._makeRenameFreeEventsFunction(
+                          i18n
+                        )}
+                        onAddEventsFunction={this._onAddFreeEventsFunction}
+                        onEventsFunctionAdded={() => {}}
+                        renderHeader={() => (
+                          <React.Fragment>
+                            <Line justifyContent="center">
+                              <FlatButton
+                                label={<Trans>Edit extension options</Trans>}
+                                primary
+                                onClick={() => this._editOptions()}
+                              />
+                            </Line>
+                            <Divider />
+                          </React.Fragment>
+                        )}
+                      />
+                  ),
+                },
+                'behavior-functions-list': {
+                  type: 'primary',
+                  title: <Trans>Behavior functions</Trans>,
+                  renderEditor: () =>
+                    selectedEventsBasedBehavior ? (
+                        <EventsFunctionsList
+                          project={project}
+                          eventsFunctionsContainer={selectedEventsBasedBehavior.getEventsFunctions()}
+                          selectedEventsFunction={selectedEventsFunction}
+                          onSelectEventsFunction={selectedEventsFunction =>
+                            this._selectEventsFunction(
+                              selectedEventsFunction,
+                              selectedEventsBasedBehavior
+                            )
+                          }
+                          onDeleteEventsFunction={this._onDeleteEventsFunction}
+                          canRename={(eventsFunction: gdEventsFunction) => {
+                            return !isBehaviorLifecycleFunction(
+                              eventsFunction.getName()
+                            );
+                          }}
+                          onRenameEventsFunction={(
+                            eventsFunction: gdEventsFunction,
+                            newName: string,
+                            done: boolean => void
+                          ) =>
+                            this._makeRenameBehaviorEventsFunction(i18n)(
+                              selectedEventsBasedBehavior,
+                              eventsFunction,
+                              newName,
+                              done
+                            )
+                          }
+                          onAddEventsFunction={
+                            this._onAddBehaviorEventsFunction
+                          }
+                          onEventsFunctionAdded={eventsFunction =>
+                            this._onBehaviorEventsFunctionAdded(
+                              selectedEventsBasedBehavior,
+                              eventsFunction
+                            )
+                          }
+                          renderHeader={() => (
+                            <React.Fragment>
+                              <Line justifyContent="center">
+                                <FlatButton
+                                  label={
+                                    <Trans>Edit behavior properties</Trans>
+                                  }
+                                  primary
+                                  onClick={() =>
+                                    this._editBehavior(
+                                      selectedEventsBasedBehavior
+                                    )
+                                  }
+                                />
+                              </Line>
+                              <Divider />
+                            </React.Fragment>
+                          )}
+                        />
+                    ) : (
+                      <Background>
+                        <EmptyMessage>
+                          <Trans>
+                            Select a behavior to display the functions inside
+                            this behavior.
+                          </Trans>
+                        </EmptyMessage>
+                      </Background>
+                    ),
+                },
 
-                'behaviors-list': (
-                  <MosaicWindow
-                    title={<Trans>Behaviors</Trans>}
-                    toolbarControls={[]}
-                    selectedEventsBasedBehavior={selectedEventsBasedBehavior}
-                  >
-                    <EventsBasedBehaviorsList
-                      project={project}
-                      eventsBasedBehaviorsList={eventsFunctionsExtension.getEventsBasedBehaviors()}
-                      selectedEventsBasedBehavior={selectedEventsBasedBehavior}
-                      onSelectEventsBasedBehavior={
-                        this._selectEventsBasedBehavior
-                      }
-                      onDeleteEventsBasedBehavior={
-                        this._onDeleteEventsBasedBehavior
-                      }
-                      onRenameEventsBasedBehavior={this._makeRenameEventsBasedBehavior(
-                        i18n
-                      )}
-                      onEventsBasedBehaviorRenamed={
-                        this._onEventsBasedBehaviorRenamed
-                      }
-                      onEditProperties={this._editBehavior}
-                    />
-                  </MosaicWindow>
-                ),
+                'behaviors-list': {
+                  type: 'secondary',
+                  title: <Trans>Behaviors</Trans>,
+                  toolbarControls: [],
+                  renderEditor: () => (
+                      <EventsBasedBehaviorsList
+                        project={project}
+                        eventsBasedBehaviorsList={eventsFunctionsExtension.getEventsBasedBehaviors()}
+                        selectedEventsBasedBehavior={
+                          selectedEventsBasedBehavior
+                        }
+                        onSelectEventsBasedBehavior={
+                          this._selectEventsBasedBehavior
+                        }
+                        onDeleteEventsBasedBehavior={
+                          this._onDeleteEventsBasedBehavior
+                        }
+                        onRenameEventsBasedBehavior={this._makeRenameEventsBasedBehavior(
+                          i18n
+                        )}
+                        onEventsBasedBehaviorRenamed={
+                          this._onEventsBasedBehaviorRenamed
+                        }
+                        onEditProperties={this._editBehavior}
+                      />
+                  ),
+                },
               }}
               initialNodes={{
                 direction: 'row',

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -145,6 +145,8 @@ const styles = {
     display: 'flex',
     width: '100%',
     flexDirection: 'column',
+    flex: 1,
+    position: 'relative', // To be sure that absolutely positioned PlaceholderMessage won't go outside of the EventsSheet
   },
 };
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -834,7 +834,6 @@ class MainFrame extends React.Component<Props, State> {
               }
               onOpenDebugger={this.openDebugger}
               onEditObject={this.props.onEditObject}
-              showObjectsList={!this.props.integratedEditor}
               resourceSources={this.props.resourceSources}
               onChooseResource={this._onChooseResource}
               resourceExternalEditors={this.props.resourceExternalEditors}
@@ -969,7 +968,6 @@ class MainFrame extends React.Component<Props, State> {
                   }
                   onOpenDebugger={this.openDebugger}
                   onEditObject={this.props.onEditObject}
-                  showObjectsList={!this.props.integratedEditor}
                   resourceSources={this.props.resourceSources}
                   onChooseResource={this._onChooseResource}
                   resourceExternalEditors={this.props.resourceExternalEditors}

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -1,5 +1,9 @@
 // @flow
 import * as React from 'react';
+import {
+  ResponsiveWindowMeasurer,
+  type WidthType,
+} from '../UI/Reponsive/ResponsiveWindowMeasurer';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import InlineCheckbox from '../UI/InlineCheckbox';
 import ResourceSelector from '../ResourcesList/ResourceSelector';
@@ -82,6 +86,7 @@ type MandatoryProps = {|
   onInstancesModified?: Instances => void,
   instances: Instances,
   schema: Schema,
+  windowWidth?: WidthType,
   mode?: 'column' | 'row',
 |};
 
@@ -342,11 +347,15 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
   };
 
   render() {
-    const { mode } = this.props;
+    const { mode, windowWidth } = this.props;
 
-    return (
+    const renderFields = (windowWidth: WidthType) => (
       <div
-        style={mode === 'row' ? styles.rowContainer : styles.columnContainer}
+        style={
+          mode === 'row' && windowWidth !== 'small'
+            ? styles.rowContainer
+            : styles.columnContainer
+        }
       >
         {this.props.schema.map(field => {
           if (field.children) {
@@ -357,6 +366,7 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
                   schema={field.children}
                   instances={this.props.instances}
                   mode="row"
+                  windowWidth={windowWidth}
                 />
               );
             }
@@ -369,6 +379,7 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
                     schema={field.children}
                     instances={this.props.instances}
                     mode="column"
+                    windowWidth={windowWidth}
                   />
                 </div>
               </div>
@@ -385,6 +396,16 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
           return null;
         })}
       </div>
+    );
+
+    if (windowWidth) {
+      return renderFields(windowWidth);
+    }
+
+    return (
+      <ResponsiveWindowMeasurer>
+        {windowWidth => renderFields(windowWidth)}
+      </ResponsiveWindowMeasurer>
     );
   }
 }

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import ResourcesList from '../ResourcesList';
 import ResourcePropertiesEditor from './ResourcePropertiesEditor';
 import Toolbar from './Toolbar';
-import EditorMosaic, { MosaicWindow } from '../UI/EditorMosaic';
+import EditorMosaic from '../UI/EditorMosaic';
 import InfoBar from '../UI/Messages/InfoBar';
 import ResourcesLoader from '../ResourcesLoader';
 import optionalRequire from '../Utils/OptionalRequire';
@@ -134,12 +134,10 @@ export default class ResourcesEditor extends React.Component<Props, State> {
     const { selectedResource } = this.state;
 
     const editors = {
-      properties: (
-        <MosaicWindow
-          title={<Trans>Properties</Trans>}
-          // Pass resources to force MosaicWindow update when selectedResource is changed
-          resources={selectedResource ? [selectedResource] : []}
-        >
+      properties: {
+        type: 'secondary',
+        title: <Trans>Properties</Trans>,
+        renderEditor: () => (
           <ResourcePropertiesEditor
             key={selectedResource ? selectedResource.ptr : undefined}
             resources={selectedResource ? [selectedResource] : []}
@@ -156,18 +154,22 @@ export default class ResourcesEditor extends React.Component<Props, State> {
             onChooseResource={onChooseResource}
             resourceSources={resourceSources}
           />
-        </MosaicWindow>
-      ),
-      'resources-list': (
-        <ResourcesList
-          project={project}
-          onDeleteResource={this.deleteResource}
-          onRenameResource={onRenameResource}
-          onSelectResource={this._onResourceSelected}
-          selectedResource={selectedResource}
-          ref={resourcesList => (this._resourcesList = resourcesList)}
-        />
-      ),
+        ),
+      },
+      'resources-list': {
+        type: 'primary',
+        noTitleBar: true,
+        renderEditor: () => (
+          <ResourcesList
+            project={project}
+            onDeleteResource={this.deleteResource}
+            onRenameResource={onRenameResource}
+            onSelectResource={this._onResourceSelected}
+            selectedResource={selectedResource}
+            ref={resourcesList => (this._resourcesList = resourcesList)}
+          />
+        ),
+      },
     };
 
     return (

--- a/newIDE/app/src/SceneEditor/Toolbar.js
+++ b/newIDE/app/src/SceneEditor/Toolbar.js
@@ -14,7 +14,6 @@ type Props = {|
   onNetworkPreview: () => void,
   onOpenDebugger: () => void,
   showPreviewButton: boolean,
-  showObjectsList: boolean,
   openObjectsList: () => void,
   openObjectGroupsList: () => void,
   openProperties: () => void,
@@ -71,20 +70,16 @@ export class Toolbar extends PureComponent<Props> {
           />
         )}
         {this.props.showPreviewButton && <ToolbarSeparator />}
-        {this.props.showObjectsList && (
-          <ToolbarIcon
-            onClick={this.props.openObjectsList}
-            src="res/ribbon_default/objects64.png"
-            tooltip={t`Open the objects editor`}
-          />
-        )}
-        {this.props.showObjectsList && (
-          <ToolbarIcon
-            onClick={this.props.openObjectGroupsList}
-            src={'res/ribbon_default/objectsgroups64.png'}
-            tooltip={t`Open the objects groups editor`}
-          />
-        )}
+        <ToolbarIcon
+          onClick={this.props.openObjectsList}
+          src="res/ribbon_default/objects64.png"
+          tooltip={t`Open the objects editor`}
+        />
+        <ToolbarIcon
+          onClick={this.props.openObjectGroupsList}
+          src={'res/ribbon_default/objectsgroups64.png'}
+          tooltip={t`Open the objects groups editor`}
+        />
         <ToolbarIcon
           onClick={this.props.openProperties}
           src="res/ribbon_default/editprop32.png"

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -97,6 +97,25 @@ const instancesDrawerPaperProps = {
   },
 };
 
+const initialEditors = {
+  direction: 'row',
+  first: 'properties',
+  splitPercentage: 23,
+  second: {
+    direction: 'row',
+    first: 'instances-editor',
+    second: 'objects-list',
+    splitPercentage: 77,
+  },
+};
+
+const initialEditorsSmallWindow = {
+  direction: 'row',
+  first: 'instances-editor',
+  second: 'objects-list',
+  splitPercentage: 70,
+};
+
 type Props = {|
   initialInstances: gdInitialInstancesContainer,
   initialUiSettings: Object,
@@ -108,7 +127,6 @@ type Props = {|
   project: gdProject,
   setToolbar: (?React.Node) => void,
   showNetworkPreviewButton: boolean,
-  showObjectsList: boolean,
   showPreviewButton: boolean,
   resourceSources: Array<ResourceSource>,
   onChooseResource: ChooseResourceFunction,
@@ -148,7 +166,6 @@ type CopyCutPasteOptions = { useLastCursorPosition?: boolean };
 
 export default class SceneEditor extends React.Component<Props, State> {
   static defaultProps = {
-    showObjectsList: true,
     setToolbar: () => {},
   };
 
@@ -212,7 +229,6 @@ export default class SceneEditor extends React.Component<Props, State> {
           this.props.onOpenDebugger();
           this.props.onPreview({});
         }}
-        showObjectsList={this.props.showObjectsList}
         instancesSelection={this.instancesSelection}
         openObjectsList={this.openObjectsList}
         openObjectGroupsList={this.openObjectGroupsList}
@@ -1002,17 +1018,11 @@ export default class SceneEditor extends React.Component<Props, State> {
             <EditorMosaic
               editors={editors}
               limitToOneSecondaryEditor={windowWidth === 'small'}
-              initialNodes={{
-                direction: 'row',
-                first: 'properties',
-                splitPercentage: 23,
-                second: {
-                  direction: 'row',
-                  first: 'instances-editor',
-                  second: this.props.showObjectsList ? 'objects-list' : null,
-                  splitPercentage: 77,
-                },
-              }}
+              initialNodes={
+                windowWidth === 'small'
+                  ? initialEditorsSmallWindow
+                  : initialEditors
+              }
               ref={editorMosaic => (this.editorMosaic = editorMosaic)}
             />
           )}

--- a/newIDE/app/src/UI/EditorMosaic/EditorNavigator.js
+++ b/newIDE/app/src/UI/EditorMosaic/EditorNavigator.js
@@ -1,0 +1,98 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import * as React from 'react';
+import { type Editor } from '.';
+import { Column, Line } from '../Grid';
+import FlatButton from '../FlatButton';
+import ArrowBack from '@material-ui/icons/ArrowBack';
+import Background from '../Background';
+
+type Props = {|
+  initialEditorName: string,
+  editors: {
+    [string]: Editor,
+  },
+  transitions: {
+    [string]: {|
+      nextEditor?: string | (() => string),
+      nextLabel?: React.Node,
+      nextIcon?: React.Node,
+      previousEditor?: string | (() => string),
+    |},
+  },
+  onEditorChanged: (editorName: string) => void,
+|};
+
+type Interface = {| openEditor: (editorName: string) => void |};
+
+// Flow types might have to be changed/removed if upgrading Flow
+// (see example at https://github.com/wgao19/flow-notes/blob/master/react/react-memo.md)
+
+export default React.forwardRef<Props, Interface>(
+  (
+    { initialEditorName, editors, transitions, onEditorChanged }: Props,
+    ref
+  ) => {
+    const [currentEditorName, setCurrentEditorName] = React.useState(
+      initialEditorName
+    );
+    React.useImperativeHandle(ref, () => ({
+      openEditor: editorName => {
+        setCurrentEditorName(editorName);
+      },
+    }));
+    React.useEffect(
+      () => {
+        onEditorChanged(currentEditorName);
+      },
+      [currentEditorName]
+    );
+
+    const transition = transitions[currentEditorName];
+    let buttonLineJustifyContent = 'space-between';
+    if (transition) {
+      if (transition.previousEditor && !transition.nextEditor) {
+        buttonLineJustifyContent = 'flex-start';
+      }
+      if (!transition.previousEditor && transition.nextEditor) {
+        buttonLineJustifyContent = 'flex-end';
+      }
+    }
+
+    return (
+      <Column noMargin expand>
+        {transition && (
+          <Background maxWidth noExpand noFullHeight>
+            <Column>
+              <Line justifyContent={buttonLineJustifyContent}>
+                {transition.previousEditor && (
+                  <FlatButton
+                    label={<Trans>Back</Trans>}
+                    onClick={() => {
+                      if (transition.previousEditor)
+                        setCurrentEditorName(transition.previousEditor);
+                    }}
+                    icon={<ArrowBack />}
+                  />
+                )}
+                {transition.nextLabel && transition.nextEditor && (
+                  <FlatButton
+                    label={transition.nextLabel}
+                    onClick={() => {
+                      if (transition.nextEditor)
+                        setCurrentEditorName(transition.nextEditor);
+                    }}
+                    icon={transition.nextIcon}
+                  />
+                )}
+              </Line>
+            </Column>
+          </Background>
+        )}
+        {editors[currentEditorName]
+          ? editors[currentEditorName].renderEditor()
+          : null}
+      </Column>
+    );
+  }
+);

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -12,6 +12,14 @@ import ThemeConsumer from '../Theme/ThemeConsumer';
 import 'react-mosaic-component/react-mosaic-component.css';
 import './style.css';
 
+export type Editor = {|
+  type: 'primary' | 'secondary',
+  renderEditor: () => React.Node,
+  noTitleBar?: boolean,
+  title?: React.Node,
+  toolbarControls?: Array<React.Node>,
+|};
+
 type MosaicNode =
   | {|
       direction: 'row' | 'column',
@@ -121,14 +129,6 @@ const MosaicWindow = (props: any) => (
     renderPreview={renderMosaicWindowPreview}
   />
 );
-
-type Editor = {|
-  type: 'primary' | 'secondary',
-  renderEditor: () => React.Node,
-  noTitleBar?: boolean,
-  title?: React.Node,
-  toolbarControls?: Array<React.Node>,
-|};
 
 type Props = {|
   initialNodes: MosaicNode,

--- a/newIDE/app/src/stories/EditorMosaicPlayground.js
+++ b/newIDE/app/src/stories/EditorMosaicPlayground.js
@@ -4,6 +4,7 @@ import DragAndDropContextProvider from '../UI/DragAndDrop/DragAndDropContextProv
 import EditorMosaic from '../UI/EditorMosaic';
 import FixedHeightFlexContainer from './FixedHeightFlexContainer';
 import { Line, Column } from '../UI/Grid';
+import EditorNavigator from '../UI/EditorMosaic/EditorNavigator';
 
 type OpenEditorFunction = (
   editorName: string,
@@ -14,12 +15,14 @@ type OpenEditorFunction = (
 type Props = {|
   renderButtons: ({| openEditor: OpenEditorFunction |}) => React.Node,
   renderEditorMosaic: ({
-    editorRef: { current: EditorMosaic | null },
+    // $FlowFixMe
+    editorRef: { current: EditorMosaic | EditorNavigator | null },
   }) => React.Node,
 |};
 
 export default ({ renderButtons, renderEditorMosaic }: Props) => {
-  const editorRef = React.useRef((null: ?EditorMosaic));
+  // $FlowFixMe
+  const editorRef = React.useRef((null: ?EditorMosaic | ?EditorNavigator));
   const openEditor = (
     editorName: string,
     position: 'start' | 'end',

--- a/newIDE/app/src/stories/EditorMosaicPlayground.js
+++ b/newIDE/app/src/stories/EditorMosaicPlayground.js
@@ -1,0 +1,42 @@
+// @flow
+import * as React from 'react';
+import DragAndDropContextProvider from '../UI/DragAndDrop/DragAndDropContextProvider';
+import EditorMosaic from '../UI/EditorMosaic';
+import FixedHeightFlexContainer from './FixedHeightFlexContainer';
+import { Line, Column } from '../UI/Grid';
+
+type OpenEditorFunction = (
+  editorName: string,
+  position: 'start' | 'end',
+  slipPercentage: number
+) => void;
+
+type Props = {|
+  renderButtons: ({| openEditor: OpenEditorFunction |}) => React.Node,
+  renderEditorMosaic: ({
+    editorRef: { current: EditorMosaic | null },
+  }) => React.Node,
+|};
+
+export default ({ renderButtons, renderEditorMosaic }: Props) => {
+  const editorRef = React.useRef((null: ?EditorMosaic));
+  const openEditor = (
+    editorName: string,
+    position: 'start' | 'end',
+    slipPercentage: number
+  ) => {
+    if (editorRef.current)
+      editorRef.current.openEditor(editorName, position, slipPercentage);
+  };
+
+  return (
+    <DragAndDropContextProvider>
+      <FixedHeightFlexContainer height={400}>
+        <Column expand>
+          {renderButtons({ openEditor })}
+          <Line expand>{renderEditorMosaic({ editorRef })}</Line>
+        </Column>
+      </FixedHeightFlexContainer>
+    </DragAndDropContextProvider>
+  );
+};

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -147,6 +147,9 @@ import MiniToolbar, { MiniToolbarText } from '../UI/MiniToolbar';
 import NewObjectDialog from '../ObjectsList/NewObjectDialog';
 import { Column } from '../UI/Grid';
 import DragAndDropTestBed from './DragAndDropTestBed';
+import EditorMosaic from '../UI/EditorMosaic';
+import FlatButton from '../UI/FlatButton';
+import EditorMosaicPlayground from './EditorMosaicPlayground';
 
 // No i18n in this file
 
@@ -556,6 +559,120 @@ storiesOf('UI Building Blocks/ColorField', module)
         onChangeComplete={() => {}}
       />
     </div>
+  ));
+
+storiesOf('UI Building Blocks/EditorMosaic', module)
+  .addDecorator(muiDecorator)
+  .add('default', () => (
+    <EditorMosaicPlayground
+      renderButtons={({ openEditor }) => (
+        <FlatButton
+          onClick={() => openEditor('thirdEditor', 'end', 65)}
+          label="Open the third editor"
+        />
+      )}
+      renderEditorMosaic={({ editorRef }) => (
+        <EditorMosaic
+          ref={editorRef}
+          editors={{
+            firstEditor: {
+              type: 'primary',
+              title: 'First editor',
+              toolbarControls: [],
+              renderEditor: () => (
+                <div>
+                  This is the first editor (left), with title bar but no
+                  controls to close the window.
+                </div>
+              ),
+            },
+            secondEditor: {
+              type: 'primary',
+              noTitleBar: true,
+              renderEditor: () => (
+                <div>
+                  This is the second editor ("central"), without title bar.
+                </div>
+              ),
+            },
+            thirdEditor: {
+              type: 'secondary',
+              title: 'Third editor',
+              renderEditor: () => <div>This is the third editor (bottom).</div>,
+            },
+          }}
+          initialNodes={{
+            direction: 'column',
+            first: {
+              direction: 'row',
+              first: 'firstEditor',
+              second: 'secondEditor',
+              splitPercentage: 25,
+            },
+            second: 'thirdEditor',
+            splitPercentage: 65,
+          }}
+        />
+      )}
+    />
+  ))
+  .add('limit to one secondary editor', () => (
+    <EditorMosaicPlayground
+      renderButtons={({ openEditor }) => (
+        <React.Fragment>
+          <FlatButton
+            onClick={() => openEditor('firstEditor', 'end', 65)}
+            label="Open the 1st secondary editor"
+          />
+          <FlatButton
+            onClick={() => openEditor('secondEditor', 'end', 65)}
+            label="Open the 2nd secondary editor"
+          />
+          <FlatButton
+            onClick={() => openEditor('thirdEditor', 'end', 65)}
+            label="Open the 3rd secondary editor"
+          />
+        </React.Fragment>
+      )}
+      renderEditorMosaic={({ editorRef }) => (
+        <EditorMosaic
+          limitToOneSecondaryEditor
+          ref={editorRef}
+          editors={{
+            firstEditor: {
+              type: 'secondary',
+              title: '1st secondary editor',
+              renderEditor: () => <div>This is a secondary editor.</div>,
+            },
+            secondEditor: {
+              type: 'secondary',
+              title: '2nd secondary editor',
+              renderEditor: () => <div>This is another secondary editor.</div>,
+            },
+            thirdEditor: {
+              type: 'secondary',
+              title: '3rd secondary editor',
+              renderEditor: () => (
+                <div>This is yet another secondary editor.</div>
+              ),
+            },
+            mainEditor: {
+              type: 'primary',
+              noTitleBar: true,
+              renderEditor: () => (
+                <div>This is the main editor, always shown</div>
+              ),
+            },
+          }}
+          initialNodes={{
+            direction: 'row',
+            first: 'mainEditor',
+            second: 'firstEditor',
+            splitPercentage: 65,
+          }}
+        />
+      )}
+    />
   ));
 
 storiesOf('UI Building Blocks/ClosableTabs', module)

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -150,6 +150,8 @@ import DragAndDropTestBed from './DragAndDropTestBed';
 import EditorMosaic from '../UI/EditorMosaic';
 import FlatButton from '../UI/FlatButton';
 import EditorMosaicPlayground from './EditorMosaicPlayground';
+import EditorNavigator from '../UI/EditorMosaic/EditorNavigator';
+import ChooseEventsFunctionsExtensionEditor from '../EventsFunctionsExtensionEditor/ChooseEventsFunctionsExtensionEditor';
 
 // No i18n in this file
 
@@ -670,6 +672,71 @@ storiesOf('UI Building Blocks/EditorMosaic', module)
             second: 'firstEditor',
             splitPercentage: 65,
           }}
+        />
+      )}
+    />
+  ));
+
+storiesOf('UI Building Blocks/EditorNavigator', module)
+  .addDecorator(muiDecorator)
+  .add('default', () => (
+    <EditorMosaicPlayground
+      renderButtons={({ openEditor }) => (
+        <React.Fragment>
+          <FlatButton
+            onClick={() => openEditor('thirdEditor', 'end', 65)}
+            label="Open the third editor"
+          />
+          <FlatButton
+            onClick={() => openEditor('noTransitionsEditor', 'end', 65)}
+            label="Open the editor without transitions"
+          />
+        </React.Fragment>
+      )}
+      renderEditorMosaic={({ editorRef }) => (
+        <EditorNavigator
+          ref={editorRef}
+          initialEditorName="firstEditor"
+          transitions={{
+            firstEditor: {
+              nextLabel: 'Second Editor',
+              nextEditor: 'secondEditor',
+            },
+            secondEditor: {
+              previousEditor: 'firstEditor',
+              nextLabel: 'Third Editor',
+              nextEditor: 'thirdEditor',
+            },
+            thirdEditor: {
+              previousEditor: 'secondEditor',
+            },
+          }}
+          editors={{
+            firstEditor: {
+              type: 'primary',
+              title: 'First editor',
+              toolbarControls: [],
+              renderEditor: () => <div>This is the first editor.</div>,
+            },
+            secondEditor: {
+              type: 'primary',
+              noTitleBar: true,
+              renderEditor: () => <div>This is the second editor.</div>,
+            },
+            thirdEditor: {
+              type: 'secondary',
+              title: 'Third editor',
+              renderEditor: () => <div>This is the third editor.</div>,
+            },
+            noTransitionsEditor: {
+              type: 'secondary',
+              title: 'Editor without transitions',
+              renderEditor: () => (
+                <div>This is an editor without transitions.</div>
+              ),
+            },
+          }}
+          onEditorChanged={action('Editor was changed')}
         />
       )}
     />
@@ -2840,6 +2907,22 @@ storiesOf('EventsFunctionsExtensionEditor/index', module)
         />
       </FixedHeightFlexContainer>
     </DragAndDropContextProvider>
+  ));
+
+storiesOf(
+  'EventsFunctionsExtensionEditor/ChooseEventsFunctionsExtensionEditor',
+  module
+)
+  .addDecorator(muiDecorator)
+  .add('default', () => (
+    <FixedHeightFlexContainer height={500}>
+      <ChooseEventsFunctionsExtensionEditor
+        eventsFunctionsExtension={testEventsFunctionsExtension}
+        onEditBehaviors={action('edit behaviors')}
+        onEditFreeFunctions={action('edit free functions')}
+        onEditExtensionOptions={action('edit extension options')}
+      />
+    </FixedHeightFlexContainer>
   ));
 
 storiesOf('EventsFunctionsExtensionEditor/OptionsEditorDialog', module)

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -152,6 +152,7 @@ import FlatButton from '../UI/FlatButton';
 import EditorMosaicPlayground from './EditorMosaicPlayground';
 import EditorNavigator from '../UI/EditorMosaic/EditorNavigator';
 import ChooseEventsFunctionsExtensionEditor from '../EventsFunctionsExtensionEditor/ChooseEventsFunctionsExtensionEditor';
+import PropertiesEditor from '../PropertiesEditor';
 
 // No i18n in this file
 
@@ -1009,6 +1010,112 @@ storiesOf('UI Building Blocks/HelpIcon', module)
 storiesOf('HelpFinder', module)
   .addDecorator(muiDecorator)
   .add('default', () => <HelpFinder open onClose={action('close')} />);
+
+storiesOf('PropertiesEditor', module)
+  .addDecorator(muiDecorator)
+  .add('default', () => (
+    <PropertiesEditor
+      schema={[
+        {
+          name: 'Object name',
+          valueType: 'string',
+          disabled: true,
+          getValue: instance => 'Disabled field',
+          setValue: (instance, newValue) => {},
+          onEditButtonClick: instance => action('edit button clicked'),
+        },
+        {
+          name: 'Position',
+          type: 'row',
+          children: [
+            {
+              name: 'X',
+              valueType: 'number',
+              getValue: instance => 10,
+              setValue: (instance, newValue) => {},
+            },
+            {
+              name: 'Y',
+              valueType: 'number',
+              getValue: instance => 20.1234,
+              setValue: (instance, newValue) => {},
+            },
+          ],
+        },
+        {
+          name: 'Angle',
+          valueType: 'number',
+          getValue: instance => 90.123456,
+          setValue: (instance, newValue) => {},
+        },
+        {
+          name: 'Checked checkbox',
+          valueType: 'boolean',
+          getValue: instance => true,
+          setValue: (instance, newValue) => {},
+        },
+        {
+          name: 'Unchecked checkbox',
+          valueType: 'boolean',
+          getValue: instance => false,
+          setValue: (instance, newValue) => {},
+        },
+      ]}
+      instances={[{ name: 'instance1' }, { name: 'instance2' }]}
+    />
+  ))
+  .add('row (window width = medium)', () => (
+    <PropertiesEditor
+      schema={[
+        {
+          name: 'Position',
+          type: 'row',
+          children: [
+            {
+              name: 'X',
+              valueType: 'number',
+              getValue: instance => 10,
+              setValue: (instance, newValue) => {},
+            },
+            {
+              name: 'Y',
+              valueType: 'number',
+              getValue: instance => 20.1234,
+              setValue: (instance, newValue) => {},
+            },
+          ],
+        },
+      ]}
+      instances={[{ name: 'instance1' }, { name: 'instance2' }]}
+      windowWidth="medium"
+    />
+  ))
+  .add('row (window width = small)', () => (
+    <PropertiesEditor
+      schema={[
+        {
+          name: 'Position',
+          type: 'row',
+          children: [
+            {
+              name: 'X',
+              valueType: 'number',
+              getValue: instance => 10,
+              setValue: (instance, newValue) => {},
+            },
+            {
+              name: 'Y',
+              valueType: 'number',
+              getValue: instance => 20.1234,
+              setValue: (instance, newValue) => {},
+            },
+          ],
+        },
+      ]}
+      instances={[{ name: 'instance1' }, { name: 'instance2' }]}
+      windowWidth="small"
+    />
+  ));
 
 storiesOf('ParameterFields', module)
   .addDecorator(paperDecorator)


### PR DESCRIPTION
See https://trello.com/c/hV7aaiz1/72-port-gdevelop-5-to-android-ios-chromebook

Introduce a single secondary editor in the scene editor (better than opening more than one on small screens) and a navigator between editors for the extension editor on small screens.