### PR TITLE
Fix_renderer_for_fix_blur_fonts_and_images

### DIFF
--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.js
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.js
@@ -34,7 +34,7 @@ gdjs.TextRuntimeObjectPixiRenderer.prototype.updateStyle = function() {
     var style = this._text.style;
     style.fontStyle = this._object._italic ? 'italic' : 'normal';
     style.fontWeight = this._object._bold ? 'bold' : 'normal';
-    style.fontSize = this._object._characterSize;
+    style.fontSize = this._object._characterSize * 4;
     style.fontFamily = fontName;
 
     if (this._object._useGradient){
@@ -72,6 +72,7 @@ gdjs.TextRuntimeObjectPixiRenderer.prototype.updateStyle = function() {
     // Prevent spikey outlines by adding a miter limit 
     style.miterLimit = 3;
 
+    this._text.scale.set(0.25,0.25);
     this.updatePosition();
 
     // Manually ask the PIXI object to re-render as we changed a style property

--- a/Extensions/TextObject/textruntimeobject.js
+++ b/Extensions/TextObject/textruntimeobject.js
@@ -93,7 +93,7 @@ gdjs.TextRuntimeObject = function(runtimeScene, textObjectData)
     this._shadowAngle = 0;
 
     /** @type {number} */
-    this._padding = 5;
+    this._padding = 50;
 
     /** @type {number} */
     this._scaleX = 1;

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
@@ -97,12 +97,12 @@ gdjs.RuntimeGamePixiRenderer.prototype._resizeCanvas = function() {
   // There is no "smart" resizing to be done here: the rendering of the game
   // should be done with the size set on the game.
   if (
-    this._pixiRenderer.width !== this._game.getGameResolutionWidth() ||
-    this._pixiRenderer.height !== this._game.getGameResolutionHeight()
+    this._pixiRenderer.width !== gdjs.evtTools.window.getWindowInnerWidth() ||
+    this._pixiRenderer.height !== gdjs.evtTools.window.getWindowInnerHeight()
   ) {
     this._pixiRenderer.resize(
-      this._game.getGameResolutionWidth(),
-      this._game.getGameResolutionHeight()
+      gdjs.evtTools.window.getWindowInnerWidth(),
+      gdjs.evtTools.window.getWindowInnerHeight()
     );
   }
 
@@ -294,7 +294,6 @@ gdjs.RuntimeGamePixiRenderer.prototype.bindStandardEvents = function(
     //Handle the fact that the game is stretched to fill the canvas.
     pos[0] *= that._game.getGameResolutionWidth() / (that._canvasWidth || 1);
     pos[1] *= that._game.getGameResolutionHeight() / (that._canvasHeight || 1);
-
     return pos;
   }
 


### PR DESCRIPTION
[See the complete thread ](https://github.com/4ian/GDevelop/issues/1449)

I've used the dimension of the window for said to the renderer to comptue a renderer equal to the size of the window.
Before this it was used the size of the game, in Project manager > Game settings > Width and height.

Only tested on preview for now.

![image](https://user-images.githubusercontent.com/1670670/79395257-83f71580-7f79-11ea-94ce-2024fab4844c.png)


I've build two release with my bug fix.

[linux-unpacked.zip	](https://mega.nz/file/obx3FZjT#VyNlXYa_S3MYHlgQ-Bzn-Kd5mzRTjNyxBTUxCJFlRbM)

[win-unpacked.zip](https://mega.nz/file/dSglUZTA#aC-WV9viWizNp-xd0BYm9-a_qxEryu712NYIsaCpXYk)