### PR TITLE
Added a new preference to toggle the visibility of menu bar in preview windows

### DIFF
--- a/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
@@ -38,7 +38,7 @@ type State = {|
     title: string,
     backgroundColor: string,
   },
-  hideMenubar: boolean,
+  hideMenuBar: boolean,
 |};
 
 export default class LocalPreviewLauncher extends React.Component<
@@ -57,6 +57,7 @@ export default class LocalPreviewLauncher extends React.Component<
     devToolsOpen: false,
     previewBrowserWindowConfig: null,
     hotReloadsCount: 0,
+    hideMenuBar: true,
   };
   _networkPreviewSubscriptionChecker: ?SubscriptionChecker = null;
   _hotReloadSubscriptionChecker: ?SubscriptionChecker = null;
@@ -70,8 +71,8 @@ export default class LocalPreviewLauncher extends React.Component<
       return;
 
     const win = new BrowserWindow(this.state.previewBrowserWindowConfig);
-    win.setMenuBarVisibility(this.state.hideMenubar);
     win.loadURL(`file://${this.state.previewGamePath}/index.html`);
+    win.setMenuBarVisibility(this.state.hideMenuBar);
     win.webContents.on('devtools-opened', () => {
       this.setState({ devToolsOpen: true });
     });
@@ -99,7 +100,7 @@ export default class LocalPreviewLauncher extends React.Component<
           },
         },
         previewGamePath: gamePath,
