### PR TITLE
Refactor MainFrame callbacks and ProjectStorageProviders

### DIFF
--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -55,8 +55,7 @@ export const create = (authentification: Authentification) => {
           defaultStorageProvider={InternalFileStorageProvider}
         >
           {({
-            currentStorageProviderOperations,
-            useStorageProvider,
+            getStorageProviderOperations,
             storageProviders,
             initialFileMetadataToOpen,
           }) => (
@@ -86,8 +85,7 @@ export const create = (authentification: Authentification) => {
                   )}
                   introDialog={<BrowserIntroDialog />}
                   storageProviders={storageProviders}
-                  useStorageProvider={useStorageProvider}
-                  storageProviderOperations={currentStorageProviderOperations}
+                  getStorageProviderOperations={getStorageProviderOperations}
                   resourceSources={browserResourceSources}
                   resourceExternalEditors={browserResourceExternalEditors}
                   extensionsLoader={makeExtensionsLoader({

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -50,8 +50,7 @@ export const create = (authentification: Authentification) => {
           defaultStorageProvider={LocalFileStorageProvider}
         >
           {({
-            currentStorageProviderOperations,
-            useStorageProvider,
+            getStorageProviderOperations,
             storageProviders,
             initialFileMetadataToOpen,
           }) => (
@@ -80,8 +79,7 @@ export const create = (authentification: Authentification) => {
                     isDev ? () => <LocalGDJSDevelopmentWatcher /> : null
                   }
                   storageProviders={storageProviders}
-                  useStorageProvider={useStorageProvider}
-                  storageProviderOperations={currentStorageProviderOperations}
+                  getStorageProviderOperations={getStorageProviderOperations}
                   resourceSources={localResourceSources}
                   resourceExternalEditors={localResourceExternalEditors}
                   extensionsLoader={makeExtensionsLoader({


### PR DESCRIPTION
Refactor some callbacks and the way `storageProvider` is used.
This also fix the issue of Google Drive opening not working on the first time because of stale prop.

@HarsimranVirk I've tried to eliminate some newState/newProps and reduce the risk of stale props/state a bit. I think the need for newState/newProps can be heavily reduced by converting the `renderEditor` into functions outside of MainFrame. I'll do that later - this will help to reduce MainFrame size and make it a bit more manageable too :) 
No input needed from you, just wanted to notify you if you want to take a look.