### PR TITLE
Added an Edit Scene Variables Context Menu to the scenes in Project Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,5 @@
 **/.DS_Store
 **/node_modules/
 .idea
+.vscode/
 .vscode/ipch

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -39,7 +39,7 @@ import AddToHomeScreen from '@material-ui/icons/AddToHomeScreen';
 import Fullscreen from '@material-ui/icons/Fullscreen';
 import FileCopy from '@material-ui/icons/FileCopy';
 import AccountCircle from '@material-ui/icons/AccountCircle';
-import SceneEditor from '../SceneEditor';
+import SceneVariablesEditorDialog from '../VariablesList/SceneVariablesEditorDialog';
 
 const LAYOUT_CLIPBOARD_KIND = 'Layout';
 const EXTERNAL_LAYOUT_CLIPBOARD_KIND = 'External layout';
@@ -275,7 +275,7 @@ type State = {|
   projectPropertiesDialogOpen: boolean,
   variablesEditorOpen: boolean,
   extensionsSearchDialogOpen: boolean,
-  name: any,
+  currentLayoutName: null | string,
 |};
 
 export default class ProjectManager extends React.Component<Props, State> {
@@ -306,17 +306,16 @@ export default class ProjectManager extends React.Component<Props, State> {
     }
   }
 
-  _onEditLayoutVariable = (name: any = null) => {
-    this.setState({ name });
+  _onEditLayoutVariable = (currentLayoutName: null | string) => {
+    this.setState({ currentLayoutName });
   };
 
   getLayout = () => {
     const { project } = this.props;
-    const { name } = this.state;
-    if (!project || !project.hasLayoutNamed(name)) return null;
+    const { currentLayoutName } = this.state;
+    if (!project || !project.hasLayoutNamed(currentLayoutName)) return null;
 
-    console.log(project.getLayout(name));
-    return project.getLayout(name);
+    return project.getLayout(currentLayoutName);
   };
 
   _onEditName = (kind: ?string, name: string) => {
@@ -761,18 +760,11 @@ export default class ProjectManager extends React.Component<Props, State> {
                 )
             }
           />
-          {!!this.state.name && (
-            <SceneEditor
+          {!!this.state.currentLayoutName && (
+            <SceneVariablesEditorDialog
+              open
               layout={this.getLayout()}
-              layoutVariablesDialogOpen={true}
-              project={project}
-              initialInstances={this.getLayout().getInitialInstances()}
-              initialUiSettings={serializeToJSObject(
-                this.getLayout().getAssociatedSettings()
-              )}
-              onLayoutVariablesDialogClose={() =>
-                this._onEditLayoutVariable(null)
-              }
+              onEditLayoutVariables={() => this._onEditLayoutVariable(null)}
             />
           )}
           <ProjectStructureItem

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -274,7 +274,7 @@ type State = {|
   projectPropertiesDialogOpen: boolean,
   variablesEditorOpen: boolean,
   extensionsSearchDialogOpen: boolean,
-  layoutVariablesDialogOpen: boolean,
+  name: any,
 |};
 
 export default class ProjectManager extends React.Component<Props, State> {
@@ -287,8 +287,7 @@ export default class ProjectManager extends React.Component<Props, State> {
     projectPropertiesDialogOpen: false,
     variablesEditorOpen: false,
     extensionsSearchDialogOpen: false,
-    layoutVariablesDialogOpen: false,
-    layoutName: '',
+    name: null,
   };
 
   shouldComponentUpdate(nextProps: Props) {
@@ -306,16 +305,16 @@ export default class ProjectManager extends React.Component<Props, State> {
     }
   }
 
-  _onEditLayoutVariable = (open: boolean, name: string) => {
-    this.setState({ layoutVariablesDialogOpen: open, layoutName: name });
+  _onEditLayoutVariable = (name: any = null) => {
+    this.setState({ name });
   };
 
   getLayoutVariables = () => {
     const { project } = this.props;
-    const { layoutName } = this.state;
-    if (!project || !project.hasLayoutNamed(layoutName)) return null;
+    const { name } = this.state;
+    if (!project || !project.hasLayoutNamed(name)) return null;
 
-    return project.getLayout(layoutName).getVariables();
+    return project.getLayout(name).getVariables();
   };
 
   _onEditName = (kind: ?string, name: string) => {
@@ -738,7 +737,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                       }}
                       onEditName={() => this._onEditName('layout', name)}
                       onEditLayoutVariable={() =>
-                        this._onEditLayoutVariable(true, name)
+                        this._onEditLayoutVariable(name)
                       }
                       onCopy={() => this._copyLayout(layout)}
                       onCut={() => this._cutLayout(layout)}
@@ -760,12 +759,12 @@ export default class ProjectManager extends React.Component<Props, State> {
                 )
             }
           />
-          {!!this.state.layoutVariablesDialogOpen && (
+          {!!this.state.name && (
             <VariablesEditorDialog
-              open={this.state.layoutVariablesDialogOpen}
+              open={!!this.state.name}
               variablesContainer={this.getLayoutVariables()}
-              onCancel={() => this._onEditLayoutVariable(false)}
-              onApply={() => this._onEditLayoutVariable(false)}
+              onCancel={() => this._onEditLayoutVariable(null)}
+              onApply={() => this._onEditLayoutVariable(null)}
               title={<Trans>Scene Variables</Trans>}
               emptyExplanationMessage={
                 <Trans>

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -179,6 +179,10 @@ class Item extends React.Component<ItemProps, {||}> {
                 click: () => this.props.onEdit(),
               },
               {
+                label: 'Edit scene Properties',
+                click:() => this.props.onEditLayoutVariable()
+              },
+              {
                 label: 'Rename',
                 click: () => this.props.onEditName(),
               },
@@ -270,6 +274,7 @@ type State = {|
   projectPropertiesDialogOpen: boolean,
   variablesEditorOpen: boolean,
   extensionsSearchDialogOpen: boolean,
+  layoutVariablesDialogOpen: boolean
 |};
 
 export default class ProjectManager extends React.Component<Props, State> {
@@ -282,6 +287,7 @@ export default class ProjectManager extends React.Component<Props, State> {
     projectPropertiesDialogOpen: false,
     variablesEditorOpen: false,
     extensionsSearchDialogOpen: false,
+    layoutVariablesDialogOpen:false,
   };
 
   shouldComponentUpdate(nextProps: Props) {
@@ -297,6 +303,10 @@ export default class ProjectManager extends React.Component<Props, State> {
     if (!this.props.freezeUpdate && prevProps.freezeUpdate) {
       if (this._searchBar) this._searchBar.focus();
     }
+  }
+
+  _onEditLayoutVariable = (open:boolean) => {
+    this.setState({layoutVariablesDialogOpen: open})
   }
 
   _onEditName = (kind: ?string, name: string) => {
@@ -718,6 +728,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                         this._onEditName(null, '');
                       }}
                       onEditName={() => this._onEditName('layout', name)}
+                      onEditLayoutVariable={() => this._onEditLayoutVariable(true)}
                       onCopy={() => this._copyLayout(layout)}
                       onCut={() => this._cutLayout(layout)}
                       onPaste={() => this._pasteLayout(i)}
@@ -738,6 +749,27 @@ export default class ProjectManager extends React.Component<Props, State> {
                 )
             }
           />
+          {!!this.state.layoutVariablesDialogOpen && (
+          <VariablesEditorDialog
+            open={this.state.layoutVariablesDialogOpen}
+            variablesContainer={project.getVariables()}
+            onCancel={() => this._onEditLayoutVariable(false)}
+            onApply={() => this._onEditLayoutVariable(false)}
+            title={<Trans>Scene Variables</Trans>}
+            emptyExplanationMessage={
+              <Trans>
+                Scene variables can be used to store any value or text during
+                the game.
+              </Trans>
+            }
+            emptyExplanationSecondMessage={
+              <Trans>
+                For example, you can have a variable called Score representing
+                the current score of the player.
+              </Trans>
+            }
+          />
+        )}
           <ProjectStructureItem
             primaryText={<Trans>External events</Trans>}
             leftIcon={

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -179,7 +179,7 @@ class Item extends React.Component<ItemProps, {||}> {
                 click: () => this.props.onEdit(),
               },
               {
-                label: 'Edit scene Properties',
+                label: 'Edit scene Variables',
                 click: () => this.props.onEditLayoutVariable(),
               },
               {

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -180,7 +180,7 @@ class Item extends React.Component<ItemProps, {||}> {
               },
               {
                 label: 'Edit scene Properties',
-                click:() => this.props.onEditLayoutVariable()
+                click: () => this.props.onEditLayoutVariable(),
               },
               {
                 label: 'Rename',
@@ -274,7 +274,7 @@ type State = {|
   projectPropertiesDialogOpen: boolean,
   variablesEditorOpen: boolean,
   extensionsSearchDialogOpen: boolean,
-  layoutVariablesDialogOpen: boolean
+  layoutVariablesDialogOpen: boolean,
 |};
 
 export default class ProjectManager extends React.Component<Props, State> {
@@ -287,7 +287,8 @@ export default class ProjectManager extends React.Component<Props, State> {
     projectPropertiesDialogOpen: false,
     variablesEditorOpen: false,
     extensionsSearchDialogOpen: false,
-    layoutVariablesDialogOpen:false,
+    layoutVariablesDialogOpen: false,
+    layoutName: '',
   };
 
   shouldComponentUpdate(nextProps: Props) {
@@ -305,9 +306,17 @@ export default class ProjectManager extends React.Component<Props, State> {
     }
   }
 
-  _onEditLayoutVariable = (open:boolean) => {
-    this.setState({layoutVariablesDialogOpen: open})
-  }
+  _onEditLayoutVariable = (open: boolean, name: string) => {
+    this.setState({ layoutVariablesDialogOpen: open, layoutName: name });
+  };
+
+  getLayoutVariables = () => {
+    const { project } = this.props;
+    const { layoutName } = this.state;
+    if (!project || !project.hasLayoutNamed(layoutName)) return null;
+
+    return project.getLayout(layoutName).getVariables();
+  };
 
   _onEditName = (kind: ?string, name: string) => {
     this.setState({
@@ -728,7 +737,9 @@ export default class ProjectManager extends React.Component<Props, State> {
                         this._onEditName(null, '');
                       }}
                       onEditName={() => this._onEditName('layout', name)}
-                      onEditLayoutVariable={() => this._onEditLayoutVariable(true)}
+                      onEditLayoutVariable={() =>
+                        this._onEditLayoutVariable(true, name)
+                      }
                       onCopy={() => this._copyLayout(layout)}
                       onCut={() => this._cutLayout(layout)}
                       onPaste={() => this._pasteLayout(i)}
@@ -750,26 +761,26 @@ export default class ProjectManager extends React.Component<Props, State> {
             }
           />
           {!!this.state.layoutVariablesDialogOpen && (
-          <VariablesEditorDialog
-            open={this.state.layoutVariablesDialogOpen}
-            variablesContainer={project.getVariables()}
-            onCancel={() => this._onEditLayoutVariable(false)}
-            onApply={() => this._onEditLayoutVariable(false)}
-            title={<Trans>Scene Variables</Trans>}
-            emptyExplanationMessage={
-              <Trans>
-                Scene variables can be used to store any value or text during
-                the game.
-              </Trans>
-            }
-            emptyExplanationSecondMessage={
-              <Trans>
-                For example, you can have a variable called Score representing
-                the current score of the player.
-              </Trans>
-            }
-          />
-        )}
+            <VariablesEditorDialog
+              open={this.state.layoutVariablesDialogOpen}
+              variablesContainer={this.getLayoutVariables()}
+              onCancel={() => this._onEditLayoutVariable(false)}
+              onApply={() => this._onEditLayoutVariable(false)}
+              title={<Trans>Scene Variables</Trans>}
+              emptyExplanationMessage={
+                <Trans>
+                  Scene variables can be used to store any value or text during
+                  the game.
+                </Trans>
+              }
+              emptyExplanationSecondMessage={
+                <Trans>
+                  For example, you can have a variable called Score representing
+                  the current score of the player.
+                </Trans>
+              }
+            />
+          )}
           <ProjectStructureItem
             primaryText={<Trans>External events</Trans>}
             leftIcon={

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -39,6 +39,7 @@ import AddToHomeScreen from '@material-ui/icons/AddToHomeScreen';
 import Fullscreen from '@material-ui/icons/Fullscreen';
 import FileCopy from '@material-ui/icons/FileCopy';
 import AccountCircle from '@material-ui/icons/AccountCircle';
+import SceneEditor from '../SceneEditor';
 
 const LAYOUT_CLIPBOARD_KIND = 'Layout';
 const EXTERNAL_LAYOUT_CLIPBOARD_KIND = 'External layout';
@@ -309,12 +310,13 @@ export default class ProjectManager extends React.Component<Props, State> {
     this.setState({ name });
   };
 
-  getLayoutVariables = () => {
+  getLayout = () => {
     const { project } = this.props;
     const { name } = this.state;
     if (!project || !project.hasLayoutNamed(name)) return null;
 
-    return project.getLayout(name).getVariables();
+    console.log(project.getLayout(name));
+    return project.getLayout(name);
   };
 
   _onEditName = (kind: ?string, name: string) => {
@@ -760,23 +762,16 @@ export default class ProjectManager extends React.Component<Props, State> {
             }
           />
           {!!this.state.name && (
-            <VariablesEditorDialog
-              open={!!this.state.name}
-              variablesContainer={this.getLayoutVariables()}
-              onCancel={() => this._onEditLayoutVariable(null)}
-              onApply={() => this._onEditLayoutVariable(null)}
-              title={<Trans>Scene Variables</Trans>}
-              emptyExplanationMessage={
-                <Trans>
-                  Scene variables can be used to store any value or text during
-                  the game.
-                </Trans>
-              }
-              emptyExplanationSecondMessage={
-                <Trans>
-                  For example, you can have a variable called Score representing
-                  the current score of the player.
-                </Trans>
+            <SceneEditor
+              layout={this.getLayout()}
+              layoutVariablesDialogOpen={true}
+              project={project}
+              initialInstances={this.getLayout().getInitialInstances()}
+              initialUiSettings={serializeToJSObject(
+                this.getLayout().getAssociatedSettings()
+              )}
+              onLayoutVariablesDialogClose={() =>
+                this._onEditLayoutVariable(null)
               }
             />
           )}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -124,6 +124,7 @@ type Props = {|
   onOpenDebugger: () => void,
   onOpenMoreSettings: () => void,
   onPreview: (options: PreviewOptions) => void,
+  onLayoutVariablesDialogClose: () => void,
   project: gdProject,
   setToolbar: (?React.Node) => void,
   showNetworkPreviewButton: boolean,
@@ -132,6 +133,7 @@ type Props = {|
   onChooseResource: ChooseResourceFunction,
   resourceExternalEditors: Array<ResourceExternalEditor>,
   isActive: boolean,
+  layoutVariablesDialogOpen: boolean,
 |};
 
 type State = {|
@@ -203,7 +205,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       }),
 
       showObjectsListInfoBar: false,
-      layoutVariablesDialogOpen: false,
+      layoutVariablesDialogOpen: this.props.layoutVariablesDialogOpen || false,
       showPropertiesInfoBar: false,
 
       selectedObjectTags: [],
@@ -344,6 +346,10 @@ export default class SceneEditor extends React.Component<Props, State> {
   };
 
   editLayoutVariables = (open: boolean = true) => {
+    if (this.props.onLayoutVariablesDialogClose) {
+      this.props.onLayoutVariablesDialogClose();
+      return;
+    }
     this.setState({ layoutVariablesDialogOpen: open });
   };
 

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -15,6 +15,7 @@ import InstancesList from '../InstancesEditor/InstancesList';
 import LayersList from '../LayersList';
 import LayerRemoveDialog from '../LayersList/LayerRemoveDialog';
 import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
+import SceneVariablesEditorDialog from '../VariablesList/SceneVariablesEditorDialog';
 import ObjectEditorDialog from '../ObjectEditor/ObjectEditorDialog';
 import ObjectGroupEditorDialog from '../ObjectGroupEditor/ObjectGroupEditorDialog';
 import InstancesSelection from './InstancesSelection';
@@ -124,7 +125,6 @@ type Props = {|
   onOpenDebugger: () => void,
   onOpenMoreSettings: () => void,
   onPreview: (options: PreviewOptions) => void,
-  onLayoutVariablesDialogClose: () => void,
   project: gdProject,
   setToolbar: (?React.Node) => void,
   showNetworkPreviewButton: boolean,
@@ -133,7 +133,6 @@ type Props = {|
   onChooseResource: ChooseResourceFunction,
   resourceExternalEditors: Array<ResourceExternalEditor>,
   isActive: boolean,
-  layoutVariablesDialogOpen: boolean,
 |};
 
 type State = {|
@@ -205,7 +204,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       }),
 
       showObjectsListInfoBar: false,
-      layoutVariablesDialogOpen: this.props.layoutVariablesDialogOpen || false,
+      layoutVariablesDialogOpen: false,
       showPropertiesInfoBar: false,
 
       selectedObjectTags: [],
@@ -346,10 +345,6 @@ export default class SceneEditor extends React.Component<Props, State> {
   };
 
   editLayoutVariables = (open: boolean = true) => {
-    if (this.props.onLayoutVariablesDialogClose) {
-      this.props.onLayoutVariablesDialogClose();
-      return;
-    }
     this.setState({ layoutVariablesDialogOpen: open });
   };
 
@@ -1239,24 +1234,10 @@ export default class SceneEditor extends React.Component<Props, State> {
           />
         )}
         {!!this.state.layoutVariablesDialogOpen && (
-          <VariablesEditorDialog
+          <SceneVariablesEditorDialog
             open
-            variablesContainer={layout.getVariables()}
-            onCancel={() => this.editLayoutVariables(false)}
-            onApply={() => this.editLayoutVariables(false)}
-            title={<Trans>Scene Variables</Trans>}
-            emptyExplanationMessage={
-              <Trans>
-                Scene variables can be used to store any value or text during
-                the game.
-              </Trans>
-            }
-            emptyExplanationSecondMessage={
-              <Trans>
-                For example, you can have a variable called Score representing
-                the current score of the player.
-              </Trans>
-            }
+            layout={layout}
+            onEditLayoutVariables={() => this.editLayoutVariables(false)}
           />
         )}
         <ContextMenu

--- a/newIDE/app/src/VariablesList/SceneVariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/SceneVariablesEditorDialog.js
@@ -1,0 +1,31 @@
+// @flow
+import React, { Component } from 'react';
+import VariablesEditorDialog from './VariablesEditorDialog.js';
+import { Trans } from '@lingui/macro';
+
+export default class SceneVariableEditorDialog extends Component {
+  render() {
+    const { layout, open, onEditLayoutVariables } = this.props;
+    return (
+      <VariablesEditorDialog
+        open={open}
+        variablesContainer={layout.getVariables()}
+        onCancel={() => onEditLayoutVariables()}
+        onApply={() => onEditLayoutVariables()}
+        title={<Trans>Scene Variables</Trans>}
+        emptyExplanationMessage={
+          <Trans>
+            Scene variables can be used to store any value or text during the
+            game.
+          </Trans>
+        }
+        emptyExplanationSecondMessage={
+          <Trans>
+            For example, you can have a variable called Score representing the
+            current score of the player.
+          </Trans>
+        }
+      />
+    );
+  }
+}


### PR DESCRIPTION
Added an Edit Scene Properties to the Context Menu in the Project Manager Panel.

The Edit scene Properties pops up a modal for editing scene variables.

Edit scene properties on the context menu
![Screenshot (80)](https://user-images.githubusercontent.com/32250849/76566214-95e22600-64ac-11ea-9c6c-e229a4ab08b6.png)


Modal pops up when the menu item is clicked
![Screenshot (79)](https://user-images.githubusercontent.com/32250849/76566132-659a8780-64ac-11ea-84f0-e613bbbfe312.png)

closes #1505 


