### PR TITLE
Multiples changes to the p2p extension

### DIFF
--- a/Extensions/P2P/B_p2ptools.ts
+++ b/Extensions/P2P/B_p2ptools.ts
@@ -15,7 +15,7 @@ namespace gdjs {
       };
 
       const isValidNetworkEvent = (event): event is NetworkEvent =>
-        typeof event.eventName === 'string' || typeof event.data === 'string';
+        typeof event.eventName === 'string' && typeof event.data === 'string';
 
       /**
        * The data bound to an event that got triggered.
@@ -47,7 +47,7 @@ namespace gdjs {
         /**
          * Returns true if the event is triggered.
          */
-        isTrigerred() {
+        isTriggered() {
           return this.data.length > 0;
         }
 
@@ -69,14 +69,14 @@ namespace gdjs {
         /**
          * Get the data sent with the last event triggering.
          */
-        getEventData() {
+        getData() {
           return this.data.length === 0 ? '' : this.data[0].data;
         }
 
         /**
          * Get the sender of the last event triggering.
          */
-        getEventSender() {
+        getSender() {
           return this.data.length === 0 ? '' : this.data[0].sender;
         }
       }
@@ -99,7 +99,6 @@ namespace gdjs {
       /**
        * Contains a map of events triggered by other p2p clients.
        * It is keyed by the event name.
-       * @note This is ignored if the event is in no dataloss mode.
        */
       const events: Record<string, Event> = {};
 
@@ -178,7 +177,7 @@ namespace gdjs {
         });
 
         // Close event is only for graceful disconnection,
-        // but we want onDisconnect to trigger for any type of dsiconnection,
+        // but we want onDisconnect to trigger for any type of disconnection,
         // so we register a listener for both event types.
         connection.on('error', () => {
           _onDisconnect(connection.peer);
@@ -233,7 +232,7 @@ namespace gdjs {
       ): boolean => {
         const event = getEvent(eventName);
         event.dataloss = defaultDataLoss;
-        return event.isTrigerred();
+        return event.isTriggered();
       };
 
       /**
@@ -303,7 +302,14 @@ namespace gdjs {
        * @returns - The data as JSON.
        */
       export const getEventData = (eventName: string) =>
-        getEvent(eventName).getEventData();
+        getEvent(eventName).getData();
+
+      /**
+       * Get the id of peer that caused the last trigger of an event.
+       * @param eventName - The event to get the sender from.
+       */
+      export const getEventSender = (eventName: string) =>
+        getEvent(eventName).getSender();
 
       /**
        * Get a variable associated to the last trigger of an event.
@@ -404,9 +410,9 @@ namespace gdjs {
       export const getConnectedPeer = (): string => connectedPeers[0] || '';
 
       gdjs.callbacksRuntimeScenePostEvents.push(() => {
-        for (const i in events) {
-          if (!events.hasOwnProperty(i)) continue;
-          events[i].popData();
+        for (const eventName in events) {
+          if (!events.hasOwnProperty(eventName)) continue;
+          events[eventName].popData();
         }
         if (disconnectedPeers.length > 0) {
           disconnectedPeers.shift();

--- a/Extensions/P2P/B_p2ptools.ts
+++ b/Extensions/P2P/B_p2ptools.ts
@@ -128,15 +128,6 @@ namespace gdjs {
       const connectedPeers: string[] = [];
 
       /**
-       * Internal function to get an event from {@link events}
-       * or create it if it doesn't exist.
-       */
-      const getEvent = (name: string) => {
-        if (!events.hasOwnProperty(name)) events[name] = new Event();
-        return events[name];
-      };
-
-      /**
        * Internal function called to initialize PeerJS after it
        * has been configured.
        */
@@ -208,6 +199,15 @@ namespace gdjs {
         if (!connections.hasOwnProperty(connectionID)) return;
         disconnectedPeers.push(connectionID);
         delete connections[connectionID];
+      };
+
+      /**
+       * Gets an event from {@link events}
+       * or creates it if it doesn't exist.
+       */
+      export const getEvent = (name: string) => {
+        if (!events.hasOwnProperty(name)) events[name] = new Event();
+        return events[name];
       };
 
       /**

--- a/Extensions/P2P/B_p2ptools.ts
+++ b/Extensions/P2P/B_p2ptools.ts
@@ -7,6 +7,81 @@ namespace gdjs {
      */
     export namespace p2p {
       /**
+       * The type of the data that is sent across peerjs.
+       */
+      type NetworkEvent = {
+        eventName: string;
+        data: string;
+      };
+
+      const isValidNetworkEvent = (event): event is NetworkEvent =>
+        typeof event.eventName === 'string' || typeof event.data === 'string';
+
+      /**
+       * The data bound to an event that got triggered.
+       */
+      class EventData {
+        constructor(data: string, sender: string) {
+          this.data = data;
+          this.sender = sender;
+        }
+
+        /**
+         * The data sent alongside the event.
+         */
+        public readonly data: string = '';
+
+        /**
+         * The ID of the sender of the event.
+         */
+        public readonly sender: string = '';
+      }
+
+      /**
+       * An event that can be listened to.
+       */
+      class Event {
+        private data: EventData[] = [];
+        public dataloss = false;
+
+        /**
+         * Returns true if the event is triggered.
+         */
+        isTrigerred() {
+          return this.data.length > 0;
+        }
+
+        /**
+         * Add new data, to be called with the event data each time the event is triggered.
+         */
+        pushData(newData: EventData) {
+          if (this.dataloss && this.data.length > 0) return;
+          else this.data.push(newData);
+        }
+
+        /**
+         * Deleted the last event data, to be called when it is sure the event was processed throughly.
+         */
+        popData() {
+          this.data.shift();
+        }
+
+        /**
+         * Get the data sent with the last event triggering.
+         */
+        getEventData() {
+          return this.data.length === 0 ? '' : this.data[0].data;
+        }
+
+        /**
+         * Get the sender of the last event triggering.
+         */
+        getEventSender() {
+          return this.data.length === 0 ? '' : this.data[0].sender;
+        }
+      }
+
+      /**
        * The peer to peer configuration.
        */
       let peerConfig: Peer.PeerJSOption = { debug: 1 };
@@ -14,36 +89,19 @@ namespace gdjs {
       /**
        * The p2p client.
        */
-      let peer: Peer | null = null;
+      let peer: Peer<NetworkEvent> | null = null;
 
       /**
        * All connected p2p clients, keyed by their ID.
        */
-      const connections: Record<string, Peer.DataConnection> = {};
+      const connections: Record<string, Peer.DataConnection<NetworkEvent>> = {};
 
       /**
-       * Contains a list of events triggered by other p2p clients.
-       * Maps an event name (string) to a boolean:
-       * true if the event has been triggered, otherwise false.
+       * Contains a map of events triggered by other p2p clients.
+       * It is keyed by the event name.
        * @note This is ignored if the event is in no dataloss mode.
        */
-      const triggeredEvents: Record<string, boolean> = {};
-
-      /**
-       * Contains the latest data sent with each event.
-       * If the event is in dataloss mode, maps an event name
-       * to the string sent with that event.
-       * If the event is in no dataloss mode, maps an event name
-       * to an array containing the data of each call of that event.
-       */
-      const lastEventData: Record<string, string | string[]> = {};
-
-      /**
-       * Tells how to handle an event (with or without data loss).
-       * Maps the event name (string) to a boolean:
-       * true for dataloss, false for no dataloss.
-       */
-      const eventHandling: Record<string, boolean> = {};
+      const events: Record<string, Event> = {};
 
       /**
        * True if PeerJS is initialized and ready.
@@ -71,10 +129,19 @@ namespace gdjs {
       const connectedPeers: string[] = [];
 
       /**
-       * Internal function called to initialize PeerJS after its
-       * broker server has been configured.
+       * Internal function to get an event from {@link events}
+       * or create it if it doesn't exist.
        */
-      const _loadPeerJS = () => {
+      const getEvent = (name: string) => {
+        if (!events.hasOwnProperty(name)) events[name] = new Event();
+        return events[name];
+      };
+
+      /**
+       * Internal function called to initialize PeerJS after it
+       * has been configured.
+       */
+      const loadPeerJS = () => {
         if (peer !== null) return;
         peer = new Peer(peerConfig);
         peer.on('open', () => {
@@ -92,7 +159,7 @@ namespace gdjs {
         });
         peer.on('close', () => {
           peer = null;
-          _loadPeerJS();
+          loadPeerJS();
         });
         peer.on('disconnected', peer.reconnect);
       };
@@ -101,25 +168,19 @@ namespace gdjs {
        * Internal function called when a connection with a remote peer is initiated.
        * @param connection The DataConnection of the peer
        */
-      const _onConnection = (connection: Peer.DataConnection) => {
+      const _onConnection = (connection: Peer.DataConnection<NetworkEvent>) => {
         connections[connection.peer] = connection;
         connection.on('data', (data) => {
-          if (data.eventName === undefined) {
-            return;
-          }
-          const dataLoss = eventHandling[data.eventName];
-          if (typeof dataLoss === 'undefined' || dataLoss === false) {
-            if (typeof lastEventData[data.eventName] !== 'object')
-              lastEventData[data.eventName] = [];
-
-            (lastEventData[data.eventName] as string[]).push(data.data);
-          } else {
-            triggeredEvents[data.eventName] = true;
-            lastEventData[data.eventName] = data.data;
-          }
+          if (isValidNetworkEvent(data))
+            getEvent(data.eventName).pushData(
+              new EventData(data.data, connection.peer)
+            );
         });
+
+        // Close event is only for graceful disconnection,
+        // but we want onDisconnect to trigger for any type of dsiconnection,
+        // so we register a listener for both event types.
         connection.on('error', () => {
-          // Close event is only for graceful disconnection, also handle error aka ungraceful disconnection
           _onDisconnect(connection.peer);
         });
         connection.on('close', () => {
@@ -130,11 +191,12 @@ namespace gdjs {
         (function disconnectChecker() {
           if (
             connection.peerConnection.connectionState === 'failed' ||
-            connection.peerConnection.connectionState === 'disconnected'
+            connection.peerConnection.connectionState === 'disconnected' ||
+            connection.peerConnection.connectionState === 'closed'
           ) {
             _onDisconnect(connection.peer);
           } else {
-            setTimeout(disconnectChecker, 500);
+            setTimeout(disconnectChecker, 1000);
           }
         })();
       };
@@ -144,6 +206,7 @@ namespace gdjs {
        * @param connectionID The ID of the peer that disconnected.
        */
       const _onDisconnect = (connectionID: string) => {
+        if (!connections.hasOwnProperty(connectionID)) return;
         disconnectedPeers.push(connectionID);
         delete connections[connectionID];
       };
@@ -168,25 +231,9 @@ namespace gdjs {
         eventName: string,
         defaultDataLoss: boolean
       ): boolean => {
-        const dataLoss = eventHandling[eventName];
-        if (dataLoss == undefined) {
-          eventHandling[eventName] = defaultDataLoss;
-          return onEvent(eventName, defaultDataLoss);
-        }
-        if (dataLoss) {
-          let returnValue = triggeredEvents[eventName];
-          if (typeof returnValue === 'undefined') {
-            return false;
-          }
-          triggeredEvents[eventName] = false;
-          return returnValue;
-        } else {
-          let returnValue = lastEventData[eventName];
-          if (typeof returnValue === 'undefined') {
-            return false;
-          }
-          return returnValue.length !== 0;
-        }
+        const event = getEvent(eventName);
+        event.dataloss = defaultDataLoss;
+        return event.isTrigerred();
       };
 
       /**
@@ -198,7 +245,7 @@ namespace gdjs {
       export const sendDataTo = (
         id: string,
         eventName: string,
-        eventData?: string
+        eventData: string
       ) => {
         if (connections[id]) {
           connections[id].send({
@@ -213,13 +260,8 @@ namespace gdjs {
        * @param eventName - The event to trigger.
        * @param [eventData] - Additional data to send with the event.
        */
-      export const sendDataToAll = (eventName: string, eventData?: string) => {
-        for (const id in connections) {
-          connections[id].send({
-            eventName: eventName,
-            data: eventData,
-          });
-        }
+      export const sendDataToAll = (eventName: string, eventData: string) => {
+        for (const id in connections) sendDataTo(id, eventName, eventData);
       };
 
       /**
@@ -260,15 +302,8 @@ namespace gdjs {
        * @param eventName - The event to get data from.
        * @returns - The data as JSON.
        */
-      export const getEventData = (eventName: string): string => {
-        const dataLoss = eventHandling[eventName];
-        if (typeof dataLoss === 'undefined' || dataLoss === false) {
-          const event = lastEventData[eventName];
-          return event[event.length - 1];
-        } else {
-          return lastEventData[eventName] as string;
-        }
-      };
+      export const getEventData = (eventName: string) =>
+        getEvent(eventName).getEventData();
 
       /**
        * Get a variable associated to the last trigger of an event.
@@ -300,16 +335,16 @@ namespace gdjs {
         key: string,
         ssl: boolean
       ) => {
-        // All servers have "peerjs" as default key
         peerConfig = {
           debug: 1,
           host,
           port,
           path,
           secure: ssl,
+          // All servers have "peerjs" as default key
           key: key.length === 0 ? 'peerjs' : key,
         };
-        _loadPeerJS();
+        loadPeerJS();
       };
 
       /**
@@ -317,16 +352,14 @@ namespace gdjs {
        * This is not recommended for published games,
        * this server should only be used for quick testing in development.
        */
-      export const useDefaultBrokerServer = _loadPeerJS;
+      export const useDefaultBrokerServer = loadPeerJS;
 
       /**
        * Returns the own current peer ID.
        * @see Peer.id
        */
       export const getCurrentId = (): string => {
-        if (peer == undefined) {
-          return '';
-        }
+        if (peer == undefined) return '';
         return peer.id || '';
       };
 
@@ -334,9 +367,7 @@ namespace gdjs {
        * Returns true once PeerJS finished initialization.
        * @see ready
        */
-      export const isReady = (): boolean => {
-        return ready;
-      };
+      export const isReady = () => ready;
 
       /**
        * Returns true once when there is an error.
@@ -350,52 +381,38 @@ namespace gdjs {
       /**
        * Returns the latest error message.
        */
-      export const getLastError = (): string => {
-        return lastError;
-      };
+      export const getLastError = () => lastError;
 
       /**
        * Returns true once a peer disconnected.
        */
-      export const onDisconnect = (): boolean => {
-        return disconnectedPeers.length > 0;
-      };
+      export const onDisconnect = () => disconnectedPeers.length > 0;
 
       /**
        * Get the ID of the peer that triggered onDisconnect.
        */
-      export const getDisconnectedPeer = (): string => {
-        return disconnectedPeers[disconnectedPeers.length - 1] || '';
-      };
+      export const getDisconnectedPeer = () => disconnectedPeers[0] || '';
 
       /**
        * Returns true once if a remote peer just initiated a connection.
        */
-      export const onConnection = (): boolean => {
-        return connectedPeers.length > 0;
-      };
+      export const onConnection = () => connectedPeers.length > 0;
 
       /**
        * Get the ID of the peer that triggered onConnection.
        */
-      export const getConnectedPeer = (): string => {
-        return connectedPeers[connectedPeers.length - 1] || '';
-      };
+      export const getConnectedPeer = (): string => connectedPeers[0] || '';
 
       gdjs.callbacksRuntimeScenePostEvents.push(() => {
-        for (const i in lastEventData) {
-          if (
-            typeof lastEventData[i] === 'object' &&
-            lastEventData[i].length > 0
-          ) {
-            (lastEventData[i] as string[]).pop();
-          }
+        for (const i in events) {
+          if (!events.hasOwnProperty(i)) continue;
+          events[i].popData();
         }
         if (disconnectedPeers.length > 0) {
-          disconnectedPeers.pop();
+          disconnectedPeers.shift();
         }
         if (connectedPeers.length > 0) {
-          connectedPeers.pop();
+          connectedPeers.shift();
         }
       });
     }

--- a/Extensions/P2P/JsExtension.js
+++ b/Extensions/P2P/JsExtension.js
@@ -298,6 +298,22 @@ module.exports = {
 
     extension
       .addStrExpression(
+        'GetEventSender',
+        _('Get event sender'),
+        _(
+          'Returns the id of the peer that triggered the event'
+        ),
+        _('P2P (experimental)'),
+        'JsPlatform/Extensions/p2picon.svg'
+      )
+      .addParameter('string', _('Event name'), '', false)
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/P2P/A_peer.js')
+      .addIncludeFile('Extensions/P2P/B_p2ptools.js')
+      .setFunctionName('gdjs.evtTools.p2p.getEventSender');
+
+    extension
+      .addStrExpression(
         'GetID',
         _('Get client ID'),
         _('Gets the client ID of the current game instance'),

--- a/Extensions/P2P/peerjs.d.ts
+++ b/Extensions/P2P/peerjs.d.ts
@@ -2,7 +2,7 @@
 // Original definitions by Toshiya Nakakura <https://github.com/nakakura>
 // at https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Peer {
+declare class Peer<T> {
   prototype: RTCIceServer;
 
   /**
@@ -24,7 +24,10 @@ declare class Peer {
    * @param id The brokering ID of the remote peer (their peer.id).
    * @param options for specifying details about Peer Connection
    */
-  connect(id: string, options?: Peer.PeerConnectOption): Peer.DataConnection;
+  connect(
+    id: string,
+    options?: Peer.PeerConnectOption
+  ): Peer.DataConnection<T>;
   /**
    * Calls the remote peer specified by id and returns a media connection.
    * @param id The brokering ID of the remote peer (their peer.id).
@@ -55,7 +58,7 @@ declare class Peer {
    */
   on(
     event: 'connection',
-    cb: (dataConnection: Peer.DataConnection) => void
+    cb: (dataConnection: Peer.DataConnection<T>) => void
   ): void;
   /**
    * Emitted when a remote peer attempts to call you.
@@ -109,7 +112,7 @@ declare class Peer {
   getConnection(
     peerId: string,
     connectionId: string
-  ): Peer.MediaConnection | Peer.DataConnection | null;
+  ): Peer.MediaConnection | Peer.DataConnection<T> | null;
 
   /**
    * Get a list of available peer IDs
@@ -161,11 +164,11 @@ declare namespace Peer {
     sdpTransform?: Function;
   }
 
-  interface DataConnection {
-    send(data: any): void;
+  interface DataConnection<T> {
+    send(data: T): void;
     close(): void;
     on(event: string, cb: () => void): void;
-    on(event: 'data', cb: (data: any) => void): void;
+    on(event: 'data', cb: (data: T) => void): void;
     on(event: 'open', cb: () => void): void;
     on(event: 'close', cb: () => void): void;
     on(event: 'error', cb: (err: any) => void): void;

--- a/Extensions/P2P/peerjs.d.ts
+++ b/Extensions/P2P/peerjs.d.ts
@@ -24,10 +24,7 @@ declare class Peer<T> {
    * @param id The brokering ID of the remote peer (their peer.id).
    * @param options for specifying details about Peer Connection
    */
-  connect(
-    id: string,
-    options?: Peer.PeerConnectOption
-  ): Peer.DataConnection<T>;
+  connect(id: string, options?: Peer.PeerConnectOption): Peer.DataConnection<T>;
   /**
    * Calls the remote peer specified by id and returns a media connection.
    * @param id The brokering ID of the remote peer (their peer.id).

--- a/newIDE/app/resources/examples/p2p-networking/p2p-networking.json
+++ b/newIDE/app/resources/examples/p2p-networking/p2p-networking.json
@@ -1,7 +1,7 @@
 {
   "firstLayout": "",
   "gdVersion": {
-    "build": 98,
+    "build": 99,
     "major": 4,
     "minor": 0,
     "revision": 0
@@ -9,17 +9,14 @@
   "properties": {
     "adaptGameResolutionAtRuntime": true,
     "folderProject": false,
-    "linuxExecutableFilename": "",
-    "macExecutableFilename": "",
     "orientation": "landscape",
     "packageName": "com.example.multiplayergame",
-    "projectFile": "D:\\Documents\\documents\\GDevelop projects\\MultiplayerExample\\game.json",
+    "projectUuid": "4e5a640f-64c8-45c4-97a3-8bf51ce318b1",
     "scaleMode": "linear",
     "sizeOnStartupMode": "",
+    "useDeprecatedZeroAsDefaultZOrder": true,
     "useExternalSourceFiles": false,
     "version": "1.0.0",
-    "winExecutableFilename": "",
-    "winExecutableIconFile": "",
     "name": "P2P Networking Example",
     "author": "Arthur Pacaud (arthuro555)",
     "windowWidth": 800,
@@ -791,7 +788,7 @@
           "creationTime": 0,
           "disabled": false,
           "folded": true,
-          "name": "UI handling",
+          "name": "UI",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
@@ -851,18 +848,6 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
-                    "idText",
-                    "=",
-                    "P2P::GetID()"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
                     "value": "TextEntryObject::String"
                   },
                   "parameters": [
@@ -914,18 +899,6 @@
                     "value": "TextObject::String"
                   },
                   "parameters": [
-                    "idText",
-                    "=",
-                    "P2P::GetID()"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
                     "idEntryText",
                     "=",
                     "idEntry.String()"
@@ -942,8 +915,54 @@
               "conditions": [
                 {
                   "type": {
+                    "inverted": false,
+                    "value": "P2P::IsReady"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Once"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "idText",
+                    "=",
+                    "P2P::GetID()"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
                     "inverted": true,
                     "value": "P2P::IsReady"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Once"
                   },
                   "parameters": [],
                   "subInstructions": []
@@ -1013,6 +1032,17 @@
                         {
                           "type": {
                             "inverted": false,
+                            "value": "SourisBouton"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
                             "value": "SourisSurObjet"
                           },
                           "parameters": [
@@ -1022,21 +1052,18 @@
                             ""
                           ],
                           "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisBouton"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ],
-                          "subInstructions": []
                         }
                       ]
                     }
                   ]
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Once"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
                 }
               ],
               "actions": [
@@ -1107,18 +1134,6 @@
                     "\"\""
                   ],
                   "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "Scene"
-                  },
-                  "parameters": [
-                    "",
-                    "\"Menu\"",
-                    "yes"
-                  ],
-                  "subInstructions": []
                 }
               ],
               "events": []
@@ -1159,6 +1174,17 @@
                 {
                   "type": {
                     "inverted": false,
+                    "value": "P2P::SendToAll"
+                  },
+                  "parameters": [
+                    "\"connected\"",
+                    "\"\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
                     "value": "Scene"
                   },
                   "parameters": [
@@ -1193,19 +1219,6 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "SourisSurObjet"
-                  },
-                  "parameters": [
-                    "Copy",
-                    "",
-                    "",
-                    ""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
                     "value": "SourisBouton"
                   },
                   "parameters": [
@@ -1223,75 +1236,79 @@
                   "subInstructions": []
                 }
               ],
-              "actions": [
+              "actions": [],
+              "events": [
                 {
-                  "type": {
-                    "inverted": false,
-                    "value": "Clipboard::WriteText"
-                  },
-                  "parameters": [
-                    "",
-                    "P2P::GetID()",
-                    ""
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SourisSurObjet"
+                      },
+                      "parameters": [
+                        "Copy",
+                        "",
+                        "",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
                   ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "SourisSurObjet"
-                  },
-                  "parameters": [
-                    "Paste",
-                    "",
-                    "",
-                    ""
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Clipboard::WriteText"
+                      },
+                      "parameters": [
+                        "",
+                        "P2P::GetID()",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
                   ],
-                  "subInstructions": []
+                  "events": []
                 },
                 {
-                  "type": {
-                    "inverted": false,
-                    "value": "SourisBouton"
-                  },
-                  "parameters": [
-                    "",
-                    "Left"
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "SourisSurObjet"
+                      },
+                      "parameters": [
+                        "Paste",
+                        "",
+                        "",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
                   ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "BuiltinCommonInstructions::Once"
-                  },
-                  "parameters": [],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TextEntryObject::String"
-                  },
-                  "parameters": [
-                    "idEntry",
-                    "+",
-                    "Clipboard::ReadText()"
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "TextEntryObject::String"
+                      },
+                      "parameters": [
+                        "idEntry",
+                        "+",
+                        "Clipboard::ReadText()"
+                      ],
+                      "subInstructions": []
+                    }
                   ],
-                  "subInstructions": []
+                  "events": []
                 }
-              ],
-              "events": []
+              ]
             }
           ],
           "parameters": []
@@ -1330,7 +1347,7 @@
                   "parameters": [
                     "ErrorText",
                     "=",
-                    "P2P::GetError()"
+                    "P2P::GetLastError()"
                   ],
                   "subInstructions": []
                 }
@@ -1391,7 +1408,7 @@
         "gridWidth": 32,
         "snap": true,
         "windowMask": false,
-        "zoomFactor": 0.7384
+        "zoomFactor": 0.6496
       },
       "objectsGroups": [],
       "variables": [],
@@ -1769,6 +1786,17 @@
                     {
                       "type": {
                         "inverted": false,
+                        "value": "SourisBouton"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
                         "value": "SourisSurObjet"
                       },
                       "parameters": [
@@ -1776,17 +1804,6 @@
                         "",
                         "",
                         ""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisBouton"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
                       ],
                       "subInstructions": []
                     },
@@ -1806,6 +1823,14 @@
                   ]
                 }
               ]
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::Once"
+              },
+              "parameters": [],
+              "subInstructions": []
             }
           ],
           "actions": [
@@ -1817,18 +1842,6 @@
               "parameters": [
                 "\"Chat\"",
                 "\"\""
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "Scene"
-              },
-              "parameters": [
-                "idEntry.String()",
-                "\"Chat\"",
-                ""
               ],
               "subInstructions": []
             }
@@ -1868,6 +1881,17 @@
                     {
                       "type": {
                         "inverted": false,
+                        "value": "SourisBouton"
+                      },
+                      "parameters": [
+                        "",
+                        "Left"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
                         "value": "SourisSurObjet"
                       },
                       "parameters": [
@@ -1875,17 +1899,6 @@
                         "",
                         "",
                         ""
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "SourisBouton"
-                      },
-                      "parameters": [
-                        "",
-                        "Left"
                       ],
                       "subInstructions": []
                     },
@@ -1905,6 +1918,14 @@
                   ]
                 }
               ]
+            },
+            {
+              "type": {
+                "inverted": false,
+                "value": "BuiltinCommonInstructions::Once"
+              },
+              "parameters": [],
+              "subInstructions": []
             }
           ],
           "actions": [
@@ -1916,18 +1937,6 @@
               "parameters": [
                 "\"SyncBtns\"",
                 "\"\""
-              ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "Scene"
-              },
-              "parameters": [
-                "idEntry.String()",
-                "\"SynchronisedCheckBox\"",
-                ""
               ],
               "subInstructions": []
             }
@@ -1970,6 +1979,17 @@
             {
               "type": {
                 "inverted": false,
+                "value": "P2P::SendToAll"
+              },
+              "parameters": [
+                "\"Chat\"",
+                "\"\""
+              ],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
                 "value": "Scene"
               },
               "parameters": [
@@ -2000,6 +2020,17 @@
             }
           ],
           "actions": [
+            {
+              "type": {
+                "inverted": false,
+                "value": "P2P::SendToAll"
+              },
+              "parameters": [
+                "\"SyncBtns\"",
+                "\"\""
+              ],
+              "subInstructions": []
+            },
             {
               "type": {
                 "inverted": false,
@@ -2075,7 +2106,7 @@
         "gridWidth": 32,
         "snap": true,
         "windowMask": false,
-        "zoomFactor": 0.8024
+        "zoomFactor": 0.5144
       },
       "objectsGroups": [],
       "variables": [],
@@ -2359,6 +2390,14 @@
             {
               "type": {
                 "inverted": false,
+                "value": "BuiltinCommonInstructions::Once"
+              },
+              "parameters": [],
+              "subInstructions": []
+            },
+            {
+              "type": {
+                "inverted": false,
                 "value": "SourisSurObjet"
               },
               "parameters": [
@@ -2367,14 +2406,6 @@
                 "",
                 ""
               ],
-              "subInstructions": []
-            },
-            {
-              "type": {
-                "inverted": false,
-                "value": "BuiltinCommonInstructions::Once"
-              },
-              "parameters": [],
               "subInstructions": []
             }
           ],
@@ -2456,23 +2487,23 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "AnimationName"
-                  },
-                  "parameters": [
-                    "checkbox",
-                    "\"unchecked\""
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
                     "value": "VarScene"
                   },
                   "parameters": [
                     "temp",
                     "=",
                     "0"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "AnimationName"
+                  },
+                  "parameters": [
+                    "checkbox",
+                    "\"unchecked\""
                   ],
                   "subInstructions": []
                 }
@@ -2532,7 +2563,7 @@
               },
               "parameters": [
                 "\"check\"",
-                "yes"
+                "no"
               ],
               "subInstructions": []
             },
@@ -2577,7 +2608,7 @@
               },
               "parameters": [
                 "\"uncheck\"",
-                "yes"
+                "no"
               ],
               "subInstructions": []
             },
@@ -2673,7 +2704,12 @@
         "zoomFactor": 0.9168
       },
       "objectsGroups": [],
-      "variables": [],
+      "variables": [
+        {
+          "name": "textBox",
+          "value": "~~Begin of conversation~~"
+        }
+      ],
       "instances": [
         {
           "angle": 0,
@@ -2973,45 +3009,13 @@
       ],
       "events": [
         {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "DepartScene"
-              },
-              "parameters": [
-                ""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "actions": [
-            {
-              "type": {
-                "inverted": false,
-                "value": "ModVarSceneTxt"
-              },
-              "parameters": [
-                "textBox",
-                "=",
-                "\"~~Begin of conversation~~\""
-              ],
-              "subInstructions": []
-            }
-          ],
-          "events": []
-        },
-        {
           "colorB": 228,
           "colorG": 176,
           "colorR": 74,
           "creationTime": 0,
           "disabled": false,
           "folded": true,
-          "name": "UI Handling",
+          "name": "Sending messages",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
           "events": [
@@ -3123,6 +3127,17 @@
                         {
                           "type": {
                             "inverted": false,
+                            "value": "SourisBouton"
+                          },
+                          "parameters": [
+                            "",
+                            "Left"
+                          ],
+                          "subInstructions": []
+                        },
+                        {
+                          "type": {
+                            "inverted": false,
                             "value": "SourisSurObjet"
                           },
                           "parameters": [
@@ -3132,31 +3147,28 @@
                             ""
                           ],
                           "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "SourisBouton"
-                          },
-                          "parameters": [
-                            "",
-                            "Left"
-                          ],
-                          "subInstructions": []
                         }
                       ]
                     }
                   ]
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "BuiltinCommonInstructions::Once"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
                 }
               ],
               "actions": [
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ModVarSceneTxt"
+                    "value": "TextObject::String"
                   },
                   "parameters": [
-                    "textBox",
+                    "ChatBox",
                     "+",
                     "NewLine() + \"You: \" + Sanitizer::removeNewLines(Entry.String())"
                   ],
@@ -3187,7 +3199,68 @@
                 }
               ],
               "events": []
-            },
+            }
+          ],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": false,
+          "name": "Receiving messages",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "P2P::OnEvent"
+                  },
+                  "parameters": [
+                    "\"message\"",
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "ChatBox",
+                    "+",
+                    "NewLine() + \"Other: \" + Sanitizer::removeNewLines(P2P::GetEventData(\"message\"))"
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": []
+        },
+        {
+          "colorB": 228,
+          "colorG": 176,
+          "colorR": 74,
+          "creationTime": 0,
+          "disabled": false,
+          "folded": true,
+          "name": "UI",
+          "source": "",
+          "type": "BuiltinCommonInstructions::Group",
+          "events": [
             {
               "disabled": false,
               "folded": false,
@@ -3225,95 +3298,12 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "ModVarSceneTxt"
-                  },
-                  "parameters": [
-                    "textBox",
-                    "=",
-                    "Sanitizer::removeFirstLine(VariableString(textBox))"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Handle ChatBox",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
                     "value": "TextObject::String"
                   },
                   "parameters": [
                     "ChatBox",
                     "=",
-                    "VariableString(textBox)"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            }
-          ],
-          "parameters": []
-        },
-        {
-          "colorB": 228,
-          "colorG": 176,
-          "colorR": 74,
-          "creationTime": 0,
-          "disabled": false,
-          "folded": true,
-          "name": "Incoming Message Handling",
-          "source": "",
-          "type": "BuiltinCommonInstructions::Group",
-          "events": [
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "P2P::OnEvent"
-                  },
-                  "parameters": [
-                    "\"message\"",
-                    ""
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "ModVarSceneTxt"
-                  },
-                  "parameters": [
-                    "textBox",
-                    "+",
-                    "NewLine() + \"Other: \" + Sanitizer::removeNewLines(P2P::GetEventData(\"message\"))"
+                    "Sanitizer::removeFirstLine(EntryText.String())"
                   ],
                   "subInstructions": []
                 }
@@ -3580,15 +3570,54 @@
   ],
   "eventsFunctionsExtensions": [
     {
-      "author": "@Bouh",
-      "description": "Expression returning the content of the clipboard. Works only on Windows, macOS and Linux (not on iOS/Android or web games).",
+      "author": "@Bouh, @arthuro555",
+      "description": "This extension adds tools to access the clipboard. It only works on Windows, macOS, Linux and web browsers.",
       "extensionNamespace": "",
       "fullName": "Clipboard",
+      "helpPath": "",
+      "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNsaXBib2FyZC10ZXh0LW11bHRpcGxlLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNCA3VjIxSDE4VjIzSDRDMi45IDIzIDIgMjIuMSAyIDIxVjdINE0yMCAzQzIxLjEgMyAyMiAzLjkgMjIgNVYxN0MyMiAxOC4xIDIxLjEgMTkgMjAgMTlIOEM2LjkgMTkgNiAxOC4xIDYgMTdWNUM2IDMuOSA2LjkgMyA4IDNIMTEuMThDMTEuNiAxLjg0IDEyLjcgMSAxNCAxQzE1LjMgMSAxNi40IDEuODQgMTYuODIgM0gyME0xNCAzQzEzLjQ1IDMgMTMgMy40NSAxMyA0QzEzIDQuNTUgMTMuNDUgNSAxNCA1QzE0LjU1IDUgMTUgNC41NSAxNSA0QzE1IDMuNDUgMTQuNTUgMyAxNCAzTTEwIDdWNUg4VjE3SDIwVjVIMThWN00xNSAxNUgxMFYxM0gxNU0xOCAxMUgxMFY5SDE4VjExWiIgLz48L3N2Zz4=",
       "name": "Clipboard",
-      "shortDescription": "Expression returning the content of the clipboard. Works only on Windows, macOS and Linux (not on iOS/Android or web games).",
-      "tags": "clipboard, pasteboard",
-      "version": "0.0.1",
+      "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/clipboard-text-multiple-outline.svg",
+      "shortDescription": "Expression returning the content of the clipboard.",
+      "version": "0.0.2",
+      "tags": [
+        "clipboard",
+        "pasteboard",
+        "paste",
+        "write"
+      ],
       "eventsFunctions": [
+        {
+          "description": "Read the text from the clipboard asynchronously. As this is \"asynchronous\", this means that the variable won't be immediately filled with the text from the clipboard. Instead, it will be filled a few milliseconds later.\n\nNote also that on some platforms (like on web browsers), the user will be asked for permissions to read from the clipboard.\n\nThis only works on Windows, macOS, Linux and web browsers.",
+          "fullName": "Get text from the clipboard (Windows, macOS, Linux, web browser)",
+          "functionType": "Action",
+          "name": "ReadTextCrossPlaform",
+          "sentence": "Read clipboard and store text in _PARAM1_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::JsCode",
+              "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst callback =\n    runtimeScene\n        .getVariables()\n        .get(eventsFunctionContext.getArgument(\"callback\"));\n\nif (electron !== null && electron.clipboard)\n    callback.setString(electron.clipboard.readText());\nelse if (\n    typeof navigator !== \"undefined\" &&\n    navigator.clipboard &&\n    navigator.clipboard.readText\n) {\n    navigator.clipboard.readText()\n        .then(text => callback.setString(text))\n        .catch(err =>\n            console.error(\"Error occured while getting clipboard content: \", err.message)\n        );\n} else console.error(\"Unable to read from the clipboard: no method found for this platform.\")\n",
+              "parameterObjects": "",
+              "useStrict": true,
+              "eventsSheetExpanded": false
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Callback variable where to store the result",
+              "longDescription": "",
+              "name": "callback",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "string"
+            }
+          ],
+          "objectGroups": []
+        },
         {
           "description": "Read the text from the clipboard (Windows, macOS, Linux only)",
           "fullName": "Get text from the clipboard (Windows, macOS, Linux)",
@@ -3599,18 +3628,34 @@
             {
               "disabled": false,
               "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "This is here for retrocompatibility. Try to use the asynchronous readTextCrossPlatform action instead.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
               "type": "BuiltinCommonInstructions::JsCode",
-              "inlineCode": "var electron = runtimeScene.getGame().getRenderer().getElectron();\nif (!electron || !electron.clipboard) {\n    return;\n}\neventsFunctionContext.returnValue = electron.clipboard.readText();\n",
+              "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nif (electron && electron.clipboard) eventsFunctionContext.returnValue = electron.clipboard.readText();\n",
               "parameterObjects": "",
-              "useStrict": true
+              "useStrict": true,
+              "eventsSheetExpanded": false
             }
           ],
           "parameters": [],
           "objectGroups": []
         },
         {
-          "description": "Write the text in the clipboard (Windows, macOS, Linux only)",
-          "fullName": "Write text to the clipboard (Windows, macOS, Linux)",
+          "description": "Write the text in the clipboard (Windows, macOS, Linux, web browser only)",
+          "fullName": "Write text to the clipboard (Windows, macOS, Linux, web browser)",
           "functionType": "Action",
           "name": "WriteText",
           "sentence": "Write _PARAM1_ to clipboard",
@@ -3619,9 +3664,10 @@
               "disabled": false,
               "folded": false,
               "type": "BuiltinCommonInstructions::JsCode",
-              "inlineCode": "var electron = runtimeScene.getGame().getRenderer().getElectron();\nif (!electron || !electron.clipboard) {\n    return;\n}\nelectron.clipboard.writeText(eventsFunctionContext.getArgument(\"text\"));\n",
+              "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst text = eventsFunctionContext.getArgument(\"text\");\n\nif (electron !== null && electron.clipboard)\n  electron.clipboard.writeText(text);\nif (\n  typeof navigator !== \"undefined\" &&\n  navigator.clipboard &&\n  navigator.clipboard.writeText\n) navigator.clipboard\n  .writeText(text)\n  .catch(e => console.error(\"Error while writing clipboard: \", e));\nelse console.error(\"Unable to write to the clipboard: no method found for this platform.\"); \n",
               "parameterObjects": "",
-              "useStrict": true
+              "useStrict": true,
+              "eventsSheetExpanded": false
             }
           ],
           "parameters": [
@@ -3646,10 +3692,17 @@
       "description": "Have multiple expressions that remove unwanted characters from a string (non-alphanumerical characters, new Lines...)",
       "extensionNamespace": "",
       "fullName": "Sanitizer",
+      "helpPath": "",
+      "iconUrl": "",
       "name": "Sanitizer",
+      "previewIconUrl": "",
       "shortDescription": "Removes unwanted text from strings",
-      "tags": "sanitization, string, string manipulation",
       "version": "1.0.0",
+      "tags": [
+        "sanitization",
+        "string",
+        "string manipulation"
+      ],
       "eventsFunctions": [
         {
           "description": "Removes every non-alphanumerical characters of a string.",
@@ -3679,7 +3732,8 @@
               "type": "BuiltinCommonInstructions::JsCode",
               "inlineCode": "eventsFunctionContext.returnValue = eventsFunctionContext.getArgument(\"text\").replace(/\\W/g, '');",
               "parameterObjects": "",
-              "useStrict": true
+              "useStrict": true,
+              "eventsSheetExpanded": false
             }
           ],
           "parameters": [
@@ -3724,7 +3778,8 @@
               "type": "BuiltinCommonInstructions::JsCode",
               "inlineCode": "eventsFunctionContext.returnValue = eventsFunctionContext.getArgument(\"text\").substring(0, eventsFunctionContext.getArgument(\"size\"));",
               "parameterObjects": "",
-              "useStrict": true
+              "useStrict": true,
+              "eventsSheetExpanded": false
             }
           ],
           "parameters": [
@@ -3779,7 +3834,8 @@
               "type": "BuiltinCommonInstructions::JsCode",
               "inlineCode": "eventsFunctionContext.returnValue = eventsFunctionContext.getArgument(\"text\").replace(/\\r?\\n|\\r/g, ' ');",
               "parameterObjects": "",
-              "useStrict": true
+              "useStrict": true,
+              "eventsSheetExpanded": false
             }
           ],
           "parameters": [
@@ -3809,7 +3865,8 @@
               "type": "BuiltinCommonInstructions::JsCode",
               "inlineCode": "eventsFunctionContext.returnValue = eventsFunctionContext.getArgument(\"text\").split(/\\r\\n|\\r|\\n/).length;",
               "parameterObjects": "",
-              "useStrict": true
+              "useStrict": true,
+              "eventsSheetExpanded": false
             }
           ],
           "parameters": [
@@ -3854,7 +3911,8 @@
               "type": "BuiltinCommonInstructions::JsCode",
               "inlineCode": "eventsFunctionContext.returnValue = eventsFunctionContext.getArgument(\"text\").substring(eventsFunctionContext.getArgument(\"text\").indexOf(\"\\n\") + 1);",
               "parameterObjects": "",
-              "useStrict": true
+              "useStrict": true,
+              "eventsSheetExpanded": false
             }
           ],
           "parameters": [


### PR DESCRIPTION
- Use a FIFO instead of LIFO "queue" in the no dataloss mode
- Use a class with a nice to use API instead of multiple global objects
- Improve typing
- Overall simplification of some code and improvements in code readability
- Optimisation of the events of the p2p example to be a better example

The changes have been tested on the p2p example and the default broker which worked flawlessly.