### PR TITLE
Add exit option to File menu

### DIFF
--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -18,6 +18,7 @@ type MainMenuEvent =
   | 'main-menu-save'
   | 'main-menu-save-as'
   | 'main-menu-close'
+  | 'main-menu-close-app'
   | 'main-menu-export'
   | 'main-menu-create'
   | 'main-menu-open-project-manager'
@@ -88,6 +89,10 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
     ipcRenderer.on(
       ('main-menu-close': MainMenuEvent),
       event => this._editor && this._editor.askToCloseProject()
+    );
+    ipcRenderer.on(
+      ('main-menu-close-app': MainMenuEvent),
+      event => this._editor && this._editor.askToCloseApp()
     );
     ipcRenderer.on(
       ('main-menu-export': MainMenuEvent),
@@ -194,6 +199,12 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
         {
           label: i18n._(t`Language`),
           onClickSendEvent: 'main-menu-open-language',
+        },
+        { type: 'separator' },
+        {
+          label: i18n._(t`Exit GDevelop`),
+          accelerator: 'Control+Q',
+          onClickSendEvent: 'main-menu-close-app',
         }
       );
     }

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -92,7 +92,7 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
     );
     ipcRenderer.on(
       ('main-menu-close-app': MainMenuEvent),
-      event => this._editor && this._editor.askToCloseApp()
+      event => this._editor && this._editor.closeApp()
     );
     ipcRenderer.on(
       ('main-menu-export': MainMenuEvent),

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -459,7 +459,7 @@ class MainFrame extends React.Component<Props, State> {
       .then(() => this.setState({ loadingProject: false }));
   };
 
-  askToCloseApp = (): void => {
+  closeApp = (): void => {
     return Window.quit();
   };
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -459,6 +459,10 @@ class MainFrame extends React.Component<Props, State> {
       .then(() => this.setState({ loadingProject: false }));
   };
 
+  askToCloseApp = (): void => {
+    return Window.quit();
+  };
+
   closeProject = (): Promise<void> => {
     const { currentProject } = this.state;
     const { eventsFunctionsExtensionsState } = this.props;

--- a/newIDE/app/src/Utils/Window.js
+++ b/newIDE/app/src/Utils/Window.js
@@ -83,6 +83,13 @@ export default class Window {
     this.show();
   }
 
+  static quit() {
+    if (!electron) return;
+
+    const electronApp = electron.remote.app;
+    electronApp.quit();
+  }
+
   static show() {
     if (!electron) return;
 


### PR DESCRIPTION
Added missing exit option to the File menu. Option is available only on
non-MacOS platforms.

User is first prompted with with a dialog box: "Exit GDevelop? Any changes that have not been saved will be lost.". The dialog box does not appear if no project is open.

Closes #1498 