### PR TITLE
Add option for clear on shape painter

### DIFF
--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -339,6 +339,36 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .SetFunctionName("closePath")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
+  obj.AddAction("ClearBetweenFrames",
+                _("Clear between frames"),
+                _("Clear the renderer before the next draw"),
+                _("The shape painter _PARAM0_ is cleared before the next draw: _PARAM1_"),
+                _("Setup"),
+                "res/actions/visibilite24.png",
+                "res/actions/visibilite.png")
+
+      .AddParameter("object", _("Shape Painter object"), "Drawer")
+      .AddParameter("yesorno", _("Clear the previous draw"), "", true)
+      .SetDefaultValue("yes")
+      .SetFunctionName("SetClearBetweenFrames")
+      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+
+  obj.AddCondition(
+         "ClearBetweenFrames",
+         _("Clear between frames"),
+         _("Test if the renderer is cleared at each frames."),
+         _("The shape painter _PARAM0_ is clear before the next draw: _PARAM1_"),
+         _("Setup"),
+         "res/conditions/visibilite24.png",
+         "res/conditions/visibilite.png")
+
+      .AddParameter("object", _("Shape Painter object"), "Drawer")
+      .AddParameter("yesorno", _("Clear the renderer at each frames is enabled (yes by default)"), "", true)
+      .SetDefaultValue("yes")
+      .SetFunctionName("IsClearedBetweenFrames")
+      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+
+
   obj.AddAction("FillColor",
                 _("Fill color"),
                 _("Change the color used when filling"),

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -217,7 +217,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                 _("Begin fill path"),
                 _("Begin to draw a simple one-color fill. Subsequent actions, such as \"Path line\" (in the Advanced category) can be used to draw. Be sure to use \"End fill path\" action when you're done drawing the shape."),
                 _("Begins drawing filling of an advanced path "
-                  "with _PARAM0_"),
+                  "with _PARAM0_ (start: _PARAM1_;_PARAM2_)"),
                 _("Advanced"),
                 "res/actions/beginFillPath24.png",
                 "res/actions/beginFillPath.png")

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -341,14 +341,14 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
 
   obj.AddAction("ClearBetweenFrames",
                 _("Clear between frames"),
-                _("Clear the renderer before the next draw"),
-                _("The shape painter _PARAM0_ is cleared before the next draw: _PARAM1_"),
+                _("Activate (or deactivate) the clearing of the rendered shape at the beginning of each frame."),
+                _("Clear the rendered image of _PARAM0_ between each frame: PARAM1"),
                 _("Setup"),
                 "res/actions/visibilite24.png",
                 "res/actions/visibilite.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("yesorno", _("Clear the previous draw"), "", true)
+      .AddParameter("yesorno", _("Clear between each frame"), "", true)
       .SetDefaultValue("yes")
       .SetFunctionName("SetClearBetweenFrames")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
@@ -356,18 +356,15 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
   obj.AddCondition(
          "ClearBetweenFrames",
          _("Clear between frames"),
-         _("Test if the renderer is cleared at each frames."),
-         _("The shape painter _PARAM0_ is clear before the next draw: _PARAM1_"),
+         _("Check if the rendered image is cleared between frames."),
+         _("_PARAM0_ is clearing its rendered image between each frame"),
          _("Setup"),
          "res/conditions/visibilite24.png",
          "res/conditions/visibilite.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("yesorno", _("Clear the renderer at each frames is enabled (yes by default)"), "", true)
-      .SetDefaultValue("yes")
       .SetFunctionName("IsClearedBetweenFrames")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
-
 
   obj.AddAction("FillColor",
                 _("Fill color"),

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -110,8 +110,7 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         .SetFunctionName("setClearBetweenFrames");
     GetAllConditionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ClearBetweenFrames"]
-        .SetFunctionName("setClearBetweenFrames")
-        .SetGetter("isClearedBetweenFrames");
+        .SetFunctionName("isClearedBetweenFrames");
     GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FillColor"]
         .SetFunctionName("setFillColor");

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -108,7 +108,7 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
     GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ClearBetweenFrames"]
         .SetFunctionName("setClearBetweenFrames");
-    GetAllActionsForObject(
+    GetAllConditionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ClearBetweenFrames"]
         .SetFunctionName("setClearBetweenFrames")
         .SetGetter("isClearedBetweenFrames");

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -106,6 +106,13 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ArcTo"]
         .SetFunctionName("drawArcTo");*/
     GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ClearBetweenFrames"]
+        .SetFunctionName("setClearBetweenFrames");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ClearBetweenFrames"]
+        .SetFunctionName("setClearBetweenFrames")
+        .SetGetter("isClearedBetweenFrames");
+    GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FillColor"]
         .SetFunctionName("setFillColor");
     GetAllActionsForObject(

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
@@ -179,13 +179,6 @@ std::size_t RuntimeShapePainterObject::GetNumberOfProperties() const {
 #endif
 
 /**
- * Change if the last draw is clear
- */
-void ShapePainterObjectBase::SetClearBetweenFrames(bool value) {
-  clearBetweenFrames = value;
-}
-
-/**
  * Change the color filter of the sprite object
  */
 void ShapePainterObjectBase::SetFillColor(unsigned int r,

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
@@ -34,6 +34,7 @@ ShapePainterObjectBase::ShapePainterObjectBase()
       outlineColorG(0),
       outlineColorB(0),
       outlineOpacity(255),
+      clearAtEachFrame(false),
       absoluteCoordinates(false) {}
 
 ShapePainterObject::ShapePainterObject(gd::String name_) : gd::Object(name_) {}
@@ -72,6 +73,10 @@ void ShapePainterObjectBase::DoUnserializeFrom(
       element.GetChild("absoluteCoordinates", 0, "AbsoluteCoordinates")
           .GetValue()
           .GetBool();
+  clearAtEachFrame =
+      element.GetChild("clearAtEachFrame", 0, "ClearAtEachFrame")
+          .GetValue()
+          .GetBool();
 }
 
 void ShapePainterObject::DoUnserializeFrom(
@@ -94,6 +99,7 @@ void ShapePainterObjectBase::DoSerializeTo(
       .SetAttribute("g", (int)outlineColorG)
       .SetAttribute("b", (int)outlineColorB);
   element.AddChild("absoluteCoordinates").SetValue(absoluteCoordinates);
+  element.AddChild("clearAtEachFrame").SetValue(clearAtEachFrame);
 }
 
 void ShapePainterObject::DoSerializeTo(gd::SerializerElement& element) const {

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
@@ -34,7 +34,7 @@ ShapePainterObjectBase::ShapePainterObjectBase()
       outlineColorG(0),
       outlineColorB(0),
       outlineOpacity(255),
-      clearAtEachFrame(false),
+      clearBetweenFrames(true),
       absoluteCoordinates(false) {}
 
 ShapePainterObject::ShapePainterObject(gd::String name_) : gd::Object(name_) {}
@@ -73,10 +73,7 @@ void ShapePainterObjectBase::DoUnserializeFrom(
       element.GetChild("absoluteCoordinates", 0, "AbsoluteCoordinates")
           .GetValue()
           .GetBool();
-  clearAtEachFrame =
-      element.GetChild("clearAtEachFrame", 0, "ClearAtEachFrame")
-          .GetValue()
-          .GetBool();
+  clearBetweenFrames = element.HasChild("clearBetweenFrames") ? element.GetChild("clearBetweenFrames").GetValue().GetBool() : true;
 }
 
 void ShapePainterObject::DoUnserializeFrom(
@@ -99,7 +96,7 @@ void ShapePainterObjectBase::DoSerializeTo(
       .SetAttribute("g", (int)outlineColorG)
       .SetAttribute("b", (int)outlineColorB);
   element.AddChild("absoluteCoordinates").SetValue(absoluteCoordinates);
-  element.AddChild("clearAtEachFrame").SetValue(clearAtEachFrame);
+  element.AddChild("clearBetweenFrames").SetValue(clearBetweenFrames);
 }
 
 void ShapePainterObject::DoSerializeTo(gd::SerializerElement& element) const {
@@ -180,6 +177,13 @@ std::size_t RuntimeShapePainterObject::GetNumberOfProperties() const {
   return 5;
 }
 #endif
+
+/**
+ * Change if the last draw is clear
+ */
+void ShapePainterObjectBase::SetClearBetweenFrames(bool value) {
+  clearBetweenFrames = value;
+}
 
 /**
  * Change the color filter of the sprite object

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.h
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.h
@@ -81,6 +81,9 @@ class GD_EXTENSION_API ShapePainterObjectBase {
   inline void SetCoordinatesRelative() { absoluteCoordinates = false; }
   inline bool AreCoordinatesAbsolute() { return absoluteCoordinates; }
 
+  inline void SetClearAtEachFrame(bool value = true) { clearAtEachFrame = value; }
+  inline bool AreClearAtEachFrame() { return clearAtEachFrame; }
+
  protected:
   virtual void DoUnserializeFrom(const gd::SerializerElement& element);
 #if defined(GD_IDE_ONLY)
@@ -102,6 +105,7 @@ class GD_EXTENSION_API ShapePainterObjectBase {
   float outlineOpacity;
 
   bool absoluteCoordinates;
+  bool clearAtEachFrame;
 };
 
 /**

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.h
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.h
@@ -81,8 +81,8 @@ class GD_EXTENSION_API ShapePainterObjectBase {
   inline void SetCoordinatesRelative() { absoluteCoordinates = false; }
   inline bool AreCoordinatesAbsolute() { return absoluteCoordinates; }
 
-  inline void SetClearAtEachFrame(bool value = true) { clearAtEachFrame = value; }
-  inline bool AreClearAtEachFrame() { return clearAtEachFrame; }
+  inline void SetClearBetweenFrames(bool value) { clearBetweenFrames = value; }
+  inline bool IsClearedBetweenFrames() { return clearBetweenFrames; }
 
  protected:
   virtual void DoUnserializeFrom(const gd::SerializerElement& element);
@@ -105,7 +105,7 @@ class GD_EXTENSION_API ShapePainterObjectBase {
   float outlineOpacity;
 
   bool absoluteCoordinates;
-  bool clearAtEachFrame;
+  bool clearBetweenFrames;
 };
 
 /**

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
@@ -18,7 +18,7 @@
  * @property {number} outlineOpacity The opacity of the outline of the painted shape
  * @property {number} outlineSize The size of the outline of the painted shape, in pixels.
  * @property {boolean} absoluteCoordinates Use absolute coordinates?
- * @property {boolean} clearAtEachFrame Clear the previous render before the next draw?
+ * @property {boolean} clearBetweenFrames Clear the previous render before the next draw?
  * 
  * @typedef {ObjectData & ShapePainterObjectDataType} ShapePainterObjectData
  */
@@ -55,7 +55,7 @@ gdjs.ShapePainterRuntimeObject = function(runtimeScene, shapePainterObjectData)
     this._absoluteCoordinates = shapePainterObjectData.absoluteCoordinates;
 
     /** @type {boolean} */
-    this._clearAtEachFrame = shapePainterObjectData.clearAtEachFrame;
+    this._clearBetweenFrames = shapePainterObjectData.clearBetweenFrames;
 
     if (this._renderer)
         gdjs.ShapePainterRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
@@ -76,7 +76,7 @@ gdjs.ShapePainterRuntimeObject.prototype.getRendererObject = function() {
 
 gdjs.ShapePainterRuntimeObject.prototype.stepBehaviorsPreEvents = function(runtimeScene) {
     //We redefine stepBehaviorsPreEvents just to clear the graphics before running events.
-    if(this._clearAtEachFrame){
+    if(this._clearBetweenFrames){
         this._renderer.clear();
     }
 
@@ -158,6 +158,14 @@ gdjs.ShapePainterRuntimeObject.prototype.drawPathQuadraticCurveTo = function(cpX
 
 gdjs.ShapePainterRuntimeObject.prototype.closePath = function() {
     this._renderer.closePath();  
+};
+
+gdjs.ShapePainterRuntimeObject.prototype.setClearBetweenFrames = function(value) {
+    this._clearBetweenFrames = value;
+};
+
+gdjs.ShapePainterRuntimeObject.prototype.isClearedBetweenFrames = function() {
+    return this._clearBetweenFrames;
 };
 
 gdjs.ShapePainterRuntimeObject.prototype.setFillColor = function(rgbColor) {

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
@@ -18,6 +18,7 @@
  * @property {number} outlineOpacity The opacity of the outline of the painted shape
  * @property {number} outlineSize The size of the outline of the painted shape, in pixels.
  * @property {boolean} absoluteCoordinates Use absolute coordinates?
+ * @property {boolean} clearAtEachFrame Clear the previous render before the next draw?
  * 
  * @typedef {ObjectData & ShapePainterObjectDataType} ShapePainterObjectData
  */
@@ -53,6 +54,9 @@ gdjs.ShapePainterRuntimeObject = function(runtimeScene, shapePainterObjectData)
     /** @type {boolean} */
     this._absoluteCoordinates = shapePainterObjectData.absoluteCoordinates;
 
+    /** @type {boolean} */
+    this._clearAtEachFrame = shapePainterObjectData.clearAtEachFrame;
+
     if (this._renderer)
         gdjs.ShapePainterRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
     else
@@ -72,7 +76,9 @@ gdjs.ShapePainterRuntimeObject.prototype.getRendererObject = function() {
 
 gdjs.ShapePainterRuntimeObject.prototype.stepBehaviorsPreEvents = function(runtimeScene) {
     //We redefine stepBehaviorsPreEvents just to clear the graphics before running events.
-    this._renderer.clear();
+    if(this._clearAtEachFrame){
+        this._renderer.clear();
+    }
 
     gdjs.RuntimeObject.prototype.stepBehaviorsPreEvents.call(this, runtimeScene);
 };

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2179,8 +2179,8 @@ interface ShapePainterObject {
     void SetCoordinatesRelative();
     boolean AreCoordinatesAbsolute();
 
-    void SetClearAtEachFrame(boolean value);
-    boolean AreClearAtEachFrame();
+    void SetClearBetweenFrames(boolean value);
+    boolean IsClearedBetweenFrames();
 
     void SetOutlineSize(float size);
     float GetOutlineSize();

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2179,6 +2179,9 @@ interface ShapePainterObject {
     void SetCoordinatesRelative();
     boolean AreCoordinatesAbsolute();
 
+    void SetClearAtEachFrame(boolean value);
+    boolean AreClearAtEachFrame();
+
     void SetOutlineSize(float size);
     float GetOutlineSize();
 

--- a/GDevelop.js/__tests__/GDJS.js
+++ b/GDevelop.js/__tests__/GDJS.js
@@ -312,6 +312,16 @@ describe('libGD.js - GDJS related tests', function() {
       expect(object.areCoordinatesAbsolute()).toBe(false);
     });
   });
+  describe('ShapePainterObject', function() {
+    it('should expose ShapePainterObject specific methods', function() {
+      var object = new gd.ShapePainterObject('MyShapePainterObject');
+      testObjectFeatures(object);
+      object.setClearBetweenFrames(true);
+      expect(object.isClearedBetweenFrames()).toBe(true);
+      object.setClearBetweenFrames(false);
+      expect(object.isClearedBetweenFrames()).toBe(false);
+    });
+  });
   describe('TextEntryObject', function() {
     it('should expose TextEntryObject', function() {
       var object = new gd.TextEntryObject('MyTextEntryObject');

--- a/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
@@ -33,11 +33,7 @@ export default class PanelSpriteEditor extends React.Component<
           }}
         />
         <Checkbox
-          label={
-            <Trans>
-              Clear the rendered image between each frame
-            </Trans>
-          }
+          label={<Trans>Clear the rendered image between each frame</Trans>}
           checked={shapePainterObject.isClearedBetweenFrames()}
           onCheck={(e, checked) => {
             shapePainterObject.setClearBetweenFrames(checked);

--- a/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
@@ -32,6 +32,19 @@ export default class PanelSpriteEditor extends React.Component<
             this.forceUpdate();
           }}
         />
+        <Checkbox
+          label={
+            <Trans>
+              Clear the render before the next draw
+            </Trans>
+          }
+          checked={shapePainterObject.areClearAtEachFrame()}
+          onCheck={(e, checked) => {
+            if (!checked) shapePainterObject.setClearAtEachFrame(false);
+            else shapePainterObject.setClearAtEachFrame(true);
+            this.forceUpdate();
+          }}
+        />
         <ResponsiveLineStackLayout noMargin>
           <ColorField
             floatingLabelText={<Trans>Outline color</Trans>}

--- a/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/ShapePainterEditor.js
@@ -35,13 +35,12 @@ export default class PanelSpriteEditor extends React.Component<
         <Checkbox
           label={
             <Trans>
-              Clear the render before the next draw
+              Clear the rendered image between each frame
             </Trans>
           }
-          checked={shapePainterObject.areClearAtEachFrame()}
+          checked={shapePainterObject.isClearedBetweenFrames()}
           onCheck={(e, checked) => {
-            if (!checked) shapePainterObject.setClearAtEachFrame(false);
-            else shapePainterObject.setClearAtEachFrame(true);
+            shapePainterObject.setClearBetweenFrames(checked);
             this.forceUpdate();
           }}
         />


### PR DESCRIPTION
Based on [this request](https://forum.gdevelop-app.com/t/change-request-dont-clear-shape-painter-on-every-frame/25395) from @arthuro555 

By default the checkbox for clear is enable for avoid issue with existing project using this object.
I have tested with the example "advanced shape painter" and it's work fine too me.

Ready for review, let me know.