### PR TITLE
[WIP] Feature: Add functionality to open recent projects

### DIFF
--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -6,7 +6,6 @@ import { type I18n as I18nType } from '@lingui/core';
 import { t } from '@lingui/macro';
 import { isMacLike } from '../Utils/Platform';
 import PreferencesContext from './Preferences/PreferencesContext';
-import {type FileMetadata} from '../ProjectsStorage';
 const electron = optionalRequire('electron');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
 
@@ -163,8 +162,8 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
       return {
         label: item.fileIdentifier,
         onClickSendEvent: 'main-menu-recent',
-        argument: item
-      }
+        argument: item,
+      };
     });
   }
 

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -73,7 +73,6 @@ type RootMenuTemplate =
 class ElectronMainMenu extends React.Component<Props, {||}> {
   _editor: ?MainFrame;
   _language: ?string;
-  recentFiles: Array<MenuItemTemplate>;
 
   componentDidMount() {
     if (!ipcRenderer) return;
@@ -83,9 +82,10 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
       event => this._editor && this._editor.chooseProject()
     );
     ipcRenderer.on('main-menu-recent', (event, fileMetadata) => {
-      if (this._editor) {
-        this._editor.openFromFileMetadata(fileMetadata).then(() => {
-          this._editor && this._editor.openSceneOrProjectManager();
+      const editor = this._editor;
+      if (editor) {
+          editor.openFromFileMetadata(fileMetadata).then(() => {
+          editor.openSceneOrProjectManager();
         });
       }
     });
@@ -156,9 +156,8 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
     }
   }
 
-  componentWillMount() {
-    const { getRecentFiles } = this.context;
-    this.recentFiles = getRecentFiles().map(item => {
+  _recentFiles(): Array<MenuItemTemplate> {
+    return this.context.getRecentFiles().map(item => {
       return {
         label: item.fileIdentifier,
         onClickSendEvent: 'main-menu-recent',
@@ -168,6 +167,7 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
   }
 
   _buildAndSendMenuTemplate() {
+    console.log(this._recentFiles());
     const { i18n } = this.props;
     const fileTemplate = {
       label: i18n._(t`File`),
@@ -185,7 +185,7 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
         },
         {
           label: i18n._(t`Open Recent...`),
-          submenu: this.recentFiles,
+          submenu: this._recentFiles(),
         },
         { type: 'separator' },
         {

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -140,8 +140,8 @@ export type Preferences = {|
     kind: ResourceKind,
     path: string
   ) => void,
-  getRecentFiles: () => Object,
-  setRecentFiles: (data: FileMetadata) => void,
+  getRecentFiles: () => [],
+  addRecentFile: (data: FileMetadata) => void,
 |};
 
 export const initialPreferences = {
@@ -178,8 +178,8 @@ export const initialPreferences = {
   setShowEffectParameterNames: (enabled: boolean) => {},
   getLastUsedPath: (project: gdProject, kind: ResourceKind) => '',
   setLastUsedPath: (project: gdProject, kind: ResourceKind, path: string) => {},
-  getRecentFiles: () => {},
-  setRecentFiles: (data: FileMetadata) => {},
+  getRecentFiles: () => [],
+  addRecentFile: (fileMetadata: FileMetadata) => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -2,6 +2,7 @@
 import { Trans } from '@lingui/macro';
 import * as React from 'react';
 import type { ResourceKind } from '../../ResourcesList/ResourceSource.flow';
+import { type FileMetadata } from '../../ProjectsStorage';
 
 export type AlertMessageIdentifier =
   | 'use-non-smoothed-textures'
@@ -111,6 +112,7 @@ export type PreferencesValues = {|
   eventsSheetUseAssignmentOperators: boolean,
   showEffectParameterNames: boolean,
   projectLastUsedPaths: { [string]: { [ResourceKind]: string } },
+  recentFiles: Array<FileMetadata>,
 |};
 
 /**
@@ -138,6 +140,8 @@ export type Preferences = {|
     kind: ResourceKind,
     path: string
   ) => void,
+  getRecentFiles: () => Object,
+  setRecentFiles: (data: FileMetadata) => void,
 |};
 
 export const initialPreferences = {
@@ -156,6 +160,7 @@ export const initialPreferences = {
     eventsSheetUseAssignmentOperators: false,
     showEffectParameterNames: false,
     projectLastUsedPaths: {},
+    recentFiles: [],
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -173,6 +178,8 @@ export const initialPreferences = {
   setShowEffectParameterNames: (enabled: boolean) => {},
   getLastUsedPath: (project: gdProject, kind: ResourceKind) => '',
   setLastUsedPath: (project: gdProject, kind: ResourceKind, path: string) => {},
+  getRecentFiles: () => {},
+  setRecentFiles: (data: FileMetadata) => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -49,7 +49,7 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     getLastUsedPath: this._getLastUsedPath.bind(this),
     setLastUsedPath: this._setLastUsedPath.bind(this),
     getRecentFiles: this._getRecentFiles.bind(this),
-    setRecentFiles: this._setRecentFiles.bind(this),
+    addRecentFile: this._addRecentFile.bind(this),
   };
 
   componentDidMount() {
@@ -328,7 +328,7 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     return null;
   }
 
-  _setRecentFiles(data: FileMetadata) {
+  _addRecentFile(data: FileMetadata) {
     const { values } = this.state;
     if (values.recentFiles.length >= 5) values.recentFiles.pop();
     if (

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -322,8 +322,7 @@ export default class PreferencesProvider extends React.Component<Props, State> {
 
   _getRecentFiles() {
     const { values } = this.state;
-    const recentFiles = values.recentFiles
-    if(values.recentFiles) {
+    if (values.recentFiles) {
       return values.recentFiles;
     }
     return null;
@@ -332,18 +331,20 @@ export default class PreferencesProvider extends React.Component<Props, State> {
   _setRecentFiles(data: FileMetadata) {
     const { values } = this.state;
     if (values.recentFiles.length > 5) values.recentFiles.pop();
-    if(!values.recentFiles.some(item => item.fileIdentifier === data.fileIdentifier)) {
-      this.setState({
-    values: {
-      ...values,
-      recentFiles: [
-        data,
-        ...values.recentFiles,
-      ]
-    }
-  },
-  () => this._persistValuesToLocalStorage(this.state)
-  );
+    if (
+      !values.recentFiles.some(
+        item => item.fileIdentifier === data.fileIdentifier
+      )
+    ) {
+      this.setState(
+        {
+          values: {
+            ...values,
+            recentFiles: [data, ...values.recentFiles],
+          },
+        },
+        () => this._persistValuesToLocalStorage(this.state)
+      );
     }
   }
 

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -330,7 +330,7 @@ export default class PreferencesProvider extends React.Component<Props, State> {
 
   _setRecentFiles(data: FileMetadata) {
     const { values } = this.state;
-    if (values.recentFiles.length > 5) values.recentFiles.pop();
+    if (values.recentFiles.length >= 5) values.recentFiles.pop();
     if (
       !values.recentFiles.some(
         item => item.fileIdentifier === data.fileIdentifier

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -6,6 +6,7 @@ import PreferencesContext, {
   type Preferences,
   type AlertMessageIdentifier,
 } from './PreferencesContext';
+import { type FileMetadata } from '../../ProjectsStorage';
 import optionalRequire from '../../Utils/OptionalRequire';
 import { getIDEVersion } from '../../Version';
 import type { PreferencesValues } from './PreferencesContext';
@@ -47,6 +48,8 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     setShowEffectParameterNames: this._setShowEffectParameterNames.bind(this),
     getLastUsedPath: this._getLastUsedPath.bind(this),
     setLastUsedPath: this._setLastUsedPath.bind(this),
+    getRecentFiles: this._getRecentFiles.bind(this),
+    setRecentFiles: this._setRecentFiles.bind(this),
   };
 
   componentDidMount() {
@@ -315,6 +318,33 @@ export default class PreferencesProvider extends React.Component<Props, State> {
       },
       () => this._persistValuesToLocalStorage(this.state)
     );
+  }
+
+  _getRecentFiles() {
+    const { values } = this.state;
+    const recentFiles = values.recentFiles
+    if(values.recentFiles) {
+      return values.recentFiles;
+    }
+    return null;
+  }
+
+  _setRecentFiles(data: FileMetadata) {
+    const { values } = this.state;
+    if (values.recentFiles.length > 5) values.recentFiles.pop();
+    if(!values.recentFiles.some(item => item.fileIdentifier === data.fileIdentifier)) {
+      this.setState({
+    values: {
+      ...values,
+      recentFiles: [
+        data,
+        ...values.recentFiles,
+      ]
+    }
+  },
+  () => this._persistValuesToLocalStorage(this.state)
+  );
+    }
   }
 
   render() {

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -231,7 +231,6 @@ class MainFrame extends React.Component<Props, State> {
     console.info('Startup times:', getStartupTimesSummary());
   }
 
-
   _openInitialFileMetadata = (isAfterUserInteraction: boolean) => {
     const { storageProviderOperations, initialFileMetadataToOpen } = this.props;
 
@@ -1411,7 +1410,7 @@ class MainFrame extends React.Component<Props, State> {
 
         return this.openFromFileMetadata(fileMetadata).then(() => {
           this.openSceneOrProjectManager();
-          this.context.setRecentFiles(fileMetadata);
+          this.context.addRecentFile(fileMetadata);
         });
       })
       .catch(error => {

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -231,11 +231,6 @@ class MainFrame extends React.Component<Props, State> {
     console.info('Startup times:', getStartupTimesSummary());
   }
 
-  componentDidUpdate() {
-    const { setRecentFiles } = this.context;
-    if (this.state.currentFileMetadata)
-      setRecentFiles(this.state.currentFileMetadata);
-  }
 
   _openInitialFileMetadata = (isAfterUserInteraction: boolean) => {
     const { storageProviderOperations, initialFileMetadataToOpen } = this.props;
@@ -1416,6 +1411,7 @@ class MainFrame extends React.Component<Props, State> {
 
         return this.openFromFileMetadata(fileMetadata).then(() => {
           this.openSceneOrProjectManager();
+          this.context.setRecentFiles(fileMetadata);
         });
       })
       .catch(error => {

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -232,8 +232,9 @@ class MainFrame extends React.Component<Props, State> {
   }
 
   componentDidUpdate() {
-    const { setRecentFiles, values } = this.context;
-    if (this.state.currentFileMetadata) setRecentFiles(this.state.currentFileMetadata);
+    const { setRecentFiles } = this.context;
+    if (this.state.currentFileMetadata)
+      setRecentFiles(this.state.currentFileMetadata);
   }
 
   _openInitialFileMetadata = (isAfterUserInteraction: boolean) => {

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1408,9 +1408,20 @@ class MainFrame extends React.Component<Props, State> {
       .then(fileMetadata => {
         if (!fileMetadata) return;
 
-        return this.openFromFileMetadata(fileMetadata).then(() =>
-          this.openSceneOrProjectManager()
-        );
+        return this.openFromFileMetadata(fileMetadata).then(() => {
+          this.openSceneOrProjectManager();
+          const recentFiles = localStorage.getItem('gd-recent-files');
+          if (recentFiles) {
+            const parsedData = JSON.parse(recentFiles);
+            parsedData.push(fileMetadata.fileIdentifier);
+            localStorage.setItem('gd-recent-files', JSON.stringify(parsedData));
+          } else {
+            localStorage.setItem(
+              'gd-recent-files',
+              JSON.stringify([fileMetadata.fileIdentifier])
+            );
+          }
+        });
       })
       .catch(error => {
         const errorMessage = storageProviderOperations.getOpenErrorMessage

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -231,6 +231,11 @@ class MainFrame extends React.Component<Props, State> {
     console.info('Startup times:', getStartupTimesSummary());
   }
 
+  componentDidUpdate() {
+    const { setRecentFiles, values } = this.context;
+    if (this.state.currentFileMetadata) setRecentFiles(this.state.currentFileMetadata);
+  }
+
   _openInitialFileMetadata = (isAfterUserInteraction: boolean) => {
     const { storageProviderOperations, initialFileMetadataToOpen } = this.props;
 
@@ -1410,17 +1415,6 @@ class MainFrame extends React.Component<Props, State> {
 
         return this.openFromFileMetadata(fileMetadata).then(() => {
           this.openSceneOrProjectManager();
-          const recentFiles = localStorage.getItem('gd-recent-files');
-          if (recentFiles) {
-            const parsedData = JSON.parse(recentFiles);
-            parsedData.push(fileMetadata.fileIdentifier);
-            localStorage.setItem('gd-recent-files', JSON.stringify(parsedData));
-          } else {
-            localStorage.setItem(
-              'gd-recent-files',
-              JSON.stringify([fileMetadata.fileIdentifier])
-            );
-          }
         });
       })
       .catch(error => {
@@ -2076,5 +2070,5 @@ class MainFrame extends React.Component<Props, State> {
     );
   }
 }
-
+MainFrame.contextType = PreferencesContext;
 export default MainFrame;

--- a/newIDE/electron-app/app/MainMenu.js
+++ b/newIDE/electron-app/app/MainMenu.js
@@ -16,13 +16,15 @@ const buildMainMenuFor = (window, mainMenuTemplate) => {
     menuTemplate.map(menuItemTemplate => {
       const hasOnClick =
         menuItemTemplate.onClickSendEvent || menuItemTemplate.onClickOpenLink;
+      const argument = menuItemTemplate.argument;
 
       return {
         ...menuItemTemplate,
         click: hasOnClick
           ? function() {
               if (menuItemTemplate.onClickSendEvent) {
-                window.webContents.send(menuItemTemplate.onClickSendEvent);
+                if (argument) window.webContents.send(menuItemTemplate.onClickSendEvent, argument);
+                else window.webContents.send(menuItemTemplate.onClickSendEvent);
               }
 
               if (menuItemTemplate.onClickOpenLink) {


### PR DESCRIPTION
Resolves #1356

@4ian I don't know if I'm doing this the proper way or not, so I'd need some guidance :)

So far I've implemented Open Recents menu and used an ipcRenderer event to open the selected project.

![Screenshot from 2020-03-26 00 15 11](https://user-images.githubusercontent.com/39851078/77573879-575e5980-6ef7-11ea-8504-d33a2062790b.png)

Also, I work on Linux, so I'm not sure whether this would work for Windows and macOS or not. I believe macOS has built-in support for recent documents by electron (ie, there is a `role`, namely `recentDocuments` for macOS).

Edit: I know @blurymind mentioned something entirely different in that issue, I guess we can reach that state when GD opens with the exact UI state, but let's start with these small steps :)