### PR TITLE
[Draft] Cameras and viewports

### DIFF
--- a/Extensions/CameraViewport/JsExtension.js
+++ b/Extensions/CameraViewport/JsExtension.js
@@ -1,0 +1,258 @@
+// @flow
+/**
+ * This is a declaration of an extension for GDevelop 5.
+ *
+ * ℹ️ Changes in this file are watched and automatically imported if the editor
+ * is running. You can also manually run `node import-GDJS-Runtime.js` (in newIDE/app/scripts).
+ *
+ * The file must be named "JsExtension.js", otherwise GDevelop won't load it.
+ * ⚠️ If you make a change and the extension is not loaded, open the developer console
+ * and search for any errors.
+ *
+ * More information on https://github.com/4ian/GDevelop/blob/master/newIDE/README-extensions.md
+ */
+
+/*::
+// Import types to allow Flow to do static type checking on this file.
+// Extensions declaration are typed using Flow (like the editor), but the files
+// for the game engine are checked with TypeScript annotations.
+import { type ObjectsRenderingService, type ObjectsEditorService } from '../JsExtensionTypes.flow.js'
+*/
+
+module.exports = {
+  createExtension: function (
+    _ /*: (string) => string */,
+    gd /*: libGDevelop */
+  ) {
+    const extension = new gd.PlatformExtension();
+    extension.setExtensionInformation(
+      'CameraViewport',
+      _('Camera Viewport Extension'),
+      _('Adds a camera viewport'),
+      'Arthur Pacaud (arthuro555)',
+      'MIT'
+    );
+
+    var cameraViewport = new gd.ObjectJsImplementation();
+
+    // $FlowExpectedError - ignore Flow warning as we're creating an object
+    cameraViewport.updateProperty = function (
+      objectContent,
+      propertyName,
+      newValue
+    ) {
+      if (propertyName === 'Camera Number') {
+        objectContent.cameraId = newValue;
+        if(parseInt(newValue) < 0) objectContent.cameraId = "0";
+        return true;
+      }
+
+      return false;
+    };
+    // $FlowExpectedError - ignore Flow warning as we're creating an object
+    cameraViewport.getProperties = function (objectContent) {
+      var objectProperties = new gd.MapStringPropertyDescriptor();
+
+      objectProperties
+        .getOrCreate('Camera Number')
+        .setValue(objectContent.cameraId)
+        .setType("number");
+
+      return objectProperties;
+    };
+    
+    cameraViewport.setRawJSONContent(
+      JSON.stringify({
+        cameraId: '0',
+      })
+    );
+
+    // $FlowExpectedError - ignore Flow warning as we're creating an object
+    cameraViewport.updateInitialInstanceProperty = function (
+      objectContent,
+      instance,
+      propertyName,
+      newValue,
+      project,
+      layout
+    ) {
+      return false;
+    };
+
+    // $FlowExpectedError - ignore Flow warning as we're creating an object
+    cameraViewport.getInitialInstanceProperties = function (
+      content,
+      instance,
+      project,
+      layout
+    ) {
+      return new gd.MapStringPropertyDescriptor();
+    };
+
+    const object = extension
+      .addObject(
+        'CameraViewport',
+        _('Camera viewport'),
+        _('Renders a camera'),
+        'CppPlatform/Extensions/topdownmovementicon.png',
+        cameraViewport
+      )
+      .setIncludeFile('Extensions/CameraViewport/cameraviewportruntimeobject.js')
+      .addIncludeFile(
+        'Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js'
+      );
+
+    return extension;
+  },
+  /**
+   * You can optionally add sanity tests that will check the basic working
+   * of your extension behaviors/objects by instanciating behaviors/objects
+   * and setting the property to a given value.
+   *
+   * If you don't have any tests, you can simply return an empty array.
+   *
+   * But it is recommended to create tests for the behaviors/objects properties you created
+   * to avoid mistakes.
+   */
+  runExtensionSanityTests: function (
+    gd /*: libGDevelop */,
+    extension /*: gdPlatformExtension*/
+  ) {
+    return true;
+  },
+  /**
+   * Register editors for objects.
+   *
+   * ℹ️ Run `node import-GDJS-Runtime.js` (in newIDE/app/scripts) if you make any change.
+   */
+  registerEditorConfigurations: function (
+    objectsEditorService /*: ObjectsEditorService */
+  ) {
+    objectsEditorService.registerEditorConfiguration(
+      'CameraViewport::CameraViewport',
+      objectsEditorService.getDefaultObjectJsImplementationPropertiesEditor({
+        helpPagePath: '/all-features/camera',
+      })
+    );
+  },
+  /**
+   * Register renderers for instance of objects on the scene editor.
+   *
+   * ℹ️ Run `node import-GDJS-Runtime.js` (in newIDE/app/scripts) if you make any change.
+   */
+  registerInstanceRenderers: function (
+    objectsRenderingService /*: ObjectsRenderingService */
+  ) {
+    const RenderedInstance = objectsRenderingService.RenderedInstance;
+    const PIXI = objectsRenderingService.PIXI;
+
+    /**
+     * Renderer for instances of DummyObject inside the IDE.
+     *
+     * @extends RenderedInstance
+     * @class RenderedDummyObjectInstance
+     * @constructor
+     */
+    function RenderedDummyObjectInstance(
+      project,
+      layout,
+      instance,
+      associatedObject,
+      pixiContainer,
+      pixiResourcesLoader
+    ) {
+      RenderedInstance.call(
+        this,
+        project,
+        layout,
+        instance,
+        associatedObject,
+        pixiContainer,
+        pixiResourcesLoader
+      );
+
+      //Setup the PIXI object:
+      this._pixiObject = new PIXI.Container();
+      this._pixiContainer.addChild(this._pixiObject);
+
+      this._pixiRectangle = new PIXI.Graphics();
+      this._pixiRectangle.lineStyle(2, 0xFEEB77, 1);
+      this._pixiRectangle.alpha = 0.25;
+
+      this._pixiText = new PIXI.Text("No camera");
+      this._pixiText.anchor.x = 0.5;
+      this._pixiText.anchor.y = 0.5;
+
+      this._pixiObject.addChild(this._pixiRectangle);
+      this._pixiObject.addChild(this._pixiText);
+
+      this.update();
+    }
+    RenderedDummyObjectInstance.prototype = Object.create(
+      RenderedInstance.prototype
+    );
+
+    /**
+     * Return the path to the thumbnail of the specified object.
+     */
+    RenderedDummyObjectInstance.getThumbnail = function (
+      project,
+      resourcesLoader,
+      object
+    ) {
+      return 'res/conditions/camera.png';
+    };
+
+    /**
+     * This is called to update the PIXI object on the scene editor
+     */
+    RenderedDummyObjectInstance.prototype.update = function () {
+      const width = this._instance.hasCustomSize() ? this._instance.getCustomWidth() : this.getDefaultWidth();
+      const height = this._instance.hasCustomSize() ? this._instance.getCustomHeight() : this.getDefaultHeight();
+
+      // Read Camera ID from the object
+      const cameraId = this._associatedObject
+        .getProperties()
+        .get('Camera Number')
+        .getValue();
+      this._pixiText.text = "Camera " + cameraId;
+      if(parseInt(cameraId) === 0) this._pixiText.text = "Main Camera";
+
+      // Read position and angle from the instance
+      this._pixiObject.position.x =
+        this._instance.getX();
+      this._pixiObject.position.y =
+        this._instance.getY();
+      this._pixiText.position.x =
+        width/ 2;
+      this._pixiText.position.y =
+        height / 2;
+      this._pixiText.style.fontSize = (height / 50) * (width / 50);
+
+      this._pixiRectangle.clear();
+
+      this._pixiRectangle.beginFill(0xFFFFFF, 1);
+      this._pixiRectangle.drawRect(0, 0, width, height);
+      this._pixiRectangle.endFill();
+    };
+
+    /**
+     * Return the width of the instance, when it's not resized.
+     */
+    RenderedDummyObjectInstance.prototype.getDefaultWidth = function () {
+      return 250;
+    };
+
+    /**
+     * Return the height of the instance, when it's not resized.
+     */
+    RenderedDummyObjectInstance.prototype.getDefaultHeight = function () {
+      return 150;
+    };
+
+    objectsRenderingService.registerInstanceRenderer(
+      'CameraViewport::CameraViewport',
+      RenderedDummyObjectInstance
+    );
+  },
+};

