### PR TITLE
Export sourcemaps with the code

### DIFF
--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -114,7 +114,7 @@ bool Exporter::ExportWholePixiProject(
 
     // Copy all dependencies and the index (or metadata) file.
     helper.RemoveIncludes(false, true, includesFiles);
-    helper.ExportIncludesAndLibs(includesFiles, exportDir);
+    helper.ExportIncludesAndLibs(includesFiles, exportDir, false);
 
     gd::String source = gdjsRoot + "/Runtime/index.html";
     if (exportForCordova)
@@ -222,7 +222,7 @@ bool Exporter::ExportWholeCocos2dProject(gd::Project& project,
 
   // Copy all dependencies and the index (or metadata) file.
   helper.RemoveIncludes(true, false, includesFiles);
-  helper.ExportIncludesAndLibs(includesFiles, exportDir + "/src");
+  helper.ExportIncludesAndLibs(includesFiles, exportDir + "/src", false);
 
   if (!helper.ExportCocos2dFiles(
           project, exportDir, debugMode, includesFiles)) {

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -174,8 +174,8 @@ bool ExporterHelper::ExportProjectForPixiPreview(
       fs, exportedProject, codeOutputDir + "/data.js", runtimeGameOptions);
   includesFiles.push_back(codeOutputDir + "/data.js");
 
-  // Copy all the dependencies
-  ExportIncludesAndLibs(includesFiles, options.exportPath);
+  // Copy all the dependencies and their source maps
+  ExportIncludesAndLibs(includesFiles, options.exportPath, true);
 
   // Create the index file
   if (!ExportPixiIndexFile(exportedProject,
@@ -811,7 +811,9 @@ gd::String ExporterHelper::GetExportedIncludeFilename(
 }
 
 bool ExporterHelper::ExportIncludesAndLibs(
-    const std::vector<gd::String> &includesFiles, gd::String exportDir) {
+    const std::vector<gd::String> &includesFiles,
+    gd::String exportDir,
+    bool exportSourceMaps) {
   for (auto &include : includesFiles) {
     if (!fs.IsAbsolute(include)) {
       // By convention, an include file that is relative is relative to
@@ -826,7 +828,7 @@ bool ExporterHelper::ExportIncludesAndLibs(
 
         gd::String sourceMap = source + ".map";
         // Copy source map if present
-        if (fs.FileExists(sourceMap)) {
+        if (exportSourceMaps && fs.FileExists(sourceMap)) {
           fs.CopyFile(sourceMap, exportDir + "/" + include + ".map");
         }
       } else {

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -268,26 +268,9 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
   };
 
   auto makeIconsIos = [&getIconFilename]() {
-    std::vector<gd::String> sizes = {"180",
-                                     "60",
-                                     "120",
-                                     "76",
-                                     "152",
-                                     "40",
-                                     "80",
-                                     "57",
-                                     "114",
-                                     "72",
-                                     "144",
-                                     "167",
-                                     "29",
-                                     "58",
-                                     "87",
-                                     "50",
-                                     "20",
-                                     "100",
-                                     "167",
-                                     "1024"};
+    std::vector<gd::String> sizes = {
+        "180", "60",  "120", "76", "152", "40", "80", "57",  "114", "72",
+        "144", "167", "29",  "58", "87",  "50", "20", "100", "167", "1024"};
 
     gd::String output;
     for (auto &size : sizes) {
@@ -840,6 +823,12 @@ bool ExporterHelper::ExportIncludesAndLibs(
         if (!fs.DirExists(path)) fs.MkDir(path);
 
         fs.CopyFile(source, exportDir + "/" + include);
+
+        gd::String sourceMap = source + ".map";
+        // Copy source map if present
+        if (fs.FileExists(sourceMap)) {
+          fs.CopyFile(sourceMap, exportDir + "/" + include + ".map");
+        }
       } else {
         std::cout << "Could not find GDJS include file " << include
                   << std::endl;

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -35,7 +35,7 @@ struct PreviewExportOptions {
       : project(project_),
         exportPath(exportPath_),
         projectDataOnlyExport(false),
-        nonRuntimeScriptsCacheBurst(0) {};
+        nonRuntimeScriptsCacheBurst(0){};
 
   /**
    * \brief Set the address of the debugger server that the game should reach
@@ -173,10 +173,13 @@ class ExporterHelper {
    * directory.
    *
    * \param includesFiles A vector with filenames to be copied.
-   * \param exportDir The directory where the files mus tbe copied.
+   * \param exportDir The directory where the files must be copied.
+   * \param exportSourceMaps Should the source maps be copied? Should be true on
+   * previews only.
    */
   bool ExportIncludesAndLibs(const std::vector<gd::String> &includesFiles,
-                             gd::String exportDir);
+                             gd::String exportDir,
+                             bool exportSourceMaps);
 
   /**
    * \brief Generate the events JS code, and save them to the export directory.


### PR DESCRIPTION
Exports sourcemaps alongside the normal code when a sourcemap is present.