### PR TITLE
Effects: change animated to animationSpeed

### DIFF
--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -381,31 +381,31 @@ module.exports = {
     const crtProperties = crtEffect.getProperties();
     crtProperties.set(
       'lineWidth',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0.2')
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
         .setLabel(_('Line width (between 0 and 5)'))
         .setType('number')
     );
     crtProperties.set(
       'lineContrast',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.25')
         .setLabel(_('Line contrast (between 0 and 1)'))
         .setType('number')
     );
     crtProperties.set(
       'noise',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0.1')
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.3')
         .setLabel(_('Noise (between 0 and 1)'))
         .setType('number')
     );
     crtProperties.set(
       'curvature',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
         .setLabel(_('Curvature (between 0 and 10)'))
         .setType('number')
     );
     crtProperties.set(
       'verticalLine',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+      new gd.PropertyDescriptor(/* defaultValue= */ 'false')
         .setLabel(_('Vertical line (true or false)'))
         .setType('boolean')
     );
@@ -446,7 +446,7 @@ module.exports = {
     );
     crtProperties.set(
       'animationFrequency',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+      new gd.PropertyDescriptor(/* defaultValue= */ '60')
         .setLabel(_('Animation Frequency of Noise'))
         .setType('number')
         .setDescription('Number of updates per second (0: no updates)')
@@ -626,7 +626,7 @@ module.exports = {
     );
     glitchProperties.set(
       'animationFrequency',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+      new gd.PropertyDescriptor(/* defaultValue= */ '60')
         .setLabel(_('Animation Frequency'))
         .setType('number')
         .setDescription('Number of updates per second (0: no updates)')
@@ -916,7 +916,7 @@ module.exports = {
     );
     oldFilmProperties.set(
       'animationFrequency',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+      new gd.PropertyDescriptor(/* defaultValue= */ '60')
         .setLabel(_('Animation Frequency'))
         .setType('number')
         .setDescription('Number of updates per second (0: no updates)')

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -436,13 +436,20 @@ module.exports = {
     crtProperties.set(
       'animationSpeed',
       new gd.PropertyDescriptor(/* defaultValue= */ '1')
-        .setLabel(_('Animation Speed'))
+        .setLabel(_('Animation Speed of Interlaced Lines'))
         .setType('number')
         .setDescription(
           _(
             '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
           )
         )
+    );
+    crtProperties.set(
+      'animationFrequency',
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Animation Frequency of Noise'))
+        .setType('number')
+        .setDescription('Number of updates per second (0: no updates)')
     );
 
     const displacementEffect = extension

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -434,11 +434,15 @@ module.exports = {
         .setType('number')
     );
     crtProperties.set(
-      'animationFrequency',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Animation Frequency'))
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
+        .setLabel(_('Animation Speed'))
         .setType('number')
-        .setDescription('Number of updates per second (0: no updates)')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+          )
+        )
     );
 
     const displacementEffect = extension
@@ -703,11 +707,15 @@ module.exports = {
         .setType('boolean')
     );
     godrayProperties.set(
-      'animationFrequency',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Animation Frequency'))
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
+        .setLabel(_('Animation Speed'))
         .setType('number')
-        .setDescription('Number of updates per second (0: no updates)')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+          )
+        )
     );
     godrayProperties.set(
       'lacunarity',
@@ -1056,11 +1064,15 @@ module.exports = {
         .setDescription(_('Ending alpha (1 by default)'))
     );
     reflectionProperties.set(
-      'animationFrequency',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Animation Frequency of waves'))
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
+        .setLabel(_('Animation Speed'))
         .setType('number')
-        .setDescription('Number of updates per second (0: no updates)')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+          )
+        )
     );
 
     const rgbSplitEffect = extension

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -434,15 +434,11 @@ module.exports = {
         .setType('number')
     );
     crtProperties.set(
-      'animationSpeed',
-      new gd.PropertyDescriptor(/* defaultValue= */ '1')
-        .setLabel(_('Animation Speed (between 0 and 1)'))
+      'animationFrequency',
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Animation Frequency'))
         .setType('number')
-        .setDescription(
-          _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed)'
-          )
-        )
+        .setDescription('Number of updates per second (0: no updates)')
     );
 
     const displacementEffect = extension
