### PR TITLE
Upgrade to create-react-app version 2.1.8

### DIFF
--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -19,7 +19,7 @@
     "follow-redirects": "^1.2.3",
     "iso-639-1": "^2.0.3",
     "prettier": "1.15.3",
-    "react-scripts": "2.1.4",
+    "react-scripts": "2.1.8",
     "recursive-copy": "^2.0.10",
     "recursive-readdir": "^2.2.2",
     "shelljs": "^0.7.7",


### PR DESCRIPTION
Things done:

- [x]     Check the release notes to see if there is any breaking changes
- [x]     Do the upgrade in package.json
- [x]     Check that the web-app still works (localhost:3000)
- [x]     Check that the standalone Electron app still works
- [ ]     Verify that there is no warning/issues.
- [x]     Verify that npm run storybook still works. It has already created issues in the past. It must continue to work.

This PR closes #1470. Upgraded to version 2.1.8 since GDevelop was giving errors when trying to run with a higher version.

PS: For electron app, the following warnings were found when running `npm install` in newIDE/electron-app for v2.1.8:

```
npm WARN gdevelop@5.0.0-beta88 No repository field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

added 262 packages from 236 contributors in 240.532s
npm WARN ajv-keywords@3.4.1 requires a peer of ajv@^6.9.1 but none is installed. You must install peer dependencies yourself.
```
I don't think these warnings will affect the app since they are dependency skips or empty field warning. Let me know if we are good to merge this PR.