### PR TITLE
Rename parameters of JsCodeEvent

### DIFF
--- a/GDJS/GDJS/Events/Builtin/JsCodeEvent.cpp
+++ b/GDJS/GDJS/Events/Builtin/JsCodeEvent.cpp
@@ -18,9 +18,32 @@ using namespace std;
 
 namespace gdjs {
 
+vector<pair<gd::Expression*, gd::ParameterMetadata> >
+    JsCodeEvent::GetAllExpressionsWithMetadata() {
+  vector<pair<gd::Expression*, gd::ParameterMetadata> >
+      allExpressionsWithMetadata;
+  auto metadata = gd::ParameterMetadata().SetType("object");
+  allExpressionsWithMetadata.push_back(
+      std::make_pair(&parameterObjects, metadata));
+
+  return allExpressionsWithMetadata;
+}
+
+vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
+    JsCodeEvent::GetAllExpressionsWithMetadata() const {
+  vector<pair<const gd::Expression*, const gd::ParameterMetadata> >
+      allExpressionsWithMetadata;
+  auto metadata = gd::ParameterMetadata().SetType("object");
+  allExpressionsWithMetadata.push_back(
+      std::make_pair(&parameterObjects, metadata));
+
+  return allExpressionsWithMetadata;
+}
+
 void JsCodeEvent::SerializeTo(gd::SerializerElement& element) const {
   element.AddChild("inlineCode").SetValue(inlineCode);
-  element.AddChild("parameterObjects").SetValue(parameterObjects);
+  element.AddChild("parameterObjects")
+      .SetValue(parameterObjects.GetPlainString());
   element.AddChild("useStrict").SetValue(useStrict);
 }
 
@@ -28,7 +51,9 @@ void JsCodeEvent::UnserializeFrom(gd::Project& project,
                                   const gd::SerializerElement& element) {
   inlineCode = element.GetChild("inlineCode").GetValue().GetString();
   parameterObjects =
-      element.GetChild("parameterObjects").GetValue().GetString();
+      gd::Expression(element.GetChild("parameterObjects")
+                         .GetValue()
+                         .GetString());
 
   if (!element.HasChild("useStrict")) {
     // Compatibility with GD <= 5.0.0-beta68

--- a/GDJS/GDJS/Events/Builtin/JsCodeEvent.h
+++ b/GDJS/GDJS/Events/Builtin/JsCodeEvent.h
@@ -6,6 +6,7 @@
 #ifndef JSCODEEVENT_H
 #define JSCODEEVENT_H
 #include "GDCore/Events/Event.h"
+#include "GDCore/Events/Expression.h"
 namespace gd {
 class Instruction;
 class Project;
@@ -31,10 +32,15 @@ class JsCodeEvent : public gd::BaseEvent {
   const gd::String& GetInlineCode() const { return inlineCode; };
   void SetInlineCode(const gd::String& code) { inlineCode = code; };
 
-  const gd::String& GetParameterObjects() const { return parameterObjects; };
+  const gd::String& GetParameterObjects() const { return parameterObjects.GetPlainString(); };
   void SetParameterObjects(const gd::String& objectName) {
-    parameterObjects = objectName;
+    parameterObjects = gd::Expression(objectName);
   };
+
+  virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata();
+  virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
+      GetAllExpressionsWithMetadata() const;
 
   virtual void SerializeTo(gd::SerializerElement& element) const;
   virtual void UnserializeFrom(gd::Project& project,
@@ -44,9 +50,9 @@ class JsCodeEvent : public gd::BaseEvent {
  private:
   void Init(const JsCodeEvent& event);
 
-  gd::String inlineCode;        ///< Contains the Javacript code of the event.
-  gd::String parameterObjects;  ///< Name of the (group of) objects to pass as
-                                ///< parameter.
+  gd::String inlineCode;            ///< Contains the Javacript code of the event.
+  gd::Expression parameterObjects;  ///< Name of the (group of) objects to pass as
+                                    ///< parameter.
   bool useStrict;  ///< Should the generated JS function have "use strict". true
                    ///< by default. Should be removed once all the game engine
                    ///< is using "use strict".


### PR DESCRIPTION
- Change the type of `parameterObjects` from `String` to `Expression`
- Add `GetAllExpressionsWithMetadata`

I think we don't need to update js code that are calling `GetParameterObjects` . Or do I miss something? :D

![3](https://user-images.githubusercontent.com/32167255/79853727-ff821800-83fa-11ea-83c4-02609b7e4895.gif)
