### PR TITLE
Expose more variables of PlatformerObject

### DIFF
--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -501,6 +501,33 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("IgnoreDefaultControls")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
+    aut.AddAction("CanGrabPlatforms",
+                  _("Can Grab Platform"),
+                  _("De/activate when the platformer object can grab the platform."),
+                  _("_PARAM0_ can grab the platforms: _PARAM2_"),
+                  _("Controls"),
+                  "res/conditions/keyboard24.png",
+                  "res/conditions/keyboard.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .AddParameter("yesorno", _("Can grab the platfroms"))
+        .MarkAsAdvanced()
+        .SetFunctionName("SetCanGrabPlatforms")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
+    aut.AddCondition("CanGrabPlatforms",
+                     _("Can grab platforms"),
+                     _("Check if the object can grab the platforms."),
+                     _("_PARAM0_ can grab the platforms"),
+                     "",
+                     "CppPlatform/Extensions/platformerobjecticon24.png",
+                     "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .MarkAsSimple()
+        .SetFunctionName("GetCanGrabPlatforms")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
     aut.AddCondition(
            "CurrentFallSpeed",
            _("Current falling speed"),

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -501,6 +501,22 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("IgnoreDefaultControls")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
+    aut.AddCondition(
+           "CurrentFallSpeed",
+           _("Current falling speed"),
+           _("Compare the current falling speed of the object (in pixels per "
+             "second)."),
+           _("the current falling speed"),
+           _("Options"),
+           "CppPlatform/Extensions/platformerobjecticon24.png",
+           "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .UseStandardRelationalOperatorParameters("number")
+        .MarkAsAdvanced()
+        .SetFunctionName("GetCurrentFallSpeed")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
     aut.AddExpression("Gravity",
                       _("Gravity"),
                       _("Get the gravity applied on the object"),

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -578,6 +578,16 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
                       "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior");
+    
+    aut.AddExpression("CurrentFallSpeed",
+                      _("Current fall speed"),
+                      _("Current fall speed"),
+                      _("Options"),
+                      "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .SetFunctionName("GetCurrentFallSpeed")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 #endif
   }
   {

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -389,7 +389,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .MarkAsSimple()
-        .SetFunctionName("GetCanJump")
+        .SetFunctionName("canJump")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction("SimulateLeftKey",
@@ -515,18 +515,16 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddAction("CanGrabPlatforms",
-                  _("Can Grab Platform"),
-                  _("De/activate when the platformer object can grab the platform."),
-                  _("_PARAM0_ can grab the platforms: _PARAM2_"),
+                  _("Platform grabbing"),
+                  _("Enable (or disable) the ability of the object to grab platforms when falling near to one."),
+                  _("Allow _PARAM0_ to grab platforms: _PARAM2_"),
                   _("Controls"),
                   "res/conditions/keyboard24.png",
                   "res/conditions/keyboard.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
-        .AddParameter("yesorno", _("Can grab the platfroms"))
-        .MarkAsAdvanced()
-        .SetFunctionName("SetCanGrabPlatforms")
-        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+        .AddParameter("yesorno", _("Can grab platfroms"))
+        .MarkAsAdvanced();
 
     aut.AddCondition("CanGrabPlatforms",
                      _("Can grab platforms"),
@@ -538,7 +536,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .MarkAsSimple()
-        .SetFunctionName("GetCanGrabPlatforms")
+        .SetFunctionName("canGrabPlatforms")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddCondition(

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -379,6 +379,19 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("SetCanJump")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
+    aut.AddCondition("CanJump",
+                     _("Can jump"),
+                     _("Check if the object can jump."),
+                     _("_PARAM0_ can jump"),
+                     "",
+                     "CppPlatform/Extensions/platformerobjecticon24.png",
+                     "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .MarkAsSimple()
+        .SetFunctionName("GetCanJump")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
     aut.AddAction("SimulateLeftKey",
                   _("Simulate left key press"),
                   _("Simulate a press of the left key."),

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -518,6 +518,22 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
     aut.AddCondition(
+           "CurrentJumpSpeed",
+           _("Current jump speed"),
+           _("Compare the current jump speed of the object (in pixels per "
+             "second)."),
+           _("the current jump speed"),
+           _("Options"),
+           "CppPlatform/Extensions/platformerobjecticon24.png",
+           "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .UseStandardRelationalOperatorParameters("number")
+        .MarkAsAdvanced()
+        .SetFunctionName("GetCurrentJumpSpeed")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
+    aut.AddCondition(
            "CurrentSpeed",
            _("Current speed"),
            _("Compare the current speed of the object (in pixels per "
@@ -629,6 +645,16 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .SetFunctionName("GetCurrentSpeed")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+    
+    aut.AddExpression("CurrentJumpSpeed",
+                      _("Current jump speed"),
+                      _("Current jump speed"),
+                      _("Options"),
+                      "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .SetFunctionName("GetCurrentJumpSpeed")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 #endif
   }

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -517,6 +517,22 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("GetCurrentFallSpeed")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 
+    aut.AddCondition(
+           "CurrentSpeed",
+           _("Current speed"),
+           _("Compare the current speed of the object (in pixels per "
+             "second)."),
+           _("the current speed"),
+           _("Options"),
+           "CppPlatform/Extensions/platformerobjecticon24.png",
+           "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .UseStandardRelationalOperatorParameters("number")
+        .MarkAsAdvanced()
+        .SetFunctionName("GetCurrentSpeed")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+
     aut.AddExpression("Gravity",
                       _("Gravity"),
                       _("Get the gravity applied on the object"),
@@ -603,6 +619,16 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .SetFunctionName("GetCurrentFallSpeed")
+        .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
+    
+    aut.AddExpression("CurrentSpeed",
+                      _("Current speed"),
+                      _("Current speed"),
+                      _("Options"),
+                      "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .SetFunctionName("GetCurrentSpeed")
         .SetIncludeFile("PlatformBehavior/PlatformerObjectRuntimeBehavior.h");
 #endif
   }

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -107,10 +107,13 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
       autConditions["PlatformBehavior::CurrentFallSpeed"].SetFunctionName(
           "getCurrentFallSpeed");
       autExpressions["CurrentFallSpeed"].SetFunctionName("getCurrentFallSpeed");
-
       autConditions["PlatformBehavior::CurrentSpeed"].SetFunctionName(
           "getCurrentSpeed");
       autExpressions["CurrentSpeed"].SetFunctionName("getCurrentSpeed");
+
+      autConditions["PlatformBehavior::CurrentJumpSpeed"].SetFunctionName(
+          "getCurrentJumpSpeed");
+      autExpressions["CurrentJumpSpeed"].SetFunctionName("getCurrentJumpSpeed");
 
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -110,11 +110,14 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
       autConditions["PlatformBehavior::CurrentSpeed"].SetFunctionName(
           "getCurrentSpeed");
       autExpressions["CurrentSpeed"].SetFunctionName("getCurrentSpeed");
-
+      autActions["PlatformBehavior::CanGrabPlatforms"]
+          .SetFunctionName("setCanGrabPlatforms")
+          .SetGetter("getCanGrabPlatforms");
+      autConditions["PlatformBehavior::CanGrabPlatforms"].SetFunctionName(
+          "getCanGrabPlatforms");    
       autConditions["PlatformBehavior::CurrentJumpSpeed"].SetFunctionName(
           "getCurrentJumpSpeed");
       autExpressions["CurrentJumpSpeed"].SetFunctionName("getCurrentJumpSpeed");
-
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(
           "simulateLeftKey");

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -119,6 +119,8 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
           "getCurrentJumpSpeed");
       autExpressions["CurrentJumpSpeed"].SetFunctionName("getCurrentJumpSpeed");
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
+      autConditions["PlatformBehavior::CanJump"].SetFunctionName(
+          "getCanJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(
           "simulateLeftKey");
       autActions["PlatformBehavior::SimulateRightKey"].SetFunctionName(

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -112,15 +112,15 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
       autExpressions["CurrentSpeed"].SetFunctionName("getCurrentSpeed");
       autActions["PlatformBehavior::CanGrabPlatforms"]
           .SetFunctionName("setCanGrabPlatforms")
-          .SetGetter("getCanGrabPlatforms");
+          .SetGetter("canGrabPlatforms");
       autConditions["PlatformBehavior::CanGrabPlatforms"].SetFunctionName(
-          "getCanGrabPlatforms");    
+          "canGrabPlatforms");    
       autConditions["PlatformBehavior::CurrentJumpSpeed"].SetFunctionName(
           "getCurrentJumpSpeed");
       autExpressions["CurrentJumpSpeed"].SetFunctionName("getCurrentJumpSpeed");
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autConditions["PlatformBehavior::CanJump"].SetFunctionName(
-          "getCanJump");
+          "canJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(
           "simulateLeftKey");
       autActions["PlatformBehavior::SimulateRightKey"].SetFunctionName(

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -104,6 +104,7 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
           .SetFunctionName("setJumpSustainTime")
           .SetGetter("getJumpSustainTime");
       autExpressions["JumpSustainTime"].SetFunctionName("getJumpSustainTime");
+      autExpressions["CurrentFallSpeed"].SetFunctionName("getCurrentFallSpeed");
 
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -108,6 +108,10 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
           "getCurrentFallSpeed");
       autExpressions["CurrentFallSpeed"].SetFunctionName("getCurrentFallSpeed");
 
+      autConditions["PlatformBehavior::CurrentSpeed"].SetFunctionName(
+          "getCurrentSpeed");
+      autExpressions["CurrentSpeed"].SetFunctionName("getCurrentSpeed");
+
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(
           "simulateLeftKey");

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -104,6 +104,8 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
           .SetFunctionName("setJumpSustainTime")
           .SetGetter("getJumpSustainTime");
       autExpressions["JumpSustainTime"].SetFunctionName("getJumpSustainTime");
+      autConditions["PlatformBehavior::CurrentFallSpeed"].SetFunctionName(
+          "getCurrentFallSpeed");
       autExpressions["CurrentFallSpeed"].SetFunctionName("getCurrentFallSpeed");
 
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");

--- a/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
+++ b/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
@@ -39,6 +39,7 @@ class GD_EXTENSION_API PlatformerObjectRuntimeBehavior
   double GetMaxSpeed() const { return maxSpeed; };
   double GetJumpSpeed() const { return jumpSpeed; };
   double GetCurrentFallSpeed() const { return currentFallSpeed; };
+  double GetCurrentSpeed() const { return currentSpeed; };
   double GetSlopeMaxAngle() const { return slopeMaxAngle; };
 
   void SetGravity(double gravity_) { gravity = gravity_; };

--- a/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
+++ b/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
@@ -42,6 +42,7 @@ class GD_EXTENSION_API PlatformerObjectRuntimeBehavior
   double GetCurrentSpeed() const { return currentSpeed; };
   double GetCurrentJumpSpeed() const { return currentJumpSpeed; };
   double GetSlopeMaxAngle() const { return slopeMaxAngle; };
+  bool GetCanGrabPlatforms() const { return canGrabPlatforms; };
 
   void SetGravity(double gravity_) { gravity = gravity_; };
   void SetMaxFallingSpeed(double maxFallingSpeed_) {

--- a/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
+++ b/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
@@ -43,6 +43,7 @@ class GD_EXTENSION_API PlatformerObjectRuntimeBehavior
   double GetCurrentJumpSpeed() const { return currentJumpSpeed; };
   double GetSlopeMaxAngle() const { return slopeMaxAngle; };
   bool GetCanGrabPlatforms() const { return canGrabPlatforms; };
+  bool GetCanJump() const { return canJump; };
 
   void SetGravity(double gravity_) { gravity = gravity_; };
   void SetMaxFallingSpeed(double maxFallingSpeed_) {

--- a/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
+++ b/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
@@ -38,6 +38,7 @@ class GD_EXTENSION_API PlatformerObjectRuntimeBehavior
   double GetDeceleration() const { return deceleration; };
   double GetMaxSpeed() const { return maxSpeed; };
   double GetJumpSpeed() const { return jumpSpeed; };
+  double GetCurrentFallSpeed() const { return currentFallSpeed; };
   double GetSlopeMaxAngle() const { return slopeMaxAngle; };
 
   void SetGravity(double gravity_) { gravity = gravity_; };

--- a/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
+++ b/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
@@ -42,8 +42,8 @@ class GD_EXTENSION_API PlatformerObjectRuntimeBehavior
   double GetCurrentSpeed() const { return currentSpeed; };
   double GetCurrentJumpSpeed() const { return currentJumpSpeed; };
   double GetSlopeMaxAngle() const { return slopeMaxAngle; };
-  bool GetCanGrabPlatforms() const { return canGrabPlatforms; };
-  bool GetCanJump() const { return canJump; };
+  bool CanGrabPlatforms() const { return canGrabPlatforms; };
+  bool CanJump() const { return canJump; };
 
   void SetGravity(double gravity_) { gravity = gravity_; };
   void SetMaxFallingSpeed(double maxFallingSpeed_) {

--- a/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
+++ b/Extensions/PlatformBehavior/PlatformerObjectRuntimeBehavior.h
@@ -40,6 +40,7 @@ class GD_EXTENSION_API PlatformerObjectRuntimeBehavior
   double GetJumpSpeed() const { return jumpSpeed; };
   double GetCurrentFallSpeed() const { return currentFallSpeed; };
   double GetCurrentSpeed() const { return currentSpeed; };
+  double GetCurrentJumpSpeed() const { return currentJumpSpeed; };
   double GetSlopeMaxAngle() const { return slopeMaxAngle; };
 
   void SetGravity(double gravity_) { gravity = gravity_; };

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -958,6 +958,14 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentJumpSpeed = function() 
 };
 
 /**
+ * Get if the Platformer Object can grab the platforms.
+ * @returns {boolean} Platformer Object can grab the platforms.
+ */
+gdjs.PlatformerObjectRuntimeBehavior.prototype.getCanGrabPlatforms = function() {
+  return this._canGrabPlatforms;
+};
+
+/**
  * Set the gravity of the Platformer Object.
  * @param {number} gravity The new gravity.
  */

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -934,6 +934,14 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.getJumpSustainTime = function() {
 };
 
 /**
+ * Get the current speed during a fall of the Platformer Object.
+ * @returns {number} The current speed during a fall.
+ */
+gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentFallSpeed = function() {
+  return this._currentFallSpeed;
+};
+
+/**
  * Set the gravity of the Platformer Object.
  * @param {number} gravity The new gravity.
  */

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -942,6 +942,14 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentFallSpeed = function() 
 };
 
 /**
+ * Get the current speed of the Platformer Object.
+ * @returns {number} The current speed.
+ */
+gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentSpeed = function() {
+  return this._currentSpeed;
+};
+
+/**
  * Set the gravity of the Platformer Object.
  * @param {number} gravity The new gravity.
  */

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -966,6 +966,14 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.getCanGrabPlatforms = function() 
 };
 
 /**
+ * Get if the Platformer Object can jump.
+ * @returns {boolean} Platformer Object can jump.
+ */
+gdjs.PlatformerObjectRuntimeBehavior.prototype.getCanJump = function() {
+  return this._canJump;
+};
+
+/**
  * Set the gravity of the Platformer Object.
  * @param {number} gravity The new gravity.
  */

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -950,6 +950,14 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentSpeed = function() {
 };
 
 /**
+ * Get the current jump speed of the Platformer Object.
+ * @returns {number} The current jump speed.
+ */
+gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentJumpSpeed = function() {
+  return this._currentJumpSpeed;
+};
+
+/**
  * Set the gravity of the Platformer Object.
  * @param {number} gravity The new gravity.
  */

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -934,8 +934,8 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.getJumpSustainTime = function() {
 };
 
 /**
- * Get the current speed during a fall of the Platformer Object.
- * @returns {number} The current speed during a fall.
+ * Get the speed at which the object is falling. It is 0 when the object is on a floor, and non 0 as soon as the object leaves the floor.
+ * @returns {number} The current fall speed.
  */
 gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentFallSpeed = function() {
   return this._currentFallSpeed;
@@ -958,18 +958,18 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.getCurrentJumpSpeed = function() 
 };
 
 /**
- * Get if the Platformer Object can grab the platforms.
- * @returns {boolean} Platformer Object can grab the platforms.
+ * Check if the Platformer Object can grab the platforms.
+ * @returns {boolean} Returns true if the object can grab the platforms.
  */
-gdjs.PlatformerObjectRuntimeBehavior.prototype.getCanGrabPlatforms = function() {
+gdjs.PlatformerObjectRuntimeBehavior.prototype.canGrabPlatforms = function() {
   return this._canGrabPlatforms;
 };
 
 /**
- * Get if the Platformer Object can jump.
- * @returns {boolean} Platformer Object can jump.
+ * Check if the Platformer Object can jump.
+ * @returns {boolean} Returns true if the object can jump.
  */
-gdjs.PlatformerObjectRuntimeBehavior.prototype.getCanJump = function() {
+gdjs.PlatformerObjectRuntimeBehavior.prototype.canJump = function() {
   return this._canJump;
 };
 

--- a/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
@@ -47,15 +47,20 @@ describe('EnumerateExpressions', () => {
       'PlatformBehavior::PlatformerObjectBehavior'
     );
 
-    expect(
-      filterExpressions(platformerObjectBehaviorExpressions, 'CurrentJumpSpeed')
-    ).toHaveLength(1);
+    const jumpSpeedExpressions = filterExpressions(
+      platformerObjectBehaviorExpressions,
+      'JumpSpeed'
+    );
+
     expect(
       filterExpressions(platformerObjectBehaviorExpressions, 'JumpSpeed')
-    ).toContainEqual(
+    ).toHaveLength(2);
+    expect(jumpSpeedExpressions).toContainEqual(
       expect.objectContaining({
         type: 'JumpSpeed',
-      }),
+      })
+    );
+    expect(jumpSpeedExpressions).toContainEqual(
       expect.objectContaining({
         type: 'CurrentJumpSpeed',
       })

--- a/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
@@ -48,13 +48,16 @@ describe('EnumerateExpressions', () => {
     );
 
     expect(
-      filterExpressions(platformerObjectBehaviorExpressions, 'JumpSpeed')
+      filterExpressions(platformerObjectBehaviorExpressions, 'CurrentJumpSpeed')
     ).toHaveLength(1);
     expect(
       filterExpressions(platformerObjectBehaviorExpressions, 'JumpSpeed')
     ).toContainEqual(
       expect.objectContaining({
         type: 'JumpSpeed',
+      }),
+      expect.objectContaining({
+        type: 'CurrentJumpSpeed',
       })
     );
   });


### PR DESCRIPTION
Still in WIP see the progress on the [trello card here](https://trello.com/c/EqPJE0hd/393-add-conditions-expressions-and-actions-to-compare-the-current-speed-falling-speed-jump-speed-etc-of-a-platformer-object
).

@Silver-Streak
I'am not sure to add actions for **fall speed** and **current speed**, these values are manage by the behavior and can be limited with max value in the behavior and the actions.
This seem useless.

Linked to https://github.com/4ian/GDevelop/issues/1357#issuecomment-572716021