### PR TITLE
Use requestFullscreen() / exitFullscreen()

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -300,9 +300,9 @@ namespace gdjs {
             }
           } else {
             // @ts-ignore
-            if (document.cancelFullscreen) {
+            if (document.exitFullscreen) {
               // @ts-ignore
-              document.cancelFullscreen();
+              document.exitFullscreen();
             } else {
               // @ts-ignore
               if (document.mozCancelFullScreen) {

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -282,9 +282,9 @@ namespace gdjs {
           //TODO: Do this on a user gesture, otherwise most browsers won't activate fullscreen
           if (this._isFullscreen) {
             // @ts-ignore
-            if (document.documentElement.requestFullScreen) {
+            if (document.documentElement.requestFullscreen) {
               // @ts-ignore
-              document.documentElement.requestFullScreen();
+              document.documentElement.requestFullscreen();
             } else {
               // @ts-ignore
               if (document.documentElement.mozRequestFullScreen) {
@@ -300,9 +300,9 @@ namespace gdjs {
             }
           } else {
             // @ts-ignore
-            if (document.cancelFullScreen) {
+            if (document.cancelFullscreen) {
               // @ts-ignore
-              document.cancelFullScreen();
+              document.cancelFullscreen();
             } else {
               // @ts-ignore
               if (document.mozCancelFullScreen) {


### PR DESCRIPTION
See [Fullscreen API on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API).

It would probably be nice to do a follow up that handles the [`fullscreenchange` event](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenchange_event).