### PR TITLE
Fix extension removal/unloading

### DIFF
--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -141,7 +141,7 @@ export default class BehaviorsEditor extends Component {
                       <Trans>Unknown behavior</Trans>{' '}
                     </MiniToolbarText>
                     <Column noMargin expand>
-                      <TextField value={behaviorName} disabled />
+                      <TextField margin="none" value={behaviorName} disabled />
                     </Column>
                     <IconButton
                       onClick={() => this._onRemoveBehavior(behaviorName)}

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/EnumerateProperties.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/EnumerateProperties.js
@@ -1,0 +1,52 @@
+// @flow
+import { mapVector } from '../Utils/MapFor';
+
+/** The JS equivalent of gdPropertyDescriptor */
+type EnumeratedProperty = {|
+  name: string,
+  type: string,
+  description: string,
+  label: string,
+  value: string,
+  extraInfo: Array<string>,
+  isHidden: boolean,
+|};
+
+/**
+ * Transform a gdNamedPropertyDescriptorsList into a JS object.
+ * **Don't use this** unless you explictely need to deal with JS objects.
+ * Otherwise, prefer just iterating and using gdNamedPropertyDescriptorsList functions.
+ */
+export const enumerateNamedPropertyDescriptorsList = (
+  namedProperties: gdNamedPropertyDescriptorsList
+): Array<EnumeratedProperty> => {
+  return mapVector(namedProperties, namedProperty => {
+    return {
+      name: namedProperty.getName(),
+      type: namedProperty.getType(),
+      description: namedProperty.getDescription(),
+      label: namedProperty.getLabel(),
+      value: namedProperty.getValue(),
+      extraInfo: namedProperty.getExtraInfo().toJSArray(),
+      isHidden: namedProperty.isHidden(),
+    };
+  });
+};
+
+export const toGdPropertyDescriptor = (
+  enumeratedProperty: EnumeratedProperty,
+  propertyDescriptor: gdPropertyDescriptor
+): gdPropertyDescriptor => {
+  propertyDescriptor
+    .setType(enumeratedProperty.type)
+    .setDescription(enumeratedProperty.description)
+    .setLabel(enumeratedProperty.label)
+    .setValue(enumeratedProperty.value)
+    .setHidden(enumeratedProperty.isHidden);
+
+  enumeratedProperty.extraInfo.forEach(extraInfo => {
+    propertyDescriptor.addExtraInfo(extraInfo);
+  });
+
+  return propertyDescriptor;
+};

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext.js
@@ -9,6 +9,10 @@ export type EventsFunctionsExtensionsState = {|
   eventsFunctionsExtensionsError: ?Error,
   loadProjectEventsFunctionsExtensions: (project: ?gdProject) => Promise<void>,
   unloadProjectEventsFunctionsExtensions: (project: gdProject) => void,
+  unloadProjectEventsFunctionsExtension: (
+    project: gdProject,
+    extensionName: string
+  ) => void,
   reloadProjectEventsFunctionsExtensions: (
     project: ?gdProject
   ) => Promise<void>,
@@ -24,6 +28,7 @@ const defaultState = {
   unloadProjectEventsFunctionsExtensions: () => {},
   reloadProjectEventsFunctionsExtensions: () =>
     Promise.reject(new Error('Use a provider')),
+  unloadProjectEventsFunctionsExtension: () => {},
   getEventsFunctionsExtensionWriter: () => null,
   getEventsFunctionsExtensionOpener: () => null,
   ensureLoadFinished: () => Promise.reject(new Error('Use a provider')),

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsProvider.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsProvider.js
@@ -8,6 +8,7 @@ import {
   loadProjectEventsFunctionsExtensions,
   type EventsFunctionCodeWriter,
   unloadProjectEventsFunctionsExtensions,
+  unloadProjectEventsFunctionsExtension,
 } from '.';
 import {
   type EventsFunctionsExtensionWriter,
@@ -44,6 +45,9 @@ export default class EventsFunctionsExtensionsProvider extends React.Component<
       this
     ),
     unloadProjectEventsFunctionsExtensions: this._unloadProjectEventsFunctionsExtensions.bind(
+      this
+    ),
+    unloadProjectEventsFunctionsExtension: this._unloadProjectEventsFunctionsExtension.bind(
       this
     ),
     reloadProjectEventsFunctionsExtensions: this._reloadProjectEventsFunctionsExtensions.bind(
@@ -111,6 +115,13 @@ export default class EventsFunctionsExtensionsProvider extends React.Component<
 
   _unloadProjectEventsFunctionsExtensions(project: gdProject) {
     unloadProjectEventsFunctionsExtensions(project);
+  }
+
+  _unloadProjectEventsFunctionsExtension(
+    project: gdProject,
+    extensionName: string
+  ) {
+    unloadProjectEventsFunctionsExtension(project, extensionName);
   }
 
   _reloadProjectEventsFunctionsExtensions(project: ?gdProject): Promise<void> {

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
@@ -402,6 +402,16 @@ export const unloadProjectEventsFunctionsExtensions = (
 };
 
 /**
+ * Unload a single extension providing events functions of a project
+ */
+export const unloadProjectEventsFunctionsExtension = (
+  project: gdProject,
+  extensionName: string
+): void => {
+  gd.JsPlatform.get().removeExtension(extensionName);
+};
+
+/**
  * Given metadata about an instruction or an expression, tells if this was created
  * from an event function.
  */

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -775,7 +775,7 @@ const MainFrame = (props: Props) => {
   };
 
   const deleteEventsFunctionsExtension = (
-    externalLayout: gdEventsFunctionsExtension
+    eventsFunctionsExtension: gdEventsFunctionsExtension
   ) => {
     const { currentProject } = state;
     const { i18n, eventsFunctionsExtensionsState } = props;
@@ -792,14 +792,22 @@ const MainFrame = (props: Props) => {
       ...state,
       editorTabs: closeEventsFunctionsExtensionTabs(
         state.editorTabs,
-        externalLayout
+        eventsFunctionsExtension
       ),
     })).then(state => {
-      currentProject.removeEventsFunctionsExtension(externalLayout.getName());
+      // Unload the Platform extension that was generated from the events
+      // functions extension.
+      const extensionName = eventsFunctionsExtension.getName();
+      eventsFunctionsExtensionsState.unloadProjectEventsFunctionsExtension(
+        currentProject,
+        extensionName
+      );
+
+      currentProject.removeEventsFunctionsExtension(extensionName);
       _onProjectItemModified();
 
-      // Reload extensions to make sure the deleted extension is removed
-      // from the platform
+      // Reload extensions to make sure any extension that would have been relying
+      // on the unloaded extension is updated.
       eventsFunctionsExtensionsState.reloadProjectEventsFunctionsExtensions(
         currentProject
       );


### PR DESCRIPTION
Fix potential crash when the IDE was mishandling an extension, and fix the unloading of extension that were still in memory (and so behaviors still working).