### PR TITLE
Fix grid snap bug by clearing alt + meta keyboard state on blur

### DIFF
--- a/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
@@ -230,6 +230,11 @@ export default class DeprecatedKeyboardShortcuts {
 
   blur() {
     this.isFocused = false;
+
+    // Clear these keys on blur to handle the case where app switching via
+    // Cmd+Tab, Win+Tab, or Alt+Tab prevents us from capturing the "keyup" event.
+    this.metaPressed = false;
+    this.altPressed = false;
   }
 
   mount() {


### PR DESCRIPTION
## What was changed
This change fixes a minor bug that has bugged me for a while: changing apps Alt+Tab on Windows breaks snap-to-grid in the scene editor until you tap Alt again.

I considered filing an issue, but I had a feeling there would be a quick fix :)

## Steps to reproduce:
1. Turn on the grid in the scene editor and ensure objects snap when they are dragged.
2. Alt+Tab to another application.
3. Alt+Tab (or click) back into GD, but do not hold Alt.
4. Drag an object.

Issue: the object will move freely as if Alt were held

## Demos
**Before**
https://gfycat.com/requiredacidicherculesbeetle

**After**
https://gfycat.com/poshweepygalapagoshawk

## Implementation
I made this change to the "deprecated" keyboard shortcuts because I tracked down that the relevant method was `shouldNotSnapToGrid` called by the `InstanceEditor`. There does not seem to be an equivalent method in the other (new?) keyboard shortcuts.

In addition to Alt, I also have the "meta" key reset. This key is also getting stuck in a pressed state on app switching, though I don't think that causes any bugs at the moment.