### PR TITLE
Refactor ElectronMainMenu to functional component

### DIFF
--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -57,254 +57,113 @@ type RootMenuTemplate =
       submenu: Array<MenuItemTemplate>,
     |};
 
+// Custom hook to run function only once, regardless of prop changes
+const useMountEffect = func => React.useEffect(func, []);
+
 /**
  * Forward events received from Electron main process
- * to the underlying child React component.
+ * to the MainFrame component.
  */
-class ElectronMainMenu extends React.Component<MainMenuProps, {||}> {
-  _language: ?string;
+const ElectronMainMenu = (props: MainMenuProps) => {
+  const { i18n, project } = props;
 
-  componentDidMount() {
+  useMountEffect(() => {
     if (!ipcRenderer) return;
 
     ipcRenderer.on(('main-menu-open': MainMenuEvent), event =>
-      this.props.onChooseProject()
+      props.onChooseProject()
     );
     ipcRenderer.on(('main-menu-save': MainMenuEvent), event =>
-      this.props.onSaveProject()
+      props.onSaveProject()
     );
     ipcRenderer.on(('main-menu-save-as': MainMenuEvent), event =>
-      this.props.onSaveProjectAs()
+      props.onSaveProjectAs()
     );
     ipcRenderer.on(('main-menu-close': MainMenuEvent), event =>
-      this.props.onCloseProject()
+      props.onCloseProject()
     );
     ipcRenderer.on(('main-menu-close-app': MainMenuEvent), event =>
-      this.props.onCloseApp()
+      props.onCloseApp()
     );
     ipcRenderer.on(('main-menu-export': MainMenuEvent), event =>
-      this.props.onExportProject()
+      props.onExportProject()
     );
     ipcRenderer.on(('main-menu-create': MainMenuEvent), event =>
-      this.props.onCreateProject()
+      props.onCreateProject()
     );
     ipcRenderer.on(('main-menu-open-project-manager': MainMenuEvent), event =>
-      this.props.onOpenProjectManager()
+      props.onOpenProjectManager()
     );
     ipcRenderer.on(('main-menu-open-start-page': MainMenuEvent), event =>
-      this.props.onOpenStartPage()
+      props.onOpenStartPage()
     );
     ipcRenderer.on(('main-menu-open-debugger': MainMenuEvent), event =>
-      this.props.onOpenDebugger()
+      props.onOpenDebugger()
     );
     ipcRenderer.on(('main-menu-open-about': MainMenuEvent), event =>
-      this.props.onOpenAbout()
+      props.onOpenAbout()
     );
     ipcRenderer.on(('main-menu-open-preferences': MainMenuEvent), event =>
-      this.props.onOpenPreferences()
+      props.onOpenPreferences()
     );
     ipcRenderer.on(('main-menu-open-language': MainMenuEvent), event =>
-      this.props.onOpenLanguage()
+      props.onOpenLanguage()
     );
     ipcRenderer.on(('main-menu-open-profile': MainMenuEvent), event =>
-      this.props.onOpenProfile()
+      props.onOpenProfile()
     );
     ipcRenderer.on(('update-status': MainMenuEvent), (event, status) =>
-      this.props.setUpdateStatus(status)
+      props.setUpdateStatus(status)
     );
+  });
 
-    this._buildAndSendMenuTemplate();
-  }
-
-  componentDidUpdate(prevProps: MainMenuProps) {
-    if (this.props.i18n.language !== this._language) {
-      this._buildAndSendMenuTemplate();
-      this._language = this.props.i18n.language;
-    }
-
-    // Update menu if a project has just been opened or closed
-    if (prevProps.project !== this.props.project) {
-      this._buildAndSendMenuTemplate();
-    }
-  }
-
-  _buildAndSendMenuTemplate() {
-    const { i18n } = this.props;
-    const fileTemplate = {
-      label: i18n._(t`File`),
-      submenu: [
-        {
-          label: i18n._(t`Create a New Project...`),
-          accelerator: 'CommandOrControl+N',
-          onClickSendEvent: 'main-menu-create',
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Open...`),
-          accelerator: 'CommandOrControl+O',
-          onClickSendEvent: 'main-menu-open',
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Save`),
-          accelerator: 'CommandOrControl+S',
-          onClickSendEvent: 'main-menu-save',
-          enabled: !!this.props.project,
-        },
-        {
-          label: i18n._(t`Save as...`),
-          accelerator: 'CommandOrControl+Alt+S',
-          onClickSendEvent: 'main-menu-save-as',
-          enabled: !!this.props.project,
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Export (web, iOS, Android)...`),
-          accelerator: 'CommandOrControl+E',
-          onClickSendEvent: 'main-menu-export',
-          enabled: !!this.props.project,
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Close Project`),
-          accelerator: 'CommandOrControl+Shift+W',
-          onClickSendEvent: 'main-menu-close',
-          enabled: !!this.props.project,
-        },
-      ],
-    };
-    if (!isMacLike()) {
-      fileTemplate.submenu.push(
-        { type: 'separator' },
-        {
-          label: i18n._(t`My Profile`),
-          onClickSendEvent: 'main-menu-open-profile',
-        },
-        {
-          label: i18n._(t`Preferences`),
-          onClickSendEvent: 'main-menu-open-preferences',
-        },
-        {
-          label: i18n._(t`Language`),
-          onClickSendEvent: 'main-menu-open-language',
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Exit GDevelop`),
-          accelerator: 'Control+Q',
-          onClickSendEvent: 'main-menu-close-app',
-        }
-      );
-    }
-
-    const editTemplate = {
-      label: i18n._(t`Edit`),
-      submenu: [
-        { role: 'undo' },
-        { role: 'redo' },
-        { type: 'separator' },
-        { role: 'cut' },
-        { role: 'copy' },
-        { role: 'paste' },
-        { role: 'pasteandmatchstyle' },
-        { role: 'delete' },
-        { role: 'selectall' },
-      ],
-    };
-
-    const viewTemplate = {
-      label: i18n._(t`View`),
-      submenu: [
-        {
-          label: i18n._(t`Show Project Manager`),
-          accelerator: 'CommandOrControl+Alt+P',
-          onClickSendEvent: 'main-menu-open-project-manager',
-          enabled: !!this.props.project,
-        },
-        {
-          label: i18n._(t`Show Start Page`),
-          onClickSendEvent: 'main-menu-open-start-page',
-        },
-        {
-          label: i18n._(t`Open Debugger`),
-          onClickSendEvent: 'main-menu-open-debugger',
-          enabled: !!this.props.project,
-        },
-        { type: 'separator' },
-        { role: 'toggledevtools' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' },
-      ],
-    };
-
-    const windowTemplate = {
-      role: 'window',
-      submenu: [{ role: 'minimize' }],
-    };
-
-    const helpTemplate = {
-      role: 'help',
-      submenu: [
-        {
-          label: i18n._(t`GDevelop website`),
-          onClickOpenLink: 'http://gdevelop-app.com',
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Community Forums`),
-          onClickOpenLink: 'https://forum.gdevelop-app.com',
-        },
-        {
-          label: i18n._(t`Community Discord Chat`),
-          onClickOpenLink: 'https://discord.gg/rjdYHvj',
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Contribute to GDevelop`),
-          onClickOpenLink: 'https://gdevelop-app.com/contribute/',
-        },
-        {
-          label: i18n._(t`Create Extensions for GDevelop`),
-          onClickOpenLink:
-            'https://github.com/4ian/GDevelop/blob/master/newIDE/README-extensions.md',
-        },
-        { type: 'separator' },
-        {
-          label: i18n._(t`Help to Translate GDevelop`),
-          onClickOpenLink: 'https://crowdin.com/project/gdevelop',
-        },
-        {
-          label: i18n._(t`Report a wrong translation`),
-          onClickOpenLink: 'https://github.com/4ian/GDevelop/issues/969',
-        },
-      ],
-    };
-    if (!isMacLike()) {
-      helpTemplate.submenu.push(
-        { type: 'separator' },
-        {
-          label: i18n._(t`About GDevelop`),
-          onClickSendEvent: 'main-menu-open-about',
-        }
-      );
-    }
-
-    const template: Array<RootMenuTemplate> = [
-      fileTemplate,
-      editTemplate,
-      viewTemplate,
-      windowTemplate,
-      helpTemplate,
-    ];
-
-    if (isMacLike()) {
-      template.unshift({
-        label: i18n._(t`GDevelop 5`),
+  const _buildAndSendMenuTemplate = React.useCallback(
+    () => {
+      const fileTemplate = {
+        label: i18n._(t`File`),
         submenu: [
           {
-            label: i18n._(t`About GDevelop`),
-            onClickSendEvent: 'main-menu-open-about',
+            label: i18n._(t`Create a New Project...`),
+            accelerator: 'CommandOrControl+N',
+            onClickSendEvent: 'main-menu-create',
           },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Open...`),
+            accelerator: 'CommandOrControl+O',
+            onClickSendEvent: 'main-menu-open',
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Save`),
+            accelerator: 'CommandOrControl+S',
+            onClickSendEvent: 'main-menu-save',
+            enabled: !!project,
+          },
+          {
+            label: i18n._(t`Save as...`),
+            accelerator: 'CommandOrControl+Alt+S',
+            onClickSendEvent: 'main-menu-save-as',
+            enabled: !!project,
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Export (web, iOS, Android)...`),
+            accelerator: 'CommandOrControl+E',
+            onClickSendEvent: 'main-menu-export',
+            enabled: !!project,
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Close Project`),
+            accelerator: 'CommandOrControl+Shift+W',
+            onClickSendEvent: 'main-menu-close',
+            enabled: !!project,
+          },
+        ],
+      };
+      if (!isMacLike()) {
+        fileTemplate.submenu.push(
           { type: 'separator' },
           {
             label: i18n._(t`My Profile`),
@@ -319,40 +178,177 @@ class ElectronMainMenu extends React.Component<MainMenuProps, {||}> {
             onClickSendEvent: 'main-menu-open-language',
           },
           { type: 'separator' },
-          { role: 'services', submenu: [] },
+          {
+            label: i18n._(t`Exit GDevelop`),
+            accelerator: 'Control+Q',
+            onClickSendEvent: 'main-menu-close-app',
+          }
+        );
+      }
+
+      const editTemplate = {
+        label: i18n._(t`Edit`),
+        submenu: [
+          { role: 'undo' },
+          { role: 'redo' },
           { type: 'separator' },
-          { role: 'hide' },
-          { role: 'hideothers' },
-          { role: 'unhide' },
-          { type: 'separator' },
-          { role: 'quit' },
+          { role: 'cut' },
+          { role: 'copy' },
+          { role: 'paste' },
+          { role: 'pasteandmatchstyle' },
+          { role: 'delete' },
+          { role: 'selectall' },
         ],
-      });
+      };
 
-      editTemplate.submenu.push(
-        { type: 'separator' },
-        {
-          label: i18n._(t`Speech`),
-          submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
-        }
-      );
+      const viewTemplate = {
+        label: i18n._(t`View`),
+        submenu: [
+          {
+            label: i18n._(t`Show Project Manager`),
+            accelerator: 'CommandOrControl+Alt+P',
+            onClickSendEvent: 'main-menu-open-project-manager',
+            enabled: !!project,
+          },
+          {
+            label: i18n._(t`Show Start Page`),
+            onClickSendEvent: 'main-menu-open-start-page',
+          },
+          {
+            label: i18n._(t`Open Debugger`),
+            onClickSendEvent: 'main-menu-open-debugger',
+            enabled: !!project,
+          },
+          { type: 'separator' },
+          { role: 'toggledevtools' },
+          { type: 'separator' },
+          { role: 'togglefullscreen' },
+        ],
+      };
 
-      windowTemplate.submenu = [
-        { role: 'minimize' },
-        { role: 'zoom' },
-        { type: 'separator' },
-        { role: 'front' },
+      const windowTemplate = {
+        role: 'window',
+        submenu: [{ role: 'minimize' }],
+      };
+
+      const helpTemplate = {
+        role: 'help',
+        submenu: [
+          {
+            label: i18n._(t`GDevelop website`),
+            onClickOpenLink: 'http://gdevelop-app.com',
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Community Forums`),
+            onClickOpenLink: 'https://forum.gdevelop-app.com',
+          },
+          {
+            label: i18n._(t`Community Discord Chat`),
+            onClickOpenLink: 'https://discord.gg/rjdYHvj',
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Contribute to GDevelop`),
+            onClickOpenLink: 'https://gdevelop-app.com/contribute/',
+          },
+          {
+            label: i18n._(t`Create Extensions for GDevelop`),
+            onClickOpenLink:
+              'https://github.com/4ian/GDevelop/blob/master/newIDE/README-extensions.md',
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Help to Translate GDevelop`),
+            onClickOpenLink: 'https://crowdin.com/project/gdevelop',
+          },
+          {
+            label: i18n._(t`Report a wrong translation`),
+            onClickOpenLink: 'https://github.com/4ian/GDevelop/issues/969',
+          },
+        ],
+      };
+      if (!isMacLike()) {
+        helpTemplate.submenu.push(
+          { type: 'separator' },
+          {
+            label: i18n._(t`About GDevelop`),
+            onClickSendEvent: 'main-menu-open-about',
+          }
+        );
+      }
+
+      const template: Array<RootMenuTemplate> = [
+        fileTemplate,
+        editTemplate,
+        viewTemplate,
+        windowTemplate,
+        helpTemplate,
       ];
