### PR TITLE
Fix BBText line heights broken in the preview and exported games

### DIFF
--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -465,6 +465,7 @@ module.exports = {
 
       const bbTextStyles = {
         default: {
+          // Use a default font family the time for the resource font to be loaded.
           fontFamily: 'Arial',
           fontSize: '24px',
           fill: '#cccccc',
@@ -501,36 +502,23 @@ module.exports = {
      * This is called to update the PIXI object on the scene editor
      */
     RenderedBBTextInstance.prototype.update = function () {
-      const rawText = this._associatedObject
-        .getProperties()
-        .get('text')
-        .getValue();
+      const properties = this._associatedObject.getProperties();
+
+      const rawText = properties.get('text').getValue();
       if (rawText !== this._pixiObject.text) {
         this._pixiObject.setText(rawText);
       }
 
-      const opacity = this._associatedObject
-        .getProperties()
-        .get('opacity')
-        .getValue();
+      const opacity = properties.get('opacity').getValue();
       this._pixiObject.alpha = opacity / 255;
 
-      const color = this._associatedObject
-        .getProperties()
-        .get('color')
-        .getValue();
+      const color = properties.get('color').getValue();
       this._pixiObject.textStyles.default.fill = color;
 
-      const fontSize = this._associatedObject
-        .getProperties()
-        .get('fontSize')
-        .getValue();
+      const fontSize = properties.get('fontSize').getValue();
       this._pixiObject.textStyles.default.fontSize = `${fontSize}px`;
 
-      const fontResourceName = this._associatedObject
-        .getProperties()
-        .get('fontFamily')
-        .getValue();
+      const fontResourceName = properties.get('fontFamily').getValue();
 
       if (this._fontResourceName !== fontResourceName) {
         this._fontResourceName = fontResourceName;
@@ -540,26 +528,24 @@ module.exports = {
           .then((fontFamily) => {
             // Once the font is loaded, we can use the given fontFamily.
             this._pixiObject.textStyles.default.fontFamily = fontFamily;
+            this._pixiObject.dirty = true;
           })
           .catch((err) => {
             // Ignore errors
-            console.warn('Unable to load font family', err);
+            console.warn(
+              'Unable to load font family for RenderedBBTextInstance',
+              err
+            );
           });
       }
 
-      const wordWrap = this._associatedObject
-        .getProperties()
-        .get('wordWrap')
-        .getValue();
+      const wordWrap = properties.get('wordWrap').getValue() === 'true';
       if (wordWrap !== this._pixiObject._style.wordWrap) {
-        this._pixiObject._style.wordWrap = wordWrap === 'true';
+        this._pixiObject._style.wordWrap = wordWrap;
         this._pixiObject.dirty = true;
       }
 
-      const align = this._associatedObject
-        .getProperties()
-        .get('align')
-        .getValue();
+      const align = properties.get('align').getValue();
       if (align !== this._pixiObject._style.align) {
         this._pixiObject._style.align = align;
         this._pixiObject.dirty = true;
@@ -577,7 +563,7 @@ module.exports = {
         const customWidth = this._instance.getCustomWidth();
         if (
           this._pixiObject &&
-          this._pixiObject.textStyles.default.wordWrapWidth !== customWidth
+          this._pixiObject._style.wordWrapWidth !== customWidth
         ) {
           this._pixiObject._style.wordWrapWidth = customWidth;
           this._pixiObject.dirty = true;

--- a/Extensions/BBText/bbtextruntimeobject-pixi-renderer.js
+++ b/Extensions/BBText/bbtextruntimeobject-pixi-renderer.js
@@ -6,7 +6,7 @@
  * @param {gdjs.BBTextRuntimeObject} runtimeObject The object to render
  * @param {gdjs.RuntimeScene} runtimeScene The gdjs.RuntimeScene in which the object is
  */
-gdjs.BBTextRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene) {
+gdjs.BBTextRuntimeObjectPixiRenderer = function (runtimeObject, runtimeScene) {
   this._object = runtimeObject;
 
   // Load (or reset) the text
@@ -53,66 +53,69 @@ gdjs.BBTextRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene) {
 
 gdjs.BBTextRuntimeObjectRenderer = gdjs.BBTextRuntimeObjectPixiRenderer;
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.getRendererObject = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.getRendererObject = function () {
   return this._pixiObject;
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateWordWrap = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateWordWrap = function () {
   this._pixiObject._style.wordWrap = this._object._wordWrap;
   this._pixiObject.dirty = true;
   this.updatePosition();
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateWrappingWidth = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateWrappingWidth = function () {
   this._pixiObject._style.wordWrapWidth = this._object._wrappingWidth;
   this._pixiObject.dirty = true;
   this.updatePosition();
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateText = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateText = function () {
   this._pixiObject.setText(this._object._text);
   this.updatePosition();
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateColor = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateColor = function () {
   this._pixiObject.textStyles.default.fill = this._object._color;
   this._pixiObject.dirty = true;
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateAlignment = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateAlignment = function () {
   this._pixiObject._style.align = this._object._align;
   this._pixiObject.dirty = true;
 };
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateFontFamily = function() {
-  this._pixiObject.textStyles.default.fontFamily = this._object._runtimeScene.getGame().getFontManager().getFontFamily(this._object._fontFamily);
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateFontFamily = function () {
+  this._pixiObject.textStyles.default.fontFamily = this._object._runtimeScene
+    .getGame()
+    .getFontManager()
+    .getFontFamily(this._object._fontFamily);
   this._pixiObject.dirty = true;
 };
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateFontSize = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateFontSize = function () {
   this._pixiObject.textStyles.default.fontSize = this._object._fontSize + 'px';
   this._pixiObject.dirty = true;
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updatePosition = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updatePosition = function () {
   this._pixiObject.position.x = this._object.x + this._pixiObject.width / 2;
   this._pixiObject.position.y = this._object.y + this._pixiObject.height / 2;
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateVisible = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateVisible = function () {
   this._pixiObject.hidden = !this._object._visible;
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateAngle = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateAngle = function () {
   this._pixiObject.rotation = gdjs.toRad(this._object.angle);
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateOpacity = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.updateOpacity = function () {
   this._pixiObject.alpha = this._object._opacity / 255;
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.getWidth = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.getWidth = function () {
   return this._pixiObject.width;
 };
 
-gdjs.BBTextRuntimeObjectPixiRenderer.prototype.getHeight = function() {
+gdjs.BBTextRuntimeObjectPixiRenderer.prototype.getHeight = function () {
   return this._pixiObject.height;
 };

--- a/Extensions/BBText/bbtextruntimeobject.js
+++ b/Extensions/BBText/bbtextruntimeobject.js
@@ -48,7 +48,6 @@ gdjs.BBTextRuntimeObject = function(runtimeScene, objectData) {
   if (this._renderer)
     gdjs.BBTextRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
   else
-    /** @type {gdjs.BBTextRuntimeObjectRenderer} */
     this._renderer = new gdjs.BBTextRuntimeObjectRenderer(this, runtimeScene);
 
   // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.

--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -85,6 +85,13 @@ bool Exporter::ExportWholePixiProject(
     // filenames may be updated)
     helper.ExportResources(fs, exportedProject, exportDir);
 
+    // Compatibility with GD <= 5.0-beta56
+    // Stay compatible with text objects declaring their font as just a filename
+    // without a font resource - by manually adding these resources.
+    helper.AddDeprecatedFontFilesToFontResources(
+        fs, exportedProject.GetResourcesManager(), exportDir);
+    // end of compatibility code
+
     // Export engine libraries
     helper.AddLibsInclude(true, false, false, includesFiles);
 
@@ -177,6 +184,13 @@ bool Exporter::ExportWholeCocos2dProject(gd::Project& project,
   // Export the resources (before generating events as some resources filenames
   // may be updated)
   helper.ExportResources(fs, exportedProject, exportDir + "/res");
+
+  // Compatibility with GD <= 5.0-beta56
+  // Stay compatible with text objects declaring their font as just a filename
+  // without a font resource - by manually adding these resources.
+  helper.AddDeprecatedFontFilesToFontResources(
+      fs, exportedProject.GetResourcesManager(), exportDir + "/res", "res/");
+  // end of compatibility code
 
   // Export engine libraries
   helper.AddLibsInclude(false, true, false, includesFiles);

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -4,11 +4,13 @@
  * reserved. This project is released under the MIT License.
  */
 #include "GDJS/IDE/ExporterHelper.h"
+
 #include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <streambuf>
 #include <string>
+
 #include "GDCore/CommonTools.h"
 #include "GDCore/Events/CodeGeneration/EffectsCodeGenerator.h"
 #include "GDCore/IDE/AbstractFileSystem.h"
@@ -34,49 +36,6 @@ static void InsertUnique(std::vector<gd::String> &container, gd::String str) {
     container.push_back(str);
 }
 
-static void GenerateDeprecatedFontsDeclaration(
-    const gd::ResourcesManager &resourcesManager,
-    gd::AbstractFileSystem &fs,
-    const gd::String &outputDir,
-    gd::String &css,
-    gd::String &html,
-    gd::String urlPrefix = "") {
-  // Compatibility with GD <= 5.0-beta56
-  // Before, fonts were detected by scanning the export folder for .TTF files.
-  // Text Object (or anything using a font) was just declaring the font filename
-  // as a file (using ArbitraryResourceWorker::ExposeFile) for export.
-  // We still support this, the time everything is migrated to using font
-  // resources.
-  std::set<gd::String> files;
-  auto makeCSSDeclarationFor = [&urlPrefix](gd::String relativeFile) {
-    gd::String css;
-    css += "@font-face{ font-family : \"gdjs_font_";
-    css += relativeFile;
-    css += "\"; src : url('";
-    css += urlPrefix + relativeFile;
-    css += "') format('truetype'); }\n";
-
-    return css;
-  };
-
-  std::vector<gd::String> ttfFiles = fs.ReadDir(outputDir, ".TTF");
-  for (std::size_t i = 0; i < ttfFiles.size(); ++i) {
-    gd::String relativeFile = ttfFiles[i];
-    fs.MakeRelative(relativeFile, outputDir);
-
-    // Skip font files already in resources
-    if (files.find(relativeFile) != files.end()) continue;
-
-    css += makeCSSDeclarationFor(relativeFile);
-
-    // This is needed to trigger the loading of the fonts.
-    html += "<div style=\"font-family: 'gdjs_font_";
-    html += relativeFile;
-    html += "'; color: black;\">.</div>";
-  }
-  // end of compatibility code
-}
-
 ExporterHelper::ExporterHelper(gd::AbstractFileSystem &fileSystem,
                                gd::String gdjsRoot_,
                                gd::String codeOutputDir_)
@@ -98,6 +57,13 @@ bool ExporterHelper::ExportLayoutForPixiPreview(gd::Project &project,
   // Export resources (*before* generating events as some resources filenames
   // may be updated)
   ExportResources(fs, exportedProject, exportDir);
+
+  // Compatibility with GD <= 5.0-beta56
+  // Stay compatible with text objects declaring their font as just a filename
+  // without a font resource - by manually adding these resources.
+  AddDeprecatedFontFilesToFontResources(
+      fs, exportedProject.GetResourcesManager(), exportDir);
+  // end of compatibility code
 
   // Export engine libraries
   AddLibsInclude(true, false, true, includesFiles);
@@ -170,20 +136,8 @@ bool ExporterHelper::ExportPixiIndexFile(
     gd::String additionalSpec) {
   gd::String str = fs.ReadFile(source);
 
-  // Generate custom declarations for font resources
-  gd::String customCss;
-  gd::String customHtml;  // Custom HTML is only needed for the deprecated way
-                          // of loading fonts
-  GenerateDeprecatedFontsDeclaration(project.GetResourcesManager(),
-                           fs,  // File system is only needed for the deprecated
-                                // way of loading fonts
-                           exportDir,
-                           customCss,
-                           customHtml);
-
   // Generate the file
-  if (!CompleteIndexFile(
-          str, customCss, customHtml, exportDir, includesFiles, additionalSpec))
+  if (!CompleteIndexFile(str, exportDir, includesFiles, additionalSpec))
     return false;
 
   // Write the index.html file
@@ -200,7 +154,8 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
   auto &platformSpecificAssets = project.GetPlatformSpecificAssets();
   auto &resourceManager = project.GetResourcesManager();
   auto getIconFilename = [&resourceManager, &platformSpecificAssets](
-      const gd::String &platform, const gd::String &name) {
+                             const gd::String &platform,
+                             const gd::String &name) {
     const gd::String &file =
         resourceManager.GetResource(platformSpecificAssets.Get(platform, name))
             .GetFile();
@@ -334,17 +289,10 @@ bool ExporterHelper::ExportCocos2dFiles(
     // Generate custom declarations for font resources
     gd::String customCss;
     gd::String customHtml;
-    GenerateDeprecatedFontsDeclaration(project.GetResourcesManager(),
-                             fs,
-                             exportDir + "/res",
-                             customCss,
-                             customHtml,
-                             "res/");
 
     // Generate the file
     std::vector<gd::String> noIncludesInThisFile;
-    if (!CompleteIndexFile(
-            str, customCss, customHtml, exportDir, noIncludesInThisFile, "")) {
+    if (!CompleteIndexFile(str, exportDir, noIncludesInThisFile, "")) {
       lastError = "Unable to complete Cocos2d-JS index.html file.";
       return false;
     }
@@ -471,8 +419,6 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
 
 bool ExporterHelper::CompleteIndexFile(
     gd::String &str,
-    gd::String customCss,
-    gd::String customHtml,
     gd::String exportDir,
     const std::vector<gd::String> &includesFiles,
     gd::String additionalSpec) {
@@ -504,8 +450,8 @@ bool ExporterHelper::CompleteIndexFile(
                          "\" crossorigin=\"anonymous\"></script>\n";
   }
 
-  str = str.FindAndReplace("/* GDJS_CUSTOM_STYLE */", customCss)
-            .FindAndReplace("<!-- GDJS_CUSTOM_HTML -->", customHtml)
+  str = str.FindAndReplace("/* GDJS_CUSTOM_STYLE */", "")
+            .FindAndReplace("<!-- GDJS_CUSTOM_HTML -->", "")
             .FindAndReplace("<!-- GDJS_CODE_FILES -->", codeFilesIncludes)
             .FindAndReplace("{}/*GDJS_ADDITIONAL_SPEC*/", additionalSpec);
 
@@ -733,6 +679,37 @@ void ExporterHelper::ExportResources(gd::AbstractFileSystem &fs,
                                      gd::String exportDir) {
   gd::ProjectResourcesCopier::CopyAllResourcesTo(
       project, fs, exportDir, true, false, false);
+}
+
+void ExporterHelper::AddDeprecatedFontFilesToFontResources(
+    gd::AbstractFileSystem &fs,
+    gd::ResourcesManager &resourcesManager,
+    const gd::String &exportDir,
+    gd::String urlPrefix) {
+  // Compatibility with GD <= 5.0-beta56
+  //
+  // Before, fonts were detected by scanning the export folder for .TTF files.
+  // Text Object (or anything using a font) was just declaring the font filename
+  // as a file (using ArbitraryResourceWorker::ExposeFile) for export.
+  //
+  // To still support this, the time everything is migrated to using font
+  // resources, we manually declare font resources for each ".TTF" file, using
+  // the name of the file as the resource name.
+  std::vector<gd::String> ttfFiles = fs.ReadDir(exportDir, ".TTF");
+  for (std::size_t i = 0; i < ttfFiles.size(); ++i) {
+    gd::String relativeFile = ttfFiles[i];
+    fs.MakeRelative(relativeFile, exportDir);
+
+    // Create a resource named like the file (to emulate the old behavior).
+    gd::FontResource fontResource;
+    fontResource.SetName(relativeFile);
+    fontResource.SetFile(urlPrefix + relativeFile);
+
+    // Note that if a resource with this name already exists, it won't be
+    // overwritten - which is expected.
+    resourcesManager.AddResource(fontResource);
+  }
+  // end of compatibility code
 }
 
 }  // namespace gdjs

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -14,6 +14,7 @@ class Project;
 class Layout;
 class ExternalLayout;
 class AbstractFileSystem;
+class ResourcesManager;
 }  // namespace gd
 class wxProgressDialog;
 
@@ -157,18 +158,15 @@ class ExporterHelper {
    * content.
    *
    * \param indexFileContent The source of the index.html file.
-   * \param customCss "<!-- GDJS_CUSTOM_STYLE -->" will be replaced by the
-   * content of the string. \param customHtml "<!-- GDJS_CUSTOM_HTML -->" will
-   * be replaced by the content of the string. \param exportDir The directory
-   * where the project must be generated. \param codeFilesIncludes "<!--
-   * GDJS_CODE_FILES -->" will be replaced by HTML tags to include the filenames
-   * contained inside the vector. \param additionalSpec The string
-   * "GDJS_ADDITIONAL_SPEC" surrounded by comments marks will be replaced by the
-   * content of the string.
+   * \param exportDir The directory where the project must be generated.
+   * \param includesFiles "<!--GDJS_CODE_FILES -->" will be
+   * replaced by HTML tags to include the filenames
+   * contained inside the vector.
+   * \param additionalSpec The string "GDJS_ADDITIONAL_SPEC"
+   * surrounded by comments marks will be replaced by the
+   * content of this string.
    */
   bool CompleteIndexFile(gd::String &indexFileContent,
-                         gd::String customCss,
-                         gd::String customHtml,
                          gd::String exportDir,
                          const std::vector<gd::String> &includesFiles,
                          gd::String additionalSpec);
@@ -231,6 +229,12 @@ class ExporterHelper {
   void SetCodeOutputDirectory(gd::String codeOutputDir_) {
     codeOutputDir = codeOutputDir_;
   }
+
+  static void AddDeprecatedFontFilesToFontResources(
+    gd::AbstractFileSystem &fs,
+    gd::ResourcesManager &resourcesManager,
+    const gd::String &exportDir,
+    gd::String urlPrefix = "");
 
   gd::AbstractFileSystem
       &fs;  ///< The abstract file system to be used for exportation.

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -2600,6 +2600,9 @@ describe('libGD.js', function() {
       fs.dirNameFrom = function(fullpath) {
         return path.dirname(fullpath);
       };
+      fs.readDir = function() {
+        return new gd.VectorString();
+      };
       fs.writeToFile = function(path, content) {
         //Validate that some code have been generated:
         expect(content).toMatch('runtimeScene.getOnceTriggers().startNewFrame');

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -81,7 +81,10 @@ RenderedTextInstance.prototype.update = function() {
       })
       .catch(err => {
         // Ignore errors
-        console.warn('Unable to load font family', err);
+        console.warn(
+          'Unable to load font family for RenderedTextInstance',
+          err
+        );
       });
   }
 


### PR DESCRIPTION
* Also improve BBText performance when rendered in the scene editor.

Don't show the rest in changelog:
* This was due to the font measurement being incorrectly done by Pixi.js because the font family was having a dot in its name. It should have been quoted but for some reason is not. Instead, ensure all font family names are slugified so we don't risk such incompatibilities in the future.
* Also rework deprecated text object font handling to entirely avoid having to declare the font families at the export time.

Fix #1521