### PR TITLE
Make the action to send a web request "asynchronous" 

### DIFF
--- a/Core/GDCore/Extensions/Builtin/NetworkExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/NetworkExtension.cpp
@@ -34,10 +34,10 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsNetworkExtension(
           "res/actions/net24.png",
           "res/actions/net.png")
       .AddParameter("string", _("Host, with protocol"))
-      .SetParameterLongDescription(
-          _("Example: \"http://example.com/\"."))
+      .SetParameterLongDescription(_("Example: \"http://example.com/\"."))
       .AddParameter("string", _("Path"))
-      .SetParameterLongDescription(_("Example: \"/user/123\" or \"/some-page.php\"."))
+      .SetParameterLongDescription(
+          _("Example: \"/user/123\" or \"/some-page.php\"."))
       .AddParameter("string", _("Request body content"))
       .AddParameter("string", _("Method: \"POST\" or \"GET\""), "", true)
       .SetParameterLongDescription(_("If empty, \"GET\" will be used."))
@@ -51,6 +51,52 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsNetworkExtension(
             "variable. If the server returns *JSON*, you may want to use the "
             "action \"Convert JSON to a scene variable\" afterwards, to "
             "explore the results with a *structure variable*."))
+      .MarkAsComplex()
+      .SetHidden();
+
+  extension
+      .AddAction(
+          "SendAsyncRequest",
+          _("Send a request to a web page"),
+          _("Send an asynchronous request to the specified web page.\n\nPlease "
+            "note that for "
+            "the web games, the game must be hosted on the same host "
+            "as specified below, except if the server is configured to answer "
+            "to all requests (cross-domain requests)."),
+          _("Send a _PARAM2_ request to _PARAM0_ with body: _PARAM1_, and "
+            "store the result in _PARAM4_ (or in _PARAM5_ in case of error)"),
+          _("Network"),
+          "res/actions/net24.png",
+          "res/actions/net.png")
+      .AddParameter("string", _("URL (API or web-page address)"))
+      .SetParameterLongDescription(
+          _("Example: \"https://example.com/user/123\". Using *https* is "
+            "highly recommended."))
+      .AddParameter("string", _("Request body content"))
+      .AddParameter("stringWithSelector",
+                    _("Resize mode"),
+                    "[\"GET\", \"POST\", \"PUT\", \"HEAD\", \"DELETE\", "
+                    "\"PATCH\", \"OPTIONS\"]",
+                    false)
+      .SetParameterLongDescription(_("If empty, \"GET\" will be used."))
+      .SetDefaultValue("\"GET\"")
+      .AddParameter("string", _("Content type"), "", true)
+      .SetParameterLongDescription(
+          _("If empty, \"application/x-www-form-urlencoded\" will be used."))
+      .AddParameter(
+          "scenevar", _("Variable where to store the response"), "", true)
+      .SetParameterLongDescription(
+          _("The response of the server will be stored, as a string, in this "
+            "variable. If the server returns *JSON*, you may want to use the "
+            "action \"Convert JSON to a scene variable\" afterwards, to "
+            "explore the results with a *structure variable*."))
+      .AddParameter(
+          "scenevar", _("Variable where to store the error message"), "", true)
+      .SetParameterLongDescription(
+          _("Optional, only used if an error occurs. This will contain the "
+            "error message (if request could not be sent) or the [\"status "
+            "code\"](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes), "
+            "if the server returns a status >= 400."))
       .MarkAsComplex();
 
   extension

