### PR TITLE
Disable some menu items if action not possible

### DIFF
--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -57,46 +57,42 @@ export const create = (authentification: Authentification) => {
           }) => (
             <UnsavedChangesContext.Consumer>
               {unsavedChanges => (
-                <ElectronMainMenu i18n={i18n}>
-                  <MainFrame
-                    i18n={i18n}
-                    eventsFunctionsExtensionsState={
-                      eventsFunctionsExtensionsState
-                    }
-                    renderPreviewLauncher={(props, ref) => (
-                      <LocalPreviewLauncher {...props} ref={ref} />
-                    )}
-                    renderExportDialog={props => (
-                      <ExportDialog
-                        {...props}
-                        exporters={getLocalExporters()}
-                      />
-                    )}
-                    renderCreateDialog={props => (
-                      <CreateProjectDialog
-                        {...props}
-                        examplesComponent={LocalExamples}
-                        startersComponent={LocalStarters}
-                      />
-                    )}
-                    renderGDJSDevelopmentWatcher={
-                      isDev ? () => <LocalGDJSDevelopmentWatcher /> : null
-                    }
-                    storageProviders={storageProviders}
-                    useStorageProvider={useStorageProvider}
-                    storageProviderOperations={currentStorageProviderOperations}
-                    resourceSources={localResourceSources}
-                    resourceExternalEditors={localResourceExternalEditors}
-                    extensionsLoader={makeExtensionsLoader({
-                      gd,
-                      objectsEditorService: ObjectsEditorService,
-                      objectsRenderingService: ObjectsRenderingService,
-                      filterExamples: !isDev,
-                    })}
-                    initialFileMetadataToOpen={initialFileMetadataToOpen}
-                    unsavedChanges={unsavedChanges}
-                  />
-                </ElectronMainMenu>
+                <MainFrame
+                  i18n={i18n}
+                  mainMenu={ElectronMainMenu}
+                  eventsFunctionsExtensionsState={
+                    eventsFunctionsExtensionsState
+                  }
+                  renderPreviewLauncher={(props, ref) => (
+                    <LocalPreviewLauncher {...props} ref={ref} />
+                  )}
+                  renderExportDialog={props => (
+                    <ExportDialog {...props} exporters={getLocalExporters()} />
+                  )}
+                  renderCreateDialog={props => (
+                    <CreateProjectDialog
+                      {...props}
+                      examplesComponent={LocalExamples}
+                      startersComponent={LocalStarters}
+                    />
+                  )}
+                  renderGDJSDevelopmentWatcher={
+                    isDev ? () => <LocalGDJSDevelopmentWatcher /> : null
+                  }
+                  storageProviders={storageProviders}
+                  useStorageProvider={useStorageProvider}
+                  storageProviderOperations={currentStorageProviderOperations}
+                  resourceSources={localResourceSources}
+                  resourceExternalEditors={localResourceExternalEditors}
+                  extensionsLoader={makeExtensionsLoader({
+                    gd,
+                    objectsEditorService: ObjectsEditorService,
+                    objectsRenderingService: ObjectsRenderingService,
+                    filterExamples: !isDev,
+                  })}
+                  initialFileMetadataToOpen={initialFileMetadataToOpen}
+                  unsavedChanges={unsavedChanges}
+                />
               )}
             </UnsavedChangesContext.Consumer>
           )}

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -59,7 +59,7 @@ export const create = (authentification: Authentification) => {
               {unsavedChanges => (
                 <MainFrame
                   i18n={i18n}
-                  mainMenu={ElectronMainMenu}
+                  renderMainMenu={props => <ElectronMainMenu {...props} />}
                   eventsFunctionsExtensionsState={
                     eventsFunctionsExtensionsState
                   }

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -1,32 +1,11 @@
 // @flow
 import * as React from 'react';
 import optionalRequire from '../Utils/OptionalRequire';
-import { type I18n as I18nType } from '@lingui/core';
 import { t } from '@lingui/macro';
 import { isMacLike } from '../Utils/Platform';
-import { type UpdateStatus } from './UpdaterTools';
+import { type MainMenuProps } from './MainMenu.flow';
 const electron = optionalRequire('electron');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
-
-type Props = {|
-  i18n: I18nType,
-  project: ?gdProject,
-  onChooseProject: () => void,
-  onSaveProject: () => void,
-  onSaveProjectAs: () => void,
-  onCloseProject: () => Promise<void>,
-  onCloseApp: () => void,
-  onExportProject: (open?: boolean) => void,
-  onCreateProject: (open?: boolean) => void,
-  onOpenProjectManager: (open?: boolean) => void,
-  onOpenStartPage: () => void,
-  onOpenDebugger: () => void,
-  onOpenAbout: (open?: boolean) => void,
-  onOpenPreferences: (open?: boolean) => void,
-  onOpenLanguage: (open?: boolean) => void,
-  onOpenProfile: (open?: boolean) => void,
-  setUpdateStatus: UpdateStatus => void,
-|};
 
 type MainMenuEvent =
   | 'main-menu-open'
@@ -82,7 +61,7 @@ type RootMenuTemplate =
  * Forward events received from Electron main process
  * to the underlying child React component.
  */
-class ElectronMainMenu extends React.Component<Props, {||}> {
+class ElectronMainMenu extends React.Component<MainMenuProps, {||}> {
   _language: ?string;
 
   componentDidMount() {
@@ -137,14 +116,14 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
     this._buildAndSendMenuTemplate();
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: MainMenuProps) {
     if (this.props.i18n.language !== this._language) {
       this._buildAndSendMenuTemplate();
       this._language = this.props.i18n.language;
     }
 
     // Update menu if a project has just been opened or closed
-    if (!!prevProps.project !== !!this.props.project) {
+    if (prevProps.project !== this.props.project) {
       this._buildAndSendMenuTemplate();
     }
   }

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -1,16 +1,31 @@
 // @flow
 import * as React from 'react';
-import MainFrame from '.';
 import optionalRequire from '../Utils/OptionalRequire';
 import { type I18n as I18nType } from '@lingui/core';
 import { t } from '@lingui/macro';
 import { isMacLike } from '../Utils/Platform';
+import { type UpdateStatus } from './UpdaterTools';
 const electron = optionalRequire('electron');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
 
 type Props = {|
-  children: React.Element<typeof MainFrame>,
   i18n: I18nType,
+  project: ?gdProject,
+  onChooseProject: () => void,
+  onSaveProject: () => void,
+  onSaveProjectAs: () => void,
+  onCloseProject: () => Promise<void>,
+  onCloseApp: () => void,
+  onExportProject: (open?: boolean) => void,
+  onCreateProject: (open?: boolean) => void,
+  onOpenProjectManager: (open?: boolean) => void,
+  onOpenStartPage: () => void,
+  onOpenDebugger: () => void,
+  onOpenAbout: (open?: boolean) => void,
+  onOpenPreferences: (open?: boolean) => void,
+  onOpenLanguage: (open?: boolean) => void,
+  onOpenProfile: (open?: boolean) => void,
+  setUpdateStatus: UpdateStatus => void,
 |};
 
 type MainMenuEvent =
@@ -68,80 +83,69 @@ type RootMenuTemplate =
  * to the underlying child React component.
  */
 class ElectronMainMenu extends React.Component<Props, {||}> {
-  _editor: ?MainFrame;
   _language: ?string;
 
   componentDidMount() {
     if (!ipcRenderer) return;
 
-    ipcRenderer.on(
-      ('main-menu-open': MainMenuEvent),
-      event => this._editor && this._editor.chooseProject()
+    ipcRenderer.on(('main-menu-open': MainMenuEvent), event =>
+      this.props.onChooseProject()
     );
-    ipcRenderer.on(
-      ('main-menu-save': MainMenuEvent),
-      event => this._editor && this._editor.saveProject()
+    ipcRenderer.on(('main-menu-save': MainMenuEvent), event =>
+      this.props.onSaveProject()
     );
-    ipcRenderer.on(
-      ('main-menu-save-as': MainMenuEvent),
-      event => this._editor && this._editor.saveProjectAs()
+    ipcRenderer.on(('main-menu-save-as': MainMenuEvent), event =>
+      this.props.onSaveProjectAs()
     );
-    ipcRenderer.on(
-      ('main-menu-close': MainMenuEvent),
-      event => this._editor && this._editor.askToCloseProject()
+    ipcRenderer.on(('main-menu-close': MainMenuEvent), event =>
+      this.props.onCloseProject()
     );
-    ipcRenderer.on(
-      ('main-menu-close-app': MainMenuEvent),
-      event => this._editor && this._editor.closeApp()
+    ipcRenderer.on(('main-menu-close-app': MainMenuEvent), event =>
+      this.props.onCloseApp()
     );
-    ipcRenderer.on(
-      ('main-menu-export': MainMenuEvent),
-      event => this._editor && this._editor.openExportDialog()
+    ipcRenderer.on(('main-menu-export': MainMenuEvent), event =>
+      this.props.onExportProject()
     );
-    ipcRenderer.on(
-      ('main-menu-create': MainMenuEvent),
-      event => this._editor && this._editor.openCreateDialog()
+    ipcRenderer.on(('main-menu-create': MainMenuEvent), event =>
+      this.props.onCreateProject()
     );
-    ipcRenderer.on(
-      ('main-menu-open-project-manager': MainMenuEvent),
-      event => this._editor && this._editor.openProjectManager()
+    ipcRenderer.on(('main-menu-open-project-manager': MainMenuEvent), event =>
+      this.props.onOpenProjectManager()
     );
-    ipcRenderer.on(
-      ('main-menu-open-start-page': MainMenuEvent),
-      event => this._editor && this._editor.openStartPage()
+    ipcRenderer.on(('main-menu-open-start-page': MainMenuEvent), event =>
+      this.props.onOpenStartPage()
     );
-    ipcRenderer.on(
-      ('main-menu-open-debugger': MainMenuEvent),
-      event => this._editor && this._editor.openDebugger()
+    ipcRenderer.on(('main-menu-open-debugger': MainMenuEvent), event =>
+      this.props.onOpenDebugger()
     );
-    ipcRenderer.on(
-      ('main-menu-open-about': MainMenuEvent),
-      event => this._editor && this._editor.openAboutDialog()
+    ipcRenderer.on(('main-menu-open-about': MainMenuEvent), event =>
+      this.props.onOpenAbout()
     );
-    ipcRenderer.on(
-      ('main-menu-open-preferences': MainMenuEvent),
-      event => this._editor && this._editor.openPreferences()
+    ipcRenderer.on(('main-menu-open-preferences': MainMenuEvent), event =>
+      this.props.onOpenPreferences()
     );
-    ipcRenderer.on(
-      ('main-menu-open-language': MainMenuEvent),
-      event => this._editor && this._editor.openLanguage()
+    ipcRenderer.on(('main-menu-open-language': MainMenuEvent), event =>
+      this.props.onOpenLanguage()
     );
-    ipcRenderer.on(
-      ('main-menu-open-profile': MainMenuEvent),
-      event => this._editor && this._editor.openProfile()
+    ipcRenderer.on(('main-menu-open-profile': MainMenuEvent), event =>
+      this.props.onOpenProfile()
     );
-    ipcRenderer.on(
-      ('update-status': MainMenuEvent),
-      (event, status) => this._editor && this._editor.setUpdateStatus(status)
+    ipcRenderer.on(('update-status': MainMenuEvent), (event, status) =>
+      this.props.setUpdateStatus(status)
     );
 
     this._buildAndSendMenuTemplate();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: Props) {
     if (this.props.i18n.language !== this._language) {
       this._buildAndSendMenuTemplate();
       this._language = this.props.i18n.language;
+    }
+
+    // Update menu if a project has just been opened or closed
+    if (!!prevProps.project !== !!this.props.project) {
+      this._buildAndSendMenuTemplate();
     }
   }
 
@@ -166,23 +170,27 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
           label: i18n._(t`Save`),
           accelerator: 'CommandOrControl+S',
           onClickSendEvent: 'main-menu-save',
+          enabled: !!this.props.project,
         },
         {
           label: i18n._(t`Save as...`),
           accelerator: 'CommandOrControl+Alt+S',
           onClickSendEvent: 'main-menu-save-as',
+          enabled: !!this.props.project,
         },
         { type: 'separator' },
         {
           label: i18n._(t`Export (web, iOS, Android)...`),
           accelerator: 'CommandOrControl+E',
           onClickSendEvent: 'main-menu-export',
+          enabled: !!this.props.project,
         },
         { type: 'separator' },
         {
           label: i18n._(t`Close Project`),
           accelerator: 'CommandOrControl+Shift+W',
           onClickSendEvent: 'main-menu-close',
+          enabled: !!this.props.project,
         },
       ],
     };
@@ -232,6 +240,7 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
           label: i18n._(t`Show Project Manager`),
           accelerator: 'CommandOrControl+Alt+P',
           onClickSendEvent: 'main-menu-open-project-manager',
+          enabled: !!this.props.project,
         },
         {
           label: i18n._(t`Show Start Page`),
@@ -240,6 +249,7 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
         {
           label: i18n._(t`Open Debugger`),
           onClickSendEvent: 'main-menu-open-debugger',
+          enabled: !!this.props.project,
         },
         { type: 'separator' },
         { role: 'toggledevtools' },
@@ -362,9 +372,7 @@ class ElectronMainMenu extends React.Component<Props, {||}> {
   }
 
   render() {
-    return React.cloneElement(this.props.children, {
-      ref: editor => (this._editor = editor),
-    });
+    return null;
   }
 }
 

--- a/newIDE/app/src/MainFrame/MainMenu.flow.js
+++ b/newIDE/app/src/MainFrame/MainMenu.flow.js
@@ -1,0 +1,23 @@
+// @flow
+import { type I18n as I18nType } from '@lingui/core';
+import { type UpdateStatus } from './UpdaterTools';
+
+export type MainMenuProps = {|
+  i18n: I18nType,
+  project: ?gdProject,
+  onChooseProject: () => void,
+  onSaveProject: () => void,
+  onSaveProjectAs: () => void,
+  onCloseProject: () => Promise<void>,
+  onCloseApp: () => void,
+  onExportProject: (open?: boolean) => void,
+  onCreateProject: (open?: boolean) => void,
+  onOpenProjectManager: (open?: boolean) => void,
+  onOpenStartPage: () => void,
+  onOpenDebugger: () => void,
+  onOpenAbout: (open?: boolean) => void,
+  onOpenPreferences: (open?: boolean) => void,
+  onOpenLanguage: (open?: boolean) => void,
+  onOpenProfile: (open?: boolean) => void,
+  setUpdateStatus: UpdateStatus => void,
+|};

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -93,6 +93,7 @@ import SaveToStorageProviderDialog from '../ProjectsStorage/SaveToStorageProvide
 import OpenConfirmDialog from '../ProjectsStorage/OpenConfirmDialog';
 import verifyProjectContent from '../ProjectsStorage/ProjectContentChecker';
 import { type UnsavedChanges } from './UnsavedChangesContext';
+import { type MainMenuProps } from './MainMenu.flow';
 import { emptyPreviewButtonSettings } from './Toolbar/PreviewButtons';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
@@ -142,7 +143,7 @@ type State = {|
 type Props = {
   integratedEditor?: boolean,
   introDialog?: React.Element<*>,
-  mainMenu?: Class<React$Component<*, *>>,
+  renderMainMenu?: MainMenuProps => React.Node,
   renderPreviewLauncher?: (
     props: PreviewLauncherProps,
     ref: (previewLauncher: ?PreviewLauncherInterface) => void
@@ -1790,7 +1791,7 @@ class MainFrame extends React.Component<Props, State> {
       useStorageProvider,
       i18n,
       renderGDJSDevelopmentWatcher,
-      mainMenu: MainMenu,
+      renderMainMenu: MainMenu,
     } = this.props;
     const showLoader =
       this.state.loadingProject ||

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -142,6 +142,7 @@ type State = {|
 type Props = {
   integratedEditor?: boolean,
   introDialog?: React.Element<*>,
+  mainMenu?: Class<React$Component<*, *>>,
   renderPreviewLauncher?: (
     props: PreviewLauncherProps,
     ref: (previewLauncher: ?PreviewLauncherInterface) => void
@@ -1789,6 +1790,7 @@ class MainFrame extends React.Component<Props, State> {
       useStorageProvider,
       i18n,
       renderGDJSDevelopmentWatcher,
+      mainMenu: MainMenu,
     } = this.props;
     const showLoader =
       this.state.loadingProject ||
@@ -1797,6 +1799,27 @@ class MainFrame extends React.Component<Props, State> {
 
     return (
       <div className="main-frame">
+        {MainMenu && (
+          <MainMenu
+            i18n={i18n}
+            project={this.state.currentProject}
+            onChooseProject={this.chooseProject}
+            onSaveProject={this.saveProject}
+            onSaveProjectAs={this.saveProjectAs}
+            onCloseProject={this.askToCloseProject}
+            onCloseApp={this.closeApp}
+            onExportProject={this.openExportDialog}
+            onCreateProject={this.openCreateDialog}
+            onOpenProjectManager={this.openProjectManager}
+            onOpenStartPage={this.openStartPage}
+            onOpenDebugger={this.openDebugger}
+            onOpenAbout={this.openAboutDialog}
+            onOpenPreferences={this.openPreferences}
+            onOpenLanguage={this.openLanguage}
+            onOpenProfile={this.openProfile}
+            setUpdateStatus={this.setUpdateStatus}
+          />
+        )}
         <ProjectTitlebar fileMetadata={currentFileMetadata} />
         <Drawer
           open={projectManagerOpen}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1791,7 +1791,7 @@ class MainFrame extends React.Component<Props, State> {
       useStorageProvider,
       i18n,
       renderGDJSDevelopmentWatcher,
-      renderMainMenu: MainMenu,
+      renderMainMenu,
     } = this.props;
     const showLoader =
       this.state.loadingProject ||
@@ -1800,27 +1800,26 @@ class MainFrame extends React.Component<Props, State> {
 
     return (
       <div className="main-frame">
-        {MainMenu && (
-          <MainMenu
-            i18n={i18n}
-            project={this.state.currentProject}
-            onChooseProject={this.chooseProject}
-            onSaveProject={this.saveProject}
-            onSaveProjectAs={this.saveProjectAs}
-            onCloseProject={this.askToCloseProject}
-            onCloseApp={this.closeApp}
-            onExportProject={this.openExportDialog}
-            onCreateProject={this.openCreateDialog}
-            onOpenProjectManager={this.openProjectManager}
-            onOpenStartPage={this.openStartPage}
-            onOpenDebugger={this.openDebugger}
-            onOpenAbout={this.openAboutDialog}
-            onOpenPreferences={this.openPreferences}
-            onOpenLanguage={this.openLanguage}
-            onOpenProfile={this.openProfile}
-            setUpdateStatus={this.setUpdateStatus}
-          />
-        )}
+        {!!renderMainMenu &&
+          renderMainMenu({
+            i18n: i18n,
+            project: this.state.currentProject,
+            onChooseProject: this.chooseProject,
+            onSaveProject: this.saveProject,
+            onSaveProjectAs: this.saveProjectAs,
+            onCloseProject: this.askToCloseProject,
+            onCloseApp: this.closeApp,
+            onExportProject: this.openExportDialog,
+            onCreateProject: this.openCreateDialog,
+            onOpenProjectManager: this.openProjectManager,
+            onOpenStartPage: this.openStartPage,
+            onOpenDebugger: this.openDebugger,
+            onOpenAbout: this.openAboutDialog,
+            onOpenPreferences: this.openPreferences,
+            onOpenLanguage: this.openLanguage,
+            onOpenProfile: this.openProfile,
+            setUpdateStatus: this.setUpdateStatus,
+          })}
         <ProjectTitlebar fileMetadata={currentFileMetadata} />
         <Drawer
           open={projectManagerOpen}


### PR DESCRIPTION
This PR partially resolves the issue #1550 by disabling menu items in File and View menus when the related action is not possible (for instance you can't save a project at the opening screen as there isn't any open project). 

I've refactored MainFrame and ElectronMainMenu so that the menu component is now contained inside the mainframe. MainFrame now takes a new prop `mainMenu` whose value is the class `ElectronMainMenu` (Flow type: `Class<React$Component<*, *>>`) and renders it, passing as props the current project and relevant IDE functions.

I know the new prop `mainMenu` probably needs a bit of renaming and refactoring. I tried using `renderMainMenu={(props) => <ElectronMainMenu {...props}>}` so that it is a bit cleaner and falls in with rest of the similar props. But then Flow typing of the prop becomes a problem - I'll have to import the `ElectronMainMenu` props type into MainFrame. It should work fine, but may get a bit worse in the future when we add a menu to the web app too. Should I move forward with it?