### PR TITLE
Rename Global color to Tint

### DIFF
--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -367,15 +367,15 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
 
   obj.AddAction(
          "ChangeColor",
-         _("Global color"),
-         _("Change the global color of an object. The default color is white."),
-         _("Change color of _PARAM0_ to _PARAM1_"),
+         _("Tint color"),
+         _("Change the tint of an object. The default color is white."),
+         _("Change tint of _PARAM0_ to _PARAM1_"),
          _("Effects"),
          "res/actions/color24.png",
          "res/actions/color.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("color", _("Color"));
+      .AddParameter("color", _("Tint"));
 
   obj.AddAction("ChangeBlendMode",
                 _("Blend mode"),

--- a/Extensions/PanelSpriteObject/Extension.cpp
+++ b/Extensions/PanelSpriteObject/Extension.cpp
@@ -66,15 +66,15 @@ void DeclarePanelSpriteObjectExtension(gd::PlatformExtension& extension) {
 
   obj.AddAction(
          "SetColor",
-         _("Global color"),
-         _("Change the global color of a Panel Sprite. The default color is white."),
-         _("Change color of _PARAM0_ to _PARAM1_"),
+         _("Tint color"),
+         _("Change the tint of a Panel Sprite. The default color is white."),
+         _("Change tint of _PARAM0_ to _PARAM1_"),
          _("Effects"),
          "res/actions/color24.png",
          "res/actions/color.png")
 
       .AddParameter("object", _("Object"), "PanelSprite")
-      .AddParameter("color", _("Color"));
+      .AddParameter("color", _("Tint"));
 
   obj.AddAction("Width",
                 _("Width"),

--- a/Extensions/TiledSpriteObject/Extension.cpp
+++ b/Extensions/TiledSpriteObject/Extension.cpp
@@ -62,15 +62,15 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
 
   obj.AddAction(
          "SetColor",
-         _("Global color"),
-         _("Change the global color of a Tiled Sprite. The default color is white."),
-         _("Change color of _PARAM0_ to _PARAM1_"),
+         _("Tint color"),
+         _("Change the tint of a Tiled Sprite. The default color is white."),
+         _("Change tint of _PARAM0_ to _PARAM1_"),
          _("Effects"),
          "res/actions/color24.png",
          "res/actions/color.png")
 
       .AddParameter("object", _("Object"), "TiledSprite")
-      .AddParameter("color", _("Color"));
+      .AddParameter("color", _("Tint"));
 
   obj.AddAction("Width",
                 _("Width"),


### PR DESCRIPTION
Because global color is false and misleading.

Tint word is used for said something colorize an object depending to another color (here color from the sprite).

Global color is in the most of other softwares an color reference used on multiple objects.

[Global color on illustrator.](https://helpx.adobe.com/fr/illustrator/how-to/global-color-swatch.html)
[Tint definition](https://www.larousse.fr/dictionnaires/francais/teinte/77010)