### PR TITLE
Add 32 bit build for windows and linux (and arm for linux (RPI))

### DIFF
--- a/newIDE/electron-app/package.json
+++ b/newIDE/electron-app/package.json
@@ -32,6 +32,29 @@
         "to": "GDJS"
       }
     ],
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
+      ]
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "ia32",
+            "arm64"
+          ]
+        }
+      ]
+    },
     "mac": {
       "category": "public.app-category.developer-tools",
       "hardenedRuntime": true,


### PR DESCRIPTION
This adds 32 bits build builds to the configuration (and also an arm build, aka RPI build)
Trello card: https://trello.com/c/ovBYewSk