### PR TITLE
add a clear state command to DialogueTree, for when starting a new game

### DIFF
--- a/Extensions/DialogueTree/JsExtension.js
+++ b/Extensions/DialogueTree/JsExtension.js
@@ -295,7 +295,7 @@ module.exports = {
         'ClearState',
         _('Clear dialogue state'),
         _(
-          'Clear dialogue state. This resets all dialogue state accumulated by the player choices. Use for when the player is starting a new game.'
+          'Clear dialogue state. This resets all dialogue state accumulated by the player choices. Useful when the player is starting a new game.'
         ),
         _('Clear dialogue state'),
         _('Dialogue Tree (experimental)'),

--- a/Extensions/DialogueTree/JsExtension.js
+++ b/Extensions/DialogueTree/JsExtension.js
@@ -291,6 +291,21 @@ module.exports = {
       .setFunctionName('gdjs.dialogueTree.loadState');
 
     extension
+      .addAction(
+        'ClearState',
+        _('Clear dialogue state'),
+        _(
+          'Clear dialogue state. This resets all dialogue state accumulated by the player choices. Use for when the player is starting a new game.'
+        ),
+        _('Clear dialogue state'),
+        _('Dialogue Tree (experimental)'),
+        'JsPlatform/Extensions/yarn24.png',
+        'JsPlatform/Extensions/yarn32.png'
+      )
+      .getCodeExtraInformation()
+      .setFunctionName('gdjs.dialogueTree.clearState');
+
+    extension
       .addStrExpression(
         'LineText',
         _('Get the current dialogue line text'),

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -725,3 +725,16 @@ gdjs.dialogueTree.loadState = function(inputVariable) {
     console.error('Failed to load state from variable:', inputVariable, e);
   }
 };
+
+/**
+ * Clear the current State of the Dialogue Parser.
+ */
+gdjs.dialogueTree.clearState = function() {
+  try {
+    gdjs.dialogueTree.runner.visited = {};
+    gdjs.dialogueTree.runner.variables.data = {};
+    });
+  } catch (e) {
+    console.error('Failed to clear yarn state:', e);
+  }
+};

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -732,5 +732,4 @@ gdjs.dialogueTree.loadState = function(inputVariable) {
 gdjs.dialogueTree.clearState = function() {
   gdjs.dialogueTree.runner.visited = {};
   gdjs.dialogueTree.runner.variables.data = {};
-  }
 };

--- a/Extensions/DialogueTree/dialoguetools.js
+++ b/Extensions/DialogueTree/dialoguetools.js
@@ -730,11 +730,7 @@ gdjs.dialogueTree.loadState = function(inputVariable) {
  * Clear the current State of the Dialogue Parser.
  */
 gdjs.dialogueTree.clearState = function() {
-  try {
-    gdjs.dialogueTree.runner.visited = {};
-    gdjs.dialogueTree.runner.variables.data = {};
-    });
-  } catch (e) {
-    console.error('Failed to clear yarn state:', e);
+  gdjs.dialogueTree.runner.visited = {};
+  gdjs.dialogueTree.runner.variables.data = {};
   }
 };

--- a/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
+++ b/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
@@ -821,7 +821,7 @@
         "kind": "json",
         "metadata": "",
         "name": "dialogueData/npcs.json",
-        "userAdded": false
+        "userAdded": true
       }
     ],
     "resourceFolders": []
@@ -840,6 +840,10 @@
     {
       "name": "yarnState",
       "value": ""
+    },
+    {
+      "name": "textScrollSpdMultiplier",
+      "value": "1"
     }
   ],
   "layouts": [
@@ -7239,6 +7243,18 @@
                     "\"walking\""
                   ],
                   "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarGlobal"
+                  },
+                  "parameters": [
+                    "textScrollSpdMultiplier",
+                    "=",
+                    "1"
+                  ],
+                  "subInstructions": []
                 }
               ],
               "events": []
