### PR TITLE
Conscistent font-weight on object name

### DIFF
--- a/newIDE/app/src/UI/Theme/DarkTheme/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/DarkTheme/EventsSheet.css
@@ -130,7 +130,7 @@
 .gd-events-sheet-dark-theme .instruction-parameter.objectList,
 .gd-events-sheet-dark-theme .instruction-parameter.objectListWithoutPicking {
   color: #b77cff;
-  font-style: italic;
+  font-weight: bold;
 }
 
 .gd-events-sheet-dark-theme .instruction-parameter.behavior {


### PR DESCRIPTION
In light theme, object parameters are bolder than in dark theme.
So italic is remove and bold is added in dark theme.