### PR TITLE
Close the extension tab when an extension is updated

### DIFF
--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -14,6 +14,7 @@ import InfoBar from '../../UI/Messages/InfoBar';
 type Props = {|
   project: gdProject,
   onClose: () => void,
+  onInstallExtension: (str: string) => void,
 |};
 
 /**
@@ -22,7 +23,7 @@ type Props = {|
 export default function ExtensionsSearchDialog({
   project,
   onClose,
-  onCloseEventsFunctionsExtensionTab,
+  onInstallExtension,
 }: Props) {
   const [isInstalling, setIsInstalling] = React.useState(false);
   const [extensionWasInstalled, setExtensionWasInstalled] = React.useState(
@@ -92,9 +93,7 @@ export default function ExtensionsSearchDialog({
             }}
             project={project}
             showOnlyWithBehaviors={false}
-            onCloseEventsFunctionsExtensionTab={
-              onCloseEventsFunctionsExtensionTab
-            }
+            onInstallExtension={onInstallExtension}
           />
           <InfoBar
             identifier="extension-installed-explanation"

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -10,11 +10,12 @@ import EventsFunctionsExtensionsContext from '../../EventsFunctionsExtensionsLoa
 import HelpButton from '../../UI/HelpButton';
 import { importExtension, installExtension } from './InstallExtension';
 import InfoBar from '../../UI/Messages/InfoBar';
+import { type ExtensionShortHeader } from '../../Utils/GDevelopServices/Extension';
 
 type Props = {|
   project: gdProject,
   onClose: () => void,
-  onInstallExtension: (str: string) => void,
+  onInstallExtension: ExtensionShortHeader => void,
 |};
 
 /**

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -82,6 +82,7 @@ export default function ExtensionsSearchDialog({
             isInstalling={isInstalling}
             onInstall={async extensionShortHeader => {
               setIsInstalling(true);
+              onInstallExtension(extensionShortHeader);
               const wasExtensionInstalled = await installExtension(
                 i18n,
                 project,
@@ -94,7 +95,6 @@ export default function ExtensionsSearchDialog({
             }}
             project={project}
             showOnlyWithBehaviors={false}
-            onInstallExtension={onInstallExtension}
           />
           <InfoBar
             identifier="extension-installed-explanation"

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -19,7 +19,11 @@ type Props = {|
 /**
  * Allows to browse and install events based extensions.
  */
