### PR TITLE
Rework text field, some buttons and some layouts

### DIFF
--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/PolygonEditor.js
@@ -11,6 +11,7 @@ import {
 import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import Warning from '@material-ui/icons/Warning';
 import IconButton from '../../../UI/IconButton';
+import ThemeConsumer from '../../../UI/Theme/ThemeConsumer';
 import AddCircle from '@material-ui/icons/AddCircle';
 import Delete from '@material-ui/icons/Delete';
 
@@ -89,64 +90,73 @@ export default class PolygonEditor extends React.Component<Props> {
     } = this.props;
 
     return (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHeaderColumn />
-            <TableHeaderColumn>X</TableHeaderColumn>
-            <TableHeaderColumn>Y</TableHeaderColumn>
-            <TableRowColumn />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {vertices.map((value, index) => {
-            return (
-              <TableRow key={`vertexRow${index}`}>
+      <ThemeConsumer>
+        {muiTheme => (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHeaderColumn />
+                <TableHeaderColumn>X</TableHeaderColumn>
+                <TableHeaderColumn>Y</TableHeaderColumn>
+                <TableRowColumn />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {vertices.map((value, index) => {
+                return (
+                  <TableRow
+                    key={`vertexRow${index}`}
+                    style={{
+                      backgroundColor: muiTheme.list.itemsBackgroundColor,
+                    }}
+                  >
+                    <TableRowColumn>
+                      {!this._isPolygonConvex(vertices) && <Warning />}
+                    </TableRowColumn>
+                    <TableRowColumn>
+                      <SemiControlledTextField
+                        margin="none"
+                        fullWidth
+                        value={value.x.toString(10)}
+                        onChange={newValue =>
+                          onChangeVertexX(parseFloat(newValue) || 0, index)
+                        }
+                        type="number"
+                      />
+                    </TableRowColumn>
+                    <TableRowColumn>
+                      <SemiControlledTextField
+                        margin="none"
+                        fullWidth
+                        value={value.y.toString(10)}
+                        onChange={newValue =>
+                          onChangeVertexY(parseFloat(newValue) || 0, index)
+                        }
+                        type="number"
+                      />
+                    </TableRowColumn>
+                    <TableRowColumn>
+                      <IconButton onClick={() => onRemove(index)}>
+                        <Delete />
+                      </IconButton>
+                    </TableRowColumn>
+                  </TableRow>
+                );
+              })}
+              <TableRow>
+                <TableRowColumn />
+                <TableRowColumn />
+                <TableRowColumn />
                 <TableRowColumn>
-                  {!this._isPolygonConvex(vertices) && <Warning />}
-                </TableRowColumn>
-                <TableRowColumn>
-                  <SemiControlledTextField
-                    margin="none"
-                    fullWidth
-                    value={value.x.toString(10)}
-                    onChange={newValue =>
-                      onChangeVertexX(parseFloat(newValue) || 0, index)
-                    }
-                    type="number"
-                  />
-                </TableRowColumn>
-                <TableRowColumn>
-                  <SemiControlledTextField
-                    margin="none"
-                    fullWidth
-                    value={value.y.toString(10)}
-                    onChange={newValue =>
-                      onChangeVertexY(parseFloat(newValue) || 0, index)
-                    }
-                    type="number"
-                  />
-                </TableRowColumn>
-                <TableRowColumn>
-                  <IconButton onClick={() => onRemove(index)}>
-                    <Delete />
+                  <IconButton onClick={onAdd}>
+                    <AddCircle />
                   </IconButton>
                 </TableRowColumn>
               </TableRow>
-            );
-          })}
-          <TableRow>
-            <TableRowColumn />
-            <TableRowColumn />
-            <TableRowColumn />
-            <TableRowColumn>
-              <IconButton onClick={onAdd}>
-                <AddCircle />
-              </IconButton>
-            </TableRowColumn>
-          </TableRow>
-        </TableBody>
-      </Table>
+            </TableBody>
+          </Table>
+        )}
+      </ThemeConsumer>
     );
   }
 }

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -11,12 +11,13 @@ import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 import ImagePreview from '../../../ResourcesList/ResourcePreview/ImagePreview';
 import ResourceSelector from '../../../ResourcesList/ResourceSelector';
 import ResourcesLoader from '../../../ResourcesLoader';
-import BackgroundText from '../../../UI/BackgroundText';
 import ShapePreview from './ShapePreview.js';
 import PolygonEditor from './PolygonEditor.js';
 import { type BehaviorEditorProps } from '../BehaviorEditorProps.flow';
 import Text from '../../../UI/Text';
 import DismissableAlertMessage from '../../../UI/DismissableAlertMessage';
+import { ResponsiveLineStackLayout } from '../../../UI/Layout';
+import EmptyMessage from '../../../UI/EmptyMessage';
 
 type Props = BehaviorEditorProps;
 
