### PR TITLE
Add tests for keyboard shortcuts

### DIFF
--- a/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
+++ b/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
@@ -1,0 +1,96 @@
+import {
+  getShortcutStringFromEvent,
+  isValidShortcutEvent,
+  getElectronAccelerator,
+} from './index';
+
+const keyEvent = (ctrlKey, shiftKey, altKey, code) => ({
+  ctrlKey,
+  shiftKey,
+  altKey,
+  code,
+});
+
+// Action key, with various modifiers
+const keyA = keyEvent(false, false, false, 'KeyA'); // A
+const ctrlA = keyEvent(true, false, false, 'KeyA'); // Ctrl+A
+const shiftA = keyEvent(false, true, false, 'KeyA'); // Shift+A
+const altA = keyEvent(false, false, true, 'KeyA'); // Alt+A
+const ctrlShiftAltA = keyEvent(true, true, true, 'KeyA'); // Ctrl+Shift+Alt+A
+
+// Partial or invalid shortcut keypresses
+const ctrlShiftAlt = keyEvent(true, true, true, ''); // Ctrl+Shift+Alt+
+const ctrlShiftAltUp = keyEvent(true, true, true, 'ArrowUp'); // Ctrl+Shift+Alt+Up
+
+// Edge cases of restricted shortcuts
+const keyTab = keyEvent(false, false, false, 'Tab'); // Tab
+const shiftTab = keyEvent(false, true, false, 'Tab'); // Shift+Tab
+const ctrlTab = keyEvent(true, false, false, 'Tab'); // Ctrl+Tab
+const altTab = keyEvent(false, false, true, 'Tab'); // Alt+Tab
+const keySpace = keyEvent(false, false, false, 'Space'); // Space
+const shiftSpace = keyEvent(false, true, false, 'Space'); // Shift+Space
+const ctrlSpace = keyEvent(true, false, false, 'Space'); // Ctrl+Space
+const altSpace = keyEvent(false, false, true, 'Space'); // Alt+Space
+
+describe('KeyboardShortcuts', () => {
+  it('creates shortcut strings from events correctly', () => {
+    // Action key, with modifiers
+    expect(getShortcutStringFromEvent(keyA)).toBe('KeyA');
+    expect(getShortcutStringFromEvent(ctrlA)).toBe('CmdOrCtrl+KeyA');
+    expect(getShortcutStringFromEvent(shiftA)).toBe('Shift+KeyA');
+    expect(getShortcutStringFromEvent(altA)).toBe('Alt+KeyA');
+    expect(getShortcutStringFromEvent(ctrlShiftAltA)).toBe(
+      'CmdOrCtrl+Shift+Alt+KeyA'
+    );
+
+    // Partial or incorrect shortcut keypresses
+    expect(getShortcutStringFromEvent(ctrlShiftAlt)).toBe(
+      'CmdOrCtrl+Shift+Alt+'
+    );
+    expect(getShortcutStringFromEvent(ctrlShiftAltUp)).toBe(
+      'CmdOrCtrl+Shift+Alt+'
+    );
+  });
+
+  it('validates shortcut presses correctly', () => {
+    // Action key, with modifiers
+    expect(isValidShortcutEvent(keyA)).toBe(true);
+    expect(isValidShortcutEvent(ctrlA)).toBe(true);
+    expect(isValidShortcutEvent(shiftA)).toBe(true);
+    expect(isValidShortcutEvent(altA)).toBe(true);
+    expect(isValidShortcutEvent(ctrlShiftAltA)).toBe(true);
+
+    // Invalid shortcut keypresses...
+    expect(isValidShortcutEvent(keyTab)).toBe(false);
+    expect(isValidShortcutEvent(keySpace)).toBe(false);
+    expect(isValidShortcutEvent(shiftTab)).toBe(false);
+    expect(isValidShortcutEvent(shiftSpace)).toBe(false);
+    // .. and valid edge cases
+    expect(isValidShortcutEvent(ctrlTab)).toBe(true);
+    expect(isValidShortcutEvent(altTab)).toBe(true);
+    expect(isValidShortcutEvent(ctrlSpace)).toBe(true);
+    expect(isValidShortcutEvent(altSpace)).toBe(true);
+  });
+
+  it('converts shortcut strings to Electron accelerators correctly', () => {
+    // Conversion of action keys...
+    expect(getElectronAccelerator('KeyA')).toBe('A');
+    expect(getElectronAccelerator('KeyZ')).toBe('Z');
+    expect(getElectronAccelerator('Digit0')).toBe('0');
+    expect(getElectronAccelerator('Digit9')).toBe('9');
+    expect(getElectronAccelerator('F1')).toBe('F1');
+    expect(getElectronAccelerator('F9')).toBe('F9');
+    expect(getElectronAccelerator('F12')).toBe('F12');
+    expect(getElectronAccelerator('NumpadAdd')).toBe('numadd');
+    expect(getElectronAccelerator('NumpadSubtract')).toBe('numsub');
+    expect(getElectronAccelerator('Minus')).toBe('-');
+    expect(getElectronAccelerator('Equal')).toBe('=');
+    expect(getElectronAccelerator('Tab')).toBe('Tab');
+    expect(getElectronAccelerator('Space')).toBe('Space');
+
+    // ... and modifier keys
+    expect(getElectronAccelerator('CmdOrCtrl+Shift+Alt+KeyA')).toBe(
+      'CmdOrCtrl+Shift+Alt+A'
+    );
+  });
+});

