### PR TITLE
[WIP] [Require help] Begin to add a CordovaExtension type

### DIFF
--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -12,16 +12,17 @@
  */
 module.exports = {
   createExtension: function(_, gd) {
-    const extension = new gd.PlatformExtension();
-    extension.setExtensionInformation(
-      'AdMob',
-      _('AdMob'),
-      _(
-        'Allow the game to display AdMob banner, interstitial and reward video ads'
-      ),
-      'Franco Maciel',
-      'MIT'
-    );
+    const extension = new gd.CordovaExtension();
+    extension
+      .setExtensionInformation(
+        'AdMob',
+        _('AdMob'),
+        _(
+          'Allow the game to display AdMob banner, interstitial and reward video ads'
+        ),
+        'Franco Maciel',
+        'MIT'
+      ).addCordovaPlugin("cordova-plugin-admob-free");
 
     // Banner
     extension

--- a/GDJS/GDJS/Extensions/CordovaExtension.cpp
+++ b/GDJS/GDJS/Extensions/CordovaExtension.cpp
@@ -1,0 +1,15 @@
+/*
+ * GDevelop JS Platform
+ * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights
+ * reserved. This project is released under the MIT License.
+ */
+#include "GDJS/Extensions/CordovaExtension.h"
+#include "GDCore/String.h"
+#include <vector>
+
+namespace gdjs {
+    CordovaExtension& CordovaExtension::AddCordovaPlugin(gd::String pluginName) {
+        cordovaPlugins.push_back(pluginName);
+        return *this;
+    }
+} // namespace gdjs

--- a/GDJS/GDJS/Extensions/CordovaExtension.h
+++ b/GDJS/GDJS/Extensions/CordovaExtension.h
@@ -14,14 +14,20 @@ namespace gdjs {
      * \brief Extension for Cordova games
      * 
      * This is an Extension type for games compiled to the Cordova Platform.
-     * The difference with a normal extension is that 
-     * 1. It only gets exported on Cordova builds
-     * 2. It let you add Cordova plugins in the exported game.
+     * The difference with a normal extension is that it let you add
+     * Cordova plugins in the exported game.
      */
     class GD_API CordovaExtension : public gd::PlatformExtension {
         public:
             // New methods
+            /**
+             * \brief Adds a cordova plugin include to the extension.
+             */
             CordovaExtension& AddCordovaPlugin(const gd::String);
+
+            /**
+             * \brief Get all cordova plugins to export.
+             */
             std::vector<gd::String> GetCordovaPluginList() { return cordovaPlugins; };
             
             // Override the return type of inherited methods
@@ -36,7 +42,7 @@ namespace gdjs {
             CordovaExtension& SetExtensionHelpPath(const gd::String& helpPath) { gd::PlatformExtension::SetExtensionHelpPath(helpPath); return *this; };
 
         private:
-            std::vector<gd::String> cordovaPlugins;
+            std::vector<gd::String> cordovaPlugins; ///< Vector of all cordova plugins to include
     };
 } // namespace gdjs
 #endif // CORDOVAEXTENSION_H

--- a/GDJS/GDJS/Extensions/CordovaExtension.h
+++ b/GDJS/GDJS/Extensions/CordovaExtension.h
@@ -1,0 +1,42 @@
+/*
+ * GDevelop JS Platform
+ * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights
+ * reserved. This project is released under the MIT License.
+ */
+#ifndef CORDOVAEXTENSION_H
+#define CORDOVAEXTENSION_H
+#include "GDCore/Extensions/PlatformExtension.h"
+#include "GDCore/String.h"
+#include <vector>
+
+namespace gdjs {
+    /**
+     * \brief Extension for Cordova games
+     * 
+     * This is an Extension type for games compiled to the Cordova Platform.
+     * The difference with a normal extension is that 
+     * 1. It only gets exported on Cordova builds
+     * 2. It let you add Cordova plugins in the exported game.
+     */
+    class GD_API CordovaExtension : public gd::PlatformExtension {
+        public:
+            // New methods
+            CordovaExtension& AddCordovaPlugin(const gd::String);
+            std::vector<gd::String> GetCordovaPluginList() { return cordovaPlugins; };
+            
+            // Override the return type of inherited methods
+            CordovaExtension& SetExtensionInformation (
+                const gd::String& name_,
+                const gd::String& fullname_,
+                const gd::String& description_,
+                const gd::String& author_,
+                const gd::String& license_
+            ) { gd::PlatformExtension::SetExtensionInformation(name_, fullname_, description_, author_, license_); return *this; };
+
+            CordovaExtension& SetExtensionHelpPath(const gd::String& helpPath) { gd::PlatformExtension::SetExtensionHelpPath(helpPath); return *this; };
+
+        private:
+            std::vector<gd::String> cordovaPlugins;
+    };
+} // namespace gdjs
+#endif // CORDOVAEXTENSION_H

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -20,6 +20,9 @@
 #include "GDCore/Project/Layout.h"
 #include "GDCore/Project/Project.h"
 #include "GDCore/Project/SourceFile.h"
+#include "GDCore/Extensions/Platform.h"
+#include "GDCore/Extensions/PlatformExtension.h"
+#include "GDJS/Extensions/CordovaExtension.h"
 #include "GDCore/Serialization/Serializer.h"
 #include "GDCore/TinyXml/tinyxml.h"
 #include "GDCore/Tools/Localization.h"
@@ -286,6 +289,22 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
             "\" />\n"
             "\t</plugin>");
   }
+
+  gd::String pluginsList = "";
+
+  for(gd::String const extensionName : project.GetUsedExtensions()) {
+    std::shared_ptr<gd::PlatformExtension> extension = project.GetCurrentPlatform().GetExtension(extensionName);
+    if (std::shared_ptr<gdjs::CordovaExtension> cordovaExtension = std::dynamic_pointer_cast<gdjs::CordovaExtension>(extension)) { // If a downcast to CordovaExtension is possible...
+      for(gd::String const cordovaPluginName : cordovaExtension->GetCordovaPluginList()) {
+        str += "<plugin name=\"" + cordovaPluginName + "\">\n"; 
+      }
+    }
+  }
+
+  str.FindAndReplace(
+        "<!-- GDJS_CORDOVA_PLUGINS -->",
+        pluginsList
+  );
 
   if (!fs.WriteToFile(exportDir + "/config.xml", str)) {
     lastError = "Unable to write Cordova config.xml file.";

--- a/GDJS/Runtime/Cordova/config.xml
+++ b/GDJS/Runtime/Cordova/config.xml
@@ -31,4 +31,5 @@
     <preference name="phonegap-version" value="cli-8.0.0" />
 
     <!-- GDJS_ADMOB_PLUGIN_AND_APPLICATION_ID -->
+    <!-- GDJS_CORDOVA_PLUGINS -->
 </widget>

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2399,3 +2399,100 @@ interface JsCodeEvent {
     void SerializeTo([Ref] SerializerElement element);
     void UnserializeFrom([Ref] Project project, [Const, Ref] SerializerElement element);
 };
+
+[Prefix="gdjs::"]
+interface CordovaExtension : PlatformExtension {
+    void CordovaExtension();
+
+    // New Exposed Methods
+    [Ref] CordovaExtension AddCordovaPlugin([Const] DOMString pluginName);
+
+    // Inherited Methods from PlatformExtension with return type override
+    [Ref] CordovaExtension SetExtensionInformation([Const] DOMString name,
+                                [Const] DOMString fullname,
+                                [Const] DOMString description,
+                                [Const] DOMString author,
+                                [Const] DOMString license);
+    [Ref] CordovaExtension SetExtensionHelpPath([Const] DOMString helpPath);
+
+    // Inherited Methods from PlatformExtension
+    void MarkAsDeprecated();
+
+    [Const, Ref] InstructionMetadata AddCondition([Const] DOMString name,
+                                        [Const] DOMString fullname,
+                                        [Const] DOMString description,
+                                        [Const] DOMString sentence,
+                                        [Const] DOMString group,
+                                        [Const] DOMString icon,
+                                        [Const] DOMString smallicon);
+
+    [Const, Ref] InstructionMetadata AddAction([Const] DOMString name,
+                                     [Const] DOMString fullname,
+                                     [Const] DOMString description,
+                                     [Const] DOMString sentence,
+                                     [Const] DOMString group,
+                                     [Const] DOMString icon,
+                                     [Const] DOMString smallicon);
+
+    [Const, Ref] ExpressionMetadata AddExpression([Const] DOMString name,
+                                        [Const] DOMString fullname,
+                                        [Const] DOMString description,
+                                        [Const] DOMString group,
+                                        [Const] DOMString smallicon);
+
+    [Const, Ref] ExpressionMetadata AddStrExpression([Const] DOMString name,
+                                           [Const] DOMString fullname,
+                                           [Const] DOMString description,
+                                           [Const] DOMString group,
+                                           [Const] DOMString smallicon);
+
+    [Ref] BehaviorMetadata WRAPPED_AddBehavior([Const] DOMString name,
+        [Const] DOMString fullname,
+        [Const] DOMString defaultName,
+        [Const] DOMString description,
+        [Const] DOMString group,
+        [Const] DOMString icon24x24,
+        [Const] DOMString className,
+        Behavior instance,
+        BehaviorsSharedData sharedDatasInstance);
+
+    [Ref] ObjectMetadata WRAPPED_AddObject([Const] DOMString name,
+        [Const] DOMString fullname,
+        [Const] DOMString description,
+        [Const] DOMString icon24x24,
+        gdObject instance);
+
+    [Ref] EffectMetadata AddEffect([Const] DOMString name);
+
+    [Const, Ref] DOMString GetFullName();
+    [Const, Ref] DOMString GetName();
+    [Const, Ref] DOMString GetDescription();
+    [Const, Ref] DOMString GetAuthor();
+    [Const, Ref] DOMString GetLicense();
+    [Const, Ref] DOMString GetHelpPath();
+    boolean IsBuiltin();
+    [Const, Ref] DOMString GetNameSpace();
+
+    [Value] VectorString GetExtensionObjectsTypes();
+    [Value] VectorString GetBehaviorsTypes();
+    [Value] VectorString GetExtensionEffectTypes();
+    [Ref] ObjectMetadata GetObjectMetadata([Const] DOMString type);
+    [Ref] BehaviorMetadata GetBehaviorMetadata([Const] DOMString type);
+    [Ref] EffectMetadata GetEffectMetadata([Const] DOMString type);
+    [Ref] MapStringEventMetadata GetAllEvents();
+    [Ref] MapStringInstructionMetadata GetAllActions();
+    [Ref] MapStringInstructionMetadata GetAllConditions();
+    [Ref] MapStringExpressionMetadata GetAllExpressions();
+    [Ref] MapStringExpressionMetadata GetAllStrExpressions();
+    [Ref] MapStringInstructionMetadata GetAllActionsForObject([Const] DOMString objectType);
+    [Ref] MapStringInstructionMetadata GetAllConditionsForObject([Const] DOMString objectType);
+    [Ref] MapStringExpressionMetadata GetAllExpressionsForObject([Const] DOMString objectType);
+    [Ref] MapStringExpressionMetadata GetAllStrExpressionsForObject([Const] DOMString objectType);
+    [Ref] MapStringInstructionMetadata GetAllActionsForBehavior([Const] DOMString autoType);
+    [Ref] MapStringInstructionMetadata GetAllConditionsForBehavior([Const] DOMString autoType);
+    [Ref] MapStringExpressionMetadata GetAllExpressionsForBehavior([Const] DOMString autoType);
+    [Ref] MapStringExpressionMetadata GetAllStrExpressionsForBehavior([Const] DOMString autoType);
+
+    [Const, Value] DOMString STATIC_GetNamespaceSeparator();
+    // End of inherited functions
+};

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -60,6 +60,8 @@
 #include <GDCore/Events/Builtin/StandardEvent.h>
 #include <GDCore/Events/Builtin/WhileEvent.h>
 
+#include <GDJS/Extensions/CordovaExtension.h>
+
 #include <GDCore/Extensions/Builtin/SpriteExtension/Animation.h>
 #include <GDCore/Extensions/Builtin/SpriteExtension/Direction.h>
 #include <GDCore/Extensions/Builtin/SpriteExtension/Sprite.h>


### PR DESCRIPTION
## Description

This PR is for adding a subclass CordovaExtension (inheriting from Platform Extension) with the Extra method `addCordovaPlugin(String)` to add cordova plugins as includes to JSExtensions.


## Task list:
- [X] Create the subclass
- [X] Add js Bindings
- [X] Test if can be used like a normal PlatformExtension
  - Results are positive (could export admob example after chaging it to a CordovaExtension)
- [ ] Modify the exporter to export the plugin list
  - [X] Add the code for exporting the plugins
  - [ ] Debug that code 😓 
    - This is the part that requires help (see the review for details)
- [ ] Add support for plugin variables
- [ ] Test on mutiple cordova extensions
- [ ] Correct typos
  - I might need help there too 😅 


## Why?

This would make mobile plugins easier to develop. Multiple developers have no problems with JavaScript but are scared of touching cpp. Some aren't even familiar enough with Low Level concepts like pointers to be able to modify it properly. This would let people declare plugins in extensions declarations (more intuitive and easier).