### PR TITLE
Fix WholeProjectRefactorer potential wrong renaming/moving of parameters

### DIFF
--- a/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
@@ -120,10 +120,10 @@ class GD_CORE_API ExpressionParameterMover
   bool hasDoneMoving;
   const gd::ObjectsContainer& globalObjectsContainer;
   const gd::ObjectsContainer& objectsContainer;
-  const gd::String& behaviorType;  // The behavior type for which the expression
-                                   // must be moved (optional)
-  const gd::String& objectType;    // The object type for which the expression
-                                   // must be moved (optional). If
+  const gd::String& behaviorType;  // The behavior type of the function which
+                                   // must have a parameter moved (optional).
+  const gd::String& objectType;    // The object type of the function which
+                                   // must have a parameter moved (optional). If
                                    // `behaviorType` is not empty, it takes
                                    // precedence over `objectType`.
   const gd::String& functionName;

--- a/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
@@ -87,7 +87,8 @@ class GD_CORE_API ExpressionParameterMover
         };
 
     if (node.functionName == functionName) {
-      if (!objectType.empty() && !node.objectName.empty()) {
+      if (behaviorType.empty() && !objectType.empty() &&
+          !node.objectName.empty()) {
         // Move parameter of an object function
         const gd::String& thisObjectType = gd::GetTypeOfObject(
             globalObjectsContainer, objectsContainer, node.objectName);
@@ -103,7 +104,7 @@ class GD_CORE_API ExpressionParameterMover
           moveParameter(node.parameters);
           hasDoneMoving = true;
         }
-      } else {
+      } else if (behaviorType.empty() && objectType.empty()) {
         // Move parameter of a free function
         moveParameter(node.parameters);
         hasDoneMoving = true;
@@ -120,9 +121,11 @@ class GD_CORE_API ExpressionParameterMover
   const gd::ObjectsContainer& globalObjectsContainer;
   const gd::ObjectsContainer& objectsContainer;
   const gd::String& behaviorType;  // The behavior type for which the expression
-                                   // must be replaced (optional)
+                                   // must be moved (optional)
   const gd::String& objectType;    // The object type for which the expression
-                                   // must be replaced (optional)
+                                   // must be moved (optional). If
+                                   // `behaviorType` is not empty, it takes
+                                   // precedence over `objectType`.
   const gd::String& functionName;
   std::size_t oldIndex;
   std::size_t newIndex;

--- a/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
@@ -73,7 +73,8 @@ class GD_CORE_API ExpressionFunctionRenamer
   void OnVisitIdentifierNode(IdentifierNode& node) override {}
   void OnVisitFunctionNode(FunctionNode& node) override {
     if (node.functionName == oldFunctionName) {
-      if (!objectType.empty() && !node.objectName.empty()) {
+      if (behaviorType.empty() && !objectType.empty() &&
+          !node.objectName.empty()) {
         // Replace an object function
         const gd::String& thisObjectType = gd::GetTypeOfObject(
             globalObjectsContainer, objectsContainer, node.objectName);
@@ -89,7 +90,7 @@ class GD_CORE_API ExpressionFunctionRenamer
           node.functionName = newFunctionName;
           hasDoneRenaming = true;
         }
-      } else {
+      } else if (behaviorType.empty() && objectType.empty()) {
         // Replace a free function
         node.functionName = newFunctionName;
         hasDoneRenaming = true;
@@ -106,9 +107,11 @@ class GD_CORE_API ExpressionFunctionRenamer
   const gd::ObjectsContainer& globalObjectsContainer;
   const gd::ObjectsContainer& objectsContainer;
   const gd::String& behaviorType;  // The behavior type for which the expression
-                                   // must be replaced (optional)
+                                   // must be replaced (optional).
   const gd::String& objectType;    // The object type for which the expression
-                                   // must be replaced (optional)
+                                   // must be replaced (optional). If
+                                   // `behaviorType` is not empty, it takes
+                                   // precedence over `objectType`.
   const gd::String& oldFunctionName;
   const gd::String& newFunctionName;
 };

--- a/Core/GDCore/IDE/WholeProjectRefactorer.cpp
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.cpp
@@ -470,7 +470,17 @@ void WholeProjectRefactorer::RenameBehaviorProperty(
   auto& properties = eventsBasedBehavior.GetPropertyDescriptors();
   if (!properties.Has(oldPropertyName)) return;
 
-  const auto& property = properties.Get(oldPropertyName);
+  // Order is important: we first rename the expressions then the instructions,
+  // to avoid being unable to fetch the metadata (the types of parameters) of
+  // instructions after they are renamed.
+  gd::ExpressionsRenamer expressionRenamer =
+      gd::ExpressionsRenamer(project.GetCurrentPlatform());
+  expressionRenamer.SetReplacedBehaviorExpression(
+      GetBehaviorFullType(eventsFunctionsExtension.GetName(),
+                          eventsBasedBehavior.GetName()),
+      EventsBasedBehavior::GetPropertyExpressionName(oldPropertyName),
+      EventsBasedBehavior::GetPropertyExpressionName(newPropertyName));
+  ExposeProjectEvents(project, expressionRenamer);
 
   gd::InstructionsTypeRenamer actionRenamer = gd::InstructionsTypeRenamer(
       project,
@@ -495,15 +505,6 @@ void WholeProjectRefactorer::RenameBehaviorProperty(
           eventsBasedBehavior.GetName(),
           EventsBasedBehavior::GetPropertyConditionName(newPropertyName)));
   ExposeProjectEvents(project, conditionRenamer);
-
-  gd::ExpressionsRenamer expressionRenamer =
-      gd::ExpressionsRenamer(project.GetCurrentPlatform());
-  expressionRenamer.SetReplacedBehaviorExpression(
-      GetBehaviorFullType(eventsFunctionsExtension.GetName(),
-                          eventsBasedBehavior.GetName()),
-      EventsBasedBehavior::GetPropertyExpressionName(oldPropertyName),
-      EventsBasedBehavior::GetPropertyExpressionName(newPropertyName));
-  ExposeProjectEvents(project, expressionRenamer);
 }
 
 void WholeProjectRefactorer::RenameEventsBasedBehavior(

--- a/Core/GDCore/IDE/WholeProjectRefactorer.h
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.h
@@ -50,7 +50,10 @@ class GD_CORE_API WholeProjectRefactorer {
                                   gd::ArbitraryEventsWorkerWithContext& worker);
 
   /**
-   * \brief Refactor the project after an events function extension is renamed
+   * \brief Refactor the project **before** an events function extension is renamed.
+   *
+   * \warning Do the renaming of the specified extension after calling this.
+   * This is because the extension is expected to have its old name for the refactoring.
    */
   static void RenameEventsFunctionsExtension(
       gd::Project& project,
@@ -59,7 +62,10 @@ class GD_CORE_API WholeProjectRefactorer {
       const gd::String& newName);
 
   /**
-   * \brief Refactor the project after an events function is renamed
+   * \brief Refactor the project **before** an events function is renamed.
+   *
+   * \warning Do the renaming of the specified function after calling this.
+   * This is because the function is expected to have its old name for the refactoring.
    */
   static void RenameEventsFunction(
       gd::Project& project,
@@ -68,8 +74,11 @@ class GD_CORE_API WholeProjectRefactorer {
       const gd::String& newFunctionName);
 
   /**
-   * \brief Refactor the project after an events function of a behavior is
+   * \brief Refactor the project **before** an events function of a behavior is
    * renamed.
+   *
+   * \warning Do the renaming of the specified function after calling this.
+   * This is because the function is expected to have its old name for the refactoring.
    */
   static void RenameBehaviorEventsFunction(
       gd::Project& project,
@@ -79,8 +88,11 @@ class GD_CORE_API WholeProjectRefactorer {
       const gd::String& newFunctionName);
 
   /**
-   * \brief Refactor the project after an events function parameter
-   * was moved.
+   * \brief Refactor the project **before** an events function parameter
+   * is moved.
+   *
+   * \warning Do the move of the specified function parameters after calling this.
+   * This is because the function is expected to be in its old state for the refactoring.
    */
   static void MoveEventsFunctionParameter(
       gd::Project& project,
@@ -90,8 +102,11 @@ class GD_CORE_API WholeProjectRefactorer {
       std::size_t newIndex);
 
   /**
-   * \brief Refactor the project after the parmaeter of an events function of a
-   * behavior was moved.
+   * \brief Refactor the project **before** the parameter of an events function of a
+   * behavior is moved.
+   *
+   * \warning Do the move of the specified function parameters after calling this.
+   * This is because the function is expected to be in its old state for the refactoring.
    */
   static void MoveBehaviorEventsFunctionParameter(
       gd::Project& project,
@@ -102,8 +117,11 @@ class GD_CORE_API WholeProjectRefactorer {
       std::size_t newIndex);
 
   /**
-   * \brief Refactor the project after a property of a behavior is
+   * \brief Refactor the project **before** a property of a behavior is
    * renamed.
+   *
+   * \warning Do the renaming of the specified property after calling this.
+   * This is because the property is expected to have its old name for the refactoring.
    */
   static void RenameBehaviorProperty(
       gd::Project& project,
@@ -113,7 +131,10 @@ class GD_CORE_API WholeProjectRefactorer {
       const gd::String& newPropertyName);
 
   /**
-   * \brief Refactor the project after a behavior is renamed.
+   * \brief Refactor the project **before** a behavior is renamed.
+   *
+   * \warning Do the renaming of the specified behavior after calling this.
+   * This is because the behavior is expected to have its old name for the refactoring.
    */
   static void RenameEventsBasedBehavior(
       gd::Project& project,


### PR DESCRIPTION
Could happen rarely that renaming a behavior method would rename a "free" function (function not attached to an object/behavior) with this same name.