### PR TITLE
Fix renaming groups and comments

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -42,6 +42,7 @@ const styles = {
 
 type State = {|
   editing: boolean,
+  prevValue: string,
 |};
 
 export default class CommentEvent extends React.Component<
@@ -50,7 +51,7 @@ export default class CommentEvent extends React.Component<
 > {
   state = {
     editing: false,
-    prevValue: undefined,
+    prevValue: '',
   };
 
   _selectable: ?HTMLSpanElement;

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -1,54 +1,54 @@
 // @flow
-import { t } from '@lingui/macro';
+import { t } from "@lingui/macro";
 
-import * as React from 'react';
-import classNames from 'classnames';
-import TextField from '../../../UI/TextField';
-import { rgbToHex } from '../../../Utils/ColorTransformer';
+import * as React from "react";
+import classNames from "classnames";
+import TextField from "../../../UI/TextField";
+import { rgbToHex } from "../../../Utils/ColorTransformer";
 import {
   largeSelectedArea,
   largeSelectableArea,
   selectableArea,
-  disabledText,
-} from '../ClassNames';
-import { type EventRendererProps } from './EventRenderer';
+  disabledText
+} from "../ClassNames";
+import { type EventRendererProps } from "./EventRenderer";
+
 const gd = global.gd;
 
 const commentTextStyle = {
-  width: '100%',
-  fontSize: 14,
+  width: "100%",
+  fontSize: 14
 };
 
 const styles = {
   container: {
-    display: 'flex',
-    flexWrap: 'wrap',
+    display: "flex",
+    flexWrap: "wrap",
     padding: 5,
-    overflow: 'hidden',
-    minHeight: 35,
+    overflow: "hidden",
+    minHeight: 35
   },
   commentTextField: commentTextStyle,
   commentSpan: {
     ...commentTextStyle,
-    boxSizing: 'border-box',
-    alignItems: 'center',
-    height: '100%',
-    whiteSpace: 'pre-wrap',
+    boxSizing: "border-box",
+    alignItems: "center",
+    height: "100%",
+    whiteSpace: "pre-wrap",
     lineHeight: 1.5,
-    border: 1,
-  },
+    border: 1
+  }
 };
 
 type State = {|
   editing: boolean,
 |};
 
