### PR TITLE
Add is fullscreen condition

### DIFF
--- a/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
@@ -46,7 +46,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
           _("Is the game in fullscreen?"),
           _("Game's window and resolution"),
           "res/actions/fullscreen24.png",
-          "res/actions/fullscreen.png");
+          "res/actions/fullscreen.png")
+      .AddCodeOnlyParameter("currentScene", "");
 
   extension
       .AddAction("SetWindowMargins",

--- a/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
@@ -43,7 +43,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
           "IsFullScreen",
           _("Fullscreen activated?"),
           _("Check if the game is currently in fullscreen."),
-          _("Is the game in fullscreen?"),
+          _("The game is in fullscreen"),
           _("Game's window and resolution"),
           "res/actions/fullscreen24.png",
           "res/actions/fullscreen.png")

--- a/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
@@ -39,6 +39,16 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
       .SetDefaultValue("yes");
 
   extension
+      .AddCondition(
+          "IsFullScreen",
+          _("Fullscreen activated?"),
+          _("Check if the game is currently in fullscreen."),
+          _("Is the game in fullscreen?"),
+          _("Game's window and resolution"),
+          "res/actions/fullscreen24.png",
+          "res/actions/fullscreen.png");
+
+  extension
       .AddAction("SetWindowMargins",
                  _("Change the window's margins"),
                  _("This action changes the margins, in pixels, between the "

--- a/GDJS/GDJS/Extensions/Builtin/WindowExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/WindowExtension.cpp
@@ -17,6 +17,8 @@ WindowExtension::WindowExtension() {
 
   GetAllActions()["SetFullScreen"].SetFunctionName(
       "gdjs.evtTools.window.setFullScreen");
+  GetAllConditions()["IsFullScreen"].SetFunctionName(
+      "gdjs.evtTools.window.isFullScreen");
   GetAllActions()["SetWindowMargins"].SetFunctionName(
       "gdjs.evtTools.window.setMargins");
   GetAllActions()["SetWindowTitle"].SetFunctionName(

--- a/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
+++ b/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
@@ -57,7 +57,7 @@ gdjs.RuntimeGamePixiRenderer.prototype.isFullScreen = function() {
     if (electron) {
       return electron.remote.getCurrentWindow().isFullScreen();
     }
-    return window.screen.height === window.innerHeight;
+    return false; // Unsupported
   }
 
 /**

--- a/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
+++ b/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
@@ -50,6 +50,17 @@ gdjs.RuntimeGameCocosRenderer.prototype.setFullScreen = function(enable) {
 };
 
 /**
+ * Checks if the game is in full screen.
+ */
+gdjs.RuntimeGamePixiRenderer.prototype.isFullScreen = function() {
+    var electron = this.getElectron();
+    if (electron) {
+      return electron.remote.getCurrentWindow().isFullScreen();
+    }
+    return window.screen.height === window.innerHeight;
+  }
+
+/**
  * Update the window size, if possible.
  * @param {number} width The new width, in pixels.
  * @param {number} height The new height, in pixels.

--- a/GDJS/Runtime/events-tools/windowtools.js
+++ b/GDJS/Runtime/events-tools/windowtools.js
@@ -22,6 +22,13 @@ gdjs.evtTools.window.setFullScreen = function(runtimeScene, enable, keepAspectRa
     runtimeScene.getGame().getRenderer().setFullScreen(enable);
 };
 
+gdjs.evtTools.window.isFullScreen = function() {
+	if (typeof require === "function") {
+		return require("electron").remote.getCurrentWindow().isFullScreen();
+	}
+	return document.fullscreenElement !== null;
+};
+
 gdjs.evtTools.window.setWindowSize = function(runtimeScene, width, height, updateGameResolution) {
 	runtimeScene.getGame().getRenderer().setWindowSize(width, height);
 	if (updateGameResolution) {

--- a/GDJS/Runtime/events-tools/windowtools.js
+++ b/GDJS/Runtime/events-tools/windowtools.js
@@ -26,7 +26,7 @@ gdjs.evtTools.window.isFullScreen = function() {
 	if (typeof require === "function") {
 		return require("electron").remote.getCurrentWindow().isFullScreen();
 	}
-	return document.fullscreenElement !== null;
+	return window.screen.height === window.innerHeight;
 };
 
 gdjs.evtTools.window.setWindowSize = function(runtimeScene, width, height, updateGameResolution) {

--- a/GDJS/Runtime/events-tools/windowtools.js
+++ b/GDJS/Runtime/events-tools/windowtools.js
@@ -22,11 +22,8 @@ gdjs.evtTools.window.setFullScreen = function(runtimeScene, enable, keepAspectRa
     runtimeScene.getGame().getRenderer().setFullScreen(enable);
 };
 
-gdjs.evtTools.window.isFullScreen = function() {
-	if (typeof require === "function") {
-		return require("electron").remote.getCurrentWindow().isFullScreen();
-	}
-	return window.screen.height === window.innerHeight;
+gdjs.evtTools.window.isFullScreen = function(runtimeScene) {
+	return runtimeScene.getGame().getRenderer().isFullScreen();
 };
 
 gdjs.evtTools.window.setWindowSize = function(runtimeScene, width, height, updateGameResolution) {

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
@@ -264,7 +264,7 @@ gdjs.RuntimeGamePixiRenderer.prototype.isFullScreen = function() {
   if (electron) {
     return electron.remote.getCurrentWindow().isFullScreen();
   }
-  // Height check is used to detect F11 triggered full screen.
+  // Height check is used to detect user triggered full screen (for example F11 shortcut).
   return this._isFullscreen || window.screen.height === window.innerHeight;
 }
 

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
@@ -257,6 +257,18 @@ gdjs.RuntimeGamePixiRenderer.prototype.setFullScreen = function(enable) {
 };
 
 /**
+ * Checks if the game is in full screen.
+ */
+gdjs.RuntimeGamePixiRenderer.prototype.isFullScreen = function() {
+  var electron = this.getElectron();
+  if (electron) {
+    return electron.remote.getCurrentWindow().isFullScreen();
+  }
+  // Height check is used to detect F11 triggered full screen.
+  return this._isFullscreen || window.screen.height === window.innerHeight;
+}
+
+/**
  * Add the standard events handler.
  */
 gdjs.RuntimeGamePixiRenderer.prototype.bindStandardEvents = function(


### PR DESCRIPTION
As requested by @Silver-Streak, a condition to check if the window is in fullscreen.
Uses a simple check `window.screen.height === window.innerHeight` for HTML5
Uses https://www.electronjs.org/docs/api/browser-window#winisfullscreen for electron

Tested on electron and browser.