--- a/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
+++ b/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
@@ -8,7 +8,7 @@ import {
  * Creates a KeyboardEvent-like object for testing
  * functions that take event objects as input
  */
-const keyEvent = (ctrlKey, shiftKey, altKey, code) => ({
+const makeKeyEvent = (ctrlKey, shiftKey, altKey, code) => ({
   ctrlKey,
   shiftKey,
   altKey,
@@ -16,25 +16,25 @@ const keyEvent = (ctrlKey, shiftKey, altKey, code) => ({
 });
 
 // Action key, with various modifiers
-const keyA = keyEvent(false, false, false, 'KeyA'); // A
-const ctrlA = keyEvent(true, false, false, 'KeyA'); // Ctrl+A
-const shiftA = keyEvent(false, true, false, 'KeyA'); // Shift+A
-const altA = keyEvent(false, false, true, 'KeyA'); // Alt+A
-const ctrlShiftAltA = keyEvent(true, true, true, 'KeyA'); // Ctrl+Shift+Alt+A
+const keyA = makeKeyEvent(false, false, false, 'KeyA'); // A
+const ctrlA = makeKeyEvent(true, false, false, 'KeyA'); // Ctrl+A
+const shiftA = makeKeyEvent(false, true, false, 'KeyA'); // Shift+A
+const altA = makeKeyEvent(false, false, true, 'KeyA'); // Alt+A
+const ctrlShiftAltA = makeKeyEvent(true, true, true, 'KeyA'); // Ctrl+Shift+Alt+A
 
 // Partial or invalid shortcut keypresses
-const ctrlShiftAlt = keyEvent(true, true, true, ''); // Ctrl+Shift+Alt+
-const ctrlShiftAltUp = keyEvent(true, true, true, 'ArrowUp'); // Ctrl+Shift+Alt+Up
+const ctrlShiftAlt = makeKeyEvent(true, true, true, ''); // Ctrl+Shift+Alt+
+const ctrlShiftAltUp = makeKeyEvent(true, true, true, 'ArrowUp'); // Ctrl+Shift+Alt+Up
 
 // Edge cases of restricted shortcuts
-const keyTab = keyEvent(false, false, false, 'Tab'); // Tab
-const shiftTab = keyEvent(false, true, false, 'Tab'); // Shift+Tab
-const ctrlTab = keyEvent(true, false, false, 'Tab'); // Ctrl+Tab
-const altTab = keyEvent(false, false, true, 'Tab'); // Alt+Tab
-const keySpace = keyEvent(false, false, false, 'Space'); // Space
-const shiftSpace = keyEvent(false, true, false, 'Space'); // Shift+Space
-const ctrlSpace = keyEvent(true, false, false, 'Space'); // Ctrl+Space
-const altSpace = keyEvent(false, false, true, 'Space'); // Alt+Space
+const keyTab = makeKeyEvent(false, false, false, 'Tab'); // Tab
+const shiftTab = makeKeyEvent(false, true, false, 'Tab'); // Shift+Tab
+const ctrlTab = makeKeyEvent(true, false, false, 'Tab'); // Ctrl+Tab
+const altTab = makeKeyEvent(false, false, true, 'Tab'); // Alt+Tab
+const keySpace = makeKeyEvent(false, false, false, 'Space'); // Space
+const shiftSpace = makeKeyEvent(false, true, false, 'Space'); // Shift+Space
+const ctrlSpace = makeKeyEvent(true, false, false, 'Space'); // Ctrl+Space
+const altSpace = makeKeyEvent(false, false, true, 'Space'); // Alt+Space
 
 describe('KeyboardShortcuts', () => {
   it('creates shortcut strings from events correctly', () => {

--- a/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
+++ b/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
@@ -4,6 +4,10 @@ import {
   getElectronAccelerator,
 } from './index';
 
+/**
+ * Creates a KeyboardEvent-like object for testing
+ * functions that take event objects as input
+ */
 const keyEvent = (ctrlKey, shiftKey, altKey, code) => ({
   ctrlKey,
   shiftKey,

--- a/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
+++ b/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
@@ -1,3 +1,4 @@
+// @flow
 import {
   getShortcutStringFromEvent,
   isValidShortcutEvent,
@@ -8,12 +9,10 @@ import {
  * Creates a KeyboardEvent-like object for testing
  * functions that take event objects as input
  */
-const makeKeyEvent = (ctrlKey, shiftKey, altKey, code) => ({
-  ctrlKey,
-  shiftKey,
-  altKey,
-  code,
-});
+const makeKeyEvent = (ctrlKey, shiftKey, altKey, code): KeyboardEvent => {
+  // $FlowIgnore - create fake KeyboardEvent object
+  return { ctrlKey, shiftKey, altKey, code };
+};
 
 // Action key, with various modifiers
 const keyA = makeKeyEvent(false, false, false, 'KeyA'); // A

--- a/newIDE/app/src/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/KeyboardShortcuts/index.js
@@ -76,7 +76,7 @@ export const isValidShortcutEvent = (e: KeyboardEvent): boolean => {
  */
 export const getShortcutMetadataFromEvent = (
   e: KeyboardEvent
-): {| shortcutString: string, isValid: boolean, invalidType?: string |} => {
+): {| shortcutString: string, isValid: boolean |} => {
   const shortcutString = getShortcutStringFromEvent(e);
   const isValidKey = isValidShortcutEvent(e);
   const isReserved = reservedShortcuts.includes(shortcutString);
@@ -183,8 +183,8 @@ export const getElectronAccelerator = (shortcutString: string) => {
   return shortcutString
     .split('+')
     .map<string>(keyCode => {
-      if (keyCode === 'CmdOrCtrl') return 'CmdOrCtrl';
-      if (keyCode === 'Shift' || keyCode === 'Alt') return keyCode;
+      if (keyCode === 'CmdOrCtrl' || keyCode === 'Shift' || keyCode === 'Alt')
+        return keyCode;
       return getElectronKeyString(keyCode);
     })
     .join('+');


### PR DESCRIPTION
This PR adds some tests for the keyboard shortcuts logic. In particular, the tests cover the following:
- `getShortcutStringFromEvent`: Parse event object into respective shortcut string
- `isValidShortcutEvent`: Check if an event object is a valid shortcut keypress
- `getElectronAccelerator`: Convert internal shortcut strings to Electron-compatible "accelerator" strings

This is my first time writing tests for an actual project, so it may not be very good :sweat_smile:. I've covered all the exported functions from `src/KeyboardShortcuts/index.js`, except:
- `getShortcutDisplayName`: it's user interface, so isn't necessary to test, right?
- `getShortcutMetadataFromEvent`: this functionality (except reserved shortcuts) is covered in tested functions
- the two React hooks `useShortcutMap` and `useKeyboardShortcuts`

I've also made some very small refactoring changes to `src/KeyboardShortcuts/index.js`, that do not change the logic in any manner.