### PR TITLE
Added Node@12.20.0 as dependency requirement

### DIFF
--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "homepage": ".",
-  "engines": {"node":"12.16.1 "},
+  "engines": {"node":"<=12.16.1 "},
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@lingui/cli": "^2.7.3",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -49,6 +49,7 @@
     "jss-rtl": "^0.3.0",
     "keen-tracking": "1.1.3",
     "lodash": "4.17.4",
+    "node": "12.20.0",
     "node-require-function": "^1.2.0",
     "pixi-simple-gesture": "git://github.com/4ian/pixi-simple-gesture#v0.3.3",
     "pixi.js-legacy": "5.3.3",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT",
   "homepage": ".",
+  "engines": {"node":"12.16.1 "},
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@lingui/cli": "^2.7.3",
@@ -49,7 +50,6 @@
     "jss-rtl": "^0.3.0",
     "keen-tracking": "1.1.3",
     "lodash": "4.17.4",
-    "node": "12.20.0",
     "node-require-function": "^1.2.0",
     "pixi-simple-gesture": "git://github.com/4ian/pixi-simple-gesture#v0.3.3",
     "pixi.js-legacy": "5.3.3",


### PR DESCRIPTION
My system is Linux amd64 (Ubuntu 20.10) which runs NODEJS 14.4.0,
While following the Development installation Instructions, I run into a problem which goes like
``` 
> grpc@1.23.3 install /home/ubuntu_18_04/projects/GDevelop/newIDE/app/node_modules/grpc
> node-pre-gyp install --fallback-to-build --library=static_library

node-pre-gyp WARN Using request for node-pre-gyp https download 
node-pre-gyp WARN Tried to download(404): https://node-precompiled-binaries.grpc.io/grpc/v1.23.3/node-v83-linux-x64-glibc.tar.gz 
node-pre-gyp WARN Pre-built binaries not found for grpc@1.23.3 and node@14.15.1 (node-v83 ABI, glibc) (falling back to source compile with node-gyp) 
make: Entering directory '/home/ubuntu_18_04/projects/GDevelop/newIDE/app/node_modules/grpc/build'
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/surface/init.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/avl/avl.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/backoff/backoff.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/channel_args.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/channel_stack.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/channel_stack_builder.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/channel_trace.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/channelz.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/channelz_registry.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/connected_channel.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/handshaker.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/handshaker_registry.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/channel/status_util.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/compression/compression.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/compression/compression_args.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/compression/compression_internal.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/compression/message_compress.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/compression/stream_compression.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/compression/stream_compression_gzip.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/compression/stream_compression_identity.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/debug/stats.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/debug/stats_data.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/http/format_request.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/http/httpcli.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/http/parser.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/buffer_list.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/call_combiner.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/cfstream_handle.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/combiner.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/endpoint.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/endpoint_cfstream.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/endpoint_pair_posix.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/endpoint_pair_uv.o
  CXX(target) Release/obj.target/grpc/deps/grpc/src/core/lib/iomgr/endpoint_pair_windows.o
 .......<followed by similar statements>
```
I talked with @arthuro555  on discord about the problem and got a suggestion to "test which versions are compatible and issue a PR", and now i am doing just that :smile: 

I've found that the latest LTS version of node (14) did not work,but the issue is with another dependency (GRPC) hence added the last LTS that worked. 

[Reference to the issue that suggests rolling back the versions](https://github.com/grpc/grpc-node/issues/922#issuecomment-551093599)
I'm new to the GDevelop developer Community, 

Please tell me what node versions you've been using (10 or 12 or something else?) :hugs: