### PR TITLE
Fixed unscrollable parameter list

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -144,7 +144,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
     } = this.props;
 
     return (
-      <Column expand noMargin scrollY>
+      <Column expand noMargin maxHeight={'100%'}>
         <Tabs value={this.state.currentTab} onChange={this._chooseTab}>
           <Tab
             label={<Trans>Configuration</Trans>}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -144,7 +144,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
     } = this.props;
 
     return (
-      <Column expand noMargin>
+      <Column expand noMargin scrollY>
         <Tabs value={this.state.currentTab} onChange={this._chooseTab}>
           <Tab
             label={<Trans>Configuration</Trans>}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -144,7 +144,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
     } = this.props;
 
     return (
-      <Column expand noMargin maxHeight={'100%'}>
+      <Column expand noMargin useMaxHeight>
         <Tabs value={this.state.currentTab} onChange={this._chooseTab}>
           <Tab
             label={<Trans>Configuration</Trans>}

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -36,7 +36,7 @@ export const Column = props => (
       alignItems: props.alignItems || 'stretch',
       justifyContent: props.justifyContent,
       flex: props.expand ? 1 : undefined,
-      useMaxHeight: props.useMaxHeight ? '100%' : undefined,
+      maxHeight: props.useMaxHeight ? '100%' : undefined,
     }}
   >
     {props.children}

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -36,7 +36,7 @@ export const Column = props => (
       alignItems: props.alignItems || 'stretch',
       justifyContent: props.justifyContent,
       flex: props.expand ? 1 : undefined,
-      overflowY: props.scrollY ? 'scroll' ? undefined,
+      overflowY: props.scrollY ? 'scroll' : undefined,
     }}
   >
     {props.children}

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -36,7 +36,7 @@ export const Column = props => (
       alignItems: props.alignItems || 'stretch',
       justifyContent: props.justifyContent,
       flex: props.expand ? 1 : undefined,
-      overflowY: props.scrollY ? 'scroll' : undefined,
+      maxHeight: props.maxHeight ? props.maxHeight : undefined,
     }}
   >
     {props.children}

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -36,6 +36,7 @@ export const Column = props => (
       alignItems: props.alignItems || 'stretch',
       justifyContent: props.justifyContent,
       flex: props.expand ? 1 : undefined,
+      overflowY: props.scrollY ? 'scroll' ? undefined,
     }}
   >
     {props.children}

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -36,7 +36,7 @@ export const Column = props => (
       alignItems: props.alignItems || 'stretch',
       justifyContent: props.justifyContent,
       flex: props.expand ? 1 : undefined,
-      maxHeight: props.maxHeight ? props.maxHeight : undefined,
+      useMaxHeight: props.useMaxHeight ? '100%' : undefined,
     }}
   >
     {props.children}

--- a/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
+++ b/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
@@ -4,7 +4,7 @@ exports[`HelpButton renders nothing if the helpPagePath is empty 1`] = `null`;
 
 exports[`HelpButton renders the button linking to a help page 1`] = `
 <button
-  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall"
+  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSizeSmall MuiButton-sizeSmall"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}

--- a/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
+++ b/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
@@ -4,7 +4,7 @@ exports[`HelpButton renders nothing if the helpPagePath is empty 1`] = `null`;
 
 exports[`HelpButton renders the button linking to a help page 1`] = `
 <button
-  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSizeSmall MuiButton-sizeSmall"
+  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}


### PR DESCRIPTION
Fixed issue #1476.

> I did look into the issue and found the problem. Just had to provide predefined height to the outer container and that seemed to make the function configuration scrollable.

This works perfectly in chrome and electron but doesn't work in firefox. So, I found another workaround. Instead of setting the height to 100%, I changed the overflow-y to scroll. Works in chrome, electron, and firefox :) 
Haven't tested on safari since I don't have it. :/