### PR TITLE
[WIP] Rename object in events' parameters

### DIFF
--- a/Core/GDCore/Events/Builtin/ForEachEvent.cpp
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.cpp
@@ -37,6 +37,18 @@ vector<gd::Expression*> ForEachEvent::GetAllExpressions() {
 
   return allExpressions;
 }
+
+vector<pair<gd::Expression*, gd::ParameterMetadata> >
+    ForEachEvent::GetAllExpressionsWithMetadata() {
+  vector<pair<gd::Expression*, gd::ParameterMetadata> >
+      allExpressionsWithMetadata;
+  auto type = gd::ParameterMetadata().SetType("object");
+  allExpressionsWithMetadata.push_back(
+      std::make_pair(&objectsToPick, type));
+
+  return allExpressionsWithMetadata;
+}
+
 vector<const gd::InstructionsList*> ForEachEvent::GetAllConditionsVectors()
     const {
   vector<const gd::InstructionsList*> allConditions;
@@ -57,6 +69,17 @@ vector<const gd::Expression*> ForEachEvent::GetAllExpressions() const {
   allExpressions.push_back(&objectsToPick);
 
   return allExpressions;
+}
+
+vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
+    ForEachEvent::GetAllExpressionsWithMetadata() const {
+  vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
+      allExpressionsWithMetadata;
+  auto type = gd::ParameterMetadata().SetType("object");
+  allExpressionsWithMetadata.push_back(
+      std::make_pair(&objectsToPick, type));
+
+  return allExpressionsWithMetadata;
 }
 
 void ForEachEvent::SerializeTo(SerializerElement& element) const {

--- a/Core/GDCore/Events/Builtin/ForEachEvent.cpp
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.cpp
@@ -31,20 +31,13 @@ vector<gd::InstructionsList*> ForEachEvent::GetAllActionsVectors() {
   return allActions;
 }
 
-vector<gd::Expression*> ForEachEvent::GetAllExpressions() {
-  vector<gd::Expression*> allExpressions;
-  allExpressions.push_back(&objectsToPick);
-
-  return allExpressions;
-}
-
 vector<pair<gd::Expression*, gd::ParameterMetadata> >
     ForEachEvent::GetAllExpressionsWithMetadata() {
   vector<pair<gd::Expression*, gd::ParameterMetadata> >
       allExpressionsWithMetadata;
-  auto type = gd::ParameterMetadata().SetType("object");
+  auto metadata = gd::ParameterMetadata().SetType("object");
   allExpressionsWithMetadata.push_back(
-      std::make_pair(&objectsToPick, type));
+      std::make_pair(&objectsToPick, metadata));
 
   return allExpressionsWithMetadata;
 }
@@ -62,13 +55,6 @@ vector<const gd::InstructionsList*> ForEachEvent::GetAllActionsVectors() const {
   allActions.push_back(&actions);
 
   return allActions;
-}
-
-vector<const gd::Expression*> ForEachEvent::GetAllExpressions() const {
-  vector<const gd::Expression*> allExpressions;
-  allExpressions.push_back(&objectsToPick);
-
-  return allExpressions;
 }
 
 vector<pair<const gd::Expression*, const gd::ParameterMetadata> >

--- a/Core/GDCore/Events/Builtin/ForEachEvent.cpp
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.cpp
@@ -61,9 +61,9 @@ vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
     ForEachEvent::GetAllExpressionsWithMetadata() const {
   vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
       allExpressionsWithMetadata;
-  auto type = gd::ParameterMetadata().SetType("object");
+  auto metadata = gd::ParameterMetadata().SetType("object");
   allExpressionsWithMetadata.push_back(
-      std::make_pair(&objectsToPick, type));
+      std::make_pair(&objectsToPick, metadata));
 
   return allExpressionsWithMetadata;
 }

