### PR TITLE
Fixes important .md files.

### DIFF
--- a/.github/ISSUE_TEMPLATE/--feature-request.md
+++ b/.github/ISSUE_TEMPLATE/--feature-request.md
@@ -1,28 +1,31 @@
 ---
 name: "\U0001F4A1Feature request"
-about: Suggest an idea for this project AFTER discussing about it on the Discord or
-  Forum first. We'll create a card for it on the roadmap.
-
+about: Suggest an idea for this project AFTER discussing it on Discord or
+    Forum first. We'll create a card for it on the roadmap.
 ---
 
 BEFORE opening a new feature request, please make sure that you:
- * Discussed about it on the discord or the forum,
- * There is not already a suggestion about it in the issues or in the roadmap: https://trello.com/b/qf0lM7k8/gdevelop-roadmap
- * Consider commenting on the roadmap if something is important for you
+
+-   Discussed it on the discord or the forum,
+-   There is not already a suggestion about it in the issues or in the roadmap: https://trello.com/b/qf0lM7k8/gdevelop-roadmap
+-   Consider commenting on the roadmap if something is important for you
 
 AFTER opening the feature request, the issue will be closed by a maintainer (@4ian or someone else) and a card will be added in the roadmap if it's relevant and does not exist yet :)
 
 ## Description
+
 Is your feature request **related to a problem**? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Solution suggested
+
 **Describe the solution**
 A clear and concise description of what could be done.
 
 Add any other context or screenshots about the feature request here.
 
-Explain if you can help implementing the solution.
+Explain if you can help to implement the solution.
 
 ## Alternatives considered
+
 A clear and concise description of any alternative solutions or features you've considered.

--- a/Core/GDevelop-Architecture-Overview.md
+++ b/Core/GDevelop-Architecture-Overview.md
@@ -2,14 +2,14 @@
 
 GDevelop is architectured around a `Core` library, platforms (`GDJS`, `GDCpp`) and extensions (`Extensions` folder). The editor (`newIDE` folder) is using all of these libraries. This is a recap table of the main folders:
 
-| Directory | ℹ️ Description |
-| --- | --- |
-| `Core` | GDevelop core library, containing common tools to implement the IDE and work with GDevelop games. |
-| `GDCpp` | The C++ game engine, used to build native games (*not used in GDevelop 5*). |
-| `GDJS` | The game engine, written in TypeScript, using PixiJS (WebGL), powering all GDevelop games. |
+| Directory     | ℹ️ Description                                                                                        |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `Core`        | GDevelop core library, containing common tools to implement the IDE and work with GDevelop games.     |
+| `GDCpp`       | The C++ game engine, used to build native games (_not used in GDevelop 5_).                           |
+| `GDJS`        | The game engine, written in TypeScript, using PixiJS (WebGL), powering all GDevelop games.            |
 | `GDevelop.js` | Bindings of `Core`/`GDCpp`/`GDJS` and `Extensions` to JavaScript (with WebAssembly), used by the IDE. |
-| `newIDE` | The game editor, written in JavaScript with React, Electron and PixiJS. |
-| `Extensions` | Extensions for the game engine, providing objects, behaviors, events and new features. |
+| `newIDE`      | The game editor, written in JavaScript with React, Electron and PixiJS.                               |
+| `Extensions`  | Extensions for the game engine, providing objects, behaviors, events and new features.                |
 
 The rest of this page is an introduction to the main concepts of GDevelop architecture.
 
@@ -17,41 +17,41 @@ The rest of this page is an introduction to the main concepts of GDevelop archit
 
 **IDE** stands for "Integrated Development Environment". A synonym for it is also simply "editor". In GDevelop, the software itself, that is used to create games and running as an app or a web-app, is called the "GDevelop Editor" or the "GDevelop IDE"
 
-> This term "IDE" is also used in some folders. When you browse `Core`, `GDCpp` or `GDJS` subfolders, some folders are called `IDE`. They contain classes and tools that are **only useful for the editor** (they are not per se mandatory to describe the structure of a game).
+> The term "IDE" is also used in some folders. When you browse `Core`, `GDCpp` or `GDJS` subfolders, some folders are called `IDE`. They contain classes and tools that are **only useful for the editor** (they are not per se mandatory to describe the structure of a game).
 
-**Runtime** is a word used to describe classes, tools and source files being used during a game. This could also be called "in game" or a "game engine".
+**Runtime** is a word used to describe classes, tools and source files being used during a game. This could also be called "in-game" or a "game engine".
 
 > When you browse `GDCpp` or `GDJS` subfolders, you can find folders called `Runtime`. They contain the **game engine** of GDevelop.
 
 Extensions do have the same distinction between the "**IDE**" part and the "**Runtime**" part. For example, most extensions have:
 
