### PR TITLE
[FIX] BBtext: color, fontSize, fontFamily 

### DIFF
--- a/Extensions/BBText/bbtextruntimeobject-pixi-renderer.js
+++ b/Extensions/BBText/bbtextruntimeobject-pixi-renderer.js
@@ -76,6 +76,7 @@ gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateText = function() {
 
 gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateColor = function() {
   this._pixiObject.textStyles.default.fill = this._object._color;
+  this._pixiObject.dirty = true;
 };
 
 gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateAlignment = function() {
@@ -83,10 +84,12 @@ gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateAlignment = function() {
   this._pixiObject.dirty = true;
 };
 gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateFontFamily = function() {
-  this._pixiObject.textStyles.default.fontFamily = this._object._fontFamily;
+  this._pixiObject.textStyles.default.fontFamily = this._object._runtimeScene.getGame().getFontManager().getFontFamily(this._object._fontFamily);
+  this._pixiObject.dirty = true;
 };
 gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateFontSize = function() {
   this._pixiObject.textStyles.default.fontSize = this._object._fontSize + 'px';
+  this._pixiObject.dirty = true;
 };
 
 gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updatePosition = function() {


### PR DESCRIPTION
The actions for change the color, fontSize, fontFamily dosen't work, this patch the bug.

Off topic:
The text with custom font are good in the scene editor. But not in the preview/export.

The red is a sprite for wrap the text, there is no event, just scaled manually for fit the text.

![image](https://user-images.githubusercontent.com/1670670/80241719-5f2f2c00-8664-11ea-8215-cd6b5fb40081.png)

Without font it's ok:
![image](https://user-images.githubusercontent.com/1670670/80241855-a4ebf480-8664-11ea-98e2-b18e3724a703.png)

I thought code from the extensions was run for both the games and the publisher. So there shouldn't be any difference, right?