--- a/GDJS/GDJS/Extensions/Builtin/NetworkExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/NetworkExtension.cpp
@@ -16,7 +16,9 @@ NetworkExtension::NetworkExtension() {
   gd::BuiltinExtensionsImplementer::ImplementsNetworkExtension(*this);
 
   GetAllActions()["SendRequest"].SetFunctionName(
-      "gdjs.evtTools.network.sendHttpRequest");
+      "gdjs.evtTools.network.sendDeprecatedSynchronousRequest");
+  GetAllActions()["SendAsyncRequest"].SetFunctionName(
+      "gdjs.evtTools.network.sendAsyncRequest");
   GetAllActions()["JSONToVariableStructure"].SetFunctionName(
       "gdjs.evtTools.network.jsonToVariableStructure");
   GetAllActions()["JSONToGlobalVariableStructure"].SetFunctionName(

--- a/GDJS/Runtime/events-tools/networktools.js
+++ b/GDJS/Runtime/events-tools/networktools.js
@@ -10,96 +10,157 @@
  */
 gdjs.evtTools.network = gdjs.evtTools.network || {};
 
-gdjs.evtTools.network.sendHttpRequest = function(host, uri, body, method, contentType, responseVar)
-{
-	try {
-		var xhr;
-	    if (typeof XMLHttpRequest !== 'undefined')
-			xhr = new XMLHttpRequest();
-	    else {
-	        var versions = ["MSXML2.XmlHttp.5.0",
-	                        "MSXML2.XmlHttp.4.0",
-	                        "MSXML2.XmlHttp.3.0",
-	                        "MSXML2.XmlHttp.2.0",
-	                        "Microsoft.XmlHttp"]
+/**
+ * Send an asynchronous request to the specified URL, with the specified (text)
+ * body, method and contentType (defaults to `application/x-www-form-urlencoded`).
+ * The result is stored in the specified response variable. Any error is stored in
+ * the specified error variable.
+ *
+ * @param {string} url The URL to send the request to.
+ * @param {string} body The content to be sent.
+ * @param {string} method The method to use ("GET", "POST", "PUT", "HEAD", "DELETE", "PATCH", "OPTIONS")
+ * @param {string} contentType The content type. Defaults to `application/x-www-form-urlencoded` if empty.
+ * @param {gdjs.Variable} responseVar The variable where to store the response text.
+ * @param {gdjs.Variable} errorVar The variable where to store the error message or status code (if status >= 400).
+ */
+gdjs.evtTools.network.sendAsyncRequest = function (
+  url,
+  body,
+  method,
+  contentType,
+  responseVar,
+  errorVar
+) {
+  const onError = (err) => {
+    errorVar.setString('' + err);
+  };
 
-	         for(var i = 0, len = versions.length; i < len; i++) {
-	            try {
-	                xhr = new ActiveXObject(versions[i]);
-	                break;
-	            }
-	            catch(e){}
-	         } // end for
-	    }
+  try {
+    const request = new XMLHttpRequest();
+    request.onerror = onError;
+    request.ontimeout = onError;
+    request.onabort = onError;
+    request.onreadystatechange = () => {
+      if (request.readyState === 4 /* "DONE" */) {
+        if (request.status >= 400) {
+          onError('' + request.status);
+        }
 
-	    if ( xhr === undefined ) return;
+        responseVar.setString(request.responseText);
+      }
+    };
 
-	    xhr.open(method, host+uri, false);
-	    xhr.setRequestHeader( "Content-Type", contentType === "" ? "application/x-www-form-urlencoded" : contentType );
-	    xhr.send(body);
-		responseVar.setString(xhr.responseText);
-	}
-	catch(e){}
+    request.open(method, url);
+    request.setRequestHeader(
+      'Content-Type',
+      contentType === '' ? 'application/x-www-form-urlencoded' : contentType
+    );
+    request.send(body);
+  } catch (err) {
+    onError(err);
+  }
+};
+
+/** @deprecated */
+gdjs.evtTools.network.sendDeprecatedSynchronousRequest = function (
+  host,
+  uri,
+  body,
+  method,
+  contentType,
+  responseVar
+) {
+  try {
+    var xhr;
+    if (typeof XMLHttpRequest !== 'undefined') xhr = new XMLHttpRequest();
+    else {
+      var versions = [
+        'MSXML2.XmlHttp.5.0',
+        'MSXML2.XmlHttp.4.0',
+        'MSXML2.XmlHttp.3.0',
+        'MSXML2.XmlHttp.2.0',
+        'Microsoft.XmlHttp',
+      ];
+
+      for (var i = 0, len = versions.length; i < len; i++) {
+        try {
+          xhr = new ActiveXObject(versions[i]);
+          break;
+        } catch (e) {}
+      } // end for
+    }
+
+    if (xhr === undefined) return;
+
+    xhr.open(method, host + uri, false);
+    xhr.setRequestHeader(
+      'Content-Type',
+      contentType === '' ? 'application/x-www-form-urlencoded' : contentType
+    );
+    xhr.send(body);
+    responseVar.setString(xhr.responseText);
+  } catch (e) {}
 };
 
 /**
  * Convert a variable to JSON.
  * TODO: Move to gdjs.Variable static
  * @param {gdjs.Variable} variable The variable to convert to JSON
- * @returns {string} The JSON string representing the variable 
+ * @returns {string} The JSON string representing the variable
  */
-gdjs.evtTools.network.variableStructureToJSON = function(variable)
-{
-    if ( !variable.isStructure() ) {
-        if ( variable.isNumber() )
-            return JSON.stringify(variable.getAsNumber());
-        else
-            return JSON.stringify(variable.getAsString());
+gdjs.evtTools.network.variableStructureToJSON = function (variable) {
+  if (!variable.isStructure()) {
+    if (variable.isNumber()) return JSON.stringify(variable.getAsNumber());
+    else return JSON.stringify(variable.getAsString());
+  }
+
+  var str = '{';
+  var firstChild = true;
+  var children = variable.getAllChildren();
+  for (var p in children) {
+    if (children.hasOwnProperty(p)) {
+      if (!firstChild) str += ',';
+      str +=
+        JSON.stringify(p) +
+        ': ' +
+        gdjs.evtTools.network.variableStructureToJSON(children[p]);
+
+      firstChild = false;
     }
+  }
 
-    var str = "{";
-    var firstChild = true;
-    var children = variable.getAllChildren();
-    for(var p in children) {
-        if (children.hasOwnProperty(p)) {
-	        if ( !firstChild ) str += ",";
-	        str += JSON.stringify(p) + ": " + gdjs.evtTools.network.variableStructureToJSON(children[p]);
-
-	        firstChild = false;
-	    }
-    }
-
-    str += "}";
-    return str;
+  str += '}';
+  return str;
 };
 
-gdjs.evtTools.network.objectVariableStructureToJSON = function(object, variable)
-{
-	return gdjs.evtTools.network.variableStructureToJSON(variable);
-}
+gdjs.evtTools.network.objectVariableStructureToJSON = function (
+  object,
+  variable
+) {
+  return gdjs.evtTools.network.variableStructureToJSON(variable);
+};
 
-gdjs.evtTools.network._objectToVariable = function(obj, variable)
-{
-	if(!isNaN(obj)) {  //Number
-		variable.setNumber(obj);
-	}
-	else if (typeof obj == 'string' || obj instanceof String) {
-		variable.setString(obj);
-	}
-    else if ( Array.isArray(obj) ) {
-	    for(var i = 0;i<obj.length;++i) {
-	        gdjs.evtTools.network._objectToVariable(obj[i], variable.getChild(i.toString()));
-		}
-	}
-	else {
-	    for(var p in obj) {
-	        if (obj.hasOwnProperty(p)) {
-	        	gdjs.evtTools.network._objectToVariable(obj[p], variable.getChild(p));
-	        }
-		}
-	}
-
-}
+gdjs.evtTools.network._objectToVariable = function (obj, variable) {
+  if (!isNaN(obj)) {
+    //Number
+    variable.setNumber(obj);
+  } else if (typeof obj == 'string' || obj instanceof String) {
+    variable.setString(obj);
+  } else if (Array.isArray(obj)) {
+    for (var i = 0; i < obj.length; ++i) {
+      gdjs.evtTools.network._objectToVariable(
+        obj[i],
+        variable.getChild(i.toString())
+      );
+    }
+  } else {
+    for (var p in obj) {
+      if (obj.hasOwnProperty(p)) {
+        gdjs.evtTools.network._objectToVariable(obj[p], variable.getChild(p));
+      }
+    }
+  }
+};
 
 /**
  * Parse the given JSON and fill the content of the variable with it
@@ -108,20 +169,22 @@ gdjs.evtTools.network._objectToVariable = function(obj, variable)
  * @param {gdjs.Variable} variable The variable where to put the parsed JSON
  * @returns {boolean} true if JSON was properly parsed
  */
-gdjs.evtTools.network.jsonToVariableStructure = function(jsonStr, variable)
-{
-    if ( jsonStr.length === 0 ) return false;
-    try {
-		var obj = JSON.parse(jsonStr);
-		gdjs.evtTools.network._objectToVariable(obj, variable);
-		return true;
-	} catch(e) {
-		//Do nothing iF JSON was not properly parsed;
-		return false;
-	}
-}
+gdjs.evtTools.network.jsonToVariableStructure = function (jsonStr, variable) {
+  if (jsonStr.length === 0) return false;
+  try {
+    var obj = JSON.parse(jsonStr);
+    gdjs.evtTools.network._objectToVariable(obj, variable);
+    return true;
+  } catch (e) {
+    //Do nothing iF JSON was not properly parsed;
+    return false;
+  }
+};
 
-gdjs.evtTools.network.jsonToObjectVariableStructure = function(jsonStr, object, variable)
-{
-	gdjs.evtTools.network.jsonToVariableStructure(jsonStr, variable);
-}
+gdjs.evtTools.network.jsonToObjectVariableStructure = function (
+  jsonStr,
+  object,
+  variable
+) {
+  gdjs.evtTools.network.jsonToVariableStructure(jsonStr, variable);
+};


### PR DESCRIPTION
* The result from the request is stored in the specified variable (and any error in a second variable)
* This avoids blocking the game execution while the request is being made, and allow multiple requests to be made at the same time.

Note that the old "synchronous" action is now deprecated (hidden in GDevelop), but still working to keep backward compatibility.
The parameters are similar as before with an added "error variable". In the future, we could add action to specify the timeout and add headers before sending the request (not part of this PR though).

Fix #1933