@@ -7301,7 +7317,7 @@
                       },
                       "parameters": [
                         "",
-                        "GlobalVariable(textScrollSpd)",
+                        "GlobalVariable(textScrollSpd) / GlobalVariable(textScrollSpdMultiplier) ",
                         "\"textScroll\""
                       ],
                       "subInstructions": []
@@ -7752,6 +7768,38 @@
                   "parameters": [
                     "avatars",
                     "DialogueTree::CommandParameter(0)"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DialogueTree::IsCommandCalled"
+                  },
+                  "parameters": [
+                    "\"speed\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ModVarGlobal"
+                  },
+                  "parameters": [
+                    "textScrollSpdMultiplier",
+                    "=",
+                    "ToNumber(DialogueTree::CommandParameter(0))"
                   ],
                   "subInstructions": []
                 }

--- a/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
+++ b/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
@@ -7701,56 +7701,6 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "DialogueTree::IsDialogueLineType"
-                  },
-                  "parameters": [
-                    "\"command\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Visible"
-                  },
-                  "parameters": [
-                    "commandsDebug"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
-                    "commandsDebug",
-                    "+",
-                    "\"<<\"+DialogueTree::CommandParameter(-1)+\">>\""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
                     "value": "DialogueTree::IsCommandCalled"
                   },
                   "parameters": [
@@ -7904,6 +7854,56 @@
                     "value": "DialogueTree::ClearState"
                   },
                   "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DialogueTree::IsDialogueLineType"
+                  },
+                  "parameters": [
+                    "\"command\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "Visible"
+                  },
+                  "parameters": [
+                    "commandsDebug"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Once"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "commandsDebug",
+                    "+",
+                    "\"<<\"+DialogueTree::CommandParameter(-1)+\">>\""
+                  ],
                   "subInstructions": []
                 }
               ],

--- a/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
+++ b/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
@@ -7832,6 +7832,34 @@
                 }
               ],
               "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DialogueTree::IsCommandCalled"
+                  },
+                  "parameters": [
+                    "\"clearGame\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "DialogueTree::ClearState"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
             }
           ],
           "parameters": []

--- a/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogueData/npcs.json
+++ b/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogueData/npcs.json
@@ -4,8 +4,8 @@
 		"tags": "",
 		"body": "<<avatar ant>>[b]Please don't bug me now[/b]... <<wait 1000>>  I am [i]quite[/i] busy at the moment.\nHave you seen my crumb?\n[[ yes |antcrumbyes ]] [[ no |antcrumbno ]] ",
 		"position": {
-			"x": 8602,
-			"y": 10190
+			"x": 8858,
+			"y": 9903
 		},
 		"colorID": 0
 	},
@@ -14,8 +14,8 @@
 		"tags": "",
 		"body": "Then [b]scram[/b]!\nI don't have time for you...",
 		"position": {
-			"x": 8406,
-			"y": 10465
+			"x": 8662,
+			"y": 10178
 		},
 		"colorID": 0
 	},
@@ -24,8 +24,8 @@
 		"tags": "",
 		"body": "<<if $seenCrumb == true>>\nOh yeah? You saw it on a branch?\nDid you taste it?...\n<<else>>\nOh ha-ha! I can see that you are lying.\n<<endif>>",
 		"position": {
-			"x": 8707,
-			"y": 10492
+			"x": 8963,
+			"y": 10205
 		},
 		"colorID": 3
 	},
@@ -34,8 +34,8 @@
 		"tags": "",
 		"body": "<<avatar crumb>> <<set $seenCrumb to true >> You stumbled on a giant crumb.\nWhat would you like to do with it?\n[[ taste it | eatCrumb]] [[ take it| takeCrumb]] [[ nothing |null ]] ",
 		"position": {
-			"x": 8436,
-			"y": 10726
+			"x": 8692,
+			"y": 10439
 		},
 		"colorID": 6
 	},
@@ -44,8 +44,8 @@
 		"tags": "",
 		"body": "0I am another weird node problem to test||<\n<<df>>\n [[Answer:debug|debug0]]",
 		"position": {
-			"x": 9244,
-			"y": 10171
+			"x": 9500,
+			"y": 9884
 		},
 		"colorID": 0
 	},
