### PR TITLE
Add Prettier to electron-app

### DIFF
--- a/newIDE/electron-app/.prettierrc
+++ b/newIDE/electron-app/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/newIDE/electron-app/app/MainMenu.js
+++ b/newIDE/electron-app/app/MainMenu.js
@@ -1,6 +1,6 @@
-const electron = require("electron");
+const electron = require('electron');
 const { app, Menu, ipcMain } = electron;
-const package = require("./package.json");
+const package = require('./package.json');
 
 /**
  * Create the editor main menu. Menu items that requires interaction
@@ -32,14 +32,14 @@ const buildMainMenuFor = (window, mainMenuTemplate) => {
           : undefined,
         submenu: menuItemTemplate.submenu
           ? adaptMenuTemplate(menuItemTemplate.submenu)
-          : undefined
+          : undefined,
       };
     });
 
   return Menu.buildFromTemplate(
     mainMenuTemplate.map(rootMenuTemplate => ({
       ...rootMenuTemplate,
-      submenu: adaptMenuTemplate(rootMenuTemplate.submenu)
+      submenu: adaptMenuTemplate(rootMenuTemplate.submenu),
     }))
   );
 };
@@ -50,33 +50,33 @@ const buildMainMenuFor = (window, mainMenuTemplate) => {
  */
 const buildPlaceholderMainMenu = () => {
   const placeholderMenuItem = {
-    label: "GDevelop is loading...",
-    enabled: false
+    label: 'GDevelop is loading...',
+    enabled: false,
   };
 
   const fileTemplate = {
-    label: "File",
-    submenu: [placeholderMenuItem]
+    label: 'File',
+    submenu: [placeholderMenuItem],
   };
 
   const editTemplate = {
-    label: "Edit",
-    submenu: [placeholderMenuItem]
+    label: 'Edit',
+    submenu: [placeholderMenuItem],
   };
 
   const viewTemplate = {
-    label: "View",
-    submenu: [placeholderMenuItem]
+    label: 'View',
+    submenu: [placeholderMenuItem],
   };
 
   const windowTemplate = {
-    role: "window",
-    submenu: [{ role: "minimize" }]
+    role: 'window',
+    submenu: [{ role: 'minimize' }],
   };
 
   const helpTemplate = {
-    role: "help",
-    submenu: [placeholderMenuItem]
+    role: 'help',
+    submenu: [placeholderMenuItem],
   };
 
   const template = [
@@ -84,20 +84,20 @@ const buildPlaceholderMainMenu = () => {
     editTemplate,
     viewTemplate,
     windowTemplate,
-    helpTemplate
+    helpTemplate,
   ];
 
-  if (process.platform === "darwin") {
+  if (process.platform === 'darwin') {
     template.unshift({
-      label: "GDevelop 5",
-      submenu: [placeholderMenuItem]
+      label: 'GDevelop 5',
+      submenu: [placeholderMenuItem],
     });
 
     windowTemplate.submenu = [
-      { role: "minimize" },
-      { role: "zoom" },
-      { type: "separator" },
-      { role: "front" }
+      { role: 'minimize' },
+      { role: 'zoom' },
+      { type: 'separator' },
+      { role: 'front' },
     ];
   }
 

--- a/newIDE/electron-app/app/ModalWindow.js
+++ b/newIDE/electron-app/app/ModalWindow.js
@@ -1,10 +1,8 @@
-const electron = require("electron");
+const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow; // Module to create native browser window.
-const isDev = require("electron-is").dev();
+const isDev = require('electron-is').dev();
 const ipcMain = electron.ipcMain;
-const {
-  load
-} = require('./Utils/UrlLoader');
+const { load } = require('./Utils/UrlLoader');
 
 // Generic function to load external editors in a modal window.
 // Keep a global reference of the window object, if you don't, the window will
@@ -23,10 +21,9 @@ const loadModalWindow = ({
   indexSubPath,
   relativeWidth = 0.7,
   relativeHeight = 0.9,
-  backgroundColor = "white",
+  backgroundColor = 'white',
   show = false,
 }) => {
-
   if (modalWindow) {
     modalWindow.show();
     onReady(modalWindow);
@@ -40,8 +37,8 @@ const loadModalWindow = ({
     modal: true,
     center: true,
     webPreferences: {
-      webSecurity: false
-    }
+      webSecurity: false,
+    },
   };
 
   modalWindow = new BrowserWindow(windowOptions);
@@ -56,31 +53,31 @@ const loadModalWindow = ({
   load({
     window: modalWindow,
     isDev,
-    path: "/external/" + indexSubPath,
-    devTools
+    path: '/external/' + indexSubPath,
+    devTools,
   });
 
   //Prevent any navigation inside the modal window.
-  modalWindow.webContents.on("will-navigate", (e, url) => {
+  modalWindow.webContents.on('will-navigate', (e, url) => {
     if (url !== modalWindow.webContents.getURL()) {
-      console.info("Opening in browser (because of will-navigate):", url);
+      console.info('Opening in browser (because of will-navigate):', url);
       e.preventDefault();
       electron.shell.openExternal(url);
     }
   });
 
   //Prevent opening any website or url inside Electron.
-  modalWindow.webContents.on("new-window", (e, url) => {
-    console.info("Opening in browser (because of new-window): ", url);
+  modalWindow.webContents.on('new-window', (e, url) => {
+    console.info('Opening in browser (because of new-window): ', url);
     e.preventDefault();
     electron.shell.openExternal(url);
   });
 
-  modalWindow.on("closed", event => {
+  modalWindow.on('closed', event => {
     modalWindow = null;
   });
 
-  modalWindow.on("close", event => {
+  modalWindow.on('close', event => {
     // use destroy as a wordaround to force window closing, which is not done properly otherwise on Windows
     modalWindow.destroy();
     modalWindow = null;
@@ -88,5 +85,5 @@ const loadModalWindow = ({
 };
 
 module.exports = {
-  loadModalWindow
+  loadModalWindow,
 };

--- a/newIDE/electron-app/app/ServeFolder.js
+++ b/newIDE/electron-app/app/ServeFolder.js
@@ -29,24 +29,26 @@ module.exports = {
    * Start a server to serve a folder
    */
   serveFolder: ({ root, useHttps }, onDone) => {
-    if (currentServerParams && currentServerParams.root === root)
-    {
+    if (currentServerParams && currentServerParams.root === root) {
       onDone(null, currentServerParams);
       return;
     }
 
     liveServer.shutdown();
-    getAvailablePort(2929).then(port => {
-      currentServerParams = {
-        port,
-        root,
-        open: false,
-        wait: 1000,
-        https: useHttps ? httpsConfiguration : undefined,
-      };
-      liveServer.start(currentServerParams);
-      onDone(null, currentServerParams);
-    }, err => onDone(err));
+    getAvailablePort(2929).then(
+      port => {
+        currentServerParams = {
+          port,
+          root,
+          open: false,
+          wait: 1000,
+          https: useHttps ? httpsConfiguration : undefined,
+        };
+        liveServer.start(currentServerParams);
+        onDone(null, currentServerParams);
+      },
+      err => onDone(err)
+    );
   },
 
   /**

--- a/newIDE/electron-app/app/Utils/DevServerHttpsConfiguration.js
+++ b/newIDE/electron-app/app/Utils/DevServerHttpsConfiguration.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var fs = require('fs');
 
 // This is a certificate generated from the private key below,
 // with passphrase 12345.
@@ -55,5 +55,5 @@ sqczMCnO4bcMHH0Oasnedk1KMALpeg+B6X+ClAr+9NvAmMPztkptVF+zyVjGBv3k
 module.exports = {
   cert: cert,
   key: key,
-  passphrase: "12345"
+  passphrase: '12345',
 };

--- a/newIDE/electron-app/app/Utils/UrlLoader.js
+++ b/newIDE/electron-app/app/Utils/UrlLoader.js
@@ -1,9 +1,9 @@
-const { protocol } = require("electron");
-const fs = require("fs");
-const path = require("path");
+const { protocol } = require('electron');
+const fs = require('fs');
+const path = require('path');
 
-const developmentServerBaseUrl = "http://localhost:3000";
-const appPublicFolderBaseUrl = path.join(__dirname + "/../www");
+const developmentServerBaseUrl = 'http://localhost:3000';
+const appPublicFolderBaseUrl = path.join(__dirname + '/../www');
 
 /**
  * Load the given path, relative to the app public folder.
@@ -15,7 +15,7 @@ const load = ({ isDev, devTools, path, window }) => {
     window.openDevTools();
   } else {
     // Production (with npm run build)
-    window.loadURL("file://" + appPublicFolderBaseUrl + path);
+    window.loadURL('file://' + appPublicFolderBaseUrl + path);
     if (devTools) window.openDevTools();
   }
 };
@@ -27,38 +27,38 @@ const load = ({ isDev, devTools, path, window }) => {
 const registerGdideProtocol = ({ isDev }) => {
   if (isDev) {
     protocol.registerHttpProtocol(
-      "gdide",
+      'gdide',
       (request, callback) => {
         callback({
           method: request.method,
           referrer: request.referrer,
-          url: request.url.replace("gdide://", developmentServerBaseUrl + "/")
+          url: request.url.replace('gdide://', developmentServerBaseUrl + '/'),
         });
       },
       error => {
         if (error) {
-          console.error("Error while registering gdide protocol:", error);
+          console.error('Error while registering gdide protocol:', error);
         }
       }
     );
   } else {
     // Production (with npm run build)
     protocol.registerBufferProtocol(
-      "gdide",
+      'gdide',
       (request, callback) => {
         fs.readFile(
-          request.url.replace("gdide://", appPublicFolderBaseUrl + "/"),
+          request.url.replace('gdide://', appPublicFolderBaseUrl + '/'),
           (error, buffer) => {
             if (error) {
-              console.error("While while loading " + request.url, error);
+              console.error('While while loading ' + request.url, error);
             }
-            callback({ mimeType: "text/javascript", data: buffer });
+            callback({ mimeType: 'text/javascript', data: buffer });
           }
         );
       },
       error => {
         if (error) {
-          console.error("Error while registering gdide protocol:", error);
+          console.error('Error while registering gdide protocol:', error);
         }
       }
     );
@@ -67,5 +67,5 @@ const registerGdideProtocol = ({ isDev }) => {
 
 module.exports = {
   load,
-  registerGdideProtocol
+  registerGdideProtocol,
 };

--- a/newIDE/electron-app/app/package-lock.json
+++ b/newIDE/electron-app/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gdevelop",
-  "version": "5.0.0-beta88",
+  "version": "5.0.0-beta89",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/newIDE/electron-app/package-lock.json
+++ b/newIDE/electron-app/package-lock.json
@@ -2168,6 +2168,12 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",

--- a/newIDE/electron-app/package.json
+++ b/newIDE/electron-app/package.json
@@ -12,6 +12,7 @@
     "postinstall": "npm run import-zipped-electron-extensions && cd app && npm install",
     "app-build": "node scripts/app-build.js",
     "build": "node scripts/build.js",
+    "format": "prettier --write --ignore-path .gitignore \"**/*.js\"",
     "electron-win": "node node_modules/electron/cli.js app",
     "electron-linux": "./node_modules/electron/dist/electron app",
     "electron-mac": "./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron app",
@@ -48,6 +49,7 @@
     "electron-builder": "20.44.4",
     "electron-notarize": "^0.2.1",
     "minimist": "^1.2.0",
+    "prettier": "1.15.3",
     "shelljs": "^0.7.7",
     "unzipper": "^0.9.11"
   },

--- a/newIDE/electron-app/package.json
+++ b/newIDE/electron-app/package.json
@@ -13,6 +13,7 @@
     "app-build": "node scripts/app-build.js",
     "build": "node scripts/build.js",
     "format": "prettier --write --ignore-path .gitignore \"**/*.js\"",
+    "check-format": "prettier --list-different --ignore-path .gitignore \"**/*.js\"",
     "electron-win": "node node_modules/electron/cli.js app",
     "electron-linux": "./node_modules/electron/dist/electron app",
     "electron-mac": "./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron app",

--- a/newIDE/electron-app/scripts/build.js
+++ b/newIDE/electron-app/scripts/build.js
@@ -16,7 +16,9 @@ if (!args['skip-app-build']) {
 }
 
 const electronBuilder = path.join('node_modules', '.bin', 'electron-builder');
-let electronBuilderArguments = process.argv.slice(2).filter(arg => arg !== '--skip-app-build');
+let electronBuilderArguments = process.argv
+  .slice(2)
+  .filter(arg => arg !== '--skip-app-build');
 shell.exec(
   [electronBuilder, electronBuilderArguments.join(' ')].join(' '),
   code => {

--- a/newIDE/electron-app/scripts/import-zipped-electron-extension.js
+++ b/newIDE/electron-app/scripts/import-zipped-electron-extension.js
@@ -2,7 +2,7 @@
  * This script will extract a zipped file of a prebuilt Electron extension.
  * The zip file must contain the raw, unchanged sources, which will be extracted
  * to the folder passed as parameter, in a subfolder with the extension name.
- * 
+ *
  * This is useful to avoid mixing the Electron extension source files inside
  * GDevelop sources.
  */
@@ -25,21 +25,11 @@ try {
       })
     )
     .on('close', function() {
-      shell.echo(
-        '✅ Extracted ' +
-          zipFilePath +
-          ' to ' +
-          basePath +
-          ' folder'
-      );
+      shell.echo('✅ Extracted ' + zipFilePath + ' to ' + basePath + ' folder');
     });
 } catch (e) {
   shell.echo(
-    '❌ Error while extracting ' +
-      zipFilePath +
-      ' to ' +
-      basePath +
-      ' folder:',
+    '❌ Error while extracting ' + zipFilePath + ' to ' + basePath + ' folder:',
     e.message
   );
 }

--- a/newIDE/electron-app/yarn.lock
+++ b/newIDE/electron-app/yarn.lock
@@ -1532,6 +1532,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
+  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
+
 pretty-bytes@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"


### PR DESCRIPTION
Added Prettier to `electron-app`, and applied formatting.

@4ian Just a few things to clarify:
- The file glob is just a `**/*.js` wildcard, excluding directories in`.gitignore`. Is that okay?
-  I noticed that updating dependencies seems to increment the version in `electron-app/app/package-lock.json` to `5.0.0-beta89`. Is it intended?