### PR TITLE
Fix compilation on iOS of exported games failing

### DIFF
--- a/Core/GDCore/Extensions/Metadata/DependencyMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/DependencyMetadata.h
@@ -101,6 +101,23 @@ class GD_CORE_API DependencyMetadata {
     return onlyIfSomeExtraSettingsNonEmpty;
   };
 
+  /**
+   * \brief Mark the dependency to be included in the export only if one other
+   * dependency is included in the export.
+   */
+  DependencyMetadata& OnlyIfOtherDependencyIsExported(const gd::String& otherDependency) {
+    onlyIfOtherDependencyIsExported = otherDependency;
+    return *this;
+  };
+
+  /**
+   * \brief Get the name of another dependency that must be exported to have this
+   * one also exported.
+   */
+  const gd::String& GetOtherDependencyThatMustBeExported() const {
+    return onlyIfOtherDependencyIsExported;
+  };
+
   const gd::String& GetName() const { return name; };
   const gd::String& GetExportName() const { return exportName; };
   const gd::String& GetVersion() const { return version; };
@@ -127,6 +144,7 @@ class GD_CORE_API DependencyMetadata {
   bool onlyIfSomeExtraSettingsNonEmpty;  ///< If true, only use this dependency
                                          ///< if at least one of the extra
                                          ///< settings is set.
+gd::String onlyIfOtherDependencyIsExported;
 };
 }  // namespace gd
 #endif  // DEPENDENCYMETADATA_H