-export default function ExtensionsSearchDialog({ project, onClose }: Props) {
+export default function ExtensionsSearchDialog({
+  project,
+  onClose,
+  onCloseEventsFunctionsExtensionTab,
+}: Props) {
   const [isInstalling, setIsInstalling] = React.useState(false);
   const [extensionWasInstalled, setExtensionWasInstalled] = React.useState(
     false
@@ -88,6 +92,9 @@ export default function ExtensionsSearchDialog({ project, onClose }: Props) {
             }}
             project={project}
             showOnlyWithBehaviors={false}
+            onCloseEventsFunctionsExtensionTab={
+              onCloseEventsFunctionsExtensionTab
+            }
           />
           <InfoBar
             identifier="extension-installed-explanation"

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -24,6 +24,9 @@ type Props = {|
   project: gdProject,
   onInstall: ExtensionShortHeader => Promise<void>,
   showOnlyWithBehaviors: boolean,
+  onCloseEventsFunctionsExtensionTab: (
+    eventsFunctionsExtension: gdEventsFunctionsExtension
+  ) => void,
 |};
 
 export const ExtensionStore = ({
@@ -31,6 +34,7 @@ export const ExtensionStore = ({
   project,
   onInstall,
   showOnlyWithBehaviors,
+  onCloseEventsFunctionsExtensionTab,
 }: Props) => {
   const [
     selectedExtensionShortHeader,
@@ -117,6 +121,10 @@ export const ExtensionStore = ({
             selectedExtensionShortHeader.name
           )}
           onInstall={() => {
+            const eventsFunctionsExtension = project.getEventsFunctionsExtension(
+              selectedExtensionShortHeader.name
+            );
+            onCloseEventsFunctionsExtensionTab(eventsFunctionsExtension);
             onInstall(selectedExtensionShortHeader);
           }}
           onClose={() => setSelectedExtensionShortHeader(null)}

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -24,7 +24,6 @@ type Props = {|
   project: gdProject,
   onInstall: ExtensionShortHeader => Promise<void>,
   showOnlyWithBehaviors: boolean,
-  onInstallExtension: ExtensionShortHeader => void,
 |};
 
 export const ExtensionStore = ({
@@ -32,7 +31,6 @@ export const ExtensionStore = ({
   project,
   onInstall,
   showOnlyWithBehaviors,
-  onInstallExtension,
 }: Props) => {
   const [
     selectedExtensionShortHeader,
@@ -119,7 +117,6 @@ export const ExtensionStore = ({
             selectedExtensionShortHeader.name
           )}
           onInstall={() => {
-            onInstallExtension(selectedExtensionShortHeader);
             onInstall(selectedExtensionShortHeader);
           }}
           onClose={() => setSelectedExtensionShortHeader(null)}

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -24,7 +24,7 @@ type Props = {|
   project: gdProject,
   onInstall: ExtensionShortHeader => Promise<void>,
   showOnlyWithBehaviors: boolean,
-  onInstallExtension: string => void,
+  onInstallExtension: ExtensionShortHeader => void,
 |};
 
 export const ExtensionStore = ({
@@ -119,7 +119,7 @@ export const ExtensionStore = ({
             selectedExtensionShortHeader.name
           )}
           onInstall={() => {
-            onInstallExtension(selectedExtensionShortHeader.name);
+            onInstallExtension(selectedExtensionShortHeader);
             onInstall(selectedExtensionShortHeader);
           }}
           onClose={() => setSelectedExtensionShortHeader(null)}

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -24,9 +24,7 @@ type Props = {|
   project: gdProject,
   onInstall: ExtensionShortHeader => Promise<void>,
   showOnlyWithBehaviors: boolean,
-  onCloseEventsFunctionsExtensionTab: (
-    eventsFunctionsExtension: gdEventsFunctionsExtension
-  ) => void,
+  onInstallExtension: string => void,
 |};
 
 export const ExtensionStore = ({
@@ -34,7 +32,7 @@ export const ExtensionStore = ({
   project,
   onInstall,
   showOnlyWithBehaviors,
-  onCloseEventsFunctionsExtensionTab,
+  onInstallExtension,
 }: Props) => {
   const [
     selectedExtensionShortHeader,
@@ -121,10 +119,7 @@ export const ExtensionStore = ({
             selectedExtensionShortHeader.name
           )}
           onInstall={() => {
-            const eventsFunctionsExtension = project.getEventsFunctionsExtension(
-              selectedExtensionShortHeader.name
-            );
-            onCloseEventsFunctionsExtensionTab(eventsFunctionsExtension);
+            onInstallExtension(selectedExtensionShortHeader.name);
             onInstall(selectedExtensionShortHeader);
           }}
           onClose={() => setSelectedExtensionShortHeader(null)}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -811,6 +811,18 @@ const MainFrame = (props: Props) => {
     _onProjectItemModified();
   };
 
+  const closeEventsFunctionsExtensionTab = (
+    eventsFunctionsExtension: gdEventsFunctionsExtension
+  ) => {
+    setState(state => ({
+      ...state,
+      editorTabs: closeEventsFunctionsExtensionTabs(
+        state.editorTabs,
+        eventsFunctionsExtension
+      ),
+    }));
+  };
+
   const deleteLayout = (layout: gdLayout) => {
     const { i18n } = props;
     if (!state.currentProject) return;
@@ -1973,6 +1985,9 @@ const MainFrame = (props: Props) => {
             onAddExternalLayout={addExternalLayout}
             onAddEventsFunctionsExtension={addEventsFunctionsExtension}
             onAddExternalEvents={addExternalEvents}
+            onCloseEventsFunctionsExtensionTab={
+              closeEventsFunctionsExtensionTab
+            }
             onDeleteLayout={deleteLayout}
             onDeleteExternalLayout={deleteExternalLayout}
             onDeleteEventsFunctionsExtension={deleteEventsFunctionsExtension}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -813,13 +813,14 @@ const MainFrame = (props: Props) => {
   };
 
   const onInstallExtension = (extensionShortHeader: ExtensionShortHeader) => {
-    //Close the extension tab before updating/reinstalling the extension
+    // Close the extension tab before updating/reinstalling the extension.
     const eventsFunctionsExtensionName = extensionShortHeader.name;
-    const hasEventsFunctionsExtension = currentProject.hasEventsFunctionsExtensionNamed(
-      eventsFunctionsExtensionName
-    );
 
-    if (hasEventsFunctionsExtension) {
+    if (
+      currentProject.hasEventsFunctionsExtensionNamed(
+        eventsFunctionsExtensionName
+      )
+    ) {
       const eventsFunctionsExtension = currentProject.getEventsFunctionsExtension(
         eventsFunctionsExtensionName
       );

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -811,16 +811,25 @@ const MainFrame = (props: Props) => {
     _onProjectItemModified();
   };
 
-  const closeEventsFunctionsExtensionTab = (
-    eventsFunctionsExtension: gdEventsFunctionsExtension
-  ) => {
-    setState(state => ({
-      ...state,
-      editorTabs: closeEventsFunctionsExtensionTabs(
-        state.editorTabs,
-        eventsFunctionsExtension
-      ),
-    }));
+  const onInstallExtension = (eventsFunctionsExtensionName: string) => {
+    //Close the extension tab before updating/reinstalling the extension
+    const hasEventsFunctionsExtension = currentProject.hasEventsFunctionsExtensionNamed(
+      eventsFunctionsExtensionName
+    );
+
+    if (hasEventsFunctionsExtension) {
+      const eventsFunctionsExtension = currentProject.getEventsFunctionsExtension(
+        eventsFunctionsExtensionName
+      );
+
+      setState(state => ({
+        ...state,
+        editorTabs: closeEventsFunctionsExtensionTabs(
+          state.editorTabs,
+          eventsFunctionsExtension
+        ),
+      }));
+    }
   };
 
   const deleteLayout = (layout: gdLayout) => {
@@ -1985,9 +1994,7 @@ const MainFrame = (props: Props) => {
             onAddExternalLayout={addExternalLayout}
             onAddEventsFunctionsExtension={addEventsFunctionsExtension}
             onAddExternalEvents={addExternalEvents}
-            onCloseEventsFunctionsExtensionTab={
-              closeEventsFunctionsExtensionTab
-            }
+            onInstallExtension={onInstallExtension}
             onDeleteLayout={deleteLayout}
             onDeleteExternalLayout={deleteExternalLayout}
             onDeleteEventsFunctionsExtension={deleteEventsFunctionsExtension}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -813,6 +813,9 @@ const MainFrame = (props: Props) => {
   };
 
   const onInstallExtension = (extensionShortHeader: ExtensionShortHeader) => {
+    const { currentProject } = state;
+    if (!currentProject) return;
+
     // Close the extension tab before updating/reinstalling the extension.
     const eventsFunctionsExtensionName = extensionShortHeader.name;
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -116,6 +116,7 @@ import HotReloadLogsDialog from '../HotReload/HotReloadLogsDialog';
 import { useDiscordRichPresence } from '../Utils/UpdateDiscordRichPresence';
 import { useResourceFetcher } from '../ProjectsStorage/ResourceFetcher';
 import { delay } from '../Utils/Delay';
+import { type ExtensionShortHeader } from '../Utils/GDevelopServices/Extension';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -811,8 +812,9 @@ const MainFrame = (props: Props) => {
     _onProjectItemModified();
   };
 
-  const onInstallExtension = (eventsFunctionsExtensionName: string) => {
+  const onInstallExtension = (extensionShortHeader: ExtensionShortHeader) => {
     //Close the extension tab before updating/reinstalling the extension
+    const eventsFunctionsExtensionName = extensionShortHeader.name;
     const hasEventsFunctionsExtension = currentProject.hasEventsFunctionsExtensionNamed(
       eventsFunctionsExtensionName
     );

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -289,6 +289,7 @@ type Props = {|
   freezeUpdate: boolean,
   unsavedChanges?: UnsavedChanges,
   hotReloadPreviewButtonProps: HotReloadPreviewButtonProps,
+  onInstallExtension: string => void,
 |};
 
 type State = {|
@@ -756,6 +757,7 @@ export default class ProjectManager extends React.Component<Props, State> {
       project,
       eventsFunctionsExtensionsError,
       onReloadEventsFunctionsExtensions,
+      onInstallExtension,
     } = this.props;
     const { renamedItemKind, renamedItemName, searchText } = this.state;
 
@@ -1196,9 +1198,7 @@ export default class ProjectManager extends React.Component<Props, State> {
           <ExtensionsSearchDialog
             project={project}
             onClose={() => this.setState({ extensionsSearchDialogOpen: false })}
-            onCloseEventsFunctionsExtensionTab={
-              this.props.onCloseEventsFunctionsExtensionTab
-            }
+            onInstallExtension={onInstallExtension}
           />
         )}
       </div>

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -50,6 +50,7 @@ import { type MenuItemTemplate } from '../UI/Menu/Menu.flow';
 import ProjectManagerCommands from './ProjectManagerCommands';
 import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewButton';
 import { shouldValidate } from '../UI/KeyboardShortcuts/InteractionKeys';
+import { type ExtensionShortHeader } from '../Utils/GDevelopServices/Extension';
 
 const LAYOUT_CLIPBOARD_KIND = 'Layout';
 const EXTERNAL_LAYOUT_CLIPBOARD_KIND = 'External layout';
@@ -289,7 +290,7 @@ type Props = {|
   freezeUpdate: boolean,
   unsavedChanges?: UnsavedChanges,
   hotReloadPreviewButtonProps: HotReloadPreviewButtonProps,
-  onInstallExtension: string => void,
+  onInstallExtension: ExtensionShortHeader => void,
 |};
 
 type State = {|

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -1196,6 +1196,9 @@ export default class ProjectManager extends React.Component<Props, State> {
           <ExtensionsSearchDialog
             project={project}
             onClose={() => this.setState({ extensionsSearchDialogOpen: false })}
+            onCloseEventsFunctionsExtensionTab={
+              this.props.onCloseEventsFunctionsExtensionTab
+            }
           />
         )}
       </div>

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -4214,6 +4214,7 @@ storiesOf('ProjectManager', module)
       onAddExternalLayout={action('onAddExternalLayout')}
       onAddEventsFunctionsExtension={action('onAddEventsFunctionsExtension')}
       onAddExternalEvents={action('onAddExternalEvents')}
+      onInstallExtension={action('onInstallExtension')}
       onDeleteLayout={action('onDeleteLayout')}
       onDeleteExternalLayout={action('onDeleteExternalLayout')}
       onDeleteEventsFunctionsExtension={action(
@@ -4255,6 +4256,7 @@ storiesOf('ProjectManager', module)
       onAddExternalLayout={action('onAddExternalLayout')}
       onAddEventsFunctionsExtension={action('onAddEventsFunctionsExtension')}
       onAddExternalEvents={action('onAddExternalEvents')}
+      onInstallExtension={action('onInstallExtension')}
       onDeleteLayout={action('onDeleteLayout')}
       onDeleteExternalLayout={action('onDeleteExternalLayout')}
       onDeleteEventsFunctionsExtension={action(
@@ -4947,6 +4949,7 @@ storiesOf('AssetStore/ExtensionsSearchDialog', module)
             <ExtensionsSearchDialog
               project={testProject.project}
               onClose={action('on close')}
+              onInstallExtension={action('onInstallExtension')}
             />
           </ExtensionStoreStateProvider>
         </EventsFunctionsExtensionsProvider>


### PR DESCRIPTION
Fixes first issue in #2187 .
If the extension tab is opened while updating/reinstalling an extension , It will close the extension tab before start of the installation
to prevent memory corruption. 