### PR TITLE
Fix Context Menu appears far away from object/cursor position

### DIFF
--- a/newIDE/app/src/UI/Menu/ContextMenu.js
+++ b/newIDE/app/src/UI/Menu/ContextMenu.js
@@ -39,28 +39,18 @@ class MaterialUIContextMenu extends React.Component {
 
   render() {
     return (
-      <div>
-        <div
-          style={{
-            position: 'fixed',
-            pointerEvents: 'none',
-            left: this.state.anchorX,
-            top: this.state.anchorY,
-          }}
-        />
-        <Menu
-          open={this.state.open}
-          anchorPosition={{left: this.state.anchorX, top: this.state.anchorY}}
-          anchorReference={'anchorPosition'}
-          onClose={this._onClose}
-          TransitionComponent={Fade}
-          {...this.menuImplementation.getMenuProps()}
-        >
-          {this.menuImplementation.buildFromTemplate(
-            this.props.buildMenuTemplate()
-          )}
-        </Menu>
-      </div>
+      <Menu
+        open={this.state.open}
+        anchorPosition={{ left: this.state.anchorX, top: this.state.anchorY }}
+        anchorReference={'anchorPosition'}
+        onClose={this._onClose}
+        TransitionComponent={Fade}
+        {...this.menuImplementation.getMenuProps()}
+      >
+        {this.menuImplementation.buildFromTemplate(
+          this.props.buildMenuTemplate()
+        )}
+      </Menu>
     );
   }
 }

--- a/newIDE/app/src/UI/Menu/ContextMenu.js
+++ b/newIDE/app/src/UI/Menu/ContextMenu.js
@@ -41,7 +41,6 @@ class MaterialUIContextMenu extends React.Component {
     return (
       <div>
         <div
-          ref={element => (this.anchorEl = element)}
           style={{
             position: 'fixed',
             pointerEvents: 'none',
@@ -51,7 +50,8 @@ class MaterialUIContextMenu extends React.Component {
         />
         <Menu
           open={this.state.open}
-          anchorEl={this.anchorEl}
+          anchorPosition={{left: this.state.anchorX, top: this.state.anchorY}}
+          anchorReference={'anchorPosition'}
           onClose={this._onClose}
           TransitionComponent={Fade}
           {...this.menuImplementation.getMenuProps()}

--- a/newIDE/app/src/UI/Menu/ElementWithMenu.js
+++ b/newIDE/app/src/UI/Menu/ElementWithMenu.js
@@ -26,8 +26,8 @@ export default class ElementWithMenu extends React.Component<Props, State> {
       const dimensions = node.getBoundingClientRect();
 
       _contextMenu.open(
-        Math.round(dimensions.left),
-        Math.round(dimensions.top + dimensions.height)
+        event.clientX - dimensions.left,
+        event.clientY - dimensions.top
       );
     }
   };

--- a/newIDE/app/src/UI/Menu/ElementWithMenu.js
+++ b/newIDE/app/src/UI/Menu/ElementWithMenu.js
@@ -26,8 +26,8 @@ export default class ElementWithMenu extends React.Component<Props, State> {
       const dimensions = node.getBoundingClientRect();
 
       _contextMenu.open(
-        event.clientX - dimensions.left,
-        event.clientY - dimensions.top
+        Math.round(dimensions.left),
+        Math.round(dimensions.top + dimensions.height)
       );
     }
   };


### PR DESCRIPTION
This is to fix #1492
I edit a bit to make the ContextMenu appears at the position of the cursor just like when we right click inside the preview. I'm not sure if this is what you want, so I just adapt with what already runs well.