### PR TITLE
Improve the search bar when adding an action/condition to search in *all* the existing actions and conditions.

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditor.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditor.js
@@ -56,12 +56,15 @@ type NewInstructionEditorState = {|
 |};
 
 type NewInstructionEditorSetters = {|
-  chooseFreeInstruction: (
+  /** Select an instruction - which can be a free or an object instruction. */
+  chooseInstruction: (
     type: string
   ) => {| ...NewInstructionEditorState, instruction: gdInstruction |},
+  /** Select an object, so that then this object specific instructions can be searched and selected. */
   chooseObject: (
     objectName: string
   ) => {| ...NewInstructionEditorState, instruction: gdInstruction |},
+  /** Select an instruction for the currently selected object. */
   chooseObjectInstruction: (
     type: string
   ) => {| ...NewInstructionEditorState, instruction: gdInstruction |},
@@ -185,7 +188,7 @@ export const useNewInstructionEditor = ({
     };
   };
 
-  const chooseFreeInstruction = (type: string) => {
+  const chooseInstruction = (type: string) => {
     instruction.setType(type);
     const newState = {
       chosenObjectName: null,
@@ -207,7 +210,7 @@ export const useNewInstructionEditor = ({
   return [
     state,
     {
-      chooseFreeInstruction,
+      chooseInstruction,
       chooseObject,
       chooseObjectInstruction,
     },

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -118,7 +118,7 @@ export default function NewInstructionEditorDialog({
     chosenObjectInstructionsInfoTree,
   } = newInstructionEditorState;
   const {
-    chooseFreeInstruction,
+    chooseInstruction,
     chooseObject,
     chooseObjectInstruction,
   } = newInstructionEditorSetters;
@@ -183,7 +183,7 @@ export default function NewInstructionEditorDialog({
         isCondition={isCondition}
         chosenInstructionType={!chosenObjectName ? instructionType : undefined}
         onChooseInstruction={(instructionType: string) => {
-          chooseFreeInstruction(instructionType);
+          chooseInstruction(instructionType);
           setStep('parameters');
         }}
         chosenObjectName={chosenObjectName}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorMenu.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorMenu.js
@@ -97,7 +97,7 @@ export default function NewInstructionEditorMenu({
     chosenObjectInstructionsInfoTree,
   } = newInstructionEditorState;
   const {
-    chooseFreeInstruction,
+    chooseInstruction,
     chooseObject,
     chooseObjectInstruction,
   } = newInstructionEditorSetters;
@@ -149,7 +149,7 @@ export default function NewInstructionEditorMenu({
       isCondition={isCondition}
       chosenInstructionType={!chosenObjectName ? instructionType : undefined}
       onChooseInstruction={(instructionType: string) => {
-        const { instruction, chosenObjectName } = chooseFreeInstruction(
+        const { instruction, chosenObjectName } = chooseInstruction(
           instructionType
         );
         submitInstruction({ instruction, chosenObjectName });

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
@@ -61,6 +61,28 @@ const freeInstructionsToRemove = {
   ],
 };
 
+/**
+ * When all instructions are searched, some can be duplicated
+ * (on purpose, so that it's easier to find them for users)
+ * in both the object instructions and in the free instructions.
+ *
+ * This removes the duplication, useful for showing results in a list.
+ */
+export const deduplicateInstructionsList = (
+  list: Array<EnumeratedInstructionMetadata>
+): Array<EnumeratedInstructionMetadata> => {
+  let createFound = false;
+  return list.filter(enumerateInstruction => {
+    if (enumerateInstruction.type === 'Create') {
+      if (createFound) return false;
+
+      createFound = true;
+    }
+
+    return true;
+  });
+};
+
 const filterInstructionsToRemove = (
   list: Array<EnumeratedInstructionMetadata>,
   typesToRemove: ?$ReadOnlyArray<string>

--- a/newIDE/app/src/InstructionOrExpression/SetupInstructionParameters.js
+++ b/newIDE/app/src/InstructionOrExpression/SetupInstructionParameters.js
@@ -68,10 +68,8 @@ export const setupInstructionParameters = (
     if (behaviorNames.length > 0) {
       instruction.setParameter(maybeBehaviorParameterIndex, behaviorNames[0]);
     } else {
-      // Ignore - this will either be shown as an error in the BehaviorField
-      // or should not happen if the instruction was added using the NewInstructionEditor
-      // (as the editor should only show instructions available for the behaviors
-      // of the object and for the object).
+      // Ignore - this will be shown as an error in the BehaviorField (the required
+      // behavior is not attached to the object).
     }
   }
 };

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -3159,59 +3159,77 @@ storiesOf('NewInstructionEditorDialog', module)
     />
   ))
   .add('New condition (scope: without layout)', () => (
-    <NewInstructionEditorDialog
-      open
-      project={testProject.project}
-      scope={{ layout: null }}
-      globalObjectsContainer={testProject.project}
-      objectsContainer={testProject.testLayout}
-      isCondition
-      isNewInstruction={true}
-      instruction={testProject.testInstruction}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      onChooseResource={() => {
-        action('onChooseResource');
-        return Promise.reject();
-      }}
-      resourceSources={[]}
-      openInstructionOrExpression={action('open instruction or expression')}
-      onCancel={action('cancel')}
-      onSubmit={action('submit')}
-      canPasteInstructions={true}
-      onPasteInstructions={action('paste instructions')}
-    />
+    <Column>
+      <Text>
+        Remember to test the search, which search across objects and all
+        instructions - including object instructions (so that object
+        instructions can be created either by selecting an object first or by
+        searching for it).
+      </Text>
+      <NewInstructionEditorDialog
+        open
+        project={testProject.project}
+        scope={{ layout: null }}
+        globalObjectsContainer={testProject.project}
+        objectsContainer={testProject.testLayout}
+        isCondition
+        isNewInstruction={true}
+        instruction={testProject.testInstruction}
+        resourceExternalEditors={fakeResourceExternalEditors}
+        onChooseResource={() => {
+          action('onChooseResource');
+          return Promise.reject();
+        }}
+        resourceSources={[]}
+        openInstructionOrExpression={action('open instruction or expression')}
+        onCancel={action('cancel')}
+        onSubmit={action('submit')}
+        canPasteInstructions={true}
+        onPasteInstructions={action('paste instructions')}
+      />
+    </Column>
   ));
 
 storiesOf('NewInstructionEditorMenu', module)
   .addDecorator(paperDecorator)
   .addDecorator(muiDecorator)
   .add('default', () => (
-    <PopoverButton>
-      {({ buttonElement, onClose }) => (
-        <NewInstructionEditorMenu
-          open
-          project={testProject.project}
-          scope={{ layout: testProject.testLayout }}
-          globalObjectsContainer={testProject.project}
-          objectsContainer={testProject.testLayout}
-          isCondition
-          isNewInstruction={false}
-          instruction={testProject.testInstruction}
-          resourceExternalEditors={fakeResourceExternalEditors}
-          onChooseResource={() => {
-            action('onChooseResource');
-            return Promise.reject();
-          }}
-          resourceSources={[]}
-          openInstructionOrExpression={action('open instruction or expression')}
-          onCancel={onClose}
-          onSubmit={onClose}
-          anchorEl={buttonElement}
-          canPasteInstructions={true}
-          onPasteInstructions={action('paste instructions')}
-        />
-      )}
-    </PopoverButton>
+    <Column>
+      <Text>
+        Remember to test the search, which search across objects and all
+        instructions - including object instructions (so that object
+        instructions can be created either by selecting an object first or by
+        searching for it).
+      </Text>
+      <PopoverButton>
+        {({ buttonElement, onClose }) => (
+          <NewInstructionEditorMenu
+            open
+            project={testProject.project}
+            scope={{ layout: testProject.testLayout }}
+            globalObjectsContainer={testProject.project}
+            objectsContainer={testProject.testLayout}
+            isCondition
+            isNewInstruction={false}
+            instruction={testProject.testInstruction}
+            resourceExternalEditors={fakeResourceExternalEditors}
+            onChooseResource={() => {
+              action('onChooseResource');
+              return Promise.reject();
+            }}
+            resourceSources={[]}
+            openInstructionOrExpression={action(
+              'open instruction or expression'
+            )}
+            onCancel={onClose}
+            onSubmit={onClose}
+            anchorEl={buttonElement}
+            canPasteInstructions={true}
+            onPasteInstructions={action('paste instructions')}
+          />
+        )}
+      </PopoverButton>
+    </Column>
   ));
 
 storiesOf('TextEditor', module)


### PR DESCRIPTION
* This includes the object actions and conditions. If one is selected, the object can be chosen as a parameter.
* This should improve the search experience for both new and advanced users.
* This should reduce confusions for users searching for an action/condition and not finding it because they have not chosen an object first.

As discussed in #2123.
I think it's a great solution for existing users that would be frustrated by this lack of "searching in everything" in the new editor, while still keeping things organized when browsing manually :) 