### PR TITLE
Update to New yarn-editor

### DIFF
--- a/newIDE/app/public/external/yarn/README.md
+++ b/newIDE/app/public/external/yarn/README.md
@@ -1,4 +1,4 @@
-This folder contains sources to embed Yarn editor (https://github.com/InfiniteAmmoInc/Yarn) so that it can
+This folder contains sources to embed Yarn editor (https://github.com/YarnSpinnerTool/YarnEditor) so that it can
 be used directly from GDevelop to edit/create Dialogue Trees.
 
 Yarn sources are downloaded by `import-zipped-editor.js` script. They are raw, unchanged sources

--- a/newIDE/app/public/external/yarn/yarn-main.js
+++ b/newIDE/app/public/external/yarn/yarn-main.js
@@ -25,6 +25,7 @@ window.addEventListener('yarnReady', e => {
   yarn = e;
   yarn.app.fs = fs;
   yarn.app.electron = electron;
+  yarn.data.restoreFromLocalStorage(false);
   ipcRenderer.send('yarn-ready');
 });
 editorFrameEl.src = 'yarn-editor/index.html';
@@ -42,16 +43,20 @@ ipcRenderer.on('yarn-open', (event, receivedData) => {
     initialResourcePath: receivedData.resourcePath,
     extension: '.json',
   });
-  
+
   // Inject custom Apply button.
   const saveToGdButton = yarn.document
-    .getElementsByClassName('menu')[0]
+    .getElementsByClassName('search-tags')[0]
     .cloneNode(true);
   saveToGdButton.onclick = () => saveAndClose(pathEditorHeader);
   yarn.document
-    .getElementsByClassName('app-menu')[0]
-    .appendChild(saveToGdButton);
-  saveToGdButton.childNodes[0].firstChild.data = 'Apply';
+    .getElementsByClassName('search-tags')[0]
+    .parentElement.appendChild(saveToGdButton);
+  saveToGdButton.childNodes[0].checked = 'checked';
+  saveToGdButton.childNodes[2].innerHTML = 'Apply';
+  saveToGdButton.childNodes[2].style = 'background-color: white;';
+  yarn.document.getElementsByClassName('app-search')[0].style = 'right: 45px';
+  saveToGdButton.style = 'padding-left: 30px;';
 
   // Process the json file to open, if any.
   if (fileExists(receivedData.resourcePath)) {


### PR DESCRIPTION
This updates the bunded yarn editor to the latest version (attached here)
[yarn-editor-0.4.116.zip](https://github.com/4ian/GDevelop/files/5831938/yarn-editor-0.4.116.zip)
https://github.com/YarnSpinnerTool/YarnEditor/commit/4fcfd2e09053b33a90450ddaa72845ebd594ee8b

try the new editor here
https://yarnspinnertool.github.io/YarnEditor/
or by building this branch :) 

New features:
- synonym suggestion on selected word 
- a brand new settings dialog that lets you configure various new features
- Settings are now actually stored (fixes https://github.com/4ian/GDevelop/issues/2040)
- Brand new interface - to modernize the look and make it work well on tiny screens, new fontawesome icons 
- Brand new support for theming with 3 new themes: Classic, Blueprint (like Twinery), Dracula(Dark)
- Ability to save/load your yarn files to gist.github.com (configure token in the settings) 
- Search by title, body  or tags now highlights on the nodes what is found and a node with search results will automatically highlight them when you open it
- Play testing yarns directly in the editor (please note that this is an alpha feature and may not work the same as in gdevelop)
- Huge improvements in performance when editing big yarn files
- many bug fixes and other small features

increase in bundle size is due to the new dependencies
"@fortawesome/fontawesome-free", (GUI)
    "sweetalert2": "^9.10.13", (GUI)
    "synonyms": "^1.0.1", (suggest synonyms feature)
"gists": "^2.0.0" (backup to gist feature)

This is a result of active contributions on the yarn-editor projects since last year. Ever since Gdevelop started using it, the number of pull requests increased and kept me and others busy reviewing