--- a/Core/GDCore/Events/Builtin/ForEachEvent.h
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.h
@@ -51,10 +51,14 @@ class GD_CORE_API ForEachEvent : public gd::BaseEvent {
       const;
   virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
   virtual std::vector<const gd::Expression*> GetAllExpressions() const;
+  virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata() const;
+
   virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
   virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
   virtual std::vector<gd::Expression*> GetAllExpressions();
-
+  virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata();
   virtual void SerializeTo(SerializerElement& element) const;
   virtual void UnserializeFrom(gd::Project& project,
                                const SerializerElement& element);

--- a/Core/GDCore/Events/Builtin/ForEachEvent.h
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.h
@@ -50,15 +50,14 @@ class GD_CORE_API ForEachEvent : public gd::BaseEvent {
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
       const;
   virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
-  virtual std::vector<const gd::Expression*> GetAllExpressions() const;
   virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
       GetAllExpressionsWithMetadata() const;
 
   virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
   virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
-  virtual std::vector<gd::Expression*> GetAllExpressions();
   virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
       GetAllExpressionsWithMetadata();
+
   virtual void SerializeTo(SerializerElement& element) const;
   virtual void UnserializeFrom(gd::Project& project,
                                const SerializerElement& element);

--- a/Core/GDCore/Events/Builtin/RepeatEvent.cpp
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.cpp
@@ -38,6 +38,17 @@ vector<gd::Expression*> RepeatEvent::GetAllExpressions() {
   return allExpressions;
 }
 
+vector<pair<gd::Expression*, gd::ParameterMetadata> >
+    RepeatEvent::GetAllExpressionsWithMetadata() {
+  vector<pair<gd::Expression*, gd::ParameterMetadata> >
+      allExpressionsWithMetadata;
+  auto type = gd::ParameterMetadata().SetType("expression");
+  allExpressionsWithMetadata.push_back(
+      std::make_pair(&repeatNumberExpression, type));
+
+  return allExpressionsWithMetadata;
+}
+
 vector<const gd::InstructionsList*> RepeatEvent::GetAllConditionsVectors()
     const {
   vector<const gd::InstructionsList*> allConditions;
@@ -58,6 +69,17 @@ vector<const gd::Expression*> RepeatEvent::GetAllExpressions() const {
   allExpressions.push_back(&repeatNumberExpression);
 
   return allExpressions;
+}
+
+vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
+    RepeatEvent::GetAllExpressionsWithMetadata() const {
+  vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
+      allExpressionsWithMetadata;
+  auto type = gd::ParameterMetadata().SetType("expression");
+  allExpressionsWithMetadata.push_back(
+      std::make_pair(&repeatNumberExpression, type));
+
+  return allExpressionsWithMetadata;
 }
 
 void RepeatEvent::SerializeTo(SerializerElement& element) const {

--- a/Core/GDCore/Events/Builtin/RepeatEvent.cpp
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.cpp
@@ -35,9 +35,9 @@ vector<pair<gd::Expression*, gd::ParameterMetadata> >
     RepeatEvent::GetAllExpressionsWithMetadata() {
   vector<pair<gd::Expression*, gd::ParameterMetadata> >
       allExpressionsWithMetadata;
-  auto type = gd::ParameterMetadata().SetType("expression");
+  auto metadata = gd::ParameterMetadata().SetType("expression");
   allExpressionsWithMetadata.push_back(
-      std::make_pair(&repeatNumberExpression, type));
+      std::make_pair(&repeatNumberExpression, metadata));
 
   return allExpressionsWithMetadata;
 }
@@ -61,9 +61,9 @@ vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
     RepeatEvent::GetAllExpressionsWithMetadata() const {
   vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
       allExpressionsWithMetadata;
-  auto type = gd::ParameterMetadata().SetType("expression");
+  auto metadata = gd::ParameterMetadata().SetType("expression");
   allExpressionsWithMetadata.push_back(
-      std::make_pair(&repeatNumberExpression, type));
+      std::make_pair(&repeatNumberExpression, metadata));
 
   return allExpressionsWithMetadata;
 }

--- a/Core/GDCore/Events/Builtin/RepeatEvent.cpp
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.cpp
@@ -31,13 +31,6 @@ vector<gd::InstructionsList*> RepeatEvent::GetAllActionsVectors() {
   return allActions;
 }
 
-vector<gd::Expression*> RepeatEvent::GetAllExpressions() {
-  vector<gd::Expression*> allExpressions;
-  allExpressions.push_back(&repeatNumberExpression);
-
-  return allExpressions;
-}
-
 vector<pair<gd::Expression*, gd::ParameterMetadata> >
     RepeatEvent::GetAllExpressionsWithMetadata() {
   vector<pair<gd::Expression*, gd::ParameterMetadata> >
@@ -62,13 +55,6 @@ vector<const gd::InstructionsList*> RepeatEvent::GetAllActionsVectors() const {
   allActions.push_back(&actions);
 
   return allActions;
-}
-
-vector<const gd::Expression*> RepeatEvent::GetAllExpressions() const {
-  vector<const gd::Expression*> allExpressions;
-  allExpressions.push_back(&repeatNumberExpression);
-
-  return allExpressions;
 }
 
 vector<pair<const gd::Expression*, const gd::ParameterMetadata> >

--- a/Core/GDCore/Events/Builtin/RepeatEvent.h
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.h
@@ -45,13 +45,12 @@ class GD_CORE_API RepeatEvent : public gd::BaseEvent {
 
   virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
   virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
-  virtual std::vector<gd::Expression*> GetAllExpressions();
   virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
       GetAllExpressionsWithMetadata();
+
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
       const;
   virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
-  virtual std::vector<const gd::Expression*> GetAllExpressions() const;
   virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
       GetAllExpressionsWithMetadata() const;
 

--- a/Core/GDCore/Events/Builtin/RepeatEvent.h
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.h
@@ -46,10 +46,14 @@ class GD_CORE_API RepeatEvent : public gd::BaseEvent {
   virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
   virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
   virtual std::vector<gd::Expression*> GetAllExpressions();
+  virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata();
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
       const;
   virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
   virtual std::vector<const gd::Expression*> GetAllExpressions() const;
+  virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata() const;
 
   virtual void SerializeTo(SerializerElement& element) const;
   virtual void UnserializeFrom(gd::Project& project,

--- a/Core/GDCore/Events/Event.h
+++ b/Core/GDCore/Events/Event.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include "GDCore/Events/Instruction.h"
 #include "GDCore/Events/InstructionsList.h"
+#include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/String.h"
 namespace gd {
 class EventsList;
@@ -136,6 +137,21 @@ class GD_CORE_API BaseEvent {
   };
   virtual std::vector<const gd::Expression*> GetAllExpressions() const {
     std::vector<const gd::Expression*> noExpr;
+    return noExpr;
+  };
+
+  /**
+   * \brief Return a list of all expressions with ParameterMetadata of the event.
+   * \note Used to preprocess or search in the expressions of the event.
+   */
+  virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata() {
+    std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> > noExpr;
+    return noExpr;
+  };
+  virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata() const {
+    std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> > noExpr;
     return noExpr;
   };
 

--- a/Core/GDCore/Events/Event.h
+++ b/Core/GDCore/Events/Event.h
@@ -128,20 +128,7 @@ class GD_CORE_API BaseEvent {
   };
 
   /**
-   * \brief Return a list of all expressions of the event.
-   * \note Used to preprocess or search in the expressions.
-   */
-  virtual std::vector<gd::Expression*> GetAllExpressions() {
-    std::vector<gd::Expression*> noExpr;
-    return noExpr;
-  };
-  virtual std::vector<const gd::Expression*> GetAllExpressions() const {
-    std::vector<const gd::Expression*> noExpr;
-    return noExpr;
-  };
-
-  /**
-   * \brief Return a list of all expressions with ParameterMetadata of the event.
+   * \brief Return a list of all expressions of the event, each with their associated metadata.
    * \note Used to preprocess or search in the expressions of the event.
    */
   virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >

--- a/Core/GDCore/IDE/Events/EventsRefactorer.h
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.h
@@ -148,7 +148,8 @@ class GD_CORE_API EventsRefactorer {
                                        gd::String oldName,
                                        gd::String newName);
    /**
-   * Replace all occurences of an object name by another name in a parameter of event.
+   * Replace all occurrences of an object name by another name in an expression
+   * with the specified metadata
    * ( include : objects or objects in math/text expressions ).
    *
    * \return true if something was modified.

--- a/Core/GDCore/IDE/Events/EventsRefactorer.h
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 #include "GDCore/Events/Instruction.h"
+#include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/String.h"
 namespace gd {
 class EventsList;
@@ -146,6 +147,19 @@ class GD_CORE_API EventsRefactorer {
                                        gd::InstructionsList& instructions,
                                        gd::String oldName,
                                        gd::String newName);
+   /**
+   * Replace all occurences of an object name by another name in a parameter of event.
+   * ( include : objects or objects in math/text expressions ).
+   *
+   * \return true if something was modified.
+   */
+  static bool RenameObjectInEventParameters(const gd::Platform& platform,
+                                            gd::ObjectsContainer& project,
+                                            gd::ObjectsContainer& layout,
+                                            gd::Expression& expression,
+                                            gd::ParameterMetadata parameterMetadata,
+                                            gd::String oldName,
+                                            gd::String newName);
 
   /**
    * Remove all conditions of the list using an object


### PR DESCRIPTION
Fix #1351 
### Screenshots
![fix](https://user-images.githubusercontent.com/32167255/79201765-21afef00-7e6b-11ea-86c4-f677b3d3d153.gif)

### Questions

#### `somethingModified` 
This is in  all rename functions in `Core/GDCore/IDE/Events/EventsRefactorer.cpp`, such as `RenameObjectInActions`.[(here)](https://github.com/4ian/GDevelop/blob/804a07c56ef756f078f24c689c6d5903d50ea6c1/Core/GDCore/IDE/Events/EventsRefactorer.cpp#L177)  
It seems like it's always false. :joy: I don't find which line to change it to true.

####  Const
`vector<pair<const gd::Expression*, const gd::ParameterMetadata>> GetAllExpressionsWithMetadata() const;`

I add the above function, just like what other `rename functions` do.  But it doesn't seem to be called. Is this useful?

#### Parameter Type
For repeat event, I use a metadata of `expression`. For foreach event, I use a metadata of `object`.
Is there any other conditions?  