### PR TITLE
Fix findRStr and findStr misunderstood descriptions

### DIFF
--- a/Core/GDCore/Extensions/Builtin/StringInstructionsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/StringInstructionsExtension.cpp
@@ -120,6 +120,18 @@ BuiltinExtensionsImplementer::ImplementsStringInstructionsExtension(
                      "res/conditions/toujours24.png")
 
       .AddParameter("string", _("Text"))
+      .AddParameter("string", _("Text to search for"))
+      .SetHidden();
+
+  extension
+      .AddExpression("StrFindLast",
+                     _("Search the last occurence in a text"),
+                     _("Search the last occurence in a string (return the position of "
+                       "the result, from the beginning of the string, or -1 if not found)"),
+                     _("Manipulation of text"),
+                     "res/conditions/toujours24.png")
+
+      .AddParameter("string", _("Text"))
       .AddParameter("string", _("Text to search for"));
 
   extension
@@ -142,6 +154,22 @@ BuiltinExtensionsImplementer::ImplementsStringInstructionsExtension(
           _("Search in a text from the end, starting from a position"),
           _("Search in a text from the end, starting from a position (return "
             "the position of the result or -1 if not found)"),
+          _("Manipulation of text"),
+          "res/conditions/toujours24.png")
+
+      .AddParameter("string", _("Text"))
+      .AddParameter("string", _("Text to search for"))
+      .AddParameter("expression",
+                    _("Position of the last character in the string to be "
+                      "considered in the search"))
+      .SetHidden();
+
+  extension
+      .AddExpression(
+          "StrFindLastFrom",
+          _("Search the last occurence in a text, starting from a position"),
+          _("Search in a text the last occurence, starting from a position (return "
+            " the position of the result, from the beginning of the string, or -1 if not found)"),
           _("Manipulation of text"),
           "res/conditions/toujours24.png")
 

--- a/GDCpp/GDCpp/Extensions/Builtin/StringInstructionsExtension.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/StringInstructionsExtension.cpp
@@ -46,11 +46,17 @@ StringInstructionsExtension::StringInstructionsExtension() {
   GetAllExpressions()["StrRFind"]
       .SetFunctionName("GDpriv::StringTools::StrRFind")
       .SetIncludeFile("GDCpp/Extensions/Builtin/StringTools.h");
+  GetAllExpressions()["StrFindLast"]
+      .SetFunctionName("GDpriv::StringTools::StrFindLast")
+      .SetIncludeFile("GDCpp/Extensions/Builtin/StringTools.h");
   GetAllExpressions()["StrFindFrom"]
       .SetFunctionName("GDpriv::StringTools::StrFindFrom")
       .SetIncludeFile("GDCpp/Extensions/Builtin/StringTools.h");
   GetAllExpressions()["StrRFindFrom"]
       .SetFunctionName("GDpriv::StringTools::StrRFindFrom")
+      .SetIncludeFile("GDCpp/Extensions/Builtin/StringTools.h");
+  GetAllExpressions()["StrFindLastFrom"]
+      .SetFunctionName("GDpriv::StringTools::StrFindLastFrom")
       .SetIncludeFile("GDCpp/Extensions/Builtin/StringTools.h");
 #endif
 }

--- a/GDCpp/GDCpp/Extensions/Builtin/StringTools.h
+++ b/GDCpp/GDCpp/Extensions/Builtin/StringTools.h
@@ -26,10 +26,14 @@ gd::String GD_API StrRepeat(const gd::String& str, std::size_t repCount);
 std::size_t GD_API StrLen(const gd::String& str);
 int GD_API StrFind(const gd::String& str, const gd::String& findwhat);
 int GD_API StrRFind(const gd::String& str, const gd::String& findwhat);
+int GD_API StrFindLast(const gd::String& str, const gd::String& findwhat);
 int GD_API StrFindFrom(const gd::String& str,
                        const gd::String& findwhat,
                        std::size_t start);
 int GD_API StrRFindFrom(const gd::String& str,
+                        const gd::String& findwhat,
+                        std::size_t start);
+int GD_API StrFindLastFrom(const gd::String& str,
                         const gd::String& findwhat,
                         std::size_t start);
 

--- a/GDJS/GDJS/Extensions/Builtin/StringInstructionsExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/StringInstructionsExtension.cpp
@@ -35,10 +35,14 @@ StringInstructionsExtension::StringInstructionsExtension() {
       "gdjs.evtTools.string.strFind");
   GetAllExpressions()["StrRFind"].SetFunctionName(
       "gdjs.evtTools.string.strRFind");
+  GetAllExpressions()["StrFindLast"].SetFunctionName(
+      "gdjs.evtTools.string.strFindLast");
   GetAllExpressions()["StrFindFrom"].SetFunctionName(
       "gdjs.evtTools.string.strFindFrom");
   GetAllExpressions()["StrRFindFrom"].SetFunctionName(
       "gdjs.evtTools.string.strRFindFrom");
+  GetAllExpressions()["StrFindLastFrom"].SetFunctionName(
+      "gdjs.evtTools.string.strFindLastFrom");
 
   StripUnimplementedInstructionsAndExpressions();
 }

--- a/GDJS/Runtime/events-tools/stringtools.js
+++ b/GDJS/Runtime/events-tools/stringtools.js
@@ -88,7 +88,7 @@ gdjs.evtTools.string.strLen = function(str) {
 };
 
 /**
- * Search in a string
+ * Search the first occurence in a string (return the position of the result, from the beginning of the string, or -1 if not found)
  * @private
  */
 gdjs.evtTools.string.strFind = function(str, what) {
@@ -96,15 +96,24 @@ gdjs.evtTools.string.strFind = function(str, what) {
 };
 
 /**
- * Reverse search in a string
+ * Search the last occurence in a string (return the position of the result, from the beginning of the string, or -1 if not found)
  * @private
+ * @deprecated
  */
 gdjs.evtTools.string.strRFind = function(str, what) {
     return str.lastIndexOf(what);
 };
 
 /**
- * Search in a string, starting from a specified position.
+ * Search the last occurence in a string (return the position of the result, from the beginning of the string, or -1 if not found)
+ * @private
+ */
+gdjs.evtTools.string.strFindLast = function(str, what) {
+    return str.lastIndexOf(what);
+};
+
+/**
+ * Search the first occurence in a string, starting from a specified position (return the position of the result, from the beginning of the string, or -1 if not found)
  * @private
  */
 gdjs.evtTools.string.strFindFrom = function(str, what, pos) {
@@ -112,9 +121,18 @@ gdjs.evtTools.string.strFindFrom = function(str, what, pos) {
 };
 
 /**
- * Reverse search in a string, starting from a specified position.
+ * Search the last occurence in a string, starting from a specified position (return the position of the result, from the beginning of the string, or -1 if not found)
  * @private
+ * @deprecated
  */
 gdjs.evtTools.string.strRFindFrom = function(str, what, pos) {
+    return str.lastIndexOf(what, pos);
+};
+
+/**
+ * Search the last occurence in a string, starting from a specified position (return the position of the result, from the beginning of the string, or -1 if not found)
+ * @private
+ */
+gdjs.evtTools.string.strFindLastFrom = function(str, what, pos) {
     return str.lastIndexOf(what, pos);
 };


### PR DESCRIPTION
Copy and rename the old expressions and improve their descriptions.
Set deprecated and hidden the previous one.

Fix #1857