### PR TITLE
Fix pixel perfect on Panel Sprite 9-patch

### DIFF
--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
@@ -90,7 +90,7 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateLocalPositions = func
   this._borderSprites[0].position.y = obj._tBorder;
 
   //Top-right
-  this._borderSprites[1].position.x = obj._width - this._borderSprites[7].width ;
+  this._borderSprites[1].position.x = obj._width - this._borderSprites[1].width ;
   this._borderSprites[1].position.y = 0;
 
   //Top
@@ -104,15 +104,13 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateLocalPositions = func
   this._borderSprites[4].position.y = obj._tBorder;
   //Bottom-Left
   this._borderSprites[5].position.x = 0;
-  this._borderSprites[5].position.y =
-    obj._height - this._borderSprites[5].height;
+  this._borderSprites[5].position.y = obj._height - this._borderSprites[5].height;
   //Bottom
   this._borderSprites[6].position.x = obj._lBorder;
   this._borderSprites[6].position.y = obj._height - obj._bBorder;
   //Bottom-Right
   this._borderSprites[7].position.x = obj._width - this._borderSprites[7].width;
-  this._borderSprites[7].position.y =
-    obj._height - this._borderSprites[7].height;
+  this._borderSprites[7].position.y = obj._height - this._borderSprites[7].height;
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateSpritesAndTexturesSize = function() {

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
@@ -1,204 +1,343 @@
-gdjs.PanelSpriteRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene, textureName, tiled)
-{
-    this._object = runtimeObject;
+gdjs.PanelSpriteRuntimeObjectPixiRenderer = function(
+  runtimeObject,
+  runtimeScene,
+  textureName,
+  tiled
+) {
+  this._object = runtimeObject;
 
-    if ( this._spritesContainer === undefined ) {
-        var texture = runtimeScene.getGame().getImageManager().getPIXITexture(textureName);
+  if (this._spritesContainer === undefined) {
+    var texture = runtimeScene
+      .getGame()
+      .getImageManager()
+      .getPIXITexture(textureName);
 
-        var StretchedSprite = !tiled ? PIXI.Sprite : PIXI.extras.TilingSprite;
+    var StretchedSprite = !tiled ? PIXI.Sprite : PIXI.extras.TilingSprite;
 
-        this._spritesContainer = new PIXI.Container();
-        this._centerSprite = new StretchedSprite(new PIXI.Texture(texture));
-        this._borderSprites = [
-            new StretchedSprite(new PIXI.Texture(texture)), //Right
-            new PIXI.Sprite(texture), //Top-Right
-            new StretchedSprite(new PIXI.Texture(texture)), //Top
-            new PIXI.Sprite(texture), //Top-Left
-            new StretchedSprite(new PIXI.Texture(texture)), //Left
-            new PIXI.Sprite(texture), //Bottom-Left
-            new StretchedSprite(new PIXI.Texture(texture)), //Bottom
-            new PIXI.Sprite(texture)  //Bottom-Right
-        ];
-    }
+    this._spritesContainer = new PIXI.Container();
+    this._centerSprite = new StretchedSprite(new PIXI.Texture(texture));
+    this._borderSprites = [
+      new StretchedSprite(new PIXI.Texture(texture)), //Right
+      new PIXI.Sprite(texture), //Top-Right
+      new StretchedSprite(new PIXI.Texture(texture)), //Top
+      new PIXI.Sprite(texture), //Top-Left
+      new StretchedSprite(new PIXI.Texture(texture)), //Left
+      new PIXI.Sprite(texture), //Bottom-Left
+      new StretchedSprite(new PIXI.Texture(texture)), //Bottom
+      new PIXI.Sprite(texture) //Bottom-Right
+    ];
+  }
 
-    this.setTexture(textureName, runtimeScene);
+  this.setTexture(textureName, runtimeScene);
 
-    this._spritesContainer.removeChildren();
-    this._spritesContainer.addChild(this._centerSprite);
-    for (var i = 0;i < this._borderSprites.length;++i) {
-        this._spritesContainer.addChild(this._borderSprites[i]);
-    }
+  this._spritesContainer.removeChildren();
+  this._spritesContainer.addChild(this._centerSprite);
+  for (var i = 0; i < this._borderSprites.length; ++i) {
+    this._spritesContainer.addChild(this._borderSprites[i]);
+  }
 
-    this._alpha = this._spritesContainer.alpha;
-    runtimeScene.getLayer("").getRenderer().addRendererObject(this._spritesContainer, runtimeObject.getZOrder());
+  this._alpha = this._spritesContainer.alpha;
+  runtimeScene
+    .getLayer("")
+    .getRenderer()
+    .addRendererObject(this._spritesContainer, runtimeObject.getZOrder());
 };
 
-gdjs.PanelSpriteRuntimeObjectRenderer = gdjs.PanelSpriteRuntimeObjectPixiRenderer; //Register the class to let the engine use it.
+gdjs.PanelSpriteRuntimeObjectRenderer =
+  gdjs.PanelSpriteRuntimeObjectPixiRenderer; //Register the class to let the engine use it.
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.getRendererObject = function() {
-    return this._spritesContainer;
+  return this._spritesContainer;
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.ensureUpToDate = function() {
-    if (this._spritesContainer.visible && this._wasRendered) { 
-        // Update the alpha of the container to make sure that it's applied.
-        // If not done, the alpha will be back to full opaque when changing the color
-        // of the object.
-        this._spritesContainer.alpha = this._alpha;
-        this._spritesContainer.cacheAsBitmap = true;        
-    }
+  if (this._spritesContainer.visible && this._wasRendered) {
+    // Update the alpha of the container to make sure that it's applied.
+    // If not done, the alpha will be back to full opaque when changing the color
+    // of the object.
+    this._spritesContainer.alpha = this._alpha;
+    this._spritesContainer.cacheAsBitmap = true;
+  }
 
-    this._wasRendered = true;
+  this._wasRendered = true;
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.updateOpacity = function() {
-    //TODO: Workaround a not working property in PIXI.js:
-    this._spritesContainer.alpha = this._spritesContainer.visible ? this._object.opacity/255 : 0;
-    this._alpha = this._spritesContainer.alpha;
-}
+  //TODO: Workaround a not working property in PIXI.js:
+  this._spritesContainer.alpha = this._spritesContainer.visible
+    ? this._object.opacity / 255
+    : 0;
+  this._alpha = this._spritesContainer.alpha;
+};
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.updateAngle = function() {
-    this._spritesContainer.rotation = gdjs.toRad(this._object.angle);
+  this._spritesContainer.rotation = gdjs.toRad(this._object.angle);
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.updatePosition = function() {
-    this._spritesContainer.position.x = this._object.x + this._object._width / 2;
-    this._spritesContainer.position.y = this._object.y + this._object._height / 2;
-}
+  this._spritesContainer.position.x = this._object.x + this._object._width / 2;
+  this._spritesContainer.position.y = this._object.y + this._object._height / 2;
+};
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateLocalPositions = function() {
-    var obj = this._object;
-    var extraPixels = obj._tiled ? 1 : 0;
+  var obj = this._object;
 
-    this._centerSprite.position.x = obj._lBorder;
-    this._centerSprite.position.y = obj._tBorder;
-    this._borderSprites[0].position.x = obj._width - obj._rBorder  - extraPixels * 2;
-    this._borderSprites[0].position.y = obj._tBorder;
+  this._centerSprite.position.x = obj._lBorder;
+  this._centerSprite.position.y = obj._tBorder;
 
-    this._borderSprites[1].position.x = obj._width - this._borderSprites[1].width  - extraPixels * 2;
-    this._borderSprites[1].position.y = 0;
+  //Right
+  this._borderSprites[0].position.x = obj._width - obj._rBorder;
+  this._borderSprites[0].position.y = obj._tBorder;
 
-    this._borderSprites[2].position.x = obj._lBorder;
-    this._borderSprites[2].position.y = 0;
+  //Top-right
+  this._borderSprites[1].position.x = obj._width - this._borderSprites[7].width ;
+  this._borderSprites[1].position.y = 0;
 
-    this._borderSprites[3].position.x = 0;
-    this._borderSprites[3].position.y = 0;
-
-    this._borderSprites[4].position.x = 0;
-    this._borderSprites[4].position.y = obj._tBorder;
-
-    this._borderSprites[5].position.x = 0;
-    this._borderSprites[5].position.y = obj._height - this._borderSprites[5].height  - extraPixels * 2;
-
-    this._borderSprites[6].position.x = obj._lBorder;
-    this._borderSprites[6].position.y = obj._height - obj._bBorder  - extraPixels * 3; //FIXME: 1 more extra pixel is somewhat needed for pixel perfect alignment
-
-    this._borderSprites[7].position.x = obj._width - this._borderSprites[7].width  - extraPixels * 2;
-    this._borderSprites[7].position.y = obj._height - this._borderSprites[7].height - extraPixels * 2;
+  //Top
+  this._borderSprites[2].position.x = obj._lBorder;
+  this._borderSprites[2].position.y = 0;
+  //Top-Left
+  this._borderSprites[3].position.x = 0;
+  this._borderSprites[3].position.y = 0;
+  //Left
+  this._borderSprites[4].position.x = 0;
+  this._borderSprites[4].position.y = obj._tBorder;
+  //Bottom-Left
+  this._borderSprites[5].position.x = 0;
+  this._borderSprites[5].position.y =
+    obj._height - this._borderSprites[5].height;
+  //Bottom
+  this._borderSprites[6].position.x = obj._lBorder;
+  this._borderSprites[6].position.y = obj._height - obj._bBorder;
+  //Bottom-Right
+  this._borderSprites[7].position.x = obj._width - this._borderSprites[7].width;
+  this._borderSprites[7].position.y =
+    obj._height - this._borderSprites[7].height;
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateSpritesAndTexturesSize = function() {
-    var obj = this._object;
+  var obj = this._object;
 
-    this._centerSprite.width = Math.max(obj._width - obj._rBorder - obj._lBorder, 0);
-    this._centerSprite.height = Math.max(obj._height - obj._tBorder - obj._bBorder, 0);
+  this._centerSprite.width = Math.max(
+    obj._width - obj._rBorder - obj._lBorder,
+    0
+  );
+  this._centerSprite.height = Math.max(
+    obj._height - obj._tBorder - obj._bBorder,
+    0
+  );
 
-    //Top, Bottom, Right, Left borders:
-    this._borderSprites[0].width = obj._rBorder;
-    this._borderSprites[0].height = Math.max(obj._height - obj._tBorder - obj._bBorder, 0);
+ //Right
+  this._borderSprites[0].width = obj._rBorder;
+  this._borderSprites[0].height = Math.max(
+    obj._height - obj._tBorder - obj._bBorder,
+    0
+  );
 
-    this._borderSprites[2].height = obj._tBorder;
-    this._borderSprites[2].width = Math.max(obj._width - obj._rBorder - obj._lBorder, 0);
+//Top
+  this._borderSprites[2].height = obj._tBorder;
+  this._borderSprites[2].width = Math.max(
+    obj._width - obj._rBorder - obj._lBorder,
+    0
+  );
+//Left
+  this._borderSprites[4].width = obj._lBorder;
+  this._borderSprites[4].height = Math.max(
+    obj._height - obj._tBorder - obj._bBorder,
+    0
+  );
+//Bottom
+  this._borderSprites[6].height = obj._bBorder;
+  this._borderSprites[6].width = Math.max(
+    obj._width - obj._rBorder - obj._lBorder,
+    0
+  );
 
-    this._borderSprites[4].width = obj._lBorder;
-    this._borderSprites[4].height = Math.max(obj._height - obj._tBorder - obj._bBorder, 0);
-
-    this._borderSprites[6].height = obj._bBorder;
-    this._borderSprites[6].width = Math.max(obj._width - obj._rBorder - obj._lBorder, 0);
-
-    this._wasRendered = true;
-    this._spritesContainer.cacheAsBitmap = false;
+  this._wasRendered = true;
+  this._spritesContainer.cacheAsBitmap = false;
 };
 
-gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setTexture = function(textureName, runtimeScene) {
-    var obj = this._object;
-    var texture = runtimeScene.getGame().getImageManager().getPIXITexture(textureName);
+gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setTexture = function(
+  textureName,
+  runtimeScene
+) {
+  var obj = this._object;
+  var texture = runtimeScene
+    .getGame()
+    .getImageManager()
+    .getPIXITexture(textureName);
 
-    function makeInsideTexture(rect) { //TODO
-        if (rect.width < 0) rect.width = 0;
-        if (rect.height < 0) rect.height = 0;
-        if (rect.x < 0) rect.x = 0;
-        if (rect.y < 0) rect.y = 0;
-        if (rect.x > texture.width) rect.x = texture.width;
-        if (rect.y > texture.height) rect.y = texture.height;
-        if (rect.x + rect.width > texture.width) rect.width = texture.width - rect.x;
-        if (rect.y + rect.height > texture.height) rect.height = texture.height - rect.y;
+  function makeInsideTexture(rect) {
+    //TODO
+    if (rect.width < 0) rect.width = 0;
+    if (rect.height < 0) rect.height = 0;
+    if (rect.x < 0) rect.x = 0;
+    if (rect.y < 0) rect.y = 0;
+    if (rect.x > texture.width) rect.x = texture.width;
+    if (rect.y > texture.height) rect.y = texture.height;
+    if (rect.x + rect.width > texture.width)
+      rect.width = texture.width - rect.x;
+    if (rect.y + rect.height > texture.height)
+      rect.height = texture.height - rect.y;
 
-        return rect;
-    }
+    return rect;
+  }
 
-    this._centerSprite.texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(obj._lBorder, obj._tBorder,
+  this._centerSprite.texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        obj._lBorder,
+        obj._tBorder,
         texture.width - obj._lBorder - obj._rBorder,
-        texture.height - obj._tBorder - obj._bBorder)));
+        texture.height - obj._tBorder - obj._bBorder
+      )
+    )
+  );
 
