### PR TITLE
Fix exiting without renaming an object

### DIFF
--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -296,15 +296,14 @@ export default class ObjectsList extends React.Component<Props, State> {
   _rename = (objectWithContext: ObjectWithContext, newName: string) => {
     const { object } = objectWithContext;
 
-    if (getObjectWithContextName(objectWithContext) === newName) {
-      return;
-    }
-
     this.setState({
       renamedObjectWithContext: null,
     });
 
-    if (this.props.canRenameObject(newName)) {
+    if (
+      getObjectWithContextName(objectWithContext) === newName ||
+      this.props.canRenameObject(newName)
+    ) {
       this.props.onRenameObject(objectWithContext, newName, doRename => {
         if (!doRename) return;
 

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -295,15 +295,13 @@ export default class ObjectsList extends React.Component<Props, State> {
 
   _rename = (objectWithContext: ObjectWithContext, newName: string) => {
     const { object } = objectWithContext;
-
     this.setState({
       renamedObjectWithContext: null,
     });
 
-    if (
-      getObjectWithContextName(objectWithContext) === newName ||
-      this.props.canRenameObject(newName)
-    ) {
+    if (getObjectWithContextName(objectWithContext) === newName) return;
+
+    if (this.props.canRenameObject(newName)) {
       this.props.onRenameObject(objectWithContext, newName, doRename => {
         if (!doRename) return;
 


### PR DESCRIPTION
Fixes #1475 #1437 
Also, fixes the issue of not exiting the field until enter is pressed. Allows to exit the field by clicking outside the object box.