### PR TITLE
Fix tooltips for editor titles

### DIFF
--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -1,5 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
 
 import * as React from 'react';
 import EditorMosaic from '../UI/EditorMosaic';
@@ -82,7 +83,7 @@ export default class DebuggerContent extends React.Component<Props, State> {
         editors={{
           inspectors: {
             type: 'primary',
-            title: <Trans>Inspectors</Trans>,
+            title: t`Inspectors`,
             toolbarControls: [],
             renderEditor: () => (
               <Background>
@@ -181,7 +182,7 @@ export default class DebuggerContent extends React.Component<Props, State> {
           },
           profiler: {
             type: 'secondary',
-            title: <Trans>Profiler</Trans>,
+            title: t`Profiler`,
             renderEditor: () => (
               <Profiler
                 onStart={onStartProfiler}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -524,7 +524,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
       },
       parameters: {
         type: 'primary',
-        title: <Trans>Function Configuration</Trans>,
+        title: t`Function Configuration`,
         toolbarControls: [],
         renderEditor: () => (
           <Background>
@@ -609,7 +609,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
       },
       'free-functions-list': {
         type: 'primary',
-        title: <Trans>Functions</Trans>,
+        title: t`Functions`,
         toolbarControls: [],
         renderEditor: () => (
           <I18n>
@@ -651,7 +651,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
       },
       'behavior-functions-list': {
         type: 'primary',
-        title: <Trans>Behavior functions</Trans>,
+        title: t`Behavior functions`,
         renderEditor: () =>
           selectedEventsBasedBehavior ? (
             <I18n>
@@ -722,7 +722,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
 
       'behaviors-list': {
         type: 'secondary',
-        title: <Trans>Behaviors</Trans>,
+        title: t`Behaviors`,
         toolbarControls: [],
         renderEditor: () => (
           <I18n>

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -1,5 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
 
 import * as React from 'react';
 import ResourcesList from '../ResourcesList';
@@ -136,7 +137,7 @@ export default class ResourcesEditor extends React.Component<Props, State> {
     const editors = {
       properties: {
         type: 'secondary',
-        title: <Trans>Properties</Trans>,
+        title: t`Properties`,
         renderEditor: () => (
           <ResourcePropertiesEditor
             key={selectedResource ? selectedResource.ptr : undefined}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -903,7 +903,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       properties: {
         type: 'secondary',
         title: <Trans>Properties</Trans>,
-        tooltip: t`Properties of Instance`,
+        tooltip: t`Display the properties of the selected instances from the scene editor`,
         renderEditor: () => (
           <InstancePropertiesEditor
             project={project}
@@ -959,7 +959,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       'objects-list': {
         type: 'secondary',
         title: <Trans>Objects</Trans>,
-        tooltip: t`List of Objects`,
+        tooltip: t`The list of objects that can be used in this scene`,
         toolbarControls: [
           <I18n key="tags">
             {({ i18n }) => (
@@ -1001,7 +1001,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       'object-groups-list': {
         type: 'secondary',
         title: <Trans>Object Groups</Trans>,
-        tooltip: t`List of Object Groups`,
+        tooltip: t`The groups of objects that can be used in events of this scene`,
         renderEditor: () => (
           <ObjectGroupsList
             globalObjectGroups={project.getObjectGroups()}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -903,6 +903,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       properties: {
         type: 'secondary',
         title: <Trans>Properties</Trans>,
+        tooltip: t`Properties of Instance`,
         renderEditor: () => (
           <InstancePropertiesEditor
             project={project}
@@ -958,6 +959,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       'objects-list': {
         type: 'secondary',
         title: <Trans>Objects</Trans>,
+        tooltip: t`List of Objects`,
         toolbarControls: [
           <I18n key="tags">
             {({ i18n }) => (
@@ -999,6 +1001,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       'object-groups-list': {
         type: 'secondary',
         title: <Trans>Object Groups</Trans>,
+        tooltip: t`List of Object Groups`,
         renderEditor: () => (
           <ObjectGroupsList
             globalObjectGroups={project.getObjectGroups()}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -902,8 +902,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     const editors = {
       properties: {
         type: 'secondary',
-        title: <Trans>Properties</Trans>,
-        tooltip: t`Display the properties of the selected instances from the scene editor`,
+        title: t`Properties`,
         renderEditor: () => (
           <InstancePropertiesEditor
             project={project}
@@ -958,8 +957,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       },
       'objects-list': {
         type: 'secondary',
-        title: <Trans>Objects</Trans>,
-        tooltip: t`The list of objects that can be used in this scene`,
+        title: t`Objects`,
         toolbarControls: [
           <I18n key="tags">
             {({ i18n }) => (
@@ -1000,8 +998,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       },
       'object-groups-list': {
         type: 'secondary',
-        title: <Trans>Object Groups</Trans>,
-        tooltip: t`The groups of objects that can be used in events of this scene`,
+        title: t`Object Groups`,
         renderEditor: () => (
           <ObjectGroupsList
             globalObjectGroups={project.getObjectGroups()}

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -111,25 +111,12 @@ const replaceNode = (
 
 const defaultToolbarControls = [<CloseButton key="close" />];
 
-// This is based on the implementation of the react-mosaic window
-// toolbar done here: https://github.com/nomcopter/react-mosaic/blob/b36984c34b0fa1e3f21a211578301933cea24992/src/MosaicWindow.tsx#L136-L183
 const renderMosaicWindowPreview = props => (
   <div className="mosaic-preview">
     <div className="mosaic-window-toolbar">
       <div className="mosaic-window-title">{props.title}</div>
     </div>
     <div className="mosaic-window-body" />
-  </div>
-);
-
-const renderMosaicWindowToolbar = props => (
-  <div className="mosaic-window-toolbar" style={{ width: '100%' }}>
-    <div className="mosaic-window-title" title={props.tooltip}>
-      {props.title}
-    </div>
-    <div className="mosaic-window-controls">
-      {props.toolbarControls || defaultToolbarControls}
-    </div>
   </div>
 );
 
@@ -141,8 +128,8 @@ const renderMosaicWindowToolbar = props => (
 const MosaicWindow = (props: any) => (
   <RMMosaicWindow
     {...props}
+    toolbarControls={props.toolbarControls || defaultToolbarControls}
     renderPreview={renderMosaicWindowPreview}
-    renderToolbar={renderMosaicWindowToolbar}
   />
 );
 
@@ -243,8 +230,7 @@ export default class EditorMosaic extends React.Component<Props, State> {
                   {({ i18n }) => (
                     <MosaicWindow
                       path={path}
-                      title={editor.title}
-                      tooltip={editor.tooltip ? i18n._(editor.tooltip) : null}
+                      title={i18n._(editor.title)}
                       toolbarControls={editor.toolbarControls}
                     >
                       {editor.renderEditor()}

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -7,6 +7,7 @@ import {
 } from 'react-mosaic-component';
 import CloseButton from './CloseButton';
 import ThemeConsumer from '../Theme/ThemeConsumer';
+import { I18n } from '@lingui/react'
 
 // EditorMosaic default styling:
 import 'react-mosaic-component/react-mosaic-component.css';
@@ -17,6 +18,7 @@ export type Editor = {|
   renderEditor: () => React.Node,
   noTitleBar?: boolean,
   title?: React.Node,
+  tooltip?: React.Node,
   toolbarControls?: Array<React.Node>,
 |};
 
@@ -117,6 +119,17 @@ const renderMosaicWindowPreview = props => (
   </div>
 );
 
+const renderMosaicWindowToolbar = props => (
+  <div className='mosaic-window-toolbar' style={{width: '100%'}}>
+    <div className='mosaic-window-title' title={props.tooltip}>
+      {props.title}
+    </div>
+    <div className='mosaic-window-controls'>
+      {props.toolbarControls || defaultToolbarControls}
+    </div>
+  </div>
+);
+
 /**
  * A window that can be used in a EditorMosaic, with a close button
  * by default in the toolbarControls and a preview when the window is
@@ -125,8 +138,8 @@ const renderMosaicWindowPreview = props => (
 const MosaicWindow = (props: any) => (
   <RMMosaicWindow
     {...props}
-    toolbarControls={props.toolbarControls || defaultToolbarControls}
     renderPreview={renderMosaicWindowPreview}
+    renderToolbar={renderMosaicWindowToolbar}
   />
 );
 
@@ -223,13 +236,19 @@ export default class EditorMosaic extends React.Component<Props, State> {
               }
 
               return (
-                <MosaicWindow
-                  path={path}
-                  title={editor.title}
-                  toolbarControls={editor.toolbarControls}
-                >
-                  {editor.renderEditor()}
-                </MosaicWindow>
+                <I18n>
+                  {({ i18n }) => (
+                    <MosaicWindow
+                      path={path}
+                      title={editor.title}
+                      tooltip={i18n._(editor.tooltip)}
+                      toolbarControls={editor.toolbarControls}
+                    >
+                      {editor.renderEditor()}
+                    </MosaicWindow>
+                  )}
+                  
+                </I18n>
               );
             }}
             value={this.state.mosaicNode}

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -7,7 +7,7 @@ import {
 } from 'react-mosaic-component';
 import CloseButton from './CloseButton';
 import ThemeConsumer from '../Theme/ThemeConsumer';
-import { I18n } from '@lingui/react'
+import { I18n } from '@lingui/react';
 
 // EditorMosaic default styling:
 import 'react-mosaic-component/react-mosaic-component.css';
@@ -120,11 +120,11 @@ const renderMosaicWindowPreview = props => (
 );
 
 const renderMosaicWindowToolbar = props => (
-  <div className='mosaic-window-toolbar' style={{width: '100%'}}>
-    <div className='mosaic-window-title' title={props.tooltip}>
+  <div className="mosaic-window-toolbar" style={{ width: '100%' }}>
+    <div className="mosaic-window-title" title={props.tooltip}>
       {props.title}
     </div>
-    <div className='mosaic-window-controls'>
+    <div className="mosaic-window-controls">
       {props.toolbarControls || defaultToolbarControls}
     </div>
   </div>
@@ -247,7 +247,6 @@ export default class EditorMosaic extends React.Component<Props, State> {
                       {editor.renderEditor()}
                     </MosaicWindow>
                   )}
-                  
                 </I18n>
               );
             }}

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -8,6 +8,7 @@ import {
 } from 'react-mosaic-component';
 import CloseButton from './CloseButton';
 import ThemeConsumer from '../Theme/ThemeConsumer';
+import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 
 // EditorMosaic default styling:
 import 'react-mosaic-component/react-mosaic-component.css';
@@ -17,7 +18,7 @@ export type Editor = {|
   type: 'primary' | 'secondary',
   renderEditor: () => React.Node,
   noTitleBar?: boolean,
-  title?: React.Node,
+  title?: MessageDescriptor,
   toolbarControls?: Array<React.Node>,
 |};
 

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -1,4 +1,5 @@
 // @flow
+import { I18n } from '@lingui/react';
 import * as React from 'react';
 import {
   MosaicWindow as RMMosaicWindow,
@@ -7,7 +8,7 @@ import {
 } from 'react-mosaic-component';
 import CloseButton from './CloseButton';
 import ThemeConsumer from '../Theme/ThemeConsumer';
-import { I18n } from '@lingui/react';
+import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 
 // EditorMosaic default styling:
 import 'react-mosaic-component/react-mosaic-component.css';
@@ -18,7 +19,7 @@ export type Editor = {|
   renderEditor: () => React.Node,
   noTitleBar?: boolean,
   title?: React.Node,
-  tooltip?: React.Node,
+  tooltip?: MessageDescriptor,
   toolbarControls?: Array<React.Node>,
 |};
 
@@ -241,7 +242,7 @@ export default class EditorMosaic extends React.Component<Props, State> {
                     <MosaicWindow
                       path={path}
                       title={editor.title}
-                      tooltip={i18n._(editor.tooltip)}
+                      tooltip={editor.tooltip ? i18n._(editor.tooltip) : null}
                       toolbarControls={editor.toolbarControls}
                     >
                       {editor.renderEditor()}

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -112,7 +112,7 @@ const replaceNode = (
 const defaultToolbarControls = [<CloseButton key="close" />];
 
 // This is based on the implementation of the react-mosaic window
-// toolbar done here: https://github.com/nomcopter/react-mosaic/blob/b36984c34b0fa1e3f21a211578301933cea24992/src/MosaicWindow.tsx#L136-L183 
+// toolbar done here: https://github.com/nomcopter/react-mosaic/blob/b36984c34b0fa1e3f21a211578301933cea24992/src/MosaicWindow.tsx#L136-L183
 const renderMosaicWindowPreview = props => (
   <div className="mosaic-preview">
     <div className="mosaic-window-toolbar">

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -8,7 +8,6 @@ import {
 } from 'react-mosaic-component';
 import CloseButton from './CloseButton';
 import ThemeConsumer from '../Theme/ThemeConsumer';
-import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 
 // EditorMosaic default styling:
 import 'react-mosaic-component/react-mosaic-component.css';
@@ -19,7 +18,6 @@ export type Editor = {|
   renderEditor: () => React.Node,
   noTitleBar?: boolean,
   title?: React.Node,
-  tooltip?: MessageDescriptor,
   toolbarControls?: Array<React.Node>,
 |};
 

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -111,6 +111,8 @@ const replaceNode = (
 
 const defaultToolbarControls = [<CloseButton key="close" />];
 
+// This is based on the implementation of the react-mosaic window
+// toolbar done here: https://github.com/nomcopter/react-mosaic/blob/b36984c34b0fa1e3f21a211578301933cea24992/src/MosaicWindow.tsx#L136-L183 
 const renderMosaicWindowPreview = props => (
   <div className="mosaic-preview">
     <div className="mosaic-window-toolbar">

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -11,6 +11,7 @@ import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
 import { I18n } from '@lingui/react';
+import { t } from '@lingui/macro';
 import Welcome from './Welcome';
 import HelpButton from '../UI/HelpButton';
 import HelpIcon from '../UI/HelpIcon';
@@ -1063,7 +1064,7 @@ storiesOf('UI Building Blocks/EditorMosaic', module)
           editors={{
             firstEditor: {
               type: 'primary',
-              title: 'First editor',
+              title: t`First editor`,
               toolbarControls: [],
               renderEditor: () => (
                 <div>
@@ -1083,7 +1084,7 @@ storiesOf('UI Building Blocks/EditorMosaic', module)
             },
             thirdEditor: {
               type: 'secondary',
-              title: 'Third editor',
+              title: t`Third editor`,
               renderEditor: () => <div>This is the third editor (bottom).</div>,
             },
           }}
@@ -1127,17 +1128,17 @@ storiesOf('UI Building Blocks/EditorMosaic', module)
           editors={{
             firstEditor: {
               type: 'secondary',
-              title: '1st secondary editor',
+              title: t`1st secondary editor`,
               renderEditor: () => <div>This is a secondary editor.</div>,
             },
             secondEditor: {
               type: 'secondary',
-              title: '2nd secondary editor',
+              title: t`2nd secondary editor`,
               renderEditor: () => <div>This is another secondary editor.</div>,
             },
             thirdEditor: {
               type: 'secondary',
-              title: '3rd secondary editor',
+              title: t`3rd secondary editor`,
               renderEditor: () => (
                 <div>This is yet another secondary editor.</div>
               ),
@@ -1198,7 +1199,7 @@ storiesOf('UI Building Blocks/EditorNavigator', module)
           editors={{
             firstEditor: {
               type: 'primary',
-              title: 'First editor',
+              title: t`First editor`,
               toolbarControls: [],
               renderEditor: () => <div>This is the first editor.</div>,
             },
@@ -1209,12 +1210,12 @@ storiesOf('UI Building Blocks/EditorNavigator', module)
             },
             thirdEditor: {
               type: 'secondary',
-              title: 'Third editor',
+              title: t`Third editor`,
               renderEditor: () => <div>This is the third editor.</div>,
             },
             noTransitionsEditor: {
               type: 'secondary',
-              title: 'Editor without transitions',
+              title: t`Editor without transitions`,
               renderEditor: () => (
                 <div>This is an editor without transitions.</div>
               ),


### PR DESCRIPTION
Resolves #1484 PR #1490 
@4ian I'm sorry I couldn't figure out how to push in the existing PR branch :( (I'm really not good at using git)

Okay so I've added a tooltip component and custom toolbar rendering function (renders with the same styling but has div with title of tooltip component) 

![WhatsApp Image 2020-03-05 at 12 30 09 AM](https://user-images.githubusercontent.com/39851078/75913308-b1c84500-5e78-11ea-8629-016b43eb26bc.jpeg)

We can change what to show in the tooltip later :)