-    }
 
-    if (ipcRenderer) {
-      ipcRenderer.send('set-main-menu', template);
-    }
-  }
+      if (isMacLike()) {
+        template.unshift({
+          label: i18n._(t`GDevelop 5`),
+          submenu: [
+            {
+              label: i18n._(t`About GDevelop`),
+              onClickSendEvent: 'main-menu-open-about',
+            },
+            { type: 'separator' },
+            {
+              label: i18n._(t`My Profile`),
+              onClickSendEvent: 'main-menu-open-profile',
+            },
+            {
+              label: i18n._(t`Preferences`),
+              onClickSendEvent: 'main-menu-open-preferences',
+            },
+            {
+              label: i18n._(t`Language`),
+              onClickSendEvent: 'main-menu-open-language',
+            },
+            { type: 'separator' },
+            { role: 'services', submenu: [] },
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'hideothers' },
+            { role: 'unhide' },
+            { type: 'separator' },
+            { role: 'quit' },
+          ],
+        });
 
-  render() {
-    return null;
-  }
-}
+        editTemplate.submenu.push(
+          { type: 'separator' },
+          {
+            label: i18n._(t`Speech`),
+            submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
+          }
+        );
+
+        windowTemplate.submenu = [
+          { role: 'minimize' },
+          { role: 'zoom' },
+          { type: 'separator' },
+          { role: 'front' },
+        ];
+      }
+
+      if (ipcRenderer) {
+        ipcRenderer.send('set-main-menu', template);
+      }
+    },
+    [i18n, project]
+  );
+
+  React.useEffect(
+    () => {
+      _buildAndSendMenuTemplate();
+    },
+    [_buildAndSendMenuTemplate, i18n.language]
+  );
+
+  return null;
+};
 
 export default ElectronMainMenu;

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -70,12 +70,234 @@ const useIPCEventListener = (ipcEvent: MainMenuEvent, func) => {
   );
 };
 
