### PR TITLE
Yarn fixes

### DIFF
--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -284,10 +284,10 @@ gdjs.dialogueTree.getLineOptionsCount = function() {
  */
 gdjs.dialogueTree.confirmSelectOption = function() {
   if (
-    this.dialogueIsRunning &&
-    this.dialogueData.select &&
-    !this.selectedOptionUpdated &&
-    this.selectedOption !== -1
+    !this.dialogueIsRunning ||
+    (this.dialogueData.select &&
+      !this.selectedOptionUpdated &&
+      this.selectedOption !== -1)
   ) {
     this.commandCalls = [];
     try {
@@ -307,7 +307,6 @@ gdjs.dialogueTree.confirmSelectOption = function() {
  * Select next option during Options type line parsing. Hook this to your game input.
  */
 gdjs.dialogueTree.selectNextOption = function() {
-  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption += 1;
     this.selectedOption = gdjs.dialogueTree._cycledOptionIndex(
@@ -321,7 +320,6 @@ gdjs.dialogueTree.selectNextOption = function() {
  * Select previous option during Options type line parsing. Hook this to your game input.
  */
 gdjs.dialogueTree.selectPreviousOption = function() {
-  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption -= 1;
     this.selectedOption = gdjs.dialogueTree._cycledOptionIndex(
@@ -336,7 +334,6 @@ gdjs.dialogueTree.selectPreviousOption = function() {
  * @param {number} optionIndex The index of the option to select
  */
 gdjs.dialogueTree.selectOption = function(optionIndex) {
-  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption = gdjs.dialogueTree._normalizedOptionIndex(
       this.selectedOption
@@ -350,7 +347,6 @@ gdjs.dialogueTree.selectOption = function(optionIndex) {
  * @returns {number} The index of the currently selected option
  */
 gdjs.dialogueTree.getSelectedOption = function() {
-  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     return this.selectedOption;
   }
@@ -365,7 +361,6 @@ gdjs.dialogueTree.getSelectedOption = function() {
  * @returns {boolean} true if the selected option was updated since the last call to this function
  */
 gdjs.dialogueTree.hasSelectedOptionChanged = function() {
-  if (!this.dialogueIsRunning) return;
   if (this.selectedOptionUpdated) {
     this.selectedOptionUpdated = false;
     if (this.selectedOption === -1) this.selectedOption = 0;
@@ -402,7 +397,6 @@ gdjs.dialogueTree.isDialogueLineType = function(type) {
  * @param {string} branchName The Dialogue Branch name you want to check.
  */
 gdjs.dialogueTree.hasDialogueBranch = function(branchName) {
-  if (!this.dialogueIsRunning) return false;
   return (
     this.runner &&
     this.runner.yarnNodes &&

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -271,7 +271,7 @@ gdjs.dialogueTree.getLineOptionsTextVertical = function(optionSelectionCursor) {
  * @returns {number} The number of options
  */
 gdjs.dialogueTree.getLineOptionsCount = function() {
-  if (!this.dialogueIsRunning || this.options.length) {
+  if (this.dialogueIsRunning && this.options.length) {
     return this.optionsCount;
   }
   return 0;
@@ -283,11 +283,11 @@ gdjs.dialogueTree.getLineOptionsCount = function() {
  * This will advance the dialogue tree to the dialogue branch was selected by the player.
  */
 gdjs.dialogueTree.confirmSelectOption = function() {
+  if (!this.dialogueIsRunning) return;
   if (
-    !this.dialogueIsRunning ||
-    (this.dialogueData.select &&
-      !this.selectedOptionUpdated &&
-      this.selectedOption !== -1)
+    this.dialogueData.select &&
+    !this.selectedOptionUpdated &&
+    this.selectedOption !== -1
   ) {
     this.commandCalls = [];
     try {
@@ -307,6 +307,7 @@ gdjs.dialogueTree.confirmSelectOption = function() {
  * Select next option during Options type line parsing. Hook this to your game input.
  */
 gdjs.dialogueTree.selectNextOption = function() {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption += 1;
     this.selectedOption = gdjs.dialogueTree._cycledOptionIndex(
@@ -320,6 +321,7 @@ gdjs.dialogueTree.selectNextOption = function() {
  * Select previous option during Options type line parsing. Hook this to your game input.
  */
 gdjs.dialogueTree.selectPreviousOption = function() {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption -= 1;
     this.selectedOption = gdjs.dialogueTree._cycledOptionIndex(
@@ -334,6 +336,7 @@ gdjs.dialogueTree.selectPreviousOption = function() {
  * @param {number} optionIndex The index of the option to select
  */
 gdjs.dialogueTree.selectOption = function(optionIndex) {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption = gdjs.dialogueTree._normalizedOptionIndex(
       this.selectedOption
@@ -347,6 +350,7 @@ gdjs.dialogueTree.selectOption = function(optionIndex) {
  * @returns {number} The index of the currently selected option
  */
 gdjs.dialogueTree.getSelectedOption = function() {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     return this.selectedOption;
   }

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -120,6 +120,7 @@ gdjs.dialogueTree.completeClippedTextScrolling = function() {
  * Useful to prevent the user from skipping to next line before the current one has been printed fully.
  */
 gdjs.dialogueTree.hasClippedScrollingCompleted = function() {
+  if (!this.dialogueIsRunning) return false;
   if (this.dialogueData && this.dialogueText.length) {
     return this.clipTextEnd >= this.dialogueText.length;
   }
@@ -131,7 +132,7 @@ gdjs.dialogueTree.hasClippedScrollingCompleted = function() {
  * Used with the scrollClippedText to achieve a classic scrolling text, as well as any <<wait>> effects to pause scrolling.
  */
 gdjs.dialogueTree.getClippedLineText = function() {
-  return this.dialogueText.length
+  return this.dialogueIsRunning && this.dialogueText.length
     ? this.dialogueText.substring(0, this.clipTextEnd)
     : '';
 };
@@ -142,7 +143,9 @@ gdjs.dialogueTree.getClippedLineText = function() {
  */
 gdjs.dialogueTree.getLineText = function() {
   this.completeClippedTextScrolling();
-  return this.dialogueText.length ? this.dialogueText : '';
+  return this.dialogueIsRunning && this.dialogueText.length
+    ? this.dialogueText
+    : '';
 };
 
 /**
@@ -177,6 +180,8 @@ gdjs.dialogueTree.getCommandParameter = function(paramIndex) {
  * @param {string} command The command you want to check for being called. Write it without the `<<>>`.
  */
 gdjs.dialogueTree.isCommandCalled = function(command) {
+  if (!this.dialogueIsRunning) return false;
+
   var commandCalls = gdjs.dialogueTree.commandCalls;
   var clipTextEnd = gdjs.dialogueTree.clipTextEnd;
   var dialogueText = gdjs.dialogueTree.dialogueText;
@@ -225,7 +230,7 @@ gdjs.dialogueTree._cycledOptionIndex = function(optionIndex) {
  * @param {number} optionIndex The index of the option you want to get
  */
 gdjs.dialogueTree.getLineOption = function(optionIndex) {
-  if (!this.options.length) return [];
+  if (!this.dialogueIsRunning || !this.options.length) return [];
   optionIndex = gdjs.dialogueTree._normalizedOptionIndex(optionIndex);
   return this.options[optionIndex];
 };
@@ -239,7 +244,7 @@ gdjs.dialogueTree.getLineOptionsText = function(
   optionSelectionCursor,
   addNewLine
 ) {
-  if (!this.options.length) return '';
+  if (!this.dialogueIsRunning || !this.options.length) return '';
   var textResult = '';
   this.options.forEach(function(optionText, index) {
     if (index === gdjs.dialogueTree.selectedOption) {
@@ -266,7 +271,7 @@ gdjs.dialogueTree.getLineOptionsTextVertical = function(optionSelectionCursor) {
  * @returns {number} The number of options
  */
 gdjs.dialogueTree.getLineOptionsCount = function() {
-  if (this.options.length) {
+  if (!this.dialogueIsRunning || this.options.length) {
     return this.optionsCount;
   }
   return 0;
@@ -279,6 +284,7 @@ gdjs.dialogueTree.getLineOptionsCount = function() {
  */
 gdjs.dialogueTree.confirmSelectOption = function() {
   if (
+    this.dialogueIsRunning &&
     this.dialogueData.select &&
     !this.selectedOptionUpdated &&
     this.selectedOption !== -1
@@ -301,6 +307,7 @@ gdjs.dialogueTree.confirmSelectOption = function() {
  * Select next option during Options type line parsing. Hook this to your game input.
  */
 gdjs.dialogueTree.selectNextOption = function() {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption += 1;
     this.selectedOption = gdjs.dialogueTree._cycledOptionIndex(
@@ -314,6 +321,7 @@ gdjs.dialogueTree.selectNextOption = function() {
  * Select previous option during Options type line parsing. Hook this to your game input.
  */
 gdjs.dialogueTree.selectPreviousOption = function() {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption -= 1;
     this.selectedOption = gdjs.dialogueTree._cycledOptionIndex(
@@ -328,6 +336,7 @@ gdjs.dialogueTree.selectPreviousOption = function() {
  * @param {number} optionIndex The index of the option to select
  */
 gdjs.dialogueTree.selectOption = function(optionIndex) {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     this.selectedOption = gdjs.dialogueTree._normalizedOptionIndex(
       this.selectedOption
@@ -341,6 +350,7 @@ gdjs.dialogueTree.selectOption = function(optionIndex) {
  * @returns {number} The index of the currently selected option
  */
 gdjs.dialogueTree.getSelectedOption = function() {
+  if (!this.dialogueIsRunning) return;
   if (this.dialogueData.select) {
     return this.selectedOption;
   }
@@ -355,6 +365,7 @@ gdjs.dialogueTree.getSelectedOption = function() {
  * @returns {boolean} true if the selected option was updated since the last call to this function
  */
 gdjs.dialogueTree.hasSelectedOptionChanged = function() {
+  if (!this.dialogueIsRunning) return;
   if (this.selectedOptionUpdated) {
     this.selectedOptionUpdated = false;
     if (this.selectedOption === -1) this.selectedOption = 0;
@@ -391,6 +402,7 @@ gdjs.dialogueTree.isDialogueLineType = function(type) {
  * @param {string} branchName The Dialogue Branch name you want to check.
  */
 gdjs.dialogueTree.hasDialogueBranch = function(branchName) {
+  if (!this.dialogueIsRunning) return false;
   return (
     this.runner &&
     this.runner.yarnNodes &&

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -133,7 +133,7 @@ gdjs.dialogueTree.hasClippedScrollingCompleted = function() {
  */
 gdjs.dialogueTree.getClippedLineText = function() {
   return this.dialogueIsRunning && this.dialogueText.length
-    ? this.dialogueText.substring(0, this.clipTextEnd)
+    ? this.dialogueText.substring(0, this.clipTextEnd + 1)
     : '';
 };
 

--- a/GDJS/Runtime/jsonmanager.js
+++ b/GDJS/Runtime/jsonmanager.js
@@ -56,7 +56,7 @@ gdjs.JsonManager.prototype.preloadJsons = function(onProgress, onComplete) {
   /** @type JsonManagerRequestCallback */
   var onLoad = function(error, jsonContent) {
     if (error) {
-      console.error("Error while preloading a json resource:" + error);
+      console.error('Error while preloading a json resource:' + error);
     }
 
     loaded++;
@@ -101,6 +101,12 @@ gdjs.JsonManager.prototype.loadJson = function(resourceName, callback) {
       ),
       null
     );
+    return;
+  }
+
+  // Don't fetch again an object that is already in memory
+  if (this._loadedJsons[resourceName]) {
+    callback(null, this._loadedJsons[resourceName]);
     return;
   }
 


### PR DESCRIPTION
- fixes bug mentioned here
https://forum.gdevelop-app.com/t/yarn-dialogue-system-fails-to-parse-json-file/22663/4
also addressing corner case where users try to load and use the json file at the beginning of the scene
- fixes yarn drops a character bug mentioned here
https://forum.gdevelop-app.com/t/yarn-drops-last-character-from-dialogue-node/21432/4

Might see to address more corner cases where improper use crashes the game. I wonder if we could show some more informative message when its not used properly - like a pop up or something. I could do console.error in a few places