### PR TITLE
Allow to choose isometry in the top-down movement behavior

### DIFF
--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -21,6 +21,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
           "Open source (MIT License)")
       .SetExtensionHelpPath("/behaviors/topdown");
 
+  {
   gd::BehaviorMetadata& aut = extension.AddBehavior(
       "TopDownMovementBehavior",
       _("Top-down movement (4 or 8 directions)"),
@@ -513,6 +514,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .SetIncludeFile(
           "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 #endif
+  }
 }
 
 /**

--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -21,7 +21,6 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
           "Open source (MIT License)")
       .SetExtensionHelpPath("/behaviors/topdown");
 
-  {
   gd::BehaviorMetadata& aut = extension.AddBehavior(
       "TopDownMovementBehavior",
       _("Top-down movement (4 or 8 directions)"),
@@ -514,7 +513,6 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .SetIncludeFile(
           "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 #endif
-  }
 }
 
 /**

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -34,6 +34,8 @@ void TopDownMovementBehavior::InitializeContent(
   behaviorContent.SetAttribute("rotateObject", true);
   behaviorContent.SetAttribute("angleOffset", 0);
   behaviorContent.SetAttribute("ignoreDefaultControls", false);
+  behaviorContent.SetAttribute("viewpoint", "TopDown");
+  behaviorContent.SetAttribute("customIsometryAngle", 30);
 }
 
 #if defined(GD_IDE_ONLY)
@@ -66,6 +68,26 @@ TopDownMovementBehavior::GetProperties(
                     : "true")
       .SetType("Boolean");
 
+  gd::String viewpoint = behaviorContent.GetStringAttribute("viewpoint");
+  gd::String viewpointStr = _("Viewpoint");
+  if (viewpoint == "TopDown")
+    viewpointStr = _("Top-Down");
+  else if (viewpoint == "PixelIsometry")
+    viewpointStr = _("Isometry 2:1 (26.565°)");
+  else if (viewpoint == "TrueIsometry")
+    viewpointStr = _("True Isometry (30°)");
+  else if (viewpoint == "CustomIsometry")
+    viewpointStr = _("Custom Isometry");
+  properties[_("Viewpoint")]
+      .SetValue(viewpointStr)
+      .SetType("Choice")
+      .AddExtraInfo(_("Top-Down"))
+      .AddExtraInfo(_("Isometry 2:1 (26.565°)"))
+      .AddExtraInfo(_("True Isometry (30°)"))
+      .AddExtraInfo(_("Custom Isometry"));
+  properties[_("Custom isometry angle")].SetValue(
+      gd::String::From(behaviorContent.GetDoubleAttribute("customIsometryAngle")));
+
   return properties;
 }
 
@@ -85,6 +107,17 @@ bool TopDownMovementBehavior::UpdateProperty(
     behaviorContent.SetAttribute("rotateObject", (value != "0"));
     return true;
   }
+  if (name == _("Viewpoint")) {
+    if (value == _("Isometry 2:1 (26.565°)"))
+      behaviorContent.SetAttribute("viewpoint", "PixelIsometry");
+    else if (value == _("True Isometry (30°)"))
+      behaviorContent.SetAttribute("viewpoint", "TrueIsometry");
+    else if (value == _("Custom Isometry"))
+      behaviorContent.SetAttribute("viewpoint", "CustomIsometry");
+    else
+      behaviorContent.SetAttribute("viewpoint", "TopDown");
+    return true;
+  }
 
   if (value.To<float>() < 0) return false;
 
@@ -98,6 +131,10 @@ bool TopDownMovementBehavior::UpdateProperty(
     behaviorContent.SetAttribute("angularMaxSpeed", value.To<float>());
   else if (name == _("Angle offset"))
     behaviorContent.SetAttribute("angleOffset", value.To<float>());
+  else if (name == _("Custom isometry angle")) {
+    if (value.To<float>() < 1 || value.To<float>() > 45) return false;
+    behaviorContent.SetAttribute("customIsometryAngle", value.To<float>());
+  }
   else
     return false;
 

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -132,7 +132,7 @@ bool TopDownMovementBehavior::UpdateProperty(
   else if (name == _("Angle offset"))
     behaviorContent.SetAttribute("angleOffset", value.To<float>());
   else if (name == _("Custom isometry angle")) {
-    if (value.To<float>() < 1 || value.To<float>() > 45) return false;
+    if (value.To<float>() < 1 || value.To<float>() > 44) return false;
     behaviorContent.SetAttribute("customIsometryAngle", value.To<float>());
   }
   else

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -382,14 +382,14 @@ namespace gdjs {
   }
 
   export class IdentityTransformation implements BasisTransformation {
-    toScreen(wordPoint: FloatPoint, screenPoint: FloatPoint): void {
-      screenPoint[0] = wordPoint[0];
-      screenPoint[1] = wordPoint[1];
+    toScreen(worldPoint: FloatPoint, screenPoint: FloatPoint): void {
+      screenPoint[0] = worldPoint[0];
+      screenPoint[1] = worldPoint[1];
     }
 
-    toWorld(screenPoint: FloatPoint, wordPoint: FloatPoint): void {
-      wordPoint[0] = screenPoint[0];
-      wordPoint[1] = screenPoint[1];
+    toWorld(screenPoint: FloatPoint, worldPoint: FloatPoint): void {
+      worldPoint[0] = screenPoint[0];
+      worldPoint[1] = screenPoint[1];
     }
   }
 
@@ -418,22 +418,22 @@ namespace gdjs {
       ];
     }
 
-    toScreen(wordPoint: FloatPoint, screenPoint: FloatPoint): void {
+    toScreen(worldPoint: FloatPoint, screenPoint: FloatPoint): void {
       const x =
-        this.screen[0][0] * wordPoint[0] + this.screen[0][1] * wordPoint[1];
+        this.screen[0][0] * worldPoint[0] + this.screen[0][1] * worldPoint[1];
       const y =
-        this.screen[1][0] * wordPoint[0] + this.screen[1][1] * wordPoint[1];
+        this.screen[1][0] * worldPoint[0] + this.screen[1][1] * worldPoint[1];
       screenPoint[0] = x;
       screenPoint[1] = y;
     }
 
-    toWorld(screenPoint: FloatPoint, wordPoint: FloatPoint): void {
+    toWorld(screenPoint: FloatPoint, worldPoint: FloatPoint): void {
       const x =
         this.world[0][0] * screenPoint[0] + this.world[0][1] * screenPoint[1];
       const y =
         this.world[1][0] * screenPoint[0] + this.world[1][1] * screenPoint[1];
-      wordPoint[0] = x;
-      wordPoint[1] = y;
+      worldPoint[0] = x;
+      worldPoint[1] = y;
     }
   }
 

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -314,8 +314,7 @@ namespace gdjs {
         // Top-down pointview
         object.setX(object.getX() + this._xVelocity * timeDelta);
         object.setY(object.getY() + this._yVelocity * timeDelta);
-      }
-      else {
+      } else {
         // Isometry pointview
         const point = this._temporaryPointForTransformations;
         point[0] = this._xVelocity * timeDelta;
@@ -389,8 +388,10 @@ namespace gdjs {
      */
     constructor(angle: float) {
       if (angle <= 0 || angle >= Math.PI / 4)
-        throw new RangeError("An isometry angle must be in ]0; pi/4] but was: " + angle);
-      
+        throw new RangeError(
+          'An isometry angle must be in ]0; pi/4] but was: ' + angle
+        );
+
       const alpha = Math.asin(Math.tan(angle));
       const sinA = Math.sin(alpha);
       const cosB = Math.cos(Math.PI / 4);

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -381,9 +381,16 @@ namespace gdjs {
   }
 
   export class IsometryTransformation implements BasisTransformation {
-    screen: float[][];
+    _screen: float[][];
 
+    /**
+     * @param angle between the x axis and the projected isometric x axis.
+     * @throws if the angle is not in ]0; pi/4[. Note that 0 is a front viewpoint and pi/4 a top-down viewpoint.
+     */
     constructor(angle: float) {
+      if (angle <= 0 || angle >= Math.PI / 4)
+        throw new RangeError("An isometry angle must be in ]0; pi/4] but was: " + angle);
+      
       const alpha = Math.asin(Math.tan(angle));
       const sinA = Math.sin(alpha);
       const cosB = Math.cos(Math.PI / 4);
@@ -393,7 +400,7 @@ namespace gdjs {
       //   / 1     0    0 \ / cosB 0 -sinB \ / 1 0  0 \
       //   | 0  cosA sinA | |    0 1     0 | | 0 0 -1 |
       //   \ 0 -sinA cosA / \ sinB 0  cosB / \ 0 1  0 /
-      this.screen = [
+      this._screen = [
         [cosB, -sinB],
         [sinA * sinB, sinA * cosB],
       ];
@@ -401,9 +408,9 @@ namespace gdjs {
 
     toScreen(worldPoint: FloatPoint, screenPoint: FloatPoint): void {
       const x =
-        this.screen[0][0] * worldPoint[0] + this.screen[0][1] * worldPoint[1];
+        this._screen[0][0] * worldPoint[0] + this._screen[0][1] * worldPoint[1];
       const y =
-        this.screen[1][0] * worldPoint[0] + this.screen[1][1] * worldPoint[1];
+        this._screen[1][0] * worldPoint[0] + this._screen[1][1] * worldPoint[1];
       screenPoint[0] = x;
       screenPoint[1] = y;
     }


### PR DESCRIPTION
This pull request doesn't have the player assistance. I think this is more waited and a lot more easy to review so I did another pull request with it.

It allows to choose the viewpoint between:
- top-down
- isometry 2:1
- true isometry
- custom isometry

This example uses the true isometry:
https://games.gdevelop-app.com/game-6abd1d9d-57aa-4b42-ac03-1b35567dd659/index.html

The exposed position is the one on screen, but for speed it's the one in the isometric world. I think it make more sense because max speed doesn't make sense screen related.
I wonder if the position in the isometric world should be exposed too. An extension to transform coordinates will be needed to make advance isometry features, but it could be good to be able to get it directly, yet maybe confusing for top-down viewpoint users.
There are functions for isometry in the Extended Math extension, but I think isometry could need a lot of functions, condition and actions to address commons issues, so a new extension may be better.

The BasisTransformation interface and its implementations can be used for the change request on the path finding. Should it be move somewhere to be shared between all extensions? And maybe do a factory?

Maybe the 2:1 isometry needs a specific implementation to avoid rounded errors.

https://trello.com/c/vp6eCCZh