### PR TITLE
Fix Panel

### DIFF
--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.js
@@ -245,7 +245,7 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setTexture = function(
     texture,
     makeInsideTexture(
       new PIXI.Rectangle(
-        this._borderSprites[1].width - obj._rBorder,
+        texture.width - obj._rBorder,
         0,
         obj._rBorder,
         obj._tBorder
@@ -261,7 +261,7 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setTexture = function(
     makeInsideTexture(
       new PIXI.Rectangle(
         0,
-        this._borderSprites[5].height - obj._bBorder,
+        texture.height - obj._bBorder,
         obj._lBorder,
         obj._bBorder
       )
@@ -271,8 +271,8 @@ gdjs.PanelSpriteRuntimeObjectPixiRenderer.prototype.setTexture = function(
     texture,
     makeInsideTexture(
       new PIXI.Rectangle(
-        this._borderSprites[7].width - obj._rBorder,
-        this._borderSprites[7].height - obj._bBorder,
+        texture.width - obj._rBorder,
+        texture.height - obj._bBorder,
         obj._rBorder,
         obj._bBorder
       )

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
@@ -273,7 +273,7 @@ RenderedPanelSpriteInstance.prototype.updateTexture = function() {
     texture,
     makeInsideTexture(
       new PIXI.Rectangle(
-        this._borderSprites[1].width - panelSprite.getRightMargin(),
+        texture.width - panelSprite.getRightMargin(),
         0,
         panelSprite.getRightMargin(),
         panelSprite.getTopMargin()
@@ -330,7 +330,7 @@ RenderedPanelSpriteInstance.prototype.updateTexture = function() {
     makeInsideTexture(
       new PIXI.Rectangle(
         0,
-        this._borderSprites[5].height - panelSprite.getBottomMargin(),
+        texture.height - panelSprite.getBottomMargin(),
         panelSprite.getLeftMargin(),
         panelSprite.getBottomMargin()
       )
@@ -357,8 +357,8 @@ RenderedPanelSpriteInstance.prototype.updateTexture = function() {
     texture,
     makeInsideTexture(
       new PIXI.Rectangle(
-        this._borderSprites[7].width - panelSprite.getRightMargin(),
-        this._borderSprites[7].height - panelSprite.getBottomMargin(),
+        texture.width - panelSprite.getRightMargin(),
+        texture.height - panelSprite.getBottomMargin(),
         panelSprite.getRightMargin(),
         panelSprite.getBottomMargin()
       )


### PR DESCRIPTION
Fix #1723 

Replace `this._borderSprites[x]` with `texture`.