### PR TITLE
Support for describing completions to display for an expression

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
@@ -359,4 +359,8 @@ void ExpressionCodeGenerator::OnVisitEmptyNode(EmptyNode& node) {
   output += GenerateDefaultValue(node.type);
 }
 
+void ExpressionCodeGenerator::OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) {
+  output += GenerateDefaultValue(node.type);
+}
+
 }  // namespace gd

--- a/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
@@ -127,7 +127,7 @@ void ExpressionCodeGenerator::OnVisitIdentifierNode(IdentifierNode& node) {
   }
 }
 
-void ExpressionCodeGenerator::OnVisitFunctionNode(FunctionNode& node) {
+void ExpressionCodeGenerator::OnVisitFunctionCallNode(FunctionCallNode& node) {
   if (gd::MetadataProvider::IsBadExpressionMetadata(node.expressionMetadata)) {
     output += "/* Error during generation, function not found: " +
               codeGenerator.ConvertToString(node.functionName) + " for type " +

--- a/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.h
+++ b/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.h
@@ -73,6 +73,7 @@ class GD_CORE_API ExpressionCodeGenerator : public ExpressionParser2NodeWorker {
   void OnVisitVariableBracketAccessorNode(
       VariableBracketAccessorNode& node) override;
   void OnVisitIdentifierNode(IdentifierNode& node) override;
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override;
   void OnVisitFunctionCallNode(FunctionCallNode& node) override;
   void OnVisitEmptyNode(EmptyNode& node) override;
 

--- a/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.h
+++ b/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.h
@@ -73,7 +73,7 @@ class GD_CORE_API ExpressionCodeGenerator : public ExpressionParser2NodeWorker {
   void OnVisitVariableBracketAccessorNode(
       VariableBracketAccessorNode& node) override;
   void OnVisitIdentifierNode(IdentifierNode& node) override;
-  void OnVisitFunctionNode(FunctionNode& node) override;
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override;
   void OnVisitEmptyNode(EmptyNode& node) override;
 
  private:

--- a/Core/GDCore/Events/Parsers/ExpressionParser2.cpp
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.cpp
@@ -76,7 +76,7 @@ size_t GetMaximumParametersNumber(
 }  // namespace
 
 std::unique_ptr<ExpressionParserDiagnostic> ExpressionParser2::ValidateFunction(
-    const gd::FunctionNode& function, size_t functionStartPosition) {
+    const gd::FunctionCallNode& function, size_t functionStartPosition) {
   if (gd::MetadataProvider::IsBadExpressionMetadata(
           function.expressionMetadata)) {
     return gd::make_unique<ExpressionParserError>(

--- a/Core/GDCore/Events/Parsers/ExpressionParser2.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.h
@@ -320,7 +320,7 @@ class GD_CORE_API ExpressionParser2 {
     return child;
   }
 
-  std::unique_ptr<FunctionNode> FreeFunction(const gd::String &type,
+  std::unique_ptr<FunctionCallNode> FreeFunction(const gd::String &type,
                                              const gd::String &functionFullName,
                                              size_t functionStartPosition) {
     // TODO: error if trying to use function for type != "number" && != "string"
@@ -335,7 +335,7 @@ class GD_CORE_API ExpressionParser2 {
                                platform, functionFullName);
 
     auto parametersAndError = Parameters(metadata.parameters);
-    auto function = gd::make_unique<FunctionNode>(
+    auto function = gd::make_unique<FunctionCallNode>(
         type, std::move(parametersAndError.first), metadata, functionFullName);
     function->diagnostic = std::move(parametersAndError.second);
     if (!function->diagnostic)
@@ -376,7 +376,7 @@ class GD_CORE_API ExpressionParser2 {
 
       auto parametersAndError = Parameters(metadata.parameters, objectName);
       auto function =
-          gd::make_unique<FunctionNode>(type,
+          gd::make_unique<FunctionCallNode>(type,
                                         objectName,
                                         std::move(parametersAndError.first),
                                         metadata,
@@ -425,7 +425,7 @@ class GD_CORE_API ExpressionParser2 {
       auto parametersAndError =
           Parameters(metadata.parameters, objectName, behaviorName);
       auto function =
-          gd::make_unique<FunctionNode>(type,
+          gd::make_unique<FunctionCallNode>(type,
                                         objectName,
                                         behaviorName,
                                         std::move(parametersAndError.first),
@@ -521,7 +521,7 @@ class GD_CORE_API ExpressionParser2 {
    */
   ///@{
   std::unique_ptr<ExpressionParserDiagnostic> ValidateFunction(
-      const gd::FunctionNode &function, size_t functionStartPosition);
+      const gd::FunctionCallNode &function, size_t functionStartPosition);
 
   std::unique_ptr<ExpressionParserDiagnostic> ValidateOperator(
       const gd::String &type, gd::String::value_type operatorChar) {

--- a/Core/GDCore/Events/Parsers/ExpressionParser2.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.h
@@ -48,8 +48,9 @@ class GD_CORE_API ExpressionParser2 {
    *
    * \param type Type of the expression: "string", "number",
    * type supported by gd::ParameterMetadata::IsObject, types supported by
-   * gd::ParameterMetadata::IsExpression or "unknown". \param expression The
-   * expression to parse \param objectName Specify the object name, only for the
+   * gd::ParameterMetadata::IsExpression or "unknown".
+   * \param expression The expression to parse
+   * \param objectName Specify the object name, only for the
    * case of "objectvar" type.
    *
    * \return The node representing the expression as a parsed tree.
@@ -76,8 +77,7 @@ class GD_CORE_API ExpressionParser2 {
 
     // Check for extra characters at the end of the expression
     if (!IsEndReached()) {
-      auto op = gd::make_unique<OperatorNode>();
-      op->op = ' ';
+      auto op = gd::make_unique<OperatorNode>(type, ' ');
       op->leftHandSide = std::move(expression);
       op->rightHandSide = ReadUntilEnd("unknown");
 
@@ -85,7 +85,8 @@ class GD_CORE_API ExpressionParser2 {
           _("The expression has extra character at the end that should be "
             "removed (or completed if your expression is not finished)."));
 
-      op->location = ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
+      op->location = ExpressionParserLocation(expressionStartPosition,
+                                              GetCurrentPosition());
       return std::move(op);
     }
 
@@ -104,14 +105,14 @@ class GD_CORE_API ExpressionParser2 {
     if (IsEndReached()) return leftHandSide;
     if (IsAnyChar(",)]")) return leftHandSide;
     if (IsAnyChar(EXPRESSION_OPERATORS)) {
-      auto op = gd::make_unique<OperatorNode>();
-      op->op = GetCurrentChar();
+      auto op = gd::make_unique<OperatorNode>(type, GetCurrentChar());
       op->leftHandSide = std::move(leftHandSide);
       op->diagnostic = ValidateOperator(type, GetCurrentChar());
       SkipChar();
       op->rightHandSide = Expression(type, objectName);
 
-      op->location = ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
+      op->location = ExpressionParserLocation(expressionStartPosition,
+                                              GetCurrentPosition());
       return std::move(op);
     }
 
@@ -129,11 +130,11 @@ class GD_CORE_API ExpressionParser2 {
           "properly written.");
     }
 
-    auto op = gd::make_unique<OperatorNode>();
-    op->op = ' ';
+    auto op = gd::make_unique<OperatorNode>(type, ' ');
     op->leftHandSide = std::move(leftHandSide);
     op->rightHandSide = Expression(type, objectName);
-    op->location = ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
+    op->location =
+        ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
     return std::move(op);
   }
 
@@ -150,13 +151,13 @@ class GD_CORE_API ExpressionParser2 {
     // to guarantee the proper operator precedence. (Expression could also
     // be reworked to use a while loop).
     while (IsAnyChar(TERM_OPERATORS)) {
-      auto op = gd::make_unique<OperatorNode>();
-      op->op = GetCurrentChar();
+      auto op = gd::make_unique<OperatorNode>(type, GetCurrentChar());
       op->leftHandSide = std::move(factor);
       op->diagnostic = ValidateOperator(type, GetCurrentChar());
       SkipChar();
       op->rightHandSide = Factor(type, objectName);
-      op->location = ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
+      op->location = ExpressionParserLocation(expressionStartPosition,
+                                              GetCurrentPosition());
       SkipWhitespace();
 
       factor = std::move(op);
@@ -183,12 +184,14 @@ class GD_CORE_API ExpressionParser2 {
             _("You entered a text, but this type was expected:") + type,
             expressionStartPosition);
     } else if (IsAnyChar(UNARY_OPERATORS)) {
-      auto unaryOperator = gd::make_unique<UnaryOperatorNode>(GetCurrentChar());
+      auto unaryOperator =
+          gd::make_unique<UnaryOperatorNode>(type, GetCurrentChar());
       unaryOperator->diagnostic = ValidateUnaryOperator(type, GetCurrentChar());
       SkipChar();
       unaryOperator->factor = Factor(type, objectName);
 
-      unaryOperator->location = ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
+      unaryOperator->location = ExpressionParserLocation(
+          expressionStartPosition, GetCurrentPosition());
       factor = std::move(unaryOperator);
     } else if (IsAnyChar(NUMBER_FIRST_CHAR)) {
       factor = ReadNumber();
@@ -229,14 +232,16 @@ class GD_CORE_API ExpressionParser2 {
   std::unique_ptr<SubExpressionNode> SubExpression(
       const gd::String &type, const gd::String &objectName) {
     size_t expressionStartPosition = GetCurrentPosition();
-    auto subExpression = gd::make_unique<SubExpressionNode>(Expression(type, objectName));
-    subExpression->location = ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
+    auto subExpression =
+        gd::make_unique<SubExpressionNode>(type, Expression(type, objectName));
+    subExpression->location =
+        ExpressionParserLocation(expressionStartPosition, GetCurrentPosition());
 
     return std::move(subExpression);
   };
 
-  std::unique_ptr<IdentifierOrFunctionOrEmptyNode> Identifier(
-      const gd::String &type) {
+  std::unique_ptr<IdentifierOrFunctionCallOrObjectFunctionNameOrEmptyNode>
+  Identifier(const gd::String &type) {
     size_t identifierStartPosition = GetCurrentPosition();
     gd::String name = ReadIdentifierName();
 
@@ -272,7 +277,8 @@ class GD_CORE_API ExpressionParser2 {
             identifierStartPosition);
       }
 
-      identifier->location = ExpressionParserLocation(identifierStartPosition, GetCurrentPosition());
+      identifier->location = ExpressionParserLocation(identifierStartPosition,
+                                                      GetCurrentPosition());
       return std::move(identifier);
     }
   }
@@ -285,7 +291,8 @@ class GD_CORE_API ExpressionParser2 {
     auto variable = gd::make_unique<VariableNode>(type, name, objectName);
     variable->child = VariableAccessorOrVariableBracketAccessor();
 
-    variable->location = ExpressionParserLocation(identifierStartPosition, GetCurrentPosition());
+    variable->location =
+        ExpressionParserLocation(identifierStartPosition, GetCurrentPosition());
     return std::move(variable);
   }
 
@@ -307,22 +314,25 @@ class GD_CORE_API ExpressionParser2 {
       }
       SkipIfIsAnyChar("]");
       child->child = VariableAccessorOrVariableBracketAccessor();
-      child->location = ExpressionParserLocation(childStartPosition, GetCurrentPosition()); // TODO
+      child->location =
+          ExpressionParserLocation(childStartPosition, GetCurrentPosition());
     } else if (IsAnyChar(DOT)) {
       SkipChar();
       SkipWhitespace();
 
       child = gd::make_unique<VariableAccessorNode>(ReadIdentifierName());
       child->child = VariableAccessorOrVariableBracketAccessor();
-      child->location = ExpressionParserLocation(childStartPosition, GetCurrentPosition()); // TODO
+      child->location =
+          ExpressionParserLocation(childStartPosition, GetCurrentPosition());
     }
 
     return child;
   }
 
-  std::unique_ptr<FunctionCallNode> FreeFunction(const gd::String &type,
-                                             const gd::String &functionFullName,
-                                             size_t functionStartPosition) {
+  std::unique_ptr<FunctionCallNode> FreeFunction(
+      const gd::String &type,
+      const gd::String &functionFullName,
+      size_t functionStartPosition) {
     // TODO: error if trying to use function for type != "number" && != "string"
     // + Test for it
 
@@ -341,14 +351,15 @@ class GD_CORE_API ExpressionParser2 {
     if (!function->diagnostic)
       function->diagnostic = ValidateFunction(*function, functionStartPosition);
 
-    function->location = ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
+    function->location =
+        ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
     return std::move(function);
   }
 
-  std::unique_ptr<FunctionOrEmptyNode> ObjectFunctionOrBehaviorFunction(
-      const gd::String &type,
-      const gd::String &objectName,
-      size_t functionStartPosition) {
+  std::unique_ptr<FunctionCallOrObjectFunctionNameOrEmptyNode>
+  ObjectFunctionOrBehaviorFunction(const gd::String &type,
+                                   const gd::String &objectName,
+                                   size_t functionStartPosition) {
     gd::String objectFunctionOrBehaviorName = ReadIdentifierName();
 
     SkipWhitespace();
@@ -377,29 +388,32 @@ class GD_CORE_API ExpressionParser2 {
       auto parametersAndError = Parameters(metadata.parameters, objectName);
       auto function =
           gd::make_unique<FunctionCallNode>(type,
-                                        objectName,
-                                        std::move(parametersAndError.first),
-                                        metadata,
-                                        objectFunctionOrBehaviorName);
+                                            objectName,
+                                            std::move(parametersAndError.first),
+                                            metadata,
+                                            objectFunctionOrBehaviorName);
       function->diagnostic = std::move(parametersAndError.second);
       if (!function->diagnostic)
         function->diagnostic =
             ValidateFunction(*function, functionStartPosition);
 
-      function->location = ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
+      function->location =
+          ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
       return std::move(function);
     }
 
-    auto node = gd::make_unique<EmptyNode>(type);
+    auto node = gd::make_unique<ObjectFunctionNameNode>(
+        type, objectName, objectFunctionOrBehaviorName);
     node->diagnostic = RaiseSyntaxError(
         _("An opening parenthesis (for an object expression), or double colon "
           "(::) was expected (for a behavior expression)."));
 
-    node->location = ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
+    node->location =
+        ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
     return std::move(node);
   }
 
-  std::unique_ptr<FunctionOrEmptyNode> BehaviorFunction(
+  std::unique_ptr<FunctionCallOrObjectFunctionNameOrEmptyNode> BehaviorFunction(
       const gd::String &type,
       const gd::String &objectName,
       const gd::String &behaviorName,
@@ -426,24 +440,27 @@ class GD_CORE_API ExpressionParser2 {
           Parameters(metadata.parameters, objectName, behaviorName);
       auto function =
           gd::make_unique<FunctionCallNode>(type,
-                                        objectName,
-                                        behaviorName,
-                                        std::move(parametersAndError.first),
-                                        metadata,
-                                        functionName);
+                                            objectName,
+                                            behaviorName,
+                                            std::move(parametersAndError.first),
+                                            metadata,
+                                            functionName);
       function->diagnostic = std::move(parametersAndError.second);
       if (!function->diagnostic)
         function->diagnostic =
             ValidateFunction(*function, functionStartPosition);
 
-      function->location = ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
+      function->location =
+          ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
       return std::move(function);
     } else {
-      auto node = gd::make_unique<EmptyNode>(type);
+      auto node = gd::make_unique<ObjectFunctionNameNode>(
+          type, objectName, behaviorName, functionName);
       node->diagnostic = RaiseSyntaxError(
           _("An opening parenthesis was expected here to call a function."));
 
-      node->location = ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
+      node->location =
+          ExpressionParserLocation(functionStartPosition, GetCurrentPosition());
       return std::move(node);
     }
   }
@@ -549,7 +566,8 @@ class GD_CORE_API ExpressionParser2 {
     } else if (gd::ParameterMetadata::IsObject(type)) {
       return gd::make_unique<ExpressionParserError>(
           "invalid_operator",
-          _("Operators (+, -, /, *) can't be used with an object name. Remove the operator."),
+          _("Operators (+, -, /, *) can't be used with an object name. Remove "
+            "the operator."),
           GetCurrentPosition());
     } else if (gd::ParameterMetadata::IsExpression("variable", type)) {
       return gd::make_unique<ExpressionParserError>(
@@ -585,7 +603,8 @@ class GD_CORE_API ExpressionParser2 {
     } else if (gd::ParameterMetadata::IsObject(type)) {
       return gd::make_unique<ExpressionParserError>(
           "invalid_operator",
-          _("Operators (+, -) can't be used with an object name. Remove the operator."),
+          _("Operators (+, -) can't be used with an object name. Remove the "
+            "operator."),
           GetCurrentPosition());
     } else if (gd::ParameterMetadata::IsExpression("variable", type)) {
       return gd::make_unique<ExpressionParserError>(
@@ -667,7 +686,8 @@ class GD_CORE_API ExpressionParser2 {
     while (currentPosition < expression.size() &&
            (IsIdentifierAllowedChar()
             // Allow whitespace in identifier name for compatibility
-            || expression[currentPosition] == ' ')) {
+            ||
+            expression[currentPosition] == ' ')) {
       name += expression[currentPosition];
       currentPosition++;
     }
@@ -697,7 +717,8 @@ class GD_CORE_API ExpressionParser2 {
     }
 
     auto node = gd::make_unique<EmptyNode>(type, text);
-    node->location = ExpressionParserLocation(startPosition, GetCurrentPosition());
+    node->location =
+        ExpressionParserLocation(startPosition, GetCurrentPosition());
     return node;
   }
 
@@ -710,7 +731,8 @@ class GD_CORE_API ExpressionParser2 {
     }
 
     auto node = gd::make_unique<EmptyNode>(type, text);
-    node->location = ExpressionParserLocation(startPosition, GetCurrentPosition());
+    node->location =
+        ExpressionParserLocation(startPosition, GetCurrentPosition());
     return node;
   }
 

--- a/Core/GDCore/Events/Parsers/ExpressionParser2Node.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2Node.h
@@ -220,7 +220,7 @@ struct VariableBracketAccessorNode
 struct IdentifierOrFunctionOrEmptyNode : public ExpressionNode {};
 
 /**
- * \brief An identifier node, usually representing an object.
+ * \brief An identifier node, usually representing an object or a function name.
  */
 struct IdentifierNode : public IdentifierOrFunctionOrEmptyNode {
   IdentifierNode(const gd::String &identifierName_, const gd::String &type_)
@@ -242,8 +242,8 @@ struct FunctionOrEmptyNode : public IdentifierOrFunctionOrEmptyNode {
 /**
  * \brief A function node. For example: "MyExtension::MyFunction(1, 2)".
  */
-struct FunctionNode : public FunctionOrEmptyNode {
-  FunctionNode(const gd::String &type_,
+struct FunctionCallNode : public FunctionOrEmptyNode {
+  FunctionCallNode(const gd::String &type_,
                std::vector<std::unique_ptr<ExpressionNode>> parameters_,
                const ExpressionMetadata &expressionMetadata_,
                const gd::String &functionName_)
@@ -251,7 +251,7 @@ struct FunctionNode : public FunctionOrEmptyNode {
         parameters(std::move(parameters_)),
         expressionMetadata(expressionMetadata_),
         functionName(functionName_){};
-  FunctionNode(const gd::String &type_,
+  FunctionCallNode(const gd::String &type_,
                const gd::String &objectName_,
                std::vector<std::unique_ptr<ExpressionNode>> parameters_,
                const ExpressionMetadata &expressionMetadata_,
@@ -261,7 +261,7 @@ struct FunctionNode : public FunctionOrEmptyNode {
         parameters(std::move(parameters_)),
         expressionMetadata(expressionMetadata_),
         functionName(functionName_){};
-  FunctionNode(const gd::String &type_,
+  FunctionCallNode(const gd::String &type_,
                const gd::String &objectName_,
                const gd::String &behaviorName_,
                std::vector<std::unique_ptr<ExpressionNode>> parameters_,
@@ -273,9 +273,9 @@ struct FunctionNode : public FunctionOrEmptyNode {
         parameters(std::move(parameters_)),
         expressionMetadata(expressionMetadata_),
         functionName(functionName_){};
-  virtual ~FunctionNode(){};
+  virtual ~FunctionCallNode(){};
   virtual void Visit(ExpressionParser2NodeWorker &worker) {
-    worker.OnVisitFunctionNode(*this);
+    worker.OnVisitFunctionCallNode(*this);
   };
 
   gd::String type;  // This could be removed if the type ("string" or "number")

--- a/Core/GDCore/Events/Parsers/ExpressionParser2NodePrinter.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2NodePrinter.h
@@ -92,7 +92,7 @@ class GD_CORE_API ExpressionParser2NodePrinter
   void OnVisitIdentifierNode(IdentifierNode& node) override {
     output += node.identifierName;
   }
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (!node.behaviorName.empty()) {
       output +=
           node.objectName + "." + node.behaviorName + "::" + node.functionName;

--- a/Core/GDCore/Events/Parsers/ExpressionParser2NodePrinter.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2NodePrinter.h
@@ -92,6 +92,14 @@ class GD_CORE_API ExpressionParser2NodePrinter
   void OnVisitIdentifierNode(IdentifierNode& node) override {
     output += node.identifierName;
   }
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    if (!node.behaviorFunctionName.empty()) {
+      output +=
+          node.objectName + "." + node.objectFunctionOrBehaviorName + "::" + node.behaviorFunctionName;
+    } else {
+      output += node.objectName + "." + node.objectFunctionOrBehaviorName;
+    }
+  };
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (!node.behaviorName.empty()) {
       output +=

--- a/Core/GDCore/Events/Parsers/ExpressionParser2NodeWorker.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2NodeWorker.h
@@ -16,9 +16,10 @@ class TextNode;
 class VariableNode;
 class VariableAccessorNode;
 class VariableBracketAccessorNode;
-class IdentifierOrFunctionOrEmptyNode;
+class IdentifierOrFunctionCallOrObjectFunctionNameOrEmptyNode;
 class IdentifierNode;
-class FunctionOrEmptyNode;
+class FunctionCallOrObjectFunctionNameOrEmptyNode;
+class ObjectFunctionNameNode;
 class FunctionCallNode;
 class EmptyNode;
 }  // namespace gd
@@ -42,9 +43,10 @@ class GD_CORE_API ExpressionParser2NodeWorker {
   friend class VariableNode;
   friend class VariableAccessorNode;
   friend class VariableBracketAccessorNode;
-  friend class IdentifierOrFunctionOrEmptyNode;
+  friend class IdentifierOrFunctionCallOrObjectFunctionNameOrEmptyNode;
   friend class IdentifierNode;
-  friend class FunctionOrEmptyNode;
+  friend class FunctionCallOrObjectFunctionNameOrEmptyNode;
+  friend class ObjectFunctionNameNode;
   friend class FunctionCallNode;
   friend class EmptyNode;
 
@@ -62,6 +64,7 @@ class GD_CORE_API ExpressionParser2NodeWorker {
   virtual void OnVisitVariableBracketAccessorNode(
       VariableBracketAccessorNode& node) = 0;
   virtual void OnVisitIdentifierNode(IdentifierNode& node) = 0;
+  virtual void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) = 0;
   virtual void OnVisitFunctionCallNode(FunctionCallNode& node) = 0;
   virtual void OnVisitEmptyNode(EmptyNode& node) = 0;
 };

--- a/Core/GDCore/Events/Parsers/ExpressionParser2NodeWorker.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2NodeWorker.h
@@ -19,7 +19,7 @@ class VariableBracketAccessorNode;
 class IdentifierOrFunctionOrEmptyNode;
 class IdentifierNode;
 class FunctionOrEmptyNode;
-class FunctionNode;
+class FunctionCallNode;
 class EmptyNode;
 }  // namespace gd
 
@@ -45,7 +45,7 @@ class GD_CORE_API ExpressionParser2NodeWorker {
   friend class IdentifierOrFunctionOrEmptyNode;
   friend class IdentifierNode;
   friend class FunctionOrEmptyNode;
-  friend class FunctionNode;
+  friend class FunctionCallNode;
   friend class EmptyNode;
 
  public:
@@ -62,7 +62,7 @@ class GD_CORE_API ExpressionParser2NodeWorker {
   virtual void OnVisitVariableBracketAccessorNode(
       VariableBracketAccessorNode& node) = 0;
   virtual void OnVisitIdentifierNode(IdentifierNode& node) = 0;
-  virtual void OnVisitFunctionNode(FunctionNode& node) = 0;
+  virtual void OnVisitFunctionCallNode(FunctionCallNode& node) = 0;
   virtual void OnVisitEmptyNode(EmptyNode& node) = 0;
 };
 

--- a/Core/GDCore/IDE/Events/EventsContextAnalyzer.cpp
+++ b/Core/GDCore/IDE/Events/EventsContextAnalyzer.cpp
@@ -63,6 +63,15 @@ class GD_CORE_API ExpressionObjectsAnalyzer
       context.AddObjectName(node.identifierName);
     }
   }
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    if (!node.objectName.empty()) {
+      context.AddObjectName(node.objectName);
+
+      if (!node.behaviorFunctionName.empty()) {
+        context.AddBehaviorName(node.objectName, node.objectFunctionOrBehaviorName);
+      }
+    }
+  }
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (!node.objectName.empty()) {
       context.AddObjectName(node.objectName);

--- a/Core/GDCore/IDE/Events/EventsContextAnalyzer.cpp
+++ b/Core/GDCore/IDE/Events/EventsContextAnalyzer.cpp
@@ -63,7 +63,7 @@ class GD_CORE_API ExpressionObjectsAnalyzer
       context.AddObjectName(node.identifierName);
     }
   }
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (!node.objectName.empty()) {
       context.AddObjectName(node.objectName);
 

--- a/Core/GDCore/IDE/Events/EventsRefactorer.cpp
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.cpp
@@ -77,6 +77,12 @@ class GD_CORE_API ExpressionObjectRenamer : public ExpressionParser2NodeWorker {
       node.identifierName = objectNewName;
     }
   }
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    if (node.objectName == objectName) {
+      hasDoneRenaming = true;
+      node.objectName = objectNewName;
+    }
+  }
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (node.objectName == objectName) {
       hasDoneRenaming = true;
@@ -145,6 +151,11 @@ class GD_CORE_API ExpressionObjectFinder : public ExpressionParser2NodeWorker {
   }
   void OnVisitIdentifierNode(IdentifierNode& node) override {
     if (gd::ParameterMetadata::IsObject(node.type) && node.identifierName == objectName) {
+      hasObject = true;
+    }
+  }
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    if (node.objectName == objectName) {
       hasObject = true;
     }
   }

--- a/Core/GDCore/IDE/Events/EventsRefactorer.cpp
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.cpp
@@ -35,7 +35,7 @@ class GD_CORE_API ExpressionObjectRenamer : public ExpressionParser2NodeWorker {
   virtual ~ExpressionObjectRenamer(){};
 
   static bool Rename(gd::ExpressionNode & node, const gd::String& objectName, const gd::String& objectNewName) {
-    if (ExpressionValidator::HasNoErrors(node)) {  
+    if (ExpressionValidator::HasNoErrors(node)) {
       ExpressionObjectRenamer renamer(objectName, objectNewName);
       node.Visit(renamer);
 
@@ -77,7 +77,7 @@ class GD_CORE_API ExpressionObjectRenamer : public ExpressionParser2NodeWorker {
       node.identifierName = objectNewName;
     }
   }
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (node.objectName == objectName) {
       hasDoneRenaming = true;
       node.objectName = objectNewName;
@@ -107,7 +107,7 @@ class GD_CORE_API ExpressionObjectFinder : public ExpressionParser2NodeWorker {
   virtual ~ExpressionObjectFinder(){};
 
   static bool CheckIfHasObject(gd::ExpressionNode & node, const gd::String & objectName) {
-    if (ExpressionValidator::HasNoErrors(node)) {  
+    if (ExpressionValidator::HasNoErrors(node)) {
       ExpressionObjectFinder finder(objectName);
       node.Visit(finder);
 
@@ -148,7 +148,7 @@ class GD_CORE_API ExpressionObjectFinder : public ExpressionParser2NodeWorker {
       hasObject = true;
     }
   }
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (node.objectName == objectName) {
       hasObject = true;
     }
@@ -184,7 +184,7 @@ bool EventsRefactorer::RenameObjectInActions(const gd::Platform& platform,
                    "number", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("number", actions[aId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectRenamer::Rename(*node, oldName, newName)) {
           actions[aId].SetParameter(pNb, ExpressionParser2NodePrinter::PrintNode(*node));
         }
@@ -194,7 +194,7 @@ bool EventsRefactorer::RenameObjectInActions(const gd::Platform& platform,
                    "string", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("string", actions[aId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectRenamer::Rename(*node, oldName, newName)) {
           actions[aId].SetParameter(pNb, ExpressionParser2NodePrinter::PrintNode(*node));
         }
@@ -237,7 +237,7 @@ bool EventsRefactorer::RenameObjectInConditions(
                    "number", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("number", conditions[cId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectRenamer::Rename(*node, oldName, newName)) {
           conditions[cId].SetParameter(pNb, ExpressionParser2NodePrinter::PrintNode(*node));
         }
@@ -247,7 +247,7 @@ bool EventsRefactorer::RenameObjectInConditions(
                    "string", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("string", conditions[cId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectRenamer::Rename(*node, oldName, newName)) {
           conditions[cId].SetParameter(pNb, ExpressionParser2NodePrinter::PrintNode(*node));
         }
@@ -323,7 +323,7 @@ bool EventsRefactorer::RemoveObjectInActions(const gd::Platform& platform,
                    "number", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("number", actions[aId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectFinder::CheckIfHasObject(*node, name)) {
           deleteMe = true;
           break;
@@ -334,7 +334,7 @@ bool EventsRefactorer::RemoveObjectInActions(const gd::Platform& platform,
                    "string", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("string", actions[aId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectFinder::CheckIfHasObject(*node, name)) {
           deleteMe = true;
           break;
@@ -384,7 +384,7 @@ bool EventsRefactorer::RemoveObjectInConditions(
                    "number", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("number", conditions[cId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectFinder::CheckIfHasObject(*node, name)) {
           deleteMe = true;
           break;
@@ -395,7 +395,7 @@ bool EventsRefactorer::RemoveObjectInConditions(
                    "string", instrInfos.parameters[pNb].type)) {
         gd::ExpressionParser2 parser(platform, project, layout);
         auto node = parser.ParseExpression("string", conditions[cId].GetParameter(pNb).GetPlainString());
-        
+
         if (ExpressionObjectFinder::CheckIfHasObject(*node, name)) {
           deleteMe = true;
           break;

--- a/Core/GDCore/IDE/Events/EventsVariablesFinder.cpp
+++ b/Core/GDCore/IDE/Events/EventsVariablesFinder.cpp
@@ -63,6 +63,7 @@ class GD_CORE_API ExpressionParameterSearcher
     if (node.child) node.child->Visit(*this);
   }
   void OnVisitIdentifierNode(IdentifierNode& node) override {}
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {}
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     bool considerFunction = objectName.empty() || node.objectName == objectName;
     for (size_t i = 0; i < node.parameters.size() &&

--- a/Core/GDCore/IDE/Events/EventsVariablesFinder.cpp
+++ b/Core/GDCore/IDE/Events/EventsVariablesFinder.cpp
@@ -63,7 +63,7 @@ class GD_CORE_API ExpressionParameterSearcher
     if (node.child) node.child->Visit(*this);
   }
   void OnVisitIdentifierNode(IdentifierNode& node) override {}
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     bool considerFunction = objectName.empty() || node.objectName == objectName;
     for (size_t i = 0; i < node.parameters.size() &&
                        i < node.expressionMetadata.parameters.size();

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -35,6 +35,7 @@ struct ExpressionCompletionDescription {
    */
   enum CompletionKind {
     Object,
+    Behavior,
     Expression,
     Variable,
   };
@@ -45,6 +46,16 @@ struct ExpressionCompletionDescription {
   static ExpressionCompletionDescription ForObject(const gd::String& prefix_) {
     return ExpressionCompletionDescription(Object, "", prefix_);
   }
+
+  /**
+   * \brief Create a completion for a behavior with the given prefix of
+   * the specified object
+   */
+  static ExpressionCompletionDescription ForBehavior(
+      const gd::String& prefix_, const gd::String& objectName_) {
+    return ExpressionCompletionDescription(Behavior, "", prefix_, objectName_);
+  }
+
   /**
    * \brief Create a completion for a variable with the given prefix
    */
@@ -88,13 +99,17 @@ struct ExpressionCompletionDescription {
   const gd::String& GetPrefix() const { return prefix; }
 
   /**
-   * \brief Return the object name, if completing an object expression.
+   * \brief Return the object name, if completing an object expression or a
+   * behavior.
    */
   const gd::String& GetObjectName() const { return objectName; }
 
   /**
    * \brief Return the behavior name, if completing an object behavior
    * expression.
+   *
+   * \warning If completing a behavior, the behavior (partial) name is returned
+   * by `GetPrefix`.
    */
   const gd::String& GetBehaviorName() const { return behaviorName; }
 
@@ -220,6 +235,8 @@ class GD_CORE_API ExpressionCompletionFinder
           node.objectName,
           node.objectFunctionOrBehaviorName));
     } else {
+      completions.push_back(ExpressionCompletionDescription::ForBehavior(
+          node.objectFunctionOrBehaviorName, node.objectName));
       completions.push_back(ExpressionCompletionDescription::ForExpression(
           node.type, node.objectFunctionOrBehaviorName, node.objectName));
     }

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -1,0 +1,240 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-present Florian Rival (Florian.Rival@gmail.com). All rights
+ * reserved. This project is released under the MIT License.
+ */
+#ifndef GDCORE_EXPRESSIONAUTOCOMPLETIONPROVIDER_H
+#define GDCORE_EXPRESSIONAUTOCOMPLETIONPROVIDER_H
+
+#include <memory>
+#include <vector>
+#include "GDCore/Events/Parsers/ExpressionParser2Node.h"
+#include "GDCore/Events/Parsers/ExpressionParser2NodeWorker.h"
+#include "GDCore/IDE/Events/ExpressionNodeLocationFinder.h"
+#include "GDCore/Extensions/Metadata/InstructionMetadata.h"
+namespace gd {
+class Expression;
+class ObjectsContainer;
+class Platform;
+class ParameterMetadata;
+class ExpressionMetadata;
+}  // namespace gd
+
+namespace gd {
+
+/**
+ * \brief Describe completions to be shown to the user.
+ *
+ * The IDE is responsible for actually *searching* and showing the completions -
+ * this is only describing what must be listed.
+ */
+struct ExpressionCompletionDescription {
+ public:
+  /**
+   * The different kind of completions that can be described.
+   */
+  enum CompletionKind {
+    OBJECT,
+    EXPRESSION,
+    VARIABLE,
+  };
+
+  /**
+   * \brief Create a completion for an object with the given prefix
+   */
+  static ExpressionCompletionDescription ForObject(const gd::String& prefix_) {
+    return ExpressionCompletionDescription(OBJECT, "", prefix_);
+  }
+  /**
+   * \brief Create a completion for a variable with the given prefix
+   */
+  static ExpressionCompletionDescription ForVariable(
+      const gd::String& prefix_) {
+    return ExpressionCompletionDescription(VARIABLE, "", prefix_);
+  }
+  /**
+   * \brief Create a completion for an expression (free, object or behavior
+   * expression) with the given prefix
+   */
+  static ExpressionCompletionDescription ForExpression(
+      const gd::String& type_,
+      const gd::String& prefix_,
+      const gd::String& objectName_ = "",
+      const gd::String& behaviorName_ = "") {
+    return ExpressionCompletionDescription(
+        EXPRESSION, type_, prefix_, objectName_, behaviorName_);
+  }
+
+  /** Check if two description of completions are equal */
+  bool operator==(const ExpressionCompletionDescription& other) const {
+    return completionKind == other.completionKind && type == other.type &&
+           prefix == other.prefix && objectName == other.objectName &&
+           behaviorName == other.behaviorName;
+  };
+
+  /** \brief Return the kind of the completion */
+  CompletionKind GetCompletionKind() const { return completionKind; }
+
+  /**
+   * \brief Return the type of the completion (same type as types supported in
+   * expressions)
+   * (in other words, for expression this is the type of what must be returned).
+   */
+  const gd::String& GetType() const { return type; }
+
+  /**
+   * \brief Return the prefix currently entered and that must be completed.
+   */
+  const gd::String& GetPrefix() const { return prefix; }
+
+  /**
+   * \brief Return the object name, if completing an object expression.
+   */
+  const gd::String& GetObjectName() const { return objectName; }
+
+  /**
+   * \brief Return the behavior name, if completing an object behavior
+   * expression.
+   */
+  const gd::String& GetBehaviorName() const { return behaviorName; }
+
+ private:
+  ExpressionCompletionDescription(CompletionKind completionKind_,
+                                  const gd::String& type_,
+                                  const gd::String& prefix_,
+                                  const gd::String& objectName_ = "",
+                                  const gd::String& behaviorName_ = "")
+      : completionKind(completionKind_),
+        type(type_),
+        prefix(prefix_),
+        objectName(objectName_),
+        behaviorName(behaviorName_) {}
+
+  CompletionKind completionKind;
+  gd::String type;
+  gd::String prefix;
+  gd::String objectName;
+  gd::String behaviorName;
+};
+
+/**
+ * \brief Turn an ExpressionCompletionDescription to a string.
+ */
+std::ostream& operator<<(std::ostream& os,
+                         ExpressionCompletionDescription const& value) {
+  os << "{ " << value.GetCompletionKind() << ", " << value.GetType() << ", "
+     << value.GetPrefix() << ", " << value.GetObjectName() << ", "
+     << value.GetBehaviorName() << " }";
+  return os;
+}
+
+/**
+ * \brief Returns the list of completion descriptions for an expression node.
+ *
+ * \see gd::ExpressionCompletionDescription
+ */
+class GD_CORE_API ExpressionCompletionFinder
+    : public ExpressionParser2NodeWorker {
+ public:
+  /**
+   * \brief Given the expression, find the node at the specified location
+   * and returns completions for it.
+   */
+  static std::vector<ExpressionCompletionDescription>
+  GetCompletionDescriptionsFor(gd::ExpressionNode& node, size_t location) {
+    gd::ExpressionNode* nodeAtLocation =
+        gd::ExpressionNodeLocationFinder::GetNodeAtPosition(node, location);
+
+    if (nodeAtLocation == nullptr) {
+      std::vector<ExpressionCompletionDescription> emptyCompletions;
+      return emptyCompletions;
+    }
+
+    gd::ExpressionCompletionFinder autocompletionProvider;
+    nodeAtLocation->Visit(autocompletionProvider);
+    return autocompletionProvider.GetCompletionDescriptions();
+  }
+
+  /**
+   * \brief Return the completions found for the visited node.
+   */
+  std::vector<ExpressionCompletionDescription> GetCompletionDescriptions() {
+    return completions;
+  };
+
+ protected:
+  void OnVisitSubExpressionNode(SubExpressionNode& node) override {
+    completions.push_back(ExpressionCompletionDescription::ForObject(""));
+    completions.push_back(
+        ExpressionCompletionDescription::ForExpression(node.type, ""));
+  }
+  void OnVisitOperatorNode(OperatorNode& node) override {
+    completions.push_back(ExpressionCompletionDescription::ForObject(""));
+    completions.push_back(
+        ExpressionCompletionDescription::ForExpression(node.type, ""));
+  }
+  void OnVisitUnaryOperatorNode(UnaryOperatorNode& node) override {
+    completions.push_back(ExpressionCompletionDescription::ForObject(""));
+    completions.push_back(
+        ExpressionCompletionDescription::ForExpression(node.type, ""));
+  }
+  void OnVisitNumberNode(NumberNode& node) override {
+    // No completions
+  }
+  void OnVisitTextNode(TextNode& node) override {
+    // No completions
+  }
+  void OnVisitVariableNode(VariableNode& node) override {
+    completions.push_back(
+        ExpressionCompletionDescription::ForVariable(node.name));
+  }
+  void OnVisitVariableAccessorNode(VariableAccessorNode& node) override {
+    // No completions
+  }
+  void OnVisitVariableBracketAccessorNode(
+      VariableBracketAccessorNode& node) override {
+    // No completions
+  }
+  void OnVisitIdentifierNode(IdentifierNode& node) override {
+    if (gd::ParameterMetadata::IsObject(node.type)) {
+      // Only show completions of objects if an object is required
+      completions.push_back(
+          ExpressionCompletionDescription::ForObject(node.identifierName));
+    } else {
+      // Show completions for expressions and objects otherwise.
+      completions.push_back(
+          ExpressionCompletionDescription::ForObject(node.identifierName));
+      completions.push_back(ExpressionCompletionDescription::ForExpression(
+          node.type, node.identifierName));
+    }
+  }
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    if (!node.behaviorFunctionName.empty()) {
+      completions.push_back(ExpressionCompletionDescription::ForExpression(
+          node.type,
+          node.behaviorFunctionName,
+          node.objectName,
+          node.objectFunctionOrBehaviorName));
+    } else {
+      completions.push_back(ExpressionCompletionDescription::ForExpression(
+          node.type, node.objectFunctionOrBehaviorName, node.objectName));
+    }
+  }
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
+    completions.push_back(ExpressionCompletionDescription::ForExpression(
+        node.type, node.functionName, node.objectName, node.behaviorName));
+  }
+  void OnVisitEmptyNode(EmptyNode& node) override {
+    completions.push_back(
+        ExpressionCompletionDescription::ForObject(node.text));
+    completions.push_back(
+        ExpressionCompletionDescription::ForExpression(node.type, node.text));
+  }
+
+ private:
+  std::vector<ExpressionCompletionDescription> completions;
+};
+
+}  // namespace gd
+
+#endif  // GDCORE_EXPRESSIONAUTOCOMPLETIONPROVIDER_H

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -10,8 +10,8 @@
 #include <vector>
 #include "GDCore/Events/Parsers/ExpressionParser2Node.h"
 #include "GDCore/Events/Parsers/ExpressionParser2NodeWorker.h"
-#include "GDCore/IDE/Events/ExpressionNodeLocationFinder.h"
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
+#include "GDCore/IDE/Events/ExpressionNodeLocationFinder.h"
 namespace gd {
 class Expression;
 class ObjectsContainer;
@@ -34,23 +34,23 @@ struct ExpressionCompletionDescription {
    * The different kind of completions that can be described.
    */
   enum CompletionKind {
-    OBJECT,
-    EXPRESSION,
-    VARIABLE,
+    Object,
+    Expression,
+    Variable,
   };
 
   /**
    * \brief Create a completion for an object with the given prefix
    */
   static ExpressionCompletionDescription ForObject(const gd::String& prefix_) {
-    return ExpressionCompletionDescription(OBJECT, "", prefix_);
+    return ExpressionCompletionDescription(Object, "", prefix_);
   }
   /**
    * \brief Create a completion for a variable with the given prefix
    */
   static ExpressionCompletionDescription ForVariable(
       const gd::String& prefix_) {
-    return ExpressionCompletionDescription(VARIABLE, "", prefix_);
+    return ExpressionCompletionDescription(Variable, "", prefix_);
   }
   /**
    * \brief Create a completion for an expression (free, object or behavior
@@ -62,7 +62,7 @@ struct ExpressionCompletionDescription {
       const gd::String& objectName_ = "",
       const gd::String& behaviorName_ = "") {
     return ExpressionCompletionDescription(
-        EXPRESSION, type_, prefix_, objectName_, behaviorName_);
+        Expression, type_, prefix_, objectName_, behaviorName_);
   }
 
   /** Check if two description of completions are equal */
@@ -97,6 +97,9 @@ struct ExpressionCompletionDescription {
    * expression.
    */
   const gd::String& GetBehaviorName() const { return behaviorName; }
+
+  /** Default constructor, only to be used by Emscripten bindings. */
+  ExpressionCompletionDescription() : completionKind(Object){};
 
  private:
   ExpressionCompletionDescription(CompletionKind completionKind_,
@@ -158,7 +161,8 @@ class GD_CORE_API ExpressionCompletionFinder
   /**
    * \brief Return the completions found for the visited node.
    */
-  std::vector<ExpressionCompletionDescription> GetCompletionDescriptions() {
+  const std::vector<ExpressionCompletionDescription>&
+  GetCompletionDescriptions() {
     return completions;
   };
 

--- a/Core/GDCore/IDE/Events/ExpressionNodeLocationFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionNodeLocationFinder.h
@@ -32,13 +32,15 @@ class GD_CORE_API ExpressionNodeLocationFinder
    * \brief Initialize the finder to search at the specified position.
    */
   ExpressionNodeLocationFinder(size_t searchedPosition_)
-      : searchedPosition(searchedPosition_), foundNode(nullptr) {};
+      : searchedPosition(searchedPosition_), foundNode(nullptr){};
   virtual ~ExpressionNodeLocationFinder(){};
 
   /**
-   * \brief Helper function to find the deepest node at the search position, if any.
+   * \brief Helper function to find the deepest node at the search position, if
+   * any.
    */
-  static ExpressionNode* GetNodeAtPosition(gd::ExpressionNode& node, size_t searchedPosition) {
+  static ExpressionNode* GetNodeAtPosition(gd::ExpressionNode& node,
+                                           size_t searchedPosition) {
     gd::ExpressionNodeLocationFinder finder(searchedPosition);
     node.Visit(finder);
     return finder.GetNode();
@@ -100,13 +102,14 @@ class GD_CORE_API ExpressionNodeLocationFinder
     }
   }
   void OnVisitEmptyNode(EmptyNode& node) override {
-    CheckSearchPositionInNode(node);
+    CheckSearchPositionInNode(node, /*inclusive=*/true);
   }
 
  private:
-  bool CheckSearchPositionInNode(ExpressionNode& node) {
+  bool CheckSearchPositionInNode(ExpressionNode& node, bool inclusive = false) {
     if (node.location.GetStartPosition() <= searchedPosition &&
-        searchedPosition < node.location.GetEndPosition()) {
+        ((!inclusive && searchedPosition < node.location.GetEndPosition()) ||
+         (inclusive && searchedPosition <= node.location.GetEndPosition()))) {
       foundNode = &node;
       return true;
     }

--- a/Core/GDCore/IDE/Events/ExpressionNodeLocationFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionNodeLocationFinder.h
@@ -90,7 +90,7 @@ class GD_CORE_API ExpressionNodeLocationFinder
   void OnVisitIdentifierNode(IdentifierNode& node) override {
     CheckSearchPositionInNode(node);
   }
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     CheckSearchPositionInNode(node);
     for (auto& parameter : node.parameters) {
       parameter->Visit(*this);

--- a/Core/GDCore/IDE/Events/ExpressionNodeLocationFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionNodeLocationFinder.h
@@ -90,6 +90,9 @@ class GD_CORE_API ExpressionNodeLocationFinder
   void OnVisitIdentifierNode(IdentifierNode& node) override {
     CheckSearchPositionInNode(node);
   }
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    CheckSearchPositionInNode(node);
+  }
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     CheckSearchPositionInNode(node);
     for (auto& parameter : node.parameters) {

--- a/Core/GDCore/IDE/Events/ExpressionValidator.h
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.h
@@ -83,7 +83,7 @@ class GD_CORE_API ExpressionValidator : public ExpressionParser2NodeWorker {
   void OnVisitIdentifierNode(IdentifierNode& node) override {
     ReportAnyError(node);
   }
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     ReportAnyError(node);
     for (auto& parameter : node.parameters) {
       parameter->Visit(*this);

--- a/Core/GDCore/IDE/Events/ExpressionValidator.h
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.h
@@ -83,6 +83,9 @@ class GD_CORE_API ExpressionValidator : public ExpressionParser2NodeWorker {
   void OnVisitIdentifierNode(IdentifierNode& node) override {
     ReportAnyError(node);
   }
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    ReportAnyError(node);
+  }
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     ReportAnyError(node);
     for (auto& parameter : node.parameters) {

--- a/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
@@ -74,7 +74,7 @@ class GD_CORE_API ExpressionParameterMover
     if (node.child) node.child->Visit(*this);
   }
   void OnVisitIdentifierNode(IdentifierNode& node) override {}
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     auto moveParameter =
         [this](std::vector<std::unique_ptr<gd::ExpressionNode>>& parameters) {
           if (oldIndex >= parameters.size() || newIndex >= parameters.size())

--- a/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
@@ -74,6 +74,7 @@ class GD_CORE_API ExpressionParameterMover
     if (node.child) node.child->Visit(*this);
   }
   void OnVisitIdentifierNode(IdentifierNode& node) override {}
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {}
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     auto moveParameter =
         [this](std::vector<std::unique_ptr<gd::ExpressionNode>>& parameters) {

--- a/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
@@ -71,7 +71,7 @@ class GD_CORE_API ExpressionFunctionRenamer
     if (node.child) node.child->Visit(*this);
   }
   void OnVisitIdentifierNode(IdentifierNode& node) override {}
-  void OnVisitFunctionNode(FunctionNode& node) override {
+  void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (node.functionName == oldFunctionName) {
       if (behaviorType.empty() && !objectType.empty() &&
           !node.objectName.empty()) {

--- a/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsRenamer.cpp
@@ -71,6 +71,33 @@ class GD_CORE_API ExpressionFunctionRenamer
     if (node.child) node.child->Visit(*this);
   }
   void OnVisitIdentifierNode(IdentifierNode& node) override {}
+  void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
+    if (!node.behaviorFunctionName.empty()) {
+      // Behavior function name
+      if (!behaviorType.empty() &&
+          node.behaviorFunctionName == oldFunctionName) {
+        const gd::String& thisBehaviorType =
+            gd::GetTypeOfBehavior(globalObjectsContainer,
+                                  objectsContainer,
+                                  node.objectFunctionOrBehaviorName);
+        if (thisBehaviorType == behaviorType) {
+          node.behaviorFunctionName = newFunctionName;
+          hasDoneRenaming = true;
+        }
+      }
+    } else {
+      // Object function name
+      if (behaviorType.empty() && !objectType.empty() &&
+          node.objectFunctionOrBehaviorName == oldFunctionName) {
+        const gd::String& thisObjectType = gd::GetTypeOfObject(
+            globalObjectsContainer, objectsContainer, node.objectName);
+        if (thisObjectType == objectType) {
+          node.objectFunctionOrBehaviorName = newFunctionName;
+          hasDoneRenaming = true;
+        }
+      }
+    }
+  }
   void OnVisitFunctionCallNode(FunctionCallNode& node) override {
     if (node.functionName == oldFunctionName) {
       if (behaviorType.empty() && !objectType.empty() &&

--- a/Core/tests/ExpressionCompletionFinder.cpp
+++ b/Core/tests/ExpressionCompletionFinder.cpp
@@ -119,6 +119,8 @@ TEST_CASE("ExpressionCompletionFinder", "[common][events]") {
   SECTION("Partial object or behavior function") {
     SECTION("Test 1") {
       std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForBehavior(
+              "Func", "MyObject"),
           gd::ExpressionCompletionDescription::ForExpression(
               "string", "Func", "MyObject")};
       REQUIRE(getCompletionsFor("string", "MyObject.Func", 0) ==

--- a/Core/tests/ExpressionCompletionFinder.cpp
+++ b/Core/tests/ExpressionCompletionFinder.cpp
@@ -1,0 +1,190 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights
+ * reserved. This project is released under the MIT License.
+ */
+#include "GDCore/IDE/Events/ExpressionCompletionFinder.h"
+#include "DummyPlatform.h"
+#include "GDCore/Events/Parsers/ExpressionParser2.h"
+#include "GDCore/Extensions/Platform.h"
+#include "GDCore/Extensions/PlatformExtension.h"
+#include "GDCore/Project/Layout.h"
+#include "GDCore/Project/Project.h"
+#include "catch.hpp"
+
+TEST_CASE("ExpressionCompletionFinder", "[common][events]") {
+  gd::Project project;
+  gd::Platform platform;
+  SetupProjectWithDummyPlatform(project, platform);
+  auto& layout1 = project.InsertNewLayout("Layout1", 0);
+
+  gd::ExpressionParser2 parser(platform, project, layout1);
+
+  auto getCompletionsFor = [&](
+      const gd::String& type, const gd::String& expression, size_t location) {
+    auto node = parser.ParseExpression(type, expression);
+    REQUIRE(node != nullptr);
+    return gd::ExpressionCompletionFinder::GetCompletionDescriptionsFor(
+        *node, location);
+  };
+
+  const std::vector<gd::ExpressionCompletionDescription>
+      expectedEmptyCompletions;
+
+  SECTION("Identifier") {
+    SECTION("Object or expression completions when type is string") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForObject("My"),
+          gd::ExpressionCompletionDescription::ForExpression("string", "My")};
+      REQUIRE(getCompletionsFor("string", "My", 0) == expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "My", 1) == expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "My", 2) == expectedEmptyCompletions);
+    }
+    SECTION("Object or expression completions when type is number") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForObject("My"),
+          gd::ExpressionCompletionDescription::ForExpression("number", "My")};
+      REQUIRE(getCompletionsFor("number", "My", 0) == expectedCompletions);
+      REQUIRE(getCompletionsFor("number", "My", 1) == expectedCompletions);
+      REQUIRE(getCompletionsFor("number", "My", 2) == expectedEmptyCompletions);
+    }
+    SECTION("Object when type is an object") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForObject("My")};
+      REQUIRE(getCompletionsFor("object", "My", 0) == expectedCompletions);
+      REQUIRE(getCompletionsFor("object", "My", 1) == expectedCompletions);
+      REQUIRE(getCompletionsFor("object", "My", 2) == expectedEmptyCompletions);
+
+      // Also test alternate types also considered as objects (but that can result
+      // in different code generation):
+      REQUIRE(getCompletionsFor("objectPtr", "My", 0) == expectedCompletions);
+      REQUIRE(getCompletionsFor("objectPtr", "My", 1) == expectedCompletions);
+      REQUIRE(getCompletionsFor("objectPtr", "My", 2) == expectedEmptyCompletions);
+    }
+  }
+  SECTION("Operator (number)") {
+    std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+        gd::ExpressionCompletionDescription::ForObject(""),
+        gd::ExpressionCompletionDescription::ForExpression("number", "")};
+    REQUIRE(getCompletionsFor("number", "1 + ", 1) == expectedCompletions);
+    REQUIRE(getCompletionsFor("number", "1 + ", 2) == expectedCompletions);
+    REQUIRE(getCompletionsFor("number", "1 + ", 3) == expectedCompletions);
+  }
+  SECTION("Operator (string)") {
+    std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+        gd::ExpressionCompletionDescription::ForObject(""),
+        gd::ExpressionCompletionDescription::ForExpression("string", "")};
+    REQUIRE(getCompletionsFor("string", "\"a\" + ", 3) == expectedCompletions);
+    REQUIRE(getCompletionsFor("string", "\"a\" + ", 4) == expectedCompletions);
+    REQUIRE(getCompletionsFor("string", "\"a\" + ", 5) == expectedCompletions);
+  }
+
+  SECTION("Free function") {
+    SECTION("Test 1") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForExpression("string",
+                                                             "Function")};
+      REQUIRE(getCompletionsFor("string", "Function(", 0) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "Function(", 1) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "Function(", 7) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "Function(", 8) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "Function(", 9) ==
+              expectedEmptyCompletions);
+    }
+    SECTION("Unknown function, test with arguments") {
+      REQUIRE(getCompletionsFor("string", "Function(1", 9) ==
+              expectedEmptyCompletions);
+      REQUIRE(getCompletionsFor("string", "Function(\"", 9) ==
+              expectedEmptyCompletions);
+
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForObject("a"),
+          gd::ExpressionCompletionDescription::ForExpression("unknown", "a")};
+      REQUIRE(getCompletionsFor("string", "Function(a", 9) ==
+              expectedCompletions);
+    }
+    SECTION("Function with a Variable as argument") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForVariable("myVar")};
+      REQUIRE(getCompletionsFor("number",
+                                "MyExtension::GetVariableAsNumber(myVar",
+                                33) == expectedCompletions);
+    }
+  }
+
+  SECTION("Partial object or behavior function") {
+    SECTION("Test 1") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForExpression(
+              "string", "Func", "MyObject")};
+      REQUIRE(getCompletionsFor("string", "MyObject.Func", 0) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func", 5) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func", 10) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func", 12) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func", 13) ==
+              expectedEmptyCompletions);
+    }
+  }
+
+  SECTION("Object function") {
+    SECTION("Test 1") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForExpression(
+              "string", "Func", "MyObject")};
+      REQUIRE(getCompletionsFor("string", "MyObject.Func(", 0) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func(", 5) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func(", 10) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func(", 12) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.Func(", 13) ==
+              expectedCompletions);
+    }
+  }
+
+  SECTION("Partial behavior function") {
+    SECTION("Test 1") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForExpression(
+              "string", "Func", "MyObject", "MyBehavior")};
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func", 0) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func", 5) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func", 10) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func", 12) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func", 13) ==
+              expectedCompletions);
+    }
+  }
+
+  SECTION("Behavior function") {
+    SECTION("Test 1") {
+      std::vector<gd::ExpressionCompletionDescription> expectedCompletions{
+          gd::ExpressionCompletionDescription::ForExpression(
+              "string", "Func", "MyObject", "MyBehavior")};
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func(", 0) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func(", 5) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func(", 10) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func(", 24) ==
+              expectedCompletions);
+      REQUIRE(getCompletionsFor("string", "MyObject.MyBehavior::Func(", 25) ==
+              expectedCompletions);
+    }
+  }
+}

--- a/Core/tests/ExpressionNodeLocationFinder.cpp
+++ b/Core/tests/ExpressionNodeLocationFinder.cpp
@@ -43,6 +43,23 @@ TEST_CASE("ExpressionNodeLocationFinder", "[common][events]") {
 
   gd::ExpressionParser2 parser(platform, project, layout1);
 
+  SECTION("Empty expressions") {
+    SECTION("Test 1") {
+      REQUIRE(CheckNodeAtLocationIs<gd::EmptyNode>(
+                  parser, "string", "", 0) == true);
+      REQUIRE(CheckNoNodeAtLocation(parser, "string", "", 1) ==
+              true);
+    }
+    SECTION("Test 2") {
+      REQUIRE(CheckNoNodeAtLocation(parser, "string", " ", 0) ==
+              true);
+      REQUIRE(CheckNodeAtLocationIs<gd::EmptyNode>(
+                  parser, "string", " ", 1) == true);
+      REQUIRE(CheckNoNodeAtLocation(parser, "string", " ", 2) ==
+              true);
+    }
+  }
+
   SECTION("Valid text") {
     SECTION("Test 1") {
       REQUIRE(CheckNodeAtLocationIs<gd::TextNode>(

--- a/Core/tests/ExpressionNodeLocationFinder.cpp
+++ b/Core/tests/ExpressionNodeLocationFinder.cpp
@@ -204,13 +204,13 @@ TEST_CASE("ExpressionNodeLocationFinder", "[common][events]") {
       REQUIRE(CheckNodeAtLocationIs<gd::OperatorNode>(
                   parser, "number", "12 + MyExtension::GetNumber()", 4) ==
               true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser, "number", "12 + MyExtension::GetNumber()", 5) ==
               true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser, "number", "12 + MyExtension::GetNumber()", 27) ==
               true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser, "number", "12 + MyExtension::GetNumber()", 28) ==
               true);
       REQUIRE(CheckNoNodeAtLocation(
@@ -218,17 +218,17 @@ TEST_CASE("ExpressionNodeLocationFinder", "[common][events]") {
               true);
     }
     SECTION("Test 2") {
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser,
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
                   0) == true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser,
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
                   1) == true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser,
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
@@ -243,12 +243,12 @@ TEST_CASE("ExpressionNodeLocationFinder", "[common][events]") {
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
                   35) == true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser,
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
                   36) == true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser,
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
@@ -268,7 +268,7 @@ TEST_CASE("ExpressionNodeLocationFinder", "[common][events]") {
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
                   50) == true);
-      REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+      REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                   parser,
                   "number",
                   "MyExtension::GetNumberWith2Params(12, \"hello world\")",
@@ -282,30 +282,30 @@ TEST_CASE("ExpressionNodeLocationFinder", "[common][events]") {
   }
 
   SECTION("Invalid function calls") {
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(12)", 0) == true);
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(12)", 1) == true);
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(12)", 2) == true);
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(12)", 10) == true);
     REQUIRE(CheckNodeAtLocationIs<gd::NumberNode>(
                 parser, "number", "Idontexist(12)", 11) == true);
     REQUIRE(CheckNodeAtLocationIs<gd::NumberNode>(
                 parser, "number", "Idontexist(12)", 12) == true);
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(12)", 13) == true);
     REQUIRE(CheckNoNodeAtLocation(parser, "number", "Idontexist(12)", 14) ==
             true);
   }
 
   SECTION("Unterminated function calls") {
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(", 0) == true);
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(", 1) == true);
-    REQUIRE(CheckNodeAtLocationIs<gd::FunctionNode>(
+    REQUIRE(CheckNodeAtLocationIs<gd::FunctionCallNode>(
                 parser, "number", "Idontexist(", 10) == true);
     REQUIRE(CheckNoNodeAtLocation(parser, "number", "Idontexist(", 11) == true);
   }

--- a/Core/tests/ExpressionParser2.cpp
+++ b/Core/tests/ExpressionParser2.cpp
@@ -560,7 +560,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
     {
       auto node = parser.ParseExpression("number", "MyExtension::GetNumber()");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
       REQUIRE(functionNode.functionName == "MyExtension::GetNumber");
       REQUIRE(functionNode.objectName == "");
       REQUIRE(functionNode.behaviorName == "");
@@ -573,7 +573,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       auto node = parser.ParseExpression(
           "number", "MyExtension::GetNumberWith2Params(12, \"hello world\")");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
       REQUIRE(functionNode.functionName == "MyExtension::GetNumberWith2Params");
       REQUIRE(functionNode.objectName == "");
       REQUIRE(functionNode.behaviorName == "");
@@ -586,7 +586,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       auto node = parser.ParseExpression(
           "number", "MyExtension::GetNumberWith3Params(12, \"hello world\")");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
 
       gd::ExpressionValidator validator;
       node->Visit(validator);
@@ -597,7 +597,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
           "number",
           "MyExtension::GetNumberWith3Params(12, \"hello world\", 34)");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
 
       gd::ExpressionValidator validator;
       node->Visit(validator);
@@ -607,7 +607,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       auto node =
           parser.ParseExpression("number", "MySpriteObject.GetObjectNumber()");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
       REQUIRE(functionNode.functionName == "GetObjectNumber");
       REQUIRE(functionNode.objectName == "MySpriteObject");
       REQUIRE(functionNode.behaviorName == "");
@@ -620,7 +620,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       auto node = parser.ParseExpression(
           "number", "WhateverObject.WhateverBehavior::WhateverFunction()");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
       REQUIRE(functionNode.functionName == "WhateverFunction");
       REQUIRE(functionNode.objectName == "WhateverObject");
       REQUIRE(functionNode.behaviorName == "WhateverBehavior");
@@ -630,7 +630,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
           "number",
           "WhateverObject.WhateverBehavior::WhateverFunction(1, \"2\", three)");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
       REQUIRE(functionNode.functionName == "WhateverFunction");
       REQUIRE(functionNode.objectName == "WhateverObject");
       REQUIRE(functionNode.behaviorName == "WhateverBehavior");
@@ -653,7 +653,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       auto node = parser.ParseExpression(
           "number", "MyExtension::GetNumberWith3Params(12, \"hello world\",)");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
 
       gd::ExpressionValidator validator;
       node->Visit(validator);
@@ -665,7 +665,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
     {
       auto node = parser.ParseExpression("number", "MyExtension::MouseX(,)");
       REQUIRE(node != nullptr);
-      auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+      auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
 
       gd::ExpressionValidator validator;
       node->Visit(validator);
@@ -890,7 +890,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
             "number",
             "WhateverObject.WhateverBehavior::WhateverFunction(1, \"2\", three)");
         REQUIRE(node != nullptr);
-        auto &functionNode = dynamic_cast<gd::FunctionNode &>(*node);
+        auto &functionNode = dynamic_cast<gd::FunctionCallNode &>(*node);
         REQUIRE(functionNode.functionName == "WhateverFunction");
         REQUIRE(functionNode.objectName == "WhateverObject");
         REQUIRE(functionNode.behaviorName == "WhateverBehavior");

--- a/Core/tests/ExpressionParser2.cpp
+++ b/Core/tests/ExpressionParser2.cpp
@@ -21,6 +21,51 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
 
   gd::ExpressionParser2 parser(platform, project, layout1);
 
+  SECTION("Empty expression") {
+    {
+      auto node = parser.ParseExpression("string", "");
+      REQUIRE(node != nullptr);
+      auto &emptyNode = dynamic_cast<gd::EmptyNode &>(*node);
+      REQUIRE(emptyNode.type == "string");
+      REQUIRE(emptyNode.text == "");
+    }
+    {
+      auto node = parser.ParseExpression("number", "");
+      REQUIRE(node != nullptr);
+      auto &emptyNode = dynamic_cast<gd::EmptyNode &>(*node);
+      REQUIRE(emptyNode.type == "number");
+      REQUIRE(emptyNode.text == "");
+    }
+    {
+      auto node = parser.ParseExpression("object", "");
+      REQUIRE(node != nullptr);
+      auto &emptyNode = dynamic_cast<gd::EmptyNode &>(*node);
+      REQUIRE(emptyNode.type == "object");
+      REQUIRE(emptyNode.text == "");
+    }
+    {
+      auto node = parser.ParseExpression("string", " ");
+      REQUIRE(node != nullptr);
+      auto &emptyNode = dynamic_cast<gd::EmptyNode &>(*node);
+      REQUIRE(emptyNode.type == "string");
+      REQUIRE(emptyNode.text == "");
+    }
+    {
+      auto node = parser.ParseExpression("number", " ");
+      REQUIRE(node != nullptr);
+      auto &emptyNode = dynamic_cast<gd::EmptyNode &>(*node);
+      REQUIRE(emptyNode.type == "number");
+      REQUIRE(emptyNode.text == "");
+    }
+    {
+      auto node = parser.ParseExpression("object", " ");
+      REQUIRE(node != nullptr);
+      auto &emptyNode = dynamic_cast<gd::EmptyNode &>(*node);
+      REQUIRE(emptyNode.type == "object");
+      REQUIRE(emptyNode.text == "");
+    }
+  }
+
   SECTION("Valid texts") {
     {
       auto node = parser.ParseExpression("string", "\"hello world\"");

--- a/Core/tests/ExpressionParser2.cpp
+++ b/Core/tests/ExpressionParser2.cpp
@@ -280,12 +280,42 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
     }
   }
 
+  SECTION("valid operators") {
+    {
+      auto node = parser.ParseExpression("number", "123 + 456");
+      REQUIRE(node != nullptr);
+      auto &operatorNode = dynamic_cast<gd::OperatorNode &>(*node);
+      REQUIRE(operatorNode.op == '+');
+      REQUIRE(operatorNode.type == "number");
+      auto &leftNumberNode =
+          dynamic_cast<gd::NumberNode &>(*operatorNode.leftHandSide);
+      REQUIRE(leftNumberNode.number == "123");
+      auto &rightNumberNode =
+          dynamic_cast<gd::NumberNode &>(*operatorNode.rightHandSide);
+      REQUIRE(rightNumberNode.number == "456");
+    }
+    {
+      auto node = parser.ParseExpression("string", "\"abc\" + \"def\"");
+      REQUIRE(node != nullptr);
+      auto &operatorNode = dynamic_cast<gd::OperatorNode &>(*node);
+      REQUIRE(operatorNode.op == '+');
+      REQUIRE(operatorNode.type == "string");
+      auto &leftTextNode =
+          dynamic_cast<gd::TextNode &>(*operatorNode.leftHandSide);
+      REQUIRE(leftTextNode.text == "abc");
+      auto &rightTextNode =
+          dynamic_cast<gd::TextNode &>(*operatorNode.rightHandSide);
+      REQUIRE(rightTextNode.text == "def");
+    }
+  }
+
   SECTION("valid unary operators") {
     {
       auto node = parser.ParseExpression("number", "-123");
       REQUIRE(node != nullptr);
       auto &unaryOperatorNode = dynamic_cast<gd::UnaryOperatorNode &>(*node);
       REQUIRE(unaryOperatorNode.op == '-');
+      REQUIRE(unaryOperatorNode.type == "number");
       auto &numberNode =
           dynamic_cast<gd::NumberNode &>(*unaryOperatorNode.factor);
       REQUIRE(numberNode.number == "123");
@@ -295,6 +325,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       REQUIRE(node != nullptr);
       auto &unaryOperatorNode = dynamic_cast<gd::UnaryOperatorNode &>(*node);
       REQUIRE(unaryOperatorNode.op == '+');
+      REQUIRE(unaryOperatorNode.type == "number");
       auto &numberNode =
           dynamic_cast<gd::NumberNode &>(*unaryOperatorNode.factor);
       REQUIRE(numberNode.number == "123");
@@ -304,6 +335,7 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       REQUIRE(node != nullptr);
       auto &unaryOperatorNode = dynamic_cast<gd::UnaryOperatorNode &>(*node);
       REQUIRE(unaryOperatorNode.op == '-');
+      REQUIRE(unaryOperatorNode.type == "number");
       auto &numberNode =
           dynamic_cast<gd::NumberNode &>(*unaryOperatorNode.factor);
       REQUIRE(numberNode.number == "123.2");

--- a/Core/tests/ExpressionParser2NodePrinter.cpp
+++ b/Core/tests/ExpressionParser2NodePrinter.cpp
@@ -176,6 +176,23 @@ TEST_CASE("ExpressionParser2NodePrinter", "[common][events]") {
                 "Idontexist(12, 34, \"56\" + 2)");
   }
 
+  SECTION("Valid function name") {
+    SECTION("Free function") {
+      testPrinter("number", "MyExtension::GetNumber");
+      testPrinter("number", "MyExtension::GetNumberWith2Params");
+      testPrinter("number", "MyExtension::UnknownFunc");
+      testPrinter("number", "UnknownFunc");
+    }
+    SECTION("Object function") {
+      testPrinter("number", "a.b");
+      testPrinter("number", "MySpriteObject.GetObjectNumber");
+      testPrinter("number", "MySpriteObject.MyOtherFunc");
+    }
+    SECTION("Behavior function") {
+      testPrinter("number", "MySpriteObject.MyBehavior::MyFunc");
+    }
+  }
+
   SECTION("Valid variables") {
     testPrinter("scenevar", "myVariable");
     testPrinter("scenevar", "myVariable.myChild");

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1672,6 +1672,7 @@ interface ExpressionValidator {
 
 enum ExpressionCompletionDescription_CompletionKind {
   "ExpressionCompletionDescription::Object",
+  "ExpressionCompletionDescription::Behavior",
   "ExpressionCompletionDescription::Variable",
   "ExpressionCompletionDescription::Expression"
 };

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1670,6 +1670,35 @@ interface ExpressionValidator {
     //Inherited from ExpressionParser2NodeWorker:
 };
 
+enum ExpressionCompletionDescription_CompletionKind {
+  "ExpressionCompletionDescription::Object",
+  "ExpressionCompletionDescription::Variable",
+  "ExpressionCompletionDescription::Expression"
+};
+
+interface ExpressionCompletionDescription {
+  ExpressionCompletionDescription_CompletionKind GetCompletionKind();
+  [Const, Ref] DOMString GetType();
+  [Const, Ref] DOMString GetPrefix();
+  [Const, Ref] DOMString GetObjectName();
+  [Const, Ref] DOMString GetBehaviorName();
+};
+
+interface VectorExpressionCompletionDescription {
+    unsigned long size();
+    [Value] ExpressionCompletionDescription at(unsigned long index);
+};
+
+interface ExpressionCompletionFinder {
+    void ExpressionCompletionFinder();
+
+    [Value] VectorExpressionCompletionDescription STATIC_GetCompletionDescriptionsFor([Ref] ExpressionNode node, unsigned long location);
+
+    [Const, Ref] VectorExpressionCompletionDescription GetCompletionDescriptions();
+
+    //Inherited from ExpressionParser2NodeWorker:
+};
+
 interface ExpressionNode {
     void Visit([Ref] ExpressionParser2NodeWorker worker);
 };

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -44,6 +44,7 @@
 #include <GDCore/IDE/Events/InstructionSentenceFormatter.h>
 #include <GDCore/IDE/Events/TextFormatting.h>
 #include <GDCore/IDE/Events/EventsListUnfolder.h>
+#include <GDCore/IDE/Events/ExpressionCompletionFinder.h>
 #include <GDCore/IDE/Project/ArbitraryResourceWorker.h>
 #include <GDCore/IDE/Project/ResourcesMergingHelper.h>
 #include <GDCore/IDE/Project/ResourcesInUseHelper.h>
@@ -385,6 +386,8 @@ typedef std::unique_ptr<ExpressionNode> UniquePtrExpressionNode;
 typedef std::vector<gd::ExpressionParserDiagnostic*> VectorExpressionParserDiagnostic;
 typedef gd::SerializableWithNameList<gd::EventsBasedBehavior> EventsBasedBehaviorsList;
 typedef gd::SerializableWithNameList<gd::NamedPropertyDescriptor> NamedPropertyDescriptorsList;
+typedef ExpressionCompletionDescription::CompletionKind ExpressionCompletionDescription_CompletionKind;
+typedef std::vector<gd::ExpressionCompletionDescription> VectorExpressionCompletionDescription;
 
 typedef ExtensionAndMetadata<BehaviorMetadata> ExtensionAndBehaviorMetadata;
 typedef ExtensionAndMetadata<ObjectMetadata> ExtensionAndObjectMetadata;
@@ -548,6 +551,8 @@ typedef ExtensionAndMetadata<ExpressionMetadata> ExtensionAndExpressionMetadata;
 #define STATIC_CopyAllResourcesTo CopyAllResourcesTo
 
 #define STATIC_IsExtensionLifecycleEventsFunction IsExtensionLifecycleEventsFunction
+
+#define STATIC_GetCompletionDescriptionsFor GetCompletionDescriptionsFor
 
 // We postfix some methods with "At" as Javascript does not support overloading
 #define GetLayoutAt GetLayout

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -2850,6 +2850,25 @@ describe('libGD.js', function() {
       parser.delete();
     }
 
+    it('completes an empty expression', function() {
+      expect.assertions(6);
+      testCompletions('number', '|', (completionDescription, index) => {
+          if (index === 0) {
+            expect(completionDescription.getCompletionKind()).toBe(
+              gd.ExpressionCompletionDescription.Object
+            );
+            expect(completionDescription.getType()).toBe('');
+            expect(completionDescription.getPrefix()).toBe('');
+          } else {
+            expect(completionDescription.getCompletionKind()).toBe(
+              gd.ExpressionCompletionDescription.Expression
+            );
+            expect(completionDescription.getType()).toBe('number');
+            expect(completionDescription.getPrefix()).toBe('');
+          }
+      });
+    });
+
     it('completes an expression with an operator', function() {
       expect.assertions(6);
       testCompletions('number', '1 +| ', (completionDescription, index) => {
@@ -2868,6 +2887,7 @@ describe('libGD.js', function() {
         }
       });
     });
+
     it('completes an expression with an operator and a prefix', function() {
       expect.assertions(6);
       testCompletions('number', '1 + My| ', (completionDescription, index) => {
@@ -2887,17 +2907,26 @@ describe('libGD.js', function() {
       });
     });
     it('completes an expression with a partial object function', function() {
-      expect.assertions(4);
+      expect.assertions(8);
       testCompletions(
         'number',
         '1 + MyObject.Func| ',
         (completionDescription, index) => {
-          expect(completionDescription.getCompletionKind()).toBe(
-            gd.ExpressionCompletionDescription.Expression
-          );
-          expect(completionDescription.getType()).toBe('number');
-          expect(completionDescription.getPrefix()).toBe('Func');
-          expect(completionDescription.getObjectName()).toBe('MyObject');
+          if (index == 0) {
+            expect(completionDescription.getCompletionKind()).toBe(
+              gd.ExpressionCompletionDescription.Behavior
+            );
+            expect(completionDescription.getType()).toBe('');
+            expect(completionDescription.getPrefix()).toBe('Func');
+            expect(completionDescription.getObjectName()).toBe('MyObject');
+          } else {
+            expect(completionDescription.getCompletionKind()).toBe(
+              gd.ExpressionCompletionDescription.Expression
+            );
+            expect(completionDescription.getType()).toBe('number');
+            expect(completionDescription.getPrefix()).toBe('Func');
+            expect(completionDescription.getObjectName()).toBe('MyObject');
+          }
         }
       );
     });

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -2808,6 +2808,139 @@ describe('libGD.js', function() {
     });
   });
 
+  describe('gd.ExpressionCompletionFinder', function() {
+    let project = null;
+    let layout = null;
+    beforeAll(() => {
+      project = new gd.ProjectHelper.createNewGDJSProject();
+      layout = project.insertNewLayout('Scene', 0);
+      layout.insertNewObject(project, 'Sprite', 'MySpriteObject', 0);
+    });
+
+    function testCompletions(
+      type,
+      expressionWithCaret,
+      onCompletionDescription
+    ) {
+      const caretLocation = expressionWithCaret.indexOf('|');
+      if (caretLocation === -1) {
+        throw new Error(
+          'Caret location not found in expression: ' + expressionWithCaret
+        );
+      }
+      const expression = expressionWithCaret.replace('|', '');
+
+      const parser = new gd.ExpressionParser2(
+        gd.JsPlatform.get(),
+        project,
+        layout
+      );
+      const expressionNode = parser.parseExpression(type, expression).get();
+      const completionDescriptions = gd.ExpressionCompletionFinder.getCompletionDescriptionsFor(
+        expressionNode,
+        caretLocation
+      );
+
+      for (let i = 0; i < completionDescriptions.size(); i++) {
+        const completionDescription = completionDescriptions.at(i);
+
+        onCompletionDescription(completionDescription, i);
+      }
+
+      parser.delete();
+    }
+
+    it('completes an expression with an operator', function() {
+      expect.assertions(6);
+      testCompletions('number', '1 +| ', (completionDescription, index) => {
+        if (index === 0) {
+          expect(completionDescription.getCompletionKind()).toBe(
+            gd.ExpressionCompletionDescription.Object
+          );
+          expect(completionDescription.getType()).toBe('');
+          expect(completionDescription.getPrefix()).toBe('');
+        } else {
+          expect(completionDescription.getCompletionKind()).toBe(
+            gd.ExpressionCompletionDescription.Expression
+          );
+          expect(completionDescription.getType()).toBe('number');
+          expect(completionDescription.getPrefix()).toBe('');
+        }
+      });
+    });
+    it('completes an expression with an operator and a prefix', function() {
+      expect.assertions(6);
+      testCompletions('number', '1 + My| ', (completionDescription, index) => {
+        if (index === 0) {
+          expect(completionDescription.getCompletionKind()).toBe(
+            gd.ExpressionCompletionDescription.Object
+          );
+          expect(completionDescription.getType()).toBe('');
+          expect(completionDescription.getPrefix()).toBe('My');
+        } else {
+          expect(completionDescription.getCompletionKind()).toBe(
+            gd.ExpressionCompletionDescription.Expression
+          );
+          expect(completionDescription.getType()).toBe('number');
+          expect(completionDescription.getPrefix()).toBe('My');
+        }
+      });
+    });
+    it('completes an expression with a partial object function', function() {
+      expect.assertions(4);
+      testCompletions(
+        'number',
+        '1 + MyObject.Func| ',
+        (completionDescription, index) => {
+          expect(completionDescription.getCompletionKind()).toBe(
+            gd.ExpressionCompletionDescription.Expression
+          );
+          expect(completionDescription.getType()).toBe('number');
+          expect(completionDescription.getPrefix()).toBe('Func');
+          expect(completionDescription.getObjectName()).toBe('MyObject');
+        }
+      );
+    });
+    it('completes an expression with a partial behavior function', function() {
+      expect.assertions(5);
+      testCompletions(
+        'number',
+        '1 + MyObject.MyBehavior::Func| ',
+        (completionDescription, index) => {
+          expect(completionDescription.getCompletionKind()).toBe(
+            gd.ExpressionCompletionDescription.Expression
+          );
+          expect(completionDescription.getType()).toBe('number');
+          expect(completionDescription.getPrefix()).toBe('Func');
+          expect(completionDescription.getObjectName()).toBe('MyObject');
+          expect(completionDescription.getBehaviorName()).toBe('MyBehavior');
+        }
+      );
+    });
+    it('completes an expression parameters', function() {
+      expect.assertions(6);
+      testCompletions(
+        'number',
+        '1 + MySpriteObject.PointX(a| ',
+        (completionDescription, index) => {
+          if (index === 0) {
+            expect(completionDescription.getCompletionKind()).toBe(
+              gd.ExpressionCompletionDescription.Object
+            );
+            expect(completionDescription.getType()).toBe('');
+            expect(completionDescription.getPrefix()).toBe('a');
+          } else {
+            expect(completionDescription.getCompletionKind()).toBe(
+              gd.ExpressionCompletionDescription.Expression
+            );
+            expect(completionDescription.getType()).toBe('string');
+            expect(completionDescription.getPrefix()).toBe('a');
+          }
+        }
+      );
+    });
+  });
+
   describe('gd.Vector2f', function() {
     describe('gd.VectorVector2f', function() {
       it('can be used to manipulate a vector of gd.Vector2f', function() {


### PR DESCRIPTION
This adds support in GDevelop.js for describing the completions to be displayed when editing an expression.
*There is still work then to integrate this in the IDE*. The idea is that the new classes are giving you the information: "for this cursor location in the expression, you should display completions for expressions/objects/behaviors starting with xxx".

This is a step towards https://trello.com/c/KOzBOMyS/13-autocompletion-of-expressions-as-you-write.