### PR TITLE
Add the expression description to the ExpressionParametersEditorDialog

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import FlatButton from '../../../UI/FlatButton';
 import ExpressionParametersEditor from './ExpressionParametersEditor';
 import Dialog from '../../../UI/Dialog';
+import Text from '../../../UI/Text';
 import { Column } from '../../../UI/Grid';
 
 export type ParameterValues = Array<string>;
@@ -59,11 +60,7 @@ export default class ExpressionParametersEditorDialog extends Component<
 
     return (
       <Dialog
-        title={<>
-          <Trans>Enter the expression parameters</Trans>
-          <br/>
-          <p style={{fontSize: "18px", marginTop: "-3px"}}>{expressionMetadata.getDescription()}</p>
-        </>}
+        title={<Trans>Enter the expression parameters</Trans>}
         cannotBeDismissed={true}
         open
         actions={
@@ -79,6 +76,7 @@ export default class ExpressionParametersEditorDialog extends Component<
       >
         <Column>
           <div style={styles.minHeightContainer}>
+            <Text>{expressionMetadata.getDescription()}</Text>
             <ExpressionParametersEditor
               project={project}
               scope={scope}

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
@@ -59,7 +59,11 @@ export default class ExpressionParametersEditorDialog extends Component<
 
     return (
       <Dialog
-        title={<Trans>Enter the expression parameters</Trans>}
+        title={<>
+          <Trans>Enter the expression parameters</Trans>
+          <br/>
+          <p style={{fontSize: "18px", marginTop: "-3px"}}>{expressionMetadata.getDescription()}</p>
+        </>}
         cannotBeDismissed={true}
         open
         actions={


### PR DESCRIPTION
Fixes #2003 

Adds the description of the expression to the dialogue to choose it's parameters.  
![image](https://user-images.githubusercontent.com/19349038/95090816-00e39a80-0726-11eb-9bc8-89da9261023b.png)
![image](https://user-images.githubusercontent.com/19349038/95090844-09d46c00-0726-11eb-8164-ff5e76b76a6e.png)
