### PR TITLE
Made New Scene naming convention consistent

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -522,7 +522,7 @@ class MainFrame extends React.Component<Props, State> {
     const { currentProject } = this.state;
     if (!currentProject) return;
 
-    const name = newNameGenerator('NewScene', name =>
+    const name = newNameGenerator('New scene', name =>
       currentProject.hasLayoutNamed(name)
     );
     const newLayout = currentProject.insertNewLayout(

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -700,11 +700,6 @@ export default class ProjectManager extends React.Component<Props, State> {
             autoGenerateNestedIndicator={!forceOpen}
             renderNestedItems={() =>
               filterProjectItemsList(enumerateLayouts(project), searchText)
-                .sort((layout1: gdLayout,layout2: gdLayout) => {
-                  const name1 = layout1.getName();
-                  const name2 = layout2.getName();
-                  return (name1.localeCompare(name2));
-                })  
                 .map((layout: gdLayout, i: number) => {
                   const name = layout.getName();
                   return (

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -345,7 +345,7 @@ export default class ProjectManager extends React.Component<Props, State> {
   _addLayout = (index: number) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('NewScene', name =>
+    const newName = newNameGenerator('New scene', name =>
       project.hasLayoutNamed(name)
     );
     const newLayout = project.insertNewLayout(newName, index + 1);
@@ -700,6 +700,11 @@ export default class ProjectManager extends React.Component<Props, State> {
             autoGenerateNestedIndicator={!forceOpen}
             renderNestedItems={() =>
               filterProjectItemsList(enumerateLayouts(project), searchText)
+                .sort((layout1: gdLayout,layout2: gdLayout) => {
+                  const name1 = layout1.getName();
+                  const name2 = layout2.getName();
+                  return (name1.localeCompare(name2));
+                })  
                 .map((layout: gdLayout, i: number) => {
                   const name = layout.getName();
                   return (


### PR DESCRIPTION
Fixes #1507  Earlier it had a default new scene `New scene` and on successive new scene creations it created new scenes named as `NewScene` which should be `New scene2`, `New scene3` and so on.

**Before changes**
![Screenshot from 2020-03-08 15-02-10 (1)](https://user-images.githubusercontent.com/45489945/76161060-cd23a080-6155-11ea-92b1-6726e742c5b4.png)

**After changes**
![Screenshot from 2020-03-08 15-57-37](https://user-images.githubusercontent.com/45489945/76161062-cf85fa80-6155-11ea-87b7-1fc84bd1159b.png)