--- a/Extensions/CameraViewport/JsExtension.js
+++ b/Extensions/CameraViewport/JsExtension.js
@@ -94,7 +94,7 @@ module.exports = {
         'CameraViewport',
         _('Camera viewport'),
         _('Renders a camera'),
-        'CppPlatform/Extensions/topdownmovementicon.png',
+        'res/conditions/camera.png',
         cameraViewport
       )
       .setIncludeFile('Extensions/CameraViewport/cameraviewportruntimeobject.js')
@@ -118,7 +118,7 @@ module.exports = {
     gd /*: libGDevelop */,
     extension /*: gdPlatformExtension*/
   ) {
-    return true;
+    return [];
   },
   /**
    * Register editors for objects.

--- a/Extensions/CameraViewport/JsExtension.js
+++ b/Extensions/CameraViewport/JsExtension.js
@@ -47,6 +47,11 @@ module.exports = {
         return true;
       }
 
+      if (propertyName === 'Render Camera Viewports') {
+        objectContent.showOtherCameras = newValue === '1' ? true : false;
+        return true;
+      }
+
       return false;
     };
     // $FlowExpectedError - ignore Flow warning as we're creating an object
@@ -57,6 +62,12 @@ module.exports = {
         .getOrCreate('Camera Number')
         .setValue(objectContent.cameraId)
         .setType("number");
+      
+      objectProperties
+        .getOrCreate('Render Camera Viewports')
+        .setValue(objectContent.showOtherCameras ? 'true' : 'false')
+        .setLabel("Should the camera render also cameras? Turning this on might cause a loose of performance.")
+        .setType("boolean");
 
       return objectProperties;
     };
@@ -64,6 +75,7 @@ module.exports = {
     cameraViewport.setRawJSONContent(
       JSON.stringify({
         cameraId: '0',
+        showOtherCameras: false,
       })
     );
 

--- a/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
@@ -1,0 +1,58 @@
+/**
+ * The PIXI.js renderer for the DummyRuntimeObject.
+ *
+ * @class DummyRuntimeObjectPixiRenderer
+ * @constructor
+ * @param {gdjs.CameraViewportObject} runtimeObject The object to render
+ * @param {gdjs.RuntimeScene} runtimeScene The gdjs.RuntimeScene in which the object is
+ */
+gdjs.CameraViewportObjectPixiRenderer = function(runtimeObject, runtimeScene)
+{
+    this._object = runtimeObject; // Keep a reference to the object to read from it later.
+    this._renderer = runtimeScene.getGame().getRenderer().getPIXIRenderer();
+    this._renderTexture = new PIXI.RenderTexture.create({width: runtimeObject.getWidth(), height: runtimeObject.getHeight()});
+    this._sprite = new PIXI.Sprite(this._renderTexture);
+    this._scene = runtimeScene;
+};
+
+gdjs.CameraViewportObjectRenderer = gdjs.CameraViewportObjectPixiRenderer; //Register the class to let the engine use it.
+
+gdjs.CameraViewportObjectPixiRenderer.prototype.getRendererObject = function() {
+    return this._sprite;
+};
+
+gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
+    /* 
+     * Remove all cameras: cameras can't render themselves as it could result in an endless loop.
+     * We could theoretically count the renders and replace the camera with a blank texture after too many renders,
+     * But chrome web gl automatically blocks textures that are made from a texture to be applied to the texture it is made from.
+     */
+     this._scene._constructListOfAllInstances();
+    for(var objectId in this._scene._allInstancesList) {
+        var object = this._scene._allInstancesList[objectId];
+        if(object.type !== "CameraViewport::CameraViewport") continue;
+        this._scene
+            .getLayer(object.layer)
+            .getRenderer()
+            .removeRendererObject(object.getRendererObject());
+    }
+
+    // Camera magic
+    this._renderer.render(this._scene.getRenderer().getPIXIContainer(), this._renderTexture);
+
+    // Add the cameras back
+    for(var objectId in this._scene._allInstancesList) {
+        var object = this._scene._allInstancesList[objectId];
+        if(object.type !== "CameraViewport::CameraViewport") continue;
+        this._scene
+            .getLayer(object.layer)
+            .getRenderer()
+            .addRendererObject(object.getRendererObject());
+    }
+    this._sprite.x = this._object.getX();
+    this._sprite.y = this._object.getY();
+};
+
+gdjs.CameraViewportObjectPixiRenderer.prototype.changeSize = function() {
+    this._renderTexture.resize(this._object.getWidth(), this._object.getHeight());
+};

