### PR TITLE
JsCodeEvent: Adjust padding and width to fit CodeEditor scroll bar

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -29,6 +29,8 @@ const styles = {
     fontSize: '12px',
     paddingLeft: 5,
     paddingRight: 5,
+    paddingTop: 2,
+    paddingBottom: 2,
     margin: 0,
     backgroundColor: '#1e1e1e',
     color: '#d4d4d4',
@@ -204,7 +206,7 @@ export default class JsCodeEvent extends React.Component<
             <CodeEditor
               value={jsCodeEvent.getInlineCode()}
               onChange={this.onChange}
-              width={contentRect.bounds.width}
+              width={contentRect.bounds.width - 5}
               onEditorMounted={() => this.props.onUpdate()}
             />
             {functionEnd}


### PR DESCRIPTION
## What was changed
This change fixes some padding problems that I noticed while working on my [expandable code editor](https://github.com/ssangervasi/GDevelop/commit/de33b55b44668e203490d672afec8713c9c7d3ad) change:
 - The text of the the "functionStart/End" lines gets cut off slightly
 - A scroll bar appears for these lines even though they should fit exactly.
 - The Monaco component pushes its scroll bar off the right a few pixels.

Platform: Windows. I should be able to check this on Linux soon as well.

## Demo
**Before**
![gdevelop_code_editor_before](https://user-images.githubusercontent.com/2236777/96198655-4bc19700-0f0a-11eb-9ff6-b44dfc872221.png)

**After**
![gdevelop_code_editor_after](https://user-images.githubusercontent.com/2236777/96198675-5a0fb300-0f0a-11eb-8e1c-a7b97376cfba.png)

