### PR TITLE
Add new GDJS callbacks: first scene loaded, pre/post events

### DIFF
--- a/GDJS/Runtime/gd.js
+++ b/GDJS/Runtime/gd.js
@@ -18,10 +18,13 @@ window.gdjs = {
    * @memberOf gdjs
    */
   evtTools: {},
+  callbacksFirstRuntimeSceneLoaded: [],
   callbacksRuntimeSceneLoaded: [],
-  callbacksRuntimeSceneUnloaded: [],
+  callbacksRuntimeScenePreEvents: [],
+  callbacksRuntimeScenePostEvents: [],
   callbacksRuntimeScenePaused: [],
   callbacksRuntimeSceneResumed: [],
+  callbacksRuntimeSceneUnloaded: [],
   callbacksObjectDeletedFromScene: [],
 };
 
@@ -123,6 +126,16 @@ gdjs.registerBehavior = function(behaviorTypeName, Ctor) {
 };
 
 /**
+ * Register a function to be called when the first {@link gdjs.RuntimeScene} is loaded, after
+ * resources loading is done. This can be considered as the "start of the game".
+ *
+ * @param {Function} callback The function to be called.
+ */
+gdjs.registerFirstRuntimeSceneLoadedCallback = function(callback) {
+  gdjs.callbacksFirstRuntimeSceneLoaded.push(callback);
+};
+
+/**
  * Register a function to be called when a scene is loaded.
  * @param {Function} callback The function to be called.
  */
@@ -131,11 +144,21 @@ gdjs.registerRuntimeSceneLoadedCallback = function(callback) {
 };
 
 /**
- * Register a function to be called when a scene is unloaded.
+ * Register a function to be called each time a scene is stepped (i.e: at every frame),
+ * before events are run.
  * @param {Function} callback The function to be called.
  */
