### PR TITLE
Specific platform ignoring

### DIFF
--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -502,6 +502,28 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .SetFunctionName("GetJumpSpeed")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
+    aut.AddExpression("ignorePlatform",
+                          _("Jump speed"),
+                          _("Jump speed"),
+                          _("Options"),
+                          "CppPlatform/Extensions/platformerobjecticon16.png")
+            .AddParameter("object", _("Object"))
+            .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+            .SetFunctionName("IgnorePlatform")
+            .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
+    aut.AddExpression("unIgnorePlatform",
+                              _("Jump speed"),
+                              _("Jump speed"),
+                              _("Options"),
+                              "CppPlatform/Extensions/platformerobjecticon16.png")
+                .AddParameter("object", _("Object"))
+                .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+                .AddParameter("object", _("Platform to ignore"))
+                .AddParameter("behavior", _("Platform Behavior"), "PlatformObjectBehavior")
+                .SetFunctionName("UnIgnorePlatform")
+                .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 #endif
   }
   {

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -93,6 +93,11 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
           .SetGetter("getJumpSpeed");
       autExpressions["JumpSpeed"].SetFunctionName("getJumpSpeed");
 
+      autActions["PlatformBehavior::ignorePlatform"]
+                .SetFunctionName("ignorePlatform")
+      autActions["PlatformBehavior::unIgnorePlatform"]
+                .SetFunctionName("unIgnorePlatform")
+
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(
           "simulateLeftKey");

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -94,9 +94,9 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
       autExpressions["JumpSpeed"].SetFunctionName("getJumpSpeed");
 
       autActions["PlatformBehavior::ignorePlatform"]
-                .SetFunctionName("ignorePlatform")
+                .SetFunctionName("ignorePlatform");
       autActions["PlatformBehavior::unIgnorePlatform"]
-                .SetFunctionName("unIgnorePlatform")
+                .SetFunctionName("unIgnorePlatform");
 
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(

--- a/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
+++ b/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
@@ -76,6 +76,9 @@ class GD_EXTENSION_API PlatformerObjectRuntimeBehavior
   }
   bool IsGrabbingPlatform() const { return isGrabbingPlatform; }
 
+  void IgnorePlatform(RuntimeBehavior platformBehavior) {};
+  void UnIgnorePlatform() {};
+
   virtual void OnOwnerChanged();
 
  private:

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -60,6 +60,7 @@ gdjs.PlatformerObjectRuntimeBehavior = function(runtimeScene, behaviorData, owne
     this._hasReallyMoved = false;
     this.setSlopeMaxAngle(behaviorData.slopeMaxAngle);
     this._manager = gdjs.PlatformObjectsManager.getManager(runtimeScene);
+    this._ignoredPlatforms = [];
 };
 
 gdjs.PlatformerObjectRuntimeBehavior.prototype = Object.create( gdjs.RuntimeBehavior.prototype );
@@ -903,4 +904,20 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.isFalling = function()
 gdjs.PlatformerObjectRuntimeBehavior.prototype.isMoving = function()
 {
     return (this._hasReallyMoved &&this._currentSpeed !== 0) || this._currentJumpSpeed !== 0 || this._currentFallSpeed !== 0;
+};
+
+/**
+ * Ignore a platform
+ * @param {gdjs.PlatformRuntimeBehavior} platformBehavior
+ */
+gdjs.PlatformerObjectRuntimeBehavior.prototype.ignorePlatform = function(platformBehavior) {
+    this._ignoredPlatforms.push(platformBehavior.getPlatformID())
+};
+
+/**
+ * Ignore a platform
+ * @param {gdjs.PlatformRuntimeBehavior} platformBehavior
+ */
+gdjs.PlatformerObjectRuntimeBehavior.prototype.unIgnorePlatform = function(platformBehavior) {
+    this._ignoredPlatforms.remove(platformBehavior.getPlatformID())
 };

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -454,7 +454,7 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype._releaseGrabbedPlatform = functio
 /**
  * Among the platforms passed in parameter, return true if there is a platform colliding with the object.
  * Ladders are *always* excluded from the test.
- * @param candidates The platform to be tested for collision
+ * @param {Array<gdjs.PlatformRuntimeBehavior>} candidates The platform to be tested for collision
  * @param exceptThisOne The object identifier of a platform to be excluded from the check. Can be null.
  * @param excludeJumpThrus If set to true, jumpthru platforms are excluded. false if not defined.
  */
@@ -466,6 +466,7 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype._isCollidingWith = function(candi
         var platform = candidates[i];
 
         if ( platform.owner.id === exceptThisOne ) continue;
+        if ( platform.getPlatformID() in this._ignoredPlatforms ) continue;
         if ( platform.getPlatformType() === gdjs.PlatformRuntimeBehavior.LADDER ) continue;
         if ( excludeJumpThrus && platform.getPlatformType() === gdjs.PlatformRuntimeBehavior.JUMPTHRU ) continue;
 

--- a/Extensions/PlatformBehavior/platformruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformruntimebehavior.js
@@ -29,6 +29,21 @@ gdjs.PlatformObjectsManager.getManager = function(runtimeScene) {
 };
 
 /**
+ * An ID used by the UID Generator.
+ * @type {number}
+ * @private
+ */
+gdjs.PlatformObjectsManager._id = 0;
+
+/**
+ * A Unique IDentifier generator.
+ * @returns {number}
+ */
+gdjs.PlatformObjectsManager._getNewUID = function() {
+    return ++gdjs.PlatformObjectsManager._id
+};
+
+/**
  * Add a platform to the list of existing platforms.
  */
 gdjs.PlatformObjectsManager.prototype.addPlatform = function(platformBehavior) {
@@ -97,6 +112,8 @@ gdjs.PlatformRuntimeBehavior = function(runtimeScene, behaviorData, owner)
 
 	this._manager = gdjs.PlatformObjectsManager.getManager(runtimeScene);
 	this._registeredInManager = false;
+
+	this.id = gdjs.PlatformObjectsManager._getNewUID()
 };
 
 gdjs.PlatformRuntimeBehavior.prototype = Object.create( gdjs.RuntimeBehavior.prototype );

--- a/Extensions/PlatformBehavior/platformruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformruntimebehavior.js
@@ -206,3 +206,12 @@ gdjs.PlatformRuntimeBehavior.prototype.getYGrabOffset = function()
 {
     return this._yGrabOffset;
 };
+
+/**
+ * Get the UID of the platform.
+ * @returns {number}
+ */
+gdjs.PlatformRuntimeBehavior.prototype.getPlatformID = function()
+{
+    return this.id;
+};


### PR DESCRIPTION
See #1339 
Let a specific instance of a Platformer behavior ignore a specific instance of a Platform Behavior.

Only has a JS implementation.

I am not sure about the declaration of the extension, and on my current setup I cannot compile GDevelop.js so I cannot test the modifications. They seem to compile fine on circle ci though.