### PR TITLE
Add a player assistance to bypass the obstacles with the top-down behavior

### DIFF
--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -9,6 +9,8 @@ This project is released under the MIT License.
 #include "GDCpp/Runtime/Project/BehaviorsSharedData.h"
 #include "TopDownMovementBehavior.h"
 #include "TopDownMovementRuntimeBehavior.h"
+#include "TopDownObstacleBehavior.h"
+//#include "TopDownObstacleRuntimeBehavior.h" no native implementation
 
 void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
   extension
@@ -21,6 +23,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
           "Open source (MIT License)")
       .SetExtensionHelpPath("/behaviors/topdown");
 
+  {
   gd::BehaviorMetadata& aut = extension.AddBehavior(
       "TopDownMovementBehavior",
       _("Top-down movement (4 or 8 directions)"),
@@ -374,7 +377,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
 
   aut.AddAction("AllowDiagonals",
                 _("Diagonal movement"),
-                _("Allow or restrict diagonal movemment"),
+                _("Allow or restrict diagonal movement"),
                 _("Allow diagonal moves for _PARAM0_: _PARAM2_"),
                 _("Movement"),
                 "CppPlatform/Extensions/topdownmovementicon24.png",
@@ -539,7 +542,55 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardParameters("number");
+
+  //TODO can use AddExpressionAndConditionAndAction?
+  aut.AddAction("EnableAssistance",
+                _("Enable obstacles bypass assistance"),
+                _("Enable or disable obstacles bypass assistance"),
+                _("Enable obstacles bypass assistance _PARAM0_: _PARAM2_"),
+                _("Movement"),
+                "CppPlatform/Extensions/topdownmovementicon24.png",
+                "CppPlatform/Extensions/topdownmovementicon16.png")
+      .AddParameter("object", _("Object"))
+      .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
+      .AddParameter("yesorno", _("Enable?"))
+      .SetFunctionName("EnableAssistance")
+      .SetIncludeFile(
+          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+
+  aut.AddCondition("IsAssistanceEnable",
+                   _("Obstacles bypass assistance activation"),
+                   _("Check if the object is assisted to bypass obstacles"),
+                   _("_PARAM0_ is assisted to bypass obstacles"),
+                   _("Movement"),
+                   "CppPlatform/Extensions/topdownmovementicon24.png",
+                   "CppPlatform/Extensions/topdownmovementicon16.png")
+      .AddParameter("object", _("Object"))
+      .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
+      .MarkAsAdvanced()
+      .SetFunctionName("IsAssistanceEnable")
+      .SetIncludeFile(
+          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+
 #endif
+  }
+  {
+    gd::BehaviorMetadata& aut = extension.AddBehavior(
+        "TopDownObstacleBehavior",
+        _("Obstacle for Top-down movement"),
+        "TopDownObstacle",
+        _("Make the player slide on its corners."),
+        "",
+        "CppPlatform/Extensions/topdownmovementicon.png",
+        "TopDownObstacleBehavior",
+        std::make_shared<TopDownObstacleBehavior>(),
+        std::make_shared<gd::BehaviorsSharedData>());
+
+#if defined(GD_IDE_ONLY)
+    aut.SetIncludeFile("TopDownMovementBehavior/TopDownObstacleRuntimeBehavior.h");
+
+#endif
+  }
 }
 
 /**

--- a/Extensions/TopDownMovementBehavior/JsExtension.cpp
+++ b/Extensions/TopDownMovementBehavior/JsExtension.cpp
@@ -27,7 +27,16 @@ class TopDownMovementBehaviorJsExtension : public gd::PlatformExtension {
     GetBehaviorMetadata("TopDownMovementBehavior::TopDownMovementBehavior")
         .SetIncludeFile(
             "Extensions/TopDownMovementBehavior/"
-            "topdownmovementruntimebehavior.js");
+            "topdownmovementruntimebehavior.js")
+	     .AddIncludeFile(
+	         "Extensions/TopDownMovementBehavior/topdownobstacleruntimebehavior.js");
+
+    GetBehaviorMetadata("TopDownMovementBehavior::TopDownObstacleBehavior")
+        .SetIncludeFile(
+            "Extensions/TopDownMovementBehavior/"
+            "topdownmovementruntimebehavior.js")
+        .AddIncludeFile(
+            "Extensions/TopDownMovementBehavior/topdownobstacleruntimebehavior.js");
 
     std::map<gd::String, gd::InstructionMetadata>& autActions =
         GetAllActionsForBehavior(
@@ -103,6 +112,10 @@ class TopDownMovementBehaviorJsExtension : public gd::PlatformExtension {
         .SetFunctionName("ignoreDefaultControls");
     autActions["TopDownMovementBehavior::SimulateStick"].SetFunctionName(
         "simulateStick");
+    autActions["TopDownMovementBehavior::EnableAssistance"].SetFunctionName(
+        "enableAssistance");
+    autConditions["TopDownMovementBehavior::IsAssistanceEnable"].SetFunctionName(
+        "isAssistanceEnable");
 
     autExpressions["Acceleration"].SetFunctionName("getAcceleration");
     autExpressions["Deceleration"].SetFunctionName("getDeceleration");

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -40,6 +40,7 @@ void TopDownMovementBehavior::InitializeContent(
   behaviorContent.SetAttribute("viewpoint", "TopDown");
   behaviorContent.SetAttribute("customIsometryAngle", 30);
   behaviorContent.SetAttribute("movementAngleOffset", 0);
+  behaviorContent.SetAttribute("enableAssistance", false);
 }
 
 #if defined(GD_IDE_ONLY)
@@ -100,6 +101,11 @@ TopDownMovementBehavior::GetProperties(
       .SetDescription(_(
           "Usually 0, unless you choose an *Isometry* viewpoint in which case "
           "-45 is recommended."));
+  properties[_("Enable obstacles bypass assistance")]
+      .SetValue(behaviorContent.GetBoolAttribute("enableAssistance")
+                    ? "true"
+                    : "false")
+      .SetType("Boolean");
 
   return properties;
 }
@@ -148,6 +154,10 @@ bool TopDownMovementBehavior::UpdateProperty(
   }
   if (name == _("Movement angle offset")) {
     behaviorContent.SetAttribute("movementAngleOffset", value.To<float>());
+  }
+  if (name == _("Enable obstacles bypass assistance")) {
+    behaviorContent.SetAttribute("enableAssistance", (value != "0"));
+    return true;
   }
 
   if (value.To<float>() < 0) return false;

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -105,7 +105,8 @@ TopDownMovementBehavior::GetProperties(
       .SetValue(behaviorContent.GetBoolAttribute("enableAssistance")
                     ? "true"
                     : "false")
-      .SetType("Boolean");
+      .SetType("Boolean")
+      .SetDescription(_("Obstacles must have the TopDownObstacle behavior."));
 
   return properties;
 }

--- a/Extensions/TopDownMovementBehavior/TopDownObstacleBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownObstacleBehavior.cpp
@@ -1,0 +1,87 @@
+/**
+
+GDevelop - TopDown Obstacle Behavior
+Copyright (c) 2014-2016 Florian Rival (Florian.Rival@gmail.com)
+This project is released under the MIT License.
+*/
+
+#include "TopDownObstacleBehavior.h"
+#include <memory>
+#include "GDCore/Tools/Localization.h"
+#include "GDCpp/Runtime/CommonTools.h"
+#include "GDCpp/Runtime/Project/Layout.h"
+#include "GDCpp/Runtime/RuntimeObject.h"
+#include "GDCpp/Runtime/RuntimeScene.h"
+#include "GDCpp/Runtime/Serialization/SerializerElement.h"
+//#include "SceneTopDownObstaclesManager.h" no native implementation
+#if defined(GD_IDE_ONLY)
+#include <iostream>
+#include <map>
+#include "GDCore/Project/PropertyDescriptor.h"
+#endif
+
+void TopDownObstacleBehavior::InitializeContent(
+    gd::SerializerElement& behaviorContent) {
+  behaviorContent.SetAttribute("slidingCornerSize", 0);
+  behaviorContent.SetAttribute("viewpoint", "TopDown");
+  behaviorContent.SetAttribute("customIsometryAngle", 30);
+}
+
+#if defined(GD_IDE_ONLY)
+std::map<gd::String, gd::PropertyDescriptor> TopDownObstacleBehavior::GetProperties(
+    const gd::SerializerElement& behaviorContent) const {
+  std::map<gd::String, gd::PropertyDescriptor> properties;
+
+  properties[_("Sliding corner size")].SetValue(
+      gd::String::From(behaviorContent.GetDoubleAttribute("slidingCornerSize")));
+
+  gd::String viewpoint = behaviorContent.GetStringAttribute("viewpoint");
+  gd::String viewpointStr = _("Viewpoint");
+  if (viewpoint == "TopDown")
+    viewpointStr = _("Top-Down");
+  else if (viewpoint == "PixelIsometry")
+    viewpointStr = _("Isometry 2:1 (26.565°)");
+  else if (viewpoint == "TrueIsometry")
+    viewpointStr = _("True Isometry (30°)");
+  else if (viewpoint == "CustomIsometry")
+    viewpointStr = _("Custom Isometry");
+  properties[_("Viewpoint")]
+      .SetValue(viewpointStr)
+      .SetType("Choice")
+      .AddExtraInfo(_("Top-Down"))
+      .AddExtraInfo(_("Isometry 2:1 (26.565°)"))
+      .AddExtraInfo(_("True Isometry (30°)"))
+      .AddExtraInfo(_("Custom Isometry"));
+  properties[_("Custom isometry angle")].SetValue(
+      gd::String::From(behaviorContent.GetDoubleAttribute("customIsometryAngle")));
+
+  return properties;
+}
+
+bool TopDownObstacleBehavior::UpdateProperty(gd::SerializerElement& behaviorContent,
+                                      const gd::String& name,
+                                      const gd::String& value) {
+  if (name == _("Sliding corner size"))
+    behaviorContent.SetAttribute("slidingCornerSize", value.To<double>());
+  else if (name == _("Viewpoint")) {
+    if (value == _("Isometry 2:1 (26.565°)"))
+      behaviorContent.SetAttribute("viewpoint", "PixelIsometry");
+    else if (value == _("True Isometry (30°)"))
+      behaviorContent.SetAttribute("viewpoint", "TrueIsometry");
+    else if (value == _("Custom Isometry"))
+      behaviorContent.SetAttribute("viewpoint", "CustomIsometry");
+    else
+      behaviorContent.SetAttribute("viewpoint", "TopDown");
+    return true;
+  }
+
+  if (value.To<float>() < 0) return false;
+
+  if (name == _("Custom isometry angle"))
+    behaviorContent.SetAttribute("customIsometryAngle", value.To<float>());
+  else
+    return false;
+
+  return true;
+}
+#endif

--- a/Extensions/TopDownMovementBehavior/TopDownObstacleBehavior.h
+++ b/Extensions/TopDownMovementBehavior/TopDownObstacleBehavior.h
@@ -1,0 +1,51 @@
+/**
+
+GDevelop - Platform Behavior Extension
+Copyright (c) 2013-2016 Florian Rival (Florian.Rival@gmail.com)
+This project is released under the MIT License.
+*/
+
+#ifndef TOPDOWNOBSTACLEBEHAVIOR_H
+#define TOPDOWNOBSTACLEBEHAVIOR_H
+#include "GDCpp/Runtime/Project/Behavior.h"
+#include "GDCpp/Runtime/Project/Object.h"
+class ScenePlatformObjectsManager;
+class RuntimeScene;
+namespace gd {
+class SerializerElement;
+}
+#if defined(GD_IDE_ONLY)
+#include <map>
+namespace gd {
+class PropertyDescriptor;
+class Project;
+class Layout;
+}  // namespace gd
+#endif
+
+/**
+ * \brief Behavior that mark object as being a platform for objects using
+ * PlatformerObject behavior.
+ */
+class GD_EXTENSION_API TopDownObstacleBehavior : public Behavior {
+ public:
+  TopDownObstacleBehavior(){};
+  virtual ~TopDownObstacleBehavior(){};
+  virtual Behavior* Clone() const override {
+    return new TopDownObstacleBehavior(*this);
+  }
+
+#if defined(GD_IDE_ONLY)
+  virtual std::map<gd::String, gd::PropertyDescriptor> GetProperties(
+      const gd::SerializerElement& behaviorContent) const override;
+  virtual bool UpdateProperty(gd::SerializerElement& behaviorContent,
+                              const gd::String& name,
+                              const gd::String& value) override;
+#endif
+  virtual void InitializeContent(
+      gd::SerializerElement& behaviorContent) override;
+
+ private:
+};
+
+#endif  // PLATFORMBEHAVIOR_H

--- a/Extensions/TopDownMovementBehavior/tests/assistancetopdownmovementbehavior.spec.js
+++ b/Extensions/TopDownMovementBehavior/tests/assistancetopdownmovementbehavior.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
+describe('gdjs.TopDownMovementRuntimeBehavior', function () {
   describe('Assistance', function () {
     const topDownName = 'auto1';
 
@@ -122,7 +122,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // The player bypassed the obstacle from below.
@@ -142,7 +141,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateStick(0, 1);
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // The player bypassed the obstacle from below.
@@ -168,7 +166,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // The player bypassed the obstacle from below.
@@ -196,7 +193,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug('position: ' + player.getX() + ' ; ' + player.getY());
       }
 
       // The player bypassed the obstacle from below.
@@ -224,7 +220,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // The player bypassed the obstacle from below.
@@ -244,7 +239,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // The player bypassed the obstacle from above.
@@ -264,7 +258,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateLeftKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be.below(obstacle.getX());
@@ -283,7 +276,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateLeftKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be.below(obstacle.getX());
@@ -302,7 +294,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateDownKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
@@ -321,7 +312,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateDownKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
@@ -340,9 +330,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateUpKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(
-          player.getX() + ' ; ' + player.getY() + obstacle.getHeight()
-        );
       }
 
       expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
@@ -361,7 +348,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateUpKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
@@ -380,7 +366,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
@@ -399,7 +384,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateLeftKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
@@ -418,7 +402,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateDownKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX());
@@ -437,7 +420,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateUpKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX());
@@ -457,7 +439,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
@@ -477,7 +458,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateLeftKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
@@ -497,7 +477,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateDownKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(playerX);
@@ -517,7 +496,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateUpKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(playerX);
@@ -545,7 +523,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
             player.getBehavior(topDownName).simulateDownKey();
           }
           runtimeScene.renderAndStep(1000 / 60);
-          console.debug(player.getX() + ' ; ' + player.getY());
         }
 
         expect(player.getX()).to.be.above(obstacle.getX());
@@ -572,7 +549,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
             player.getBehavior(topDownName).simulateUpKey();
           }
           runtimeScene.renderAndStep(1000 / 60);
-          console.debug(player.getX() + ' ; ' + player.getY());
         }
 
         expect(player.getX()).to.be.above(obstacle2.getX());
@@ -599,7 +575,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
             player.getBehavior(topDownName).simulateDownKey();
           }
           runtimeScene.renderAndStep(1000 / 60);
-          console.debug(player.getX() + ' ; ' + player.getY());
         }
 
         expect(player.getX()).to.be.below(obstacle.getX());
@@ -626,7 +601,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
             player.getBehavior(topDownName).simulateUpKey();
           }
           runtimeScene.renderAndStep(1000 / 60);
-          console.debug(player.getX() + ' ; ' + player.getY());
         }
 
         expect(player.getX()).to.be.below(obstacle2.getX());
@@ -653,7 +627,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
             player.getBehavior(topDownName).simulateRightKey();
           }
           runtimeScene.renderAndStep(1000 / 60);
-          console.debug(player.getX() + ' ; ' + player.getY());
         }
 
         expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
@@ -680,7 +653,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
             player.getBehavior(topDownName).simulateLeftKey();
           }
           runtimeScene.renderAndStep(1000 / 60);
-          console.debug(player.getX() + ' ; ' + player.getY());
         }
 
         expect(player.getX()).to.be(obstacle2.getX() - player.getWidth());
