### PR TITLE
Add missing shortcut indicator for zoom in

### DIFF
--- a/newIDE/app/src/SceneEditor/Toolbar.js
+++ b/newIDE/app/src/SceneEditor/Toolbar.js
@@ -140,7 +140,7 @@ export class Toolbar extends PureComponent<Props> {
             {
               label: 'Zoom in',
               click: this.props.zoomIn,
-              accelerator: 'CmdOrCtrl++',
+              accelerator: 'CmdOrCtrl+Plus',
             },
             {
               label: 'Zoom out',


### PR DESCRIPTION
Tries to fix #1592 
The fix seems to work fine in Mac. I haven't tested it in other platforms. @4ian Can you please review this?

![Screenshot 2020-03-27 at 5 42 10 PM](https://user-images.githubusercontent.com/42793024/77754944-4e35cf80-7052-11ea-8a0c-0fd44df263e9.png)
