### PR TITLE
Layers editor as a panel and tweaks

### DIFF
--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -57,7 +57,7 @@ export default class DebuggerContent extends React.Component<Props, State> {
   _editors: ?EditorMosaic = null;
 
   openProfiler = () => {
-    if (this._editors) this._editors.openEditor('profiler', 'end', 75);
+    if (this._editors) this._editors.openEditor('profiler', 'end', 75, 'row');
   };
 
   render() {
@@ -116,66 +116,78 @@ export default class DebuggerContent extends React.Component<Props, State> {
             type: 'primary',
             noTitleBar: true,
             renderEditor: () => (
-              <Column expand noMargin>
-                {selectedInspector ? (
-                  rawMode ? (
-                    <RawContentInspector
-                      gameData={get(gameData, selectedInspectorFullPath, null)}
-                      onEdit={(path, newValue) =>
-                        onEdit(selectedInspectorFullPath.concat(path), newValue)
-                      }
-                    />
-                  ) : (
-                    selectedInspector.renderInspector(
-                      get(gameData, selectedInspectorFullPath, null),
-                      {
-                        onCall: (path, args) =>
-                          onCall(selectedInspectorFullPath.concat(path), args),
-                        onEdit: (path, newValue) =>
+              <Background>
+                <Column expand noMargin>
+                  {selectedInspector ? (
+                    rawMode ? (
+                      <RawContentInspector
+                        gameData={get(
+                          gameData,
+                          selectedInspectorFullPath,
+                          null
+                        )}
+                        onEdit={(path, newValue) =>
                           onEdit(
                             selectedInspectorFullPath.concat(path),
                             newValue
-                          ),
-                      }
-                    ) || (
-                      <EmptyMessage>
-                        <Trans>
-                          No inspector, choose another element in the list or
-                          toggle the raw data view.
-                        </Trans>
-                      </EmptyMessage>
-                    )
-                  )
-                ) : (
-                  <EmptyMessage>
-                    {gameData ? (
-                      <Trans>Choose an element to inspect in the list</Trans>
-                    ) : (
-                      <Trans>
-                        Pause the game (from the toolbar) or hit refresh (on the
-                        left) to inspect the game
-                      </Trans>
-                    )}
-                  </EmptyMessage>
-                )}
-                <Column>
-                  <Line justifyContent="space-between" alignItems="center">
-                    <HelpButton helpPagePath="/interface/debugger" />
-                    <div>
-                      <Checkbox
-                        checkedIcon={<Flash />}
-                        uncheckedIcon={<FlashOff />}
-                        checked={rawMode}
-                        onCheck={(e, enabled) =>
-                          this.setState({
-                            rawMode: enabled,
-                          })
+                          )
                         }
                       />
-                    </div>
-                  </Line>
+                    ) : (
+                      selectedInspector.renderInspector(
+                        get(gameData, selectedInspectorFullPath, null),
+                        {
+                          onCall: (path, args) =>
+                            onCall(
+                              selectedInspectorFullPath.concat(path),
+                              args
+                            ),
+                          onEdit: (path, newValue) =>
+                            onEdit(
+                              selectedInspectorFullPath.concat(path),
+                              newValue
+                            ),
+                        }
+                      ) || (
+                        <EmptyMessage>
+                          <Trans>
+                            No inspector, choose another element in the list or
+                            toggle the raw data view.
+                          </Trans>
+                        </EmptyMessage>
+                      )
+                    )
+                  ) : (
+                    <EmptyMessage>
+                      {gameData ? (
+                        <Trans>Choose an element to inspect in the list</Trans>
+                      ) : (
+                        <Trans>
+                          Pause the game (from the toolbar) or hit refresh (on
+                          the left) to inspect the game
+                        </Trans>
+                      )}
+                    </EmptyMessage>
+                  )}
+                  <Column>
+                    <Line justifyContent="space-between" alignItems="center">
+                      <HelpButton helpPagePath="/interface/debugger" />
+                      <div>
+                        <Checkbox
+                          checkedIcon={<Flash />}
+                          uncheckedIcon={<FlashOff />}
+                          checked={rawMode}
+                          onCheck={(e, enabled) =>
+                            this.setState({
+                              rawMode: enabled,
+                            })
+                          }
+                        />
+                      </div>
+                    </Line>
+                  </Column>
                 </Column>
-              </Column>
+              </Background>
             ),
           },
           profiler: {

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -310,7 +310,12 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
         this.updateToolbar();
         if (selectedEventsBasedBehavior) {
           if (this._editorMosaic)
-            this._editorMosaic.openEditor('behavior-functions-list', 'end', 75);
+            this._editorMosaic.openEditor(
+              'behavior-functions-list',
+              'end',
+              75,
+              'row'
+            );
           if (this._editorNavigator)
             this._editorNavigator.openEditor('behavior-functions-list');
         }

--- a/newIDE/app/src/LayersList/BackgroundColorRow.js
+++ b/newIDE/app/src/LayersList/BackgroundColorRow.js
@@ -2,12 +2,12 @@
 import { t } from '@lingui/macro';
 
 import React from 'react';
-import { TableRow, TableRowColumn } from '../UI/Table';
 import TextField from '../UI/TextField';
 
 import styles from './styles';
 import ThemeConsumer from '../UI/Theme/ThemeConsumer';
 import ColorPicker from '../UI/ColorField/ColorPicker';
+import { TreeTableCell, TreeTableRow } from '../UI/TreeTable';
 
 type Props = {|
   layout: gdLayout,
@@ -15,34 +15,31 @@ type Props = {|
 |};
 
 export default ({ layout, onBackgroundColorChanged }: Props) => (
-  <ThemeConsumer>
-    {muiTheme => (
-      <TableRow
-        style={{
-          backgroundColor: muiTheme.list.itemsBackgroundColor,
+  <TreeTableRow>
+    <TreeTableCell style={styles.handleColumn} />
+    <TreeTableCell expand>
+      <TextField
+        fullWidth
+        hintText={t`Background color`}
+        margin="none"
+        disabled
+      />
+    </TreeTableCell>
+    <TreeTableCell style={styles.effectsColumn}>
+      <ColorPicker
+        disableAlpha
+        color={{
+          r: layout.getBackgroundColorRed(),
+          g: layout.getBackgroundColorGreen(),
+          b: layout.getBackgroundColorBlue(),
+          a: 255,
         }}
-      >
-        <TableRowColumn style={styles.handleColumn} />
-        <TableRowColumn>
-          <TextField hintText={t`Background color`} margin="none" disabled />
-        </TableRowColumn>
-        <TableRowColumn style={styles.effectsColumn}>
-          <ColorPicker
-            disableAlpha
-            color={{
-              r: layout.getBackgroundColorRed(),
-              g: layout.getBackgroundColorGreen(),
-              b: layout.getBackgroundColorBlue(),
-              a: 255,
-            }}
-            onChangeComplete={color => {
-              layout.setBackgroundColor(color.rgb.r, color.rgb.g, color.rgb.b);
-              onBackgroundColorChanged();
-            }}
-          />
-        </TableRowColumn>
-        <TableRowColumn style={styles.toolColumn} />
-      </TableRow>
-    )}
-  </ThemeConsumer>
+        onChangeComplete={color => {
+          layout.setBackgroundColor(color.rgb.r, color.rgb.g, color.rgb.b);
+          onBackgroundColorChanged();
+        }}
+      />
+    </TreeTableCell>
+    <TreeTableCell style={styles.toolColumn} />
+  </TreeTableRow>
 );

--- a/newIDE/app/src/LayersList/LayerRemoveDialog.js
+++ b/newIDE/app/src/LayersList/LayerRemoveDialog.js
@@ -4,6 +4,7 @@ import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import SelectField from '../UI/SelectField';
 import SelectOption from '../UI/SelectOption';
+import Text from '../UI/Text';
 import enumerateLayers from './EnumerateLayers';
 
 export default class VariablesEditorDialog extends Component {
@@ -63,9 +64,9 @@ export default class VariablesEditorDialog extends Component {
         open={this.props.open}
         onRequestClose={this.props.onCancel}
       >
-        <div>
+        <Text>
           <Trans>Move objects on layer {this.props.layerRemoved} to:</Trans>
-        </div>
+        </Text>
         <SelectField
           value={this.state.selectedLayer}
           onChange={(event, index, newValue) => {

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React from 'react';
-import { TableRow, TableRowColumn } from '../UI/Table';
+import { TreeTableRow, TreeTableCell } from '../UI/TreeTable';
 import InlineCheckbox from '../UI/InlineCheckbox';
 import Visibility from '@material-ui/icons/Visibility';
 import VisibilityOff from '@material-ui/icons/VisibilityOff';
@@ -36,52 +36,45 @@ export default ({
   onEditEffects,
   onChangeVisibility,
 }: Props) => (
-  <ThemeConsumer>
-    {muiTheme => (
-      <TableRow
-        style={{
-          backgroundColor: muiTheme.list.itemsBackgroundColor,
-        }}
-      >
-        <TableRowColumn style={styles.handleColumn}>
-          <DragHandle />
-        </TableRowColumn>
-        <TableRowColumn>
-          <TextField
-            margin="none"
-            defaultValue={layerName || 'Base layer'}
-            id={layerName}
-            errorText={
-              nameError ? <Trans>This name is already taken</Trans> : undefined
-            }
-            disabled={!layerName}
-            onBlur={onBlur}
-          />
-        </TableRowColumn>
-        <TableRowColumn style={styles.effectsColumn}>
-          <FlatButton
-            label={
-              effectsCount === 0 ? (
-                <Trans>Add effect</Trans>
-              ) : (
-                <Trans>{effectsCount} effect(s)</Trans>
-              )
-            }
-            onClick={onEditEffects}
-          />
-        </TableRowColumn>
-        <TableRowColumn style={styles.toolColumn}>
-          <InlineCheckbox
-            checked={isVisible}
-            checkedIcon={<Visibility />}
-            uncheckedIcon={<VisibilityOff />}
-            onCheck={(e, value) => onChangeVisibility(value)}
-          />
-          <IconButton onClick={onRemove} disabled={!layerName}>
-            <Delete />
-          </IconButton>
-        </TableRowColumn>
-      </TableRow>
-    )}
-  </ThemeConsumer>
+  <TreeTableRow>
+    <TreeTableCell style={styles.handleColumn}>
+      <DragHandle />
+    </TreeTableCell>
+    <TreeTableCell expand>
+      <TextField
+        margin="none"
+        defaultValue={layerName || 'Base layer'}
+        id={layerName}
+        errorText={
+          nameError ? <Trans>This name is already taken</Trans> : undefined
+        }
+        disabled={!layerName}
+        onBlur={onBlur}
+        fullWidth
+      />
+    </TreeTableCell>
+    <TreeTableCell style={styles.effectsColumn}>
+      <FlatButton
+        label={
+          effectsCount === 0 ? (
+            <Trans>Add effect</Trans>
+          ) : (
+            <Trans>{effectsCount} effect(s)</Trans>
+          )
+        }
+        onClick={onEditEffects}
+      />
+    </TreeTableCell>
+    <TreeTableCell style={styles.toolColumn}>
+      <InlineCheckbox
+        checked={isVisible}
+        checkedIcon={<Visibility />}
+        uncheckedIcon={<VisibilityOff />}
+        onCheck={(e, value) => onChangeVisibility(value)}
+      />
+      <IconButton onClick={onRemove} disabled={!layerName}>
+        <Delete />
+      </IconButton>
+    </TreeTableCell>
+  </TreeTableRow>
 );

--- a/newIDE/app/src/LayersList/index.js
+++ b/newIDE/app/src/LayersList/index.js
@@ -1,14 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
-import {
-  Table,
-  TableBody,
-  TableHeader,
-  TableHeaderColumn,
-  TableRow,
-  TableRowColumn,
-} from '../UI/Table';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import { mapReverseFor } from '../Utils/MapFor';
@@ -25,6 +17,7 @@ import {
 } from '../ResourcesList/ResourceSource.flow';
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
+import ScrollView from '../UI/ScrollView';
 
 const SortableLayerRow = SortableElement(LayerRow);
 
@@ -99,19 +92,18 @@ class LayersListBody extends Component<*, LayersListBodyState> {
     });
 
     return (
-      <TableBody>
+      <Column noMargin>
         {containerLayersList}
         <BackgroundColorRow
           layout={layersContainer}
           onBackgroundColorChanged={() => this._onLayerModified()}
         />
-      </TableBody>
+      </Column>
     );
   }
 }
 
 const SortableLayersListBody = SortableContainer(LayersListBody);
-SortableLayersListBody.muiName = 'TableBody';
 
 type Props = {|
   project: gdProject,
@@ -176,18 +168,8 @@ export default class LayersList extends Component<Props, State> {
     const listKey = this.props.layersContainer.ptr;
 
     return (
-      <React.Fragment>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderColumn style={styles.handleColumn} />
-              <TableHeaderColumn>Layer name</TableHeaderColumn>
-              <TableHeaderColumn style={styles.effectsColumn}>
-                Effects
-              </TableHeaderColumn>
-              <TableRowColumn style={styles.toolColumn} />
-            </TableRow>
-          </TableHeader>
+      <ScrollView>
+        <Column noMargin expand>
           <SortableLayersListBody
             key={listKey}
             layersContainer={this.props.layersContainer}
@@ -206,33 +188,33 @@ export default class LayersList extends Component<Props, State> {
             useDragHandle
             unsavedChanges={this.props.unsavedChanges}
           />
-        </Table>
-        <Column>
-          <Line justifyContent="flex-end" expand>
-            <RaisedButton
-              label={<Trans>Add a layer</Trans>}
-              primary
-              onClick={this._addLayer}
-              labelPosition="before"
-              icon={<Add />}
+          <Column>
+            <Line justifyContent="flex-end" expand>
+              <RaisedButton
+                label={<Trans>Add a layer</Trans>}
+                primary
+                onClick={this._addLayer}
+                labelPosition="before"
+                icon={<Add />}
+              />
+            </Line>
+          </Column>
+          {effectsEditedLayer && (
+            <EffectsListDialog
+              project={project}
+              resourceSources={this.props.resourceSources}
+              onChooseResource={this.props.onChooseResource}
+              resourceExternalEditors={this.props.resourceExternalEditors}
+              effectsContainer={effectsEditedLayer}
+              onApply={() =>
+                this.setState({
+                  effectsEditedLayer: null,
+                })
+              }
             />
-          </Line>
+          )}
         </Column>
-        {effectsEditedLayer && (
-          <EffectsListDialog
-            project={project}
-            resourceSources={this.props.resourceSources}
-            onChooseResource={this.props.onChooseResource}
-            resourceExternalEditors={this.props.resourceExternalEditors}
-            effectsContainer={effectsEditedLayer}
-            onApply={() =>
-              this.setState({
-                effectsEditedLayer: null,
-              })
-            }
-          />
-        )}
-      </React.Fragment>
+      </ScrollView>
     );
   }
 }

--- a/newIDE/app/src/LayersList/styles.js
+++ b/newIDE/app/src/LayersList/styles.js
@@ -7,7 +7,7 @@ export default {
   },
   effectsColumn: {
     width: 100,
-    textAlign: 'center',
+    justifyContent: 'center',
   },
   toolColumn: {
     width: 96,

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -17,6 +17,7 @@ export type AlertMessageIdentifier =
   | 'instance-drag-n-drop-explanation'
   | 'objects-panel-explanation'
   | 'instance-properties-panel-explanation'
+  | 'layers-panel-explanation'
   | 'physics2-shape-collisions'
   | 'edit-instruction-explanation'
   | 'lifecycle-events-function-included-only-if-extension-used';
@@ -76,6 +77,10 @@ export const allAlertMessages: Array<{
   {
     key: 'instance-properties-panel-explanation',
     label: <Trans>Using the instance properties panel</Trans>,
+  },
+  {
+    key: 'layers-panel-explanation',
+    label: <Trans>Using the layers panel</Trans>,
   },
   {
     key: 'physics2-shape-collisions',

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -106,7 +106,7 @@ export default class ResourcesEditor extends React.Component<Props, State> {
 
   openProperties = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('properties', 'start', 66)) {
+    if (!this.editorMosaic.openEditor('properties', 'start', 66, 'column')) {
       this.setState({
         showPropertiesInfoBar: true,
       });

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -163,6 +163,7 @@ type State = {|
   showObjectsListInfoBar: boolean,
   layoutVariablesDialogOpen: boolean,
   showPropertiesInfoBar: boolean,
+  showLayersInfoBar: boolean,
 
   // State for tags of objects:
   selectedObjectTags: SelectedTags,
@@ -211,6 +212,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       showObjectsListInfoBar: false,
       layoutVariablesDialogOpen: false,
       showPropertiesInfoBar: false,
+      showLayersInfoBar: false,
 
       selectedObjectTags: [],
     };
@@ -282,7 +284,7 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   openObjectsList = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('objects-list', 'end', 75)) {
+    if (!this.editorMosaic.openEditor('objects-list', 'end', 75, 'column')) {
       this.setState({
         showObjectsListInfoBar: true,
       });
@@ -291,7 +293,7 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   openProperties = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('properties', 'start', 25)) {
+    if (!this.editorMosaic.openEditor('properties', 'start', 25, 'column')) {
       this.setState({
         showPropertiesInfoBar: true,
       });
@@ -300,7 +302,7 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   openObjectGroupsList = () => {
     if (!this.editorMosaic) return;
-    this.editorMosaic.openEditor('object-groups-list', 'end', 75);
+    this.editorMosaic.openEditor('object-groups-list', 'end', 75, 'column');
   };
 
   toggleInstancesList = () => {
@@ -308,7 +310,12 @@ export default class SceneEditor extends React.Component<Props, State> {
   };
 
   toggleLayersList = () => {
-    this.setState({ layersListOpen: !this.state.layersListOpen });
+    if (!this.editorMosaic) return;
+    if (!this.editorMosaic.openEditor('layers', 'end', 75, 'row')) {
+      this.setState({
+        showLayersInfoBar: true,
+      });
+    }
   };
 
   toggleWindowMask = () => {
@@ -929,6 +936,23 @@ export default class SceneEditor extends React.Component<Props, State> {
           />
         ),
       },
+      layers: {
+        type: 'secondary',
+        title: t`Layers`,
+        renderEditor: () => (
+          <LayersList
+            project={project}
+            resourceSources={resourceSources}
+            resourceExternalEditors={resourceExternalEditors}
+            onChooseResource={onChooseResource}
+            freezeUpdate={false}
+            onRemoveLayer={this._onRemoveLayer}
+            onRenameLayer={this._onRenameLayer}
+            layersContainer={layout}
+            unsavedChanges={this.props.unsavedChanges}
+          />
+        ),
+      },
       'instances-editor': {
         type: 'primary',
         noTitleBar: true,
@@ -1108,29 +1132,6 @@ export default class SceneEditor extends React.Component<Props, State> {
             }}
           />
         </Drawer>
-        <Drawer
-          open={this.state.layersListOpen}
-          PaperProps={layersDrawerPaperProps}
-          anchor="right"
-          onClose={this.toggleLayersList}
-        >
-          <EditorBar
-            title={<Trans>Layers</Trans>}
-            displayLeftCloseButton
-            onClose={this.toggleLayersList}
-          />
-          <LayersList
-            project={project}
-            resourceSources={resourceSources}
-            resourceExternalEditors={resourceExternalEditors}
-            onChooseResource={onChooseResource}
-            freezeUpdate={!this.state.layersListOpen}
-            onRemoveLayer={this._onRemoveLayer}
-            onRenameLayer={this._onRenameLayer}
-            layersContainer={layout}
-            unsavedChanges={this.props.unsavedChanges}
-          />
-        </Drawer>
         <InfoBar
           identifier="instance-drag-n-drop-explanation"
           message={
@@ -1165,6 +1166,16 @@ export default class SceneEditor extends React.Component<Props, State> {
             </Trans>
           }
           show={!!this.state.showPropertiesInfoBar}
+        />
+        <InfoBar
+          identifier="layers-panel-explanation"
+          message={
+            <Trans>
+              Layers panel is already opened. You can add new layers and apply
+              effects on them from this panel.
+            </Trans>
+          }
+          show={!!this.state.showLayersInfoBar}
         />
         {this.state.setupGridOpen && (
           <SetupGridDialog

--- a/newIDE/app/src/UI/ColorField/ColorPicker.js
+++ b/newIDE/app/src/UI/ColorField/ColorPicker.js
@@ -3,6 +3,9 @@
 
 import * as React from 'react';
 import { SketchPicker } from 'react-color';
+import Popper from '@material-ui/core/Popper';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import muiZIndex from '@material-ui/core/styles/zIndex';
 
 export type RGBColor = {|
   r: number,
@@ -46,20 +49,15 @@ const styles = {
     cursor: 'pointer',
   },
   popover: {
-    position: 'fixed',
-    zIndex: '2',
-    transform: 'translateX(-174px)',
-  },
-  cover: {
-    position: 'fixed',
-    top: '0px',
-    right: '0px',
-    bottom: '0px',
-    left: '0px',
+    // Ensure the popper is above everything (modal, dialog, snackbar, tooltips, etc).
+    // There will be only one ColorPicker opened at a time, so it's fair to put the
+    // highest z index. If this is breaking, check the z-index of material-ui.
+    zIndex: muiZIndex.tooltip + 100,
   },
 };
 
 class ColorPicker extends React.Component<Props, State> {
+  _swatch = React.createRef<HTMLDivElement>();
   state = {
     displayColorPicker: false,
   };
@@ -90,7 +88,11 @@ class ColorPicker extends React.Component<Props, State> {
 
     return (
       <div style={style}>
-        <div style={styles.swatch} onClick={this.handleClick}>
+        <div
+          style={styles.swatch}
+          onClick={this.handleClick}
+          ref={this._swatch}
+        >
           <div
             style={{
               ...styles.color,
@@ -102,13 +104,17 @@ class ColorPicker extends React.Component<Props, State> {
             {color ? null : '?'}
           </div>
         </div>
-        {this.state.displayColorPicker ? (
-          <React.Fragment>
-            <div style={styles.cover} onClick={this.handleClose} />
-            <div style={styles.popover}>
+        {this.state.displayColorPicker && this._swatch.current ? (
+          <ClickAwayListener onClickAway={this.handleClose}>
+            <Popper
+              open
+              anchorEl={this._swatch.current}
+              style={styles.popover}
+              placement="bottom"
+            >
               <SketchPicker color={displayedColor} {...otherProps} />
-            </div>
-          </React.Fragment>
+            </Popper>
+          </ClickAwayListener>
         ) : null}
       </div>
     );

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -37,7 +37,7 @@ const addNode = (
   newNode: MosaicNode | string,
   position: 'start' | 'end',
   splitPercentage: number,
-  direction: 'row' | 'column' = 'row'
+  direction: 'row' | 'column'
 ): MosaicNode => {
   if (!currentNode) return newNode;
 
@@ -78,7 +78,11 @@ const addNode = (
 
   // Or add the node here.
   return {
-    direction,
+    direction:
+      direction === 'row'
+        ? // Direction of split is the opposite of what is requested for the editor
+          'column'
+        : 'row',
     first: position === 'end' ? currentNode : newNode,
     second: position === 'end' ? newNode : currentNode,
     splitPercentage,
@@ -158,7 +162,8 @@ export default class EditorMosaic extends React.Component<Props, State> {
   openEditor = (
     editorName: string,
     position: 'start' | 'end',
-    splitPercentage: number
+    splitPercentage: number,
+    direction: 'row' | 'column'
   ) => {
     const { editors, limitToOneSecondaryEditor } = this.props;
 
@@ -193,7 +198,8 @@ export default class EditorMosaic extends React.Component<Props, State> {
         this.state.mosaicNode,
         editorName,
         position,
-        splitPercentage
+        splitPercentage,
+        direction
       ),
     });
 

--- a/newIDE/app/src/UI/EditorMosaic/style.css
+++ b/newIDE/app/src/UI/EditorMosaic/style.css
@@ -21,6 +21,12 @@
   display: flex;
 }
 
+/* Make the horizontal split to have the same thickness as the vertical */
+.mosaic-gd-theme .mosaic-split.-column {
+  margin-top: -4px;
+  height: 4px;
+}
+
 /* Mosaic window and tile */
 .mosaic-gd-theme.mosaic.mosaic-blueprint-theme .mosaic-window,
 .mosaic-gd-theme.mosaic.mosaic-blueprint-theme .mosaic-preview {

--- a/newIDE/app/src/UI/Theme/DarkTheme/Mosaic.css
+++ b/newIDE/app/src/UI/Theme/DarkTheme/Mosaic.css
@@ -1,6 +1,6 @@
 /* Mosaic layout */
 .mosaic-gd-dark-theme.mosaic {
-  background-color: #303030 !important;
+  background-color: #5a5a5a !important;
 }
 
 /* Mosaic window and tile */
@@ -25,14 +25,17 @@
   background: #3c4698 !important;
 }
 
+.mosaic-gd-dark-theme .mosaic-split.-column {
+  background-color: #5a5a5a !important;
+}
+
 /* Separator draggable background */
 .mosaic-gd-dark-theme .mosaic-split.-column .mosaic-split-line {
   height: 1px;
-  border-bottom: 1px solid #888888 !important;
   border-top: 1px solid #888888 !important;
-  width: 100px;
+  width: 25px;
   margin: auto;
-  bottom: auto !important;
+  bottom: 1px;
 }
 
 .mosaic-gd-dark-theme .mosaic-split:hover .mosaic-split-line {

--- a/newIDE/app/src/UI/Theme/DefaultTheme/Mosaic.css
+++ b/newIDE/app/src/UI/Theme/DefaultTheme/Mosaic.css
@@ -1,6 +1,6 @@
 /* Mosaic layout */
 .mosaic-gd-default-theme.mosaic {
-  background-color: #f0f0f0 !important;
+  background-color: #e0e0e0 !important;
 }
 
 /* Mosaic window and tile */
@@ -21,14 +21,17 @@
   background: #9100ce !important;
 }
 
+.mosaic-gd-default-theme .mosaic-split.-column {
+  background-color: #e0e0e0 !important;
+}
+
 /* Separator draggable background */
 .mosaic-gd-default-theme .mosaic-split.-column .mosaic-split-line {
   height: 1px;
-  border-bottom: 1px solid #bbbbbb !important;
   border-top: 1px solid #bbbbbb !important;
-  width: 100px;
+  width: 25px;
   margin: auto;
-  bottom: auto !important;
+  bottom: 1px;
 }
 
 .mosaic-gd-default-theme .mosaic-split:hover .mosaic-split-line {

--- a/newIDE/app/src/UI/TreeTable/index.js
+++ b/newIDE/app/src/UI/TreeTable/index.js
@@ -1,4 +1,6 @@
-import React from 'react';
+// @flow
+import * as React from 'react';
+import GDevelopThemeContext from '../Theme/ThemeContext';
 
 const styles = {
   row: {
@@ -6,19 +8,45 @@ const styles = {
   },
   cell: {
     display: 'flex',
-    flex: 1,
     alignItems: 'center',
     paddingLeft: 8,
     paddingRight: 8,
   },
 };
 
-export const TreeTable = props => <div>{props.children}</div>;
+type TreeTableRowProps = {|
+  children: React.Node,
+|};
 
-export const TreeTableRow = props => (
-  <div style={{ ...styles.row, ...props.style }}>{props.children}</div>
-);
+export const TreeTableRow = (props: TreeTableRowProps) => {
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
 
-export const TreeTableCell = props => (
-  <div style={{ ...styles.cell, ...props.style }}>{props.children}</div>
+  return (
+    <div
+      style={{
+        ...styles.row,
+        backgroundColor: gdevelopTheme.list.itemsBackgroundColor,
+      }}
+    >
+      {props.children}
+    </div>
+  );
+};
+
+type TreeTableCellProps = {|
+  style?: Object,
+  expand?: boolean,
+  children?: React.Node,
+|};
+
+export const TreeTableCell = (props: TreeTableCellProps) => (
+  <div
+    style={{
+      ...styles.cell,
+      flex: props.expand ? 1 : undefined,
+      ...props.style,
+    }}
+  >
+    {props.children}
+  </div>
 );

--- a/newIDE/app/src/VariablesList/EditVariableRow.js
+++ b/newIDE/app/src/VariablesList/EditVariableRow.js
@@ -1,3 +1,5 @@
+// @flow
+import { Trans } from '@lingui/macro';
 import React from 'react';
 import { TreeTableRow, TreeTableCell } from '../UI/TreeTable';
 import Add from '@material-ui/icons/Add';
@@ -6,8 +8,18 @@ import EmptyMessage from '../UI/EmptyMessage';
 import Copy from '../UI/CustomSvgIcons/Copy';
 import Paste from '../UI/CustomSvgIcons/Paste';
 import Delete from '@material-ui/icons/Delete';
-
+import { Line, Column } from '../UI/Grid';
 import styles from './styles';
+import RaisedButton from '../UI/RaisedButton';
+
+type Props = {|
+  onAdd: () => void,
+  onCopy: () => void,
+  hasSelection: boolean,
+  onPaste: () => void,
+  hasClipboard: boolean,
+  onDeleteSelection: () => void,
+|};
 
 const EditVariableRow = ({
   onAdd,
@@ -16,30 +28,32 @@ const EditVariableRow = ({
   onPaste,
   hasClipboard,
   onDeleteSelection,
-}) => (
-  <TreeTableRow>
-    <TreeTableCell style={styles.toolColumnHeader}>
-      <IconButton onClick={onCopy} disabled={!hasSelection}>
-        <Copy />
-      </IconButton>
-      <IconButton onClick={onPaste} disabled={!hasClipboard}>
-        <Paste />
-      </IconButton>
-      <IconButton onClick={onDeleteSelection} disabled={!hasSelection}>
-        <Delete />
-      </IconButton>
-    </TreeTableCell>
+}: Props) => (
+  <Line justifyContent="space-between" alignItems="center">
+    <Column>
+      <Line noMargin>
+        <IconButton onClick={onCopy} disabled={!hasSelection}>
+          <Copy />
+        </IconButton>
+        <IconButton onClick={onPaste} disabled={!hasClipboard}>
+          <Paste />
+        </IconButton>
+        <IconButton onClick={onDeleteSelection} disabled={!hasSelection}>
+          <Delete />
+        </IconButton>
+      </Line>
+    </Column>
 
-    <TreeTableCell>
-      <EmptyMessage style={styles.addVariableMessage} />
-    </TreeTableCell>
-
-    <TreeTableCell style={styles.toolColumn}>
-      <IconButton onClick={onAdd}>
-        <Add />
-      </IconButton>
-    </TreeTableCell>
-  </TreeTableRow>
+    <Column>
+      <RaisedButton
+        primary
+        label={<Trans>Add</Trans>}
+        onClick={onAdd}
+        labelPosition="before"
+        icon={<Add />}
+      />
+    </Column>
+  </Line>
 );
 
 export default EditVariableRow;

--- a/newIDE/app/src/VariablesList/VariableRow.js
+++ b/newIDE/app/src/VariablesList/VariableRow.js
@@ -63,7 +63,7 @@ const VariableRow = ({
   const limitEditing = origin === 'parent' || origin === 'inherited';
 
   const columns = [
-    <TreeTableCell key="name">
+    <TreeTableCell key="name" expand>
       {depth > 0 && (
         <Indent width={(depth + 1) * styles.tableChildIndentation} />
       )}
@@ -90,7 +90,7 @@ const VariableRow = ({
   ];
   if (!isStructure) {
     columns.push(
-      <TreeTableCell key="value">
+      <TreeTableCell key="value" expand>
         <SemiControlledTextField
           margin="none"
           commitOnBlur
@@ -110,6 +110,7 @@ const VariableRow = ({
   } else {
     columns.push(
       <TreeTableCell
+        expand
         key="value"
         style={limitEditing ? styles.fadedButton : undefined}
       >
@@ -141,18 +142,10 @@ const VariableRow = ({
   );
 
   return (
-    <ThemeConsumer>
-      {muiTheme => (
-        <div>
-          <TreeTableRow
-            style={{ backgroundColor: muiTheme.list.itemsBackgroundColor }}
-          >
-            {columns}
-          </TreeTableRow>
-          {children}
-        </div>
-      )}
-    </ThemeConsumer>
+    <div>
+      <TreeTableRow>{columns}</TreeTableRow>
+      {children}
+    </div>
   );
 };
 

--- a/newIDE/app/src/VariablesList/index.js
+++ b/newIDE/app/src/VariablesList/index.js
@@ -373,33 +373,22 @@ export default class VariablesList extends React.Component<Props, State> {
     );
 
     return (
-      <div>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderColumn>Name</TableHeaderColumn>
-              <TableHeaderColumn>Value</TableHeaderColumn>
-              <TableHeaderColumn style={styles.toolColumnHeader} />
-            </TableRow>
-          </TableHeader>
-        </Table>
-        <SortableVariablesListBody
-          variablesContainer={this.props.variablesContainer}
-          onSortEnd={({ oldIndex, newIndex }) => {
-            this.props.variablesContainer.move(oldIndex, newIndex);
-            this.forceUpdate();
-          }}
-          helperClass="sortable-helper"
-          useDragHandle
-          lockToContainerEdges
-        >
-          {!!containerInheritedVariablesTree.length &&
-            containerInheritedVariablesTree}
-          {!containerVariablesTree.length && this._renderEmpty()}
-          {!!containerVariablesTree.length && containerVariablesTree}
-          {editRow}
-        </SortableVariablesListBody>
-      </div>
+      <SortableVariablesListBody
+        variablesContainer={this.props.variablesContainer}
+        onSortEnd={({ oldIndex, newIndex }) => {
+          this.props.variablesContainer.move(oldIndex, newIndex);
+          this.forceUpdate();
+        }}
+        helperClass="sortable-helper"
+        useDragHandle
+        lockToContainerEdges
+      >
+        {!!containerInheritedVariablesTree.length &&
+          containerInheritedVariablesTree}
+        {!containerVariablesTree.length && this._renderEmpty()}
+        {!!containerVariablesTree.length && containerVariablesTree}
+        {editRow}
+      </SortableVariablesListBody>
     );
   }
 }

--- a/newIDE/app/src/VariablesList/styles.js
+++ b/newIDE/app/src/VariablesList/styles.js
@@ -15,9 +15,6 @@ export default {
     justifyContent: 'flex-end',
   },
   indentIconColor: '#DDD', //TODO: Use theme color instead
-  addVariableMessage: {
-    justifyContent: 'flex-end',
-  },
   emptyExplanation: {
     justifyContent: 'flex-start',
   },

--- a/newIDE/app/src/stories/EditorMosaicPlayground.js
+++ b/newIDE/app/src/stories/EditorMosaicPlayground.js
@@ -9,7 +9,8 @@ import EditorNavigator from '../UI/EditorMosaic/EditorNavigator';
 type OpenEditorFunction = (
   editorName: string,
   position: 'start' | 'end',
-  slipPercentage: number
+  slipPercentage: number,
+  direction: 'column' | 'row'
 ) => void;
 
 type Props = {|
@@ -26,10 +27,16 @@ export default ({ renderButtons, renderEditorMosaic }: Props) => {
   const openEditor = (
     editorName: string,
     position: 'start' | 'end',
-    slipPercentage: number
+    slipPercentage: number,
+    direction: 'column' | 'row'
   ) => {
     if (editorRef.current)
-      editorRef.current.openEditor(editorName, position, slipPercentage);
+      editorRef.current.openEditor(
+        editorName,
+        position,
+        slipPercentage,
+        direction
+      );
   };
 
   return (

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -1147,7 +1147,7 @@ storiesOf('UI Building Blocks/EditorMosaic', module)
     <EditorMosaicPlayground
       renderButtons={({ openEditor }) => (
         <FlatButton
-          onClick={() => openEditor('thirdEditor', 'end', 65)}
+          onClick={() => openEditor('thirdEditor', 'end', 65, 'column')}
           label="Open the third editor"
         />
       )}
@@ -1201,15 +1201,15 @@ storiesOf('UI Building Blocks/EditorMosaic', module)
       renderButtons={({ openEditor }) => (
         <React.Fragment>
           <FlatButton
-            onClick={() => openEditor('firstEditor', 'end', 65)}
+            onClick={() => openEditor('firstEditor', 'end', 65, 'column')}
             label="Open the 1st secondary editor"
           />
           <FlatButton
-            onClick={() => openEditor('secondEditor', 'end', 65)}
+            onClick={() => openEditor('secondEditor', 'end', 65, 'column')}
             label="Open the 2nd secondary editor"
           />
           <FlatButton
-            onClick={() => openEditor('thirdEditor', 'end', 65)}
+            onClick={() => openEditor('thirdEditor', 'end', 65, 'column')}
             label="Open the 3rd secondary editor"
           />
         </React.Fragment>
@@ -1262,11 +1262,13 @@ storiesOf('UI Building Blocks/EditorNavigator', module)
       renderButtons={({ openEditor }) => (
         <React.Fragment>
           <FlatButton
-            onClick={() => openEditor('thirdEditor', 'end', 65)}
+            onClick={() => openEditor('thirdEditor', 'end', 65, 'column')}
             label="Open the third editor"
           />
           <FlatButton
-            onClick={() => openEditor('noTransitionsEditor', 'end', 65)}
+            onClick={() =>
+              openEditor('noTransitionsEditor', 'end', 65, 'column')
+            }
             label="Open the editor without transitions"
           />
         </React.Fragment>


### PR DESCRIPTION
Show the layers editor as a panel, that is by default at the bottom of the screen.

![image](https://user-images.githubusercontent.com/1280130/79641847-3c030900-819a-11ea-8224-c83a195ebf01.png)

Also make the splits between editors of a different color than the editor backgrounds. Turns out the lack of visual separation is not understood properly by all users. 
And other misc changes:
  * Ensure ColorPicker is never shown out of the window area
  * Refactor TreeTable
  * Fix text in LayerRemoveDialog
  * Use a RaisedButton to add a variable for consistency