### PR TITLE
Destroying renderers of deleted objects

### DIFF
--- a/GDJS/Runtime/runtimeobject.js
+++ b/GDJS/Runtime/runtimeobject.js
@@ -322,6 +322,7 @@ gdjs.RuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
     var rendererObject = this.getRendererObject();
     if (rendererObject) {
         theLayer.getRenderer().removeRendererObject(rendererObject);
+        if (rendererObject.destroy) rendererObject.destroy();
     }
 
     for(var j = 0, lenj = this._behaviors.length;j<lenj;++j) {


### PR DESCRIPTION
This is not a very good solution, especially if we one day switch/add renderers. 