### PR TITLE
Remove useless divider component in select language list

### DIFF
--- a/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
@@ -142,7 +142,6 @@ export default class LanguageDialog extends Component<Props, State> {
                         {goodProgressLocales.map(localeMetadata =>
                           renderLanguageSelectOption(localeMetadata)
                         )}
-                        <Divider />
                         {startedLocales.map(localeMetadata =>
                           renderLanguageSelectOption(localeMetadata)
                         )}


### PR DESCRIPTION
Remove useless divider for avoid this warning at the opening of the list, seen in dev mode:

```
index.js:1 Warning: validateDOMNesting(...): <hr> cannot appear as a child of <select>.
    in hr (created by ForwardRef(Divider))
    in ForwardRef(Divider) (created by WithStyles(ForwardRef(Divider)))
    in WithStyles(ForwardRef(Divider)) (at LanguageDialog.js:145)
    in select (created by ForwardRef(NativeSelectInput))
    in ForwardRef(NativeSelectInput) (created by ForwardRef(InputBase))
    in div (created by ForwardRef(InputBase))
    in ForwardRef(InputBase) (created by WithStyles(ForwardRef(InputBase)))
    in WithStyles(ForwardRef(InputBase)) (created by ForwardRef(FilledInput))
    in ForwardRef(FilledInput) (created by WithStyles(ForwardRef(FilledInput)))
    in WithStyles(ForwardRef(FilledInput)) (created by ForwardRef(Select))
    in ForwardRef(Select) (created by WithStyles(ForwardRef(Select)))
    in WithStyles(ForwardRef(Select)) (created by ForwardRef(TextField))
    in div (created by ForwardRef(FormControl))
    in ForwardRef(FormControl) (created by WithStyles(ForwardRef(FormControl)))
    in WithStyles(ForwardRef(FormControl)) (created by ForwardRef(TextField))
    in ForwardRef(TextField) (created by WithStyles(ForwardRef(TextField)))
    in WithStyles(ForwardRef(TextField)) (at SelectField.js:84)
    in I18n (at SelectField.js:82)
    in SelectField (at LanguageDialog.js:125)
    in div (at Grid.js:10)
    in Line (at LanguageDialog.js:124)
    in div (at Grid.js:30)
    in Column (at LanguageDialog.js:114)
    in div (created by ForwardRef(DialogContent))
    in ForwardRef(DialogContent) (created by WithStyles(ForwardRef(DialogContent)))
    in WithStyles(ForwardRef(DialogContent)) (at Dialog/index.js:117)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(Dialog))
    in div (created by Transition)
    in Transition (created by ForwardRef(Fade))
    in ForwardRef(Fade) (created by TrapFocus)
    in TrapFocus (created by ForwardRef(Modal))
    in div (created by ForwardRef(Modal))
    in ForwardRef(Portal) (created by ForwardRef(Modal))
    in ForwardRef(Modal) (created by ForwardRef(Dialog))
    in ForwardRef(Dialog) (created by WithStyles(ForwardRef(Dialog)))
    in WithStyles(ForwardRef(Dialog)) (at Dialog/index.js:101)
    in ResponsiveWindowMeasurer (at Dialog/index.js:99)
    in Unknown (at LanguageDialog.js:79)
    in I18n (at LanguageDialog.js:72)
    in LanguageDialog (at MainFrame/index.js:2002)
    in div (at MainFrame/index.js:1671)
    in MainFrame (at LocalApp.js:60)
    in ProjectStorageProviders (at LocalApp.js:47)
    in EventsFunctionsExtensionsProvider (at Providers.js:67)
    in I18n (at Providers.js:65)
    in UserProfileProvider (at Providers.js:62)
    in ThemeProvider (at Providers.js:61)
    in I18nProvider (at GDI18nProvider.js:90)
    in GDI18nProvider (at Providers.js:59)
    in PreferencesProvider (at Providers.js:54)
    in UnsavedChangesContextProvider (at Providers.js:53)
    in DragAndDropContextProvider (created by DragDropContext(DragAndDropContextProvider))
    in DragDropContext(DragAndDropContextProvider) (at Providers.js:52)
    in Providers (at LocalApp.js:39)
    in Bootstrapper (at src/index.js:125)
```