### PR TITLE
fix yarn command type clips empty space between two text types

### DIFF
--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -472,7 +472,8 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
       this.dialogueText = this.dialogueData.text;
       this.commandCalls = [];
     } else {
-      this.dialogueText += (this.dialogueText === '' ? '' : ' ') + this.dialogueData.text;
+      this.dialogueText +=
+        (this.dialogueText === '' ? '' : ' ') + this.dialogueData.text;
     }
 
     this.dialogueDataType = 'text';
@@ -482,7 +483,7 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
     this.dialogueData = this.dialogue.next().value;
   } else if (gdjs.dialogueTree._isLineTypeOptions()) {
     this.dialogueDataType = 'options';
-    this.dialogueText = ' ';
+    this.dialogueText = '';
     this.clipTextEnd = 0;
     this.optionsCount = this.dialogueData.options.length;
     this.options = this.dialogueData.options;

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -472,7 +472,7 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
       this.dialogueText = this.dialogueData.text;
       this.commandCalls = [];
     } else {
-      this.dialogueText += this.dialogueData.text;
+      this.dialogueText += ' ' + this.dialogueData.text;
     }
 
     this.dialogueDataType = 'text';
@@ -489,7 +489,6 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
     this.selectedOptionUpdated = true;
   } else if (gdjs.dialogueTree._isLineTypeCommand()) {
     this.dialogueDataType = 'command';
-    this.dialogueText += ' ';
     this.clipTextEnd = 0;
 
     var command = this.dialogueData.text.split(' ');

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -472,7 +472,7 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
       this.dialogueText = this.dialogueData.text;
       this.commandCalls = [];
     } else {
-      this.dialogueText += this.dialogueData.text;
+      this.dialogueText += ' ' + this.dialogueData.text;
     }
 
     this.dialogueDataType = 'text';

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -472,7 +472,7 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
       this.dialogueText = this.dialogueData.text;
       this.commandCalls = [];
     } else {
-      this.dialogueText += ' ' + this.dialogueData.text;
+      this.dialogueText += this.dialogueData.text;
     }
 
     this.dialogueDataType = 'text';
@@ -482,11 +482,15 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
     this.dialogueData = this.dialogue.next().value;
   } else if (gdjs.dialogueTree._isLineTypeOptions()) {
     this.dialogueDataType = 'options';
+    this.dialogueText = ' ';
+    this.clipTextEnd = 0;
     this.optionsCount = this.dialogueData.options.length;
     this.options = this.dialogueData.options;
     this.selectedOptionUpdated = true;
   } else if (gdjs.dialogueTree._isLineTypeCommand()) {
     this.dialogueDataType = 'command';
+    this.dialogueText += ' ';
+    this.clipTextEnd = 0;
 
     var command = this.dialogueData.text.split(' ');
     // If last command was to wait, increase time by one

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -472,7 +472,7 @@ gdjs.dialogueTree.goToNextDialogueLine = function() {
       this.dialogueText = this.dialogueData.text;
       this.commandCalls = [];
     } else {
-      this.dialogueText += ' ' + this.dialogueData.text;
+      this.dialogueText += (this.dialogueText === '' ? '' : ' ') + this.dialogueData.text;
     }
 
     this.dialogueDataType = 'text';


### PR DESCRIPTION
This fixes a bug that was brought up at the forum with yarn clipping empty space between two text results if you put a command between them

example:
`my <<command>>text ` resulting in `mytext`

with this fix
`my <<command>text `results in `my text` (as expected)

bug reported here (among other places)
https://forum.gdevelop-app.com/t/yarn-lines-of-text-merging-together-when-using-commands-on-the-yarn-node/21452/6

I'm surprised how many people are using this extension, but not so surprised they are reporting the bugs at the forum instead of here. Perhaps we should soon remove the experimental status? I've ironed out all the bugs they reported :)
Please let me know if I missed something from the forum

Maybe I should give yarn editor some love once I have the tilemap extension ready