### PR TITLE
Generate automatically reference pages for all features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /Core/GDCore/Tools/VersionPriv.h
 /docs
+/docs-wiki
 /ExtLibs/SFML
 /ExtLibs/*.7z
 /scripts/logs/*.txt

--- a/Extensions/DraggableBehavior/Extension.cpp
+++ b/Extensions/DraggableBehavior/Extension.cpp
@@ -5,29 +5,32 @@ Copyright (c) 2014-2016 Florian Rival (Florian.Rival@gmail.com)
 This project is released under the MIT License.
 */
 
-#include "GDCpp/Extensions/ExtensionBase.h"
 #include "DraggableBehavior.h"
 #include "DraggableRuntimeBehavior.h"
+#include "GDCpp/Extensions/ExtensionBase.h"
 
 void DeclareDraggableBehaviorExtension(gd::PlatformExtension& extension) {
-  extension.SetExtensionInformation(
-      "DraggableBehavior",
-      _("Draggable Behavior"),
-      _("This Extension enables the movement of objects with a mouse."),
-      "Florian Rival",
-      "Open source (MIT License)")
-      .SetExtensionHelpPath("behaviors/draggable");
+  extension
+      .SetExtensionInformation(
+          "DraggableBehavior",
+          _("Draggable Behavior"),
+          _("Allows objects to be moved using the mouse (or touch). Add the "
+            "behavior to an object to make it draggable. Use events to enable "
+            "or disable the behavior when needed."),
+          "Florian Rival",
+          "Open source (MIT License)")
+      .SetExtensionHelpPath("/behaviors/draggable");
 
-  gd::BehaviorMetadata& aut =
-      extension.AddBehavior("Draggable",
-                            _("Draggable object"),
-                            _("Draggable"),
-                            _("Allows objects to be moved using the mouse (or touch)."),
-                            "",
-                            "CppPlatform/Extensions/draggableicon.png",
-                            "DraggableBehavior",
-                            std::make_shared<DraggableBehavior>(),
-                            std::shared_ptr<gd::BehaviorsSharedData>());
+  gd::BehaviorMetadata& aut = extension.AddBehavior(
+      "Draggable",
+      _("Draggable object"),
+      _("Draggable"),
+      _("Allows objects to be moved using the mouse (or touch)."),
+      "",
+      "CppPlatform/Extensions/draggableicon.png",
+      "DraggableBehavior",
+      std::make_shared<DraggableBehavior>(),
+      std::shared_ptr<gd::BehaviorsSharedData>());
 
 #if defined(GD_IDE_ONLY)
   aut.AddCondition("Dragged",

--- a/newIDE/app/package-lock.json
+++ b/newIDE/app/package-lock.json
@@ -24063,6 +24063,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
     "ua-parser-js": {
       "version": "0.7.22",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -25,6 +25,7 @@
     "recursive-readdir": "^2.2.2",
     "shelljs": "0.8.4",
     "style-dictionary": "^2.10.2",
+    "typescript": "^4.1.3",
     "unzipper": "^0.9.11",
     "webpack": "4.41.5",
     "workbox-build": "^4.3.1"
@@ -94,6 +95,7 @@
     "check-format": "prettier --list-different \"src/!(locales)/**/*.js\"",
     "test": "react-scripts test --env=node",
     "flow": "flow",
+    "check-script-types": "cd scripts && tsc",
     "storybook": "start-storybook -p 9009 -s public",
     "analyze-test-coverage": "react-scripts test --env=node --coverage",
     "analyze-flow-coverage": "flow-coverage-report",

--- a/newIDE/app/package.json.README.md
+++ b/newIDE/app/package.json.README.md
@@ -2,6 +2,8 @@
 
 GDevelop relies a some dependencies that can have special requirements:
 
+* **TypeScript** here is only used to check the types in the `scripts/` files. The IDE uses Flow for static typing. TypeScript is used in the game engine too (see GDJS and Extensions folders).
+
 * **Storybook** is depending on webpack and babel.
   * It's important to have the same webpack version as the one provided by create-react-app, hence why `webpack` is specified in the `devDependencies`.
   * `@babel/core`, `babel-core` are also specified to avoid incompatibilities after upgrading to Storybook 4.

--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -1,37 +1,61 @@
+// @ts-check
 /**
- * Launch this script to generate a list(in markdown format) of all custom extensions.
+ * Launch this script to generate a list (in markdown format) of all custom extensions.
  */
 
-const fs = require('fs');
-const axios = require('axios');
+const fs = require('fs').promises;
+const { default: axios } = require('axios');
+const path = require('path');
 
 const extensionsRegistoryURL =
   'https://raw.githubusercontent.com/4ian/GDevelop-extensions/master/extensions-registry.json';
-const outputFile = 'community-made-extensions.dokuwiki.md';
-
-const writeFile = content => {
-  return new Promise((resolve, reject) => {
-    fs.writeFile(outputFile, content, err => {
-      if (err) return reject(err);
-      resolve();
-    });
-  });
-};
+const gdRootPath = path.join(__dirname, '..', '..', '..');
+const outputRootPath = path.join(gdRootPath, 'docs-wiki');
+const outputFilePath = path.join(outputRootPath, 'extensions.txt');
 
 (async () => {
   try {
     const response = await axios.get(extensionsRegistoryURL);
-    let texts = '# List of community-made extensions\n\n';
+    let texts = `# Extensions
+
+GDevelop is built in a flexible way. In addition to [[gdevelop5:all-features|core features]], new capabilities are provided by extensions. Extensions can contain objects, behaviors, actions, conditions, expressions or events.
+
+[[gdevelop5:extensions:search|Directly from GDevelop]], you have access to a collection of community created extensions, listed here. You can also [[gdevelop5:extensions:create|create]], directly in your project, new behaviors, actions, conditions or expressions for your game.
+
+`;
 
     response.data.extensionShortHeaders.forEach(element => {
+      // TODO: link to help
       texts +=
-        '## ' + element.fullName + '\n' + element.shortDescription + '\n\n';
+        '## ' +
+        element.fullName +
+        '\n' +
+        // Use the `&.png?` syntax to force Dokuwiki to display the image.
+        // See https://www.dokuwiki.org/images.
+        `{{${element.previewIconUrl}?&.png?nolink&48x48 |}}` +
+        '\n' +
+        element.shortDescription +
+        '\n\n';
     });
 
-    writeFile(texts).then(
-      () => console.info(`✅ Done. File generated: ${outputFile}`),
-      err => console.error('❌ Error while writing output', err)
-    );
+    texts += `
+## Make your own extension
+
+It's easy to create, directly in your project, new behaviors, actions, conditions or expressions for your game.
+
+Read more about this:
+
+* [[gdevelop5:extensions:create|Create your own extensions]]
+* [[gdevelop5:extensions:share|Share extensions with the community]]
+* [[gdevelop5:extensions:extend-gdevelop|Extend GDevelop with JavaScript or C++]]`
+
+    try {
+      await fs.mkdir(path.dirname(outputFilePath), { recursive: true });
+      await fs.writeFile(outputFilePath, texts);
+      console.info(`✅ Done. File generated: ${outputFilePath}`);
+    } catch (err) {
+      console.error('❌ Error while writing output', err);
+    }
   } catch (err) {
     console.error('❌ Error while fetching data', err);
   }

--- a/newIDE/app/scripts/tsconfig.json
+++ b/newIDE/app/scripts/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "//": "This configuration is for scripts only. TypeScript is not used in the newIDE sources (instead, Flow is used).",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": false,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "lib": ["DOM", "ES5", "ES2015", "ES2016", "ES2017", "ES2018", "ES2019"],
+    "target": "es5",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["**/*.js"]
+}

--- a/newIDE/app/yarn.lock
+++ b/newIDE/app/yarn.lock
@@ -15280,6 +15280,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+
 ua-parser-js@^0.7.18:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"

--- a/scripts/GenerateAllDocs.sh
+++ b/scripts/GenerateAllDocs.sh
@@ -23,4 +23,10 @@ npm install
 npm run generate-doc
 echo ℹ️ Generated GDJS Runtime docs
 cd ..
+cd newIDE/app/scripts
+npm install
+node extract-extensions-document.js
+node extract-reference-document.js
+cd ../../..
+echo ℹ️ Generated wiki docs
 cd scripts


### PR DESCRIPTION
* Generate automatically pages for all builtin "official" extensions.
* Slightly update the page with all expressions too.
* Improve the page with the community extension too to .

Automatic update of the wiki done in https://github.com/4ian/GDevelop-documentation/pull/12

TODO:
- [x] Footer in the community extension page + explanation. Link to the official reference page.
- [x] Link in the official reference page to the community extension page.
- [x] Link to the official reference page in each extension page (footer) + in the rest of the wiki