### PR TITLE
Add network preview command, hide debug and network preview commands on web

### DIFF
--- a/newIDE/app/src/MainFrame/MainFrameCommands.js
+++ b/newIDE/app/src/MainFrame/MainFrameCommands.js
@@ -43,7 +43,9 @@ type CommandHandlers = {|
   onOpenProjectManager: () => void,
   onLaunchPreview: () => void | Promise<void>,
   onLaunchDebugPreview: () => void,
+  onLaunchNetworkPreview: () => void,
   onHotReloadPreview: () => void,
+  allowNetworkPreview: boolean,
   onOpenStartPage: () => void,
   onCreateProject: () => void,
   onOpenProject: () => void,
@@ -63,6 +65,7 @@ const openProjectManagerText = t`Open project manager`;
 const launchPreviewText = t`Launch preview`;
 const launchPreviewNewWindowText = t`Launch another preview in a new window`;
 const launchDebugPreviewText = t`Launch preview with debugger and profiler`;
+const launchNetworkPreviewText = t`Launch network preview over WiFi/LAN`;
 const openStartPageText = t`Open start page`;
 const createNewProjectText = t`Create a new project`;
 const openProjectText = t`Open project`;
@@ -98,10 +101,23 @@ const useMainFrameCommands = (handlers: CommandHandlers) => {
     handler: handlers.onHotReloadPreview,
   });
 
-  useCommand('LAUNCH_DEBUG_PREVIEW', handlers.previewEnabled, {
-    displayText: launchDebugPreviewText,
-    handler: handlers.onLaunchDebugPreview,
-  });
+  useCommand(
+    'LAUNCH_DEBUG_PREVIEW',
+    handlers.previewEnabled && handlers.allowNetworkPreview,
+    {
+      displayText: launchDebugPreviewText,
+      handler: handlers.onLaunchDebugPreview,
+    }
+  );
+
+  useCommand(
+    'LAUNCH_NETWORK_PREVIEW',
+    handlers.previewEnabled && handlers.allowNetworkPreview,
+    {
+      displayText: launchNetworkPreviewText,
+      handler: handlers.onLaunchNetworkPreview,
+    }
+  );
 
   useCommand('OPEN_START_PAGE', true, {
     displayText: openStartPageText,

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1796,9 +1796,13 @@ const MainFrame = (props: Props) => {
       !!state.currentProject && state.currentProject.getLayoutsCount() > 0,
     onOpenProjectManager: toggleProjectManager,
     hasPreviewsRunning,
+    allowNetworkPreview:
+      !!_previewLauncher.current &&
+      _previewLauncher.current.canDoNetworkPreview(),
     onLaunchPreview: launchNewPreview,
     onHotReloadPreview: launchHotReloadPreview,
     onLaunchDebugPreview: launchDebuggerAndPreview,
+    onLaunchNetworkPreview: launchNetworkPreview,
     onOpenStartPage: openStartPage,
     onCreateProject: openCreateDialog,
     onOpenProject: chooseProject,


### PR DESCRIPTION
This PR adds a new command for launching a network preview. Also, now debug preview and network preview commands are usable only on the desktop app (earlier they were incorrectly available on web app too and didn't work on launching the command).