### PR TITLE
Improve comment

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -6,9 +6,12 @@
 .gd-events-sheet .rst__moveHandle {
     width: 10px;
     background: #4ab0e4;
-    border: 1px solid #49AFE4;
     box-shadow: none;
     border-radius: 0;
+}
+
+.gd-events-sheet .rst__moveHandle:hover {
+    background-color: #767676!important;
 }
 
 .gd-events-sheet .events-tree {
@@ -121,7 +124,6 @@
  */
 .gd-events-sheet .selectable {
     box-sizing: border-box;
-    border: 1px transparent solid;
 }
 
 /**
@@ -129,7 +131,6 @@
  */
 .gd-events-sheet .large-selectable {
     box-sizing: border-box;
-    border: 1px transparent solid;
 }
 
 /**

--- a/newIDE/app/src/EventsSheet/InstructionEditor/TextEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/TextEditorDialog.js
@@ -1,0 +1,172 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
+
+import * as React from 'react';
+import Dialog from '../../UI/Dialog';
+import FlatButton from '../../UI/FlatButton';
+import HelpButton from '../../UI/HelpButton';
+import { Line, Column } from '../../UI/Grid';
+import ColorPicker from '../../UI/ColorField/ColorPicker';
+import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';
+import SemiControlledTextField from '../../UI/SemiControlledTextField';
+import { getSelectedEvents } from '../SelectionHandler';
+
+const gd = global.gd;
+
+const toolbarItemStyle = {
+  marginRight: 10,
+};
+
+const styles = {
+  sizeTextField: {
+    width: 90,
+    ...toolbarItemStyle,
+  },
+  toolbarItem: toolbarItemStyle,
+  checkbox: toolbarItemStyle,
+};
+
+type Props = {|
+  event: any,
+  open: boolean,
+  onClose: () => void,
+  onApply: () => void,
+|};
+
+type State = {|
+  searchText: string,
+  textValue: any,
+|};
+
+//TODO prendre en compte aussi les commentaires des groupes, vérifié le type de l'event getType()
+//Puis selon le cas retourné le text avec la methode approprié a l'event getComment() ou getName()
+//Voir comment recup l'event car ma façon de faire dans le state récupère ce text "\"
+export default class TextEditorDialog extends React.PureComponent<
+  Props,
+  State
+> {
+  recupereLecommentaire = () => {
+    return gd
+      .asCommentEvent(
+        getSelectedEvents(this.props.event).some(event => {
+          return event;
+        })
+      )
+      .getComment();
+  };
+
+  state = {
+    searchText: '',
+    textValue: this.recupereLecommentaire(),
+  };
+
+  componentWillReceiveProps(newProps: Props) {
+    if (newProps.open && !this.props.open) {
+    }
+  }
+
+  _handleSearchTextChange = (searchText: string) => {
+    this.setState({
+      searchText,
+    });
+  };
+
+  render() {
+    const { event, open, onApply, onClose } = this.props;
+
+    console.log(event);
+
+    return (
+      <Dialog
+        title={<Trans>Text editor</Trans>}
+        onRequestClose={onClose}
+        noMargin
+        actions={[
+          <FlatButton
+            key="close"
+            label={<Trans>Cancel</Trans>}
+            primary={false}
+            onClick={onClose}
+          />,
+          <FlatButton
+            key={'Apply'}
+            label={<Trans>Apply</Trans>}
+            primary
+            onClick={onApply}
+            keyboardFocused
+          />,
+        ]}
+        secondaryActions={[
+          <HelpButton
+            key="help"
+            helpPagePath="/interface/scene-editor/layers-and-cameras"
+          />,
+        ]}
+        open={open}
+      >
+        <Column noMargin>
+          <MiniToolbar>
+            <MiniToolbarText>
+              <Trans />
+            </MiniToolbarText>
+            <MiniToolbarText>
+              <Trans>Background color:</Trans>
+            </MiniToolbarText>
+            <ColorPicker
+              style={styles.sizeTextField}
+              disableAlpha
+              color={{
+                r: 125,
+                g: 125,
+                b: 125,
+                a: 255,
+              }}
+              onChangeComplete={color => {
+                this.forceUpdate();
+              }}
+            />
+            <MiniToolbarText>
+              <Trans>Text color:</Trans>
+            </MiniToolbarText>
+            <ColorPicker
+              style={styles.sizeTextField}
+              disableAlpha
+              color={{
+                r: 125,
+                g: 125,
+                b: 125,
+                a: 255,
+              }}
+              onChangeComplete={color => {
+                this.forceUpdate();
+              }}
+            />
+          </MiniToolbar>
+          <Line noMargin>
+            <Column expand>
+              <Line>
+                <SemiControlledTextField
+                  commitOnBlur
+                  hintText={t`Enter the text to be displayed in your comment`}
+                  fullWidth
+                  multiLine
+                  rows={8}
+                  rowsMax={8}
+                  value={this.state.textValue}
+                  onChange={value => {
+                    this.setState({
+                      textValue: value,
+                    });
+                    //event.setComment(value);
+                    this.forceUpdate();
+                  }}
+                />
+              </Line>
+            </Column>
+          </Line>
+        </Column>
+      </Dialog>
+    );
+  }
+}

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -1068,85 +1068,107 @@ export default class EventsSheet extends React.Component<Props, State> {
                           ref={eventContextMenu =>
                             (this.eventContextMenu = eventContextMenu)
                           }
-                          buildMenuTemplate={() => [
-                            {
-                              label: 'Copy',
+                          buildMenuTemplate={() => {
+                            let contextList = [
+                              {
+                                label: 'Copy',
+                                click: () => this.copySelection(),
+                                accelerator: 'CmdOrCtrl+C',
+                              },
+                              {
+                                label: 'Cut',
+                                click: () => this.cutSelection(),
+                                accelerator: 'CmdOrCtrl+X',
+                              },
+                              {
+                                label: 'Paste',
+                                click: () => this.pasteEvents(),
+                                enabled: hasClipboardEvents(),
+                                accelerator: 'CmdOrCtrl+V',
+                              },
+                              {
+                                label: 'Delete',
+                                click: () => this.deleteSelection(),
+                                accelerator: 'Delete',
+                              },
+                              {
+                                label: 'Toggle disabled',
+                                click: () => this.toggleDisabled(),
+                                enabled: this._selectionCanToggleDisabled(),
+                              },
+                              { type: 'separator' },
+                              {
+                                label: 'Add New Event Below',
+                                click: () =>
+                                  this.addNewEvent(
+                                    'BuiltinCommonInstructions::Standard'
+                                  ),
+                              },
+                              {
+                                label: 'Add Sub Event',
+                                click: () => this.addSubEvents(),
+                                enabled: this._selectionCanHaveSubEvents(),
+                              },
+                              {
+                                label: 'Add Other',
+                                submenu: this.state.allEventsMetadata.map(
+                                  metadata => {
+                                    return {
+                                      label: metadata.fullName,
+                                      click: () =>
+                                        this.addNewEvent(metadata.type),
+                                    };
+                                  }
+                                ),
+                              },
+                              { type: 'separator' },
+                              {
+                                label: 'Undo',
+                                click: this.undo,
+                                enabled: canUndo(this.state.history),
+                                accelerator: 'CmdOrCtrl+Z',
+                              },
+                              {
+                                label: 'Redo',
+                                click: this.redo,
+                                enabled: canRedo(this.state.history),
+                                accelerator: 'CmdOrCtrl+Shift+Z',
+                              },
+                              { type: 'separator' },
+                              {
+                                label: 'Extract Events to a Function',
+                                click: () => this.extractEventsToFunction(),
+                              },
+                              {
+                                label: 'Move Events into a Group',
+                                click: () => this.moveEventsIntoNewGroup(),
+                              },
+                              {
+                                label: 'Analyze Objects Used in this Event',
+                                click: this._openEventsContextAnalyzer,
+                              },
+                            ];
+
+                            const edition = {
+                              label: 'Edit',
                               click: () => this.copySelection(),
                               accelerator: 'CmdOrCtrl+C',
-                            },
-                            {
-                              label: 'Cut',
-                              click: () => this.cutSelection(),
-                              accelerator: 'CmdOrCtrl+X',
-                            },
-                            {
-                              label: 'Paste',
-                              click: () => this.pasteEvents(),
-                              enabled: hasClipboardEvents(),
-                              accelerator: 'CmdOrCtrl+V',
-                            },
-                            {
-                              label: 'Delete',
-                              click: () => this.deleteSelection(),
-                              accelerator: 'Delete',
-                            },
-                            {
-                              label: 'Toggle disabled',
-                              click: () => this.toggleDisabled(),
-                              enabled: this._selectionCanToggleDisabled(),
-                            },
-                            { type: 'separator' },
-                            {
-                              label: 'Add New Event Below',
-                              click: () =>
-                                this.addNewEvent(
-                                  'BuiltinCommonInstructions::Standard'
-                                ),
-                            },
-                            {
-                              label: 'Add Sub Event',
-                              click: () => this.addSubEvents(),
-                              enabled: this._selectionCanHaveSubEvents(),
-                            },
-                            {
-                              label: 'Add Other',
-                              submenu: this.state.allEventsMetadata.map(
-                                metadata => {
-                                  return {
-                                    label: metadata.fullName,
-                                    click: () =>
-                                      this.addNewEvent(metadata.type),
-                                  };
+                            };
+
+                            getSelectedEvents(this.state.selection).forEach(
+                              event => {
+                                if (
+                                  event.getType() ===
+                                    'BuiltinCommonInstructions::Comment' ||
+                                  event.getType() ===
+                                    'BuiltinCommonInstructions::Group'
+                                ) {
+                                  contextList.unshift(edition);
                                 }
-                              ),
-                            },
-                            { type: 'separator' },
-                            {
-                              label: 'Undo',
-                              click: this.undo,
-                              enabled: canUndo(this.state.history),
-                              accelerator: 'CmdOrCtrl+Z',
-                            },
-                            {
-                              label: 'Redo',
-                              click: this.redo,
-                              enabled: canRedo(this.state.history),
-                              accelerator: 'CmdOrCtrl+Shift+Z',
-                            },
-                            { type: 'separator' },
-                            {
-                              label: 'Extract Events to a Function',
-                              click: () => this.extractEventsToFunction(),
-                            },
-                            {
-                              label: 'Move Events into a Group',
-                              click: () => this.moveEventsIntoNewGroup(),
-                            },
-                            {
-                              label: 'Analyze Objects Used in this Event',
-                              click: this._openEventsContextAnalyzer,
-                            },
-                          ]}
+                              }
+                            );
+                            return contextList;
+                          }}
                         />
                         <ContextMenu
                           ref={instructionContextMenu =>

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import EventsTree from './EventsTree';
 import NewInstructionEditorDialog from './InstructionEditor/NewInstructionEditorDialog';
 import InstructionEditorDialog from './InstructionEditor/InstructionEditorDialog';
+import TextEditorDialog from './InstructionEditor/TextEditorDialog';
 import Toolbar from './Toolbar';
 import KeyboardShortcuts from '../UI/KeyboardShortcuts';
 import InlineParameterEditor from './InlineParameterEditor';
@@ -133,6 +134,8 @@ type State = {|
 
   serializedEventsToExtract: ?Object,
 
+  textEditorDialog: boolean,
+
   showSearchPanel: boolean,
   searchResults: ?Array<gdBaseEvent>,
   searchFocusOffset: ?number,
@@ -204,6 +207,8 @@ export default class EventsSheet extends React.Component<Props, State> {
     searchFocusOffset: null,
 
     allEventsMetadata: [],
+
+    textEditorDialog: false,
   };
 
   componentDidMount() {
@@ -361,6 +366,20 @@ export default class EventsSheet extends React.Component<Props, State> {
     });
 
     return newEvents;
+  };
+
+  //TODO ideally see for use toggle
+  openTextEditorDialog = () => {
+    this.setState({
+      textEditorDialog: true,
+    });
+  };
+
+  //TODO close and save in history
+  closeTextEditorDialog = () => {
+    this.setState({
+      textEditorDialog: false,
+    });
   };
 
   openInstructionEditor = (
@@ -1151,8 +1170,7 @@ export default class EventsSheet extends React.Component<Props, State> {
 
                             const edition = {
                               label: 'Edit',
-                              click: () => this.copySelection(),
-                              accelerator: 'CmdOrCtrl+C',
+                              click: () => this.openTextEditorDialog(),
                             };
 
                             getSelectedEvents(this.state.selection).forEach(
@@ -1288,6 +1306,23 @@ export default class EventsSheet extends React.Component<Props, State> {
                                 serializedEventsToExtract: null,
                               });
                             }}
+                          />
+                        )}
+                        {this.state.textEditorDialog && (
+                          <TextEditorDialog
+                            open={this.state.textEditorDialog}
+                            event={this.state.selection}
+                            onApply={() => {
+                              //TODO save dans l'eventsheet les changements
+                              this.setState({
+                                textEditorDialog: false,
+                              });
+                            }}
+                            onClose={() =>
+                              this.setState({
+                                textEditorDialog: false,
+                              })
+                            }
                           />
                         )}
                         <InfoBar

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -97,6 +97,7 @@ export default class TextEditor extends React.Component<EditorProps, void> {
             resourcesLoader={ResourcesLoader}
             resourceKind="font"
             fullWidth
+            canBeReset
             initialResourceName={textObject.getFontName()}
             onChange={resourceName => {
               textObject.setFontName(resourceName);

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -1,6 +1,15 @@
 // @flow
+import { Trans } from '@lingui/macro';
+
 import * as React from 'react';
 import IconButton from '../UI/IconButton';
+import SemiControlledAutoComplete, {
+  type DataSource,
+} from '../UI/SemiControlledAutoComplete';
+import ElementWithMenu from '../UI/Menu/ElementWithMenu';
+import FlatButton from '../UI/FlatButton';
+import { Line } from '../UI/Grid';
+import BackspaceIcon from '@material-ui/icons/Backspace';
 import Add from '@material-ui/icons/Add';
 import Brush from '@material-ui/icons/Brush';
 import {
@@ -9,12 +18,8 @@ import {
   type ResourceKind,
 } from '../ResourcesList/ResourceSource.flow';
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
-import ElementWithMenu from '../UI/Menu/ElementWithMenu';
 import ResourcesLoader from '../ResourcesLoader';
 import { applyResourceDefaults } from './ResourceUtils';
-import SemiControlledAutoComplete, {
-  type DataSource,
-} from '../UI/SemiControlledAutoComplete';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 
 type Props = {|
@@ -25,6 +30,7 @@ type Props = {|
   resourcesLoader: typeof ResourcesLoader,
   resourceKind: ResourceKind,
   fullWidth?: boolean,
+  canBeReset?: boolean,
   initialResourceName: string,
   onChange: string => void,
   floatingLabelText?: React.Node,
@@ -42,6 +48,10 @@ const styles = {
 };
 
 export default class ResourceSelector extends React.Component<Props, State> {
+  static defaultProps = {
+    canBeReset: false,
+  };
+
   constructor(props: Props) {
     super(props);
 
@@ -141,7 +151,23 @@ export default class ResourceSelector extends React.Component<Props, State> {
       });
   };
 
+  _onResetResourceName = () => {
+    this.setState(
+      {
+        resourceName: '',
+        notExistingError: false,
+      },
+      () => {
+        if (this.props.onChange) this.props.onChange(this.state.resourceName);
+      }
+    );
+  };
+
   _onChangeResourceName = (resourceName: string) => {
+    if (resourceName === '') {
+      this._onResetResourceName();
+      return;
+    }
     this.setState(
       {
         resourceName,
@@ -240,33 +266,44 @@ export default class ResourceSelector extends React.Component<Props, State> {
     );
     return (
       <div style={styles.container}>
-        <SemiControlledAutoComplete
-          floatingLabelText={this.props.floatingLabelText}
-          hintText={this.props.hintText}
-          openOnFocus
-          dataSource={this.autoCompleteData || []}
-          value={this.state.resourceName}
-          onChange={this._onChangeResourceName}
-          errorText={errorText}
-          fullWidth={this.props.fullWidth}
-          margin={this.props.margin}
-          ref={autoComplete => (this._autoComplete = autoComplete)}
-        />
-        {!!externalEditors.length && (
-          <ElementWithMenu
-            element={
-              <IconButton>
-                <Brush />
-              </IconButton>
-            }
-            buildMenuTemplate={() =>
-              externalEditors.map(externalEditor => ({
-                label: externalEditor.displayName,
-                click: () => this._editWith(externalEditor),
-              }))
-            }
+        <Line expand>
+          <SemiControlledAutoComplete
+            floatingLabelText={this.props.floatingLabelText}
+            hintText={this.props.hintText}
+            openOnFocus
+            dataSource={this.autoCompleteData || []}
+            value={this.state.resourceName}
+            onChange={this._onChangeResourceName}
+            errorText={errorText}
+            fullWidth={this.props.fullWidth}
+            margin={this.props.margin}
+            ref={autoComplete => (this._autoComplete = autoComplete)}
           />
-        )}
+          {this.props.canBeReset && (
+            <FlatButton
+              label={<Trans>Reset</Trans>}
+              icon={<BackspaceIcon />}
+              onClick={() => {
+                this._onResetResourceName();
+              }}
+            />
+          )}
+          {!!externalEditors.length && (
+            <ElementWithMenu
+              element={
+                <IconButton>
+                  <Brush />
+                </IconButton>
+              }
+              buildMenuTemplate={() =>
+                externalEditors.map(externalEditor => ({
+                  label: externalEditor.displayName,
+                  click: () => this._editWith(externalEditor),
+                }))
+              }
+            />
+          )}
+        </Line>
       </div>
     );
   }

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -80,6 +80,7 @@ type Props = {|
     width?: number | '100%',
     flex?: 1,
     top?: number,
+    padding?: number | string,
   |},
   inputStyle?: {|
     // Allow to customize color (replace by color prop?) // TO VERIFY
@@ -89,6 +90,7 @@ type Props = {|
     // Allow to display monospaced font
     fontFamily?: '"Lucida Console", Monaco, monospace',
     lineHeight?: 1.4,
+    padding?: number | string,
   |},
   underlineFocusStyle?: {| borderColor: string |}, // TODO
   underlineShow?: boolean,


### PR DESCRIPTION
Here a other thing for :
- Comment looks like group in eventsheet
- Add a reset button for font in text object ([Discuss on forum](https://forum.gdevelop-app.com/t/pending-can-not-remove-custom-font-from-text-object-properties/21534))
New props canBeReset on ResourceSelector
- Add "Edit" in context menu on comment for edit all content and change background color (WIP)

I don't got the event back in the right way.
getComment() gives me something strange.  "\".

Height size of comment event are adjust at each input.

Oh i see that **modal** prop dosen't work at all, on all existing dialog, i've tried to remove it on other dialog but it's not working too.

I was on this code to learn a little more about React & eventsheet.
Now go back to Guideline :) 


![image](https://user-images.githubusercontent.com/1670670/69995406-4c4e7a80-1550-11ea-849d-892b3db67a28.png)

![image](https://user-images.githubusercontent.com/1670670/69995486-6e47fd00-1550-11ea-908f-4c895608794a.png)