-    //Top, Bottom, Right, Left borders:
-    this._borderSprites[0].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(texture.width - obj._rBorder - 1, obj._tBorder, obj._rBorder + 1,
-        texture.height - obj._tBorder - obj._bBorder)));
-    this._borderSprites[2].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(obj._lBorder, 0, texture.width - obj._lBorder - obj._rBorder, obj._tBorder + 1)));
-    this._borderSprites[4].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(0, obj._tBorder, obj._lBorder + 1, texture.height - obj._tBorder - obj._bBorder)));
-    this._borderSprites[6].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(obj._lBorder, texture.height - obj._bBorder - 1,
-        texture.width - obj._lBorder - obj._rBorder, obj._bBorder + 1)));
+  //Top, Bottom, Right, Left borders:
+  this._borderSprites[0].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        texture.width - obj._rBorder ,
+        obj._tBorder,
+        obj._rBorder ,
+        texture.height - obj._tBorder - obj._bBorder
+      )
+    )
+  );
+  this._borderSprites[2].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        obj._lBorder,
+        0,
+        texture.width - obj._lBorder - obj._rBorder,
+        obj._tBorder
+      )
+    )
+  );
+  this._borderSprites[4].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        0,
+        obj._tBorder,
+        obj._lBorder,
+        texture.height - obj._tBorder - obj._bBorder
+      )
+    )
+  );
+  this._borderSprites[6].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        obj._lBorder,
+        texture.height - obj._bBorder ,
+        texture.width - obj._lBorder - obj._rBorder,
+        obj._bBorder 
+      )
+    )
+  );
 
