### PR TITLE
Allow CodeEditor to be expanded to view more lines within a JsCodeEvent 

### DIFF
--- a/newIDE/app/src/CodeEditor/index.js
+++ b/newIDE/app/src/CodeEditor/index.js
@@ -16,7 +16,8 @@ export type State = {|
 export type Props = {|
   value: string,
   onChange: string => void,
-  width: number,
+  width?: number,
+  height?: number,
   onEditorMounted?: () => void,
 |};
 
@@ -136,7 +137,7 @@ export class CodeEditor extends React.Component<Props, State> {
           {({ values }) => (
             <MonacoEditor
               width={this.props.width || 600}
-              height="400"
+              height={this.props.height || 200}
               language="javascript"
               theme={values.codeEditorThemeName}
               value={this.props.value}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/EventRenderer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/EventRenderer.js
@@ -43,4 +43,5 @@ export type EventRendererProps = {
 
   screenType: ScreenType,
   windowWidth: WidthType,
+  eventsSheetHeight: number,
 };

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -2,6 +2,9 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import Button from '@material-ui/core/Button';
 import InlinePopover from '../../InlinePopover';
 import ObjectField from '../../ParameterFields/ObjectField';
 import {
@@ -45,11 +48,15 @@ const styles = {
     color: '#777',
     textDecoration: 'underline',
   },
+  expandIcon: {
+    color: '#d4d4d4',
+  },
 };
 
 type State = {|
   editing: boolean,
   editingObject: boolean,
+  expanded: boolean,
   anchorEl: ?any,
 |};
 
@@ -61,6 +68,7 @@ export default class JsCodeEvent extends React.Component<
   state = {
     editing: false,
     editingObject: false,
+    expanded: false,
     anchorEl: null,
   };
 
@@ -133,6 +141,12 @@ export default class JsCodeEvent extends React.Component<
     });
   };
 
+  toggleExpanded = () => {
+    this.setState({
+      expanded: !this.state.expanded,
+    });
+  };
+
   render() {
     const jsCodeEvent = gd.asJsCodeEvent(this.props.event);
     const parameterObjects = jsCodeEvent.getParameterObjects();
@@ -191,6 +205,16 @@ export default class JsCodeEvent extends React.Component<
       </p>
     );
 
+    const expandIcon = (
+      <div style={styles.expandIcon}>
+        {this.state.expanded ? (
+          <ExpandLess fontSize="small" color="inherit" />
+        ) : (
+          <ExpandMore fontSize="small" color="inherit" />
+        )}
+      </div>
+    );
+
     return (
       <Measure bounds>
         {({ measureRef, contentRect }) => (
@@ -207,9 +231,13 @@ export default class JsCodeEvent extends React.Component<
               value={jsCodeEvent.getInlineCode()}
               onChange={this.onChange}
               width={contentRect.bounds.width - 5}
+              height={this.state.expanded ? 1000 : 200}
               onEditorMounted={() => this.props.onUpdate()}
             />
             {functionEnd}
+            <Button onClick={this.toggleExpanded} fullWidth size="small">
+              {expandIcon}
+            </Button>
             <InlinePopover
               open={this.state.editingObject}
               anchorEl={this.state.anchorEl}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -19,6 +19,8 @@ import { CodeEditor } from '../../../CodeEditor';
 const gd: libGDevelop = global.gd;
 
 const fontFamily = '"Lucida Console", Monaco, monospace';
+const MINIMUM_EDITOR_HEIGHT = 200;
+const EDITOR_PADDING = 100;
 
 const styles = {
   container: {
@@ -147,6 +149,17 @@ export default class JsCodeEvent extends React.Component<
     });
   };
 
+  _codeEditorHeight = () => {
+    // Always use the minimum height when collapsed.
+    if (!this.state.expanded) {
+      return MINIMUM_EDITOR_HEIGHT;
+    }
+
+    // Shrink the editor enough for the additional event elements to fit in the sheet space.
+    const heightToFillSheet = this.props.eventsSheetHeight - EDITOR_PADDING;
+    return Math.max(MINIMUM_EDITOR_HEIGHT, heightToFillSheet);
+  };
+
   render() {
     const jsCodeEvent = gd.asJsCodeEvent(this.props.event);
     const parameterObjects = jsCodeEvent.getParameterObjects();
@@ -231,7 +244,7 @@ export default class JsCodeEvent extends React.Component<
               value={jsCodeEvent.getInlineCode()}
               onChange={this.onChange}
               width={contentRect.bounds.width - 5}
-              height={this.state.expanded ? 1000 : 200}
+              height={this._codeEditorHeight()}
               onEditorMounted={() => this.props.onUpdate()}
             />
             {functionEnd}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -149,7 +149,7 @@ export default class JsCodeEvent extends React.Component<
     });
   };
 
-  _codeEditorHeight = () => {
+  _getCodeEditorHeight = () => {
     // Always use the minimum height when collapsed.
     if (!this.state.expanded) {
       return MINIMUM_EDITOR_HEIGHT;
@@ -244,7 +244,7 @@ export default class JsCodeEvent extends React.Component<
               value={jsCodeEvent.getInlineCode()}
               onChange={this.onChange}
               width={contentRect.bounds.width - 5}
-              height={this._codeEditorHeight()}
+              height={this._getCodeEditorHeight()}
               onEditorMounted={() => this.props.onUpdate()}
             />
             {functionEnd}

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -90,6 +90,7 @@ type EventsContainerProps = {|
 
   screenType: ScreenType,
   windowWidth: WidthType,
+  eventsSheetHeight: number,
 |};
 
 /**
@@ -157,6 +158,7 @@ class EventContainer extends Component<EventsContainerProps, {||}> {
             renderObjectThumbnail={this.props.renderObjectThumbnail}
             screenType={this.props.screenType}
             windowWidth={this.props.windowWidth}
+            eventsSheetHeight={this.props.eventsSheetHeight}
           />
         )}
       </div>
@@ -222,6 +224,7 @@ type EventsTreeProps = {|
 
   screenType: ScreenType,
   windowWidth: WidthType,
+  eventsSheetHeight: number,
 |};
 
 // A node displayed by the SortableTree. Almost always represents an
@@ -525,6 +528,7 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
         renderObjectThumbnail={this._renderObjectThumbnail}
         screenType={this.props.screenType}
         windowWidth={this.props.windowWidth}
+        eventsSheetHeight={this.props.eventsSheetHeight}
       />
     );
   };

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -1079,6 +1079,11 @@ export default class EventsSheet extends React.Component<Props, State> {
                           }
                           screenType={screenType}
                           windowWidth={windowWidth}
+                          eventsSheetHeight={
+                            this._containerDiv.current
+                              ? this._containerDiv.current.clientHeight
+                              : 0
+                          }
                         />
                         {this.state.showSearchPanel && (
                           <SearchPanel

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -2720,6 +2720,7 @@ storiesOf('EventsTree', module)
             showObjectThumbnails={true}
             screenType={'normal'}
             windowWidth={'medium'}
+            eventsSheetHeight={500}
           />
         </FixedHeightFlexContainer>
       </div>
@@ -2758,6 +2759,7 @@ storiesOf('EventsTree', module)
             showObjectThumbnails={true}
             screenType={'normal'}
             windowWidth={'small'}
+            eventsSheetHeight={500}
           />
         </FixedHeightFlexContainer>
       </div>
@@ -2796,6 +2798,7 @@ storiesOf('EventsTree', module)
             showObjectThumbnails={true}
             screenType={'normal'}
             windowWidth={'small'}
+            eventsSheetHeight={500}
           />
         </FixedHeightFlexContainer>
       </div>


### PR DESCRIPTION
## What was changed
This PR adds an expand/collapse button to the bottom of the JsCodeEvent which toggles the height of the CodeEditor between 200px (current size) and 1000px (~50 lines of code). This provides a more ergonomic editing space when you need it, while still taking up minimal space by default.

## Demo
![gdevelop_expand_code_editor](https://user-images.githubusercontent.com/2236777/96198722-757abe00-0f0a-11eb-81dd-ec6e27b6f4bb.gif)

## Style questions
I haven't added styles to this code base before, so I expect there is a different preferred way of styling this button and its icon. MUI overrides seemed like to much for a single button, but changing the icon color via `inherit` feels a bit hacky. Note that the color was chosen to match the grey functionStart/End text.

## Alternatives tried
I went looking for a way to solve the problem of only being able to see 10 lines of code at once. I landed on this expand/collapse after trying a few other approaches:

1. Making the editor bigger permanently - This was tempting, but I don't think there's a single height that shows enough lines without overly inflating the height of the events sheet, especially on smaller screens.
2. Auto-resizing the content to fit the code - I got this to work, but it had a few problems:
  a. Monaco requires a fixed height, so resize had to be done via props. As a result, this meant counting the lines of code in the `onChange` callback, storing that in state, and triggering a re-render. This was especially bad because we'd also need to call `onUpdate` to let the parent know that it _also_ has to resize.
  b. You would still probably want a way of collapsing the code so you wouldn't have to scroll past your 100 line block of code all the time.
3. Custom sizing with a drag handle - This might be worth doing eventually, but it also has problems:
  a. Sticking `resize` on the element sort of makes this work, but it's ugly and it takes hacks to make the handle look better.
  b. Alternatively, Mosaic seems like overkill for resizing a single rectangle.
  c. This might end up being annoying b/c you'd have to drag every time when really you probably just want the code big or small.