### PR TITLE
Fix: Convert confirm, alert calls to platform-dependent calls

### DIFF
--- a/newIDE/app/public/external/utils/path-editor.js
+++ b/newIDE/app/public/external/utils/path-editor.js
@@ -228,12 +228,14 @@ const selectBaseFolderPath = headerObject => {
   }
   const selectedDirPath = selectedDir[0];
   if (!selectedDirPath.startsWith(state.projectBasePath)) {
-    alert(
-      'Please select a folder inside your project path!\n' +
+    dialog.showMessageBoxSync(remote.getCurrentWindow(), {
+      message:
+        'Please select a folder inside your project path!\n' +
         state.projectBasePath +
         '\n\nSelected:\n' +
-        selectedDirPath
-    );
+        selectedDirPath,
+      buttons: ['OK'],
+    });
     return;
   }
   state.folderPath = selectedDirPath;

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -76,8 +76,7 @@ export default class BehaviorsEditor extends Component {
       },
       () => {
         if (this._hasBehaviorWithType(type)) {
-          //eslint-disable-next-line
-          const answer = confirm(
+          const answer = Window.showConfirmDialog(
             "There is already a behavior of this type attached to the object. It's possible to add again this behavior but it's unusual and may not be always supported properly. Are you sure you want to add again this behavior?"
           );
 
@@ -111,8 +110,7 @@ export default class BehaviorsEditor extends Component {
 
   _onRemoveBehavior = behaviorName => {
     const { object } = this.props;
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       "Are you sure you want to remove this behavior? This can't be undone."
     );
 

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -13,6 +13,7 @@ import NewBehaviorDialog from './NewBehaviorDialog';
 import { getBehaviorHelpPagePath } from './BehaviorsHelpPagePaths';
 import BehaviorsEditorService from './BehaviorsEditorService';
 import { isNullPtr } from '../Utils/IsNullPtr';
+import Window from '../Utils/Window';
 import { Column, Line } from '../UI/Grid';
 import RaisedButton from '../UI/RaisedButton';
 const gd = global.gd;

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -13,6 +13,7 @@ import {
   filterEventsBasedBehaviorsList,
 } from './EnumerateEventsBasedBehaviors';
 import Clipboard from '../Utils/Clipboard';
+import Window from '../Utils/Window';
 import {
   serializeToJSObject,
   unserializeFromJSObject,
@@ -88,8 +89,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
     const { eventsBasedBehaviorsList } = this.props;
 
     if (askForConfirmation) {
-      //eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         "Are you sure you want to remove this behavior? This can't be undone."
       );
       if (!answer) return;

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -9,6 +9,7 @@ import EventsFunctionPropertiesEditor from './EventsFunctionPropertiesEditor';
 import ScrollView from '../../UI/ScrollView';
 import { Column } from '../../UI/Grid';
 import { showWarningBox } from '../../UI/Messages/MessageBox';
+import Window from '../../Utils/Window';
 import { type GroupWithContext } from '../../ObjectsList/EnumerateObjects';
 import { type UnsavedChanges } from '../../MainFrame/UnsavedChangesContext';
 
@@ -78,8 +79,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
       objectsContainer,
     } = this.props;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       'Do you want to remove all references to this group in events (actions and conditions using the group)?'
     );
 

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -13,6 +13,7 @@ import {
   filterEventFunctionsList,
 } from './EnumerateEventsFunctions';
 import Clipboard from '../Utils/Clipboard';
+import Window from '../Utils/Window';
 import {
   serializeToJSObject,
   unserializeFromJSObject,
@@ -89,8 +90,7 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
     const { eventsFunctionsContainer } = this.props;
 
     if (askForConfirmation) {
-      //eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         "Are you sure you want to remove this function? This can't be undone."
       );
       if (!answer) return;

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
@@ -17,6 +17,7 @@ import {
 import { type ResourceExternalEditor } from '../../ResourcesList/ResourceExternalEditor.flow';
 import { Line, Spacer } from '../../UI/Grid';
 import AlertMessage from '../../UI/AlertMessage';
+import Window from '../../Utils/Window';
 import { getExtraInstructionInformation } from '../../Hints';
 import { isAnEventFunctionMetadata } from '../../EventsFunctionsExtensionsLoader';
 import OpenInNew from '@material-ui/icons/OpenInNew';
@@ -169,8 +170,7 @@ export default class InstructionParametersEditor extends React.Component<
 
   _openExtension = (i18n: I18nType) => {
     if (this.state.isDirty) {
-      //eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         i18n._(
           t`You've made some changes here. Are you sure you want to discard them and open the function?`
         )

--- a/newIDE/app/src/ExtensionsSearch/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/ExtensionsSearch/ExtensionsSearchDialog.js
@@ -13,6 +13,7 @@ import EventsFunctionsExtensionsContext, {
 } from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
 import HelpButton from '../UI/HelpButton';
 import { showWarningBox } from '../UI/Messages/MessageBox';
+import Window from '../Utils/Window';
 
 type Props = {|
   project: gdProject,
@@ -38,8 +39,7 @@ const importExtension = (
           if (
             project.hasEventsFunctionsExtensionNamed(serializedExtension.name)
           ) {
-            //eslint-disable-next-line
-            const answer = confirm(
+            const answer = Window.showConfirmDialog(
               i18n._(
                 t`An extension with this name already exists in the project. Importing this extension will replace it: are you sure you want to continue?`
               )

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -385,8 +385,7 @@ class MainFrame extends React.Component<Props, State> {
       return hasAutoSave(fileMetadata, true).then(canOpenAutosave => {
         if (!canOpenAutosave) return fileMetadata;
 
-        //eslint-disable-next-line
-        const answer = confirm(
+        const answer = Window.showConfirmDialog(
           i18n._(
             t`An autosave file (backup made automatically by GDevelop) that is newer than the project file exists. Would you like to load it instead?`
           )
@@ -405,8 +404,7 @@ class MainFrame extends React.Component<Props, State> {
       return hasAutoSave(fileMetadata, false).then(canOpenAutosave => {
         if (!canOpenAutosave) return null;
 
-        //eslint-disable-next-line
-        const answer = confirm(
+        const answer = Window.showConfirmDialog(
           i18n._(
             t`The project file appears to be malformed, but an autosave file exists (backup made automatically by GDevelop). Would you like to try to load it instead?`
           )
@@ -608,8 +606,7 @@ class MainFrame extends React.Component<Props, State> {
     const { i18n } = this.props;
     if (!currentProject) return;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       i18n._(
         t`Are you sure you want to remove this scene? This can't be undone.`
       )
@@ -632,8 +629,7 @@ class MainFrame extends React.Component<Props, State> {
     const { i18n } = this.props;
     if (!currentProject) return;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       i18n._(
         t`Are you sure you want to remove this external layout? This can't be undone.`
       )
@@ -659,8 +655,7 @@ class MainFrame extends React.Component<Props, State> {
     const { i18n } = this.props;
     if (!currentProject) return;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       i18n._(
         t`Are you sure you want to remove these external events? This can't be undone.`
       )
@@ -688,8 +683,7 @@ class MainFrame extends React.Component<Props, State> {
     const { i18n, eventsFunctionsExtensionsState } = this.props;
     if (!currentProject) return;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       i18n._(
         t`Are you sure you want to remove this extension? This can't be undone.`
       )
@@ -1536,8 +1530,7 @@ class MainFrame extends React.Component<Props, State> {
       if (!this.state.currentProject) return Promise.resolve();
       const { i18n } = this.props;
 
-      //eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         i18n._(
           t`Close the project? Any changes that have not been saved will be lost.`
         )

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -13,6 +13,7 @@ import {
   copyAnimationsSpriteCollisionMasks,
 } from '../Utils/SpriteObjectHelper';
 import SpriteSelector from '../Utils/SpriteSelector';
+import Window from '../Utils/Window';
 import every from 'lodash/every';
 const gd = global.gd;
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -129,8 +129,7 @@ export default class CollisionMasksEditor extends Component {
 
   _setSameCollisionMasksForAllAnimations = enable => {
     if (enable) {
-      // eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         "Having the same collision masks for all animations will erase and reset all the other animations collision masks. This can't be undone. Are you sure you want to share these collision masks amongst all the animations of the object?"
       );
       if (!answer) return;
@@ -151,8 +150,7 @@ export default class CollisionMasksEditor extends Component {
 
   _setSameCollisionMasksForAllSprites = enable => {
     if (enable) {
-      // eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         "Having the same collision masks for all frames will erase and reset all the other frames collision masks. This can't be undone. Are you sure you want to share these collision masks amongst all the frames of the animation?"
       );
       if (!answer) return;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -95,8 +95,7 @@ class PointsListBody extends Component {
             });
           }}
           onRemove={() => {
-            //eslint-disable-next-line
-            const answer = confirm(
+            const answer = Window.showConfirmDialog(
               "Are you sure you want to remove this point? This can't be undone."
             );
             if (!answer) return;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -10,6 +10,7 @@ import {
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import newNameGenerator from '../../../../Utils/NewNameGenerator';
 import { mapVector } from '../../../../Utils/MapFor';
+import Window from '../../../../Utils/Window';
 import styles from './styles';
 import PointRow from './PointRow';
 import AddPointRow from './AddPointRow';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
@@ -105,8 +105,7 @@ export default class PointsEditor extends Component {
 
   _setSamePointsForAllAnimations = enable => {
     if (enable) {
-      // eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         "Having the same points for all animations will erase and reset all the other animations points. This can't be undone. Are you sure you want to share these points amongst all the animations of the object?"
       );
       if (!answer) return;
@@ -125,8 +124,7 @@ export default class PointsEditor extends Component {
 
   _setSamePointsForAllSprites = enable => {
     if (enable) {
-      // eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         "Having the same points for all frames will erase and reset all the other frames points. This can't be undone. Are you sure you want to share these points amongst all the frames of the animation?"
       );
       if (!answer) return;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
@@ -12,6 +12,7 @@ import {
   copyAnimationsSpritePoints,
 } from '../Utils/SpriteObjectHelper';
 import SpriteSelector from '../Utils/SpriteSelector';
+import Window from '../Utils/Window';
 import every from 'lodash/every';
 const gd = global.gd;
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -22,6 +22,7 @@ import { showWarningBox } from '../../../UI/Messages/MessageBox';
 import ResourcesLoader from '../../../ResourcesLoader';
 import PointsEditor from './PointsEditor';
 import CollisionMasksEditor from './CollisionMasksEditor';
+import Window from '../../../Utils/Window';
 import {
   deleteSpritesFromAnimation,
   duplicateSpritesInAnimation,
@@ -255,8 +256,9 @@ class AnimationsListContainer extends React.Component<
   };
 
   removeAnimation = i => {
-    //eslint-disable-next-line
-    const answer = confirm('Are you sure you want to remove this animation?');
+    const answer = Window.showConfirmDialog(
+      'Are you sure you want to remove this animation?'
+    );
 
     if (answer) {
       this.props.spriteObject.removeAnimation(i);

--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -19,6 +19,7 @@ import {
   type GroupWithContext,
 } from '../ObjectsList/EnumerateObjects';
 import { listItemWithoutIconHeight } from '../UI/List';
+import Window from '../Utils/Window';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 
 // TODO: This component should be updated to be implemented using SortableVirtualizedItemList,
@@ -206,8 +207,7 @@ export default class GroupsListContainer extends React.Component<Props, State> {
     const { group, global } = groupWithContext;
     const { globalObjectGroups, objectGroups } = this.props;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       "Are you sure you want to remove this group? This can't be undone."
     );
     if (!answer) return;
@@ -307,8 +307,7 @@ export default class GroupsListContainer extends React.Component<Props, State> {
       return;
     }
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       "This group will be loaded and available in all the scenes. This is only recommended for groups that you reuse a lot and can't be undone. Make this group global?"
     );
     if (!answer) return;

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -10,6 +10,7 @@ import NewObjectDialog from './NewObjectDialog';
 import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import Clipboard from '../Utils/Clipboard';
+import Window from '../Utils/Window';
 import {
   serializeToJSObject,
   unserializeFromJSObject,
@@ -189,8 +190,7 @@ export default class ObjectsList extends React.Component<Props, State> {
     const { object, global } = objectWithContext;
     const { project, objectsContainer } = this.props;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       "Are you sure you want to remove this object? This can't be undone."
     );
     if (!answer) return;
@@ -376,8 +376,7 @@ export default class ObjectsList extends React.Component<Props, State> {
       return;
     }
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       "This object will be loaded and available in all the scenes. This is only recommended for objects that you reuse a lot and can't be undone. Make this object global?"
     );
     if (!answer) return;

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -86,8 +86,7 @@ export default class SubscriptionDialog extends React.Component<Props, State> {
     sendChoosePlanClicked(plan.planId);
 
     if (subscription.stripeSubscriptionId) {
-      //eslint-disable-next-line
-      const answer = confirm(
+      const answer = Window.showConfirmDialog(
         plan.planId
           ? i18n._(t`Are you sure you want to subscribe to this new plan?`)
           : i18n._(t`Are you sure you want to cancel your subscription?`)

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -10,6 +10,7 @@ import EditorMosaic from '../UI/EditorMosaic';
 import InfoBar from '../UI/Messages/InfoBar';
 import ResourcesLoader from '../ResourcesLoader';
 import optionalRequire from '../Utils/OptionalRequire';
+import Window from '../Utils/Window';
 
 import {
   type ResourceSource,
@@ -77,8 +78,7 @@ export default class ResourcesEditor extends React.Component<Props, State> {
     const { project, onDeleteResource } = this.props;
     if (!resource) return;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       "Are you sure you want to remove this resource? This can't be undone."
     );
     if (!answer) return;

--- a/newIDE/app/src/ResourcesList/LocalResourceSources.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceSources.js
@@ -9,6 +9,7 @@ import {
   copyAllToProjectFolder,
 } from './ResourceUtils.js';
 import optionalRequire from '../Utils/OptionalRequire.js';
+import Window from '../Utils/Window';
 const electron = optionalRequire('electron');
 const dialog = electron ? electron.remote.dialog : null;
 const path = optionalRequire('path');
@@ -263,8 +264,7 @@ const selectLocalResourcePath = (
       );
 
       if (outsideProjectFolderPaths.length) {
-        // eslint-disable-next-line
-        const answer = confirm(
+        const answer = Window.showConfirmDialog(
           i18n._(
             t`This/these file(s) are outside the project folder. Would you like to make a copy of them in your project folder first (recommended)?`
           )

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -7,6 +7,7 @@ import SearchBar from '../UI/SearchBar';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import { filterResourcesList } from './EnumerateResources';
 import optionalRequire from '../Utils/OptionalRequire.js';
+import Window from '../Utils/Window';
 import {
   createOrUpdateResource,
   getLocalResourceFullPath,
@@ -185,8 +186,7 @@ export default class ResourcesList extends React.Component<Props, State> {
       return;
     }
 
-    // eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       'Are you sure you want to rename this resource? \nGame objects using the old name will no longer be able to find it!'
     );
     if (!answer) return;

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -26,6 +26,7 @@ import {
   unserializeFromJSObject,
 } from '../Utils/Serializer';
 import Clipboard from '../Utils/Clipboard';
+import Window from '../Utils/Window';
 import { passFullSize } from '../UI/FullSizeMeasurer';
 import { addScrollbars } from '../InstancesEditor/ScrollbarContainer';
 import { type PreviewOptions } from '../Export/PreviewLauncher.flow';
@@ -606,8 +607,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     const { object, global } = objectWithContext;
     const { project, layout } = this.props;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       'Do you want to remove all references to this object in groups and events (actions and conditions using the object)?'
     );
 
@@ -700,8 +700,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     const { group, global } = groupWithContext;
     const { project, layout } = this.props;
 
-    //eslint-disable-next-line
-    const answer = confirm(
+    const answer = Window.showConfirmDialog(
       'Do you want to remove all references to this group in events (actions and conditions using the group)?'
     );
 

--- a/newIDE/app/src/UI/CloseConfirmDialog.js
+++ b/newIDE/app/src/UI/CloseConfirmDialog.js
@@ -40,8 +40,7 @@ export default React.memo<Props>(function CloseConfirmDialog({
             // which would make Electron to close the window for some weird reason.
             // See https://github.com/electron/electron/issues/7977
             setTimeout(() => {
-              //eslint-disable-next-line
-              const answer = confirm(message);
+              const answer = Window.showConfirmDialog(message);
               if (answer) {
                 // If answer is positive, re-trigger the close
                 delayElectronClose.current = false;

--- a/newIDE/app/src/UI/DismissableAlertMessage.js
+++ b/newIDE/app/src/UI/DismissableAlertMessage.js
@@ -4,6 +4,7 @@ import PreferencesContext, {
   type AlertMessageIdentifier,
 } from '../MainFrame/Preferences/PreferencesContext';
 import AlertMessage from './AlertMessage';
+import Window from '../Utils/Window';
 
 type Props = {|
   kind: 'info' | 'warning',
@@ -23,8 +24,7 @@ const DismissableAlertMessage = ({ identifier, kind, children }: Props) => (
           kind={kind}
           children={children}
           onHide={() => {
-            //eslint-disable-next-line
-            const answer = confirm(
+            const answer = Window.showConfirmDialog(
               "Are you sure you want to hide this hint? You won't see it again, unless you re-activate it from the preferences."
             );
 

--- a/newIDE/app/src/Utils/Window.js
+++ b/newIDE/app/src/Utils/Window.js
@@ -168,6 +168,24 @@ export default class Window {
     });
   }
 
+  static showConfirmDialog(
+    message: string,
+    type?: 'none' | 'info' | 'error' | 'question' | 'warning'
+  ) {
+    if (!dialog || !electron) {
+      // eslint-disable-next-line
+      return confirm(message);
+    }
+
+    const browserWindow = electron.remote.getCurrentWindow();
+    const answer = dialog.showMessageBoxSync(browserWindow, {
+      message,
+      type,
+      buttons: ['OK', 'Cancel'],
+    });
+    return answer === 0;
+  }
+
   static setUpContextMenu() {
     const textEditorSelectors = 'textarea, input, [contenteditable="true"]';
 


### PR DESCRIPTION
Resolves #1646.
- Added `showConfirmDialog` to Window.js that uses browser's `confirm` API on web-app and `dialog.showMessageBoxSync` on Electron app. 
- Converted all `confirm` calls in the codebase to use this function, removing the now-unnecessary ESLint ignore-lines.
- Also converted an `alert` call in `path-editor.js` to use `dialog.showMessageBoxSync` instead.

Built and tested on Windows - the issue seems to be fixed.