### PR TITLE
Rename objects to instances

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -920,7 +920,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   extension
       .AddAction("AjoutObjConcern",
                  _("Pick all instances"),
-                 _("Pick all instances of specified object(s) . When you pick all instances, "
+                 _("Pick all instances of the specified object(s). When you pick all instances, "
                    "the next conditions and actions of this event work on all "
                    "of them."),
                  _("Pick all instances of _PARAM1_"),

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -919,11 +919,11 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   extension
       .AddAction("AjoutObjConcern",
-                 _("Pick all objects"),
-                 _("Pick all the specified objects. When you pick all objects, "
+                 _("Pick all instances"),
+                 _("Pick all instances of specified object(s) . When you pick all instances, "
                    "the next conditions and actions of this event work on all "
                    "of them."),
-                 _("Pick all _PARAM1_ objects"),
+                 _("Pick all instances of _PARAM1_"),
                  _("Objects"),
                  "res/actions/add24.png",
                  "res/actions/add.png")

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
@@ -81,7 +81,7 @@ export default class ForEachEvent extends React.Component<
             onClick={this.edit}
           >
             {objectName ? (
-              `Repeat for each instances of ${objectName}:`
+              `Repeat for each instance of ${objectName}:`
             ) : (
               <i>
                 Click to choose for which objects this event will be repeated

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
@@ -81,7 +81,7 @@ export default class ForEachEvent extends React.Component<
             onClick={this.edit}
           >
             {objectName ? (
-              `Repeat for each ${objectName} object:`
+              `Repeat for each instances of ${objectName}:`
             ) : (
               <i>
                 Click to choose for which objects this event will be repeated


### PR DESCRIPTION
Maybe this is just a first step.

Lot of instructions use the term "object", but this is not an "object" this is an "instance".

"Add an object" should also change to "Add an instance of object XXX" 
There are multiples sentences to change.

https://forum.gdevelop-app.com/t/solved-invert-condition-isnt-work-properly-how-work-instances-and-multiple-objects/21954/14
