### PR TITLE
Improve font for Text & BBText

### DIFF
--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -85,7 +85,8 @@ module.exports = {
       objectProperties.set(
         'fontFamily',
         new gd.PropertyDescriptor(objectContent.fontFamily)
-          .setType('string')
+          .setType("resource")
+          .addExtraInfo("font")
           .setLabel(_('Base font family'))
       );
 

--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -85,8 +85,8 @@ module.exports = {
       objectProperties.set(
         'fontFamily',
         new gd.PropertyDescriptor(objectContent.fontFamily)
-          .setType("resource")
-          .addExtraInfo("font")
+          .setType('resource')
+          .addExtraInfo('font')
           .setLabel(_('Base font family'))
       );
 
@@ -520,7 +520,10 @@ module.exports = {
         .getProperties(this.project)
         .get('fontFamily')
         .getValue();
-      this._pixiObject.textStyles.default.fontFamily = fontFamily;
+      this._pixiObject.textStyles.default.fontFamily = this._pixiResourcesLoader.getFontFamily(
+        this.project,
+        fontFamily
+      );
 
       const wordWrap = this._associatedObject
         .getProperties(this.project)

--- a/Extensions/BBText/bbtextruntimeobject-pixi-renderer.js
+++ b/Extensions/BBText/bbtextruntimeobject-pixi-renderer.js
@@ -13,7 +13,10 @@ gdjs.BBTextRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene) {
   if (this._pixiObject === undefined) {
     this._pixiObject = new MultiStyleText(runtimeObject._text, {
       default: {
-        fontFamily: runtimeObject._fontFamily,
+        fontFamily: runtimeScene
+          .getGame()
+          .getFontManager()
+          .getFontFamily(runtimeObject._fontFamily),
         fontSize: runtimeObject._fontSize + 'px',
         fill: runtimeObject._color,
         tagStyle: 'bbcode',

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -89,6 +89,9 @@ export default class TextEditor extends React.Component<EditorProps, void> {
             }}
             style={styles.checkbox}
           />
+          <MiniToolbarText>
+            <Trans>Font:</Trans>
+          </MiniToolbarText>
           <ResourceSelector
             margin="none"
             project={project}


### PR DESCRIPTION
@blurymind 
In the second commit i try to add the resource selector for the font.
In the IDE the resource selector is showing, but the font value correct for the BBText object ?

Edit : 
For the first commit i add a font label because it's hard to see the input if you didn't know.

Note see if canBeReset can be used too
https://github.com/4ian/GDevelop/pull/1308
