### PR TITLE
Fixes tooltip issue which shows [object Object]

### DIFF
--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -225,7 +225,7 @@ export default class EditorMosaic extends React.Component<Props, State> {
               return (
                 <MosaicWindow
                   path={path}
-                  title={editor.title}
+                  title={editor.title.props.id}
                   toolbarControls={editor.toolbarControls}
                 >
                   {editor.renderEditor()}


### PR DESCRIPTION
Fixes #1484 

The bug: It showed [object Object] on the toolbar and on hovering.
![IMG_8725](https://user-images.githubusercontent.com/39700577/75790746-a2ba9780-5d91-11ea-9517-c635af8adf49.JPG)

Solution: Now, it shows the actual title
![IMG_8727](https://user-images.githubusercontent.com/39700577/75790759-a5b58800-5d91-11ea-8822-c9095f212e47.JPG)
PS: Photo was taken via phone as it was not coming during the screenshot.

After understanding the folder structure, I found that various editors had their individual folder where they were creating their properties and it was finally called in UI.

It was a small change in `src/UI/EditorMosaic/index.js`