-gdjs.registerRuntimeSceneUnloadedCallback = function(callback) {
-  gdjs.callbacksRuntimeSceneUnloaded.push(callback);
+gdjs.registerRuntimeScenePreEventsCallback = function(callback) {
+  gdjs.callbacksRuntimeScenePreEvents.push(callback);
+};
+
+/**
+ * Register a function to be called each time a scene is stepped (i.e: at every frame),
+ * after events are run and before rendering.
+ * @param {Function} callback The function to be called.
+ */
+gdjs.registerRuntimeScenePostEventsCallback = function(callback) {
+  gdjs.callbacksRuntimeScenePostEvents.push(callback);
 };
 
 /**
@@ -152,6 +175,14 @@ gdjs.registerRuntimeScenePausedCallback = function(callback) {
  */
 gdjs.registerRuntimeSceneResumedCallback = function(callback) {
   gdjs.callbacksRuntimeSceneResumed.push(callback);
+};
+
+/**
+ * Register a function to be called when a scene is unloaded.
+ * @param {Function} callback The function to be called.
+ */
+gdjs.registerRuntimeSceneUnloadedCallback = function(callback) {
+  gdjs.callbacksRuntimeSceneUnloaded.push(callback);
 };
 
 /**
@@ -179,10 +210,13 @@ gdjs.registerGlobalCallbacks = function() {
  * Should only be used for testing - this should never be used at runtime.
  */
 gdjs.clearGlobalCallbacks = function() {
+  gdjs.callbacksFirstRuntimeSceneLoaded = [];
   gdjs.callbacksRuntimeSceneLoaded = [];
-  gdjs.callbacksRuntimeSceneUnloaded = [];
+  gdjs.callbacksRuntimeScenePreEvents = [];
+  gdjs.callbacksRuntimeScenePostEvents = [];
   gdjs.callbacksRuntimeScenePaused = [];
   gdjs.callbacksRuntimeSceneResumed = [];
+  gdjs.callbacksRuntimeSceneUnloaded = [];
   gdjs.callbacksObjectDeletedFromScene = [];
 };
 

--- a/GDJS/Runtime/runtimegame.js
+++ b/GDJS/Runtime/runtimegame.js
@@ -129,7 +129,7 @@ gdjs.RuntimeGame.prototype.getGameData = function() {
  * Get the data associated to a scene.
  *
  * @param {string} sceneName The name of the scene. If not defined, the first scene will be returned.
- * @return The data associated to the scene.
+ * @return {?Object} The data associated to the scene.
  */
 gdjs.RuntimeGame.prototype.getSceneData = function(sceneName) {
   var scene = undefined;
@@ -151,7 +151,7 @@ gdjs.RuntimeGame.prototype.getSceneData = function(sceneName) {
 /**
  * Check if a scene exists
  *
- * @param {string} sceneName The name of the scene to search.
+ * @param {string=} sceneName The name of the scene to search.
  * @return {boolean} true if the scene exists. If sceneName is undefined, true if the game has a scene.
  */
 gdjs.RuntimeGame.prototype.hasScene = function(sceneName) {
@@ -172,7 +172,7 @@ gdjs.RuntimeGame.prototype.hasScene = function(sceneName) {
  * Get the data associated to an external layout.
  *
  * @param {string} name The name of the external layout.
- * @return {Object} The data associated to the external layout or null if not found.
+ * @return {?Object} The data associated to the external layout or null if not found.
  */
 gdjs.RuntimeGame.prototype.getExternalLayoutData = function(name) {
   var externalLayout = null;
@@ -519,3 +519,10 @@ gdjs.RuntimeGame.prototype.stopCurrentSceneProfiler = function() {
 
   currentScene.stopProfiler();
 };
+
+/**
+ * Return true if a scene was loaded, false otherwise (i.e: game not yet started).
+ */
+gdjs.RuntimeGame.prototype.wasFirstSceneLoaded = function() {
+  return this._sceneStack.wasFirstSceneLoaded();
+}

--- a/GDJS/Runtime/runtimescene.js
+++ b/GDJS/Runtime/runtimescene.js
@@ -139,7 +139,12 @@ gdjs.RuntimeScene.prototype.loadFromScene = function(sceneData) {
 
     this._onceTriggers = new gdjs.OnceTriggers();
 
-    //Call global callback
+    // Notify the global callbacks
+    if (this._runtimeGame && !this._runtimeGame.wasFirstSceneLoaded()) {
+        for(var i = 0;i<gdjs.callbacksFirstRuntimeSceneLoaded.length;++i) {
+            gdjs.callbacksFirstRuntimeSceneLoaded[i](this);
+        }
+    }
     for(var i = 0;i<gdjs.callbacksRuntimeSceneLoaded.length;++i) {
         gdjs.callbacksRuntimeSceneLoaded[i](this);
     }
@@ -166,7 +171,6 @@ gdjs.RuntimeScene.prototype.onPause = function() {
  * on screen after having being paused.
  */
 gdjs.RuntimeScene.prototype.onResume = function() {
-
     this._isJustResumed = true;
 
     for(var i = 0;i < gdjs.callbacksRuntimeSceneResumed.length;++i) {
@@ -194,7 +198,9 @@ gdjs.RuntimeScene.prototype.unloadScene = function() {
     if (this._renderer && this._renderer.onSceneUnloaded)
         this._renderer.onSceneUnloaded();
 
-    // Notify the global callbacks
+    // Notify the global callbacks (after notifying objects and renderer, because
+    // callbacks from extensions might want to free resources - which can't be done
+    // safely before destroying objects and the renderer).
     for(var i = 0;i < gdjs.callbacksRuntimeSceneUnloaded.length;++i) {
         gdjs.callbacksRuntimeSceneUnloaded[i](this);
     }
@@ -274,6 +280,12 @@ gdjs.RuntimeScene.prototype.renderAndStep = function(elapsedTime) {
     this._updateObjectsPreEvents();
     if (this._profiler) this._profiler.end("objects (pre-events)");
 
+    if (this._profiler) this._profiler.begin("callbacks and extensions (pre-events)");
+    for(var i = 0;i < gdjs.callbacksRuntimeScenePreEvents.length;++i) {
+        gdjs.callbacksRuntimeScenePreEvents[i](this);
+    }
+    if (this._profiler) this._profiler.end("callbacks and extensions (pre-events)");
+
     if (this._profiler) this._profiler.begin("events");
     this._eventsFunction(this);
     if (this._profiler) this._profiler.end("events");
@@ -281,6 +293,12 @@ gdjs.RuntimeScene.prototype.renderAndStep = function(elapsedTime) {
     if (this._profiler) this._profiler.begin("objects (post-events)");
     this._updateObjectsPostEvents();
     if (this._profiler) this._profiler.end("objects (post-events)");
+
+    if (this._profiler) this._profiler.begin("callbacks and extensions (post-events)");
+    for(var i = 0;i < gdjs.callbacksRuntimeScenePostEvents.length;++i) {
+        gdjs.callbacksRuntimeScenePostEvents[i](this);
+    }
+    if (this._profiler) this._profiler.end("callbacks and extensions (post-events)");
 
     if (this._profiler) this._profiler.begin("objects (visibility)");
     this._updateObjectsVisibility();
@@ -606,7 +624,7 @@ gdjs.RuntimeScene.prototype.markObjectForDeletion = function(obj) {
     //Notify the object it was removed from the scene
     obj.onDestroyFromScene(this);
 
-    //Call global callback
+    // Notify the global callbacks
     for(var j = 0;j<gdjs.callbacksObjectDeletedFromScene.length;++j) {
         gdjs.callbacksObjectDeletedFromScene[j](this, obj);
     }

--- a/GDJS/Runtime/scenestack.js
+++ b/GDJS/Runtime/scenestack.js
@@ -14,8 +14,11 @@ gdjs.SceneStack = function(runtimeGame) {
 
     this._runtimeGame = runtimeGame;
 
-    /** @type gdjs.RuntimeScene[] */
-	this._stack = [];
+    /** @type {gdjs.RuntimeScene[]} */
+    this._stack = [];
+
+    /** @type {boolean} */
+    this._wasFirstSceneLoaded = false;
 };
 
 /**
@@ -91,6 +94,7 @@ gdjs.SceneStack.prototype.push = function(newSceneName, externalLayoutName) {
     // Load the new one
     var newScene = new gdjs.RuntimeScene(this._runtimeGame);
     newScene.loadFromScene(this._runtimeGame.getSceneData(newSceneName));
+    this._wasFirstSceneLoaded = true;
 
     //Optionally create the objects from an external layout.
     if (externalLayoutName) {
@@ -129,3 +133,10 @@ gdjs.SceneStack.prototype.getCurrentScene = function() {
 
 	return this._stack[this._stack.length - 1];
 };
+
+/**
+ * Return true if a scene was loaded, false otherwise (i.e: game not yet started).
+ */
+gdjs.SceneStack.prototype.wasFirstSceneLoaded = function() {
+    return this._wasFirstSceneLoaded;
+}

--- a/GDJS/tests/tests/scenestack.js
+++ b/GDJS/tests/tests/scenestack.js
@@ -24,15 +24,20 @@ describe('gdjs.SceneStack', function() {
       },
     ],
   });
-  var sceneStack = new gdjs.SceneStack(runtimeGame);
+  // @ts-ignore - access to a private member for testing purposes.
+  var sceneStack = runtimeGame._sceneStack;
 
   it('should support pushing, replacing and popping scenes', function() {
     // Set up some global callbacks
+    var firstLoadedScene = null;
     var lastLoadedScene = null;
     var lastUnloadedScene = null;
     var lastPausedScene = null;
     var lastResumedScene = null;
 
+    gdjs.registerFirstRuntimeSceneLoadedCallback(function(runtimeScene) {
+      firstLoadedScene = runtimeScene;
+    });
     gdjs.registerRuntimeSceneLoadedCallback(function(runtimeScene) {
       lastLoadedScene = runtimeScene;
     });
@@ -48,44 +53,58 @@ describe('gdjs.SceneStack', function() {
 
     // Test the stack
     expect(sceneStack.pop()).to.be(null);
+    expect(lastLoadedScene).to.be(null);
+    expect(firstLoadedScene).to.be(null);
+    expect(sceneStack.wasFirstSceneLoaded()).to.be(false);
 
     var scene1 = sceneStack.push('Scene 1');
     expect(lastLoadedScene).to.be(scene1);
+    expect(firstLoadedScene).to.be(scene1);
+    expect(sceneStack.wasFirstSceneLoaded()).to.be(true);
 
     var scene2 = sceneStack.push('Scene 2');
     expect(lastPausedScene).to.be(scene1);
     expect(lastLoadedScene).to.be(scene2);
+    expect(firstLoadedScene).to.be(scene1); // Not changed
 
     var scene3 = sceneStack.push('Scene 1');
     expect(lastPausedScene).to.be(scene2);
     expect(lastLoadedScene).to.be(scene3);
+    expect(firstLoadedScene).to.be(scene1); // Not changed
 
     var scene4 = sceneStack.replace('Scene 1');
     expect(lastPausedScene).to.be(scene2); // Not changed
     expect(lastUnloadedScene).to.be(scene3);
     expect(lastLoadedScene).to.be(scene4);
+    expect(firstLoadedScene).to.be(scene1); // Not changed
 
     expect(sceneStack.pop()).to.be(scene4);
     expect(lastUnloadedScene).to.be(scene4);
     expect(lastResumedScene).to.be(scene2);
     expect(lastPausedScene).to.be(scene2); // Not changed
+    expect(firstLoadedScene).to.be(scene1); // Not changed
 
     expect(sceneStack.pop()).to.be(scene2);
     expect(lastUnloadedScene).to.be(scene2);
     expect(lastResumedScene).to.be(scene1);
     expect(lastPausedScene).to.be(scene2); // Not changed
+    expect(firstLoadedScene).to.be(scene1); // Not changed
 
     var scene5 = sceneStack.replace('Scene 2', true);
     expect(lastLoadedScene).to.be(scene5);
     expect(lastUnloadedScene).to.be(scene1);
     expect(lastPausedScene).to.be(scene2); // Not changed
     expect(lastResumedScene).to.be(scene1); // Not changed
+    expect(firstLoadedScene).to.be(scene1); // Not changed
 
     expect(sceneStack.pop()).to.be(null);
     expect(lastLoadedScene).to.be(scene5); // Not changed
     expect(lastUnloadedScene).to.be(scene1); // Not changed
     expect(lastPausedScene).to.be(scene2); // Not changed
     expect(lastResumedScene).to.be(scene1); // Not changed
+    expect(firstLoadedScene).to.be(scene1); // Not changed
+
+    expect(sceneStack.wasFirstSceneLoaded()).to.be(true);
 
     // Remove all the global callbacks
     gdjs.clearGlobalCallbacks();


### PR DESCRIPTION
Will be useful for allowing events-based extension to declare functions to be run at "game startup" and at every frame before or after events :)

cc @Bouh (it's not done yet though!)