### PR TITLE
Lighting fixes

### DIFF
--- a/Core/GDCore/Project/Layer.cpp
+++ b/Core/GDCore/Project/Layer.cpp
@@ -68,9 +68,9 @@ void Layer::UnserializeFrom(const SerializerElement& element) {
   SetVisibility(element.GetBoolAttribute("visibility", true, "Visibility"));
   SetLightingLayer(element.GetBoolAttribute("isLightingLayer", false));
   SetFollowBaseLayerCamera(element.GetBoolAttribute("followBaseLayerCamera", false));
-  SetAmbientLightColor(element.GetIntAttribute("ambientLightColorR", 128), 
-                       element.GetIntAttribute("ambientLightColorG", 128),
-                       element.GetIntAttribute("ambientLightColorB", 128));
+  SetAmbientLightColor(element.GetIntAttribute("ambientLightColorR", 200), 
+                       element.GetIntAttribute("ambientLightColorG", 200),
+                       element.GetIntAttribute("ambientLightColorB", 200));
 
   // Compatibility with GD <= 3.3
   if (element.HasChild("Camera")) {

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.js
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.js
@@ -267,17 +267,20 @@ gdjs.LightRuntimeObjectPixiRenderer.prototype._updateDebugGraphics = function ()
   }
 
   this._debugGraphics.clear();
-  for (var i = 0; i < vertices.length; i += 2) {
+  this._debugGraphics.moveTo(vertices[2], vertices[3]);
+  var verticesCount = vertices.length;
+  for (var i = 2; i < verticesCount; i += 2) {
     var lineColor = i % 4 === 0 ? 0xff0000 : 0x00ff00;
+    var lastX = i+2 >= verticesCount ? 2 : i+2;
+    var lastY = i+3 >= verticesCount ? 3 : i+3;
     this._debugGraphics
       .lineStyle(1, lineColor, 1)
+      .lineTo(vertices[i], vertices[i + 1])
+      .lineTo(vertices[lastX], vertices[lastY])
       .moveTo(vertices[0], vertices[1])
-      .lineTo(vertices[i], vertices[i + 1]);
-    if (i !== vertices.length - 2) {
-      this._debugGraphics.lineTo(vertices[i + 2], vertices[i + 3]);
-    } else {
-      this._debugGraphics.lineTo(vertices[2], vertices[3]);
-    }
+      .lineTo(vertices[i], vertices[i+1])
+      .moveTo(vertices[0], vertices[1])
+      .lineTo(vertices[lastX], vertices[lastY]);
   }
 };
 

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.js
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.js
@@ -18,7 +18,7 @@ gdjs.LightRuntimeObjectPixiRenderer = function (runtimeObject, runtimeScene) {
     objectColor[2] / 255,
   ];
 
-  /** @type {string} */
+  /** @type {?PIXI.Texture} */
   this._texture = null;
   this.updateTexture();
 
@@ -115,14 +115,13 @@ gdjs.LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint = function 
   lightObject,
   angle,
   polygons,
-  halfOfDiag
+  boundingSquareHalfDiag
 ) {
   var centerX = lightObject.getX();
   var centerY = lightObject.getY();
-  //var halfOfDiag = Math.sqrt(2) * lightObject.getRadius();
-  var targetX = centerX + halfOfDiag * Math.cos(angle);
-  var targetY = centerY + halfOfDiag * Math.sin(angle);
-  var minSqDist = halfOfDiag * halfOfDiag;
+  var targetX = centerX + boundingSquareHalfDiag * Math.cos(angle);
+  var targetY = centerY + boundingSquareHalfDiag * Math.sin(angle);
+  var minSqDist = boundingSquareHalfDiag * boundingSquareHalfDiag;
   var closestPoint = [null, null];
   for (var poly of polygons) {
     var raycastResult = gdjs.Polygon.raycastTest(
@@ -429,7 +428,7 @@ gdjs.LightRuntimeObjectPixiRenderer.prototype._computeLightVertices = function (
   obstaclePolygons[0].vertices[3][0] = minX;
   obstaclePolygons[0].vertices[3][1] = maxY;
 
-  var halfOfDiag = Math.max(
+  var boundingSquareHalfDiag = Math.max(
     Math.hypot(this._object.x - minX, this._object.y - minY),
     Math.hypot(maxX - this._object.x, this._object.y - minY),
     Math.hypot(maxX - this._object.x, maxY - this._object.y),
@@ -451,7 +450,7 @@ gdjs.LightRuntimeObjectPixiRenderer.prototype._computeLightVertices = function (
       this._object,
       angle,
       obstaclePolygons,
-      halfOfDiag
+      boundingSquareHalfDiag
     );
     if (closestVertex) {
       closestVertices.push({
@@ -465,7 +464,7 @@ gdjs.LightRuntimeObjectPixiRenderer.prototype._computeLightVertices = function (
       this._object,
       angle + 0.0001,
       obstaclePolygons,
-      halfOfDiag
+      boundingSquareHalfDiag
     );
     if (closestVertexOffsetLeft) {
       closestVertices.push({
@@ -477,7 +476,7 @@ gdjs.LightRuntimeObjectPixiRenderer.prototype._computeLightVertices = function (
       this._object,
       angle - 0.0001,
       obstaclePolygons,
-      halfOfDiag
+      boundingSquareHalfDiag
     );
     if (closestVertexOffsetRight) {
       closestVertices.push({

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.js
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.js
@@ -8,6 +8,7 @@
  */
 gdjs.LightRuntimeObjectPixiRenderer = function (runtimeObject, runtimeScene) {
   this._object = runtimeObject;
+  this._runtimeScene = runtimeScene;
   this._manager = runtimeObject.getObstaclesManager();
   this._radius = runtimeObject.getRadius();
   var objectColor = runtimeObject.getColor();
@@ -17,10 +18,11 @@ gdjs.LightRuntimeObjectPixiRenderer = function (runtimeObject, runtimeScene) {
     objectColor[2] / 255,
   ];
 
-  /** @type {?PIXI.Texture} */
-  this._texture = runtimeObject.getPIXITexture();
-  this._center = new Float32Array([runtimeObject.x, runtimeObject.y]);
+  /** @type {string} */
+  this._texture = null;
+  this.updateTexture();
 
+  this._center = new Float32Array([runtimeObject.x, runtimeObject.y]);
   this._defaultVertexBuffer = new Float32Array(8);
   this._vertexBuffer = new Float32Array([
     runtimeObject.x - this._radius,
@@ -36,7 +38,7 @@ gdjs.LightRuntimeObjectPixiRenderer = function (runtimeObject, runtimeScene) {
 
   /** @type {?PIXI.Mesh} */
   this._light = null;
-  this._updateMesh();
+  this.updateMesh();
 
   this._isPreview = runtimeScene.getGame().isPreview();
   this._debugMode = null;
@@ -157,7 +159,8 @@ gdjs.LightRuntimeObjectPixiRenderer.prototype.ensureUpToDate = function () {
   this._updateBuffers();
 };
 
-gdjs.LightRuntimeObjectPixiRenderer.prototype._updateMesh = function () {
+gdjs.LightRuntimeObjectPixiRenderer.prototype.updateMesh = function () {
+  this.updateTexture();
   var fragmentShader =
     this._texture === null
       ? gdjs.LightRuntimeObjectPixiRenderer.defaultFragmentShader
@@ -204,8 +207,11 @@ gdjs.LightRuntimeObjectPixiRenderer.prototype.updateColor = function () {
 };
 
 gdjs.LightRuntimeObjectPixiRenderer.prototype.updateTexture = function () {
-  this._texture = this._object.getPIXITexture();
-  this._updateMesh();
+  var texture = this._object.getTexture();
+  this._texture =
+    texture !== ''
+      ? this._runtimeScene.getGame().getImageManager().getPIXITexture(texture)
+      : null;
 };
 
 gdjs.LightRuntimeObjectPixiRenderer.prototype.updateDebugMode = function () {

--- a/Extensions/Lighting/lightruntimeobject.js
+++ b/Extensions/Lighting/lightruntimeobject.js
@@ -33,19 +33,10 @@ gdjs.LightRuntimeObject = function (runtimeScene, lightObjectData) {
   this._debugMode = lightObjectData.content.debugMode;
 
   /** @type {?PIXI.Texture} */
-  this._texture =
-    lightObjectData.content.texture === ''
-      ? null
-      : runtimeScene
-          .getGame()
-          .getImageManager()
-          .getPIXITexture(lightObjectData.content.texture);
+  this._texture = lightObjectData.content.texture;
 
-  /** @type {?gdjs.LightObstaclesManager} */
-  this._obstaclesManager =
-    gdjs.LightObstaclesManager !== undefined
-      ? gdjs.LightObstaclesManager.getManager(runtimeScene)
-      : null;
+  /** @type {gdjs.LightObstaclesManager} */
+  this._obstaclesManager = gdjs.LightObstaclesManager.getManager(runtimeScene);
 
   if (this._renderer)
     gdjs.LightRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
@@ -90,14 +81,8 @@ gdjs.LightRuntimeObject.prototype.updateFromObjectData = function (
   }
 
   if (oldObjectData.content.texture !== newObjectData.content.texture) {
-    this._texture =
-      newObjectData.content.texture === ''
-        ? null
-        : this._runtimeScene
-            .getGame()
-            .getImageManager()
-            .getPIXITexture(newObjectData.content.texture);
-    this._renderer.updateTexture();
+    this._texture = newObjectData.content.texture;
+    this._renderer.updateMesh();
   }
 
   if (oldObjectData.content.debugMode !== newObjectData.content.debugMode) {
@@ -201,8 +186,8 @@ gdjs.LightRuntimeObject.prototype.getDebugMode = function () {
 
 /**
  * Returns PIXI.Texture if it exists, null otherwise.
- * @returns {?PIXI.Texture} the texture, if any, null otherwise.
+ * @returns {string} the path of texture.
  */
-gdjs.LightRuntimeObject.prototype.getPIXITexture = function () {
+gdjs.LightRuntimeObject.prototype.getTexture = function () {
   return this._texture;
 };

--- a/Extensions/Lighting/lightruntimeobject.js
+++ b/Extensions/Lighting/lightruntimeobject.js
@@ -32,7 +32,7 @@ gdjs.LightRuntimeObject = function (runtimeScene, lightObjectData) {
   /** @type {boolean} */
   this._debugMode = lightObjectData.content.debugMode;
 
-  /** @type {?PIXI.Texture} */
+  /** @type {string} */
   this._texture = lightObjectData.content.texture;
 
   /** @type {gdjs.LightObstaclesManager} */
@@ -185,7 +185,7 @@ gdjs.LightRuntimeObject.prototype.getDebugMode = function () {
 };
 
 /**
- * Returns PIXI.Texture if it exists, null otherwise.
+ * Returns the path of texture resource.
  * @returns {string} the path of texture.
  */
 gdjs.LightRuntimeObject.prototype.getTexture = function () {

--- a/newIDE/app/src/LayersList/index.js
+++ b/newIDE/app/src/LayersList/index.js
@@ -167,7 +167,7 @@ export default class LayersList extends Component<Props, State> {
     const layer = layersContainer.getLayer(name);
     layer.setLightingLayer(true);
     layer.setFollowBaseLayerCamera(true);
-    layer.setAmbientLightColor(128, 128, 128);
+    layer.setAmbientLightColor(200, 200, 200);
     this._onLayerModified();
   };
 


### PR DESCRIPTION
We have 4 fixes here,

1. Removal of unnecessary undefined handling of `gdjs.LightObstaclesManager`.
2. Moving the handling of light texture to pixi renderer.
3. A really weird bugfix of debugging mode's graphics. I don't know what happened, but this is how the pixi graphics was being rendered:
![Screenshot (1)](https://user-images.githubusercontent.com/39851078/90646783-36572600-e255-11ea-8542-1f17dfabe8e0.png)

Neither I understand why this happened, nor I'm sure about why this particular fix works 😓. All I did was randomly change the order of `lineTo` and `moveTo` calls, and it worked. I'm guessing this is really specific to pixi, as we've upgraded the version as well, but arguably it was a minor change.

4. Also changed the algorithm a bit (specifics about it in the review below) to have that expanding boundary box of light.

