### PR TITLE
Rework objects recycling to be opt-in with a reinitialize method

### DIFF
--- a/Extensions/BBText/bbtextruntimeobject.js
+++ b/Extensions/BBText/bbtextruntimeobject.js
@@ -23,7 +23,7 @@
  * @param {gdjs.RuntimeScene} runtimeScene The {@link gdjs.RuntimeScene} the object belongs to
  * @param {BBTextObjectData} objectData The object data used to initialize the object
  */
-gdjs.BBTextRuntimeObject = function(runtimeScene, objectData) {
+gdjs.BBTextRuntimeObject = function (runtimeScene, objectData) {
   gdjs.RuntimeObject.call(this, runtimeScene, objectData);
 
   /** @type {number} */
@@ -32,7 +32,9 @@ gdjs.BBTextRuntimeObject = function(runtimeScene, objectData) {
   /** @type {string} */
   this._text = objectData.content.text;
   /** @type {number[]} color in format [r, g, b], where each component is in the range [0, 255] */
-  this._color = gdjs.BBTextRuntimeObject.hexToRGBColor(objectData.content.color);
+  this._color = gdjs.BBTextRuntimeObject.hexToRGBColor(
+    objectData.content.color
+  );
   /** @type {string} */
   this._fontFamily = objectData.content.fontFamily;
   /** @type {number} */
@@ -45,10 +47,7 @@ gdjs.BBTextRuntimeObject = function(runtimeScene, objectData) {
   /** @type {string} */
   this._align = objectData.content.align;
 
-  if (this._renderer)
-    gdjs.BBTextRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
-  else
-    this._renderer = new gdjs.BBTextRuntimeObjectRenderer(this, runtimeScene);
+  this._renderer = new gdjs.BBTextRuntimeObjectRenderer(this, runtimeScene);
 
   // While this should rather be exposed as a property for all objects, honor the "visible"
   // property that is specific to this object.
@@ -68,7 +67,9 @@ gdjs.BBTextRuntimeObject.hexToRGBColor = function (hex) {
   return [(hexNumber >> 16) & 0xff, (hexNumber >> 8) & 0xff, hexNumber & 0xff];
 };
 
-gdjs.BBTextRuntimeObject.prototype.getRendererObject = function() {
+gdjs.BBTextRuntimeObject.supportsReinitialization = false;
+
+gdjs.BBTextRuntimeObject.prototype.getRendererObject = function () {
   return this._renderer.getRendererObject();
 };
 
@@ -76,7 +77,10 @@ gdjs.BBTextRuntimeObject.prototype.getRendererObject = function() {
  * @param {BBTextObjectDataType} oldObjectData
  * @param {BBTextObjectDataType} newObjectData
  */
-gdjs.BBTextRuntimeObject.prototype.updateFromObjectData = function(oldObjectData, newObjectData) {
+gdjs.BBTextRuntimeObject.prototype.updateFromObjectData = function (
+  oldObjectData,
+  newObjectData
+) {
   if (oldObjectData.content.opacity !== newObjectData.content.opacity) {
     this.setOpacity(newObjectData.content.opacity);
   }
@@ -87,7 +91,9 @@ gdjs.BBTextRuntimeObject.prototype.updateFromObjectData = function(oldObjectData
     this.setBBText(newObjectData.content.text);
   }
   if (oldObjectData.content.color !== newObjectData.content.color) {
-    this._color = gdjs.BBTextRuntimeObject.hexToRGBColor(newObjectData.content.color);
+    this._color = gdjs.BBTextRuntimeObject.hexToRGBColor(
+      newObjectData.content.color
+    );
     this._renderer.updateColor();
   }
   if (oldObjectData.content.fontFamily !== newObjectData.content.fontFamily) {
@@ -110,21 +116,24 @@ gdjs.BBTextRuntimeObject.prototype.updateFromObjectData = function(oldObjectData
  * Initialize the extra parameters that could be set for an instance.
  * @private
  */
-gdjs.BBTextRuntimeObject.prototype.extraInitializationFromInitialInstance = function(initialInstanceData) {
+gdjs.BBTextRuntimeObject.prototype.extraInitializationFromInitialInstance = function (
+  initialInstanceData
+) {
   if (initialInstanceData.customSize)
     this.setWrappingWidth(initialInstanceData.width);
-  else
-    this.setWrappingWidth(250); // This value is the default wrapping width of the runtime object.
+  else this.setWrappingWidth(250); // This value is the default wrapping width of the runtime object.
 };
 
-gdjs.BBTextRuntimeObject.prototype.onDestroyFromScene = function(runtimeScene) {
+gdjs.BBTextRuntimeObject.prototype.onDestroyFromScene = function (
+  runtimeScene
+) {
   gdjs.RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);
 };
 
 /**
  * Set the markup text to display.
  */
-gdjs.BBTextRuntimeObject.prototype.setBBText = function(text) {
+gdjs.BBTextRuntimeObject.prototype.setBBText = function (text) {
   this._text = text;
   this._renderer.updateText();
 };
@@ -132,11 +141,11 @@ gdjs.BBTextRuntimeObject.prototype.setBBText = function(text) {
 /**
  * Get the markup text displayed by the object.
  */
-gdjs.BBTextRuntimeObject.prototype.getBBText = function() {
+gdjs.BBTextRuntimeObject.prototype.getBBText = function () {
   return this._text;
 };
 
-gdjs.BBTextRuntimeObject.prototype.setColor = function(rgbColorString) {
+gdjs.BBTextRuntimeObject.prototype.setColor = function (rgbColorString) {
   const splitValue = rgbColorString.split(';');
   if (splitValue.length !== 3) return;
 
@@ -150,34 +159,34 @@ gdjs.BBTextRuntimeObject.prototype.setColor = function(rgbColorString) {
  * Get the base color.
  * @return {string} The color as a "R;G;B" string, for example: "255;0;0"
  */
-gdjs.BBTextRuntimeObject.prototype.getColor = function() {
-  return this._color[0] + ";" + this._color[1] + ";" + this._color[2];
+gdjs.BBTextRuntimeObject.prototype.getColor = function () {
+  return this._color[0] + ';' + this._color[1] + ';' + this._color[2];
 };
 
-gdjs.BBTextRuntimeObject.prototype.setFontSize = function(fontSize) {
+gdjs.BBTextRuntimeObject.prototype.setFontSize = function (fontSize) {
   this._fontSize = fontSize;
   this._renderer.updateFontSize();
 };
 
-gdjs.BBTextRuntimeObject.prototype.getFontSize = function() {
+gdjs.BBTextRuntimeObject.prototype.getFontSize = function () {
   return this._fontSize;
 };
 
-gdjs.BBTextRuntimeObject.prototype.setFontFamily = function(fontFamily) {
+gdjs.BBTextRuntimeObject.prototype.setFontFamily = function (fontFamily) {
   this._fontFamily = fontFamily;
   this._renderer.updateFontFamily();
 };
 
-gdjs.BBTextRuntimeObject.prototype.getFontFamily = function() {
+gdjs.BBTextRuntimeObject.prototype.getFontFamily = function () {
   return this._fontFamily;
 };
 
-gdjs.BBTextRuntimeObject.prototype.setAlignment = function(align) {
+gdjs.BBTextRuntimeObject.prototype.setAlignment = function (align) {
   this._align = align;
   this._renderer.updateAlignment();
 };
 
-gdjs.BBTextRuntimeObject.prototype.getAlignment = function() {
+gdjs.BBTextRuntimeObject.prototype.getAlignment = function () {
   return this._align;
 };
 
@@ -185,7 +194,7 @@ gdjs.BBTextRuntimeObject.prototype.getAlignment = function() {
  * Set object position on X axis.
  * @param {number} x The new position X of the object.
  */
-gdjs.BBTextRuntimeObject.prototype.setX = function(x) {
+gdjs.BBTextRuntimeObject.prototype.setX = function (x) {
   gdjs.RuntimeObject.prototype.setX.call(this, x);
   this._renderer.updatePosition();
 };
@@ -194,7 +203,7 @@ gdjs.BBTextRuntimeObject.prototype.setX = function(x) {
  * Set object position on Y axis.
  * @param {number} y The new position Y of the object.
  */
-gdjs.BBTextRuntimeObject.prototype.setY = function(y) {
+gdjs.BBTextRuntimeObject.prototype.setY = function (y) {
   gdjs.RuntimeObject.prototype.setY.call(this, y);
   this._renderer.updatePosition();
 };
@@ -203,7 +212,7 @@ gdjs.BBTextRuntimeObject.prototype.setY = function(y) {
  * Set the angle of the object.
  * @param {number} angle The new angle of the object.
  */
-gdjs.BBTextRuntimeObject.prototype.setAngle = function(angle) {
+gdjs.BBTextRuntimeObject.prototype.setAngle = function (angle) {
   gdjs.RuntimeObject.prototype.setAngle.call(this, angle);
   this._renderer.updateAngle();
 };
@@ -212,7 +221,7 @@ gdjs.BBTextRuntimeObject.prototype.setAngle = function(angle) {
  * Set object opacity.
  * @param {number} opacity The new opacity of the object (0-255).
  */
-gdjs.BBTextRuntimeObject.prototype.setOpacity = function(opacity) {
+gdjs.BBTextRuntimeObject.prototype.setOpacity = function (opacity) {
   this._opacity = opacity;
   this._renderer.updateOpacity();
 };
@@ -220,7 +229,7 @@ gdjs.BBTextRuntimeObject.prototype.setOpacity = function(opacity) {
 /**
  * Get object opacity.
  */
-gdjs.BBTextRuntimeObject.prototype.getOpacity = function() {
+gdjs.BBTextRuntimeObject.prototype.getOpacity = function () {
   return this._opacity;
 };
 
@@ -228,7 +237,7 @@ gdjs.BBTextRuntimeObject.prototype.getOpacity = function() {
  * Set the width.
  * @param {number} width The new width in pixels.
  */
-gdjs.BBTextRuntimeObject.prototype.setWrappingWidth = function(width) {
+gdjs.BBTextRuntimeObject.prototype.setWrappingWidth = function (width) {
   this._wrappingWidth = width;
   this._renderer.updateWrappingWidth();
 };
@@ -236,29 +245,29 @@ gdjs.BBTextRuntimeObject.prototype.setWrappingWidth = function(width) {
 /**
  * Get the wrapping width of the object.
  */
-gdjs.BBTextRuntimeObject.prototype.getWrappingWidth = function() {
+gdjs.BBTextRuntimeObject.prototype.getWrappingWidth = function () {
   return this._wrappingWidth;
 };
 
-gdjs.BBTextRuntimeObject.prototype.setWordWrap = function(wordWrap) {
+gdjs.BBTextRuntimeObject.prototype.setWordWrap = function (wordWrap) {
   this._wordWrap = wordWrap;
   this._renderer.updateWordWrap();
 };
 
-gdjs.BBTextRuntimeObject.prototype.getWordWrap = function(wordWrap) {
+gdjs.BBTextRuntimeObject.prototype.getWordWrap = function (wordWrap) {
   return this._wordWrap;
 };
 
 /**
  * Get the width of the object.
  */
-gdjs.BBTextRuntimeObject.prototype.getWidth = function() {
+gdjs.BBTextRuntimeObject.prototype.getWidth = function () {
   return this._renderer.getWidth();
 };
 
 /**
  * Get the height of the object.
  */
-gdjs.BBTextRuntimeObject.prototype.getHeight = function() {
+gdjs.BBTextRuntimeObject.prototype.getHeight = function () {
   return this._renderer.getHeight();
 };

--- a/Extensions/ExampleJsExtension/dummyruntimeobject.js
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject.js
@@ -13,9 +13,7 @@ gdjs.DummyRuntimeObject = function(runtimeScene, objectData) {
   this._property1 = objectData.content.property1;
 
   // Create the renderer (see dummyruntimeobject-pixi-renderer.js)
-  if (this._renderer)
-    gdjs.DummyRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
-  else this._renderer = new gdjs.DummyRuntimeObjectRenderer(this, runtimeScene);
+  this._renderer = new gdjs.DummyRuntimeObjectRenderer(this, runtimeScene);
 
   // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
   this.onCreated();

--- a/Extensions/Lighting/lightruntimeobject.js
+++ b/Extensions/Lighting/lightruntimeobject.js
@@ -40,9 +40,7 @@ gdjs.LightRuntimeObject = function (runtimeScene, lightObjectData) {
   /** @type {gdjs.LightObstaclesManager} */
   this._obstaclesManager = gdjs.LightObstaclesManager.getManager(runtimeScene);
 
-  if (this._renderer)
-    gdjs.LightRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
-  else this._renderer = new gdjs.LightRuntimeObjectRenderer(this, runtimeScene);
+  this._renderer = new gdjs.LightRuntimeObjectRenderer(this, runtimeScene);
 
   /** @type {gdjs.RuntimeScene} */
   this._runtimeScene = runtimeScene;

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
@@ -55,23 +55,13 @@ gdjs.PanelSpriteRuntimeObject = function(runtimeScene, panelSpriteObjectData) {
   /** @type {number} */
   this.opacity = 255;
 
-  if (this._renderer) {
-    gdjs.PanelSpriteRuntimeObjectRenderer.call(
-      this._renderer,
-      this,
-      runtimeScene,
-      panelSpriteObjectData.texture,
-      panelSpriteObjectData.tiled
-    );
-  } else {
-    /** @type {gdjs.PanelSpriteRuntimeObjectRenderer} */
-    this._renderer = new gdjs.PanelSpriteRuntimeObjectRenderer(
-      this,
-      runtimeScene,
-      panelSpriteObjectData.texture,
-      panelSpriteObjectData.tiled
-    );
-  }
+  /** @type {gdjs.PanelSpriteRuntimeObjectRenderer} */
+  this._renderer = new gdjs.PanelSpriteRuntimeObjectRenderer(
+    this,
+    runtimeScene,
+    panelSpriteObjectData.texture,
+    panelSpriteObjectData.tiled
+  );
 
   // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
   this.onCreated();

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js
@@ -59,11 +59,8 @@ gdjs.ShapePainterRuntimeObject = function(runtimeScene, shapePainterObjectData)
     /** @type {boolean} */
     this._clearBetweenFrames = shapePainterObjectData.clearBetweenFrames;
 
-    if (this._renderer)
-        gdjs.ShapePainterRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
-    else
-        /** @type {gdjs.ShapePainterRuntimeObjectRenderer} */
-        this._renderer = new gdjs.ShapePainterRuntimeObjectRenderer(this, runtimeScene);
+    /** @type {gdjs.ShapePainterRuntimeObjectRenderer} */
+    this._renderer = new gdjs.ShapePainterRuntimeObjectRenderer(this, runtimeScene);
 
     // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
     this.onCreated();
@@ -71,6 +68,8 @@ gdjs.ShapePainterRuntimeObject = function(runtimeScene, shapePainterObjectData)
 
 gdjs.ShapePainterRuntimeObject.prototype = Object.create( gdjs.RuntimeObject.prototype );
 gdjs.registerObject("PrimitiveDrawing::Drawer", gdjs.ShapePainterRuntimeObject);
+
+gdjs.ShapePainterRuntimeObject.supportsReinitialization = false;
 
 gdjs.ShapePainterRuntimeObject.prototype.getRendererObject = function() {
     return this._renderer.getRendererObject();

--- a/Extensions/TextEntryObject/textentryruntimeobject.js
+++ b/Extensions/TextEntryObject/textentryruntimeobject.js
@@ -22,11 +22,8 @@ gdjs.TextEntryRuntimeObject = function(runtimeScene, textEntryObjectData)
     /** @type {boolean} */
     this._activated = true;
 
-    if (this._renderer)
-        gdjs.TextEntryRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
-    else
-        /** @type {gdjs.TextEntryRuntimeObjectRenderer} */
-        this._renderer = new gdjs.TextEntryRuntimeObjectRenderer(this, runtimeScene);
+    /** @type {gdjs.TextEntryRuntimeObjectRenderer} */
+    this._renderer = new gdjs.TextEntryRuntimeObjectRenderer(this, runtimeScene);
 
     // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
     this.onCreated();

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.js
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.js
@@ -3,7 +3,7 @@ gdjs.TextRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene)
     this._object = runtimeObject;
     this._fontManager = runtimeScene.getGame().getFontManager();
 
-    if ( this._text === undefined ) this._text = new PIXI.Text(" ", {align:"left"});
+    this._text = new PIXI.Text(" ", {align:"left"});
     this._text.anchor.x = 0.5;
     this._text.anchor.y = 0.5;
     runtimeScene.getLayer("").getRenderer().addRendererObject(this._text, runtimeObject.getZOrder());
@@ -69,7 +69,7 @@ gdjs.TextRuntimeObjectPixiRenderer.prototype.updateStyle = function() {
     style.dropShadowAngle = this._object._shadowAngle;
     style.dropShadowDistance = this._object._shadowDistance;
     style.padding = this._object._padding;
-    // Prevent spikey outlines by adding a miter limit 
+    // Prevent spikey outlines by adding a miter limit
     style.miterLimit = 3;
 
     this.updatePosition();
@@ -123,7 +123,7 @@ gdjs.TextRuntimeObjectPixiRenderer.prototype._getGradientHex = function() {
                 this._object._gradient[colorIndex][2]
             )
         );
-    } 
+    }
     return gradient;
 }
 /**

--- a/Extensions/TextObject/textruntimeobject.js
+++ b/Extensions/TextObject/textruntimeobject.js
@@ -106,11 +106,8 @@ gdjs.TextRuntimeObject = function(runtimeScene, textObjectData)
     /** @type {string} */
     this._str = textObjectData.string;
 
-    if (this._renderer)
-        gdjs.TextRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
-    else
-        /** @type {gdjs.TextRuntimeObjectRenderer} */
-        this._renderer = new gdjs.TextRuntimeObjectRenderer(this, runtimeScene);
+    /** @type {gdjs.TextRuntimeObjectRenderer} */
+    this._renderer = new gdjs.TextRuntimeObjectRenderer(this, runtimeScene);
 
     // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
     this.onCreated();

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.js
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.js
@@ -29,11 +29,8 @@ gdjs.TiledSpriteRuntimeObject = function(runtimeScene, tiledSpriteObjectData)
     this._yOffset = 0;
     this.opacity = 255;
 
-    if (this._renderer)
-        gdjs.TiledSpriteRuntimeObjectRenderer.call(this._renderer, this, runtimeScene, tiledSpriteObjectData.texture);
-    else
-        /** @type {gdjs.TiledSpriteRuntimeObjectRenderer} */
-        this._renderer = new gdjs.TiledSpriteRuntimeObjectRenderer(this, runtimeScene, tiledSpriteObjectData.texture);
+    /** @type {gdjs.TiledSpriteRuntimeObjectRenderer} */
+    this._renderer = new gdjs.TiledSpriteRuntimeObjectRenderer(this, runtimeScene, tiledSpriteObjectData.texture);
 
     this.setWidth(tiledSpriteObjectData.width);
     this.setHeight(tiledSpriteObjectData.height);

--- a/Extensions/Video/videoruntimeobject-pixi-renderer.js
+++ b/Extensions/Video/videoruntimeobject-pixi-renderer.js
@@ -10,23 +10,19 @@ gdjs.VideoRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene) {
   this._object = runtimeObject;
 
   // Load (or reset) the video
-  if (this._pixiObject === undefined) {
-    this._pixiObject = new PIXI.Sprite(
-      runtimeScene
-        .getGame()
-        .getImageManager()
-        .getPIXIVideoTexture(this._object._videoResource)
-    );
-    this._pixiObject._texture.baseTexture.autoPlay = false;
-  } else {
-    this._pixiObject._texture.baseTexture.resource.source.currentTime = 0;
-  }
-  
+  this._pixiObject = new PIXI.Sprite(
+    runtimeScene
+      .getGame()
+      .getImageManager()
+      .getPIXIVideoTexture(this._object._videoResource)
+  );
+  this._pixiObject._texture.baseTexture.autoPlay = false;
+
   // Needed to avoid video not playing/crashing in Chrome/Chromium browsers.
   // See https://github.com/pixijs/pixi.js/issues/5996
   this._pixiObject._texture.baseTexture.resource.source.preload = "auto";
   this._pixiObject._texture.baseTexture.resource.source.autoload = true;
-  
+
   this._textureWasValid = false; // Will be set to true when video texture is loaded.
 
   runtimeScene

--- a/Extensions/Video/videoruntimeobject.js
+++ b/Extensions/Video/videoruntimeobject.js
@@ -42,10 +42,8 @@ gdjs.VideoRuntimeObject = function(runtimeScene, videoObjectData) {
   /** @type {boolean} */
   this._pausedAsScenePaused = false;
 
-  if (this._renderer)
-    gdjs.VideoRuntimeObjectRenderer.call(this._renderer, this, runtimeScene);
-  /** @type {gdjs.VideoRuntimeObjectRenderer} */ else
-    this._renderer = new gdjs.VideoRuntimeObjectRenderer(this, runtimeScene);
+  /** @type {gdjs.VideoRuntimeObjectRenderer} */
+  this._renderer = new gdjs.VideoRuntimeObjectRenderer(this, runtimeScene);
 
   // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
   this.onCreated();

--- a/GDJS/Runtime/cocos-renderers/spriteruntimeobject-cocos-renderer.js
+++ b/GDJS/Runtime/cocos-renderers/spriteruntimeobject-cocos-renderer.js
@@ -17,6 +17,17 @@ gdjs.SpriteRuntimeObjectCocosRenderer = function(runtimeObject, runtimeScene)
 
 gdjs.SpriteRuntimeObjectRenderer = gdjs.SpriteRuntimeObjectCocosRenderer; //Register the class to let the engine use it.
 
+// Same as the constructor - we don't really support reinitialization.
+gdjs.SpriteRuntimeObjectCocosRenderer.prototype.reinitialize = function(runtimeObject, runtimeScene) {
+    this._object = runtimeObject;
+    this._sprite = new cc.Sprite(runtimeScene.getGame().getImageManager().getInvalidTexture());
+    this._currentBlendMode = undefined;
+
+    var renderer = runtimeScene.getLayer("").getRenderer();
+    renderer.addRendererObject(this._sprite, runtimeObject.getZOrder());
+    this._convertYPosition = renderer.convertYPosition;
+};
+
 gdjs.SpriteRuntimeObjectCocosRenderer.prototype.getRendererObject = function() {
     return this._sprite;
 };

--- a/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.js
@@ -20,6 +20,15 @@ gdjs.SpriteRuntimeObjectPixiRenderer = function(runtimeObject, runtimeScene)
 
 gdjs.SpriteRuntimeObjectRenderer = gdjs.SpriteRuntimeObjectPixiRenderer; //Register the class to let the engine use it.
 
+gdjs.SpriteRuntimeObjectPixiRenderer.prototype.reinitialize = function(runtimeObject, runtimeScene) {
+    this._object = runtimeObject;
+    this._spriteDirty = true;
+    this._textureDirty = true;
+
+    var layer = runtimeScene.getLayer("");
+    if (layer) layer.getRenderer().addRendererObject(this._sprite, runtimeObject.getZOrder());
+}
+
 gdjs.SpriteRuntimeObjectPixiRenderer.prototype.getRendererObject = function() {
     return this._sprite;
 };


### PR DESCRIPTION
This removes all "hacks" that would call the constructor as a usual method to reinitialize an object.

While looking at the memory charts seems to indicate no real difference (which is fine!), I believe this could confuse some JS engine optimizations, and was confusing for the reader. It would also not be supported with ES6 classes and TypeScript. 

Now, we have a clear "reinitialize" method to be implemented for objects that want to opt in in this behavior (it's only implemented for sprites for now, as they are the most used objects and the ones usually used for "bullets" and other objects often destroyed/re-created).