### PR TITLE
Add VSCode tasks for common tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,7 @@
 		},
 		"problemMatcher": [],
 		"label": "Start development server",
-		"detail": "Starts the GDevelop development server"
+		"detail": "Starts the GDevelop development server."
 	},
 	{
 		"type": "npm",
@@ -20,7 +20,7 @@
 		"group": "build",
 		"problemMatcher": [],
 		"label": "Build GDevelop.js",
-		"detail": "Builds GDCore for newIDE"
+		"detail": "Builds GDCore for newIDE."
 	},
 	{
 		"type": "npm",
@@ -28,19 +28,19 @@
 		"path": "newIDE/app/",
 		"problemMatcher": [],
 		"label": "Format newIDE",
-		"detail": "Formats via prettier the javascript in the newIDE/app directory."
+		"detail": "Run auto-formatting (with Prettier) for the newIDE/app directory."
 	},
 	{
 		"type": "npm",
 		"script": "test",
-		"path": "GDJS/",
+		"path": "newIDE/app/",
 		"group": {
 			"kind": "test",
 			"isDefault": true
 		},
 		"problemMatcher": [],
 		"label": "Run newIDE tests",
-		"detail": "Run tests for newIDE"
+		"detail": "Run tests for newIDE."
 	},
 	{
 		"type": "typescript",
@@ -60,16 +60,7 @@
 		"group": "test",
 		"problemMatcher": [],
 		"label": "Run GDJS tests",
-		"detail": "Run tests for GDJS"
-	},
-	{
-		"type": "npm",
-		"script": "build",
-		"path": "GDevelop.js/",
-		"group": "build",
-		"problemMatcher": [],
-		"label": "Build GDevelop.js",
-		"detail": "Builds GDCore for newIDE"
+		"detail": "Run tests for GDJS."
 	}
 ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,75 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+	{
+		"type": "npm",
+		"script": "start",
+		"path": "newIDE/app/",
+		"group": {
+			"kind": "build",
+			"isDefault": true
+		},
+		"problemMatcher": [],
+		"label": "Start development server",
+		"detail": "Starts the GDevelop development server"
+	},
+	{
+		"type": "npm",
+		"script": "build",
+		"path": "GDevelop.js/",
+		"group": "build",
+		"problemMatcher": [],
+		"label": "Build GDevelop.js",
+		"detail": "Builds GDCore for newIDE"
+	},
+	{
+		"type": "npm",
+		"script": "format",
+		"path": "newIDE/app/",
+		"problemMatcher": [],
+		"label": "Format newIDE",
+		"detail": "Formats via prettier the javascript in the newIDE/app directory."
+	},
+	{
+		"type": "npm",
+		"script": "test",
+		"path": "GDJS/",
+		"group": {
+			"kind": "test",
+			"isDefault": true
+		},
+		"problemMatcher": [],
+		"label": "Run newIDE tests",
+		"detail": "Run tests for newIDE"
+	},
+	{
+		"type": "typescript",
+		"tsconfig": "GDJS/tsconfig.json",
+		"option": "watch",
+		"problemMatcher": [
+			"$tsc-watch"
+		],
+		"group": "test",
+		"label": "GDJS TS Check",
+		"detail": "Runs a types check on the GDJS Runtime."
+	},
+	{
+		"type": "npm",
+		"script": "test",
+		"path": "GDJS/",
+		"group": "test",
+		"problemMatcher": [],
+		"label": "Run GDJS tests",
+		"detail": "Run tests for GDJS"
+	},
+	{
+		"type": "npm",
+		"script": "build",
+		"path": "GDevelop.js/",
+		"group": "build",
+		"problemMatcher": [],
+		"label": "Build GDevelop.js",
+		"detail": "Builds GDCore for newIDE"
+	}
+]
+}


### PR DESCRIPTION
This makes working on GDevelop easier and faster, and makes it more friendly for new contributors to work on.