### PR TITLE
Extract events into new group

### DIFF
--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -757,7 +757,7 @@ export default class EventsSheet extends React.Component<Props, State> {
       eventsList.insertEvent(event, eventsList.getEventsCount())
     );
 
-    this._replaceSelectionByGroupsOfEvents(eventsList);
+    this._replaceSelectionByGroupOfEvents(eventsList);
     eventsList.delete();
   };
 
@@ -788,7 +788,7 @@ export default class EventsSheet extends React.Component<Props, State> {
     this.deleteSelection({ deleteInstructions: false });
   };
 
-  _replaceSelectionByGroupsOfEvents = (eventsList: gdEventsList) => {
+  _replaceSelectionByGroupOfEvents = (eventsList: gdEventsList) => {
     const contexts = getSelectedEventContexts(this.state.selection);
     if (!contexts.length) return;
 

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -803,7 +803,7 @@ export default class EventsSheet extends React.Component<Props, State> {
 
     const groupEvent = gd.asGroupEvent(newEvents[0]);
 
-    groupEvent.setName('Grouped event');
+    groupEvent.setName('Grouped events');
     groupEvent.setFolded(true);
     groupEvent
       .getSubEvents()

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -807,12 +807,7 @@ export default class EventsSheet extends React.Component<Props, State> {
     groupEvent.setFolded(true);
     groupEvent
       .getSubEvents()
-      .insertEvents(
-        eventsList,
-        0,
-        eventsList.getEventsCount(),
-        groupEvent.indexInList
-      );
+      .insertEvents(eventsList, 0, eventsList.getEventsCount(), 0);
 
     this.deleteSelection({ deleteInstructions: false });
   };

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -805,7 +805,9 @@ export default class EventsSheet extends React.Component<Props, State> {
 
     groupEvent.setName('Grouped event');
     groupEvent.setFolded(true);
-    groupEvent.getSubEvents().insertEvents(
+    groupEvent
+      .getSubEvents()
+      .insertEvents(
         eventsList,
         0,
         eventsList.getEventsCount(),


### PR DESCRIPTION
![qsd](https://user-images.githubusercontent.com/1670670/66707939-0a236c80-ed49-11e9-9c11-d38887bd75b8.gif)


Add the new button in submenu with right click, just under "Extract events to a function"
Move the events selected in a new group, this group is closed by default.

[Roadmap card](https://trello.com/c/JykQTO5L/364-move-selected-events-in-a-new-group-with-right-click)

----------

Thank for help @4ian , it's difficult to understand all relations between GDCore, GDJS, GDevelop.js.

[GDcore c++ Documentation](http://4ian.github.io/GD-Documentation/GDCore%20Documentation/namespacegd.html)
