### PR TITLE
fix middle click drag not working while the path-editor is visible

### DIFF
--- a/newIDE/app/public/external/jfxr/jfxr-style.css
+++ b/newIDE/app/public/external/jfxr/jfxr-style.css
@@ -8,11 +8,12 @@ body {
   margin: 0;
   overflow-y: hidden;
   background-color: black;
+  display: flex;
+  flex-direction: column;
 }
 
 #jfxr-frame {
-  width: 100%;
-  height: 100%;
+  flex: 1;
   border: none;
   overflow-y: hidden;
 }

--- a/newIDE/app/public/external/piskel/piskel-style.css
+++ b/newIDE/app/public/external/piskel/piskel-style.css
@@ -7,11 +7,12 @@ body {
   font-family: Helvetica;
   margin: 0;
   overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 #piskel-frame {
-  width: 100%;
-  height: 100%;
+  flex: 1;
   border: none;
   overflow-y: hidden;
 }

--- a/newIDE/app/public/external/yarn/yarn-style.css
+++ b/newIDE/app/public/external/yarn/yarn-style.css
@@ -7,11 +7,12 @@ body {
   margin: 0;
   overflow-y: hidden;
   background-color: white;
+  display: flex;
+  flex-direction: column;
 }
 
 #yarn-frame {
-  width: 100%;
-  height: 100%;
+  flex: 1;
   border: none;
   overflow-y: hidden;
 }


### PR DESCRIPTION
To reproduce the issue, open yarn-editor in gdevelop,
make sure the file path editor is visible (not collapsed), then try to middle click drag to pan.
It wont work.

This PR fixes that