### PR TITLE
Add string selector as function parameter type

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -25,6 +25,7 @@ import {
 } from '../../EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers';
 import { getParametersIndexOffset } from '../../EventsFunctionsExtensionsLoader';
 import Add from '@material-ui/icons/Add';
+import Delete from '@material-ui/icons/Delete';
 import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
 import { ColumnStackLayout, ResponsiveLineStackLayout } from '../../UI/Layout';
 import { getLastObjectParameterObjectType } from '../../EventsSheet/ParameterFields/ParameterMetadataTools';
@@ -363,59 +364,63 @@ export default class EventsFunctionParametersEditor extends React.Component<
                               />
                             )}
                           </ResponsiveLineStackLayout>
-                          <ResponsiveLineStackLayout>
-                            {parameter.getType() === 'stringWithSelector' && (
-                              <Column justifyContent="flex-end" expand>
-                                {parseJSONArray(
-                                  parameter.getExtraInfo(),
-                                  array =>
-                                    array.map((item, index) => (
-                                      <Line
-                                        key={index}
-                                        justifyContent="flex-end"
-                                        expand
-                                        marginSize="5px"
-                                      >
-                                        <SemiControlledTextField
-                                          commitOnBlur
-                                          value={item}
-                                          onChange={text => {
-                                            array[index] = text;
-                                            parameter.setExtraInfo(
-                                              JSON.stringify(array)
-                                            );
-                                            this.forceUpdate();
-                                          }}
-                                          fullWidth
-                                        />
-                                      </Line>
-                                    ))
-                                )}
-
-                                <Line justifyContent="flex-end" expand>
-                                  <RaisedButton
-                                    primary
-                                    onClick={() => {
-                                      parseJSONArray(
-                                        parameter.getExtraInfo(),
-                                        array => {
-                                          array.push('New String');
+                          {parameter.getType() === 'stringWithSelector' &&
+                            parseJSONArray(parameter.getExtraInfo(), array => (
+                              <ResponsiveLineStackLayout>
+                                <Column justifyContent="flex-end" expand>
+                                  {array.map((item, index) => (
+                                    <Line
+                                      key={index}
+                                      justifyContent="flex-end"
+                                      expand
+                                      marginSize="5px"
+                                    >
+                                      <SemiControlledTextField
+                                        commitOnBlur
+                                        value={item}
+                                        onChange={text => {
+                                          array[index] = text;
                                           parameter.setExtraInfo(
                                             JSON.stringify(array)
                                           );
-                                        }
-                                      );
-                                      this.forceUpdate();
-                                    }}
-                                    label={
-                                      <Trans>Add a string to the list</Trans>
-                                    }
-                                    icon={<Add />}
-                                  />
-                                </Line>
-                              </Column>
-                            )}
-                          </ResponsiveLineStackLayout>
+                                          this.forceUpdate();
+                                        }}
+                                        fullWidth
+                                      />
+                                      <IconButton
+                                        tooltip={t`Delete`}
+                                        onClick={() => {
+                                          array.splice(index, 1);
+                                          parameter.setExtraInfo(
+                                            JSON.stringify(array)
+                                          );
+                                          this.forceUpdate();
+                                        }}
+                                      >
+                                        <Delete />
+                                      </IconButton>
+                                    </Line>
+                                  ))}
+
+                                  <Line justifyContent="flex-end" expand>
+                                    <RaisedButton
+                                      primary
+                                      onClick={() => {
+                                        array.push('New String');
+                                        parameter.setExtraInfo(
+                                          JSON.stringify(array)
+                                        );
+                                        this.forceUpdate();
+                                      }}
+                                      label={
+                                        <Trans>Add a string to the list</Trans>
+                                      }
+                                      icon={<Add />}
+                                    />
+                                  </Line>
+                                </Column>
+                              </ResponsiveLineStackLayout>
+                            ))}
                           {isParameterDescriptionAndTypeShown(i) && (
                             <SemiControlledTextField
                               commitOnBlur

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -53,17 +53,6 @@ const styles = {
   },
 };
 
-const parseJSONArray = (json, callback) => {
-  let array;
-  try {
-    array = JSON.parse(json);
-    if (!Array.isArray(array)) array = [];
-  } catch (e) {
-    array = [];
-  }
-  return callback(array);
-};
-
 const validateParameterName = (i18n: I18nType, newName: string) => {
   if (!newName) {
     showWarningBox(

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -17,6 +17,7 @@ import HelpButton from '../../UI/HelpButton';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';
 import { showWarningBox } from '../../UI/Messages/MessageBox';
+import { List, ListItem } from '../../UI/List';
 import ObjectTypeSelector from '../../ObjectTypeSelector';
 import BehaviorTypeSelector from '../../BehaviorTypeSelector';
 import {
@@ -48,6 +49,17 @@ const styles = {
   parametersContainer: {
     flex: 1,
   },
+};
+
+const parseJSONArray = (json, callback) => {
+  let array;
+  try {
+    array = JSON.parse(json);
+    if (!Array.isArray(array)) array = [];
+  } catch (e) {
+    array = [];
+  }
+  return callback(array);
 };
 
 const validateParameterName = (i18n: I18nType, newName: string) => {
@@ -296,6 +308,10 @@ export default class EventsFunctionParametersEditor extends React.Component<
                                   primaryText={t`String (text)`}
                                 />
                                 <SelectOption
+                                  value="stringWithSelector"
+                                  primaryText={t`String from a list of strings (text)`}
+                                />
+                                <SelectOption
                                   value="key"
                                   primaryText={t`Keyboard Key (text)`}
                                 />
@@ -346,6 +362,62 @@ export default class EventsFunctionParametersEditor extends React.Component<
                                 }}
                                 disabled={isParameterDisabled(i)}
                               />
+                            )}
+                          </ResponsiveLineStackLayout>
+                          <ResponsiveLineStackLayout>
+                            {parameter.getType() === 'stringWithSelector' && (
+                              <Column>
+                                <Line>
+                                  <List>
+                                    {parseJSONArray(
+                                      parameter.getExtraInfo(),
+                                      array =>
+                                        array.map((item, index) => (
+                                          <ListItem key={index}>
+                                            <SemiControlledTextField
+                                              commitOnBlur
+                                              floatingLabelText={
+                                                <Trans>Label</Trans>
+                                              }
+                                              floatingLabelFixed
+                                              value={item}
+                                              onChange={text => {
+                                                array[index] = text;
+                                                parameter.setExtraInfo(
+                                                  JSON.stringify(array)
+                                                );
+                                                this.forceUpdate();
+                                              }}
+                                              fullWidth
+                                            />
+                                          </ListItem>
+                                        ))
+                                    )}
+                                  </List>
+                                </Line>
+
+                                <Line justifyContent="flex-end" expand>
+                                  <RaisedButton
+                                    primary
+                                    onClick={() => {
+                                      parseJSONArray(
+                                        parameter.getExtraInfo(),
+                                        array => {
+                                          array.push('New String');
+                                          parameter.setExtraInfo(
+                                            JSON.stringify(array)
+                                          );
+                                        }
+                                      );
+                                      this.forceUpdate();
+                                    }}
+                                    label={
+                                      <Trans>Add a string to the list</Trans>
+                                    }
+                                    icon={<Add />}
+                                  />
+                                </Line>
+                              </Column>
                             )}
                           </ResponsiveLineStackLayout>
                           {isParameterDescriptionAndTypeShown(i) && (

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -17,7 +17,6 @@ import HelpButton from '../../UI/HelpButton';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';
 import { showWarningBox } from '../../UI/Messages/MessageBox';
-import { List } from '../../UI/List';
 import ObjectTypeSelector from '../../ObjectTypeSelector';
 import BehaviorTypeSelector from '../../BehaviorTypeSelector';
 import {

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -76,7 +76,7 @@ const validateParameterName = (i18n: I18nType, newName: string) => {
 
 type StringSelectorEditorProps = {|
   extraInfo: string,
-  setExtraInfo: newExtraInfo => void,
+  setExtraInfo: string => void,
 |};
 
 const StringSelectorEditor = ({
@@ -85,7 +85,8 @@ const StringSelectorEditor = ({
 }: StringSelectorEditorProps) => {
   let array = [];
   try {
-    array = JSON.parse(extraInfo);
+    if (extraInfo !== '') array = JSON.parse(extraInfo);
+    if (!Array.isArray(array)) array = [];
   } catch (e) {
     console.error('Cannot parse parameter extraInfo: ', e);
   }

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -17,7 +17,7 @@ import HelpButton from '../../UI/HelpButton';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';
 import { showWarningBox } from '../../UI/Messages/MessageBox';
-import { List, ListItem } from '../../UI/List';
+import { List } from '../../UI/List';
 import ObjectTypeSelector from '../../ObjectTypeSelector';
 import BehaviorTypeSelector from '../../BehaviorTypeSelector';
 import {
@@ -366,35 +366,32 @@ export default class EventsFunctionParametersEditor extends React.Component<
                           </ResponsiveLineStackLayout>
                           <ResponsiveLineStackLayout>
                             {parameter.getType() === 'stringWithSelector' && (
-                              <Column>
-                                <Line>
-                                  <List>
-                                    {parseJSONArray(
-                                      parameter.getExtraInfo(),
-                                      array =>
-                                        array.map((item, index) => (
-                                          <ListItem key={index}>
-                                            <SemiControlledTextField
-                                              commitOnBlur
-                                              floatingLabelText={
-                                                <Trans>Label</Trans>
-                                              }
-                                              floatingLabelFixed
-                                              value={item}
-                                              onChange={text => {
-                                                array[index] = text;
-                                                parameter.setExtraInfo(
-                                                  JSON.stringify(array)
-                                                );
-                                                this.forceUpdate();
-                                              }}
-                                              fullWidth
-                                            />
-                                          </ListItem>
-                                        ))
-                                    )}
-                                  </List>
-                                </Line>
+                              <Column justifyContent="flex-end" expand>
+                                {parseJSONArray(
+                                  parameter.getExtraInfo(),
+                                  array =>
+                                    array.map((item, index) => (
+                                      <Line
+                                        key={index}
+                                        justifyContent="flex-end"
+                                        expand
+                                        marginSize="5px"
+                                      >
+                                        <SemiControlledTextField
+                                          commitOnBlur
+                                          value={item}
+                                          onChange={text => {
+                                            array[index] = text;
+                                            parameter.setExtraInfo(
+                                              JSON.stringify(array)
+                                            );
+                                            this.forceUpdate();
+                                          }}
+                                          fullWidth
+                                        />
+                                      </Line>
+                                    ))
+                                )}
 
                                 <Line justifyContent="flex-end" expand>
                                   <RaisedButton

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -74,7 +74,7 @@ const validateParameterName = (i18n: I18nType, newName: string) => {
   return true;
 };
 
-type StrngSelectorEditorProps = {|
+type StringSelectorEditorProps = {|
   extraInfo: string,
   setExtraInfo: newExtraInfo => void,
 |};
@@ -82,29 +82,15 @@ type StrngSelectorEditorProps = {|
 const StringSelectorEditor = ({
   extraInfo,
   setExtraInfo,
-}: StrngSelectorEditorProps) => {
-  const [array, setArray] = React.useState([]);
-  const forceUpdate = useForceUpdate();
-  React.useEffect(
-    () => {
-      let parsedArray = null;
-      try {
-        parsedArray = JSON.parse(extraInfo);
-      } catch (e) {
-        console.warn('Cannot parse parameter extraInfo: ', e);
-      }
+}: StringSelectorEditorProps) => {
+  let array = [];
+  try {
+    array = JSON.parse(extraInfo);
+  } catch (e) {
+    console.error('Cannot parse parameter extraInfo: ', e);
+  }
 
-      if (parsedArray !== null) {
-        setArray(parsedArray);
-      }
-    },
-    [extraInfo, array]
-  );
-
-  const updateExtraInfo = () => {
-    setExtraInfo(JSON.stringify(array));
-    forceUpdate();
-  };
+  const updateExtraInfo = () => setExtraInfo(JSON.stringify(array));
 
   return (
     <ResponsiveLineStackLayout>
@@ -121,7 +107,7 @@ const StringSelectorEditor = ({
               fullWidth
             />
             <IconButton
-              tooltip={t`Delete`}
+              tooltip={t`Delete option`}
               onClick={() => {
                 array.splice(index, 1);
                 updateExtraInfo();
@@ -136,10 +122,10 @@ const StringSelectorEditor = ({
           <RaisedButton
             primary
             onClick={() => {
-              array.push('New String');
+              array.push('New Option');
               updateExtraInfo();
             }}
-            label={<Trans>Add a string to the list</Trans>}
+            label={<Trans>Add a new option</Trans>}
             icon={<Add />}
           />
         </Line>
@@ -373,7 +359,7 @@ export default class EventsFunctionParametersEditor extends React.Component<
                                 />
                                 <SelectOption
                                   value="stringWithSelector"
-                                  primaryText={t`String from a list of strings (text)`}
+                                  primaryText={t`String from a list of options (text)`}
                                 />
                                 <SelectOption
                                   value="key"
@@ -431,7 +417,10 @@ export default class EventsFunctionParametersEditor extends React.Component<
                           {parameter.getType() === 'stringWithSelector' && (
                             <StringSelectorEditor
                               extraInfo={parameter.getExtraInfo()}
-                              setExtraInfo={parameter.setExtraInfo}
+                              setExtraInfo={newExtraInfo => {
+                                parameter.setExtraInfo(newExtraInfo);
+                                this.forceUpdate();
+                              }}
                             />
                           )}
                           {isParameterDescriptionAndTypeShown(i) && (

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -30,7 +30,6 @@ import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
 import { ColumnStackLayout, ResponsiveLineStackLayout } from '../../UI/Layout';
 import { getLastObjectParameterObjectType } from '../../EventsSheet/ParameterFields/ParameterMetadataTools';
 import useForceUpdate from '../../Utils/UseForceUpdate';
-import { string } from 'prop-types';
 
 const gd: libGDevelop = global.gd;
 


### PR DESCRIPTION
Fixes #1768

Adds a string selector type as possible parameters types to event function extensions.  
![image](https://user-images.githubusercontent.com/19349038/96455388-7323a700-121d-11eb-9666-f2cd92b7c16a.png)
![image](https://user-images.githubusercontent.com/19349038/96455442-859de080-121d-11eb-8abf-81463ea3bc0f.png)