-export default class CommentEvent extends React.Component<
-  EventRendererProps,
-  State
-> {
+export default class CommentEvent extends React.Component<EventRendererProps,
+  State> {
   state = {
     editing: false,
+    prevValue: undefined
   };
 
   _selectable: ?HTMLSpanElement;
@@ -57,7 +57,7 @@ export default class CommentEvent extends React.Component<
   edit = () => {
     this.setState(
       {
-        editing: true,
+        editing: true
       },
       () => {
         if (this._textField) this._textField.focus();
@@ -78,7 +78,7 @@ export default class CommentEvent extends React.Component<
 
     this.setState(
       {
-        editing: false,
+        editing: false
       },
       () => this.props.onUpdate()
     );
@@ -88,10 +88,10 @@ export default class CommentEvent extends React.Component<
     const commentEvent = gd.asCommentEvent(this.props.event);
     return commentEvent
       .getComment()
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/\n/g, '<br>');
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\n/g, "<br>");
   };
 
   render() {
@@ -113,13 +113,18 @@ export default class CommentEvent extends React.Component<
       <div
         className={classNames({
           [largeSelectableArea]: true,
-          [largeSelectedArea]: this.props.selected,
+          [largeSelectedArea]: this.props.selected
         })}
         style={{
           ...styles.container,
-          backgroundColor: `#${backgroundColor}`,
+          backgroundColor: `#${backgroundColor}`
         }}
-        onClick={this.edit}
+        onClick={()=>{
+          this.setState({
+            prevValue: commentEvent.getComment()
+          })
+          this.edit();
+        }}
       >
         {this.state.editing ? (
           <TextField
@@ -134,27 +139,38 @@ export default class CommentEvent extends React.Component<
             inputStyle={{
               color: `#${textColor}`,
               padding: 0,
-              lineHeight: 1.5,
+              lineHeight: 1.5
             }}
             underlineFocusStyle={{
-              borderColor: `#${textColor}`,
+              borderColor: `#${textColor}`
             }}
             fullWidth
             id="comment-title"
+            onKeyUp={(e) => {
+              if (e.key === "Escape") {
+                this.onEvent(e, this.state.prevValue);
+                this.endEditing();
+              }
+            }}
+            onKeyPress={(e) => {
+              if (e.charCode === 13 && !e.shiftKey) {
+                this.endEditing();
+              }
+            }}
           />
         ) : (
           <span
             ref={selectable => (this._selectable = selectable)}
             className={classNames({
               [selectableArea]: true,
-              [disabledText]: this.props.disabled,
+              [disabledText]: this.props.disabled
             })}
             style={{
               ...styles.commentSpan,
-              color: `#${textColor}`,
+              color: `#${textColor}`
             }}
             dangerouslySetInnerHTML={{
-              __html: this._getCommentHTML(),
+              __html: this._getCommentHTML()
             }}
           />
         )}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -12,7 +12,6 @@ import {
   disabledText,
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
-
 const gd = global.gd;
 
 const commentTextStyle = {
@@ -120,9 +119,7 @@ export default class CommentEvent extends React.Component<
           ...styles.container,
           backgroundColor: `#${backgroundColor}`,
         }}
-        onClick={() => {
-          this.edit();
-        }}
+        onClick={this.edit}
       >
         {this.state.editing ? (
           <TextField
@@ -144,8 +141,8 @@ export default class CommentEvent extends React.Component<
             }}
             fullWidth
             id="comment-title"
-            onKeyUp={e => {
-              if (e.key === 'Escape') {
+            onKeyUp={event => {
+              if (event.key === 'Escape') {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -1,54 +1,56 @@
 // @flow
-import { t } from "@lingui/macro";
+import { t } from '@lingui/macro';
 
-import * as React from "react";
-import classNames from "classnames";
-import TextField from "../../../UI/TextField";
-import { rgbToHex } from "../../../Utils/ColorTransformer";
+import * as React from 'react';
+import classNames from 'classnames';
+import TextField from '../../../UI/TextField';
+import { rgbToHex } from '../../../Utils/ColorTransformer';
 import {
   largeSelectedArea,
   largeSelectableArea,
   selectableArea,
-  disabledText
-} from "../ClassNames";
-import { type EventRendererProps } from "./EventRenderer";
+  disabledText,
+} from '../ClassNames';
+import { type EventRendererProps } from './EventRenderer';
 
 const gd = global.gd;
 
 const commentTextStyle = {
-  width: "100%",
-  fontSize: 14
+  width: '100%',
+  fontSize: 14,
 };
 
 const styles = {
   container: {
-    display: "flex",
-    flexWrap: "wrap",
+    display: 'flex',
+    flexWrap: 'wrap',
     padding: 5,
-    overflow: "hidden",
-    minHeight: 35
+    overflow: 'hidden',
+    minHeight: 35,
   },
   commentTextField: commentTextStyle,
   commentSpan: {
     ...commentTextStyle,
-    boxSizing: "border-box",
-    alignItems: "center",
-    height: "100%",
-    whiteSpace: "pre-wrap",
+    boxSizing: 'border-box',
+    alignItems: 'center',
+    height: '100%',
+    whiteSpace: 'pre-wrap',
     lineHeight: 1.5,
-    border: 1
-  }
+    border: 1,
+  },
 };
 
 type State = {|
   editing: boolean,
 |};
 
-export default class CommentEvent extends React.Component<EventRendererProps,
-  State> {
+export default class CommentEvent extends React.Component<
+  EventRendererProps,
+  State
+> {
   state = {
     editing: false,
-    prevValue: undefined
+    prevValue: undefined,
   };
 
   _selectable: ?HTMLSpanElement;
@@ -57,7 +59,7 @@ export default class CommentEvent extends React.Component<EventRendererProps,
   edit = () => {
     this.setState(
       {
-        editing: true
+        editing: true,
       },
       () => {
         if (this._textField) this._textField.focus();
@@ -78,7 +80,7 @@ export default class CommentEvent extends React.Component<EventRendererProps,
 
     this.setState(
       {
-        editing: false
+        editing: false,
       },
       () => this.props.onUpdate()
     );
@@ -88,10 +90,10 @@ export default class CommentEvent extends React.Component<EventRendererProps,
     const commentEvent = gd.asCommentEvent(this.props.event);
     return commentEvent
       .getComment()
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/\n/g, "<br>");
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br>');
   };
 
   render() {
@@ -113,16 +115,16 @@ export default class CommentEvent extends React.Component<EventRendererProps,
       <div
         className={classNames({
           [largeSelectableArea]: true,
-          [largeSelectedArea]: this.props.selected
+          [largeSelectedArea]: this.props.selected,
         })}
         style={{
           ...styles.container,
-          backgroundColor: `#${backgroundColor}`
+          backgroundColor: `#${backgroundColor}`,
         }}
-        onClick={()=>{
+        onClick={() => {
           this.setState({
-            prevValue: commentEvent.getComment()
-          })
+            prevValue: commentEvent.getComment(),
+          });
           this.edit();
         }}
       >
@@ -139,20 +141,20 @@ export default class CommentEvent extends React.Component<EventRendererProps,
             inputStyle={{
               color: `#${textColor}`,
               padding: 0,
-              lineHeight: 1.5
+              lineHeight: 1.5,
             }}
             underlineFocusStyle={{
-              borderColor: `#${textColor}`
+              borderColor: `#${textColor}`,
             }}
             fullWidth
             id="comment-title"
-            onKeyUp={(e) => {
-              if (e.key === "Escape") {
+            onKeyUp={e => {
+              if (e.key === 'Escape') {
                 this.onEvent(e, this.state.prevValue);
                 this.endEditing();
               }
             }}
-            onKeyPress={(e) => {
+            onKeyPress={e => {
               if (e.charCode === 13 && !e.shiftKey) {
                 this.endEditing();
               }
@@ -163,14 +165,14 @@ export default class CommentEvent extends React.Component<EventRendererProps,
             ref={selectable => (this._selectable = selectable)}
             className={classNames({
               [selectableArea]: true,
-              [disabledText]: this.props.disabled
+              [disabledText]: this.props.disabled,
             })}
             style={{
               ...styles.commentSpan,
-              color: `#${textColor}`
+              color: `#${textColor}`,
             }}
             dangerouslySetInnerHTML={{
-              __html: this._getCommentHTML()
+              __html: this._getCommentHTML(),
             }}
           />
         )}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -42,7 +42,6 @@ const styles = {
 
 type State = {|
   editing: boolean,
-  prevValue: string,
 |};
 
 export default class CommentEvent extends React.Component<
@@ -51,7 +50,6 @@ export default class CommentEvent extends React.Component<
 > {
   state = {
     editing: false,
-    prevValue: '',
   };
 
   _selectable: ?HTMLSpanElement;
@@ -123,9 +121,6 @@ export default class CommentEvent extends React.Component<
           backgroundColor: `#${backgroundColor}`,
         }}
         onClick={() => {
-          this.setState({
-            prevValue: commentEvent.getComment(),
-          });
           this.edit();
         }}
       >
@@ -151,12 +146,6 @@ export default class CommentEvent extends React.Component<
             id="comment-title"
             onKeyUp={e => {
               if (e.key === 'Escape') {
-                this.onEvent(e, this.state.prevValue);
-                this.endEditing();
-              }
-            }}
-            onKeyPress={e => {
-              if (e.charCode === 13 && !e.shiftKey) {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -1,41 +1,44 @@
 // @flow
-import { t } from '@lingui/macro';
+import { t } from "@lingui/macro";
 
-import * as React from 'react';
-import classNames from 'classnames';
-import TextField from '../../../UI/TextField';
+import * as React from "react";
+import classNames from "classnames";
+import TextField from "../../../UI/TextField";
 import {
   largeSelectedArea,
   largeSelectableArea,
   selectableArea,
-  disabledText,
-} from '../ClassNames';
-import { type EventRendererProps } from './EventRenderer';
+  disabledText
+} from "../ClassNames";
+import { type EventRendererProps } from "./EventRenderer";
+
 const gd = global.gd;
 
 const styles = {
   container: {
     height: 40,
-    display: 'flex',
-    alignItems: 'center',
+    display: "flex",
+    alignItems: "center",
     padding: 5,
-    overflow: 'hidden',
+    overflow: "hidden"
   },
   title: {
     fontSize: 18,
-  },
+    width: "100%"
+  }
 };
 
 export default class GroupEvent extends React.Component<EventRendererProps, *> {
   state = {
     editing: false,
+    prevValue: ""
   };
   _textField: ?TextField = null;
 
   edit = () => {
     this.setState(
       {
-        editing: true,
+        editing: true
       },
       () => {
         if (this._textField) this._textField.focus();
@@ -45,7 +48,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
 
   endEditing = () => {
     this.setState({
-      editing: false,
+      editing: false
     });
   };
 
@@ -56,19 +59,24 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
       g = groupEvent.getBackgroundColorG(),
       b = groupEvent.getBackgroundColorB();
 
-    const textColor = (r + g + b) / 3 > 200 ? 'black' : 'white';
+    const textColor = (r + g + b) / 3 > 200 ? "black" : "white";
 
     return (
       <div
         className={classNames({
           [largeSelectableArea]: true,
-          [largeSelectedArea]: this.props.selected,
+          [largeSelectedArea]: this.props.selected
         })}
         style={{
           ...styles.container,
-          backgroundColor: `rgb(${r}, ${g}, ${b})`,
+          backgroundColor: `rgb(${r}, ${g}, ${b})`
         }}
-        onClick={this.edit}
+        onClick={()=>{
+          this.setState({
+            prevValue: groupEvent.getName()
+          });
+          this.edit();
+        }}
       >
         {this.state.editing ? (
           <TextField
@@ -83,23 +91,34 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
             style={styles.title}
             inputStyle={{
               color: textColor,
-              WebkitTextFillColor: textColor,
+              WebkitTextFillColor: textColor
             }}
             underlineFocusStyle={{
-              borderColor: textColor,
+              borderColor: textColor
             }}
             fullWidth
             id="group-title"
+            onKeyUp={(e) => {
+              if (e.key === "Escape") {
+                groupEvent.setName(this.state.prevValue);
+                this.endEditing();
+              }
+            }}
+            onKeyPress={(e) => {
+              if (e.charCode === 13 && !e.shiftKey) {
+                this.endEditing();
+              }
+            }}
           />
         ) : (
           <span
             className={classNames({
               [selectableArea]: true,
-              [disabledText]: this.props.disabled,
+              [disabledText]: this.props.disabled
             })}
             style={{ ...styles.title, color: textColor }}
           >
-            {groupEvent.getName() || '<Enter group name>'}
+            {groupEvent.getName() || "<Enter group name>"}
           </span>
         )}
       </div>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -31,7 +31,6 @@ const styles = {
 export default class GroupEvent extends React.Component<EventRendererProps, *> {
   state = {
     editing: false,
-    prevValue: '',
   };
   _textField: ?TextField = null;
 
@@ -72,9 +71,6 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
           backgroundColor: `rgb(${r}, ${g}, ${b})`,
         }}
         onClick={() => {
-          this.setState({
-            prevValue: groupEvent.getName(),
-          });
           this.edit();
         }}
       >
@@ -100,12 +96,11 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
             id="group-title"
             onKeyUp={e => {
               if (e.key === 'Escape') {
-                groupEvent.setName(this.state.prevValue);
                 this.endEditing();
               }
             }}
             onKeyPress={e => {
-              if (e.charCode === 13 && !e.shiftKey) {
+              if (e.charCode === 13) {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -11,7 +11,6 @@ import {
   disabledText,
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
-
 const gd = global.gd;
 
 const styles = {
@@ -70,9 +69,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
           ...styles.container,
           backgroundColor: `rgb(${r}, ${g}, ${b})`,
         }}
-        onClick={() => {
-          this.edit();
-        }}
+        onClick={this.edit}
       >
         {this.state.editing ? (
           <TextField
@@ -94,13 +91,13 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
             }}
             fullWidth
             id="group-title"
-            onKeyUp={e => {
-              if (e.key === 'Escape') {
+            onKeyUp={event => {
+              if (event.key === 'Escape') {
                 this.endEditing();
               }
             }}
-            onKeyPress={e => {
-              if (e.charCode === 13) {
+            onKeyPress={event => {
+              if (event.key === 'Enter') {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -1,44 +1,44 @@
 // @flow
-import { t } from "@lingui/macro";
+import { t } from '@lingui/macro';
 
-import * as React from "react";
-import classNames from "classnames";
-import TextField from "../../../UI/TextField";
+import * as React from 'react';
+import classNames from 'classnames';
+import TextField from '../../../UI/TextField';
 import {
   largeSelectedArea,
   largeSelectableArea,
   selectableArea,
-  disabledText
-} from "../ClassNames";
-import { type EventRendererProps } from "./EventRenderer";
+  disabledText,
+} from '../ClassNames';
+import { type EventRendererProps } from './EventRenderer';
 
 const gd = global.gd;
 
 const styles = {
   container: {
     height: 40,
-    display: "flex",
-    alignItems: "center",
+    display: 'flex',
+    alignItems: 'center',
     padding: 5,
-    overflow: "hidden"
+    overflow: 'hidden',
   },
   title: {
     fontSize: 18,
-    width: "100%"
-  }
+    width: '100%',
+  },
 };
 
 export default class GroupEvent extends React.Component<EventRendererProps, *> {
   state = {
     editing: false,
-    prevValue: ""
+    prevValue: '',
   };
   _textField: ?TextField = null;
 
   edit = () => {
     this.setState(
       {
-        editing: true
+        editing: true,
       },
       () => {
         if (this._textField) this._textField.focus();
@@ -48,7 +48,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
 
   endEditing = () => {
     this.setState({
-      editing: false
+      editing: false,
     });
   };
 
@@ -59,21 +59,21 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
       g = groupEvent.getBackgroundColorG(),
       b = groupEvent.getBackgroundColorB();
 
-    const textColor = (r + g + b) / 3 > 200 ? "black" : "white";
+    const textColor = (r + g + b) / 3 > 200 ? 'black' : 'white';
 
     return (
       <div
         className={classNames({
           [largeSelectableArea]: true,
-          [largeSelectedArea]: this.props.selected
+          [largeSelectedArea]: this.props.selected,
         })}
         style={{
           ...styles.container,
-          backgroundColor: `rgb(${r}, ${g}, ${b})`
+          backgroundColor: `rgb(${r}, ${g}, ${b})`,
         }}
-        onClick={()=>{
+        onClick={() => {
           this.setState({
-            prevValue: groupEvent.getName()
+            prevValue: groupEvent.getName(),
           });
           this.edit();
         }}
@@ -91,20 +91,20 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
             style={styles.title}
             inputStyle={{
               color: textColor,
-              WebkitTextFillColor: textColor
+              WebkitTextFillColor: textColor,
             }}
             underlineFocusStyle={{
-              borderColor: textColor
+              borderColor: textColor,
             }}
             fullWidth
             id="group-title"
-            onKeyUp={(e) => {
-              if (e.key === "Escape") {
+            onKeyUp={e => {
+              if (e.key === 'Escape') {
                 groupEvent.setName(this.state.prevValue);
                 this.endEditing();
               }
             }}
-            onKeyPress={(e) => {
+            onKeyPress={e => {
               if (e.charCode === 13 && !e.shiftKey) {
                 this.endEditing();
               }
@@ -114,11 +114,11 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
           <span
             className={classNames({
               [selectableArea]: true,
-              [disabledText]: this.props.disabled
+              [disabledText]: this.props.disabled,
             })}
             style={{ ...styles.title, color: textColor }}
           >
-            {groupEvent.getName() || "<Enter group name>"}
+            {groupEvent.getName() || '<Enter group name>'}
           </span>
         )}
       </div>

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -44,11 +44,7 @@ type Props = {|
       value: string,
     },
   }) => void,
-  onKeyPress?: (event: {|
-    charCode: number,
-    key: string,
-    shiftKey: string,
-  |}) => void,
+  onKeyPress?: (event: {| charCode: number, key: string |}) => void,
   onKeyUp?: (event: {| charCode: number, key: string |}) => void,
 
   // Error handling:

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -44,7 +44,11 @@ type Props = {|
       value: string,
     },
   }) => void,
-  onKeyPress?: (event: {| charCode: number, key: string |}) => void,
+  onKeyPress?: (event: {|
+    charCode: number,
+    key: string,
+    shiftKey: string,
+  |}) => void,
   onKeyUp?: (event: {| charCode: number, key: string |}) => void,
 
   // Error handling:


### PR DESCRIPTION
Fixes #1430 

Added the following keybindings to Group Event:
1. On "Escape", remove the focus
2. On "Enter", remove the focus // because new line is not needed here
3. On "Click", focus to edit
4. Ctrl + Z to undo recent changes while editing
5. Clicking anywhere outside: remove the focus

Added the following keybindings to Comment Event:
1. On "Escape", remove the focus
2. On "Enter", add a new line
3. On "Click", focus to edit
4. Ctrl + Z to undo recent changes while editing
5. Clicking anywhere outside: remove the focus