+  this._borderSprites[1].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        this._borderSprites[1].width - obj._rBorder,
+        0,
+        obj._rBorder,
+        obj._tBorder
+      )
+    )
+  );
+  this._borderSprites[3].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(new PIXI.Rectangle(0, 0, obj._lBorder, obj._tBorder))
+  );
+  this._borderSprites[5].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        0,
+        this._borderSprites[5].height - obj._bBorder,
+        obj._lBorder,
+        obj._bBorder
+      )
+    )
+  );
+  this._borderSprites[7].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        this._borderSprites[7].width - obj._rBorder,
+        this._borderSprites[7].height - obj._bBorder,
+        obj._rBorder,
+        obj._bBorder
+      )
+    )
+  );
 
-    this._borderSprites[1].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(this._borderSprites[1].width - obj._rBorder, 0, obj._rBorder, obj._tBorder)));
-    this._borderSprites[3].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(0, 0, obj._lBorder, obj._tBorder)));
-    this._borderSprites[5].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(0, this._borderSprites[5].height - obj._bBorder, obj._lBorder, obj._bBorder)));
-    this._borderSprites[7].texture = new PIXI.Texture(texture,
-        makeInsideTexture(new PIXI.Rectangle(this._borderSprites[7].width - obj._rBorder, this._borderSprites[7].height - obj._bBorder, obj._rBorder, obj._bBorder)));
-
-    this._updateSpritesAndTexturesSize();
-    this._updateLocalPositions();
-    this.updatePosition();
-    this._spritesContainer.pivot.x = this._object._width / 2;
-    this._spritesContainer.pivot.y = this._object._height / 2;
+  this._updateSpritesAndTexturesSize();
+  this._updateLocalPositions();
+  this.updatePosition();
+  this._spritesContainer.pivot.x = this._object._width / 2;
+  this._spritesContainer.pivot.y = this._object._height / 2;
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.updateWidth = function() {
-    this._spritesContainer.pivot.x = this._object._width / 2;
-    this._updateSpritesAndTexturesSize();
-    this._updateLocalPositions();
-    this.updatePosition();
+  this._spritesContainer.pivot.x = this._object._width / 2;
+  this._updateSpritesAndTexturesSize();
+  this._updateLocalPositions();
+  this.updatePosition();
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.updateHeight = function() {
-    this._spritesContainer.pivot.y = this._object._height / 2;
-    this._updateSpritesAndTexturesSize();
-    this._updateLocalPositions();
-    this.updatePosition();
+  this._spritesContainer.pivot.y = this._object._height / 2;
+  this._updateSpritesAndTexturesSize();
+  this._updateLocalPositions();
+  this.updatePosition();
 };
 
-gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setColor = function(rgbColor) {
-    var colors = rgbColor.split(";");
-    if ( colors.length < 3 ) return;
- 
-    this._centerSprite.tint = "0x" + gdjs.rgbToHex(parseInt(colors[0], 10), parseInt(colors[1], 10), parseInt(colors[2], 10));
+gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setColor = function(
+  rgbColor
+) {
+  var colors = rgbColor.split(";");
+  if (colors.length < 3) return;
 
-    for (var borderCounter = 0; borderCounter < this._borderSprites.length; borderCounter++){
-        this._borderSprites[borderCounter].tint = "0x" + gdjs.rgbToHex(parseInt(colors[0], 10), parseInt(colors[1], 10), parseInt(colors[2], 10));
-    }
+  this._centerSprite.tint =
+    "0x" +
+    gdjs.rgbToHex(
+      parseInt(colors[0], 10),
+      parseInt(colors[1], 10),
+      parseInt(colors[2], 10)
+    );
 
-    this._spritesContainer.cacheAsBitmap = false;
- };
- 
- gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.getColor = function() {
-     var rgb = PIXI.utils.hex2rgb(this._centerSprite.tint)
-     return Math.floor(rgb[0]*255) + ';' + Math.floor(rgb[1]*255) + ';' + Math.floor(rgb[2]*255);
- }
+  for (
+    var borderCounter = 0;
+    borderCounter < this._borderSprites.length;
+    borderCounter++
+  ) {
+    this._borderSprites[borderCounter].tint =
+      "0x" +
+      gdjs.rgbToHex(
+        parseInt(colors[0], 10),
+        parseInt(colors[1], 10),
+        parseInt(colors[2], 10)
+      );
+  }
+
+  this._spritesContainer.cacheAsBitmap = false;
+};
+
+gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.getColor = function() {
+  var rgb = PIXI.utils.hex2rgb(this._centerSprite.tint);
+  return (
+    Math.floor(rgb[0] * 255) +
+    ";" +
+    Math.floor(rgb[1] * 255) +
+    ";" +
+    Math.floor(rgb[2] * 255)
+  );
+};

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
@@ -24,7 +24,7 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer = function(
       new StretchedSprite(new PIXI.Texture(texture)), //Left
       new PIXI.Sprite(texture), //Bottom-Left
       new StretchedSprite(new PIXI.Texture(texture)), //Bottom
-      new PIXI.Sprite(texture) //Bottom-Right
+      new PIXI.Sprite(texture), //Bottom-Right
     ];
   }
 