@@ -703,7 +675,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
         player.getBehavior(topDownName).simulateRightKey();
         player.getBehavior(topDownName).simulateDownKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
 
         expect(player.getX()).to.be(playerX);
         expect(player.getY()).to.be.above(playerLastY);
@@ -725,7 +696,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
@@ -748,7 +718,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be.above(obstacle.getX());
@@ -771,7 +740,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(
@@ -794,7 +762,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 90; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
@@ -815,7 +782,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 50; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
@@ -827,7 +793,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 10; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
       // still no change
       expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
@@ -840,7 +805,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 60; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
       // the object moved
       expect(player.getX()).to.be.above(obstacle.getX());
@@ -860,7 +824,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 47; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // the player is bypassing the obstacle
@@ -879,7 +842,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 20; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // the player continued its path
@@ -903,7 +865,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 47; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // the player is bypassing the obstacle
@@ -936,7 +897,6 @@ describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
       for (let i = 0; i < 10; i++) {
         player.getBehavior(topDownName).simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
-        console.debug(player.getX() + ' ; ' + player.getY());
       }
 
       // the player didn't moved

--- a/Extensions/TopDownMovementBehavior/tests/assistancetopdownmovementbehavior.spec.js
+++ b/Extensions/TopDownMovementBehavior/tests/assistancetopdownmovementbehavior.spec.js
@@ -1,0 +1,947 @@
+// @ts-check
+describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
+  describe('Assistance', function () {
+    const topDownName = 'auto1';
+
+    const createScene = () => {
+      const runtimeGame = new gdjs.RuntimeGame({
+        variables: [],
+        // @ts-ignore - missing properties.
+        properties: { windowWidth: 800, windowHeight: 600 },
+        resources: { resources: [] },
+      });
+      const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
+      runtimeScene.loadFromScene({
+        layers: [
+          {
+            name: '',
+            visibility: true,
+            effects: [],
+            cameras: [],
+
+            ambientLightColorR: 0,
+            ambientLightColorG: 0,
+            ambientLightColorB: 0,
+            isLightingLayer: false,
+            followBaseLayerCamera: true,
+          },
+        ],
+        variables: [],
+        r: 0,
+        v: 0,
+        b: 0,
+        mangledName: 'Scene1',
+        name: 'Scene1',
+        stopSoundsOnStartup: false,
+        title: '',
+        behaviorsSharedData: [],
+        objects: [],
+        instances: [],
+      });
+      runtimeScene._timeManager.getElapsedTime = function () {
+        return (1 / 60) * 1000;
+      };
+      return runtimeScene;
+    };
+
+    const addPlayer = (runtimeScene) => {
+      const player = new gdjs.TestRuntimeObject(runtimeScene, {
+        name: 'player',
+        type: '',
+        behaviors: [
+          {
+            type: 'TopDownMovementBehavior::TopDownMovementBehavior',
+            name: 'auto1',
+            // @ts-ignore - properties are not typed
+            allowDiagonals: true,
+            acceleration: 400,
+            deceleration: 800,
+            maxSpeed: 200,
+            angularMaxSpeed: 180,
+            rotateObject: false,
+            angleOffset: 0,
+            ignoreDefaultControls: true,
+            movementAngleOffset: 0,
+            enableAssistance: true,
+            viewpoint: 'TopDown',
+            customIsometryAngle: 30,
+          },
+        ],
+      });
+      player.setCustomWidthAndHeight(100, 100);
+      runtimeScene.addObject(player);
+      return player;
+    };
+
+    const addObstacle = (runtimeScene) => {
+      const obstacle = new gdjs.TestRuntimeObject(runtimeScene, {
+        name: 'obstacle',
+        type: '',
+        behaviors: [
+          {
+            type: 'TopDownMovementBehavior::TopDownObstacleBehavior',
+            // @ts-ignore - properties are not typed
+            slidingCornerSize: 50,
+          },
+        ],
+      });
+      obstacle.setCustomWidthAndHeight(100, 100);
+      runtimeScene.addObject(obstacle);
+      return obstacle;
+    };
+
+    let runtimeScene;
+    let player;
+    beforeEach(function () {
+      runtimeScene = createScene();
+      player = addPlayer(runtimeScene);
+    });
+
+    it('can move without any obstacle at all', function () {
+      player.setPosition(200, 300);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 30; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+
+      expect(player.getX()).to.be.above(200);
+      expect(player.getY()).to.be(300);
+    });
+
+    it('can bypass an obstacle in the way (go right, left bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - 20
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // The player bypassed the obstacle from below.
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can bypass an obstacle in the way with stick controls (go right, left bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - 20
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateStick(0, 1);
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // The player bypassed the obstacle from below.
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can bypass an obstacle in the way after a position change (go right, left bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      // Set the object at a random position...
+      obstacle.setPosition(1024, 2048);
+      player.setPosition(4096, 8192);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      // ...to change there position
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - 20
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // The player bypassed the obstacle from below.
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can bypass an obstacle in the way after an obstacle dimension change (go right, left bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - 20
+      );
+
+      // set a random dimensions...
+      obstacle.setCustomWidthAndHeight(10, 10);
+      // this is the 1rst call so object are 10x10 initially
+      runtimeScene.renderAndStep(1000 / 60);
+
+      // and set back the right dimensions
+      obstacle.setCustomWidthAndHeight(100, 100);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug('position: ' + player.getX() + ' ; ' + player.getY());
+      }
+
+      // The player bypassed the obstacle from below.
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can bypass an obstacle in the way after a player dimension change (go right, left bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - 20
+      );
+
+      // set a random dimensions...
+      player.setCustomWidthAndHeight(10, 10);
+      // this is the 1rst call so object are 10x10 initially
+      runtimeScene.renderAndStep(1000 / 60);
+
+      // and set back the right dimensions
+      player.setCustomWidthAndHeight(100, 100);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // The player bypassed the obstacle from below.
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can bypass an obstacle in the way (go right, left top corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() - player.getHeight() + 20
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // The player bypassed the obstacle from above.
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() - player.getHeight());
+    });
+
+    it('can bypass an obstacle in the way (go left, right bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() + obstacle.getWidth() + 100,
+        obstacle.getY() + obstacle.getHeight() - 20
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateLeftKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be.below(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can bypass an obstacle in the way (go left, right top corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() + obstacle.getWidth() + 100,
+        obstacle.getY() - player.getHeight() + 20
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateLeftKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be.below(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() - player.getHeight());
+    });
+
+    it('can bypass an obstacle in the way (go down, right top corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() + obstacle.getWidth() - 20,
+        obstacle.getY() - player.getHeight() - 100
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateDownKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
+      expect(player.getY()).to.be.above(obstacle.getY());
+    });
+
+    it('can bypass an obstacle in the way (go down, left top corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() + 20,
+        obstacle.getY() - player.getHeight() - 100
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateDownKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
+      expect(player.getY()).to.be.above(obstacle.getY());
+    });
+
+    it('can bypass an obstacle in the way (go up, right bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() + obstacle.getWidth() - 20,
+        obstacle.getY() + obstacle.getHeight() + 100
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateUpKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(
+          player.getX() + ' ; ' + player.getY() + obstacle.getHeight()
+        );
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
+      expect(player.getY()).to.be.below(obstacle.getY());
+    });
+
+    it('can bypass an obstacle in the way (go up, left bottom corner)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() + 20,
+        obstacle.getY() + obstacle.getHeight() + 100
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateUpKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
+      expect(player.getY()).to.be.below(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can be stopped by an obstacle (go right)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY()
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
+      expect(player.getY()).to.be(obstacle.getY());
+    });
+
+    it('can be stopped by an obstacle (go left)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() + obstacle.getWidth() + 100,
+        obstacle.getY()
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateLeftKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
+      expect(player.getY()).to.be(obstacle.getY());
+    });
+
+    it('can be stopped by an obstacle (go down)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX(),
+        obstacle.getY() - player.getHeight() - 100
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateDownKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() - player.getHeight());
+    });
+
+    it('can be stopped by an obstacle (go up)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX(),
+        obstacle.getY() + obstacle.getHeight() + 100
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateUpKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('must not be moved aside when pushing against 2 obstacles (go right)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      const obstacle2 = addObstacle(runtimeScene);
+      // put the player on the corner of both obstacles
+      obstacle.setPosition(400, 140);
+      obstacle2.setPosition(400, 260);
+      const playerY = (obstacle.getY() + obstacle2.getY()) / 2;
+      player.setPosition(obstacle.getX() - player.getWidth() - 100, playerY);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
+      expect(player.getY()).to.be(playerY);
+    });
+
+    it('must not be moved aside when pushing against 2 obstacles (go left)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      const obstacle2 = addObstacle(runtimeScene);
+      // put the player on the corner of both obstacles
+      obstacle.setPosition(400, 140);
+      obstacle2.setPosition(400, 260);
+      const playerY = (obstacle.getY() + obstacle2.getY()) / 2;
+      player.setPosition(obstacle.getX() + obstacle.getWidth() + 100, playerY);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateLeftKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
+      expect(player.getY()).to.be(playerY);
+    });
+
+    it('must not be moved aside when pushing against 2 obstacles (go down)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      const obstacle2 = addObstacle(runtimeScene);
+      // put the player on the corner of both obstacles
+      obstacle.setPosition(340, 200);
+      obstacle2.setPosition(460, 200);
+      const playerX = (obstacle.getX() + obstacle2.getX()) / 2;
+      player.setPosition(playerX, obstacle.getY() - player.getHeight() - 100);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateDownKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(playerX);
+      expect(player.getY()).to.be(obstacle.getY() - player.getHeight());
+    });
+
+    it('must not be moved aside when pushing against 2 obstacles (go Up)', function () {
+      const obstacle = addObstacle(runtimeScene);
+      const obstacle2 = addObstacle(runtimeScene);
+      // put the player on the corner of both obstacles
+      obstacle.setPosition(340, 200);
+      obstacle2.setPosition(460, 200);
+      const playerX = (obstacle.getX() + obstacle2.getX()) / 2;
+      player.setPosition(playerX, obstacle.getY() + obstacle.getHeight() + 100);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateUpKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(playerX);
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    [false, true].forEach((playerIsGoingInDiagonal) => {
+      it(`can go between 2 obstacles${
+        playerIsGoingInDiagonal ? ' in diagonal' : ''
+      } (go right, left bottom corner)`, function () {
+        const obstacle = addObstacle(runtimeScene);
+        const obstacle2 = addObstacle(runtimeScene);
+        // put the player on the corner of both obstacles
+        obstacle.setPosition(400, 100);
+        obstacle2.setPosition(400, 300);
+        player.setPosition(
+          obstacle.getX() - player.getWidth() - 10,
+          obstacle.getY() + obstacle.getHeight() - 40
+        );
+        runtimeScene.renderAndStep(1000 / 60);
+
+        for (let i = 0; i < 80; i++) {
+          player.getBehavior(topDownName).simulateRightKey();
+          if (playerIsGoingInDiagonal) {
+            player.getBehavior(topDownName).simulateDownKey();
+          }
+          runtimeScene.renderAndStep(1000 / 60);
+          console.debug(player.getX() + ' ; ' + player.getY());
+        }
+
+        expect(player.getX()).to.be.above(obstacle.getX());
+        expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+      });
+
+      it(`can go between 2 obstacles${
+        playerIsGoingInDiagonal ? ' in diagonal' : ''
+      } (go right, left top corner)`, function () {
+        const obstacle = addObstacle(runtimeScene);
+        const obstacle2 = addObstacle(runtimeScene);
+        // put the player on the corner of both obstacles
+        obstacle.setPosition(400, 100);
+        obstacle2.setPosition(400, 300);
+        player.setPosition(
+          obstacle2.getX() - player.getWidth() - 10,
+          obstacle2.getY() - player.getHeight() + 40
+        );
+        runtimeScene.renderAndStep(1000 / 60);
+
+        for (let i = 0; i < 80; i++) {
+          player.getBehavior(topDownName).simulateRightKey();
+          if (playerIsGoingInDiagonal) {
+            player.getBehavior(topDownName).simulateUpKey();
+          }
+          runtimeScene.renderAndStep(1000 / 60);
+          console.debug(player.getX() + ' ; ' + player.getY());
+        }
+
+        expect(player.getX()).to.be.above(obstacle2.getX());
+        expect(player.getY()).to.be(obstacle2.getY() - player.getHeight());
+      });
+
+      it(`can go between 2 obstacles${
+        playerIsGoingInDiagonal ? ' in diagonal' : ''
+      } (go left, right bottom corner)`, function () {
+        const obstacle = addObstacle(runtimeScene);
+        const obstacle2 = addObstacle(runtimeScene);
+        // put the player on the corner of both obstacles
+        obstacle.setPosition(400, 100);
+        obstacle2.setPosition(400, 300);
+        player.setPosition(
+          obstacle.getX() + obstacle.getWidth() + 10,
+          obstacle.getY() + obstacle.getHeight() - 40
+        );
+        runtimeScene.renderAndStep(1000 / 60);
+
+        for (let i = 0; i < 80; i++) {
+          player.getBehavior(topDownName).simulateLeftKey();
+          if (playerIsGoingInDiagonal) {
+            player.getBehavior(topDownName).simulateDownKey();
+          }
+          runtimeScene.renderAndStep(1000 / 60);
+          console.debug(player.getX() + ' ; ' + player.getY());
+        }
+
+        expect(player.getX()).to.be.below(obstacle.getX());
+        expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+      });
+
+      it(`can go between 2 obstacles${
+        playerIsGoingInDiagonal ? ' in diagonal' : ''
+      } (go left, right top corner)`, function () {
+        const obstacle = addObstacle(runtimeScene);
+        const obstacle2 = addObstacle(runtimeScene);
+        // put the player on the corner of both obstacles
+        obstacle.setPosition(400, 100);
+        obstacle2.setPosition(400, 300);
+        player.setPosition(
+          obstacle2.getX() + player.getWidth() + 10,
+          obstacle2.getY() - player.getHeight() + 40
+        );
+        runtimeScene.renderAndStep(1000 / 60);
+
+        for (let i = 0; i < 80; i++) {
+          player.getBehavior(topDownName).simulateLeftKey();
+          if (playerIsGoingInDiagonal) {
+            player.getBehavior(topDownName).simulateUpKey();
+          }
+          runtimeScene.renderAndStep(1000 / 60);
+          console.debug(player.getX() + ' ; ' + player.getY());
+        }
+
+        expect(player.getX()).to.be.below(obstacle2.getX());
+        expect(player.getY()).to.be(obstacle2.getY() - player.getHeight());
+      });
+
+      it(`can go between 2 obstacles${
+        playerIsGoingInDiagonal ? ' in diagonal' : ''
+      } (go down, right top corner)`, function () {
+        const obstacle = addObstacle(runtimeScene);
+        const obstacle2 = addObstacle(runtimeScene);
+        // put the player on the corner of both obstacles
+        obstacle.setPosition(300, 200);
+        obstacle2.setPosition(500, 200);
+        player.setPosition(
+          obstacle.getX() + obstacle.getWidth() - 40,
+          obstacle.getY() - player.getHeight() - 10
+        );
+        runtimeScene.renderAndStep(1000 / 60);
+
+        for (let i = 0; i < 80; i++) {
+          player.getBehavior(topDownName).simulateDownKey();
+          if (playerIsGoingInDiagonal) {
+            player.getBehavior(topDownName).simulateRightKey();
+          }
+          runtimeScene.renderAndStep(1000 / 60);
+          console.debug(player.getX() + ' ; ' + player.getY());
+        }
+
+        expect(player.getX()).to.be(obstacle.getX() + obstacle.getWidth());
+        expect(player.getY()).to.be.above(obstacle.getY());
+      });
+
+      it(`can go between 2 obstacles${
+        playerIsGoingInDiagonal ? ' in diagonal' : ''
+      } (go down, left top corner)`, function () {
+        const obstacle = addObstacle(runtimeScene);
+        const obstacle2 = addObstacle(runtimeScene);
+        // put the player on the corner of both obstacles
+        obstacle.setPosition(300, 200);
+        obstacle2.setPosition(500, 200);
+        player.setPosition(
+          obstacle2.getX() - player.getWidth() + 40,
+          obstacle2.getY() - player.getHeight() - 10
+        );
+        runtimeScene.renderAndStep(1000 / 60);
+
+        for (let i = 0; i < 80; i++) {
+          player.getBehavior(topDownName).simulateDownKey();
+          if (playerIsGoingInDiagonal) {
+            player.getBehavior(topDownName).simulateLeftKey();
+          }
+          runtimeScene.renderAndStep(1000 / 60);
+          console.debug(player.getX() + ' ; ' + player.getY());
+        }
+
+        expect(player.getX()).to.be(obstacle2.getX() - player.getWidth());
+        expect(player.getY()).to.be.above(obstacle.getY());
+      });
+    });
+
+    it('can slide against an obstacles wall', function () {
+      const obstacleX = 400;
+      for (let y = 0; y < 10; y++) {
+        const obstacle = addObstacle(runtimeScene);
+        obstacle.setPosition(obstacleX, 200 + obstacle.getHeight() * y);
+      }
+      const playerX = obstacleX - player.getWidth();
+      player.setPosition(playerX, 200);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 300; i++) {
+        const playerLastY = player.getY();
+        player.getBehavior(topDownName).simulateRightKey();
+        player.getBehavior(topDownName).simulateDownKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+
+        expect(player.getX()).to.be(playerX);
+        expect(player.getY()).to.be.above(playerLastY);
+      }
+      // reached the last obstacle
+      expect(player.getY()).to.be.above(200 + 100 * 9);
+    });
+
+    it('must not bypass an obstacle if there is an other obstacle in the way before it can turn', function () {
+      const obstacle = addObstacle(runtimeScene);
+      const inTheWayObstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      // a diagonal of 99x99 between them
+      inTheWayObstacle.setPosition(301, 399);
+      const playerY = obstacle.getY() + obstacle.getHeight() - 20;
+      player.setPosition(obstacle.getX() - player.getWidth() - 100, playerY);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
+      expect(player.getY()).to.be(playerY);
+    });
+
+    it('can bypass an obstacle if there is an other obstacle near the way before it can turn', function () {
+      const bypassDistance = 20;
+      const obstacle = addObstacle(runtimeScene);
+      const inTheWayObstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      // a diagonal of 100x100 between them
+      inTheWayObstacle.setPosition(300, 400);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - bypassDistance
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('can bypass an obstacle if the bypass distance is shorter that the one possible in the right direction after the corner', function () {
+      const bypassDistance = 20;
+      const obstacle = addObstacle(runtimeScene);
+      const inTheWayObstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      // a right way the same length as the bypass way
+      inTheWayObstacle.setPosition(400 + bypassDistance, 300);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - bypassDistance
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(
+        inTheWayObstacle.getX() - inTheWayObstacle.getWidth()
+      );
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('must not bypass an obstacle if the bypass distance is longer that the one possible in the right direction after the corner', function () {
+      const bypassDistance = 20;
+      const obstacle = addObstacle(runtimeScene);
+      const inTheWayObstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      // a right way shorter than the bypass way
+      inTheWayObstacle.setPosition(400 + bypassDistance - 1, 300);
+      const playerY = obstacle.getY() + obstacle.getHeight() - bypassDistance;
+      player.setPosition(obstacle.getX() - player.getWidth() - 100, playerY);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 90; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
+      expect(player.getY()).to.be(playerY);
+    });
+
+    it('must only start to bypass an obstacle when the way is cleared if the inputs change', function () {
+      const bypassDistance = 49;
+      const obstacle = addObstacle(runtimeScene);
+      const inTheWayObstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      // a right way shorter than the bypass way
+      inTheWayObstacle.setPosition(400 + bypassDistance - 1, 300);
+      const playerY = obstacle.getY() + obstacle.getHeight() - bypassDistance;
+      player.setPosition(obstacle.getX() - player.getWidth() - 100, playerY);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 50; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
+      expect(player.getY()).to.be(playerY);
+
+      // move the obstacle out of the bypass way
+      inTheWayObstacle.setPosition(1024, 2048);
+
+      for (let i = 0; i < 10; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+      // still no change
+      expect(player.getX()).to.be(obstacle.getX() - obstacle.getWidth());
+      expect(player.getY()).to.be(playerY);
+
+      // right key is released
+      runtimeScene.renderAndStep(1000 / 60);
+
+      // press it again
+      for (let i = 0; i < 60; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+      // the object moved
+      expect(player.getX()).to.be.above(obstacle.getX());
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('must continue to bypass an object when the key is hold even if an obstacle comes in the way', function () {
+      const bypassDistance = 49;
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - bypassDistance
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 47; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // the player is bypassing the obstacle
+      expect(player.getX()).to.be(
+        obstacle.getX() - player.getWidth()
+      );
+      expect(player.getY()).to.be.within(
+        obstacle.getY() + obstacle.getHeight() - (bypassDistance - 1), 
+        obstacle.getY() + obstacle.getHeight() - bypassDistance * 1 / 2);
+
+      const inTheWayObstacle = addObstacle(runtimeScene);
+      // a right way shorter than the bypass way
+      inTheWayObstacle.setPosition(obstacle.getX() + 1, obstacle.getY() + obstacle.getHeight());
+
+      // still holding the key
+      for (let i = 0; i < 20; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // the player continued its path
+      // and is against inTheWayObstacle
+      expect(player.getX()).to.be(
+        inTheWayObstacle.getX() - inTheWayObstacle.getWidth()
+      );
+      expect(player.getY()).to.be(obstacle.getY() + obstacle.getHeight());
+    });
+
+    it('must stop to bypass an object when the key is release and pressed again if an obstacle came in the way', function () {
+      const bypassDistance = 49;
+      const obstacle = addObstacle(runtimeScene);
+      obstacle.setPosition(400, 200);
+      player.setPosition(
+        obstacle.getX() - player.getWidth() - 100,
+        obstacle.getY() + obstacle.getHeight() - bypassDistance
+      );
+      runtimeScene.renderAndStep(1000 / 60);
+
+      for (let i = 0; i < 47; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // the player is bypassing the obstacle
+      expect(player.getX()).to.be(
+        obstacle.getX() - player.getWidth()
+      );
+      expect(player.getY()).to.be.within(
+        obstacle.getY() + obstacle.getHeight() - (bypassDistance - 1), 
+        obstacle.getY() + obstacle.getHeight() - bypassDistance * 1 / 2);
+
+      const inTheWayObstacle = addObstacle(runtimeScene);
+      // a right way shorter than the bypass way
+      inTheWayObstacle.setPosition(obstacle.getX() + 1, obstacle.getY() + obstacle.getHeight());
+      
+      // release the key
+      for (let i = 0; i < 20; i++) {
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      // the player is still in the bypass way
+      expect(player.getX()).to.be(
+        obstacle.getX() - player.getWidth()
+      );
+      expect(player.getY()).to.be.below(
+        obstacle.getY() + obstacle.getHeight() - bypassDistance * 1 / 4);
+
+      const playerX = player.getX();
+      const playerY = player.getY();
+
+      // press the key again
+      for (let i = 0; i < 10; i++) {
+        player.getBehavior(topDownName).simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        console.debug(player.getX() + ' ; ' + player.getY());
+      }
+
+      // the player didn't moved
+      expect(player.getX()).to.be(playerX);
+      expect(player.getY()).to.be(playerY);
+    });
+  });
+});

--- a/Extensions/TopDownMovementBehavior/tests/assistancetopdownmovementbehavior.spec.js
+++ b/Extensions/TopDownMovementBehavior/tests/assistancetopdownmovementbehavior.spec.js
@@ -827,16 +827,18 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
       }
 
       // the player is bypassing the obstacle
-      expect(player.getX()).to.be(
-        obstacle.getX() - player.getWidth()
-      );
+      expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
       expect(player.getY()).to.be.within(
-        obstacle.getY() + obstacle.getHeight() - (bypassDistance - 1), 
-        obstacle.getY() + obstacle.getHeight() - bypassDistance * 1 / 2);
+        obstacle.getY() + obstacle.getHeight() - (bypassDistance - 1),
+        obstacle.getY() + obstacle.getHeight() - (bypassDistance * 1) / 2
+      );
 
       const inTheWayObstacle = addObstacle(runtimeScene);
       // a right way shorter than the bypass way
-      inTheWayObstacle.setPosition(obstacle.getX() + 1, obstacle.getY() + obstacle.getHeight());
+      inTheWayObstacle.setPosition(
+        obstacle.getX() + 1,
+        obstacle.getY() + obstacle.getHeight()
+      );
 
       // still holding the key
       for (let i = 0; i < 20; i++) {
@@ -868,27 +870,28 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
       }
 
       // the player is bypassing the obstacle
-      expect(player.getX()).to.be(
-        obstacle.getX() - player.getWidth()
-      );
+      expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
       expect(player.getY()).to.be.within(
-        obstacle.getY() + obstacle.getHeight() - (bypassDistance - 1), 
-        obstacle.getY() + obstacle.getHeight() - bypassDistance * 1 / 2);
+        obstacle.getY() + obstacle.getHeight() - (bypassDistance - 1),
+        obstacle.getY() + obstacle.getHeight() - (bypassDistance * 1) / 2
+      );
 
       const inTheWayObstacle = addObstacle(runtimeScene);
       // a right way shorter than the bypass way
-      inTheWayObstacle.setPosition(obstacle.getX() + 1, obstacle.getY() + obstacle.getHeight());
-      
+      inTheWayObstacle.setPosition(
+        obstacle.getX() + 1,
+        obstacle.getY() + obstacle.getHeight()
+      );
+
       // release the key
       for (let i = 0; i < 20; i++) {
         runtimeScene.renderAndStep(1000 / 60);
       }
       // the player is still in the bypass way
-      expect(player.getX()).to.be(
-        obstacle.getX() - player.getWidth()
-      );
+      expect(player.getX()).to.be(obstacle.getX() - player.getWidth());
       expect(player.getY()).to.be.below(
-        obstacle.getY() + obstacle.getHeight() - bypassDistance * 1 / 4);
+        obstacle.getY() + obstacle.getHeight() - (bypassDistance * 1) / 4
+      );
 
       const playerX = player.getX();
       const playerY = player.getY();

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -1313,7 +1313,6 @@ namespace gdjs {
     }
 
     shift(deltaX: float, deltaY: float) {
-      //FIXME use a relative hitBox to avoid rounding errors
       this._behavior._transformedPosition[0] += deltaX;
       this._behavior._transformedPosition[1] += deltaY;
     }

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -9,7 +9,7 @@ namespace gdjs {
    * and rotation.
    */
   export class TopDownMovementRuntimeBehavior extends gdjs.RuntimeBehavior {
-    //Behavior configuration:
+    // Behavior configuration:
     private _allowDiagonals: boolean;
     private _acceleration: float;
     private _deceleration: float;
@@ -19,15 +19,15 @@ namespace gdjs {
     private _angleOffset: float;
     private _ignoreDefaultControls: boolean;
     private _movementAngleOffset: float;
+    private _isAssistanceEnable: boolean;
 
     /** The latest angle of movement, in degrees. */
     private _angle: float = 0;
 
-    //Attributes used when moving
-    private _x: float = 0;
-    private _y: float = 0;
-    private _xVelocity: float = 0;
-    private _yVelocity: float = 0;
+    // Attributes used when moving
+    _transformedPosition: FloatPoint = [0, 0];
+    _xVelocity: float = 0;
+    _yVelocity: float = 0;
     private _angularSpeed: float = 0;
 
     // Inputs
@@ -43,8 +43,9 @@ namespace gdjs {
     private _stickForce: float = 0;
 
     // @ts-ignore The setter "setViewpoint" is not detected as an affectation.
-    private _basisTransformation: gdjs.TopDownMovementRuntimeBehavior.BasisTransformation | null;
-    private _temporaryPointForTransformations: FloatPoint = [0, 0];
+    _basisTransformation: BasisTransformation;
+    _temporaryPointForTransformations: FloatPoint = [0, 0];
+    private _assistance: Assistance;
 
     constructor(
       runtimeScene: gdjs.RuntimeScene,
@@ -60,6 +61,8 @@ namespace gdjs {
       this._rotateObject = behaviorData.rotateObject;
       this._angleOffset = behaviorData.angleOffset;
       this._ignoreDefaultControls = behaviorData.ignoreDefaultControls;
+      this._isAssistanceEnable = behaviorData.enableAssistance || false;
+      this._assistance = new Assistance(this, runtimeScene);
       this.setViewpoint(
         behaviorData.viewpoint,
         behaviorData.customIsometryAngle
@@ -111,24 +114,25 @@ namespace gdjs {
       ) {
         this._movementAngleOffset = newBehaviorData.movementAngleOffset;
       }
+      if (
+        oldBehaviorData.enableAssistance !== newBehaviorData.enableAssistance
+      ) {
+        this._isAssistanceEnable = newBehaviorData.enableAssistance;
+      }
       return true;
     }
 
     setViewpoint(viewpoint: string, customIsometryAngle: float): void {
       if (viewpoint === 'PixelIsometry') {
-        this._basisTransformation = new gdjs.TopDownMovementRuntimeBehavior.IsometryTransformation(
-          Math.atan(0.5)
-        );
+        this._basisTransformation = new IsometryTransformation(Math.atan(0.5));
       } else if (viewpoint === 'TrueIsometry') {
-        this._basisTransformation = new gdjs.TopDownMovementRuntimeBehavior.IsometryTransformation(
-          Math.PI / 6
-        );
+        this._basisTransformation = new IsometryTransformation(Math.PI / 6);
       } else if (viewpoint === 'CustomIsometry') {
-        this._basisTransformation = new gdjs.TopDownMovementRuntimeBehavior.IsometryTransformation(
+        this._basisTransformation = new IsometryTransformation(
           (customIsometryAngle * Math.PI) / 180
         );
       } else {
-        this._basisTransformation = null;
+        this._basisTransformation = new IdentityTransformation();
       }
     }
 
@@ -218,7 +222,17 @@ namespace gdjs {
       return this._movementAngleOffset;
     }
 
+    enableAssistance(enableAssistance: boolean) {
+      this._isAssistanceEnable = enableAssistance;
+    }
+
+    isAssistanceEnable() {
+      return this._isAssistanceEnable;
+    }
+
     doStepPreEvents(runtimeScene: gdjs.RuntimeScene) {
+      const object = this.owner;
+
       const LEFTKEY = 37;
       const UPKEY = 38;
       const RIGHTKEY = 39;
@@ -320,7 +334,43 @@ namespace gdjs {
         }
       }
 
-      const object = this.owner;
+      if (this._isAssistanceEnable) {
+        // Check if the object has moved
+        // To avoid to loop on the transform and its inverse
+        // because of float approximation.
+        const position = this._temporaryPointForTransformations;
+        this._basisTransformation.toScreen(this._transformedPosition, position);
+        if (object.getX() !== position[0] || object.getY() !== position[1]) {
+          position[0] = object.getX();
+          position[1] = object.getY();
+          this._basisTransformation.toWorld(
+            position,
+            this._transformedPosition
+          );
+        }
+
+        const stickIsUsed = this._stickForce !== 0 && direction === -1;
+        let inputDirection: float;
+        if (stickIsUsed) {
+          inputDirection = this._getStickDirection();
+          console.debug('inputDirection: ' + inputDirection);
+        } else {
+          inputDirection = direction;
+        }
+        const assistanceDirection: integer = this._assistance.suggestDirection(
+          runtimeScene,
+          inputDirection
+        );
+        if (assistanceDirection !== -1) {
+          if (stickIsUsed) {
+            console.debug('assistanceDirection: ' + assistanceDirection);
+            this._stickAngle = assistanceDirection * 45;
+          } else {
+            direction = assistanceDirection;
+          }
+        }
+      }
+
       const timeDelta = this.owner.getElapsedTime(runtimeScene) / 1000;
       let directionInRad = 0;
       let directionInDeg = 0;
@@ -375,18 +425,28 @@ namespace gdjs {
       //No acceleration for angular speed for now
 
       //Position object
-      if (this._basisTransformation === null) {
-        // Top-down viewpoint
-        object.setX(object.getX() + this._xVelocity * timeDelta);
-        object.setY(object.getY() + this._yVelocity * timeDelta);
+      if (this._isAssistanceEnable) {
+        // FIXME This is just to ease tests, to be removed
+        console.debug('Velocity: ' + this._xVelocity + ' ; ' + this._yVelocity);
+
+        this._assistance.shift(
+          this._xVelocity * timeDelta,
+          this._yVelocity * timeDelta
+        );
       } else {
-        // Isometry viewpoint
-        const point = this._temporaryPointForTransformations;
-        point[0] = this._xVelocity * timeDelta;
-        point[1] = this._yVelocity * timeDelta;
-        this._basisTransformation.toScreen(point, point);
-        object.setX(object.getX() + point[0]);
-        object.setY(object.getY() + point[1]);
+        if (this._basisTransformation === null) {
+          // Top-down viewpoint
+          object.setX(object.getX() + this._xVelocity * timeDelta);
+          object.setY(object.getY() + this._yVelocity * timeDelta);
+        } else {
+          // Isometry viewpoint
+          const point = this._temporaryPointForTransformations;
+          point[0] = this._xVelocity * timeDelta;
+          point[1] = this._yVelocity * timeDelta;
+          this._basisTransformation.toScreen(point, point);
+          object.setX(object.getX() + point[0]);
+          object.setY(object.getY() + point[1]);
+        }
       }
 
       //Also update angle if needed
@@ -399,6 +459,15 @@ namespace gdjs {
             runtimeScene
           );
         }
+      }
+
+      if (this._isAssistanceEnable) {
+        this._assistance.applyCollision(runtimeScene);
+
+        const position = this._temporaryPointForTransformations;
+        this._basisTransformation.toScreen(this._transformedPosition, position);
+        object.setX(position[0]);
+        object.setY(position[1]);
       }
 
       this._leftKey = false;
@@ -443,54 +512,1111 @@ namespace gdjs {
       this._stickAngle = stickAngle % 360;
       this._stickForce = Math.max(0, Math.min(1, stickForce));
     }
+
+    _getStickDirection() {
+      let direction = (this._stickAngle + this._movementAngleOffset) / 45;
+      direction = direction - Math.floor(direction / 8) * 8;
+      for (let strait = 0; strait < 8; strait += 2) {
+        if (strait - 0.125 < direction && direction < strait + 0.125) {
+          direction = strait;
+        }
+        if (strait + 0.125 <= direction && direction <= strait + 2 - 0.125) {
+          direction = strait + 1;
+        }
+      }
+      if (8 - 0.125 < direction) {
+        direction = 0;
+      }
+      return direction;
+    }
   }
-  export namespace TopDownMovementRuntimeBehavior {
-    export interface BasisTransformation {
-      toScreen(worldPoint: FloatPoint, screenPoint: FloatPoint): void;
+
+  interface BasisTransformation {
+    toScreen(worldPoint: FloatPoint, screenPoint: FloatPoint): void;
+
+    toWorld(screenPoint: FloatPoint, worldPoint: FloatPoint): void;
+
+    toScreen(worldPoint: FloatPoint): void;
+
+    toWorld(screenPoint: FloatPoint): void;
+  }
+
+  class IdentityTransformation implements BasisTransformation {
+    toScreen(worldPoint: FloatPoint, screenPoint?: FloatPoint): void {
+      if (screenPoint) {
+        screenPoint[0] = worldPoint[0];
+        screenPoint[1] = worldPoint[1];
+      }
     }
 
-    export class IsometryTransformation
-      implements gdjs.TopDownMovementRuntimeBehavior.BasisTransformation {
-      private _screen: float[][];
+    toWorld(screenPoint: FloatPoint, worldPoint?: FloatPoint): void {
+      if (worldPoint) {
+        worldPoint[0] = screenPoint[0];
+        worldPoint[1] = screenPoint[1];
+      }
+    }
+  }
 
-      /**
-       * @param angle between the x axis and the projected isometric x axis.
-       * @throws if the angle is not in ]0; pi/4[. Note that 0 is a front viewpoint and pi/4 a top-down viewpoint.
-       */
-      constructor(angle: float) {
-        if (angle <= 0 || angle >= Math.PI / 4)
-          throw new RangeError(
-            'An isometry angle must be in ]0; pi/4] but was: ' + angle
+  class IsometryTransformation implements BasisTransformation {
+    _screen: float[][];
+    _world: float[][];
+
+    /**
+     * @param angle between the x axis and the projected isometric x axis.
+     * @throws if the angle is not in ]0; pi/4[. Note that 0 is a front viewpoint and pi/4 a top-down viewpoint.
+     */
+    constructor(angle: float) {
+      if (angle <= 0 || angle >= Math.PI / 4)
+        throw new RangeError(
+          'An isometry angle must be in ]0; pi/4] but was: ' + angle
+        );
+
+      const alpha = Math.asin(Math.tan(angle));
+      const sinA = Math.sin(alpha);
+      const cosB = Math.cos(Math.PI / 4);
+      const sinB = cosB;
+      // https://en.wikipedia.org/wiki/Isometric_projection
+      //
+      //   / 1     0    0 \ / cosB 0 -sinB \ / 1 0  0 \
+      //   | 0  cosA sinA | |    0 1     0 | | 0 0 -1 |
+      //   \ 0 -sinA cosA / \ sinB 0  cosB / \ 0 1  0 /
+      this._screen = [
+        [cosB, -sinB],
+        [sinA * sinB, sinA * cosB],
+      ];
+      // invert
+      this._world = [
+        [cosB, sinB / sinA],
+        [-sinB, cosB / sinA],
+      ];
+    }
+
+    toScreen(worldPoint: FloatPoint, screenPoint?: FloatPoint): void {
+      if (!screenPoint) {
+        screenPoint = worldPoint;
+      }
+      const x =
+        this._screen[0][0] * worldPoint[0] + this._screen[0][1] * worldPoint[1];
+      const y =
+        this._screen[1][0] * worldPoint[0] + this._screen[1][1] * worldPoint[1];
+      screenPoint[0] = x;
+      screenPoint[1] = y;
+    }
+
+    toWorld(screenPoint: FloatPoint, worldPoint?: FloatPoint): void {
+      if (!worldPoint) {
+        worldPoint = screenPoint;
+      }
+      const x =
+        this._world[0][0] * screenPoint[0] + this._world[0][1] * screenPoint[1];
+      const y =
+        this._world[1][0] * screenPoint[0] + this._world[1][1] * screenPoint[1];
+      worldPoint[0] = x;
+      worldPoint[1] = y;
+    }
+  }
+
+  /** Corner sliding on TopDownObstacleRuntimeBehavior instances.
+   *
+   * To change of direction the player must be perfectly aligned.
+   * It's a very frustrating thing to do so he must be helped.
+   * The pressed key gives the player intent. If he presses left,
+   * he want to go that way, but he needs to be aligned to do so,
+   * so the assistance makes him move up or down in the 1st place.
+   */
+  class Assistance {
+    static epsilon: float = 0.015625;
+    private _behavior: gdjs.TopDownMovementRuntimeBehavior;
+
+    // Obstacles near the object, updated with _updatePotentialCollidingObjects.
+    private _potentialCollidingObjects: gdjs.TopDownObstacleRuntimeBehavior[];
+    private _manager: gdjs.TopDownObstaclesManager;
+
+    // Remember the decision to bypass an obstacle...
+    private _lastAnyObstacle: boolean = false;
+    private _needToCheckBypassWay: boolean = true;
+
+    // ...and the context of that decision
+    private _lastAssistanceDirection: integer = -1;
+    private _lastDirection: integer = -1;
+    private _deltasX: integer[];
+    private _deltasY: integer[];
+
+    private _relativeHitBoxesAABB: gdjs.AABB = { min: [0, 0], max: [0, 0] };
+    private _absoluteHitBoxesAABB: gdjs.AABB = { min: [0, 0], max: [0, 0] };
+    private _hitBoxesAABBUpToDate: boolean = false;
+    private _oldWidth: float = 0;
+    private _oldHeight: float = 0;
+
+    private _collidingObjects: gdjs.RuntimeObject[];
+
+    private _result: AssistanceResult = new AssistanceResult();
+
+    constructor(
+      behavior: gdjs.TopDownMovementRuntimeBehavior,
+      runtimeScene: gdjs.RuntimeScene
+    ) {
+      this._behavior = behavior;
+      this._potentialCollidingObjects = [];
+      this._potentialCollidingObjects.length = 0;
+      this._collidingObjects = [];
+      this._collidingObjects.length = 0;
+      this._manager = gdjs.TopDownObstaclesManager.getManager(runtimeScene);
+      this._deltasX = [1, 1, 0, -1, -1, -1, 0, 1];
+      this._deltasY = [0, 1, 1, 1, 0, -1, -1, -1];
+    }
+
+    /**
+     * FIXME This is just to ease tests, to be removed
+     */
+    setAnimation(object: RuntimeObject, animation: integer) {
+      console.debug(object.id + ' : ' + animation);
+      if (object instanceof gdjs.SpriteRuntimeObject) {
+        object.setAnimation(animation);
+      }
+    }
+    /**
+     * FIXME This is just to ease tests, to be removed
+     */
+    getAnimation(object: RuntimeObject): integer {
+      if (object instanceof gdjs.SpriteRuntimeObject) {
+        return object.getAnimation();
+      }
+      return 0;
+    }
+    /**
+     * FIXME This is just to ease tests, to be removed
+     */
+    setOpacity(object: RuntimeObject, opacity: integer) {
+      if (object instanceof gdjs.SpriteRuntimeObject) {
+        object.setOpacity(opacity);
+      }
+    }
+
+    almostEquals(a: float, b: float) {
+      return b - Assistance.epsilon < a && a < b + Assistance.epsilon;
+    }
+
+    /** Analyse the real intent of the player instead of applying the input blindly.
+     * @returns a direction that matches the player intents.
+     */
+    suggestDirection(
+      runtimeScene: gdjs.RuntimeScene,
+      direction: integer
+    ): integer {
+      this._needToCheckBypassWay =
+        this._needToCheckBypassWay || direction !== this._lastDirection;
+
+      if (direction === -1) {
+        return this.noAssistance();
+      }
+
+      const object = this._behavior.owner;
+      if (
+        object.getWidth() !== this._oldWidth ||
+        object.getHeight() !== this._oldHeight
+      ) {
+        this._hitBoxesAABBUpToDate = false;
+        this._oldWidth = object.getWidth();
+        this._oldHeight = object.getHeight();
+      }
+
+      // Compute the list of the objects that will be used
+      const timeDelta = object.getElapsedTime(runtimeScene) / 1000;
+      this._updatePotentialCollidingObjects(
+        1 + this._behavior.getMaxSpeed() * timeDelta
+      );
+
+      const downKey: boolean = 1 <= direction && direction <= 3;
+      const leftKey: boolean = 3 <= direction && direction <= 5;
+      const upKey: boolean = 5 <= direction && direction <= 7;
+      const rightKey: boolean = direction <= 1 || 7 <= direction;
+
+      // Used to align the player when the assistance make him bypass an obstacle
+      let stopMinX: float = Number.MAX_VALUE;
+      let stopMinY: float = Number.MAX_VALUE;
+      let stopMaxX: float = -Number.MAX_VALUE;
+      let stopMaxY: float = -Number.MAX_VALUE;
+      let isBypassX: boolean = false;
+      let isBypassY: boolean = false;
+
+      // Incites of how the player should be assisted
+      let assistanceLeft: integer = 0;
+      let assistanceRight: integer = 0;
+      let assistanceUp: integer = 0;
+      let assistanceDown: integer = 0;
+
+      // the actual decision
+      let assistanceDirection: integer = -1;
+
+      const objectAABB: AABB = this.getHitBoxesAABB();
+      const minX: float = objectAABB.min[0];
+      const minY: float = objectAABB.min[1];
+      const maxX: float = objectAABB.max[0];
+      const maxY: float = objectAABB.max[1];
+      const width: float = maxX - minX;
+      const height: float = maxY - minY;
+
+      // FIXME This is just to ease tests, to be removed
+      let debug = '';
+      //runtimeScene.getVariables().get("Debug").setString(minX + ", " + minY + " -> " + maxX + ", " + maxY + "\n");
+
+      // This affectation has no meaning, it will be override.
+      let bypassedObstacleAABB: AABB | null = null;
+
+      this._collidingObjects.length = 0;
+      this._collidingObjects.push(object);
+
+      for (var i = 0; i < this._potentialCollidingObjects.length; ++i) {
+        const obstacleBehavior = this._potentialCollidingObjects[i];
+        const corner: float = obstacleBehavior.getSlidingCornerSize();
+        const obstacle = obstacleBehavior.owner;
+        if (obstacle === object) {
+          continue;
+        }
+
+        const obstacleAABB: AABB = obstacleBehavior.getHitBoxesAABB();
+        const obstacleMinX: float = obstacleAABB.min[0];
+        const obstacleMinY: float = obstacleAABB.min[1];
+        const obstacleMaxX: float = obstacleAABB.max[0];
+        const obstacleMaxY: float = obstacleAABB.max[1];
+
+        const deltaX: float = this._deltasX[direction];
+        const deltaY: float = this._deltasY[direction];
+        // Extends the box in the player direction
+        if (
+          Math.max(maxX, Math.floor(maxX + deltaX)) > obstacleMinX &&
+          Math.min(minX, Math.ceil(minX + deltaX)) < obstacleMaxX &&
+          Math.max(maxY, Math.floor(maxY + deltaY)) > obstacleMinY &&
+          Math.min(minY, Math.ceil(minY + deltaY)) < obstacleMaxY
+        ) {
+          this._collidingObjects.push(obstacle);
+          // FIXME This is just to ease tests, to be removed
+          this.setAnimation(obstacle, 0);
+          this.setOpacity(obstacle, 64 + 128 * Math.random());
+          debug +=
+            'obstacle: ' +
+            obstacleMinX / 64 +
+            ', ' +
+            obstacleMinY / 64 +
+            ' -> ' +
+            obstacleMaxX / 64 +
+            ', ' +
+            obstacleMaxY / 64 +
+            '\n';
+
+          // The player is corner to corner to the obstacle.
+          // The assistance will depend on other obstacles.
+          // Both direction are set and the actual to take
+          // is decided at the end.
+          if (
+            this.almostEquals(maxX, obstacleMinX) &&
+            this.almostEquals(maxY, obstacleMinY)
+          ) {
+            assistanceRight++;
+            assistanceDown++;
+
+            // FIXME This is just to ease tests, to be removed
+            this.setAnimation(obstacle, 9);
+          } else if (
+            this.almostEquals(maxX, obstacleMinX) &&
+            this.almostEquals(minY, obstacleMaxY)
+          ) {
+            assistanceRight++;
+            assistanceUp++;
+
+            // FIXME This is just to ease tests, to be removed
+            this.setAnimation(obstacle, 10);
+          } else if (
+            this.almostEquals(minX, obstacleMaxX) &&
+            this.almostEquals(minY, obstacleMaxY)
+          ) {
+            assistanceLeft++;
+            assistanceUp++;
+
+            // FIXME This is just to ease tests, to be removed
+            this.setAnimation(obstacle, 8);
+          } else if (
+            this.almostEquals(minX, obstacleMaxX) &&
+            this.almostEquals(maxY, obstacleMinY)
+          ) {
+            assistanceLeft++;
+            assistanceDown++;
+
+            // FIXME This is just to ease tests, to be removed
+            this.setAnimation(obstacle, 7);
+          } else if (
+            (upKey && this.almostEquals(minY, obstacleMaxY)) ||
+            (downKey && this.almostEquals(maxY, obstacleMinY))
+          ) {
+            // The player is not on the corner of the obstacle.
+            // Set the assistance both ways to fall back in
+            // the same case as 2 obstacles side by side
+            // being collide with the player.
+            if (
+              (rightKey || maxX > obstacleMinX + corner) &&
+              minX < obstacleMaxX &&
+              (leftKey || minX < obstacleMaxX - corner) &&
+              maxX > obstacleMinX
+            ) {
+              assistanceLeft++;
+              assistanceRight++;
+
+              // FIXME This is just to ease tests, to be removed
+              this.setAnimation(obstacle, 5);
+            }
+            // The player is on the corner of the obstacle.
+            // (not the exact corner, see corner affectation)
+            else if (
+              !rightKey &&
+              obstacleMinX < maxX &&
+              maxX <= obstacleMinX + corner &&
+              // In case the cornerSize is bigger than the obstacle size,
+              // go the on the shortest side.
+              (leftKey || minX + maxX <= obstacleMinX + obstacleMaxX)
+            ) {
+              assistanceLeft++;
+              isBypassX = true;
+              if (obstacleMinX - width < stopMinX) {
+                stopMinX = obstacleMinX - width;
+                bypassedObstacleAABB = obstacleAABB;
+              }
+              // FIXME This is just to ease tests, to be removed
+              this.setAnimation(obstacle, 3);
+              debug +=
+                'assistanceLeft: ' +
+                obstacleMinX +
+                ', ' +
+                obstacleMinY +
+                ' -> ' +
+                obstacleMaxX +
+                ', ' +
+                obstacleMaxY +
+                '\n';
+            } else if (
+              !leftKey &&
+              obstacleMaxX - corner <= minX &&
+              minX < obstacleMaxX &&
+              (rightKey || minX + maxX > obstacleMinX + obstacleMaxX)
+            ) {
+              assistanceRight++;
+              isBypassX = true;
+              if (obstacleMaxX > stopMaxX) {
+                stopMaxX = obstacleMaxX;
+                bypassedObstacleAABB = obstacleAABB;
+              }
+              // FIXME This is just to ease tests, to be removed
+              this.setAnimation(obstacle, 1);
+              //debug += "assistanceRight: " + obstacleMinX + ", " + obstacleMinY + " -> " + obstacleMaxX + ", " + obstacleMaxY + "\n";
+            }
+          } else if (
+            (leftKey && this.almostEquals(minX, obstacleMaxX)) ||
+            (rightKey && this.almostEquals(maxX, obstacleMinX))
+          ) {
+            // The player is not on the corner of the obstacle.
+            // Set the assistance both ways to fall back in
+            // the same case as 2 obstacles side by side
+            // being collide with the player.
+            if (
+              (downKey || maxY > obstacleMinY + corner) &&
+              minY < obstacleMaxY &&
+              (upKey || minY < obstacleMaxY - corner) &&
+              maxY > obstacleMinY
+            ) {
+              assistanceUp++;
+              assistanceDown++;
+
+              // FIXME This is just to ease tests, to be removed
+              this.setAnimation(obstacle, 6);
+            }
+            // The player is on the corner of the obstacle.
+            // (not the exact corner, see corner affectation)
+            else if (
+              !downKey &&
+              obstacleMinY < maxY &&
+              maxY <= obstacleMinY + corner &&
+              (upKey || minY + maxY <= obstacleMinY + obstacleMaxY)
+            ) {
+              assistanceUp++;
+              isBypassY = true;
+              if (obstacleMinY - height < stopMinY) {
+                stopMinY = obstacleMinY - height;
+                bypassedObstacleAABB = obstacleAABB;
+              }
+              // FIXME This is just to ease tests, to be removed
+              if (this.getAnimation(obstacle) === 3) {
+                this.setAnimation(obstacle, 8);
+              } else if (this.getAnimation(obstacle) === 1) {
+                this.setAnimation(obstacle, 10);
+              } else {
+                this.setAnimation(obstacle, 4);
+              }
+              //debug += "assistanceUp: " + obstacleMinX + ", " + obstacleMinY + " -> " + obstacleMaxX + ", " + obstacleMaxY + "\n";
+            } else if (
+              !upKey &&
+              obstacleMaxY - corner <= minY &&
+              minY < obstacleMaxY &&
+              (downKey || minY + maxY > obstacleMinY + obstacleMaxY)
+            ) {
+              assistanceDown++;
+              isBypassY = true;
+              if (obstacleMaxY > stopMaxY) {
+                stopMaxY = obstacleMaxY;
+                bypassedObstacleAABB = obstacleAABB;
+              }
+              // FIXME This is just to ease tests, to be removed
+              if (this.getAnimation(obstacle) === 3) {
+                this.setAnimation(obstacle, 7);
+              } else if (this.getAnimation(obstacle) === 1) {
+                this.setAnimation(obstacle, 9);
+              } else {
+                this.setAnimation(obstacle, 2);
+              }
+              //debug += "assistanceDown: " + obstacleMinX + ", " + obstacleMinY + " -> " + obstacleMaxX + ", " + obstacleMaxY + "\n";
+            }
+          }
+        }
+      }
+
+      // FIXME This is just to ease tests, to be removed
+      debug +=
+        'assistanceLeft: ' +
+        assistanceLeft +
+        '\n' +
+        'assistanceRight: ' +
+        assistanceRight +
+        '\n' +
+        'assistanceUp: ' +
+        assistanceUp +
+        '\n' +
+        'assistanceDown: ' +
+        assistanceDown +
+        '\n' +
+        minX / 64 +
+        ', ' +
+        minY / 64 +
+        ' -> ' +
+        maxX / 64 +
+        ', ' +
+        maxY / 64 +
+        '\n';
+      runtimeScene.getVariables().get('Debug').setString(debug);
+
+      // This may happen when the player is in the corner of 2 perpendicular walls.
+      // No assistance is needed.
+      if (assistanceLeft && assistanceRight && assistanceUp && assistanceDown) {
+        console.debug('Against perpendicular walls: No Assist');
+        return this.noAssistance();
+      }
+      // This may happen when the player goes in diagonal against a wall.
+      // Make him follow the wall. This allows player to keep full speed.
+      //
+      // When he collided a square from the wall corner to corner,
+      // a 3rd assistance may be true but it fall back in the same case.
+      else if (assistanceLeft && assistanceRight) {
+        isBypassX = false;
+        if (leftKey && !rightKey) {
+          assistanceDirection = 4;
+          console.debug('Slide on walls: Go Right');
+        } else if (rightKey && !leftKey) {
+          assistanceDirection = 0;
+          console.debug('Slide on walls: Go Left');
+        } else {
+          console.debug('Against walls: No Assist');
+          // Contradictory decisions are dismissed.
+          //
+          // This can happen, for instance, with a wall composed of squares.
+          // Taken separately from one to another, a square could be bypass one the right
+          // and the next one on the left even though they are side by side
+          // and the player can't actually go between them.
+          return this.noAssistance();
+        }
+      } else if (assistanceUp && assistanceDown) {
+        isBypassY = false;
+        if (upKey && !downKey) {
+          assistanceDirection = 6;
+          console.debug('Slide on walls: Go Up');
+        } else if (downKey && !upKey) {
+          assistanceDirection = 2;
+          console.debug('Slide on walls: Go Down');
+        } else {
+          console.debug('Against walls: No Assist');
+          // see previous comment
+          return this.noAssistance();
+        }
+      }
+      // The player goes in diagonal and is corner to corner with the obstacle.
+      // (but not against a wall, this time)
+      // The velocity is used to decide.
+      // This may only happen after an alignment.
+      // (see "Alignment:" comment)
+      else if (assistanceRight && assistanceDown) {
+        if (
+          (downKey && !rightKey) ||
+          (downKey === rightKey && assistanceDown > assistanceRight) ||
+          (assistanceDown === assistanceRight &&
+            this._behavior._yVelocity > 0 &&
+            Math.abs(this._behavior._xVelocity) <
+              Math.abs(this._behavior._yVelocity))
+        ) {
+          assistanceDirection = 2;
+          console.debug('Corner TopLeft: Go Down');
+        } else {
+          assistanceDirection = 0;
+          console.debug('Corner TopLeft: Go Right');
+        }
+      } else if (assistanceLeft && assistanceDown) {
+        if (
+          (downKey && !leftKey) ||
+          (downKey === leftKey && assistanceDown > assistanceLeft) ||
+          (assistanceDown === assistanceLeft &&
+            this._behavior._yVelocity > 0 &&
+            Math.abs(this._behavior._xVelocity) <
+              Math.abs(this._behavior._yVelocity))
+        ) {
+          assistanceDirection = 2;
+          console.debug('Corner TopRight: Go Down');
+        } else {
+          assistanceDirection = 4;
+          console.debug('Corner TopRight: Go Left');
+        }
+      } else if (assistanceLeft && assistanceUp) {
+        if (
+          (upKey && !leftKey) ||
+          (upKey === leftKey && assistanceUp > assistanceLeft) ||
+          (assistanceUp === assistanceLeft &&
+            this._behavior._yVelocity < 0 &&
+            Math.abs(this._behavior._xVelocity) <
+              Math.abs(this._behavior._yVelocity))
+        ) {
+          assistanceDirection = 6;
+          console.debug('Corner DownRight: Go Up');
+        } else {
+          assistanceDirection = 4;
+          console.debug('Corner DownRight: Go Left');
+        }
+      } else if (assistanceRight && assistanceUp) {
+        if (
+          (upKey && !rightKey) ||
+          (upKey === rightKey && assistanceUp > assistanceRight) ||
+          (assistanceUp === assistanceRight &&
+            this._behavior._yVelocity < 0 &&
+            Math.abs(this._behavior._xVelocity) <
+              Math.abs(this._behavior._yVelocity))
+        ) {
+          assistanceDirection = 6;
+          console.debug('Corner DownLeft: Go Up');
+        } else {
+          assistanceDirection = 0;
+          console.debug('Corner DownLeft: Go Right');
+        }
+      } else {
+        // Slide on the corner of an obstacle to bypass it.
+        // Every tricky cases are already handled .
+        if (assistanceLeft) {
+          console.debug(
+            'Go Left (Left: %s, Down: %s, Right: %s, Up: %s)',
+            assistanceLeft,
+            assistanceDown,
+            assistanceRight,
+            assistanceUp
           );
+          assistanceDirection = 4;
+        } else if (assistanceRight) {
+          console.debug(
+            'Go Right (Left: %s, Down: %s, Right: %s, Up: %s)',
+            assistanceLeft,
+            assistanceDown,
+            assistanceRight,
+            assistanceUp
+          );
+          assistanceDirection = 0;
+        } else if (assistanceUp) {
+          console.debug(
+            'Go Up (Left: %s, Down: %s, Right: %s, Up: %s)',
+            assistanceLeft,
+            assistanceDown,
+            assistanceRight,
+            assistanceUp
+          );
+          assistanceDirection = 6;
+        } else if (assistanceDown) {
+          console.debug(
+            'Go Down (Left: %s, Down: %s, Right: %s, Up: %s)',
+            assistanceLeft,
+            assistanceDown,
+            assistanceRight,
+            assistanceUp
+          );
+          assistanceDirection = 2;
+        } else {
+          console.debug(
+            'No Assist (Left: %s, Down: %s, Right: %s, Up: %s)',
+            assistanceLeft,
+            assistanceDown,
+            assistanceRight,
+            assistanceUp
+          );
+          return this.noAssistance();
+        }
+      }
 
-        const alpha = Math.asin(Math.tan(angle));
-        const sinA = Math.sin(alpha);
-        const cosB = Math.cos(Math.PI / 4);
-        const sinB = cosB;
-        // https://en.wikipedia.org/wiki/Isometric_projection
+      // Check if there is any obstacle in the way.
+      //
+      // There must be no obstacle to go at least
+      // as far in the direction the player chose
+      // as the assistance must take to align the player.
+      //
+      // Because, if the assistance moves the player by 32 pixels
+      // before been able to go in the right direction
+      // and can only move by 4 pixels afterward
+      // that it'll sound silly.
+      this._needToCheckBypassWay =
+        this._needToCheckBypassWay ||
+        assistanceDirection !== this._lastAssistanceDirection;
+      if ((isBypassX || isBypassY) && !this._needToCheckBypassWay) {
+        // Don't check again if the player intent stays the same.
         //
-        //   / 1     0    0 \ / cosB 0 -sinB \ / 1 0  0 \
-        //   | 0  cosA sinA | |    0 1     0 | | 0 0 -1 |
-        //   \ 0 -sinA cosA / \ sinB 0  cosB / \ 0 1  0 /
-        this._screen = [
-          [cosB, -sinB],
-          [sinA * sinB, sinA * cosB],
-        ];
+        // Do it, for instance, if an obstacle has moved out of the way
+        // and the player releases and presses agin the key.
+        // Because, doing it automatically would seems weird.
+        if (this._lastAnyObstacle) {
+          console.debug('Obstacle was in the bypass way: No Assist');
+          return this.noAssistance();
+        }
+      } else if (isBypassX || isBypassY) {
+        this._lastAssistanceDirection = assistanceDirection;
+        this._lastDirection = direction;
+
+        let anyObstacle: boolean = false;
+        // reflection symmetry: y = x
+        // 0 to 6, 2 to 4, 4 to 2, 6 to 0
+        if (direction + assistanceDirection === 6) {
+          // Because the obstacle may not be a square.
+          let cornerX: float;
+          let cornerY: float;
+          if (assistanceDirection === 4 || assistanceDirection === 6) {
+            cornerX = bypassedObstacleAABB!.min[0];
+            cornerY = bypassedObstacleAABB!.min[1];
+          } else {
+            cornerX = bypassedObstacleAABB!.max[0];
+            cornerY = bypassedObstacleAABB!.max[1];
+          }
+          // / cornerX \   / 0  1 \   / x - cornerX \
+          // \ cornerY / + \ 1  0 / * \ y - cornerY /
+          //
+          // min and max are preserved by the symmetry.
+          // The symmetry image is extended to check there is no obstacle before going into the passage.
+          const epsilon: float = Assistance.epsilon;
+          const searchMinX: float =
+            cornerX +
+            minY -
+            cornerY +
+            epsilon +
+            (assistanceDirection === 6 ? cornerY - maxY : 0);
+          const searchMaxX: float =
+            cornerX +
+            maxY -
+            cornerY -
+            epsilon +
+            (assistanceDirection === 2 ? cornerY - minY : 0);
+          const searchMinY: float =
+            cornerY +
+            minX -
+            cornerX +
+            epsilon +
+            (assistanceDirection === 4 ? cornerX - maxX : 0);
+          const searchMaxY: float =
+            cornerY +
+            maxX -
+            cornerX -
+            epsilon +
+            (assistanceDirection === 0 ? cornerX - minX : 0);
+
+          anyObstacle = this._manager.anyObstacle(
+            searchMinX,
+            searchMaxX,
+            searchMinY,
+            searchMaxY,
+            this._collidingObjects
+          );
+        }
+        // reflection symmetry: y = -x
+        // 0 to 2, 2 to 0, 4 to 6, 6 to 4
+        else if ((direction + assistanceDirection) % 8 === 2) {
+          // Because the obstacle may not be a square.
+          let cornerX: float;
+          let cornerY: float;
+          if (assistanceDirection === 2 || assistanceDirection === 4) {
+            cornerX = bypassedObstacleAABB!.min[0];
+            cornerY = bypassedObstacleAABB!.max[1];
+          } else {
+            cornerX = bypassedObstacleAABB!.max[0];
+            cornerY = bypassedObstacleAABB!.min[1];
+          }
+          // / cornerX \   /  0  -1 \   / x - cornerX \
+          // \ cornerY / + \ -1   0 / * \ y - cornerY /
+          //
+          // min and max are switched by the symmetry.
+          // The symmetry image is extended to check there is no obstacle before going into the passage.
+          const epsilon: float = Assistance.epsilon;
+          const searchMinX: float =
+            cornerX -
+            (maxY - cornerY) +
+            epsilon +
+            (assistanceDirection === 2 ? minY - cornerY : 0);
+          const searchMaxX: float =
+            cornerX -
+            (minY - cornerY) -
+            epsilon +
+            (assistanceDirection === 6 ? maxY - cornerY : 0);
+          const searchMinY: float =
+            cornerY -
+            (maxX - cornerX) +
+            epsilon +
+            (assistanceDirection === 0 ? minX - cornerX : 0);
+          const searchMaxY: float =
+            cornerY -
+            (minX - cornerX) -
+            epsilon +
+            (assistanceDirection === 4 ? maxX - cornerX : 0);
+
+          anyObstacle = this._manager.anyObstacle(
+            searchMinX,
+            searchMaxX,
+            searchMinY,
+            searchMaxY,
+            this._collidingObjects
+          );
+        }
+        this._lastAnyObstacle = anyObstacle;
+        this._needToCheckBypassWay = false;
+
+        if (anyObstacle) {
+          console.debug('Obstacle in the bypass way: No Assist');
+          return this.noAssistance();
+        }
       }
 
-      toScreen(worldPoint: FloatPoint, screenPoint: FloatPoint): void {
-        const x =
-          this._screen[0][0] * worldPoint[0] +
-          this._screen[0][1] * worldPoint[1];
-        const y =
-          this._screen[1][0] * worldPoint[0] +
-          this._screen[1][1] * worldPoint[1];
-        screenPoint[0] = x;
-        screenPoint[1] = y;
+      this._result._inputDirection = direction;
+      this._result._assistanceLeft = assistanceLeft > 0;
+      this._result._assistanceRight = assistanceRight > 0;
+      this._result._assistanceUp = assistanceUp > 0;
+      this._result._assistanceDown = assistanceDown > 0;
+      this._result._isBypassX = isBypassX;
+      this._result._isBypassY = isBypassY;
+      this._result._stopMinX = stopMinX;
+      this._result._stopMinY = stopMinY;
+      this._result._stopMaxX = stopMaxX;
+      this._result._stopMaxY = stopMaxY;
+
+      return assistanceDirection;
+    }
+
+    noAssistance(): integer {
+      this._result._isBypassX = false;
+      this._result._isBypassY = false;
+
+      return -1;
+    }
+
+    applyCollision(runtimeScene: gdjs.RuntimeScene) {
+      this._checkCornerStop();
+      this._separateFromObstacles();
+      // check again because the object can be pushed on the stop limit,
+      // it won't be detected on the next frame and the alignment won't be applied.
+      this._checkCornerStop();
+    }
+
+    /**
+     * Check if the object must take a corner.
+     *
+     * When the object reach the limit of an obstacle
+     * and it should take the corner according to the player intent,
+     * it is aligned right on this limit and the velocity is set in the right direction.
+     *
+     * This avoid issues with the inertia. For instance,
+     * when the object could go between 2 obstacles,
+     * with it will just fly over the hole because of its inertia.
+     */
+    _checkCornerStop() {
+      const objectAABB: gdjs.AABB = this.getHitBoxesAABB();
+      const minX: float = objectAABB.min[0];
+      const minY: float = objectAABB.min[1];
+      const object = this._behavior.owner;
+
+      const direction = this._result._inputDirection;
+      const leftKey: boolean = 3 <= direction && direction <= 5;
+      const upKey: boolean = 5 <= direction && direction <= 7;
+
+      console.debug(
+        'stop ' +
+          this._result._isBypassX +
+          ': ' +
+          this._result._stopMinX +
+          ' --> ' +
+          this._result._stopMaxX +
+          '  ;  ' +
+          this._result._isBypassY +
+          ': ' +
+          this._result._stopMinY +
+          ' --> ' +
+          this._result._stopMaxY
+      );
+
+      // Alignment: avoid to go too far and kind of drift or oscillate in front of a hole.
+      if (
+        this._result._isBypassX &&
+        ((this._result._assistanceLeft && minX <= this._result._stopMinX) ||
+          (this._result._assistanceRight && minX >= this._result._stopMaxX))
+      ) {
+        this.shift(
+          -minX +
+            (this._result._assistanceLeft
+              ? this._result._stopMinX
+              : this._result._stopMaxX),
+          0
+        );
+        this._behavior._yVelocity =
+          (upKey ? -1 : 1) *
+          Math.sqrt(
+            this._behavior._xVelocity * this._behavior._xVelocity +
+              this._behavior._yVelocity * this._behavior._yVelocity
+          );
+        this._behavior._xVelocity = 0;
+
+        // FIXME This is just to ease tests, to be removed
+        this.setAnimation(
+          this._behavior.owner,
+          (this.getAnimation(this._behavior.owner) + 1) % 6
+        );
+        console.debug('Align X');
       }
+      if (
+        this._result._isBypassY &&
+        ((this._result._assistanceUp && minY <= this._result._stopMinY) ||
+          (this._result._assistanceDown && minY >= this._result._stopMaxY))
+      ) {
+        this.shift(
+          0,
+          -minY +
+            (this._result._assistanceUp
+              ? this._result._stopMinY
+              : this._result._stopMaxY)
+        );
+        this._behavior._xVelocity =
+          (leftKey ? -1 : 1) *
+          Math.sqrt(
+            this._behavior._xVelocity * this._behavior._xVelocity +
+              this._behavior._yVelocity * this._behavior._yVelocity
+          );
+        this._behavior._yVelocity = 0;
+
+        // FIXME This is just to ease tests, to be removed
+        this.setAnimation(
+          this._behavior.owner,
+          (this.getAnimation(this._behavior.owner) + 1) % 6
+        );
+        console.debug('Align Y');
+      }
+    }
+
+    /**
+     * Separate from TopDownObstacleRuntimeBehavior instances.
+     */
+    _separateFromObstacles() {
+      const object = this._behavior.owner;
+      console.debug(
+        'separateFromObstacles x:' +
+          this._behavior._transformedPosition[0] +
+          ' y:' +
+          this._behavior._transformedPosition[1]
+      );
+      const objectAABB: gdjs.AABB = this.getHitBoxesAABB();
+      const minX: float = objectAABB.min[0];
+      const minY: float = objectAABB.min[1];
+      const maxX: float = objectAABB.max[0];
+      const maxY: float = objectAABB.max[1];
+
+      // Search the obstacle with the biggest intersection
+      // to separate from this one first.
+      // Because smaller collisions may shift the player
+      // in the wrong direction.
+      let maxSurface: float = 0;
+      let bestObstacleBehavior: TopDownObstacleRuntimeBehavior | null = null;
+      for (var i = 0; i < this._potentialCollidingObjects.length; ++i) {
+        const obstacleBehavior = this._potentialCollidingObjects[i];
+        if (obstacleBehavior.owner === object) {
+          continue;
+        }
+
+        const obstacleAABB: gdjs.AABB = obstacleBehavior.getHitBoxesAABB();
+        const obstacleMinX: float = obstacleAABB.min[0];
+        const obstacleMinY: float = obstacleAABB.min[1];
+        const obstacleMaxX: float = obstacleAABB.max[0];
+        const obstacleMaxY: float = obstacleAABB.max[1];
+
+        const interMinX: float = Math.max(minX, obstacleMinX);
+        const interMinY: float = Math.max(minY, obstacleMinY);
+        const interMaxX: float = Math.min(maxX, obstacleMaxX);
+        const interMaxY: float = Math.min(maxY, obstacleMaxY);
+
+        if (interMinX < interMaxX && interMinY < interMaxY) {
+          const surface = (interMaxX - interMinX) * (interMaxY - interMinY);
+          if (surface > maxSurface) {
+            maxSurface = surface;
+            bestObstacleBehavior = obstacleBehavior;
+          }
+        }
+      }
+      if (bestObstacleBehavior !== null) {
+        this.separateFrom(bestObstacleBehavior);
+      }
+      for (var i = 0; i < this._potentialCollidingObjects.length; ++i) {
+        const obstacleBehavior = this._potentialCollidingObjects[i];
+        const obstacle = obstacleBehavior.owner;
+        if (obstacle === object) {
+          continue;
+        }
+        this.separateFrom(obstacleBehavior);
+      }
+      console.debug(
+        'separateFromObstacles done x:' +
+          this._behavior._transformedPosition[0] +
+          ' y:' +
+          this._behavior._transformedPosition[1]
+      );
+    }
+
+    /**
+     * Separate object and obstacle, only object move.
+     * @param obstacle
+     */
+    separateFrom(obstacleBehavior: gdjs.TopDownObstacleRuntimeBehavior) {
+      const objectAABB: gdjs.AABB = this.getHitBoxesAABB();
+      const minX: float = objectAABB.min[0];
+      const minY: float = objectAABB.min[1];
+      const maxX: float = objectAABB.max[0];
+      const maxY: float = objectAABB.max[1];
+
+      const obstacleAABB: AABB = obstacleBehavior.getHitBoxesAABB();
+      const obstacleMinX: float = obstacleAABB.min[0];
+      const obstacleMinY: float = obstacleAABB.min[1];
+      const obstacleMaxX: float = obstacleAABB.max[0];
+      const obstacleMaxY: float = obstacleAABB.max[1];
+
+      const leftDistance: float = maxX - obstacleMinX;
+      const upDistance: float = maxY - obstacleMinY;
+      const rightDistance: float = obstacleMaxX - minX;
+      const downDistance: float = obstacleMaxY - minY;
+      const minDistance: float = Math.min(
+        leftDistance,
+        upDistance,
+        rightDistance,
+        downDistance
+      );
+
+      if (minDistance > 0) {
+        if (leftDistance === minDistance) {
+          this.shift(-maxX + obstacleMinX, 0);
+        } else if (rightDistance === minDistance) {
+          this.shift(-minX + obstacleMaxX, 0);
+        } else if (upDistance === minDistance) {
+          this.shift(0, -maxY + obstacleMinY);
+        } else if (downDistance === minDistance) {
+          this.shift(0, -minY + obstacleMaxY);
+        }
+      }
+    }
+
+    shift(deltaX: float, deltaY: float) {
+      //FIXME use a relative hitBox to avoid rounding errors
+      this._behavior._transformedPosition[0] += deltaX;
+      this._behavior._transformedPosition[1] += deltaY;
+    }
+
+    getHitBoxesAABB(): gdjs.AABB {
+      if (!this._hitBoxesAABBUpToDate) {
+        const hitBoxes: Polygon[] = this._behavior.owner.getHitBoxes();
+
+        let minX: float = Number.MAX_VALUE;
+        let minY: float = Number.MAX_VALUE;
+        let maxX: float = -Number.MAX_VALUE;
+        let maxY: float = -Number.MAX_VALUE;
+        for (let h = 0, lenh = hitBoxes.length; h < lenh; ++h) {
+          let hitBox: Polygon = hitBoxes[h];
+          for (let p = 0, lenp = hitBox.vertices.length; p < lenp; ++p) {
+            const point = this._behavior._temporaryPointForTransformations;
+            if (this._behavior._basisTransformation === null) {
+              point[0] = hitBox.vertices[p][0];
+              point[1] = hitBox.vertices[p][1];
+            } else {
+              this._behavior._basisTransformation.toWorld(
+                hitBox.vertices[p],
+                point
+              );
+            }
+            minX = Math.min(minX, point[0]);
+            maxX = Math.max(maxX, point[0]);
+            minY = Math.min(minY, point[1]);
+            maxY = Math.max(maxY, point[1]);
+          }
+        }
+        this._relativeHitBoxesAABB.min[0] =
+          minX - this._behavior._transformedPosition[0];
+        this._relativeHitBoxesAABB.min[1] =
+          minY - this._behavior._transformedPosition[1];
+        this._relativeHitBoxesAABB.max[0] =
+          maxX - this._behavior._transformedPosition[0];
+        this._relativeHitBoxesAABB.max[1] =
+          maxY - this._behavior._transformedPosition[1];
+
+        this._hitBoxesAABBUpToDate = true;
+      }
+      this._absoluteHitBoxesAABB.min[0] =
+        this._relativeHitBoxesAABB.min[0] +
+        this._behavior._transformedPosition[0];
+      this._absoluteHitBoxesAABB.min[1] =
+        this._relativeHitBoxesAABB.min[1] +
+        this._behavior._transformedPosition[1];
+      this._absoluteHitBoxesAABB.max[0] =
+        this._relativeHitBoxesAABB.max[0] +
+        this._behavior._transformedPosition[0];
+      this._absoluteHitBoxesAABB.max[1] =
+        this._relativeHitBoxesAABB.max[1] +
+        this._behavior._transformedPosition[1];
+      return this._absoluteHitBoxesAABB;
+    }
+
+    /**
+     * Update _potentialCollidingObjects member with platforms near the object.
+     */
+    private _updatePotentialCollidingObjects(maxMovementLength: float) {
+      this._manager.getAllObstaclesAround(
+        this.getHitBoxesAABB(),
+        maxMovementLength,
+        this._potentialCollidingObjects
+      );
     }
   }
 
+  /**
+   * TopDownMovementRuntimeBehavior represents a behavior allowing objects to
+   * follow a path computed to avoid obstacles.
+   */
+  class AssistanceResult {
+    _inputDirection: integer = -1;
+    _assistanceLeft: boolean = false;
+    _assistanceRight: boolean = false;
+    _assistanceUp: boolean = false;
+    _assistanceDown: boolean = false;
+    _isBypassX: boolean = false;
+    _isBypassY: boolean = false;
+    _stopMinX: float = 0;
+    _stopMinY: float = 0;
+    _stopMaxX: float = 0;
+    _stopMaxY: float = 0;
+  }
   gdjs.registerBehavior(
     'TopDownMovementBehavior::TopDownMovementBehavior',
     gdjs.TopDownMovementRuntimeBehavior

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -353,7 +353,6 @@ namespace gdjs {
         let inputDirection: float;
         if (stickIsUsed) {
           inputDirection = this._getStickDirection();
-          console.debug('inputDirection: ' + inputDirection);
         } else {
           inputDirection = direction;
         }
@@ -363,7 +362,6 @@ namespace gdjs {
         );
         if (assistanceDirection !== -1) {
           if (stickIsUsed) {
-            console.debug('assistanceDirection: ' + assistanceDirection);
             this._stickAngle = assistanceDirection * 45;
           } else {
             direction = assistanceDirection;
@@ -426,9 +424,6 @@ namespace gdjs {
 
       //Position object
       if (this._isAssistanceEnable) {
-        // FIXME This is just to ease tests, to be removed
-        console.debug('Velocity: ' + this._xVelocity + ' ; ' + this._yVelocity);
-
         this._assistance.shift(
           this._xVelocity * timeDelta,
           this._yVelocity * timeDelta
@@ -666,33 +661,6 @@ namespace gdjs {
       this._deltasY = [0, 1, 1, 1, 0, -1, -1, -1];
     }
 
-    /**
-     * FIXME This is just to ease tests, to be removed
-     */
-    setAnimation(object: RuntimeObject, animation: integer) {
-      console.debug(object.id + ' : ' + animation);
-      if (object instanceof gdjs.SpriteRuntimeObject) {
-        object.setAnimation(animation);
-      }
-    }
-    /**
-     * FIXME This is just to ease tests, to be removed
-     */
-    getAnimation(object: RuntimeObject): integer {
-      if (object instanceof gdjs.SpriteRuntimeObject) {
-        return object.getAnimation();
-      }
-      return 0;
-    }
-    /**
-     * FIXME This is just to ease tests, to be removed
-     */
-    setOpacity(object: RuntimeObject, opacity: integer) {
-      if (object instanceof gdjs.SpriteRuntimeObject) {
-        object.setOpacity(opacity);
-      }
-    }
-
     almostEquals(a: float, b: float) {
       return b - Assistance.epsilon < a && a < b + Assistance.epsilon;
     }
@@ -757,10 +725,6 @@ namespace gdjs {
       const width: float = maxX - minX;
       const height: float = maxY - minY;
 
-      // FIXME This is just to ease tests, to be removed
-      let debug = '';
-      //runtimeScene.getVariables().get("Debug").setString(minX + ", " + minY + " -> " + maxX + ", " + maxY + "\n");
-
       // This affectation has no meaning, it will be override.
       let bypassedObstacleAABB: AABB | null = null;
 
@@ -791,19 +755,6 @@ namespace gdjs {
           Math.min(minY, Math.ceil(minY + deltaY)) < obstacleMaxY
         ) {
           this._collidingObjects.push(obstacle);
-          // FIXME This is just to ease tests, to be removed
-          this.setAnimation(obstacle, 0);
-          this.setOpacity(obstacle, 64 + 128 * Math.random());
-          debug +=
-            'obstacle: ' +
-            obstacleMinX / 64 +
-            ', ' +
-            obstacleMinY / 64 +
-            ' -> ' +
-            obstacleMaxX / 64 +
-            ', ' +
-            obstacleMaxY / 64 +
-            '\n';
 
           // The player is corner to corner to the obstacle.
           // The assistance will depend on other obstacles.
@@ -815,36 +766,24 @@ namespace gdjs {
           ) {
             assistanceRight++;
             assistanceDown++;
-
-            // FIXME This is just to ease tests, to be removed
-            this.setAnimation(obstacle, 9);
           } else if (
             this.almostEquals(maxX, obstacleMinX) &&
             this.almostEquals(minY, obstacleMaxY)
           ) {
             assistanceRight++;
             assistanceUp++;
-
-            // FIXME This is just to ease tests, to be removed
-            this.setAnimation(obstacle, 10);
           } else if (
             this.almostEquals(minX, obstacleMaxX) &&
             this.almostEquals(minY, obstacleMaxY)
           ) {
             assistanceLeft++;
             assistanceUp++;
-
-            // FIXME This is just to ease tests, to be removed
-            this.setAnimation(obstacle, 8);
           } else if (
             this.almostEquals(minX, obstacleMaxX) &&
             this.almostEquals(maxY, obstacleMinY)
           ) {
             assistanceLeft++;
             assistanceDown++;
-
-            // FIXME This is just to ease tests, to be removed
-            this.setAnimation(obstacle, 7);
           } else if (
             (upKey && this.almostEquals(minY, obstacleMaxY)) ||
             (downKey && this.almostEquals(maxY, obstacleMinY))
@@ -861,9 +800,6 @@ namespace gdjs {
             ) {
               assistanceLeft++;
               assistanceRight++;
-
-              // FIXME This is just to ease tests, to be removed
-              this.setAnimation(obstacle, 5);
             }
             // The player is on the corner of the obstacle.
             // (not the exact corner, see corner affectation)
@@ -881,18 +817,6 @@ namespace gdjs {
                 stopMinX = obstacleMinX - width;
                 bypassedObstacleAABB = obstacleAABB;
               }
-              // FIXME This is just to ease tests, to be removed
-              this.setAnimation(obstacle, 3);
-              debug +=
-                'assistanceLeft: ' +
-                obstacleMinX +
-                ', ' +
-                obstacleMinY +
-                ' -> ' +
-                obstacleMaxX +
-                ', ' +
-                obstacleMaxY +
-                '\n';
             } else if (
               !leftKey &&
               obstacleMaxX - corner <= minX &&
@@ -905,9 +829,6 @@ namespace gdjs {
                 stopMaxX = obstacleMaxX;
                 bypassedObstacleAABB = obstacleAABB;
               }
-              // FIXME This is just to ease tests, to be removed
-              this.setAnimation(obstacle, 1);
-              //debug += "assistanceRight: " + obstacleMinX + ", " + obstacleMinY + " -> " + obstacleMaxX + ", " + obstacleMaxY + "\n";
             }
           } else if (
             (leftKey && this.almostEquals(minX, obstacleMaxX)) ||
@@ -925,9 +846,6 @@ namespace gdjs {
             ) {
               assistanceUp++;
               assistanceDown++;
-
-              // FIXME This is just to ease tests, to be removed
-              this.setAnimation(obstacle, 6);
             }
             // The player is on the corner of the obstacle.
             // (not the exact corner, see corner affectation)
@@ -943,15 +861,6 @@ namespace gdjs {
                 stopMinY = obstacleMinY - height;
                 bypassedObstacleAABB = obstacleAABB;
               }
-              // FIXME This is just to ease tests, to be removed
-              if (this.getAnimation(obstacle) === 3) {
-                this.setAnimation(obstacle, 8);
-              } else if (this.getAnimation(obstacle) === 1) {
-                this.setAnimation(obstacle, 10);
-              } else {
-                this.setAnimation(obstacle, 4);
-              }
-              //debug += "assistanceUp: " + obstacleMinX + ", " + obstacleMinY + " -> " + obstacleMaxX + ", " + obstacleMaxY + "\n";
             } else if (
               !upKey &&
               obstacleMaxY - corner <= minY &&
@@ -964,48 +873,14 @@ namespace gdjs {
                 stopMaxY = obstacleMaxY;
                 bypassedObstacleAABB = obstacleAABB;
               }
-              // FIXME This is just to ease tests, to be removed
-              if (this.getAnimation(obstacle) === 3) {
-                this.setAnimation(obstacle, 7);
-              } else if (this.getAnimation(obstacle) === 1) {
-                this.setAnimation(obstacle, 9);
-              } else {
-                this.setAnimation(obstacle, 2);
-              }
-              //debug += "assistanceDown: " + obstacleMinX + ", " + obstacleMinY + " -> " + obstacleMaxX + ", " + obstacleMaxY + "\n";
             }
           }
         }
       }
 
-      // FIXME This is just to ease tests, to be removed
-      debug +=
-        'assistanceLeft: ' +
-        assistanceLeft +
-        '\n' +
-        'assistanceRight: ' +
-        assistanceRight +
-        '\n' +
-        'assistanceUp: ' +
-        assistanceUp +
-        '\n' +
-        'assistanceDown: ' +
-        assistanceDown +
-        '\n' +
-        minX / 64 +
-        ', ' +
-        minY / 64 +
-        ' -> ' +
-        maxX / 64 +
-        ', ' +
-        maxY / 64 +
-        '\n';
-      runtimeScene.getVariables().get('Debug').setString(debug);
-
       // This may happen when the player is in the corner of 2 perpendicular walls.
       // No assistance is needed.
       if (assistanceLeft && assistanceRight && assistanceUp && assistanceDown) {
-        console.debug('Against perpendicular walls: No Assist');
         return this.noAssistance();
       }
       // This may happen when the player goes in diagonal against a wall.
@@ -1017,12 +892,9 @@ namespace gdjs {
         isBypassX = false;
         if (leftKey && !rightKey) {
           assistanceDirection = 4;
-          console.debug('Slide on walls: Go Right');
         } else if (rightKey && !leftKey) {
           assistanceDirection = 0;
-          console.debug('Slide on walls: Go Left');
         } else {
-          console.debug('Against walls: No Assist');
           // Contradictory decisions are dismissed.
           //
           // This can happen, for instance, with a wall composed of squares.
@@ -1035,12 +907,9 @@ namespace gdjs {
         isBypassY = false;
         if (upKey && !downKey) {
           assistanceDirection = 6;
-          console.debug('Slide on walls: Go Up');
         } else if (downKey && !upKey) {
           assistanceDirection = 2;
-          console.debug('Slide on walls: Go Down');
         } else {
-          console.debug('Against walls: No Assist');
           // see previous comment
           return this.noAssistance();
         }
@@ -1060,10 +929,8 @@ namespace gdjs {
               Math.abs(this._behavior._yVelocity))
         ) {
           assistanceDirection = 2;
-          console.debug('Corner TopLeft: Go Down');
         } else {
           assistanceDirection = 0;
-          console.debug('Corner TopLeft: Go Right');
         }
       } else if (assistanceLeft && assistanceDown) {
         if (
@@ -1075,10 +942,8 @@ namespace gdjs {
               Math.abs(this._behavior._yVelocity))
         ) {
           assistanceDirection = 2;
-          console.debug('Corner TopRight: Go Down');
         } else {
           assistanceDirection = 4;
-          console.debug('Corner TopRight: Go Left');
         }
       } else if (assistanceLeft && assistanceUp) {
         if (
@@ -1090,10 +955,8 @@ namespace gdjs {
               Math.abs(this._behavior._yVelocity))
         ) {
           assistanceDirection = 6;
-          console.debug('Corner DownRight: Go Up');
         } else {
           assistanceDirection = 4;
-          console.debug('Corner DownRight: Go Left');
         }
       } else if (assistanceRight && assistanceUp) {
         if (
@@ -1105,58 +968,21 @@ namespace gdjs {
               Math.abs(this._behavior._yVelocity))
         ) {
           assistanceDirection = 6;
-          console.debug('Corner DownLeft: Go Up');
         } else {
           assistanceDirection = 0;
-          console.debug('Corner DownLeft: Go Right');
         }
       } else {
         // Slide on the corner of an obstacle to bypass it.
         // Every tricky cases are already handled .
         if (assistanceLeft) {
-          console.debug(
-            'Go Left (Left: %s, Down: %s, Right: %s, Up: %s)',
-            assistanceLeft,
-            assistanceDown,
-            assistanceRight,
-            assistanceUp
-          );
           assistanceDirection = 4;
         } else if (assistanceRight) {
-          console.debug(
-            'Go Right (Left: %s, Down: %s, Right: %s, Up: %s)',
-            assistanceLeft,
-            assistanceDown,
-            assistanceRight,
-            assistanceUp
-          );
           assistanceDirection = 0;
         } else if (assistanceUp) {
-          console.debug(
-            'Go Up (Left: %s, Down: %s, Right: %s, Up: %s)',
-            assistanceLeft,
-            assistanceDown,
-            assistanceRight,
-            assistanceUp
-          );
           assistanceDirection = 6;
         } else if (assistanceDown) {
-          console.debug(
-            'Go Down (Left: %s, Down: %s, Right: %s, Up: %s)',
-            assistanceLeft,
-            assistanceDown,
-            assistanceRight,
-            assistanceUp
-          );
           assistanceDirection = 2;
         } else {
-          console.debug(
-            'No Assist (Left: %s, Down: %s, Right: %s, Up: %s)',
-            assistanceLeft,
-            assistanceDown,
-            assistanceRight,
-            assistanceUp
-          );
           return this.noAssistance();
         }
       }
@@ -1181,7 +1007,6 @@ namespace gdjs {
         // and the player releases and presses agin the key.
         // Because, doing it automatically would seems weird.
         if (this._lastAnyObstacle) {
-          console.debug('Obstacle was in the bypass way: No Assist');
           return this.noAssistance();
         }
       } else if (isBypassX || isBypassY) {
@@ -1293,7 +1118,6 @@ namespace gdjs {
         this._needToCheckBypassWay = false;
 
         if (anyObstacle) {
-          console.debug('Obstacle in the bypass way: No Assist');
           return this.noAssistance();
         }
       }
@@ -1349,21 +1173,6 @@ namespace gdjs {
       const leftKey: boolean = 3 <= direction && direction <= 5;
       const upKey: boolean = 5 <= direction && direction <= 7;
 
-      console.debug(
-        'stop ' +
-          this._result._isBypassX +
-          ': ' +
-          this._result._stopMinX +
-          ' --> ' +
-          this._result._stopMaxX +
-          '  ;  ' +
-          this._result._isBypassY +
-          ': ' +
-          this._result._stopMinY +
-          ' --> ' +
-          this._result._stopMaxY
-      );
-
       // Alignment: avoid to go too far and kind of drift or oscillate in front of a hole.
       if (
         this._result._isBypassX &&
@@ -1384,13 +1193,6 @@ namespace gdjs {
               this._behavior._yVelocity * this._behavior._yVelocity
           );
         this._behavior._xVelocity = 0;
-
-        // FIXME This is just to ease tests, to be removed
-        this.setAnimation(
-          this._behavior.owner,
-          (this.getAnimation(this._behavior.owner) + 1) % 6
-        );
-        console.debug('Align X');
       }
       if (
         this._result._isBypassY &&
@@ -1411,13 +1213,6 @@ namespace gdjs {
               this._behavior._yVelocity * this._behavior._yVelocity
           );
         this._behavior._yVelocity = 0;
-
-        // FIXME This is just to ease tests, to be removed
-        this.setAnimation(
-          this._behavior.owner,
-          (this.getAnimation(this._behavior.owner) + 1) % 6
-        );
-        console.debug('Align Y');
       }
     }
 
@@ -1426,12 +1221,6 @@ namespace gdjs {
      */
     _separateFromObstacles() {
       const object = this._behavior.owner;
-      console.debug(
-        'separateFromObstacles x:' +
-          this._behavior._transformedPosition[0] +
-          ' y:' +
-          this._behavior._transformedPosition[1]
-      );
       const objectAABB: gdjs.AABB = this.getHitBoxesAABB();
       const minX: float = objectAABB.min[0];
       const minY: float = objectAABB.min[1];
@@ -1480,12 +1269,6 @@ namespace gdjs {
         }
         this.separateFrom(obstacleBehavior);
       }
-      console.debug(
-        'separateFromObstacles done x:' +
-          this._behavior._transformedPosition[0] +
-          ' y:' +
-          this._behavior._transformedPosition[1]
-      );
     }
 
     /**

--- a/Extensions/TopDownMovementBehavior/topdownobstacleruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownobstacleruntimebehavior.ts
@@ -117,45 +117,11 @@ namespace gdjs {
       searchArea.maxY = maxY;
       var nearbyObstacles = this._obstacleRBush.search(searchArea);
 
-      // Sometimes RBush.search returns several times the player.
-      // Could it be a bug?
-
-      // FIXME This is just to ease tests, to be remove
-      var debug = '' + excluded.length + '\n';
-      for (var i = 0; i < excluded.length; i++) {
-        debug += excluded[i].id + '\n';
-      }
       for (var i = 0; i < nearbyObstacles.length; i++) {
-        const obstacleAABB: gdjs.AABB = nearbyObstacles[i].getHitBoxesAABB();
-        const obstacleMinX: number = obstacleAABB.min[0];
-        const obstacleMinY: number = obstacleAABB.min[1];
-        const obstacleMaxX: number = obstacleAABB.max[0];
-        const obstacleMaxY: number = obstacleAABB.max[1];
-        debug +=
-          nearbyObstacles[i].owner.id +
-          ' : ' +
-          obstacleMinX +
-          ' ' +
-          obstacleMinY +
-          ' -> ' +
-          obstacleMaxX +
-          ' ' +
-          obstacleMaxY +
-          '\n';
-
-        if (excluded.indexOf(nearbyObstacles[i].owner) < 0) {
-          // FIXME This is just to ease tests, to be remove
-          if (nearbyObstacles[i].owner instanceof gdjs.SpriteRuntimeObject) {
-            var alpha = 64 + 128 * Math.random();
-            nearbyObstacles[i].owner.setOpacity(alpha);
-            this._runtimeScene.getVariables().get('Debug').setString(debug);
-          }
-
+        if (!excluded.includes(nearbyObstacles[i].owner)) {
           return true;
         }
       }
-      //this._runtimeScene.getVariables().get("Debug").setString(debug);
-
       return false;
     }
   }

--- a/Extensions/TopDownMovementBehavior/topdownobstacleruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownobstacleruntimebehavior.ts
@@ -1,0 +1,427 @@
+/**
+GDevelop - Top-Down Movement Behavior Extension
+Copyright (c) 2013-2016 Florian Rival (Florian.Rival@gmail.com)
+ */
+namespace gdjs {
+  declare var rbush: any;
+
+  /**
+   * Manages the common objects shared by objects having a
+   * top-down obstacle behavior: in particular, the top-down obstacle behaviors are required to declare
+   * themselves (see gdjs.TopDownObstaclesManager.addObstacle) to the manager of their associated scene
+   * (see gdjs.TopDownObstaclesManager.getManager).
+   */
+  export class TopDownObstaclesManager {
+    _obstacleRBush: any;
+    _runtimeScene: gdjs.RuntimeScene;
+
+    /**
+     * @param object The object
+     */
+    constructor(runtimeScene: gdjs.RuntimeScene) {
+      this._obstacleRBush = new rbush(9, [
+        '.getHitBoxesAABB().min[0]',
+        '.getHitBoxesAABB().min[1]',
+        '.getHitBoxesAABB().max[0]',
+        '.getHitBoxesAABB().max[1]',
+      ]);
+      this._runtimeScene = runtimeScene;
+    }
+
+    /**
+     * Get the obstacles manager of a scene.
+     */
+    static getManager(
+      runtimeScene: gdjs.RuntimeScene
+    ): gdjs.TopDownObstaclesManager {
+      // @ts-ignore
+      if (!runtimeScene.topDownObstaclesManager) {
+        //Create the shared manager if necessary.
+        // @ts-ignore
+        runtimeScene.topDownObstaclesManager = new gdjs.TopDownObstaclesManager(
+          runtimeScene
+        );
+      }
+      // @ts-ignore
+      return runtimeScene.topDownObstaclesManager;
+    }
+
+    /**
+     * Add a obstacle to the list of existing obstacles.
+     */
+    addObstacle(obstacleBehavior: gdjs.TopDownObstacleRuntimeBehavior) {
+      this._obstacleRBush.insert(obstacleBehavior);
+    }
+
+    /**
+     * Remove a obstacle from the list of existing obstacles. Be sure that the obstacle was
+     * added before.
+     */
+    removeObstacle(obstacleBehavior: gdjs.TopDownObstacleRuntimeBehavior) {
+      this._obstacleRBush.remove(obstacleBehavior);
+    }
+
+    /**
+     * Returns all the obstacles around the specified object.
+     * @param object
+     * @param maxMovementLength The maximum distance, in pixels, the object is going to do.
+     * @return An array with all obstacles near the object.
+     */
+    getAllObstaclesAround(
+      object: gdjs.AABB,
+      maxMovementLength: number,
+      result: gdjs.TopDownObstacleRuntimeBehavior[]
+    ): any {
+      const searchArea = gdjs.staticObject(
+        gdjs.TopDownObstaclesManager.prototype.getAllObstaclesAround
+      );
+
+      // @ts-ignore
+      searchArea.minX = object.min[0] - maxMovementLength;
+      // @ts-ignore
+      searchArea.minY = object.min[1] - maxMovementLength;
+      // @ts-ignore
+      searchArea.maxX = object.max[0] + maxMovementLength;
+      // @ts-ignore
+      searchArea.maxY = object.max[1] + maxMovementLength;
+      const nearbyObstacles = this._obstacleRBush.search(searchArea);
+      result.length = 0;
+      result.push.apply(result, nearbyObstacles);
+    }
+
+    /**
+     * Returns true if there is any obstacle intersecting the area.
+     * @param minX
+     * @param maxX
+     * @param minY
+     * @param maxY
+     * @param excluded
+     */
+    anyObstacle(
+      minX: number,
+      maxX: number,
+      minY: number,
+      maxY: number,
+      excluded: gdjs.RuntimeObject[]
+    ): boolean {
+      const searchArea = gdjs.staticObject(
+        gdjs.TopDownObstaclesManager.prototype.anyObstacle
+      );
+      // @ts-ignore
+      searchArea.minX = minX;
+      // @ts-ignore
+      searchArea.minY = minY;
+      // @ts-ignore
+      searchArea.maxX = maxX;
+      // @ts-ignore
+      searchArea.maxY = maxY;
+      var nearbyObstacles = this._obstacleRBush.search(searchArea);
+
+      // Sometimes RBush.search returns several times the player.
+      // Could it be a bug?
+
+      // FIXME This is just to ease tests, to be remove
+      var debug = '' + excluded.length + '\n';
+      for (var i = 0; i < excluded.length; i++) {
+        debug += excluded[i].id + '\n';
+      }
+      for (var i = 0; i < nearbyObstacles.length; i++) {
+        const obstacleAABB: gdjs.AABB = nearbyObstacles[i].getHitBoxesAABB();
+        const obstacleMinX: number = obstacleAABB.min[0];
+        const obstacleMinY: number = obstacleAABB.min[1];
+        const obstacleMaxX: number = obstacleAABB.max[0];
+        const obstacleMaxY: number = obstacleAABB.max[1];
+        debug +=
+          nearbyObstacles[i].owner.id +
+          ' : ' +
+          obstacleMinX +
+          ' ' +
+          obstacleMinY +
+          ' -> ' +
+          obstacleMaxX +
+          ' ' +
+          obstacleMaxY +
+          '\n';
+
+        if (excluded.indexOf(nearbyObstacles[i].owner) < 0) {
+          // FIXME This is just to ease tests, to be remove
+          if (nearbyObstacles[i].owner instanceof gdjs.SpriteRuntimeObject) {
+            var alpha = 64 + 128 * Math.random();
+            nearbyObstacles[i].owner.setOpacity(alpha);
+            this._runtimeScene.getVariables().get('Debug').setString(debug);
+          }
+
+          return true;
+        }
+      }
+      //this._runtimeScene.getVariables().get("Debug").setString(debug);
+
+      return false;
+    }
+  }
+
+  /**
+   * TopDownObstacleRuntimeBehavior represents a behavior allowing objects to be
+   * considered as a obstacle by objects having TopDownMovement Behavior.
+   */
+  export class TopDownObstacleRuntimeBehavior extends gdjs.RuntimeBehavior {
+    _slidingCornerSize: float;
+    _customIsometryAngle: float;
+
+    //Note that we can't use getX(), getWidth()... of owner here: The owner is not fully constructed.
+    _oldX: float = 0;
+    _oldY: float = 0;
+    _oldWidth: float = 0;
+    _oldHeight: float = 0;
+    _manager: gdjs.TopDownObstaclesManager;
+    _registeredInManager: boolean = false;
+
+    _hitBoxesAABB: gdjs.AABB = { min: [0, 0], max: [0, 0] };
+    _hitBoxesAABBUpToDate: boolean = false;
+
+    // @ts-ignore
+    _basisTransformation: BasisTransformation;
+    _point: FloatPoint = [0, 0];
+
+    constructor(
+      runtimeScene: gdjs.RuntimeScene,
+      behaviorData,
+      owner: gdjs.RuntimeObject
+    ) {
+      super(runtimeScene, behaviorData, owner);
+
+      this._slidingCornerSize = behaviorData.slidingCornerSize || 0;
+      this._customIsometryAngle = behaviorData.customIsometryAngle;
+      this._manager = gdjs.TopDownObstaclesManager.getManager(runtimeScene);
+
+      this.setViewpoint(
+        behaviorData.viewpoint,
+        behaviorData.customIsometryAngle
+      );
+    }
+
+    updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
+      if (
+        oldBehaviorData._slidingCornerSize !==
+        newBehaviorData._slidingCornerSize
+      ) {
+        this._slidingCornerSize = newBehaviorData._slidingCornerSize;
+      }
+      if (
+        oldBehaviorData.platformType !== newBehaviorData.platformType ||
+        oldBehaviorData.customIsometryAngle !==
+          newBehaviorData.customIsometryAngle
+      ) {
+        this.setViewpoint(
+          newBehaviorData.platformType,
+          newBehaviorData.customIsometryAngle
+        );
+      }
+      return true;
+    }
+
+    setViewpoint(viewpoint: string, customIsometryAngle: number): void {
+      this._customIsometryAngle = customIsometryAngle;
+      if (viewpoint === 'PixelIsometry') {
+        this._basisTransformation = new IsometryTransformation(Math.atan(0.5));
+      } else if (viewpoint === 'TrueIsometry') {
+        this._basisTransformation = new IsometryTransformation(Math.PI / 6);
+      } else if (viewpoint === 'CustomIsometry') {
+        this._basisTransformation = new IsometryTransformation(
+          this._customIsometryAngle
+        );
+      } else {
+        this._basisTransformation = new IdentityTransformation();
+      }
+    }
+
+    onDestroy() {
+      if (this._manager && this._registeredInManager) {
+        this._manager.removeObstacle(this);
+      }
+    }
+
+    doStepPreEvents(runtimeScene: gdjs.RuntimeScene) {
+      //Scene change is not supported
+      /*if ( parentScene != &scene ) //Parent scene has changed
+            {
+                if ( sceneManager ) //Remove the object from any old scene manager.
+                    sceneManager->RemoveObstacle(this);
+                parentScene = &scene;
+                sceneManager = parentScene ? &SceneObstacleObjectsManager::managers[&scene] : NULL;
+                registeredInManager = false;
+            }*/
+
+      //Make sure the obstacle is or is not in the obstacles manager.
+      if (!this.activated() && this._registeredInManager) {
+        this._manager.removeObstacle(this);
+        this._registeredInManager = false;
+      } else {
+        if (this.activated() && !this._registeredInManager) {
+          this._manager.addObstacle(this);
+          this._registeredInManager = true;
+        }
+      }
+
+      //Track changes in size or position
+      if (
+        this._oldX !== this.owner.getX() ||
+        this._oldY !== this.owner.getY() ||
+        this._oldWidth !== this.owner.getWidth() ||
+        this._oldHeight !== this.owner.getHeight()
+      ) {
+        this._hitBoxesAABBUpToDate = false;
+        if (this._registeredInManager) {
+          this._manager.removeObstacle(this);
+          this._manager.addObstacle(this);
+        }
+        this._oldX = this.owner.getX();
+        this._oldY = this.owner.getY();
+        this._oldWidth = this.owner.getWidth();
+        this._oldHeight = this.owner.getHeight();
+      }
+    }
+
+    doStepPostEvents(runtimeScene) {}
+
+    onActivate() {
+      if (this._registeredInManager) {
+        return;
+      }
+      this._manager.addObstacle(this);
+      this._registeredInManager = true;
+    }
+
+    onDeActivate() {
+      if (!this._registeredInManager) {
+        return;
+      }
+      this._manager.removeObstacle(this);
+      this._registeredInManager = false;
+    }
+
+    getHitBoxesAABB(): gdjs.AABB {
+      if (!this._hitBoxesAABBUpToDate) {
+        const hitBoxes: gdjs.Polygon[] = this.owner.getHitBoxes();
+
+        let minX: number = Number.MAX_VALUE;
+        let minY: number = Number.MAX_VALUE;
+        let maxX: number = -Number.MAX_VALUE;
+        let maxY: number = -Number.MAX_VALUE;
+        for (let h = 0, lenh = hitBoxes.length; h < lenh; ++h) {
+          let hitBox: gdjs.Polygon = hitBoxes[h];
+          for (let p = 0, lenp = hitBox.vertices.length; p < lenp; ++p) {
+            const point = this._point;
+            this._basisTransformation.toWorld(hitBox.vertices[p], point);
+
+            minX = Math.min(minX, point[0]);
+            maxX = Math.max(maxX, point[0]);
+            minY = Math.min(minY, point[1]);
+            maxY = Math.max(maxY, point[1]);
+          }
+        }
+        this._hitBoxesAABB.min[0] = minX;
+        this._hitBoxesAABB.min[1] = minY;
+        this._hitBoxesAABB.max[0] = maxX;
+        this._hitBoxesAABB.max[1] = maxY;
+
+        this._hitBoxesAABBUpToDate = true;
+      }
+      return this._hitBoxesAABB;
+    }
+
+    getSlidingCornerSize() {
+      return this._slidingCornerSize;
+    }
+  }
+
+  interface BasisTransformation {
+    toScreen(worldPoint: FloatPoint, screenPoint: FloatPoint): void;
+
+    toWorld(screenPoint: FloatPoint, worldPoint: FloatPoint): void;
+
+    toScreen(worldPoint: FloatPoint): void;
+
+    toWorld(screenPoint: FloatPoint): void;
+  }
+
+  class IdentityTransformation implements BasisTransformation {
+    toScreen(worldPoint: FloatPoint, screenPoint?: FloatPoint): void {
+      if (screenPoint) {
+        screenPoint[0] = worldPoint[0];
+        screenPoint[1] = worldPoint[1];
+      }
+    }
+
+    toWorld(screenPoint: FloatPoint, worldPoint?: FloatPoint): void {
+      if (worldPoint) {
+        worldPoint[0] = screenPoint[0];
+        worldPoint[1] = screenPoint[1];
+      }
+    }
+  }
+
+  class IsometryTransformation implements BasisTransformation {
+    _screen: float[][];
+    _world: float[][];
+
+    /**
+     * @param angle between the x axis and the projected isometric x axis.
+     * @throws if the angle is not in ]0; pi/4[. Note that 0 is a front viewpoint and pi/4 a top-down viewpoint.
+     */
+    constructor(angle: float) {
+      if (angle <= 0 || angle >= Math.PI / 4)
+        throw new RangeError(
+          'An isometry angle must be in ]0; pi/4] but was: ' + angle
+        );
+
+      const alpha = Math.asin(Math.tan(angle));
+      const sinA = Math.sin(alpha);
+      const cosB = Math.cos(Math.PI / 4);
+      const sinB = cosB;
+      // https://en.wikipedia.org/wiki/Isometric_projection
+      //
+      //   / 1     0    0 \ / cosB 0 -sinB \ / 1 0  0 \
+      //   | 0  cosA sinA | |    0 1     0 | | 0 0 -1 |
+      //   \ 0 -sinA cosA / \ sinB 0  cosB / \ 0 1  0 /
+      this._screen = [
+        [cosB, -sinB],
+        [sinA * sinB, sinA * cosB],
+      ];
+      // invert
+      this._world = [
+        [cosB, sinB / sinA],
+        [-sinB, cosB / sinA],
+      ];
+    }
+
+    toScreen(worldPoint: FloatPoint, screenPoint?: FloatPoint): void {
+      if (!screenPoint) {
+        screenPoint = worldPoint;
+      }
+      const x =
+        this._screen[0][0] * worldPoint[0] + this._screen[0][1] * worldPoint[1];
+      const y =
+        this._screen[1][0] * worldPoint[0] + this._screen[1][1] * worldPoint[1];
+      screenPoint[0] = x;
+      screenPoint[1] = y;
+    }
+
+    toWorld(screenPoint: FloatPoint, worldPoint?: FloatPoint): void {
+      if (!worldPoint) {
+        worldPoint = screenPoint;
+      }
+      const x =
+        this._world[0][0] * screenPoint[0] + this._world[0][1] * screenPoint[1];
+      const y =
+        this._world[1][0] * screenPoint[0] + this._world[1][1] * screenPoint[1];
+      worldPoint[0] = x;
+      worldPoint[1] = y;
+    }
+  }
+
+  gdjs.registerBehavior(
+    'TopDownMovementBehavior::TopDownObstacleBehavior',
+    gdjs.TopDownObstacleRuntimeBehavior
+  );
+}


### PR DESCRIPTION
This extension allows to make instances of Top-Down Movement behavior slide on the obstacles corners to bypass them smoothly. The controls are not directly applied. Instead, the behavior analyzes the player intents and move accordingly. It can choose to apply another control if it sees fit.

For instance, the player wants to go between 2 obstacles with just enough space between them. Without assistance, the player will always be a bit too much above or below and he may need to adjust the position 3 or 4 times which can be frustrating. With the assistance, when the right key is pressed and the player touches one obstacle, it will automatically align the player like if he were pressing up just the right amount.
![TopDownAssistance](https://user-images.githubusercontent.com/2611977/111213615-3b087080-85d1-11eb-9e84-8c34f6aa2211.png)


These are the exports from 2021-04-12:

* The interactive presentation
https://games.gdevelop-app.com/game-4d1afcce-647d-45bf-b8d3-980f26ef822a/index.html

* The isometric version (PageUp/PageDown to change level also)
https://games.gdevelop-app.com/game-c45be234-9ace-4dcd-920d-eea9feac0c87/index.html

* This is a build of the Bomberman example that uses it instead of the workaround with events
https://games.gdevelop-app.com/game-d9d9cb36-c8a7-45da-bb02-81f78c135da5/index.html

* The sources of the 2 test projects
https://www.dropbox.com/s/4fb052mw0961nyp/TopDownObstacleTestProjects.zip?dl=1
