### PR TITLE
Add support for scale with tweens

### DIFF
--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -147,14 +147,14 @@ namespace gdjs {
     }
 
     /**
-     * Get y-scale of the text.
+     * Get x-scale of the text.
      */
     getScaleX(): float {
       return this._text.scale.x;
     }
 
     /**
-     * Get x-scale of the text.
+     * Get y-scale of the text.
      */
     getScaleY(): float {
       return this._text.scale.y;

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -164,7 +164,7 @@ namespace gdjs {
      * Set the text object scale.
      * @param newScale The new scale for the text object.
      */
-    setScale(newScale: number): void {
+    setScale(newScale: float): void {
       this._text.scale.x = newScale;
       this._text.scale.y = newScale;
     }
@@ -173,7 +173,7 @@ namespace gdjs {
      * Set the text object x-scale.
      * @param newScale The new x-scale for the text object.
      */
-    setScaleX(newScale: number): void {
+    setScaleX(newScale: float): void {
       this._text.scale.x = newScale;
     }
 
@@ -181,7 +181,7 @@ namespace gdjs {
      * Set the text object y-scale.
      * @param newScale The new y-scale for the text object.
      */
-    setScaleY(newScale: number): void {
+    setScaleY(newScale: float): void {
       this._text.scale.y = newScale;
     }
   }

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -297,7 +297,7 @@ namespace gdjs {
     /**
      * Get scale of the text.
      */
-    getScale() {
+    getScale(): float {
       return (Math.abs(this._scaleX) + Math.abs(this._scaleY)) / 2.0;
     }
 
@@ -319,7 +319,7 @@ namespace gdjs {
      * Set the text object scale.
      * @param newScale The new scale for the text object.
      */
-    setScale(newScale: number): void {
+    setScale(newScale: float): void {
       this._scaleX = newScale;
       this._scaleY = newScale;
       this._renderer.setScale(newScale);
@@ -329,7 +329,7 @@ namespace gdjs {
      * Set the text object x-scale.
      * @param newScale The new x-scale for the text object.
      */
-    setScaleX(newScale: number): void {
+    setScaleX(newScale: float): void {
       this._scaleX = newScale;
       this._renderer.setScaleX(newScale);
     }
@@ -338,7 +338,7 @@ namespace gdjs {
      * Set the text object y-scale.
      * @param newScale The new y-scale for the text object.
      */
-    setScaleY(newScale: number): void {
+    setScaleY(newScale: float): void {
       this._scaleY = newScale;
       this._renderer.setScaleY(newScale);
     }

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -302,14 +302,14 @@ namespace gdjs {
     }
 
     /**
-     * Get y-scale of the text.
+     * Get x-scale of the text.
      */
     getScaleX(): float {
       return this._renderer.getScaleX();
     }
 
     /**
-     * Get x-scale of the text.
+     * Get y-scale of the text.
      */
     getScaleY(): float {
       return this._renderer.getScaleY();

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -108,14 +108,14 @@ namespace gdjs {
     }
 
     /**
-     * Get y-scale of the tiled sprite object.
+     * Get x-scale of the tiled sprite object.
      */
     getScaleX(): float {
       return this._tiledSprite.scale.x;
     }
 
     /**
-     * Get x-scale of the tiled sprite object.
+     * Get y-scale of the tiled sprite object.
      */
     getScaleY(): float {
       return this._tiledSprite.scale.y;

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -106,6 +106,45 @@ namespace gdjs {
         Math.floor(rgb[2] * 255)
       );
     }
+
+    /**
+     * Get y-scale of the tiled sprite object.
+     */
+    getScaleX(): float {
+      return this._tiledSprite.scale.x;
+    }
+
+    /**
+     * Get x-scale of the tiled sprite object.
+     */
+    getScaleY(): float {
+      return this._tiledSprite.scale.y;
+    }
+
+    /**
+     * Set the tiled sprite object scale.
+     * @param newScale The new scale for the object.
+     */
+    setScale(newScale: float): void {
+      this._tiledSprite.scale.x = newScale;
+      this._tiledSprite.scale.y = newScale;
+    }
+
+    /**
+     * Set the tiled sprite object x-scale.
+     * @param newScale The new x-scale for the object.
+     */
+    setScaleX(newScale: float): void {
+      this._tiledSprite.scale.x = newScale;
+    }
+
+    /**
+     * Set the tiled sprite object y-scale.
+     * @param newScale The new y-scale for the object.
+     */
+    setScaleY(newScale: float): void {
+      this._tiledSprite.scale.y = newScale;
+    }
   }
 
   export const TiledSpriteRuntimeObjectRenderer = TiledSpriteRuntimeObjectPixiRenderer;

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
@@ -228,14 +228,14 @@ namespace gdjs {
     }
 
     /**
-     * Get y-scale of the tiled sprite object.
+     * Get x-scale of the tiled sprite object.
      */
     getScaleX(): float {
       return this._renderer.getScaleX();
     }
 
     /**
-     * Get x-scale of the tiled sprite object.
+     * Get y-scale of the tiled sprite object.
      */
     getScaleY(): float {
       return this._renderer.getScaleY();

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
@@ -219,6 +219,55 @@ namespace gdjs {
     getColor(): string {
       return this._renderer.getColor();
     }
+
+    /**
+     * Get scale of the tiled sprite object.
+     */
+    getScale(): float {
+      return (Math.abs(this._scaleX) + Math.abs(this._scaleY)) / 2.0;
+    }
+
+    /**
+     * Get y-scale of the tiled sprite object.
+     */
+    getScaleX(): float {
+      return this._renderer.getScaleX();
+    }
+
+    /**
+     * Get x-scale of the tiled sprite object.
+     */
+    getScaleY(): float {
+      return this._renderer.getScaleY();
+    }
+
+    /**
+     * Set the tiled sprite object scale.
+     * @param newScale The new scale for the tiled sprite object.
+     */
+    setScale(newScale: float): void {
+      this._scaleX = newScale;
+      this._scaleY = newScale;
+      this._renderer.setScale(newScale);
+    }
+
+    /**
+     * Set the tiled sprite object x-scale.
+     * @param newScale The new x-scale for the tiled sprite object.
+     */
+    setScaleX(newScale: float): void {
+      this._scaleX = newScale;
+      this._renderer.setScaleX(newScale);
+    }
+
+    /**
+     * Set the tiled sprite object y-scale.
+     * @param newScale The new y-scale for the tiled sprite object.
+     */
+    setScaleY(newScale: float): void {
+      this._scaleY = newScale;
+      this._renderer.setScaleY(newScale);
+    }
   }
   gdjs.registerObject(
     'TiledSpriteObject::TiledSprite',


### PR DESCRIPTION
Close #1181
Scale X Y and both are now supported by Tweens.
As suggested in the issue setWidth() / setHeight(), work already with Tweens
Trello card is now done.