@@ -38,7 +38,7 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer = function(
 
   this._alpha = this._spritesContainer.alpha;
   runtimeScene
-    .getLayer("")
+    .getLayer('')
     .getRenderer()
     .addRendererObject(this._spritesContainer, runtimeObject.getZOrder());
 };
@@ -90,7 +90,7 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateLocalPositions = func
   this._borderSprites[0].position.y = obj._tBorder;
 
   //Top-right
-  this._borderSprites[1].position.x = obj._width - this._borderSprites[1].width ;
+  this._borderSprites[1].position.x = obj._width - this._borderSprites[1].width;
   this._borderSprites[1].position.y = 0;
 
   //Top
@@ -104,13 +104,15 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateLocalPositions = func
   this._borderSprites[4].position.y = obj._tBorder;
   //Bottom-Left
   this._borderSprites[5].position.x = 0;
-  this._borderSprites[5].position.y = obj._height - this._borderSprites[5].height;
+  this._borderSprites[5].position.y =
+    obj._height - this._borderSprites[5].height;
   //Bottom
   this._borderSprites[6].position.x = obj._lBorder;
   this._borderSprites[6].position.y = obj._height - obj._bBorder;
   //Bottom-Right
   this._borderSprites[7].position.x = obj._width - this._borderSprites[7].width;
