### PR TITLE
Edit readme gdevelop.js

### DIFF
--- a/GDevelop.js/Readme.md
+++ b/GDevelop.js/Readme.md
@@ -8,7 +8,7 @@ This is the port of GDevelop core classes to JavaScript. This allow [GDevelop Co
 
 > 👋 Usually if you're working on GDevelop editor or extensions in JavaScript, you don't need rebuilding GDevelop.js. If you want to make changes in C++ extensions or classes, read this section.
 
-- Make sure you have [CMake 3.17+](http://www.cmake.org/) and [Node.js](nodejs.org/) installed.
+- Make sure you have [CMake 3.17+](http://www.cmake.org/) (3.5+ should work on Linux/macOS) and [Node.js](nodejs.org/) installed.
 
 - Install [Emscripten](https://github.com/kripken/emscripten), as explained on the [Emscripten installation instructions](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html):
 
@@ -57,10 +57,7 @@ The npm _build_ task:
 - Creates `Binaries/embuild` directory,
 - Launches CMake inside to compile GDevelop with _emconfigure_ to use Emscripten toolchain,
 - Updates the glue.cpp and glue.js from Bindings.idl using _Emscripten WebIDL Binder_,
-- Launches the compilation with `make` (or `ninja` on Windows with CMake 3.17+).
-
-You can also compile using MinGW-32 using `npm run build-with-MinGW`
-
+- Launches the compilation with `make` (or `ninja` on Windows with CMake 3.17+) (you can also compile using MinGW-32 using `npm run build-with-MinGW`).
 
 See the [CMakeLists.txt](./CMakeLists.txt) for the arguments passed to the Emscripten linker.
 

--- a/GDevelop.js/Readme.md
+++ b/GDevelop.js/Readme.md
@@ -8,7 +8,7 @@ This is the port of GDevelop core classes to JavaScript. This allow [GDevelop Co
 
 > 👋 Usually if you're working on GDevelop editor or extensions in JavaScript, you don't need rebuilding GDevelop.js. If you want to make changes in C++ extensions or classes, read this section.
 
-- Make sure you have [CMake 3.5+](http://www.cmake.org/) and [Node.js](nodejs.org/) installed.
+- Make sure you have [CMake 3.17+](http://www.cmake.org/) and [Node.js](nodejs.org/) installed.
 
 - Install [Emscripten](https://github.com/kripken/emscripten), as explained on the [Emscripten installation instructions](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html):
 
@@ -57,7 +57,10 @@ The npm _build_ task:
 - Creates `Binaries/embuild` directory,
 - Launches CMake inside to compile GDevelop with _emconfigure_ to use Emscripten toolchain,
 - Updates the glue.cpp and glue.js from Bindings.idl using _Emscripten WebIDL Binder_,
-- Launches the compilation with `make` (or `ninja` on Windows).
+- Launches the compilation with `make` (or `ninja` on Windows with CMake 3.17+).
+
+You can also compile using MinGW-32 using `npm run build-with-MinGW`
+
 
 See the [CMakeLists.txt](./CMakeLists.txt) for the arguments passed to the Emscripten linker.
 


### PR DESCRIPTION
A user from Ninja repo [told me to go on CMake 3.17](https://github.com/ninja-build/ninja/issues/1757) (lastest), and it's works!
I can compile Core, build GD and open it and export games like before :)

Then here new PR for update the readme of Gdevelop.js with lastest informations.

Add table for ninja (Cmake 3.5+) / MinGW32-make (CMake 3.17+)