### PR TITLE
[WIP] Add support for side-separate modifier keys

### DIFF
--- a/GDJS/Runtime/events-tools/inputtools.js
+++ b/GDJS/Runtime/events-tools/inputtools.js
@@ -95,7 +95,7 @@ gdjs.evtTools.input.keysNameToCode = {
     "x": 88,
     "y": 89,
     "z": 90,
-    
+
     "Num0": 48,
     "Num1": 49,
     "Num2": 50,
@@ -118,14 +118,16 @@ gdjs.evtTools.input.keysNameToCode = {
     "Numpad8": 104,
     "Numpad9": 105,
 
-    "RControl": 17,
-    "RShift": 16,
-    "RAlt": 18,
+    // Negative keycodes for right-modifier keys
+    "RControl": -17,
+    "RShift": -16,
+    "RAlt": -18,
+    "RSystem": -91,
+
     "LControl": 17,
     "LShift": 16,
     "LAlt": 18,
     "LSystem": 91,
-    "RSystem": 91,
     /*"Menu": sf::Keyboard::Menu ,
     "LBracket": sf::Keyboard::LBracket ,
     "RBracket": sf::Keyboard::RBracket ,

--- a/GDJS/Runtime/inputmanager.js
+++ b/GDJS/Runtime/inputmanager.js
@@ -46,7 +46,10 @@ gdjs.InputManager.MOUSE_MIDDLE_BUTTON = 2;
  * Should be called whenever a key is pressed
  * @param {number} keyCode The key code associated to the key press.
  */
-gdjs.InputManager.prototype.onKeyPressed = function(keyCode) {
+gdjs.InputManager.prototype.onKeyPressed = function(keyCode, location) {
+    // Negative keycode for right-modifier keys (RCtrl, RShift, RAlt, RSystem)
+    if (location === 2) keyCode = -keyCode;
+
     this._pressedKeys.put(keyCode, true);
     this._lastPressedKey = keyCode;
 };
@@ -55,7 +58,10 @@ gdjs.InputManager.prototype.onKeyPressed = function(keyCode) {
  * Should be called whenever a key is released
  * @param {number} keyCode The key code associated to the key release.
  */
-gdjs.InputManager.prototype.onKeyReleased = function(keyCode) {
+gdjs.InputManager.prototype.onKeyReleased = function(keyCode, location) {
+  // Negative keycode for right-modifier keys (RCtrl, RShift, RAlt, RSystem)
+    if (location === 2) keyCode = -keyCode;
+
     this._pressedKeys.put(keyCode, false);
     this._releasedKeys.put(keyCode, true);
 };
@@ -131,7 +137,7 @@ gdjs.InputManager.prototype.getMouseY = function() {
 
 /**
  * Should be called whenever a mouse button is pressed
- * @param {number} buttonCode The mouse button code associated to the event. 
+ * @param {number} buttonCode The mouse button code associated to the event.
  * See gdjs.InputManager.MOUSE_LEFT_BUTTON, gdjs.InputManager.MOUSE_RIGHT_BUTTON, gdjs.InputManager.MOUSE_MIDDLE_BUTTON
  */
 gdjs.InputManager.prototype.onMouseButtonPressed = function(buttonCode) {

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
@@ -327,10 +327,10 @@ gdjs.RuntimeGamePixiRenderer.prototype.bindStandardEvents = function(
 
   //Keyboard
   document.onkeydown = function(e) {
-    manager.onKeyPressed(e.keyCode);
+    manager.onKeyPressed(e.keyCode, e.location);
   };
   document.onkeyup = function(e) {
-    manager.onKeyReleased(e.keyCode);
+    manager.onKeyReleased(e.keyCode, e.location);
   };
   //Mouse
   renderer.view.onmousemove = function(e) {

--- a/GDJS/tests/tests/inputmanager.js
+++ b/GDJS/tests/tests/inputmanager.js
@@ -32,14 +32,14 @@ describe('gdjs.InputManager', function() {
 		expect(inputManager.anyKeyPressed()).to.be(false);
 
     inputManager.onKeyPressed(16, 1);
-		expect(inputManager.wasKeyPressed(16)).to.be(true);
-		expect(inputManager.wasKeyPressed(-16)).to.be(false);
+		expect(inputManager.isKeyPressed(16)).to.be(true);
+		expect(inputManager.isKeyPressed(-16)).to.be(false);
 		inputManager.onKeyReleased(16, 1);
 		expect(inputManager.wasKeyReleased(16)).to.be(true);
 		expect(inputManager.wasKeyReleased(-16)).to.be(false);
 		inputManager.onKeyPressed(16, 2);
-		expect(inputManager.wasKeyPressed(16)).to.be(false);
-		expect(inputManager.wasKeyPressed(-16)).to.be(true);
+		expect(inputManager.isKeyPressed(16)).to.be(false);
+		expect(inputManager.isKeyPressed(-16)).to.be(true);
 		inputManager.onKeyReleased(16, 2);
 		expect(inputManager.wasKeyReleased(16)).to.be(true);
 		expect(inputManager.wasKeyReleased(-16)).to.be(true);

--- a/GDJS/tests/tests/inputmanager.js
+++ b/GDJS/tests/tests/inputmanager.js
@@ -31,6 +31,18 @@ describe('gdjs.InputManager', function() {
 		expect(inputManager.wasKeyReleased(33)).to.be(true);
 		expect(inputManager.anyKeyPressed()).to.be(false);
 
+    inputManager.onKeyPressed(16, 1);
+		expect(inputManager.wasKeyPressed(16)).to.be(true);
+		expect(inputManager.wasKeyPressed(-16)).to.be(false);
+		inputManager.onKeyReleased(16, 1);
+		expect(inputManager.wasKeyReleased(16)).to.be(true);
+		expect(inputManager.wasKeyReleased(-16)).to.be(false);
+		inputManager.onKeyPressed(16, 2);
+		expect(inputManager.wasKeyPressed(16)).to.be(false);
+		expect(inputManager.wasKeyPressed(-16)).to.be(true);
+		inputManager.onKeyReleased(16, 2);
+		expect(inputManager.wasKeyReleased(16)).to.be(true);
+		expect(inputManager.wasKeyReleased(-16)).to.be(true);
 	});
 
 	it('should handle mouse events', function(){


### PR DESCRIPTION
This is a WIP PR for adding support for side-separate modifier keys.

Currently keys like LShift and RShift are treated as the same key, since they have the same keycode. This PR adds support for differing between these pairs of keys, by taking in `event.location` into account as well.