-  this._borderSprites[7].position.y = obj._height - this._borderSprites[7].height;
+  this._borderSprites[7].position.y =
+    obj._height - this._borderSprites[7].height;
 };
 
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateSpritesAndTexturesSize = function() {
@@ -125,26 +127,26 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype._updateSpritesAndTexturesSiz
     0
   );
 
- //Right
+  //Right
   this._borderSprites[0].width = obj._rBorder;
   this._borderSprites[0].height = Math.max(
     obj._height - obj._tBorder - obj._bBorder,
     0
   );
 
-//Top
+  //Top
   this._borderSprites[2].height = obj._tBorder;
   this._borderSprites[2].width = Math.max(
     obj._width - obj._rBorder - obj._lBorder,
     0
   );
-//Left
+  //Left
   this._borderSprites[4].width = obj._lBorder;
   this._borderSprites[4].height = Math.max(
     obj._height - obj._tBorder - obj._bBorder,
     0
   );
-//Bottom
+  //Bottom
   this._borderSprites[6].height = obj._bBorder;
   this._borderSprites[6].width = Math.max(
     obj._width - obj._rBorder - obj._lBorder,
@@ -198,9 +200,9 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setTexture = function(
     texture,
     makeInsideTexture(
       new PIXI.Rectangle(
-        texture.width - obj._rBorder ,
+        texture.width - obj._rBorder,
         obj._tBorder,
-        obj._rBorder ,
+        obj._rBorder,
         texture.height - obj._tBorder - obj._bBorder
       )
     )
@@ -232,9 +234,9 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setTexture = function(
     makeInsideTexture(
       new PIXI.Rectangle(
         obj._lBorder,
-        texture.height - obj._bBorder ,
+        texture.height - obj._bBorder,
         texture.width - obj._lBorder - obj._rBorder,
-        obj._bBorder 
+        obj._bBorder
       )
     )
   );
@@ -301,11 +303,11 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.updateHeight = function() {
 gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setColor = function(
   rgbColor
 ) {
-  var colors = rgbColor.split(";");
+  var colors = rgbColor.split(';');
   if (colors.length < 3) return;
 
   this._centerSprite.tint =
-    "0x" +
+    '0x' +
     gdjs.rgbToHex(
       parseInt(colors[0], 10),
       parseInt(colors[1], 10),
@@ -318,7 +320,7 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setColor = function(
     borderCounter++
   ) {
     this._borderSprites[borderCounter].tint =
-      "0x" +
+      '0x' +
       gdjs.rgbToHex(
         parseInt(colors[0], 10),
         parseInt(colors[1], 10),
@@ -333,9 +335,9 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.getColor = function() {
   var rgb = PIXI.utils.hex2rgb(this._centerSprite.tint);
   return (
     Math.floor(rgb[0] * 255) +
-    ";" +
+    ';' +
     Math.floor(rgb[1] * 255) +
-    ";" +
+    ';' +
     Math.floor(rgb[2] * 255)
   );
 };

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
@@ -47,7 +47,7 @@ gdjs.PanelSpriteRuntimeObject.prototype = Object.create(
   gdjs.RuntimeObject.prototype
 );
 gdjs.PanelSpriteRuntimeObject.thisIsARuntimeObjectConstructor =
-  "PanelSpriteObject::PanelSprite";
+  'PanelSpriteObject::PanelSprite';
 
 gdjs.PanelSpriteRuntimeObject.prototype.getRendererObject = function() {
   return this._renderer.getRendererObject();

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
@@ -10,57 +10,73 @@
  * @extends RuntimeObject
  * @memberof gdjs
  */
-gdjs.PanelSpriteRuntimeObject = function(runtimeScene, objectData)
-{
-    gdjs.RuntimeObject.call(this, runtimeScene, objectData);
+gdjs.PanelSpriteRuntimeObject = function(runtimeScene, objectData) {
+  gdjs.RuntimeObject.call(this, runtimeScene, objectData);
 
-    this._rBorder = objectData.rightMargin;
-    this._lBorder = objectData.leftMargin;
-    this._tBorder = objectData.topMargin;
-    this._bBorder = objectData.bottomMargin;
-    this._tiled = objectData.tiled;
-    this._width = objectData.width;
-    this._height = objectData.height;
-    this.opacity = 255;
+  this._rBorder = objectData.rightMargin;
+  this._lBorder = objectData.leftMargin;
+  this._tBorder = objectData.topMargin;
+  this._bBorder = objectData.bottomMargin;
+  this._tiled = objectData.tiled;
+  this._width = objectData.width;
+  this._height = objectData.height;
+  this.opacity = 255;
 
-    if (this._renderer)
-        gdjs.PanelSpriteRuntimeObjectRenderer.call(this._renderer, this, runtimeScene,
-            objectData.texture, objectData.tiled);
-    else
-        this._renderer = new gdjs.PanelSpriteRuntimeObjectRenderer(this, runtimeScene,
-            objectData.texture, objectData.tiled);
+  if (this._renderer) {
+    gdjs.PanelSpriteRuntimeObjectRenderer.call(
+      this._renderer,
+      this,
+      runtimeScene,
+      objectData.texture,
+      objectData.tiled
+    );
+  } else {
+    this._renderer = new gdjs.PanelSpriteRuntimeObjectRenderer(
+      this,
+      runtimeScene,
+      objectData.texture,
+      objectData.tiled
+    );
+  }
 
-    // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
-    this.onCreated();
+  // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+  this.onCreated();
 };
 
-gdjs.PanelSpriteRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );
-gdjs.PanelSpriteRuntimeObject.thisIsARuntimeObjectConstructor = "PanelSpriteObject::PanelSprite";
+gdjs.PanelSpriteRuntimeObject.prototype = Object.create(
+  gdjs.RuntimeObject.prototype
+);
+gdjs.PanelSpriteRuntimeObject.thisIsARuntimeObjectConstructor =
+  "PanelSpriteObject::PanelSprite";
 
 gdjs.PanelSpriteRuntimeObject.prototype.getRendererObject = function() {
-    return this._renderer.getRendererObject();
+  return this._renderer.getRendererObject();
 };
 
-gdjs.PanelSpriteRuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
-    gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
+gdjs.PanelSpriteRuntimeObject.prototype.onDestroyFromScene = function(
+  runtimeScene
+) {
+  gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
 
-    if (this._renderer.onDestroy) {
-        this._renderer.onDestroy();
-    }
+  if (this._renderer.onDestroy) {
+    this._renderer.onDestroy();
+  }
 };
 
 gdjs.PanelSpriteRuntimeObject.prototype.update = function() {
-    this._renderer.ensureUpToDate();
-}
+  this._renderer.ensureUpToDate();
+};
 
 /**
  * Initialize the extra parameters that could be set for an instance.
  */
-gdjs.PanelSpriteRuntimeObject.prototype.extraInitializationFromInitialInstance = function(initialInstanceData) {
-    if ( initialInstanceData.customSize ) {
-        this.setWidth(initialInstanceData.width);
-        this.setHeight(initialInstanceData.height);
-    }
+gdjs.PanelSpriteRuntimeObject.prototype.extraInitializationFromInitialInstance = function(
+  initialInstanceData
+) {
+  if (initialInstanceData.customSize) {
+    this.setWidth(initialInstanceData.width);
+    this.setHeight(initialInstanceData.height);
+  }
 };
 
 /**
@@ -68,8 +84,8 @@ gdjs.PanelSpriteRuntimeObject.prototype.extraInitializationFromInitialInstance =
  * @param {number} x The new x position in pixels.
  */
 gdjs.PanelSpriteRuntimeObject.prototype.setX = function(x) {
-    gdjs.RuntimeObject.prototype.setX.call(this, x);
-    this._renderer.updatePosition();
+  gdjs.RuntimeObject.prototype.setX.call(this, x);
+  this._renderer.updatePosition();
 };
 
 /**
@@ -77,8 +93,8 @@ gdjs.PanelSpriteRuntimeObject.prototype.setX = function(x) {
  * @param {number} y The new y position in pixels.
  */
 gdjs.PanelSpriteRuntimeObject.prototype.setY = function(y) {
-    gdjs.RuntimeObject.prototype.setY.call(this, y);
-    this._renderer.updatePosition();
+  gdjs.RuntimeObject.prototype.setY.call(this, y);
+  this._renderer.updatePosition();
 };
 
 /**
@@ -86,8 +102,11 @@ gdjs.PanelSpriteRuntimeObject.prototype.setY = function(y) {
  * @param {string} textureName The name of the texture.
  * @param {gdjs.RuntimeScene} runtimeScene The scene the object lives in.
  */
-gdjs.PanelSpriteRuntimeObject.prototype.setTexture = function(textureName, runtimeScene) {
-    this._renderer.setTexture(textureName, runtimeScene);
+gdjs.PanelSpriteRuntimeObject.prototype.setTexture = function(
+  textureName,
+  runtimeScene
+) {
+  this._renderer.setTexture(textureName, runtimeScene);
 };
 
 /**
@@ -95,8 +114,8 @@ gdjs.PanelSpriteRuntimeObject.prototype.setTexture = function(textureName, runti
  * @param {number} angle The new angle in degrees.
  */
 gdjs.PanelSpriteRuntimeObject.prototype.setAngle = function(angle) {
-    gdjs.RuntimeObject.prototype.setAngle.call(this, angle);
-    this._renderer.updateAngle();
+  gdjs.RuntimeObject.prototype.setAngle.call(this, angle);
+  this._renderer.updateAngle();
 };
 
 /**
@@ -104,7 +123,7 @@ gdjs.PanelSpriteRuntimeObject.prototype.setAngle = function(angle) {
  * @return {number} The width in pixels
  */
 gdjs.PanelSpriteRuntimeObject.prototype.getWidth = function() {
-    return this._width;
+  return this._width;
 };
 
 /**
@@ -112,7 +131,7 @@ gdjs.PanelSpriteRuntimeObject.prototype.getWidth = function() {
  * @return {number} The height in pixels
  */
 gdjs.PanelSpriteRuntimeObject.prototype.getHeight = function() {
-    return this._height;
+  return this._height;
 };
 
 /**
@@ -120,8 +139,8 @@ gdjs.PanelSpriteRuntimeObject.prototype.getHeight = function() {
  * @param {number} width The new width in pixels.
  */
 gdjs.PanelSpriteRuntimeObject.prototype.setWidth = function(width) {
-    this._width = width;
-    this._renderer.updateWidth();
+  this._width = width;
+  this._renderer.updateWidth();
 };
 
 /**
@@ -129,8 +148,8 @@ gdjs.PanelSpriteRuntimeObject.prototype.setWidth = function(width) {
  * @param {number} height The new height in pixels.
  */
 gdjs.PanelSpriteRuntimeObject.prototype.setHeight = function(height) {
-    this._height = height;
-    this._renderer.updateHeight();
+  this._height = height;
+  this._renderer.updateHeight();
 };
 
 /**
@@ -138,11 +157,11 @@ gdjs.PanelSpriteRuntimeObject.prototype.setHeight = function(height) {
  * @param {number} opacity The new opacity, between 0 (transparent) and 255 (opaque).
  */
 gdjs.PanelSpriteRuntimeObject.prototype.setOpacity = function(opacity) {
-    if ( opacity < 0 ) opacity = 0;
-    if ( opacity > 255 ) opacity = 255;
+  if (opacity < 0) opacity = 0;
+  if (opacity > 255) opacity = 255;
 
-    this.opacity = opacity;
-    this._renderer.updateOpacity();
+  this.opacity = opacity;
+  this._renderer.updateOpacity();
 };
 
 /**
@@ -150,7 +169,7 @@ gdjs.PanelSpriteRuntimeObject.prototype.setOpacity = function(opacity) {
  * @return {number} The opacity, between 0 (transparent) and 255 (opaque).
  */
 gdjs.PanelSpriteRuntimeObject.prototype.getOpacity = function() {
-    return this.opacity;
+  return this.opacity;
 };
 
 /**
@@ -159,7 +178,7 @@ gdjs.PanelSpriteRuntimeObject.prototype.getOpacity = function() {
  * @param {string} rgbColor The color, in RGB format ("128;200;255").
  */
 gdjs.PanelSpriteRuntimeObject.prototype.setColor = function(rgbColor) {
-    this._renderer.setColor(rgbColor);
+  this._renderer.setColor(rgbColor);
 };
 
 /**
@@ -168,5 +187,5 @@ gdjs.PanelSpriteRuntimeObject.prototype.setColor = function(rgbColor) {
  * @returns {string} rgbColor The color, in RGB format ("128;200;255").
  */
 gdjs.PanelSpriteRuntimeObject.prototype.getColor = function() {
-    return this._renderer.getColor();
+  return this._renderer.getColor();
 };

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
@@ -116,39 +116,47 @@ RenderedPanelSpriteInstance.prototype.updatePosition = function() {
 
 RenderedPanelSpriteInstance.prototype._updateLocalPositions = function() {
   const panelSprite = gd.asPanelSpriteObject(this._associatedObject);
-  var extraPixels = panelSprite.isTiled() ? 1 : 0;
 
   this._centerSprite.position.x = panelSprite.getLeftMargin();
   this._centerSprite.position.y = panelSprite.getTopMargin();
+
+  //Right
   this._borderSprites[0].position.x =
-    this._width - panelSprite.getRightMargin() - extraPixels * 2;
+    this._width - panelSprite.getRightMargin();
   this._borderSprites[0].position.y = panelSprite.getTopMargin();
 
+  //Top-right
   this._borderSprites[1].position.x =
-    this._width - this._borderSprites[1].width - extraPixels * 2;
+    this._width - this._borderSprites[1].width;
   this._borderSprites[1].position.y = 0;
 
+  //Top
   this._borderSprites[2].position.x = panelSprite.getLeftMargin();
   this._borderSprites[2].position.y = 0;
 
+  //Top-Left
   this._borderSprites[3].position.x = 0;
   this._borderSprites[3].position.y = 0;
 
+  //Left
   this._borderSprites[4].position.x = 0;
   this._borderSprites[4].position.y = panelSprite.getTopMargin();
 
+  //Bottom-Left
   this._borderSprites[5].position.x = 0;
   this._borderSprites[5].position.y =
-    this._height - this._borderSprites[5].height - extraPixels * 2;
+    this._height - this._borderSprites[5].height;
 
+  //Bottom
   this._borderSprites[6].position.x = panelSprite.getLeftMargin();
   this._borderSprites[6].position.y =
-    this._height - panelSprite.getBottomMargin() - extraPixels * 3; //FIXME: 1 more extra pixel is somewhat needed for pixel perfect alignment
+    this._height - panelSprite.getBottomMargin();
 
+  //Bottom-Right
   this._borderSprites[7].position.x =
-    this._width - this._borderSprites[7].width - extraPixels * 2;
+    this._width - this._borderSprites[7].width;
   this._borderSprites[7].position.y =
-    this._height - this._borderSprites[7].height - extraPixels * 2;
+    this._height - this._borderSprites[7].height;
 };
 
 RenderedPanelSpriteInstance.prototype._updateSpritesAndTexturesSize = function() {
@@ -162,25 +170,28 @@ RenderedPanelSpriteInstance.prototype._updateSpritesAndTexturesSize = function()
     0
   );
 
-  //Top, Bottom, Right, Left borders:
+  //Right
   this._borderSprites[0].width = panelSprite.getRightMargin();
   this._borderSprites[0].height = Math.max(
     this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
     0
   );
 
+  //Top
   this._borderSprites[2].height = panelSprite.getTopMargin();
   this._borderSprites[2].width = Math.max(
     this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
     0
   );
 
+  //Left
   this._borderSprites[4].width = panelSprite.getLeftMargin();
   this._borderSprites[4].height = Math.max(
     this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
     0
   );
 
+  //Bottom
   this._borderSprites[6].height = panelSprite.getBottomMargin();
   this._borderSprites[6].width = Math.max(
     this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
@@ -242,60 +253,22 @@ RenderedPanelSpriteInstance.prototype.updateTexture = function() {
     )
   );
 
-  //Top, Bottom, Right, Left borders:
+  //Right
   this._borderSprites[0].texture = new PIXI.Texture(
     texture,
     makeInsideTexture(
       new PIXI.Rectangle(
-        texture.width - panelSprite.getRightMargin() - 1,
+        texture.width - panelSprite.getRightMargin(),
         panelSprite.getTopMargin(),
-        panelSprite.getRightMargin() + 1,
+        panelSprite.getRightMargin(),
         texture.height -
           panelSprite.getTopMargin() -
           panelSprite.getBottomMargin()
-      )
-    )
-  );
-  this._borderSprites[2].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        panelSprite.getLeftMargin(),
-        0,
-        texture.width -
-          panelSprite.getLeftMargin() -
-          panelSprite.getRightMargin(),
-        panelSprite.getTopMargin() + 1
-      )
-    )
-  );
-  this._borderSprites[4].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        0,
-        panelSprite.getTopMargin(),
-        panelSprite.getLeftMargin() + 1,
-        texture.height -
-          panelSprite.getTopMargin() -
-          panelSprite.getBottomMargin()
-      )
-    )
-  );
-  this._borderSprites[6].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        panelSprite.getLeftMargin(),
-        texture.height - panelSprite.getBottomMargin() - 1,
-        texture.width -
-          panelSprite.getLeftMargin() -
-          panelSprite.getRightMargin(),
-        panelSprite.getBottomMargin() + 1
       )
     )
   );
 
+  //Top-right
   this._borderSprites[1].texture = new PIXI.Texture(
     texture,
     makeInsideTexture(
@@ -307,6 +280,23 @@ RenderedPanelSpriteInstance.prototype.updateTexture = function() {
       )
     )
   );
+
+  //Top
+  this._borderSprites[2].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        panelSprite.getLeftMargin(),
+        0,
+        texture.width -
+          panelSprite.getLeftMargin() -
+          panelSprite.getRightMargin(),
+        panelSprite.getTopMargin()
+      )
+    )
+  );
+
+  //Top-Left
   this._borderSprites[3].texture = new PIXI.Texture(
     texture,
     makeInsideTexture(
@@ -318,6 +308,23 @@ RenderedPanelSpriteInstance.prototype.updateTexture = function() {
       )
     )
   );
