### PR TITLE
Issue #1533:  Format optional parameters with defaults

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.js
@@ -20,6 +20,40 @@ const filterOutCodeOnlyParameters = (
   });
 };
 
+const filterVisibleParameters = (
+  array: Array<string>,
+  expressionMetadata: gdExpressionMetadata | gdInstructionMetadata,
+  firstParameterIndex: number
+) => {
+  let lastRequiredIndex = -1;
+  let lastProvidedIndex = -1;
+
+  const arrayWithDefaults = array.map((parameter, index) => {
+    const metadata = expressionMetadata.getParameter(index);
+
+    if (!metadata.isOptional()) {
+      lastRequiredIndex = index;
+    }
+
+    if (parameter.length > 0) {
+      lastProvidedIndex = index;
+      return parameter;
+    } else {
+      // Fill default values for intermediate parameters so that the user doesn't have to.
+      return metadata.getDefaultValue();
+    }
+  });
+
+  const lastParameterIndex = Math.max(lastRequiredIndex, lastProvidedIndex, 0);
+
+  return arrayWithDefaults.filter(
+    (parameter, index) =>
+      firstParameterIndex <= index &&
+      index <= lastParameterIndex &&
+      !expressionMetadata.getParameter(index).isCodeOnly()
+  );
+};
+
 export const getVisibleParameterTypes = (
   expressionMetadata: EnumeratedInstructionOrExpressionMetadata
 ): Array<string> => {
@@ -58,7 +92,7 @@ export const formatExpressionCall = (
   if (expressionInfo.scope.objectMetadata) {
     const objectName = parameterValues[0];
 
-    const functionArgs = filterOutCodeOnlyParameters(
+    const functionArgs = filterVisibleParameters(
       parameterValues,
       expressionInfo.metadata,
       1
@@ -68,14 +102,14 @@ export const formatExpressionCall = (
     const objectName = parameterValues[0];
     const behaviorName = parameterValues[1];
 
-    const functionArgs = filterOutCodeOnlyParameters(
+    const functionArgs = filterVisibleParameters(
       parameterValues,
       expressionInfo.metadata,
       2
     ).join(', ');
     return `${objectName}.${behaviorName}::${functionName}(${functionArgs})`;
   } else {
-    const functionArgs = filterOutCodeOnlyParameters(
+    const functionArgs = filterVisibleParameters(
       parameterValues,
       expressionInfo.metadata,
       0

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.spec.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.spec.js
@@ -11,7 +11,7 @@ import {
 } from '../../../InstructionOrExpression/EnumerateExpressions';
 
 describe('FormatExpressionCall', () => {
-  it('properly format a free function, with one or more arguments', () => {
+  it('properly formats a free function, with one or more arguments', () => {
     const freeExpressions = enumerateFreeExpressions('number');
     const countExpression = filterExpressions(freeExpressions, 'Count')[0];
     expect(formatExpressionCall(countExpression, ['MyObject'])).toBe(
@@ -24,7 +24,7 @@ describe('FormatExpressionCall', () => {
     );
   });
 
-  it('properly format a free function, with "code-only" parameters', () => {
+  it('properly formats a free function, with "code-only" parameters', () => {
     const freeExpressions = enumerateFreeExpressions('number');
     const cameraHeightExpression = filterExpressions(
       freeExpressions,
@@ -35,7 +35,7 @@ describe('FormatExpressionCall', () => {
     ).toBe('CameraHeight("My layer", 0)');
   });
 
-  it('properly format a free function, with "code-only" and optional parameters', () => {
+  it('properly formats a free function, with "code-only" and optional parameters', () => {
     const freeExpressions = enumerateFreeExpressions('number');
     const touchExpression = filterExpressions(freeExpressions, 'TouchX')[0];
     expect(formatExpressionCall(touchExpression, ['', '1'])).toBe('TouchX(1)');
@@ -50,7 +50,7 @@ describe('FormatExpressionCall', () => {
     );
   });
 
-  it('properly format an object function', () => {
+  it('properly formats an object function', () => {
     const objectsExpressions = enumerateObjectExpressions('number', 'Sprite');
     const variableStringExpression = filterExpressions(
       objectsExpressions,
@@ -62,7 +62,7 @@ describe('FormatExpressionCall', () => {
     ).toBe('MyObject.Variable(Variable1)');
   });
 
-  it('properly format an object function with an argument', () => {
+  it('properly formats an object function with an argument', () => {
     const objectsExpressions = enumerateObjectExpressions('number', 'Sprite');
     const pointXExpression = filterExpressions(objectsExpressions, 'PointX')[0];
     expect(pointXExpression).not.toBeUndefined();
@@ -71,7 +71,7 @@ describe('FormatExpressionCall', () => {
     ).toBe('MyObject.PointX("MyPoint")');
   });
 
-  it('properly format an object behavior function', () => {
+  it('properly formats an object behavior function', () => {
     const behaviorsExpressions = enumerateBehaviorExpressions(
       'number',
       'PlatformBehavior::PlatformerObjectBehavior'
@@ -89,7 +89,7 @@ describe('FormatExpressionCall', () => {
     ).toBe('MyObject.PlatformerObject::JumpSpeed()');
   });
 
-  it('can returns the visible parameters of a function', () => {
+  it('can return the visible parameters of a function', () => {
     const objectsExpressions = enumerateObjectExpressions('number', 'Sprite');
     const pointXExpression = filterExpressions(objectsExpressions, 'PointX')[0];
     expect(pointXExpression).not.toBeUndefined();

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.spec.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.spec.js
@@ -35,6 +35,21 @@ describe('FormatExpressionCall', () => {
     ).toBe('CameraHeight("My layer", 0)');
   });
 
+  it('properly format a free function, with "code-only" and optional parameters', () => {
+    const freeExpressions = enumerateFreeExpressions('number');
+    const touchExpression = filterExpressions(freeExpressions, 'TouchX')[0];
+    expect(formatExpressionCall(touchExpression, ['', '1'])).toBe('TouchX(1)');
+    expect(formatExpressionCall(touchExpression, ['', '1', '"My layer"'])).toBe(
+      'TouchX(1, "My layer")'
+    );
+    expect(formatExpressionCall(touchExpression, ['', '1', '', ''])).toBe(
+      'TouchX(1)'
+    );
+    expect(formatExpressionCall(touchExpression, ['', '1', '', '2'])).toBe(
+      'TouchX(1, "", 2)'
+    );
+  });
+
   it('properly format an object function', () => {
     const objectsExpressions = enumerateObjectExpressions('number', 'Sprite');
     const variableStringExpression = filterExpressions(

--- a/newIDE/electron-app/app/package-lock.json
+++ b/newIDE/electron-app/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gdevelop",
-  "version": "5.0.0-beta99",
+  "version": "5.0.0-beta100",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -447,17 +447,19 @@
       "version": "github:discordjs/rpc#707b744b6662a97c9016709556d625860df14121",
       "from": "github:discordjs/rpc",
       "requires": {
-        "node-fetch": "2.6.0",
-        "ws": "7.1.2"
+        "node-fetch": "^2.6.1",
+        "ws": "^7.3.1"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
         "ws": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-          "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
-          "requires": {
-            "async-limiter": "^1.0.0"
-          }
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
         }
       }
     },
@@ -1797,11 +1799,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
-    "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-path": {
       "version": "2.1.1",


### PR DESCRIPTION
**Issue link:** https://github.com/4ian/GDevelop/issues/1533

## What was changed
This change makes expression call formatting more user-friendly by removing some situations where the formatted expression would be invalid due to empty optional parameters. These cases are covered in the new test:

1. All optional params are left blank: the user does not need to worry about the extra params on the end, so the end of the list is truncated.
2. The first N optional params are filled: only these N params are formatted. Any params after N are truncated.
3. Parameter M is blank, but M + 1 is filled: params are positional, so we need to fill M with something. We fill in the default value, as that's what the user intended.

There were also some up some English grammar mistakes FormatExpressionCall test cases that I corrected.

## IDE Demo 
Case 2
![gdev-case2](https://user-images.githubusercontent.com/2236777/95694733-6f25d280-0be8-11eb-94be-42e1c7bb9571.gif)

Case 3
![gdev-case3](https://user-images.githubusercontent.com/2236777/95694738-764ce080-0be8-11eb-89ce-e36b69b7ab4e.gif)

## Implementation
~~I changed the existing "code-only" function from using Array `filter` to using a `slice`. The filter implementation had the potential problem of removing a parameter from the middle of the array, which would be wrong because parameters are identified by position. I think the slice makes it clear we always want a contiguous piece of the parameters.~~

After discussion it's clear that filtering code-only parameters is more consistent with code generation.