### PR TITLE
Add missing translation tags for events

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
@@ -104,7 +104,7 @@ export default class ForEachEvent extends React.Component<
             tabIndex={0}
           >
             {objectName ? (
-              <Trans>{`Repeat for each instance of ${objectName}:`}</Trans>
+              <Trans>Repeat for each instance of {objectName}:</Trans>
             ) : (
               <i>
                 <Trans>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
@@ -14,6 +14,7 @@ import ObjectField from '../../ParameterFields/ObjectField';
 import { type EventRendererProps } from './EventRenderer';
 import ConditionsActionsColumns from '../ConditionsActionsColumns';
 import { shouldActivate } from '../../../UI/KeyboardShortcuts/InteractionKeys.js';
+import { Trans } from '@lingui/macro';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -103,10 +104,12 @@ export default class ForEachEvent extends React.Component<
             tabIndex={0}
           >
             {objectName ? (
-              `Repeat for each instance of ${objectName}:`
+              <Trans>{`Repeat for each instance of ${objectName}:`}</Trans>
             ) : (
               <i>
-                Click to choose for which objects this event will be repeated
+                <Trans>
+                  Click to choose for which objects this event will be repeated
+                </Trans>
               </i>
             )}
           </span>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -16,6 +16,7 @@ import {
   shouldCloseOrCancel,
   shouldValidate,
 } from '../../../UI/KeyboardShortcuts/InteractionKeys';
+import { Trans } from '@lingui/macro';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -121,7 +122,11 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
             })}
             style={{ ...styles.title, color: textColor }}
           >
-            {groupEvent.getName() || '<Enter group name>'}
+            {groupEvent.getName() ? (
+              groupEvent.getName()
+            ) : (
+              <Trans>{`<Enter group name>`}</Trans>
+            )}
           </span>
         )}
       </div>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -17,6 +17,7 @@ import { type EventRendererProps } from './EventRenderer';
 import Measure from 'react-measure';
 import { CodeEditor } from '../../../CodeEditor';
 import { shouldActivate } from '../../../UI/KeyboardShortcuts/InteractionKeys';
+import { Trans } from '@lingui/macro';
 const gd: libGDevelop = global.gd;
 
 const fontFamily = '"Lucida Console", Monaco, monospace';
@@ -32,7 +33,7 @@ const styles = {
   },
   wrappingText: {
     fontFamily,
-    fontSize: '12px',
+    fontSize: '13px',
     paddingLeft: 5,
     paddingRight: 5,
     paddingTop: 2,
@@ -186,9 +187,11 @@ export default class JsCodeEvent extends React.Component<
         tabIndex={0}
         style={textStyle}
       >
-        {parameterObjects
-          ? `, objects /*${parameterObjects}*/`
-          : ' /* Click here to choose objects to pass to JavaScript */'}
+        {parameterObjects ? (
+          <Trans>{`, objects /*${parameterObjects}*/`}</Trans>
+        ) : (
+          <Trans>{`\u00A0/* Click here to choose objects to pass to JavaScript */`}</Trans>
+        )}
       </span>
     );
 

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -190,8 +190,11 @@ export default class JsCodeEvent extends React.Component<
         {parameterObjects ? (
           <Trans>, objects /*{parameterObjects}*/</Trans>
         ) : (
-          <>{' '}
-          <Trans>/* Click here to choose objects to pass to JavaScript */</Trans>
+          <>
+            {' '}
+            <Trans>
+              /* Click here to choose objects to pass to JavaScript */
+            </Trans>
           </>
         )}
       </span>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/JsCodeEvent.js
@@ -188,9 +188,11 @@ export default class JsCodeEvent extends React.Component<
         style={textStyle}
       >
         {parameterObjects ? (
-          <Trans>{`, objects /*${parameterObjects}*/`}</Trans>
+          <Trans>, objects /*{parameterObjects}*/</Trans>
         ) : (
-          <Trans>{`\u00A0/* Click here to choose objects to pass to JavaScript */`}</Trans>
+          <>{' '}
+          <Trans>/* Click here to choose objects to pass to JavaScript */</Trans>
+          </>
         )}
       </span>
     );

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent.js
@@ -135,7 +135,7 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
                 tabIndex={0}
               >
                 {target || (
-                  <Trans>&lt; Enter the name of external events &gt;</Trans>
+                  <Trans>{`<Enter the name of external events>`}</Trans>
                 )}
               </i>
             </span>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
@@ -14,6 +14,7 @@ import DefaultField from '../../ParameterFields/DefaultField';
 import { type EventRendererProps } from './EventRenderer';
 import ConditionsActionsColumns from '../ConditionsActionsColumns';
 import { shouldActivate } from '../../../UI/KeyboardShortcuts/InteractionKeys.js';
+import { Trans } from '@lingui/macro';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -104,9 +105,11 @@ export default class RepeatEvent extends React.Component<
             tabIndex={0}
           >
             {expression ? (
-              `Repeat ${expression} times:`
+              <Trans>{`Repeat ${expression} times:`}</Trans>
             ) : (
-              <i>Click to choose how many times will be repeated</i>
+              <i>
+                <Trans>Click to choose how many times will be repeated</Trans>
+              </i>
             )}
           </span>
         </div>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
@@ -105,7 +105,7 @@ export default class RepeatEvent extends React.Component<
             tabIndex={0}
           >
             {expression ? (
-              <Trans>{`Repeat ${expression} times:`}</Trans>
+              <Trans>Repeat {expression} times:</Trans>
             ) : (
               <i>
                 <Trans>Click to choose how many times will be repeated</Trans>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
@@ -11,6 +11,7 @@ import {
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
 import ConditionsActionsColumns from '../ConditionsActionsColumns';
+import { Trans } from '@lingui/macro';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -47,7 +48,7 @@ export default class ForEachEvent extends React.Component<
             [disabledText]: this.props.disabled,
           })}
         >
-          While these conditions are true:
+          <Trans>While these conditions are true:</Trans>
         </div>
         <InstructionsList
           instrsList={whileEvent.getWhileConditions()}
@@ -76,7 +77,7 @@ export default class ForEachEvent extends React.Component<
             [disabledText]: this.props.disabled,
           })}
         >
-          Repeat these:
+          <Trans>Repeat these:</Trans>
         </div>
         <ConditionsActionsColumns
           leftIndentWidth={this.props.leftIndentWidth}


### PR DESCRIPTION
https://github.com/4ian/GDevelop/issues/969#issuecomment-752101542

A review is needed for the white space added with `\u00A0` in `JSCodeEvent.js`
It's working fine, just maybe there is something prettier :)
