### PR TITLE
Add scene dialog boxes to Project Manager

### DIFF
--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -39,9 +39,9 @@ import AddToHomeScreen from '@material-ui/icons/AddToHomeScreen';
 import Fullscreen from '@material-ui/icons/Fullscreen';
 import FileCopy from '@material-ui/icons/FileCopy';
 import AccountCircle from '@material-ui/icons/AccountCircle';
-import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 import ScenePropertiesDialog from '../SceneEditor/ScenePropertiesDialog';
 import SceneVariablesDialog from '../SceneEditor/SceneVariablesDialog';
+import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 
 const LAYOUT_CLIPBOARD_KIND = 'Layout';
 const EXTERNAL_LAYOUT_CLIPBOARD_KIND = 'External layout';

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -155,64 +155,6 @@ class Item extends React.Component<ItemProps, {||}> {
     }
   }
 
-  _buildMenuTemplate = () => {
-    const menuTemplate = [
-      {
-        label: 'Edit',
-        click: () => this.props.onEdit(),
-      },
-      {
-        label: 'Rename',
-        click: () => this.props.onEditName(),
-      },
-      {
-        label: 'Delete',
-        click: () => this.props.onDelete(),
-      },
-      {
-        label: this.props.addLabel,
-        visible: !!this.props.onAdd,
-        click: () => this.props.onAdd(),
-      },
-      { type: 'separator' },
-      {
-        label: 'Copy',
-        click: () => this.props.onCopy(),
-      },
-      {
-        label: 'Cut',
-        click: () => this.props.onCut(),
-      },
-      {
-        label: 'Paste',
-        enabled: this.props.canPaste(),
-        click: () => this.props.onPaste(),
-      },
-      {
-        label: 'Duplicate',
-        click: () => this.props.onDuplicate(),
-      },
-      { type: 'separator' },
-      {
-        label: 'Move up',
-        enabled: this.props.canMoveUp,
-        click: () => this.props.onMoveUp(),
-      },
-      {
-        label: 'Move down',
-        enabled: this.props.canMoveDown,
-        click: () => this.props.onMoveDown(),
-      },
-    ];
-
-    // Append the extra menu options (if provided) to base menu
-    const addedMenu = this.props.extraMenuOptions;
-    if (addedMenu && addedMenu.length !== 0) {
-      menuTemplate.push({ type: 'separator' }, ...addedMenu);
-    }
-    return menuTemplate;
-  };
-
   render() {
     const label = this.props.editingName ? (
       <TextField
@@ -244,7 +186,63 @@ class Item extends React.Component<ItemProps, {||}> {
             }}
             primaryText={label}
             displayMenuButton
-            buildMenuTemplate={this._buildMenuTemplate}
+            buildMenuTemplate={() => {
+              const menuTemplate = [
+                {
+                  label: 'Edit',
+                  click: () => this.props.onEdit(),
+                },
+                {
+                  label: 'Rename',
+                  click: () => this.props.onEditName(),
+                },
+                {
+                  label: 'Delete',
+                  click: () => this.props.onDelete(),
+                },
+                {
+                  label: this.props.addLabel,
+                  visible: !!this.props.onAdd,
+                  click: () => this.props.onAdd(),
+                },
+                { type: 'separator' },
+                {
+                  label: 'Copy',
+                  click: () => this.props.onCopy(),
+                },
+                {
+                  label: 'Cut',
+                  click: () => this.props.onCut(),
+                },
+                {
+                  label: 'Paste',
+                  enabled: this.props.canPaste(),
+                  click: () => this.props.onPaste(),
+                },
+                {
+                  label: 'Duplicate',
+                  click: () => this.props.onDuplicate(),
+                },
+                { type: 'separator' },
+                {
+                  label: 'Move up',
+                  enabled: this.props.canMoveUp,
+                  click: () => this.props.onMoveUp(),
+                },
+                {
+                  label: 'Move down',
+                  enabled: this.props.canMoveDown,
+                  click: () => this.props.onMoveDown(),
+                },
+              ];
+
+              // Append the extra menu options (if provided) to base menu
+              const addedMenu = this.props.extraMenuOptions;
+              if (addedMenu && addedMenu.length !== 0) {
+                menuTemplate.push({ type: 'separator' }, ...addedMenu);
+              }
+              return menuTemplate;
+            }}
             onClick={() => {
               // It's essential to discard clicks when editing the name,
               // to avoid weird opening of an editor (accompanied with a

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -155,27 +155,7 @@ class Item extends React.Component<ItemProps, {||}> {
     }
   }
 
-  render() {
-    const label = this.props.editingName ? (
-      <TextField
-        id="rename-item-field"
-        margin="none"
-        ref={textField => (this.textField = textField)}
-        defaultValue={this.props.primaryText}
-        onBlur={e => this.props.onRename(e.currentTarget.value)}
-        onKeyPress={event => {
-          if (event.charCode === 13) {
-            // enter key pressed
-            if (this.textField) this.textField.blur();
-          }
-        }}
-        fullWidth
-        style={styles.itemTextField}
-      />
-    ) : (
-      <div style={styles.itemName}>{this.props.primaryText}</div>
-    );
-
+  _buildMenuTemplate = () => {
     const menuTemplate = [
       {
         label: 'Edit',
@@ -230,6 +210,29 @@ class Item extends React.Component<ItemProps, {||}> {
     if (addedMenu && addedMenu.length !== 0) {
       menuTemplate.push({ type: 'separator' }, ...addedMenu);
     }
+    return menuTemplate;
+  };
+
+  render() {
+    const label = this.props.editingName ? (
+      <TextField
+        id="rename-item-field"
+        margin="none"
+        ref={textField => (this.textField = textField)}
+        defaultValue={this.props.primaryText}
+        onBlur={e => this.props.onRename(e.currentTarget.value)}
+        onKeyPress={event => {
+          if (event.charCode === 13) {
+            // enter key pressed
+            if (this.textField) this.textField.blur();
+          }
+        }}
+        fullWidth
+        style={styles.itemTextField}
+      />
+    ) : (
+      <div style={styles.itemName}>{this.props.primaryText}</div>
+    );
 
     return (
       <ThemeConsumer>
@@ -241,7 +244,7 @@ class Item extends React.Component<ItemProps, {||}> {
             }}
             primaryText={label}
             displayMenuButton
-            buildMenuTemplate={() => menuTemplate}
+            buildMenuTemplate={this._buildMenuTemplate}
             onClick={() => {
               // It's essential to discard clicks when editing the name,
               // to avoid weird opening of an editor (accompanied with a

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -201,7 +201,8 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
             label={<Trans>Open advanced settings</Trans>}
             fullWidth
             onClick={() => {
-              this.props.onOpenMoreSettings && this.props.onOpenMoreSettings();
+              if (this.props.onOpenMoreSettings)
+                this.props.onOpenMoreSettings();
               this.props.onClose();
             }}
           />

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -19,7 +19,7 @@ type Props = {|
   open: boolean,
   layout: gdLayout,
   project: gdProject,
-  onApply?: () => void,
+  onApply: () => void,
   onClose: () => void,
   onOpenMoreSettings?: () => void,
   onEditVariables: () => void,
@@ -74,7 +74,7 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
       this.state.backgroundColor.g,
       this.state.backgroundColor.b
     );
-    if (this.props.onApply) this.props.onApply();
+    this.props.onApply();
   };
 
   render() {

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -21,7 +21,7 @@ type Props = {|
   project: gdProject,
   onApply?: () => void,
   onClose: () => void,
-  onOpenMoreSettings: () => void,
+  onOpenMoreSettings?: () => void,
   onEditVariables: () => void,
 |};
 
@@ -201,7 +201,7 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
             label={<Trans>Open advanced settings</Trans>}
             fullWidth
             onClick={() => {
-              this.props.onOpenMoreSettings();
+              this.props.onOpenMoreSettings && this.props.onOpenMoreSettings();
               this.props.onClose();
             }}
           />

--- a/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
+++ b/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
@@ -6,7 +6,7 @@ import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
 type Props = {|
   open: boolean,
   layout: gdLayout,
-  onApply?: () => void,
+  onApply: () => void,
   onClose: () => void,
 |};
 

--- a/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
+++ b/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
@@ -10,28 +10,26 @@ type Props = {|
   onClose: () => void,
 |};
 
-export default class SceneVariablesDialog extends React.Component<Props, {||}> {
-  render() {
-    return (
-      <VariablesEditorDialog
-        open={this.props.open}
-        variablesContainer={this.props.layout.getVariables()}
-        onCancel={this.props.onClose}
-        onApply={this.props.onApply}
-        title={<Trans>Scene Variables</Trans>}
-        emptyExplanationMessage={
-          <Trans>
-            Scene variables can be used to store any value or text during the
-            game.
-          </Trans>
-        }
-        emptyExplanationSecondMessage={
-          <Trans>
-            For example, you can have a variable called Score representing the
-            current score of the player.
-          </Trans>
-        }
-      />
-    );
-  }
-}
+export default (props: Props) => {
+  return (
+    <VariablesEditorDialog
+      open={props.open}
+      variablesContainer={props.layout.getVariables()}
+      onCancel={props.onClose}
+      onApply={props.onApply}
+      title={<Trans>Scene Variables</Trans>}
+      emptyExplanationMessage={
+        <Trans>
+          Scene variables can be used to store any value or text during the
+          game.
+        </Trans>
+      }
+      emptyExplanationSecondMessage={
+        <Trans>
+          For example, you can have a variable called Score representing the
+          current score of the player.
+        </Trans>
+      }
+    />
+  );
+};

--- a/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
+++ b/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react';
+import { Trans } from '@lingui/macro';
+import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
+
+type Props = {|
+  open: boolean,
+  layout: gdLayout,
+  onApply?: () => void,
+  onClose: () => void,
+|};
+
+export default class SceneVariablesDialog extends React.Component<Props, {||}> {
+  render() {
+    return (
+      <VariablesEditorDialog
+        open={this.props.open}
+        variablesContainer={this.props.layout.getVariables()}
+        onCancel={this.props.onClose}
+        onApply={this.props.onApply}
+        title={<Trans>Scene Variables</Trans>}
+        emptyExplanationMessage={
+          <Trans>
+            Scene variables can be used to store any value or text during the
+            game.
+          </Trans>
+        }
+        emptyExplanationSecondMessage={
+          <Trans>
+            For example, you can have a variable called Score representing the
+            current score of the player.
+          </Trans>
+        }
+      />
+    );
+  }
+}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -69,7 +69,7 @@ import { ScreenTypeMeasurer } from '../UI/Reponsive/ScreenTypeMeasurer';
 import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 import { type PreviewButtonSettings } from '../MainFrame/Toolbar/PreviewButtons';
-
+import SceneVariablesDialog from './SceneVariablesDialog';
 const gd = global.gd;
 
 const INSTANCES_CLIPBOARD_KIND = 'Instances';
@@ -1249,24 +1249,11 @@ export default class SceneEditor extends React.Component<Props, State> {
           />
         )}
         {!!this.state.layoutVariablesDialogOpen && (
-          <VariablesEditorDialog
+          <SceneVariablesDialog
             open
-            variablesContainer={layout.getVariables()}
-            onCancel={() => this.editLayoutVariables(false)}
+            layout={layout}
             onApply={() => this.editLayoutVariables(false)}
-            title={<Trans>Scene Variables</Trans>}
-            emptyExplanationMessage={
-              <Trans>
-                Scene variables can be used to store any value or text during
-                the game.
-              </Trans>
-            }
-            emptyExplanationSecondMessage={
-              <Trans>
-                For example, you can have a variable called Score representing
-                the current score of the player.
-              </Trans>
-            }
+            onClose={() => this.editLayoutVariables(false)}
           />
         )}
         <ContextMenu


### PR DESCRIPTION
This PR adds the option of opening the dialog boxes for scene properties and scene variables from the Project Manager. Resolves #1505. 
Here's a screenshot:

![scene-in-pm](https://user-images.githubusercontent.com/18032938/78065831-8110f800-73b1-11ea-9a96-8a0033e61dba.png)

- Modified the `Item` component in `ProjectManager/index.js` to take additional context menu options if provided, and append them to the base menu. 
- Had to fix an issue related to Flow - see changes in `ScenePropertiesDialog.js`. 

  Earlier, it took a compulsory prop `onOpenMoreSettings`, which is actually `undefined` when used by the mainframe (rightclicking on scene and opening scene properties) (confirmed from React DevTools).
 
  I'm not sure how Flow allowed that - [`SceneEditorContainer` here](https://github.com/4ian/GDevelop/blob/master/newIDE/app/src/MainFrame/Editors/SceneEditor.js) does not pass `onOpenMoreSettings` to `SceneEditor` at all, for example, and Flow never complained.