### PR TITLE
Fix the issue double extension prefix

### DIFF
--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -317,6 +317,8 @@ export const insertAutocompletionInExpression = (
     endString: string,
     startString: string
   ): boolean => {
+    if (!startString || !endString) return false;
+
     for (let index = 0; index < endString.length; index++) {
       let subStr = endString.substring(index);
       if (startString.indexOf(subStr) === 0) {
@@ -328,7 +330,7 @@ export const insertAutocompletionInExpression = (
 
   const formatCompletion = (
     nextCharacter: ?string,
-    newExpressionStart: string
+    newExpressionStart: ?string
   ) => {
     const suffix = insertedAutocompletion.addDot
       ? '.'
@@ -347,7 +349,7 @@ export const insertAutocompletionInExpression = (
 
     // If the result from insertedAutocompletion.completion is redundant with startOfTheExpression then takes only function/object part of the expression.
     if (compareExpressionsForRedundancy(newExpressionStart, endExpression)) {
-      let charSeparatorPosition: Number = endExpression.length - 1;
+      let charSeparatorPosition = endExpression.length - 1;
       while (
         charSeparatorPosition > 0 &&
         !isSeparatorChar(endExpression[charSeparatorPosition])
@@ -366,7 +368,7 @@ export const insertAutocompletionInExpression = (
   }
 
   if (caretLocation === 0 || !expression) {
-    const newExpression = formatCompletion(undefined) + expression;
+    const newExpression = formatCompletion(undefined, undefined) + expression;
     return {
       caretLocation: newExpression.length,
       expression: newExpression,

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -348,7 +348,7 @@ export const insertAutocompletionInExpression = (
     return separatorChars.indexOf(char) !== -1;
   };
 
-  const isExpression = (word: String) => {
+  const isExpression = (word: string) => {
     return word.includes('::');
   };
 

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -314,8 +314,8 @@ export const insertAutocompletionInExpression = (
 ): ExpressionAndCaretLocation => {
   // Compare two expressions one from end and one from start.
   const compareExpressionsForRedundancy = (
-    endString: string,
-    startString: string
+    endString: ?string,
+    startString: ?string
   ): boolean => {
     if (!startString || !endString) return false;
 


### PR DESCRIPTION
fixes issue #2195 .
Reconsidered this issue as  I thought last time I nearly solved it.
@4ian Your thoughts about changing `formatCompletion` were right. As there was no need to disturb `newExpressionStart` and output is wrong due to `insertedAutocompletion.completion` so checking it and improving it makes more sense.

So I changed the logic and figured out to change the logic behind `formatCompletion`. Now code checks for the completion word before returning it into `insertedWord`. **If the completion word is returning `MyExtension::MyFunction` (kind of expressions) whereas just `MyFunction` is accurate. The MyFunciton will be extracted from completion and returned to `insertedWord` with completed format.**