--- a/Core/GDCore/IDE/ExportedDependencyResolver.h
+++ b/Core/GDCore/IDE/ExportedDependencyResolver.h
@@ -1,0 +1,124 @@
+#pragma once
+#include <vector>
+
+#include "GDCore/Extensions/Metadata/DependencyMetadata.h"
+#include "GDCore/Extensions/PlatformExtension.h"
+#include "GDCore/Project/Project.h"
+
+namespace gd {
+
+/**
+ * \brief Store references to a gd::DependencyMetadata and its associated
+ * gd::PlatformExtension.
+ *
+ * \note Both objects must be kept alive, as this is keeping a pointer to them.
+ */
+struct DependencyMetadataAndExtension {
+  DependencyMetadataAndExtension(gd::DependencyMetadata& dependency_,
+                                 gd::PlatformExtension& extension_)
+      : dependency(&dependency_), extension(&extension_){};
+
+  gd::DependencyMetadata& GetDependency() const { return *dependency; };
+  gd::PlatformExtension& GetExtension() const { return *extension; };
+
+ private:
+  gd::DependencyMetadata* dependency;
+  gd::PlatformExtension* extension;
+};
+
+/**
+ * \brief Helpers to manipulate dependencies of extensions to be exported along
+ * with a game.
+ */
+class ExportedDependencyResolver {
+ public:
+  /**
+   * \brief Return the list of dependencies to be exported for the given project
+   * and dependency type.
+   *
+   * Not all dependencies declared by extensions must be exported: some are only
+   * exported when some settings are filled. Then, some others are only exported
+   * when some other dependencies are exported (this won't work for more than
+   * one level though).
+   */
+  static std::vector<DependencyMetadataAndExtension> GetDependenciesFor(
+      const gd::Project& project, const gd::String& dependencyType) {
+    std::vector<DependencyMetadataAndExtension> dependenciesWithProperType;
+    for (std::shared_ptr<gd::PlatformExtension> extension :
+         project.GetCurrentPlatform().GetAllPlatformExtensions()) {
+      for (gd::DependencyMetadata& dependency :
+           extension->GetAllDependencies()) {
+        if (dependency.GetDependencyType() == dependencyType) {
+          DependencyMetadataAndExtension dependencyMetadataAndExtension(
+              dependency, *extension);
+          dependenciesWithProperType.push_back(dependencyMetadataAndExtension);
+        }
+      }
+    }
+
+    // Keep only the dependencies that have their extra settings filled
+    // and those that don't require extra settings to be filled.
+    std::vector<DependencyMetadataAndExtension> dependenciesWithFilledSettings;
+    for (auto dependencyAndExtension : dependenciesWithProperType) {
+      auto& dependency = dependencyAndExtension.GetDependency();
+      auto extraSettingValues = GetExtensionDependencyExtraSettingValues(
+          project, dependencyAndExtension);
+
+      bool hasExtraSettings = !extraSettingValues.empty();
+      if (!dependency.IsOnlyIfSomeExtraSettingsNonEmpty() || hasExtraSettings)
+        dependenciesWithFilledSettings.push_back(dependencyAndExtension);
+    }
+
+    // Keep only the dependency that depends on another dependencies that is
+    // exported (or dependencies that don't require another dependency).
+    std::vector<DependencyMetadataAndExtension> exportedDependencies;
+    for (auto dependencyAndExtension : dependenciesWithFilledSettings) {
+      auto& dependency = dependencyAndExtension.GetDependency();
+      auto& otherDependencyName =
+          dependency.GetOtherDependencyThatMustBeExported();
+      if (otherDependencyName.empty() ||
+          std::find_if(
+              dependenciesWithFilledSettings.begin(),
+              dependenciesWithFilledSettings.end(),
+              [&otherDependencyName](
+                  DependencyMetadataAndExtension& otherDependencyAndExtension) {
+                return otherDependencyAndExtension.GetDependency().GetName() ==
+                       otherDependencyName;
+              }) != dependenciesWithFilledSettings.end()) {
+        exportedDependencies.push_back(dependencyAndExtension);
+      }
+    }
+
+    return exportedDependencies;
+  }
+
+  /**
+   * \brief Return the values that were stored in the project for the given
+   * dependency.
+   */
+  static std::map<gd::String, gd::String>
+  GetExtensionDependencyExtraSettingValues(
+      const gd::Project& project,
+      const gd::DependencyMetadataAndExtension& dependencyAndExtension) {
+    std::map<gd::String, gd::String> values;
+    auto& dependency = dependencyAndExtension.GetDependency();
+    const gd::String& extensionName =
+        dependencyAndExtension.GetExtension().GetName();
+
+    for (const auto& extraSetting : dependency.GetAllExtraSettings()) {
+      const gd::String& type = extraSetting.second.GetType();
+      const gd::String extraSettingValue =
+          type == "ExtensionProperty"
+              ? project.GetExtensionProperties().GetValue(
+                    extensionName, extraSetting.second.GetValue())
+              : extraSetting.second.GetValue();
+
+      if (!extraSettingValue.empty())
+        values[extraSetting.first] = extraSettingValue;
+    }
+
+    return values;
+  };
+};
+
+}  // namespace gd

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -71,7 +71,8 @@ module.exports = {
       .addDependency()
       .setName('Consent Cordova plugin')
       .setDependencyType('cordova')
-      .setExportName('cordova-plugin-consent');
+      .setExportName('cordova-plugin-consent')
+      .onlyIfOtherDependencyIsExported('AdMob Cordova plugin');
 
     extension
       .addAction(

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <functional>
 #include <sstream>
 #include <streambuf>
 #include <string>
@@ -18,6 +19,7 @@
 #include "GDCore/Extensions/Platform.h"
 #include "GDCore/Extensions/PlatformExtension.h"
 #include "GDCore/IDE/AbstractFileSystem.h"
+#include "GDCore/IDE/ExportedDependencyResolver.h"
 #include "GDCore/IDE/Project/ProjectResourcesCopier.h"
 #include "GDCore/IDE/ProjectStripper.h"
 #include "GDCore/IDE/SceneNameMangler.h"
@@ -34,31 +36,6 @@
 #include "GDJS/Events/CodeGeneration/LayoutCodeGenerator.h"
 #include "GDJS/Extensions/JsPlatform.h"
 #undef CopyFile  // Disable an annoying macro
-
-namespace {
-
-std::map<gd::String, gd::String> GetExtensionDependencyExtraSettingValues(
-    const gd::Project &project,
-    const gd::String &extensionName,
-    const gd::DependencyMetadata &dependency) {
-  std::map<gd::String, gd::String> values;
-
-  for (const auto &extraSetting : dependency.GetAllExtraSettings()) {
-    const gd::String &type = extraSetting.second.GetType();
-    const gd::String extraSettingValue =
-        type == "ExtensionProperty"
-            ? project.GetExtensionProperties().GetValue(
-                  extensionName, extraSetting.second.GetValue())
-            : extraSetting.second.GetValue();
-
-    if (!extraSettingValue.empty())
-      values[extraSetting.first] = extraSettingValue;
-  }
-
-  return values;
-};
-
-}  // namespace
 
 namespace gdjs {
 
@@ -283,35 +260,31 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
           .FindAndReplace("<!-- GDJS_ICONS_IOS -->", makeIconsIos());
 
   gd::String plugins = "";
+  auto dependenciesAndExtensions =
+      gd::ExportedDependencyResolver::GetDependenciesFor(project, "cordova");
+  for (auto &dependencyAndExtension : dependenciesAndExtensions) {
+    const auto &dependency = dependencyAndExtension.GetDependency();
 
-  for (std::shared_ptr<gd::PlatformExtension> extension :
-       project.GetCurrentPlatform().GetAllPlatformExtensions()) {
-    for (gd::DependencyMetadata &dependency : extension->GetAllDependencies()) {
-      if (dependency.GetDependencyType() == "cordova") {
-        gd::String plugin;
-        plugin += "<plugin name=\"" + dependency.GetExportName();
-        if (dependency.GetVersion() != "") {
-          plugin += "\" spec=\"" + dependency.GetVersion();
-        }
-        plugin += "\">\n";
-
-        auto extraSettingValues = GetExtensionDependencyExtraSettingValues(
-            project, extension->GetName(), dependency);
-
-        // For Cordova, all settings are considered a plugin variable.
-        for (auto &extraSetting : extraSettingValues) {
-          plugin += "\t\t<variable name=\"" + extraSetting.first +
-                    "\" value=\"" + extraSetting.second + "\" />\n";
-        }
-
-        plugin += "\t</plugin>";
-
-        // Don't include the plugin if no extra setting was fulfilled.
-        bool hasExtraSettings = !extraSettingValues.empty();
-        if (!dependency.IsOnlyIfSomeExtraSettingsNonEmpty() || hasExtraSettings)
-          plugins += plugin;
-      }
+    gd::String plugin;
+    plugin += "<plugin name=\"" + dependency.GetExportName();
+    if (dependency.GetVersion() != "") {
+      plugin += "\" spec=\"" + dependency.GetVersion();
     }
+    plugin += "\">\n";
+
+    auto extraSettingValues = gd::ExportedDependencyResolver::
+        GetExtensionDependencyExtraSettingValues(project,
+                                                 dependencyAndExtension);
+
+    // For Cordova, all settings are considered a plugin variable.
+    for (auto &extraSetting : extraSettingValues) {
+      plugin += "\t\t<variable name=\"" + extraSetting.first + "\" value=\"" +
+                extraSetting.second + "\" />\n";
+    }
+
+    plugin += "\t</plugin>";
+
+    plugins += plugin;
   }
 
   // TODO: migrate the plugins to the package.json
@@ -477,27 +450,23 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
 
     gd::String packages = "";
 
-    for (std::shared_ptr<gd::PlatformExtension> extension :
-         project.GetCurrentPlatform()
-             .GetAllPlatformExtensions()) {  // TODO Add a way to select only
-                                             // used Extensions
-      for (gd::DependencyMetadata dependency :
-           extension->GetAllDependencies()) {
-        if (dependency.GetDependencyType() == "npm") {
-          if (dependency.GetVersion() == "") {
-            gd::LogError(
-                "Latest Version not available for NPM dependencies, "
-                "dependency " +
-                dependency.GetName() +
-                " is not exported. Please specify a version when calling "
-                "addDependency.");
-            continue;
-          }
-          packages += "\n\t\"" + dependency.GetExportName() + "\": \"" +
-                      dependency.GetVersion() + "\",";
-          // For node extra settings are ignored
-        }
+    auto dependenciesAndExtensions =
+        gd::ExportedDependencyResolver::GetDependenciesFor(project, "npm");
+    for (auto &dependencyAndExtension : dependenciesAndExtensions) {
+      const auto &dependency = dependencyAndExtension.GetDependency();
+      if (dependency.GetVersion() == "") {
+        gd::LogError(
+            "Latest Version not available for NPM dependencies, "
+            "dependency " +
+            dependency.GetName() +
+            " is not exported. Please specify a version when calling "
+            "addDependency.");
+        continue;
       }
+
+      // For Electron, extra settings of dependencies are ignored.
+      packages += "\n\t\"" + dependency.GetExportName() + "\": \"" +
+                  dependency.GetVersion() + "\",";
     }
 
     if (!packages.empty()) {

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1099,6 +1099,7 @@ interface DependencyMetadata {
     [Const, Ref] MapStringPropertyDescriptor GetAllExtraSettings();
 
     [Ref] DependencyMetadata OnlyIfSomeExtraSettingsNonEmpty();
+    [Ref] DependencyMetadata OnlyIfOtherDependencyIsExported([Const] DOMString otherDependency);
 };
 
 interface ParameterMetadata {

--- a/GDevelop.js/types/gddependencymetadata.js
+++ b/GDevelop.js/types/gddependencymetadata.js
@@ -12,6 +12,7 @@ declare class gdDependencyMetadata {
   setExtraSetting(settingName: string, settingValue: gdPropertyDescriptor): gdDependencyMetadata;
   getAllExtraSettings(): gdMapStringPropertyDescriptor;
   onlyIfSomeExtraSettingsNonEmpty(): gdDependencyMetadata;
+  onlyIfOtherDependencyIsExported(otherDependency: string): gdDependencyMetadata;
   delete(): void;
   ptr: number;
 };


### PR DESCRIPTION
* This was because an SDK related to AdMob was wrongly included and would trigger a compiler error in XCode.