-        hideMenubar: !options.getIsMenubarHiddenInPreview(),
+        hideMenuBar: !options.getIsMenuBarHiddenInPreview(),
       },
       () => {
         if (!options.networkPreview) {

--- a/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
@@ -38,6 +38,7 @@ type State = {|
     title: string,
     backgroundColor: string,
   },
+  hideMenubar: boolean,
 |};
 
 export default class LocalPreviewLauncher extends React.Component<
@@ -69,6 +70,7 @@ export default class LocalPreviewLauncher extends React.Component<
       return;
 
     const win = new BrowserWindow(this.state.previewBrowserWindowConfig);
+    win.setMenuBarVisibility(this.state.hideMenubar);
     win.loadURL(`file://${this.state.previewGamePath}/index.html`);
     win.webContents.on('devtools-opened', () => {
       this.setState({ devToolsOpen: true });
@@ -97,6 +99,7 @@ export default class LocalPreviewLauncher extends React.Component<
           },
         },
         previewGamePath: gamePath,
+        hideMenubar: !options.getIsMenubarHiddenInPreview(),
       },
       () => {
         if (!options.networkPreview) {

--- a/newIDE/app/src/Export/PreviewLauncher.flow.js
+++ b/newIDE/app/src/Export/PreviewLauncher.flow.js
@@ -8,7 +8,7 @@ export type PreviewOptions = {|
   networkPreview: boolean,
   hotReload: boolean,
   projectDataOnlyExport: boolean,
-  getIsMenubarHiddenInPreview: () => boolean,
+  getIsMenuBarHiddenInPreview: () => boolean,
 |};
 
 /** The functions that PreviewLauncher must expose on their class */

--- a/newIDE/app/src/Export/PreviewLauncher.flow.js
+++ b/newIDE/app/src/Export/PreviewLauncher.flow.js
@@ -8,6 +8,7 @@ export type PreviewOptions = {|
   networkPreview: boolean,
   hotReload: boolean,
   projectDataOnlyExport: boolean,
+  getIsMenubarHiddenInPreview: () => boolean,
 |};
 
 /** The functions that PreviewLauncher must expose on their class */

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -175,7 +175,7 @@ export type PreferencesValues = {|
   hasProjectOpened: boolean,
   userShortcutMap: ShortcutMap,
   newObjectDialogDefaultTab: 'asset-store' | 'new-object',
-  isMenubarHiddenInPreview: boolean,
+  isMenuBarHiddenInPreview: boolean,
 |};
 
 /**
@@ -224,8 +224,8 @@ export type Preferences = {|
   setShortcutForCommand: (commandName: CommandName, shortcut: string) => void,
   getNewObjectDialogDefaultTab: () => 'asset-store' | 'new-object',
   setNewObjectDialogDefaultTab: ('asset-store' | 'new-object') => void,
-  getIsMenubarHiddenInPreview: () => boolean,
-  setIsMenubarHiddenInPreview: (enabled: boolean) => void,
+  getIsMenuBarHiddenInPreview: () => boolean,
+  setIsMenuBarHiddenInPreview: (enabled: boolean) => void,
 |};
 
 export const initialPreferences = {
@@ -255,7 +255,7 @@ export const initialPreferences = {
     hasProjectOpened: false,
     userShortcutMap: {},
     newObjectDialogDefaultTab: electron ? 'new-object' : 'asset-store',
-    isMenubarHiddenInPreview: true,
+    isMenuBarHiddenInPreview: true,
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -294,8 +294,8 @@ export const initialPreferences = {
   setShortcutForCommand: (commandName: CommandName, shortcut: string) => {},
   getNewObjectDialogDefaultTab: () => 'asset-store',
   setNewObjectDialogDefaultTab: () => {},
-  getIsMenubarHiddenInPreview: () => true,
-  setIsMenubarHiddenInPreview: () => {},
+  getIsMenuBarHiddenInPreview: () => true,
+  setIsMenuBarHiddenInPreview: () => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -175,6 +175,7 @@ export type PreferencesValues = {|
   hasProjectOpened: boolean,
   userShortcutMap: ShortcutMap,
   newObjectDialogDefaultTab: 'asset-store' | 'new-object',
+  isMenubarHiddenInPreview: boolean,
 |};
 
 /**
@@ -223,6 +224,8 @@ export type Preferences = {|
   setShortcutForCommand: (commandName: CommandName, shortcut: string) => void,
   getNewObjectDialogDefaultTab: () => 'asset-store' | 'new-object',
   setNewObjectDialogDefaultTab: ('asset-store' | 'new-object') => void,
+  getIsMenubarHiddenInPreview: () => boolean,
+  setIsMenubarHiddenInPreview: (enabled: boolean) => void,
 |};
 
 export const initialPreferences = {
@@ -252,6 +255,7 @@ export const initialPreferences = {
     hasProjectOpened: false,
     userShortcutMap: {},
     newObjectDialogDefaultTab: electron ? 'new-object' : 'asset-store',
+    isMenubarHiddenInPreview: true,
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -290,6 +294,8 @@ export const initialPreferences = {
   setShortcutForCommand: (commandName: CommandName, shortcut: string) => {},
   getNewObjectDialogDefaultTab: () => 'asset-store',
   setNewObjectDialogDefaultTab: () => {},
+  getIsMenubarHiddenInPreview: () => true,
+  setIsMenubarHiddenInPreview: () => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -45,6 +45,7 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
     setAutoOpenMostRecentProject,
     resetShortcutsToDefault,
     setShortcutForCommand,
+    setIsMenubarHiddenInPreview,
   } = React.useContext(PreferencesContext);
 
   return (
@@ -244,6 +245,14 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
                   Automatically re-open the project edited during last session
                 </Trans>
               }
+            />
+          </Line>
+          <Line>
+            <Toggle
+              onToggle={(e, check) => setIsMenubarHiddenInPreview(check)}
+              toggled={values.isMenubarHiddenInPreview}
+              labelPosition="right"
+              label={<Trans>Hide menubar in preview window</Trans>}
             />
           </Line>
           {Window.isDev() && (

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -45,7 +45,7 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
     setAutoOpenMostRecentProject,
     resetShortcutsToDefault,
     setShortcutForCommand,
-    setIsMenubarHiddenInPreview,
+    setIsMenuBarHiddenInPreview,
   } = React.useContext(PreferencesContext);
 
   return (
@@ -249,10 +249,10 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
           </Line>
           <Line>
             <Toggle
-              onToggle={(e, check) => setIsMenubarHiddenInPreview(check)}
-              toggled={values.isMenubarHiddenInPreview}
+              onToggle={(e, check) => setIsMenuBarHiddenInPreview(check)}
+              toggled={values.isMenuBarHiddenInPreview}
               labelPosition="right"
-              label={<Trans>Hide menubar in preview window</Trans>}
+              label={<Trans>Hide the menu bar in the preview window</Trans>}
             />
           </Line>
           {Window.isDev() && (

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -71,6 +71,8 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     resetShortcutsToDefault: this._resetShortcutsToDefault.bind(this),
     getNewObjectDialogDefaultTab: this._getNewObjectDialogDefaultTab.bind(this),
     setNewObjectDialogDefaultTab: this._setNewObjectDialogDefaultTab.bind(this),
+    getIsMenubarHiddenInPreview: this._getIsMenubarHiddenInPreview.bind(this),
+    setIsMenubarHiddenInPreview: this._setIsMenubarHiddenInPreview.bind(this),
   };
 
   componentDidMount() {
@@ -482,6 +484,22 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     this.setState(
       state => ({
         values: { ...state.values, newObjectDialogDefaultTab },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _getIsMenubarHiddenInPreview() {
+    return this.state.values.isMenubarHiddenInPreview;
+  }
+
+  _setIsMenubarHiddenInPreview(enabled: boolean) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          isMenubarHiddenInPreview: enabled,
+        },
       }),
       () => this._persistValuesToLocalStorage(this.state)
     );

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -71,8 +71,8 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     resetShortcutsToDefault: this._resetShortcutsToDefault.bind(this),
     getNewObjectDialogDefaultTab: this._getNewObjectDialogDefaultTab.bind(this),
     setNewObjectDialogDefaultTab: this._setNewObjectDialogDefaultTab.bind(this),
-    getIsMenubarHiddenInPreview: this._getIsMenubarHiddenInPreview.bind(this),
-    setIsMenubarHiddenInPreview: this._setIsMenubarHiddenInPreview.bind(this),
+    getIsMenuBarHiddenInPreview: this._getIsMenuBarHiddenInPreview.bind(this),
+    setIsMenuBarHiddenInPreview: this._setIsMenuBarHiddenInPreview.bind(this),
   };
 
   componentDidMount() {
@@ -489,16 +489,16 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     );
   }
 
-  _getIsMenubarHiddenInPreview() {
-    return this.state.values.isMenubarHiddenInPreview;
+  _getIsMenuBarHiddenInPreview() {
+    return this.state.values.isMenuBarHiddenInPreview;
   }
 
-  _setIsMenubarHiddenInPreview(enabled: boolean) {
+  _setIsMenuBarHiddenInPreview(enabled: boolean) {
     this.setState(
       state => ({
         values: {
           ...state.values,
-          isMenubarHiddenInPreview: enabled,
+          isMenuBarHiddenInPreview: enabled,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1184,6 +1184,8 @@ const MainFrame = (props: Props) => {
             networkPreview: !!networkPreview,
             hotReload: !!hotReload,
             projectDataOnlyExport: !!projectDataOnlyExport,
+            getIsMenubarHiddenInPreview:
+              preferences.getIsMenubarHiddenInPreview,
           })
         )
         .catch(error => {
@@ -1202,6 +1204,7 @@ const MainFrame = (props: Props) => {
       eventsFunctionsExtensionsState,
       previewState,
       state.editorTabs,
+      preferences.getIsMenubarHiddenInPreview,
     ]
   );
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1184,8 +1184,8 @@ const MainFrame = (props: Props) => {
             networkPreview: !!networkPreview,
             hotReload: !!hotReload,
             projectDataOnlyExport: !!projectDataOnlyExport,
-            getIsMenubarHiddenInPreview:
-              preferences.getIsMenubarHiddenInPreview,
+            getIsMenuBarHiddenInPreview:
+              preferences.getIsMenuBarHiddenInPreview,
           })
         )
         .catch(error => {
@@ -1204,7 +1204,7 @@ const MainFrame = (props: Props) => {
       eventsFunctionsExtensionsState,
       previewState,
       state.editorTabs,
-      preferences.getIsMenubarHiddenInPreview,
+      preferences.getIsMenuBarHiddenInPreview,
     ]
   );
 


### PR DESCRIPTION
fixes #2190

[win.setMenuBarVisibility(visible)](https://www.electronjs.org/docs/api/browser-window#winsetmenubarvisibilityvisible-windows-linux) is used to hide the menu bar. This works as expected on Windows and should also work fine on Linux. I need help to test this on macOS.

If preference `Hide menubar in preview window` is set true, then menu bar will be will hidden when the preview is launched. And if preference is false, then the menu bar will be visible.

![image](https://user-images.githubusercontent.com/43215292/104120212-10910180-535b-11eb-8353-dea823571aa6.png)