--- a/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
@@ -10,12 +10,15 @@ gdjs.CameraViewportObjectPixiRenderer = function(runtimeObject, runtimeScene)
 {
     this._object = runtimeObject; // Keep a reference to the object to read from it later.
     this._renderer = runtimeScene.getGame().getRenderer().getPIXIRenderer();
+    /** @type {PIXI.RenderTexture} */
     this._renderTexture = new PIXI.RenderTexture.create({width: runtimeObject.getWidth(), height: runtimeObject.getHeight()});
     this._sprite = new PIXI.Sprite(this._renderTexture);
     this._scene = runtimeScene;
 };
 
 gdjs.CameraViewportObjectRenderer = gdjs.CameraViewportObjectPixiRenderer; //Register the class to let the engine use it.
+
+gdjs.CameraViewportObjectPixiRenderer.tempTexture = PIXI.RenderTexture.create();
 
 gdjs.CameraViewportObjectPixiRenderer.prototype.getRendererObject = function() {
     return this._sprite;
@@ -24,8 +27,6 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.getRendererObject = function() {
 gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
     if(!this._sprite.visible) return;
 
-    var layerBackups = {};
-
     // If not main camera, set layer the current camera's data
     if(this._object.camera > 0) {
         var allLayers = [];
@@ -33,13 +34,7 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
         for(var layerId in allLayers) {
             /** @type {gdjs.Layer} */
             var layer = this._scene.getLayer(allLayers[layerId]);
-            layerBackups[allLayers[layerId]] = {
-                cameraX: layer.getCameraX(),
-                cameraY: layer.getCameraY(),
-                zoomFactor: layer.getCameraZoom(),
-                cameraRotation: layer.getCameraRotation(),
-            }
-            layer._applyCamera(layer.getCamera(this._object.camera));
+            layer.setCurrentCamera(this._object.camera);
         }
     }
 
@@ -59,8 +54,21 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
     // Recalculate culling for new camera parameters before rendering
     this._scene._updateObjectsVisibility();
 
-    // Camera magic
-    this._renderer.render(this._scene.getRenderer().getPIXIContainer(), this._renderTexture);
+    /**
+     * We can't directly render to the render texture as 
+     * the render texture is part of what is being rendered, 
+     * and webgl is blocking that (it could make an infinite loop).
+     * So we need to render to an intermediate outside of the main container
+     * and then render it to the real render texture
+     * 
+     * @TODO
+     * There is probably a better method for rerendering from a render texture
+     * than just rendering a sprite using it as texture.
+     * Possible hint: https://www.html5gamedevs.com/topic/45423-why-is-this-not-allowed/?do=findComment&comment=251116
+     */
+    gdjs.CameraViewportObjectPixiRenderer.tempTexture.resize(this._renderTexture.width, this._renderTexture.height);
+    this._renderer.render(this._scene.getRenderer().getPIXIContainer(), gdjs.CameraViewportObjectPixiRenderer.tempTexture);
+    this._renderer.render(new PIXI.Sprite(gdjs.CameraViewportObjectPixiRenderer.tempTexture), this._renderTexture);
 
     // Add the viewports back
     for(var objectId in this._scene._allInstancesList) {
@@ -75,7 +83,7 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
         this._scene.getAllLayerNames(allLayers);
         for(var layerId in allLayers) {
             var layer = this._scene.getLayer(allLayers[layerId]);
-            layer._applyCamera(layerBackups[allLayers[layerId]]);
+            layer.setCurrentCamera(0);
         }
     }
 

--- a/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
@@ -31,10 +31,7 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
     for(var objectId in this._scene._allInstancesList) {
         var object = this._scene._allInstancesList[objectId];
         if(object.type !== "CameraViewport::CameraViewport") continue;
-        this._scene
-            .getLayer(object.layer)
-            .getRenderer()
-            .removeRendererObject(object.getRendererObject());
+        object.getRendererObject().visible = false;
     }
 
     // Camera magic
@@ -44,10 +41,7 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
     for(var objectId in this._scene._allInstancesList) {
         var object = this._scene._allInstancesList[objectId];
         if(object.type !== "CameraViewport::CameraViewport") continue;
-        this._scene
-            .getLayer(object.layer)
-            .getRenderer()
-            .addRendererObject(object.getRendererObject());
+        object.getRendererObject().visible = true;
     }
     this._sprite.x = this._object.getX();
     this._sprite.y = this._object.getY();

--- a/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
@@ -22,8 +22,10 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.getRendererObject = function() {
 };
 
 gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
+    if(!this._sprite.visible) return;
+
     /* 
-     * Remove all cameras: cameras can't render themselves as it could result in an endless loop.
+     * Remove all viewports: viewports can't render themselves as it could result in an endless loop.
      * We could theoretically count the renders and replace the camera with a blank texture after too many renders,
      * But chrome web gl automatically blocks textures that are made from a texture to be applied to the texture it is made from.
      */
@@ -37,7 +39,7 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
     // Camera magic
     this._renderer.render(this._scene.getRenderer().getPIXIContainer(), this._renderTexture);
 
-    // Add the cameras back
+    // Add the viewports back
     for(var objectId in this._scene._allInstancesList) {
         var object = this._scene._allInstancesList[objectId];
         if(object.type !== "CameraViewport::CameraViewport") continue;
@@ -49,4 +51,8 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
 
 gdjs.CameraViewportObjectPixiRenderer.prototype.changeSize = function() {
     this._renderTexture.resize(this._object.getWidth(), this._object.getHeight());
+};
+
+gdjs.CameraViewportObjectPixiRenderer.prototype.changeVisible = function() {
+    this._sprite.visible = !this._object.hidden;
 };

--- a/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
@@ -53,6 +53,6 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.changeSize = function() {
     this._renderTexture.resize(this._object.getWidth(), this._object.getHeight());
 };
 
-gdjs.CameraViewportObjectPixiRenderer.prototype.changeVisible = function() {
-    this._sprite.visible = !this._object.hidden;
+gdjs.CameraViewportObjectPixiRenderer.prototype.changeVisible = function(hidden) {
+    this._sprite.visible = hidden;
 };

--- a/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject-pixi-renderer.js
@@ -56,6 +56,9 @@ gdjs.CameraViewportObjectPixiRenderer.prototype.update = function() {
         object.getRendererObject().visible = false;
     }
 
+    // Recalculate culling for new camera parameters before rendering
+    this._scene._updateObjectsVisibility();
+
     // Camera magic
     this._renderer.render(this._scene.getRenderer().getPIXIContainer(), this._renderTexture);
 

--- a/Extensions/CameraViewport/cameraviewportruntimeobject.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject.js
@@ -13,6 +13,7 @@ gdjs.CameraViewportObject = function(runtimeScene, objectData) {
 
   this.width  = 250;
   this.height = 150;
+  this.hidden = false;
 
   this.camera = objectData.content.cameraId;
   this._scene = runtimeScene;
@@ -77,6 +78,16 @@ gdjs.CameraViewportObject.prototype.getHeight = function() {
 gdjs.CameraViewportObject.prototype.getWidth = function() {
   return this.width;
 }
+
+/**
+ * Hide (or show) the object
+ * @param {boolean} hidden true to hide the object, false to show it again.
+ */
+gdjs.CameraViewportObject.prototype.hide = function(hidden) {
+  if ( hidden === undefined ) hidden = true;
+  this.hidden = hidden;
+  this._renderer.changeVisible();
+};
 
 /**
  * Get the camera being rendered.

--- a/Extensions/CameraViewport/cameraviewportruntimeobject.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject.js
@@ -1,0 +1,93 @@
+/**
+ * A viewport for cameras
+ *
+ * @memberof gdjs
+ * @class CameraViewportObject
+ * @extends gdjs.RuntimeObject
+ */
+gdjs.CameraViewportObject = function(runtimeScene, objectData) {
+  // *ALWAYS* call the base gdjs.RuntimeObject constructor.
+  gdjs.RuntimeObject.call(this, runtimeScene, objectData);
+
+  window.c = this;
+
+  this.width  = 250;
+  this.height = 150;
+
+  this.camera = objectData.content.cameraId;
+  this._scene = runtimeScene;
+
+  if (this._renderer)
+    gdjs.CameraViewportObjectRenderer.call(this._renderer, this, runtimeScene);
+  else this._renderer = new gdjs.CameraViewportObjectRenderer(this, runtimeScene);
+
+  // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+  this.onCreated();
+};
+
+gdjs.CameraViewportObject.prototype = Object.create(gdjs.RuntimeObject.prototype);
+gdjs.registerObject("CameraViewport::CameraViewport", gdjs.CameraViewportObject); //Replace by your extension + object name.
+
+gdjs.CameraViewportObject.prototype.getRendererObject = function() {
+  return this._renderer.getRendererObject();
+};
+
+gdjs.CameraViewportObject.prototype.update = function() {
+  return this._renderer.update();
+};
+
+gdjs.CameraViewportObject.prototype.updateFromObjectData = function(oldObjectData, newObjectData) {
+  // Compare previous and new data for the object and update it accordingly.
+  // This is useful for "hot-reloading".
+  if (oldObjectData.content.cameraId !== newObjectData.content.cameraId) {
+    this.camera = newObjectData.content.cameraId;
+  }
+
+  return true;
+};
+
+/**
+ * Initialize the extra parameters that could be set for an instance.
+ * @private
+ * @param {{customSize: {width: number, height: number}}} initialInstanceData The initial instance data
+ */
+gdjs.CameraViewportObject.prototype.extraInitializationFromInitialInstance = function(
+  initialInstanceData
+) {
+  if (initialInstanceData.customSize) {
+    this.setWidth(initialInstanceData.width);
+    this.setHeight(initialInstanceData.height);
+  }
+};
+
+gdjs.CameraViewportObject.prototype.setHeight = function(height) {
+  this.height = height;
+  this._renderer.changeSize();
+}
+
+gdjs.CameraViewportObject.prototype.setWidth = function(width) {
+  this.width = width;
+  this._renderer.changeSize();
+}
+
+gdjs.CameraViewportObject.prototype.getHeight = function() {
+  return this.height;
+}
+
+gdjs.CameraViewportObject.prototype.getWidth = function() {
+  return this.width;
+}
+
+/**
+ * Get the camera being rendered.
+ */
+gdjs.CameraViewportObject.prototype.getCameraID = function() {
+  return this.camera;
+};
+
+/**
+ * Set the camera being rendered.
+ */
+gdjs.CameraViewportObject.prototype.setCameraID = function(newCameraID) {
+  this.camera = newCameraID;
+};

--- a/Extensions/CameraViewport/cameraviewportruntimeobject.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject.js
@@ -9,11 +9,8 @@ gdjs.CameraViewportObject = function(runtimeScene, objectData) {
   // *ALWAYS* call the base gdjs.RuntimeObject constructor.
   gdjs.RuntimeObject.call(this, runtimeScene, objectData);
 
-  window.c = this;
-
   this.width  = 250;
   this.height = 150;
-  this.hidden = false;
 
   this.camera = objectData.content.cameraId;
   this._scene = runtimeScene;
@@ -84,9 +81,7 @@ gdjs.CameraViewportObject.prototype.getWidth = function() {
  * @param {boolean} hidden true to hide the object, false to show it again.
  */
 gdjs.CameraViewportObject.prototype.hide = function(hidden) {
-  if ( hidden === undefined ) hidden = true;
-  this.hidden = hidden;
-  this._renderer.changeVisible();
+  this._renderer.changeVisible(hidden);
 };
 
 /**

--- a/Extensions/CameraViewport/cameraviewportruntimeobject.js
+++ b/Extensions/CameraViewport/cameraviewportruntimeobject.js
@@ -8,11 +8,12 @@
 gdjs.CameraViewportObject = function(runtimeScene, objectData) {
   // *ALWAYS* call the base gdjs.RuntimeObject constructor.
   gdjs.RuntimeObject.call(this, runtimeScene, objectData);
+  console.log(objectData)
 
   this.width  = 250;
   this.height = 150;
-
   this.camera = objectData.content.cameraId;
+  this.showOtherCameras = objectData.content.showOtherCameras;
   this._scene = runtimeScene;
 
   if (this._renderer)
@@ -39,6 +40,10 @@ gdjs.CameraViewportObject.prototype.updateFromObjectData = function(oldObjectDat
   // This is useful for "hot-reloading".
   if (oldObjectData.content.cameraId !== newObjectData.content.cameraId) {
     this.camera = newObjectData.content.cameraId;
+  }
+
+  if (oldObjectData.content.showOtherCameras !== newObjectData.content.showOtherCameras) {
+    this.showOtherCameras = newObjectData.content.showOtherCameras;
   }
 
   return true;

--- a/Extensions/CameraViewport/cameraviewporttools.js
+++ b/Extensions/CameraViewport/cameraviewporttools.js
@@ -1,0 +1,67 @@
+/**
+ * This is an example of some functions that can be used through events.
+ * They could live on any object but it's usual to store them in an object
+ * with the extension name in `gdjs.evtTools`.
+ *
+ * Functions are being passed the arguments that were declared in the extension.
+ *
+ * @memberof gdjs.evtTools
+ * @class exampleJsExtension
+ * @static
+ * @private
+ */
+gdjs.evtTools.exampleJsExtension = {};
+
+gdjs.evtTools.exampleJsExtension.myConditionFunction = function(number, text) {
+  return number <= 10 && text.length < 5;
+};
+
+gdjs.evtTools.exampleJsExtension.getString = function() {
+  return 'Hello World';
+};
+
+/**
+ * You can also attach an object to gdjs, that you can use to store more information
+ * or objects - even if you should have doing so as global state can make things harder
+ * to debug. Most of the time you can have all the logic in your functions, your gdjs.RuntimeBehavior
+ * or your gdjs.RuntimeObject.
+ */
+gdjs.exampleJsExtension = {
+  myGlobalString: 'Hello World',
+};
+
+/**
+ * In **rare cases** you may want to run code at the start of the scene. You can define a callback
+ * that will be called at this moment.
+ */
+gdjs.registerRuntimeSceneLoadedCallback(function(runtimeScene) {
+  console.log('A gdjs.RuntimeScene was loaded:', runtimeScene);
+});
+
+/**
+ * In **rare cases** you may want to run code at the end of a scene. You can define a callback
+ * that will be called at this moment.
+ */
+gdjs.registerRuntimeSceneUnloadedCallback(function(runtimeScene) {
+  console.log('A gdjs.RuntimeScene was unloaded:', runtimeScene);
+});
+
+/**
+ * In **very rare cases** you may want to run code whenever an object is deleted.
+ */
+gdjs.registerObjectDeletedFromSceneCallback(function(
+  runtimeScene,
+  runtimeObject
+) {
+  console.log(
+    'A gdjs.RuntimeObject was deleted from a gdjs.RuntimeScene:',
+    runtimeScene,
+    runtimeObject
+  );
+});
+
+// Finally, note that you can also simply run code here. Most of the time you shouldn't need it though.
+console.log(
+  'gdjs.exampleJsExtension was created, with myGlobalString containing:' +
+    gdjs.exampleJsExtension.myGlobalString
+);

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -131,10 +131,11 @@ gdjs.Layer.prototype.getCamera = function(cameraId) {
 /**
  * Change the camera center X position.
  *
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  * @return The x position of the camera
  */
 gdjs.Layer.prototype.getCameraX = function(cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId >= 1) {
     return this.getCamera(cameraId).cameraX;
   }
@@ -144,10 +145,11 @@ gdjs.Layer.prototype.getCameraX = function(cameraId) {
 /**
  * Change the camera center Y position.
  *
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  * @return The y position of the camera
  */
 gdjs.Layer.prototype.getCameraY = function(cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId >= 1) {
     return this.getCamera(cameraId).cameraY;
   }
@@ -158,9 +160,10 @@ gdjs.Layer.prototype.getCameraY = function(cameraId) {
  * Set the camera center X position.
  *
  * @param {number} x The new x position
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraX = function(x, cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     this._cameraX = x;
     this._renderer.updatePosition();
@@ -175,9 +178,10 @@ gdjs.Layer.prototype.setCameraX = function(x, cameraId) {
  * Set the camera center Y position.
  *
  * @param {number} y The new y position
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraY = function(y, cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     this._cameraY = y;
     this._renderer.updatePosition();
@@ -192,10 +196,11 @@ gdjs.Layer.prototype.setCameraY = function(y, cameraId) {
  * Get the camera width (which can be different than the game resolution width
  * if the camera is zoomed).
  *
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  * @return {number} The width of the camera
  */
 gdjs.Layer.prototype.getCameraWidth = function(cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     return (+this._cachedGameResolutionWidth * 1) / this._zoomFactor;
   } else {
@@ -207,10 +212,11 @@ gdjs.Layer.prototype.getCameraWidth = function(cameraId) {
  * Get the camera height (which can be different than the game resolution height
  * if the camera is zoomed).
  *
- * @param {number=} cameraId The camera number. Currently ignored.
+ * @param {number} [cameraId] The camera number.
  * @return {number} The height of the camera
  */
 gdjs.Layer.prototype.getCameraHeight = function(cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     return (+this._cachedGameResolutionHeight * 1) / this._zoomFactor;
   } else {
@@ -240,9 +246,10 @@ gdjs.Layer.prototype.isVisible = function() {
  * Set the zoom of a camera.
  *
  * @param {number} newZoom The new zoom. Must be superior to 0. 1 is the default zoom.
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraZoom = function(newZoom, cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     this._zoomFactor = newZoom;
     this._renderer.updatePosition();
@@ -254,10 +261,11 @@ gdjs.Layer.prototype.setCameraZoom = function(newZoom, cameraId) {
 /**
  * Get the zoom of a camera.
  *
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  * @return {number} The zoom.
  */
 gdjs.Layer.prototype.getCameraZoom = function(cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     return this._zoomFactor;
   } else {
@@ -268,10 +276,11 @@ gdjs.Layer.prototype.getCameraZoom = function(cameraId) {
 /**
  * Get the rotation of the camera, expressed in degrees.
  *
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  * @return {number} The rotation, in degrees.
  */
 gdjs.Layer.prototype.getCameraRotation = function(cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     return this._cameraRotation;
   } else {
@@ -284,9 +293,10 @@ gdjs.Layer.prototype.getCameraRotation = function(cameraId) {
  * The rotation is made around the camera center.
  *
  * @param {number} rotation The new rotation, in degrees.
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraRotation = function(rotation, cameraId) {
+  cameraId = cameraId || 0;
   if(cameraId === 0) {
     this._cameraRotation = rotation;
     this._renderer.updatePosition();
@@ -303,7 +313,7 @@ gdjs.Layer.prototype.setCameraRotation = function(rotation, cameraId) {
  *
  * @param {number} x The x position, in canvas coordinates.
  * @param {number} y The y position, in canvas coordinates.
- * @param {number=} cameraId The camera number. Currently ignored.
+ * @param {number} [cameraId] The camera number. Currently ignored.
  */
 gdjs.Layer.prototype.convertCoords = function(x, y, cameraId) {
   x -= this._cachedGameResolutionWidth / 2;

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -117,6 +117,16 @@ gdjs.Layer.prototype._createCamera = function(cameraId) {
 };
 
 /**
+ * @param {Camera} camera 
+ */
+gdjs.Layer.prototype._applyCamera = function(camera) {
+  this.setCameraX(camera.cameraX);
+  this.setCameraY(camera.cameraY);
+  this.setCameraZoom(camera.zoomFactor);
+  this.setCameraRotation(camera.cameraRotation);
+}
+
+/**
  * Returns the requested camera. Creates it if not existing.
  * @param {number} cameraId The camera number.
  * @returns {Camera}

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -72,9 +72,9 @@ gdjs.Layer.prototype.onGameResolutionResized = function() {
   // expected not to "move". Not adapting the center position would make the camera
   // move from its initial position (which is centered in the screen) - and anchor
   // behavior would behave counterintuitively.
-  this._cameraX +=
+  this.getCamera().cameraX +=
     (this._cachedGameResolutionWidth - oldGameResolutionWidth) / 2;
-  this._cameraY +=
+  this.getCamera().cameraY +=
     (this._cachedGameResolutionHeight - oldGameResolutionHeight) / 2;
   this._renderer.updatePosition();
 };
@@ -124,10 +124,11 @@ gdjs.Layer.prototype.getCurrentCamera = function() {
 
 /**
  * Returns the requested camera. Creates it if not existing.
- * @param {number} cameraId The camera number.
+ * @param {number} [cameraId] The camera number.
  * @returns {Camera}
  */
 gdjs.Layer.prototype.getCamera = function(cameraId) {
+  if(cameraId == undefined) cameraId = this.getCurrentCamera();
   if(this._cameras.length <= cameraId || this._cameras[cameraId] == undefined) {
     this._createCamera(cameraId);
   }
@@ -141,7 +142,6 @@ gdjs.Layer.prototype.getCamera = function(cameraId) {
  * @return The x position of the camera
  */
 gdjs.Layer.prototype.getCameraX = function(cameraId) {
-  cameraId = cameraId || 0;
   return this.getCamera(cameraId).cameraX;
 };
 
@@ -152,7 +152,6 @@ gdjs.Layer.prototype.getCameraX = function(cameraId) {
  * @return The y position of the camera
  */
 gdjs.Layer.prototype.getCameraY = function(cameraId) {
-  cameraId = cameraId || 0;
   return this.getCamera(cameraId).cameraY;
 };
 
@@ -163,7 +162,6 @@ gdjs.Layer.prototype.getCameraY = function(cameraId) {
  * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraX = function(x, cameraId) {
-  cameraId = cameraId || 0;
   this.getCamera(cameraId).cameraX = x;
   if(cameraId === this._currentCamera) {
     this._renderer.updatePosition();
@@ -177,7 +175,6 @@ gdjs.Layer.prototype.setCameraX = function(x, cameraId) {
  * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraY = function(y, cameraId) {
-  cameraId = cameraId || 0;
   this.getCamera(cameraId).cameraY = y;
   if(cameraId === this._currentCamera) {
     this._renderer.updatePosition();
@@ -192,7 +189,6 @@ gdjs.Layer.prototype.setCameraY = function(y, cameraId) {
  * @return {number} The width of the camera
  */
 gdjs.Layer.prototype.getCameraWidth = function(cameraId) {
-  cameraId = cameraId || 0;
   return (+this._cachedGameResolutionWidth * 1) / this.getCamera(cameraId).zoomFactor;
 };
 
@@ -204,7 +200,6 @@ gdjs.Layer.prototype.getCameraWidth = function(cameraId) {
  * @return {number} The height of the camera
  */
 gdjs.Layer.prototype.getCameraHeight = function(cameraId) {
-  cameraId = cameraId || 0;
   return (+this._cachedGameResolutionWidth * 1) / this.getCamera(cameraId).zoomFactor;
 };
 
@@ -233,7 +228,6 @@ gdjs.Layer.prototype.isVisible = function() {
  * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraZoom = function(newZoom, cameraId) {
-  cameraId = cameraId || 0;
   this.getCamera(cameraId).zoomFactor = newZoom;
   if(cameraId === this._currentCamera) {
     this._renderer.updatePosition();
@@ -247,7 +241,6 @@ gdjs.Layer.prototype.setCameraZoom = function(newZoom, cameraId) {
  * @return {number} The zoom.
  */
 gdjs.Layer.prototype.getCameraZoom = function(cameraId) {
-  cameraId = cameraId || 0;
   return this.getCamera(cameraId).zoomFactor;
 };
 
@@ -258,7 +251,6 @@ gdjs.Layer.prototype.getCameraZoom = function(cameraId) {
  * @return {number} The rotation, in degrees.
  */
 gdjs.Layer.prototype.getCameraRotation = function(cameraId) {
-  cameraId = cameraId || 0;
   return this.getCamera(cameraId).cameraRotation;
 };
 
@@ -270,7 +262,6 @@ gdjs.Layer.prototype.getCameraRotation = function(cameraId) {
  * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.setCameraRotation = function(rotation, cameraId) {
-  cameraId = cameraId || 0;
   this.getCamera(cameraId).cameraRotation = rotation;
   if(cameraId === this._currentCamera) {
     this._renderer.updatePosition();
@@ -288,7 +279,6 @@ gdjs.Layer.prototype.setCameraRotation = function(rotation, cameraId) {
  * @param {number} [cameraId] The camera number.
  */
 gdjs.Layer.prototype.convertCoords = function(x, y, cameraId) {
-  cameraId = cameraId || 0;
   var camera = this.getCamera(cameraId);
 
   x -= this._cachedGameResolutionWidth / 2;
@@ -308,7 +298,6 @@ gdjs.Layer.prototype.convertCoords = function(x, y, cameraId) {
 };
 
 gdjs.Layer.prototype.convertInverseCoords = function(x, y, cameraId) {
-  cameraId = cameraId || 0;
   var camera = this.getCamera(cameraId);
 
   x -= camera.cameraX;

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -35,8 +35,9 @@ gdjs.LayerPixiRenderer.prototype.getRendererObject = function() {
  * @private
  */
 gdjs.LayerPixiRenderer.prototype.updatePosition = function() {
-  var angle = -gdjs.toRad(this._layer.getCameraRotation());
-  var zoomFactor = this._layer.getCameraZoom();
+  var camera = this._layer.getCamera(this._layer.getCurrentCamera());
+  var angle = -gdjs.toRad(camera.cameraRotation);
+  var zoomFactor = camera.zoomFactor;
 
   this._pixiContainer.rotation = angle;
   this._pixiContainer.scale.x = zoomFactor;
@@ -45,11 +46,11 @@ gdjs.LayerPixiRenderer.prototype.updatePosition = function() {
   var cosValue = Math.cos(angle);
   var sinValue = Math.sin(angle);
   var centerX =
-    this._layer.getCameraX() * zoomFactor * cosValue -
-    this._layer.getCameraY() * zoomFactor * sinValue;
+    camera.cameraX * zoomFactor * cosValue -
+    camera.cameraY * zoomFactor * sinValue;
   var centerY =
-    this._layer.getCameraX() * zoomFactor * sinValue +
-    this._layer.getCameraY() * zoomFactor * cosValue;
+  camera.cameraX * zoomFactor * sinValue +
+  camera.cameraY * zoomFactor * cosValue;
 
   this._pixiContainer.position.x = -centerX;
   this._pixiContainer.position.y = -centerY;

--- a/newIDE/app/src/JsExtensionsLoader/BrowserJsExtensionsLoader.js
+++ b/newIDE/app/src/JsExtensionsLoader/BrowserJsExtensionsLoader.js
@@ -73,6 +73,11 @@ const jsExtensions = [
     extensionModule: require('GDJS-for-web-app-only/Runtime/Extensions/Effects/JsExtension.js'),
     objectsRenderingServiceModules: {},
   },
+  {
+    name: 'CameraViewport',
+    extensionModule: require('GDJS-for-web-app-only/Runtime/Extensions/CameraViewport/JsExtension.js'),
+    objectsRenderingServiceModules: {},
+  },
 ];
 
 type MakeExtensionsLoaderArguments = {|


### PR DESCRIPTION
This PR adds multiple cameras and viewport objects. 
The cameras that are not 0 have their values recorded in a list of additional cameras.  
The camera viewport object does a simple thing: it renders `runtimeScene.getRenderer().getPIXIContainer()` into a RenderTexture and puts it in a sprite (which is the rendered object). When rendering from another camera than 0, it will set the additional camera's data as the main data for all layer, and restore it to the main camera's data after rendering.