@@ -54,8 +54,8 @@
 		"tags": "",
 		"body": "]<<avatar sign>> >1[color=#e90b0b]Press Z[/color] to interact with the tree critters 🐜🐛🐞 [color=#07a9b0]Spacebar[/color] to jump.wait test .<<wait 1000>>.<<wait 1000>>.<<wait 1000>>||<<wait 2000>> \n2And welcome to yarn's example GD project!>||\n [[Answer:debug|debug1]]",
 		"position": {
-			"x": 9509,
-			"y": 10170
+			"x": 9765,
+			"y": 9883
 		},
 		"colorID": 0
 	},
@@ -64,8 +64,8 @@
 		"tags": "",
 		"body": "<<avatar ant>>\n>3Now scram!||<\n<<test>>\n\n[[ answer: |debug2 ]] ",
 		"position": {
-			"x": 9749,
-			"y": 10174
+			"x": 10005,
+			"y": 9887
 		},
 		"colorID": 0
 	},
@@ -74,8 +74,8 @@
 		"tags": "",
 		"body": "<<err>> >4 text with < <<avatar crumb>> >command in the middle ||\n5This is my tree|| <\n\n6||< <<avatar ant>>\n\n>7and my crumb||\n[[ answer: |debug3 ]] ",
 		"position": {
-			"x": 10003,
-			"y": 10177
+			"x": 10259,
+			"y": 9890
 		},
 		"colorID": 0
 	},
@@ -84,8 +84,8 @@
 		"tags": "",
 		"body": "<<only command>>\n[[ answer: |debug4 ]] ",
 		"position": {
-			"x": 10260,
-			"y": 10181
+			"x": 10516,
+			"y": 9894
 		},
 		"colorID": 0
 	},
@@ -94,8 +94,8 @@
 		"tags": "",
 		"body": "one last text",
 		"position": {
-			"x": 10502,
-			"y": 10185
+			"x": 10758,
+			"y": 9898
 		},
 		"colorID": 0
 	},
@@ -104,8 +104,8 @@
 		"tags": "",
 		"body": "Let see <<wait 1000>>.<<wait 200>>.<<wait 200>> .<<wait 200>>these 🥨 are making you thirsty...",
 		"position": {
-			"x": 8373,
-			"y": 11185
+			"x": 8629,
+			"y": 10898
 		},
 		"colorID": 0
 	},
@@ -114,8 +114,8 @@
 		"tags": "",
 		"body": "node1= Once upon a time you<<command>>  pressed SPACE to progress to the next node. [[Answer:Node2|Node2]]",
 		"position": {
-			"x": 9246,
-			"y": 10424
+			"x": 9471,
+			"y": 10129
 		},
 		"colorID": 0
 	},
@@ -124,8 +124,8 @@
 		"tags": "",
 		"body": "node2= <<big_boi>>2 But suddenly the small boi black box started to move! [[Answer:Node3|Node3]]",
 		"position": {
-			"x": 9495,
-			"y": 10416
+			"x": 9751,
+			"y": 10129
 		},
 		"colorID": 0
 	},
@@ -134,8 +134,8 @@
 		"tags": "",
 		"body": "<<not_a_registered_command>> node3= But something horrible happened! All the text merged to the single text box, this is Node3. Press Space... [[Answer:Node4|Node4]]",
 		"position": {
-			"x": 9729,
-			"y": 10412
+			"x": 9985,
+			"y": 10125
 		},
 		"colorID": 0
 	},
@@ -144,8 +144,8 @@
 		"tags": "",
 		"body": "node4 I am Node4 and I didn't get merged as I don't have a command!",
 		"position": {
-			"x": 9953,
-			"y": 10407
+			"x": 10209,
+			"y": 10120
 		},
 		"colorID": 0
 	},
@@ -154,8 +154,8 @@
 		"tags": "",
 		"body": "<<wait 100>> ",
 		"position": {
-			"x": 8185,
-			"y": 10733
+			"x": 8441,
+			"y": 10446
 		},
 		"colorID": 0
 	},
