### PR TITLE
signInWithProvider requires two parameters

### DIFF
--- a/Extensions/Firebase/JsExtension.js
+++ b/Extensions/Firebase/JsExtension.js
@@ -321,6 +321,7 @@ module.exports = {
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
+      .addParameter('string', _('Provider'), '', false)
       .addParameter(
         'scenevar',
         _('Callback variable with state (ok or error)'),

--- a/Extensions/Firebase/JsExtension.js
+++ b/Extensions/Firebase/JsExtension.js
@@ -321,7 +321,12 @@ module.exports = {
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
-      .addParameter('string', _('Provider'), '', false)
+      .addParameter(
+        'stringWithSelector',
+        _('Provider'),
+        '["google", "facebook", "github", "twitter"]',
+        false
+      )
       .addParameter(
         'scenevar',
         _('Callback variable with state (ok or error)'),


### PR DESCRIPTION
`gdjs.evtTools.firebase.auth.signInWithProvider` takes two parameters.

This is just a quick guess at why it's not working, in my debugger the first variable is variable container:

https://github.com/4ian/GDevelop/blob/153ccdb2830c3fd6f572b8f899bdc84d426a1048/Extensions/Firebase/C_firebasetools/D_authtools.ts#L414-L417