### PR TITLE
Wrap some Mainframe functions in useCallback

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -38,12 +38,12 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
     return (
       <ResourcesEditor
         setToolbar={this.props.setToolbar}
-        project={project}
         onDeleteResource={this.props.onDeleteResource}
         onRenameResource={this.props.onRenameResource}
         resourceSources={this.props.resourceSources}
         onChooseResource={this.props.onChooseResource}
         ref={editor => (this.editor = editor)}
+        project={project}
       />
     );
   }

--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -38,12 +38,12 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
     return (
       <ResourcesEditor
         setToolbar={this.props.setToolbar}
+        project={project}
         onDeleteResource={this.props.onDeleteResource}
         onRenameResource={this.props.onRenameResource}
         resourceSources={this.props.resourceSources}
         onChooseResource={this.props.onChooseResource}
         ref={editor => (this.editor = editor)}
-        project={project}
       />
     );
   }

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1293,12 +1293,7 @@ const MainFrame = (props: Props) => {
   );
 
   const openSceneOrProjectManager = React.useCallback(
-    (
-      newState = {
-        currentProject: state.currentProject,
-        editorTabs: state.editorTabs,
-      }
-    ) => {
+    (newState: { currentProject: gdProject, editorTabs: EditorTabsState }) => {
       const { currentProject, editorTabs } = newState;
       if (!currentProject) return;
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1293,7 +1293,10 @@ const MainFrame = (props: Props) => {
   );
 
   const openSceneOrProjectManager = React.useCallback(
-    (newState: { currentProject: gdProject, editorTabs: EditorTabsState }) => {
+    (newState: {|
+      currentProject: gdProject,
+      editorTabs: EditorTabsState,
+    |}) => {
       const { currentProject, editorTabs } = newState;
       if (!currentProject) return;
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1320,7 +1320,7 @@ const MainFrame = (props: Props) => {
         });
       }
     },
-    [openLayout, setState, state.currentProject, state.editorTabs]
+    [openLayout, setState]
   );
 
   const chooseProjectWithStorageProviderPicker = React.useCallback(

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1294,7 +1294,7 @@ const MainFrame = (props: Props) => {
 
   const openSceneOrProjectManager = React.useCallback(
     (newState: {|
-      currentProject: gdProject,
+      currentProject: ?gdProject,
       editorTabs: EditorTabsState,
     |}) => {
       const { currentProject, editorTabs } = newState;

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -228,7 +228,29 @@ const MainFrame = (props: Props) => {
   //   console.log(state);
   // });
 
-  const { integratedEditor, initialFileMetadataToOpen, introDialog } = props;
+  const {
+    currentProject,
+    currentFileMetadata,
+    updateStatus,
+    eventsFunctionsExtensionsError,
+  } = state;
+  const {
+    renderExportDialog,
+    renderCreateDialog,
+    resourceSources,
+    renderPreviewLauncher,
+    resourceExternalEditors,
+    eventsFunctionsExtensionsState,
+    getStorageProviderOperations,
+    getStorageProvider,
+    integratedEditor,
+    initialFileMetadataToOpen,
+    introDialog,
+    i18n,
+    renderGDJSDevelopmentWatcher,
+    renderMainMenu,
+  } = props;
+
   React.useEffect(
     () => {
       if (!integratedEditor) openStartPage();
@@ -279,6 +301,26 @@ const MainFrame = (props: Props) => {
     },
     // eslint-disable-next-line
     []
+  );
+
+  const _showSnackMessage = React.useCallback(
+    (snackMessage: string) => {
+      setState(state => ({
+        ...state,
+        snackMessage,
+        snackMessageOpen: true,
+      }));
+    },
+    [setState]
+  );
+  const _closeSnackMessage = React.useCallback(
+    () => {
+      setState(state => ({
+        ...state,
+        snackMessageOpen: false,
+      }));
+    },
+    [setState]
   );
 
   const _openInitialFileMetadata = (isAfterUserInteraction: boolean) => {
@@ -378,215 +420,225 @@ const MainFrame = (props: Props) => {
       });
   };
 
-  const loadFromSerializedProject = (
-    serializedProject: gdSerializerElement,
-    fileMetadata: ?FileMetadata
-  ): Promise<State> => {
-    return timePromise(
-      () => {
-        const newProject = gd.ProjectHelper.createNewGDJSProject();
-        newProject.unserializeFrom(serializedProject);
-
-        return loadFromProject(newProject, fileMetadata);
-      },
-      time => console.info(`Unserialization took ${time} ms`)
-    );
-  };
-
-  const loadFromProject = (
-    project: gdProject,
-    fileMetadata: ?FileMetadata
-  ): Promise<State> => {
-    const { eventsFunctionsExtensionsState, getStorageProvider } = props;
-
-    if (fileMetadata)
-      preferences.insertRecentProjectFile({
-        fileMetadata,
-        storageProviderName: getStorageProvider().internalName,
-      });
-
-    return closeProject().then(() => {
-      // Make sure that the ResourcesLoader cache is emptied, so that
-      // the URL to a resource with a name in the old project is not re-used
-      // for another resource with the same name in the new project.
-      ResourcesLoader.burstAllUrlsCache();
-      // TODO: Pixi cache should also be burst
-      preferences.setHasProjectOpened(true);
-
-      return setState(state => ({
-        ...state,
-        currentProject: project,
-        currentFileMetadata: fileMetadata,
-        createDialogOpen: false,
-      })).then(state => {
-        // Load all the EventsFunctionsExtension when the game is loaded. If they are modified,
-        // their editor will take care of reloading them.
-        eventsFunctionsExtensionsState.loadProjectEventsFunctionsExtensions(
-          project
-        );
-
-        if (fileMetadata) {
-          project.setProjectFile(fileMetadata.fileIdentifier);
+  const closeProject = React.useCallback(
+    (): Promise<void> => {
+      preferences.setHasProjectOpened(false);
+      setPreviewState(initialPreviewState);
+      return setState(state => {
+        if (!currentProject) {
+          // It's important to return a new object to ensure that the promise
+          // will be fired.
+          return { ...state };
         }
 
-        return state;
-      });
-    });
-  };
+        if (currentProject) {
+          eventsFunctionsExtensionsState.unloadProjectEventsFunctionsExtensions(
+            currentProject
+          );
+          currentProject.delete();
+        }
 
-  const openFromFileMetadata = (
-    fileMetadata: FileMetadata
-  ): Promise<?State> => {
-    const { i18n, getStorageProviderOperations } = props;
-    return getStorageProviderOperations().then(storageProviderOperations => {
-      const {
-        hasAutoSave,
-        onGetAutoSave,
-        onOpen,
-        getOpenErrorMessage,
-      } = storageProviderOperations;
+        return {
+          ...state,
+          currentProject: null,
+          currentFileMetadata: null,
+          editorTabs: closeProjectTabs(state.editorTabs, currentProject),
+        };
+      }).then(() => {});
+    },
+    [currentProject, eventsFunctionsExtensionsState, preferences, setState]
+  );
 
-      if (!onOpen) {
-        console.error(
-          'Tried to open a file for a storage without onOpen support:',
+  const loadFromProject = React.useCallback(
+    (project: gdProject, fileMetadata: ?FileMetadata): Promise<State> => {
+      if (fileMetadata)
+        preferences.insertRecentProjectFile({
           fileMetadata,
-          storageProviderOperations
-        );
-        return Promise.resolve();
-      }
-
-      const checkForAutosave = (): Promise<FileMetadata> => {
-        if (!hasAutoSave || !onGetAutoSave) {
-          return Promise.resolve(fileMetadata);
-        }
-
-        return hasAutoSave(fileMetadata, true).then(canOpenAutosave => {
-          if (!canOpenAutosave) return fileMetadata;
-
-          const answer = Window.showConfirmDialog(
-            i18n._(
-              t`An autosave file (backup made automatically by GDevelop) that is newer than the project file exists. Would you like to load it instead?`
-            )
-          );
-          if (!answer) return fileMetadata;
-
-          return onGetAutoSave(fileMetadata);
+          storageProviderName: getStorageProvider().internalName,
         });
-      };
 
-      const checkForAutosaveAfterFailure = (): Promise<?FileMetadata> => {
-        if (!hasAutoSave || !onGetAutoSave) {
-          return Promise.resolve(null);
-        }
+      return closeProject().then(() => {
+        // Make sure that the ResourcesLoader cache is emptied, so that
+        // the URL to a resource with a name in the old project is not re-used
+        // for another resource with the same name in the new project.
+        ResourcesLoader.burstAllUrlsCache();
+        // TODO: Pixi cache should also be burst
+        preferences.setHasProjectOpened(true);
 
-        return hasAutoSave(fileMetadata, false).then(canOpenAutosave => {
-          if (!canOpenAutosave) return null;
-
-          const answer = Window.showConfirmDialog(
-            i18n._(
-              t`The project file appears to be malformed, but an autosave file exists (backup made automatically by GDevelop). Would you like to try to load it instead?`
-            )
+        return setState(state => ({
+          ...state,
+          currentProject: project,
+          currentFileMetadata: fileMetadata,
+          createDialogOpen: false,
+        })).then(state => {
+          // Load all the EventsFunctionsExtension when the game is loaded. If they are modified,
+          // their editor will take care of reloading them.
+          eventsFunctionsExtensionsState.loadProjectEventsFunctionsExtensions(
+            project
           );
-          if (!answer) return null;
 
-          return onGetAutoSave(fileMetadata);
-        });
-      };
-
-      setIsLoadingProject(true);
-
-      // Try to find an autosave (and ask user if found)
-      return checkForAutosave()
-        .then(fileMetadata => onOpen(fileMetadata))
-        .catch(err => {
-          // onOpen failed, tried to find again an autosave
-          return checkForAutosaveAfterFailure().then(fileMetadata => {
-            if (fileMetadata) {
-              return onOpen(fileMetadata);
-            }
-
-            throw err;
-          });
-        })
-        .then(({ content }) => {
-          if (!verifyProjectContent(i18n, content)) {
-            // The content is not recognized and the user was warned. Abort the opening.
-            setIsLoadingProject(false);
-            return;
+          if (fileMetadata) {
+            project.setProjectFile(fileMetadata.fileIdentifier);
           }
 
-          const serializedProject = gd.Serializer.fromJSObject(content);
-          return loadFromSerializedProject(
-            serializedProject,
-            // Note that fileMetadata is the original, unchanged one, even if we're loading
-            // an autosave. If we're for some reason loading an autosave, we still consider
-            // that we're opening the file that was originally requested by the user.
-            fileMetadata
-          ).then(
-            state => {
-              serializedProject.delete();
-              return Promise.resolve(state);
-            },
-            err => {
-              serializedProject.delete();
-              throw err;
-            }
-          );
-        })
-        .catch(error => {
-          const errorMessage = getOpenErrorMessage
-            ? getOpenErrorMessage(error)
-            : t`Check that the path/URL is correct, that you selected a file that is a game file created with GDevelop and that is was not removed.`;
-          showErrorBox(
-            [i18n._(t`Unable to open the project.`), i18n._(errorMessage)].join(
-              '\n'
-            ),
-            error
-          );
-          setIsLoadingProject(false);
-          return Promise.reject(error);
+          return state;
         });
-    });
-  };
+      });
+    },
+    [
+      setState,
+      closeProject,
+      preferences,
+      eventsFunctionsExtensionsState,
+      getStorageProvider,
+    ]
+  );
 
-  const closeApp = (): void => {
+  const loadFromSerializedProject = React.useCallback(
+    (
+      serializedProject: gdSerializerElement,
+      fileMetadata: ?FileMetadata
+    ): Promise<State> => {
+      return timePromise(
+        () => {
+          const newProject = gd.ProjectHelper.createNewGDJSProject();
+          newProject.unserializeFrom(serializedProject);
+
+          return loadFromProject(newProject, fileMetadata);
+        },
+        time => console.info(`Unserialization took ${time} ms`)
+      );
+    },
+    [loadFromProject]
+  );
+
+  const openFromFileMetadata = React.useCallback(
+    (fileMetadata: FileMetadata): Promise<?State> => {
+      return getStorageProviderOperations().then(storageProviderOperations => {
+        const {
+          hasAutoSave,
+          onGetAutoSave,
+          onOpen,
+          getOpenErrorMessage,
+        } = storageProviderOperations;
+
+        if (!onOpen) {
+          console.error(
+            'Tried to open a file for a storage without onOpen support:',
+            fileMetadata,
+            storageProviderOperations
+          );
+          return Promise.resolve();
+        }
+
+        const checkForAutosave = (): Promise<FileMetadata> => {
+          if (!hasAutoSave || !onGetAutoSave) {
+            return Promise.resolve(fileMetadata);
+          }
+
+          return hasAutoSave(fileMetadata, true).then(canOpenAutosave => {
+            if (!canOpenAutosave) return fileMetadata;
+
+            const answer = Window.showConfirmDialog(
+              i18n._(
+                t`An autosave file (backup made automatically by GDevelop) that is newer than the project file exists. Would you like to load it instead?`
+              )
+            );
+            if (!answer) return fileMetadata;
+
+            return onGetAutoSave(fileMetadata);
+          });
+        };
+
+        const checkForAutosaveAfterFailure = (): Promise<?FileMetadata> => {
+          if (!hasAutoSave || !onGetAutoSave) {
+            return Promise.resolve(null);
+          }
+
+          return hasAutoSave(fileMetadata, false).then(canOpenAutosave => {
+            if (!canOpenAutosave) return null;
+
+            const answer = Window.showConfirmDialog(
+              i18n._(
+                t`The project file appears to be malformed, but an autosave file exists (backup made automatically by GDevelop). Would you like to try to load it instead?`
+              )
+            );
+            if (!answer) return null;
+
+            return onGetAutoSave(fileMetadata);
+          });
+        };
+
+        setIsLoadingProject(true);
+
+        // Try to find an autosave (and ask user if found)
+        return checkForAutosave()
+          .then(fileMetadata => onOpen(fileMetadata))
+          .catch(err => {
+            // onOpen failed, tried to find again an autosave
+            return checkForAutosaveAfterFailure().then(fileMetadata => {
+              if (fileMetadata) {
+                return onOpen(fileMetadata);
+              }
+
+              throw err;
+            });
+          })
+          .then(({ content }) => {
+            if (!verifyProjectContent(i18n, content)) {
+              // The content is not recognized and the user was warned. Abort the opening.
+              setIsLoadingProject(false);
+              return;
+            }
+
+            const serializedProject = gd.Serializer.fromJSObject(content);
+            return loadFromSerializedProject(
+              serializedProject,
+              // Note that fileMetadata is the original, unchanged one, even if we're loading
+              // an autosave. If we're for some reason loading an autosave, we still consider
+              // that we're opening the file that was originally requested by the user.
+              fileMetadata
+            ).then(
+              state => {
+                serializedProject.delete();
+                return Promise.resolve(state);
+              },
+              err => {
+                serializedProject.delete();
+                throw err;
+              }
+            );
+          })
+          .catch(error => {
+            const errorMessage = getOpenErrorMessage
+              ? getOpenErrorMessage(error)
+              : t`Check that the path/URL is correct, that you selected a file that is a game file created with GDevelop and that is was not removed.`;
+            showErrorBox(
+              [
+                i18n._(t`Unable to open the project.`),
+                i18n._(errorMessage),
+              ].join('\n'),
+              error
+            );
+            setIsLoadingProject(false);
+            return Promise.reject(error);
+          });
+      });
+    },
+    [i18n, getStorageProviderOperations, loadFromSerializedProject]
+  );
+
+  const closeApp = React.useCallback((): void => {
     return Window.quit();
-  };
+  }, []);
 
-  const closeProject = (): Promise<void> => {
-    const { eventsFunctionsExtensionsState } = props;
-
-    preferences.setHasProjectOpened(false);
-    setPreviewState(initialPreviewState);
-    return setState(state => {
-      const { currentProject, editorTabs } = state;
-
-      if (!currentProject) {
-        // It's important to return a new object to ensure that the promise
-        // will be fired.
-        return { ...state };
-      }
-
-      if (currentProject) {
-        eventsFunctionsExtensionsState.unloadProjectEventsFunctionsExtensions(
-          currentProject
-        );
-        currentProject.delete();
-      }
-
-      return {
-        ...state,
-        currentProject: null,
-        currentFileMetadata: null,
-        editorTabs: closeProjectTabs(editorTabs, currentProject),
-      };
-    }).then(() => {});
-  };
-
-  const toggleProjectManager = () => {
-    if (toolbar.current)
-      openProjectManager(projectManagerOpen => !projectManagerOpen);
-  };
+  const toggleProjectManager = React.useCallback(
+    () => {
+      if (toolbar.current)
+        openProjectManager(projectManagerOpen => !projectManagerOpen);
+    },
+    [openProjectManager]
+  );
 
   const setEditorToolbar = (editorToolbar: any) => {
     if (!toolbar.current) return;
@@ -928,95 +980,129 @@ const MainFrame = (props: Props) => {
     }));
   };
 
-  const launchPreview = (networkPreview: boolean) => {
-    const { eventsFunctionsExtensionsState } = props;
+  const autosaveProjectIfNeeded = React.useCallback(
+    () => {
+      if (!currentProject) return;
 
-    if (!currentProject) return;
-    if (currentProject.getLayoutsCount() === 0) return;
-
-    setPreviewLoading(true);
-
-    notifyPreviewWillStart(state.editorTabs);
-
-    const layoutName = previewState.isPreviewOverriden
-      ? previewState.overridenPreviewLayoutName
-      : previewState.previewLayoutName;
-    const externalLayoutName = previewState.isPreviewOverriden
-      ? previewState.overridenPreviewExternalLayoutName
-      : previewState.previewExternalLayoutName;
-
-    const layout =
-      layoutName && currentProject.hasLayoutNamed(layoutName)
-        ? currentProject.getLayout(layoutName)
-        : currentProject.getLayoutAt(0);
-    const externalLayout =
-      externalLayoutName &&
-      currentProject.hasExternalLayoutNamed(externalLayoutName)
-        ? currentProject.getExternalLayout(externalLayoutName)
-        : null;
-
-    const previewLauncher = _previewLauncher.current;
-    if (previewLauncher) {
-      return eventsFunctionsExtensionsState
-        .ensureLoadFinished()
-        .then(() =>
-          previewLauncher.launchPreview({
-            project: currentProject,
-            layout,
-            externalLayout,
-            networkPreview,
-          })
-        )
-        .catch(error => {
-          console.error(
-            'Error caught while launching preview, this should never happen.',
-            error
+      getStorageProviderOperations().then(storageProviderOperations => {
+        if (
+          preferences.values.autosaveOnPreview &&
+          storageProviderOperations.onAutoSaveProject &&
+          currentFileMetadata
+        ) {
+          storageProviderOperations.onAutoSaveProject(
+            currentProject,
+            currentFileMetadata
           );
-        })
-        .then(() => {
-          setPreviewLoading(false);
-        });
-    }
-    autosaveProjectIfNeeded();
-  };
+        }
+      });
+    },
+    [
+      currentProject,
+      currentFileMetadata,
+      getStorageProviderOperations,
+      preferences.values.autosaveOnPreview,
+    ]
+  );
 
-  const openLayout = (
-    name: string,
-    {
-      openEventsEditor = true,
-      openSceneEditor = true,
-    }: { openEventsEditor: boolean, openSceneEditor: boolean } = {},
-    editorTabs = state.editorTabs
-  ) => {
-    const { i18n } = props;
-    const sceneEditorOptions = {
-      label: name,
-      projectItemName: name,
-      renderEditorContainer: renderSceneEditorContainer,
-      key: 'layout ' + name,
-    };
-    const eventsEditorOptions = {
-      label: name + ' ' + i18n._(t`(Events)`),
-      projectItemName: name,
-      renderEditorContainer: renderEventsEditorContainer,
-      key: 'layout events ' + name,
-      dontFocusTab: openSceneEditor,
-    };
+  const launchPreview = React.useCallback(
+    (networkPreview: boolean) => {
+      if (!currentProject) return;
+      if (currentProject.getLayoutsCount() === 0) return;
 
-    const tabsWithSceneEditor = openSceneEditor
-      ? openEditorTab(editorTabs, sceneEditorOptions)
-      : editorTabs;
-    const tabsWithSceneAndEventsEditors = openEventsEditor
-      ? openEditorTab(tabsWithSceneEditor, eventsEditorOptions)
-      : tabsWithSceneEditor;
+      setPreviewLoading(true);
 
-    setState(state => ({
-      ...state,
-      editorTabs: tabsWithSceneAndEventsEditors,
-    }));
-    setIsLoadingProject(false);
-    openProjectManager(false);
-  };
+      notifyPreviewWillStart(state.editorTabs);
+
+      const layoutName = previewState.isPreviewOverriden
+        ? previewState.overridenPreviewLayoutName
+        : previewState.previewLayoutName;
+      const externalLayoutName = previewState.isPreviewOverriden
+        ? previewState.overridenPreviewExternalLayoutName
+        : previewState.previewExternalLayoutName;
+
+      const layout =
+        layoutName && currentProject.hasLayoutNamed(layoutName)
+          ? currentProject.getLayout(layoutName)
+          : currentProject.getLayoutAt(0);
+      const externalLayout =
+        externalLayoutName &&
+        currentProject.hasExternalLayoutNamed(externalLayoutName)
+          ? currentProject.getExternalLayout(externalLayoutName)
+          : null;
+
+      const previewLauncher = _previewLauncher.current;
+      if (previewLauncher) {
+        return eventsFunctionsExtensionsState
+          .ensureLoadFinished()
+          .then(() =>
+            previewLauncher.launchPreview({
+              project: currentProject,
+              layout,
+              externalLayout,
+              networkPreview,
+            })
+          )
+          .catch(error => {
+            console.error(
+              'Error caught while launching preview, this should never happen.',
+              error
+            );
+          })
+          .then(() => {
+            setPreviewLoading(false);
+          });
+      }
+      autosaveProjectIfNeeded();
+    },
+    [
+      autosaveProjectIfNeeded,
+      currentProject,
+      eventsFunctionsExtensionsState,
+      previewState,
+      state.editorTabs,
+    ]
+  );
+
+  const openLayout = React.useCallback(
+    (
+      name: string,
+      {
+        openEventsEditor = true,
+        openSceneEditor = true,
+      }: { openEventsEditor: boolean, openSceneEditor: boolean } = {},
+      editorTabs = state.editorTabs
+    ) => {
+      const sceneEditorOptions = {
+        label: name,
+        projectItemName: name,
+        renderEditorContainer: renderSceneEditorContainer,
+        key: 'layout ' + name,
+      };
+      const eventsEditorOptions = {
+        label: name + ' ' + i18n._(t`(Events)`),
+        projectItemName: name,
+        renderEditorContainer: renderEventsEditorContainer,
+        key: 'layout events ' + name,
+        dontFocusTab: openSceneEditor,
+      };
+
+      const tabsWithSceneEditor = openSceneEditor
+        ? openEditorTab(editorTabs, sceneEditorOptions)
+        : editorTabs;
+      const tabsWithSceneAndEventsEditors = openEventsEditor
+        ? openEditorTab(tabsWithSceneEditor, eventsEditorOptions)
+        : tabsWithSceneEditor;
+
+      setState(state => ({
+        ...state,
+        editorTabs: tabsWithSceneAndEventsEditors,
+      }));
+      setIsLoadingProject(false);
+      openProjectManager(false);
+    },
+    [i18n, setState, state.editorTabs]
+  );
 
   const openExternalEvents = (name: string) => {
     setState(state => ({
@@ -1079,32 +1165,36 @@ const MainFrame = (props: Props) => {
     }));
   };
 
-  const openStartPage = () => {
-    const { i18n } = props;
-    setState(state => ({
-      ...state,
-      editorTabs: openEditorTab(state.editorTabs, {
-        label: i18n._(t`Start Page`),
-        projectItemName: null,
-        renderEditorContainer: renderStartPageContainer,
-        key: 'start page',
-        closable: false,
-      }),
-    }));
-  };
+  const openStartPage = React.useCallback(
+    () => {
+      setState(state => ({
+        ...state,
+        editorTabs: openEditorTab(state.editorTabs, {
+          label: i18n._(t`Start Page`),
+          projectItemName: null,
+          renderEditorContainer: renderStartPageContainer,
+          key: 'start page',
+          closable: false,
+        }),
+      }));
+    },
+    [i18n, setState]
+  );
 
-  const openDebugger = () => {
-    const { i18n } = props;
-    setState(state => ({
-      ...state,
-      editorTabs: openEditorTab(state.editorTabs, {
-        label: i18n._(t`Debugger`),
-        projectItemName: null,
-        renderEditorContainer: renderDebuggerEditorContainer,
-        key: 'debugger',
-      }),
-    }));
-  };
+  const openDebugger = React.useCallback(
+    () => {
+      setState(state => ({
+        ...state,
+        editorTabs: openEditorTab(state.editorTabs, {
+          label: i18n._(t`Debugger`),
+          projectItemName: null,
+          renderEditorContainer: renderDebuggerEditorContainer,
+          key: 'debugger',
+        }),
+      }));
+    },
+    [i18n, setState]
+  );
 
   const openInstructionOrExpression = (
     extension: gdPlatformExtension,
@@ -1185,55 +1275,115 @@ const MainFrame = (props: Props) => {
     );
   };
 
-  const openCreateDialog = (open: boolean = true) => {
-    setState(state => ({ ...state, createDialogOpen: open }));
-  };
+  const openCreateDialog = React.useCallback(
+    (open: boolean = true) => {
+      setState(state => ({ ...state, createDialogOpen: open }));
+    },
+    [setState]
+  );
 
-  const chooseProject = () => {
-    const { storageProviders } = props;
+  const openOpenFromStorageProviderDialog = React.useCallback(
+    (open: boolean = true) => {
+      setState(state => ({
+        ...state,
+        openFromStorageProviderDialogOpen: open,
+      }));
+    },
+    [setState]
+  );
 
-    if (
-      storageProviders.filter(({ hiddenInOpenDialog }) => !hiddenInOpenDialog)
-        .length > 1
-    ) {
-      openOpenFromStorageProviderDialog();
-    } else {
-      chooseProjectWithStorageProviderPicker();
-    }
-  };
+  const openSceneOrProjectManager = React.useCallback(
+    (
+      newState = {
+        currentProject: state.currentProject,
+        editorTabs: state.editorTabs,
+      }
+    ) => {
+      const { currentProject, editorTabs } = newState;
+      if (!currentProject) return;
 
-  const chooseProjectWithStorageProviderPicker = () => {
-    const { getStorageProviderOperations, i18n } = props;
-    getStorageProviderOperations().then(storageProviderOperations => {
-      if (!storageProviderOperations.onOpenWithPicker) return;
-
-      return storageProviderOperations
-        .onOpenWithPicker()
-        .then(fileMetadata => {
-          if (!fileMetadata) return;
-
-          return openFromFileMetadata(fileMetadata).then(state => {
-            if (state)
-              openSceneOrProjectManager({
-                currentProject: state.currentProject,
-                editorTabs: state.editorTabs,
-              });
-            //addRecentFile(fileMetadata);
-          });
-        })
-        .catch(error => {
-          const errorMessage = storageProviderOperations.getOpenErrorMessage
-            ? storageProviderOperations.getOpenErrorMessage(error)
-            : t`Verify that you have the authorizations for reading the file you're trying to access.`;
-          showErrorBox(
-            [i18n._(t`Unable to open the project.`), i18n._(errorMessage)].join(
-              '\n'
-            ),
-            error
-          );
+      if (currentProject.getLayoutsCount() === 1) {
+        openLayout(
+          currentProject.getLayoutAt(0).getName(),
+          {
+            openSceneEditor: true,
+            openEventsEditor: true,
+          },
+          editorTabs
+        );
+      } else {
+        setState(state => ({
+          ...state,
+          currentProject,
+          editorTabs,
+        })).then(() => {
+          setIsLoadingProject(false);
+          openProjectManager(true);
         });
-    });
-  };
+      }
+    },
+    [openLayout, setState, state.currentProject, state.editorTabs]
+  );
+
+  const chooseProjectWithStorageProviderPicker = React.useCallback(
+    () => {
+      getStorageProviderOperations().then(storageProviderOperations => {
+        if (!storageProviderOperations.onOpenWithPicker) return;
+
+        return storageProviderOperations
+          .onOpenWithPicker()
+          .then(fileMetadata => {
+            if (!fileMetadata) return;
+
+            return openFromFileMetadata(fileMetadata).then(state => {
+              if (state)
+                openSceneOrProjectManager({
+                  currentProject: state.currentProject,
+                  editorTabs: state.editorTabs,
+                });
+              //addRecentFile(fileMetadata);
+            });
+          })
+          .catch(error => {
+            const errorMessage = storageProviderOperations.getOpenErrorMessage
+              ? storageProviderOperations.getOpenErrorMessage(error)
+              : t`Verify that you have the authorizations for reading the file you're trying to access.`;
+            showErrorBox(
+              [
+                i18n._(t`Unable to open the project.`),
+                i18n._(errorMessage),
+              ].join('\n'),
+              error
+            );
+          });
+      });
+    },
+    [
+      i18n,
+      getStorageProviderOperations,
+      openFromFileMetadata,
+      openSceneOrProjectManager,
+    ]
+  );
+
+  const chooseProject = React.useCallback(
+    () => {
+      if (
+        props.storageProviders.filter(
+          ({ hiddenInOpenDialog }) => !hiddenInOpenDialog
+        ).length > 1
+      ) {
+        openOpenFromStorageProviderDialog();
+      } else {
+        chooseProjectWithStorageProviderPicker();
+      }
+    },
+    [
+      props.storageProviders,
+      openOpenFromStorageProviderDialog,
+      chooseProjectWithStorageProviderPicker,
+    ]
+  );
 
   const openFromFileMetadataWithStorageProvider = (
     fileMetadataAndStorageProviderName: FileMetadataAndStorageProviderName
@@ -1267,166 +1417,158 @@ const MainFrame = (props: Props) => {
     }
   };
 
-  const saveProject = () => {
-    const { currentProject, currentFileMetadata } = state;
-    const { i18n, getStorageProviderOperations } = props;
-    if (!currentProject) return;
-    if (!currentFileMetadata) {
-      return saveProjectAs();
-    }
+  const openSaveToStorageProviderDialog = React.useCallback(
+    (open: boolean = true) => {
+      if (open) {
+        // Ensure the project manager is closed as Google Drive storage provider
+        // display a picker that does not play nice with material-ui's overlays.
+        openProjectManager(false);
+      }
+      setState(state => ({ ...state, saveToStorageProviderDialogOpen: open }));
+    },
+    [setState]
+  );
 
-    getStorageProviderOperations().then(storageProviderOperations => {
-      const { onSaveProject } = storageProviderOperations;
-      if (!onSaveProject) {
+  const saveProjectAsWithStorageProvider = React.useCallback(
+    () => {
+      if (!currentProject) return;
+
+      saveUiSettings(state.editorTabs);
+
+      getStorageProviderOperations().then(storageProviderOperations => {
+        if (!storageProviderOperations.onSaveProjectAs) {
+          return;
+        }
+
+        storageProviderOperations
+          .onSaveProjectAs(currentProject, currentFileMetadata)
+          .then(
+            ({ wasSaved, fileMetadata }) => {
+              if (wasSaved) {
+                if (props.unsavedChanges)
+                  props.unsavedChanges.sealUnsavedChanges();
+                _showSnackMessage(i18n._(t`Project properly saved`));
+
+                if (fileMetadata) {
+                  setState(state => ({
+                    ...state,
+                    currentFileMetadata: fileMetadata,
+                  }));
+                }
+              }
+            },
+            err => {
+              showErrorBox(
+                i18n._(
+                  t`Unable to save as the project! Please try again by choosing another location.`
+                ),
+                err
+              );
+            }
+          );
+      });
+    },
+    [
+      i18n,
+      currentProject,
+      currentFileMetadata,
+      getStorageProviderOperations,
+      props.unsavedChanges,
+      setState,
+      state.editorTabs,
+      _showSnackMessage,
+    ]
+  );
+
+  const saveProjectAs = React.useCallback(
+    () => {
+      if (!currentProject) return;
+
+      getStorageProviderOperations().then(storageProviderOperations => {
+        if (
+          props.storageProviders.filter(
+            ({ hiddenInSaveDialog }) => !hiddenInSaveDialog
+          ).length > 1 ||
+          !storageProviderOperations.onSaveProjectAs
+        ) {
+          openSaveToStorageProviderDialog();
+        } else {
+          saveProjectAsWithStorageProvider();
+        }
+      });
+    },
+    [
+      currentProject,
+      getStorageProviderOperations,
+      openSaveToStorageProviderDialog,
+      props.storageProviders,
+      saveProjectAsWithStorageProvider,
+    ]
+  );
+
+  const saveProject = React.useCallback(
+    () => {
+      if (!currentProject) return;
+      if (!currentFileMetadata) {
         return saveProjectAs();
       }
 
-      saveUiSettings(state.editorTabs);
-      _showSnackMessage(i18n._(t`Saving...`));
-
-      onSaveProject(currentProject, currentFileMetadata).then(
-        ({ wasSaved }) => {
-          if (wasSaved) {
-            if (props.unsavedChanges) props.unsavedChanges.sealUnsavedChanges();
-            _showSnackMessage(i18n._(t`Project properly saved`));
-          }
-        },
-        err => {
-          showErrorBox(
-            i18n._(
-              t`Unable to save the project! Please try again by choosing another location.`
-            ),
-            err
-          );
+      getStorageProviderOperations().then(storageProviderOperations => {
+        const { onSaveProject } = storageProviderOperations;
+        if (!onSaveProject) {
+          return saveProjectAs();
         }
-      );
-    });
-  };
 
-  const saveProjectAs = () => {
-    const { currentProject } = state;
-    const { storageProviders, getStorageProviderOperations } = props;
-    if (!currentProject) return;
+        saveUiSettings(state.editorTabs);
+        _showSnackMessage(i18n._(t`Saving...`));
 
-    getStorageProviderOperations().then(storageProviderOperations => {
-      if (
-        storageProviders.filter(({ hiddenInSaveDialog }) => !hiddenInSaveDialog)
-          .length > 1 ||
-        !storageProviderOperations.onSaveProjectAs
-      ) {
-        openSaveToStorageProviderDialog();
-      } else {
-        saveProjectAsWithStorageProvider();
-      }
-    });
-  };
-
-  const autosaveProjectIfNeeded = () => {
-    const { currentProject, currentFileMetadata } = state;
-    const { getStorageProviderOperations } = props;
-
-    if (!currentProject) return;
-
-    getStorageProviderOperations().then(storageProviderOperations => {
-      if (
-        preferences.values.autosaveOnPreview &&
-        storageProviderOperations.onAutoSaveProject &&
-        currentFileMetadata
-      ) {
-        storageProviderOperations.onAutoSaveProject(
-          currentProject,
-          currentFileMetadata
-        );
-      }
-    });
-  };
-
-  const saveProjectAsWithStorageProvider = () => {
-    const { currentProject, currentFileMetadata } = state;
-    if (!currentProject) return;
-
-    saveUiSettings(state.editorTabs);
-    const { i18n, getStorageProviderOperations } = props;
-
-    getStorageProviderOperations().then(storageProviderOperations => {
-      if (!storageProviderOperations.onSaveProjectAs) {
-        return;
-      }
-
-      storageProviderOperations
-        .onSaveProjectAs(currentProject, currentFileMetadata)
-        .then(
-          ({ wasSaved, fileMetadata }) => {
+        onSaveProject(currentProject, currentFileMetadata).then(
+          ({ wasSaved }) => {
             if (wasSaved) {
               if (props.unsavedChanges)
                 props.unsavedChanges.sealUnsavedChanges();
               _showSnackMessage(i18n._(t`Project properly saved`));
-
-              if (fileMetadata) {
-                setState(state => ({
-                  ...state,
-                  currentFileMetadata: fileMetadata,
-                }));
-              }
             }
           },
           err => {
             showErrorBox(
               i18n._(
-                t`Unable to save as the project! Please try again by choosing another location.`
+                t`Unable to save the project! Please try again by choosing another location.`
               ),
               err
             );
           }
         );
-    });
-  };
-
-  const askToCloseProject = (): Promise<void> => {
-    const { currentProject } = state;
-    const { unsavedChanges } = props;
-    if (unsavedChanges && unsavedChanges.hasUnsavedChanges) {
-      if (!currentProject) return Promise.resolve();
-
-      const answer = Window.showConfirmDialog(
-        i18n._(
-          t`Close the project? Any changes that have not been saved will be lost.`
-        )
-      );
-      if (!answer) return Promise.resolve();
-    }
-    return closeProject();
-  };
-
-  const openSceneOrProjectManager = (
-    newState = {
-      currentProject: state.currentProject,
-      editorTabs: state.editorTabs,
-    }
-  ) => {
-    const { currentProject, editorTabs } = newState;
-    if (!currentProject) return;
-
-    if (currentProject.getLayoutsCount() === 1) {
-      openLayout(
-        currentProject.getLayoutAt(0).getName(),
-        {
-          openSceneEditor: true,
-          openEventsEditor: true,
-        },
-        editorTabs
-      );
-    } else {
-      setState(state => ({
-        ...state,
-        currentProject,
-        editorTabs,
-      })).then(() => {
-        setIsLoadingProject(false);
-        openProjectManager(true);
       });
-    }
-  };
+    },
+    [
+      currentProject,
+      currentFileMetadata,
+      getStorageProviderOperations,
+      _showSnackMessage,
+      i18n,
+      props.unsavedChanges,
+      saveProjectAs,
+      state.editorTabs,
+    ]
+  );
+
+  const askToCloseProject = React.useCallback(
+    (): Promise<void> => {
+      if (props.unsavedChanges && props.unsavedChanges.hasUnsavedChanges) {
+        if (!currentProject) return Promise.resolve();
+
+        const answer = Window.showConfirmDialog(
+          i18n._(
+            t`Close the project? Any changes that have not been saved will be lost.`
+          )
+        );
+        if (!answer) return Promise.resolve();
+      }
+      return closeProject();
+    },
+    [currentProject, props.unsavedChanges, i18n, closeProject]
+  );
 
   const _openOpenConfirmDialog = (open: boolean = true) => {
     setState(state => ({ ...state, openConfirmDialogOpen: open }));
@@ -1488,19 +1630,6 @@ const MainFrame = (props: Props) => {
     return resourceSourceDialog.chooseResources(currentProject, multiSelection);
   };
 
-  const openOpenFromStorageProviderDialog = (open: boolean = true) => {
-    setState(state => ({ ...state, openFromStorageProviderDialogOpen: open }));
-  };
-
-  const openSaveToStorageProviderDialog = (open: boolean = true) => {
-    if (open) {
-      // Ensure the project manager is closed as Google Drive storage provider
-      // display a picker that does not play nice with material-ui's overlays.
-      openProjectManager(false);
-    }
-    setState(state => ({ ...state, saveToStorageProviderDialogOpen: open }));
-  };
-
   const setUpdateStatus = (updateStatus: UpdateStatus) => {
     setState(state => ({ ...state, updateStatus }));
 
@@ -1529,38 +1658,6 @@ const MainFrame = (props: Props) => {
       message: 'Update available',
     });
 
-  const _showSnackMessage = (snackMessage: string) => {
-    setState(state => ({
-      ...state,
-      snackMessage,
-      snackMessageOpen: true,
-    }));
-  };
-  const _closeSnackMessage = () => {
-    setState(state => ({
-      ...state,
-      snackMessageOpen: false,
-    }));
-  };
-
-  const {
-    currentProject,
-    currentFileMetadata,
-    updateStatus,
-    eventsFunctionsExtensionsError,
-  } = state;
-  const {
-    renderExportDialog,
-    renderCreateDialog,
-    resourceSources,
-    renderPreviewLauncher,
-    resourceExternalEditors,
-    eventsFunctionsExtensionsState,
-    getStorageProviderOperations,
-    i18n,
-    renderGDJSDevelopmentWatcher,
-    renderMainMenu,
-  } = props;
   const showLoader = isLoadingProject || previewLoading || props.loading;
 
   return (


### PR DESCRIPTION
This PR wraps some essential Mainframe functions, like `saveProject`, `chooseProject` etc and their dependency functions in useCallback, to avoid things like IPC listeners being re-registered on every render, and also to prepare for adding the new command palette. I've also reordered some functions to avoid use before declaration.

Also, the PR fixes some minor warnings, coming from two other files.