@@ -164,18 +164,18 @@
 		"tags": "",
 		"body": "<<if $debug == true>>\n\n<<if $debugLinks == true>> \n[[ answer: |Node1 ]] \n<<else>> \n[[ debug|debug ]] \n<<endif>>\n\n<<else>>\n[[ start|Start1 ]] \n<<endif>>",
 		"position": {
-			"x": 8973,
-			"y": 10188
+			"x": 9229,
+			"y": 9901
 		},
 		"colorID": 0
 	},
 	{
 		"title": "Start1",
 		"tags": "",
-		"body": "<<avatar sign>>[color=#e90b0b]Press Z[/color] to interact with the tree critters 🐜🐛🐞 [color=#07a9b0]Spacebar[/color] to jump.\nAnd welcome to yarn's example GD project!\n",
+		"body": "<<avatar sign>>[color=#e90b0b]Press Z[/color] to interact with the tree critters 🐜🐛🐞 [color=#07a9b0]Spacebar[/color] to jump.\nAnd welcome to yarn's example GD project! <<speed 0.2>> Enjoy your stay!\n",
 		"position": {
-			"x": 8964,
-			"y": 10494
+			"x": 9220,
+			"y": 10207
 		},
 		"colorID": 0
 	},
@@ -184,8 +184,8 @@
 		"tags": "",
 		"body": "The thing is way too heavy 😬 ....",
 		"position": {
-			"x": 8698,
-			"y": 10967
+			"x": 8954,
+			"y": 10680
 		},
 		"colorID": 0
 	},
@@ -194,8 +194,8 @@
 		"tags": "",
 		"body": "<<avatar cricket>> \nI am a cricket.\nWould you like to me to load/save the state\n\n[[ save it |saveState ]] \n[[ load it |loadState ]] \n[[ clear it |clearState ]] \n[[ cancel |null ]] ",
 		"position": {
-			"x": 8053,
-			"y": 10164
+			"x": 8309,
+			"y": 9877
 		},
 		"colorID": 0
 	},
@@ -204,8 +204,8 @@
 		"tags": "",
 		"body": "<<saveGame>>\nGame stored to a GD variable",
 		"position": {
-			"x": 7701,
-			"y": 10160
+			"x": 7957,
+			"y": 9873
 		},
 		"colorID": 0
 	},
@@ -214,8 +214,8 @@
 		"tags": "",
 		"body": "<<loadGame>> \ngame loaded from GD variable",
 		"position": {
-			"x": 7694,
-			"y": 10393
+			"x": 7950,
+			"y": 10106
 		},
 		"colorID": 0
 	},
@@ -224,8 +224,8 @@
 		"tags": "",
 		"body": "<<clearGame>> \ngame cleared dialogue state",
 		"position": {
-			"x": 7885,
-			"y": 10624
+			"x": 8141,
+			"y": 10337
 		},
 		"colorID": 0
 	}

--- a/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogueData/npcs.json
+++ b/newIDE/app/resources/examples/dialogue-tree-with-yarn/dialogueData/npcs.json
@@ -4,8 +4,8 @@
 		"tags": "",
 		"body": "<<avatar ant>>[b]Please don't bug me now[/b]... <<wait 1000>>  I am [i]quite[/i] busy at the moment.\nHave you seen my crumb?\n[[ yes |antcrumbyes ]] [[ no |antcrumbno ]] ",
 		"position": {
-			"x": 7566,
-			"y": 10185
+			"x": 8602,
+			"y": 10190
 		},
 		"colorID": 0
 	},
@@ -14,8 +14,8 @@
 		"tags": "",
 		"body": "Then [b]scram[/b]!\nI don't have time for you...",
 		"position": {
-			"x": 7370,
-			"y": 10460
+			"x": 8406,
+			"y": 10465
 		},
 		"colorID": 0
 	},
