### PR TITLE
Fix ExpressionsRenamer when renaming an object function

### DIFF
--- a/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
@@ -77,7 +77,7 @@ class GD_CORE_API ExpressionFunctionRenamer
         // Replace an object function
         const gd::String& thisObjectType = gd::GetTypeOfObject(
             globalObjectsContainer, objectsContainer, node.objectName);
-        if (thisObjectType == behaviorType) {
+        if (thisObjectType == objectType) {
           node.functionName = newFunctionName;
           hasDoneRenaming = true;
         }


### PR DESCRIPTION
This mistake is actually not creating a bug because never used by the IDE. Still fixing in case it's used later and for completeness.