+
+  //Left
+  this._borderSprites[4].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        0,
+        panelSprite.getTopMargin(),
+        panelSprite.getLeftMargin(),
+        texture.height -
+          panelSprite.getTopMargin() -
+          panelSprite.getBottomMargin()
+      )
+    )
+  );
+
+  //Bottom-Left
   this._borderSprites[5].texture = new PIXI.Texture(
     texture,
     makeInsideTexture(
@@ -329,6 +336,23 @@ RenderedPanelSpriteInstance.prototype.updateTexture = function() {
       )
     )
   );
+
+  //Bottom
+  this._borderSprites[6].texture = new PIXI.Texture(
+    texture,
+    makeInsideTexture(
+      new PIXI.Rectangle(
+        panelSprite.getLeftMargin(),
+        texture.height - panelSprite.getBottomMargin(),
+        texture.width -
+          panelSprite.getLeftMargin() -
+          panelSprite.getRightMargin(),
+        panelSprite.getBottomMargin()
+      )
+    )
+  );
+
+  //Bottom-Right
   this._borderSprites[7].texture = new PIXI.Texture(
     texture,
     makeInsideTexture(


### PR DESCRIPTION
This is for fix the renderer of Panel Sprite ("9-patch").

Lot of weird code have been added over time.
And lot of weird little patch with 1px here or 2px somewhere else for obscure reasons.

I've read the code and rework and verify twice on my PC, and a other user have check too.

[For see the problem check this topic on forum.](https://forum.gdevelop-app.com/t/les-9-panels-sprites-ne-saffichent-pas-correctement/21867/3)

This need to be verify with a retina screen from Apple.
I hope in future we will be able to have same quality of preview in scene editor. 