### PR TITLE
Add support for the Asset Store on the desktop app

### DIFF
--- a/Core/GDCore/Project/ResourcesManager.cpp
+++ b/Core/GDCore/Project/ResourcesManager.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "GDCore/Project/ResourcesManager.h"
+
 #include <iostream>
 #include <map>
+
 #include "GDCore/CommonTools.h"
 #include "GDCore/Project/Project.h"
 #include "GDCore/Project/PropertyDescriptor.h"
@@ -20,6 +22,7 @@ namespace gd {
 gd::String Resource::badStr;
 
 Resource ResourcesManager::badResource;
+gd::String ResourcesManager::badResourceName;
 #if defined(GD_IDE_ONLY)
 ResourceFolder ResourcesManager::badFolder;
 Resource ResourceFolder::badResource;
@@ -90,6 +93,33 @@ bool ResourcesManager::HasResource(const gd::String& name) const {
   return false;
 }
 
+const gd::String& ResourcesManager::GetResourceNameWithOrigin(
+    const gd::String& originName, const gd::String& originIdentifier) const {
+  for (const auto& resource : resources) {
+    if (!resource) continue;
+
+    if (resource->GetOriginName() == originName &&
+        resource->GetOriginIdentifier() == originIdentifier) {
+      return resource->GetName();
+    }
+  }
+
+  return badResourceName;
+}
+
+const gd::String& ResourcesManager::GetResourceNameWithFile(
+    const gd::String& file) const {
+  for (const auto& resource : resources) {
+    if (!resource) continue;
+
+    if (resource->GetFile() == file) {
+      return resource->GetName();
+    }
+  }
+
+  return badResourceName;
+}
+
 std::vector<gd::String> ResourcesManager::GetAllResourceNames() const {
   std::vector<gd::String> allResources;
   for (std::size_t i = 0; i < resources.size(); ++i)
@@ -104,7 +134,8 @@ std::map<gd::String, gd::PropertyDescriptor> Resource::GetProperties() const {
   return nothing;
 }
 
-std::map<gd::String, gd::PropertyDescriptor> ImageResource::GetProperties() const {
+std::map<gd::String, gd::PropertyDescriptor> ImageResource::GetProperties()
+    const {
   std::map<gd::String, gd::PropertyDescriptor> properties;
   properties[_("Smooth the image")]
       .SetValue(smooth ? "true" : "false")
@@ -413,6 +444,15 @@ void ResourcesManager::UnserializeFrom(const SerializerElement& element) {
     std::shared_ptr<Resource> resource = CreateResource(kind);
     resource->SetName(name);
     resource->SetMetadata(metadata);
+
+    if (resourceElement.HasChild("origin")) {
+      gd::String originName =
+          resourceElement.GetChild("origin").GetStringAttribute("name", "");
+      gd::String originIdentifier =
+          resourceElement.GetChild("origin").GetStringAttribute("identifier",
+                                                                "");
+      resource->SetOrigin(originName, originIdentifier);
+    }
     resource->UnserializeFrom(resourceElement);
 
     resources.push_back(resource);
@@ -443,6 +483,14 @@ void ResourcesManager::SerializeTo(SerializerElement& element) const {
     resourceElement.SetAttribute("kind", resources[i]->GetKind());
     resourceElement.SetAttribute("name", resources[i]->GetName());
     resourceElement.SetAttribute("metadata", resources[i]->GetMetadata());
+
+    const gd::String& originName = resources[i]->GetOriginName();
+    const gd::String& originIdentifier = resources[i]->GetOriginIdentifier();
+    if (!originName.empty() || !originIdentifier.empty()) {
+      resourceElement.AddChild("origin")
+          .SetAttribute("name", originName)
+          .SetAttribute("identifier", originIdentifier);
+    }
 
     resources[i]->SerializeTo(resourceElement);
   }
@@ -560,7 +608,8 @@ void JsonResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("disablePreload", IsPreloadDisabled());
 }
 
-std::map<gd::String, gd::PropertyDescriptor> JsonResource::GetProperties() const {
+std::map<gd::String, gd::PropertyDescriptor> JsonResource::GetProperties()
+    const {
   std::map<gd::String, gd::PropertyDescriptor> properties;
   properties["disablePreload"]
       .SetValue(disablePreload ? "true" : "false")

--- a/Core/GDCore/Project/ResourcesManager.h
+++ b/Core/GDCore/Project/ResourcesManager.h
@@ -80,6 +80,17 @@ class GD_CORE_API Resource {
   virtual void SetFile(const gd::String& newFile){};
 
   /**
+   * TODO: make a ResourceOrigin object?
+   */
+  virtual void SetOrigin(const gd::String& originName_, const gd::String& originIdentifier_) {
+    originName = originName_;
+    originIdentifier = originIdentifier_;
+  }
+
+  virtual const gd::String& GetOriginName() const { return originName; }
+  virtual const gd::String& GetOriginIdentifier() const { return originIdentifier; }
+
+  /**
    * \brief Set the metadata (any string) associated to the resource.
    * \note Can be used by external editors to store extra information, for
    * example the configuration used to produce a sound.
@@ -142,6 +153,8 @@ class GD_CORE_API Resource {
   gd::String kind;
   gd::String name;
   gd::String metadata;
+  gd::String originName;
+  gd::String originIdentifier;
   bool userAdded;  ///< True if the resource was added by the user, and not
                    ///< automatically by GDevelop.
 
@@ -355,6 +368,18 @@ class GD_CORE_API ResourcesManager {
   bool HasResource(const gd::String& name) const;
 
   /**
+   * \brief Return the name of the resource with the given origin, if any.
+   * If not found, an empty string is returned.
+   */
+  const gd::String& GetResourceNameWithOrigin(const gd::String& originName, const gd::String& originIdentifier) const;
+
+  /**
+   * \brief Return the name of the first resource with the given file, if any.
+   * If not found, an empty string is returned.
+   */
+  const gd::String& GetResourceNameWithFile(const gd::String& file) const;
+
+  /**
    * \brief Return a reference to a resource.
    */
   Resource& GetResource(const gd::String& name);
@@ -487,6 +512,7 @@ class GD_CORE_API ResourcesManager {
   static ResourceFolder badFolder;
 #endif
   static Resource badResource;
+  static gd::String badResourceName;
 };
 
 #if defined(GD_IDE_ONLY)

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -715,6 +715,9 @@ interface Resource {
     [Const, Ref] DOMString GetFile();
     void SetMetadata([Const] DOMString metadata);
     [Const, Ref] DOMString GetMetadata();
+    void SetOrigin([Const] DOMString originName, [Const] DOMString originIdentifier);
+    [Const, Ref] DOMString GetOriginName();
+    [Const, Ref] DOMString GetOriginIdentifier();
 
     [Value] MapStringPropertyDescriptor GetProperties();
     boolean UpdateProperty([Const] DOMString name, [Const] DOMString value);
@@ -729,6 +732,8 @@ interface ResourcesManager {
     [Value] VectorString GetAllResourceNames();
     boolean HasResource([Const] DOMString name);
     [Const, Ref] Resource GetResource([Const] DOMString name);
+    [Const, Ref] DOMString GetResourceNameWithOrigin([Const] DOMString originName, [Const] DOMString originIdentifier);
+    [Const, Ref] DOMString GetResourceNameWithFile([Const] DOMString file);
     boolean AddResource([Const, Ref] Resource res);
     void RemoveResource([Const] DOMString name);
     void RenameResource([Const] DOMString oldName, [Const] DOMString name);

--- a/GDevelop.js/types/gdresource.js
+++ b/GDevelop.js/types/gdresource.js
@@ -13,6 +13,9 @@ declare class gdResource {
   getFile(): string;
   setMetadata(metadata: string): void;
   getMetadata(): string;
+  setOrigin(originName: string, originIdentifier: string): void;
+  getOriginName(): string;
+  getOriginIdentifier(): string;
   getProperties(): gdMapStringPropertyDescriptor;
   updateProperty(name: string, value: string): boolean;
   serializeTo(element: gdSerializerElement): void;

--- a/GDevelop.js/types/gdresourcesmanager.js
+++ b/GDevelop.js/types/gdresourcesmanager.js
@@ -4,6 +4,8 @@ declare class gdResourcesManager {
   getAllResourceNames(): gdVectorString;
   hasResource(name: string): boolean;
   getResource(name: string): gdResource;
+  getResourceNameWithOrigin(originName: string, originIdentifier: string): string;
+  getResourceNameWithFile(file: string): string;
   addResource(res: gdResource): boolean;
   removeResource(name: string): void;
   renameResource(oldName: string, name: string): void;

--- a/newIDE/app/flow-typed/npm/@supercharge/promise-pool_vx.x.x.js
+++ b/newIDE/app/flow-typed/npm/@supercharge/promise-pool_vx.x.x.js
@@ -1,0 +1,59 @@
+// flow-typed signature: ee6aa6690ad469d64aa59033fa0e19eb
+// flow-typed version: <<STUB>>/@supercharge/promise-pool_v1.6.0/flow_v0.120.1
+
+declare module '@supercharge/promise-pool' {
+  declare class PromisePoolError<T> extends Error {
+    /**
+     * Returns the item that caused this error.
+     */
+    item: T;
+
+    /**
+     * Create a new instance for the given `message` and `item`.
+     *
+     * @param error  The original error
+     * @param item   The item causing the error
+     */
+    constructor(error: any, item: T): PromisePoolError<T>;
+
+    /**
+     * Returns a new promise pool error instance wrapping the `error` and `item`.
+     *
+     * @param {*} error
+     * @param {*} item
+     *
+     * @returns {PromisePoolError}
+     */
+    static createFrom<T>(error: any, item: T): PromisePoolError<T>;
+  }
+
+  declare type ReturnValue<T, R> = {
+    /**
+     * The list of processed items.
+     */
+    results: R[],
+
+    /**
+     * The list of errors that occurred while processing all items in the pool.
+     * Each error contains the error-causing item at `error.item` as a
+     * reference for re-processing.
+     */
+    errors: Array<PromisePoolError<T>>,
+  };
+
+  declare class PromisePool<T> {
+    constructor(): PromisePool<T>;
+    withConcurrency(concurrency: number): PromisePool<T>;
+    static withConcurrency(concurrency: number): typeof PromisePool;
+    for(items: T[]): PromisePool<T>;
+    static for<T>(items: T[]): PromisePool<T>;
+    handleError(
+      handler: (error: Error, item: T) => Promise<void> | void
+    ): PromisePool<T>;
+    process<R>(
+      callback: (item: T) => R | Promise<R>
+    ): Promise<ReturnValue<T, R>>;
+  }
+
+  declare export default typeof PromisePool;
+}

--- a/newIDE/app/package-lock.json
+++ b/newIDE/app/package-lock.json
@@ -3812,6 +3812,19 @@
         }
       }
     },
+    "@supercharge/goodies": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@supercharge/goodies/-/goodies-1.5.1.tgz",
+      "integrity": "sha512-LrbIgboxJ9labELaN6JUcZEWAdKveohRI3u11ILb/rqrKbeXkN8/ezoLvWJ0oo9s/HeBf0REFTD3XpVEio053g=="
+    },
+    "@supercharge/promise-pool": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-1.6.0.tgz",
+      "integrity": "sha512-/zQnPJ2CMfGdVI1OlWn7fUfYSyLjTUHWxQ3svvrCwNznrpxZsa+nMC1QDkJ5LCiVzYrfQx7sK5pYcSSaQpmE+w==",
+      "requires": {
+        "@supercharge/goodies": "~1.5.1"
+      }
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -34,6 +34,7 @@
     "@material-ui/core": "4.11.0",
     "@material-ui/icons": "4.9.1",
     "@material-ui/lab": "4.0.0-alpha.56",
+    "@supercharge/promise-pool": "^1.6.0",
     "algoliasearch": "3.33.0",
     "axios": "^0.18.1",
     "blueimp-md5": "^2.10.0",

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -193,6 +193,7 @@ export const AssetDetails = ({
                     assetAuthors.map(author => {
                       return (
                         <Link
+                          key={author.name}
                           component="button"
                           onClick={() => {
                             Window.openExternalURL(author.website);

--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -11,8 +11,6 @@ import {
   listAllLicenses,
 } from '../Utils/GDevelopServices/Asset';
 import { useSearchItem } from './UseSearchItem';
-import optionalRequire from '../Utils/OptionalRequire';
-const electron = optionalRequire('electron');
 
 const defaultSearchText = '';
 
@@ -118,9 +116,6 @@ export const AssetStoreStateProvider = ({
 
   React.useEffect(
     () => {
-      // Don't prefetch anything if not on the web-app.
-      if (!!electron) return;
-
       // Don't attempt to load again assets and filters if they
       // were loaded already.
       if (assetShortHeadersById || isLoading.current) return;

--- a/newIDE/app/src/AssetStore/InstallAsset.spec.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.spec.js
@@ -111,6 +111,10 @@ describe('InstallAsset', () => {
       const resource = new gd.ImageResource();
       resource.setName('player-ship1.png');
       resource.setFile('https://example.com/player-ship1.png');
+      resource.setOrigin(
+        'gdevelop-asset-store',
+        'https://example.com/player-ship1.png'
+      );
       project.getResourcesManager().addResource(resource);
       resource.delete();
 
@@ -135,6 +139,48 @@ describe('InstallAsset', () => {
       ]);
     });
 
+    it('does not add a resource if it is already existing, even if changed but origin is the same', async () => {
+      const { project } = makeTestProject(gd);
+      const layout = project.insertNewLayout('MyTestLayout', 0);
+
+      const originalResourceNames = project
+        .getResourcesManager()
+        .getAllResourceNames()
+        .toJSArray();
+
+      // Create a resource that is originally the same as the one of the spaceship (same origin),
+      // but which was modified (file is different, name is different)
+      const resource = new gd.ImageResource();
+      resource.setName('renamed-player-ship1.png');
+      resource.setFile('https://example.com/modified-player-ship.png');
+      resource.setOrigin(
+        'gdevelop-asset-store',
+        'https://example.com/player-ship1.png'
+      );
+      project.getResourcesManager().addResource(resource);
+      resource.delete();
+
+      // Install the spaceship
+      await addAssetToProject({
+        project,
+        objectsContainer: layout,
+        events: layout.getEvents(),
+        asset: fakeAsset1,
+      });
+
+      // Verify there was not extra resource added.
+      expect(
+        project
+          .getResourcesManager()
+          .getAllResourceNames()
+          .toJSArray()
+      ).toEqual([
+        ...originalResourceNames,
+        'renamed-player-ship1.png',
+        'player-ship2.png',
+      ]);
+    });
+
     it('add a resource with a new name, if this name is already taken by another', async () => {
       const { project } = makeTestProject(gd);
       const layout = project.insertNewLayout('MyTestLayout', 0);
@@ -149,6 +195,7 @@ describe('InstallAsset', () => {
       const resource = new gd.ImageResource();
       resource.setName('player-ship1.png');
       resource.setFile('https://example.com/some-unrelated-file.png');
+      resource.setOrigin('some-origin', 'some-unrelated-identifier');
       project.getResourcesManager().addResource(resource);
       resource.delete();
 

--- a/newIDE/app/src/AssetStore/ResourceStore/ResourceStoreContext.js
+++ b/newIDE/app/src/AssetStore/ResourceStore/ResourceStoreContext.js
@@ -11,8 +11,6 @@ import {
   listAllResources,
 } from '../../Utils/GDevelopServices/Asset';
 import { useSearchItem } from '../UseSearchItem';
-import optionalRequire from '../../Utils/OptionalRequire';
-const electron = optionalRequire('electron');
 
 const defaultSearchText = '';
 
@@ -112,9 +110,6 @@ export const ResourceStoreStateProvider = ({
 
   React.useEffect(
     () => {
-      // Don't prefetch anything if not on the web-app.
-      if (!!electron) return;
-
       // Don't attempt to load again resources and filters if they
       // were loaded already.
       if (resourcesByUrl || isLoading.current) return;

--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -27,6 +27,7 @@ import DownloadFileStorageProvider from './ProjectsStorage/DownloadFileStoragePr
 import DropboxStorageProvider from './ProjectsStorage/DropboxStorageProvider';
 import OneDriveStorageProvider from './ProjectsStorage/OneDriveStorageProvider';
 import UnsavedChangesContext from './MainFrame/UnsavedChangesContext';
+import { BrowserResourceFetcher } from './ProjectsStorage/ResourceFetcher/BrowserResourceFetcher';
 
 export const create = (authentification: Authentification) => {
   Window.setUpContextMenu();
@@ -41,6 +42,7 @@ export const create = (authentification: Authentification) => {
       makeEventsFunctionCodeWriter={makeBrowserS3EventsFunctionCodeWriter}
       eventsFunctionsExtensionWriter={null}
       eventsFunctionsExtensionOpener={null}
+      resourceFetcher={BrowserResourceFetcher}
     >
       {({ i18n, eventsFunctionsExtensionsState }) => (
         <ProjectStorageProviders

--- a/newIDE/app/src/Export/LocalExporters/LocalFileSystem.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalFileSystem.js
@@ -46,37 +46,37 @@ export default {
     return os.tmpdir();
   },
   fileNameFrom: function(fullpath) {
-    if (this._isExternalURL(fullpath)) return fullpath;
+    if (this._isExternalUrl(fullpath)) return fullpath;
 
-    fullpath = this._translateURL(fullpath);
+    fullpath = this._translateUrl(fullpath);
     return path.basename(fullpath);
   },
   dirNameFrom: function(fullpath) {
-    if (this._isExternalURL(fullpath)) return '';
+    if (this._isExternalUrl(fullpath)) return '';
 
-    fullpath = this._translateURL(fullpath);
+    fullpath = this._translateUrl(fullpath);
     return path.dirname(fullpath);
   },
   makeAbsolute: function(filename, baseDirectory) {
-    if (this._isExternalURL(filename)) return filename;
+    if (this._isExternalUrl(filename)) return filename;
 
-    filename = this._translateURL(filename);
+    filename = this._translateUrl(filename);
     if (!this.isAbsolute(baseDirectory))
       baseDirectory = path.resolve(baseDirectory);
 
     return path.resolve(baseDirectory, path.normalize(filename));
   },
   makeRelative: function(filename, baseDirectory) {
-    if (this._isExternalURL(filename)) return filename;
+    if (this._isExternalUrl(filename)) return filename;
 
-    filename = this._translateURL(filename);
+    filename = this._translateUrl(filename);
     return path.relative(baseDirectory, path.normalize(filename));
   },
   isAbsolute: function(fullpath) {
-    if (this._isExternalURL(fullpath)) return true;
+    if (this._isExternalUrl(fullpath)) return true;
 
     if (fullpath.length === 0) return true;
-    fullpath = this._translateURL(fullpath);
+    fullpath = this._translateUrl(fullpath);
     return (
       (fullpath.length > 0 && fullpath.charAt(0) === '/') ||
       (fullpath.length > 1 && fullpath.charAt(1) === ':')
@@ -84,9 +84,9 @@ export default {
   },
   copyFile: function(source, dest) {
     //URL are not copied.
-    if (this._isExternalURL(source)) return true;
+    if (this._isExternalUrl(source)) return true;
 
-    source = this._translateURL(source);
+    source = this._translateUrl(source);
     try {
       if (source !== dest) fs.copySync(source, dest);
     } catch (e) {
@@ -136,7 +136,7 @@ export default {
     return output;
   },
   fileExists: function(filename) {
-    filename = this._translateURL(filename);
+    filename = this._translateUrl(filename);
     try {
       const stat = fs.statSync(filename);
       return stat.isFile();
@@ -144,14 +144,19 @@ export default {
       return false;
     }
   },
-  _isExternalURL: function(filename) {
-    return filename.substr(0, 4) === 'http' || filename.substr(0, 4) === 'ftp';
+  _isExternalUrl: function(filename) {
+    return (
+      filename.startsWith('http://') ||
+      filename.startsWith('https://') ||
+      filename.startsWith('ftp://')
+    );
   },
   /**
    * Return the filename associated to the URL on the server, relative to the games directory.
    * (i.e: Transform g/mydirectory/myfile.png to mydirectory/myfile.png).
    */
-  _translateURL: function(filename) {
+  _translateUrl: function(filename) {
+    // TODO: remove
     if (filename.substr(0, 2) === 'g/' || filename.substr(0, 2) === 'g\\')
       filename = filename.substr(2);
 

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -26,6 +26,7 @@ import ProjectStorageProviders from './ProjectsStorage/ProjectStorageProviders';
 import LocalFileStorageProvider from './ProjectsStorage/LocalFileStorageProvider';
 import { LocalGDJSDevelopmentWatcher } from './GameEngineFinder/LocalGDJSDevelopmentWatcher';
 import UnsavedChangesContext from './MainFrame/UnsavedChangesContext';
+import { LocalResourceFetcher } from './ProjectsStorage/ResourceFetcher/LocalResourceFetcher';
 
 const gd: libGDevelop = global.gd;
 
@@ -42,6 +43,7 @@ export const create = (authentification: Authentification) => {
       makeEventsFunctionCodeWriter={makeLocalEventsFunctionCodeWriter}
       eventsFunctionsExtensionWriter={LocalEventsFunctionsExtensionWriter}
       eventsFunctionsExtensionOpener={LocalEventsFunctionsExtensionOpener}
+      resourceFetcher={LocalResourceFetcher}
     >
       {({ i18n, eventsFunctionsExtensionsState }) => (
         <ProjectStorageProviders

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -173,6 +173,7 @@ export type PreferencesValues = {|
   autoOpenMostRecentProject: boolean,
   hasProjectOpened: boolean,
   userShortcutMap: ShortcutMap,
+  newObjectDialogDefaultTab: 'asset-store' | 'new-object',
 |};
 
 /**
@@ -219,6 +220,8 @@ export type Preferences = {|
   setHasProjectOpened: (enabled: boolean) => void,
   resetShortcutsToDefault: () => void,
   setShortcutForCommand: (commandName: CommandName, shortcut: string) => void,
+  getNewObjectDialogDefaultTab: () => 'asset-store' | 'new-object',
+  setNewObjectDialogDefaultTab: ('asset-store' | 'new-object') => void,
 |};
 
 export const initialPreferences = {
@@ -247,6 +250,7 @@ export const initialPreferences = {
     autoOpenMostRecentProject: true,
     hasProjectOpened: false,
     userShortcutMap: {},
+    newObjectDialogDefaultTab: electron ? 'new-object' : 'asset-store',
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -283,6 +287,8 @@ export const initialPreferences = {
   setHasProjectOpened: () => {},
   resetShortcutsToDefault: () => {},
   setShortcutForCommand: (commandName: CommandName, shortcut: string) => {},
+  getNewObjectDialogDefaultTab: () => 'asset-store',
+  setNewObjectDialogDefaultTab: () => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -68,6 +68,8 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     setHasProjectOpened: this._setHasProjectOpened.bind(this),
     setShortcutForCommand: this._setShortcutForCommand.bind(this),
     resetShortcutsToDefault: this._resetShortcutsToDefault.bind(this),
+    getNewObjectDialogDefaultTab: this._getNewObjectDialogDefaultTab.bind(this),
+    setNewObjectDialogDefaultTab: this._setNewObjectDialogDefaultTab.bind(this),
   };
 
   componentDidMount() {
@@ -464,6 +466,21 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     this.setState(
       state => ({
         values: { ...state.values, userShortcutMap: updatedShortcutMap },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _getNewObjectDialogDefaultTab() {
+    return this.state.values.newObjectDialogDefaultTab;
+  }
+
+  _setNewObjectDialogDefaultTab(
+    newObjectDialogDefaultTab: 'asset-store' | 'new-object'
+  ) {
+    this.setState(
+      state => ({
+        values: { ...state.values, newObjectDialogDefaultTab },
       }),
       () => this._persistValuesToLocalStorage(this.state)
     );

--- a/newIDE/app/src/MainFrame/Providers.js
+++ b/newIDE/app/src/MainFrame/Providers.js
@@ -30,6 +30,10 @@ import { create } from 'jss';
 import rtl from 'jss-rtl';
 import { AssetStoreStateProvider } from '../AssetStore/AssetStoreContext';
 import { ResourceStoreStateProvider } from '../AssetStore/ResourceStore/ResourceStoreContext';
+import {
+  type ResourceFetcher,
+  ResourceFetcherContext,
+} from '../ProjectsStorage/ResourceFetcher';
 
 // Add the rtl plugin to the JSS instance to support RTL languages in material-ui components.
 const jss = create({
@@ -42,6 +46,7 @@ type Props = {|
   makeEventsFunctionCodeWriter: EventsFunctionCodeWriterCallbacks => ?EventsFunctionCodeWriter,
   eventsFunctionsExtensionWriter: ?EventsFunctionsExtensionWriter,
   eventsFunctionsExtensionOpener: ?EventsFunctionsExtensionOpener,
+  resourceFetcher: ResourceFetcher,
   children: ({
     i18n: I18nType,
     eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
@@ -61,6 +66,7 @@ export default class Providers extends React.Component<Props, {||}> {
       makeEventsFunctionCodeWriter,
       eventsFunctionsExtensionWriter,
       eventsFunctionsExtensionOpener,
+      resourceFetcher,
     } = this.props;
     return (
       <DragAndDropContextProvider>
@@ -97,14 +103,18 @@ export default class Providers extends React.Component<Props, {||}> {
                                   <CommandsContextProvider>
                                     <AssetStoreStateProvider>
                                       <ResourceStoreStateProvider>
-                                        <EventsFunctionsExtensionsContext.Consumer>
-                                          {eventsFunctionsExtensionsState =>
-                                            children({
-                                              i18n,
-                                              eventsFunctionsExtensionsState,
-                                            })
-                                          }
-                                        </EventsFunctionsExtensionsContext.Consumer>
+                                        <ResourceFetcherContext.Provider
+                                          value={resourceFetcher}
+                                        >
+                                          <EventsFunctionsExtensionsContext.Consumer>
+                                            {eventsFunctionsExtensionsState =>
+                                              children({
+                                                i18n,
+                                                eventsFunctionsExtensionsState,
+                                              })
+                                            }
+                                          </EventsFunctionsExtensionsContext.Consumer>
+                                        </ResourceFetcherContext.Provider>
                                       </ResourceStoreStateProvider>
                                     </AssetStoreStateProvider>
                                   </CommandsContextProvider>

--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/BrowserResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/BrowserResourceFetcher.js
@@ -1,0 +1,25 @@
+// @flow
+import { type ResourceFetcher, type FetchResourcesArgs } from '.';
+
+const getResourcesToFetch = (project: gdProject): Array<string> => {
+  // Currently, the web-app only supports resources with URLs.
+  // TODO: Detect non URLs resources and explain that it can be opened
+  // only on the desktop app.
+  return [];
+};
+
+const fetchResources = async ({
+  project,
+  resourceNames,
+  onProgress,
+}: FetchResourcesArgs) => {
+  return {
+    fetchedResources: [],
+    erroredResources: [],
+  };
+};
+
+export const BrowserResourceFetcher: ResourceFetcher = {
+  getResourcesToFetch,
+  fetchResources,
+};

--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.js
@@ -1,0 +1,86 @@
+// @flow
+import optionalRequire from '../../Utils/OptionalRequire.js';
+import newNameGenerator from '../../Utils/NewNameGenerator';
+import { type ResourceFetcher, type FetchResourcesArgs } from '.';
+import PromisePool from '@supercharge/promise-pool';
+const electron = optionalRequire('electron');
+const ipcRenderer = electron ? electron.ipcRenderer : null;
+const fs = optionalRequire('fs-extra');
+const path = optionalRequire('path');
+
+const isExternalUrl = (filename: string) => {
+  return (
+    filename.startsWith('http://') ||
+    filename.startsWith('https://') ||
+    filename.startsWith('ftp://')
+  );
+};
+
+const getResourcesToFetch = (project: gdProject): Array<string> => {
+  const resourcesManager = project.getResourcesManager();
+
+  const allResourceNames = resourcesManager.getAllResourceNames().toJSArray();
+  return allResourceNames.filter(resourceName => {
+    const resource = resourcesManager.getResource(resourceName);
+
+    return isExternalUrl(resource.getFile());
+  });
+};
+
+const fetchResources = async ({
+  project,
+  resourceNames,
+  onProgress,
+}: FetchResourcesArgs) => {
+  if (!fs || !ipcRenderer) throw new Error('Unsupported');
+  const resourcesManager = project.getResourcesManager();
+
+  const projectPath = path.dirname(project.getProjectFile());
+  const baseAssetsPath = path.join(projectPath, 'assets');
+  const downloadedFilePaths = new Set<string>();
+  const erroredResources = [];
+  const fetchedResources = [];
+
+  let fetchedResourcesCount = 0;
+  const resourcesToFetch = getResourcesToFetch(project);
+
+  return PromisePool.withConcurrency(3)
+    .for(resourceNames)
+    .process(async resourceName => {
+      const resource = resourcesManager.getResource(resourceName);
+
+      const url = resource.getFile();
+      const extension = path.extname(url);
+      const filenameWithoutExtension = path.basename(url, extension);
+      const name = newNameGenerator(filenameWithoutExtension, name => {
+        const tentativePath = path.join(baseAssetsPath, name) + extension;
+        return (
+          fs.existsSync(tentativePath) || downloadedFilePaths.has(tentativePath)
+        );
+      });
+      const newPath = path.join(baseAssetsPath, name) + extension;
+      downloadedFilePaths.add(newPath);
+
+      try {
+        await fs.ensureDir(baseAssetsPath);
+        await ipcRenderer.invoke('local-file-download', url, newPath);
+        resource.setFile(
+          path.relative(projectPath, newPath).replace(/\\/g, '/')
+        );
+        fetchedResources.push({ resourceName });
+      } catch (error) {
+        erroredResources.push({ resourceName, error });
+      }
+
+      onProgress(fetchedResourcesCount++, resourcesToFetch.length);
+    })
+    .then(() => ({
+      fetchedResources,
+      erroredResources,
+    }));
+};
+
+export const LocalResourceFetcher: ResourceFetcher = {
+  getResourcesToFetch,
+  fetchResources,
+};

--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.spec.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.spec.js
@@ -1,0 +1,118 @@
+// @flow
+import optionalRequire from '../../Utils/OptionalRequire.js';
+import { LocalResourceFetcher } from './LocalResourceFetcher';
+import { makeTestProject } from '../../fixtures/TestProject';
+import path from 'path';
+const gd: libGDevelop = global.gd;
+
+jest.mock('../../Utils/OptionalRequire.js');
+
+const mockFn = (fn: Function): JestMockFn<any, any> => fn;
+
+const makeTestProjectWithResourcesToDownload = () => {
+  const { project } = makeTestProject(gd);
+
+  // Add a resource that uses a URL, which will be download
+  // by the LocalResourceFetcher (whatever the origin).
+  {
+    const newResource = new gd.ImageResource();
+    newResource.setName('MyResourceToDownload');
+    newResource.setFile('http://example/file-to-download.png');
+    project.getResourcesManager().addResource(newResource);
+    newResource.delete();
+  }
+
+  // Add a resource that won't need to be downloaded (like other
+  // resources in the test project).
+  {
+    const newResource = new gd.ImageResource();
+    newResource.setName('MyAlreadyLocalResource');
+    newResource.setFile('some-local-file.png');
+    project.getResourcesManager().addResource(newResource);
+    newResource.delete();
+  }
+
+  return project;
+};
+
+describe('LocalResourceFetcher', () => {
+  beforeEach(() => {
+    mockFn(optionalRequire.mockFsExtra.ensureDir).mockReset();
+    mockFn(optionalRequire.mockFsExtra.existsSync).mockReset();
+    mockFn(optionalRequire.mockElectron.ipcRenderer.invoke).mockReset();
+  });
+
+  it('fetches resources and can download them', async () => {
+    const project = makeTestProjectWithResourcesToDownload();
+
+    // Ensure just the files to be downloaded are listed
+    const resourceNames = LocalResourceFetcher.getResourcesToFetch(project);
+    expect(resourceNames).toEqual(['MyResourceToDownload']);
+
+    // Mock a proper download
+    const onProgress = jest.fn();
+    mockFn(optionalRequire.mockFsExtra.ensureDir).mockImplementation(
+      async () => {}
+    );
+    mockFn(optionalRequire.mockFsExtra.existsSync).mockImplementation(
+      () => false
+    );
+    mockFn(optionalRequire.mockElectron.ipcRenderer.invoke).mockImplementation(
+      () => Promise.resolve()
+    );
+
+    const fetchedResources = await LocalResourceFetcher.fetchResources({
+      project,
+      resourceNames,
+      onProgress,
+    });
+
+    // Verify that download was done
+    expect(
+      optionalRequire.mockElectron.ipcRenderer.invoke
+    ).toHaveBeenCalledWith(
+      'local-file-download',
+      'http://example/file-to-download.png',
+      path.join('assets', 'file-to-download.png')
+    );
+    expect(fetchedResources.erroredResources).toEqual([]);
+  });
+
+  it('reports errors in case of download failure', async () => {
+    const project = makeTestProjectWithResourcesToDownload();
+
+    // Ensure just the files to be downloaded are listed
+    const resourceNames = LocalResourceFetcher.getResourcesToFetch(project);
+    expect(resourceNames).toEqual(['MyResourceToDownload']);
+
+    // Mock a failed download
+    const onProgress = jest.fn();
+    mockFn(optionalRequire.mockFsExtra.ensureDir).mockImplementation(
+      async () => {}
+    );
+    mockFn(optionalRequire.mockFsExtra.existsSync).mockImplementation(
+      () => false
+    );
+    mockFn(optionalRequire.mockElectron.ipcRenderer.invoke).mockImplementation(
+      () => Promise.reject(new Error('Fake download failure'))
+    );
+
+    const fetchedResources = await LocalResourceFetcher.fetchResources({
+      project,
+      resourceNames,
+      onProgress,
+    });
+
+    // Verify that download was done and reported as failed.
+    expect(
+      optionalRequire.mockElectron.ipcRenderer.invoke
+    ).toHaveBeenCalledWith(
+      'local-file-download',
+      'http://example/file-to-download.png',
+      path.join('assets', 'file-to-download.png')
+    );
+    expect(fetchedResources.erroredResources).toEqual([
+      { resourceName: 'MyResourceToDownload', error: expect.any(Error) },
+    ]);
+  });
+});

--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/index.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/index.js
@@ -1,0 +1,241 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import * as React from 'react';
+import Dialog from '../../UI/Dialog';
+import FlatButton from '../../UI/FlatButton';
+import { Line } from '../../UI/Grid';
+import Text from '../../UI/Text';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn,
+} from '../../UI/Table';
+import RaisedButton from '../../UI/RaisedButton';
+import { ColumnStackLayout } from '../../UI/Layout';
+
+export type FetchedResources = {|
+  erroredResources: Array<{|
+    resourceName: string,
+    error: Error,
+  |}>,
+  fetchedResources: Array<{|
+    resourceName: string,
+  |}>,
+|};
+
+export type FetchResourcesArgs = {|
+  project: gdProject,
+  resourceNames: Array<string>,
+  onProgress: (count: number, total: number) => void,
+|};
+
+/**
+ * Describe a way to fetch resources so that they can be used in the editor
+ * and in previews. For the local editor, this means downloading the resources
+ * that have URLs.
+ */
+export type ResourceFetcher = {|
+  getResourcesToFetch: (project: gdProject) => Array<string>,
+  fetchResources: FetchResourcesArgs => Promise<FetchedResources>,
+|};
+
+export const ResourceFetcherContext = React.createContext<?ResourceFetcher>(
+  null
+);
+
+type ResourceFetcherDialogProps = {|
+  progress: number,
+  fetchedResources: ?FetchedResources,
+  onAbandon: ?() => void,
+  onRetry: ?() => void,
+|};
+
+export const ResourceFetcherDialog = ({
+  progress,
+  fetchedResources,
+  onAbandon,
+  onRetry,
+}: ResourceFetcherDialogProps) => {
+  const hasErrors =
+    fetchedResources && fetchedResources.erroredResources.length > 0;
+
+  return (
+    <Dialog
+      actions={[
+        onRetry ? (
+          <RaisedButton
+            label={<Trans>Retry</Trans>}
+            primary
+            onClick={onRetry}
+            key="retry"
+          />
+        ) : null,
+        <FlatButton
+          label={
+            onAbandon ? <Trans>Abandon</Trans> : <Trans>Please wait...</Trans>
+          }
+          disabled={!onAbandon}
+          onClick={onAbandon}
+          key="close"
+        />,
+      ]}
+      cannotBeDismissed={true}
+      noMargin
+      open
+      maxWidth="sm"
+    >
+      <Line>
+        <ColumnStackLayout expand>
+          <Text>
+            {hasErrors ? (
+              <Trans>
+                There were errors when fetching resources for the project.
+              </Trans>
+            ) : (
+              <Trans>Resources needed for the project are downloaded...</Trans>
+            )}
+          </Text>
+          <LinearProgress variant="determinate" value={progress} />
+          {hasErrors && fetchedResources ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderColumn>Resource name</TableHeaderColumn>
+                  <TableHeaderColumn>Error</TableHeaderColumn>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {fetchedResources.erroredResources.map(
+                  ({ resourceName, error }) => (
+                    <TableRow key={resourceName}>
+                      <TableRowColumn>{resourceName}</TableRowColumn>
+                      <TableRowColumn>{error.toString()}</TableRowColumn>
+                    </TableRow>
+                  )
+                )}
+              </TableBody>
+            </Table>
+          ) : null}
+        </ColumnStackLayout>
+      </Line>
+    </Dialog>
+  );
+};
+
+type RetryOrAbandonCallback = () => void;
+
+type UseResourceFetcherOutput = {
+  /**
+   * Launch the fetching of the resources, if needed. For example, for the desktop
+   * app, this means downloading the resources that have URLs.
+   */
+  ensureResourcesAreFetched: (
+    project: gdProject
+  ) => Promise<{|
+    someResourcesWereFetched: boolean,
+  |}>,
+  /**
+   * Render, if needed, the dialog that will show the progress of resources fetching.
+   */
+  renderResourceFetcherDialog: () => React.Node,
+};
+
+/**
+ * Hook allowing to launch the fetching of resources, useful after opening a project
+ * or adding assets from the asset store (as they must be downloaded on the desktop app).
+ */
+export const useResourceFetcher = (): UseResourceFetcherOutput => {
+  const resourceFetcher = React.useContext(ResourceFetcherContext);
+  const [progress, setProgress] = React.useState(0);
+  const [isFetching, setIsFetching] = React.useState(false);
+  const [
+    fetchedResources,
+    setFetchedResources,
+  ] = React.useState<?FetchedResources>(null);
+  const [onRetry, setOnRetry] = React.useState<?RetryOrAbandonCallback>(null);
+  const [onAbandon, setOnAbandon] = React.useState<?RetryOrAbandonCallback>(
+    null
+  );
+
+  const ensureResourcesAreFetched = React.useCallback(
+    async (project: gdProject) => {
+      if (!resourceFetcher) throw new Error('No resourceFetcher was defined');
+
+      const resourceNames = resourceFetcher.getResourcesToFetch(project);
+      if (resourceNames.length === 0)
+        return { someResourcesWereFetched: false };
+
+      setProgress(0);
+      setOnRetry(null);
+      setOnAbandon(null);
+      setFetchedResources(null);
+      setIsFetching(true);
+
+      // TODO: handle error?
+      const fetchedResources = await resourceFetcher.fetchResources({
+        project,
+        resourceNames,
+        onProgress: (count, total) => {
+          setProgress((count / total) * 100);
+        },
+      });
+
+      setProgress(100);
+      if (fetchedResources.erroredResources.length === 0) {
+        // No error happened: finish normally, closing the dialog.
+        setIsFetching(false);
+        setFetchedResources(null);
+        return { someResourcesWereFetched: true };
+      }
+
+      // An error happened. Store the errors and offer a way to
+      // retry.
+      return new Promise(resolve => {
+        setOnRetry(
+          (): RetryOrAbandonCallback => () => {
+            // Launch the fetch again, and solve the promise once
+            // this new fetch resolve itself.
+            resolve(ensureResourcesAreFetched(project));
+          }
+        );
+        setOnAbandon(
+          (): RetryOrAbandonCallback => () => {
+            // Abandon: resolve immediately, closing the dialog
+            setIsFetching(false);
+            setFetchedResources(null);
+            resolve({ someResourcesWereFetched: true });
+          }
+        );
+
+        // Display the errors to the user:
+        setFetchedResources(fetchedResources);
+        setIsFetching(false);
+      });
+    },
+    [resourceFetcher]
+  );
+
+  const renderResourceFetcherDialog = () => {
+    const hasErrors =
+      fetchedResources && fetchedResources.erroredResources.length >= 0;
+    if (!isFetching && !hasErrors) return null;
+
+    return (
+      <ResourceFetcherDialog
+        progress={progress}
+        fetchedResources={fetchedResources}
+        onAbandon={onAbandon}
+        onRetry={onRetry}
+      />
+    );
+  };
+
+  return {
+    ensureResourcesAreFetched,
+    renderResourceFetcherDialog,
+  };
+};

--- a/newIDE/app/src/ResourcesList/BrowserResourceSources.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceSources.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
 import Dialog from '../UI/Dialog';
 import { ResourceStore } from '../AssetStore/ResourceStore';
+import path from 'path';
 const gd = global.gd;
 
 class GenericResourcesChooser extends Component {
@@ -26,7 +27,8 @@ class GenericResourcesChooser extends Component {
 
     const newResource = this.props.createNewResource();
     newResource.setFile(chosenResourceUrl);
-    newResource.setName(chosenResourceUrl);
+    newResource.setName(path.basename(chosenResourceUrl));
+    newResource.setOrigin('gdevelop-asset-store', chosenResourceUrl);
 
     resolveWithResources([newResource]);
     this.setState({

--- a/newIDE/app/src/UI/LoaderModal.js
+++ b/newIDE/app/src/UI/LoaderModal.js
@@ -1,38 +1,30 @@
 import React from 'react';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import { Dialog, DialogContent } from '@material-ui/core';
 
 const loaderSize = 50;
 
+const styles = {
+  dialogContent: {
+    padding: 10,
+    overflowX: 'hidden',
+    display: 'flex',
+    flexDirection: 'row',
+  },
+};
+
+const transitionDuration = { enter: 0, exit: 150 };
+
 export default props => {
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0,0,0,0.5)',
-        zIndex: 2000, // 2000 is higher than any Material-UI modal
-        pointerEvents: props.show ? 'cursor' : 'none',
-        display: props.show ? 'block' : 'none',
-      }}
-    >
-      <div
-        style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          marginTop: -loaderSize / 2,
-          marginLeft: -loaderSize / 2,
-          width: loaderSize,
-          height: loaderSize,
-        }}
-      >
-        {props.show /* Don't render CircularProgress to avoid it to use a timeout that would wake regularly the CPU  */ && (
-          <CircularProgress size={loaderSize} disableShrink />
-        )}
-      </div>
-    </div>
+    <Dialog open={props.show} transitionDuration={transitionDuration}>
+      <DialogContent style={styles.dialogContent}>
+        <CircularProgress
+          style={styles.circularProgress}
+          size={loaderSize}
+          disableShrink
+        />
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/newIDE/app/src/Utils/__mocks__/OptionalRequire.js
+++ b/newIDE/app/src/Utils/__mocks__/OptionalRequire.js
@@ -1,0 +1,39 @@
+import path from 'path';
+
+const mockElectron = {
+  ipcRenderer: {
+    invoke: jest.fn(),
+  },
+};
+const mockFsExtra = {
+  ensureDir: jest.fn(),
+  existsSync: jest.fn(),
+};
+
+const mockOptionalRequire = jest.fn(
+  (
+    moduleName,
+    config = {
+      rethrowException: false,
+    }
+  ) => {
+    if (moduleName === 'electron') {
+      return mockElectron;
+    }
+    if (moduleName === 'fs-extra') {
+      return mockFsExtra;
+    }
+    if (moduleName === 'path') {
+      return path;
+    }
+
+    throw new Error(
+      `The mock of optionalRequire does not support module with name: ${moduleName}. Please edit the mock to add it.`
+    );
+  }
+);
+
+mockOptionalRequire.mockElectron = mockElectron;
+mockOptionalRequire.mockFsExtra = mockFsExtra;
+
+module.exports = mockOptionalRequire;

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -289,6 +289,10 @@ const spaceshipSerializedResources = [
   {
     alwaysLoaded: false,
     file: 'https://example.com/player-ship1.png',
+    origin: {
+      name: 'gdevelop-asset-store',
+      identifier: 'https://example.com/player-ship1.png',
+    },
     kind: 'image',
     metadata: '',
     name: 'player-ship1.png',
@@ -298,6 +302,10 @@ const spaceshipSerializedResources = [
   {
     alwaysLoaded: false,
     file: 'https://example.com/player-ship2.png',
+    origin: {
+      name: 'gdevelop-asset-store',
+      identifier: 'https://example.com/player-ship2.png',
+    },
     kind: 'image',
     metadata: '',
     name: 'player-ship2.png',

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -215,6 +215,7 @@ import { SearchResults } from '../AssetStore/SearchResults';
 import { AssetDetails } from '../AssetStore/AssetDetails';
 import { ResourceStoreStateProvider } from '../AssetStore/ResourceStore/ResourceStoreContext';
 import { ResourceStore } from '../AssetStore/ResourceStore';
+import { ResourceFetcherDialog } from '../ProjectsStorage/ResourceFetcher';
 
 configureActions({
   depth: 2,
@@ -4644,5 +4645,36 @@ storiesOf('AssetStore/AssetDetails', module)
         return Promise.reject();
       }}
       resourceSources={[]}
+    />
+  ));
+
+storiesOf('ResourceFetcher/ResourceFetcherDialog', module)
+  .addDecorator(muiDecorator)
+  .add('in progress', () => (
+    <ResourceFetcherDialog
+      progress={40}
+      fetchedResources={null}
+      onAbandon={null}
+      onRetry={null}
+    />
+  ))
+  .add('with errors', () => (
+    <ResourceFetcherDialog
+      progress={100}
+      fetchedResources={{
+        fetchedResources: [],
+        erroredResources: [
+          {
+            resourceName: 'Player.png',
+            error: new Error('Fake download error'),
+          },
+          {
+            resourceName: 'Spaceship.png',
+            error: new Error('Another fake error'),
+          },
+        ],
+      }}
+      onAbandon={action('abandon')}
+      onRetry={action('retry')}
     />
   ));

--- a/newIDE/app/yarn.lock
+++ b/newIDE/app/yarn.lock
@@ -2656,6 +2656,18 @@
     telejson "^2.2.1"
     util-deprecate "^1.0.2"
 
+"@supercharge/goodies@~1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@supercharge/goodies/-/goodies-1.5.1.tgz#7ec3327419fd700074770b9363eafd6053e6a3e6"
+  integrity sha512-LrbIgboxJ9labELaN6JUcZEWAdKveohRI3u11ILb/rqrKbeXkN8/ezoLvWJ0oo9s/HeBf0REFTD3XpVEio053g==
+
+"@supercharge/promise-pool@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@supercharge/promise-pool/-/promise-pool-1.6.0.tgz#033aa064a4fdbe316f57d0ae1072d4ba05b02973"
+  integrity sha512-/zQnPJ2CMfGdVI1OlWn7fUfYSyLjTUHWxQ3svvrCwNznrpxZsa+nMC1QDkJ5LCiVzYrfQx7sK5pYcSSaQpmE+w==
+  dependencies:
+    "@supercharge/goodies" "~1.5.1"
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"

--- a/newIDE/electron-app/app/LocalFileDownloader.js
+++ b/newIDE/electron-app/app/LocalFileDownloader.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const axios = require('axios');
+const log = require('electron-log');
+
+module.exports = {
+  downloadLocalFile: async (url, outputPath) => {
+    const writer = fs.createWriteStream(outputPath);
+
+    log.verbose(`Downloading ${url} to ${outputPath}...`);
+    const response = await axios.get(url, {
+      responseType: 'stream',
+    });
+
+    return new Promise((resolve, reject) => {
+      response.data.pipe(writer);
+      let error = null;
+      writer.on('error', err => {
+        error = err;
+        writer.close();
+        reject(err);
+      });
+      writer.on('close', () => {
+        if (!error) {
+          resolve(true);
+        }
+        // No need to call `reject` here, as it will have been called in the
+        // 'error' callback.
+      });
+    });
+  },
+};

--- a/newIDE/electron-app/app/LocalFileUploader.js
+++ b/newIDE/electron-app/app/LocalFileUploader.js
@@ -1,10 +1,5 @@
 const fs = require('fs');
-const path = require('path');
 const axios = require('axios');
-const async = require('async');
-const { makeTimestampedId } = require('./Utils/TimestampedId');
-const isDev = require('electron-is').dev();
-const log = require('electron-log');
 const { Transform } = require('stream');
 
 module.exports = {

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -19,6 +19,7 @@ const { load, registerGdideProtocol } = require('./Utils/UrlLoader');
 const throttle = require('lodash.throttle');
 const { findLocalIp } = require('./Utils/LocalNetworkIpFinder');
 const setUpDiscordRichPresence = require('./DiscordRichPresence');
+const { downloadLocalFile } = require('./LocalFileDownloader');
 
 log.info('GDevelop Electron app starting...');
 
@@ -243,6 +244,12 @@ app.on('ready', function() {
       }
     );
   });
+
+  // LocalFileDownloader events:
+  ipcMain.handle('local-file-download', async (event, url, outputPath) => {
+    const result = await downloadLocalFile(url, outputPath);
+    return result;
+  })
 
   // ServeFolder events:
   ipcMain.on('serve-folder', (event, options) => {


### PR DESCRIPTION
This was only available on the web-app, the assets store is now also available on the desktop app. This will be getting more and more useful as we grow it in the future with community contributions :) Even currently, it's a good way to quickly start a game or do prototypes.

Also:
* Automatically download resources when a project made on the web-app is opened on the desktop-app.
  * Note that the reverse operation, opening a project made on the desktop-app in the web-app, is not possible for now, but could be something that could be added later. Not a priority at all though.
  * Internally, resources can now have an "origin". This is useful to annotate resources to know where they are coming from, so that we don't download them again if a user is adding multiple times the same object from the assets store. This could also be useful later if we add support for resources from cloud providers.
* Rework the loader when opening a project or launching a preview (properly block clicks behind the loader)
* Shorten names for resources added from the resource store, in the web-app.
