### PR TITLE
Replace swapi.co with swapi.dev in JSON parse from api example

### DIFF
--- a/newIDE/app/resources/examples/parse-json-from-api/parse-json-from-api.json
+++ b/newIDE/app/resources/examples/parse-json-from-api/parse-json-from-api.json
@@ -566,7 +566,7 @@
                 "value": "SendRequest"
               },
               "parameters": [
-                "\"https://swapi.co/\"",
+                "\"https://swapi.dev/\"",
                 "\"api/people/\" + ToString(Variable(num)) + \"/\"",
                 "\"person\"",
                 "\"GET\"",
@@ -581,7 +581,7 @@
                 "value": "SendRequest"
               },
               "parameters": [
-                "\"https://swapi.co/\"",
+                "\"https://swapi.dev/\"",
                 "\"api/planets/\" + ToString(Variable(num)) + \"/\"",
                 "\"planet\"",
                 "\"GET\"",


### PR DESCRIPTION
swapi.co, which was used in the "Parse JSON from API" example, has been abandoned and the servers have been taken down. This PR uses swapi.dev, a maintained for of that project. [This was originally reported on the forum](https://forum.gdevelop-app.com/t/how-come-this-doesnt-work-json-to-variable-example/30874/2?u=arthuro555)).