### PR TITLE
update piskel version

### DIFF
--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -74,7 +74,7 @@
   },
   "scripts": {
     "postinstall": "npm run import-resources && npm run make-version-metadata",
-    "import-resources": "cd scripts && node import-libGD.js && node import-GDJS-Runtime.js && node import-monaco-editor.js && node import-zipped-external-libs.js && node import-zipped-editor.js piskel 5.0.0-beta82 a2c36775109a1c1181d0b9ab9b7c903365c4ecb340118f1237b66236f23e20dd && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.0-beta80 5930c686ccf2b6fd3433b1c9539483473a6aedb8b6a73dd13c07030c95efecb9",
+    "import-resources": "cd scripts && node import-libGD.js && node import-GDJS-Runtime.js && node import-monaco-editor.js && node import-zipped-external-libs.js && node import-zipped-editor.js piskel 5.0.0-beta82 e02f67866b338b4cc577e1ffa48f55f52cd520ed751dccc6f0931e3c1b995de0 && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.0-beta80 5930c686ccf2b6fd3433b1c9539483473a6aedb8b6a73dd13c07030c95efecb9",
     "make-version-metadata": "cd scripts && node make-version-metadata.js",
     "make-service-worker": "cd scripts && node make-service-worker.js",
     "start": "npm run import-resources && npm run make-version-metadata && react-scripts start",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -74,7 +74,7 @@
   },
   "scripts": {
     "postinstall": "npm run import-resources && npm run make-version-metadata",
-    "import-resources": "cd scripts && node import-libGD.js && node import-GDJS-Runtime.js && node import-monaco-editor.js && node import-zipped-external-libs.js && node import-zipped-editor.js piskel 5.0.0-beta83 a2c36775109a1c1181d0b9ab9b7c903365c4ecb340118f1237b66236f23e20dd && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.0-beta80 5930c686ccf2b6fd3433b1c9539483473a6aedb8b6a73dd13c07030c95efecb9",
+    "import-resources": "cd scripts && node import-libGD.js && node import-GDJS-Runtime.js && node import-monaco-editor.js && node import-zipped-external-libs.js && node import-zipped-editor.js piskel 5.0.0-beta82 a2c36775109a1c1181d0b9ab9b7c903365c4ecb340118f1237b66236f23e20dd && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.0-beta80 5930c686ccf2b6fd3433b1c9539483473a6aedb8b6a73dd13c07030c95efecb9",
     "make-version-metadata": "cd scripts && node make-version-metadata.js",
     "make-service-worker": "cd scripts && node make-service-worker.js",
     "start": "npm run import-resources && npm run make-version-metadata && react-scripts start",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -74,7 +74,7 @@
   },
   "scripts": {
     "postinstall": "npm run import-resources && npm run make-version-metadata",
-    "import-resources": "cd scripts && node import-libGD.js && node import-GDJS-Runtime.js && node import-monaco-editor.js && node import-zipped-external-libs.js && node import-zipped-editor.js piskel 5.0.0-beta56 a2c36775109a1c1181d0b9ab9b7c903365c4ecb340118f1237b66236f23e20dd && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.0-beta80 5930c686ccf2b6fd3433b1c9539483473a6aedb8b6a73dd13c07030c95efecb9",
+    "import-resources": "cd scripts && node import-libGD.js && node import-GDJS-Runtime.js && node import-monaco-editor.js && node import-zipped-external-libs.js && node import-zipped-editor.js piskel 5.0.0-beta83 a2c36775109a1c1181d0b9ab9b7c903365c4ecb340118f1237b66236f23e20dd && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.0-beta80 5930c686ccf2b6fd3433b1c9539483473a6aedb8b6a73dd13c07030c95efecb9",
     "make-version-metadata": "cd scripts && node make-version-metadata.js",
     "make-service-worker": "cd scripts && node make-service-worker.js",
     "start": "npm run import-resources && npm run make-version-metadata && react-scripts start",

--- a/newIDE/app/public/external/piskel/README.md
+++ b/newIDE/app/public/external/piskel/README.md
@@ -1,6 +1,10 @@
 This folder contains sources to embed Piskel editor (https://www.piskelapp.com/) so that it can
 be used directly from GDevelop to edit images.
 
+GD uses an updated version of piskel from https://github.com/blurymind/piskel/tree/piskel-plus
+It contains a number of advanced color manipulation features and improvements to aid artists.
+commit number: a300d17eb88d2b9d1fa2bbe3a810ad1bb76f1f81
+
 Piskel sources are downloaded by `import-zipped-editor.js` script. They are raw, unchanged sources
 of the Piskel editor build. Sources will be stored in `piskel-editor` folder.
 See `piskel-main.js` for the code running the editor.


### PR DESCRIPTION
I made a new build of piskel based on https://github.com/blurymind/piskel/tree/piskel-plus (a300d17) here:
[piskel-editor.zip](https://github.com/4ian/GDevelop/files/3859182/piskel-editor.zip)


This PR updates GD to use that new build.

I've been working on piskel for a while, improving some of it's weak points. The new features are:
- color index shift brush (super useful for cell shading sprites) (1)
- ability to source all  layers when using the bucket tool
- palette transfer tool (apply the currently selected palette colors to the frame you are on) (2)
![piskelNew](https://user-images.githubusercontent.com/6495061/68996319-4d18b880-0890-11ea-9661-ce976d48dad5.png)

![bucketToolSourcePiskel](https://user-images.githubusercontent.com/6495061/69063084-c55bb700-0a13-11ea-9516-caa94a78b312.gif)
![piskelPaletteTool](https://user-images.githubusercontent.com/6495061/69063093-cb519800-0a13-11ea-93ea-2024189519c1.gif)

