### PR TITLE
Effects: Remove window

### DIFF
--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -1191,20 +1191,20 @@ module.exports = {
     const zoomBlurProperties = zoomBlurEffect.getProperties();
     zoomBlurProperties.set(
       'centerX',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
-        .setLabel(_('Center X (between 0 and 1, 0.5 is window middle)'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Center X'))
         .setType('number')
     );
     zoomBlurProperties.set(
       'centerY',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
-        .setLabel(_('Center Y (between 0 and 1, 0.5 is window middle)'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0')
+        .setLabel(_('Center Y'))
         .setType('number')
     );
     zoomBlurProperties.set(
       'innerRadius',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0.2')
-        .setLabel(_('Inner radius (between 0 and 1, 0.5 is mid-way)'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '200')
+        .setLabel(_('Inner radius'))
         .setType('number')
     );
     zoomBlurProperties.set(

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -970,14 +970,14 @@ module.exports = {
     );
     radialBlurProperties.set(
       'centerX',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Center X'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
+        .setLabel(_('Center X (between 0 and 1, 0.5 is image middle)'))
         .setType('number')
     );
     radialBlurProperties.set(
       'centerY',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Center Y'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
+        .setLabel(_('Center Y (between 0 and 1, 0.5 is image middle)'))
         .setType('number')
     );
 
@@ -1171,14 +1171,14 @@ module.exports = {
     );
     twistProperties.set(
       'offsetX',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Center X'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
+        .setLabel(_('Offset X (between 0 and 1, 0.5 is image middle)'))
         .setType('number')
     );
     twistProperties.set(
       'offsetY',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Center Y'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
+        .setLabel(_('Offset Y (between 0 and 1, 0.5 is image middle)'))
         .setType('number')
     );
 
@@ -1191,14 +1191,14 @@ module.exports = {
     const zoomBlurProperties = zoomBlurEffect.getProperties();
     zoomBlurProperties.set(
       'centerX',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Center X'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
+        .setLabel(_('Center X (between 0 and 1, 0.5 is image middle)'))
         .setType('number')
     );
     zoomBlurProperties.set(
       'centerY',
-      new gd.PropertyDescriptor(/* defaultValue= */ '0')
-        .setLabel(_('Center Y'))
+      new gd.PropertyDescriptor(/* defaultValue= */ '0.5')
+        .setLabel(_('Center Y (between 0 and 1, 0.5 is image middle)'))
         .setType('number')
     );
     zoomBlurProperties.set(

--- a/Extensions/Effects/radial-blur-pixi-filter.js
+++ b/Extensions/Effects/radial-blur-pixi-filter.js
@@ -1,6 +1,12 @@
 gdjs.PixiFiltersTools.registerFilterCreator('RadialBlur', {
   makePIXIFilter: function(layer, effectData) {
     var radialBlurFilter = new PIXI.filters.RadialBlurFilter();
+    PIXI.filters.RadialBlurFilter.prototype.apply = function(filterManager, input, output, clear) {
+      this.center[0] = Math.round(this._centerX * input.sourceFrame.width);
+      this.center[1] = Math.round(this._centerY * input.sourceFrame.height);
+      this.uniforms.uKernelSize = this._angle !== 0 ? this.kernelSize : 0;
+      filterManager.applyFilter(this, input, output, clear);
+    }
 
     return radialBlurFilter;
   },
@@ -17,10 +23,10 @@ gdjs.PixiFiltersTools.registerFilterCreator('RadialBlur', {
       filter.kernelSize = gdjs.PixiFiltersTools.clampKernelSize(value, 3, 25);
     }
     else if (parameterName === 'centerX') {
-      filter.center[0] = value;
+      filter._centerX = value;
     }
     else if (parameterName === 'centerY') {
-      filter.center[1] = value;
+      filter._centerY = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {

--- a/Extensions/Effects/radial-blur-pixi-filter.js
+++ b/Extensions/Effects/radial-blur-pixi-filter.js
@@ -1,16 +1,12 @@
 gdjs.PixiFiltersTools.registerFilterCreator('RadialBlur', {
   makePIXIFilter: function(layer, effectData) {
     var radialBlurFilter = new PIXI.filters.RadialBlurFilter();
-    PIXI.filters.RadialBlurFilter.prototype.apply = function(filterManager, input, output, clear) {
-      this.center[0] = Math.round(this._centerX * input.sourceFrame.width);
-      this.center[1] = Math.round(this._centerY * input.sourceFrame.height);
-      this.uniforms.uKernelSize = this._angle !== 0 ? this.kernelSize : 0;
-      filterManager.applyFilter(this, input, output, clear);
-    }
 
     return radialBlurFilter;
   },
   update: function(filter, layer) {
+    filter.center[0] = Math.round(filter._centerX * layer.getWidth());
+    filter.center[1] = Math.round(filter._centerY * layer.getHeight());
   },
   updateDoubleParameter: function(filter, parameterName, value) {
     if (parameterName === 'radius') {

--- a/Extensions/Effects/twist-pixi-filter.js
+++ b/Extensions/Effects/twist-pixi-filter.js
@@ -1,11 +1,15 @@
 gdjs.PixiFiltersTools.registerFilterCreator('Twist', {
   makePIXIFilter: function(layer, effectData) {
     var twistFilter = new PIXI.filters.TwistFilter();
+    PIXI.filters.TwistFilter.prototype.apply = function(filterManager, input, output, clear) {
+      this.offset[0] = Math.round(this._offsetX * input.sourceFrame.width);
+      this.offset[1] = Math.round(this._offsetY * input.sourceFrame.height);
+      filterManager.applyFilter(this, input, output, clear);
+    }
 
     return twistFilter;
   },
-  update: function(filter, layer) {
-  },
+  update: function(filter, layer) { },
   updateDoubleParameter: function(filter, parameterName, value) {
     if (parameterName === 'radius') {
       filter.radius = value;
@@ -17,10 +21,10 @@ gdjs.PixiFiltersTools.registerFilterCreator('Twist', {
       filter.padding = value;
     }
     else if (parameterName === 'offsetX') {
-      filter.offset[0] = value;
+      filter._offsetX = value;
     }
     else if (parameterName === 'offsetY') {
-      filter.offset[1] = value;
+      filter._offsetY = value;
     }
   },
   updateStringParameter: function(filter, parameterName, value) {

--- a/Extensions/Effects/twist-pixi-filter.js
+++ b/Extensions/Effects/twist-pixi-filter.js
@@ -1,15 +1,13 @@
 gdjs.PixiFiltersTools.registerFilterCreator('Twist', {
   makePIXIFilter: function(layer, effectData) {
     var twistFilter = new PIXI.filters.TwistFilter();
-    PIXI.filters.TwistFilter.prototype.apply = function(filterManager, input, output, clear) {
-      this.offset[0] = Math.round(this._offsetX * input.sourceFrame.width);
-      this.offset[1] = Math.round(this._offsetY * input.sourceFrame.height);
-      filterManager.applyFilter(this, input, output, clear);
-    }
 
     return twistFilter;
   },
-  update: function(filter, layer) { },
+  update: function(filter, layer) {
+    filter.offset[0] = Math.round(filter._offsetX * layer.getWidth());
+    filter.offset[1] = Math.round(filter._offsetY * layer.getHeight());
+  },
   updateDoubleParameter: function(filter, parameterName, value) {
     if (parameterName === 'radius') {
       filter.radius = value;

--- a/Extensions/Effects/zoom-blur-pixi-filter.js
+++ b/Extensions/Effects/zoom-blur-pixi-filter.js
@@ -8,13 +8,13 @@ gdjs.PixiFiltersTools.registerFilterCreator('ZoomBlur', {
   },
   updateDoubleParameter: function(filter, parameterName, value) {
     if (parameterName === 'centerX') {
-      filter.center[0] = Math.round(window.innerWidth * value);
+      filter.center[0] = value;
     }
     else if (parameterName === 'centerY') {
-      filter.center[1] = Math.round(window.innerHeight * value);
+      filter.center[1] = value;
     }
     else if (parameterName === 'innerRadius') {
-      filter.innerRadius = Math.round(window.innerWidth * value);
+      filter.innerRadius = value;
     }
     else if (parameterName === 'strength') {
       filter.strength = gdjs.PixiFiltersTools.clampValue(value / 10, 0, 20);

--- a/Extensions/Effects/zoom-blur-pixi-filter.js
+++ b/Extensions/Effects/zoom-blur-pixi-filter.js
@@ -1,15 +1,12 @@
 gdjs.PixiFiltersTools.registerFilterCreator('ZoomBlur', {
   makePIXIFilter: function(layer, effectData) {
     var zoomBlurFilter = new PIXI.filters.ZoomBlurFilter();
-    PIXI.filters.ZoomBlurFilter.prototype.apply = function(filterManager, input, output, clear) {
-      this.center[0] = Math.round(this._centerX * input.sourceFrame.width);
-      this.center[1] = Math.round(this._centerY * input.sourceFrame.height);
-      filterManager.applyFilter(this, input, output, clear);
-    }
 
     return zoomBlurFilter;
   },
   update: function(filter, layer) {
+    filter.center[0] = Math.round(filter._centerX * layer.getWidth());
+    filter.center[1] = Math.round(filter._centerY * layer.getHeight());
   },
   updateDoubleParameter: function(filter, parameterName, value) {
     if (parameterName === 'centerX') {

--- a/Extensions/Effects/zoom-blur-pixi-filter.js
+++ b/Extensions/Effects/zoom-blur-pixi-filter.js
@@ -1,6 +1,11 @@
 gdjs.PixiFiltersTools.registerFilterCreator('ZoomBlur', {
   makePIXIFilter: function(layer, effectData) {
     var zoomBlurFilter = new PIXI.filters.ZoomBlurFilter();
+    PIXI.filters.ZoomBlurFilter.prototype.apply = function(filterManager, input, output, clear) {
+      this.center[0] = Math.round(this._centerX * input.sourceFrame.width);
+      this.center[1] = Math.round(this._centerY * input.sourceFrame.height);
+      filterManager.applyFilter(this, input, output, clear);
+    }
 
     return zoomBlurFilter;
   },
@@ -8,10 +13,10 @@ gdjs.PixiFiltersTools.registerFilterCreator('ZoomBlur', {
   },
   updateDoubleParameter: function(filter, parameterName, value) {
     if (parameterName === 'centerX') {
-      filter.center[0] = value;
+      filter._centerX = value;
     }
     else if (parameterName === 'centerY') {
-      filter.center[1] = value;
+      filter._centerY = value;
     }
     else if (parameterName === 'innerRadius') {
       filter.innerRadius = value;


### PR DESCRIPTION
Sorry, I delete the branch by mistake and it can't be restored.

### Code
Here is an example for `TwistFilter`
```javascript
gdjs.PixiFiltersTools.registerFilterCreator('Twist', {
  makePIXIFilter: function(layer, effectData) {
    var twistFilter = new PIXI.filters.TwistFilter();
    PIXI.filters.TwistFilter.prototype.apply = function(filterManager, input, output, clear) {
        this.offset[0] = Math.round(this._offsetX * input.sourceFrame.width);
        this.offset[1] = Math.round(this._offsetY * input.sourceFrame.height);
        filterManager.applyFilter(this, input, output, clear);
    }
    
    return twistFilter;
  },
  update: function(filter, layer) { },
  updateDoubleParameter: function(filter, parameterName, value) {
    if (parameterName === 'offsetX') {
      filter._offsetX = value;
    }
    else if (parameterName === 'offsetY') {
      filter._offsetY = value;
    }
  }
```

### Explanations

- Override `apply` in `PIXI.filter`
- Replace `window.innerWidth/innerHeight` with `filter.uniforms.dimensions`.
- Updating `filter.offset` moves from `updateDoubleParameter` to `apply`. This is because `filter.offset` must be updated after  `filter.uniforms.dimensions` getting a value.
- `apply` should be updated if we update `PIXI.filter` to v3. (replace `sourceFrame` with filterFrame).
### Questions

- I think it's really dangerous to override functions in `PIXI.filter`. But it is the best way that I could think of. (I don't know if I made it clear.) Can you give me some advice?
- I think `radius` in pixels is a reasonable choice. Should I change it to 0-1?