### PR TITLE
Add Map Object as replacement for basis object in Hashmap

### DIFF
--- a/GDJS/Runtime/inputmanager.js
+++ b/GDJS/Runtime/inputmanager.js
@@ -88,7 +88,7 @@ gdjs.InputManager.prototype.wasKeyReleased = function(keyCode) {
  * Return true if any key is pressed
  */
 gdjs.InputManager.prototype.anyKeyPressed = function() {
-    for(var keyCode in this._pressedKeys) {
+    for(var keyCode of Hastable.keys(this._pressedKeys)) {
         if (this._pressedKeys.containsKey(keyCode)) {
             if (this._pressedKeys.get(keyCode)) {
                 return true;
@@ -211,7 +211,7 @@ gdjs.InputManager.prototype.getAllTouchIdentifiers = function() {
     gdjs.InputManager._allTouchIds = gdjs.InputManager._allTouchIds || [];
     gdjs.InputManager._allTouchIds.length = 0;
 
-    for(var id in this._touches) {
+    for(var id of Hashtable.keys(this._touches)) {
         if (this._touches.containsKey(id)) {
             gdjs.InputManager._allTouchIds.push(parseInt(id, 10));
         }
@@ -286,7 +286,7 @@ gdjs.InputManager.prototype.touchSimulateMouse = function(enable) {
  */
 gdjs.InputManager.prototype.onFrameEnded = function() {
     //Only clear the ended touches at the end of the frame.
-    for(var id in this._touches) {
+    for(var id of Hastable.keys(this._touches)) {
         if (this._touches.containsKey(id)) {
             var touch = this._touches.get(id);
             if(touch.justEnded) {

--- a/GDJS/Runtime/libs/jshashtable.js
+++ b/GDJS/Runtime/libs/jshashtable.js
@@ -180,21 +180,24 @@ Hashtable.prototype.clear = function() {
 
 /**
  * Function for getting an array of the values of a Hashtable.
- * @memberOf Hashtable
- * @static
- */
-Hashtable.keys = function(hashtable) {
-    return hashtable.items.keys();
-}
-
-/**
- * Function for getting an array of the keys of a Hashtable.
  * Comparable to {@link Object.keys()}.
  * @memberOf Hashtable
  * @static
  */
+Hashtable.keys = function(hashtable) {
+    if (hashtable.map) { return hashtable.items.keys(); }
+    else { return Object.keys(hashtable.items); }
+}
+
+/**
+ * Function for getting an array of the keys of a Hashtable.
+ * Comparable to {@link Object.values()}.
+ * @memberOf Hashtable
+ * @static
+ */
 Hashtable.values = function(hashtable) {
-    return hashtable.items.values();
+    if (hashtable.map) { return hashtable.items.values(); }
+    else { return Object.values(hashtable.items); }
 }
 
 Hashtable.prototype[Symbol.iterator] = function*() {

--- a/GDJS/Runtime/libs/jshashtable.js
+++ b/GDJS/Runtime/libs/jshashtable.js
@@ -13,15 +13,22 @@ function Hashtable()
      * The content of the Hashtable. Prefer using methods rather
      * than accessing this internal object, unless you need to iterate
      * on the values.
-     * @type {Object.<string, any>}
+     * @type {Map|Object.<string, any>}
      */
-    this.items = {};
+    this.items = null;
+    if(Map !== undefined) {
+        this.items = new Map();
+        this.map = true;
+    else {
+        this.items = {};
+        this.map = false;
+    }
 }
 
 /**
  * Construct a Hashtable from a JS object.
  *
- * @param {Object.<string, any>} items The content of the Hashtable.
+ * @param {Map|Object.<string, any>} items The content of the Hashtable.
  * @returns {Hashtable} The new hashtable.
  * @static
  */
@@ -40,6 +47,10 @@ Hashtable.newFrom = function(items) {
  * @param {any} value The value to associate to the key.
  */
 Hashtable.prototype.put = function(key, value) {
+    if(this.map) { 
+        this.items.set(key, value);
+        return;
+    }
     this.items[key] = value;
 }
 
@@ -50,6 +61,7 @@ Hashtable.prototype.put = function(key, value) {
  * @param {string} key The key associated to the value.
  */
 Hashtable.prototype.get = function(key) {
+    if(this.map) { return this.items.get(key); }
     return this.items[key];
 }
 
@@ -61,6 +73,7 @@ Hashtable.prototype.get = function(key) {
  * @returns {boolean} true if the key exists.
  */
 Hashtable.prototype.containsKey = function(key) {
+    if(this.map) { return this.items.has(key); }
     return this.items.hasOwnProperty(key);
 }
 
@@ -71,6 +84,10 @@ Hashtable.prototype.containsKey = function(key) {
  * @param {string} key The key to remove.
  */
 Hashtable.prototype.remove = function(key) {
+    if(this.map) { 
+        this.items.delete(key); 
+        return;
+    }
     delete this.items[key];
 }
 
@@ -81,6 +98,13 @@ Hashtable.prototype.remove = function(key) {
  * @returns {?string} The first key of the Hashtable, or undefined if empty.
  */
 Hashtable.prototype.firstKey = function() {
+    if(this.map) {
+        for (var k of this.items.keys()) {
+            if (this.items.has(k)) {
+                return k;
+            }
+        }
+    }
     for (var k in this.items) {
         if (this.items.hasOwnProperty(k)) {
             return k;
@@ -98,6 +122,14 @@ Hashtable.prototype.firstKey = function() {
  */
 Hashtable.prototype.keys = function(result) {
     result.length = 0;
+    if(this.map) {
+        for (var k of this.items.keys()) {
+            if (this.items.has(k)) {
+                result.push(k);
+            }
+        }
+        return;
+    }
     for (var k in this.items) {
         if (this.items.hasOwnProperty(k)) {
             result.push(k);
@@ -109,10 +141,18 @@ Hashtable.prototype.keys = function(result) {
  * Dump all the values of the Hashtable to an array (which is cleared first).
  *
  * @memberof Hashtable
- * @param {Array<any>} result The Array where the results get pushed.
+ * @param {Array} result The Array where the results get pushed.
  */
 Hashtable.prototype.values = function(result) {
     result.length = 0;
+    if(this.map) {
+        for (var k of this.items.keys()) {
+            if (this.items.has(k)) {
+                result.push(this.items.get(k));
+            }
+        }
+        return;
+    }
     for (var k in this.items) {
         if (this.items.hasOwnProperty(k)) {
             result.push(this.items[k]);
@@ -126,6 +166,10 @@ Hashtable.prototype.values = function(result) {
  * @memberof Hashtable
  */
 Hashtable.prototype.clear = function() {
+    if(this.map) {
+        this.items.clear();
+        return;
+    }
     for (var k in this.items) {
         if (this.items.hasOwnProperty(k)) {
             delete this.items[k];

--- a/GDJS/Runtime/libs/jshashtable.js
+++ b/GDJS/Runtime/libs/jshashtable.js
@@ -178,6 +178,25 @@ Hashtable.prototype.clear = function() {
     }
 }
 
+/**
+ * Function for getting an array of the values of a Hashtable.
+ * @memberOf Hashtable
+ * @static
+ */
+Hashtable.keys = function(hashtable) {
+    return hashtable.items.keys();
+}
+
+/**
+ * Function for getting an array of the keys of a Hashtable.
+ * Comparable to {@link Object.keys()}.
+ * @memberOf Hashtable
+ * @static
+ */
+Hashtable.values = function(hashtable) {
+    return hashtable.items.values();
+}
+
 Hashtable.prototype[Symbol.iterator] = function*() {
     if(this.map) {
         for(var k of this.items.keys()){

--- a/GDJS/Runtime/libs/jshashtable.js
+++ b/GDJS/Runtime/libs/jshashtable.js
@@ -177,3 +177,19 @@ Hashtable.prototype.clear = function() {
         }
     }
 }
+
+Hashtable[Symbol.iterator] = function*() {
+    if(this.map) {
+        for(var k in this.items.keys()){
+            if(this.items.has(k)){
+                yield this.items.get(k);
+            }
+        }
+    } else {
+        for (var k in this.items) {
+            if (this.items.hasOwnProperty(k)) {
+                yield this.items[k];
+            }
+        }
+    }
+}

--- a/GDJS/Runtime/libs/jshashtable.js
+++ b/GDJS/Runtime/libs/jshashtable.js
@@ -19,6 +19,7 @@ function Hashtable()
     if(Map !== undefined) {
         this.items = new Map();
         this.map = true;
+    }
     else {
         this.items = {};
         this.map = false;

--- a/GDJS/Runtime/libs/jshashtable.js
+++ b/GDJS/Runtime/libs/jshashtable.js
@@ -178,9 +178,9 @@ Hashtable.prototype.clear = function() {
     }
 }
 
-Hashtable[Symbol.iterator] = function*() {
+Hashtable.prototype[Symbol.iterator] = function*() {
     if(this.map) {
-        for(var k in this.items.keys()){
+        for(var k of this.items.keys()){
             if(this.items.has(k)){
                 yield this.items.get(k);
             }


### PR DESCRIPTION
Because it should be faster for dynamic key-values attribution. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Objects_and_maps_compared to have a better understanding of the différences.