### PR TITLE
Add appid to the electron export

### DIFF
--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -454,6 +454,8 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
                                          gd::String exportDir) {
   gd::String jsonName =
       gd::Serializer::ToJSON(gd::SerializerElement(project.GetName()));
+  gd::String jsonPackageName =
+      gd::Serializer::ToJSON(gd::SerializerElement(project.GetPackageName()));
   gd::String jsonAuthor =
       gd::Serializer::ToJSON(gd::SerializerElement(project.GetAuthor()));
   gd::String jsonVersion =
@@ -468,6 +470,7 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
     gd::String str =
         fs.ReadFile(gdjsRoot + "/Runtime/Electron/package.json")
             .FindAndReplace("\"GDJS_GAME_NAME\"", jsonName)
+            .FindAndReplace("\"GDJS_GAME_PACKAGE_NAME\"", jsonPackageName)
             .FindAndReplace("\"GDJS_GAME_AUTHOR\"", jsonAuthor)
             .FindAndReplace("\"GDJS_GAME_VERSION\"", jsonVersion)
             .FindAndReplace("\"GDJS_GAME_MANGLED_NAME\"", jsonMangledName);

--- a/GDJS/Runtime/Electron/package.json
+++ b/GDJS/Runtime/Electron/package.json
@@ -1,19 +1,25 @@
 {
-    "name": "GDJS_GAME_MANGLED_NAME",
-    "main": "main.js",
-    "productName": "GDJS_GAME_NAME",
-    "description": "GDJS_GAME_NAME",
-    "author": "GDJS_GAME_AUTHOR",
-    "version": "GDJS_GAME_VERSION",
-    "dependencies": {
-      "GDJS_EXTENSION_NPM_DEPENDENCY": "0"
-    },
-    "devDependencies": {
-      "electron": "8.2.5"
-    },
-    "build": {
-        "directories": {
-            "buildResources": "buildResources"
-        }
+  "name": "GDJS_GAME_MANGLED_NAME",
+  "main": "main.js",
+  "productName": "GDJS_GAME_NAME",
+  "description": "GDJS_GAME_NAME",
+  "author": "GDJS_GAME_AUTHOR",
+  "version": "GDJS_GAME_VERSION",
+  "dependencies": {
+    "GDJS_EXTENSION_NPM_DEPENDENCY": "0"
+  },
+  "scripts": {
+    "start": "electron main.js",
+    "build": "electron-builder"
+  },
+  "devDependencies": {
+    "electron": "8.2.5",
+    "electron-builder": "22.9.1"
+  },
+  "build": {
+    "appId": "GDJS_GAME_PACKAGE_NAME",
+    "directories": {
+      "buildResources": "buildResources"
     }
+  }
 }


### PR DESCRIPTION
- Adds the package name as app id to electron exports. 
- Adds electron and electron-builder as devDependencies and script to simplify the build process.