### PR TITLE
Convert structure back to number when it has no chlidren

### DIFF
--- a/Core/GDCore/Project/Variable.cpp
+++ b/Core/GDCore/Project/Variable.cpp
@@ -76,6 +76,7 @@ const Variable& Variable::GetChild(const gd::String& name) const {
 void Variable::RemoveChild(const gd::String& name) {
   if (!isStructure) return;
   children.erase(name);
+  isStructure = !children.empty();
 }
 
 bool Variable::RenameChild(const gd::String& oldName,
@@ -190,6 +191,7 @@ void Variable::RemoveRecursively(const gd::Variable& variableToRemove) {
       it++;
     }
   }
+  isStructure = !children.empty();
 }
 
 Variable::Variable(const Variable& other)


### PR DESCRIPTION
First step of fixing #1218 
Convert structure back to a number when removing the only remaining child of the structure.

### Screenshot
![Fix1218](https://user-images.githubusercontent.com/32167255/79744751-7fe04480-8339-11ea-93b3-da68b2b571fb.gif)
