### PR TITLE
Update cordova to v9

### DIFF
--- a/GDJS/Runtime/Cordova/config.xml
+++ b/GDJS/Runtime/Cordova/config.xml
@@ -28,7 +28,7 @@
     <preference name="Fullscreen" value="true" />
 
     <!-- Cordova/Phonegap version -->
-    <preference name="phonegap-version" value="cli-8.0.0" />
+    <preference name="phonegap-version" value="cli-9.0.0" />
 
     <!-- GDJS_ADMOB_PLUGIN_AND_APPLICATION_ID -->
 </widget>


### PR DESCRIPTION
The gdevelop services probably also require updating the cordova cli. 
This update is needed for compliance with the Play Store requirements, as since the 3rd August 2020 the minimal target sdk has to be 29 for new apps, and SDK 29 is only supported since cordova-android v9.