### PR TITLE
Add a way to see if a JS event is disabled

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -134,13 +134,16 @@ export default class JsCodeEvent extends React.Component<
   render() {
     const jsCodeEvent = gd.asJsCodeEvent(this.props.event);
     const parameterObjects = jsCodeEvent.getParameterObjects();
+
+    const textStyle = this.props.disabled ? styles.comment : undefined;
+
     const objects = (
       <span
         className={classNames({
           [selectableArea]: true,
         })}
         onClick={this.editObject}
-        style={this.props.disabled ? styles.comment : {}}
+        style={textStyle}
       >
         {parameterObjects
           ? `, objects /*${parameterObjects}*/`
@@ -149,30 +152,26 @@ export default class JsCodeEvent extends React.Component<
     );
 
     const eventsFunctionContext = this.props.scope.eventsFunction ? (
-      <span style={this.props.disabled ? styles.comment : {}}>
-        , eventsFunctionContext
-      </span>
+      <span style={textStyle}>, eventsFunctionContext</span>
     ) : null;
 
     const functionStart = (
       <p style={styles.wrappingText}>
-        <span style={this.props.disabled ? styles.comment : {}}>
+        <span style={textStyle}>
           {this.props.disabled ? '/*' : ''}
           {'(function(runtimeScene'}
         </span>
         {objects}
         {eventsFunctionContext}
-        <span style={this.props.disabled ? styles.comment : {}}>{') {'}</span>
+        <span style={textStyle}>{') {'}</span>
       </p>
     );
     const functionEnd = (
       <p style={styles.wrappingText}>
-        <span style={this.props.disabled ? styles.comment : {}}>
-          {'})(runtimeScene'}
-        </span>
+        <span style={textStyle}>{'})(runtimeScene'}</span>
         {objects}
         {eventsFunctionContext}
-        <span style={this.props.disabled ? styles.comment : {}}>
+        <span style={textStyle}>
           {');'}
           {this.props.disabled ? '*/' : ''}
         </span>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -140,6 +140,7 @@ export default class JsCodeEvent extends React.Component<
           [selectableArea]: true,
         })}
         onClick={this.editObject}
+        style={this.props.disabled ? styles.comment : {}}
       >
         {parameterObjects
           ? `, objects /*${parameterObjects}*/`
@@ -148,23 +149,23 @@ export default class JsCodeEvent extends React.Component<
     );
 
     const eventsFunctionContext = this.props.scope.eventsFunction ? (
-      <span>, eventsFunctionContext</span>
+      <span style={this.props.disabled ? styles.comment : {}}>, eventsFunctionContext</span>
     ) : null;
 
     const functionStart = (
       <p style={styles.wrappingText}>
-        <span>{'(function(runtimeScene'}</span>
+        <span style={this.props.disabled ? styles.comment : {}}>{this.props.disabled ? "/*" : ""}{'(function(runtimeScene'}</span>
         {objects}
         {eventsFunctionContext}
-        <span>{') {'}</span>
+        <span style={this.props.disabled ? styles.comment : {}}>{') {'}</span>
       </p>
     );
     const functionEnd = (
       <p style={styles.wrappingText}>
-        <span>{'})(runtimeScene'}</span>
+        <span style={this.props.disabled ? styles.comment : {}}>{'})(runtimeScene'}</span>
         {objects}
         {eventsFunctionContext}
-        <span>{');'}</span>
+        <span style={this.props.disabled ? styles.comment : {}}>{');'}{this.props.disabled ? "*/" : ""}</span>
         <span style={styles.comment}>
           {' // '}
           <a

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -149,12 +149,17 @@ export default class JsCodeEvent extends React.Component<
     );
 
     const eventsFunctionContext = this.props.scope.eventsFunction ? (
-      <span style={this.props.disabled ? styles.comment : {}}>, eventsFunctionContext</span>
+      <span style={this.props.disabled ? styles.comment : {}}>
+        , eventsFunctionContext
+      </span>
     ) : null;
 
     const functionStart = (
       <p style={styles.wrappingText}>
-        <span style={this.props.disabled ? styles.comment : {}}>{this.props.disabled ? "/*" : ""}{'(function(runtimeScene'}</span>
+        <span style={this.props.disabled ? styles.comment : {}}>
+          {this.props.disabled ? '/*' : ''}
+          {'(function(runtimeScene'}
+        </span>
         {objects}
         {eventsFunctionContext}
         <span style={this.props.disabled ? styles.comment : {}}>{') {'}</span>
@@ -162,10 +167,15 @@ export default class JsCodeEvent extends React.Component<
     );
     const functionEnd = (
       <p style={styles.wrappingText}>
-        <span style={this.props.disabled ? styles.comment : {}}>{'})(runtimeScene'}</span>
+        <span style={this.props.disabled ? styles.comment : {}}>
+          {'})(runtimeScene'}
+        </span>
         {objects}
         {eventsFunctionContext}
-        <span style={this.props.disabled ? styles.comment : {}}>{');'}{this.props.disabled ? "*/" : ""}</span>
+        <span style={this.props.disabled ? styles.comment : {}}>
+          {');'}
+          {this.props.disabled ? '*/' : ''}
+        </span>
         <span style={styles.comment}>
           {' // '}
           <a


### PR DESCRIPTION
It comments out the text wrapping the editor when the event is disabled, as there is no visual hint saying if it is disabled or not:

Enabled (like before):
![image](https://user-images.githubusercontent.com/19349038/86340877-db8e4e80-bc55-11ea-8739-42ec7aabb256.png)

Disabled:
![image](https://user-images.githubusercontent.com/19349038/86340937-e77a1080-bc55-11ea-95ef-6c913c3271a0.png)

Technically it is not correct JS but that's just visual so it is not very important (and I couldn't find any other way).