@@ -618,15 +614,11 @@ module.exports = {
         .setDescription('The resolution of the displacement image')
     );
     glitchProperties.set(
-      'animationSpeed',
-      new gd.PropertyDescriptor(/* defaultValue= */ '1')
-        .setLabel(_('Animation Speed (between 0 and 1)'))
+      'animationFrequency',
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Animation Frequency'))
         .setType('number')
-        .setDescription(
-          _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed)'
-          )
-        )
+        .setDescription('Number of updates per second (0: no updates)')
     );
     glitchProperties.set(
       'redX',
@@ -711,15 +703,11 @@ module.exports = {
         .setType('boolean')
     );
     godrayProperties.set(
-      'animationSpeed',
-      new gd.PropertyDescriptor(/* defaultValue= */ '1')
-        .setLabel(_('Animation Speed'))
+      'animationFrequency',
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Animation Frequency'))
         .setType('number')
-        .setDescription(
-          _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
-          )
-        )
+        .setDescription('Number of updates per second (0: no updates)')
     );
     godrayProperties.set(
       'lacunarity',
@@ -912,15 +900,11 @@ module.exports = {
         .setDescription('Blur intensity of the vignette')
     );
     oldFilmProperties.set(
-      'animationSpeed',
-      new gd.PropertyDescriptor(/* defaultValue= */ '1')
-        .setLabel(_('Animation Speed (between 0 and 1)'))
+      'animationFrequency',
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Animation Frequency'))
         .setType('number')
-        .setDescription(
-          _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed)'
-          )
-        )
+        .setDescription('Number of updates per second (0: no updates)')
     );
 
     const outlineEffect = extension
@@ -1072,15 +1056,11 @@ module.exports = {
         .setDescription(_('Ending alpha (1 by default)'))
     );
     reflectionProperties.set(
-      'animationSpeed',
+      'animationFrequency',
       new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Animation Speed of waves'))
+        .setLabel(_('Animation Frequency of waves'))
         .setType('number')
-        .setDescription(
-          _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
-          )
-        )
+        .setDescription('Number of updates per second (0: no updates)')
     );
 
     const rgbSplitEffect = extension

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -436,18 +436,18 @@ module.exports = {
     crtProperties.set(
       'animationSpeed',
       new gd.PropertyDescriptor(/* defaultValue= */ '1')
-        .setLabel(_('Animation Speed of Interlaced Lines'))
+        .setLabel(_('Interlaced Lines Speed'))
         .setType('number')
         .setDescription(
           _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+            '0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed, etc...'
           )
         )
     );
     crtProperties.set(
       'animationFrequency',
       new gd.PropertyDescriptor(/* defaultValue= */ '60')
-        .setLabel(_('Frequency of Noise'))
+        .setLabel(_('Noise Frequency'))
         .setType('number')
         .setDescription('Number of updates per second (0: no updates)')
     );

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -434,10 +434,15 @@ module.exports = {
         .setType('number')
     );
     crtProperties.set(
-      'animated',
-      new gd.PropertyDescriptor(/* defaultValue= */ 'true')
-        .setLabel(_('Animated (Enable animations)'))
-        .setType('boolean')
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
+        .setLabel(_('Animation Speed (between 0 and 1)'))
+        .setType('number')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed)'
+          )
+        )
     );
 
     const displacementEffect = extension
@@ -613,10 +618,15 @@ module.exports = {
         .setDescription('The resolution of the displacement image')
     );
     glitchProperties.set(
-      'animated',
-      new gd.PropertyDescriptor(/* defaultValue= */ 'true')
-        .setLabel(_('Animated (Enable animations)'))
-        .setType('boolean')
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
+        .setLabel(_('Animation Speed (between 0 and 1)'))
+        .setType('number')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed)'
+          )
+        )
     );
     glitchProperties.set(
       'redX',
@@ -701,10 +711,15 @@ module.exports = {
         .setType('boolean')
     );
     godrayProperties.set(
-      'animated',
-      new gd.PropertyDescriptor(/* defaultValue= */ 'true')
-        .setLabel(_('Animated (animate rays)'))
-        .setType('boolean')
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
+        .setLabel(_('Animation Speed'))
+        .setType('number')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+          )
+        )
     );
     godrayProperties.set(
       'lacunarity',
@@ -887,7 +902,7 @@ module.exports = {
       new gd.PropertyDescriptor(/* defaultValue= */ '1.0')
         .setLabel(_('Vignetting Alpha (between 0 and 1)'))
         .setType('number')
-        .setDescription('The size of the noise particles')
+        .setDescription('Amount of opacity of vignette')
     );
     oldFilmProperties.set(
       'vignettingBlur',
@@ -897,10 +912,15 @@ module.exports = {
         .setDescription('Blur intensity of the vignette')
     );
     oldFilmProperties.set(
-      'animated',
-      new gd.PropertyDescriptor(/* defaultValue= */ 'true')
-        .setLabel(_('Animated (Enable animations)'))
-        .setType('boolean')
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '1')
+        .setLabel(_('Animation Speed (between 0 and 1)'))
+        .setType('number')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed)'
+          )
+        )
     );
 
     const outlineEffect = extension
