### PR TITLE
Set cursor to pointer in SceneEditor Menu

### DIFF
--- a/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
+++ b/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
@@ -3,6 +3,7 @@ import { type CommandName } from '../CommandPalette/CommandsList';
 
 export type ShortcutMap = { [CommandName]: string };
 
+
 const defaultShortcuts: ShortcutMap = {
   QUIT_APP: 'CmdOrCtrl+Shift+KeyQ',
   OPEN_PROJECT_MANAGER: 'CmdOrCtrl+Alt+KeyE',

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -5,6 +5,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { I18n } from '@lingui/react';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 import { adaptAcceleratorString } from '../UI/AcceleratorString';
+import { string } from 'prop-types';
 
 type IconProps =
   | {|

--- a/newIDE/app/src/UI/ToolbarIcon.js
+++ b/newIDE/app/src/UI/ToolbarIcon.js
@@ -47,6 +47,7 @@ const ToolbarIcon = React.forwardRef<Props, IconButton>((props: Props, ref) => {
               filter: disabled
                 ? 'grayscale(100%)'
                 : muiTheme.gdevelopIconsCSSFilter,
+                cursor: "pointer"
             }}
           />
         </IconButton>


### PR DESCRIPTION
Hello. My name is Advait and I am a classmate of arthuro555. He recommended this repo to learn and improve my ReactJs and coding skills. I have only been coding for a year, so my contributions will most likely be useless. 

I changed the cursor of the toolbar Iconbuttons to cursor, as to indicate that it is a button. Even though it looks like a button, a pointer cursor really helps my brain register it as a button. 

I hope you consider my PR.

Regards,
Advait