@@ -24,8 +24,8 @@
 		"tags": "",
 		"body": "<<if $seenCrumb == true>>\nOh yeah? You saw it on a branch?\nDid you taste it?...\n<<else>>\nOh ha-ha! I can see that you are lying.\n<<endif>>",
 		"position": {
-			"x": 7671,
-			"y": 10487
+			"x": 8707,
+			"y": 10492
 		},
 		"colorID": 3
 	},
@@ -34,8 +34,8 @@
 		"tags": "",
 		"body": "<<avatar crumb>> <<set $seenCrumb to true >> You stumbled on a giant crumb.\nWhat would you like to do with it?\n[[ taste it | eatCrumb]] [[ take it| takeCrumb]] [[ nothing |null ]] ",
 		"position": {
-			"x": 7400,
-			"y": 10721
+			"x": 8436,
+			"y": 10726
 		},
 		"colorID": 6
 	},
@@ -44,8 +44,8 @@
 		"tags": "",
 		"body": "0I am another weird node problem to test||<\n<<df>>\n [[Answer:debug|debug0]]",
 		"position": {
-			"x": 8208,
-			"y": 10166
+			"x": 9244,
+			"y": 10171
 		},
 		"colorID": 0
 	},
@@ -54,8 +54,8 @@
 		"tags": "",
 		"body": "]<<avatar sign>> >1[color=#e90b0b]Press Z[/color] to interact with the tree critters 🐜🐛🐞 [color=#07a9b0]Spacebar[/color] to jump.wait test .<<wait 1000>>.<<wait 1000>>.<<wait 1000>>||<<wait 2000>> \n2And welcome to yarn's example GD project!>||\n [[Answer:debug|debug1]]",
 		"position": {
-			"x": 8473,
-			"y": 10165
+			"x": 9509,
+			"y": 10170
 		},
 		"colorID": 0
 	},
@@ -64,8 +64,8 @@
 		"tags": "",
 		"body": "<<avatar ant>>\n>3Now scram!||<\n<<test>>\n\n[[ answer: |debug2 ]] ",
 		"position": {
-			"x": 8713,
-			"y": 10169
+			"x": 9749,
+			"y": 10174
 		},
 		"colorID": 0
 	},
@@ -74,8 +74,8 @@
 		"tags": "",
 		"body": "<<err>> >4 text with < <<avatar crumb>> >command in the middle ||\n5This is my tree|| <\n\n6||< <<avatar ant>>\n\n>7and my crumb||\n[[ answer: |debug3 ]] ",
 		"position": {
-			"x": 8967,
-			"y": 10172
+			"x": 10003,
+			"y": 10177
 		},
 		"colorID": 0
 	},
@@ -84,8 +84,8 @@
 		"tags": "",
 		"body": "<<only command>>\n[[ answer: |debug4 ]] ",
 		"position": {
-			"x": 9224,
-			"y": 10176
+			"x": 10260,
+			"y": 10181
 		},
 		"colorID": 0
 	},
@@ -94,8 +94,8 @@
 		"tags": "",
 		"body": "one last text",
 		"position": {
-			"x": 9466,
-			"y": 10180
+			"x": 10502,
+			"y": 10185
 		},
 		"colorID": 0
 	},
@@ -104,8 +104,8 @@
 		"tags": "",
 		"body": "Let see <<wait 1000>>.<<wait 200>>.<<wait 200>> .<<wait 200>>these 🥨 are making you thirsty...",
 		"position": {
-			"x": 7337,
-			"y": 11180
+			"x": 8373,
+			"y": 11185
 		},
 		"colorID": 0
 	},
@@ -114,8 +114,8 @@
 		"tags": "",
 		"body": "node1= Once upon a time you<<command>>  pressed SPACE to progress to the next node. [[Answer:Node2|Node2]]",
 		"position": {
-			"x": 8210,
-			"y": 10419
+			"x": 9246,
+			"y": 10424
 		},
 		"colorID": 0
 	},
@@ -124,8 +124,8 @@
 		"tags": "",
 		"body": "node2= <<big_boi>>2 But suddenly the small boi black box started to move! [[Answer:Node3|Node3]]",
 		"position": {
-			"x": 8459,
-			"y": 10411
+			"x": 9495,
+			"y": 10416
 		},
 		"colorID": 0
 	},