-* A file called [`JsExtension.js`(https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/JsExtension.js)], which contains the *declaration* of the extension for the **IDE**
-* One or more files implementing the feature for the game, in other words for **Runtime**. This can be a [Runtime Object](https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/dummyruntimeobject.ts) or a [Runtime Behavior](https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/dummyruntimebehavior.ts), [functions called by actions or conditions](https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/examplejsextensiontools.ts) or by the game engine.
+-   A file called [`JsExtension.js`(https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/JsExtension.js)], which contains the _declaration_ of the extension for the **IDE**
+-   One or more files implementing the feature for the game, in other words for **Runtime**. This can be a [Runtime Object](https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/dummyruntimeobject.ts) or a [Runtime Behavior](https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/dummyruntimebehavior.ts), [functions called by actions or conditions](https://github.com/4ian/GDevelop/blob/master/Extensions/ExampleJsExtension/examplejsextensiontools.ts) or by the game engine.
 
 ### "Runtime" and "IDE" difference using an example: the `gd::Variable` class
 
 In GDevelop, developers can associate and manipulate variables in their games. To represent them, we have two things:
 
-* The **editor** `gd::Variable` that is part of the structure of the game, so living in [GDCore in Variable.h](https://4ian.github.io/GD-Documentation/GDCore%20Documentation/classgd_1_1_variable.html). This is what is shown in the editor, saved on disk in the project file.
-* The **game engine** variable, called `gdjs.Variable` in GDJS. [Documentation is in the GDJS **game engine**](https://docs.gdevelop-app.com/GDJS%20Runtime%20Documentation/Variable.html). This JavaScript class is what is used during a game.
+-   The **editor** `gd::Variable` that is part of the structure of the game, so living in [GDCore in Variable.h](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_variable.html). This is what is shown in the editor, saved on disk in the project file.
+-   The **game engine** variable, called `gdjs.Variable` in GDJS. [Documentation is in the GDJS **game engine**](https://docs.gdevelop-app.com/GDJS%20Runtime%20Documentation/Variable.html). This JavaScript class is what is used during a game.
 
 The editor `gd::Variable` **knows nothing** about the game engine class `gdjs.Variable`. And the `gdjs.Variable` class in the game engine knows almost nothing from `gd::Variable` (apart from how it's written in JSON, to be able to load a game default variables).
 
-> Note that the name `gdjs.Variable` is maybe a *bad decision*: it should have been called a `gdjs.RuntimeVariable`, like `gdjs.RuntimeObject` and like most other classes of the game engine.
+> Note that the name `gdjs.Variable` is maybe a _bad decision_: it should have been called a `gdjs.RuntimeVariable`, like `gdjs.RuntimeObject` and like most other classes of the game engine.
 
 ## What's inside "Core" (`GDCore` folder)?
 
-GDevelop "Core" is basically containing everything that is used to **describe and manipulate the structure of a game** (called a `Project` internally). This includes events, scenes, objects, behaviors, events etc... All of these are implemented using C++ classes, in [this folder named `Project`](https://github.com/4ian/GDevelop/tree/master/Core/GDCore/Project).
+GDevelop "Core" is basically containing everything that is used to **describe and manipulate the structure of a game** (called a `Project` internally). This includes events, scenes, objects, behaviors, events, etc... All of these are implemented using C++ classes, in [this folder named `Project`](https://github.com/4ian/GDevelop/tree/master/Core/GDCore/Project).
 
-GDevelop "Core" also contains **tools** to manipulate these `Project`. In particular, `Core/GDCore/IDE` folder is containing C++ classes allowing to do operations on the structure of a game. For example, [WholeProjectRefactorer](https://github.com/4ian/GDevelop/blob/master/Core/GDCore/IDE/WholeProjectRefactorer.cpp) is a very powerful tool, used to rename all objects in a game, update events after an object is deleted and more generally do Project wide refactoring. The directory contains other "tool" functions to manipulate [resources of projects](https://github.com/4ian/GDevelop/tree/master/Core/GDCore/IDE/Project) or do [search in events](https://github.com/4ian/GDevelop/tree/master/Core/GDCore/IDE/Events).
+GDevelop "Core" also contains **tools** to manipulate these `Project`. In particular, `Core/GDCore/IDE` folder is containing C++ classes allowing to do operations on the structure of a game. For example, [WholeProjectRefactorer](https://github.com/4ian/GDevelop/blob/master/Core/GDCore/IDE/WholeProjectRefactorer.cpp) is a very powerful tool, used to rename all objects in a game, update events after an object is deleted, and more generally do Project-wide refactoring. The directory contains other "tool" functions to manipulate the [resources of projects](https://github.com/4ian/GDevelop/tree/master/Core/GDCore/IDE/Project) or do a [search in events](https://github.com/4ian/GDevelop/tree/master/Core/GDCore/IDE/Events).
 
 ## What's inside GDJS? Why do I see some C++ file there?
 
 While `GDJS/Runtime` folder is the game engine that is executed inside a game, `GDJS/GDJS` is the "IDE" part, which are the C++ classes describing to the editor various things like:
 
-* How [do you do an export](https://github.com/4ian/GDevelop/tree/master/GDJS/GDJS/IDE),
-* What are [the default extensions](https://github.com/4ian/GDevelop/tree/master/GDJS/GDJS/Extensions/Builtin),
-* How do you [generate JS code from events](https://github.com/4ian/GDevelop/tree/master/GDJS/GDJS/Events/CodeGeneration),
+-   How [do you do an export](https://github.com/4ian/GDevelop/tree/master/GDJS/GDJS/IDE),
+-   What are [the default extensions](https://github.com/4ian/GDevelop/tree/master/GDJS/GDJS/Extensions/Builtin),
+-   How do you [generate JS code from events](https://github.com/4ian/GDevelop/tree/master/GDJS/GDJS/Events/CodeGeneration),
 
 The game engine is in GDJS/Runtime and is all written in TypeScript.
 
@@ -60,9 +60,9 @@ The game engine is in GDJS/Runtime and is all written in TypeScript.
 An "**event**" is by default something that [is mostly empty](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_base_event.html). In a more traditional programming language, an event can be seen as a scope or block (example: `{ some code here }` in a C style language like JavaScript, Java or C++).
 
 [Default events are defined](https://github.com/4ian/GDevelop/tree/master/Core/GDCore/Events/Builtin) in GDevelop Core.
-In particular, there is StandardEvent, which has conditions and actions. Conditions and actions are both a list of [`gd::Instruction`](https://4ian.github.io/GD-Documentation/GDCore%20Documentation/classgd_1_1_instruction.html). A `gd::Instruction` is either a condition or an action (it depends only on the context where they are used).
+In particular, there is StandardEvent, which has conditions and actions. Conditions and actions are both a list of [`gd::Instruction`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_instruction.html). A `gd::Instruction` is either a condition or an action (it depends only on the context where they are used).
 
-A `gd::Instruction` is "just" a type (the name of the action or condition), and some parameters. You can think of it as a function in a programming language (`add(2, 3)` is calling a function called "add" with parameter "2" and "3"). Conditions have the special thing that they are functions returning true or false (and potentially being used to do filter on the objects being picked for next conditions and actions).
+A `gd::Instruction` is "just" a type (the name of the action or condition), and some parameters. You can think of it as a function in a programming language (`add(2, 3)` is calling a function called "add" with parameters "2" and "3"). Conditions have the special thing that they are functions returning true or false (and potentially being used to do a filter on the objects being picked for next conditions and actions).
 
 ### Why can't I see any "RuntimeEvent" or events during the game?
 
@@ -70,39 +70,39 @@ They do not exist anymore! ✨
 
 Events are translated (we also say "transpiled" or "generated") into "real" code in a programming language. This process is called "Code Generation", and is [done here for the TypeScript game engine](https://github.com/4ian/GDevelop/tree/master/GDJS/GDJS/Events/CodeGeneration).
 
-### Can I extract Events classes and code generator to make a development environment based on GDevelop events?
+### Can I extract Events classes and a code generator to make a development environment based on GDevelop events?
 
 You're welcome to do so! Please get in touch :)
 
 ## I can see more than one Extensions folder, why?
 
-The idea of GDevelop editor and game engine is to have a lean game engine, supporting almost nothing. Then, one can add "mods", "plugins", "modules" for GDevelop. We chose to call them "**Extensions**" in GDevelop.
+The idea of the GDevelop editor and game engine is to have a lean game engine, supporting almost nothing. Then, one can add "mods", "plugins", "modules" for GDevelop. We chose to call them "**Extensions**" in GDevelop.
 
-* `GDevelop/Core/GDCore/Extensions` is the **declaration** of default (we say "builtin") extensions, that are available for any game and are "mandatory". They are called Extensions but they could be named "Extensions that will always be in your game". In programming languages, this is called a "[Standard Library](https://en.wikipedia.org/wiki/Standard_library)" (but don't get too distracted by this naming).
-* `GDevelop/GDJS/GDJS/Extensions/` and `GDevelop/GDCpp/GDCpp/Extensions/` are reusing these **declarations** and **adding** their own declarations. Mainly, they are setting the name of the functions to be called (either in TypeScript or in C++) for each action, condition or expression.
-* `GDevelop/Extensions/` is the folder for the "mods"/"plugins" for GDevelop - the one that are not mandatory. They are not part of GDCore - they work on their own.
+-   `GDevelop/Core/GDCore/Extensions` is the **declaration** of default (we say "builtin") extensions, that are available for any game and are "mandatory". They are called Extensions but they could be named "Extensions that will always be in your game". In programming languages, this is called a "[Standard Library](https://en.wikipedia.org/wiki/Standard_library)" (but don't get too distracted by this naming).
+-   `GDevelop/GDJS/GDJS/Extensions/` and `GDevelop/GDCpp/GDCpp/Extensions/` are reusing these **declarations** and **adding** their own declarations. Mainly, they are setting the name of the functions to be called (either in TypeScript or in C++) for each action, condition or expression.
+-   `GDevelop/Extensions/` is the folder for the "mods"/"plugins" for GDevelop - the ones that are not mandatory. They are not part of GDCore - they work on their own.
 
-> In theory, all extensions could be moved to `GDevelop/Extensions/`. In practice, it's more pragmatic to have a set of "builtin" extensions with basic features.
+> In theory, all extensions could be moved to `GDevelop/Extensions/`. In practice, it's more pragmatic to have a set of "built-in" extensions with basic features.
 
 ## What's GDevelop.js? Do we care about this?
 
-Everything in GDevelop.js is meant to create a "bridge" allowing to run and use C++ from JavaScript for the **IDE**, so that [we can write an editor entirely in JavaScript](https://github.com/4ian/GDevelop/tree/master/newIDE) and have it working in a web browser.
+Everything in GDevelop.js is meant to create a "bridge" allowing us to run and use C++ from JavaScript for the **IDE** so that [we can write an editor entirely in JavaScript](https://github.com/4ian/GDevelop/tree/master/newIDE) and have it working in a web browser.
 
-* We're using Emscripten which is compiling C++, but instead of writing a "native binary", it's writing a file that works in a browser (basically, JavaScript!).
+-   We're using Emscripten which is compiling C++, but instead of writing a "native binary", it's writing a file that works in a browser (basically, JavaScript!).
 
-* The most useful file is [Bindings.idl](https://github.com/4ian/GDevelop/blob/master/GDevelop.js/Bindings/Bindings.idl) that is describing everything in C++ that must be exposed to JavaScript (in the editor, not in game. Remember that during the game, we're at **Runtime**, so all of this does not exist anymore)
+-   The most useful file is [Bindings.idl](https://github.com/4ian/GDevelop/blob/master/GDevelop.js/Bindings/Bindings.idl) that is describing everything in C++ that must be exposed to JavaScript (in the editor, not in-game. Remember that during the game, we're at **Runtime**, so all of this does not exist anymore)
 
-* Rest of the files are mostly bridges doing "weird stuff" to translate from JS to C++ or vice versa. It requires a bit of knowledge about how the ["bridge", made by Emscripten, called WebIDL](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html) is working.
+-   The rest of the files are mostly bridges doing "weird stuff" to translate from JS to C++ or vice versa. It requires a bit of knowledge about how the ["bridge", made by Emscripten, called WebIDL](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html) is working.
 
-  You don't need to work with these unless you want to expose something that is written in C++ to the editor, and writing the interface in Bindings.idl is not sufficient.
+    You don't need to work with these unless you want to expose something that is written in C++ to the editor, and writing the interface in Bindings.idl is not sufficient.
 
-90% of the time, you can just read or write about a class in [Bindings.idl](https://github.com/4ian/GDevelop/blob/master/GDevelop.js/Bindings/Bindings.idl). If you work in C++ classes, you may have sometime to add a header file in Wrapper.cpp and your C++ class is "automagically" compiled and available in JavaScript after writing the corresponding interface in Bindings.idl.
+90% of the time, you can just read or write about a class in [Bindings.idl](https://github.com/4ian/GDevelop/blob/master/GDevelop.js/Bindings/Bindings.idl). If you work in C++ classes, you may have some time to add a header file in Wrapper.cpp, and your C++ class is "automagically" compiled and available in JavaScript after writing the corresponding interface in Bindings.idl.
 
 ### I want all the gory details about GDevelop.js 🧐
 
 All the required C++ files are imported into this huge list: https://github.com/4ian/GDevelop/blob/master/GDevelop.js/Bindings/Wrapper.cpp#L1-L79. C++ compilation is done with a "build system" called CMake, which is using [this file](https://github.com/4ian/GDevelop/blob/master/GDevelop.js/CMakeLists.txt#L82-L101) to see what to compile.
 
-> In an ideal world, there would be something to do this automatically, so GDevelop.js folder would not even exist 😉
+> In an ideal world, there would be something to do this automatically, so the GDevelop.js folder would not even exist 😉
 > If you're interested and want to know more about GDevelop.js bridging between C++ and JavaScript, look at [this talk from GDevelop original author](https://www.youtube.com/watch?v=6La7jSCnYyk).
 
 ## Misc questions
@@ -113,10 +113,10 @@ GDevelop was originally written in C++. It's a scary language at first but is po
 
 ### What's the deal with JavaScript/TypeScript? Why so much of it?
 
-JavaScript, with the latest language proposals, is actually a very capable language, fast to write and safe with typing:
+JavaScript, with the latest language proposals, is a very capable language, fast to write and safe with typing:
 
-* Performance is getting pretty good with recent browsers JIT features.
-* Frontend frameworks like React, used for GDevelop IDE, allow for very fast and modular interface development.
-* The web is an incredible and unmatched target when it comes to cross platform (and cross form factor) apps.
+-   Performance is getting pretty good with recent browsers JIT features.
+-   Frontend frameworks like React, used for GDevelop IDE, allow for very fast and modular interface development.
+-   The web is an incredible and unmatched target when it comes to cross-platform (and cross-form factor) apps.
 
 More generally, the web is a great target for games with the rise of WebGL and WebAssembly - though GDevelop should stay modular to adapt to newer platforms for the exported games in the future.

--- a/Core/README.md
+++ b/Core/README.md
@@ -6,21 +6,20 @@ GDevelop Core is a portable C++ library, compiled to be used in JavaScript in th
 
 ## 1) Getting started 🤓
 
-First, take a look at the *Readme.md* at the root of the repository and the [developer documentation](https://docs.gdevelop-app.com/).
+First, take a look at the _Readme.md_ at the root of the repository and the [developer documentation](https://docs.gdevelop-app.com/).
 
 ## 2) How to contribute 😎
 
 Any contribution is welcome! Whether you want to submit a bug report, a feature request
 or any pull request so as to add a nice feature, do not hesitate to get in touch.
 
-* Check the [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
+-   Check [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
 
-* Follow the [Development](https://github.com/4ian/GDevelop/tree/master/newIDE#development) section of the README to set up GDevelop and start modifying either **the editor** or **[the game engine/extensions](https://github.com/4ian/GDevelop/tree/master/newIDE#development-of-the-game-engine-or-extensions)**.
+-   Follow the [Development](https://github.com/4ian/GDevelop/tree/master/newIDE#development) section of the README to set up GDevelop and start modifying either **the editor** or **[the game engine/extensions](https://github.com/4ian/GDevelop/tree/master/newIDE#development-of-the-game-engine-or-extensions)**.
 
-* To submit your changes, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
+-   To submit your changes, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
-License
--------
+## License
 
 GDevelop Core is distributed under the MIT license: see license.txt for
 more information.

--- a/Extensions/README.md
+++ b/Extensions/README.md
@@ -2,7 +2,7 @@
 
 These are the "official" extensions directly bundled with GDevelop.
 
-## Writing your own extensions or contributing to an existing one 😎
+## Writing your extensions or contributing to an existing one 😎
 
 Most extensions can be written in JavaScript.
 
@@ -10,5 +10,5 @@ Most extensions can be written in JavaScript.
 
 ## License
 
-  * Extensions are provided under the MIT License: see license.txt file.
-  * External libraries can be used by extensions (Box2D, Dlib or SPARK for example). See their licenses in their directories.
+- Extensions are provided under the MIT License: see license.txt file.
+- External libraries can be used by extensions (Box2D, Dlib or SPARK for example). See their licenses in their directories.

--- a/GDCpp/README.md
+++ b/GDCpp/README.md
@@ -1,31 +1,26 @@
-GDevelop C++ Platform (Native game engine)
-=========================
+# GDevelop C++ Platform (Native game engine)
 
-GDevelop C++ Platform (GDcpp) is a platform for developing *native games* with GDevelop.
+GDevelop C++ Platform (GDcpp) is a platform for developing _native games_ with GDevelop.
 
-Getting started
----------------
+## Getting started
 
-First, take a look at the *Readme.md* at the root of the repository and the [developer documentation](https://docs.gdevelop-app.com/).
+First, take a look at the _Readme.md_ at the root of the repository and the [developer documentation](https://docs.gdevelop-app.com/).
 
-This platform uses the same files for exposing its functionalities to the IDE and for the game engine. When compiled the game engine only, a define is set (*GD_IDE_ONLY*). Look at the code using this define to check if the code will be included or not into the game engine:
+This platform uses the same files for exposing its functionalities to the IDE and for the game engine. When compiled the game engine only, a define is set (_GD_IDE_ONLY_). Look at the code using this define to check if the code will be included or not into the game engine:
 
     #if defined(GD_IDE_ONLY)
         //Code that will be only exposed to the IDE, and not compiled for games.
     #endif
     //Code that will be available for compiled games as well as when compiled for the IDE.
 
-
 The documentation of this specific platform and the game engine is available [here](https://docs.gdevelop-app.com/GDCpp%20Documentation).
 
-Contributing
-------------
+## Contributing
 
 Any contribution is welcome! Whether you want to submit a bug report, a feature request
 or any pull request so as to add a nice feature, do not hesitate to get in touch.
 
-License
--------
+## License
 
 GDevelop C++ Platform is distributed under the MIT license: See license.txt for
 more information.

--- a/GDJS/README.md
+++ b/GDJS/README.md
@@ -18,28 +18,28 @@ GDJS is composed of two parts:
 
 ### GDJS Runtime (game engine)
 
-The game engine is in the _Runtime_ folder. If you want to work on the engine directly, follow the [GDevelop 5 README about development of the game engine](https://github.com/4ian/GDevelop/blob/master/newIDE/README.md#development-of-the-game-engine).
+The game engine is in the _Runtime_ folder. If you want to work on the engine directly, follow the [GDevelop 5 README about the development of the game engine](https://github.com/4ian/GDevelop/blob/master/newIDE/README.md#development-of-the-game-engine).
 
-* To use the game engine, you can look into the **[GDJS Runtime (game engine) documentation](https://docs.gdevelop-app.com/GDJS%20Runtime%20Documentation)**.
+- To use the game engine, you can look into the **[GDJS Runtime (game engine) documentation](https://docs.gdevelop-app.com/GDJS%20Runtime%20Documentation)**.
 
-* To run tests for the game engine, go to `GDJS/tests`, run `npm install` and `npm test`. More information in the [README for the tests](https://github.com/4ian/GDevelop/tree/master/GDJS/tests).
+- To run tests for the game engine, go to `GDJS/tests`, run `npm install` and `npm test`. More information in the [README for the tests](https://github.com/4ian/GDevelop/tree/master/GDJS/tests).
 
-* To launch type checking with TypeScript, run `npm install` and `npm run check-types` in `GDJS` folder.
+- To launch type checking with TypeScript, run `npm install` and `npm run check-types` in `GDJS` folder.
 
 ### GDJS Platform (exporters, code generation...)
 
-Check the [GDJS Platform](https://docs.gdevelop-app.com/GDJS%20Documentation/index.html) documentation, or the [full GDevelop developers documentation](https://docs.gdevelop-app.com/).
+Check the [GDJS Platform](https://docs.gdevelop-app.com/GDJS%20Documentation/index.html) documentation or the [full GDevelop developers documentation](https://docs.gdevelop-app.com/).
 
 ## 3) How to contribute 😎
 
 Any contribution is welcome! Whether you want to submit a bug report, a feature request
 or any pull request to add a feature, do not hesitate to get in touch.
 
-* Check the [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
+- Check [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
 
-* Follow the [Development](https://github.com/4ian/GDevelop/tree/master/newIDE#development) section of the README to set up GDevelop and start modifying either **the editor** or **[the game engine/extensions](https://github.com/4ian/GDevelop/tree/master/newIDE#development-of-the-game-engine-or-extensions)**.
+- Follow the [Development](https://github.com/4ian/GDevelop/tree/master/newIDE#development) section of the README to set up GDevelop and start modifying either **the editor** or **[the game engine/extensions](https://github.com/4ian/GDevelop/tree/master/newIDE#development-of-the-game-engine-or-extensions)**.
 
-* To submit your changes, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
+- To submit your changes, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
 ## License
 

--- a/GDJS/docs/Readme.md
+++ b/GDJS/docs/Readme.md
@@ -1,6 +1,6 @@
 # GDJS Documentation
 
-📚 Read the documentation online: **[GDJS Runtime (game engine) documentation](http://4ian.github.io/GD-Documentation/GDJS%20Runtime%20Documentation/index.html)** or [GDJS Platform documentation for the IDE](http://4ian.github.io/GD-Documentation/GDJS%20Documentation/index.html).
+📚 Read the documentation online: **[GDJS Runtime (game engine) documentation](https://docs.gdevelop-app.com/GDJS%20Runtime%20Documentation/index.html)** or [GDJS Platform documentation for the IDE](https://docs.gdevelop-app.com/GDJS%20Documentation/index.html).
 
 ## How to generate the documentation
 
@@ -13,7 +13,7 @@
 
   Output will be in `<GDevelop repository>/docs/GDJS Documentation`.
 
-- To generate the GDJS Platform documentation for the IDE, install [Doxygen](www.doxygen.org). Then:
+- To generate the GDJS Platform documentation for the IDE, install [Doxygen](https://www.doxygen.nl/index.html). Then:
 
   ```bash
   cd <GDevelop repository>/GDJS/docs

--- a/GDJS/tests/README.md
+++ b/GDJS/tests/README.md
@@ -22,8 +22,8 @@ npm test:firefox #To run tests using Firefox
 
 Tests are launched using Chrome. You need Chrome installed to run them. You can change the browser by modifying the package.json "test" command and install the appropriate karma package.
 
-Tests are located in **tests** folder for the game engine, or directly in the folder of the tested extensions. 
+Tests are located in the **tests** folder for the game engine, or directly in the folder of the tested extensions.
 
-### Games in *games* folder
+### Games in the _games_ folder
 
-Games contained in *games* folder are mainly here to be launched manually in order to check that a particular feature is working. Read the comments in the events to see what is the expected behavior, or compare with the native platform if you can.
+Games contained in the _games_ folder are mainly here to be launched manually to check that a particular feature is working. Read the comments in the events to see what is the expected behavior, or compare with the native platform if you can.

--- a/GDevelop.js/Readme.md
+++ b/GDevelop.js/Readme.md
@@ -1,14 +1,14 @@
 # GDevelop.js
 
-This is the port of GDevelop core classes to JavaScript. This allow [GDevelop Core libraries](https://github.com/4ian/GDevelop) to run in a browser or on Node.js.
+This is the port of GDevelop core classes to JavaScript. This allows [GDevelop Core libraries](https://github.com/4ian/GDevelop) to run in a browser or on Node.js.
 
-> 🎮 GDevelop is a full featured, cross-platform, open-source game development software requiring no programming skills. Download it on [the official website](https://gdevelop-app.com).
+> 🎮 GDevelop is a full-featured, cross-platform, open-source game development software requiring no programming skills. Download it on [the official website](https://gdevelop-app.com).
 
 ## How to build
 
-> 👋 Usually if you're working on GDevelop editor or extensions in JavaScript, you don't need rebuilding GDevelop.js. If you want to make changes in C++ extensions or classes, read this section.
+> 👋 Usually, if you're working on the GDevelop editor or extensions in JavaScript, you don't need to rebuild GDevelop.js. If you want to make changes in C++ extensions or classes, read this section.
 
-- Make sure you have [CMake 3.17+](http://www.cmake.org/) (3.5+ should work on Linux/macOS) and [Node.js](nodejs.org/) installed.
+- Make sure you have [CMake 3.17+](http://www.cmake.org/) (3.5+ should work on Linux/macOS) and [Node.js](https://nodejs.org/) installed.
 
 - Install [Emscripten](https://github.com/kripken/emscripten), as explained on the [Emscripten installation instructions](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html):
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,69 +4,64 @@ GDevelop is a full-featured, open-source game development software, allowing to 
 
 ![GDevelop in action, used to add a trigger in a platformer game](https://raw.githubusercontent.com/4ian/GDevelop/master/Core/docs/images/demo.gif "GDevelop in action, used to add a trigger in a platformer game")
 
-Getting started
----------------
+## Getting started
 
-| ❔ I want to... | 🚀 What to do |
-| --- | --- |
-| Download GDevelop to make games | Go on [GDevelop website](https://gdevelop-app.com) to download GD! |
-| Contribute to the editor | Download [Node.js] and follow this [README](newIDE/README.md). |
-| Create/improve an extension | Download [Node.js] and follow this [README](newIDE/README-extensions.md). |
-| Help to translate GDevelop | Go on the [GDevelop project on Crowdin](https://crowdin.com/project/gdevelop). |
+| ❔ I want to...                 | 🚀 What to do                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------ |
+| Download GDevelop to make games | Go on [GDevelop website](https://gdevelop-app.com) to download GD!             |
+| Contribute to the editor        | Download [Node.js] and follow this [README](newIDE/README.md).                 |
+| Create/improve an extension     | Download [Node.js] and follow this [README](newIDE/README-extensions.md).      |
+| Help to translate GDevelop      | Go on the [GDevelop project on Crowdin](https://crowdin.com/project/gdevelop). |
 
-> Are you interested in contributing to GDevelop for the first time? Or want to participate to [Google Summer of Code 2021](https://summerofcode.withgoogle.com/organizations/5586892420022272/)? Take a look at the list of **[good first issues](https://github.com/4ian/GDevelop/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%91%8Cgood+first+issue%22)** and the **["🏐 not too hard" cards](https://trello.com/b/qf0lM7k8/gdevelop-roadmap?menu=filter&filter=label:Not%20too%20hard%20%E2%9A%BD%EF%B8%8F)** on the Roadmap.
+> Are you interested in contributing to GDevelop for the first time? Or want to participate in [Google Summer of Code 2021](https://summerofcode.withgoogle.com/organizations/5586892420022272/)? Take a look at the list of **[good first issues](https://github.com/4ian/GDevelop/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%91%8Cgood+first+issue%22)** and the **["🏐 not too hard" cards](https://trello.com/b/qf0lM7k8/gdevelop-roadmap?menu=filter&filter=label:Not%20too%20hard%20%E2%9A%BD%EF%B8%8F)** on the Roadmap.
 
-Overview of the architecture
-----------------------------
+## Overview of the architecture
 
-| Directory | ℹ️ Description |
-| --- | --- |
-| `Core` | GDevelop core library, containing common tools to implement the IDE and work with GDevelop games. |
-| `GDCpp` | The C++ game engine, used to build native games (*not used in GDevelop 5*). |
-| `GDJS` | The game engine, written in TypeScript, using PixiJS (WebGL), powering all GDevelop games. |
+| Directory     | ℹ️ Description                                                                                        |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `Core`        | GDevelop core library, containing common tools to implement the IDE and work with GDevelop games.     |
+| `GDCpp`       | The C++ game engine, used to build native games (_not used in GDevelop 5_).                           |
+| `GDJS`        | The game engine, written in TypeScript, using PixiJS (WebGL), powering all GDevelop games.            |
 | `GDevelop.js` | Bindings of `Core`/`GDCpp`/`GDJS` and `Extensions` to JavaScript (with WebAssembly), used by the IDE. |
-| `newIDE` | The game editor, written in JavaScript with React, Electron and PixiJS. |
-| `Extensions` | Extensions for the game engine, providing objects, behaviors, events and new features. |
+| `newIDE`      | The game editor, written in JavaScript with React, Electron and PixiJS.                               |
+| `Extensions`  | Extensions for the game engine, providing objects, behaviors, events and new features.                |
 
 To learn more about GDevelop Architecture, read the [architecture overview here](Core/GDevelop-Architecture-Overview.md).
 
-A pre-generated documentation of the Core library, C++ and TypeScript game engines is [available here](https://docs.gdevelop-app.com).
+Pre-generated documentation of the Core library, C++ and TypeScript game engines is [available here](https://docs.gdevelop-app.com).
 
 Status of the tests and builds: [![Build status](https://circleci.com/gh/4ian/GDevelop.svg?style=shield)](https://app.circleci.com/pipelines/github/4ian/GDevelop) [![Quick tests status](https://semaphoreci.com/api/v1/4ian/gd/branches/master/shields_badge.svg)](https://semaphoreci.com/4ian/gd) [![All tests Status](https://travis-ci.org/4ian/GDevelop.svg?branch=master)](https://travis-ci.org/4ian/GDevelop) [![Windows Build status](https://ci.appveyor.com/api/projects/status/84uhtdox47xp422x/branch/master?svg=true)](https://ci.appveyor.com/project/4ian/gdevelop/branch/master) [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 
-Links
------
+## Links
 
 ### Community
 
-* [GDevelop forums](https://forum.gdevelop-app.com) and [Discord chat](https://discord.gg/rjdYHvj).
-* [GDevelop homepage](https://gdevelop-app.com)
-* [GDevelop wiki (documentation)](http://wiki.compilgames.net/doku.php/gdevelop5/start)
-* Help translate GDevelop in your language: [GDevelop project on Crowdin](https://crowdin.com/project/gdevelop).
+-   [GDevelop forums](https://forum.gdevelop-app.com) and [Discord chat](https://discord.gg/rjdYHvj).
+-   [GDevelop homepage](https://gdevelop-app.com)
+-   [GDevelop wiki (documentation)](http://wiki.compilgames.net/doku.php/gdevelop5/start)
+-   Help translate GDevelop in your language: [GDevelop project on Crowdin](https://crowdin.com/project/gdevelop).
 
 ### Development Roadmap
 
-* [GDevelop Roadmap on Trello.com](https://trello.com/b/qf0lM7k8/gdevelop-roadmap), for a global view of the features that could be added. Please vote and comment here for new features/requests.
-* [GitHub issue page](https://github.com/4ian/GDevelop/issues), for technical issues and bugs.
+-   [GDevelop Roadmap on Trello.com](https://trello.com/b/qf0lM7k8/gdevelop-roadmap), for a global view of the features that could be added. Please vote and comment here for new features/requests.
+-   [GitHub issue page](https://github.com/4ian/GDevelop/issues), for technical issues and bugs.
 
 ### Games made with GDevelop
 
-* See the [Showcase of games](https://gdevelop-app.com/games-showcase) created with GDevelop.
-* Suggest your game to be [added to the showcase here](https://github.com/GDevelopApp/GDevelop-website-showcase/issues/new/choose).
+-   See the [Showcase of games](https://gdevelop-app.com/games-showcase) created with GDevelop.
+-   Suggest your game to be [added to the showcase here](https://github.com/GDevelopApp/GDevelop-website-showcase/issues/new/choose).
 
 ![Lil Bub](http://compilgames.net/assets/bub/screenshots-background.jpg "GDevelop logo")
 
 > [Lil BUB's HELLO EARTH](https://gdevelop-app.com/games/lil-bub-hello-earth) is one of the many games built with GDevelop.
 
-License
--------
+## License
 
-* The Core library, the native and HTML5 game engines, the IDE, and all extensions (respectively `Core`, `GDCpp`, `GDJS`, `newIDE` and `Extensions` folders) are under the **MIT license**.
-* The name, GDevelop, and its logo are the exclusive property of Florian Rival.
+-   The Core library, the native and HTML5 game engines, the IDE, and all extensions (respectively `Core`, `GDCpp`, `GDJS`, `newIDE` and `Extensions` folders) are under the **MIT license**.
+-   The name, GDevelop, and its logo are the exclusive property of Florian Rival.
 
 Games exported with GDevelop are based on the native and/or HTML5 game engines (see `Core`, `GDCpp` and `GDJS` folders): these engines are distributed under the MIT license so that you can **distribute, sell or do anything** with the games you created with GDevelop. In particular, you are not forced to make your game open source.
 
-
-[Node.js]:https://nodejs.org
-[CMake]:http://www.cmake.org/
-[Ninja]:http://martine.github.io/ninja/
+[node.js]: https://nodejs.org
+[cmake]: http://www.cmake.org/
+[ninja]: http://martine.github.io/ninja/

--- a/newIDE/README-extensions.md
+++ b/newIDE/README-extensions.md
@@ -3,8 +3,8 @@
 GDevelop editor and games engines are designed so that all objects, behaviors, effects, actions, conditions and expressions
 are provided by _extensions_. These extensions are composed of two parts:
 
-- the _declaration_ of the extension, traditionally done in a file called `JsExtension.js`.
-- the _implementation_ of the extension for the game engine (also called the "Runtime"), written in [TypeScript](typescriptlang.org), containing the functions corresponding to the actions/conditions/expressions and the classes used for the objects or behaviors. The implementation is traditionally in files called `extensionnametools.ts`, `objectnameruntimeobject.ts` or `objectnameruntimebehavior.ts`.
+-   the _declaration_ of the extension, traditionally done in a file called `JsExtension.js`.
+-   the _implementation_ of the extension for the game engine (also called the "Runtime"), written in [TypeScript](https://www.typescriptlang.org/), containing the functions corresponding to the actions/conditions/expressions and the classes used for the objects or behaviors. The implementation is traditionally in files called `extensionnametools.ts`, `objectnameruntimeobject.ts` or `objectnameruntimebehavior.ts`.
 
 > Note that some GDevelop extensions are declared in C++, in files called `JsExtension.cpp`. If you want to edit them,
 > refer to the paragraph about them at the end.
@@ -23,32 +23,32 @@ Refer to the [GDevelop IDE Readme](./README.md) for more information about the i
 
 ## 2) Development 🤓
 
-- First, run [GDevelop with Electron](https://github.com/4ian/GDevelop/blob/master/newIDE/README.md#development-of-the-standalone-app).
+-   First, run [GDevelop with Electron](https://github.com/4ian/GDevelop/blob/master/newIDE/README.md#development-of-the-standalone-app).
 
-  When GDevelop is started, the developer console should be opened. Search for the message `Loaded x JS extensions.` that indicates the loading of extensions.
+    When GDevelop is started, the developer console should be opened. Search for the message `Loaded x JS extensions.` that indicates the loading of extensions.
 
-- You can now open an extension contained in the folder _Extensions_ at the root of the repository. For example, you can open [Extensions/FacebookInstantGames](https://github.com/4ian/GDevelop/tree/master/Extensions/FacebookInstantGames). Edit the JsExtension.js file or a runtime file. Any changes will be automatically imported in the editor.
+-   You can now open an extension contained in the folder _Extensions_ at the root of the repository. For example, you can open [Extensions/FacebookInstantGames](https://github.com/4ian/GDevelop/tree/master/Extensions/FacebookInstantGames). Edit the JsExtension.js file or a runtime file. Any changes will be automatically imported into the editor.
 
-  > Verify that changes are imported in the console: you should see a message starting by `GDJS Runtime update`.
-  > If you deactivated the automatic import in the preferences or want to import manually your changes, run `import-GDJS-Runtime.js` script:
-  >
-  > ```bash
-  > cd scripts
-  > node import-GDJS-Runtime.js # This copy extensions declaration and runtime into GDevelop.
-  > ```
+    > Verify that changes are imported in the console: you should see a message starting with `GDJS Runtime update`.
+    > If you deactivated the automatic import in the preferences or want to import manually your changes, run the `import-GDJS-Runtime.js` script:
+    >
+    > ```bash
+    > cd scripts
+    > node import-GDJS-Runtime.js # This copy extensions declaration and runtime into GDevelop.
+    > ```
 
-- Finally, verify that the changes are applied:
+-   Finally, verify that the changes are applied:
 
-  - If you modified the declaration (`JsExtension.js`), reload GDevelop by pressing Ctrl+R (or Cmd+R on macOS) in the developer console.
-  - If you modified a Runtime file, relaunch a preview. Open the developer console if you want to check for any errors.
+    -   If you modified the declaration (`JsExtension.js`), reload GDevelop by pressing Ctrl+R (or Cmd+R on macOS) in the developer console.
+    -   If you modified a Runtime file, relaunch a preview. Open the developer console if you want to check for any errors.
 
-- You can now iterate and relaunch the script to develop the extension! 🚀
+-   You can now iterate and relaunch the script to develop the extension! 🚀
 
-  > ⚠️ Always check the developer console after reloading GDevelop. If there is any error signaled, click on it to see what went wrong. You may have done a syntax error or mis-used an API.
+    > ⚠️ Always check the developer console after reloading GDevelop. If there is any error signaled, click on it to see what went wrong. You may have done a syntax error or misused an API.
 
 ### 2.1) Implement your feature for the game engine 👾
 
-> ℹ️ Implement your extension in file called `extensionnametools.ts` (for general functions), `objectnameruntimeobject.ts` (for objects) or `behaviornameruntimebehavior.ts` (for behaviors). See then the next section for declaring these files and the content of the extension to the IDE.
+> ℹ️ Implement your extension in a file called `extensionnametools.ts` (for general functions), `objectnameruntimeobject.ts` (for objects) or `behaviornameruntimebehavior.ts` (for behaviors). See then the next section for declaring these files and the content of the extension to the IDE.
 
 Check the [GDJS game engine documentation here](https://docs.gdevelop-app.com/GDJS%20Runtime%20Documentation/index.html). It's also a good idea to check the [Runtime folder of GDJS](../GDJS/README.md) to see directly how the game engine is done when needed. Files for the game engine should [almost all be written in TypeScript, with a few precautions to ensure good performance (click to learn more)](https://github.com/4ian/GDevelop/blob/master/newIDE/docs/Supported-JavaScript-features-and-coding-style.md).
 
@@ -69,7 +69,7 @@ Read about [`gdjs.RuntimeBehavior`](https://docs.gdevelop-app.com/GDJS%20Runtime
 
 #### How to create an object by extending `gdjs.RuntimeObject`
 
-See example in [dummyruntimeobject.js](../Extensions/ExampleJsExtension/dummyruntimeobject.js) (the object itself) and [dummyruntimeobject-pixi-renderer.js](../Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.js) (the renderer, using PixiJS).
+See example in [dummyruntimeobject.ts](../Extensions/ExampleJsExtension/dummyruntimeobject.ts) (the object itself) and [dummyruntimeobject-pixi-renderer.ts](../Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.ts) (the renderer, using PixiJS).
 
 You'll be interested in the constructor (to initialize things), `update` (called every frame) and the other methods. In the PIXI renderer, check the constructor (where PixiJS objects are created). Other methods depend on the renderer.
 
@@ -77,13 +77,13 @@ Read about [`gdjs.RuntimeObject`](https://docs.gdevelop-app.com/GDJS%20Runtime%2
 
 #### How to create an effect ("shader", PixiJS "filter")
 
-See lots of examples in [Effects](../Extensions/Effects/) (the extension containing lots of effects) and [light-night-pixi-filter.js](../Extensions/Effects/light-night-pixi-filter.js) (an example of a custom filter for PixiJS).
+See lots of examples in [Effects](../Extensions/Effects/) (the extension containing lots of effects) and [light-night-pixi-filter.ts](../Extensions/Effects/light-night-pixi-filter.ts) (an example of a custom filter for PixiJS).
 
 You'll have to store the code for your PixiJS filter in the file, and then call `gdjs.PixiFiltersTools.registerFilterCreator` to tell the game engine how to create and update the filter. Don't forget to then **declare** the effect (see next section).
 
 ### 2.2) Declare your extension to the IDE 👋
 
-> ℹ️ Declaration must be done in a file called `JsExtension.js`. Your extension must be in Extensions folder, in its own directory.
+> ℹ️ Declaration must be done in a file called `JsExtension.js`. Your extension must be in the Extensions folder, in its own directory.
 
 The API to declare extensions is almost 100% equivalent to the way extensions are declared in C++, so most links will redirect to this documentation.
 
@@ -97,12 +97,12 @@ Use [`extension.setExtensionInformation`](https://docs.gdevelop-app.com/GDCore%2
 
 Use [`addAction`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_platform_extension.html#a34e95be54f2dfa80b804e8e4830e7d9c), `addCondition`, `addExpression` or `addStrExpression` to declare actions, conditions or expressions.
 
-- Chain calls to [`addParameter`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_instruction_metadata.html#a95486188a843f9ac8cdb1b0700c6c7e5) to declare the parameters of your action/condition/expression.
-- Call `getCodeExtraInformation()` and then functions like [`setFunctionName` and `setIncludeFile`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_instruction_metadata_1_1_extra_information.html) to declare the JavaScript function to be called and the file to be included.
+-   Chain calls to [`addParameter`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_instruction_metadata.html#a95486188a843f9ac8cdb1b0700c6c7e5) to declare the parameters of your action/condition/expression.
+-   Call `getCodeExtraInformation()` and then functions like [`setFunctionName` and `setIncludeFile`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_instruction_metadata_1_1_extra_information.html) to declare the JavaScript function to be called and the file to be included.
 
 > You can call these functions on the `extension` object, or on the objects returned by `extension.addObject` (for objects) or `extension.addBehavior` (for behaviors). See below.
 
-> ⚠️ Always double check that you've not forgotten an argument. Such errors/mismatchs can create silent bugs that could make GDevelop instable or crash while being used.
+> ⚠️ Always double-check that you've not forgotten an argument. Such errors/mismatches can create silent bugs that could make GDevelop unstable or crash while being used.
 
 > 👉 See an example in the [example extension _JsExtension.js_ file](../Extensions/ExampleJsExtension/JsExtension.js).
 
@@ -110,8 +110,8 @@ Use [`addAction`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1
 
 Add a behavior using [`addBehavior`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_platform_extension.html#a75992fed9afce730db56af9d4d8177ca). The last two parameters are the `gd.Behavior` and the `gd.BehaviorsSharedData` object representing the behavior and its (optional) shared data
 
-- For the behavior, create a `new gd.BehaviorJsImplementation()` and define `initializeContent`, `updateProperty` and `getProperties`.
-- For the shared data (which are properties shared between all behaviors of the same type), if you don't have the need for it, just pass `new gd.BehaviorsSharedData()`. If you need shared data, create a `new gd.BehaviorSharedDataJsImplementation()` and define `initializeContent`, `updateProperty` and `getProperties`.
+-   For the behavior, create a `new gd.BehaviorJsImplementation()` and define `initializeContent`, `updateProperty` and `getProperties`.
+-   For the shared data (which are properties shared between all behaviors of the same type), if you don't need it, just pass the `new gd.BehaviorsSharedData()`. If you need shared data, create a `new gd.BehaviorSharedDataJsImplementation()` and define `initializeContent`, `updateProperty` and `getProperties`.
 
 > ⚠️ Like other functions to declare extensions, make sure that you've not forgotten to declare a function and that all arguments are correct.
 
@@ -121,7 +121,7 @@ Add a behavior using [`addBehavior`](https://docs.gdevelop-app.com/GDCore%20Docu
 
 Add an object using [`addObject`](https://docs.gdevelop-app.com/GDCore%20Documentation/classgd_1_1_platform_extension.html#a554baca486909e8741e902133cceeec0). The last parameter is the `gd.Object` representing the object:
 
-- Create a `new gd.ObjectJsImplementation()` and define `updateProperty` and `getProperties` (for the object properties) and `updateInitialInstanceProperty` and `getInitialInstanceProperties` (for the optional properties that are attached to each instance).
+-   Create a `new gd.ObjectJsImplementation()` and define `updateProperty` and `getProperties` (for the object properties) and `updateInitialInstanceProperty` and `getInitialInstanceProperties` (for the optional properties that are attached to each instance).
 
 > 👉 See an example in the [example extension _JsExtension.js_ file](../Extensions/ExampleJsExtension/JsExtension.js). Learn more about [properties here](docs/Properties-schema-and-PropertiesEditor-explanations.md).
 
@@ -132,15 +132,18 @@ Add an object using [`addObject`](https://docs.gdevelop-app.com/GDCore%20Documen
 A property is a global configuration value for your extension. An example would be the App ID for AdMob.
 
 To declare one, just use `registerProperty`:
+
 ```js
 // From ExampleJsExtension/JsExtension.js:
-extension.registerProperty("DummyPropertyString")
-  .setLabel(_("Dummy Property Name"))
-  .setDescription(_("Type in anything :)"))
-  .setType("string");
+extension
+	.registerProperty("DummyPropertyString")
+	.setLabel(_("Dummy Property Name"))
+	.setDescription(_("Type in anything :)"))
+	.setType("string");
 ```
 
 Once declared, you can access the property from JavaScript in the game engine using `getExtensionProperty` method of `gdjs.RuntimeGame`. Pass the extension name and the property name. This would get the AdMobAppId property of the AdMob extension for example:
+
 ```js
 const appId = runtimeGame.getExtensionProperty("AdMob", "AdMobAppId");
 ```
@@ -151,48 +154,54 @@ If the property doesn't exist it will return null.
 #### Declare a dependency on an external package
 
 You can declare a dependency on an npm package or cordova plugin with `addDependency`. Example:
+
 ```js
 // From ExampleJsExtension/JsExtension.js:
 extension
-  .addDependency()
-  .setName("Thirteen Checker")
-  .setDependencyType("npm")
-  .setExportName("is-thirteen")
-  .setVersion("2.0.0");
+	.addDependency()
+	.setName("Thirteen Checker")
+	.setDependencyType("npm")
+	.setExportName("is-thirteen")
+	.setVersion("2.0.0");
 ```
 
 On cordova you can add plugin variables as extra properties:
+
 ```js
-extension.addDependency()
-  .setName("Some Cordova Extension")
-  .setDependencyType("cordova")
-  .setExportName("cordova-some-plugin")
-  .setVersion("1.0.0")
-  .setExtraSetting(
-    "VARIABLE_NAME",
-    new gd.PropertyDescriptor().setValue("42")
-  );
+extension
+	.addDependency()
+	.setName("Some Cordova Extension")
+	.setDependencyType("cordova")
+	.setExportName("cordova-some-plugin")
+	.setVersion("1.0.0")
+	.setExtraSetting(
+		"VARIABLE_NAME",
+		new gd.PropertyDescriptor().setValue("42")
+	);
 ```
 
 You can also use an extension property to determine the value of the plugin variable:
+
 ```js
 // From AdMob/JsExtension.js:
-extension.registerProperty("AdMobAppId") // Remember Property Name
-      .setLabel("AdMob App ID")
-      .setDescription("ca-app-pub-XXXXXXXXXXXXXXXX/YYYYYYYYYY")
-      .setType("string");
+extension
+	.registerProperty("AdMobAppId") // Remember Property Name
+	.setLabel("AdMob App ID")
+	.setDescription("ca-app-pub-XXXXXXXXXXXXXXXX/YYYYYYYYYY")
+	.setType("string");
 
-extension.addDependency()
-  .setName("AdMob Cordova Extension")
-  .setDependencyType("cordova")
-  .setExportName("cordova-plugin-admob-free")
-  .setVersion("~0.21.0")
-  .setExtraSetting(
-    "ADMOB_APP_ID",
-    new gd.PropertyDescriptor()
-      .setType("ExtensionProperty") // Tell the exporter this is an extension property...
-      .setValue("AdMobAppId") // ... and what property it is (name of the property).
-  );
+extension
+	.addDependency()
+	.setName("AdMob Cordova Extension")
+	.setDependencyType("cordova")
+	.setExportName("cordova-plugin-admob-free")
+	.setVersion("~0.21.0")
+	.setExtraSetting(
+		"ADMOB_APP_ID",
+		new gd.PropertyDescriptor()
+			.setType("ExtensionProperty") // Tell the exporter this is an extension property...
+			.setValue("AdMobAppId") // ... and what property it is (name of the property).
+	);
 ```
 
 #### Declare an object editor
@@ -234,31 +243,31 @@ Add an effect using [`addEffect`](https://docs.gdevelop-app.com/GDCore%20Documen
 
 If you want to start a new extension:
 
-- Choose a unique and descriptive name. Create a folder with this name in _Extensions_.
-- Create a file in it named _JsExtension.js_ and copy the content of the _JsExtension.js_ of another extension.
-- Change the extension information (`extension.setExtensionInformation`). The first argument is the extension internal name and should be the same name as your folder for consistency.
-- Remove all the actions/conditions/expressions declarations and tests, run `node import-GDJS-Runtime.js` and reload GDevelop to verify that your extension is loaded.
-- Create a file called for example _yourextensionnametools.js_ in the same directory.
-- Add back the declarations in your extension. Use `setIncludeFile` when declaring your actions/conditions/expressions and set the name of the ts file that you've created **but with a js extension**, prefixed by the path from the root folder. For example:
-  ```js
-  .setIncludeFile("Extensions/FacebookInstantGames/facebookinstantgamestools.js")
-  ```
+-   Choose a unique and descriptive name. Create a folder with this name in _Extensions_.
+-   Create a file in it named _JsExtension.js_ and copy the content of the _JsExtension.js_ of another extension.
+-   Change the extension information (`extension.setExtensionInformation`). The first argument is the extension internal name and should be the same name as your folder for consistency.
+-   Remove all the actions/conditions/expressions declarations and tests, run `node import-GDJS-Runtime.js` and reload GDevelop to verify that your extension is loaded.
+-   Create a file called for example _yourextensionnametools.js_ in the same directory.
+-   Add back the declarations in your extension. Use `setIncludeFile` when declaring your actions/conditions/expressions and set the name of the ts file that you've created **but with a js extension**, prefixed by the path from the root folder. For example:
+    ```js
+    .setIncludeFile("Extensions/FacebookInstantGames/facebookinstantgamestools.ts")
+    ```
 
 ## 4) How to contribute? 😎
 
 If you have ideas or are creating a new extension, your contribution is welcome!
 
-- To submit your extension, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
+-   To submit your extension, you have first to create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
-- Check the [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
+-   Check [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
 
-- A few enhancements are also possible to exploit the full potential of extensions:
+-   A few enhancements are also possible to exploit the full potential of extensions:
 
-  - [ ] Add support for events
-  - [ ] Document how to add custom icons
-  - [ ] Add a button to reload extensions without reloading GDevelop IDE entirely.
+    -   [ ] Add support for events
+    -   [ ] Document how to add custom icons
+    -   [ ] Add a button to reload extensions without reloading GDevelop IDE entirely.
 
 ## 4) Note on the development of extensions declared in C++ (`JsExtension.cpp` or `Extension.cpp`)
 
 Some extensions are still declared in C++ for being compatible with GDevelop 4.
-Check the sources in [Extensions folder](https://github.com/4ian/GDevelop/tree/master/Extensions) and install [GDevelop.js](https://github.com/4ian/GDevelop.js). You'll then be able to make changes in C++ source files and have this reflected in the editor.
+Check the sources in the [Extensions folder](https://github.com/4ian/GDevelop/tree/master/Extensions) and install [GDevelop.js](https://github.com/4ian/GDevelop.js). You'll then be able to make changes in C++ source files and have this reflected in the editor.

--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -105,7 +105,7 @@ Any text editor is fine, but it's a good idea to have one with _Prettier_ (code 
 
 ### Testing and developing with the cloud storage providers (Google Drive, Dropbox, OneDrive, etc...)
 
-Cloud storage providers are set up with development keys when you're running GDevelop in development mode. For these, to work, you must execute the web-app not from the traditional `http://localhost:3000` origin, but not from `http://gdevelop-app-local:3000`:
+Cloud storage providers are set up with development keys when you're running GDevelop in development mode. For these, to work, you must execute the web-app not from the traditional `http://localhost:3000` origin, but from `http://gdevelop-app-local:3000`:
 
 -   Set up a [redirection in your hosts file](https://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/), that should look like: `127.0.0.1 gdevelop-app-local.com`.
 -   Launch then the web app from `http://gdevelop-app-local:3000`.

--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -31,7 +31,7 @@ Images resources, GDJS Runtime, extensions will be copied in resources, and [lib
 
 ### Development of the standalone app
 
-You can run the standalone app with Electron. **Make sure that you've launched `npm start` (or `yarn start`) in `app` folder before** (see above) and **keep it running** (in development, the app is served from a local server, even for the standalone app).
+You can run the standalone app with Electron. **Make sure that you've launched `npm start` (or `yarn start`) in the `app` folder before** (see above) and **keep it running** (in development, the app is served from a local server, even for the standalone app).
 
 > Note for Windows: With **Node.js 14 or older**, there is an error related to `git-sh-setup` when running npm install.  
 > To solve this problem: add [this folder to your path environment variable](https://stackoverflow.com/questions/49256190/how-to-fix-git-sh-setup-file-not-found-in-windows) **OR** run `npm install` in newIDE/electron-app/app **before** npm install in newIDE/electron-app.
@@ -57,7 +57,7 @@ npm run electron-linux
 
 There is a script file that automates cloning this repository, building the IDE and running it:
 
--   For Windows: You can download the batch script [here](https://raw.githubusercontent.com/4ian/GDevelop/master/scripts/gitCloneAndBuildGD.bat) and save it to where you want GDevelop to be cloned to, then simply run it.
+-   For Windows: You can download the batch script [here](https://raw.githubusercontent.com/4ian/GDevelop/master/scripts/gitCloneAndBuildGD.bat) and save it to where you want GDevelop to be cloned, then simply run it.
 
 ### Development of UI components
 
@@ -87,7 +87,7 @@ It's pretty easy to create new themes. Check the [README about themes](./README-
 
 Make sure to have the standalone app running with Electron.
 
--   If you want create/modify _extensions_, check the [README about extensions](./README-extensions.md) for a step-by-step explanations to get started in 5 minutes.
+-   If you want to create/modify _extensions_, check the [README about extensions](./README-extensions.md) for step-by-step explanations to get started in 5 minutes.
 
 -   The _game engine core_ ([GDJS](https://github.com/4ian/GDevelop/tree/master/GDJS)) is in [GDJS/Runtime folder](https://github.com/4ian/GDevelop/tree/master/GDJS/Runtime).
 
@@ -105,10 +105,10 @@ Any text editor is fine, but it's a good idea to have one with _Prettier_ (code 
 
 ### Testing and developing with the cloud storage providers (Google Drive, Dropbox, OneDrive, etc...)
 
-Cloud storage providers are set up with development keys when you're running GDevelop in development mode. For these, to work, you must execute the web-app not from the traditional `http://localhost:3000` origin, but from `http://gdevelop-app-local:3000`:
+Cloud storage providers are set up with development keys when you're running GDevelop in development mode. For these, to work, you must execute the web-app not from the traditional `http://localhost:3000` origin, but not from `http://gdevelop-app-local:3000`:
 
 -   Set up a [redirection in your hosts file](https://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/), that should look like: `127.0.0.1 gdevelop-app-local.com`.
--   Launch then the webapp from `http://gdevelop-app-local:3000`.
+-   Launch then the web app from `http://gdevelop-app-local:3000`.
 
 > This is only necessary if you want to have cloud storage providers working in development. If not done, GDevelop will simply display an error while trying to use them.
 
@@ -118,7 +118,7 @@ Cloud storage providers are set up with development keys when you're running GDe
 
 ### Desktop version
 
-First, update version number in `newIDE/electron-app/app/package.json`.
+First, update the version number in `newIDE/electron-app/app/package.json`.
 
 ```bash
 cd newIDE/electron-app
@@ -142,7 +142,7 @@ cd newIDE/web-app
 yarn deploy # or npm run deploy
 ```
 
-> Note: this will also upload the game engine (GDJS) and extensions sources, needed by the IDE and purge the CloudFlare cache. If examples have been added/changed, be also sure to run `newIDE/web-app/scripts/deploy-examples-resources.js`.
+> Note: this will also upload the game engine (GDJS) and extension sources, needed by the IDE and purge the CloudFlare cache. If examples have been added/changed, be also sure to run `newIDE/web-app/scripts/deploy-examples-resources.js`.
 
 ### (Optional) Updating translations
 
@@ -165,7 +165,7 @@ yarn compile-translations # or npm run compile-translations
 
 The editor, the game engine and extensions are always in development. Your contribution is welcome!
 
--   Check the [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
+-   Check [the **roadmap** for ideas and features planned](https://trello.com/b/qf0lM7k8/gdevelop-roadmap).
 
     You can contribute by picking anything here or anything that you think is missing or could be improved in GD5! If you don't know how to start, it's a good idea to play a bit with the editor and see if there is something that is unavailable and that you can add or fix.
 
@@ -173,4 +173,4 @@ The editor, the game engine and extensions are always in development. Your contr
 
 -   To submit your changes, you have to first create a Fork on GitHub (use the Fork button on the top right), then [create a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
--   Finally, make sure that the tests pass (refer to this README and to the [game engine README](https://github.com/4ian/GDevelop/tree/master/GDJS) for learning how to run tests).
+-   Finally, make sure that the tests pass (refer to this README and the [game engine README](https://github.com/4ian/GDevelop/tree/master/GDJS) for learning how to run tests).

--- a/newIDE/app/package.json.README.md
+++ b/newIDE/app/package.json.README.md
@@ -1,24 +1,26 @@
 # About GDevelop IDE dependencies (package.json)
 
-GDevelop relies a some dependencies that can have special requirements:
+GDevelop relies on some dependencies that can have special requirements:
 
-* **TypeScript** here is only used to check the types in the `scripts/` files. The IDE uses Flow for static typing. TypeScript is used in the game engine too (see GDJS and Extensions folders).
+- **TypeScript** here is only used to check the types in the `scripts/` files. The IDE uses Flow for static typing. TypeScript is used in the game engine too (see GDJS and Extensions folders).
 
-* **Storybook** is depending on webpack and babel.
-  * It's important to have the same webpack version as the one provided by create-react-app, hence why `webpack` is specified in the `devDependencies`.
-  * `@babel/core`, `babel-core` are also specified to avoid incompatibilities after upgrading to Storybook 4.
-  * **Try removing these extra `devDependencies`** if you upgrade Storybook.
+- **Storybook** is depending on webpack and babel.
 
-* **`react-dnd`** is used by `react-mosaic-component` and `react-sortable-tree` (but not `react-sortable-hoc`). It is important that both are using **the same versions** of `react-dnd` and `react-dnd-html5-backend`. Otherwise, you get blanks/not rendered components.
+  - It's important to have the same webpack version as the one provided by create-react-app, hence why `webpack` is specified in the `devDependencies`.
+  - `@babel/core`, `babel-core` are also specified to avoid incompatibilities after upgrading to Storybook 4.
+  - **Try removing these extra `devDependencies`** if you upgrade Storybook.
+
+- **`react-dnd`** is used by `react-mosaic-component` and `react-sortable-tree` (but not `react-sortable-hoc`). Both must be using **the same versions** of `react-dnd` and `react-dnd-html5-backend`. Otherwise, you get blanks/not rendered components.
 
 > You can check if there is only one version of a package by doing `npm ls` or `yarn why`:
-> * `yarn why react-dnd`
-> * `npm ls webpack`
+>
+> - `yarn why react-dnd`
+> - `npm ls webpack`
 
-* Latest versions of `react-sortable-hoc` seems to be breaking the lists. The exact version in which this occurs was not determined.
+- The latest versions of `react-sortable-hoc` seem to be breaking the lists. The exact version in which this occurs was not determined.
 
 A few fixes have been applied:
 
-* `react-mosaic-component` is a custom version where `react-dnd` was simply upgraded to version `7.7.0`
-* `@lingui/react` is a version where Flow definitions have been fixed.
-* `pixi-simple-gesture` is a version where an extra check for `undefined` have been added to `touchStart` in `pan.js`, following traces of errors that have been inspected (though the bug could not be reproduced - but better be safe).
+- `react-mosaic-component` is a custom version where `react-dnd` was simply upgraded to version `7.7.0`
+- `@lingui/react` is a version where Flow definitions have been fixed.
+- `pixi-simple-gesture` is a version where an extra check for `undefined` have been added to `touchStart` in `pan.js`, following traces of errors that have been inspected (though the bug could not be reproduced - but better be safe).

--- a/newIDE/app/package.json.README.md
+++ b/newIDE/app/package.json.README.md
@@ -17,7 +17,7 @@ GDevelop relies on some dependencies that can have special requirements:
 > - `yarn why react-dnd`
 > - `npm ls webpack`
 
-- The latest versions of `react-sortable-hoc` seem to be breaking the lists. The exact version in which this occurs was not determined.
+- Latest versions of `react-sortable-hoc` seems to be breaking the lists. The exact version in which this occurs was not determined.
 
 A few fixes have been applied:
 

--- a/newIDE/app/public/external/jfxr/README.md
+++ b/newIDE/app/public/external/jfxr/README.md
@@ -4,4 +4,4 @@ be used directly from GDevelop to edit sound effects.
 Jfxr sources are downloaded by `import-zipped-editor.js` script. They are raw, unchanged sources
 of the Jfxr editor build. Sources will be stored in `Jfxr-editor` folder.
 See `jfxr-main.js` for the code running the editor.
-See `ModalWindow.js` and `LocalJfxrBridge.js` files for the bridge that open the Window and pass data from GDevelop to Jfxr.
+See `ModalWindow.js` and `LocalJfxrBridge.js` files for the bridge that opens the Window and passes data from GDevelop to Jfxr.

--- a/newIDE/app/public/external/piskel/README.md
+++ b/newIDE/app/public/external/piskel/README.md
@@ -1,4 +1,4 @@
-This folder contains sources to embed Piskel editor (https://www.piskelapp.com/) so that it can
+This folder contains sources to embed the Piskel editor (https://www.piskelapp.com/) so that it can
 be used directly from GDevelop to edit images.
 
 GD uses an updated version of piskel from https://github.com/blurymind/piskel/tree/piskel-plus
@@ -6,6 +6,6 @@ It contains a number of advanced color manipulation features and improvements to
 commit number: a300d17eb88d2b9d1fa2bbe3a810ad1bb76f1f81
 
 Piskel sources are downloaded by `import-zipped-editor.js` script. They are raw, unchanged sources
-of the Piskel editor build. Sources will be stored in `piskel-editor` folder.
+of the Piskel editor build. Sources will be stored in the `piskel-editor` folder.
 See `piskel-main.js` for the code running the editor.
-See `ModalWindow.js` and `LocalPiskelBridge.js` files for the bridge that open the Window and pass data from GDevelop to Piskel.
+See `ModalWindow.js` and `LocalPiskelBridge.js` files for the bridge that opens the Window and passes data from GDevelop to Piskel.

--- a/newIDE/app/public/external/yarn/README.md
+++ b/newIDE/app/public/external/yarn/README.md
@@ -2,6 +2,6 @@ This folder contains sources to embed Yarn editor (https://github.com/InfiniteAm
 be used directly from GDevelop to edit/create Dialogue Trees.
 
 Yarn sources are downloaded by `import-zipped-editor.js` script. They are raw, unchanged sources
-of the Yarn editor build. Sources will be stored in `yarn-editor` folder.
+of the Yarn editor build. Sources will be stored in the `yarn-editor` folder.
 See `yarn-main.js` for the code running the editor.
-See `ModalWindow.js` and `LocalYarnBridge.js` files for the bridge that open the Window and pass data from GDevelop to yarn.
+See `ModalWindow.js` and `LocalYarnBridge.js` files for the bridge that opens the Window and passes data from GDevelop to yarn.

--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -1,7 +1,7 @@
 # Scripts files for GDevelop
 
-* **ReleaseProcedure.bat**: this script compiles, generate documentation (see **GenerateAllDocs.bat**) and package GDevelop for Windows in an installer and an archive.
-* **ReleaseProcedure.sh**: compiles and package GD for Ubuntu (see *Binaries/Packaging*).
-* **CopyWindowsToLinuxReleaseFiles.sh**: Copy all files in *Binaries/Output/Release_Windows* to *Binaries/Output/Release_Linux*. Call it after any change in *Binaries/Output/Release_Windows*.
-* **GenerateAllDocs.[bat|sh]**: Call doxygen and yuidoc to generate all the documentations into *docs* folder.
-* **ExtractTranslations.[bat|sh]**: Create the *source.pot* file containing the strings to be translated using [Crowdin](https://crowdin.com/project/gdevelop).
+-   **ReleaseProcedure.bat**: this script compiles, generate documentation (see **GenerateAllDocs.bat**) and package GDevelop for Windows in an installer and an archive.
+-   **ReleaseProcedure.sh**: compiles and package GD for Ubuntu (see _Binaries/Packaging_).
+-   **CopyWindowsToLinuxReleaseFiles.sh**: Copy all files in _Binaries/Output/Release_Windows_ to _Binaries/Output/Release_Linux_. Call it after any change in _Binaries/Output/Release_Windows_.
+-   **GenerateAllDocs.[bat|sh]**: Call doxygen and yuidoc to generate all documentations into _docs_ folder.
+-   **ExtractTranslations.[bat|sh]**: Create the _source.pot_ file containing the strings to be translated using [Crowdin](https://crowdin.com/project/gdevelop).


### PR DESCRIPTION
**Problems:**
1.GDevelop/ExtLibs/Readme.md => (The documentation) link is not working.

**Fixed:**
Basic fixes => Current coding styles of readme like symbol usage for bold text and symbols for list creation or recommendations by prettier.

1.Core\README.md - Basic fixes.

2.GDCpp\README.md - Basic fixes.

3.GDJS\docs\Readme.md - 

- Update documentation urls to docs.gdevelop-app.com/...
- Fixed url of doxygen.org

4.GDJS\README.md - Basic and grammar fixes.

5.newIDE\README.md - Basic and grammar fixes.

6.Readme.md - Basic and grammar fixes.

7.scripts\Readme.md - Basic fixes.

8.Extensions\README.md - Basic and grammar fixes.

9.GDJS\tests\README.md - Basic and grammar fixes.

10.GDevelop.js\Readme.md - 

- Grammar fixes.
- Fixed url of nodejs.org

11.newIDE\README-extensions.md - 

- Basic and grammar fixes
- Fixes some spelling mistakes.
- Fixed url of typescriptlang.org
- Some files mentioned in the readme changed from .js to .ts as some links are not working after typescript update in GD.

12.newIDE\app\package.json.README.md - Basic and grammar fixes.

13..github\ISSUE_TEMPLATE\--feature-request.md - Basic and grammar fixes.

14.Core\GDevelop-Architecture-Overview.md -

- Basic and grammar fixes.
- Update documentation urls to docs.gdevelop-app.com/...

15.newIDE\app\public\external\jfxr\README.md - Grammar fixes.

16.newIDE\app\public\external\yarn\README.md - Grammar fixes.

17.newIDE\app\public\external\yarn\README.md - Grammar fixes.
