### PR TITLE
Update runtime electron to 8.2.5

### DIFF
--- a/GDJS/Runtime/Electron/main.js
+++ b/GDJS/Runtime/Electron/main.js
@@ -16,13 +16,10 @@ function createWindow() {
     height: 600 /*GDJS_WINDOW_HEIGHT*/,
     useContentSize: true,
     title: "GDJS_GAME_NAME",
-    backgroundColor: '#000000'
-    // To be added once upgraded to Electron 8+
-    // (or custom events to be written for each usage of electron
-    // in the game engine):
-    // ,webPreferences: {
-    //   nodeIntegration: true,
-    // }
+    backgroundColor: '#000000',
+    webPreferences: {
+      nodeIntegration: true,
+    }
   });
 
   // Open external link in the OS default browser
@@ -45,6 +42,14 @@ function createWindow() {
     mainWindow = null;
   });
 }
+
+// Should be set to true, which will be the default value in future Electron
+// versions, but then causes an issue on Windows where the `fs` module stops	
+// working in the renderer process after a reload.
+// See https://github.com/electron/electron/issues/22119
+// For now, out of caution, disable this as we rely heavily on `fs` in the 
+// renderer process.
+app.allowRendererProcessReuse = false;
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.

--- a/GDJS/Runtime/Electron/package.json
+++ b/GDJS/Runtime/Electron/package.json
@@ -7,7 +7,7 @@
     "version": "GDJS_GAME_VERSION",
     "dependencies": {},
     "devDependencies": {
-      "electron": "3.0.9"
+      "electron": "8.2.5"
     },
     "build": {
         "directories": {


### PR DESCRIPTION
### Motivation
https://github.com/4ian/GDevelop/issues/1469#issuecomment-647344206

### What was changed
This change updates the electron version of the export template
to 8.2.5 to match the electron version that is used in the IDE.

This change also sets `allowRendererProcessReuse` app option to
further match the IDE environment.

This also allows us to uncomment the `webPreferences` browser
window option.

### How I tested this
After making these changes I used my dev build of GDevelop to export the Platformer example game in "Windows/macOS/Linux (manual)" format. I then took that build directory and used electron-builder to build it. The resulting app ran just fine.   
OS: Linux
Electron debugger process.versions:
```json
{
  "chrome": "80.0.3987.165",
  "electron": "8.2.5",
  "node": "12.13.0"
}
```