### PR TITLE
Add zoom shortcuts for non-Mac platforms

### DIFF
--- a/newIDE/app/src/SceneEditor/Toolbar.js
+++ b/newIDE/app/src/SceneEditor/Toolbar.js
@@ -140,12 +140,12 @@ export class Toolbar extends PureComponent<Props> {
             {
               label: 'Zoom in',
               click: this.props.zoomIn,
-              accelerator: 'CmdOrCtrl++',
+              accelerator: 'CmdOrCtrl+numadd',
             },
             {
               label: 'Zoom out',
               click: this.props.zoomOut,
-              accelerator: 'CmdOrCtrl+-',
+              accelerator: 'CmdOrCtrl+numsub',
             },
             {
               label: 'Center View',

--- a/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
@@ -161,25 +161,15 @@ export default class DeprecatedKeyboardShortcuts {
     if (this._isControlPressed() && evt.which === MINUS_KEY) {
       this.onZoomOut();
     }
+    if (evt.which === NUMPAD_SUBTRACT) {
+      this.onZoomOut();
+    }
+
     if (this._isControlPressed() && evt.which === EQUAL_KEY) {
       this.onZoomIn();
     }
-
-    if (isMacLike()) {
-      // Mac specific shortcuts
-      if (evt.which === NUMPAD_SUBTRACT) {
-        this.onZoomOut();
-      }
-      if (evt.which === NUMPAD_ADD) {
-        this.onZoomIn();
-      }
-    } else {
-      if (this._isControlPressed() && evt.which === NUMPAD_SUBTRACT) {
-        this.onZoomOut();
-      }
-      if (this._isControlPressed() && evt.which === NUMPAD_ADD) {
-        this.onZoomIn();
-      }
+    if (evt.which === NUMPAD_ADD) {
+      this.onZoomIn();
     }
 
     if (preventDefault) {

--- a/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
@@ -12,7 +12,7 @@ const DELETE_KEY = 46;
 const EQUAL_KEY = 187;
 const MINUS_KEY = 189;
 const NUMPAD_ADD = 107;
-const NUMPAD_SUBSTRACT = 109;
+const NUMPAD_SUBTRACT = 109;
 const C_KEY = 67;
 const F_KEY = 70;
 const V_KEY = 86;
@@ -158,18 +158,26 @@ export default class DeprecatedKeyboardShortcuts {
       this.onSearch();
     }
 
+    if (this._isControlPressed() && evt.which === MINUS_KEY) {
+      this.onZoomOut();
+    }
+    if (this._isControlPressed() && evt.which === EQUAL_KEY) {
+      this.onZoomIn();
+    }
+
     if (isMacLike()) {
-      //Mac specific shortcuts -- zooming done differently on windows and linux
-      if (this._isControlPressed() && evt.which === MINUS_KEY) {
-        this.onZoomOut();
-      }
-      if (this._isControlPressed() && evt.which === EQUAL_KEY) {
-        this.onZoomIn();
-      }
-      if (evt.which === NUMPAD_SUBSTRACT) {
+      // Mac specific shortcuts
+      if (evt.which === NUMPAD_SUBTRACT) {
         this.onZoomOut();
       }
       if (evt.which === NUMPAD_ADD) {
+        this.onZoomIn();
+      }
+    } else {
+      if (this._isControlPressed() && evt.which === NUMPAD_SUBTRACT) {
+        this.onZoomOut();
+      }
+      if (this._isControlPressed() && evt.which === NUMPAD_ADD) {
         this.onZoomIn();
       }
     }

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -10,7 +10,7 @@ const DELETE_KEY = 46;
 const EQUAL_KEY = 187;
 const MINUS_KEY = 189;
 const NUMPAD_ADD = 107;
-const NUMPAD_SUBSTRACT = 109;
+const NUMPAD_SUBTRACT = 109;
 const C_KEY = 67;
 const F_KEY = 70;
 const V_KEY = 86;
@@ -153,26 +153,34 @@ export default class KeyboardShortcuts {
       onSearch();
     }
 
+    if (onZoomOut && this._isControlOrCmdPressed() && evt.which === MINUS_KEY) {
+      onZoomOut();
+    }
+    if (onZoomIn && this._isControlOrCmdPressed() && evt.which === EQUAL_KEY) {
+      onZoomIn();
+    }
+
     if (isMacLike()) {
-      //Mac specific shortcuts -- zooming done differently on windows and linux
+      // Mac specific shortcuts
+      if (onZoomOut && evt.which === NUMPAD_SUBTRACT) {
+        onZoomOut();
+      }
+      if (onZoomIn && evt.which === NUMPAD_ADD) {
+        onZoomIn();
+      }
+    } else {
       if (
         onZoomOut &&
         this._isControlOrCmdPressed() &&
-        evt.which === MINUS_KEY
+        evt.which === NUMPAD_SUBTRACT
       ) {
         onZoomOut();
       }
       if (
         onZoomIn &&
         this._isControlOrCmdPressed() &&
-        evt.which === EQUAL_KEY
+        evt.which === NUMPAD_ADD
       ) {
-        onZoomIn();
-      }
-      if (onZoomOut && evt.which === NUMPAD_SUBSTRACT) {
-        onZoomOut();
-      }
-      if (onZoomIn && evt.which === NUMPAD_ADD) {
         onZoomIn();
       }
     }

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -1,6 +1,4 @@
 // @flow
-import { isMacLike } from '../../Utils/Platform';
-
 const LEFT_KEY = 37;
 const UP_KEY = 38;
 const RIGHT_KEY = 39;
@@ -156,33 +154,15 @@ export default class KeyboardShortcuts {
     if (onZoomOut && this._isControlOrCmdPressed() && evt.which === MINUS_KEY) {
       onZoomOut();
     }
+    if (onZoomOut && evt.which === NUMPAD_SUBTRACT) {
+      onZoomOut();
+    }
+
     if (onZoomIn && this._isControlOrCmdPressed() && evt.which === EQUAL_KEY) {
       onZoomIn();
     }
-
-    if (isMacLike()) {
-      // Mac specific shortcuts
-      if (onZoomOut && evt.which === NUMPAD_SUBTRACT) {
-        onZoomOut();
-      }
-      if (onZoomIn && evt.which === NUMPAD_ADD) {
-        onZoomIn();
-      }
-    } else {
-      if (
-        onZoomOut &&
-        this._isControlOrCmdPressed() &&
-        evt.which === NUMPAD_SUBTRACT
-      ) {
-        onZoomOut();
-      }
-      if (
-        onZoomIn &&
-        this._isControlOrCmdPressed() &&
-        evt.which === NUMPAD_ADD
-      ) {
-        onZoomIn();
-      }
+    if (onZoomIn && evt.which === NUMPAD_ADD) {
+      onZoomIn();
     }
   };
 }


### PR DESCRIPTION
This PR fixes keyboard shortcuts for zooming in and out in the InstancesEditor not working for non-Mac platforms (Linux and Windows). Resolves #1580.

Till now, the shortcuts were being shown in the editor zoom dropdown but didn't really work on Linux or Windows, as the zoom shortcuts were set up only for Mac platform in `DeprecatedKeyboardShortcuts`, and the new KeyboardShortcuts too. I've added somewhat similar shortcuts for Linux and Windows.

I've added the following shortcuts for Windows/Linux:
- Zoom in: `Ctrl+Equal` and `Ctrl+NumpadPlus`
- Zoom out: `Ctrl+Minus` and `Ctrl+NumpadMinus`

I've also added the new numpad accelerator `CmdOrCtrl+numadd` and `CmdOrCtrl+numsub` to the Change Editor Zoom toolbar menu.