### PR TITLE
Removed non-required use of Hashtable.items

### DIFF
--- a/GDJS/Runtime/variablescontainer.js
+++ b/GDJS/Runtime/variablescontainer.js
@@ -94,7 +94,7 @@ gdjs.VariablesContainer.prototype.add = function(name, variable) {
  * @param {string} name Variable to be removed
  */
 gdjs.VariablesContainer.prototype.remove = function(name) {
-    var variable = this._variables.items[name];
+    var variable = this._variables.get(name);
 	if (variable) {
         variable.setUndefinedInContainer();
     }
@@ -106,7 +106,7 @@ gdjs.VariablesContainer.prototype.remove = function(name) {
  * @return {gdjs.Variable} The specified variable. If not found, an empty variable is added to the container.
  */
 gdjs.VariablesContainer.prototype.get = function(name) {
-    var variable = this._variables.items[name];
+    var variable = this._variables.get(name);
 	if (!variable) { //Add automatically inexisting variables.
         variable = new gdjs.Variable();
         this._variables.put(name, variable);
@@ -150,7 +150,7 @@ gdjs.VariablesContainer.prototype.getFromIndex = function(id) {
  * @return {boolean} true if the variable exists.
  */
 gdjs.VariablesContainer.prototype.has = function(name) {
-    var variable = this._variables.items[name];
+    var variable = this._variables.get(name);
 	return variable && !variable.isUndefinedInContainer();
 };
 

--- a/GDJS/tests/package-lock.json
+++ b/GDJS/tests/package-lock.json
@@ -951,7 +951,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -972,12 +973,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -992,17 +995,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1119,7 +1125,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1131,6 +1138,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1145,6 +1153,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1152,12 +1161,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1176,6 +1187,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1256,7 +1268,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1268,6 +1281,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1353,7 +1367,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1389,6 +1404,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1408,6 +1424,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1451,12 +1468,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Hastable.items was used in a non-iteration context. This should not be the case. Hashtable.get() is the correct way to proceed.