### PR TITLE
Feature/rtl

### DIFF
--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -43,6 +43,7 @@
     "element-closest": "2.0.2",
     "firebase": "^6.1.0",
     "fontfaceobserver": "2.0.13",
+    "jss-rtl": "^0.3.0",
     "keen-tracking": "1.1.3",
     "lodash": "4.17.4",
     "node-require-function": "^1.2.0",

--- a/newIDE/app/src/MainFrame/Providers.js
+++ b/newIDE/app/src/MainFrame/Providers.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import DragAndDropContextProvider from '../UI/DragAndDrop/DragAndDropContextProvider';
 import { ThemeProvider } from '@material-ui/styles';
+import { StylesProvider, jssPreset } from '@material-ui/core/styles';
 import { getTheme } from '../UI/Theme';
 import UserProfileProvider from '../Profile/UserProfileProvider';
 import Authentification from '../Utils/GDevelopServices/Authentification';
@@ -25,6 +26,13 @@ import {
 import GDevelopThemeContext from '../UI/Theme/ThemeContext';
 import { UnsavedChangesContextProvider } from './UnsavedChangesContext';
 import { CommandsContextProvider } from '../CommandPalette/CommandsContext';
+import { create } from 'jss';
+import rtl from 'jss-rtl';
+
+// Add the rtl plugin to the JSS instance to support RTL languages in material-ui components.
+const jss = create({
+  plugins: [...jssPreset().plugins, rtl()],
+});
 
 type Props = {|
   authentification: Authentification,
@@ -58,11 +66,12 @@ export default class Providers extends React.Component<Props, {||}> {
           <PreferencesProvider disableCheckForUpdates={disableCheckForUpdates}>
             <PreferencesContext.Consumer>
               {({ values }) => {
-                const theme = getTheme(values.themeName);
+                const theme = getTheme({ themeName: values.themeName, language: values.language });
                 return (
                   <GDI18nProvider language={values.language}>
                     <GDevelopThemeContext.Provider value={theme.gdevelopTheme}>
-                      <ThemeProvider theme={theme.muiTheme}>
+                      <StylesProvider jss={jss}>
+                        <ThemeProvider theme={theme.muiTheme}>
                         <UserProfileProvider
                           authentification={authentification}
                         >
@@ -94,7 +103,8 @@ export default class Providers extends React.Component<Props, {||}> {
                             )}
                           </I18n>
                         </UserProfileProvider>
-                      </ThemeProvider>
+                        </ThemeProvider>
+                      </StylesProvider>
                     </GDevelopThemeContext.Provider>
                   </GDI18nProvider>
                 );

--- a/newIDE/app/src/UI/Theme/DarkTheme/index.js
+++ b/newIDE/app/src/UI/Theme/DarkTheme/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Theme } from '../DefaultTheme';
-import { createMuiTheme, darken, lighten } from '@material-ui/core/styles';
+import { darken, lighten } from '@material-ui/core/styles';
 import './Mosaic.css';
 import './EventsSheet.css';
 import 'react-virtualized/styles.css'; // Styles for react-virtualized Table
@@ -98,7 +98,7 @@ const gdevelopTheme = {
 };
 
 // Theme for Material-UI components
-const muiTheme = createMuiTheme({
+const muiThemeOptions = {
   typography: {
     fontFamily,
   },
@@ -225,11 +225,11 @@ const muiTheme = createMuiTheme({
       },
     },
   },
-});
+};
 
 const theme: Theme = {
   gdevelopTheme,
-  muiTheme,
+  muiThemeOptions,
 };
 
 export default theme;

--- a/newIDE/app/src/UI/Theme/DefaultTheme/index.js
+++ b/newIDE/app/src/UI/Theme/DefaultTheme/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { createMuiTheme, darken, lighten } from '@material-ui/core/styles';
+import { darken, lighten } from '@material-ui/core/styles';
 import './Mosaic.css';
 import './EventsSheet.css';
 import 'react-virtualized/styles.css'; // Styles for react-virtualized Table
@@ -93,7 +93,7 @@ const gdevelopTheme = {
 };
 
 // Theme for Material-UI components
-const muiTheme = createMuiTheme({
+const muiThemeOptions = {
   typography: {
     fontFamily,
   },
@@ -226,11 +226,12 @@ const muiTheme = createMuiTheme({
       },
     },
   },
-});
+};
 
 const theme = {
   gdevelopTheme,
-  muiTheme,
+  muiThemeOptions,
 };
 export type Theme = $Exact<typeof theme>;
+export const themeName = 'GDevelop default';
 export default theme;

--- a/newIDE/app/src/UI/Theme/NordTheme/index.js
+++ b/newIDE/app/src/UI/Theme/NordTheme/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Theme } from '../DefaultTheme';
-import { createMuiTheme, darken, lighten } from '@material-ui/core/styles';
+import { darken, lighten } from '@material-ui/core/styles';
 import './Mosaic.css';
 import './EventsSheet.css';
 import 'react-virtualized/styles.css'; // Styles for react-virtualized Table