@@ -34,6 +35,7 @@ function NumericProperty(props: {|
 
   return (
     <SemiControlledTextField
+      fullWidth
       value={properties.get(propertyName).getValue()}
       key={propertyName}
       floatingLabelText={properties.get(propertyName).getLabel()}
@@ -105,6 +107,7 @@ export default class Physics2Editor extends React.Component<Props, State> {
         <Line>
           <SelectField
             key={'bodyType'}
+            fullWidth
             floatingLabelText={properties.get('bodyType').getLabel()}
             value={properties.get('bodyType').getValue()}
             onChange={(e, i, newValue: string) => {
@@ -136,53 +139,47 @@ export default class Physics2Editor extends React.Component<Props, State> {
             ]}
           </SelectField>
         </Line>
-        <Line>
-          <Column expand>
-            <Checkbox
-              label={properties.get('bullet').getLabel()}
-              checked={properties.get('bullet').getValue() === 'true'}
-              onCheck={(e, checked) => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'bullet',
-                  checked ? '1' : '0',
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand>
-            <Checkbox
-              label={properties.get('fixedRotation').getLabel()}
-              checked={properties.get('fixedRotation').getValue() === 'true'}
-              onCheck={(e, checked) => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'fixedRotation',
-                  checked ? '1' : '0',
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand>
-            <Checkbox
-              label={properties.get('canSleep').getLabel()}
-              checked={properties.get('canSleep').getValue() === 'true'}
-              onCheck={(e, checked) => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'canSleep',
-                  checked ? '1' : '0',
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
+        <ResponsiveLineStackLayout>
+          <Checkbox
+            label={properties.get('bullet').getLabel()}
+            checked={properties.get('bullet').getValue() === 'true'}
+            onCheck={(e, checked) => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'bullet',
+                checked ? '1' : '0',
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+          <Checkbox
+            label={properties.get('fixedRotation').getLabel()}
+            checked={properties.get('fixedRotation').getValue() === 'true'}
+            onCheck={(e, checked) => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'fixedRotation',
+                checked ? '1' : '0',
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+          <Checkbox
+            label={properties.get('canSleep').getLabel()}
+            checked={properties.get('canSleep').getValue() === 'true'}
+            onCheck={(e, checked) => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'canSleep',
+                checked ? '1' : '0',
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
         <Line>
           <DismissableAlertMessage
             identifier="physics2-shape-collisions"
@@ -199,6 +196,7 @@ export default class Physics2Editor extends React.Component<Props, State> {
         </Line>
         <Line>
           <SelectField
+            fullWidth
             floatingLabelText={properties.get('shape').getLabel()}
             value={properties.get('shape').getValue()}
             onChange={(e, i, newValue: string) => {
@@ -225,9 +223,10 @@ export default class Physics2Editor extends React.Component<Props, State> {
             />
           </SelectField>
         </Line>
-        <Line>
+        <ResponsiveLineStackLayout>
           {shape !== 'Polygon' && (
             <SemiControlledTextField
+              fullWidth
               value={properties
                 .get(shape === 'Polygon' ? 'PolygonOriginX' : 'shapeDimensionA')
                 .getValue()}
@@ -254,6 +253,7 @@ export default class Physics2Editor extends React.Component<Props, State> {
           )}
           {shape !== 'Polygon' && shape !== 'Circle' && (
             <SemiControlledTextField
+              fullWidth
               value={properties
                 .get(shape === 'Polygon' ? 'PolygonOriginY' : 'shapeDimensionB')
                 .getValue()}
@@ -274,6 +274,7 @@ export default class Physics2Editor extends React.Component<Props, State> {
           )}
           {shape === 'Polygon' && (
             <SelectField
+              fullWidth
               floatingLabelText={properties.get('polygonOrigin').getLabel()}
               value={properties.get('polygonOrigin').getValue()}
               onChange={(e, i, newValue: string) => {
@@ -333,78 +334,94 @@ export default class Physics2Editor extends React.Component<Props, State> {
               this.forceUpdate();
             }}
           />
-        </Line>
+        </ResponsiveLineStackLayout>
         <Line>
-          <div
-            style={{
-              width:
-                '100%' /* This div prevents ImagePreview to overflow outside the parent */,
+          <ResourceSelector
+            floatingLabelText={
+              <Trans>
+                A temporary image to help you visualize the shape/polygon
+              </Trans>
+            }
+            project={this.props.project}
+            resourceSources={this.props.resourceSources}
+            onChooseResource={this.props.onChooseResource}
+            resourceExternalEditors={this.props.resourceExternalEditors}
+            resourcesLoader={this.resourcesLoader}
+            resourceKind={'image'}
+            initialResourceName={''}
+            fullWidth
+            onChange={resourceName => {
+              this.setState({ image: resourceName });
+              this.forceUpdate();
             }}
-          >
-            <ImagePreview
-              resourceName={this.state.image}
-              project={this.props.project}
-              resourcesLoader={this.resourcesLoader}
-              renderOverlay={({ imageWidth, imageHeight, imageZoomFactor }) => (
-                <ShapePreview
-                  shape={properties.get('shape').getValue()}
-                  dimensionA={parseFloat(
-                    properties.get('shapeDimensionA').getValue()
-                  )}
-                  dimensionB={parseFloat(
-                    properties.get('shapeDimensionB').getValue()
-                  )}
-                  offsetX={parseFloat(
-                    properties.get('shapeOffsetX').getValue()
-                  )}
-                  offsetY={parseFloat(
-                    properties.get('shapeOffsetY').getValue()
-                  )}
-                  polygonOrigin={properties.get('polygonOrigin').getValue()}
-                  vertices={JSON.parse(properties.get('vertices').getValue())}
-                  width={imageWidth}
-                  height={imageHeight}
-                  zoomFactor={imageZoomFactor}
-                  onMoveVertex={(index, newX, newY) => {
-                    let vertices = JSON.parse(
-                      properties.get('vertices').getValue()
-                    );
-                    vertices[index].x = newX;
-                    vertices[index].y = newY;
-                    behavior.updateProperty(
-                      behaviorContent.getContent(),
-                      'vertices',
-                      JSON.stringify(vertices),
-                      project
-                    );
-                    this.forceUpdate();
-                  }}
-                />
-              )}
-            />
-          </div>
+          />
         </Line>
-        <Line alignItems="center">
-          <Column noMargin>
-            <ResourceSelector
-              project={this.props.project}
-              resourceSources={this.props.resourceSources}
-              onChooseResource={this.props.onChooseResource}
-              resourceExternalEditors={this.props.resourceExternalEditors}
-              resourcesLoader={this.resourcesLoader}
-              resourceKind={'image'}
-              initialResourceName={''}
-              fullWidth
-              onChange={resourceName => {
-                this.setState({ image: resourceName });
-                this.forceUpdate();
+        {!this.state.image && (
+          <Line>
+            <EmptyMessage>
+              <Trans>
+                To preview the shape that the Physics engine will use for this
+                object, choose first a temporary image to use for the preview.
+              </Trans>
+            </EmptyMessage>
+          </Line>
+        )}
+        {this.state.image && (
+          <Line>
+            <div
+              style={{
+                width:
+                  '100%' /* This div prevents ImagePreview to overflow outside the parent */,
               }}
-            />
-          </Column>
-          <BackgroundText>
-            A temporary image to help you visualize the shape/polygon
-          </BackgroundText>
-        </Line>
+            >
+              <ImagePreview
+                resourceName={this.state.image}
+                project={this.props.project}
+                resourcesLoader={this.resourcesLoader}
+                renderOverlay={({
+                  imageWidth,
+                  imageHeight,
+                  imageZoomFactor,
+                }) => (
+                  <ShapePreview
+                    shape={properties.get('shape').getValue()}
+                    dimensionA={parseFloat(
+                      properties.get('shapeDimensionA').getValue()
+                    )}
+                    dimensionB={parseFloat(
+                      properties.get('shapeDimensionB').getValue()
+                    )}
+                    offsetX={parseFloat(
+                      properties.get('shapeOffsetX').getValue()
+                    )}
+                    offsetY={parseFloat(
+                      properties.get('shapeOffsetY').getValue()
+                    )}
+                    polygonOrigin={properties.get('polygonOrigin').getValue()}
+                    vertices={JSON.parse(properties.get('vertices').getValue())}
+                    width={imageWidth}
+                    height={imageHeight}
+                    zoomFactor={imageZoomFactor}
+                    onMoveVertex={(index, newX, newY) => {
+                      let vertices = JSON.parse(
+                        properties.get('vertices').getValue()
+                      );
+                      vertices[index].x = newX;
+                      vertices[index].y = newY;
+                      behavior.updateProperty(
+                        behaviorContent.getContent(),
+                        'vertices',
+                        JSON.stringify(vertices),
+                        project
+                      );
+                      this.forceUpdate();
+                    }}
+                  />
+                )}
+              />
+            </div>
+          </Line>
+        )}
         {shape === 'Polygon' && (
           <Line>
             <PolygonEditor
@@ -465,108 +482,96 @@ export default class Physics2Editor extends React.Component<Props, State> {
             />
           </Line>
         )}
-        <Line>
-          <Column expand>
-            <NumericProperty
-              properties={properties}
-              propertyName={'density'}
-              step={0.1}
-              onUpdate={newValue => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'density',
-                  parseFloat(newValue) > 0 ? newValue : '0',
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand>
-            <NumericProperty
-              properties={properties}
-              propertyName={'gravityScale'}
-              step={0.1}
-              onUpdate={newValue => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'gravityScale',
-                  newValue,
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand>
-            <NumericProperty
-              properties={properties}
-              propertyName={'friction'}
-              step={0.1}
-              onUpdate={newValue => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'friction',
-                  parseFloat(newValue) > 0 ? newValue : '0',
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand>
-            <NumericProperty
-              properties={properties}
-              propertyName={'restitution'}
-              step={0.1}
-              onUpdate={newValue => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'restitution',
-                  parseFloat(newValue) > 0 ? newValue : '0',
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand>
-            <NumericProperty
-              properties={properties}
-              propertyName={'linearDamping'}
-              step={0.05}
-              onUpdate={newValue => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'linearDamping',
-                  newValue,
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand>
-            <NumericProperty
-              properties={properties}
-              propertyName={'angularDamping'}
-              step={0.05}
-              onUpdate={newValue => {
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'angularDamping',
-                  newValue,
-                  project
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
+        <ResponsiveLineStackLayout>
+          <NumericProperty
+            properties={properties}
+            propertyName={'density'}
+            step={0.1}
+            onUpdate={newValue => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'density',
+                parseFloat(newValue) > 0 ? newValue : '0',
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+          <NumericProperty
+            properties={properties}
+            propertyName={'gravityScale'}
+            step={0.1}
+            onUpdate={newValue => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'gravityScale',
+                newValue,
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <NumericProperty
+            properties={properties}
+            propertyName={'friction'}
+            step={0.1}
+            onUpdate={newValue => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'friction',
+                parseFloat(newValue) > 0 ? newValue : '0',
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+          <NumericProperty
+            properties={properties}
+            propertyName={'restitution'}
+            step={0.1}
+            onUpdate={newValue => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'restitution',
+                parseFloat(newValue) > 0 ? newValue : '0',
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <NumericProperty
+            properties={properties}
+            propertyName={'linearDamping'}
+            step={0.05}
+            onUpdate={newValue => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'linearDamping',
+                newValue,
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+          <NumericProperty
+            properties={properties}
+            propertyName={'angularDamping'}
+            step={0.05}
+            onUpdate={newValue => {
+              behavior.updateProperty(
+                behaviorContent.getContent(),
+                'angularDamping',
+                newValue,
+                project
+              );
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
         <Line>
           <Text>{properties.get('layers').getLabel()}</Text>
           {bits.map((value, index) => {

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -167,9 +167,11 @@ export default class BehaviorsEditor extends Component {
                     </span>
                   </MiniToolbar>
                   <EmptyMessage>
-                    This behavior is unknown. It might be a behavior that was
-                    defined in an extension and that was later removed. You
-                    should delete it.
+                    <Trans>
+                      This behavior is unknown. It might be a behavior that was
+                      defined in an extension and that was later removed. You
+                      should delete it.
+                    </Trans>
                   </EmptyMessage>
                 </div>
               );

--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -149,9 +149,14 @@ export default class DebuggerContent extends React.Component<Props, State> {
                   )
                 ) : (
                   <EmptyMessage>
-                    {gameData
-                      ? 'Choose an element to inspect in the list'
-                      : 'Pause the game (from the toolbar) or hit refresh (on the left) to inspect the game'}
+                    {gameData ? (
+                      <Trans>Choose an element to inspect in the list</Trans>
+                    ) : (
+                      <Trans>
+                        Pause the game (from the toolbar) or hit refresh (on the
+                        left) to inspect the game
+                      </Trans>
+                    )}
                   </EmptyMessage>
                 )}
                 <Column>

--- a/newIDE/app/src/Debugger/Inspectors/RuntimeSceneInspector.js
+++ b/newIDE/app/src/Debugger/Inspectors/RuntimeSceneInspector.js
@@ -9,7 +9,7 @@ import {
   type EditFunction,
   type CallFunction,
 } from '../GDJSInspectorDescriptions';
-import { Line } from '../../UI/Grid';
+import { TextFieldWithButtonLayout } from '../../UI/Layout';
 import mapValues from 'lodash/mapValues';
 import RaisedButton from '../../UI/RaisedButton';
 import SemiControlledAutoComplete from '../../UI/SemiControlledAutoComplete';
@@ -134,32 +134,38 @@ export default class RuntimeSceneInspector extends React.Component<
           </Trans>
         </Text>
         {runtimeScene._objects && runtimeScene._objects.items && (
-          <Line noMargin alignItems="center">
-            <SemiControlledAutoComplete
-              hintText={t`Enter the name of the object`}
-              value={this.state.newObjectName}
-              onChange={value => {
-                this.setState({
-                  newObjectName: value,
-                });
-              }}
-              dataSource={Object.keys(runtimeScene._objects.items).map(
-                objectName => ({
-                  text: objectName,
-                  value: objectName,
-                })
-              )}
-              openOnFocus
-              fullWidth
-            />
-            <RaisedButton
-              label={<Trans>Create</Trans>}
-              primary
-              onClick={() => {
-                onCall(['createObject'], [this.state.newObjectName]);
-              }}
-            />
-          </Line>
+          <TextFieldWithButtonLayout
+            noFloatingLabelText
+            renderTextField={() => (
+              <SemiControlledAutoComplete
+                hintText={t`Enter the name of the object`}
+                value={this.state.newObjectName}
+                onChange={value => {
+                  this.setState({
+                    newObjectName: value,
+                  });
+                }}
+                dataSource={Object.keys(runtimeScene._objects.items).map(
+                  objectName => ({
+                    text: objectName,
+                    value: objectName,
+                  })
+                )}
+                openOnFocus
+                fullWidth
+              />
+            )}
+            renderButton={style => (
+              <RaisedButton
+                style={style}
+                label={<Trans>Create</Trans>}
+                primary
+                onClick={() => {
+                  onCall(['createObject'], [this.state.newObjectName]);
+                }}
+              />
+            )}
+          />
         )}
       </div>
     );

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -41,6 +41,15 @@ const styles = {
 };
 
 const validateParameterName = (i18n: I18nType, newName: string) => {
+  if (!newName) {
+    showWarningBox(
+      i18n._(
+        t`The name of a parameter can not be empty. Enter a name for the parameter or you won't be able to use it.`
+      )
+    );
+    return false;
+  }
+
   if (!gd.Project.validateObjectName(newName)) {
     showWarningBox(
       i18n._(
@@ -131,7 +140,7 @@ export default class EventsFunctionParametersEditor extends React.Component<
                           <SemiControlledTextField
                             commitOnBlur
                             margin="none"
-                            hintText={t`Enter the parameter name`}
+                            hintText={t`Enter the parameter name (mandatory)`}
                             value={parameter.getName()}
                             onChange={text => {
                               if (!validateParameterName(i18n, text)) return;
@@ -141,13 +150,6 @@ export default class EventsFunctionParametersEditor extends React.Component<
                               this.props.onParametersUpdated();
                             }}
                             disabled={isParameterDisabled(i)}
-                            errorText={
-                              parameter.getName() ? null : (
-                                <Trans>
-                                  Name of the parameter is mandatory.
-                                </Trans>
-                              )
-                            }
                             fullWidth
                           />
                         </Column>

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -103,9 +103,11 @@ export default class EventsFunctionParametersEditor extends React.Component<
     if (isABehaviorLifecycleFunction) {
       return (
         <EmptyMessage>
-          This is a "lifecycle method". It will be called automatically by the
-          game engine and has two parameters: "Object" (the object the behavior
-          is acting on) and "Behavior" (the behavior itself).
+          <Trans>
+            This is a "lifecycle method". It will be called automatically by the
+            game engine and has two parameters: "Object" (the object the
+            behavior is acting on) and "Behavior" (the behavior itself).
+          </Trans>
         </EmptyMessage>
       );
     }

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -15,6 +15,7 @@ import { isBehaviorLifecycleFunction } from '../../EventsFunctionsExtensionsLoad
 import EmptyMessage from '../../UI/EmptyMessage';
 import { getParametersIndexOffset } from '../../EventsFunctionsExtensionsLoader';
 import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 
 const gd = global.gd;
 
@@ -34,6 +35,7 @@ const styles = {
     width: 32,
     height: 32,
     marginRight: 8,
+    flexSrink: 0,
   },
 };
 
@@ -130,9 +132,9 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
         {({ i18n }) => (
           <Column>
             {renderConfigurationHeader ? renderConfigurationHeader() : null}
-            <Line alignItems="center">
-              <img src="res/function32.png" alt="" style={styles.icon} />
-              <Column expand>
+            <ResponsiveLineStackLayout alignItems="center">
+              <Line alignItems="center" noMargin>
+                <img src="res/function32.png" alt="" style={styles.icon} />
                 <SelectField
                   value={type}
                   floatingLabelText={<Trans>Function type</Trans>}
@@ -161,24 +163,20 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
                     primaryText={t`String Expression`}
                   />
                 </SelectField>
-              </Column>
-              <Column expand>
-                <SemiControlledTextField
-                  commitOnBlur
-                  floatingLabelText={
-                    <Trans>Full name displayed in editor</Trans>
-                  }
-                  hintText={getFullNameHintText(type)}
-                  value={eventsFunction.getFullName()}
-                  onChange={text => {
-                    eventsFunction.setFullName(text);
-                    if (onConfigurationUpdated) onConfigurationUpdated();
-                    this.forceUpdate();
-                  }}
-                  fullWidth
-                />
-              </Column>
-            </Line>
+              </Line>
+              <SemiControlledTextField
+                commitOnBlur
+                floatingLabelText={<Trans>Full name displayed in editor</Trans>}
+                hintText={getFullNameHintText(type)}
+                value={eventsFunction.getFullName()}
+                onChange={text => {
+                  eventsFunction.setFullName(text);
+                  if (onConfigurationUpdated) onConfigurationUpdated();
+                  this.forceUpdate();
+                }}
+                fullWidth
+              />
+            </ResponsiveLineStackLayout>
             <Line noMargin>
               <SemiControlledTextField
                 commitOnBlur

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -1,4 +1,5 @@
 // @flow
+import { Trans } from '@lingui/macro';
 import { t } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
@@ -13,6 +14,7 @@ import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import { isBehaviorLifecycleFunction } from '../../EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers';
 import EmptyMessage from '../../UI/EmptyMessage';
 import { getParametersIndexOffset } from '../../EventsFunctionsExtensionsLoader';
+import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 
 const gd = global.gd;
 
@@ -72,6 +74,30 @@ const getSentenceErrorText = (
   return undefined;
 };
 
+const getFullNameHintText = (type: any): MessageDescriptor => {
+  if (type === gd.EventsFunction.Condition) {
+    return t`Example: Is flashing?`;
+  } else if (type === gd.EventsFunction.Expression) {
+    return t`Example: Life remaining`;
+  } else if (type === gd.EventsFunction.StringExpression) {
+    return t`Example: Equipped shield name`;
+  }
+
+  return t`Example: Flash the object`;
+};
+
+const getDescriptionHintText = (type: any): MessageDescriptor => {
+  if (type === gd.EventsFunction.Condition) {
+    return t`Example: Check if the object is flashing.`;
+  } else if (type === gd.EventsFunction.Expression) {
+    return t`Example: Life remaining for the player.`;
+  } else if (type === gd.EventsFunction.StringExpression) {
+    return t`Example: Name of the shield equipped by the player.`;
+  }
+
+  return t`Example: Make the object flash for 5 seconds.`;
+};
+
 export default class EventsFunctionPropertiesEditor extends React.Component<
   Props,
   State
@@ -109,6 +135,7 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
               <Column expand>
                 <SelectField
                   value={type}
+                  floatingLabelText={<Trans>Function type</Trans>}
                   fullWidth
                   disabled={!!freezeEventsFunctionType}
                   onChange={(e, i, value: string) => {
@@ -138,7 +165,10 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
               <Column expand>
                 <SemiControlledTextField
                   commitOnBlur
-                  hintText={t`Full name displayed in editor`}
+                  floatingLabelText={
+                    <Trans>Full name displayed in editor</Trans>
+                  }
+                  hintText={getFullNameHintText(type)}
                   value={eventsFunction.getFullName()}
                   onChange={text => {
                     eventsFunction.setFullName(text);
@@ -152,7 +182,10 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
             <Line noMargin>
               <SemiControlledTextField
                 commitOnBlur
-                hintText={t`Description, displayed in editor`}
+                floatingLabelText={
+                  <Trans>Description, displayed in editor</Trans>
+                }
+                hintText={getDescriptionHintText(type)}
                 fullWidth
                 multiLine
                 value={eventsFunction.getDescription()}
@@ -168,7 +201,8 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
               type === gd.EventsFunction.Condition ? (
                 <SemiControlledTextField
                   commitOnBlur
-                  hintText={t`Sentence in Events Sheet (write _PARAMx_ for parameters, e.g: _PARAM1_)`}
+                  floatingLabelText={<Trans>Sentence in Events Sheet</Trans>}
+                  hintText={t`Note: write _PARAMx_ for parameters, e.g: Flash _PARAM1_ for 5 seconds`}
                   fullWidth
                   value={eventsFunction.getSentence()}
                   onChange={text => {

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -121,8 +121,10 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
     if (isABehaviorLifecycleFunction) {
       return (
         <EmptyMessage>
-          This is a "lifecycle method". It will be called automatically by the
-          game engine.
+          <Trans>
+            This is a "lifecycle method". It will be called automatically by the
+            game engine.
+          </Trans>
         </EmptyMessage>
       );
     }

--- a/newIDE/app/src/EventsSheet/InlinePopover.js
+++ b/newIDE/app/src/EventsSheet/InlinePopover.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Popper from '@material-ui/core/Popper';
 import Background from '../UI/Background';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
-import { Column } from '../UI/Grid';
+import { Column, Line } from '../UI/Grid';
 
 const styles = {
   popover: {
@@ -20,9 +20,6 @@ const styles = {
     // then. Only one InlinePopover should be shown at a time anyway.
     zIndex: 2,
   },
-  contentContainer: {
-    overflow: 'hidden',
-  },
 };
 
 export default class InlinePopover extends Component {
@@ -36,8 +33,10 @@ export default class InlinePopover extends Component {
           placement="bottom"
         >
           <Background>
-            <Column>
-              <div style={styles.contentContainer}>{this.props.children}</div>
+            <Column expand>
+              <Line>
+                {this.props.children}
+              </Line>
             </Column>
           </Background>
         </Popper>

--- a/newIDE/app/src/EventsSheet/InlinePopover.js
+++ b/newIDE/app/src/EventsSheet/InlinePopover.js
@@ -34,9 +34,7 @@ export default class InlinePopover extends Component {
         >
           <Background>
             <Column expand>
-              <Line>
-                {this.props.children}
-              </Line>
+              <Line>{this.props.children}</Line>
             </Column>
           </Background>
         </Popper>

--- a/newIDE/app/src/EventsSheet/ParameterFields/AudioResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AudioResourceField.js
@@ -31,6 +31,7 @@ export default class AudioResourceField extends Component<
 
     return (
       <ResourceSelector
+        margin={this.props.isInline ? 'none' : 'dense'}
         project={this.props.project}
         resourceSources={this.props.resourceSources}
         onChooseResource={this.props.onChooseResource}

--- a/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
@@ -127,6 +127,7 @@ export default class BehaviorField extends React.Component<
 
     return (
       <SemiControlledAutoComplete
+        margin={this.props.isInline ? 'none' : 'dense'}
         floatingLabelText={this._description}
         fullWidth
         errorText={

--- a/newIDE/app/src/EventsSheet/ParameterFields/DefaultField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/DefaultField.js
@@ -21,6 +21,7 @@ export default class DefaultField extends React.Component<
 
     return (
       <SemiControlledTextField
+        margin={this.props.isInline ? 'none' : 'dense'}
         commitOnBlur
         value={this.props.value}
         floatingLabelText={description}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ExternalEventsField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ExternalEventsField.js
@@ -48,6 +48,7 @@ export default class ExternalEventsField extends React.Component<
 
     return (
       <SemiControlledAutoComplete
+        margin={this.props.isInline ? 'none' : 'dense'}
         floatingLabelText={
           parameterMetadata ? parameterMetadata.getDescription() : undefined
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -20,17 +20,8 @@ import BackgroundHighlighting, {
 import debounce from 'lodash/debounce';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Paper from '@material-ui/core/Paper';
+import { TextFieldWithButtonLayout } from '../../../UI/Layout';
 const gd = global.gd;
-
-export const textFieldRightButtonMargins = {
-  marginTop: 17, //Properly align with the text field
-  marginLeft: 10,
-};
-
-export const textFieldWithLabelRightButtonMargins = {
-  marginTop: 33, //Properly align with the text field
-  marginLeft: 10,
-};
 
 const styles = {
   container: {
@@ -53,10 +44,14 @@ const styles = {
     lineHeight: 1.4,
   },
   backgroundHighlighting: {
-    marginTop: 22, //Properly align with the text field
+    marginTop: 13, //Properly align with the text field
+    paddingLeft: 12,
+    paddingRight: 12,
   },
   backgroundHighlightingWithDescription: {
-    marginTop: 38, //Properly align with the text field
+    marginTop: 29, //Properly align with the text field
+    paddingLeft: 12,
+    paddingRight: 12,
   },
 };
 
@@ -277,80 +272,85 @@ export default class ExpressionField extends React.Component<Props, State> {
       : styles.backgroundHighlighting;
 
     return (
-      <div style={styles.container}>
-        <div style={styles.textFieldContainer}>
-          <div style={styles.textFieldAndHightlightContainer}>
-            <BackgroundHighlighting
-              value={this.state.validatedValue}
-              style={{ ...styles.input, ...backgroundHighlightingStyle }}
-              highlights={this.state.errorHighlights}
-            />
-            <SemiControlledTextField
-              value={value}
-              floatingLabelText={description}
-              hintText={expressionType === 'string' ? '""' : undefined}
-              inputStyle={styles.input}
-              onChange={this._handleChange}
-              onBlur={this._handleBlur}
-              ref={field => (this._field = field)}
-              onFocus={this._handleFocus}
-              errorText={this.state.errorText}
-              multiLine
-              fullWidth
-            />
-          </div>
-          {this._fieldElement && this.state.popoverOpen && (
-            <ClickAwayListener onClickAway={this._handleRequestClose}>
-              <Popper
-                style={popoverStyle}
-                open={this.state.popoverOpen}
-                anchorEl={this._fieldElement}
-                placement="bottom"
-                disablePortal={
-                  true /* Can't use portals as this would put the Popper outside of the Modal, which is keeping the focus in the modal (so the search bar and keyboard browsing won't not work) */
-                }
-              >
-                <Paper style={styles.expressionSelectorPopoverContent}>
-                  <ExpressionSelector
-                    selectedType=""
-                    onChoose={(type, expression) => {
-                      this._handleExpressionChosen(expression);
-                    }}
-                    expressionType={expressionType}
-                    focusOnMount
-                    scope={scope}
-                  />
-                </Paper>
-              </Popper>
-            </ClickAwayListener>
+      <React.Fragment>
+        <TextFieldWithButtonLayout
+          margin={this.props.isInline ? 'none' : 'dense'}
+          renderTextField={() => (
+            <div style={styles.textFieldContainer}>
+              <div style={styles.textFieldAndHightlightContainer}>
+                <BackgroundHighlighting
+                  value={this.state.validatedValue}
+                  style={{ ...styles.input, ...backgroundHighlightingStyle }}
+                  highlights={this.state.errorHighlights}
+                />
+                <SemiControlledTextField
+                  margin={this.props.isInline ? 'none' : 'dense'}
+                  value={value}
+                  floatingLabelText={description}
+                  hintText={expressionType === 'string' ? '""' : undefined}
+                  inputStyle={styles.input}
+                  onChange={this._handleChange}
+                  onBlur={this._handleBlur}
+                  ref={field => (this._field = field)}
+                  onFocus={this._handleFocus}
+                  errorText={this.state.errorText}
+                  multiLine
+                  fullWidth
+                />
+              </div>
+              {this._fieldElement && this.state.popoverOpen && (
+                <ClickAwayListener onClickAway={this._handleRequestClose}>
+                  <Popper
+                    style={popoverStyle}
+                    open={this.state.popoverOpen}
+                    anchorEl={this._fieldElement}
+                    placement="bottom"
+                    disablePortal={
+                      true /* Can't use portals as this would put the Popper outside of the Modal, which is keeping the focus in the modal (so the search bar and keyboard browsing won't not work) */
+                    }
+                  >
+                    <Paper style={styles.expressionSelectorPopoverContent}>
+                      <ExpressionSelector
+                        selectedType=""
+                        onChoose={(type, expression) => {
+                          this._handleExpressionChosen(expression);
+                        }}
+                        expressionType={expressionType}
+                        focusOnMount
+                        scope={scope}
+                      />
+                    </Paper>
+                  </Popper>
+                </ClickAwayListener>
+              )}
+            </div>
           )}
-        </div>
-        {!this.props.isInline &&
-          this.props.renderExtraButton &&
-          this.props.renderExtraButton({
-            style: description
-              ? textFieldWithLabelRightButtonMargins
-              : textFieldRightButtonMargins,
-          })}
-        {!this.props.isInline && (
-          <RaisedButton
-            icon={<Functions />}
-            label={
-              expressionType === 'string'
-                ? '"ABC"'
-                : expressionType === 'number'
-                ? '123'
-                : ''
-            }
-            primary
-            style={
-              description
-                ? textFieldWithLabelRightButtonMargins
-                : textFieldRightButtonMargins
-            }
-            onClick={this._openExpressionPopover}
-          />
-        )}
+          renderButton={style => (
+            <React.Fragment>
+              {!this.props.isInline &&
+                this.props.renderExtraButton &&
+                this.props.renderExtraButton({
+                  style,
+                })}
+              {!this.props.isInline && (
+                <RaisedButton
+                  icon={<Functions />}
+                  label={
+                    expressionType === 'string'
+                      ? '"ABC"'
+                      : expressionType === 'number'
+                      ? '123'
+                      : ''
+                  }
+                  primary
+                  style={style}
+                  onClick={this._openExpressionPopover}
+                />
+              )}
+            </React.Fragment>
+          )}
+        />
+
         {this.state.parametersDialogOpen && this.state.selectedExpressionInfo && (
           <ExpressionParametersEditorDialog
             open={true}
@@ -380,7 +380,7 @@ export default class ExpressionField extends React.Component<Props, State> {
             parameterRenderingService={parameterRenderingService}
           />
         )}
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
@@ -27,7 +27,7 @@ export default class GlobalVariableField extends React.Component<
     const { project, scope } = this.props;
 
     return (
-      <div>
+      <React.Fragment>
         <VariableField
           variablesContainer={project ? project.getVariables() : null}
           parameterMetadata={this.props.parameterMetadata}
@@ -56,7 +56,7 @@ export default class GlobalVariableField extends React.Component<
             }
           />
         )}
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/newIDE/app/src/EventsSheet/ParameterFields/JsonResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/JsonResourceField.js
@@ -31,6 +31,7 @@ export default class JsonResourceField extends Component<
 
     return (
       <ResourceSelector
+        margin={this.props.isInline ? 'none' : 'dense'}
         project={this.props.project}
         resourceSources={this.props.resourceSources}
         onChooseResource={this.props.onChooseResource}

--- a/newIDE/app/src/EventsSheet/ParameterFields/KeyField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/KeyField.js
@@ -109,6 +109,7 @@ export default class KeyField extends Component<ParameterFieldProps, {||}> {
 
     return (
       <SemiControlledAutoComplete
+        margin={this.props.isInline ? 'none' : 'dense'}
         floatingLabelText={
           parameterMetadata ? parameterMetadata.getDescription() : undefined
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
@@ -23,6 +23,7 @@ export default class LayerField extends Component<ParameterFieldProps, {||}> {
 
     return (
       <SemiControlledAutoComplete
+        margin={this.props.isInline ? 'none' : 'dense'}
         floatingLabelText={
           parameterMetadata ? parameterMetadata.getDescription() : undefined
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
@@ -16,6 +16,7 @@ export default class MouseField extends Component {
 
     return (
       <SelectField
+        margin={this.props.isInline ? 'none' : 'dense'}
         fullWidth
         floatingLabelText={description}
         value={value}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectField.js
@@ -34,6 +34,7 @@ export default class ObjectField extends React.Component<
   render() {
     return (
       <ObjectSelector
+        margin={this.props.isInline ? 'none' : 'dense'}
         project={this.props.project}
         value={this.props.value}
         onChange={this.props.onChange}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
@@ -53,7 +53,7 @@ export default class ObjectVariableField extends React.Component<
     }
 
     return (
-      <div>
+      <React.Fragment>
         <VariableField
           variablesContainer={variablesContainer}
           parameterMetadata={this.props.parameterMetadata}
@@ -76,7 +76,7 @@ export default class ObjectVariableField extends React.Component<
             }}
           />
         )}
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
@@ -21,6 +21,7 @@ export default class OperatorField extends Component<ParameterFieldProps> {
 
     return (
       <SelectField
+        margin={this.props.isInline ? 'none' : 'dense'}
         fullWidth
         floatingLabelText={description}
         value={this.props.value}

--- a/newIDE/app/src/EventsSheet/ParameterFields/RelationalOperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/RelationalOperatorField.js
@@ -21,6 +21,7 @@ export default class RelationalOperatorField extends Component<ParameterFieldPro
 
     return (
       <SelectField
+        margin={this.props.isInline ? 'none' : 'dense'}
         fullWidth
         floatingLabelText={description}
         value={this.props.value}

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
@@ -28,6 +28,7 @@ export default class SceneNameField extends Component<
 
     return (
       <SemiControlledAutoComplete
+        margin={this.props.isInline ? 'none' : 'dense'}
         floatingLabelText={
           parameterMetadata ? parameterMetadata.getDescription() : undefined
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
@@ -35,6 +35,7 @@ export default class StringWithSelectorField extends Component<
 
     return (
       <SemiControlledAutoComplete
+        margin={this.props.isInline ? 'none' : 'dense'}
         floatingLabelText={
           parameterMetadata ? parameterMetadata.getDescription() : undefined
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -40,6 +40,7 @@ export default class VariableField extends Component<Props, {||}> {
       <TextFieldWithButtonLayout
         renderTextField={() => (
           <SemiControlledAutoComplete
+            margin={this.props.isInline ? 'none' : 'dense'}
             floatingLabelText={description}
             fullWidth
             value={value}

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -7,17 +7,7 @@ import { type ParameterFieldProps } from './ParameterFieldCommons';
 import classNames from 'classnames';
 import { icon } from '../EventsTree/ClassNames';
 import SemiControlledAutoComplete from '../../UI/SemiControlledAutoComplete';
-import {
-  textFieldRightButtonMargins,
-  textFieldWithLabelRightButtonMargins,
-} from './GenericExpressionField';
-
-const styles = {
-  container: {
-    display: 'flex',
-    alignItems: 'flex-start',
-  },
-};
+import { TextFieldWithButtonLayout } from '../../UI/Layout';
 
 type Props = {
   ...ParameterFieldProps,
@@ -47,35 +37,35 @@ export default class VariableField extends Component<Props, {||}> {
       : undefined;
 
     return (
-      <div style={styles.container}>
-        <SemiControlledAutoComplete
-          floatingLabelText={description}
-          fullWidth
-          value={value}
-          onChange={onChange}
-          dataSource={enumerateVariables(variablesContainer).map(
-            variableName => ({
-              text: variableName,
-              value: variableName,
-            })
-          )}
-          openOnFocus={!isInline}
-          ref={field => (this._field = field)}
-        />
-        {onOpenDialog && !isInline && (
-          <RaisedButton
-            icon={<OpenInNew />}
-            disabled={!this.props.variablesContainer}
-            primary
-            style={
-              description
-                ? textFieldWithLabelRightButtonMargins
-                : textFieldRightButtonMargins
-            }
-            onClick={onOpenDialog}
+      <TextFieldWithButtonLayout
+        renderTextField={() => (
+          <SemiControlledAutoComplete
+            floatingLabelText={description}
+            fullWidth
+            value={value}
+            onChange={onChange}
+            dataSource={enumerateVariables(variablesContainer).map(
+              variableName => ({
+                text: variableName,
+                value: variableName,
+              })
+            )}
+            openOnFocus={!isInline}
+            ref={field => (this._field = field)}
           />
         )}
-      </div>
+        renderButton={style =>
+          onOpenDialog && !isInline ? (
+            <RaisedButton
+              icon={<OpenInNew />}
+              disabled={!this.props.variablesContainer}
+              primary
+              style={style}
+              onClick={onOpenDialog}
+            />
+          ) : null
+        }
+      />
     );
   }
 }

--- a/newIDE/app/src/EventsSheet/ParameterFields/VideoResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VideoResourceField.js
@@ -31,6 +31,7 @@ export default class VideoResourceField extends Component<
 
     return (
       <ResourceSelector
+        margin={this.props.isInline ? 'none' : 'dense'}
         project={this.props.project}
         resourceSources={this.props.resourceSources}
         onChooseResource={this.props.onChooseResource}

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -6,7 +6,6 @@ import React, { PureComponent } from 'react';
 import Background from '../UI/Background';
 import TextField from '../UI/TextField';
 import { Line, Column, Spacer } from '../UI/Grid';
-import FlatButton from '../UI/FlatButton';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import IconButton from '../UI/IconButton';
@@ -16,6 +15,7 @@ import {
   type SearchInEventsInputs,
   type ReplaceInEventsInputs,
 } from './EventsSearcher';
+import RaisedButton from '../UI/RaisedButton';
 
 type Props = {|
   onSearchInEvents: SearchInEventsInputs => void,
@@ -104,15 +104,17 @@ export default class SearchPanel extends PureComponent<Props, State> {
         <Column>
           <Line alignItems="baseline">
             <TextField
+              margin="none"
               ref={_searchTextField =>
                 (this.searchTextField = _searchTextField)
               }
-              hintText={t`Text to search`}
+              hintText={t`Text to search in parameters`}
               onChange={(e, searchText) => this.setState({ searchText })}
               value={searchText}
               fullWidth
             />
-            <FlatButton
+            <Spacer />
+            <RaisedButton
               disabled={!searchText}
               primary
               label={<Trans>Search</Trans>}
@@ -121,12 +123,14 @@ export default class SearchPanel extends PureComponent<Props, State> {
           </Line>
           <Line alignItems="baseline">
             <TextField
-              hintText={t`Text to replace`}
+              margin="none"
+              hintText={t`Text to replace in parameters`}
               onChange={(e, replaceText) => this.setState({ replaceText })}
               value={replaceText}
               fullWidth
             />
-            <FlatButton
+            <Spacer />
+            <RaisedButton
               disabled={
                 !replaceText ||
                 !searchText ||

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -102,9 +102,9 @@ export default class SearchPanel extends PureComponent<Props, State> {
     return (
       <Background noFullHeight noExpand>
         <Column>
-          <Line alignItems="baseline">
+          <Line alignItems="baseline" noMargin>
             <TextField
-              margin="none"
+              margin="dense"
               ref={_searchTextField =>
                 (this.searchTextField = _searchTextField)
               }
@@ -121,9 +121,9 @@ export default class SearchPanel extends PureComponent<Props, State> {
               onClick={this.launchSearch}
             />
           </Line>
-          <Line alignItems="baseline">
+          <Line alignItems="baseline" noMargin>
             <TextField
-              margin="none"
+              margin="dense"
               hintText={t`Text to replace in parameters`}
               onChange={(e, replaceText) => this.setState({ replaceText })}
               value={replaceText}

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -112,12 +112,14 @@ export default class PreferencesDialog extends Component<Props, State> {
                 </ResponsiveLineStackLayout>
                 <Line noMargin>
                   <Text>
-                    You can contribute and create your own themes:{' '}
-                    <FlatButton
-                      label={<Trans>Learn more</Trans>}
-                      onClick={this.createTheme}
-                    />{' '}
+                    <Trans>
+                      You can contribute and create your own themes:{' '}
+                    </Trans>
                   </Text>
+                  <FlatButton
+                    label={<Trans>Learn more</Trans>}
+                    onClick={this.createTheme}
+                  />
                 </Line>
                 <Line>
                   <Toggle

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -16,6 +16,7 @@ import PreferencesContext, {
   type AlertMessageIdentifier,
 } from './PreferencesContext';
 import Text from '../../UI/Text';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 
 type Props = {|
   open: boolean,
@@ -58,6 +59,7 @@ export default class PreferencesDialog extends Component<Props, State> {
         onRequestClose={onClose}
         open={open}
         title={<Trans>GDevelop preferences</Trans>}
+        maxWidth="sm"
       >
         <PreferencesContext.Consumer>
           {({
@@ -78,7 +80,7 @@ export default class PreferencesDialog extends Component<Props, State> {
 
             return (
               <Column noMargin>
-                <Line noMargin>
+                <ResponsiveLineStackLayout noMargin>
                   <SelectField
                     floatingLabelText={<Trans>UI Theme</Trans>}
                     value={values.themeName}
@@ -107,7 +109,7 @@ export default class PreferencesDialog extends Component<Props, State> {
                       />
                     ))}
                   </SelectField>
-                </Line>
+                </ResponsiveLineStackLayout>
                 <Line noMargin>
                   <Text>
                     You can contribute and create your own themes:{' '}

--- a/newIDE/app/src/ObjectEditor/Editors/PanelSpriteEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/PanelSpriteEditor.js
@@ -7,6 +7,7 @@ import { Line, Column } from '../../UI/Grid';
 import ResourceSelectorWithThumbnail from '../../ResourcesList/ResourceSelectorWithThumbnail';
 import { type EditorProps } from './EditorProps.flow';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 const gd = global.gd;
 
 export default class PanelSpriteEditor extends React.Component<
@@ -54,7 +55,7 @@ export default class PanelSpriteEditor extends React.Component<
             }}
           />
         </Line>
-        <Line>
+        <ResponsiveLineStackLayout>
           <SemiControlledTextField
             commitOnBlur
             floatingLabelText={<Trans>Top margin</Trans>}
@@ -77,8 +78,8 @@ export default class PanelSpriteEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-        </Line>
-        <Line>
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
           <SemiControlledTextField
             commitOnBlur
             floatingLabelText={<Trans>Left margin</Trans>}
@@ -101,8 +102,8 @@ export default class PanelSpriteEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-        </Line>
-        <Line>
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
           <SemiControlledTextField
             commitOnBlur
             floatingLabelText={<Trans>Default width (in pixels)</Trans>}
@@ -125,7 +126,7 @@ export default class PanelSpriteEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-        </Line>
+        </ResponsiveLineStackLayout>
       </Column>
     );
   }

--- a/newIDE/app/src/ObjectEditor/Editors/ParticleEmitterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ParticleEmitterEditor.js
@@ -11,6 +11,7 @@ import ColorField from '../../UI/ColorField';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import { type EditorProps } from './EditorProps.flow';
 import ResourceSelectorWithThumbnail from '../../ResourcesList/ResourceSelectorWithThumbnail';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 const gd = global.gd;
 
 export default class ParticleEmitterEditor extends React.Component<
@@ -79,34 +80,30 @@ export default class ParticleEmitterEditor extends React.Component<
         )}
         {particleEmitterObject.getRendererType() ===
           gd.ParticleEmitterObject.Line && (
-          <Line>
-            <Column expand noMargin>
-              <SemiControlledTextField
-                commitOnBlur
-                floatingLabelText={<Trans>Lines length</Trans>}
-                fullWidth
-                type="number"
-                value={particleEmitterObject.getRendererParam1()}
-                onChange={value => {
-                  particleEmitterObject.setRendererParam1(parseFloat(value));
-                  this.forceUpdate();
-                }}
-              />
-            </Column>
-            <Column expand noMargin>
-              <SemiControlledTextField
-                commitOnBlur
-                floatingLabelText={<Trans>Lines thickness</Trans>}
-                fullWidth
-                type="number"
-                value={particleEmitterObject.getRendererParam2()}
-                onChange={value => {
-                  particleEmitterObject.setRendererParam2(parseFloat(value));
-                  this.forceUpdate();
-                }}
-              />
-            </Column>
-          </Line>
+          <ResponsiveLineStackLayout>
+            <SemiControlledTextField
+              commitOnBlur
+              floatingLabelText={<Trans>Lines length</Trans>}
+              fullWidth
+              type="number"
+              value={particleEmitterObject.getRendererParam1()}
+              onChange={value => {
+                particleEmitterObject.setRendererParam1(parseFloat(value));
+                this.forceUpdate();
+              }}
+            />
+            <SemiControlledTextField
+              commitOnBlur
+              floatingLabelText={<Trans>Lines thickness</Trans>}
+              fullWidth
+              type="number"
+              value={particleEmitterObject.getRendererParam2()}
+              onChange={value => {
+                particleEmitterObject.setRendererParam2(parseFloat(value));
+                this.forceUpdate();
+              }}
+            />
+          </ResponsiveLineStackLayout>
         )}
         {particleEmitterObject.getRendererType() ===
           gd.ParticleEmitterObject.Quad && (
@@ -126,41 +123,37 @@ export default class ParticleEmitterEditor extends React.Component<
                 floatingLabelText={<Trans>Select an image</Trans>}
               />
             </Line>
-            <Line>
-              <Column expand noMargin>
-                <SemiControlledTextField
-                  commitOnBlur
-                  floatingLabelText={<Trans>Particles start width</Trans>}
-                  fullWidth
-                  type="number"
-                  value={particleEmitterObject.getRendererParam1()}
-                  onChange={value => {
-                    particleEmitterObject.setRendererParam1(
-                      Math.max(0, parseFloat(value))
-                    );
-                    this.forceUpdate();
-                  }}
-                />
-              </Column>
-              <Column expand noMargin>
-                <SemiControlledTextField
-                  commitOnBlur
-                  floatingLabelText={<Trans>Particles start height</Trans>}
-                  fullWidth
-                  type="number"
-                  value={particleEmitterObject.getRendererParam2()}
-                  onChange={value => {
-                    particleEmitterObject.setRendererParam2(
-                      Math.max(0, parseFloat(value))
-                    );
-                    this.forceUpdate();
-                  }}
-                />
-              </Column>
-            </Line>
+            <ResponsiveLineStackLayout>
+              <SemiControlledTextField
+                commitOnBlur
+                floatingLabelText={<Trans>Particles start width</Trans>}
+                fullWidth
+                type="number"
+                value={particleEmitterObject.getRendererParam1()}
+                onChange={value => {
+                  particleEmitterObject.setRendererParam1(
+                    Math.max(0, parseFloat(value))
+                  );
+                  this.forceUpdate();
+                }}
+              />
+              <SemiControlledTextField
+                commitOnBlur
+                floatingLabelText={<Trans>Particles start height</Trans>}
+                fullWidth
+                type="number"
+                value={particleEmitterObject.getRendererParam2()}
+                onChange={value => {
+                  particleEmitterObject.setRendererParam2(
+                    Math.max(0, parseFloat(value))
+                  );
+                  this.forceUpdate();
+                }}
+              />
+            </ResponsiveLineStackLayout>
           </React.Fragment>
         )}
-        <Line>
+        <ResponsiveLineStackLayout>
           <ColorField
             floatingLabelText={<Trans>Particles start color</Trans>}
             disableAlpha
@@ -190,8 +183,8 @@ export default class ParticleEmitterEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-        </Line>
-        <Line>
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
           <ColorField
             floatingLabelText={<Trans>Particles end color</Trans>}
             disableAlpha
@@ -221,7 +214,7 @@ export default class ParticleEmitterEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-        </Line>
+        </ResponsiveLineStackLayout>
         <Line>
           <Checkbox
             label={<Trans>Additive rendering</Trans>}
@@ -243,151 +236,129 @@ export default class ParticleEmitterEditor extends React.Component<
             }}
           />
         </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Maximum number of particles displayed</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getMaxParticleNb()}
-              onChange={value => {
-                particleEmitterObject.setMaxParticleNb(
-                  parseInt(value, 10) || 0
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Number of particles in tank (-1 for infinite)</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getTank()}
-              onChange={value => {
-                particleEmitterObject.setTank(parseInt(value, 10) || 0);
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Flow of particles (particles/seconds)</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getFlow()}
-              onChange={value => {
-                particleEmitterObject.setFlow(parseInt(value, 10) || 0);
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Minimum emitter force applied on particles</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getEmitterForceMin()}
-              onChange={value => {
-                particleEmitterObject.setEmitterForceMin(
-                  parseInt(value, 10) || 0
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Maximum emitter force applied on particles</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getEmitterForceMax()}
-              onChange={value => {
-                particleEmitterObject.setEmitterForceMax(
-                  parseInt(value, 10) || 0
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={<Trans>Spray cone angle (in degrees)</Trans>}
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getConeSprayAngle()}
-              onChange={value => {
-                particleEmitterObject.setConeSprayAngle(
-                  parseInt(value, 10) || 0
-                );
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={<Trans>Radius of the emitter</Trans>}
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getZoneRadius()}
-              onChange={value => {
-                particleEmitterObject.setZoneRadius(parseInt(value, 10) || 0);
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={<Trans>Gravity on particles on X axis</Trans>}
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleGravityX()}
-              onChange={value => {
-                particleEmitterObject.setParticleGravityX(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={<Trans>Gravity on particles on Y axis</Trans>}
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleGravityY()}
-              onChange={value => {
-                particleEmitterObject.setParticleGravityY(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Maximum number of particles displayed</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getMaxParticleNb()}
+            onChange={value => {
+              particleEmitterObject.setMaxParticleNb(parseInt(value, 10) || 0);
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Number of particles in tank (-1 for infinite)</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getTank()}
+            onChange={value => {
+              particleEmitterObject.setTank(parseInt(value, 10) || 0);
+              this.forceUpdate();
+            }}
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Flow of particles (particles/seconds)</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getFlow()}
+            onChange={value => {
+              particleEmitterObject.setFlow(parseInt(value, 10) || 0);
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Minimum emitter force applied on particles</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getEmitterForceMin()}
+            onChange={value => {
+              particleEmitterObject.setEmitterForceMin(
+                parseInt(value, 10) || 0
+              );
+              this.forceUpdate();
+            }}
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Maximum emitter force applied on particles</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getEmitterForceMax()}
+            onChange={value => {
+              particleEmitterObject.setEmitterForceMax(
+                parseInt(value, 10) || 0
+              );
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Spray cone angle (in degrees)</Trans>}
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getConeSprayAngle()}
+            onChange={value => {
+              particleEmitterObject.setConeSprayAngle(parseInt(value, 10) || 0);
+              this.forceUpdate();
+            }}
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Radius of the emitter</Trans>}
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getZoneRadius()}
+            onChange={value => {
+              particleEmitterObject.setZoneRadius(parseInt(value, 10) || 0);
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Gravity on particles on X axis</Trans>}
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleGravityX()}
+            onChange={value => {
+              particleEmitterObject.setParticleGravityX(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Gravity on particles on Y axis</Trans>}
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleGravityY()}
+            onChange={value => {
+              particleEmitterObject.setParticleGravityY(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
         <Line>
           <Column expand noMargin>
             <SemiControlledTextField
@@ -403,100 +374,86 @@ export default class ParticleEmitterEditor extends React.Component<
             />
           </Column>
         </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Particle minimum lifetime (in seconds)</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleLifeTimeMin()}
-              onChange={value => {
-                particleEmitterObject.setParticleLifeTimeMin(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Particle maximum lifetime (in seconds)</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleLifeTimeMax()}
-              onChange={value => {
-                particleEmitterObject.setParticleLifeTimeMax(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Particle start size (in percents)</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleSize1()}
-              onChange={value => {
-                particleEmitterObject.setParticleSize1(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={<Trans>Particle end size (in percents)</Trans>}
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleSize2()}
-              onChange={value => {
-                particleEmitterObject.setParticleSize2(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
-        <Line>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Particle minimum rotation speed (degrees/second)</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleAngle1()}
-              onChange={value => {
-                particleEmitterObject.setParticleAngle1(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-          <Column expand noMargin>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Particle maximum rotation speed (degrees/second)</Trans>
-              }
-              fullWidth
-              type="number"
-              value={particleEmitterObject.getParticleAngle2()}
-              onChange={value => {
-                particleEmitterObject.setParticleAngle2(parseFloat(value));
-                this.forceUpdate();
-              }}
-            />
-          </Column>
-        </Line>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Particle minimum lifetime (in seconds)</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleLifeTimeMin()}
+            onChange={value => {
+              particleEmitterObject.setParticleLifeTimeMin(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Particle maximum lifetime (in seconds)</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleLifeTimeMax()}
+            onChange={value => {
+              particleEmitterObject.setParticleLifeTimeMax(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Particle start size (in percents)</Trans>}
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleSize1()}
+            onChange={value => {
+              particleEmitterObject.setParticleSize1(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Particle end size (in percents)</Trans>}
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleSize2()}
+            onChange={value => {
+              particleEmitterObject.setParticleSize2(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Particle minimum rotation speed (degrees/second)</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleAngle1()}
+            onChange={value => {
+              particleEmitterObject.setParticleAngle1(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={
+              <Trans>Particle maximum rotation speed (degrees/second)</Trans>
+            }
+            fullWidth
+            type="number"
+            value={particleEmitterObject.getParticleAngle2()}
+            onChange={value => {
+              particleEmitterObject.setParticleAngle2(parseFloat(value));
+              this.forceUpdate();
+            }}
+          />
+        </ResponsiveLineStackLayout>
       </Column>
     );
   }

--- a/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
@@ -3,10 +3,11 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import Checkbox from '../../UI/Checkbox';
-import { Line, Column, Spacer } from '../../UI/Grid';
+import { Line, Column } from '../../UI/Grid';
 import ColorField from '../../UI/ColorField';
 import { type EditorProps } from './EditorProps.flow';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 const gd = global.gd;
 
 export default class PanelSpriteEditor extends React.Component<
@@ -34,7 +35,7 @@ export default class PanelSpriteEditor extends React.Component<
             }}
           />
         </Line>
-        <Line>
+        <ResponsiveLineStackLayout>
           <ColorField
             floatingLabelText={<Trans>Outline color</Trans>}
             disableAlpha
@@ -76,8 +77,8 @@ export default class PanelSpriteEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-        </Line>
-        <Line>
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
           <ColorField
             floatingLabelText={<Trans>Fill color</Trans>}
             disableAlpha
@@ -108,8 +109,7 @@ export default class PanelSpriteEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-          <Spacer expand />
-        </Line>
+        </ResponsiveLineStackLayout>
       </Column>
     );
   }

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteSelector.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteSelector.js
@@ -7,9 +7,9 @@ import SelectField from '../../../../UI/SelectField';
 import SelectOption from '../../../../UI/SelectOption';
 
 import Toggle from '../../../../UI/Toggle';
-import { Line } from '../../../../UI/Grid';
 import { mapFor } from '../../../../Utils/MapFor';
 import { getCurrentElements } from './SpriteObjectHelper';
+import { ResponsiveLineStackLayout } from '../../../../UI/Layout';
 
 type Props = {|
   spriteObject: gdSpriteObject,
@@ -70,7 +70,7 @@ export default class SpriteSelector extends React.Component<Props, void> {
 
     return (
       <React.Fragment>
-        <Line>
+        <ResponsiveLineStackLayout>
           <SelectField
             floatingLabelText={<Trans>Animation</Trans>}
             value={this.props.animationIndex}
@@ -127,7 +127,7 @@ export default class SpriteSelector extends React.Component<Props, void> {
               })}
             </SelectField>
           )}
-        </Line>
+        </ResponsiveLineStackLayout>
         <Toggle
           label={setSameForAllAnimationsLabel}
           labelPosition="right"

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -33,6 +33,7 @@ import {
 } from '../../../ResourcesList/ResourceSource.flow';
 import { type ResourceExternalEditor } from '../../../ResourcesList/ResourceExternalEditor.flow';
 import { Column, Line } from '../../../UI/Grid';
+import { ResponsiveLineStackLayout } from '../../../UI/Layout';
 
 const gd = global.gd;
 
@@ -48,9 +49,6 @@ const styles = {
   },
   addAnimation: {
     display: 'flex',
-  },
-  buttonRightMargin: {
-    marginRight: 4,
   },
 };
 
@@ -447,13 +445,12 @@ export default class SpriteEditor extends React.Component<EditorProps, State> {
           objectName={objectName}
           onSizeUpdated={onSizeUpdated}
           extraBottomTools={
-            <div>
+            <ResponsiveLineStackLayout>
               <RaisedButton
                 label={<Trans>Edit hitboxes</Trans>}
                 primary={false}
                 onClick={() => this.openCollisionMasksEditor(true)}
                 disabled={spriteObject.getAnimationsCount() === 0}
-                style={styles.buttonRightMargin}
               />
               <RaisedButton
                 label={<Trans>Edit points</Trans>}
@@ -461,7 +458,7 @@ export default class SpriteEditor extends React.Component<EditorProps, State> {
                 onClick={() => this.openPointsEditor(true)}
                 disabled={spriteObject.getAnimationsCount() === 0}
               />
-            </div>
+            </ResponsiveLineStackLayout>
           }
         />
         {this.state.pointsEditorOpen && (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -47,24 +47,19 @@ const styles = {
   animationTools: {
     flexShrink: 0,
   },
-  addAnimation: {
-    display: 'flex',
-  },
 };
 
 const AddAnimationLine = ({ onAdd, extraTools }) => (
-  <Column>
-    <Line justifyContent="space-between" expand>
+  <Column expand>
+    <Line justifyContent="space-between">
       {extraTools}
-      <div style={styles.addAnimation}>
-        <RaisedButton
-          label={<Trans>Add an animation</Trans>}
-          primary
-          onClick={onAdd}
-          labelPosition="before"
-          icon={<Add />}
-        />
-      </div>
+      <RaisedButton
+        label={<Trans>Add an animation</Trans>}
+        primary
+        onClick={onAdd}
+        labelPosition="before"
+        icon={<Add />}
+      />
     </Line>
   </Column>
 );
@@ -445,7 +440,7 @@ export default class SpriteEditor extends React.Component<EditorProps, State> {
           objectName={objectName}
           onSizeUpdated={onSizeUpdated}
           extraBottomTools={
-            <ResponsiveLineStackLayout>
+            <ResponsiveLineStackLayout noMargin>
               <RaisedButton
                 label={<Trans>Edit hitboxes</Trans>}
                 primary={false}

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -90,6 +90,7 @@ export default class TextEditor extends React.Component<EditorProps, void> {
             style={styles.checkbox}
           />
           <ResourceSelector
+            margin="none"
             project={project}
             resourceSources={resourceSources}
             onChooseResource={onChooseResource}
@@ -110,6 +111,8 @@ export default class TextEditor extends React.Component<EditorProps, void> {
           <Column expand>
             <Line>
               <SemiControlledTextField
+                floatingLabelText={<Trans>Initial text to display</Trans>}
+                floatingLabelFixed
                 commitOnBlur
                 hintText={t`Enter the text to be displayed by the object`}
                 fullWidth

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -58,7 +58,7 @@ export default class TextEditor extends React.Component<EditorProps, void> {
             <Trans>Color:</Trans>
           </MiniToolbarText>
           <ColorPicker
-            style={styles.sizeTextField}
+            style={styles.toolbarItem}
             disableAlpha
             color={{
               r: textObject.getColorR(),

--- a/newIDE/app/src/ObjectEditor/Editors/TiledSpriteEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TiledSpriteEditor.js
@@ -6,6 +6,7 @@ import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import { Line, Column } from '../../UI/Grid';
 import ResourceSelectorWithThumbnail from '../../ResourcesList/ResourceSelectorWithThumbnail';
 import { type EditorProps } from './EditorProps.flow';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 const gd = global.gd;
 
 export default class TiledSpriteEditor extends React.Component<
@@ -39,7 +40,7 @@ export default class TiledSpriteEditor extends React.Component<
             floatingLabelText={<Trans>Select an image</Trans>}
           />
         </Line>
-        <Line>
+        <ResponsiveLineStackLayout>
           <SemiControlledTextField
             commitOnBlur
             floatingLabelText={<Trans>Default width (in pixels)</Trans>}
@@ -62,7 +63,7 @@ export default class TiledSpriteEditor extends React.Component<
               this.forceUpdate();
             }}
           />
-        </Line>
+        </ResponsiveLineStackLayout>
       </Column>
     );
   }

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -9,10 +9,7 @@ import HelpButton from '../UI/HelpButton';
 import BehaviorsEditor from '../BehaviorsEditor';
 import { Tabs, Tab } from '../UI/Tabs';
 import { withSerializableObject } from '../Utils/SerializableObjectEditorContainer';
-
-import { Column, Line } from '../UI/Grid';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
-import Text from '../UI/Text';
 import MiniToolbar, { MiniToolbarText } from '../UI/MiniToolbar';
 
 type StateType = {|

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -13,6 +13,7 @@ import { withSerializableObject } from '../Utils/SerializableObjectEditorContain
 import { Column, Line } from '../UI/Grid';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import Text from '../UI/Text';
+import MiniToolbar, { MiniToolbarText } from '../UI/MiniToolbar';
 
 type StateType = {|
   currentTab: string,
@@ -83,25 +84,25 @@ export class ObjectEditorDialog extends Component<*, StateType> {
           </div>
         }
       >
-        <Line alignItems="baseline">
-          <Column>
-            <Text noShrink>Object Name:</Text>
-          </Column>
-          <Column expand>
-            <SemiControlledTextField
-              fullWidth
-              commitOnBlur
-              margin="none"
-              value={this.state.newObjectName}
-              hintText={t`Object Name`}
-              onChange={text => {
-                if (this.props.canRenameObject(text)) {
-                  this.setState({ newObjectName: text });
-                }
-              }}
-            />
-          </Column>
-        </Line>
+        <MiniToolbar alignItems="baseline">
+          <MiniToolbarText>
+            <Trans>Object Name:</Trans>
+          </MiniToolbarText>
+          <SemiControlledTextField
+            fullWidth
+            commitOnBlur
+            margin="none"
+            value={this.state.newObjectName}
+            hintText={t`Object Name`}
+            onChange={text => {
+              if (text === this.state.newObjectName) return;
+
+              if (this.props.canRenameObject(text)) {
+                this.setState({ newObjectName: text });
+              }
+            }}
+          />
+        </MiniToolbar>
         {currentTab === 'properties' && EditorComponent && (
           <EditorComponent
             object={this.props.object}

--- a/newIDE/app/src/ObjectsList/ObjectSelector.js
+++ b/newIDE/app/src/ObjectsList/ObjectSelector.js
@@ -24,6 +24,7 @@ type Props = {|
   floatingLabelText?: ?string,
   openOnFocus?: boolean,
   hintText?: ?React.Node,
+  margin?: 'none' | 'dense',
 |};
 
 const iconSize = 24;
@@ -94,6 +95,7 @@ export default class ObjectSelector extends React.Component<Props, {||}> {
       allowedObjectType,
       noGroups,
       errorTextIfInvalid,
+      margin,
       ...rest
     } = this.props;
 
@@ -111,6 +113,7 @@ export default class ObjectSelector extends React.Component<Props, {||}> {
 
     return (
       <SemiControlledAutoComplete
+        margin={margin}
         hintText={t`Choose an object`}
         value={value}
         onChange={onChange}

--- a/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
+++ b/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
@@ -241,6 +241,7 @@ export default class PlatformSpecificAssetsDialog extends React.Component<
 
     return (
       <Dialog
+        title={<Trans>Project icons</Trans>}
         actions={actions}
         open={this.props.open}
         onRequestClose={this.props.onClose}

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -16,8 +16,8 @@ import {
   validatePackageName,
 } from './ProjectErrorsChecker';
 import DismissableAlertMessage from '../UI/DismissableAlertMessage';
-import { Line, Column } from '../UI/Grid';
 import HelpButton from '../UI/HelpButton';
+import { ResponsiveLineStackLayout } from '../UI/Layout';
 
 type Props = {|
   project: gdProject,
@@ -252,34 +252,30 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
               primaryText={t`Multiple files, saved in folder next to the main file`}
             />
           </SelectField>
-          <Line noMargin>
-            <Column expand noMargin>
-              <SemiControlledTextField
-                floatingLabelText={<Trans>Minimum FPS</Trans>}
-                fullWidth
-                type="number"
-                value={'' + minFPS}
-                onChange={value =>
-                  this.setState({
-                    minFPS: Math.max(0, parseInt(value, 10)),
-                  })
-                }
-              />
-            </Column>
-            <Column expand noMargin>
-              <SemiControlledTextField
-                floatingLabelText={<Trans>Maximum FPS (0 to disable)</Trans>}
-                fullWidth
-                type="number"
-                value={'' + maxFPS}
-                onChange={value =>
-                  this.setState({
-                    maxFPS: Math.max(0, parseInt(value, 10)),
-                  })
-                }
-              />
-            </Column>
-          </Line>
+          <ResponsiveLineStackLayout noMargin>
+            <SemiControlledTextField
+              floatingLabelText={<Trans>Minimum FPS</Trans>}
+              fullWidth
+              type="number"
+              value={'' + minFPS}
+              onChange={value =>
+                this.setState({
+                  minFPS: Math.max(0, parseInt(value, 10)),
+                })
+              }
+            />
+            <SemiControlledTextField
+              floatingLabelText={<Trans>Maximum FPS (0 to disable)</Trans>}
+              fullWidth
+              type="number"
+              value={'' + maxFPS}
+              onChange={value =>
+                this.setState({
+                  maxFPS: Math.max(0, parseInt(value, 10)),
+                })
+              }
+            />
+          </ResponsiveLineStackLayout>
           {maxFPS > 0 && maxFPS < 60 && (
             <DismissableAlertMessage
               identifier="maximum-fps-too-low"

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -164,6 +164,7 @@ class ProjectPropertiesDialog extends React.Component<Props, State> {
               key="help"
             />,
           ]}
+          title={<Trans>Project properties</Trans>}
           open={this.props.open}
           onRequestClose={this.props.onClose}
         >

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -1,4 +1,5 @@
 // @flow
+import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import {
   ResponsiveWindowMeasurer,
@@ -13,13 +14,14 @@ import FlatButton from '../UI/FlatButton';
 import SelectField from '../UI/SelectField';
 import SelectOption from '../UI/SelectOption';
 import Edit from '@material-ui/icons/Edit';
-import IconButton from '../UI/IconButton';
 import {
   type ResourceKind,
   type ResourceSource,
   type ChooseResourceFunction,
 } from '../ResourcesList/ResourceSource.flow';
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
+import { TextFieldWithButtonLayout } from '../UI/Layout';
+import RaisedButton from '../UI/RaisedButton';
 
 // An "instance" here is the objects for which properties are shown
 export type Instance = Object; // This could be improved using generics.
@@ -216,32 +218,39 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
     } else {
       const { onEditButtonClick, setValue } = field;
       return (
-        <div style={styles.fieldContainer} key={field.name}>
-          <SemiControlledTextField
-            value={getFieldValue(
-              this.props.instances,
-              field,
-              '(Multiple values)'
-            )}
-            id={field.name}
-            floatingLabelText={getFieldLabel(this.props.instances, field)}
-            floatingLabelFixed
-            onChange={newValue => {
-              this.props.instances.forEach(i => setValue(i, newValue || ''));
-              this._onInstancesModified(this.props.instances);
-            }}
-            style={styles.field}
-            disabled={field.disabled}
-          />
-          {onEditButtonClick && (
-            <IconButton
-              disabled={this.props.instances.length !== 1}
-              onClick={() => onEditButtonClick(this.props.instances[0])}
-            >
-              <Edit />
-            </IconButton>
+        <TextFieldWithButtonLayout
+          key={field.name}
+          renderTextField={() => (
+            <SemiControlledTextField
+              value={getFieldValue(
+                this.props.instances,
+                field,
+                '(Multiple values)'
+              )}
+              id={field.name}
+              floatingLabelText={getFieldLabel(this.props.instances, field)}
+              floatingLabelFixed
+              onChange={newValue => {
+                this.props.instances.forEach(i => setValue(i, newValue || ''));
+                this._onInstancesModified(this.props.instances);
+              }}
+              style={styles.field}
+              disabled={field.disabled}
+            />
           )}
-        </div>
+          renderButton={style =>
+            onEditButtonClick ? (
+              <RaisedButton
+                style={style}
+                primary
+                disabled={this.props.instances.length !== 1}
+                icon={<Edit />}
+                label={<Trans>Edit</Trans>}
+                onClick={() => onEditButtonClick(this.props.instances[0])}
+              />
+            ) : null
+          }
+        />
       );
     }
   };

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -10,6 +10,7 @@ import MiniToolbar from '../../UI/MiniToolbar';
 import ZoomIn from '@material-ui/icons/ZoomIn';
 import ZoomOut from '@material-ui/icons/ZoomOut';
 import ZoomOutMap from '@material-ui/icons/ZoomOutMap';
+import PlaceholderMessage from '../../UI/PlaceholderMessage';
 import Text from '../../UI/Text';
 
 const MARGIN = 50;
@@ -145,7 +146,8 @@ export default class ImagePreview extends React.Component<Props, State> {
             imageZoomFactor,
           } = this.state;
 
-          const imageLoaded = !!imageWidth && !!imageHeight;
+          const imageLoaded =
+            !!imageWidth && !!imageHeight && !this.state.errored;
 
           const imagePositionTop = 0;
           const imagePositionLeft = Math.max(
@@ -211,9 +213,11 @@ export default class ImagePreview extends React.Component<Props, State> {
                 }}
               >
                 {!!this.state.errored && (
-                  <Text>
-                    <Trans>Unable to load the image</Trans>
-                  </Text>
+                  <PlaceholderMessage>
+                    <Text>
+                      <Trans>Unable to load the image</Trans>
+                    </Text>
+                  </PlaceholderMessage>
                 )}
                 {!this.state.errored && (
                   <img

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -1,12 +1,10 @@
 // @flow
+import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import IconButton from '../UI/IconButton';
 import SemiControlledAutoComplete, {
   type DataSource,
 } from '../UI/SemiControlledAutoComplete';
-import ElementWithMenu from '../UI/Menu/ElementWithMenu';
-import { Line } from '../UI/Grid';
 import BackspaceIcon from '@material-ui/icons/Backspace';
 import Add from '@material-ui/icons/Add';
 import Brush from '@material-ui/icons/Brush';
@@ -19,6 +17,9 @@ import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEd
 import ResourcesLoader from '../ResourcesLoader';
 import { applyResourceDefaults } from './ResourceUtils';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
+import RaisedButtonWithMenu from '../UI/RaisedButtonWithMenu';
+import { TextFieldWithButtonLayout } from '../UI/Layout';
+import IconButton from '../UI/IconButton';
 
 type Props = {|
   project: gdProject,
@@ -33,17 +34,13 @@ type Props = {|
   onChange: string => void,
   floatingLabelText?: React.Node,
   hintText?: MessageDescriptor,
-  margin?: 'none' | 'normal',
+  margin?: 'none' | 'dense',
 |};
 
 type State = {|
   notExistingError: boolean,
   resourceName: string,
 |};
-
-const styles = {
-  container: { display: 'flex', flex: 1, alignItems: 'flex-end' },
-};
 
 export default class ResourceSelector extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -259,8 +256,10 @@ export default class ResourceSelector extends React.Component<Props, State> {
       externalEditor => externalEditor.kind === this.props.resourceKind
     );
     return (
-      <div style={styles.container}>
-        <Line nomargin expand>
+      <TextFieldWithButtonLayout
+        noFloatingLabelText={!this.props.floatingLabelText}
+        margin={this.props.margin}
+        renderTextField={() => (
           <SemiControlledAutoComplete
             floatingLabelText={this.props.floatingLabelText}
             hintText={this.props.hintText}
@@ -273,32 +272,42 @@ export default class ResourceSelector extends React.Component<Props, State> {
             margin={this.props.margin}
             ref={autoComplete => (this._autoComplete = autoComplete)}
           />
-          {this.props.canBeReset && (
-            <IconButton
-              onClick={() => {
-                this._onResetResourceName();
-              }}
-            >
-              <BackspaceIcon />
-            </IconButton>
-          )}
-          {!!externalEditors.length && (
-            <ElementWithMenu
-              element={
-                <IconButton>
-                  <Brush />
-                </IconButton>
-              }
-              buildMenuTemplate={() =>
-                externalEditors.map(externalEditor => ({
-                  label: externalEditor.displayName,
-                  click: () => this._editWith(externalEditor),
-                }))
-              }
-            />
-          )}
-        </Line>
-      </div>
+        )}
+        renderButton={style => (
+          <React.Fragment>
+            {this.props.canBeReset && (
+             <IconButton
+                size="small"
+               onClick={() => {
+                 this._onResetResourceName();
+               }}
+             >
+               <BackspaceIcon />
+             </IconButton>
+            )}
+            {!!externalEditors.length ? (
+              <RaisedButtonWithMenu
+                style={style}
+                icon={<Brush />}
+                label={
+                  this.state.resourceName ? (
+                    <Trans>Edit</Trans>
+                  ) : (
+                    <Trans>Create</Trans>
+                  )
+                }
+                primary
+                buildMenuTemplate={() =>
+                  externalEditors.map(externalEditor => ({
+                    label: externalEditor.displayName,
+                    click: () => this._editWith(externalEditor),
+                  }))
+                }
+              />
+            ) : null}
+          </React.Fragment>
+        )}
+      />
     );
   }
 }

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -276,14 +276,14 @@ export default class ResourceSelector extends React.Component<Props, State> {
         renderButton={style => (
           <React.Fragment>
             {this.props.canBeReset && (
-             <IconButton
+              <IconButton
                 size="small"
-               onClick={() => {
-                 this._onResetResourceName();
-               }}
-             >
-               <BackspaceIcon />
-             </IconButton>
+                onClick={() => {
+                  this._onResetResourceName();
+                }}
+              >
+                <BackspaceIcon />
+              </IconButton>
             )}
             {!!externalEditors.length ? (
               <RaisedButtonWithMenu

--- a/newIDE/app/src/ResourcesList/ResourceSelectorWithThumbnail.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelectorWithThumbnail.js
@@ -26,7 +26,7 @@ type Props = {|
 const styles = {
   container: { flex: 1, display: 'flex', alignItems: 'flex-end' },
   selectorContainer: { flex: 1 },
-  resourceThumbnail: { marginLeft: 10 },
+  resourceThumbnail: { marginLeft: 10, marginBottom: 4 },
 };
 
 const ResourceSelectorWithThumbnail = ({

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -145,7 +145,18 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
 
     return (
       <Dialog
+        title={<Trans>Scene properties</Trans>}
         actions={actions}
+        secondaryActions={
+          <RaisedButton
+            label={<Trans>Edit scene variables</Trans>}
+            fullWidth
+            onClick={() => {
+              this.props.onEditVariables();
+              this.props.onClose();
+            }}
+          />
+        }
         open={this.props.open}
         onRequestClose={this.props.onClose}
         maxWidth="sm"
@@ -174,14 +185,6 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
           onChangeComplete={color =>
             this.setState({ backgroundColor: color.rgb })
           }
-        />
-        <RaisedButton
-          label={<Trans>Edit scene variables</Trans>}
-          fullWidth
-          onClick={() => {
-            this.props.onEditVariables();
-            this.props.onClose();
-          }}
         />
         {!some(propertiesEditors) && (
           <EmptyMessage>

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -1,6 +1,11 @@
 import React from 'react';
 const marginsSize = 4;
 
+/**
+ * A Line in the standard GDevelop grid to position components.
+ * Check `Layout` first to see if there is already a layout made
+ * specifically for your components (like TextFieldWithButton).
+ */
 export const Line = props => (
   <div
     style={{
@@ -16,6 +21,11 @@ export const Line = props => (
   </div>
 );
 
+/**
+ * A Column in the standard GDevelop grid to position components.
+ * Check `Layout` first to see if there is already a layout made
+ * specifically for your components (like TextFieldWithButton).
+ */
 export const Column = props => (
   <div
     style={{
@@ -32,6 +42,11 @@ export const Column = props => (
   </div>
 );
 
+/**
+ * A Spacer in the standard GDevelop grid to position components.
+ * Check `Layout` first to see if there is already a layout made
+ * specifically for your components (like TextFieldWithButton).
+ */
 export const Spacer = props => (
   <span
     style={{

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -4,7 +4,7 @@ const marginsSize = 4;
 /**
  * A Line in the standard GDevelop grid to position components.
  * Check `Layout` first to see if there is already a layout made
- * specifically for your components (like TextFieldWithButton).
+ * specifically for your components (like `TextFieldWithButton`).
  */
 export const Line = props => (
   <div
@@ -24,7 +24,7 @@ export const Line = props => (
 /**
  * A Column in the standard GDevelop grid to position components.
  * Check `Layout` first to see if there is already a layout made
- * specifically for your components (like TextFieldWithButton).
+ * specifically for your components (like `TextFieldWithButton`).
  */
 export const Column = props => (
   <div
@@ -45,13 +45,14 @@ export const Column = props => (
 /**
  * A Spacer in the standard GDevelop grid to position components.
  * Check `Layout` first to see if there is already a layout made
- * specifically for your components (like TextFieldWithButton).
+ * specifically for your components (like `TextFieldWithButton`).
  */
 export const Spacer = props => (
   <span
     style={{
-      width: props.expand ? '100%' : marginsSize,
+      width: marginsSize,
       height: marginsSize,
+      flexShrink: 0, // Ensure the spacer is not shrinked when in a flex container
     }}
   />
 );

--- a/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
+++ b/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
@@ -39,6 +39,7 @@ exports[`HelpButton renders the button linking to a help page 1`] = `
     <span
       style={
         Object {
+          "flexShrink": 0,
           "height": 4,
           "width": 4,
         }

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -29,7 +29,11 @@ type Props = {|
     transform?: string,
     transition?: string,
     opacity?: number,
+    margin?: number,
     marginRight?: number,
+    marginLeft?: number,
+    marginTop?: number,
+    marginBottom?: number,
   |},
   size?: 'small',
 

--- a/newIDE/app/src/UI/Layout.js
+++ b/newIDE/app/src/UI/Layout.js
@@ -80,8 +80,7 @@ export const ResponsiveLineStackLayout = ({
   noMargin,
   children,
 }: ResponsiveLineStackLayoutProps) => {
-  const count = React.Children.count(children);
-
+  let isFirstChild = true;
   return (
     <ResponsiveWindowMeasurer>
       {windowWidth =>
@@ -96,13 +95,17 @@ export const ResponsiveLineStackLayout = ({
             expand={expand}
             noMargin={noMargin}
           >
-            {' '}
             {React.Children.map(children, (child, index) => {
+              if (!child) return null;
+
+              const addSpacers = !isFirstChild;
+              isFirstChild = false;
+
               return (
                 <React.Fragment>
-                  {index !== 0 && <Spacer />}
+                  {addSpacers && <Spacer />}
+                  {addSpacers && <Spacer />}
                   {child}
-                  {index !== count - 1 && <Spacer />}
                 </React.Fragment>
               );
             })}

--- a/newIDE/app/src/UI/Layout.js
+++ b/newIDE/app/src/UI/Layout.js
@@ -22,23 +22,26 @@ const textFieldWithButtonLayoutStyles = {
     display: 'flex',
     alignItems: 'flex-start', // Align from the top to stay at the same position when error/multiline
   },
-  filledTextFieldRightButtonMargins: {
+  filledTextFieldWithLabelRightButtonMargins: {
     marginTop: 24, // Properly align with the text field (only dense "filled" text fields supported)
     marginLeft: 10,
   },
+  filledTextFieldWithoutLabelRightButtonMargins: {
+    marginTop: 15, // Properly align with the text field (only dense "filled" text fields supported)
+    marginLeft: 10,
+  },
   standardTextFieldWithLabelRightButtonMargins: {
-    marginTop: 17, // Properly align with the text field (only dense "standard" text fields supported)
+    marginTop: 17, // Properly align with the text field (only "standard" text fields with margin "none" supported)
     marginLeft: 10,
   },
   standardTextFieldWithoutLabelRightButtonMargins: {
-    marginTop: 0, // Properly align with the text field (only dense "standard" text fields supported)
+    marginTop: 0, // Properly align with the text field (only "standard" text fields with margin "none" supported)
     marginLeft: 10,
   },
 };
 
 /**
  * Position a button on the right of a TextField.
- * Only compatible with TextField with a label.
  */
 export const TextFieldWithButtonLayout = ({
   margin,
@@ -54,7 +57,9 @@ export const TextFieldWithButtonLayout = ({
           ? noFloatingLabelText
             ? textFieldWithButtonLayoutStyles.standardTextFieldWithoutLabelRightButtonMargins
             : textFieldWithButtonLayoutStyles.standardTextFieldWithLabelRightButtonMargins
-          : textFieldWithButtonLayoutStyles.filledTextFieldRightButtonMargins
+          : noFloatingLabelText
+          ? textFieldWithButtonLayoutStyles.filledTextFieldWithoutLabelRightButtonMargins
+          : textFieldWithButtonLayoutStyles.filledTextFieldWithLabelRightButtonMargins
       )}
     </div>
   );

--- a/newIDE/app/src/UI/Layout.js
+++ b/newIDE/app/src/UI/Layout.js
@@ -1,0 +1,59 @@
+// @flow
+import * as React from 'react';
+
+type TextFieldWithButtonLayoutProps = {|
+  renderTextField: () => React.Node,
+  renderButton: (style: {|
+    marginTop?: number,
+    marginBottom?: number,
+    marginLeft?: number,
+    marginRight?: number,
+    margin?: number,
+  |}) => React.Node,
+  margin?: 'none' | 'dense',
+  noFloatingLabelText?: boolean,
+|};
+
+const textFieldWithButtonLayoutStyles = {
+  container: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'flex-start', // Align from the top to stay at the same position when error/multiline
+  },
+  filledTextFieldRightButtonMargins: {
+    marginTop: 24, // Properly align with the text field (only dense "filled" text fields supported)
+    marginLeft: 10,
+  },
+  standardTextFieldWithLabelRightButtonMargins: {
+    marginTop: 17, // Properly align with the text field (only dense "standard" text fields supported)
+    marginLeft: 10,
+  },
+  standardTextFieldWithoutLabelRightButtonMargins: {
+    marginTop: 0, // Properly align with the text field (only dense "standard" text fields supported)
+    marginLeft: 10,
+  },
+};
+
+/**
+ * Position a button on the right of a TextField.
+ * Only compatible with TextField with a label.
+ */
+export const TextFieldWithButtonLayout = ({
+  margin,
+  noFloatingLabelText,
+  renderTextField,
+  renderButton,
+}: TextFieldWithButtonLayoutProps) => {
+  return (
+    <div style={textFieldWithButtonLayoutStyles.container}>
+      {renderTextField()}
+      {renderButton(
+        margin === 'none'
+          ? noFloatingLabelText
+            ? textFieldWithButtonLayoutStyles.standardTextFieldWithoutLabelRightButtonMargins
+            : textFieldWithButtonLayoutStyles.standardTextFieldWithLabelRightButtonMargins
+          : textFieldWithButtonLayoutStyles.filledTextFieldRightButtonMargins
+      )}
+    </div>
+  );
+};

--- a/newIDE/app/src/UI/Layout.js
+++ b/newIDE/app/src/UI/Layout.js
@@ -1,5 +1,7 @@
 // @flow
 import * as React from 'react';
+import { Spacer, Line } from './Grid';
+import { ResponsiveWindowMeasurer } from './Reponsive/ResponsiveWindowMeasurer';
 
 type TextFieldWithButtonLayoutProps = {|
   renderTextField: () => React.Node,
@@ -55,5 +57,53 @@ export const TextFieldWithButtonLayout = ({
           : textFieldWithButtonLayoutStyles.filledTextFieldRightButtonMargins
       )}
     </div>
+  );
+};
+
+type ResponsiveLineStackLayoutProps = {|
+  alignItems?: string,
+  justifyContent?: string,
+  expand?: boolean,
+  noMargin?: boolean,
+  children: React.Node,
+|};
+
+export const ResponsiveLineStackLayout = ({
+  alignItems,
+  justifyContent,
+  expand,
+  noMargin,
+  children,
+}: ResponsiveLineStackLayoutProps) => {
+  const count = React.Children.count(children);
+
+  return (
+    <ResponsiveWindowMeasurer>
+      {windowWidth =>
+        windowWidth === 'small' ? (
+          React.Children.map(children, (child, index) => {
+            return <Line expand>{child}</Line>;
+          })
+        ) : (
+          <Line
+            alignItems={alignItems}
+            justifyContent={justifyContent}
+            expand={expand}
+            noMargin={noMargin}
+          >
+            {' '}
+            {React.Children.map(children, (child, index) => {
+              return (
+                <React.Fragment>
+                  {index !== 0 && <Spacer />}
+                  {child}
+                  {index !== count - 1 && <Spacer />}
+                </React.Fragment>
+              );
+            })}
+          </Line>
+        )
+      }
+    </ResponsiveWindowMeasurer>
   );
 };

--- a/newIDE/app/src/UI/LocalFilePicker/index.js
+++ b/newIDE/app/src/UI/LocalFilePicker/index.js
@@ -4,8 +4,8 @@ import { t } from '@lingui/macro';
 
 import React, { PureComponent } from 'react';
 import TextField from '../TextField';
-import FlatButton from '../FlatButton';
 import optionalRequire from '../../Utils/OptionalRequire.js';
+import RaisedButton from '../RaisedButton';
 const electron = optionalRequire('electron');
 const dialog = electron ? electron.remote.dialog : null;
 
@@ -30,7 +30,6 @@ type Props = {|
   message: string,
   defaultPath?: string,
   fullWidth?: boolean,
-  floatingLabelText?: string,
   filters: Array<{
     name: string,
     extensions: Array<string>,
@@ -65,15 +64,14 @@ export default class LocalFilePicker extends PureComponent<Props, *> {
         }}
       >
         <TextField
+          margin="none"
           style={styles.textField}
-          floatingLabelText={this.props.floatingLabelText}
-          floatingLabelFixed
           type="text"
-          hintText={t`Click to choose`}
+          hintText={t`Choose a file`}
           value={this.props.value}
           onChange={(event, value) => this.props.onChange(value)}
         />
-        <FlatButton
+        <RaisedButton
           label={<Trans>Choose</Trans>}
           style={styles.button}
           onClick={this.onChooseFolder}

--- a/newIDE/app/src/UI/LocalFilePicker/index.js
+++ b/newIDE/app/src/UI/LocalFilePicker/index.js
@@ -64,7 +64,7 @@ export default class LocalFilePicker extends PureComponent<Props, *> {
         }}
       >
         <TextField
-          margin="none"
+          margin="dense"
           style={styles.textField}
           type="text"
           hintText={t`Choose a file`}

--- a/newIDE/app/src/UI/LocalFolderPicker/index.js
+++ b/newIDE/app/src/UI/LocalFolderPicker/index.js
@@ -6,7 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import React, { PureComponent } from 'react';
 import TextField from '../TextField';
-import FlatButton from '../FlatButton';
+import RaisedButton from '../RaisedButton';
 import optionalRequire from '../../Utils/OptionalRequire.js';
 const electron = optionalRequire('electron');
 const dialog = electron ? electron.remote.dialog : null;
@@ -31,7 +31,6 @@ type Props = {|
   onChange: string => void,
   defaultPath?: string,
   fullWidth?: boolean,
-  floatingLabelText?: string,
 |};
 
 type TitleAndMessage = {|
@@ -83,31 +82,32 @@ export default class LocalFolderPicker extends PureComponent<Props, {||}> {
   render() {
     return (
       <I18n>
-        {({ i18n }) => (
-          <div
-            style={{
-              ...styles.container,
-              width: this.props.fullWidth ? '100%' : undefined,
-            }}
-          >
-            <TextField
-              style={styles.textField}
-              floatingLabelText={this.props.floatingLabelText}
-              floatingLabelFixed
-              type="text"
-              hintText={t`Click to choose`}
-              value={this.props.value}
-              onChange={(event, value) => this.props.onChange(value)}
-            />
-            <FlatButton
-              label={<Trans>Choose folder</Trans>}
-              style={styles.button}
-              onClick={() =>
-                this._onChooseFolder(this._getTitleAndMessage(i18n))
-              }
-            />
-          </div>
-        )}
+        {({ i18n }) => {
+          const titleAndMessage = this._getTitleAndMessage(i18n);
+          return (
+            <div
+              style={{
+                ...styles.container,
+                width: this.props.fullWidth ? '100%' : undefined,
+              }}
+            >
+              <TextField
+                margin="none"
+                style={styles.textField}
+                type="text"
+                hintText={titleAndMessage.title}
+                value={this.props.value}
+                onChange={(event, value) => this.props.onChange(value)}
+              />
+              <RaisedButton
+                label={<Trans>Choose folder</Trans>}
+                primary={false}
+                style={styles.button}
+                onClick={() => this._onChooseFolder(titleAndMessage)}
+              />
+            </div>
+          );
+        }}
       </I18n>
     );
   }

--- a/newIDE/app/src/UI/LocalFolderPicker/index.js
+++ b/newIDE/app/src/UI/LocalFolderPicker/index.js
@@ -92,7 +92,7 @@ export default class LocalFolderPicker extends PureComponent<Props, {||}> {
               }}
             >
               <TextField
-                margin="none"
+                margin="dense"
                 style={styles.textField}
                 type="text"
                 hintText={titleAndMessage.title}

--- a/newIDE/app/src/UI/MiniToolbar.js
+++ b/newIDE/app/src/UI/MiniToolbar.js
@@ -37,7 +37,9 @@ const toolbarTextStyle = {
 };
 
 export const MiniToolbarText = ({ children }) => (
-  <Text style={toolbarTextStyle}>{children}</Text>
+  <Text noShrink style={toolbarTextStyle}>
+    {children}
+  </Text>
 );
 
 export default MiniToolbar;

--- a/newIDE/app/src/UI/RaisedButton.js
+++ b/newIDE/app/src/UI/RaisedButton.js
@@ -5,9 +5,8 @@ import { Spacer } from './Grid';
 
 // We support a subset of the props supported by Material-UI v0.x RaisedButton
 // They should be self descriptive - refer to Material UI docs otherwise.
-type Props = {|
+export type RaisedButtonPropsWithoutOnClick = {|
   label?: React.Node,
-  onClick: ?() => void,
   primary?: boolean,
   disabled?: boolean,
   fullWidth?: boolean,
@@ -21,6 +20,11 @@ type Props = {|
   |},
   labelPosition?: 'before',
 |};
+
+type Props = {
+  ...RaisedButtonPropsWithoutOnClick,
+  onClick: ?() => void,
+};
 
 /**
  * A raised button based on Material-UI button.

--- a/newIDE/app/src/UI/RaisedButtonWithMenu.js
+++ b/newIDE/app/src/UI/RaisedButtonWithMenu.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react';
+import RaisedButton, {
+  type RaisedButtonPropsWithoutOnClick,
+} from './RaisedButton';
+import ElementWithMenu from './Menu/ElementWithMenu';
+
+// We support a subset of the props supported by Material-UI v0.x RaisedButton
+// They should be self descriptive - refer to Material UI docs otherwise.
+type Props = {|
+  ...RaisedButtonPropsWithoutOnClick,
+  buildMenuTemplate: () => Array<any>,
+|};
+
+const shouldNeverBeCalled = () => {
+  throw new Error('This RaisedButtonWithMenu onClick should never be called');
+};
+
+/**
+ * A raised button based on Material-UI button, that has a menu displayed when clicked.
+ */
+const RaisedButtonWithMenu = (props: Props) => {
+  const { buildMenuTemplate, ...otherProps } = props;
+
+  return (
+    <ElementWithMenu
+      element={<RaisedButton {...otherProps} onClick={shouldNeverBeCalled} />}
+      buildMenuTemplate={buildMenuTemplate}
+    />
+  );
+};
+
+export default RaisedButtonWithMenu;

--- a/newIDE/app/src/UI/SelectField.js
+++ b/newIDE/app/src/UI/SelectField.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { I18n } from '@lingui/react';
 import TextField from '@material-ui/core/TextField';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
+import { computeTextFieldStyleProps } from './TextField';
 
 type ValueProps = {|
   value: number | string,
@@ -76,8 +77,7 @@ export default class SelectField extends React.Component<Props, {||}> {
         {({ i18n }) => (
           <TextField
             select
-            variant={props.margin === 'none' ? 'standard' : 'filled'}
-            margin={props.margin || 'dense'}
+            {...computeTextFieldStyleProps(props)}
             disabled={props.disabled}
             fullWidth={props.fullWidth}
             label={props.floatingLabelText}

--- a/newIDE/app/src/UI/SelectField.js
+++ b/newIDE/app/src/UI/SelectField.js
@@ -76,7 +76,8 @@ export default class SelectField extends React.Component<Props, {||}> {
         {({ i18n }) => (
           <TextField
             select
-            margin={props.margin || 'normal'}
+            variant={props.margin === 'none' ? 'standard' : 'filled'}
+            margin={props.margin || 'dense'}
             disabled={props.disabled}
             fullWidth={props.fullWidth}
             label={props.floatingLabelText}

--- a/newIDE/app/src/UI/SelectField.js
+++ b/newIDE/app/src/UI/SelectField.js
@@ -27,7 +27,7 @@ type Props = {|
     flex?: 1,
     width?: 'auto',
   },
-  margin?: 'none',
+  margin?: 'none' | 'dense',
 
   floatingLabelText?: React.Node,
 

--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -27,7 +27,6 @@ export type DataSource = Array<
 
 const styles = {
   container: {
-    flexGrow: 1,
     position: 'relative',
   },
   inputRoot: {
@@ -126,7 +125,7 @@ type Props = {|
   floatingLabelText?: React.Node,
   hintText?: MessageDescriptor | string,
   fullWidth?: boolean,
-  margin?: 'none' | 'normal',
+  margin?: 'none' | 'dense',
   textFieldStyle?: Object,
   openOnFocus?: boolean,
 |};
@@ -271,7 +270,12 @@ export default class SemiControlledAutoComplete extends React.Component<
               };
 
               return (
-                <div style={styles.container}>
+                <div
+                  style={{
+                    ...styles.container,
+                    flexGrow: props.fullWidth ? 1 : undefined,
+                  }}
+                >
                   {renderTextField({
                     disabled: props.disabled,
                     label: props.floatingLabelText,
@@ -297,7 +301,8 @@ export default class SemiControlledAutoComplete extends React.Component<
                     // Style:
                     style: props.textFieldStyle,
                     fullWidth: props.fullWidth,
-                    margin: props.margin || 'normal',
+                    variant: props.margin === 'none' ? 'standard' : 'filled',
+                    margin: props.margin || 'dense',
 
                     inputRef: this._input,
                   })}

--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -12,6 +12,7 @@ import Popper from '@material-ui/core/Popper';
 import muiZIndex from '@material-ui/core/styles/zIndex';
 import SvgIcon from '@material-ui/core/SvgIcon';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
+import { computeTextFieldStyleProps } from './TextField';
 
 export type DataSource = Array<
   | {|
@@ -301,8 +302,7 @@ export default class SemiControlledAutoComplete extends React.Component<
                     // Style:
                     style: props.textFieldStyle,
                     fullWidth: props.fullWidth,
-                    variant: props.margin === 'none' ? 'standard' : 'filled',
-                    margin: props.margin || 'dense',
+                    ...computeTextFieldStyleProps(props),
 
                     inputRef: this._input,
                   })}

--- a/newIDE/app/src/UI/SemiControlledTextField.js
+++ b/newIDE/app/src/UI/SemiControlledTextField.js
@@ -25,7 +25,7 @@ type Props = {|
   type?: 'text' | 'number',
 
   // Some TextField props that can be reused:
-  margin?: 'none' | 'normal',
+  margin?: 'none' | 'dense',
   disabled?: boolean,
   errorText?: React.Node,
   floatingLabelFixed?: boolean,

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -72,7 +72,7 @@ type Props = {|
   rowsMax?: number,
 
   // Styling:
-  margin?: 'none' | 'normal',
+  margin?: 'none' | 'dense',
   fullWidth?: boolean,
   style?: {|
     fontSize?: 18,
@@ -128,6 +128,7 @@ export default class TextField extends React.Component<Props, {||}> {
       <I18n>
         {({ i18n }) => (
           <MUITextField
+            variant={props.margin === 'none' ? 'standard' : 'filled'}
             // Value and change handling:
             type={props.type !== undefined ? props.type : undefined}
             value={props.value !== undefined ? props.value : undefined}
@@ -157,7 +158,7 @@ export default class TextField extends React.Component<Props, {||}> {
             rows={props.rows}
             rowsMax={props.rowsMax}
             // Styling:
-            margin={props.margin || 'normal'}
+            margin={props.margin || 'dense'}
             fullWidth={props.fullWidth}
             InputProps={{
               disableUnderline:

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -158,7 +158,13 @@ export default class TextField extends React.Component<Props, {||}> {
             rows={props.rows}
             rowsMax={props.rowsMax}
             // Styling:
-            margin={props.margin || 'dense'}
+            margin={props.margin === 'none' ? 'none' : 'dense'}
+            hiddenLabel={
+              // For "none", if there is no label, no extra space is taken. For "filled",
+              // even when no label is passed, there is a space for it. Remove this space if no
+              // label is provided.
+              this.props.margin !== 'none' && !props.floatingLabelText
+            }
             fullWidth={props.fullWidth}
             InputProps={{
               disableUnderline:

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -95,6 +95,57 @@ type Props = {|
 |};
 
 /**
+ * Compute the `variant`, `margin` and `hiddenLabel` props for a material-ui `TextField`
+ * to give it the proper style according to its usage.
+ *
+ * 1. A traditional `TextField` is by default "filled"
+ *    (see material-ui component doc: https://material-ui.com/components/text-fields/
+ *     and [Material Design specification](https://material.io/components/text-fields/#specs)).
+ *
+ *   The filled background gives them more emphasize compared compared to a single underline
+ *   (as done in previous GDevelop versions). They have a label indicating what they refer to.
+ *
+ * 2. Sometimes, a floating label would not provide more information and is considered to be
+ *   obvious (thanks to the existing value, dialog title or button label).
+ *
+ *   In this case, not specifying a label is fine (`floatingLabelText` is undefined or empty).
+ *   This will lead to a filled text field without the extra space for the label.
+ *
+ *   A `placeholder` should still be passed so that the user can know what the field is about
+ *     when not filled.
+ *   Example: this is particularly adapted to file/folder pickers (see `LocalFilePicker`,
+ *     `LocalFolderPicker`) or a `SearchPanel`.
+ *
+ * 3. `TextField` in `MiniToolbar` are usually less changed by the user than other text fields
+ *   (for example, they are the animation name or the object name in a Sprite editor.
+ *   These are not changed a lot compared to behaviours or object properties).
+ *
+ *   They also are already in a MiniToolbar that has an "emphasis" with the slightly
+ *   different background color of `MiniToolbar`. Finally, `MiniToolbar` is also small in height.
+ *
+ *   In these cases, use `none` for `margin`.
+ *   This will generate a text field without filled background (just an underline).
+ *
+ * 4. `TextField` can be used with `margin="none"` and also the underline hidden,
+ *   in the very special case of an embedded text field in another form control (like `SearchBar`).
+ */
+export const computeTextFieldStyleProps = (props: {
+  margin?: 'none' | 'dense',
+  floatingLabelText?: React.Node,
+}) => {
+  return {
+    // Use "filled" variant by default, unless `margin` is "none" (see 1. and 2.)
+    variant: props.margin === 'none' ? 'standard' : 'filled',
+    // Use "dense" fields by default, unless `margin` is "none" (see 3.)
+    margin: props.margin === 'none' ? 'none' : 'dense',
+    // For variant "standard", if there is no label, no extra space is taken. For variant "filled",
+    // even when no label is passed, there is a space for it. Remove this space if no
+    // label is provided. (see 2.)
+    hiddenLabel: props.margin !== 'none' && !props.floatingLabelText,
+  };
+};
+
+/**
  * A text field based on Material-UI text field.
  */
 export default class TextField extends React.Component<Props, {||}> {
@@ -128,7 +179,6 @@ export default class TextField extends React.Component<Props, {||}> {
       <I18n>
         {({ i18n }) => (
           <MUITextField
-            variant={props.margin === 'none' ? 'standard' : 'filled'}
             // Value and change handling:
             type={props.type !== undefined ? props.type : undefined}
             value={props.value !== undefined ? props.value : undefined}
@@ -158,13 +208,7 @@ export default class TextField extends React.Component<Props, {||}> {
             rows={props.rows}
             rowsMax={props.rowsMax}
             // Styling:
-            margin={props.margin === 'none' ? 'none' : 'dense'}
-            hiddenLabel={
-              // For "none", if there is no label, no extra space is taken. For "filled",
-              // even when no label is passed, there is a space for it. Remove this space if no
-              // label is provided.
-              this.props.margin !== 'none' && !props.floatingLabelText
-            }
+            {...computeTextFieldStyleProps(props)}
             fullWidth={props.fullWidth}
             InputProps={{
               disableUnderline:

--- a/newIDE/app/src/stories/FakeResourceExternalEditors.js
+++ b/newIDE/app/src/stories/FakeResourceExternalEditors.js
@@ -1,0 +1,34 @@
+// @flow
+import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
+
+/**
+ * Fake "external editors" to be used in Storybook.
+ */
+const fakeResourceExternalEditors: Array<ResourceExternalEditor> = [
+  {
+    name: 'fake-image-editor',
+    displayName: 'Edit with Super Image Editor',
+    kind: 'image',
+    edit: options => {
+      console.log('Open the image editor with these options:', options);
+    },
+  },
+  {
+    name: 'fake-audio-editor',
+    displayName: 'Create/Edit a Sound effect with Super Audio Editor',
+    kind: 'audio',
+    edit: options => {
+      console.log('Open the audio editor with these options:', options);
+    },
+  },
+  {
+    name: 'fake-json-editor',
+    displayName: 'Create/Edit a Dialogue Tree with Super JSON Dialogue Editor',
+    kind: 'json',
+    edit: options => {
+      console.log('Open the json editor with these options:', options);
+    },
+  },
+];
+
+export default fakeResourceExternalEditors;

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -1420,58 +1420,6 @@ storiesOf('PropertiesEditor', module)
       ]}
       instances={[{ name: 'instance1' }, { name: 'instance2' }]}
     />
-  ))
-  .add('row (window width = medium)', () => (
-    <PropertiesEditor
-      schema={[
-        {
-          name: 'Position',
-          type: 'row',
-          children: [
-            {
-              name: 'X',
-              valueType: 'number',
-              getValue: instance => 10,
-              setValue: (instance, newValue) => {},
-            },
-            {
-              name: 'Y',
-              valueType: 'number',
-              getValue: instance => 20.1234,
-              setValue: (instance, newValue) => {},
-            },
-          ],
-        },
-      ]}
-      instances={[{ name: 'instance1' }, { name: 'instance2' }]}
-      windowWidth="medium"
-    />
-  ))
-  .add('row (window width = small)', () => (
-    <PropertiesEditor
-      schema={[
-        {
-          name: 'Position',
-          type: 'row',
-          children: [
-            {
-              name: 'X',
-              valueType: 'number',
-              getValue: instance => 10,
-              setValue: (instance, newValue) => {},
-            },
-            {
-              name: 'Y',
-              valueType: 'number',
-              getValue: instance => 20.1234,
-              setValue: (instance, newValue) => {},
-            },
-          ],
-        },
-      ]}
-      instances={[{ name: 'instance1' }, { name: 'instance2' }]}
-      windowWidth="small"
-    />
   ));
 
 storiesOf('ParameterFields', module)

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -692,28 +692,31 @@ storiesOf('UI Building Blocks/Layout', module)
       )}
     />
   ))
-  .add('Empty auto complete field, margin=none, noFloatingLabelText, with a small IconButton', () => (
-    <TextFieldWithButtonLayout
-      margin="none"
-      noFloatingLabelText
-      renderTextField={() => (
-        <SemiControlledAutoComplete
-          margin="none"
-          value={''}
-          onChange={() => {}}
-          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
-            text: `Choice ${i}`,
-            value: `Choice ${i}`,
-          }))}
-        />
-      )}
-      renderButton={style => (
-        <IconButton size="small">
-          <Brush />
-        </IconButton>
-      )}
-    />
-  ))
+  .add(
+    'Empty auto complete field, margin=none, noFloatingLabelText, with a small IconButton',
+    () => (
+      <TextFieldWithButtonLayout
+        margin="none"
+        noFloatingLabelText
+        renderTextField={() => (
+          <SemiControlledAutoComplete
+            margin="none"
+            value={''}
+            onChange={() => {}}
+            dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+              text: `Choice ${i}`,
+              value: `Choice ${i}`,
+            }))}
+          />
+        )}
+        renderButton={style => (
+          <IconButton size="small">
+            <Brush />
+          </IconButton>
+        )}
+      />
+    )
+  )
   .add('Filled text field', () => (
     <TextFieldWithButtonLayout
       renderTextField={() => (

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -147,7 +147,7 @@ import SubscriptionPendingDialog from '../Profile/SubscriptionPendingDialog';
 import Dialog from '../UI/Dialog';
 import MiniToolbar, { MiniToolbarText } from '../UI/MiniToolbar';
 import NewObjectDialog from '../ObjectsList/NewObjectDialog';
-import { Column } from '../UI/Grid';
+import { Column, Line } from '../UI/Grid';
 import DragAndDropTestBed from './DragAndDropTestBed';
 import EditorMosaic from '../UI/EditorMosaic';
 import FlatButton from '../UI/FlatButton';
@@ -162,6 +162,16 @@ import GoogleDriveSaveAsDialog from '../ProjectsStorage/GoogleDriveStorageProvid
 import OpenConfirmDialog from '../ProjectsStorage/OpenConfirmDialog';
 import CreateAccountDialog from '../Profile/CreateAccountDialog';
 import BrowserPreviewErrorDialog from '../Export/BrowserExporters/BrowserS3PreviewLauncher/BrowserPreviewErrorDialog';
+import RaisedButton from '../UI/RaisedButton';
+import Text from '../UI/Text';
+import ToolbarIcon from '../UI/ToolbarIcon';
+import ElementWithMenu from '../UI/Menu/ElementWithMenu';
+import IconButton from '../UI/IconButton';
+import FilterList from '@material-ui/icons/FilterList';
+import Brush from '@material-ui/icons/Brush';
+import RaisedButtonWithMenu from '../UI/RaisedButtonWithMenu';
+import fakeResourceExternalEditors from './FakeResourceExternalEditors';
+import { TextFieldWithButtonLayout } from '../UI/Layout';
 
 // No i18n in this file
 
@@ -194,9 +204,116 @@ const {
 
 const Placeholder = () => <div>Placeholder component</div>;
 
+const buildFakeMenuTemplate = () => [
+  {
+    label: 'Option 1',
+    click: action('click option 1'),
+  },
+  { type: 'separator' },
+  {
+    label: 'Option 2',
+    click: action('click option 2'),
+  },
+];
+
 storiesOf('Welcome', module).add('to Storybook', () => (
   <Welcome showApp={linkTo('Button')} />
 ));
+
+storiesOf('UI Building Blocks/Buttons', module)
+  .addDecorator(muiDecorator)
+  .add('default', () => (
+    <Column>
+      <Line>
+        <Text>Buttons:</Text>
+      </Line>
+      <Line>
+        <RaisedButton label="Raised button" onClick={action('onClick')} />
+        <RaisedButton
+          label="Primary Raised button"
+          primary
+          onClick={action('onClick')}
+        />
+      </Line>
+      <Line>
+        <FlatButton label="Flat button" onClick={action('onClick')} />
+        <FlatButton
+          label="Primary Flat button"
+          primary
+          onClick={action('onClick')}
+        />
+      </Line>
+      <Line>
+        <Text>Buttons with menus:</Text>
+      </Line>
+      <Line>
+        <RaisedButton
+          label="Traditional Raised button"
+          onClick={action('onClick')}
+        />
+        <RaisedButtonWithMenu
+          label="Button with menu"
+          buildMenuTemplate={buildFakeMenuTemplate}
+        />
+        <RaisedButtonWithMenu
+          label="... and with icon"
+          icon={<Brush />}
+          buildMenuTemplate={buildFakeMenuTemplate}
+        />
+      </Line>
+      <Line>
+        <Text>Icons with menu:</Text>
+      </Line>
+      <Line>
+        <ElementWithMenu
+          element={
+            <ToolbarIcon
+              src="res/ribbon_default/bug32.png"
+              tooltip={'ToolbarIcon with menu'}
+            />
+          }
+          buildMenuTemplate={buildFakeMenuTemplate}
+        />
+        <ElementWithMenu
+          element={
+            <IconButton>
+              <FilterList />
+            </IconButton>
+          }
+          buildMenuTemplate={buildFakeMenuTemplate}
+        />
+      </Line>
+      <Line>
+        <Text>In a mini toolbar:</Text>
+      </Line>
+      <Line>
+        <MiniToolbar>
+          <MiniToolbarText>Some text:</MiniToolbarText>
+          <IconButton>
+            <Brush />
+          </IconButton>
+          <ElementWithMenu
+            element={
+              <IconButton>
+                <FilterList />
+              </IconButton>
+            }
+            buildMenuTemplate={() => [
+              {
+                label: 'Option 1',
+                click: action('click option 1'),
+              },
+              { type: 'separator' },
+              {
+                label: 'Option 2',
+                click: action('click option 2'),
+              },
+            ]}
+          />
+        </MiniToolbar>
+      </Line>
+    </Column>
+  ));
 
 storiesOf('UI Building Blocks/SemiControlledTextField', module)
   .addDecorator(muiDecorator)
@@ -255,6 +372,25 @@ storiesOf('UI Building Blocks/SemiControlledTextField', module)
           <p>
             State value is {value} ({typeof value})
           </p>
+        </React.Fragment>
+      )}
+    />
+  ))
+  .add('reduced margin, in a MiniToolbar', () => (
+    <ValueStateHolder
+      initialValue={'Choice 6'}
+      render={(value, onChange) => (
+        <React.Fragment>
+          <MiniToolbar>
+            <MiniToolbarText>Please enter something:</MiniToolbarText>
+            <SemiControlledTextField
+              margin="none"
+              value={value}
+              onChange={onChange}
+              commitOnBlur
+            />
+          </MiniToolbar>
+          <p>State value is {value}</p>
         </React.Fragment>
       )}
     />
@@ -445,6 +581,218 @@ storiesOf('UI Building Blocks/SearchBar', module)
           click: () => {},
         },
       ]}
+    />
+  ));
+
+storiesOf('UI Building Blocks/Layout', module)
+  .addDecorator(muiDecorator)
+  .add('Empty text field', () => (
+    <TextFieldWithButtonLayout
+      renderTextField={() => (
+        <SemiControlledTextField
+          floatingLabelText="Hello world"
+          value=""
+          onChange={() => {}}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Empty text field, margin=none', () => (
+    <TextFieldWithButtonLayout
+      margin="none"
+      renderTextField={() => (
+        <SemiControlledTextField
+          margin="none"
+          floatingLabelText="Hello world"
+          value=""
+          onChange={() => {}}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Empty auto complete field', () => (
+    <TextFieldWithButtonLayout
+      renderTextField={() => (
+        <SemiControlledAutoComplete
+          floatingLabelText="Hello world"
+          value={''}
+          onChange={() => {}}
+          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+            text: `Choice ${i}`,
+            value: `Choice ${i}`,
+          }))}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Empty auto complete field, noFloatingLabelText', () => (
+    <TextFieldWithButtonLayout
+      noFloatingLabelText
+      renderTextField={() => (
+        <SemiControlledAutoComplete
+          value={''}
+          onChange={() => {}}
+          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+            text: `Choice ${i}`,
+            value: `Choice ${i}`,
+          }))}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Empty auto complete field, margin=none', () => (
+    <TextFieldWithButtonLayout
+      margin="none"
+      renderTextField={() => (
+        <SemiControlledAutoComplete
+          margin="none"
+          floatingLabelText="Hello world"
+          value={''}
+          onChange={() => {}}
+          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+            text: `Choice ${i}`,
+            value: `Choice ${i}`,
+          }))}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Empty auto complete field, margin=none, noFloatingLabelText', () => (
+    <TextFieldWithButtonLayout
+      margin="none"
+      noFloatingLabelText
+      renderTextField={() => (
+        <SemiControlledAutoComplete
+          margin="none"
+          value={''}
+          onChange={() => {}}
+          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+            text: `Choice ${i}`,
+            value: `Choice ${i}`,
+          }))}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Empty auto complete field, margin=none, noFloatingLabelText, with a small IconButton', () => (
+    <TextFieldWithButtonLayout
+      margin="none"
+      noFloatingLabelText
+      renderTextField={() => (
+        <SemiControlledAutoComplete
+          margin="none"
+          value={''}
+          onChange={() => {}}
+          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+            text: `Choice ${i}`,
+            value: `Choice ${i}`,
+          }))}
+        />
+      )}
+      renderButton={style => (
+        <IconButton size="small">
+          <Brush />
+        </IconButton>
+      )}
+    />
+  ))
+  .add('Filled text field', () => (
+    <TextFieldWithButtonLayout
+      renderTextField={() => (
+        <SemiControlledTextField
+          floatingLabelText="Hello"
+          value="123"
+          onChange={() => {}}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Filled text field, full width', () => (
+    <TextFieldWithButtonLayout
+      renderTextField={() => (
+        <SemiControlledTextField
+          floatingLabelText="Hello"
+          value="123"
+          onChange={() => {}}
+          fullWidth
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Filled multiline text field', () => (
+    <TextFieldWithButtonLayout
+      renderTextField={() => (
+        <SemiControlledTextField
+          floatingLabelText="Hello"
+          multiLine
+          value={'123\n456\n789\nblablabla bla bla'}
+          onChange={() => {}}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Filled auto complete field', () => (
+    <TextFieldWithButtonLayout
+      renderTextField={() => (
+        <SemiControlledAutoComplete
+          floatingLabelText="Hello world"
+          value={'Choice 5'}
+          onChange={() => {}}
+          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+            text: `Choice ${i}`,
+            value: `Choice ${i}`,
+          }))}
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
+    />
+  ))
+  .add('Filled auto complete field, full width', () => (
+    <TextFieldWithButtonLayout
+      renderTextField={() => (
+        <SemiControlledAutoComplete
+          floatingLabelText="Hello world"
+          value={'Choice 5'}
+          onChange={() => {}}
+          dataSource={[1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => ({
+            text: `Choice ${i}`,
+            value: `Choice ${i}`,
+          }))}
+          fullWidth
+        />
+      )}
+      renderButton={style => (
+        <RaisedButton style={style} label="Button" onClick={() => {}} />
+      )}
     />
   ));
 
@@ -1143,7 +1491,7 @@ storiesOf('ParameterFields', module)
           parameterRenderingService={ParameterRenderingService}
           resourceSources={[]}
           onChooseResource={() => Promise.reject('unimplemented')}
-          resourceExternalEditors={[]}
+          resourceExternalEditors={fakeResourceExternalEditors}
         />
       )}
     />
@@ -2028,7 +2376,7 @@ storiesOf('EventsSheet', module)
           onChooseResource={source =>
             action('Choose resource from source', source)
           }
-          resourceExternalEditors={[]}
+          resourceExternalEditors={fakeResourceExternalEditors}
           onOpenDebugger={action('open debugger')}
           onOpenLayout={action('open layout')}
           onOpenSettings={action('open settings')}
@@ -2056,7 +2404,7 @@ storiesOf('EventsSheet', module)
           onChooseResource={source =>
             action('Choose resource from source', source)
           }
-          resourceExternalEditors={[]}
+          resourceExternalEditors={fakeResourceExternalEditors}
           onOpenDebugger={action('open debugger')}
           onOpenLayout={action('open layout')}
           onOpenSettings={action('open settings')}
@@ -2239,7 +2587,7 @@ storiesOf('InstructionEditor', module)
         objectsContainer={testLayout}
         isCondition
         instruction={testInstruction}
-        resourceExternalEditors={[]}
+        resourceExternalEditors={fakeResourceExternalEditors}
         onChooseResource={() => {
           action('onChooseResource');
           return Promise.reject();
@@ -2258,7 +2606,7 @@ storiesOf('InstructionEditor', module)
         objectsContainer={testLayout}
         isCondition
         instruction={testInstruction}
-        resourceExternalEditors={[]}
+        resourceExternalEditors={fakeResourceExternalEditors}
         onChooseResource={() => {
           action('onChooseResource');
           return Promise.reject();
@@ -2282,7 +2630,7 @@ storiesOf('NewInstructionEditorDialog', module)
       isCondition
       isNewInstruction={false}
       instruction={testInstruction}
-      resourceExternalEditors={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
       onChooseResource={() => {
         action('onChooseResource');
         return Promise.reject();
@@ -2303,7 +2651,7 @@ storiesOf('NewInstructionEditorDialog', module)
       isCondition
       isNewInstruction={false}
       instruction={testInstruction}
-      resourceExternalEditors={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
       onChooseResource={() => {
         action('onChooseResource');
         return Promise.reject();
@@ -2324,7 +2672,7 @@ storiesOf('NewInstructionEditorDialog', module)
       isCondition
       isNewInstruction={true}
       instruction={testInstruction}
-      resourceExternalEditors={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
       onChooseResource={() => {
         action('onChooseResource');
         return Promise.reject();
@@ -2348,7 +2696,7 @@ storiesOf('TextEditor', module)
         onChooseResource={source =>
           action('Choose resource from source', source)
         }
-        resourceExternalEditors={[]}
+        resourceExternalEditors={fakeResourceExternalEditors}
       />
     </SerializedObjectDisplay>
   ));
@@ -2365,7 +2713,7 @@ storiesOf('TiledSpriteEditor', module)
         onChooseResource={source =>
           action('Choose resource from source', source)
         }
-        resourceExternalEditors={[]}
+        resourceExternalEditors={fakeResourceExternalEditors}
       />
     </SerializedObjectDisplay>
   ));
@@ -2382,7 +2730,7 @@ storiesOf('PanelSpriteEditor', module)
         onChooseResource={source =>
           action('Choose resource from source', source)
         }
-        resourceExternalEditors={[]}
+        resourceExternalEditors={fakeResourceExternalEditors}
       />
     </SerializedObjectDisplay>
   ));
@@ -2399,7 +2747,7 @@ storiesOf('SpriteEditor and related editors', module)
         onChooseResource={source =>
           action('Choose resource from source', source)
         }
-        resourceExternalEditors={[]}
+        resourceExternalEditors={fakeResourceExternalEditors}
       />
     </SerializedObjectDisplay>
   ))
@@ -2996,7 +3344,7 @@ storiesOf('ResourceSelector (and ResourceSelectorWithThumbnail)', module)
       project={project}
       resourceSources={[]}
       onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
       initialResourceName="resource-that-does-not-exists-in-the-project"
       onChange={action('on change')}
       resourcesLoader={ResourcesLoader}
@@ -3008,7 +3356,20 @@ storiesOf('ResourceSelector (and ResourceSelectorWithThumbnail)', module)
       project={project}
       resourceSources={[]}
       onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
+      initialResourceName="icon128.png"
+      onChange={action('on change')}
+      resourcesLoader={ResourcesLoader}
+    />
+  ))
+  .add('image resource, no margin', () => (
+    <ResourceSelector
+      margin="none"
+      resourceKind="image"
+      project={project}
+      resourceSources={[]}
+      onChooseResource={() => Promise.reject('Unimplemented')}
+      resourceExternalEditors={fakeResourceExternalEditors}
       initialResourceName="icon128.png"
       onChange={action('on change')}
       resourcesLoader={ResourcesLoader}
@@ -3020,7 +3381,7 @@ storiesOf('ResourceSelector (and ResourceSelectorWithThumbnail)', module)
       project={project}
       resourceSources={[]}
       onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
       resourceName="icon128.png"
       onChange={action('on change')}
     />
@@ -3031,8 +3392,35 @@ storiesOf('ResourceSelector (and ResourceSelectorWithThumbnail)', module)
       project={project}
       resourceSources={[]}
       onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
       initialResourceName="fake-audio1.mp3"
+      onChange={action('on change')}
+      resourcesLoader={ResourcesLoader}
+    />
+  ))
+  .add('font resource, with reset button', () => (
+    <ResourceSelector
+      canBeReset
+      resourceKind="font"
+      project={project}
+      resourceSources={[]}
+      onChooseResource={() => Promise.reject('Unimplemented')}
+      resourceExternalEditors={fakeResourceExternalEditors}
+      initialResourceName="font.otf"
+      onChange={action('on change')}
+      resourcesLoader={ResourcesLoader}
+    />
+  ))
+  .add('font resource, no margin, with reset button', () => (
+    <ResourceSelector
+      canBeReset
+      margin="none"
+      resourceKind="font"
+      project={project}
+      resourceSources={[]}
+      onChooseResource={() => Promise.reject('Unimplemented')}
+      resourceExternalEditors={fakeResourceExternalEditors}
+      initialResourceName="font.otf"
       onChange={action('on change')}
       resourcesLoader={ResourcesLoader}
     />
@@ -3139,7 +3527,7 @@ storiesOf('EventsFunctionsExtensionEditor/index', module)
           onChooseResource={source =>
             action('Choose resource from source', source)
           }
-          resourceExternalEditors={[]}
+          resourceExternalEditors={fakeResourceExternalEditors}
           openInstructionOrExpression={action('open instruction or expression')}
           initiallyFocusedFunctionName={null}
           initiallyFocusedBehaviorName={null}

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -171,7 +171,10 @@ import FilterList from '@material-ui/icons/FilterList';
 import Brush from '@material-ui/icons/Brush';
 import RaisedButtonWithMenu from '../UI/RaisedButtonWithMenu';
 import fakeResourceExternalEditors from './FakeResourceExternalEditors';
-import { TextFieldWithButtonLayout } from '../UI/Layout';
+import {
+  TextFieldWithButtonLayout,
+  ResponsiveLineStackLayout,
+} from '../UI/Layout';
 
 // No i18n in this file
 
@@ -584,7 +587,41 @@ storiesOf('UI Building Blocks/SearchBar', module)
     />
   ));
 
-storiesOf('UI Building Blocks/Layout', module)
+storiesOf('UI Building Blocks/Layout/ResponsiveLineStackLayout', module)
+  .addDecorator(muiDecorator)
+  .add('Default', () => (
+    <ResponsiveLineStackLayout>
+      <div>Some Div</div>
+      <span>Some Span</span>
+      <RaisedButton label="Raised Button" onClick={action('on click')} />
+      <RaisedButton label="Raised Button" onClick={action('on click')} />
+      <FlatButton label="Flat Button" onClick={action('on click')} />
+    </ResponsiveLineStackLayout>
+  ))
+  .add('Default with null items', () => (
+    <ResponsiveLineStackLayout>
+      {null}
+      {null}
+      <div>Some Div</div>
+      {null}
+      {null}
+      <span>Some Span</span>
+      <RaisedButton label="Raised Button" onClick={action('on click')} />
+      <RaisedButton label="Raised Button" onClick={action('on click')} />
+      <FlatButton label="Flat Button" onClick={action('on click')} />
+      {null}
+      {null}
+    </ResponsiveLineStackLayout>
+  ))
+  .add('alignItems=center', () => (
+    <ResponsiveLineStackLayout alignItems="center">
+      <div>Some Div</div>
+      <span>Some Span</span>
+      <RaisedButton label="Raised Button" onClick={action('on click')} />
+    </ResponsiveLineStackLayout>
+  ));
+
+storiesOf('UI Building Blocks/Layout/TextFieldWithButtonLayout', module)
   .addDecorator(muiDecorator)
   .add('Empty text field', () => (
     <TextFieldWithButtonLayout


### PR DESCRIPTION
After discussing the text fields [here](https://github.com/4ian/GDevelop/issues/927#issuecomment-554348476) and remembering that some people think GD has not enough contrast or issues seeing what is a field/what is not a field, I think it's fair to say that the "flat" text field from the first version of Material Design are not the best for users. I've been reading a bit about text fields and turns out Material Design is now recommending outlined or filled text fields. They have written an [interesting research here](https://material.io/components/text-fields/#research): 

> Enclosed text fields with a rectangular (box) shape performed better than those with a line affordance
> The text field box should be represented with a semi-transparent fill and a bottom line or with a fully transparent fill and an opaque stroke.

Material-UI added these new field design in the version that GDevelop is now using: https://material-ui.com/components/text-fields/. 

I think it can solve some complaints and ease the learning curve for new users to use filled text fields instead of the old "flat ones". As much as I like the clean result of the old ones, they seem no optimal.

I've made the changes to use the filled version everywhere except:
* In "MiniToolbar", where I use still use the "Flat" version without any borders
* that's basically it :)

Ideally, I think we could also add a background to the flat version.

These new fields are taking **less space** than before, because the margins were reduced. The label is included in the background color as provided by material-ui and suggested by material.io - this is not changing the space used by the fields.

Here are a few comparisons:

<img width="883" alt="Screenshot 2019-11-17 22 17 39" src="https://user-images.githubusercontent.com/1280130/69015483-2e97e780-098c-11ea-9a8b-9a351810e3fe.png">
<img width="536" alt="Screenshot 2019-11-17 22 18 28" src="https://user-images.githubusercontent.com/1280130/69015484-2fc91480-098c-11ea-81d0-007eb2f9259c.png">
<img width="1750" alt="Screenshot 2019-11-17 22 19 10" src="https://user-images.githubusercontent.com/1280130/69015485-2fc91480-098c-11ea-83fb-b6c177658169.png">
<img width="1610" alt="Screenshot 2019-11-17 22 20 38" src="https://user-images.githubusercontent.com/1280130/69015486-2fc91480-098c-11ea-97d4-59434575c8c1.png">

Another few improvements:

* Fields that are on two columns on desktop/tablets will automatically be stacked in a single column on small windows/phones (this was already done in the properties panel, this is now generalised).
* Some buttons have been changed to be "RaisedButtons" instead of just icons, to make them more visible. I also set the label "Create" or "Edit" for the resource selectors, so that users can discover that they can use external editors :) 
* I've started a file "UI/Layout.js" that contains some utilities for commonly used layouts.

I know that visually this is **quite a big change** :) But I think that going forward this will be much more intuitive for users. After a few hours working with this, I already get used to it.

TODO: 
- [x] Fix margins of AutoComplete and SelectFields when isInline is true
- [x] Fix selection of project file type (isFolderProject) with SelectField