@@ -134,8 +134,8 @@
 		"tags": "",
 		"body": "<<not_a_registered_command>> node3= But something horrible happened! All the text merged to the single text box, this is Node3. Press Space... [[Answer:Node4|Node4]]",
 		"position": {
-			"x": 8693,
-			"y": 10407
+			"x": 9729,
+			"y": 10412
 		},
 		"colorID": 0
 	},
@@ -144,8 +144,8 @@
 		"tags": "",
 		"body": "node4 I am Node4 and I didn't get merged as I don't have a command!",
 		"position": {
-			"x": 8917,
-			"y": 10402
+			"x": 9953,
+			"y": 10407
 		},
 		"colorID": 0
 	},
@@ -154,8 +154,8 @@
 		"tags": "",
 		"body": "<<wait 100>> ",
 		"position": {
-			"x": 7149,
-			"y": 10728
+			"x": 8185,
+			"y": 10733
 		},
 		"colorID": 0
 	},
@@ -164,8 +164,8 @@
 		"tags": "",
 		"body": "<<if $debug == true>>\n\n<<if $debugLinks == true>> \n[[ answer: |Node1 ]] \n<<else>> \n[[ debug|debug ]] \n<<endif>>\n\n<<else>>\n[[ start|Start1 ]] \n<<endif>>",
 		"position": {
-			"x": 7937,
-			"y": 10183
+			"x": 8973,
+			"y": 10188
 		},
 		"colorID": 0
 	},
@@ -174,8 +174,8 @@
 		"tags": "",
 		"body": "<<avatar sign>>[color=#e90b0b]Press Z[/color] to interact with the tree critters 🐜🐛🐞 [color=#07a9b0]Spacebar[/color] to jump.\nAnd welcome to yarn's example GD project!\n",
 		"position": {
-			"x": 7928,
-			"y": 10489
+			"x": 8964,
+			"y": 10494
 		},
 		"colorID": 0
 	},
@@ -184,18 +184,18 @@
 		"tags": "",
 		"body": "The thing is way too heavy 😬 ....",
 		"position": {
-			"x": 7662,
-			"y": 10962
+			"x": 8698,
+			"y": 10967
 		},
 		"colorID": 0
 	},
 	{
 		"title": "cricket",
 		"tags": "",
-		"body": "<<avatar cricket>> \nI am a cricket.\nWould you like to me to load/save the state\n\n[[ save it |saveState ]] \n[[ load it |loadState ]] \n[[ cancel |null ]] ",
+		"body": "<<avatar cricket>> \nI am a cricket.\nWould you like to me to load/save the state\n\n[[ save it |saveState ]] \n[[ load it |loadState ]] \n[[ clear it |clearState ]] \n[[ cancel |null ]] ",
 		"position": {
-			"x": 7017,
-			"y": 10159
+			"x": 8053,
+			"y": 10164
 		},
 		"colorID": 0
 	},
@@ -204,8 +204,8 @@
 		"tags": "",
 		"body": "<<saveGame>>\nGame stored to a GD variable",
 		"position": {
-			"x": 6678,
-			"y": 10466
+			"x": 7701,
+			"y": 10160
 		},
 		"colorID": 0
 	},
@@ -214,8 +214,18 @@
 		"tags": "",
 		"body": "<<loadGame>> \ngame loaded from GD variable",
 		"position": {
-			"x": 6930,
-			"y": 10468
+			"x": 7694,
+			"y": 10393
+		},
+		"colorID": 0
+	},
+	{
+		"title": "clearState",
+		"tags": "",
+		"body": "<<clearGame>> \ngame cleared dialogue state",
+		"position": {
+			"x": 7885,
+			"y": 10624
 		},
 		"colorID": 0
 	}


### PR DESCRIPTION
This is a feature requested at the forum
https://forum.gdevelop-app.com/t/dialogue-tree-extension-global-feedback-enhancement-suggestions/24910/3

It lets you clear all dialogue state for things like starting a new game


also improve example a bit more