### PR TITLE
Refactor/sentences

### DIFF
--- a/Core/GDCore/Extensions/Builtin/AudioExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AudioExtension.cpp
@@ -143,117 +143,97 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAudioExtension(
                  _("Volume of the sound on a channel"),
                  _("This action modifies the volume of the sound on the "
                    "specified channel. The volume is between 0 and 100."),
-                 _("Do _PARAM2__PARAM3_ to the volume of the sound on channel "
-                   "_PARAM1_"),
+                 _("the volume of the sound on channel _PARAM1_"),
                  _("Audio/Sounds on channels"),
                  "res/actions/sonVolume24.png",
                  "res/actions/sonVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction("ModVolumeMusicCanal",
                  _("Volume of the music on a channel"),
                  _("This action modifies the volume of the music on the "
                    "specified channel. The volume is between 0 and 100."),
-                 _("Do _PARAM2__PARAM3_ to the volume of the music on channel "
-                   "_PARAM1_"),
+                 _("the volume of the music on channel _PARAM1_"),
                  _("Audio/Music on channels"),
                  "res/actions/musicVolume24.png",
                  "res/actions/musicVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction("ModGlobalVolume",
                  _("Game global volume"),
                  _("This action modifies the global volume of the game. The "
                    "volume is between 0 and 100."),
-                 _("Do _PARAM1__PARAM2_ to global sound level"),
+                 _("the global sound level"),
                  _("Audio"),
                  "res/actions/volume24.png",
                  "res/actions/volume.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsSimple();
 
   extension
       .AddAction("ModPitchSoundChannel",
                  _("Pitch of the sound of a channel"),
                  _("This action modifies the pitch (speed) of the sound on a "
                    "channel.\n1 is the default pitch."),
-                 _("Do _PARAM2__PARAM3_ to the pitch of the sound on channel "
-                   "_PARAM1_"),
+                 _("the pitch of the sound on channel _PARAM1_"),
                  _("Audio/Sounds on channels"),
                  "res/actions/son24.png",
                  "res/actions/son.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction("ModPitchMusicChannel",
                  _("Pitch of the music on a channel"),
                  _("This action modifies the pitch of the music on the "
                    "specified channel. 1 is the default pitch"),
-                 _("Do _PARAM2__PARAM3_ to the pitch of the music on channel "
-                   "_PARAM1_"),
+                 _("the pitch of the music on channel _PARAM1_"),
                  _("Audio/Music on channels"),
                  "res/actions/music24.png",
                  "res/actions/music.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction("ModPlayingOffsetSoundChannel",
                  _("Playing offset of the sound on a channel"),
                  _("This action modifies the playing offset of the sound on a "
                    "channel"),
-                 _("Do _PARAM2__PARAM3_ to the playing offset of the sound on "
-                   "channel _PARAM1_"),
+                 _("the playing offset of the sound on channel _PARAM1_"),
                  _("Audio/Sounds on channels"),
                  "res/actions/son24.png",
                  "res/actions/son.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction("ModPlayingOffsetMusicChannel",
                  _("Playing offset of the music on a channel"),
                  _("This action modifies the playing offset of the music on "
                    "the specified channel"),
-                 _("Do _PARAM2__PARAM3_ to the playing offset of the music on "
-                   "channel _PARAM1_"),
+                 _("the playing offset of the music on channel _PARAM1_"),
                  _("Audio/Music on channels"),
                  "res/actions/music24.png",
                  "res/actions/music.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction("PlaySound",
@@ -373,16 +353,14 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAudioExtension(
           _("Volume of the sound on a channel"),
           _("Test the volume of the sound on the specified channel. The volume "
             "is between 0 and 100."),
-          _("The volume of the sound on channel _PARAM1_ is _PARAM2__PARAM3_"),
+          _("the volume of the sound on channel _PARAM1_"),
           _("Audio/Sounds on channels"),
           "res/conditions/sonVolume24.png",
           "res/conditions/sonVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Volume to test"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition(
@@ -390,30 +368,26 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAudioExtension(
           _("Volume of the music on a channel"),
           _("Test the volume of the music on a specified channel. The volume "
             "is between 0 and 100."),
-          _("The volume of the music on channel _PARAM1_ is _PARAM2__PARAM3_"),
+          _("the volume of the music on channel _PARAM1_"),
           _("Audio/Music on channels"),
           "res/conditions/musicVolume24.png",
           "res/conditions/musicVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Volume to test"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition(
           "GlobalVolume",
           _("Global volume"),
           _("Test the global sound level. The volume is between 0 and 100."),
-          _("The global game volume is _PARAM1__PARAM2_"),
+          _("the global game volume"),
           _("Audio"),
           "res/conditions/volume24.png",
           "res/conditions/volume.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Volume to test"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   extension
       .AddCondition(
@@ -421,16 +395,14 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAudioExtension(
           _("Pitch of the sound of a channel"),
           _("Test the pitch of the sound on the specified channel. 1 is the "
             "default pitch."),
-          _("The pitch of the sound on channel _PARAM1_ is _PARAM2__PARAM3_"),
+          _("the pitch of the sound on channel _PARAM1_"),
           _("Audio/Sounds on channels"),
           "res/conditions/sonVolume24.png",
           "res/conditions/sonVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Pitch to test"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition(
@@ -438,50 +410,42 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAudioExtension(
           _("Pitch of the music on a channel"),
           _("Test the pitch (speed) of the music on a specified channel. 1 is "
             "the default pitch."),
-          _("The pitch of the music on channel _PARAM1_ is _PARAM2__PARAM3_"),
+          _("the pitch of the music on channel _PARAM1_"),
           _("Audio/Music on channels"),
           "res/conditions/musicVolume24.png",
           "res/conditions/musicVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Pitch to test"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition(
           "SoundChannelPlayingOffset",
           _("Playing offset of the sound on a channel"),
           _("Test the playing offset of the sound on the specified channel."),
-          _("The playing offset of the sound on channel _PARAM1_ is "
-            "_PARAM2__PARAM3_"),
+          _("the playing offset of the sound on channel _PARAM1_"),
           _("Audio/Sounds on channels"),
           "res/conditions/sonVolume24.png",
           "res/conditions/sonVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Playing position (in seconds)"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition(
           "MusicChannelPlayingOffset",
           _("Playing offset of the music on a channel"),
           _("Test the playing offset of the music on the specified channel."),
-          _("The playing offset of the music on channel _PARAM1_ is "
-            "_PARAM2__PARAM3_"),
+          _("the playing offset of the music on channel _PARAM1_"),
           _("Audio/Music on channels"),
           "res/conditions/musicVolume24.png",
           "res/conditions/musicVolume.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Channel identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Playing position (in seconds)"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddExpression("SoundChannelPlayingOffset",

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -84,7 +84,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          "MettreXY",
          _("Position of an object"),
          _("Change the position of an object."),
-         _("Do _PARAM1__PARAM2_;_PARAM3__PARAM4_ to the position of _PARAM0_"),
+         _("Change the position of _PARAM0_: _PARAM1_ _PARAM2_ (x axis), _PARAM3_ _PARAM4_ (y axis)"),
          _("Position"),
          "res/actions/position24.png",
          "res/actions/position.png")

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -27,58 +27,50 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddCondition("PosX",
                    _("Compare X position of an object"),
                    _("Compare the X position of the object."),
-                   _("The X position of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the X position"),
                    _("Position"),
                    "res/conditions/position24.png",
                    "res/conditions/position.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("X position"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddAction("MettreX",
                 _("X position of an object"),
                 _("Change the X position of an object."),
-                _("Do _PARAM1__PARAM2_ to the X position of _PARAM0_"),
+                _("the X position"),
                 _("Position"),
                 "res/actions/position24.png",
                 "res/actions/position.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddCondition("PosY",
                    _("Compare Y position of an object"),
                    _("Compare the Y position of an object."),
-                   _("The Y position of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the Y position"),
                    _("Position"),
                    "res/conditions/position24.png",
                    "res/conditions/position.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Y position"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddAction("MettreY",
                 _("Y position of an object"),
                 _("Change the Y position of an object."),
-                _("Do _PARAM1__PARAM2_ to the Y position of _PARAM0_"),
+                _("the Y position"),
                 _("Position"),
                 "res/actions/position24.png",
                 "res/actions/position.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddAction(
          "MettreXY",
@@ -117,15 +109,13 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddAction("SetAngle",
                 _("Angle"),
                 _("Change the angle of rotation of an object."),
-                _("Do _PARAM1__PARAM2_ to angle of _PARAM0_"),
+                _("the angle"),
                 _("Angle"),
                 "res/actions/direction24.png",
                 "res/actions/direction.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddAction("Rotate",
                 _("Rotate"),
@@ -271,15 +261,13 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddAction("ChangePlan",
                 _("Z order"),
                 _("Modify the Z-order of an object"),
-                _("Do _PARAM1__PARAM2_ to Z-order of _PARAM0_"),
+                _("the z-order"),
                 _("Z order"),
                 "res/actions/planicon24.png",
                 "res/actions/planicon.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddAction("ChangeLayer",
                 _("Layer"),
@@ -297,31 +285,27 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddAction("ModVarObjet",
                 _("Modify a variable of an object"),
                 _("Modify the value of a variable of an object"),
-                _("Do _PARAM2__PARAM3_ to variable _PARAM1_ of _PARAM0_"),
+                _("the variable _PARAM1_"),
                 _("Variables"),
                 "res/actions/var24.png",
                 "res/actions/var.png")
 
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Variable"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddAction(
          "ModVarObjetTxt",
          _("Modify the text of a variable of an object"),
          _("Modify the text of a variable of an object"),
-         _("Do _PARAM2__PARAM3_ to the text of variable _PARAM1_ of _PARAM0_"),
+         _("the text of variable _PARAM1_"),
          _("Variables"),
          "res/actions/var24.png",
          "res/actions/var.png")
 
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Variable"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("string", _("Text"))
-      .SetManipulatedType("string");
+      .UseStandardOperatorParameters("string");
 
   obj.AddCondition(
          "ObjectVariableChildExists",
@@ -385,30 +369,26 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddCondition("Angle",
                    _("Angle"),
                    _("Compare the angle of the specified object."),
-                   _("Angle of _PARAM0_ is _PARAM1__PARAM2_ deg."),
+                   _("the angle (in degrees)"),
                    _("Angle"),
                    "res/conditions/direction24.png",
                    "res/conditions/direction.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare (in degrees)"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition("Plan",
                    _("Compare Z order"),
                    _("Compare the Z-order of the specified object."),
-                   _("Z Order of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the z Order"),
                    _("Z order"),
                    "res/conditions/planicon24.png",
                    "res/conditions/planicon.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Z order"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition("Layer",
                    _("Compare layer"),
@@ -458,16 +438,14 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddCondition("Vitesse",
                    _("Speed"),
                    _("Compare the overall speed of an object"),
-                   _("Overall speed of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the overall speed"),
                    _("Movement"),
                    "res/conditions/vitesse24.png",
                    "res/conditions/vitesse.png")
 
       .AddParameter("object", _("Object"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Speed"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition("AngleOfDisplacement",
                    _("Angle of movement"),
@@ -486,31 +464,27 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddCondition("VarObjet",
                    _("Value of an object's variable"),
                    _("Compare the value of a variable of an object."),
-                   _("Variable _PARAM1_ of _PARAM0_ is _PARAM2__PARAM3_"),
+                   _("the variable _PARAM1_"),
                    _("Variables"),
                    "res/conditions/var24.png",
                    "res/conditions/var.png")
 
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Variable"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddCondition(
          "VarObjetTxt",
          _("Text of an object's variable"),
          _("Compare the text of a variable of an object."),
-         _("The text of variable _PARAM1_ of _PARAM0_ is _PARAM2__PARAM3_"),
+         _("the text of variable _PARAM1_"),
          _("Variables"),
          "res/conditions/var24.png",
          "res/conditions/var.png")
 
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Variable"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text to test"))
-      .SetManipulatedType("string");
+      .UseStandardRelationalOperatorParameters("string");
 
   obj.AddCondition("VarObjetDef",
                    _("Variable defined"),
@@ -1046,15 +1020,13 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
             "compare that number to a value. If previous conditions on the "
             "objects have not been used, this condition counts how many of "
             "these objects exist in the current scene."),
-          _("The number of _PARAM0_ objects is _PARAM1__PARAM2_"),
+          _("the number objects"),
           _("Objects"),
           "res/conditions/nbObjet24.png",
           "res/conditions/nbObjet.png")
       .AddParameter("objectList", _("Object"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsSimple();
 
   extension
       .AddCondition(

--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -24,86 +24,73 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddCondition("CameraX",
                     _("Camera center X position"),
                     _("Compare the X position of the center of a camera."),
-                    _("X position of camera _PARAM4_ is _PARAM1__PARAM2_ "
-                      "(layer: _PARAM3_)"),
+                    _("the x position of camera _PARAM4_ (layer: _PARAM3_)"),
                     _("Layers and cameras"),
                     "res/conditions/camera24.png",
                     "res/conditions/camera.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0")
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .MarkAsAdvanced();
 
   extension
       .AddCondition("CameraY",
                     _("Camera center Y position"),
                     _("Compare the Y position of the center of a camera."),
-                    _("The Y position of camera _PARAM4_ is _PARAM1__PARAM2_ "
-                      "(layer: _PARAM3_)"),
+                    _("the Y position of camera _PARAM4_ (layer: _PARAM3_)"),
                     _("Layers and cameras"),
                     "res/conditions/camera24.png",
                     "res/conditions/camera.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"))
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"))
       .SetDefaultValue("0")
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .MarkAsAdvanced();
 
   extension
       .AddAction(
           "CameraX",
           _("Camera center X position"),
           _("Change the X position of the center of the specified camera."),
-          _("Do _PARAM1__PARAM2_ to X position of camera _PARAM4_ (layer: "
-            "_PARAM3_)"),
+          _("the x position of camera _PARAM4_ (layer: _PARAM3_)"),
           _("Layers and cameras"),
           "res/conditions/camera24.png",
           "res/conditions/camera.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0")
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .MarkAsAdvanced();
 
   extension
       .AddAction(
           "CameraY",
           _("Camera center Y position"),
           _("Change the Y position of the center of the specified camera."),
-          _("Do _PARAM1__PARAM2_ to Y position of camera _PARAM4_ (layer: "
-            "_PARAM3_)"),
+          _("the y position of camera _PARAM4_ (layer: _PARAM3_)"),
           _("Layers and cameras"),
           "res/conditions/camera24.png",
           "res/conditions/camera.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0")
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .MarkAsAdvanced();
 
   extension
       .AddCondition("CameraWidth",
                     _("Width of a camera"),
                     _("Test the width of a camera of a layer"),
-                    _("The width of camera _PARAM2_ of layer _PARAM1_ is "
-                      "_PARAM3__PARAM4_"),
+                    _("the width of camera _PARAM2_ of layer _PARAM1_"),
                     _("Layers and cameras"),
                     "res/conditions/camera24.png",
                     "res/conditions/camera.png")
@@ -111,17 +98,14 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("layer", _("Layer"))
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition("CameraHeight",
                     _("Height of a camera"),
                     _("Test the height of a camera of a layer"),
-                    _("The height of camera _PARAM2_ of layer _PARAM1_ is "
-                      "_PARAM3__PARAM4_"),
+                    _("the height of camera _PARAM2_ of layer _PARAM1_"),
                     _("Layers and cameras"),
                     "res/conditions/camera24.png",
                     "res/conditions/camera.png")
@@ -129,48 +113,40 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("layer", _("Layer (base layer if empty)"))
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition("CameraAngle",
                     _("Angle of a camera of a layer"),
                     _("Test a camera angle."),
-                    _("Angle of camera is _PARAM1__PARAM2_ (layer: _PARAM3_, "
-                      "camera: _PARAM4_)"),
+                    _("the angle of camera (layer: _PARAM3_, camera: _PARAM4_)"),
                     _("Layers and cameras"),
                     "res/conditions/camera24.png",
                     "res/conditions/camera.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0")
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .MarkAsAdvanced();
 
   extension
       .AddAction("RotateCamera",
                  _("Change camera angle"),
                  _("This action modifies the angle of a camera in the "
                    "specified layer."),
-                 _("Do _PARAM1__PARAM2_ to angle of camera (layer: _PARAM3_, "
-                   "camera: _PARAM4_)"),
+                 _("the angle of camera (layer: _PARAM3_, camera: _PARAM4_)"),
                  _("Layers and cameras"),
                  "res/actions/camera24.png",
                  "res/actions/camera.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
-      .SetDefaultValue("0")
-      .SetManipulatedType("number");
+      .SetDefaultValue("0");
 
   extension
       .AddAction("AddCamera",
@@ -468,17 +444,15 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
           "LayerTimeScale",
           _("Layer time scale"),
           _("Compare the time scale applied to the objects of the layer."),
-          _("The time scale of layer _PARAM1_ is _PARAM2__PARAM3_"),
+          _("the time scale of layer _PARAM1_"),
           _("Layers and cameras/Time"),
           "res/conditions/time24.png",
           "res/conditions/time.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction(

--- a/Core/GDCore/Extensions/Builtin/JoystickExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/JoystickExtension.cpp
@@ -37,17 +37,14 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsJoystickExtension(
       .AddCondition("JoystickAxis",
                     _("Value of an axis of a joystick"),
                     _("Test the value of an axis of a joystick."),
-                    _("The value of the axis _PARAM2_ of joystick _PARAM1_ is "
-                      "_PARAM3__PARAM4_"),
+                    _("the value of the axis _PARAM2_ of joystick _PARAM1_"),
                     _("Joystick"),
                     "res/conditions/joystick24.png",
                     "res/conditions/joystick.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Joystick number (first joystick: 0)"))
       .AddParameter("joyaxis", _("Axis"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   extension
       .AddAction(

--- a/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
@@ -164,35 +164,31 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsMouseExtension(
       .AddCondition("SourisX",
                     _("Cursor X position"),
                     _("Compare the X position of the cursor or of a touch."),
-                    _("Cursor X position is _PARAM1__PARAM2_"),
+                    _("the cursor X position"),
                     _("Mouse and touch"),
                     "res/conditions/mouse24.png",
                     "res/conditions/mouse.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("X position"))
+      .UseStandardRelationalOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
-      .SetDefaultValue("0")
-      .SetManipulatedType("number");
+      .SetDefaultValue("0");
 
   extension
       .AddCondition("SourisY",
                     _("Cursor Y position"),
                     _("Compare the Y position of the cursor or of a touch."),
-                    _("Cursor Y position is _PARAM1__PARAM2_"),
+                    _("the cursor Y position"),
                     _("Mouse and touch"),
                     "res/conditions/mouse24.png",
                     "res/conditions/mouse.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Y position"))
+      .UseStandardRelationalOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
-      .SetDefaultValue("0")
-      .SetManipulatedType("number");
+      .SetDefaultValue("0");
 
   extension
       .AddCondition("SourisBouton",
@@ -224,37 +220,33 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsMouseExtension(
       .AddCondition("TouchX",
                     _("Touch X position"),
                     _("Compare the X position of a specific touch."),
-                    _("Touch #_PARAM1_ X position is _PARAM2__PARAM3_"),
+                    _("the touch #_PARAM1_ X position"),
                     _("Mouse and touch/Multitouch"),
                     "res/conditions/touch24.png",
                     "res/conditions/touch.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Touch identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("X position"))
+      .UseStandardRelationalOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
-      .SetDefaultValue("0")
-      .SetManipulatedType("number");
+      .SetDefaultValue("0");
 
   extension
       .AddCondition("TouchY",
                     _("Touch Y position"),
                     _("Compare the Y position of a specific touch."),
-                    _("Touch #_PARAM1_ Y position is _PARAM2__PARAM3_"),
+                    _("the touch #_PARAM1_ Y position"),
                     _("Mouse and touch/Multitouch"),
                     "res/conditions/touch24.png",
                     "res/conditions/touch.png")
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("expression", _("Touch identifier"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Y position"))
+      .UseStandardRelationalOperatorParameters("number")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
-      .SetDefaultValue("0")
-      .SetManipulatedType("number");
+      .SetDefaultValue("0");
 
   extension
       .AddCondition(

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -34,32 +34,27 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                 _("Change sprite opacity"),
                 _("Change the opacity of a Sprite. 0 is fully transparent, 255 "
                   "is opaque (default)."),
-                _("Do _PARAM1__PARAM2_ to the opacity of _PARAM0_"),
+                _("the opacity"),
                 _("Visibility"),
                 "res/actions/opacity24.png",
                 "res/actions/opacity.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value (between 0 and 255)"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddAction("ChangeAnimation",
                 _("Change the animation"),
                 _("Change the animation of the object, using the animation "
                   "number in the animations list."),
-                _("Do _PARAM1__PARAM2_ to the number of current animation of "
-                  "_PARAM0_"),
+                _("the number of current animation"),
                 _("Animations and images"),
                 "res/actions/animation24.png",
                 "res/actions/animation.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddAction("SetAnimationName",
                 _("Change the animation (by name)"),
@@ -80,30 +75,26 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
          _("Change the direction of the object.\nIf the object is set to "
            "automatically rotate, the direction is its angle.\nIf the object "
            "is in 8 directions mode, the valid directions are 0..7"),
-         _("Do _PARAM1__PARAM2_ to the direction of _PARAM0_"),
+         _("the direction"),
          _("Direction"),
          "res/actions/direction24.png",
          "res/actions/direction.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddAction("ChangeSprite",
                 _("Current frame"),
                 _("Modify the current frame of the object"),
-                _("Do _PARAM1__PARAM2_ to animation frame of _PARAM0_"),
+                _("the animation frame"),
                 _("Animations and images"),
                 "res/actions/sprite24.png",
                 "res/actions/sprite.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddAction("PauseAnimation",
                 _("Pause the animation"),
@@ -132,16 +123,14 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
          _("Animation speed scale"),
          _("Modify the animation speed scale (1 = the default speed, >1 = "
            "faster and <1 = slower)."),
-         _("Do _PARAM1__PARAM2_ to the animation speed scale of _PARAM0_"),
+         _("the animation speed scale"),
          _("Animations and images"),
          "res/actions/animation24.png",
          "res/actions/animation.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddAction("TourneVersPos",
                 _("Rotate an object toward a position"),
@@ -162,88 +151,75 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
   obj.AddAction("ChangeScale",
                 _("Scale"),
                 _("Modify the scale of the specified object."),
-                _("Do _PARAM1__PARAM2_ to the scale of _PARAM0_"),
+                _("the scale"),
                 _("Size"),
                 "res/actions/scale24.png",
                 "res/actions/scale.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddAction("ChangeScaleWidth",
                 _("Scale on X axis"),
                 _("Modify the scale of the width of an object."),
-                _("Do _PARAM1__PARAM2_ to the width's scale of _PARAM0_"),
+                _("the width's scale"),
                 _("Size"),
                 "res/actions/scale24.png",
                 "res/actions/scale.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddAction("ChangeScaleHeight",
                 _("Scale on Y axis"),
                 _("Modify the scale of the height of an object."),
-                _("Do _PARAM1__PARAM2_ to the height's scale of _PARAM0_"),
+                _("the height's scale"),
                 _("Size"),
                 "res/actions/scale24.png",
                 "res/actions/scale.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddAction("ChangeWidth",
                 _("Width"),
                 _("Change the width of a Sprite object."),
-                _("Do _PARAM1__PARAM2_ to the width of _PARAM0_"),
+                _("the width"),
                 _("Size"),
                 "res/actions/scale24.png",
                 "res/actions/scale.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddAction("ChangeHeight",
                 _("Height"),
                 _("Change the height of a Sprite object."),
-                _("Do _PARAM1__PARAM2_ to the height of _PARAM0_"),
+                _("the height"),
                 _("Size"),
                 "res/actions/scale24.png",
                 "res/actions/scale.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition(
          "Animation",
          _("Current animation"),
          _("Compare the number of the current animation of the object."),
-         _("The number of the current animation of _PARAM0_ is "
-           "_PARAM1__PARAM2_"),
+         _("the number of the current animation"),
          _("Animations and images"),
          "res/conditions/animation24.png",
          "res/conditions/animation.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Number to test"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition("AnimationName",
                    _("Current animation name"),
@@ -263,29 +239,25 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
          _("Compare the direction of the object. If 8 direction mode is "
            "activated for the sprite, the value taken for direction will be "
            "from 0 to 7. Otherwise, the direction is in degrees."),
-         _("Direction of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the direction"),
          _("Direction"),
          "res/conditions/direction24.png",
          "res/conditions/direction.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Direction to test"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddCondition("Sprite",
                    _("Current frame"),
                    _("Test the number of the current animation frame."),
-                   _("The animation frame of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the animation frame"),
                    _("Animations and images"),
                    "res/conditions/sprite24.png",
                    "res/conditions/sprite.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Animation frame to test"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition("AnimStopped",
                    _("Animation paused"),
@@ -313,62 +285,52 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
   obj.AddCondition("ScaleWidth",
                    _("Scale on X axis"),
                    _("Compare the scale of the width of an object."),
-                   _("The width's scale of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the width's scale"),
                    _("Size"),
                    "res/conditions/scaleWidth24.png",
                    "res/conditions/scaleWidth.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition("ScaleHeight",
                    _("Scale on Y axis"),
                    _("Compare the scale of the height of an object."),
-                   _("The height's scale of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the height's scale"),
                    _("Size"),
                    "res/conditions/scaleHeight24.png",
                    "res/conditions/scaleHeight.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddCondition("Opacity",
                    _("Opacity"),
                    _("Compare the opacity of a Sprite, between 0 (fully "
                      "transparent) to 255 (opaque)."),
-                   _("The opacity of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the opacity"),
                    _("Visibility"),
                    "res/conditions/opacity24.png",
                    "res/conditions/opacity.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsSimple()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsSimple();
 
   obj.AddCondition(
          "BlendMode",
          _("Blend mode"),
          _("Compare the number of the blend mode currently used by an object"),
-         _("The number of the current blend mode of _PARAM0_ is "
-           "_PARAM1__PARAM2_"),
+         _("the number of the current blend mode"),
          _("Effects"),
          "res/conditions/opacity24.png",
          "res/conditions/opacity.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression",
-                    _("Value to compare (0: Alpha, 1: Add, 2: Multiply, 3: None)"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   obj.AddAction("CopyImageOnImageOfSprite",
                 _("Copy an image on the current one of an object"),

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -47,7 +47,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                 _("Change the animation"),
                 _("Change the animation of the object, using the animation "
                   "number in the animations list."),
-                _("the number of current animation"),
+                _("the number of the animation"),
                 _("Animations and images"),
                 "res/actions/animation24.png",
                 "res/actions/animation.png")
@@ -98,8 +98,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
 
   obj.AddAction("PauseAnimation",
                 _("Pause the animation"),
-                _("Pause the current animation of the object"),
-                _("Pause the current animation of _PARAM0_"),
+                _("Pause the animation of the object"),
+                _("Pause the animation of _PARAM0_"),
                 _("Animations and images"),
                 "res/actions/animation24.png",
                 "res/actions/animation.png")
@@ -109,8 +109,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
 
   obj.AddAction("PlayAnimation",
                 _("Play the animation"),
-                _("Play the current animation of the object"),
-                _("Play the current animation of _PARAM0_"),
+                _("Play the animation of the object"),
+                _("Play the animation of _PARAM0_"),
                 _("Animations and images"),
                 "res/actions/animation24.png",
                 "res/actions/animation.png")
@@ -211,8 +211,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
   obj.AddCondition(
          "Animation",
          _("Current animation"),
-         _("Compare the number of the current animation of the object."),
-         _("the number of the current animation"),
+         _("Compare the number of the animation played by the object."),
+         _("the number of the animation"),
          _("Animations and images"),
          "res/conditions/animation24.png",
          "res/conditions/animation.png")
@@ -223,7 +223,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
 
   obj.AddCondition("AnimationName",
                    _("Current animation name"),
-                   _("Check the current animation of the object."),
+                   _("Check the animation by played by the object."),
                    _("The animation of _PARAM0_ is _PARAM1_"),
                    _("Animations and images"),
                    "res/conditions/animation24.png",
@@ -249,7 +249,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
 
   obj.AddCondition("Sprite",
                    _("Current frame"),
-                   _("Test the number of the current animation frame."),
+                   _("Compare the index of the current frame in the animation displayed by the specified object. The first frame in an animation starts at index 0."),
                    _("the animation frame"),
                    _("Animations and images"),
                    "res/conditions/sprite24.png",
@@ -261,7 +261,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
 
   obj.AddCondition("AnimStopped",
                    _("Animation paused"),
-                   _("Test if the animation of an object is paused"),
+                   _("Check if the animation of an object is paused."),
                    _("The animation of _PARAM0_ is paused"),
                    _("Animations and images"),
                    "res/conditions/animation24.png",

--- a/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
@@ -38,15 +38,13 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsTimeExtension(
       .AddCondition("TimeScale",
                     _("Time scale"),
                     _("Test the time scale."),
-                    _("The time scale is _PARAM1__PARAM2_"),
+                    _("the time scale"),
                     _("Timers and time"),
                     "res/conditions/time24.png",
                     "res/conditions/time.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition("TimerPaused",

--- a/Core/GDCore/Extensions/Builtin/VariablesExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/VariablesExtension.cpp
@@ -25,27 +25,23 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
       .AddCondition("VarScene",
                     _("Value of a scene variable"),
                     _("Compare the value of a scene variable."),
-                    _("Scene variable _PARAM0_ is _PARAM1__PARAM2_"),
+                    _("the scene variable _PARAM0_"),
                     _("Variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   extension
       .AddCondition("VarSceneTxt",
                     _("Text of a scene variable"),
                     _("Compare the text of a scene variable."),
-                    _("The text of scene variable _PARAM0_ is _PARAM1__PARAM2_"),
+                    _("the text of scene variable _PARAM0_"),
                     _("Variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text to compare"))
-      .SetManipulatedType("string");
+      .UseStandardRelationalOperatorParameters("string");
 
   extension
       .AddCondition(
@@ -89,30 +85,26 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
       .AddCondition("VarGlobal",
                     _("Value of a global variable"),
                     _("Compare the value of a global variable."),
-                    _("Global variable _PARAM0_ is _PARAM1__PARAM2_"),
+                    _("the global variable _PARAM0_"),
                     _("Variables/Global variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition(
           "VarGlobalTxt",
           _("Text of a global variable"),
           _("Compare the text of a global variable."),
-          _("The text of the global variable _PARAM0_ is _PARAM1__PARAM2_"),
+          _("the text of the global variable _PARAM0_"),
           _("Variables/Global variables"),
           "res/conditions/var24.png",
           "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text to compare"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("string");
+      .UseStandardRelationalOperatorParameters("string")
+      .MarkAsAdvanced();
 
   extension
       .AddCondition("VarGlobalDef",
@@ -131,56 +123,48 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
       .AddAction("ModVarScene",
                  _("Value of a scene variable"),
                  _("Modify the value of a scene variable."),
-                 _("Do _PARAM1__PARAM2_ to scene variable _PARAM0_"),
+                 _("the scene variable _PARAM0_"),
                  _("Variables"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Variable"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   extension
       .AddAction("ModVarSceneTxt",
                  _("String of a scene variable"),
                  _("Modify the text of a scene variable."),
-                 _("Do _PARAM1__PARAM2_ to the text of scene variable _PARAM0_"),
+                 _("the text of scene variable _PARAM0_"),
                  _("Variables"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Variable"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("string", _("Text"))
-      .SetManipulatedType("string");
+      .UseStandardOperatorParameters("string");
 
   extension
       .AddAction("ModVarGlobal",
                  _("Value of a global variable"),
                  _("Modify the value of a global variable"),
-                 _("Do _PARAM1__PARAM2_ to global variable _PARAM0_"),
+                 _("the global variable _PARAM0_"),
                  _("Variables/Global variables"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("globalvar", _("Variable"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
 
   extension
       .AddAction(
           "ModVarGlobalTxt",
           _("String of a global variable"),
           _("Modify the text of a global variable."),
-          _("Do _PARAM1__PARAM2_ to the text of global variable _PARAM0_"),
+          _("the text of global variable _PARAM0_"),
           _("Variables/Global variables"),
           "res/actions/var24.png",
           "res/actions/var.png")
       .AddParameter("globalvar", _("Variable"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("string", _("Text"))
-      .MarkAsAdvanced()
-      .SetManipulatedType("string");
+      .UseStandardOperatorParameters("string")
+      .MarkAsAdvanced();
 
   extension
       .AddAction("VariableRemoveChild",

--- a/Core/GDCore/Extensions/Metadata/BehaviorMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/BehaviorMetadata.cpp
@@ -59,7 +59,8 @@ gd::InstructionMetadata& BehaviorMetadata::AddCondition(
                                                            group,
                                                            icon,
                                                            smallicon)
-                                           .SetHelpPath(GetHelpPath());
+                                           .SetHelpPath(GetHelpPath())
+                                           .SetIsBehaviorInstruction();
   return conditionsInfos[nameWithNamespace];
 #endif
 }
@@ -83,7 +84,8 @@ gd::InstructionMetadata& BehaviorMetadata::AddAction(
                                                         group,
                                                         icon,
                                                         smallicon)
-                                        .SetHelpPath(GetHelpPath());
+                                        .SetHelpPath(GetHelpPath())
+                                        .SetIsBehaviorInstruction();
   return actionsInfos[nameWithNamespace];
 #endif
 }
@@ -107,7 +109,8 @@ gd::InstructionMetadata& BehaviorMetadata::AddScopedCondition(
                                                            group,
                                                            icon,
                                                            smallicon)
-                                           .SetHelpPath(GetHelpPath());
+                                           .SetHelpPath(GetHelpPath())
+                                           .SetIsBehaviorInstruction();
   return conditionsInfos[nameWithNamespace];
 #endif
 }
@@ -131,7 +134,8 @@ gd::InstructionMetadata& BehaviorMetadata::AddScopedAction(
                                                         group,
                                                         icon,
                                                         smallicon)
-                                        .SetHelpPath(GetHelpPath());
+                                        .SetHelpPath(GetHelpPath())
+                                        .SetIsBehaviorInstruction();
   return actionsInfos[nameWithNamespace];
 #endif
 }

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
@@ -3,23 +3,24 @@
  * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights
  * reserved. This project is released under the MIT License.
  */
+#include "InstructionMetadata.h"
 #include <algorithm>
 #include "GDCore/CommonTools.h"
 #include "GDCore/Serialization/SerializerElement.h"
 #include "GDCore/Tools/Localization.h"
-#include "InstructionMetadata.h"
 
 namespace gd {
 InstructionMetadata::InstructionMetadata()
-    : sentence(
-          "Unknown or unsupported instruction"),  // Avoid translating this
-                                                  // string, so that it's safe
-                                                  // and *fast* to use a
-                                                  // InstructionMetadata.
+    : sentence("Unknown or unsupported instruction"),  // Avoid translating this
+                                                       // string, so that it's
+                                                       // safe and *fast* to use
+                                                       // a InstructionMetadata.
       canHaveSubInstructions(false),
       hidden(true),
       usageComplexity(5),
-      isPrivate(false) {}
+      isPrivate(false),
+      isObjectInstruction(false),
+      isBehaviorInstruction(false) {}
 
 InstructionMetadata::InstructionMetadata(const gd::String& extensionNamespace_,
                                          const gd::String& name_,
@@ -40,8 +41,9 @@ InstructionMetadata::InstructionMetadata(const gd::String& extensionNamespace_,
       extensionNamespace(extensionNamespace_),
       hidden(false),
       usageComplexity(5),
-      isPrivate(false) {
-}
+      isPrivate(false),
+      isObjectInstruction(false),
+      isBehaviorInstruction(false) {}
 
 ParameterMetadata::ParameterMetadata() : optional(false), codeOnly(false) {}
 
@@ -83,6 +85,51 @@ InstructionMetadata& InstructionMetadata::AddCodeOnlyParameter(
   info.supplementaryInformation = supplementaryInformation;
 
   parameters.push_back(info);
+  return *this;
+}
+
+InstructionMetadata& InstructionMetadata::UseStandardOperatorParameters(
+    const gd::String& type) {
+  SetManipulatedType(type);
+
+  AddParameter("operator", _("Modification's sign"));
+  AddParameter(type == "number" ? "expression" : type, _("TODO"));
+  size_t operatorParamIndex = parameters.size() - 2;
+  size_t valueParamIndex = parameters.size() - 1;
+
+  if (isObjectInstruction || isBehaviorInstruction) {
+    sentence = "Change " + sentence + " of _PARAM0_: _PARAM" +
+               gd::String::From(operatorParamIndex) + "_ _PARAM" +
+               gd::String::From(valueParamIndex) + "_";  // TODO: translation
+  } else {
+    sentence = "Change " + sentence + ": _PARAM" +
+               gd::String::From(operatorParamIndex) + "_ _PARAM" +
+               gd::String::From(valueParamIndex) + "_";  // TODO: translation
+  }
+
+  return *this;
+}
+
+InstructionMetadata&
+InstructionMetadata::UseStandardRelationalOperatorParameters(
+    const gd::String& type) {
+  SetManipulatedType(type);
+
+  AddParameter("relationalOperator", _("Sign of the test"));
+  AddParameter("expression", _("TODO"));
+  size_t operatorParamIndex = parameters.size() - 2;
+  size_t valueParamIndex = parameters.size() - 1;
+
+  if (isObjectInstruction || isBehaviorInstruction) {
+    sentence = sentence + " of _PARAM0_ _PARAM" +
+               gd::String::From(operatorParamIndex) + "_ _PARAM" +
+               gd::String::From(valueParamIndex) + "_";  // TODO: translation
+  } else {
+    sentence = sentence + " _PARAM" + gd::String::From(operatorParamIndex) +
+               "_ _PARAM" + gd::String::From(valueParamIndex) +
+               "_";  // TODO: translation
+  }
+
   return *this;
 }
 

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
@@ -93,18 +93,31 @@ InstructionMetadata& InstructionMetadata::UseStandardOperatorParameters(
   SetManipulatedType(type);
 
   AddParameter("operator", _("Modification's sign"));
-  AddParameter(type == "number" ? "expression" : type, _("TODO"));
+  AddParameter(type == "number" ? "expression" : type, _("Value"));
   size_t operatorParamIndex = parameters.size() - 2;
   size_t valueParamIndex = parameters.size() - 1;
 
   if (isObjectInstruction || isBehaviorInstruction) {
-    sentence = "Change " + sentence + " of _PARAM0_: _PARAM" +
-               gd::String::From(operatorParamIndex) + "_ _PARAM" +
-               gd::String::From(valueParamIndex) + "_";  // TODO: translation
+    gd::String templateSentence =
+        _("Change <subject> of _PARAM0_: <operator> <value>");
+
+    sentence =
+        templateSentence.FindAndReplace("<subject>", sentence)
+            .FindAndReplace(
+                "<operator>",
+                "_PARAM" + gd::String::From(operatorParamIndex) + "_")
+            .FindAndReplace("<value>",
+                            "_PARAM" + gd::String::From(valueParamIndex) + "_");
   } else {
-    sentence = "Change " + sentence + ": _PARAM" +
-               gd::String::From(operatorParamIndex) + "_ _PARAM" +
-               gd::String::From(valueParamIndex) + "_";  // TODO: translation
+    gd::String templateSentence = _("Change <subject>: <operator> <value>");
+
+    sentence =
+        templateSentence.FindAndReplace("<subject>", sentence)
+            .FindAndReplace(
+                "<operator>",
+                "_PARAM" + gd::String::From(operatorParamIndex) + "_")
+            .FindAndReplace("<value>",
+                            "_PARAM" + gd::String::From(valueParamIndex) + "_");
   }
 
   return *this;
@@ -116,18 +129,30 @@ InstructionMetadata::UseStandardRelationalOperatorParameters(
   SetManipulatedType(type);
 
   AddParameter("relationalOperator", _("Sign of the test"));
-  AddParameter("expression", _("TODO"));
+  AddParameter(type == "number" ? "expression" : type, _("Value to compare"));
   size_t operatorParamIndex = parameters.size() - 2;
   size_t valueParamIndex = parameters.size() - 1;
 
   if (isObjectInstruction || isBehaviorInstruction) {
-    sentence = sentence + " of _PARAM0_ _PARAM" +
-               gd::String::From(operatorParamIndex) + "_ _PARAM" +
-               gd::String::From(valueParamIndex) + "_";  // TODO: translation
+    gd::String templateSentence = _("<subject> of _PARAM0_ <operator> <value>");
+
+    sentence =
+        templateSentence.FindAndReplace("<subject>", sentence)
+            .FindAndReplace(
+                "<operator>",
+                "_PARAM" + gd::String::From(operatorParamIndex) + "_")
+            .FindAndReplace("<value>",
+                            "_PARAM" + gd::String::From(valueParamIndex) + "_");
   } else {
-    sentence = sentence + " _PARAM" + gd::String::From(operatorParamIndex) +
-               "_ _PARAM" + gd::String::From(valueParamIndex) +
-               "_";  // TODO: translation
+    gd::String templateSentence = _("<subject> <operator> <value>");
+
+    sentence =
+        templateSentence.FindAndReplace("<subject>", sentence)
+            .FindAndReplace(
+                "<operator>",
+                "_PARAM" + gd::String::From(operatorParamIndex) + "_")
+            .FindAndReplace("<value>",
+                            "_PARAM" + gd::String::From(valueParamIndex) + "_");
   }
 
   return *this;

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
@@ -222,10 +222,10 @@ class GD_CORE_API ParameterMetadata {
                   ///< i.e. must not be shown in editor
  private:
   gd::String longDescription;  ///< Long description shown in the editor.
-  gd::String defaultValue;  ///< Used as a default value in editor or if an
-                            ///< optional parameter is empty.
-  gd::String name;  ///< The name of the parameter to be used in code
-                    ///< generation. Optional.
+  gd::String defaultValue;     ///< Used as a default value in editor or if an
+                               ///< optional parameter is empty.
+  gd::String name;             ///< The name of the parameter to be used in code
+                               ///< generation. Optional.
 };
 
 /**
@@ -355,10 +355,10 @@ class GD_CORE_API InstructionMetadata {
    * \brief Add a parameter not displayed in editor.
    *
    * \param type One of the type handled by GDevelop. This will also determine
-   * the type of the argument used when calling the function in the generated code.
-   * \param supplementaryInformation Depends on `type`. For example, when `type ==
-   * "inlineCode"`, the content of supplementaryInformation is inserted in the
-   * generated code.
+   * the type of the argument used when calling the function in the generated
+   * code. \param supplementaryInformation Depends on `type`. For example, when
+   * `type == "inlineCode"`, the content of supplementaryInformation is inserted
+   * in the generated code.
    *
    * \see EventsCodeGenerator::GenerateParametersCodes
    */
@@ -371,30 +371,50 @@ class GD_CORE_API InstructionMetadata {
    *
    * \see AddParameter
    */
-  InstructionMetadata &SetDefaultValue(gd::String defaultValue_) {
+  InstructionMetadata &SetDefaultValue(const gd::String &defaultValue_) {
     if (!parameters.empty()) parameters.back().SetDefaultValue(defaultValue_);
     return *this;
   };
 
   /**
-   * \brief Set the long description shown in the editor for the last added parameter.
+   * \brief Set the long description shown in the editor for the last added
+   * parameter.
    *
    * \see AddParameter
    */
-  InstructionMetadata &SetParameterLongDescription(gd::String longDescription) {
-    if (!parameters.empty()) parameters.back().SetLongDescription(longDescription);
+  InstructionMetadata &SetParameterLongDescription(
+      const gd::String &longDescription) {
+    if (!parameters.empty())
+      parameters.back().SetLongDescription(longDescription);
     return *this;
   };
 
+  /**
+   * \brief Add the default parameters for an instruction manipulating the
+   * specified type ("string", "number") with the default operators.
+   */
   InstructionMetadata &UseStandardOperatorParameters(const gd::String &type);
 
-  InstructionMetadata &UseStandardRelationalOperatorParameters(const gd::String &type);
+  /**
+   * \brief Add the default parameters for an instruction comparing the
+   * specified type ("string", "number") with the default relational operators.
+   */
+  InstructionMetadata &UseStandardRelationalOperatorParameters(
+      const gd::String &type);
 
+  /**
+   * \brief Mark the instruction as an object instruction. Automatically called
+   * when using `AddAction`/`AddCondition` on an `ObjectMetadata`.
+   */
   InstructionMetadata &SetIsObjectInstruction() {
     isObjectInstruction = true;
     return *this;
   }
 
+  /**
+   * \brief Mark the instruction as a behavior instruction. Automatically called
+   * when using `AddAction`/`AddCondition` on a `BehaviorMetadata`.
+   */
   InstructionMetadata &SetIsBehaviorInstruction() {
     isBehaviorInstruction = true;
     return *this;

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
@@ -386,6 +386,20 @@ class GD_CORE_API InstructionMetadata {
     return *this;
   };
 
+  InstructionMetadata &UseStandardOperatorParameters(const gd::String &type);
+
+  InstructionMetadata &UseStandardRelationalOperatorParameters(const gd::String &type);
+
+  InstructionMetadata &SetIsObjectInstruction() {
+    isObjectInstruction = true;
+    return *this;
+  }
+
+  InstructionMetadata &SetIsBehaviorInstruction() {
+    isBehaviorInstruction = true;
+    return *this;
+  }
+
   /**
    * \brief Consider that the instruction is easy for an user to understand.
    */
@@ -587,6 +601,8 @@ class GD_CORE_API InstructionMetadata {
   int usageComplexity;  ///< Evaluate the instruction from 0 (simple&easy to
                         ///< use) to 10 (complex to understand)
   bool isPrivate;
+  bool isObjectInstruction;
+  bool isBehaviorInstruction;
 };
 
 }  // namespace gd

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
@@ -488,7 +488,7 @@ class GD_CORE_API InstructionMetadata {
      *  obj.AddAction("String",
      *                 _("Change the string"),
      *                 _("Change the string of a text"),
-     *                 _("Do _PARAM1__PARAM2_ to the string of _PARAM0_"),
+     *                 _("the string"),
      *                 _("Text"),
      *                 "CppPlatform/Extensions/text24.png",
      *                 "CppPlatform/Extensions/text.png");

--- a/Core/GDCore/Extensions/Metadata/ObjectMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ObjectMetadata.cpp
@@ -77,7 +77,8 @@ gd::InstructionMetadata& ObjectMetadata::AddCondition(
                                                            group,
                                                            icon,
                                                            smallicon)
-                                           .SetHelpPath(GetHelpPath());
+                                           .SetHelpPath(GetHelpPath())
+                                           .SetIsObjectInstruction();
   return conditionsInfos[nameWithNamespace];
 #endif
 }
@@ -101,7 +102,8 @@ gd::InstructionMetadata& ObjectMetadata::AddAction(
                                                         group,
                                                         icon,
                                                         smallicon)
-                                        .SetHelpPath(GetHelpPath());
+                                        .SetHelpPath(GetHelpPath())
+                                        .SetIsObjectInstruction();
   return actionsInfos[nameWithNamespace];
 #endif
 }

--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -296,9 +296,9 @@ module.exports = {
         type: 'string',
         paramLabel: _('BBCode text'),
         conditionDescription: _('Compare the value of the BBCode text.'),
-        conditionSentence: _('The BBCode text of _PARAM0_ is _PARAM1__PARAM2_'),
+        conditionSentence: _('the BBCode text'),
         actionDescription: _('Set BBCode text'),
-        actionSentence: _('Do _PARAM1__PARAM2_ to the BBCode text of _PARAM0_'),
+        actionSentence: _('the BBCode text'),
         expressionDescription: _('Get BBCode text'),
         expressionSentence: _('Get BBCode text'),
       },
@@ -322,13 +322,9 @@ module.exports = {
         conditionDescription: _(
           'Compare the value of the base opacity of the text.'
         ),
-        conditionSentence: _(
-          'The base opacity of _PARAM0_ is _PARAM1__PARAM2_'
-        ),
+        conditionSentence: _('the base opacity'),
         actionDescription: _('Set base opacity'),
-        actionSentence: _(
-          'Do _PARAM1__PARAM2_ to the base opacity of _PARAM0_'
-        ),
+        actionSentence: _('the base opacity'),
         expressionDescription: _('Get the base opacity'),
         expressionSentence: _('Get the base opacity'),
       },
@@ -338,13 +334,9 @@ module.exports = {
         type: 'number',
         paramLabel: _('Font size'),
         conditionDescription: _('Compare the base font size of the text.'),
-        conditionSentence: _(
-          'The base font size of _PARAM0_ is _PARAM1__PARAM2_'
-        ),
+        conditionSentence: _('the base font size'),
         actionDescription: _('Set base font size'),
-        actionSentence: _(
-          'Do _PARAM1__PARAM2_ to the base font size of _PARAM0_'
-        ),
+        actionSentence: _('the base font size'),
         expressionDescription: _('Get the base font size'),
         expressionSentence: _('Get the base font size'),
       },
@@ -354,13 +346,9 @@ module.exports = {
         type: 'string',
         paramLabel: _('Font family'),
         conditionDescription: _('Compare the value of font family'),
-        conditionSentence: _(
-          'The base font family of _PARAM0_ is _PARAM1__PARAM2_'
-        ),
+        conditionSentence: _('the base font family'),
         actionDescription: _('Set font family'),
-        actionSentence: _(
-          'Do _PARAM1__PARAM2_ to the base font family of _PARAM0_'
-        ),
+        actionSentence: _('the base font family'),
         expressionDescription: _('Get the base font family'),
         expressionSentence: _('Get the base font family'),
       },
@@ -397,15 +385,11 @@ module.exports = {
         conditionDescription: _(
           'Compare the width, in pixels, after which the text is wrapped on next line.'
         ),
-        conditionSentence: _(
-          'The wrapping width of _PARAM0_ is _PARAM1__PARAM2_'
-        ),
+        conditionSentence: _('the wrapping width'),
         actionDescription: _(
           'Change the width, in pixels, after which the text is wrapped on next line.'
         ),
-        actionSentence: _(
-          'Do _PARAM1__PARAM2_ to the wrapping width of _PARAM0_'
-        ),
+        actionSentence: _('the wrapping width'),
         expressionDescription: _('Get the wrapping width'),
         expressionSentence: _('Get the wrapping width'),
       },

--- a/Extensions/DestroyOutsideBehavior/Extension.cpp
+++ b/Extensions/DestroyOutsideBehavior/Extension.cpp
@@ -37,34 +37,30 @@ void DeclareDestroyOutsideBehaviorExtension(gd::PlatformExtension& extension) {
                    _("Additional border"),
                    _("Compare the additional border that the object must cross "
                      "before being deleted."),
-                   _("The additional border of _PARAM0_ is _PARAM2__PARAM3_"),
+                   _("the additional border"),
                    "",
                    "CppPlatform/Extensions/destroyoutsideicon24.png",
                    "CppPlatform/Extensions/destroyoutsideicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "DestroyOutside")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetExtraBorder")
-      .SetManipulatedType("number")
       .SetIncludeFile("DestroyOutsideBehavior/DestroyOutsideRuntimeBehavior.h");
 
   aut.AddAction("ExtraBorder",
                 _("Additional border"),
                 _("Change the additional border that the object must cross "
                   "before being deleted."),
-                _("Do _PARAM2__PARAM3_ to the additional border of _PARAM0_"),
+                _("the additional border"),
                 "",
                 "CppPlatform/Extensions/destroyoutsideicon24.png",
                 "CppPlatform/Extensions/destroyoutsideicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "DestroyOutside")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetExtraBorder")
-      .SetManipulatedType("number")
       .SetGetter("GetExtraBorder")
       .SetIncludeFile("DestroyOutsideBehavior/DestroyOutsideRuntimeBehavior.h");
 #endif

--- a/Extensions/DeviceSensors/JsExtension.js
+++ b/Extensions/DeviceSensors/JsExtension.js
@@ -48,7 +48,7 @@ module.exports = {
         _(
           "Compare the value of orientation alpha. (Range: 0 to 360°)"
         ),
-        _("Orientation alpha is _PARAM0__PARAM1_"),
+        _("the orientation alpha"),
         _("Sensors/Orientation"),
         "JsPlatform/Extensions/orientation_alpha24.png",
         "JsPlatform/Extensions/orientation_alpha32.png"
@@ -68,7 +68,7 @@ module.exports = {
         _(
           "Compare the value of orientation beta. (Range: -180 to 180°)"
         ),
-        _("Orientation beta is _PARAM0__PARAM1_"),
+        _("the orientation beta"),
         _("Sensors/Orientation"),
         "JsPlatform/Extensions/orientation_beta24.png",
         "JsPlatform/Extensions/orientation_beta32.png"
@@ -88,7 +88,7 @@ module.exports = {
         _(
           "Compare the value of orientation gamma. (Range: -90 to 90°)"
         ),
-        _("Orientation gamma is _PARAM0__PARAM1_"),
+        _("the orientation gamma"),
         _("Sensors/Orientation"),
         "JsPlatform/Extensions/orientation_gamma24.png",
         "JsPlatform/Extensions/orientation_gamma32.png"
@@ -214,7 +214,7 @@ module.exports = {
         _(
           "Compare the value of rotation alpha. (Note: few devices support this sensor)"
         ),
-        _("Rotation alpha is _PARAM0__PARAM1_"),
+        _("the rotation alpha"),
         _("Sensors/Motion"),
         "JsPlatform/Extensions/motion_rotation_alpha24.png",
         "JsPlatform/Extensions/motion_rotation_alpha32.png"
@@ -234,7 +234,7 @@ module.exports = {
         _(
           "Compare the value of rotation beta. (Note: few devices support this sensor)"
         ),
-        _("Rotation beta is _PARAM0__PARAM1_"),
+        _("the rotation beta"),
         _("Sensors/Motion"),
         "JsPlatform/Extensions/motion_rotation_beta24.png",
         "JsPlatform/Extensions/motion_rotation_beta32.png"
@@ -254,7 +254,7 @@ module.exports = {
         _(
           "Compare the value of rotation gamma. (Note: few devices support this sensor)"
         ),
-        _("Rotation gamma is _PARAM0__PARAM1_"),
+        _("the rotation gamma"),
         _("Sensors/Motion"),
         "JsPlatform/Extensions/motion_rotation_gamma24.png",
         "JsPlatform/Extensions/motion_rotation_gamma32.png"
@@ -274,7 +274,7 @@ module.exports = {
         _(
           "Compare the value of acceleration on the X-axis (m/s²)."
         ),
-        _("Acceleration X is _PARAM0__PARAM1_"),
+        _("the acceleration X"),
         _("Sensors/Motion"),
         "JsPlatform/Extensions/motion_acceleration_x24.png",
         "JsPlatform/Extensions/motion_acceleration_x32.png"
@@ -294,7 +294,7 @@ module.exports = {
         _(
           "Compare the value of acceleration on the Y-axis (m/s²)."
         ),
-        _("Acceleration Y is _PARAM0__PARAM1_"),
+        _("the acceleration Y"),
         _("Sensors/Motion"),
         "JsPlatform/Extensions/motion_acceleration_y24.png",
         "JsPlatform/Extensions/motion_acceleration_y32.png"
@@ -314,7 +314,7 @@ module.exports = {
         _(
           "Compare the value of acceleration on the Z-axis (m/s²)."
         ),
-        _("Acceleration Z is _PARAM0__PARAM1_"),
+        _("the acceleration Z"),
         _("Sensors/Motion"),
         "JsPlatform/Extensions/motion_acceleration_z24.png",
         "JsPlatform/Extensions/motion_acceleration_z32.png"

--- a/Extensions/Inventory/Extension.cpp
+++ b/Extensions/Inventory/Extension.cpp
@@ -55,7 +55,7 @@ void DeclareInventoryExtension(gd::PlatformExtension& extension) {
       .AddCondition("Count",
                     _("Item count"),
                     _("Compare the number of an item in an inventory."),
-                    _("Count of _PARAM2_ in _PARAM1_ is _PARAM3__PARAM4_"),
+                    _("the count of _PARAM2_ in _PARAM1_"),
                     _("Inventories"),
                     "CppPlatform/Extensions/Inventoryicon24.png",
                     "CppPlatform/Extensions/Inventoryicon16.png")
@@ -63,11 +63,9 @@ void DeclareInventoryExtension(gd::PlatformExtension& extension) {
       .AddCodeOnlyParameter("currentScene", "")
       .AddParameter("string", _("Inventory name"))
       .AddParameter("string", _("Item name"))
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Count"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("InventoryTools::Count")
-      .SetIncludeFile("Inventory/InventoryTools.h")
-      .SetManipulatedType("number");
+      .SetIncludeFile("Inventory/InventoryTools.h");
 
   extension
       .AddCondition("Has",

--- a/Extensions/PanelSpriteObject/Extension.cpp
+++ b/Extensions/PanelSpriteObject/Extension.cpp
@@ -37,29 +37,25 @@ void DeclarePanelSpriteObjectExtension(gd::PlatformExtension& extension) {
                    _("Opacity"),
                    _("Compare the opacity of a Panel Sprite, between 0 (fully "
                      "transparent) to 255 (opaque)."),
-                   _("The opacity of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the opacity"),
                    _("Visibility"),
                    "res/conditions/opacity24.png",
                    "res/conditions/opacity.png")
 
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetOpacity",
                 _("Change Panel Sprite opacity"),
                 _("Change the opacity of a Panel Sprite. 0 is fully transparent, 255 "
                   "is opaque (default)."),
-                _("Do _PARAM1__PARAM2_ to the opacity of _PARAM0_"),
+                _("the opacity"),
                 _("Visibility"),
                 "res/actions/opacity24.png",
                 "res/actions/opacity.png")
 
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value (between 0 and 255)"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("Opacity",
                     _("Opacity"),
@@ -83,97 +79,85 @@ void DeclarePanelSpriteObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("Width",
                 _("Width"),
                 _("Modify the width of a Panel Sprite."),
-                _("Do _PARAM1__PARAM2_ to the width of _PARAM0_"),
+                _("the width"),
                 _("Size and angle"),
                 "res/actions/scaleWidth24.png",
                 "res/actions/scaleWidth.png")
 
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetWidth")
-      .SetManipulatedType("number")
       .SetGetter("GetWidth")
       .SetIncludeFile("PanelSpriteObject/PanelSpriteObject.h");
 
   obj.AddCondition("Width",
                    _("Width"),
                    _("Check the width of a Panel Sprite."),
-                   _("The width of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the width"),
                    _("Size and angle"),
                    "res/conditions/scaleWidth24.png",
                    "res/conditions/scaleWidth.png")
 
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetWidth")
-      .SetManipulatedType("number")
       .SetIncludeFile("PanelSpriteObject/PanelSpriteObject.h");
 
   obj.AddAction("Height",
                 _("Height"),
                 _("Modify the height of a Panel Sprite."),
-                _("Do _PARAM1__PARAM2_ to the height of _PARAM0_"),
+                _("the height"),
                 _("Size and angle"),
                 "res/actions/scaleHeight24.png",
                 "res/actions/scaleHeight.png")
 
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetHeight")
-      .SetManipulatedType("number")
       .SetGetter("GetHeight")
       .SetIncludeFile("PanelSpriteObject/PanelSpriteObject.h");
 
   obj.AddCondition("Height",
                    _("Height"),
                    _("Check the height of a Panel Sprite."),
-                   _("The height of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the height"),
                    _("Size and angle"),
                    "res/conditions/scaleHeight24.png",
                    "res/conditions/scaleHeight.png")
 
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("SetHeight")
-      .SetManipulatedType("number")
       .SetGetter("GetHeight")
       .SetIncludeFile("PanelSpriteObject/PanelSpriteObject.h");
 
   obj.AddAction("Angle",
                 _("Angle"),
                 _("Modify the angle of a Panel Sprite."),
-                _("Do _PARAM1__PARAM2_ to the angle of _PARAM0_"),
+                _("the angle"),
                 _("Size and angle"),
                 "res/actions/rotate24.png",
                 "res/actions/rotate.png")
 
       .SetHidden()  // Deprecated
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetAngle")
-      .SetManipulatedType("number")
       .SetGetter("GetAngle")
       .SetIncludeFile("PanelSpriteObject/PanelSpriteObject.h");
 
   obj.AddCondition("Angle",
                    _("Angle"),
                    _("Check the angle of a Panel Sprite."),
-                   _("The angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the angle"),
                    _("Size and angle"),
                    "res/conditions/rotate24.png",
                    "res/conditions/rotate.png")
 
       .SetHidden()  // Deprecated
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("SetAngle")
-      .SetManipulatedType("number")
       .SetGetter("GetAngle")
       .SetIncludeFile("PanelSpriteObject/PanelSpriteObject.h");
 

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration1.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration1.cpp
@@ -18,433 +18,363 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
   obj.AddAction("EmitterForceMin",
                 _("Emission minimal force"),
                 _("Modify minimal emission force of particles."),
-                _("Do _PARAM1__PARAM2_ to minimal emission force of _PARAM0_"),
+                _("the minimal emission force"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddAction("EmitterForceMax",
                 _("Emission maximal force"),
                 _("Modify maximal emission force of particles."),
-                _("Do _PARAM1__PARAM2_ to maximal emission force of _PARAM0_"),
+                _("the maximal emission force"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddAction(
          "EmitterXDirection",
          _("Emission X direction"),
          _("Modify emission X direction."),
-         _("Do _PARAM1__PARAM2_ to the emission X direction of _PARAM0_"),
+         _("the emission X direction"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "EmitterXDirection",
          _("Emission X direction"),
          _("Test emission X direction."),
-         _("The emission X direction of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the emission X direction"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "EmitterYDirection",
          _("Emission Y direction"),
          _("Modify emission Y direction."),
-         _("Do _PARAM1__PARAM2_ to the emission Y direction of _PARAM0_"),
+         _("the emission Y direction"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("EmitterYDirection",
                    _("Emission Y direction"),
                    _("Test emission Y direction."),
-                   _("Emission Y direction of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the emission Y direction"),
                    _("Advanced"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "EmitterZDirection",
          _("Emission Z direction"),
          _("Modify emission Z direction."),
-         _("Do _PARAM1__PARAM2_ to the emission Z direction of _PARAM0_"),
+         _("the emission Z direction"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("EmitterZDirection",
                    _("Emission Z direction"),
                    _("Test emission Z direction."),
-                   _("Emission Z direction of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the emission Z direction"),
                    _("Advanced"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("EmitterAngle",
                 _("Emission angle"),
                 _("Modify emission angle."),
-                _("Do _PARAM1__PARAM2_ to the emission angle of _PARAM0_"),
+                _("the emission angle"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetAngle")
-      .SetManipulatedType("number")
       .SetGetter("GetAngle")
       .SetIncludeFile("ParticleSystem/ParticleEmitterObject.h");
 
   obj.AddCondition("EmitterAngle",
                    _("Emission angle"),
                    _("Test the value of emission angle of the emitter."),
-                   _("Emission angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the emission angle"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("EmitterAngleA",
                 _("Emission angle 1"),
                 _("Change emission angle #1"),
-                _("Do _PARAM1__PARAM2_ to the 1st emission angle of _PARAM0_"),
+                _("the 1st emission angle"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("EmitterAngleA",
                    _("Emission angle 1"),
                    _("Test the value of emission 1st angle of the emitter"),
-                   _("Emission 1st angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the emission 1st angle"),
                    _("Advanced"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("EmitterAngleB",
                 _("Emission angle 2"),
                 _("Change emission angle #2"),
-                _("Do _PARAM1__PARAM2_ to the 2nd emission angle of _PARAM0_"),
+                _("the 2nd emission angle"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("EmitterAngleB",
                    _("Emission angle 2"),
                    _("Test the emission angle #2 of the emitter."),
-                   _("Emission 2nd angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the emission 2nd angle"),
                    _("Advanced"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ConeSprayAngle",
          _("Angle of the spray cone"),
          _("Modify the angle of the spray cone."),
-         _("Do _PARAM1__PARAM2_ to the angle of the spray cone of _PARAM0_"),
+         _("the angle of the spray cone"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ConeSprayAngle",
                    _("Angle of the spray cone"),
                    _("Test the angle of the spray cone of the emitter"),
-                   _("Angle of the spray cone of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the angle of the spray cone"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "Friction",
          _("Friction"),
          _("Modify friction applied to particles."),
-         _("Do _PARAM1__PARAM2_ to the friction of particles of _PARAM0_"),
+         _("the friction of particles"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number")
+      .UseStandardOperatorParameters("number")
+      .GetCodeExtraInformation()
       .SetGetter("GetFriction");
 
   obj.AddCondition("Friction",
                    _("Friction"),
                    _("Test friction applied to particles."),
-                   _("Particles' friction of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the particles' friction"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
 
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ZoneRadius",
                 _("Creation radius"),
                 _("Modify creation radius of particles.\nParticles have to be "
                   "recreated in order to take changes in account."),
-                _("Do _PARAM1__PARAM2_ to creation radius of _PARAM0_"),
+                _("the creation radius"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ZoneRadius",
                    _("Creation radius"),
                    _("Test creation radius of particles."),
-                   _("Creation radius of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the creation radius"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleLifeTimeMin",
          _("Minimum lifetime"),
          _("Modify particles minimum lifetime.Particles have to be recreated "
            "in order to take changes in account."),
-         _("Do _PARAM1__PARAM2_ to minimum lifetime of particles of _PARAM0_"),
+         _("the minimum lifetime of particles"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleLifeTimeMin",
          _("Minimum lifetime"),
          _("Test minimum lifetime of particles."),
-         _("Minimum lifetime of particles of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the minimum lifetime of particles"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleLifeTimeMax",
          _("Maximum lifetime"),
          _("Modify particles maximum lifetime.\nParticles have to be recreated "
            "in order to take changes in account."),
-         _("Do _PARAM1__PARAM2_ to maximum lifetime of particles of _PARAM0_"),
+         _("the maximum lifetime of particles"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleLifeTimeMax",
          _("Maximum lifetime"),
          _("Test maximum lifetime of particles."),
-         _("Maximum lifetime of particles of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the maximum lifetime of particles"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleGravityX",
                 _("Gravity value on X axis"),
                 _("Change value of the gravity on X axis."),
-                _("Do _PARAM1__PARAM2_ to the gravity on X axis "
-                  "of _PARAM0_"),
+                _("the gravity on X axis of _PARAM0_"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleGravityX",
          _("Gravity value on X axis"),
          _("Compare value of the gravity on X axis."),
-         _("Gravity on X axis of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the gravity on X axis"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleGravityY",
                 _("Gravity value on Y axis"),
                 _("Change value of the gravity on Y axis."),
-                _("Do _PARAM1__PARAM2_ to the gravity on Y axis "
-                  "of _PARAM0_"),
+                _("the gravity on Y axis of _PARAM0_"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleGravityY",
          _("Gravity value on Y axis"),
          _("Compare value of the gravity on Y axis."),
-         _("Gravity on Y axis of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the gravity on Y axis"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleGravityZ",
                 _("Z Gravity"),
                 _("Change value of the gravity on Z axis."),
-                _("Do _PARAM1__PARAM2_ to gravity direction on Z axis "
-                  "of_PARAM0_"),
+                _("the gravity direction on Z axis of_PARAM0_"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleGravityZ",
          _("Direction of gravity on Z axis"),
          _("Test the direction of gravity on Z axis"),
-         _("Gravity direction on Z axis of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the gravity direction on Z axis"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleGravityAngle",
                 _("Gravity angle"),
                 _("Change gravity angle"),
-                _("Do _PARAM1__PARAM2_ to the gravity angle of _PARAM0_"),
+                _("the gravity angle"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ParticleGravityAngle",
                    _("Gravity angle"),
                    _("Test the gravity angle of the emitter"),
-                   _("Gravity angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the gravity angle"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleGravityLength",
                 _("Gravity"),
                 _("Change the gravity of the emitter."),
-                _("Do _PARAM1__PARAM2_ to the gravity of _PARAM0_"),
+                _("the gravity"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ParticleGravityLength",
                    _("Gravity"),
                    _("Test the gravity of the emitter."),
-                   _("The gravity of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the gravity"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 #endif
 }

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration1.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration1.cpp
@@ -324,7 +324,7 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
   obj.AddAction("ParticleGravityX",
                 _("Gravity value on X axis"),
                 _("Change value of the gravity on X axis."),
-                _("Do _PARAM1__PARAM2_ to the value of gravity on X axis "
+                _("Do _PARAM1__PARAM2_ to the gravity on X axis "
                   "of _PARAM0_"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
@@ -338,7 +338,7 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
          "ParticleGravityX",
          _("Gravity value on X axis"),
          _("Compare value of the gravity on X axis."),
-         _("Value of gravity on X axis of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("Gravity on X axis of _PARAM0_ is _PARAM1__PARAM2_"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
@@ -350,7 +350,7 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
   obj.AddAction("ParticleGravityY",
                 _("Gravity value on Y axis"),
                 _("Change value of the gravity on Y axis."),
-                _("Do _PARAM1__PARAM2_ to the value of gravity on Y axis "
+                _("Do _PARAM1__PARAM2_ to the gravity on Y axis "
                   "of _PARAM0_"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
@@ -364,7 +364,7 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
          "ParticleGravityY",
          _("Gravity value on Y axis"),
          _("Compare value of the gravity on Y axis."),
-         _("Value of gravity on Y axis of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("Gravity on Y axis of _PARAM0_ is _PARAM1__PARAM2_"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
@@ -376,7 +376,7 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
   obj.AddAction("ParticleGravityZ",
                 _("Z Gravity"),
                 _("Change value of the gravity on Z axis."),
-                _("Do _PARAM1__PARAM2_ to the direction of gravity on Z axis "
+                _("Do _PARAM1__PARAM2_ to gravity direction on Z axis "
                   "of_PARAM0_"),
                 _("Advanced"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
@@ -390,7 +390,7 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
          "ParticleGravityZ",
          _("Direction of gravity on Z axis"),
          _("Test the direction of gravity on Z axis"),
-         _("Direction of gravity on Z axis of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("Gravity direction on Z axis of _PARAM0_ is _PARAM1__PARAM2_"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration2.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration2.cpp
@@ -39,307 +39,257 @@ void ExtensionSubDeclaration2(gd::ObjectMetadata& obj) {
          "ParticleRed1",
          _("Red color, parameter 1"),
          _("Modify parameter 1 of the red color."),
-         _("Do _PARAM1__PARAM2_ to parameter 1 of red color of _PARAM0_"),
+         _("the parameter 1 of red color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleRed1",
          _("Red color, parameter 1"),
          _("Test parameter 1 of the red color"),
-         _("Parameter 1 of red color of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 1 of red color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleRed2",
          _("Red color, parameter 2"),
          _("Modify parameter 2 of the red color"),
-         _("Do _PARAM1__PARAM2_ to parameter 2 of red color of _PARAM0_"),
+         _("the parameter 2 of red color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleRed2",
          _("Red color, parameter 2"),
          _("Test parameter 2 of the red color"),
-         _("Parameter 2 of red color of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 2 of red color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleBlue1",
          _("Blue color, parameter 1"),
          _("Modify parameter 1 of blue color"),
-         _("Do _PARAM1__PARAM2_ to the parameter 1 of blue color of _PARAM0_"),
+         _("the parameter 1 of blue color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleBlue1",
          _("Blue color, parameter 1"),
          _("Test parameter 1 of blue color"),
-         _("Parameter 1 of blue color of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 1 of blue color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleBlue2",
          _("Blue color, parameter 2"),
          _("Modify parameter 2 of blue color"),
-         _("Do _PARAM1__PARAM2_ to the parameter 2 of blue color of _PARAM0_"),
+         _("the parameter 2 of blue color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleBlue2",
          _("Blue color, parameter 2"),
          _("Test parameter 2 of blue color"),
-         _("Parameter 2 of blue color of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 2 of blue color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleGreen1",
          _("Green color, parameter 1"),
          _("Modify parameter 1 of green color"),
-         _("Do _PARAM1__PARAM2_ to the parameter 1 of green color of _PARAM0_"),
+         _("the parameter 1 of green color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleGreen1",
          _("Green color, parameter 1"),
          _("Test parameter 1 of green color"),
-         _("Parameter 1 of green color of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 1 of green color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleGreen2",
          _("Green color, parameter 2"),
          _("Modify the parameter 2 of the green color"),
-         _("Do _PARAM1__PARAM2_ to the parameter 2 of green color of _PARAM0_"),
+         _("the parameter 2 of green color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleGreen2",
          _("Green color, parameter 2"),
          _("Test the parameter 2 of the green color"),
-         _("Parameter 2 of green color of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 2 of green color"),
          _("Advanced"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleSize1",
                 _("SIze, parameter 1"),
                 _("Modify parameter 1 of the size of particles"),
-                _("Do _PARAM1__PARAM2_ to the parameter 1 of size of _PARAM0_"),
+                _("the parameter 1 of size"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ParticleSize1",
                    _("Size, parameter 1"),
                    _("Test parameter 1 of the size of particles"),
-                   _("Parameter 1 of the size of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the parameter 1 of the size"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleSize2",
                 _("Size, parameter 2"),
                 _("Modify parameter 2 of the size of particles"),
-                _("Do _PARAM1__PARAM2_ to the parameter 2 of size of _PARAM0_"),
+                _("the parameter 2 of size"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ParticleSize2",
                    _("Size, parameter 2"),
                    _("Test parameter 2 of the size of particles"),
-                   _("Parameter 2 of the size of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the parameter 2 of the size"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleAngle1",
          _("Angle, parameter 1"),
          _("Modify parameter 1 of the angle of particles"),
-         _("Do _PARAM1__PARAM2_ to the parameter 1 of angle of _PARAM0_"),
+         _("the parameter 1 of angle"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ParticleAngle1",
                    _("Angle, parameter 1"),
                    _("Test parameter 1 of the angle of particles"),
-                   _("Parameter 1 of angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the parameter 1 of angle"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "ParticleAngle2",
          _("Angle, parameter 2"),
          _("Modify parameter 2 of the angle of particles"),
-         _("Do _PARAM1__PARAM2_ to the parameter 2 of angle of _PARAM0_"),
+         _("the parameter 2 of angle"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("ParticleAngle2",
                    _("Angle, parameter 2"),
                    _("Test parameter 2 of the angle of particles"),
-                   _("Parameter 2 of angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the parameter 2 of angle"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleAlpha1",
                 _("Transparency, parameter 1"),
                 _("Modify parameter 1 of the transparency of particles"),
-                _("Do _PARAM1__PARAM2_ to parameter 1 of the transparency of "
-                  "_PARAM0_"),
+                _("the parameter 1 of the transparency"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleAlpha1",
          _("Transparency, parameter 1"),
          _("Test parameter 1 of the transparency of particles"),
-         _("Parameter 1 of the transparency of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 1 of the transparency"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("ParticleAlpha2",
                 _("Transparency, parameter 2"),
                 _("Modify parameter 2 of the transparency of particles"),
-                _("Do _PARAM1__PARAM2_ to parameter 2 of the transparency of "
-                  "_PARAM0_"),
+                _("the parameter 2 of the transparency"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "ParticleAlpha2",
          _("Transparency, parameter 2"),
          _("Test parameter 2 of the transparency of particles"),
-         _("Parameter 2 of the transparency of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the parameter 2 of the transparency"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddCondition("NoMoreParticles",
                    _("No more particles"),

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
@@ -30,103 +30,87 @@ void ExtensionSubDeclaration3(gd::ObjectMetadata& obj) {
          _("Rendering first parameter"),
          _("Modify first parameter of rendering ( Size/Length ).\nParticles "
            "have to be recreated in order to take changes in account."),
-         _("Do _PARAM1__PARAM2_ to rendering 1st parameter of _PARAM0_"),
+         _("the rendering 1st parameter"),
          _("Setup"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "RendererParam1",
          _("Rendering first parameter"),
          _("Test the first parameter of rendering ( Size/Length )."),
-         _("The 1nd rendering parameter of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the 1nd rendering parameter"),
          _("Setup"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
 
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("RendererParam2",
                 _("Rendering second parameter"),
                 _("Modify the second parameter of rendering ( Size/Length "
                   ").\nParticles have to be recreated in order to take changes "
                   "in account."),
-                _("Do _PARAM1__PARAM2_ to rendering 2nd parameter of _PARAM0_"),
+                _("the rendering 2nd parameter"),
                 _("Setup"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition(
          "RendererParam2",
          _("Rendering second parameter"),
          _("Test the second parameter of rendering ( Size/Length )."),
-         _("The 2nd rendering parameter of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the 2nd rendering parameter"),
          _("Setup"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("Tank",
                 _("Capacity"),
                 _("Change the capacity of the emitter."),
-                _("Do _PARAM1__PARAM2_ to the capacity of _PARAM0_"),
+                _("the capacity"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("Tank",
                    _("Capacity"),
                    _("Test the capacity of the emitter."),
-                   _("The capacity of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the capacity"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("Flow",
                 _("Flow"),
                 _("Change the flow of the emitter."),
-                _("Do _PARAM1__PARAM2_ to flow of _PARAM0_"),
+                _("the flow"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("Flow",
                    _("Flow"),
                    _("Test the flow of the emitter."),
-                   _("The flow of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the flow"),
                    _("Common"),
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("Texture",
                 _("Image"),
@@ -142,14 +126,12 @@ void ExtensionSubDeclaration3(gd::ObjectMetadata& obj) {
          "Texture",
          _("Image"),
          _("Test the name of the image displayed by particles."),
-         _("Image displayed by particles of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the image displayed by particles"),
          _("Common"),
          "CppPlatform/Extensions/particleSystemicon24.png",
          "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text to test"))
-      .SetManipulatedType("string");
+      .UseStandardRelationalOperatorParameters("string");
 
   obj.AddStrExpression("Texture",
                        _("Particles image"),

--- a/Extensions/PathfindingBehavior/Extension.cpp
+++ b/Extensions/PathfindingBehavior/Extension.cpp
@@ -83,242 +83,210 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
     aut.AddAction("CellWidth",
                   _("Width of the cells"),
                   _("Change the width of the cells of the virtual grid."),
-                  _("Do _PARAM2__PARAM3_ to the width of the virtual cells of "
-                    "_PARAM0_"),
+                  _("the width of the virtual cells"),
                   _("Virtual grid"),
                   "CppPlatform/Extensions/AStaricon24.png",
                   "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Width (pixels)"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetCellWidth")
         .SetGetter("GetCellWidth")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition(
            "CellWidth",
            _("Width of the virtual grid"),
            _("Compare the width of the cells of the virtual grid."),
-           _("Width of the virtual cells of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the width of the virtual cells"),
            _("Virtual grid"),
            "CppPlatform/Extensions/AStaricon24.png",
            "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Width (pixels)"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetCellWidth")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction("CellHeight",
                   _("Height of the cells"),
                   _("Change the height of the cells of the virtual grid."),
-                  _("Do _PARAM2__PARAM3_ to the height of the virtual cells of "
-                    "_PARAM0_"),
+                  _("the height of the virtual cells"),
                   _("Virtual grid"),
                   "CppPlatform/Extensions/AStaricon24.png",
                   "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Height (pixels)"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetCellHeight")
         .SetGetter("GetCellHeight")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition(
            "CellHeight",
            _("Height of the virtual grid"),
            _("Compare the height of the cells of the virtual grid."),
-           _("Height of the virtual cells of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the height of the virtual cells"),
            _("Virtual grid"),
            "CppPlatform/Extensions/AStaricon24.png",
            "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Height (pixels)"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetCellHeight")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction(
            "Acceleration",
            _("Acceleration"),
            _("Change the acceleration when moving the object"),
-           _("Do _PARAM2__PARAM3_ to the acceleration of _PARAM0_ on the path"),
+           _("the acceleration on the path"),
            _("Path"),
            "CppPlatform/Extensions/AStaricon24.png",
            "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetAcceleration")
         .SetGetter("GetAcceleration")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition("Acceleration",
                      _("Acceleration"),
                      _("Compare the acceleration when moving the object"),
-                     _("Acceleration of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the acceleration"),
                      _("Path"),
                      "CppPlatform/Extensions/AStaricon24.png",
                      "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetAcceleration")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction(
            "MaxSpeed",
            _("Maximum speed"),
            _("Change the maximum speed when moving the object"),
-           _("Do _PARAM2__PARAM3_ to the max. speed of _PARAM0_ on the path"),
+           _("the max. speed on the path"),
            _("Path"),
            "CppPlatform/Extensions/AStaricon24.png",
            "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetMaxSpeed")
         .SetGetter("GetMaxSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition("MaxSpeed",
                      _("Maximum speed"),
                      _("Compare the maximum speed when moving the object"),
-                     _("Max. speed of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the max. speed"),
                      _("Path"),
                      "CppPlatform/Extensions/AStaricon24.png",
                      "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetMaxSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction("Speed",
                   _("Speed"),
                   _("Change the speed of the object on the path"),
-                  _("Do _PARAM2__PARAM3_ to the speed of _PARAM0_ on the path"),
+                  _("the speed on the path"),
                   _("Path"),
                   "CppPlatform/Extensions/AStaricon24.png",
                   "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetSpeed")
         .SetGetter("GetSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition("Speed",
                      _("Speed"),
                      _("Compare the speed of the object on the path"),
-                     _("Speed of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the speed"),
                      _("Path"),
                      "CppPlatform/Extensions/AStaricon24.png",
                      "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction("AngularMaxSpeed",
                   _("Angular maximum speed"),
                   _("Change the maximum angular speed when moving the object"),
-                  _("Do _PARAM2__PARAM3_ to the max. angular speed of _PARAM0_ "
-                    "on the path"),
+                  _("the max. angular speed on the path"),
                   _("Path"),
                   "CppPlatform/Extensions/AStaricon24.png",
                   "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetAngularMaxSpeed")
         .SetGetter("GetAngularMaxSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition(
            "AngularMaxSpeed",
            _("Angular maximum speed"),
            _("Compare the maximum angular speed when moving the object"),
-           _("Max. angular speed of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the max. angular speed"),
            _("Path"),
            "CppPlatform/Extensions/AStaricon24.png",
            "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetAngularMaxSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction(
            "AngleOffset",
            _("Rotation offset"),
            _("Change the rotation offset applied when moving the object"),
-           _("Do _PARAM2__PARAM3_ to the rotation offset of _PARAM0_ on the "
-             "path"),
+           _("the rotation offset on the path"),
            _("Path"),
            "CppPlatform/Extensions/AStaricon24.png",
            "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetAngleOffset")
         .SetGetter("GetAngleOffset")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition("AngleOffset",
                      _("Rotation offset"),
                      _("Compare the rotation offset when moving the object"),
-                     _("Rotation offset of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the rotation offset"),
                      _("Path"),
                      "CppPlatform/Extensions/AStaricon24.png",
                      "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetAngleOffset")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction(
@@ -326,36 +294,31 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
            _("Extra border"),
            _("Change the size of the extra border applied to the object when "
              "planning a path"),
-           _("Do _PARAM2__PARAM3_ to the extra border of _PARAM0_ on the path"),
+           _("the extra border on the path"),
            _("Path"),
            "CppPlatform/Extensions/AStaricon24.png",
            "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value (in pixels)"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetExtraBorder")
         .SetGetter("GetExtraBorder")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition("ExtraBorder",
                      _("Extra border"),
                      _("Compare the size of the extra border applied to the "
                        "object when planning a path"),
-                     _("Size of the extra border applied to _PARAM0_ is "
-                       "_PARAM2__PARAM3_"),
+                     _("the size of the extra border applied to _PARAM0_"),
                      _("Path"),
                      "CppPlatform/Extensions/AStaricon24.png",
                      "CppPlatform/Extensions/AStaricon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Value (in pixels)"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetExtraBorder")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddAction(
@@ -617,34 +580,30 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
     aut.AddAction("Cost",
                   _("Cost"),
                   _("Change the cost of going through the object."),
-                  _("Do _PARAM2__PARAM3_ to the cost of _PARAM0_"),
+                  _("the cost"),
                   _("Obstacles"),
                   "CppPlatform/Extensions/pathfindingobstacleicon24.png",
                   "CppPlatform/Extensions/pathfindingobstacleicon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingObstacleBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Difficulty"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetCost")
         .SetGetter("GetCost")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingObstacleRuntimeBehavior.h");
 
     aut.AddCondition("Cost",
                      _("Cost"),
                      _("Compare the cost of going through the object"),
-                     _("Cost of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the cost"),
                      _("Obstacles"),
                      "CppPlatform/Extensions/pathfindingobstacleicon24.png",
                      "CppPlatform/Extensions/pathfindingobstacleicon16.png")
 
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingObstacleBehavior")
-        .AddParameter("relationalOperator", _("Sign of the test"))
-        .AddParameter("expression", _("Difficulty"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetCost")
-        .SetManipulatedType("number")
         .SetIncludeFile("PathfindingBehavior/PathfindingObstacleRuntimeBehavior.h");
 
     aut.AddAction("SetImpassable",

--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -406,18 +406,16 @@ module.exports = {
         'GravityX',
         _('Gravity X'),
         _('Test the world gravity on X.'),
-        _('Gravity on X is _PARAM2__PARAM3_'),
+        _('the gravity on X'),
         _('Global'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getGravityX')
-      .setManipulatedType('number');
+      .setFunctionName('getGravityX');
 
     aut
       .addExpression(
@@ -437,18 +435,16 @@ module.exports = {
         'GravityY',
         _('Gravity Y'),
         _('Test the world gravity on Y.'),
-        _('Gravity on Y is _PARAM2__PARAM3_'),
+        _('the gravity on Y'),
         _('Global'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getGravityY')
-      .setManipulatedType('number');
+      .setFunctionName('getGravityY');
 
     aut
       .addExpression(
@@ -485,18 +481,16 @@ module.exports = {
         'TimeScale',
         _('Time scale'),
         _('Test the world time scale.'),
-        _('Time scale is _PARAM2__PARAM3_'),
+        _('the time scale'),
         _('Global'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getTimeScale')
-      .setManipulatedType('number');
+      .setFunctionName('getTimeScale');
 
     // This action has to be owned by the extension to run only once per objects list, not per instance
     extension
@@ -751,18 +745,17 @@ module.exports = {
         _(
           'Modify an object shape scale. It affects custom shape dimensions and shape offset, if custom dimensions are not set the body will be scaled automatically to the object size.'
         ),
-        _('Do _PARAM2__PARAM3_ to the shape scale of _PARAM0_'),
+        _('the shape scale'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setShapeScale')
-      .setManipulatedType('number')
+      
       .setGetter('getShapeScale');
 
     aut
@@ -770,18 +763,16 @@ module.exports = {
         'Density',
         _('Density'),
         _('Test an object density.'),
-        _('_PARAM0_ density is _PARAM2__PARAM3_'),
+        _('the _PARAM0_ density'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getDensity')
-      .setManipulatedType('number');
+      .setFunctionName('getDensity');
 
     aut
       .addAction(
@@ -790,18 +781,17 @@ module.exports = {
         _(
           "Modify an object density. The body's density and volume determine its mass."
         ),
-        _('Do _PARAM2__PARAM3_ to the density of _PARAM0_'),
+        _('the density'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value (non-negative)'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setDensity')
-      .setManipulatedType('number')
+      
       .setGetter('getDensity');
 
     aut
@@ -822,18 +812,16 @@ module.exports = {
         'Friction',
         _('Friction'),
         _('Test an object friction.'),
-        _('_PARAM0_ friction is _PARAM2__PARAM3_'),
+        _('the _PARAM0_ friction'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getFriction')
-      .setManipulatedType('number');
+      .setFunctionName('getFriction');
 
     aut
       .addAction(
@@ -842,18 +830,17 @@ module.exports = {
         _(
           "Modify an object friction. How much energy is lost from the movement of one object over another. The combined friction from two bodies is calculated as 'sqrt(bodyA.friction * bodyB.friction)'."
         ),
-        _('Do _PARAM2__PARAM3_ to the friction of _PARAM0_'),
+        _('the friction'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value (non-negative)'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setFriction')
-      .setManipulatedType('number')
+      
       .setGetter('getFriction');
 
     aut
@@ -874,18 +861,16 @@ module.exports = {
         'Restitution',
         _('Restitution'),
         _('Test an object restitution.'),
-        _('_PARAM0_ restitution is _PARAM2__PARAM3_'),
+        _('the _PARAM0_ restitution'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getRestitution')
-      .setManipulatedType('number');
+      .setFunctionName('getRestitution');
 
     aut
       .addAction(
@@ -894,18 +879,17 @@ module.exports = {
         _(
           "Modify an object restitution. Energy conservation on collision. The combined restitution from two bodies is calculated as 'max(bodyA.restitution, bodyB.restitution)'."
         ),
-        _('Do _PARAM2__PARAM3_ to the restitution of _PARAM0_'),
+        _('the restitution'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value (non-negative)'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setRestitution')
-      .setManipulatedType('number')
+      
       .setGetter('getRestitution');
 
     aut
@@ -926,18 +910,16 @@ module.exports = {
         'LinearDamping',
         _('Linear damping'),
         _('Test an object linear damping.'),
-        _('_PARAM0_ linear damping is _PARAM2__PARAM3_'),
+        _('the _PARAM0_ linear damping'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getLinearDamping')
-      .setManipulatedType('number');
+      .setFunctionName('getLinearDamping');
 
     aut
       .addAction(
@@ -946,18 +928,17 @@ module.exports = {
         _(
           'Modify an object linear damping. How much movement speed is lost across the time.'
         ),
-        _('Do _PARAM2__PARAM3_ to the linear damping of _PARAM0_'),
+        _('the linear damping'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setLinearDamping')
-      .setManipulatedType('number')
+      
       .setGetter('getLinearDamping');
 
     aut
@@ -978,18 +959,16 @@ module.exports = {
         'AngularDamping',
         _('Angular damping'),
         _('Test an object angular damping.'),
-        _('_PARAM0_ angular damping is _PARAM2__PARAM3_'),
+        _('the _PARAM0_ angular damping'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getAngularDamping')
-      .setManipulatedType('number');
+      .setFunctionName('getAngularDamping');
 
     aut
       .addAction(
@@ -998,18 +977,17 @@ module.exports = {
         _(
           'Modify an object angular damping. How much angular speed is lost across the time.'
         ),
-        _('Do _PARAM2__PARAM3_ to the angular damping of _PARAM0_'),
+        _('the angular damping'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setAngularDamping')
-      .setManipulatedType('number')
+      
       .setGetter('getAngularDamping');
 
     aut
@@ -1030,18 +1008,16 @@ module.exports = {
         'GravityScale',
         _('Gravity scale'),
         _('Test an object gravity scale.'),
-        _('_PARAM0_ gravity scale is _PARAM2__PARAM3_'),
+        _('the _PARAM0_ gravity scale'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getGravityScale')
-      .setManipulatedType('number');
+      .setFunctionName('getGravityScale');
 
     aut
       .addAction(
@@ -1050,18 +1026,17 @@ module.exports = {
         _(
           'Modify an object gravity scale. The gravity applied to an object is the world gravity multiplied by the object gravity scale.'
         ),
-        _('Do _PARAM2__PARAM3_ to the gravity scale of _PARAM0_'),
+        _('the gravity scale'),
         _('Body settings'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setGravityScale')
-      .setManipulatedType('number')
+      
       .setGetter('getGravityScale');
 
     aut
@@ -1156,36 +1131,33 @@ module.exports = {
         'LinearVelocityX',
         _('Linear velocity X'),
         _('Test an object linear velocity on X.'),
-        _('Linear velocity on X of _PARAM0_ is _PARAM2__PARAM3_'),
+        _('the linear velocity on X'),
         _('Velocity'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getLinearVelocityX')
-      .setManipulatedType('number');
+      .setFunctionName('getLinearVelocityX');
 
     aut
       .addAction(
         'LinearVelocityX',
         _('Linear velocity X'),
         _('Modify an object linear velocity on X.'),
-        _('Do _PARAM2__PARAM3_ to the linear velocity on X of _PARAM0_'),
+        _('the linear velocity on X'),
         _('Velocity'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value (pixels/second)'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setLinearVelocityX')
-      .setManipulatedType('number')
+      
       .setGetter('getLinearVelocityX');
 
     aut
@@ -1206,36 +1178,33 @@ module.exports = {
         'LinearVelocityY',
         _('Linear velocity Y'),
         _('Test an object linear velocity on Y.'),
-        _('Linear velocity on Y of _PARAM0_ is _PARAM2__PARAM3_'),
+        _('the linear velocity on Y'),
         _('Velocity'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getLinearVelocityY')
-      .setManipulatedType('number');
+      .setFunctionName('getLinearVelocityY');
 
     aut
       .addAction(
         'LinearVelocityY',
         _('Linear velocity Y'),
         _('Modify an object linear velocity on Y.'),
-        _('Do _PARAM2__PARAM3_ to the linear velocity on Y of _PARAM0_'),
+        _('the linear velocity on Y'),
         _('Velocity'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value (pixels/second)'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setLinearVelocityY')
-      .setManipulatedType('number')
+      
       .setGetter('getLinearVelocityY');
 
     aut
@@ -1256,18 +1225,16 @@ module.exports = {
         'LinearVelocityLength',
         _('Linear velocity'),
         _('Test an object linear velocity length.'),
-        _('Linear velocity length of _PARAM0_ is _PARAM2__PARAM3_'),
+        _('the linear velocity length'),
         _('Velocity'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getLinearVelocityLength')
-      .setManipulatedType('number');
+      .setFunctionName('getLinearVelocityLength');
 
     aut
       .addExpression(
@@ -1287,36 +1254,33 @@ module.exports = {
         'AngularVelocity',
         _('Angular velocity'),
         _('Test an object angular velocity.'),
-        _('Angular velocity of _PARAM0_ is _PARAM2__PARAM3_'),
+        _('the angular velocity'),
         _('Velocity'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getAngularVelocity')
-      .setManipulatedType('number');
+      .setFunctionName('getAngularVelocity');
 
     aut
       .addAction(
         'AngularVelocity',
         _('Angular velocity'),
         _('Modify an object angular velocity.'),
-        _('Do _PARAM2__PARAM3_ to the angular velocity of _PARAM0_'),
+        _('the angular velocity'),
         _('Velocity'),
         'res/physics24.png',
         'res/physics16.png'
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value (º/s)'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setAngularVelocity')
-      .setManipulatedType('number')
+      
       .setGetter('getAngularVelocity');
 
     aut
@@ -1619,7 +1583,7 @@ module.exports = {
         'JointReactionForce',
         _('Joint reaction force'),
         _('Test a joint reaction force.'),
-        _('Joint _PARAM2_ reaction force is _PARAM3__PARAM4_'),
+        _('the joint _PARAM2_ reaction force'),
         _('Joints'),
         'res/physics24.png',
         'res/physics16.png'
@@ -1627,11 +1591,9 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getJointReactionForce')
-      .setManipulatedType('number');
+      .setFunctionName('getJointReactionForce');
 
     aut
       .addExpression(
@@ -1652,7 +1614,7 @@ module.exports = {
         'JointReactionTorque',
         _('Joint reaction torque'),
         _('Test a joint reaction torque.'),
-        _('Joint _PARAM2_ reaction torque is _PARAM3__PARAM4_'),
+        _('the joint _PARAM2_ reaction torque'),
         _('Joints'),
         'res/physics24.png',
         'res/physics16.png'
@@ -1660,11 +1622,9 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('relationalOperator', _('Sign of the test'))
-      .addParameter('expression', _('Value'))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName('getJointReactionTorque')
-      .setManipulatedType('number');
+      .setFunctionName('getJointReactionTorque');
 
     aut
       .addExpression(
@@ -1758,7 +1718,7 @@ module.exports = {
         'DistanceJointLength',
         _('Distance joint length'),
         _('Modify a distance joint length.'),
-        _('Do _PARAM3__PARAM4_ to the length for distance joint _PARAM2_'),
+        _('the length for distance joint _PARAM2_'),
         _('Joints/Distance'),
         'JsPlatform/Extensions/distance_joint24.png',
         'JsPlatform/Extensions/distance_joint16.png'
@@ -1766,11 +1726,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setDistanceJointLength')
-      .setManipulatedType('number')
+      
       .setGetter('getDistanceJointLength');
 
     aut
@@ -1792,7 +1751,7 @@ module.exports = {
         'DistanceJointFrequency',
         _('Distance joint frequency'),
         _('Modify a distance joint frequency.'),
-        _('Do _PARAM3__PARAM4_ to the frequency for distance joint _PARAM2_'),
+        _('the frequency for distance joint _PARAM2_'),
         _('Joints/Distance'),
         'JsPlatform/Extensions/distance_joint24.png',
         'JsPlatform/Extensions/distance_joint16.png'
@@ -1800,11 +1759,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setDistanceJointFrequency')
-      .setManipulatedType('number')
+      
       .setGetter('getDistanceJointFrequency');
 
     aut
@@ -1826,9 +1784,7 @@ module.exports = {
         'DistanceJointDampingRatio',
         _('Distance joint damping ratio'),
         _('Modify a distance joint damping ratio.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the damping ratio for distance joint _PARAM2_'
-        ),
+        _('the damping ratio for distance joint _PARAM2_'),
         _('Joints/Distance'),
         'JsPlatform/Extensions/distance_joint24.png',
         'JsPlatform/Extensions/distance_joint16.png'
@@ -1836,11 +1792,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setDistanceJointDampingRatio')
-      .setManipulatedType('number')
+      
       .setGetter('getDistanceJointDampingRatio');
 
     aut
@@ -2125,7 +2080,7 @@ module.exports = {
         'RevoluteJointMotorSpeed',
         _('Revolute joint motor speed'),
         _('Modify a revolute joint motor speed.'),
-        _('Do _PARAM3__PARAM4_ to the motor speed for revolute joint _PARAM2_'),
+        _('the motor speed for revolute joint _PARAM2_'),
         _('Joints/Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
@@ -2133,11 +2088,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setRevoluteJointMotorSpeed')
-      .setManipulatedType('number')
+      
       .setGetter('getRevoluteJointMotorSpeed');
 
     aut
@@ -2159,9 +2113,7 @@ module.exports = {
         'RevoluteJointMaxMotorTorque',
         _('Revolute joint max motor torque'),
         _('Modify a revolute joint maximum motor torque.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the maximum motor torque for revolute joint _PARAM2_'
-        ),
+        _('the maximum motor torque for revolute joint _PARAM2_'),
         _('Joints/Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
@@ -2169,11 +2121,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setRevoluteJointMaxMotorTorque')
-      .setManipulatedType('number')
+      
       .setGetter('getRevoluteJointMaxMotorTorque');
 
     aut
@@ -2443,9 +2394,7 @@ module.exports = {
         'PrismaticJointMotorSpeed',
         _('Prismatic joint motor speed'),
         _('Modify a prismatic joint motor speed.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the motor force for prismatic joint _PARAM2_'
-        ),
+        _('the motor force for prismatic joint _PARAM2_'),
         _('Joints/Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
@@ -2453,11 +2402,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setPrismaticJointMotorSpeed')
-      .setManipulatedType('number')
+      
       .setGetter('getPrismaticJointMotorSpeed');
 
     aut
@@ -2479,9 +2427,7 @@ module.exports = {
         'PrismaticJointMaxMotorForce',
         _('Prismatic joint max motor force'),
         _('Modify a prismatic joint maximum motor force.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the maximum motor force for prismatic joint _PARAM2_'
-        ),
+        _('the maximum motor force for prismatic joint _PARAM2_'),
         _('Joints/Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
@@ -2489,11 +2435,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setPrismaticJointMaxMotorForce')
-      .setManipulatedType('number')
+      
       .setGetter('getPrismaticJointMaxMotorForce');
 
     aut
@@ -2753,7 +2698,7 @@ module.exports = {
         'GearJointRatio',
         _('Gear joint ratio'),
         _('Modify a Gear joint ratio.'),
-        _('Do _PARAM3__PARAM4_ to the ratio for gear joint _PARAM2_'),
+        _('the ratio for gear joint _PARAM2_'),
         _('Joints/Gear'),
         'JsPlatform/Extensions/gear_joint24.png',
         'JsPlatform/Extensions/gear_joint16.png'
@@ -2761,11 +2706,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setGearJointRatio')
-      .setManipulatedType('number')
+      
       .setGetter('getGearJointRatio');
 
     aut
@@ -2880,7 +2824,7 @@ module.exports = {
         'MouseJointMaxForce',
         _('Mouse joint max force'),
         _('Set a mouse joint maximum force.'),
-        _('Do _PARAM3__PARAM4_ to the maximum force for mouse joint _PARAM2_'),
+        _('the maximum force for mouse joint _PARAM2_'),
         _('Joints/Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
@@ -2888,11 +2832,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setMouseJointMaxForce')
-      .setManipulatedType('number')
+      
       .setGetter('getMouseJointMaxForce');
 
     aut
@@ -2914,7 +2857,7 @@ module.exports = {
         'MouseJointFrequency',
         _('Mouse joint frequency'),
         _('Set a mouse joint frequency.'),
-        _('Do _PARAM3__PARAM4_ to the frequency for mouse joint _PARAM2_'),
+        _('the frequency for mouse joint _PARAM2_'),
         _('Joints/Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
@@ -2922,11 +2865,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setMouseJointFrequency')
-      .setManipulatedType('number')
+      
       .setGetter('getMouseJointFrequency');
 
     aut
@@ -2948,7 +2890,7 @@ module.exports = {
         'MouseJointDampingRatio',
         _('Mouse joint damping ratio'),
         _('Set a mouse joint damping ratio.'),
-        _('Do _PARAM3__PARAM4_ to the damping ratio for mouse joint _PARAM2_'),
+        _('the damping ratio for mouse joint _PARAM2_'),
         _('Joints/Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
@@ -2956,11 +2898,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setMouseJointDampingRatio')
-      .setManipulatedType('number')
+      
       .setGetter('getMouseJointDampingRatio');
 
     aut
@@ -3119,7 +3060,7 @@ module.exports = {
         'WheelJointMotorSpeed',
         _('Wheel joint motor speed'),
         _('Modify a wheel joint motor speed.'),
-        _('Do _PARAM3__PARAM4_ to the motor speed for wheel joint _PARAM2_'),
+        _('the motor speed for wheel joint _PARAM2_'),
         _('Joints/Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
@@ -3127,11 +3068,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setWheelJointMotorSpeed')
-      .setManipulatedType('number')
+      
       .setGetter('getWheelJointMotorSpeed');
 
     aut
@@ -3153,9 +3093,7 @@ module.exports = {
         'WheelJointMaxMotorTorque',
         _('Wheel joint max motor torque'),
         _('Modify a wheel joint maximum motor torque.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the maximum motor torque for wheel joint _PARAM2_'
-        ),
+        _('the maximum motor torque for wheel joint _PARAM2_'),
         _('Joints/Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
@@ -3163,11 +3101,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setWheelJointMaxMotorTorque')
-      .setManipulatedType('number')
+      
       .setGetter('getWheelJointMaxMotorTorque');
 
     aut
@@ -3203,7 +3140,7 @@ module.exports = {
         'WheelJointFrequency',
         _('Wheel joint frequency'),
         _('Modify a wheel joint frequency.'),
-        _('Do _PARAM3__PARAM4_ to the frequency for wheel joint _PARAM2_'),
+        _('the frequency for wheel joint _PARAM2_'),
         _('Joints/Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
@@ -3211,11 +3148,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setWheelJointFrequency')
-      .setManipulatedType('number')
+      
       .setGetter('getWheelJointFrequency');
 
     aut
@@ -3237,7 +3173,7 @@ module.exports = {
         'WheelJointDampingRatio',
         _('Wheel joint damping ratio'),
         _('Modify a wheel joint damping ratio.'),
-        _('Do _PARAM3__PARAM4_ to the damping ratio for wheel joint _PARAM2_'),
+        _('the damping ratio for wheel joint _PARAM2_'),
         _('Joints/Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
@@ -3245,11 +3181,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setWheelJointDampingRatio')
-      .setManipulatedType('number')
+      
       .setGetter('getWheelJointDampingRatio');
 
     aut
@@ -3335,7 +3270,7 @@ module.exports = {
         'WeldJointFrequency',
         _('Weld joint frequency'),
         _('Modify a weld joint frequency.'),
-        _('Do _PARAM3__PARAM4_ to the frequency for weld joint _PARAM2_'),
+        _('the frequency for weld joint _PARAM2_'),
         _('Joints/Weld'),
         'JsPlatform/Extensions/weld_joint24.png',
         'JsPlatform/Extensions/weld_joint16.png'
@@ -3343,11 +3278,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setWeldJointFrequency')
-      .setManipulatedType('number')
+      
       .setGetter('getWeldJointFrequency');
 
     aut
@@ -3369,7 +3303,7 @@ module.exports = {
         'WeldJointDampingRatio',
         _('Weld joint damping ratio'),
         _('Modify a weld joint damping ratio.'),
-        _('Do _PARAM3__PARAM4_ to the damping ratio for weld joint _PARAM2_'),
+        _('the damping ratio for weld joint _PARAM2_'),
         _('Joints/Weld'),
         'JsPlatform/Extensions/weld_joint24.png',
         'JsPlatform/Extensions/weld_joint16.png'
@@ -3377,11 +3311,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setWeldJointDampingRatio')
-      .setManipulatedType('number')
+      
       .setGetter('getWeldJointDampingRatio');
 
     aut
@@ -3446,7 +3379,7 @@ module.exports = {
         'RopeJointMaxLength',
         _('Rope joint max length'),
         _('Modify a rope joint maximum length.'),
-        _('Do _PARAM3__PARAM4_ to the maximum length for rope joint _PARAM2_'),
+        _('the maximum length for rope joint _PARAM2_'),
         _('Joints/Rope'),
         'JsPlatform/Extensions/rope_joint24.png',
         'JsPlatform/Extensions/rope_joint16.png'
@@ -3454,11 +3387,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setRopeJointMaxLength')
-      .setManipulatedType('number')
+      
       .setGetter('getRopeJointMaxLength');
 
     aut
@@ -3516,9 +3448,7 @@ module.exports = {
         'FrictionJointMaxForce',
         _('Friction joint max force'),
         _('Modify a friction joint maximum force.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the maximum force for friction joint _PARAM2_'
-        ),
+        _('the maximum force for friction joint _PARAM2_'),
         _('Joints/Friction'),
         'JsPlatform/Extensions/friction_joint24.png',
         'JsPlatform/Extensions/friction_joint16.png'
@@ -3526,11 +3456,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setFrictionJointMaxForce')
-      .setManipulatedType('number')
+      
       .setGetter('getFrictionJointMaxForce');
 
     aut
@@ -3552,9 +3481,7 @@ module.exports = {
         'FrictionJointMaxTorque',
         _('Friction joint max torque'),
         _('Modify a friction joint maximum torque.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the maximum torque for friction joint _PARAM2_'
-        ),
+        _('the maximum torque for friction joint _PARAM2_'),
         _('Joints/Friction'),
         'JsPlatform/Extensions/friction_joint24.png',
         'JsPlatform/Extensions/friction_joint16.png'
@@ -3562,11 +3489,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setFrictionJointMaxTorque')
-      .setManipulatedType('number')
+      
       .setGetter('getFrictionJointMaxTorque');
 
     aut
@@ -3673,7 +3599,7 @@ module.exports = {
         'MotorJointAngularOffset',
         _('Motor joint angular offset'),
         _('Modify a motor joint angular offset.'),
-        _('Do _PARAM3__PARAM4_ to the angular offset for motor joint _PARAM2_'),
+        _('the angular offset for motor joint _PARAM2_'),
         _('Joints/Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
@@ -3681,11 +3607,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setMotorJointAngularOffset')
-      .setManipulatedType('number')
+      
       .setGetter('getMotorJointAngularOffset');
 
     aut
@@ -3707,7 +3632,7 @@ module.exports = {
         'MotorJointMaxForce',
         _('Motor joint max force'),
         _('Modify a motor joint maximum force.'),
-        _('Do _PARAM3__PARAM4_ to the maximum force for motor joint _PARAM2_'),
+        _('the maximum force for motor joint _PARAM2_'),
         _('Joints/Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
@@ -3715,11 +3640,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setMotorJointMaxForce')
-      .setManipulatedType('number')
+      
       .setGetter('getMotorJointMaxForce');
 
     aut
@@ -3741,7 +3665,7 @@ module.exports = {
         'MotorJointMaxTorque',
         _('Motor joint max torque'),
         _('Modify a motor joint maximum torque.'),
-        _('Do _PARAM3__PARAM4_ to the maximum torque for motor joint _PARAM2_'),
+        _('the maximum torque for motor joint _PARAM2_'),
         _('Joints/Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
@@ -3749,11 +3673,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setMotorJointMaxTorque')
-      .setManipulatedType('number')
+      
       .setGetter('getMotorJointMaxTorque');
 
     aut
@@ -3775,9 +3698,7 @@ module.exports = {
         'MotorJointCorrectionFactor',
         _('Motor joint correction factor'),
         _('Modify a motor joint correction factor.'),
-        _(
-          'Do _PARAM3__PARAM4_ to the correction factor for motor joint _PARAM2_'
-        ),
+        _('the correction factor for motor joint _PARAM2_'),
         _('Joints/Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
@@ -3785,11 +3706,10 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('operator', _("Modification's sign"))
-      .addParameter('expression', _('Value'))
+      .useStandardOperatorParameters("number")
       .getCodeExtraInformation()
       .setFunctionName('setMotorJointCorrectionFactor')
-      .setManipulatedType('number')
+      
       .setGetter('getMotorJointCorrectionFactor');
 
     aut

--- a/Extensions/PhysicsBehavior/Extension.cpp
+++ b/Extensions/PhysicsBehavior/Extension.cpp
@@ -352,50 +352,44 @@ void DeclarePhysicsBehaviorExtension(gd::PlatformExtension& extension) {
            "LinearVelocityX",
            _("X component"),
            _("Compare the linear velocity on the X axis of the object."),
-           _("Linear velocity on X axis of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the linear velocity on X axis"),
            _("Displacement"),
            "res/physics24.png",
            "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetLinearVelocityX")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddCondition(
            "LinearVelocityY",
            _("Y component"),
            _("Compare the linear velocity on the Y axis of the object."),
-           _("Linear velocity on Y axis of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the linear velocity on Y axis"),
            _("Displacement"),
            "res/physics24.png",
            "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetLinearVelocityY")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddCondition("LinearVelocity",
                      _("Linear speed"),
                      _("Compare the linear velocity of the object."),
-                     _("Linear velocity of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the linear velocity"),
                      _("Displacement"),
                      "res/physics24.png",
                      "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetLinearVelocity")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddAction("SetAngularVelocity",
@@ -415,33 +409,29 @@ void DeclarePhysicsBehaviorExtension(gd::PlatformExtension& extension) {
     aut.AddCondition("AngularVelocity",
                      _("Angular speed"),
                      _("Compare the angular speed of the object."),
-                     _("Angular speed of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the angular speed"),
                      _("Rotation"),
                      "res/physics24.png",
                      "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetAngularVelocity")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddCondition("LinearDamping",
                      _("Linear damping"),
                      _("Compare the linear damping of the object."),
-                     _("Linear damping of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the linear damping"),
                      _("Displacement"),
                      "res/physics24.png",
                      "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetLinearDamping")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddCondition("CollisionWith",
@@ -478,17 +468,15 @@ void DeclarePhysicsBehaviorExtension(gd::PlatformExtension& extension) {
     aut.AddCondition("AngularDamping",
                      _("Angular damping"),
                      _("Test the object's angular damping"),
-                     _("Angular damping of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the angular damping"),
                      _("Displacement"),
                      "res/physics24.png",
                      "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetAngularDamping")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddAction("SetAngularDamping",
@@ -556,36 +544,30 @@ void DeclarePhysicsBehaviorExtension(gd::PlatformExtension& extension) {
            "GetPolygonScaleX",
            _("Collision polygon X scale"),
            _("Test the value of the X scale of the collision polygon."),
-           _("The X scale of the collision polygon of _PARAM0_ is "
-             "_PARAM2__PARAM3_"),
+           _("the X scale of the collision polygon"),
            _("Collision polygon"),
            "res/physics24.png",
            "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetPolygonScaleX")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddCondition(
            "GetPolygonScaleY",
            _("Collision polygon Y scale"),
            _("Test the value of the Y scale of the collision polygon."),
-           _("The Y scale of the collision polygon of _PARAM0_ is "
-             "_PARAM2__PARAM3_"),
+           _("the Y scale of the collision polygon"),
            _("Collision polygon"),
            "res/physics24.png",
            "res/physics16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PhysicsBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .AddCodeOnlyParameter("currentScene", "")
         .SetFunctionName("GetPolygonScaleY")
-        .SetManipulatedType("number")
         .SetIncludeFile("PhysicsBehavior/PhysicsRuntimeBehavior.h");
 
     aut.AddExpression("PolygonScaleX",

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -137,7 +137,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
                   _("Gravity"),
                   _("Change the gravity applied on an object (in pixels per "
                     "second per second)."),
-                  _("Do _PARAM2__PARAM3_ to the gravity applied on _PARAM0_"),
+                  _("Do _PARAM2__PARAM3_ to the gravity of _PARAM0_"),
                   _("Options"),
                   "CppPlatform/Extensions/platformerobjecticon24.png",
                   "CppPlatform/Extensions/platformerobjecticon16.png")

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -120,34 +120,30 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
                      _("Gravity"),
                      _("Compare the gravity applied on the object (in pixels "
                        "per second per second)."),
-                     _("Gravity of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the gravity"),
                      _("Options"),
                      "CppPlatform/Extensions/platformerobjecticon24.png",
                      "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("GetGravity")
-        .SetManipulatedType("number")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction("Gravity",
                   _("Gravity"),
                   _("Change the gravity applied on an object (in pixels per "
                     "second per second)."),
-                  _("Do _PARAM2__PARAM3_ to the gravity of _PARAM0_"),
+                  _("the gravity"),
                   _("Options"),
                   "CppPlatform/Extensions/platformerobjecticon24.png",
                   "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("SetGravity")
-        .SetManipulatedType("number")
         .SetGetter("GetGravity")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
@@ -156,17 +152,15 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
            _("Maximum falling speed"),
            _("Compare the maximum falling speed of the object (in pixels per "
              "second)."),
-           _("The maximum falling speed of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the maximum falling speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("GetMaxFallingSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction(
@@ -174,17 +168,15 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
            _("Maximum falling speed"),
            _("Change the maximum falling speed of an object (in pixels per "
              "second)."),
-           _("Do _PARAM2__PARAM3_ to the maximum falling speed of _PARAM0_"),
+           _("the maximum falling speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("SetMaxFallingSpeed")
-        .SetManipulatedType("number")
         .SetGetter("GetMaxFallingSpeed")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
@@ -192,34 +184,30 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
                      _("Acceleration"),
                      _("Compare the acceleration of the object (in pixels per "
                        "second per second)."),
-                     _("The acceleration of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the acceleration"),
                      _("Options"),
                      "CppPlatform/Extensions/platformerobjecticon24.png",
                      "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("GetAcceleration")
-        .SetManipulatedType("number")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction("Acceleration",
                   _("Acceleration"),
                   _("Change the acceleration of an object (in pixels per "
                     "second per second)."),
-                  _("Do _PARAM2__PARAM3_ to the acceleration of _PARAM0_"),
+                  _("the acceleration"),
                   _("Options"),
                   "CppPlatform/Extensions/platformerobjecticon24.png",
                   "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("SetAcceleration")
-        .SetManipulatedType("number")
         .SetGetter("GetAcceleration")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
@@ -227,34 +215,30 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
                      _("Deceleration"),
                      _("Compare the deceleration of the object (in pixels per "
                        "second per second)."),
-                     _("The deceleration of _PARAM0_ is _PARAM2__PARAM3_"),
+                     _("the deceleration"),
                      _("Options"),
                      "CppPlatform/Extensions/platformerobjecticon24.png",
                      "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("GetDeceleration")
-        .SetManipulatedType("number")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction("Deceleration",
                   _("Deceleration"),
                   _("Change the deceleration of an object (in pixels per "
                     "second per second)."),
-                  _("Do _PARAM2__PARAM3_ to the deceleration of _PARAM0_"),
+                  _("the deceleration"),
                   _("Options"),
                   "CppPlatform/Extensions/platformerobjecticon24.png",
                   "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("SetDeceleration")
-        .SetManipulatedType("number")
         .SetGetter("GetDeceleration")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
@@ -262,33 +246,29 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
            "MaxSpeed",
            _("Maximum speed"),
            _("Compare the maximum speed of the object (in pixels per second)."),
-           _("The maximum speed of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the maximum speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .SetFunctionName("GetMaxSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction(
            "MaxSpeed",
            _("Maximum speed"),
            _("Change the maximum speed of an object (in pixels per second)."),
-           _("Do _PARAM2__PARAM3_ to the maximum speed of _PARAM0_"),
+           _("the maximum speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("SetMaxSpeed")
-        .SetManipulatedType("number")
         .SetGetter("GetMaxSpeed")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
@@ -296,33 +276,29 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
            "JumpSpeed",
            _("Jump speed"),
            _("Compare the jump speed of the object (in pixels per second)."),
-           _("The jump speed of _PARAM0_ is _PARAM2__PARAM3_"),
+           _("the jump speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("relationalOperator", _("Comparison sign"))
-        .AddParameter("expression", _("Value to compare"))
+        .UseStandardRelationalOperatorParameters("number")
         .MarkAsAdvanced()
         .SetFunctionName("GetJumpSpeed")
-        .SetManipulatedType("number")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction(
            "JumpSpeed",
            _("Jump speed"),
            _("Change the jump speed of an object (in pixels per second)."),
-           _("Do _PARAM2__PARAM3_ to the jump speed of _PARAM0_"),
+           _("the jump speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("operator", _("Modification's sign"))
-        .AddParameter("expression", _("Value"))
+        .UseStandardOperatorParameters("number")
         .SetFunctionName("SetJumpSpeed")
-        .SetManipulatedType("number")
         .SetGetter("GetJumpSpeed")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -368,48 +368,42 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
   obj.AddAction("OutlineSize",
                 _("Outline size"),
                 _("Modify the size of the outline of future drawings."),
-                _("Do _PARAM1__PARAM2_ to the size of the outline of _PARAM0_"),
+                _("the size of the outline"),
                 _("Setup"),
                 "res/actions/outlineSize24.png",
                 "res/actions/outlineSize.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Size in pixels"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetOutlineSize")
-      .SetManipulatedType("number")
       .SetGetter("GetOutlineSize")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
   obj.AddCondition("OutlineSize",
                    _("Outline size"),
                    _("Test the size of the outline."),
-                   _("The size of the outline of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the size of the outline"),
                    _("Setup"),
                    "res/conditions/outlineSize24.png",
                    "res/conditions/outlineSize.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Size to test"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetOutlineSize")
-      .SetManipulatedType("number")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
   obj.AddAction(
          "FillOpacity",
          _("Fill opacity"),
          _("Modify the opacity level used when filling future drawings."),
-         _("Do _PARAM1__PARAM2_ to the opacity of filling of _PARAM0_"),
+         _("the opacity of filling"),
          _("Setup"),
          "res/actions/opacity24.png",
          "res/actions/opacity.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetFillOpacity")
-      .SetManipulatedType("number")
       .SetGetter("GetFillOpacity")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
@@ -417,32 +411,28 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
          "FillOpacity",
          _("Fill opacity"),
          _("Test the value of the opacity level used when filling."),
-         _("The opacity level when filling of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the opacity level when filling"),
          _("Setup"),
          "res/conditions/opacity24.png",
          "res/conditions/opacity.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetFillOpacity")
-      .SetManipulatedType("number")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
   obj.AddAction(
          "OutlineOpacity",
          _("Outline opacity"),
          _("Modify the opacity of the outline of future drawings."),
-         _("Do _PARAM1__PARAM2_ to the opacity of the outline of _PARAM0_"),
+         _("the opacity of the outline"),
          _("Setup"),
          "res/actions/opacity24.png",
          "res/actions/opacity.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetOutlineOpacity")
-      .SetManipulatedType("number")
       .SetGetter("GetOutlineOpacity")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
@@ -450,16 +440,14 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
          "OutlineOpacity",
          _("Outline opacity"),
          _("Test the opacity of the outline."),
-         _("The opacity of the outline of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the opacity of the outline"),
          _("Setup"),
          "res/conditions/opacity24.png",
          "res/conditions/opacity.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetOutlineOpacity")
-      .SetManipulatedType("number")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
 #endif

--- a/Extensions/SkeletonObject/Extension.cpp
+++ b/Extensions/SkeletonObject/Extension.cpp
@@ -31,14 +31,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("ScaleX",
                    _("Scale X"),
                    _("Check the object scale X."),
-                   _("Current scale X of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the current scale X"),
                    _("Size"),
                    "JsPlatform/Extensions/skeletonicon24.png",
                    "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetScaleX",
                 _("Scale X"),
@@ -48,9 +46,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                 "JsPlatform/Extensions/skeletonicon24.png",
                 "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("ScaleX",
                     _("Scale X"),
@@ -62,14 +58,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("ScaleY",
                    _("Scale Y"),
                    _("Check the object scale Y."),
-                   _("Current scale Y of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the current scale Y"),
                    _("Size"),
                    "JsPlatform/Extensions/skeletonicon24.png",
                    "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetScaleY",
                 _("Scale Y"),
@@ -79,9 +73,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                 "JsPlatform/Extensions/skeletonicon24.png",
                 "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("ScaleY",
                     _("Scale Y"),
@@ -93,14 +85,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("Width",
                    _("Width"),
                    _("Check the object width."),
-                   _("Current width of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the current width"),
                    _("Size"),
                    "JsPlatform/Extensions/skeletonicon24.png",
                    "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetWidth",
                 _("Width"),
@@ -110,9 +100,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                 "JsPlatform/Extensions/skeletonicon24.png",
                 "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("Width",
                     _("Width"),
@@ -124,14 +112,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("Height",
                    _("Height"),
                    _("Check the object height."),
-                   _("Current height of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the current height"),
                    _("Size"),
                    "JsPlatform/Extensions/skeletonicon24.png",
                    "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetHeight",
                 _("Height"),
@@ -141,9 +127,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                 "JsPlatform/Extensions/skeletonicon24.png",
                 "JsPlatform/Extensions/skeletonicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("Height",
                     _("Height"),
@@ -208,14 +192,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("AnimationTime",
                    _("Current time"),
                    _("Check the current animation elapsed time."),
-                   _("Current animation time of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the current animation time"),
                    _("Animation"),
                    "JsPlatform/Extensions/skeletonanimationicon24.png",
                    "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetAnimationTime",
                 _("Current time"),
@@ -225,9 +207,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                 "JsPlatform/Extensions/skeletonanimationicon24.png",
                 "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("AnimationTime",
                     _("Current time"),
@@ -248,14 +228,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
          _("Current frame"),
          _("Check the current animation frame.\nIf the animation is set as "
            "smooth, a float can be (and probably will be) returned."),
-         _("Current animation frame of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the current animation frame"),
          _("Animation"),
          "JsPlatform/Extensions/skeletonanimationicon24.png",
          "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetAnimationFrame",
                 _("Current frame"),
@@ -265,9 +243,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                 "JsPlatform/Extensions/skeletonanimationicon24.png",
                 "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddExpression("AnimationFrame",
                     _("Current frame"),
@@ -287,14 +263,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                    _("Animation index"),
                    _("Check the current animation index.\nIf not sure about "
                      "the index, you can use the \"by name\" action"),
-                   _("Current animation of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the current animation"),
                    _("Animation"),
                    "JsPlatform/Extensions/skeletonanimationicon24.png",
                    "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction(
          "SetAnimationIndex",
@@ -306,14 +280,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
          "JsPlatform/Extensions/skeletonanimationicon24.png",
          "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .AddParameter(
           "expression", _("Blend time (0 for automatic blending)"), "", true)
       .SetDefaultValue("0")
       .AddParameter("expression", _("Loops (0 for infinite loops)"), "", true)
-      .SetDefaultValue("-1")
-      .SetManipulatedType("number");
+      .SetDefaultValue("-1");
 
   obj.AddExpression("AnimationIndex",
                     _("Animation index"),
@@ -325,14 +297,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("AnimationName",
                    _("Animation name"),
                    _("Check the current animation name."),
-                   _("Current animation of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the current animation"),
                    _("Animation"),
                    "JsPlatform/Extensions/skeletonanimationicon24.png",
                    "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text"))
-      .SetManipulatedType("string");
+      .UseStandardRelationalOperatorParameters("string");
 
   obj.AddAction("SetAnimationName",
                 _("Animation name"),
@@ -378,14 +348,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("AnimationTimeScale",
                    _("Time scale"),
                    _("Check the animation time scale."),
-                   _("Animation time scale of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the animation time scale"),
                    _("Animation"),
                    "JsPlatform/Extensions/skeletonanimationicon24.png",
                    "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetAnimationTimeScale",
                 _("Time scale"),
@@ -395,9 +363,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
                 "JsPlatform/Extensions/skeletonanimationicon24.png",
                 "JsPlatform/Extensions/skeletonanimationicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("AnimationTimeScale",
                     _("Time scale"),
@@ -420,16 +386,14 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
          "BonePositionX",
          _("Position X"),
          _("Check the bone position X."),
-         _("Current position X of _PARAM0_:_PARAM1_ is _PARAM2__PARAM3_"),
+         _("the current position X :_PARAM1_"),
          _("Bone"),
          "JsPlatform/Extensions/skeletonboneicon24.png",
          "JsPlatform/Extensions/skeletonboneicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetBonePositionX",
                 _("Position X"),
@@ -441,9 +405,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("BonePositionX",
                     _("Position X"),
@@ -458,16 +420,14 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
          "BonePositionY",
          _("Position Y"),
          _("Check the bone position Y."),
-         _("Current position Y of _PARAM0_:_PARAM1_ is _PARAM2__PARAM3_"),
+         _("the current position Y :_PARAM1_"),
          _("Bone"),
          "JsPlatform/Extensions/skeletonboneicon24.png",
          "JsPlatform/Extensions/skeletonboneicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetBonePositionY",
                 _("Position Y"),
@@ -479,9 +439,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("BonePositionY",
                     _("Position Y"),
@@ -505,13 +463,12 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .SetDefaultValue("\"\"")
       .AddParameter("operator", _("Modification's sign"))
       .AddParameter("expression", _("Position X"))
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Position Y"));
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("BoneAngle",
                    _("Angle"),
                    _("Check the bone angle (in degrees)."),
-                   _("Current angle of _PARAM0_:_PARAM1_ is _PARAM2__PARAM3_"),
+                   _("the current angle :_PARAM1_"),
                    _("Bone"),
                    "JsPlatform/Extensions/skeletonboneicon24.png",
                    "JsPlatform/Extensions/skeletonboneicon16.png")
@@ -519,8 +476,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
       .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .AddParameter("expression", _("Value"));
 
   obj.AddAction("SetBoneAngle",
                 _("Angle"),
@@ -532,9 +488,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("BoneAngle",
                     _("Angle"),
@@ -549,16 +503,14 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
          "BoneScaleX",
          _("Scale X"),
          _("Check the bone scale X."),
-         _("Current scale X of _PARAM0_:_PARAM1_ is _PARAM2__PARAM3_"),
+         _("the current scale X :_PARAM1_"),
          _("Bone"),
          "JsPlatform/Extensions/skeletonboneicon24.png",
          "JsPlatform/Extensions/skeletonboneicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetBoneScaleX",
                 _("Scale X"),
@@ -570,9 +522,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("BoneScaleX",
                     _("Scale X"),
@@ -587,16 +537,14 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
          "BoneScaleY",
          _("Scale Y"),
          _("Check the bone scale Y."),
-         _("Current scale Y of _PARAM0_:_PARAM1_ is _PARAM2__PARAM3_"),
+         _("the current scale Y :_PARAM1_"),
          _("Bone"),
          "JsPlatform/Extensions/skeletonboneicon24.png",
          "JsPlatform/Extensions/skeletonboneicon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetBoneScaleY",
                 _("Scale Y"),
@@ -608,9 +556,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Bone path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("BoneScaleY",
                     _("Scale Y"),
@@ -701,16 +647,14 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("SlotZOrder",
                    _("Z-order"),
                    _("Check the slot Z-order."),
-                   _("Z-order of _PARAM0_:_PARAM1_ is _PARAM2__PARAM3_"),
+                   _("the z-order :_PARAM1_"),
                    _("Slot"),
                    "JsPlatform/Extensions/skeletonsloticon24.png",
                    "JsPlatform/Extensions/skeletonsloticon16.png")
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Slot path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetSlotZOrder",
                 _("Z-order"),
@@ -722,9 +666,7 @@ void DeclareSkeletonObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Skeleton")
       .AddParameter("string", _("Slot path"))
       .SetDefaultValue("\"\"")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("SlotZOrder",
                     _("Z-order"),

--- a/Extensions/TextEntryObject/Extension.cpp
+++ b/Extensions/TextEntryObject/Extension.cpp
@@ -31,32 +31,28 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("String",
                 _("Text in memory"),
                 _("Modify text in memory of the object"),
-                _("Do _PARAM1__PARAM2_ to the text in memory of _PARAM0_"),
+                _("the text in memory"),
                 "",
                 "CppPlatform/Extensions/textentry24.png",
                 "CppPlatform/Extensions/textentryicon.png")
 
       .AddParameter("object", _("Object"), "TextEntry")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("string", _("Text"))
+      .UseStandardOperatorParameters("string")
       .SetFunctionName("SetString")
-      .SetManipulatedType("string")
       .SetGetter("GetString")
       .SetIncludeFile("TextEntryObject/TextEntryObject.h");
 
   obj.AddCondition("String",
                    _("Text in memory"),
                    _("Test the text of a Text Entry object."),
-                   _("The text of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the text"),
                    "",
                    "CppPlatform/Extensions/textentry24.png",
                    "CppPlatform/Extensions/textentryicon.png")
 
       .AddParameter("object", _("Object"), "TextEntry")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text to test"))
+      .UseStandardRelationalOperatorParameters("string")
       .SetFunctionName("GetString")
-      .SetManipulatedType("string")
       .SetIncludeFile("TextEntryObject/TextEntryObject.h");
 
   obj.AddAction(

--- a/Extensions/TextObject/Extension.cpp
+++ b/Extensions/TextObject/Extension.cpp
@@ -36,32 +36,28 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("String",
                 _("Modify the text"),
                 _("Modify the text of a Text object."),
-                _("Do _PARAM1__PARAM2_ to the text of _PARAM0_"),
+                _("the text"),
                 "",
                 "res/actions/text24.png",
                 "res/actions/text.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("string", _("Text"))
+      .UseStandardOperatorParameters("string")
       .SetFunctionName("SetString")
-      .SetManipulatedType("string")
       .SetGetter("GetString")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddCondition("String",
                    _("Compare the text"),
                    _("Compare the text of a Text object."),
-                   _("Text of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the text"),
                    "",
                    "res/conditions/text24.png",
                    "res/conditions/text.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text to compare"))
+      .UseStandardRelationalOperatorParameters("string")
       .SetFunctionName("GetString")
-      .SetManipulatedType("string")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddAction("Font",
@@ -80,110 +76,96 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("Size",
                 _("Size"),
                 _("Change the size of the text."),
-                _("Do _PARAM1__PARAM2_ to the size of the text of _PARAM0_"),
+                _("the size of the text"),
                 "",
                 "res/actions/characterSize24.png",
                 "res/actions/characterSize.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetCharacterSize")
-      .SetManipulatedType("number")
       .SetGetter("GetCharacterSize")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddCondition("Size",
                    _("Size"),
                    _("Compare the size of the text"),
-                   _("The size of the text of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the size of the text"),
                    "",
                    "res/conditions/characterSize24.png",
                    "res/conditions/characterSize.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Size to test"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetCharacterSize")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddCondition("ScaleX",
                    _("Scale on X axis"),
                    _("Compare the scale of the text on the X axis"),
-                   _("The X scale of the text _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the X scale of the text _PARAM0_"),
                    "Scale",
                    "res/conditions/scaleWidth24.png",
                    "res/conditions/scaleWidth.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("x-scale to test"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetScaleX")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddAction(
          "ScaleX",
          _("Scale on X axis"),
          _("Modify the scale of the text on the X axis (default scale is 1)"),
-         _("Do _PARAM1__PARAM2_ to the scale of _PARAM0_ on the X axis"),
+         _("the scale on the X axis"),
          _("Scale"),
          "res/actions/scaleWidth24.png",
          "res/actions/scaleWidth.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetScaleX")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddCondition("ScaleY",
                    _("Scale on Y axis"),
                    _("Compare the scale of the text on the Y axis"),
-                   _("The Y scale of the text _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the Y scale of the text _PARAM0_"),
                    "Scale",
                    "res/conditions/scaleHeight24.png",
                    "res/conditions/scaleHeight.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("y-scale to test"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetScaleY")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddAction(
          "ScaleY",
          _("Scale on Y axis"),
          _("Modify the scale of the text on the Y axis (default scale is 1)"),
-         _("Do _PARAM1__PARAM2_ to the scale of _PARAM0_ on the Y axis"),
+         _("the scale on the Y axis"),
          _("Scale"),
          "res/actions/scaleHeight24.png",
          "res/actions/scaleHeight.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetScaleY")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddAction(
          "Scale",
          _("Scale"),
          _("Modify the scale of the specified object (default scale is 1)"),
-         _("Do _PARAM1__PARAM2_ to the scale of _PARAM0_"),
+         _("the scale"),
          _("Scale"),
          "res/actions/scale24.png",
          "res/actions/scale.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetScale")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddAction(
@@ -263,16 +245,14 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                 _("Change text opacity"),
                 _("Change the opacity of a Text. 0 is fully transparent, 255 "
                   "is opaque (default)."),
-                _("Do _PARAM1__PARAM2_ to the opacity of _PARAM0_"),
+                _("the opacity"),
                 "",
                 "res/actions/opacity24.png",
                 "res/actions/opacity.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetOpacity")
-      .SetManipulatedType("number")
       .SetGetter("GetOpacity")
       .SetIncludeFile("TextObject/TextObject.h");
 
@@ -280,16 +260,14 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                    _("Opacity"),
                    _("Compare the opacity of a Text object, between 0 (fully "
                      "transparent) to 255 (opaque)."),
-                   _("The opacity of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the opacity"),
                    "",
                    "res/conditions/opacity24.png",
                    "res/conditions/opacity.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetOpacity")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddAction("SetSmooth",
@@ -395,32 +373,28 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("Angle",
                 _("Angle"),
                 _("Modify the angle of a Text object."),
-                _("Do _PARAM1__PARAM2_ to the angle of _PARAM0_"),
+                _("the angle"),
                 _("Rotation"),
                 "res/actions/rotate24.png",
                 "res/actions/rotate.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetAngle")
-      .SetManipulatedType("number")
       .SetGetter("GetAngle")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddCondition("Angle",
                    _("Angle"),
                    _("Compare the value of the angle of a Text object."),
-                   _("The angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the angle"),
                    _("Rotation"),
                    "res/conditions/rotate24.png",
                    "res/conditions/rotate.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetAngle")
-      .SetManipulatedType("number")
       .SetIncludeFile("TextObject/TextObject.h");
 
   obj.AddCondition("Padding",
@@ -428,30 +402,26 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                    _("Compare the number of pixels around a text object. If "
                      "the shadow or the outline around the text are getting "
                      "cropped, raise this value."),
-                   _("The padding of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the padding"),
                    _("Style"),
                    "res/conditions/textPadding24.png",
                    "res/conditions/textPadding.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetPadding",
                 _("Padding"),
                 _("Set the number of pixels around a text object. If the "
                   "shadow or the outline around the text are getting cropped, "
                   "raise this value."),
-                _("Do _PARAM1__PARAM2_ to the padding of _PARAM0_"),
+                _("the padding"),
                 _("Style"),
                 "res/actions/textPadding24.png",
                 "res/actions/textPadding.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddAction("SetTextAlignment",
                 _("Alignment"),
@@ -473,15 +443,13 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
   obj.AddCondition("TextAlignment",
                    _("Alignment"),
                    _("Compare the text alignment of a multiline text object."),
-                   _("The alignment of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the alignment"),
                    _("Style"),
                    "res/conditions/textAlign24.png",
                    "res/conditions/textAlign.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("string", _("Text to compare"))
-      .SetManipulatedType("string");
+      .UseStandardRelationalOperatorParameters("string");
 
   obj.AddAction(
          "SetWrapping",
@@ -509,28 +477,24 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("WrappingWidth",
                 _("Wrapping width"),
                 _("Modify the word wrapping width of a Text object."),
-                _("Do _PARAM1__PARAM2_ to the wrapping width of _PARAM0_"),
+                _("the wrapping width"),
                 _("Style"),
                 "res/actions/wordWrap24.png",
                 "res/actions/wordWrap.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddCondition("WrappingWidth",
                    _("Wrapping width"),
                    _("Test the word wrapping width of a Text object."),
-                   _("The wrapping width of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the wrapping width"),
                    _("Style"),
                    "res/conditions/wordWrap24.png",
                    "res/conditions/wordWrap.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddExpression("Padding",
                     _("Padding"),

--- a/Extensions/TiledSpriteObject/Extension.cpp
+++ b/Extensions/TiledSpriteObject/Extension.cpp
@@ -33,29 +33,25 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
                    _("Opacity"),
                    _("Compare the opacity of a Tiled Sprite, between 0 (fully "
                      "transparent) to 255 (opaque)."),
-                   _("The opacity of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the opacity"),
                    _("Visibility"),
                    "res/conditions/opacity24.png",
                    "res/conditions/opacity.png")
 
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
-      .SetManipulatedType("number");
+      .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("SetOpacity",
                 _("Change Tiled Sprite opacity"),
                 _("Change the opacity of a Tiled Sprite. 0 is fully transparent, 255 "
                   "is opaque (default)."),
-                _("Do _PARAM1__PARAM2_ to the opacity of _PARAM0_"),
+                _("the opacity"),
                 _("Visibility"),
                 "res/actions/opacity24.png",
                 "res/actions/opacity.png")
 
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value (between 0 and 255)"))
-      .SetManipulatedType("number");
+      .UseStandardOperatorParameters("number");
 
   obj.AddExpression("Opacity",
                     _("Opacity"),
@@ -79,112 +75,98 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("Width",
                 _("Width"),
                 _("Modify the width of a Tiled Sprite."),
-                _("Do _PARAM1__PARAM2_ to the width of _PARAM0_"),
+                _("the width"),
                 _("Size and angle"),
                 "res/actions/scaleWidth24.png",
                 "res/actions/scaleWidth.png")
 
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetWidth")
-      .SetManipulatedType("number")
       .SetGetter("GetWidth")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
   obj.AddCondition("Width",
                    _("Width"),
                    _("Test the width of a Tiled Sprite."),
-                   _("The width of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the width"),
                    _("Size and angle"),
                    "res/conditions/scaleWidth24.png",
                    "res/conditions/scaleWidth.png")
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetWidth")
-      .SetManipulatedType("number")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
   obj.AddAction("Height",
                 _("Height"),
                 _("Modify the height of a Tiled Sprite."),
-                _("Do _PARAM1__PARAM2_ to the height of _PARAM0_"),
+                _("the height"),
                 _("Size and angle"),
                 "res/actions/scaleHeight24.png",
                 "res/actions/scaleHeight.png")
 
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetHeight")
-      .SetManipulatedType("number")
       .SetGetter("GetHeight")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
   obj.AddCondition("Height",
                    _("Height"),
                    _("Test the height of a Tiled Sprite."),
-                   _("The height of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the height"),
                    _("Size and angle"),
                    "res/conditions/scaleHeight24.png",
                    "res/conditions/scaleHeight.png")
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetHeight")
-      .SetManipulatedType("number")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
   obj.AddAction("Angle",
                 _("Angle"),
                 _("Modify the angle of a Tiled Sprite."),
-                _("Do _PARAM1__PARAM2_ to the angle of _PARAM0_"),
+                _("the angle"),
                 _("Size and angle"),
                 "res/actions/rotate24.png",
                 "res/actions/rotate.png")
 
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetAngle")
-      .SetManipulatedType("number")
       .SetGetter("GetAngle")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
   obj.AddCondition("Angle",
                    _("Angle"),
                    _("Test the angle of a Tiled Sprite."),
-                   _("The angle of _PARAM0_ is _PARAM1__PARAM2_"),
+                   _("the angle"),
                    _("Size and angle"),
                    "res/conditions/rotate24.png",
                    "res/conditions/rotate.png")
 
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetHidden()  // Now available for all objects
       .SetFunctionName("GetAngle")
-      .SetManipulatedType("number")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
   obj.AddAction(
          "XOffset",
          _("Image X Offset"),
          _("Modify the offset used on the X axis when displaying the image."),
-         _("Do _PARAM1__PARAM2_ to the X offset of _PARAM0_"),
+         _("the X offset"),
          _("Image offset"),
          "res/conditions/scaleWidth24.png",
          "res/conditions/scaleWidth.png")
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetXOffset")
-      .SetManipulatedType("number")
       .SetGetter("GetXOffset")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
@@ -192,32 +174,28 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
          "XOffset",
          _("Image X Offset"),
          _("Test the offset used on the X axis when displaying the image."),
-         _("The X offset of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the X offset"),
          _("Image offset"),
          "res/conditions/scaleWidth24.png",
          "res/conditions/scaleWidth.png")
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetXOffset")
-      .SetManipulatedType("number")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
   obj.AddAction(
          "YOffset",
          _("Image Y Offset"),
          _("Modify the offset used on the Y axis when displaying the image."),
-         _("Do _PARAM1__PARAM2_ to the Y offset of _PARAM0_"),
+         _("the Y offset"),
          _("Image offset"),
          "res/conditions/scaleWidth24.png",
          "res/conditions/scaleWidth.png")
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetYOffset")
-      .SetManipulatedType("number")
       .SetGetter("GetYOffset")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
@@ -225,16 +203,14 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
          "YOffset",
          _("Image Y Offset"),
          _("Test the offset used on the Y axis when displaying the image."),
-         _("The Y offset of _PARAM0_ is _PARAM1__PARAM2_"),
+         _("the Y offset"),
          _("Image offset"),
          "res/conditions/scaleWidth24.png",
          "res/conditions/scaleWidth.png")
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value to compare"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetYOffset")
-      .SetManipulatedType("number")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 #endif
 }

--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -132,232 +132,204 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
   aut.AddAction("Acceleration",
                 _("Acceleration"),
                 _("Change the acceleration of the object"),
-                _("Do _PARAM2__PARAM3_ to the acceleration of _PARAM0_"),
+                _("the acceleration"),
                 _("Movement"),
                 "CppPlatform/Extensions/topdownmovementicon24.png",
                 "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetAcceleration")
       .SetGetter("GetAcceleration")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition("Acceleration",
                    _("Acceleration"),
                    _("Compare the acceleration of the object"),
-                   _("Acceleration of _PARAM0_ is _PARAM2__PARAM3_"),
+                   _("the acceleration"),
                    _("Movement"),
                    "CppPlatform/Extensions/topdownmovementicon24.png",
                    "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetAcceleration")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddAction("Deceleration",
                 _("Deceleration"),
                 _("Change the deceleration of the object"),
-                _("Do _PARAM2__PARAM3_ to the deceleration of _PARAM0_"),
+                _("the deceleration"),
                 _("Movement"),
                 "CppPlatform/Extensions/topdownmovementicon24.png",
                 "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetDeceleration")
       .SetGetter("GetDeceleration")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition("Deceleration",
                    _("Deceleration"),
                    _("Compare the deceleration of the object"),
-                   _("Deceleration of _PARAM0_ is _PARAM2__PARAM3_"),
+                   _("the deceleration"),
                    _("Movement"),
                    "CppPlatform/Extensions/topdownmovementicon24.png",
                    "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetDeceleration")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddAction("MaxSpeed",
                 _("Maximum speed"),
                 _("Change the maximum speed of the object"),
-                _("Do _PARAM2__PARAM3_ to the max. speed of _PARAM0_"),
+                _("the max. speed"),
                 _("Movement"),
                 "CppPlatform/Extensions/topdownmovementicon24.png",
                 "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .SetFunctionName("SetMaxSpeed")
       .SetGetter("GetMaxSpeed")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition("MaxSpeed",
                    _("Maximum speed"),
                    _("Compare the maximum speed of the object"),
-                   _("Max. speed of _PARAM0_ is _PARAM2__PARAM3_"),
+                   _("the max. speed"),
                    _("Movement"),
                    "CppPlatform/Extensions/topdownmovementicon24.png",
                    "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetMaxSpeed")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition("Speed",
                    _("Speed"),
                    _("Compare the speed of the object"),
-                   _("Speed of _PARAM0_ is _PARAM2__PARAM3_"),
+                   _("the speed"),
                    _("Movement"),
                    "CppPlatform/Extensions/topdownmovementicon24.png",
                    "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .SetFunctionName("GetSpeed")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddAction("AngularMaxSpeed",
                 _("Angular maximum speed"),
                 _("Change the maximum angular speed of the object"),
-                _("Do _PARAM2__PARAM3_ to the max. angular speed of _PARAM0_"),
+                _("the max. angular speed"),
                 _("Movement"),
                 "CppPlatform/Extensions/topdownmovementicon24.png",
                 "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetAngularMaxSpeed")
       .SetGetter("GetAngularMaxSpeed")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition("AngularMaxSpeed",
                    _("Angular maximum speed"),
                    _("Compare the maximum angular speed of the object"),
-                   _("Max. angular speed of _PARAM0_ is _PARAM2__PARAM3_"),
+                   _("the max. angular speed"),
                    _("Movement"),
                    "CppPlatform/Extensions/topdownmovementicon24.png",
                    "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetAngularMaxSpeed")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddAction("AngleOffset",
                 _("Rotation offset"),
                 _("Change the rotation offset applied when moving the object"),
-                _("Do _PARAM2__PARAM3_ to the rotation offset of _PARAM0_"),
+                _("the rotation offset"),
                 _("Movement"),
                 "CppPlatform/Extensions/topdownmovementicon24.png",
                 "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("operator", _("Modification's sign"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetAngleOffset")
       .SetGetter("GetAngleOffset")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition(
          "AngleOffset",
          _("Rotation offset"),
          _("Compare the rotation offset applied when moving the object"),
-         _("Rotation offset of _PARAM0_ is _PARAM2__PARAM3_"),
+         _("the rotation offset"),
          _("Movement"),
          "CppPlatform/Extensions/topdownmovementicon24.png",
          "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetAngleOffset")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition(
          "Angle",
          _("Angle of movement"),
          _("Compare the angle of the top-down movemement of the object."),
-         _("Angle of movemement of _PARAM0_ is _PARAM2__PARAM3_"),
+         _("the angle of movemement"),
          _("Movement"),
          "CppPlatform/Extensions/topdownmovementicon24.png",
          "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetAngle")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition(
          "XVelocity",
          _("Speed on X axis"),
          _("Compare the velocity of the top-down movemement of the object on the X axis."),
-         _("Speed of movemement on X axis of _PARAM0_ is _PARAM2__PARAM3_"),
+         _("the speed of movemement on X axis"),
          _("Movement"),
          "CppPlatform/Extensions/topdownmovementicon24.png",
          "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetXVelocity")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddCondition(
          "YVelocity",
          _("Speed on Y axis"),
          _("Compare the velocity of the top-down movemement of the object on the Y axis."),
-         _("Speed of movemement on Y axis of _PARAM0_ is _PARAM2__PARAM3_"),
+         _("the speed of movemement on Y axis"),
          _("Movement"),
          "CppPlatform/Extensions/topdownmovementicon24.png",
          "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("relationalOperator", _("Sign of the test"))
-      .AddParameter("expression", _("Value"))
+      .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("GetYVelocity")
-      .SetManipulatedType("number")
       .SetIncludeFile("TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
   aut.AddAction("AllowDiagonals",

--- a/Extensions/Video/JsExtension.js
+++ b/Extensions/Video/JsExtension.js
@@ -205,7 +205,7 @@ module.exports = {
         _(
           "Set the volume of the video object, between 0 (muted) and 100 (maximum)."
         ),
-        _("Do _PARAM1__PARAM2_ to the volume of _PARAM0_"),
+        _("the volume"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
@@ -279,17 +279,15 @@ module.exports = {
         "Volume",
         _("Volume"),
         _("Compare the current volume of a video object."),
-        _("Volume of _PARAM0_ is _PARAM1__PARAM2_"),
+        _("the volume"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
       )
       .addParameter("object", _("Video object"), "VideoObject", false)
-      .addParameter("relationalOperator", _("Sign of the test"))
-      .addParameter("expression", _("Value (0-100)"))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName("getVolume")
-      .setManipulatedType("number");
+      .setFunctionName("getVolume");
 
     object
       .addCondition(
@@ -334,34 +332,30 @@ module.exports = {
         "Duration",
         _("Duration"),
         _("Compare the duration of a video object"),
-        _("Duration of _PARAM0_ is _PARAM1__PARAM2_ seconds"),
+        _("the duration (in seconds)"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
       )
       .addParameter("object", _("Video object"), "VideoObject", false)
-      .addParameter("relationalOperator", _("Sign of the test"))
-      .addParameter("expression", _("Value"))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName("getDuration")
-      .setManipulatedType("number");
+      .setFunctionName("getDuration");
 
     object
       .addCondition(
         "CurrentTime",
         _("Current time"),
         _("Compare the current time of a video object"),
-        _("Current time of _PARAM0_ is _PARAM1__PARAM2_ seconds"),
+        _("the current time (in seconds)"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
       )
       .addParameter("object", _("Video object"), "VideoObject", false)
-      .addParameter("relationalOperator", _("Sign of the test"))
-      .addParameter("expression", _("Value"))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName("getCurrentTime")
-      .setManipulatedType("number");
+      .setFunctionName("getCurrentTime");
 
     object
       .addCondition(
@@ -384,7 +378,7 @@ module.exports = {
         _(
           "Set opacity of the specified video object, between 0 (fully transparent) and 255 (opaque)."
         ),
-        _("Do _PARAM1__PARAM2_ to the opacity of _PARAM0_"),
+        _("the opacity"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
@@ -402,17 +396,15 @@ module.exports = {
         "GetOpacity",
         _("Opacity"),
         _("Compare the opacity of a video object"),
-        _("Opacity of _PARAM0_ is _PARAM1__PARAM2_"),
+        _("the opacity"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
       )
       .addParameter("object", _("Video object"), "VideoObject", false)
-      .addParameter("relationalOperator", _("Sign of the test"))
-      .addParameter("expression", _("Opacity (0-255)"))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName("getOpacity")
-      .setManipulatedType("number");
+      .setFunctionName("getOpacity");
 
     object
       .addExpression(
@@ -433,7 +425,7 @@ module.exports = {
         _(
           "Set playback speed of the specified video object, (1 = the default speed, >1 = faster and <1 = slower)."
         ),
-        _("Do _PARAM1__PARAM2_ to the playback speed of _PARAM0_"),
+        _("the playback speed"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
@@ -451,17 +443,15 @@ module.exports = {
         "GetPlaybackSpeed",
         _("Playback speed "),
         _("Compare the playback speed of a video object"),
-        _("Playback speed of _PARAM0_ is _PARAM1__PARAM2_"),
+        _("the playback speed"),
         "",
         "JsPlatform/Extensions/videoicon24.png",
         "JsPlatform/Extensions/videoicon16.png"
       )
       .addParameter("object", _("Video object"), "VideoObject", false)
-      .addParameter("relationalOperator", _("Sign of the test"))
-      .addParameter("expression", _("Speed (0-100)"))
+      .useStandardRelationalOperatorParameters("number")
       .getCodeExtraInformation()
-      .setFunctionName("getPlaybackSpeed")
-      .setManipulatedType("number");
+      .setFunctionName("getPlaybackSpeed");
 
     object
       .addExpression(

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -962,6 +962,10 @@ interface InstructionMetadata {
         [Const] DOMString type, [Const] DOMString supplementaryInformation);
     [Ref] InstructionMetadata SetDefaultValue([Const] DOMString defaultValue);
     [Ref] InstructionMetadata SetParameterLongDescription([Const] DOMString longDescription);
+
+    [Ref] InstructionMetadata UseStandardOperatorParameters([Const] DOMString type);
+    [Ref] InstructionMetadata UseStandardRelationalOperatorParameters([Const] DOMString type);
+
     [Ref] InstructionMetadata MarkAsSimple();
     [Ref] InstructionMetadata MarkAsAdvanced();
     [Ref] InstructionMetadata MarkAsComplex();

--- a/newIDE/app/scripts/codemod-sentences.js
+++ b/newIDE/app/scripts/codemod-sentences.js
@@ -1,0 +1,275 @@
+const shell = require('shelljs');
+const path = require('path');
+const fs = require('fs');
+const recursive = require('recursive-readdir');
+
+const corePath = path.join(__dirname, '../../../Core/GDCore');
+const extensionsPath = path.join(__dirname, '../../../Extensions');
+const newIdeAppSrcPath = path.join(__dirname, '../src');
+const verbose = true;
+const dryRun = true;
+
+const excludedPaths = ['locales'];
+
+let totalSentenceReplacementCount = 0;
+let totalParameterReplacementCount = 0;
+
+const sanitizeExtracts = extract => {
+  return extract.replace(/"\s+"/g, '').trim();
+};
+
+const isSubjectTheObject = subject => {
+  return subject.match(/^_PARAM0_/);
+};
+
+const uncapitalize = str => {
+  if (!str) return str;
+  return str[0].toLowerCase() + str.substr(1);
+}
+
+const normalizeSubject = subject => {
+  if (subject.indexOf('the ') !== 0 &&
+  subject.indexOf('The ') !== 0) return 'the ' + uncapitalize(subject);
+  return uncapitalize(subject);
+};
+
+const normalizeExtraDetails = extraDetails => {
+  if (!extraDetails) return;
+  if (extraDetails === 'seconds') {
+    return '(in seconds)'
+  }
+  if (extraDetails === 'deg.') {
+    return '(in degrees)'
+  }
+
+  if (extraDetails.indexOf('(') !== 0) {
+    console.warn('⚠️ Extra details found but not normalized:', extraDetails);
+  }
+
+  return extraDetails;
+}
+
+const patternsToReplace = [
+  {
+    regexp: /_\(\s*(["'])Do\s*_PARAM.__PARAM._\s+to\s+(.*)\s*of\s(([\S\s](?!["']\s*\)))*.)["']\s*\)/g,
+    replacer: (match, quote, rawAttribute, rawSubject) => {
+      totalSentenceReplacementCount++;
+
+      let finalSubject = '';
+      const attribute = sanitizeExtracts(rawAttribute);
+      const subject = sanitizeExtracts(rawSubject);
+      if (isSubjectTheObject(subject)) {
+        // Some details can be after the object
+        const extraSubjectDetails = subject.replace(/^_PARAM0_/, '').trim();
+        finalSubject = normalizeSubject(
+          attribute + (extraSubjectDetails ? ' ' + extraSubjectDetails : '')
+        );
+      } else {
+        finalSubject = normalizeSubject(attribute + ' of ' + subject);
+      }
+
+      const replacement = `_(${quote}${finalSubject}${quote})`;
+
+      if (verbose) {
+        console.log('Replaced "' + match + '" by "' + replacement + '"');
+        console.log('action finalSubject:', finalSubject);
+      }
+
+      return replacement;
+    },
+  },
+  {
+    regexp: /_\(\s*(["'])Do\s*_PARAM.__PARAM._\s+to\s+(([\S\s](?!["']\s*\)))*.)["']\s*\)/g,
+    replacer: (match, quote, rawSubject) => {
+      totalSentenceReplacementCount++;
+
+      const finalSubject = normalizeSubject(sanitizeExtracts(rawSubject));
+
+      const replacement = `_(${quote}${finalSubject}${quote})`;
+
+      if (verbose) {
+        console.log('Replaced "' + match + '" by "' + replacement + '"');
+        console.log('(action standalone subject: ' + finalSubject + ')');
+      }
+
+      return replacement;
+    },
+  },
+  {
+    regexp: /_\(\s*(["'])(.*)\s*of(.*)\s+is\s+_PARAM.__PARAM._(([\S\s](?!\s*\),))*).?["']\s*\)/g,
+    replacer: (match, quote, rawAttribute, rawSubject, rawExtraDetails) => {
+      totalSentenceReplacementCount++;
+
+      let finalSubject = '';
+      const extraDetails = normalizeExtraDetails(sanitizeExtracts(rawExtraDetails));
+      const attribute = sanitizeExtracts(rawAttribute);
+      const subject = sanitizeExtracts(rawSubject);
+      if (isSubjectTheObject(subject)) {
+        // Some details can be after the object
+        const extraSubjectDetails = subject.replace(/^_PARAM0_/, '').trim();
+        finalSubject = normalizeSubject(
+          attribute +
+            (extraSubjectDetails ? ' ' + extraSubjectDetails : '') +
+            (extraDetails ? ' ' + extraDetails : '')
+        );
+      } else {
+        finalSubject = normalizeSubject(
+          attribute +
+            ' of ' +
+            subject +
+            (extraDetails ? ' ' + extraDetails : '')
+        );
+      }
+
+      const replacement = `_(${quote}${finalSubject}${quote})`;
+
+      if (verbose) {
+        console.log('Replaced "' + match + '" by "' + replacement + '"');
+        console.log('condition finalSubject:', finalSubject);
+      }
+
+      return replacement;
+    },
+  },
+  {
+    regexp: /_\(\s*(["'])(.*)\s+is\s+_PARAM.__PARAM._(([\S\s](?!\s*\),))*).?["']\s*\)/g,
+    replacer: (match, quote, rawSubject, rawExtraDetails) => {
+      totalSentenceReplacementCount++;
+
+      const extraDetails = normalizeExtraDetails(sanitizeExtracts(rawExtraDetails));
+      const finalSubject = normalizeSubject(
+        sanitizeExtracts(rawSubject) + (extraDetails ? ' ' + extraDetails : '')
+      );
+
+      const replacement = `_(${quote}${finalSubject}${quote})`;
+
+      if (verbose) {
+        console.log('Replaced "' + match + '" by "' + replacement + '"');
+        console.log('(condition standalone subject: ' + finalSubject + ')');
+      }
+
+      return replacement;
+    },
+  },
+  {
+    regexp: /.([aA])ddParameter\(\s*(["'])(operator|relationalOperator)["']\s*,\s*_\(\s*["'](.*)["']\s*\)\s*\)\s*.[aA]ddParameter\(\s*["'](.*)["']\s*,\s*_\(["'].*["']\)\s*\)(([\s\S](?!\);))*)\.[sS]etManipulatedType\("(.*)"\)/g,
+    replacer: (match, a, quote, operatorType, operatorLabel, valueType, otherFunctionCalls, unused, type) => {
+      totalParameterReplacementCount++;
+      const isCamelCase = a === 'a';
+
+      if (valueType === 'expression') {
+        valueType = 'number'
+      }
+
+      if (operatorLabel !== "Modification's sign" && operatorLabel !== "Comparison sign" && operatorLabel !== "Sign of the test") {
+        console.warn('⚠️ Unknown operator label:', operatorLabel);
+      }
+
+      if (type !== valueType) {
+        console.warn('⚠️ These types differs (between value and SetManipulatedType):', type, valueType);
+      }
+      if (type !== 'string' && type !== 'number') {
+        console.warn('⚠️ This type (for SetManipulatedType) was not recognized:', type);
+      }
+
+      let method = operatorType === 'operator' ? 'UseStandardOperatorParameters' : 'UseStandardRelationalOperatorParameters';
+      if (isCamelCase) method = uncapitalize(method);
+
+      const replacement = `.${method}("${type}")${otherFunctionCalls}`;
+      if (verbose) {
+        console.log('Replaced "' + match + '" by "' + replacement + '"');
+      }
+
+      return replacement;
+    },
+  },
+];
+
+const replacePattern = (source, pattern) => {
+  return source.replace(pattern.regexp, pattern.replacer);
+};
+
+const replaceSentencesInFile = filePath =>
+  new Promise((resolve, reject) =>
+    fs.readFile(filePath, { encoding: 'utf8' }, (err, source) => {
+      if (err) return reject(err);
+
+      let newSource = source;
+      patternsToReplace.forEach(pattern => {
+        newSource = replacePattern(newSource, pattern);
+      });
+
+      if (source === newSource) {
+        return resolve({
+          filePath,
+          changed: false,
+        });
+      }
+
+      if (!dryRun) {
+        fs.writeFile(filePath, newSource, { encoding: 'utf8' }, err => {
+          if (err) {
+            shell.echo(`❌ Error while writing file ${filePath}: `, err);
+            return reject(err);
+          }
+
+          resolve({
+            filePath,
+            changed: true,
+          });
+        });
+      } else {
+        shell.echo('ℹ️  Would write ' + filePath);
+        resolve({
+          filePath,
+          changed: true,
+        });
+      }
+    })
+  );
+
+const readRecursiveFiles = path =>
+  new Promise((resolve, reject) => {
+    recursive(path, (err, files) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(files);
+    });
+  });
+
+const flatten = arr => [].concat(...arr);
+
+Promise.all([
+  readRecursiveFiles(corePath),
+  readRecursiveFiles(extensionsPath),
+  readRecursiveFiles(newIdeAppSrcPath),
+]).then(
+  allFileLists => {
+    const files = flatten(allFileLists);
+
+    return Promise.all(
+      files.map(filePath => {
+        if (excludedPaths.some(excludedPath => filePath.includes(excludedPath)))
+          return null;
+
+        return replaceSentencesInFile(filePath);
+      })
+    ).then(results => {
+      shell.echo(`ℹ️ Made ${totalSentenceReplacementCount} sentence replacements.`);
+      shell.echo(`ℹ️ Made ${totalParameterReplacementCount} parameter replacements.`);
+      if (dryRun) {
+        shell.echo(
+          `⚠️  This was a dry-run, set dryRun to false to do real changes.`
+        );
+        shell.exit(0);
+      }
+    });
+  },
+  err => {
+    shell.echo(`❌ Error(s) occurred while reading files `, err);
+    shell.exit(1);
+  }
+);

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -331,36 +331,26 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
           gd.EventsBasedBehavior.getPropertyConditionName(propertyName),
           propertyLabel,
           i18n._(t`Compare the content of ${propertyLabel}`),
-          i18n._(t`Property ${propertyName} of _PARAM0_ is _PARAM2__PARAM3_`),
+          i18n._(t`the property ${propertyName}`),
           eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
           'res/function.png'
         )
       )
-        .addParameter(
-          'relationalOperator',
-          i18n._(t`Sign of the test`),
-          '',
-          false
-        )
-        .addParameter('string', i18n._(t`String to compare against`), '', false)
+        .useStandardRelationalOperatorParameters('string')
         .getCodeExtraInformation()
-        .setFunctionName(getterName)
-        .setManipulatedType('string');
+        .setFunctionName(getterName);
 
       addObjectAndBehaviorParameters(
         behaviorMetadata.addScopedAction(
           gd.EventsBasedBehavior.getPropertyActionName(propertyName),
           propertyLabel,
-          i18n._(t`Update the content of ${propertyLabel}`),
-          i18n._(
-            t`Do _PARAM2__PARAM3_ to property ${propertyName} of _PARAM0_`
-          ),
+          i18n._(t`Change the content of ${propertyLabel}`),
+          i18n._(t`the property ${propertyName}`),
           eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
           'res/function.png'
         )
       )
-        .addParameter('operator', i18n._(t`Modification's sign`), '', false)
-        .addParameter('string', i18n._(t`New value`), '', false)
+        .useStandardOperatorParameters('string')
         .getCodeExtraInformation()
         .setFunctionName(setterName)
         .setManipulatedType('string')
@@ -383,44 +373,28 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
           gd.EventsBasedBehavior.getPropertyConditionName(propertyName),
           propertyLabel,
           i18n._(t`Compare the value of ${propertyLabel}`),
-          i18n._(t`Property ${propertyName} of _PARAM0_ is _PARAM2__PARAM3_`),
+          i18n._(t`the property ${propertyName}`),
           eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
           'res/function.png'
         )
       )
-        .addParameter(
-          'relationalOperator',
-          i18n._(t`Sign of the test`),
-          '',
-          false
-        )
-        .addParameter(
-          'expression',
-          i18n._(t`Value to compare against`),
-          '',
-          false
-        )
+        .useStandardRelationalOperatorParameters('number')
         .getCodeExtraInformation()
-        .setFunctionName(getterName)
-        .setManipulatedType('number');
+        .setFunctionName(getterName);
 
       addObjectAndBehaviorParameters(
         behaviorMetadata.addScopedAction(
           gd.EventsBasedBehavior.getPropertyActionName(propertyName),
           propertyLabel,
-          i18n._(t`Update the value of ${propertyLabel}`),
-          i18n._(
-            t`Do _PARAM2__PARAM3_ to property ${propertyName} of _PARAM0_`
-          ),
+          i18n._(t`Change the value of ${propertyLabel}`),
+          i18n._(t`the property ${propertyName}`),
           eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
           'res/function.png'
         )
       )
-        .addParameter('operator', i18n._(t`Modification's sign`), '', false)
-        .addParameter('expression', i18n._(t`New value`), '', false)
+        .useStandardOperatorParameters('number')
         .getCodeExtraInformation()
         .setFunctionName(setterName)
-        .setManipulatedType('number')
         .setGetter(getterName);
     } else if (propertyType === 'Boolean') {
       addObjectAndBehaviorParameters(

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -38,6 +38,12 @@ const styles = {
 
 export const reactDndInstructionType = 'GD_DRAGGED_INSTRUCTION';
 
+const capitalize = (str: string) => {
+  if (!str) return '';
+
+  return str[0].toUpperCase() + str.substr(1);
+};
+
 const DragSourceAndDropTarget = makeDragSourceAndDropTarget<{
   isCondition: boolean,
 }>(reactDndInstructionType);
@@ -106,8 +112,15 @@ export default class Instruction extends React.Component<Props> {
           const isParameter =
             parameterIndex >= 0 && parameterIndex < parametersCount;
 
-          if (!isParameter)
-            return <span key={i}>{formattedTexts.getString(i)}</span>;
+          if (!isParameter) {
+            return (
+              <span key={i}>
+                {i === 0
+                  ? capitalize(formattedTexts.getString(i))
+                  : formattedTexts.getString(i)}
+              </span>
+            );
+          }
 
           const parameterMetadata = metadata.getParameter(parameterIndex);
           const parameterType = parameterMetadata.getType();

--- a/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
@@ -54,15 +54,11 @@ export const renderInlineOperator = ({
     );
   }
 
-  if (
-    value !== '=' &&
-    value !== '+' &&
-    value !== '-' &&
-    value !== '*' &&
-    value !== '/'
-  ) {
-    return <InvalidParameterValue>{value}</InvalidParameterValue>;
-  }
+  if (value === '=') return <Trans>set to</Trans>;
+  else if (value === '+') return <Trans>add</Trans>;
+  else if (value === '-') return <Trans>subtract</Trans>;
+  else if (value === '/') return <Trans>divide by</Trans>;
+  else if (value === '*') return <Trans>multiply by</Trans>;
 
-  return value;
+  return <InvalidParameterValue>{value}</InvalidParameterValue>;
 };

--- a/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
@@ -45,6 +45,7 @@ export default class OperatorField extends Component<ParameterFieldProps> {
 export const renderInlineOperator = ({
   value,
   InvalidParameterValue,
+  useAssignmentOperators,
 }: ParameterInlineRendererProps) => {
   if (!value) {
     return (
@@ -54,11 +55,19 @@ export const renderInlineOperator = ({
     );
   }
 
-  if (value === '=') return <Trans>set to</Trans>;
-  else if (value === '+') return <Trans>add</Trans>;
-  else if (value === '-') return <Trans>subtract</Trans>;
-  else if (value === '/') return <Trans>divide by</Trans>;
-  else if (value === '*') return <Trans>multiply by</Trans>;
+  if (useAssignmentOperators) {
+    if (value === '=') return <Trans>=</Trans>;
+    else if (value === '+') return <Trans>+=</Trans>;
+    else if (value === '-') return <Trans>-=</Trans>;
+    else if (value === '/') return <Trans>/=</Trans>;
+    else if (value === '*') return <Trans>*=</Trans>;
+  } else {
+    if (value === '=') return <Trans>set to</Trans>;
+    else if (value === '+') return <Trans>add</Trans>;
+    else if (value === '-') return <Trans>subtract</Trans>;
+    else if (value === '/') return <Trans>divide by</Trans>;
+    else if (value === '*') return <Trans>multiply by</Trans>;
+  }
 
   return <InvalidParameterValue>{value}</InvalidParameterValue>;
 };

--- a/newIDE/app/src/EventsSheet/ParameterFields/ParameterInlineRenderer.flow.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ParameterInlineRenderer.flow.js
@@ -14,6 +14,7 @@ export type ParameterInlineRendererProps = {|
   value: string,
   renderObjectThumbnail: string => React.Node,
   InvalidParameterValue: InvalidParameterValueProps => React.Node,
+  useAssignmentOperators: boolean,
 |};
 
 /**

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -30,6 +30,7 @@ export type PreferencesValues = {|
   autosaveOnPreview: boolean,
   useNewInstructionEditorDialog: boolean,
   useGDJSDevelopmentWatcher: boolean,
+  eventsSheetUseAssignmentOperators: boolean,
 |};
 
 export type Preferences = {|
@@ -46,6 +47,7 @@ export type Preferences = {|
   setAutosaveOnPreview: (enabled: boolean) => void,
   setUseNewInstructionEditorDialog: (enabled: boolean) => void,
   setUseGDJSDevelopmentWatcher: (enabled: boolean) => void,
+  setEventsSheetUseAssignmentOperators: (enabled: boolean) => void,
 |};
 
 export const initialPreferences = {
@@ -61,6 +63,7 @@ export const initialPreferences = {
     autosaveOnPreview: true,
     useNewInstructionEditorDialog: false,
     useGDJSDevelopmentWatcher: true,
+    eventsSheetUseAssignmentOperators: false,
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -74,6 +77,7 @@ export const initialPreferences = {
   setAutosaveOnPreview: () => {},
   setUseNewInstructionEditorDialog: (enabled: boolean) => {},
   setUseGDJSDevelopmentWatcher: (enabled: boolean) => {},
+  setEventsSheetUseAssignmentOperators: (enabled: boolean) => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -73,6 +73,7 @@ export default class PreferencesDialog extends Component<Props, State> {
             setAutosaveOnPreview,
             setUseNewInstructionEditorDialog,
             setUseGDJSDevelopmentWatcher,
+            setEventsSheetUseAssignmentOperators,
           }) => {
             const dismissedAlertMessages = getDismissedAlertMessages(
               values.hiddenAlertMessages
@@ -155,6 +156,20 @@ export default class PreferencesDialog extends Component<Props, State> {
                     labelPosition="right"
                     label={
                       <Trans>Display object thumbnails in Events Sheets</Trans>
+                    }
+                  />
+                </Line>
+                <Line>
+                  <Toggle
+                    onToggle={(e, check) =>
+                      setEventsSheetUseAssignmentOperators(check)
+                    }
+                    toggled={values.eventsSheetUseAssignmentOperators}
+                    labelPosition="right"
+                    label={
+                      <Trans>
+                        Display assignment operators in Events Sheets
+                      </Trans>
                     }
                   />
                 </Line>

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -40,6 +40,9 @@ export default class PreferencesProvider extends React.Component<Props, State> {
       this
     ),
     setUseGDJSDevelopmentWatcher: this._setUseGDJSDevelopmentWatcher.bind(this),
+    setEventsSheetUseAssignmentOperators: this._setEventsSheetUseAssignmentOperators.bind(
+      this
+    ),
   };
 
   componentDidMount() {
@@ -102,6 +105,20 @@ export default class PreferencesProvider extends React.Component<Props, State> {
         values: {
           ...state.values,
           useGDJSDevelopmentWatcher,
+        },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _setEventsSheetUseAssignmentOperators(
+    eventsSheetUseAssignmentOperators: boolean
+  ) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          eventsSheetUseAssignmentOperators,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)


### PR DESCRIPTION
I made a script that automatically update all the sentences for action/condition acting on a value (number or string) + additional changes to move from the "canonical":

> `Do [operator][value] to [subject] [of object]` (for actions) and `[value] [of object] is [operator] [value]` (for conditions)

to a more english readable:

> `Change [subject] [of object]: [operator][value]` (for actions) and `[value] [of object][operator] [value]` (for conditions)

As an example, instead of "Do +3 to the variable Test of MyObject", we now have "Change variable Test of MyObject: Add 3" (operators for actions are now shown in plain english).

This is following [this discussion](https://github.com/4ian/GDevelop/issues/927#issuecomment-567153253).

The reasons are to have:
* Proper english sentences
* Consistency between actions/conditions in the order of operator/values/subjects.

Another advantage is that this refactoring made the API simpler (cc @blurymind ;)) (could be made even more simple): 
![image](https://user-images.githubusercontent.com/1280130/71419962-cd41f300-2672-11ea-986c-6c4dd72adf49.png)

Here are real examples to give you an idea:

<img width="300" alt="Screenshot 2019-12-24 16 27 20" src="https://user-images.githubusercontent.com/1280130/71420020-227e0480-2673-11ea-81d2-a780ab15caed.png">
<img width="388" alt="Screenshot 2019-12-24 16 27 27" src="https://user-images.githubusercontent.com/1280130/71420021-227e0480-2673-11ea-9314-b474e26b0ebd.png">
<img width="219" alt="Screenshot 2019-12-24 16 27 40" src="https://user-images.githubusercontent.com/1280130/71420022-227e0480-2673-11ea-9d43-52d2d18cfe64.png">
<img width="463" alt="Screenshot 2019-12-24 16 27 01" src="https://user-images.githubusercontent.com/1280130/71420018-21e56e00-2673-11ea-846d-adb7e31f6776.png">
<img width="410" alt="Screenshot 2019-12-24 16 27 10" src="https://user-images.githubusercontent.com/1280130/71420019-21e56e00-2673-11ea-9fa7-a944fa966fac.png">
<img width="531" alt="Screenshot 2019-12-24 16 26 27" src="https://user-images.githubusercontent.com/1280130/71420015-214cd780-2673-11ea-9988-368755d61bd8.png">
<img width="404" alt="Screenshot 2019-12-24 16 26 37" src="https://user-images.githubusercontent.com/1280130/71420016-21e56e00-2673-11ea-9de5-2fa9a3ed3575.png">

It should be much simpler to update this/translate this because **all the hardcoded sentences are gone** and **only the subjects** ("the width", "the height", "the x position") are now to be translated! So instead of translating two sentences (one for condition, one for  action), you only have to translate one word for both :)

Let me know what you think. The main downside of this will be to see how to update all the doc/tutorials for this.