### PR TITLE
Quick fix for redundant scrollbar in project manager

### DIFF
--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -1057,7 +1057,7 @@ export default class ProjectManager extends React.Component<Props, State> {
           value={searchText}
           onRequestSearch={this._onRequestSearch}
           onChange={this._onSearchChange}
-          elevation={24}
+          elevation={3}
         />
         {this.state.projectVariablesEditorOpen && (
           <VariablesEditorDialog

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -54,6 +54,7 @@ const styles = {
     flex: 1,
     display: 'flex',
     flexDirection: 'column',
+    overflowY: 'hidden',
   },
   list: {
     flex: 1,
@@ -1056,6 +1057,7 @@ export default class ProjectManager extends React.Component<Props, State> {
           value={searchText}
           onRequestSearch={this._onRequestSearch}
           onChange={this._onSearchChange}
+          elevation={24}
         />
         {this.state.projectVariablesEditorOpen && (
           <VariablesEditorDialog

--- a/newIDE/app/src/UI/SearchBar.js
+++ b/newIDE/app/src/UI/SearchBar.js
@@ -29,6 +29,8 @@ type Props = {|
   buildTagsMenuTemplate?: () => any,
   /** If defined, a help icon button redirecting to this page will be shown */
   helpPagePath?: ?string,
+  /** Elevation of Paper Component */
+  elevation?: number
 |};
 
 type State = {|
@@ -161,6 +163,7 @@ export default class SearchBar extends React.PureComponent<Props, State> {
           ...styles.root,
           ...style,
         }}
+        elevation={this.props.elevation || 1}
       >
         <div style={styles.searchContainer}>
           <TextField

--- a/newIDE/app/src/UI/SearchBar.js
+++ b/newIDE/app/src/UI/SearchBar.js
@@ -30,7 +30,7 @@ type Props = {|
   /** If defined, a help icon button redirecting to this page will be shown */
   helpPagePath?: ?string,
   /** Elevation of Paper Component */
-  elevation?: number
+  elevation?: number,
 |};
 
 type State = {|


### PR DESCRIPTION
![Screenshot from 2020-04-10 17-11-52](https://user-images.githubusercontent.com/39851078/78988453-9377f800-7b4e-11ea-8a0b-b45b39a89ca8.png)

There is a redundant scrollbar in project manager drawer. I believe the intention was to keep the search bar onscreen irrespective of the list, but this is not happening at all. Two scrollbars look super unprofessional, especially when one of them is redundant :/

This is a quick fix to solve this, now there's only 1 scrollbar and the search bar remains onscreen irrespective of the list and scroll :)

![Screenshot from 2020-04-10 17-05-31](https://user-images.githubusercontent.com/39851078/78988659-3597e000-7b4f-11ea-86f1-ed39200e4e21.png)

Works well with chrome, firefox and electron. Not sure about safari :/