### PR TITLE
Inline parameter editor popover improvements

### DIFF
--- a/newIDE/app/package-lock.json
+++ b/newIDE/app/package-lock.json
@@ -2444,22 +2444,22 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.9.10",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.10.tgz",
-      "integrity": "sha512-CQuZU9Y10RkwSdxjn785kw2EPcXhv5GKauuVQufR9LlD37kjfn21Im1yvr6wsUzn81oLhEvVPz727UWC0gbqxg==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.0.tgz",
+      "integrity": "sha512-bYo9uIub8wGhZySHqLQ833zi4ZML+XCBE1XwJ8EuUVSpTWWG57Pm+YugQToJNFsEyiKFhPh8DPD0bgupz8n01g==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.9.10",
-        "@material-ui/system": "^4.9.10",
-        "@material-ui/types": "^5.0.1",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/styles": "^4.10.0",
+        "@material-ui/system": "^4.9.14",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.10.2",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
         "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "^1.16.1-lts",
+        "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0",
-        "react-transition-group": "^4.3.0"
+        "react-transition-group": "^4.4.0"
       },
       "dependencies": {
         "hoist-non-react-statics": {
@@ -2469,6 +2469,11 @@
           "requires": {
             "react-is": "^16.7.0"
           }
+        },
+        "popper.js": {
+          "version": "1.16.1-lts",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+          "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
         }
       }
     },
@@ -8613,9 +8618,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
         }
       }
     },
@@ -15238,9 +15243,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
         }
       }
     },
@@ -17569,7 +17574,8 @@
     "popper.js": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.28",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -31,7 +31,7 @@
     "@blueprintjs/core": "file:src/Utils/BlueprintJsPlaceholder",
     "@blueprintjs/icons": "file:src/Utils/BlueprintJsPlaceholder",
     "@lingui/react": "git://github.com/4ian/lingui-react.git#master",