@@ -99,7 +99,7 @@ const gdevelopTheme = {
 };
 
 // Theme for Material-UI components
-const muiTheme = createMuiTheme({
+const muiThemeOptions = {
   typography: {
     fontFamily,
   },
@@ -236,11 +236,11 @@ const muiTheme = createMuiTheme({
       },
     },
   },
-});
+};
 
 const theme: Theme = {
   gdevelopTheme,
-  muiTheme,
+  muiThemeOptions,
 };
 
 export default theme;

--- a/newIDE/app/src/UI/Theme/SolarizedDarkTheme/index.js
+++ b/newIDE/app/src/UI/Theme/SolarizedDarkTheme/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Theme } from '../DefaultTheme';
-import { createMuiTheme, darken, lighten } from '@material-ui/core/styles';
+import { darken, lighten } from '@material-ui/core/styles';
 import './Mosaic.css';
 import './EventsSheet.css';
 import 'react-virtualized/styles.css'; // Styles for react-virtualized Table
@@ -97,7 +97,7 @@ const gdevelopTheme = {
 };
 
 // Theme for Material-UI components
-const muiTheme = createMuiTheme({
+const muiThemeOptions = {
   typography: {
     fontFamily,
   },
@@ -220,11 +220,11 @@ const muiTheme = createMuiTheme({
       },
     },
   },
-});
+};
 
 const theme: Theme = {
   gdevelopTheme,
-  muiTheme,
+  muiThemeOptions,
 };
 
 export default theme;

--- a/newIDE/app/src/Utils/Memoize.js
+++ b/newIDE/app/src/Utils/Memoize.js
@@ -1,0 +1,21 @@
+// @flow
+
+export default function<Input, Output>(func: (Input) => Output): (Input) => Output {
+  const primitives = new Map();
+  const objects = new WeakMap();
+
+  function cacheFor(input: Input) {
+    const isObject = typeof input === 'object';
+    return isObject ? objects : primitives;
+  }
+
+  return (input: Input): Output => {
+    const cache = cacheFor(input);
+    const isCached = cache.has(input);
+    if (!isCached) {
+      cache.set(input, func(input));
+    }
+
+    return (cache.get(input): Output);
+  };
+}

--- a/newIDE/app/src/Utils/i18n/RtlLanguages.js
+++ b/newIDE/app/src/Utils/i18n/RtlLanguages.js
@@ -1,0 +1,18 @@
+// @flow
+
+const rtlLanguages = new Set([
+  /******* Hebrew scripts *******/
+  'he_IL'/* Hebrew */,
+  
+  /******* Arabic scripts *******/
+  'ar_SA'/* Arabic */,
+  'az_AZ'/* Azerbaijani */,
+  'ms_MY'/* Malay */,
+  'fa_IR'/* Persian */,
+  'ur_PK'/* Urdu */,
+]);
+
+export function isLtr(name: string): boolean {
+  return !rtlLanguages.has(name);
+}
+

--- a/newIDE/app/src/stories/ThemeDecorator.js
+++ b/newIDE/app/src/stories/ThemeDecorator.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import GDevelopThemeContext from '../UI/Theme/ThemeContext';
 import { ThemeProvider } from '@material-ui/styles';
-import defaultTheme from '../UI/Theme/DefaultTheme';
+import defaultTheme from '../UI/Theme';
 import { type StoryDecorator } from '@storybook/react';
 
 const themeDecorator: StoryDecorator = (story, context) => (


### PR DESCRIPTION
This solution is simpler - no more unneeded modules; `RtlLanguages` contains only those languages defined in `LocalesMetadata`.
Simply using `createMuiTheme()` with changed `muiTheme.direction` isn't working.
Using `rtlOverrides` gets the job done and doesn't pollute, while ensuring proper render-time styling.