### PR TITLE
Make object creating and adding to a scene through JS less riskfull

### DIFF
--- a/GDJS/Runtime/runtimebehavior.js
+++ b/GDJS/Runtime/runtimebehavior.js
@@ -15,12 +15,22 @@
  */
 gdjs.RuntimeBehavior = function(runtimeScene, behaviorData, owner)
 {
-    this.name = behaviorData.name || "";
+	this._behaviorData = behaviorData; // To be able to access it later
+	this.name = behaviorData.name || "";
     this.type = behaviorData.type || "";
     this._nameId = gdjs.RuntimeObject.getNameIdentifier(this.name);
     this._activated = true;
     this.owner = owner;
 };
+
+/**
+ * Get the behaviorData of the behavior.
+ * @return {string} The behavior Data.
+ */
+gdjs.RuntimeBehavior.prototype.getOriginalData = function() {
+	return this._behaviorData;
+};
+
 /**
  * Get the name of the behavior.
  * @return {string} The behavior's name.

--- a/GDJS/Runtime/runtimeobject.js
+++ b/GDJS/Runtime/runtimeobject.js
@@ -24,6 +24,7 @@
  */
 gdjs.RuntimeObject = function(runtimeScene, objectData)
 {
+    this._objectData = objectData;
     this.name = objectData.name || "";
     this._nameId = gdjs.RuntimeObject.getNameIdentifier(this.name);
     this.type = objectData.type || "";
@@ -1454,6 +1455,14 @@ gdjs.RuntimeObject.getNameIdentifier = function(name) {
 
     gdjs.RuntimeObject.getNameIdentifier.identifiers.put(name, newIdentifier);
     return newIdentifier;
+};
+
+/**
+ * Get the objectData passed to the constructor
+ * @return {string} The object Data.
+ */
+gdjs.RuntimeObject.getOriginalData = function() {
+    return this._objectData;
 };
 
 //Notify gdjs the RuntimeObject exists.

--- a/GDJS/Runtime/runtimeobject.js
+++ b/GDJS/Runtime/runtimeobject.js
@@ -1434,6 +1434,14 @@ gdjs.RuntimeObject.prototype.isCollidingWithPoint = function(pointX, pointY) {
     return false;
 }
 
+/**
+ * Get the objectData passed to the constructor
+ * @return {string} The object Data.
+ */
+gdjs.RuntimeObject.prototype.getOriginalData = function() {
+    return this._objectData;
+};
+
 
 /**
  * Get the identifier associated to an object name :<br>
@@ -1455,14 +1463,6 @@ gdjs.RuntimeObject.getNameIdentifier = function(name) {
 
     gdjs.RuntimeObject.getNameIdentifier.identifiers.put(name, newIdentifier);
     return newIdentifier;
-};
-
-/**
- * Get the objectData passed to the constructor
- * @return {string} The object Data.
- */
-gdjs.RuntimeObject.getOriginalData = function() {
-    return this._objectData;
 };
 
 //Notify gdjs the RuntimeObject exists.

--- a/GDJS/Runtime/runtimescene.js
+++ b/GDJS/Runtime/runtimescene.js
@@ -522,11 +522,11 @@ gdjs.RuntimeScene.prototype.updateObjectsForces = function() {
  */
 gdjs.RuntimeScene.prototype.addObject = function(obj) {
     if ( !this._objects.containsKey(obj.name) ) {
-        that._objects.put(obj.name, obj.getOriginalData());
-        that._instances.put(obj.name, []); //Also reserve an array for the instances
-        that._instancesCache.put(obj.name, []); //and for cached instances
+        this._objects.put(obj.name, obj.getOriginalData());
+        this._instances.put(obj.name, []); //Also reserve an array for the instances
+        this._instancesCache.put(obj.name, []); //and for cached instances
         //And cache the constructor for the performance sake:
-        that._objectsCtor.put(obj.name, obj);
+        this._objectsCtor.put(obj.name, obj);
     }
 
     if ( !this._instances.containsKey(obj.name) ) {

--- a/GDJS/Runtime/runtimescene.js
+++ b/GDJS/Runtime/runtimescene.js
@@ -521,6 +521,14 @@ gdjs.RuntimeScene.prototype.updateObjectsForces = function() {
  * @param obj The object to be added.
  */
 gdjs.RuntimeScene.prototype.addObject = function(obj) {
+    if ( !this._objects.containsKey(obj.name) ) {
+        that._objects.put(obj.name, obj.getOriginalData());
+        that._instances.put(obj.name, []); //Also reserve an array for the instances
+        that._instancesCache.put(obj.name, []); //and for cached instances
+        //And cache the constructor for the performance sake:
+        that._objectsCtor.put(obj.name, obj);
+    }
+
     if ( !this._instances.containsKey(obj.name) ) {
         console.log("RuntimeScene.addObject: No objects called \""+obj.name+"\"! Adding it.");
         this._instances.put(obj.name, []);


### PR DESCRIPTION
Automatically add the needed references to this._objects of runtimeScene etc. Needed to add the original objectData as attribute to add the object data to this._objects.