### PR TITLE
Add line color option to grid setup dialog

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/EventTextDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/EventTextDialog.js
@@ -6,7 +6,8 @@ import * as React from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
 import { Line, Column } from '../../UI/Grid';
-import ColorPicker, { type RGBColor } from '../../UI/ColorField/ColorPicker';
+import ColorPicker from '../../UI/ColorField/ColorPicker';
+import { type RGBColor } from '../../Utils/ColorTransformer';
 import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
 

--- a/newIDE/app/src/InstancesEditor/Grid.js
+++ b/newIDE/app/src/InstancesEditor/Grid.js
@@ -1,4 +1,12 @@
 import * as PIXI from 'pixi.js-legacy';
+import { rgbColorToHexNumber, type RGBColor } from '../Utils/ColorTransformer';
+
+// Equal to #6868E8
+const DEFAULT_COLOR: RGBColor = {
+  r: 104,
+  g: 104,
+  b: 232,
+};
 
 export default class SelectionRectangle {
   constructor({ viewPosition, options }) {
@@ -25,10 +33,14 @@ export default class SelectionRectangle {
       return;
     }
 
+    const gridColor = options.gridColor || DEFAULT_COLOR;
+    const gridHex = rgbColorToHexNumber(gridColor);
+    const gridAlpha = gridColor.a || 1;
+
     this.pixiGrid.visible = true;
     this.pixiGrid.clear();
-    this.pixiGrid.beginFill(0x6868e8);
-    this.pixiGrid.lineStyle(1, 0x6868e8, 1);
+    this.pixiGrid.beginFill(gridHex);
+    this.pixiGrid.lineStyle(1, gridHex, gridAlpha);
     this.pixiGrid.fill.alpha = 0.1;
     this.pixiGrid.alpha = 0.8;
 

--- a/newIDE/app/src/SceneEditor/SetupGridDialog.js
+++ b/newIDE/app/src/SceneEditor/SetupGridDialog.js
@@ -2,12 +2,16 @@ import { Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
 import TextField from '../UI/TextField';
+import { ResponsiveLineStackLayout } from '../UI/Layout';
 import Dialog from '../UI/Dialog';
+import ColorField from '../UI/ColorField';
 
 export default class SetupGridDialog extends Component {
   constructor(props) {
     super(props);
-    this.state = { ...props.gridOptions };
+    this.state = {
+      ...props.gridOptions,
+    };
   }
 
   _onApply = () => {
@@ -16,6 +20,7 @@ export default class SetupGridDialog extends Component {
       gridHeight: this.state.gridHeight,
       gridOffsetX: this.state.gridOffsetX,
       gridOffsetY: this.state.gridOffsetY,
+      gridColor: this.state.gridColor,
     });
   };
 
@@ -43,38 +48,51 @@ export default class SetupGridDialog extends Component {
         open={this.props.open}
         onRequestClose={this.props.onCancel}
       >
-        <TextField
-          floatingLabelText={<Trans>Cell width (in pixels)</Trans>}
-          type="number"
-          value={this.state.gridWidth}
-          onChange={(e, value) =>
-            this.setState({ gridWidth: parseInt(value, 10) })
-          }
-        />
-        <TextField
-          floatingLabelText={<Trans>Cell height (in pixels)</Trans>}
-          type="number"
-          value={this.state.gridHeight}
-          onChange={(e, value) =>
-            this.setState({ gridHeight: parseInt(value, 10) })
-          }
-        />
-        <TextField
-          floatingLabelText={<Trans>X offset (in pixels)</Trans>}
-          type="number"
-          value={this.state.gridOffsetX}
-          onChange={(e, value) =>
-            this.setState({ gridOffsetX: parseInt(value, 10) })
-          }
-        />
-        <TextField
-          floatingLabelText={<Trans>Y offset (in pixels)</Trans>}
-          type="number"
-          value={this.state.gridOffsetY}
-          onChange={(e, value) =>
-            this.setState({ gridOffsetY: parseInt(value, 10) })
-          }
-        />
+        <ResponsiveLineStackLayout>
+          <ColorField
+            floatingLabelText={<Trans>Line color</Trans>}
+            color={this.state.gridColor}
+            onChangeComplete={color => {
+              this.setState({ gridColor: color.rgb });
+            }}
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <TextField
+            floatingLabelText={<Trans>Cell width (in pixels)</Trans>}
+            type="number"
+            value={this.state.gridWidth}
+            onChange={(e, value) =>
+              this.setState({ gridWidth: parseInt(value, 10) })
+            }
+          />
+          <TextField
+            floatingLabelText={<Trans>Cell height (in pixels)</Trans>}
+            type="number"
+            value={this.state.gridHeight}
+            onChange={(e, value) =>
+              this.setState({ gridHeight: parseInt(value, 10) })
+            }
+          />
+        </ResponsiveLineStackLayout>
+        <ResponsiveLineStackLayout>
+          <TextField
+            floatingLabelText={<Trans>X offset (in pixels)</Trans>}
+            type="number"
+            value={this.state.gridOffsetX}
+            onChange={(e, value) =>
+              this.setState({ gridOffsetX: parseInt(value, 10) })
+            }
+          />
+          <TextField
+            floatingLabelText={<Trans>Y offset (in pixels)</Trans>}
+            type="number"
+            value={this.state.gridOffsetY}
+            onChange={(e, value) =>
+              this.setState({ gridOffsetY: parseInt(value, 10) })
+            }
+          />
+        </ResponsiveLineStackLayout>
       </Dialog>
     );
   }

--- a/newIDE/app/src/UI/ColorField/ColorPicker.js
+++ b/newIDE/app/src/UI/ColorField/ColorPicker.js
@@ -5,13 +5,7 @@ import * as React from 'react';
 import { SketchPicker } from 'react-color';
 import Popover from '@material-ui/core/Popover';
 import muiZIndex from '@material-ui/core/styles/zIndex';
-
-export type RGBColor = {|
-  r: number,
-  g: number,
-  b: number,
-  a?: number,
-|};
+import { type RGBColor } from '../../Utils/ColorTransformer';
 
 export type ColorResult = {
   rgb: RGBColor,

--- a/newIDE/app/src/Utils/ColorTransformer.js
+++ b/newIDE/app/src/Utils/ColorTransformer.js
@@ -1,5 +1,17 @@
 // @flow
 
+export type RGBColor = {|
+  r: number,
+  g: number,
+  b: number,
+  a?: number,
+|};
+
+export const rgbColorToHexNumber = (rgbColor: RGBColor) => {
+  const { r, g, b } = rgbColor;
+  return rgbToHexNumber(r, g, b);
+};
+
 /**
  * Convert a rgb color value to a string hex value.
  * @note No "#" or "0x" are added.


### PR DESCRIPTION
## What was changed
This introduces a `gridColor` field to the UI settings that can be set from the grid setup dialogue. This option is used in the grid renderer to change the color & alpha of the grid lines.

## Motivation
I often find when working a scene with many dark colors that the default grid makes it hard to spot object edges. This reduces the usefulness of the snap-to-grid feature, as I have to toggle the grid off to see the objects I'm moving. Being able to reduces the opacity and/or contrast of the grid will totally fix this.

## Demo
Updated: 
![gdev-grid-opacity](https://user-images.githubusercontent.com/2236777/99749578-aa42dd80-2a93-11eb-8527-0d8de56820c6.gif)


Original:
[Before apply](https://user-images.githubusercontent.com/2236777/99724263-393a0080-2a68-11eb-89c8-29f0b8d9ed51.png)
[After apply.](https://user-images.githubusercontent.com/2236777/99724273-3c34f100-2a68-11eb-9d50-ff6387147605.png)

## UI Questions  
Updated answer: Switch to ColorField, stack fields in columns.

Original:
> I don't _love_ the way the color picker show's up in the dialogue, as there's a toolbar with nothing else in it. However, I'm not sure what a nicer layout would be; the picker doesn't really fit next to the the text fields either. I went with the matching the EventTextDialogue for consistency. 