@@ -1052,10 +1072,15 @@ module.exports = {
         .setDescription(_('Ending alpha (1 by default)'))
     );
     reflectionProperties.set(
-      'animated',
-      new gd.PropertyDescriptor(/* defaultValue= */ 'false')
-        .setLabel(_('Animate waves'))
-        .setType('boolean')
+      'animationSpeed',
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Animation Speed of waves'))
+        .setType('number')
+        .setDescription(
+          _(
+            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+          )
+        )
     );
 
     const rgbSplitEffect = extension

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -447,7 +447,7 @@ module.exports = {
     crtProperties.set(
       'animationFrequency',
       new gd.PropertyDescriptor(/* defaultValue= */ '60')
-        .setLabel(_('Animation Frequency of Noise'))
+        .setLabel(_('Frequency of Noise'))
         .setType('number')
         .setDescription('Number of updates per second (0: no updates)')
     );
@@ -905,14 +905,12 @@ module.exports = {
       new gd.PropertyDescriptor(/* defaultValue= */ '1.0')
         .setLabel(_('Vignetting Alpha (between 0 and 1)'))
         .setType('number')
-        .setDescription('Amount of opacity of vignette')
     );
     oldFilmProperties.set(
       'vignettingBlur',
       new gd.PropertyDescriptor(/* defaultValue= */ '0.3')
         .setLabel(_('Vignetting Blur (between 0 and 1)'))
         .setType('number')
-        .setDescription('Blur intensity of the vignette')
     );
     oldFilmProperties.set(
       'animationFrequency',

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -720,7 +720,7 @@ module.exports = {
         .setType('number')
         .setDescription(
           _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+            '0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed, etc...'
           )
         )
     );
@@ -1075,7 +1075,7 @@ module.exports = {
         .setType('number')
         .setDescription(
           _(
-            '(E.g., 0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed)'
+            '0: Pause, 0.5: Half speed, 1: Normal speed, 2: Double speed, etc...'
           )
         )
     );

--- a/Extensions/Effects/crt-pixi-filter.js
+++ b/Extensions/Effects/crt-pixi-filter.js
@@ -5,12 +5,12 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
     return crtFilter;
   },
   update: function(filter, layer) {
-    if (filter.animationSpeed !== 0) {
-      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
-      filter._animationTimer += filter.animationSpeed;
-      if (filter._animationTimer >= 1) {
+    if (filter.animationFrequency !== 0) { 
+      filter._animationTimer += layer.getElapsedTime() / 1000;
+      if (filter._animationTimer >= 1 / filter.animationFrequency) {
         filter.seed = Math.random();
-        filter._animationTimer = 0
+        filter.time += layer.getElapsedTime() / 1000;
+        filter._animationTimer = 0;
       }
     }
   },
@@ -31,8 +31,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
       filter.vignettingAlpha = value;
     } else if (parameterName === 'vignettingBlur') {
       filter.vignettingBlur = value;
-    } else if (parameterName === 'animationSpeed') {
-      filter.animationSpeed = value;
+    } else if (parameterName === 'animationFrequency') {
+      filter.animationFrequency = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/crt-pixi-filter.js
+++ b/Extensions/Effects/crt-pixi-filter.js
@@ -6,7 +6,7 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
   },
   update: function(filter, layer) {
     if (filter.animationSpeed !== 0) { 
-      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
+      filter.time += layer.getElapsedTime() / 100 * filter.animationSpeed;
     } 
     if (filter.animationFrequency !== 0) { 
       filter._animationTimer += layer.getElapsedTime() / 1000;

--- a/Extensions/Effects/crt-pixi-filter.js
+++ b/Extensions/Effects/crt-pixi-filter.js
@@ -1,13 +1,17 @@
 gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
   makePIXIFilter: function(layer, effectData) {
     var crtFilter = new PIXI.filters.CRTFilter();
-
+    crtFilter._animationTimer = 0;
     return crtFilter;
   },
   update: function(filter, layer) {
-    if (filter.animated) {
-      filter.time += layer.getElapsedTime() / 1000;
-      filter.seed = Math.random();
+    if (filter.animationSpeed !== 0) {
+      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
+      filter._animationTimer += filter.animationSpeed;
+      if (filter._animationTimer >= 1) {
+        filter.seed = Math.random();
+        filter._animationTimer = 0
+      }
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -27,15 +31,14 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
       filter.vignettingAlpha = value;
     } else if (parameterName === 'vignettingBlur') {
       filter.vignettingBlur = value;
+    } else if (parameterName === 'animationSpeed') {
+      filter.animationSpeed = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},
   updateBooleanParameter: function(filter, parameterName, value) {
     if (parameterName === 'verticalLine') {
       filter.verticalLine = value;
-    }
-    if (parameterName === 'animated') {
-      filter.animated = value;
     }
   },
 });

--- a/Extensions/Effects/crt-pixi-filter.js
+++ b/Extensions/Effects/crt-pixi-filter.js
@@ -1,17 +1,13 @@
 gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
   makePIXIFilter: function(layer, effectData) {
     var crtFilter = new PIXI.filters.CRTFilter();
-    crtFilter._animationTimer = 0;
+
     return crtFilter;
   },
   update: function(filter, layer) {
-    if (filter.animationFrequency !== 0) { 
-      filter._animationTimer += layer.getElapsedTime() / 1000;
-      if (filter._animationTimer >= 1 / filter.animationFrequency) {
-        filter.seed = Math.random();
-        filter.time += layer.getElapsedTime() / 1000;
-        filter._animationTimer = 0;
-      }
+    if (filter.animationSpeed !== 0) { 
+      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
+      filter.seed = Math.random();
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -31,8 +27,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
       filter.vignettingAlpha = value;
     } else if (parameterName === 'vignettingBlur') {
       filter.vignettingBlur = value;
-    } else if (parameterName === 'animationFrequency') {
-      filter.animationFrequency = value;
+    } else if (parameterName === 'animationSpeed') {
+      filter.animationSpeed = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/crt-pixi-filter.js
+++ b/Extensions/Effects/crt-pixi-filter.js
@@ -1,13 +1,19 @@
 gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
   makePIXIFilter: function(layer, effectData) {
     var crtFilter = new PIXI.filters.CRTFilter();
-
+    crtFilter._animationTimer = 0;
     return crtFilter;
   },
   update: function(filter, layer) {
     if (filter.animationSpeed !== 0) { 
       filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
-      filter.seed = Math.random();
+    } 
+    if (filter.animationFrequency !== 0) { 
+      filter._animationTimer += layer.getElapsedTime() / 1000;
+      if (filter._animationTimer >= 1 / filter.animationFrequency) {
+        filter.seed = Math.random();
+        filter._animationTimer = 0;
+      }
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -29,6 +35,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
       filter.vignettingBlur = value;
     } else if (parameterName === 'animationSpeed') {
       filter.animationSpeed = value;
+    } else if (parameterName === 'animationFrequency') {
+      filter.animationFrequency = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/crt-pixi-filter.js
+++ b/Extensions/Effects/crt-pixi-filter.js
@@ -6,7 +6,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
   },
   update: function(filter, layer) {
     if (filter.animationSpeed !== 0) { 
-      filter.time += layer.getElapsedTime() / 100 * filter.animationSpeed;
+      // Multiply by 10 so that the default value shows use a sensible speed
+      filter.time += layer.getElapsedTime() / 1000 * 10 * filter.animationSpeed;
     } 
     if (filter.animationFrequency !== 0) { 
       filter._animationTimer += layer.getElapsedTime() / 1000;

--- a/Extensions/Effects/crt-pixi-filter.js
+++ b/Extensions/Effects/crt-pixi-filter.js
@@ -6,7 +6,7 @@ gdjs.PixiFiltersTools.registerFilterCreator('CRT', {
   },
   update: function(filter, layer) {
     if (filter.animationSpeed !== 0) { 
-      // Multiply by 10 so that the default value shows use a sensible speed
+      // Multiply by 10 so that the default value is a sensible speed
       filter.time += layer.getElapsedTime() / 1000 * 10 * filter.animationSpeed;
     } 
     if (filter.animationFrequency !== 0) { 

--- a/Extensions/Effects/glitch-pixi-filter.js
+++ b/Extensions/Effects/glitch-pixi-filter.js
@@ -5,11 +5,11 @@ gdjs.PixiFiltersTools.registerFilterCreator('Glitch', {
     return glitchFilter;
   },
   update: function(filter, layer) {
-    if (filter.animationSpeed !== 0) {
-      filter._animationTimer += filter.animationSpeed;
-      if (filter._animationTimer >= 1) {
+    if (filter.animationFrequency !== 0) { 
+      filter._animationTimer += layer.getElapsedTime() / 1000;
+      if (filter._animationTimer >= 1 / filter.animationFrequency) {
         filter.seed = Math.random();
-        filter._animationTimer = 0
+        filter._animationTimer = 0;
       }
     }
   },
@@ -50,8 +50,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('Glitch', {
     else if (parameterName === 'blueY') {
       filter.blue.y = value;
     }
-    else if (parameterName === 'animationSpeed') {
-      filter.animationSpeed = value;
+    else if (parameterName === 'animationFrequency') {
+      filter.animationFrequency = value;
     }
 
   },

--- a/Extensions/Effects/glitch-pixi-filter.js
+++ b/Extensions/Effects/glitch-pixi-filter.js
@@ -1,13 +1,16 @@
 gdjs.PixiFiltersTools.registerFilterCreator('Glitch', {
   makePIXIFilter: function(layer, effectData) {
     var glitchFilter = new PIXI.filters.GlitchFilter();
-
+    glitchFilter._animationTimer = 0;
     return glitchFilter;
   },
   update: function(filter, layer) {
-    if (filter.animated) {
-      filter.time += layer.getElapsedTime() / 1000;
-      filter.seed = Math.random();
+    if (filter.animationSpeed !== 0) {
+      filter._animationTimer += filter.animationSpeed;
+      if (filter._animationTimer >= 1) {
+        filter.seed = Math.random();
+        filter._animationTimer = 0
+      }
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -47,14 +50,14 @@ gdjs.PixiFiltersTools.registerFilterCreator('Glitch', {
     else if (parameterName === 'blueY') {
       filter.blue.y = value;
     }
+    else if (parameterName === 'animationSpeed') {
+      filter.animationSpeed = value;
+    }
 
   },
   updateStringParameter: function(filter, parameterName, value) {},
   updateBooleanParameter: function(filter, parameterName, value) {
-    if (parameterName === 'animated') {
-      filter.animated = value;
-    }
-    else if (parameterName === 'average') {
+    if (parameterName === 'average') {
       filter.average = value;
     }
   },

--- a/Extensions/Effects/godray-pixi-filter.js
+++ b/Extensions/Effects/godray-pixi-filter.js
@@ -1,16 +1,12 @@
 gdjs.PixiFiltersTools.registerFilterCreator('Godray', {
   makePIXIFilter: function(layer, effectData) {
     var godrayFilter = new PIXI.filters.GodrayFilter();
-    godrayFilter._animationTimer = 0;
+
     return godrayFilter;
   },
   update: function(filter, layer) {
-    if (filter.animationFrequency !== 0) { 
-      filter._animationTimer += layer.getElapsedTime() / 1000;
-      if (filter._animationTimer >= 1 / filter.animationFrequency) {
-        filter.time += layer.getElapsedTime() / 1000;
-        filter._animationTimer = 0;
-      }
+    if (filter.animationSpeed !== 0) { 
+      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -26,8 +22,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('Godray', {
       filter.x = value;
     } else if (parameterName === 'y') {
       filter.y = value;
-    } else if (parameterName === 'animationFrequency') {
-      filter.animationFrequency = value;
+    } else if (parameterName === 'animationSpeed') {
+      filter.animationSpeed = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/godray-pixi-filter.js
+++ b/Extensions/Effects/godray-pixi-filter.js
@@ -1,12 +1,16 @@
 gdjs.PixiFiltersTools.registerFilterCreator('Godray', {
   makePIXIFilter: function(layer, effectData) {
     var godrayFilter = new PIXI.filters.GodrayFilter();
-
+    godrayFilter._animationTimer = 0;
     return godrayFilter;
   },
   update: function(filter, layer) {
-    if (filter.animationSpeed !== 0) {
-      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
+    if (filter.animationFrequency !== 0) { 
+      filter._animationTimer += layer.getElapsedTime() / 1000;
+      if (filter._animationTimer >= 1 / filter.animationFrequency) {
+        filter.time += layer.getElapsedTime() / 1000;
+        filter._animationTimer = 0;
+      }
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -22,8 +26,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('Godray', {
       filter.x = value;
     } else if (parameterName === 'y') {
       filter.y = value;
-    } else if (parameterName === 'animationSpeed') {
-      filter.animationSpeed = value;
+    } else if (parameterName === 'animationFrequency') {
+      filter.animationFrequency = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/godray-pixi-filter.js
+++ b/Extensions/Effects/godray-pixi-filter.js
@@ -5,8 +5,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('Godray', {
     return godrayFilter;
   },
   update: function(filter, layer) {
-    if (filter.animated) {
-      filter.time += layer.getElapsedTime() / 1000;
+    if (filter.animationSpeed !== 0) {
+      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -22,15 +22,14 @@ gdjs.PixiFiltersTools.registerFilterCreator('Godray', {
       filter.x = value;
     } else if (parameterName === 'y') {
       filter.y = value;
+    } else if (parameterName === 'animationSpeed') {
+      filter.animationSpeed = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},
   updateBooleanParameter: function(filter, parameterName, value) {
     if (parameterName === 'parallel') {
       filter.parallel = value;
-    }
-    if (parameterName === 'animated') {
-      filter.animated = value;
     }
   },
 });

--- a/Extensions/Effects/old-film-pixi-filter.js
+++ b/Extensions/Effects/old-film-pixi-filter.js
@@ -1,13 +1,16 @@
 gdjs.PixiFiltersTools.registerFilterCreator('OldFilm', {
   makePIXIFilter: function(layer, effectData) {
     var oldFilmFilter = new PIXI.filters.OldFilmFilter();
-
+    oldFilmFilter._animationTimer = 0;
     return oldFilmFilter;
   },  
   update: function(filter, layer) {
-    if (filter.animated) {
-      filter.time += layer.getElapsedTime() / 1000;
-      filter.seed = Math.random();
+    if (filter.animationSpeed !== 0) {
+      filter._animationTimer += filter.animationSpeed;
+      if (filter._animationTimer >= 1) {
+        filter.seed = Math.random();
+        filter._animationTimer = 0
+      }
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -38,11 +41,10 @@ gdjs.PixiFiltersTools.registerFilterCreator('OldFilm', {
     else if (parameterName === 'vignettingBlur') {
       filter.vignettingBlur = value;
     }
-  },
-  updateStringParameter: function(filter, parameterName, value) {},
-  updateBooleanParameter: function(filter, parameterName, value) {
-    if (parameterName === 'animated') {
-      filter.animated = value;
+    else if (parameterName === 'animationSpeed') {
+      filter.animationSpeed = value;
     }
   },
+  updateStringParameter: function(filter, parameterName, value) {},
+  updateBooleanParameter: function(filter, parameterName, value) {},
 });

--- a/Extensions/Effects/old-film-pixi-filter.js
+++ b/Extensions/Effects/old-film-pixi-filter.js
@@ -5,11 +5,11 @@ gdjs.PixiFiltersTools.registerFilterCreator('OldFilm', {
     return oldFilmFilter;
   },  
   update: function(filter, layer) {
-    if (filter.animationSpeed !== 0) {
-      filter._animationTimer += filter.animationSpeed;
-      if (filter._animationTimer >= 1) {
+    if (filter.animationFrequency !== 0) { 
+      filter._animationTimer += layer.getElapsedTime() / 1000;
+      if (filter._animationTimer >= 1 / filter.animationFrequency) {
         filter.seed = Math.random();
-        filter._animationTimer = 0
+        filter._animationTimer = 0;
       }
     }
   },
@@ -41,8 +41,8 @@ gdjs.PixiFiltersTools.registerFilterCreator('OldFilm', {
     else if (parameterName === 'vignettingBlur') {
       filter.vignettingBlur = value;
     }
-    else if (parameterName === 'animationSpeed') {
-      filter.animationSpeed = value;
+    else if (parameterName === 'animationFrequency') {
+      filter.animationFrequency = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/reflection-pixi-filter.js
+++ b/Extensions/Effects/reflection-pixi-filter.js
@@ -19,16 +19,12 @@ gdjs.PixiFiltersTools.registerFilterCreator("Reflection", {
       ],
       time
     );
-    reflectionFilter._animationTimer = 0;
+
     return reflectionFilter;
   },
   update: function(filter, layer) {
-    if (filter.animationFrequency !== 0) { 
-      filter._animationTimer += layer.getElapsedTime() / 1000;
-      if (filter._animationTimer >= 1 / filter.animationFrequency) {
-        filter.time += layer.getElapsedTime() / 1000;
-        filter._animationTimer = 0;
-      }
+    if (filter.animationSpeed !== 0) { 
+      filter.time += layer.getElapsedTime() / 1000 * filter.animationSpeed;
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -60,8 +56,8 @@ gdjs.PixiFiltersTools.registerFilterCreator("Reflection", {
       filter.alpha[1] = value;
     }
 
-    if (parameterName === "animationFrequency") {
-      filter.animationFrequency = value;
+    if (parameterName === "animationSpeed") {
+      filter.animationSpeed = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/reflection-pixi-filter.js
+++ b/Extensions/Effects/reflection-pixi-filter.js
@@ -19,12 +19,16 @@ gdjs.PixiFiltersTools.registerFilterCreator("Reflection", {
       ],
       time
     );
-
+    reflectionFilter._animationTimer = 0;
     return reflectionFilter;
   },
   update: function(filter, layer) {
-    if (filter.animationSpeed !== 0) {
-      filter.time -= layer.getElapsedTime() / 1000 * filter.animationSpeed;
+    if (filter.animationFrequency !== 0) { 
+      filter._animationTimer += layer.getElapsedTime() / 1000;
+      if (filter._animationTimer >= 1 / filter.animationFrequency) {
+        filter.time += layer.getElapsedTime() / 1000;
+        filter._animationTimer = 0;
+      }
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -56,8 +60,8 @@ gdjs.PixiFiltersTools.registerFilterCreator("Reflection", {
       filter.alpha[1] = value;
     }
 
-    if (parameterName === "animationSpeed") {
-      filter.animationSpeed = value;
+    if (parameterName === "animationFrequency") {
+      filter.animationFrequency = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {},

--- a/Extensions/Effects/reflection-pixi-filter.js
+++ b/Extensions/Effects/reflection-pixi-filter.js
@@ -23,8 +23,8 @@ gdjs.PixiFiltersTools.registerFilterCreator("Reflection", {
     return reflectionFilter;
   },
   update: function(filter, layer) {
-    if (filter.animated) {
-      filter.time -= layer.getElapsedTime() / 1000;
+    if (filter.animationSpeed !== 0) {
+      filter.time -= layer.getElapsedTime() / 1000 * filter.animationSpeed;
     }
   },
   updateDoubleParameter: function(filter, parameterName, value) {
@@ -55,14 +55,15 @@ gdjs.PixiFiltersTools.registerFilterCreator("Reflection", {
     if (parameterName === "alphaEnding") {
       filter.alpha[1] = value;
     }
+
+    if (parameterName === "animationSpeed") {
+      filter.animationSpeed = value;
+    }
   },
   updateStringParameter: function(filter, parameterName, value) {},
   updateBooleanParameter: function(filter, parameterName, value) {
     if (parameterName === "mirror") {
       filter.mirror = value;
-    }
-    if (parameterName === "animated") {
-      filter.animated = value;
     }
   }
 });


### PR DESCRIPTION


### Change `animated` to `animationSpeed`

- [x] crt
- [x] glitch
- [x] godray
- [x] oldFilm
- [x] reflection

### Problems
According to their animation, I divide them into 2 groups.
- Depend on `time` (`reflection`, `godray`, `crt`)
  Their animation depend on `filter.time`, so `Animation Speed` has no limits.
- Depend on `seed` (`glitch`, `oldFilm`, `crt`)
  Their animation depend on how often `filter.seed` change(frequency of calling `update`), so they have a max value of `Animation Speed`.
   ```javascript
  update: function(filter, layer) {
     if (filter.animationSpeed !== 0) {
       filter._animationTimer += filter.animationSpeed;
       if (filter._animationTimer >= 1) {
         filter.seed = Math.random();
         filter._animationTimer = 0
       }
     }
  },
  ```
Is that acceptable? I think users may be confused with this. Or is there a way to call `update` once and render it twice?
 
I think `Slider` may be helpful(just between `minSpeed` and `maxSpeed`), or we can keep `animated`.