### PR TITLE
Fix wording & type in function parameters

### DIFF
--- a/Core/GDCore/IDE/Events/InstructionSentenceFormatter.cpp
+++ b/Core/GDCore/IDE/Events/InstructionSentenceFormatter.cpp
@@ -136,7 +136,7 @@ gd::String InstructionSentenceFormatter::LabelFromType(const gd::String &type) {
   else if (type == "mouse")
     return _("Mouse button");
   else if (type == "yesorno")
-    return _("Yes or no");
+    return _("Yes or No");
   else if (type == "police")
     return _("Font");
   else if (type == "color")

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -385,11 +385,11 @@ export default class EventsFunctionParametersEditor extends React.Component<
                                 />
                                 <SelectOption
                                   value="yesorno"
-                                  primaryText={t`Yes or No (number)`}
+                                  primaryText={t`Yes or No (boolean)`}
                                 />
                                 <SelectOption
                                   value="trueorfalse"
-                                  primaryText={t`True or False (text)`}
+                                  primaryText={t`True or False (boolean)`}
                                 />
                               </SelectField>
                             )}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -385,11 +385,11 @@ export default class EventsFunctionParametersEditor extends React.Component<
                                 />
                                 <SelectOption
                                   value="yesorno"
-                                  primaryText={t`Yes or no (boolean)`}
+                                  primaryText={t`Yes or No (number)`}
                                 />
                                 <SelectOption
                                   value="trueorfalse"
-                                  primaryText={t`True or false (boolean)`}
+                                  primaryText={t`True or False (text)`}
                                 />
                               </SelectField>
                             )}


### PR DESCRIPTION
The term (boolean) wasn't correct, it must describe the type of the value returned like the other options.
![image](https://user-images.githubusercontent.com/1670670/103557810-0763e880-4eb4-11eb-807e-ea3d53c7aa72.png)

This type is useful for know what to use `GetArgumentAsNumber ` or `GetArgumentAsString`.

- Yes or no (boolean) act like 0 and 1, we have to get the parameter with `GetArgumentAsNumber ` goes to `Yes or No (number)`
- True or false (boolean) we have to use `GetArgumentAsString` goes to `True or False (text) `




