### PR TITLE
Fix lights crash

### DIFF
--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -335,6 +335,7 @@ gdjs.LayerPixiRenderer.prototype._updateRenderTexture = function () {
  */
 gdjs.LayerPixiRenderer.prototype._replaceContainerWithSprite = function () {
   if (!this._pixiRenderer) return;
+  if (this._pixiRenderer.type !== PIXI.RENDERER_TYPE.WEBGL) return;
 
   this._updateRenderTexture();
   if (!this._renderTexture) return;

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.js
@@ -284,7 +284,7 @@ gdjs.LayerPixiRenderer.prototype.updateClearColor = function () {
  * Also, render texture is cleared with a specified clear color.
  */
 gdjs.LayerPixiRenderer.prototype._updateRenderTexture = function () {
-  if (!this._pixiRenderer) return;
+  if (!this._pixiRenderer || this._pixiRenderer.type !== PIXI.RENDERER_TYPE.WEBGL) return;
 
   if (!this._renderTexture) {
     this._oldWidth = this._pixiRenderer.screen.width;
@@ -334,8 +334,7 @@ gdjs.LayerPixiRenderer.prototype._updateRenderTexture = function () {
  * @private used only in lighting for now as the sprite could have MULTIPLY blend mode.
  */
 gdjs.LayerPixiRenderer.prototype._replaceContainerWithSprite = function () {
-  if (!this._pixiRenderer) return;
-  if (this._pixiRenderer.type !== PIXI.RENDERER_TYPE.WEBGL) return;
+  if (!this._pixiRenderer || this._pixiRenderer.type !== PIXI.RENDERER_TYPE.WEBGL) return;
 
   this._updateRenderTexture();
   if (!this._renderTexture) return;


### PR DESCRIPTION
`pixiRenderer.renderTexture` is used but only present on the webgl renderer. Using it on the Canvas renderer causes a crash, so return early if the renderer is not supported.