### PR TITLE
Use css instead of electron for color scheme detection

### DIFF
--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -239,9 +239,11 @@ export const initialPreferences = {
   values: {
     language: 'en',
     autoDownloadUpdates: true,
-    themeName: window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'Nord'
-      : 'GDevelop default',
+    themeName:
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'Nord'
+        : 'GDevelop default',
     codeEditorThemeName: 'vs-dark',
     hiddenAlertMessages: {},
     hiddenTutorialHints: {},

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -239,10 +239,8 @@ export const initialPreferences = {
   values: {
     language: 'en',
     autoDownloadUpdates: true,
-    themeName: electron
-      ? electron.remote.nativeTheme.shouldUseDarkColors
-        ? 'Nord'
-        : 'GDevelop default'
+    themeName: window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'Nord'
       : 'GDevelop default',
     codeEditorThemeName: 'vs-dark',
     hiddenAlertMessages: {},


### PR DESCRIPTION
Instead of using electron, use css to detect the users prefered color scheme, to ensure browser compatibility.