### PR TITLE
Fix Typos

### DIFF
--- a/Core/GDCore/IDE/WholeProjectRefactorer.h
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.h
@@ -181,7 +181,7 @@ class GD_CORE_API WholeProjectRefactorer {
       bool isObjectGroup);
 
   /**
-   * \brief Refactor the events function after an object or group is renamed
+   * \brief Refactor the events function after an object or group is removed
    *
    * This will update the events of the function and groups.
    */


### PR DESCRIPTION
Changed Description of WholeProjectRefactorer::ObjectOrGroupRemovedInEventsFunction() from "rename" to "remove".
