### PR TITLE
Fix object name not being correctly cleared in ObjectGroup editor

### DIFF
--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -33,7 +33,6 @@ type Props = {|
   onChange: string => void,
   onChoose?: string => void,
   dataSource: DataSource,
-  clearOnChoose: boolean,
 
   id?: string,
   onBlur?: (event: SyntheticFocusEvent<HTMLInputElement>) => void,

--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -33,6 +33,7 @@ type Props = {|
   onChange: string => void,
   onChoose?: string => void,
   dataSource: DataSource,
+  clearOnChoose: boolean,
 
   id?: string,
   onBlur?: (event: SyntheticFocusEvent<HTMLInputElement>) => void,
@@ -243,6 +244,7 @@ export default React.forwardRef<Props, SemiControlledAutoCompleteInterface>(
               if (option === null || !input.current) return;
 
               handleChange(input.current, option, props);
+              setInputValue(null);
               setIsMenuOpen(false);
             }}
             open={isMenuOpen}


### PR DESCRIPTION
When selecting an object in the ObjectGroup editor, the text field should be cleared, as you can witness here:
https://github.com/4ian/GDevelop/blob/f83bea54c9601f3ded89e08a9c07beb0112b41df/newIDE/app/src/ObjectGroupEditor/index.js#L41-L43
This doesn't happen though, as when `onChoose` is called on the autocomplete, the new value isn't read from the props by setting the state `inputValue` to `null`. 

I toyed arround with the expressions autocomplete as I believe it is using the same component and I couldn't notice any regressions with those changes.