### PR TITLE
Fix Menu import for hide menu in game preview

### DIFF
--- a/GDJS/Runtime/Electron/main.js
+++ b/GDJS/Runtime/Electron/main.js
@@ -3,7 +3,7 @@
  * running in Electron Runtime.
  */
 // Modules to control application life and create native browser window
-const { app, BrowserWindow, shell } = require("electron");
+const { app, BrowserWindow, shell, Menu } = require("electron");
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.


### PR DESCRIPTION
[This fix](https://github.com/4ian/GDevelop/commit/1f4042bff00a68fdfaf1a95dec921ae66475fac4) doesn't containt the import for the Menu.
I've added the menu to the import and compiled Gdevelop and tested to export on the build services, the menu is now gone!

Without this PR you will see this error
![image](https://user-images.githubusercontent.com/1670670/89656621-1fffb080-d8cc-11ea-89aa-6f56e6d13aef.png)

**Ready to merge.**

