### PR TITLE
Add warning if exporting game with default package name

### DIFF
--- a/newIDE/app/src/Export/BrowserExporters/BrowserCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserCordovaExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import { findGDJS } from '../../GameEngineFinder/BrowserS3GDJSFinder';
 import BrowserFileSystem from './BrowserFileSystem';
@@ -52,6 +52,7 @@ export const browserCordovaExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'browser-cordova',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserCordovaExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import { findGDJS } from '../../GameEngineFinder/BrowserS3GDJSFinder';
 import BrowserFileSystem from './BrowserFileSystem';
@@ -52,7 +52,7 @@ export const browserCordovaExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'browser-cordova',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
+  packageNameWarningType: 'mobile',
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserElectronExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserElectronExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import { findGDJS } from '../../GameEngineFinder/BrowserS3GDJSFinder';
 import BrowserFileSystem from './BrowserFileSystem';
@@ -52,7 +52,7 @@ export const browserElectronExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'browser-electron',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
+  packageNameWarningType: 'desktop',
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserElectronExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserElectronExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import { findGDJS } from '../../GameEngineFinder/BrowserS3GDJSFinder';
 import BrowserFileSystem from './BrowserFileSystem';
@@ -52,6 +52,7 @@ export const browserElectronExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'browser-electron',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -54,6 +54,7 @@ export const browserOnlineCordovaExportPipeline: ExportPipeline<
 > = {
   name: 'browser-online-cordova',
   onlineBuildType: 'cordova-build',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -54,7 +54,7 @@ export const browserOnlineCordovaExportPipeline: ExportPipeline<
 > = {
   name: 'browser-online-cordova',
   onlineBuildType: 'cordova-build',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
+  packageNameWarningType: 'mobile',
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -55,7 +55,7 @@ export const browserOnlineElectronExportPipeline: ExportPipeline<
 > = {
   name: 'browser-online-electron',
   onlineBuildType: 'electron-build',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
+  packageNameWarningType: 'desktop',
 
   getInitialExportState: () => ({
     targets: ['winExe'],

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -55,6 +55,7 @@ export const browserOnlineElectronExportPipeline: ExportPipeline<
 > = {
   name: 'browser-online-electron',
   onlineBuildType: 'electron-build',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
 
   getInitialExportState: () => ({
     targets: ['winExe'],

--- a/newIDE/app/src/Export/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportLauncher.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { I18n } from '@lingui/react';
 import RaisedButton from '../UI/RaisedButton';
 import { sendExportLaunched } from '../Utils/Analytics/EventSender';
 import {
@@ -25,6 +26,7 @@ import BuildStepsProgress, {
 } from './Builds/BuildStepsProgress';
 import { type ExportPipeline } from './ExportPipeline.flow';
 import { GameRegistration } from '../GameDashboard/GameRegistration';
+import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 
 type State = {|
   exportStep: BuildStep,
@@ -245,6 +247,21 @@ export default class ExportLauncher extends Component<Props, State> {
 
     return (
       <Column noMargin>
+        {!!exportPipeline.shouldHaveUniquePackageName &&
+          project.getPackageName().indexOf('com.example') !== -1 && (
+            <Line>
+              <DismissableAlertMessage
+                identifier="project-should-have-unique-package-name"
+                kind="warning"
+              >
+                <I18n>
+                  {({ i18n }) =>
+                    i18n._(exportPipeline.shouldHaveUniquePackageName)
+                  }
+                </I18n>
+              </DismissableAlertMessage>
+            </Line>
+          )}
         <Line>
           {exportPipeline.renderHeader({
             project,

--- a/newIDE/app/src/Export/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportLauncher.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import { I18n } from '@lingui/react';
+import { t } from '@lingui/macro';
 import RaisedButton from '../UI/RaisedButton';
 import { sendExportLaunched } from '../Utils/Analytics/EventSender';
 import {
@@ -247,7 +248,7 @@ export default class ExportLauncher extends Component<Props, State> {
 
     return (
       <Column noMargin>
-        {!!exportPipeline.shouldHaveUniquePackageName &&
+        {!!exportPipeline.packageNameWarningType &&
           project.getPackageName().indexOf('com.example') !== -1 && (
             <Line>
               <DismissableAlertMessage
@@ -256,7 +257,11 @@ export default class ExportLauncher extends Component<Props, State> {
               >
                 <I18n>
                   {({ i18n }) =>
-                    i18n._(exportPipeline.shouldHaveUniquePackageName)
+                    i18n._(
+                      exportPipeline.packageNameWarningType === 'mobile'
+                        ? t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`
+                        : t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`
+                    )
                   }
                 </I18n>
               </DismissableAlertMessage>

--- a/newIDE/app/src/Export/ExportPipeline.flow.js
+++ b/newIDE/app/src/Export/ExportPipeline.flow.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow.js';
 import { type Build } from '../Utils/GDevelopServices/Build';
 import { type UserProfile } from '../Profile/UserProfileContext';
-import { string } from '../GameEngineFinder/BrowserS3GDJSFinder';
 
 export type ExportPipelineContext<ExportState> = {|
   project: gdProject,

--- a/newIDE/app/src/Export/ExportPipeline.flow.js
+++ b/newIDE/app/src/Export/ExportPipeline.flow.js
@@ -22,7 +22,7 @@ export type ExportPipeline<
 > = {|
   name: string,
   onlineBuildType?: string,
-  shouldHaveUniquePackageName?: MessageDescriptor,
+  packageNameWarningType?: 'mobile' | 'desktop',
 
   getInitialExportState: (project: gdProject) => ExportState,
 

--- a/newIDE/app/src/Export/ExportPipeline.flow.js
+++ b/newIDE/app/src/Export/ExportPipeline.flow.js
@@ -1,7 +1,9 @@
 // @flow
 import * as React from 'react';
+import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow.js';
 import { type Build } from '../Utils/GDevelopServices/Build';
 import { type UserProfile } from '../Profile/UserProfileContext';
+import { string } from '../GameEngineFinder/BrowserS3GDJSFinder';
 
 export type ExportPipelineContext<ExportState> = {|
   project: gdProject,
@@ -21,6 +23,7 @@ export type ExportPipeline<
 > = {|
   name: string,
   onlineBuildType?: string,
+  shouldHaveUniquePackageName?: MessageDescriptor,
 
   getInitialExportState: (project: gdProject) => ExportState,
 

--- a/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -44,6 +44,7 @@ export const localCordovaExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'local-cordova',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
 
   getInitialExportState: (project: gdProject) => ({
     outputDir: project.getLastCompilationDirectory(),

--- a/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -44,7 +44,7 @@ export const localCordovaExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'local-cordova',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
+  packageNameWarningType: 'mobile',
 
   getInitialExportState: (project: gdProject) => ({
     outputDir: project.getLastCompilationDirectory(),

--- a/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -44,6 +44,7 @@ export const localElectronExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'local-electron',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
 
   getInitialExportState: (project: gdProject) => ({
     outputDir: project.getLastCompilationDirectory(),

--- a/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -44,7 +44,7 @@ export const localElectronExportPipeline: ExportPipeline<
   CompressionOutput
 > = {
   name: 'local-electron',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
+  packageNameWarningType: 'desktop',
 
   getInitialExportState: (project: gdProject) => ({
     outputDir: project.getLastCompilationDirectory(),

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -48,7 +48,7 @@ export const localOnlineCordovaExportPipeline: ExportPipeline<
 > = {
   name: 'local-online-cordova',
   onlineBuildType: 'cordova-build',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
+  packageNameWarningType: 'mobile',
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -48,6 +48,7 @@ export const localOnlineCordovaExportPipeline: ExportPipeline<
 > = {
   name: 'local-online-cordova',
   onlineBuildType: 'cordova-build',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one to be able to publish your game on app stores.`,
 
   getInitialExportState: () => null,
 

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -49,6 +49,7 @@ export const localOnlineElectronExportPipeline: ExportPipeline<
 > = {
   name: 'local-online-electron',
   onlineBuildType: 'electron-build',
+  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
 
   getInitialExportState: () => ({
     targets: ['winExe'],

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Trans, t } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import assignIn from 'lodash/assignIn';
 import {
   type Build,
@@ -49,7 +49,7 @@ export const localOnlineElectronExportPipeline: ExportPipeline<
 > = {
   name: 'local-online-electron',
   onlineBuildType: 'electron-build',
-  shouldHaveUniquePackageName: t`The package name begins with com.example, make sure you replace it with an unique one, else installing your game might overwrite other games.`,
+  packageNameWarningType: 'desktop',
 
   getInitialExportState: () => ({
     targets: ['winExe'],

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -35,7 +35,8 @@ export type AlertMessageIdentifier =
   | 'p2p-broker-recommendation'
   | 'command-palette-shortcut'
   | 'asset-installed-explanation'
-  | 'extension-installed-explanation';
+  | 'extension-installed-explanation'
+  | 'project-should-have-unique-package-name';
 
 export type EditorMosaicName =
   | 'scene-editor'
@@ -144,6 +145,12 @@ export const allAlertMessages: Array<{
     key: 'asset-installed-explanation',
     label: (
       <Trans>Explanation after an object is installed from the store</Trans>
+    ),
+  },
+  {
+    key: 'project-should-have-unique-package-name',
+    label: (
+      <Trans>Project package names should not begin with com.example</Trans>
     ),
   },
 ];


### PR DESCRIPTION
Adds a dismissable warning when exporting for cordova or electron and the package name is com.example (the default).
The warning for electron will only be valid once the suggested solution for #2252 is implemented.