### PR TITLE
Workaround for whitespace in objects panel

### DIFF
--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -2,6 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
+import {findDOMNode} from 'react-dom';
 import { AutoSizer, List } from 'react-virtualized';
 import Background from '../UI/Background';
 import SearchBar from '../UI/SearchBar';
@@ -55,6 +56,14 @@ class GroupsList extends Component<*, *> {
 
   forceUpdateGrid() {
     if (this.list) this.list.forceUpdateGrid();
+  }
+
+  // Workaround for whitespace issue caused by react-virtualized
+  componentDidUpdate(){
+    const listNode = findDOMNode(this.list);
+    if(listNode.hasChildNodes() && listNode.firstChild.hasChildNodes())
+      if(!listNode.scrollTop && !!listNode.firstChild.firstChild.offsetTop)
+        this.list.scrollToPosition(listNode.firstChild.firstChild.offsetTop);
   }
 
   render() {

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/index.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { findDOMNode } from 'react-dom';
 import { List } from 'react-virtualized';
 import ItemRow from './ItemRow';
 import { AddListItem } from '../ListCommonItem';
@@ -84,6 +85,14 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
         connectIconDragSource={connectIconDragSource || null}
       />
     );
+  }
+
+  // Workaround for whitespace issue cause by react-visualized
+  componentDidUpdate(){
+    const listNode = findDOMNode(this._list);
+    if(listNode.hasChildNodes() && listNode.firstChild.hasChildNodes())
+      if(!listNode.scrollTop && !!listNode.firstChild.firstChild.offsetTop)
+        this._list.scrollToPosition(listNode.firstChild.firstChild.offsetTop);
   }
 
   render() {


### PR DESCRIPTION
Used a bit of DOM manipulation to solve this. It basically compares the position of the scrollbar of the list with the position of the first element in that list and uses that to decided whether or not it should fix the scroll. Here is what the end result looks like:

![ScrollIssue-2020-12-22_04 43 22](https://user-images.githubusercontent.com/37783178/102831323-8287c200-4411-11eb-8848-d00d40617adb.gif)

I can't seem to find a solution for the flickering as it's most likely from the `react-virtualized` library :(

Also, I tried using `List.forceUpdateGrid()` instead of `List.scrollToPosition()`, but it didn't seem to work. In my opinion that is the better way if someone can get it to work with that (unless I'm misunderstanding what it actually does).

Should fix Issue #1999 :)