### PR TITLE
Added updatePreRender() in gdjs.RuntimeObject

### DIFF
--- a/Extensions/Lighting/lightruntimeobject.ts
+++ b/Extensions/Lighting/lightruntimeobject.ts
@@ -84,7 +84,7 @@ namespace gdjs {
       return true;
     }
 
-    update(): void {
+    updatePreRender(): void {
       this._renderer.ensureUpToDate();
     }
 

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -189,6 +189,12 @@ namespace gdjs {
      */
     update(runtimeScene: gdjs.RuntimeScene): void {}
 
+    /**
+     * Called once during the game loop, after events and before rendering.
+     * @param runtimeScene The gdjs.RuntimeScene the object belongs to.
+     */
+    updatePreRender(runtimeScene: gdjs.RuntimeScene): void {}
+
     //Nothing to do.
     /**
      * Called when the object is created from an initial instance at the startup of the scene.<br>

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -556,7 +556,7 @@ namespace gdjs {
     /**
      * Called to update visibility of the renderers of objects
      * rendered on the scene and give a last chance for objects to update before rendering.
-     * 
+     *
      * Visibility is set to false if object is hidden, or if
      * object is too far from the camera of its layer ("culling").
      */
@@ -565,12 +565,12 @@ namespace gdjs {
         this._constructListOfAllInstances();
         for (let i = 0, len = this._allInstancesList.length; i < len; ++i) {
           const object = this._allInstancesList[i];
-          // Perform pre-render update.
-          object.updatePreRender(this);
           const rendererObject = object.getRendererObject();
           if (rendererObject) {
             object.getRendererObject().visible = !object.isHidden();
           }
+          // Perform pre-render update.
+          object.updatePreRender(this);
         }
         return;
       } else {
@@ -580,8 +580,6 @@ namespace gdjs {
         this._constructListOfAllInstances();
         for (let i = 0, len = this._allInstancesList.length; i < len; ++i) {
           const object = this._allInstancesList[i];
-          // Perform pre-render update.
-          object.updatePreRender(this);
           const cameraCoords = this._layersCameraCoordinates[object.getLayer()];
           const rendererObject = object.getRendererObject();
           if (!cameraCoords || !rendererObject) {
@@ -604,6 +602,8 @@ namespace gdjs {
               rendererObject.visible = true;
             }
           }
+          // Perform pre-render update.
+          object.updatePreRender(this);
         }
       }
     }

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -485,9 +485,9 @@ namespace gdjs {
       if (this._profiler) {
         this._profiler.begin('objects (visibility)');
       }
-      this._updateObjectsVisibility();
+      this._updateObjectsPreRender();
       if (this._profiler) {
-        this._profiler.end('objects (visibility)');
+        this._profiler.end('objects (pre-render)');
       }
       if (this._profiler) {
         this._profiler.begin('layers (effects update)');
@@ -560,12 +560,14 @@ namespace gdjs {
      * Visibility is set to false if object is hidden, or if
      * object is too far from the camera of its layer ("culling").
      */
-    _updateObjectsVisibility() {
+    _updateObjectsPreRender() {
       if (this._timeManager.isFirstFrame()) {
         this._constructListOfAllInstances();
         for (let i = 0, len = this._allInstancesList.length; i < len; ++i) {
-          let object = this._allInstancesList[i];
-          let rendererObject = object.getRendererObject();
+          const object = this._allInstancesList[i];
+          // Perform pre-render update.
+          object.updatePreRender(this);
+          const rendererObject = object.getRendererObject();
           if (rendererObject) {
             object.getRendererObject().visible = !object.isHidden();
           }
@@ -577,9 +579,11 @@ namespace gdjs {
         this._updateLayersCameraCoordinates();
         this._constructListOfAllInstances();
         for (let i = 0, len = this._allInstancesList.length; i < len; ++i) {
-          let object = this._allInstancesList[i];
+          const object = this._allInstancesList[i];
+          // Perform pre-render update.
+          object.updatePreRender(this);
           const cameraCoords = this._layersCameraCoordinates[object.getLayer()];
-          let rendererObject = object.getRendererObject();
+          const rendererObject = object.getRendererObject();
           if (!cameraCoords || !rendererObject) {
             continue;
           }

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -483,7 +483,7 @@ namespace gdjs {
         this._profiler.end('callbacks and extensions (post-events)');
       }
       if (this._profiler) {
-        this._profiler.begin('objects (visibility)');
+        this._profiler.begin('objects (pre-render)');
       }
       this._updateObjectsPreRender();
       if (this._profiler) {

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -554,9 +554,9 @@ namespace gdjs {
     }
 
     /**
-     * Called to update visibility of PIXI.DisplayObject of objects
-     * rendered on the scene.
-     *
+     * Called to update visibility of the renderers of objects
+     * rendered on the scene and give a last chance for objects to update before rendering.
+     * 
      * Visibility is set to false if object is hidden, or if
      * object is too far from the camera of its layer ("culling").
      */


### PR DESCRIPTION
Resolves #2261

- Adds updatePreRender() in gdjs.RuntimeObject which is called after events and before rendering.
- Light object uses updatePreRender to correct positioning error.