+const buildAndSendMenuTemplate = (project, i18n) => {
+  const fileTemplate = {
+    label: i18n._(t`File`),
+    submenu: [
+      {
+        label: i18n._(t`Create a New Project...`),
+        accelerator: 'CommandOrControl+N',
+        onClickSendEvent: 'main-menu-create',
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Open...`),
+        accelerator: 'CommandOrControl+O',
+        onClickSendEvent: 'main-menu-open',
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Save`),
+        accelerator: 'CommandOrControl+S',
+        onClickSendEvent: 'main-menu-save',
+        enabled: !!project,
+      },
+      {
+        label: i18n._(t`Save as...`),
+        accelerator: 'CommandOrControl+Alt+S',
+        onClickSendEvent: 'main-menu-save-as',
+        enabled: !!project,
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Export (web, iOS, Android)...`),
+        accelerator: 'CommandOrControl+E',
+        onClickSendEvent: 'main-menu-export',
+        enabled: !!project,
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Close Project`),
+        accelerator: 'CommandOrControl+Shift+W',
+        onClickSendEvent: 'main-menu-close',
+        enabled: !!project,
+      },
+    ],
+  };
+  if (!isMacLike()) {
+    fileTemplate.submenu.push(
+      { type: 'separator' },
+      {
+        label: i18n._(t`My Profile`),
+        onClickSendEvent: 'main-menu-open-profile',
+      },
+      {
+        label: i18n._(t`Preferences`),
+        onClickSendEvent: 'main-menu-open-preferences',
+      },
+      {
+        label: i18n._(t`Language`),
+        onClickSendEvent: 'main-menu-open-language',
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Exit GDevelop`),
+        accelerator: 'Control+Q',
+        onClickSendEvent: 'main-menu-close-app',
+      }
+    );
+  }
+
+  const editTemplate = {
+    label: i18n._(t`Edit`),
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'pasteandmatchstyle' },
+      { role: 'delete' },
+      { role: 'selectall' },
+    ],
+  };
+
+  const viewTemplate = {
+    label: i18n._(t`View`),
+    submenu: [
+      {
+        label: i18n._(t`Show Project Manager`),
+        accelerator: 'CommandOrControl+Alt+P',
+        onClickSendEvent: 'main-menu-open-project-manager',
+        enabled: !!project,
+      },
+      {
+        label: i18n._(t`Show Start Page`),
+        onClickSendEvent: 'main-menu-open-start-page',
+      },
+      {
+        label: i18n._(t`Open Debugger`),
+        onClickSendEvent: 'main-menu-open-debugger',
+        enabled: !!project,
+      },
+      { type: 'separator' },
+      { role: 'toggledevtools' },
+      { type: 'separator' },
+      { role: 'togglefullscreen' },
+    ],
+  };
+
+  const windowTemplate = {
+    role: 'window',
+    submenu: [{ role: 'minimize' }],
+  };
+
+  const helpTemplate = {
+    role: 'help',
+    submenu: [
+      {
+        label: i18n._(t`GDevelop website`),
+        onClickOpenLink: 'http://gdevelop-app.com',
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Community Forums`),
+        onClickOpenLink: 'https://forum.gdevelop-app.com',
+      },
+      {
+        label: i18n._(t`Community Discord Chat`),
+        onClickOpenLink: 'https://discord.gg/rjdYHvj',
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Contribute to GDevelop`),
+        onClickOpenLink: 'https://gdevelop-app.com/contribute/',
+      },
+      {
+        label: i18n._(t`Create Extensions for GDevelop`),
+        onClickOpenLink:
+          'https://github.com/4ian/GDevelop/blob/master/newIDE/README-extensions.md',
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Help to Translate GDevelop`),
+        onClickOpenLink: 'https://crowdin.com/project/gdevelop',
+      },
+      {
+        label: i18n._(t`Report a wrong translation`),
+        onClickOpenLink: 'https://github.com/4ian/GDevelop/issues/969',
+      },
+    ],
+  };
+  if (!isMacLike()) {
+    helpTemplate.submenu.push(
+      { type: 'separator' },
+      {
+        label: i18n._(t`About GDevelop`),
+        onClickSendEvent: 'main-menu-open-about',
+      }
+    );
+  }
+
+  const template: Array<RootMenuTemplate> = [
+    fileTemplate,
+    editTemplate,
+    viewTemplate,
+    windowTemplate,
+    helpTemplate,
+  ];
+
+  if (isMacLike()) {
+    template.unshift({
+      label: i18n._(t`GDevelop 5`),
+      submenu: [
+        {
+          label: i18n._(t`About GDevelop`),
+          onClickSendEvent: 'main-menu-open-about',
+        },
+        { type: 'separator' },
+        {
+          label: i18n._(t`My Profile`),
+          onClickSendEvent: 'main-menu-open-profile',
+        },
+        {
+          label: i18n._(t`Preferences`),
+          onClickSendEvent: 'main-menu-open-preferences',
+        },
+        {
+          label: i18n._(t`Language`),
+          onClickSendEvent: 'main-menu-open-language',
+        },
+        { type: 'separator' },
+        { role: 'services', submenu: [] },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideothers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    });
+
+    editTemplate.submenu.push(
+      { type: 'separator' },
+      {
+        label: i18n._(t`Speech`),
+        submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
+      }
+    );
+
+    windowTemplate.submenu = [
+      { role: 'minimize' },
+      { role: 'zoom' },
+      { type: 'separator' },
+      { role: 'front' },
+    ];
+  }
+
+  if (ipcRenderer) {
+    ipcRenderer.send('set-main-menu', template);
+  }
+};
+
 /**
  * Forward events received from Electron main process
  * to the MainFrame component.
  */
 const ElectronMainMenu = (props: MainMenuProps) => {
   const { i18n, project } = props;
+  const language = i18n.language;
 
   useIPCEventListener('main-menu-open', props.onChooseProject);
   useIPCEventListener('main-menu-save', props.onSaveProject);
@@ -96,235 +318,11 @@ const ElectronMainMenu = (props: MainMenuProps) => {
   useIPCEventListener('main-menu-open-profile', props.onOpenProfile);
   useIPCEventListener('update-status', props.setUpdateStatus);
 
-  const _buildAndSendMenuTemplate = React.useCallback(
-    () => {
-      const fileTemplate = {
-        label: i18n._(t`File`),
-        submenu: [
-          {
-            label: i18n._(t`Create a New Project...`),
-            accelerator: 'CommandOrControl+N',
-            onClickSendEvent: 'main-menu-create',
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Open...`),
-            accelerator: 'CommandOrControl+O',
-            onClickSendEvent: 'main-menu-open',
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Save`),
-            accelerator: 'CommandOrControl+S',
-            onClickSendEvent: 'main-menu-save',
-            enabled: !!project,
-          },
-          {
-            label: i18n._(t`Save as...`),
-            accelerator: 'CommandOrControl+Alt+S',
-            onClickSendEvent: 'main-menu-save-as',
-            enabled: !!project,
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Export (web, iOS, Android)...`),
-            accelerator: 'CommandOrControl+E',
-            onClickSendEvent: 'main-menu-export',
-            enabled: !!project,
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Close Project`),
-            accelerator: 'CommandOrControl+Shift+W',
-            onClickSendEvent: 'main-menu-close',
-            enabled: !!project,
-          },
-        ],
-      };
-      if (!isMacLike()) {
-        fileTemplate.submenu.push(
-          { type: 'separator' },
-          {
-            label: i18n._(t`My Profile`),
-            onClickSendEvent: 'main-menu-open-profile',
-          },
-          {
-            label: i18n._(t`Preferences`),
-            onClickSendEvent: 'main-menu-open-preferences',
-          },
-          {
-            label: i18n._(t`Language`),
-            onClickSendEvent: 'main-menu-open-language',
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Exit GDevelop`),
-            accelerator: 'Control+Q',
-            onClickSendEvent: 'main-menu-close-app',
-          }
-        );
-      }
-
-      const editTemplate = {
-        label: i18n._(t`Edit`),
-        submenu: [
-          { role: 'undo' },
-          { role: 'redo' },
-          { type: 'separator' },
-          { role: 'cut' },
-          { role: 'copy' },
-          { role: 'paste' },
-          { role: 'pasteandmatchstyle' },
-          { role: 'delete' },
-          { role: 'selectall' },
-        ],
-      };
-
-      const viewTemplate = {
-        label: i18n._(t`View`),
-        submenu: [
-          {
-            label: i18n._(t`Show Project Manager`),
-            accelerator: 'CommandOrControl+Alt+P',
-            onClickSendEvent: 'main-menu-open-project-manager',
-            enabled: !!project,
-          },
-          {
-            label: i18n._(t`Show Start Page`),
-            onClickSendEvent: 'main-menu-open-start-page',
-          },
-          {
-            label: i18n._(t`Open Debugger`),
-            onClickSendEvent: 'main-menu-open-debugger',
-            enabled: !!project,
-          },
-          { type: 'separator' },
-          { role: 'toggledevtools' },
-          { type: 'separator' },
-          { role: 'togglefullscreen' },
-        ],
-      };
-
-      const windowTemplate = {
-        role: 'window',
-        submenu: [{ role: 'minimize' }],
-      };
-
-      const helpTemplate = {
-        role: 'help',
-        submenu: [
-          {
-            label: i18n._(t`GDevelop website`),
-            onClickOpenLink: 'http://gdevelop-app.com',
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Community Forums`),
-            onClickOpenLink: 'https://forum.gdevelop-app.com',
-          },
-          {
-            label: i18n._(t`Community Discord Chat`),
-            onClickOpenLink: 'https://discord.gg/rjdYHvj',
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Contribute to GDevelop`),
-            onClickOpenLink: 'https://gdevelop-app.com/contribute/',
-          },
-          {
-            label: i18n._(t`Create Extensions for GDevelop`),
-            onClickOpenLink:
-              'https://github.com/4ian/GDevelop/blob/master/newIDE/README-extensions.md',
-          },
-          { type: 'separator' },
-          {
-            label: i18n._(t`Help to Translate GDevelop`),
-            onClickOpenLink: 'https://crowdin.com/project/gdevelop',
-          },
-          {
-            label: i18n._(t`Report a wrong translation`),
-            onClickOpenLink: 'https://github.com/4ian/GDevelop/issues/969',
-          },
-        ],
-      };
-      if (!isMacLike()) {
-        helpTemplate.submenu.push(
-          { type: 'separator' },
-          {
-            label: i18n._(t`About GDevelop`),
-            onClickSendEvent: 'main-menu-open-about',
-          }
-        );
-      }
-
-      const template: Array<RootMenuTemplate> = [
-        fileTemplate,
-        editTemplate,
-        viewTemplate,
-        windowTemplate,
-        helpTemplate,
-      ];
-
-      if (isMacLike()) {
-        template.unshift({
-          label: i18n._(t`GDevelop 5`),
-          submenu: [
-            {
-              label: i18n._(t`About GDevelop`),
-              onClickSendEvent: 'main-menu-open-about',
-            },
-            { type: 'separator' },
-            {
-              label: i18n._(t`My Profile`),
-              onClickSendEvent: 'main-menu-open-profile',
-            },
-            {
-              label: i18n._(t`Preferences`),
-              onClickSendEvent: 'main-menu-open-preferences',
-            },
-            {
-              label: i18n._(t`Language`),
-              onClickSendEvent: 'main-menu-open-language',
-            },
-            { type: 'separator' },
-            { role: 'services', submenu: [] },
-            { type: 'separator' },
-            { role: 'hide' },
-            { role: 'hideothers' },
-            { role: 'unhide' },
-            { type: 'separator' },
-            { role: 'quit' },
-          ],
-        });
-
-        editTemplate.submenu.push(
-          { type: 'separator' },
-          {
-            label: i18n._(t`Speech`),
-            submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
-          }
-        );
-
-        windowTemplate.submenu = [
-          { role: 'minimize' },
-          { role: 'zoom' },
-          { type: 'separator' },
-          { role: 'front' },
-        ];
-      }
-
-      if (ipcRenderer) {
-        ipcRenderer.send('set-main-menu', template);
-      }
-    },
-    [i18n, project]
-  );
-
   React.useEffect(
     () => {
-      _buildAndSendMenuTemplate();
+      buildAndSendMenuTemplate(project, i18n);
     },
-    [_buildAndSendMenuTemplate, i18n.language]
+    [i18n, language, project]
   );
 
   return null;

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -57,8 +57,18 @@ type RootMenuTemplate =
       submenu: Array<MenuItemTemplate>,
     |};
 
-// Custom hook to run function only once, regardless of prop changes
-const useMountEffect = func => React.useEffect(func, []);
+// Custom hook to register and deregister IPC listener
+const useIPCEventListener = (ipcEvent: MainMenuEvent, func) => {
+  React.useEffect(
+    () => {
+      if (!ipcRenderer) return;
+      const handler = (event, ...eventArgs) => func(...eventArgs);
+      ipcRenderer.on(ipcEvent, handler);
+      return () => ipcRenderer.removeListener(ipcEvent, handler);
+    },
+    [ipcEvent, func]
+  );
+};
 
 /**
  * Forward events received from Electron main process
@@ -67,55 +77,24 @@ const useMountEffect = func => React.useEffect(func, []);
 const ElectronMainMenu = (props: MainMenuProps) => {
   const { i18n, project } = props;
 
-  useMountEffect(() => {
-    if (!ipcRenderer) return;
-
-    ipcRenderer.on(('main-menu-open': MainMenuEvent), event =>
-      props.onChooseProject()
-    );
-    ipcRenderer.on(('main-menu-save': MainMenuEvent), event =>
-      props.onSaveProject()
-    );
-    ipcRenderer.on(('main-menu-save-as': MainMenuEvent), event =>
-      props.onSaveProjectAs()
-    );
-    ipcRenderer.on(('main-menu-close': MainMenuEvent), event =>
-      props.onCloseProject()
-    );
-    ipcRenderer.on(('main-menu-close-app': MainMenuEvent), event =>
-      props.onCloseApp()
-    );
-    ipcRenderer.on(('main-menu-export': MainMenuEvent), event =>
-      props.onExportProject()
-    );
-    ipcRenderer.on(('main-menu-create': MainMenuEvent), event =>
-      props.onCreateProject()
-    );
-    ipcRenderer.on(('main-menu-open-project-manager': MainMenuEvent), event =>
-      props.onOpenProjectManager()
-    );
-    ipcRenderer.on(('main-menu-open-start-page': MainMenuEvent), event =>
-      props.onOpenStartPage()
-    );
-    ipcRenderer.on(('main-menu-open-debugger': MainMenuEvent), event =>
-      props.onOpenDebugger()
-    );
-    ipcRenderer.on(('main-menu-open-about': MainMenuEvent), event =>
-      props.onOpenAbout()
-    );
-    ipcRenderer.on(('main-menu-open-preferences': MainMenuEvent), event =>
-      props.onOpenPreferences()
-    );
-    ipcRenderer.on(('main-menu-open-language': MainMenuEvent), event =>
-      props.onOpenLanguage()
-    );
-    ipcRenderer.on(('main-menu-open-profile': MainMenuEvent), event =>
-      props.onOpenProfile()
-    );
-    ipcRenderer.on(('update-status': MainMenuEvent), (event, status) =>
-      props.setUpdateStatus(status)
-    );
-  });
+  useIPCEventListener('main-menu-open', props.onChooseProject);
+  useIPCEventListener('main-menu-save', props.onSaveProject);
+  useIPCEventListener('main-menu-save-as', props.onSaveProjectAs);
+  useIPCEventListener('main-menu-close', props.onCloseProject);
+  useIPCEventListener('main-menu-close-app', props.onCloseApp);
+  useIPCEventListener('main-menu-export', props.onExportProject);
+  useIPCEventListener('main-menu-create', props.onCreateProject);
+  useIPCEventListener(
+    'main-menu-open-project-manager',
+    props.onOpenProjectManager
+  );
+  useIPCEventListener('main-menu-open-start-page', props.onOpenStartPage);
+  useIPCEventListener('main-menu-open-debugger', props.onOpenDebugger);
+  useIPCEventListener('main-menu-open-about', props.onOpenAbout);
+  useIPCEventListener('main-menu-open-preferences', props.onOpenPreferences);
+  useIPCEventListener('main-menu-open-language', props.onOpenLanguage);
+  useIPCEventListener('main-menu-open-profile', props.onOpenProfile);
+  useIPCEventListener('update-status', props.setUpdateStatus);
 
   const _buildAndSendMenuTemplate = React.useCallback(
     () => {

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -292,8 +292,7 @@ const buildAndSendMenuTemplate = (project, i18n) => {
 };
 
 /**
- * Forward events received from Electron main process
- * to the MainFrame component.
+ * Create and update the editor main menu using Electron APIs.
  */
 const ElectronMainMenu = (props: MainMenuProps) => {
   const { i18n, project } = props;


### PR DESCRIPTION
This PR refactors ElectronMainMenu into a functional component.
I've tested it properly: there's exactly one menu build call on language change, and one menu build call on project open or close. No unnecessary menu builds, no repetitive listeners, no React warnings :)

I've used a simple custom hook `useMountEffect` for running the effect for setting up the IPC renderer listeners just once, regardless of prop changes. Directly using `useEffect(func, [])` leads to complains about missing dependencies (which are all the functions passed as prop) and then, if I do add them to the dependency array, the effect start running a lot leading to repetitive listeners.