-    "@material-ui/core": "4.9.10",
+    "@material-ui/core": "4.11.0",
     "@material-ui/icons": "4.9.1",
     "@material-ui/lab": "4.0.0-alpha.56",
     "algoliasearch": "3.33.0",

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -29,6 +29,7 @@ import {
 import { type WidthType } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
 import PreferencesContext from '../../MainFrame/Preferences/PreferencesContext';
 import { useLongTouch } from '../../Utils/UseLongTouch';
+import { shouldActivate, shouldValidate } from '../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -161,7 +162,7 @@ const Instruction = (props: Props) => {
                 }
               }}
               onKeyPress={event => {
-                if (event.key === 'Enter' || event.key === ' ') {
+                if (shouldActivate(event)) {
                   props.onParameterClick(event, parameterIndex);
                   event.stopPropagation();
                   event.preventDefault();
@@ -260,11 +261,11 @@ const Instruction = (props: Props) => {
             }}
             {...longTouchForContextMenuProps}
             onKeyPress={event => {
-              if (event.key === 'Enter') {
+              if (shouldValidate(event)) {
                 props.onDoubleClick();
                 event.stopPropagation();
                 event.preventDefault();
-              } else if (event.key === ' ') {
+              } else if (shouldActivate(event)) {
                 props.onClick();
                 event.stopPropagation();
                 event.preventDefault();

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -29,7 +29,10 @@ import {
 import { type WidthType } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
 import PreferencesContext from '../../MainFrame/Preferences/PreferencesContext';
 import { useLongTouch } from '../../Utils/UseLongTouch';
-import { shouldActivate, shouldValidate } from '../../UI/KeyboardShortcuts/InteractionKeys';
+import {
+  shouldActivate,
+  shouldValidate,
+} from '../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const styles = {

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -12,6 +12,7 @@ import {
   disabledText,
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
+import { shouldCloseOrCancel } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const commentTextStyle = {
@@ -142,7 +143,7 @@ export default class CommentEvent extends React.Component<
             fullWidth
             id="comment-title"
             onKeyUp={event => {
-              if (event.key === 'Escape') {
+              if (shouldCloseOrCancel(event)) {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -12,7 +12,10 @@ import {
   disabledText,
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
-import { shouldCloseOrCancel } from '../../../UI/KeyboardShortcuts/InteractionKeys';
+import {
+  shouldActivate,
+  shouldCloseOrCancel,
+} from '../../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const commentTextStyle = {
@@ -121,6 +124,12 @@ export default class CommentEvent extends React.Component<
           backgroundColor: `#${backgroundColor}`,
         }}
         onClick={this.edit}
+        onKeyPress={event => {
+          if (shouldActivate(event)) {
+            this.edit();
+          }
+        }}
+        tabIndex={0}
       >
         {this.state.editing ? (
           <TextField

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
@@ -13,6 +13,7 @@ import InlinePopover from '../../InlinePopover';
 import ObjectField from '../../ParameterFields/ObjectField';
 import { type EventRendererProps } from './EventRenderer';
 import ConditionsActionsColumns from '../ConditionsActionsColumns';
+import { shouldActivate } from '../../../UI/KeyboardShortcuts/InteractionKeys.js';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -63,6 +64,11 @@ export default class ForEachEvent extends React.Component<
   };
 
   endEditing = () => {
+    const { anchorEl } = this.state;
+    // Put back the focus after closing the inline popover.
+    // $FlowFixMe
+    if (anchorEl) anchorEl.focus();
+
     this.setState({
       editing: false,
       anchorEl: null,
@@ -89,6 +95,12 @@ export default class ForEachEvent extends React.Component<
               [disabledText]: this.props.disabled,
             })}
             onClick={this.edit}
+            onKeyPress={event => {
+              if (shouldActivate(event)) {
+                this.edit(event);
+              }
+            }}
+            tabIndex={0}
           >
             {objectName ? (
               `Repeat for each instance of ${objectName}:`
@@ -171,6 +183,7 @@ export default class ForEachEvent extends React.Component<
               this.props.onUpdate();
             }}
             isInline
+            onRequestClose={this.endEditing}
             ref={objectField => (this._objectField = objectField)}
           />
         </InlinePopover>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -11,6 +11,7 @@ import {
   disabledText,
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
+import { shouldCloseOrCancel, shouldValidate } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -92,12 +93,12 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
             fullWidth
             id="group-title"
             onKeyUp={event => {
-              if (event.key === 'Escape') {
+              if (shouldCloseOrCancel(event)) {
                 this.endEditing();
               }
             }}
             onKeyPress={event => {
-              if (event.key === 'Enter') {
+              if (shouldValidate(event)) {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -11,7 +11,10 @@ import {
   disabledText,
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
-import { shouldCloseOrCancel, shouldValidate } from '../../../UI/KeyboardShortcuts/InteractionKeys';
+import {
+  shouldCloseOrCancel,
+  shouldValidate,
+} from '../../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const styles = {

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -12,6 +12,7 @@ import {
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
 import {
+  shouldActivate,
   shouldCloseOrCancel,
   shouldValidate,
 } from '../../../UI/KeyboardShortcuts/InteractionKeys';
@@ -74,6 +75,12 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
           backgroundColor: `rgb(${r}, ${g}, ${b})`,
         }}
         onClick={this.edit}
+        onKeyPress={event => {
+          if (shouldActivate(event)) {
+            this.edit();
+          }
+        }}
+        tabIndex={0}
       >
         {this.state.editing ? (
           <TextField

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -16,6 +16,7 @@ import { getHelpLink } from '../../../Utils/HelpLink';
 import { type EventRendererProps } from './EventRenderer';
 import Measure from 'react-measure';
 import { CodeEditor } from '../../../CodeEditor';
+import { shouldActivate } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const fontFamily = '"Lucida Console", Monaco, monospace';
@@ -135,6 +136,12 @@ export default class JsCodeEvent extends React.Component<
   };
 
   endObjectEditing = () => {
+    const { anchorEl } = this.state;
+
+    // Put back the focus after closing the inline popover.
+    // $FlowFixMe
+    if (anchorEl) anchorEl.focus();
+
     this.setState({
       editingObject: false,
       anchorEl: null,
@@ -171,6 +178,12 @@ export default class JsCodeEvent extends React.Component<
           [selectableArea]: true,
         })}
         onClick={this.editObject}
+        onKeyPress={event => {
+          if (shouldActivate(event)) {
+            this.editObject(event);
+          }
+        }}
+        tabIndex={0}
         style={textStyle}
       >
         {parameterObjects
@@ -266,6 +279,7 @@ export default class JsCodeEvent extends React.Component<
                   this.props.onUpdate();
                 }}
                 isInline
+                onRequestClose={this.endObjectEditing}
                 ref={objectField => (this._objectField = objectField)}
               />
             </InlinePopover>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent.js
@@ -19,6 +19,7 @@ import InlinePopover from '../../InlinePopover';
 import ExternalEventsField from '../../ParameterFields/ExternalEventsField';
 import { showWarningBox } from '../../../UI/Messages/MessageBox';
 import { type EventRendererProps } from './EventRenderer';
+import { shouldActivate } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -87,6 +88,12 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
   };
 
   endEditing = () => {
+    const { anchorEl } = this.state;
+
+    // Put back the focus after closing the inline popover.
+    // $FlowFixMe
+    if (anchorEl) anchorEl.focus();
+
     this.setState({
       editing: false,
       anchorEl: null,
@@ -120,6 +127,12 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
                   [selectableArea]: true,
                 })}
                 onClick={this.edit}
+                onKeyPress={event => {
+                  if (shouldActivate(event)) {
+                    this.edit(event);
+                  }
+                }}
+                tabIndex={0}
               >
                 {target || (
                   <Trans>&lt; Enter the name of external events &gt;</Trans>
@@ -148,6 +161,7 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
                   this.props.onUpdate();
                 }}
                 isInline
+                onRequestClose={this.endEditing}
                 ref={externalEventsField =>
                   (this._externalEventsField = externalEventsField)
                 }

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
@@ -13,6 +13,7 @@ import InlinePopover from '../../InlinePopover';
 import DefaultField from '../../ParameterFields/DefaultField';
 import { type EventRendererProps } from './EventRenderer';
 import ConditionsActionsColumns from '../ConditionsActionsColumns';
+import { shouldActivate } from '../../../UI/KeyboardShortcuts/InteractionKeys.js';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -63,6 +64,12 @@ export default class RepeatEvent extends React.Component<
   };
 
   endEditing = () => {
+    const { anchorEl } = this.state;
+
+    // Put back the focus after closing the inline popover.
+    // $FlowFixMe
+    if (anchorEl) anchorEl.focus();
+
     this.setState({
       editing: false,
       anchorEl: null,
@@ -89,6 +96,12 @@ export default class RepeatEvent extends React.Component<
               [disabledText]: this.props.disabled,
             })}
             onClick={this.edit}
+            onKeyPress={event => {
+              if (shouldActivate(event)) {
+                this.edit(event);
+              }
+            }}
+            tabIndex={0}
           >
             {expression ? (
               `Repeat ${expression} times:`

--- a/newIDE/app/src/EventsSheet/InlinePopover.js
+++ b/newIDE/app/src/EventsSheet/InlinePopover.js
@@ -3,6 +3,7 @@ import Popper from '@material-ui/core/Popper';
 import Background from '../UI/Background';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import { Column, Line } from '../UI/Grid';
+import { shouldCloseOrCancel } from '../UI/KeyboardShortcuts/InteractionKeys';
 
 const styles = {
   popover: {
@@ -34,6 +35,16 @@ export default class InlinePopover extends Component {
           anchorEl={this.props.anchorEl}
           style={styles.popover}
           placement="bottom"
+          onKeyDown={event => {
+            // Much like a dialog, offer a way to close the popover
+            // with a key.
+            // Note that the content of the popover can capture the event
+            // and stop its propagation (for example, the GenericExpressionField
+            // when showing autocompletion), which is fine.
+            if (shouldCloseOrCancel(event)) {
+              this.props.onRequestClose();
+            }
+          }}
         >
           <Background>
             <Column expand>

--- a/newIDE/app/src/EventsSheet/InlinePopover.js
+++ b/newIDE/app/src/EventsSheet/InlinePopover.js
@@ -29,7 +29,29 @@ const styles = {
 export default class InlinePopover extends Component {
   render() {
     return (
-      <ClickAwayListener onClickAway={this.props.onRequestClose}>
+      <ClickAwayListener
+        onClickAway={event => {
+          if (event instanceof MouseEvent) {
+            // onClickAway is triggered on a "click" (which can actually happen
+            // on a touchscreen too!).
+            // The click already gave the opportunity to the popover content to
+            // get blurred (allowing "semi controlled" text fields
+            // to apply their changes). We can close now.
+            this.props.onRequestClose();
+          } else {
+            // Give a bit of time to the popover content to be blurred
+            // (useful for the "semi controlled" text fields for example)
+            // for touch events.
+            //
+            // This timeout needs to be at least around 50ms, otherwise
+            // blur events for GenericExpressionField are not triggered on iOS.
+            // There might be a better way to do this without waiting this much time.
+            setTimeout(() => {
+              this.props.onRequestClose();
+            }, 50);
+          }
+        }}
+      >
         <Popper
           open={this.props.open}
           anchorEl={this.props.anchorEl}

--- a/newIDE/app/src/EventsSheet/InlinePopover.js
+++ b/newIDE/app/src/EventsSheet/InlinePopover.js
@@ -1,9 +1,14 @@
-import React, { Component } from 'react';
+// @flow
+import * as React from 'react';
 import Popper from '@material-ui/core/Popper';
 import Background from '../UI/Background';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import { Column, Line } from '../UI/Grid';
-import { shouldCloseOrCancel } from '../UI/KeyboardShortcuts/InteractionKeys';
+import {
+  shouldCloseOrCancel,
+  shouldFocusNextField,
+  shouldFocusPreviousField,
+} from '../UI/KeyboardShortcuts/InteractionKeys';
 
 const styles = {
   popover: {
@@ -26,55 +31,94 @@ const styles = {
   },
 };
 
-export default class InlinePopover extends Component {
-  render() {
-    return (
-      <ClickAwayListener
-        onClickAway={event => {
-          if (event instanceof MouseEvent) {
-            // onClickAway is triggered on a "click" (which can actually happen
-            // on a touchscreen too!).
-            // The click already gave the opportunity to the popover content to
-            // get blurred (allowing "semi controlled" text fields
-            // to apply their changes). We can close now.
-            this.props.onRequestClose();
-          } else {
-            // Give a bit of time to the popover content to be blurred
-            // (useful for the "semi controlled" text fields for example)
-            // for touch events.
-            //
-            // This timeout needs to be at least around 50ms, otherwise
-            // blur events for GenericExpressionField are not triggered on iOS.
-            // There might be a better way to do this without waiting this much time.
-            setTimeout(() => {
-              this.props.onRequestClose();
-            }, 50);
+type Props = {|
+  children: React.Node,
+  anchorEl: ?HTMLElement,
+  open: boolean,
+  onRequestClose: () => void,
+|};
+
+/**
+ * A popover that can be used to show the field to edit a parameter, without
+ * opening the full instruction editor.
+ * Works like a dialog when opened (trapping the focus, dismissed on Escape,
+ * dismissed on click/touch outside) but positioned under the edited parameter.
+ */
+export default function InlinePopover(props: Props) {
+  const startSentinel = React.useRef<?HTMLDivElement>(null);
+  const endSentinel = React.useRef<?HTMLDivElement>(null);
+
+  return (
+    <ClickAwayListener
+      onClickAway={event => {
+        if (event instanceof MouseEvent) {
+          // onClickAway is triggered on a "click" (which can actually happen
+          // on a touchscreen too!).
+          // The click already gave the opportunity to the popover content to
+          // get blurred (allowing "semi controlled" text fields
+          // to apply their changes). We can close now.
+          props.onRequestClose();
+        } else {
+          // Give a bit of time to the popover content to be blurred
+          // (useful for the "semi controlled" text fields for example)
+          // for touch events.
+          //
+          // This timeout needs to be at least around 50ms, otherwise
+          // blur events for GenericExpressionField are not triggered on iOS.
+          // There might be a better way to do this without waiting this much time.
+          setTimeout(() => {
+            props.onRequestClose();
+          }, 50);
+        }
+      }}
+    >
+      <Popper
+        open={props.open}
+        anchorEl={props.anchorEl}
+        style={styles.popover}
+        placement="bottom-start"
+        onKeyDown={event => {
+          // Much like a dialog, offer a way to close the popover
+          // with a key.
+          // Note that the content of the popover can capture the event
+          // and stop its propagation (for example, the GenericExpressionField
+          // when showing autocompletion), which is fine.
+          if (shouldCloseOrCancel(event)) {
+            props.onRequestClose();
+          }
+
+          // Also like a dialog, add a "focus trap". If the user keeps pressing tab
+          // (or shift+tab), we "loop" the focus so that it stays inside the popover.
+          // Otherwise, the focus would espace and could go in some unrelated element
+          // in the events sheet, triggering a scroll, which would be very disturbing
+          // and would break the keyboard navigation.
+          if (shouldFocusNextField(event)) {
+            if (event.target && event.target === endSentinel.current) {
+              event.stopPropagation();
+              event.preventDefault();
+              if (startSentinel.current) {
+                startSentinel.current.focus();
+              }
+            }
+          } else if (shouldFocusPreviousField(event)) {
+            if (event.target && event.target === startSentinel.current) {
+              event.stopPropagation();
+              event.preventDefault();
+              if (endSentinel.current) {
+                endSentinel.current.focus();
+              }
+            }
           }
         }}
       >
-        <Popper
-          open={this.props.open}
-          anchorEl={this.props.anchorEl}
-          style={styles.popover}
-          placement="bottom"
-          onKeyDown={event => {
-            // Much like a dialog, offer a way to close the popover
-            // with a key.
-            // Note that the content of the popover can capture the event
-            // and stop its propagation (for example, the GenericExpressionField
-            // when showing autocompletion), which is fine.
-            if (shouldCloseOrCancel(event)) {
-              this.props.onRequestClose();
-            }
-          }}
-        >
-          <Background>
-            <Column expand>
-              <Line>{this.props.children}</Line>
-            </Column>
-          </Background>
-        </Popper>
-      </ClickAwayListener>
-    );
-  }
+        <Background>
+          <div tabIndex={0} ref={startSentinel} />
+          <Column expand>
+            <Line>{props.children}</Line>
+          </Column>
+          <div tabIndex={0} ref={endSentinel} />
+        </Background>
+      </Popper>
+    </ClickAwayListener>
+  );
 }

--- a/newIDE/app/src/EventsSheet/ParameterFields/AudioResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AudioResourceField.js
@@ -42,6 +42,7 @@ export default class AudioResourceField extends Component<
         initialResourceName={this.props.value}
         onChange={this.props.onChange}
         floatingLabelText={<Trans>Choose the audio file to use</Trans>}
+        onRequestClose={this.props.onRequestClose}
         ref={field => (this._field = field)}
       />
     );

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
@@ -1,5 +1,10 @@
 // @flow
 import { type ExpressionAutocompletion } from '../../../ExpressionAutocompletion';
+import {
+  shouldCloseOrCancel,
+  shouldValidate,
+  shouldFocusNextField,
+} from '../../../UI/KeyboardShortcuts/InteractionKeys';
 
 export type AutocompletionsState = {|
   autocompletions: Array<ExpressionAutocompletion>,
@@ -91,14 +96,14 @@ export const handleAutocompletionsKeyDown = (
         (visibleAutocompletionsLength + state.selectedCompletionIndex - 1) %
         visibleAutocompletionsLength,
     };
-  } else if (event.key === 'Escape') {
+  } else if (shouldCloseOrCancel(event)) {
     // Stop propagation to avoid closing the modal the
     // field is contained in.
     event.preventDefault();
     event.stopPropagation();
 
     return getAutocompletionsInitialState();
-  } else if (event.key === 'Enter' || event.key === 'Tab') {
+  } else if (shouldValidate(event) || shouldFocusNextField(event)) {
     const autocompletion = state.autocompletions[state.selectedCompletionIndex];
     if (autocompletion) onInsertAutocompletion(autocompletion);
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -36,6 +36,7 @@ import {
 } from './ExpressionAutocompletionsHandler';
 import ExpressionAutocompletionsDisplayer from './ExpressionAutocompletionsDisplayer';
 import { ResponsiveWindowMeasurer } from '../../../UI/Reponsive/ResponsiveWindowMeasurer';
+import { shouldCloseOrCancel } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -435,6 +436,15 @@ export default class ExpressionField extends React.Component<Props, State> {
                       }
                     );
                     this.setState({ autocompletions });
+
+                    // If the user pressed the key to close, there is a chance
+                    // that this will trigger the closing of the dialog/popover
+                    // containing the expression field. Apply the changes now
+                    // as otherwise the onBlur handler has a risk not to be called.
+                    if (shouldCloseOrCancel(event)) {
+                      const value = event.currentTarget.value;
+                      if (this.props.onChange) this.props.onChange(value);
+                    }
                   }}
                   multiline
                   fullWidth

--- a/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
@@ -34,6 +34,7 @@ export default class GlobalVariableField extends React.Component<
           value={this.props.value}
           onChange={this.props.onChange}
           isInline={this.props.isInline}
+          onRequestClose={this.props.onRequestClose}
           ref={field => (this._field = field)}
           onOpenDialog={() => this.setState({ editorOpen: true })}
           globalObjectsContainer={this.props.globalObjectsContainer}

--- a/newIDE/app/src/EventsSheet/ParameterFields/JsonResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/JsonResourceField.js
@@ -42,6 +42,7 @@ export default class JsonResourceField extends Component<
         initialResourceName={this.props.value}
         onChange={this.props.onChange}
         floatingLabelText={<Trans>Choose the json file to use</Trans>}
+        onRequestClose={this.props.onRequestClose}
         ref={field => (this._field = field)}
       />
     );

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
@@ -61,6 +61,7 @@ export default class ObjectVariableField extends React.Component<
           value={this.props.value}
           onChange={this.props.onChange}
           isInline={this.props.isInline}
+          onRequestClose={this.props.onRequestClose}
           ref={field => (this._field = field)}
           onOpenDialog={() => this.setState({ editorOpen: true })}
           globalObjectsContainer={this.props.globalObjectsContainer}

--- a/newIDE/app/src/EventsSheet/ParameterFields/VideoResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VideoResourceField.js
@@ -42,6 +42,7 @@ export default class VideoResourceField extends Component<
         initialResourceName={this.props.value}
         onChange={this.props.onChange}
         floatingLabelText={<Trans>Choose the video file to use</Trans>}
+        onRequestClose={this.props.onRequestClose}
         ref={field => (this._field = field)}
       />
     );

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -18,6 +18,10 @@ import {
 } from './EventsSearcher';
 import RaisedButton from '../UI/RaisedButton';
 import { ColumnStackLayout } from '../UI/Layout';
+import {
+  shouldCloseOrCancel,
+  shouldValidate,
+} from '../UI/KeyboardShortcuts/InteractionKeys';
 
 type Props = {|
   onSearchInEvents: SearchInEventsInputs => void,
@@ -139,8 +143,13 @@ export default class SearchPanel extends PureComponent<Props, State> {
                 });
               }}
               onKeyPress={event => {
-                if (event.key === 'Enter') {
+                if (shouldValidate(event)) {
                   this.launchSearchIfResultsDirty();
+                }
+              }}
+              onKeyUp={event => {
+                if (shouldCloseOrCancel(event)) {
+                  onCloseSearchPanel();
                 }
               }}
               value={searchText}
@@ -165,6 +174,16 @@ export default class SearchPanel extends PureComponent<Props, State> {
               margin="dense"
               hintText={t`Text to replace in parameters`}
               onChange={(e, replaceText) => this.setState({ replaceText })}
+              onKeyPress={event => {
+                if (shouldValidate(event)) {
+                  this.launchReplace();
+                }
+              }}
+              onKeyUp={event => {
+                if (shouldCloseOrCancel(event)) {
+                  onCloseSearchPanel();
+                }
+              }}
               value={replaceText}
               fullWidth
             />

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -570,6 +570,12 @@ export default class EventsSheet extends React.Component<Props, State> {
       this._saveChangesToHistory();
     }
 
+    if (this.state.inlineEditingAnchorEl) {
+      // Focus back the parameter - especially useful when editing
+      // with the keyboard only.
+      this.state.inlineEditingAnchorEl.focus();
+    }
+
     this.setState({
       inlineEditing: false,
       inlineEditingAnchorEl: null,

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -36,6 +36,7 @@ type Props = {|
   floatingLabelText?: React.Node,
   helperMarkdownText?: ?string,
   hintText?: MessageDescriptor,
+  onRequestClose?: () => void,
   margin?: 'none' | 'dense',
   style?: {| alignSelf?: 'center' |},
 |};
@@ -275,6 +276,7 @@ export default class ResourceSelector extends React.Component<Props, State> {
             errorText={errorText}
             fullWidth={this.props.fullWidth}
             margin={this.props.margin}
+            onRequestClose={this.props.onRequestClose}
             ref={autoComplete => (this._autoComplete = autoComplete)}
           />
         )}

--- a/newIDE/app/src/UI/EditTagsDialog.js
+++ b/newIDE/app/src/UI/EditTagsDialog.js
@@ -6,6 +6,7 @@ import TextField from './TextField';
 import FlatButton from './FlatButton';
 import { Trans } from '@lingui/macro';
 import { type Tags, getTagsFromString } from '../Utils/TagsHelper';
+import { shouldValidate } from './KeyboardShortcuts/InteractionKeys';
 
 type Props = {|
   tagsString: string,
@@ -64,7 +65,7 @@ export default class EditTagsDialog extends React.Component<Props, State> {
             disabled={!this.props.tagsString && !tags.length}
           />,
         ]}
-        cannotBeDismissed={true}
+        cannotBeDismissed={false}
         open
         onRequestClose={onCancel}
       >
@@ -79,7 +80,7 @@ export default class EditTagsDialog extends React.Component<Props, State> {
           floatingLabelText="Tag(s) (comma-separated)"
           hintText={t`For example: player, spaceship, inventory...`}
           onKeyPress={event => {
-            if (event.key === 'Enter') {
+            if (shouldValidate(event)) {
               onEdit(tags);
             }
           }}

--- a/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
+++ b/newIDE/app/src/UI/HelpButton/__snapshots__/HelpButton.spec.js.snap
@@ -26,7 +26,7 @@ exports[`HelpButton renders the button linking to a help page 1`] = `
     className="MuiButton-label"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="MuiSvgIcon-root"
       focusable="false"
       viewBox="0 0 24 24"

--- a/newIDE/app/src/UI/HelpIcon/__snapshots__/HelpIcon.spec.js.snap
+++ b/newIDE/app/src/UI/HelpIcon/__snapshots__/HelpIcon.spec.js.snap
@@ -25,7 +25,7 @@ exports[`HelpIcon renders the icon linking to a help page 1`] = `
     className="MuiIconButton-label"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="MuiSvgIcon-root"
       focusable="false"
       viewBox="0 0 24 24"

--- a/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react';
+
+// These functions are very simple, but are there to ensure consistency
+// in the codebase when dealing with keys.
+
+type SupportedEvent = KeyboardEvent | SyntheticKeyboardEvent<any>;
+
+/**
+ * Check if the user asked to close/cancel what is being edited.
+ */
+export const shouldCloseOrCancel = (event: SupportedEvent) => {
+  return event.key === 'Escape';
+};
+
+/**
+ * Check if the user asked to validate what is being edited.
+ */
+export const shouldValidate = (event: SupportedEvent) => {
+  return event.key === 'Enter';
+};
+
+/**
+ * Check if the user asked to activate something.
+ */
+export const shouldActivate = (event: SupportedEvent) => {
+  return event.key === 'Enter' || event.key === ' ';
+};
+
+/**
+ * Check if the user asked to go to the next field.
+ * Note that in most case, this should be automatically handled by the browser
+ * (or material-ui), and using this should not be needed.
+ */
+export const shouldFocusNextField = (event: SupportedEvent) => {
+  return event.key === 'Tab';
+};

--- a/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
@@ -1,5 +1,4 @@
 // @flow
-import * as React from 'react';
 
 // These functions are very simple, but are there to ensure consistency
 // in the codebase when dealing with keys.

--- a/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
@@ -32,5 +32,14 @@ export const shouldActivate = (event: SupportedEvent) => {
  * (or material-ui), and using this should not be needed.
  */
 export const shouldFocusNextField = (event: SupportedEvent) => {
-  return event.key === 'Tab';
+  return event.key === 'Tab' && !event.shiftKey;
+};
+
+/**
+ * Check if the user asked to go to the previous field.
+ * Note that in most case, this should be automatically handled by the browser
+ * (or material-ui), and using this should not be needed.
+ */
+export const shouldFocusPreviousField = (event: SupportedEvent) => {
+  return event.key === 'Tab' && event.shiftKey;
 };

--- a/newIDE/app/src/UI/SearchBar.js
+++ b/newIDE/app/src/UI/SearchBar.js
@@ -13,6 +13,7 @@ import ThemeConsumer from './Theme/ThemeConsumer';
 import HelpIcon from './HelpIcon';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 import { useScreenType } from './Reponsive/ScreenTypeMeasurer';
+import { shouldValidate } from './KeyboardShortcuts/InteractionKeys';
 
 type Props = {|
   /** Disables text field. */
@@ -148,8 +149,8 @@ export default class SearchBar extends React.PureComponent<Props, State> {
     this.props.onChange && this.props.onChange('');
   };
 
-  handleKeyPressed = (e: { charCode: number, key: string }) => {
-    if (e.charCode === 13 || e.key === 'Enter') {
+  handleKeyPressed = (event: SyntheticKeyboardEvent<>) => {
+    if (shouldValidate(event)) {
       this.props.onRequestSearch(this.state.value);
     }
   };

--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -13,6 +13,7 @@ import ListItem from '@material-ui/core/ListItem';
 import { computeTextFieldStyleProps } from './TextField';
 import { makeStyles } from '@material-ui/core/styles';
 import muiZIndex from '@material-ui/core/styles/zIndex';
+import { shouldCloseOrCancel } from './KeyboardShortcuts/InteractionKeys';
 
 type Option =
   | {|
@@ -175,7 +176,7 @@ const getDefaultStylingProps = (
       className: null,
       disabled: props.disabled,
       onKeyDown: (event: SyntheticKeyboardEvent<HTMLInputElement>): void => {
-        if (event.key === 'Escape' && props.onRequestClose)
+        if (shouldCloseOrCancel(event) && props.onRequestClose)
           props.onRequestClose();
       },
     },

--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -143,17 +143,30 @@ const filterFunction = (
 };
 
 const handleChange = (
-  event: SyntheticKeyboardEvent<HTMLInputElement>,
+  input: HTMLInputElement,
   option: Option,
   props: Props
 ): void => {
-  if (option.type !== 'separator') {
-    if (option.onClick) option.onClick();
-    else {
-      props.onChoose
-        ? props.onChoose(option.value)
-        : props.onChange(option.value);
-      if (props.onRequestClose) props.onRequestClose();
+  if (option.type === 'separator') return;
+  else if (option.onClick) option.onClick();
+  else {
+    // Force the input to the selected value. We do this, bypassing inputValue state,
+    // because the change could be immediately followed by a blur, in which case the blur
+    // must have the updated value.
+    // Search for "blur-value" in this file for the rest of this "workaround".
+    input.value = option.value;
+
+    // Call the props to notify of the change. Note that if the component is blurred just after,
+    // onChange could be called again. Hence why we immediately set the input.value below.
+    // Search for "blur-value" in this file for the rest of this "workaround".
+    if (props.onChoose) {
+      props.onChoose(option.value);
+    } else {
+      props.onChange(option.value);
+    }
+
+    if (props.onRequestClose) {
+      props.onRequestClose();
     }
   }
 };
@@ -227,10 +240,10 @@ export default React.forwardRef<Props, SemiControlledAutoCompleteInterface>(
               event: SyntheticKeyboardEvent<HTMLInputElement>,
               option: Option | null
             ) => {
-              if (option !== null) {
-                handleChange(event, option, props);
-                setIsMenuOpen(false);
-              }
+              if (option === null || !input.current) return;
+
+              handleChange(input.current, option, props);
+              setIsMenuOpen(false);
             }}
             open={isMenuOpen}
             style={{
@@ -243,24 +256,6 @@ export default React.forwardRef<Props, SemiControlledAutoCompleteInterface>(
             options={props.dataSource}
             renderOption={renderItem}
             getOptionDisabled={isOptionDisabled}
-            ListboxProps={{
-              // We need to stop the propagation since ClickAwayListener of InlinePopover does not
-              // recognise listbox as a part of Autocomplete, which is fair since it's in a different DOM tree.
-              // We have basically killed these events completely by using stopImmediatePropagation() since Portals dont
-              // stop propagation by simply using stopPropagation(), more about this issue https://github.com/facebook/react/issues/11387
-              // Material-UI has issues regarding this too, https://github.com/mui-org/material-ui/issues/18586.
-              // This change was implemented in this PR https://github.com/4ian/GDevelop/pull/1586,
-              // which is meant to solve this issue, https://github.com/4ian/GDevelop/issues/1562
-              // Important takeaway: Never try to catch these events, our underlying assumption is that we don't need these events
-              // anymore after selection of option. Stopping propagation of events is never a good idea,
-              // but this is meant to be a hack and not a proper solution.
-              onClick: (event: SyntheticMouseEvent<HTMLUListElement>) => {
-                event.nativeEvent.stopImmediatePropagation();
-              },
-              onTouchEnd: (event: SyntheticTouchEvent<HTMLUListElement>) => {
-                event.nativeEvent.stopImmediatePropagation();
-              },
-            }}
             getOptionLabel={(option: Option) =>
               getOptionLabel(option, currentInputValue)
             }
@@ -271,7 +266,7 @@ export default React.forwardRef<Props, SemiControlledAutoCompleteInterface>(
               const {
                 InputProps,
                 inputProps,
-                ...other
+                ...otherStylingProps
               } = getDefaultStylingProps(params, currentInputValue, props);
               return (
                 <TextField
@@ -292,22 +287,31 @@ export default React.forwardRef<Props, SemiControlledAutoCompleteInterface>(
                         input.current.selectionStart =
                           input.current.value.length;
                     },
+                    // Redefine onBlur to call onChange when the component is blurred.
+                    // We do this because the default behavior of the Autocomplete is not
+                    // to call onChange when blurred (though it should according to the docs?).
                     onBlur: (
                       event: SyntheticFocusEvent<HTMLInputElement>
                     ): void => {
                       setInputValue(null);
                       setIsMenuOpen(false);
+
+                      // Use the value of the input, rather than inputValue
+                      // that could be not updated.
+                      // Search for "blur-value" in this file for the rest of this "workaround".
                       props.onChange(event.currentTarget.value);
+
                       if (props.onBlur) props.onBlur(event);
                     },
                     onMouseDown: (
                       event: SyntheticMouseEvent<HTMLInputElement>
                     ): void => {
+                      // Toggle the menu when clicked and empty
                       if (input.current && !input.current.value.length)
                         setIsMenuOpen(!isMenuOpen);
                     },
                   }}
-                  {...other}
+                  {...otherStylingProps}
                   {...computeTextFieldStyleProps(props)}
                   style={props.textFieldStyle}
                   label={props.floatingLabelText}

--- a/newIDE/app/src/UI/SemiControlledTextField.js
+++ b/newIDE/app/src/UI/SemiControlledTextField.js
@@ -26,9 +26,9 @@ type Props = {|
 
   // Some TextField props that can be reused:
   onClick?: () => void,
-  onKeyPress?: (event: SyntheticKeyboardEvent<>) => void,
-  onKeyUp?: (event: SyntheticKeyboardEvent<>) => void,
-  onKeyDown?: (event: SyntheticKeyboardEvent<>) => void,
+  onKeyPress?: (event: SyntheticKeyboardEvent<HTMLInputElement>) => void,
+  onKeyUp?: (event: SyntheticKeyboardEvent<HTMLInputElement>) => void,
+  onKeyDown?: (event: SyntheticKeyboardEvent<HTMLInputElement>) => void,
   margin?: 'none' | 'dense',
   disabled?: boolean,
   errorText?: React.Node,

--- a/newIDE/app/yarn.lock
+++ b/newIDE/app/yarn.lock
@@ -1754,23 +1754,23 @@
     hoist-non-react-statics "3.0.1"
     prop-types "^15.6.2"
 
-"@material-ui/core@4.9.10":
-  version "4.9.10"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.10.tgz#53f1d18bd274c258698b6cfdab3c4bee0edf7892"
-  integrity sha512-CQuZU9Y10RkwSdxjn785kw2EPcXhv5GKauuVQufR9LlD37kjfn21Im1yvr6wsUzn81oLhEvVPz727UWC0gbqxg==
+"@material-ui/core@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.0.tgz#b69b26e4553c9e53f2bfaf1053e216a0af9be15a"
+  integrity sha512-bYo9uIub8wGhZySHqLQ833zi4ZML+XCBE1XwJ8EuUVSpTWWG57Pm+YugQToJNFsEyiKFhPh8DPD0bgupz8n01g==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.9.10"
-    "@material-ui/system" "^4.9.10"
-    "@material-ui/types" "^5.0.1"
-    "@material-ui/utils" "^4.9.6"
+    "@material-ui/styles" "^4.10.0"
+    "@material-ui/system" "^4.9.14"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.10.2"
     "@types/react-transition-group" "^4.2.0"
     clsx "^1.0.4"
     hoist-non-react-statics "^3.3.2"
-    popper.js "^1.16.1-lts"
+    popper.js "1.16.1-lts"
     prop-types "^15.7.2"
     react-is "^16.8.0"
-    react-transition-group "^4.3.0"
+    react-transition-group "^4.4.0"
 
 "@material-ui/icons@4.9.1":
   version "4.9.1"
@@ -1790,7 +1790,7 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
-"@material-ui/styles@^4.9.10":
+"@material-ui/styles@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"
   integrity sha512-XPwiVTpd3rlnbfrgtEJ1eJJdFCXZkHxy8TrdieaTvwxNYj42VnnCyFzxYeNW9Lhj4V1oD8YtQ6S5Gie7bZDf7Q==
@@ -1812,7 +1812,7 @@
     jss-plugin-vendor-prefixer "^10.0.3"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.9.10":
+"@material-ui/system@^4.9.14":
   version "4.9.14"
   resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.9.14.tgz#4b00c48b569340cefb2036d0596b93ac6c587a5f"
   integrity sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==
@@ -1822,7 +1822,7 @@
     csstype "^2.5.2"
     prop-types "^15.7.2"
 
-"@material-ui/types@^5.0.1", "@material-ui/types@^5.1.0":
+"@material-ui/types@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
   integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
@@ -11626,7 +11626,12 @@ polished@^3.3.1:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-popper.js@^1.14.4, popper.js@^1.14.7, popper.js@^1.16.1-lts:
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
+popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -13226,7 +13231,7 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^4.3.0:
+react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==


### PR DESCRIPTION
This brings multiple improvements to the inline popover that is shown when editing a parameter in the events sheet:
- it can always be closed using Escape now.
- when closed, it focuses back the parameter, useful to edit the events sheet using the keyboard
- fix issues on touchscreen where changes were not applied when closing the popover

This also take the opportunity to update to latest material-ui core version, which allow to remove a hack in SemiControlledAutoComplete (though we kind of add another). 
Needs to do a global check of the app to verify nothing else was changed/broken by the update.