### PR TITLE
Platformer big refactor: state pattern

### DIFF
--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -89,7 +89,9 @@ namespace gdjs {
       this._falling = new PlatformerObjectRuntimeBehavior.Falling(this);
       this._onFloor = new PlatformerObjectRuntimeBehavior.OnFloor(this);
       this._jumping = new PlatformerObjectRuntimeBehavior.Jumping(this);
-      this._grabbingPlatform = new PlatformerObjectRuntimeBehavior.GrabbingPlatform(this);
+      this._grabbingPlatform = new PlatformerObjectRuntimeBehavior.GrabbingPlatform(
+        this
+      );
       this._onLadder = new PlatformerObjectRuntimeBehavior.OnLadder(this);
       this._state = this._falling;
     }
@@ -174,7 +176,9 @@ namespace gdjs {
       const oldX = object.getX();
       if (this._requestedDeltaX !== 0) {
         const floorPlatformId =
-          this._onFloor.getFloorPlatform() !== null ? this._onFloor.getFloorPlatform()!.owner.id : null;
+          this._onFloor.getFloorPlatform() !== null
+            ? this._onFloor.getFloorPlatform()!.owner.id
+            : null;
         object.setX(object.getX() + this._requestedDeltaX);
         let tryRounding = true;
 
@@ -228,7 +232,7 @@ namespace gdjs {
         }
       }
     }
-    
+
     _setFalling() {
       console.debug(`${this._state} --> ${this._falling}`);
       this._state.leave();
@@ -326,18 +330,19 @@ namespace gdjs {
       let tryGrabbingPlatform = false;
       object.setX(
         object.getX() +
-          (this._requestedDeltaX > 0 ? this._xGrabTolerance : -this._xGrabTolerance)
+          (this._requestedDeltaX > 0
+            ? this._xGrabTolerance
+            : -this._xGrabTolerance)
       );
       let collidingPlatform = this._getCollidingPlatform();
-      if (
-        collidingPlatform !== null &&
-        this._canGrab(collidingPlatform)
-      ) {
+      if (collidingPlatform !== null && this._canGrab(collidingPlatform)) {
         tryGrabbingPlatform = true;
       }
       object.setX(
         object.getX() +
-          (this._requestedDeltaX > 0 ? -this._xGrabTolerance : this._xGrabTolerance)
+          (this._requestedDeltaX > 0
+            ? -this._xGrabTolerance
+            : this._xGrabTolerance)
       );
 
       //Check if we can grab the collided platform
@@ -429,34 +434,35 @@ namespace gdjs {
       this._requestedDeltaY = 0;
 
       const inputManager = runtimeScene.getGame().getInputManager();
-      this._leftKey || (this._leftKey =
-        !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(LEFTKEY));
+      this._leftKey ||
+        (this._leftKey =
+          !this._ignoreDefaultControls && inputManager.isKeyPressed(LEFTKEY));
       // @ts-ignore
-      this._rightKey || (this._rightKey =
-        !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(RIGHTKEY));
-      
-      this._jumpKey || (this._jumpKey =
-      !this._ignoreDefaultControls &&
-      (inputManager.isKeyPressed(LSHIFTKEY) ||
-      inputManager.isKeyPressed(RSHIFTKEY) ||
-      inputManager.isKeyPressed(SPACEKEY)));
-      
-      this._ladderKey || (this._ladderKey =
-      !this._ignoreDefaultControls &&
-      inputManager.isKeyPressed(UPKEY));
-      
-      this._upKey || (this._upKey =
-        !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(UPKEY));
-      this._downKey || (this._downKey =
-        !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(DOWNKEY));
-      
-      this._releaseKey || (this._releaseKey =
-        !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(DOWNKEY));
+      this._rightKey ||
+        (this._rightKey =
+          !this._ignoreDefaultControls && inputManager.isKeyPressed(RIGHTKEY));
+
+      this._jumpKey ||
+        (this._jumpKey =
+          !this._ignoreDefaultControls &&
+          (inputManager.isKeyPressed(LSHIFTKEY) ||
+            inputManager.isKeyPressed(RSHIFTKEY) ||
+            inputManager.isKeyPressed(SPACEKEY)));
+
+      this._ladderKey ||
+        (this._ladderKey =
+          !this._ignoreDefaultControls && inputManager.isKeyPressed(UPKEY));
+
+      this._upKey ||
+        (this._upKey =
+          !this._ignoreDefaultControls && inputManager.isKeyPressed(UPKEY));
+      this._downKey ||
+        (this._downKey =
+          !this._ignoreDefaultControls && inputManager.isKeyPressed(DOWNKEY));
+
+      this._releaseKey ||
+        (this._releaseKey =
+          !this._ignoreDefaultControls && inputManager.isKeyPressed(DOWNKEY));
 
       this._requestedDeltaX += this._updateSpeed(timeDelta);
 
@@ -545,9 +551,7 @@ namespace gdjs {
      * Mark the platformer object has not being grabbing any platform.
      */
     _releaseGrabbedPlatform() {
-      if (
-        this._state == this._grabbingPlatform
-      ) {
+      if (this._state == this._grabbingPlatform) {
         this._setFalling();
       }
     }
@@ -705,7 +709,8 @@ namespace gdjs {
      * Return true if the object is overlapping a ladder.
      * Note: _updatePotentialCollidingObjects must have been called before.
      */
-    _isOverlappingLadder() { //FIXME put back private
+    _isOverlappingLadder() {
+      //FIXME put back private
       for (let i = 0; i < this._potentialCollidingObjects.length; ++i) {
         const platform = this._potentialCollidingObjects[i];
         if (
@@ -1102,32 +1107,32 @@ namespace gdjs {
      * @see PlatformerObjectRuntimeBehavior.doStepPreEvents to understand how the functions are called.
      */
     export interface State {
-    /**
-     * Called when the object leaves this state.
-     * It's a good place to reset the internal state.
-     * @see OnFloor.enter that is not part of the interface because it take specific parameters.
-     */
+      /**
+       * Called when the object leaves this state.
+       * It's a good place to reset the internal state.
+       * @see OnFloor.enter that is not part of the interface because it take specific parameters.
+       */
       leave(): void;
       /**
-      * Called before the obstacle search.
-      * The object position may need adjustments to handle external changes.
-      */
+       * Called before the obstacle search.
+       * The object position may need adjustments to handle external changes.
+       */
       beforeUpdatingObstacles(): void;
       /**
-      * Check if transition to other states is needed and apply them before moving horizontally.
-      */
+       * Check if transition to other states is needed and apply them before moving horizontally.
+       */
       checkTransitionBeforeX(): void;
       /**
-      * Use _requestedDeltaX and _requestedDeltaY to choose the movement that suite the state before moving horizontally.
-      */
+       * Use _requestedDeltaX and _requestedDeltaY to choose the movement that suite the state before moving horizontally.
+       */
       beforeMovingX(): void;
       /**
-      * Check if transition to other states is needed and apply them before moving vertically.
-      */
+       * Check if transition to other states is needed and apply them before moving vertically.
+       */
       checkTransitionBeforeY(timeDelta: float): void;
       /**
-      * Use _requestedDeltaY to choose the movement that suite the state before moving vertically.
-      */
+       * Use _requestedDeltaY to choose the movement that suite the state before moving vertically.
+       */
       beforeMovingY(timeDelta: float, oldX: float): void;
     }
 
@@ -1135,8 +1140,8 @@ namespace gdjs {
      * The object is on the floor standing or walking.
      */
     export class OnFloor implements State {
-      private _behavior : PlatformerObjectRuntimeBehavior;
-      private _floorPlatform:PlatformRuntimeBehavior | null = null;
+      private _behavior: PlatformerObjectRuntimeBehavior;
+      private _floorPlatform: PlatformRuntimeBehavior | null = null;
       private _floorLastX: float = 0;
       private _floorLastY: float = 0;
       _oldHeight: float = 0;
@@ -1168,9 +1173,7 @@ namespace gdjs {
       beforeUpdatingObstacles() {
         const object = this._behavior.owner;
         //Stick the object to the floor if its height has changed.
-        if (
-          this._oldHeight !== object.getHeight()
-        ) {
+        if (this._oldHeight !== object.getHeight()) {
           object.setY(
             this._floorLastY -
               object.getHeight() +
@@ -1179,7 +1182,7 @@ namespace gdjs {
           );
         }
       }
-  
+
       checkTransitionBeforeX() {
         const behavior = this._behavior;
         //Check that the floor object still exists and is near the object.
@@ -1192,14 +1195,16 @@ namespace gdjs {
           behavior._setFalling();
         }
       }
-  
+
       beforeMovingX() {
         const behavior = this._behavior;
         //Shift the object according to the floor movement.
-        behavior._requestedDeltaX += this._floorPlatform!.owner.getX() - this._floorLastX;
-        behavior._requestedDeltaY += this._floorPlatform!.owner.getY() - this._floorLastY;
+        behavior._requestedDeltaX +=
+          this._floorPlatform!.owner.getX() - this._floorLastX;
+        behavior._requestedDeltaY +=
+          this._floorPlatform!.owner.getY() - this._floorLastY;
       }
-  
+
       checkTransitionBeforeY(timeDelta: float) {
         const behavior = this._behavior;
         //Go on a ladder
@@ -1207,11 +1212,11 @@ namespace gdjs {
         //Jumping
         behavior.checkTransitionJumping();
       }
-  
+
       beforeMovingY(timeDelta: float, oldX: float) {
         const behavior = this._behavior;
         const object = behavior.owner;
-        
+
         //Follow the floor
         if (
           gdjs.RuntimeObject.collisionTest(
@@ -1227,12 +1232,19 @@ namespace gdjs {
           do {
             if (
               step >=
-              Math.floor(Math.abs(behavior._requestedDeltaX * behavior._slopeClimbingFactor))
+              Math.floor(
+                Math.abs(
+                  behavior._requestedDeltaX * behavior._slopeClimbingFactor
+                )
+              )
             ) {
               //Slope is too step ( > 50% )
               object.setY(
                 object.getY() -
-                  (Math.abs(behavior._requestedDeltaX * behavior._slopeClimbingFactor) - step)
+                  (Math.abs(
+                    behavior._requestedDeltaX * behavior._slopeClimbingFactor
+                  ) -
+                    step)
               );
 
               //Try to add the decimal part.
@@ -1281,8 +1293,15 @@ namespace gdjs {
           );
           let step = 0;
           let noMoreOnFloor = false;
-          while (!behavior._isCollidingWith(behavior._potentialCollidingObjects)) {
-            if (step > Math.abs(behavior._requestedDeltaX * behavior._slopeClimbingFactor)) {
+          while (
+            !behavior._isCollidingWith(behavior._potentialCollidingObjects)
+          ) {
+            if (
+              step >
+              Math.abs(
+                behavior._requestedDeltaX * behavior._slopeClimbingFactor
+              )
+            ) {
               //Slope is too step ( > 50% )
               noMoreOnFloor = true;
               break;
@@ -1306,7 +1325,7 @@ namespace gdjs {
       }
 
       toString(): String {
-        return "OnFloor";
+        return 'OnFloor';
       }
     }
 
@@ -1314,50 +1333,42 @@ namespace gdjs {
      * The object is falling.
      */
     export class Falling implements State {
-      private _behavior : PlatformerObjectRuntimeBehavior;
+      private _behavior: PlatformerObjectRuntimeBehavior;
 
       constructor(behavior: PlatformerObjectRuntimeBehavior) {
         this._behavior = behavior;
       }
 
-      enter() {
-      }
+      enter() {}
 
-      leave() {
-      }
+      leave() {}
 
-      beforeUpdatingObstacles() {
-      }
-  
-      checkTransitionBeforeX() {
-      }
-  
-      beforeMovingX() {
-      }
-  
+      beforeUpdatingObstacles() {}
+
+      checkTransitionBeforeX() {}
+
+      beforeMovingX() {}
+
       checkTransitionBeforeY(timeDelta: float) {
         const behavior = this._behavior;
         //Go on a ladder
         behavior.checkTransitionOnLadder();
         //Jumping
         behavior.checkTransitionJumping();
-  
+
         //Grabbing a platform
-        if (
-          behavior._canGrabPlatforms &&
-          behavior._requestedDeltaX !== 0
-        ) {
+        if (behavior._canGrabPlatforms && behavior._requestedDeltaX !== 0) {
           behavior.checkGrabPlatform();
         }
       }
-  
+
       beforeMovingY(timeDelta: float, oldX: float) {
         //Fall
         this._behavior.fall(timeDelta);
       }
 
       toString(): String {
-        return "Falling";
+        return 'Falling';
       }
     }
 
@@ -1365,7 +1376,7 @@ namespace gdjs {
      * The object is on the ascending part of the jump (otherwise it's falling).
      */
     export class Jumping implements State {
-      private _behavior : PlatformerObjectRuntimeBehavior;
+      private _behavior: PlatformerObjectRuntimeBehavior;
       private _currentJumpSpeed: number = 0;
       private _timeSinceCurrentJumpStart: number = 0;
       private _jumpKeyHeldSinceJumpStart: boolean = false;
@@ -1383,12 +1394,11 @@ namespace gdjs {
         const behavior = this._behavior;
         this._timeSinceCurrentJumpStart = 0;
         this._jumpKeyHeldSinceJumpStart = true;
-        
-        if (from != behavior._jumping &&
-            from != behavior._falling) {
+
+        if (from != behavior._jumping && from != behavior._falling) {
           this._jumpingFirstDelta = true;
         }
-        
+
         behavior._canJump = false;
 
         //FIXME can't be Jumping and OnFloor at the same time, need a fix and a test
@@ -1401,15 +1411,12 @@ namespace gdjs {
         this._currentJumpSpeed = 0;
       }
 
-      beforeUpdatingObstacles() {
-      }
-  
-      checkTransitionBeforeX() {
-      }
-  
-      beforeMovingX() {
-      }
-  
+      beforeUpdatingObstacles() {}
+
+      checkTransitionBeforeX() {}
+
+      beforeMovingX() {}
+
       checkTransitionBeforeY(timeDelta: float) {
         const behavior = this._behavior;
         //Go on a ladder
@@ -1426,18 +1433,16 @@ namespace gdjs {
           behavior.checkGrabPlatform();
         }
       }
-  
+
       beforeMovingY(timeDelta: float, oldX: float) {
         const behavior = this._behavior;
-        
+
         //Fall
-        if (
-          !this._jumpingFirstDelta
-        ) {
+        if (!this._jumpingFirstDelta) {
           behavior.fall(timeDelta);
         }
         this._jumpingFirstDelta = false;
-        
+
         // Check if the jump key is continuously held since
         // the beginning of the jump.
         if (!behavior._jumpKey) {
@@ -1459,7 +1464,7 @@ namespace gdjs {
       }
 
       toString(): String {
-        return "Jumping";
+        return 'Jumping';
       }
     }
 
@@ -1467,7 +1472,7 @@ namespace gdjs {
      * The object grabbed the edge of a platform and is standing there.
      */
     export class GrabbingPlatform implements State {
-      private _behavior : PlatformerObjectRuntimeBehavior;
+      private _behavior: PlatformerObjectRuntimeBehavior;
       private _grabbedPlatform: any = null;
       private _grabbedPlatformLastX: any;
       private _grabbedPlatformLastY: any;
@@ -1486,9 +1491,8 @@ namespace gdjs {
         this._grabbedPlatform = null;
       }
 
-      beforeUpdatingObstacles() {
-      }
-  
+      beforeUpdatingObstacles() {}
+
       checkTransitionBeforeX() {
         const behavior = this._behavior;
         //Check that the grabbed platform object still exists and is near the object.
@@ -1501,7 +1505,7 @@ namespace gdjs {
           behavior._releaseGrabbedPlatform();
         }
       }
-  
+
       beforeMovingX() {
         const behavior = this._behavior;
         //Shift the object according to the grabbed platform movement.
@@ -1511,7 +1515,7 @@ namespace gdjs {
         behavior._requestedDeltaY =
           this._grabbedPlatform.owner.getY() - this._grabbedPlatformLastY;
       }
-  
+
       checkTransitionBeforeY(timeDelta: float) {
         const behavior = this._behavior;
         //Go on a ladder
@@ -1520,11 +1524,11 @@ namespace gdjs {
         if (behavior._releaseKey) {
           behavior._releaseGrabbedPlatform();
         }
-  
+
         //Jumping
         behavior.checkTransitionJumping();
       }
-  
+
       beforeMovingY(timeDelta: float, oldX: float) {
         const behavior = this._behavior;
         this._grabbedPlatformLastX = this._grabbedPlatform.owner.getX();
@@ -1532,7 +1536,7 @@ namespace gdjs {
       }
 
       toString(): String {
-        return "GrabbingPlatform";
+        return 'GrabbingPlatform';
       }
     }
 
@@ -1540,7 +1544,7 @@ namespace gdjs {
      * The object grabbed a ladder. It can stand or move in 8 directions.
      */
     export class OnLadder implements State {
-      private _behavior : PlatformerObjectRuntimeBehavior;
+      private _behavior: PlatformerObjectRuntimeBehavior;
 
       constructor(behavior: PlatformerObjectRuntimeBehavior) {
         this._behavior = behavior;
@@ -1551,42 +1555,40 @@ namespace gdjs {
         this._behavior._currentFallSpeed = 0;
       }
 
-      leave() {
-      }
+      leave() {}
 
-      beforeUpdatingObstacles() {
-      }
-  
-      checkTransitionBeforeX() {
-      }
-  
-      beforeMovingX() {
-      }
-  
+      beforeUpdatingObstacles() {}
+
+      checkTransitionBeforeX() {}
+
+      beforeMovingX() {}
+
       checkTransitionBeforeY(timeDelta: float) {
         const behavior = this._behavior;
         //Coming to an extremity of a ladder
         if (!behavior._isOverlappingLadder()) {
           behavior._setFalling();
         }
-  
+
         //Jumping
         behavior.checkTransitionJumping();
       }
-  
+
       beforeMovingY(timeDelta: float, oldX: float) {
         const behavior = this._behavior;
-        
+
         if (behavior._upKey) {
-          behavior._requestedDeltaY -= behavior._ladderClimbingSpeed * timeDelta;
+          behavior._requestedDeltaY -=
+            behavior._ladderClimbingSpeed * timeDelta;
         }
         if (behavior._downKey) {
-          behavior._requestedDeltaY += behavior._ladderClimbingSpeed * timeDelta;
+          behavior._requestedDeltaY +=
+            behavior._ladderClimbingSpeed * timeDelta;
         }
       }
 
       toString(): String {
-        return "OnLadder";
+        return 'OnLadder';
       }
     }
   }

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -44,6 +44,7 @@ namespace gdjs {
     _upKey: boolean = false;
     _downKey: boolean = false;
     _jumpKey: boolean = false;
+    _jumpingFirstDelta:boolean = false;
     _state: PlatformerObjectRuntimeBehavior.State =
       PlatformerObjectRuntimeBehavior.State.Falling;
 
@@ -289,6 +290,9 @@ namespace gdjs {
 
     checkTransitionJumping() {
       if (this._canJump && this._jumpKey) {
+        if (this._state != PlatformerObjectRuntimeBehavior.State.Jumping) {
+          this._jumpingFirstDelta = true;
+        }
         this.setState(PlatformerObjectRuntimeBehavior.State.Jumping);
         this._canJump = false;
         this._timeSinceCurrentJumpStart = 0;
@@ -487,8 +491,12 @@ namespace gdjs {
         this._releaseGrabbedPlatform();
       }
 
+      //Jumping
+      this.checkTransitionJumping();
+
       //Fall
       if (
+        !this._jumpingFirstDelta &&
         this._state != PlatformerObjectRuntimeBehavior.State.OnFloor &&
         this._state != PlatformerObjectRuntimeBehavior.State.OnLadder &&
         this._state != PlatformerObjectRuntimeBehavior.State.GrabbingPlatform
@@ -505,9 +513,6 @@ namespace gdjs {
       ) {
         this.checkGrabPlatform();
       }
-
-      //Jumping
-      this.checkTransitionJumping();
     }
 
     beforeMovingY(timeDelta: float, oldX: float) {
@@ -660,6 +665,8 @@ namespace gdjs {
       const SPACEKEY = 32;
       const object = this.owner;
       const timeDelta = this.owner.getElapsedTime(runtimeScene) / 1000;
+
+      this._jumpingFirstDelta = false;
 
       //0.1) Get the player input:
       this._requestedDeltaX = 0;

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1110,7 +1110,7 @@ namespace gdjs {
       /**
        * Called when the object leaves this state.
        * It's a good place to reset the internal state.
-       * @see OnFloor.enter that is not part of the interface because it take specific parameters.
+       * @see OnFloor.enter that is not part of the interface because it takes specific parameters.
        */
       leave(): void;
       /**
@@ -1119,19 +1119,19 @@ namespace gdjs {
        */
       beforeUpdatingObstacles(): void;
       /**
-       * Check if transition to other states is needed and apply them before moving horizontally.
+       * Check if transitions to other states are needed and apply them before moving horizontally.
        */
       checkTransitionBeforeX(): void;
       /**
-       * Use _requestedDeltaX and _requestedDeltaY to choose the movement that suite the state before moving horizontally.
+       * Use _requestedDeltaX and _requestedDeltaY to choose the movement that suits the state before moving horizontally.
        */
       beforeMovingX(): void;
       /**
-       * Check if transition to other states is needed and apply them before moving vertically.
+       * Check if transitions to other states are needed and apply them before moving vertically.
        */
       checkTransitionBeforeY(timeDelta: float): void;
       /**
-       * Use _requestedDeltaY to choose the movement that suite the state before moving vertically.
+       * Use _requestedDeltaY to choose the movement that suits the state before moving vertically.
        */
       beforeMovingY(timeDelta: float, oldX: float): void;
     }
@@ -1373,7 +1373,8 @@ namespace gdjs {
     }
 
     /**
-     * The object is on the ascending part of the jump (otherwise it's falling).
+     * The object is on the ascending and descending part of the jump.
+     * The object is considered falling when the jump continue to a lower position than the initial one.
      */
     export class Jumping implements State {
       private _behavior: PlatformerObjectRuntimeBehavior;

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -483,6 +483,10 @@ namespace gdjs {
         }
       }
 
+      if (this._releaseKey) {
+        this._releaseGrabbedPlatform();
+      }
+
       //Fall
       if (
         this._state != PlatformerObjectRuntimeBehavior.State.OnFloor &&
@@ -500,9 +504,6 @@ namespace gdjs {
         this._state != PlatformerObjectRuntimeBehavior.State.OnFloor
       ) {
         this.checkGrabPlatform();
-      }
-      if (this._releaseKey) {
-        this._releaseGrabbedPlatform();
       }
 
       //Jumping

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -473,13 +473,6 @@ namespace gdjs {
       //Go on a ladder
       this.checkTransitionOnLadder();
       if (this._state == PlatformerObjectRuntimeBehavior.State.OnLadder) {
-        if (this._upKey) {
-          this._requestedDeltaY -= this._ladderClimbingSpeed * timeDelta;
-        }
-        if (this._downKey) {
-          this._requestedDeltaY += this._ladderClimbingSpeed * timeDelta;
-        }
-
         //Coming to an extremity of a ladder
         if (!this._isOverlappingLadder()) {
           this._state = PlatformerObjectRuntimeBehavior.State.Falling;
@@ -524,6 +517,16 @@ namespace gdjs {
 
     beforeMovingY(timeDelta: float, oldX: float) {
       const object = this.owner;
+
+      if (this._state == PlatformerObjectRuntimeBehavior.State.OnLadder) {
+        if (this._upKey) {
+          this._requestedDeltaY -= this._ladderClimbingSpeed * timeDelta;
+        }
+        if (this._downKey) {
+          this._requestedDeltaY += this._ladderClimbingSpeed * timeDelta;
+        }
+      }
+
       // Check if the jump key is continuously held since
       // the beginning of the jump.
       if (!this._jumpKey) {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -227,6 +227,11 @@ namespace gdjs {
       }
     }
 
+    setState(state: PlatformerObjectRuntimeBehavior.State) {
+      console.debug(`${PlatformerObjectRuntimeBehavior.getStateName(this._state)} --> ${PlatformerObjectRuntimeBehavior.getStateName(state)}`);
+      this._state = state;
+    }
+
     moveY() {
       const object = this.owner;
       //Move the object on Y axis
@@ -252,7 +257,7 @@ namespace gdjs {
         ) {
           //Jumpthru = obstacle <=> Only if not already overlapped when going down
           if (PlatformerObjectRuntimeBehavior.State.Jumping) {
-            this._state = PlatformerObjectRuntimeBehavior.State.Falling;
+            this.setState(PlatformerObjectRuntimeBehavior.State.Falling);
           }
           this._currentJumpSpeed = 0;
           if (
@@ -278,13 +283,13 @@ namespace gdjs {
         this._floorPlatform = null;
         this._currentJumpSpeed = 0;
         this._currentFallSpeed = 0;
-        this._state = PlatformerObjectRuntimeBehavior.State.OnLadder;
+        this.setState(PlatformerObjectRuntimeBehavior.State.OnLadder);
       }
     }
 
     checkTransitionJumping() {
       if (this._canJump && this._jumpKey) {
-        this._state = PlatformerObjectRuntimeBehavior.State.Jumping;
+        this.setState(PlatformerObjectRuntimeBehavior.State.Jumping);
         this._canJump = false;
         this._timeSinceCurrentJumpStart = 0;
         this._jumpKeyHeldSinceJumpStart = true;
@@ -333,8 +338,7 @@ namespace gdjs {
             true
           )
         ) {
-          this._state =
-            PlatformerObjectRuntimeBehavior.State.GrabbingPlatform;
+          this.setState(PlatformerObjectRuntimeBehavior.State.GrabbingPlatform);
           this._grabbedPlatform = collidingPlatform;
           this._requestedDeltaY = 0;
         } else {
@@ -383,12 +387,12 @@ namespace gdjs {
 
           //Ensure nothing is grabbed.
           this._releaseGrabbedPlatform();
-          this._state = PlatformerObjectRuntimeBehavior.State.OnFloor;
+          this.setState(PlatformerObjectRuntimeBehavior.State.OnFloor);
         } else if (this._state != PlatformerObjectRuntimeBehavior.State.GrabbingPlatform) {
           //In the air
           this._canJump = false;
           if (this._state == PlatformerObjectRuntimeBehavior.State.OnFloor) {
-            this._state = PlatformerObjectRuntimeBehavior.State.Falling;
+            this.setState(PlatformerObjectRuntimeBehavior.State.Falling);
             this._floorPlatform = null;
           }
         }
@@ -434,7 +438,7 @@ namespace gdjs {
           this._floorPlatform.owner.id
         )
       ) {
-        this._state = PlatformerObjectRuntimeBehavior.State.Falling;
+        this.setState(PlatformerObjectRuntimeBehavior.State.Falling);
         this._floorPlatform = null;
       }
 
@@ -475,7 +479,7 @@ namespace gdjs {
       if (this._state == PlatformerObjectRuntimeBehavior.State.OnLadder) {
         //Coming to an extremity of a ladder
         if (!this._isOverlappingLadder()) {
-          this._state = PlatformerObjectRuntimeBehavior.State.Falling;
+          this.setState(PlatformerObjectRuntimeBehavior.State.Falling);
         }
       }
 
@@ -546,7 +550,7 @@ namespace gdjs {
         }
         if (this._currentJumpSpeed < 0) {
           this._currentJumpSpeed = 0;
-          this._state = PlatformerObjectRuntimeBehavior.State.Falling;
+          this.setState(PlatformerObjectRuntimeBehavior.State.Falling);
         }
       }
 
@@ -782,7 +786,7 @@ namespace gdjs {
       if (
         this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform
       ) {
-        this._state = PlatformerObjectRuntimeBehavior.State.Falling;
+        this.setState(PlatformerObjectRuntimeBehavior.State.Falling);
       }
 
       //Ensure nothing is grabbed.
@@ -1335,12 +1339,17 @@ namespace gdjs {
   }
 
   export namespace PlatformerObjectRuntimeBehavior {
-    export enum State {
-      Falling,
+    export const enum State {
+      Falling = 0,
       OnFloor,
       Jumping,
       OnLadder,
       GrabbingPlatform,
+    }
+
+    const stateNames = ["Falling", "OnFloor", "Jumping", "OnLadder", "GrabbingPlatform"];
+    export function getStateName(state: PlatformerObjectRuntimeBehavior.State): String {
+      return stateNames[state];
     }
   }
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -657,34 +657,34 @@ namespace gdjs {
       this._requestedDeltaY = 0;
 
       const inputManager = runtimeScene.getGame().getInputManager();
-      this._leftKey ||=
+      this._leftKey || (this._leftKey =
         !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(LEFTKEY);
+        inputManager.isKeyPressed(LEFTKEY));
       // @ts-ignore
-      this._rightKey ||=
+      this._rightKey || (this._rightKey =
         !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(RIGHTKEY);
+        inputManager.isKeyPressed(RIGHTKEY));
       
-      this._jumpKey ||=
+      this._jumpKey || (this._jumpKey =
       !this._ignoreDefaultControls &&
       (inputManager.isKeyPressed(LSHIFTKEY) ||
       inputManager.isKeyPressed(RSHIFTKEY) ||
-      inputManager.isKeyPressed(SPACEKEY));
+      inputManager.isKeyPressed(SPACEKEY)));
       
-      this._ladderKey ||=
+      this._ladderKey || (this._ladderKey =
       !this._ignoreDefaultControls &&
-      inputManager.isKeyPressed(UPKEY);
+      inputManager.isKeyPressed(UPKEY));
       
-      this._upKey ||=
+      this._upKey || (this._upKey =
         !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(UPKEY);
-      this._downKey ||=
+        inputManager.isKeyPressed(UPKEY));
+      this._downKey || (this._downKey =
         !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(DOWNKEY);
+        inputManager.isKeyPressed(DOWNKEY));
       
-      this._releaseKey ||=
+      this._releaseKey || (this._releaseKey =
         !this._ignoreDefaultControls &&
-        inputManager.isKeyPressed(DOWNKEY);
+        inputManager.isKeyPressed(DOWNKEY));
 
       this._requestedDeltaX += this.updateSpeed(timeDelta);
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -311,7 +311,6 @@ namespace gdjs {
 
     checkTransitionOnLadder() {
       if (this._ladderKey && this._isOverlappingLadder()) {
-        this._currentFallSpeed = 0;
         this._setOnLadder();
       }
     }
@@ -392,18 +391,11 @@ namespace gdjs {
         //Check if landing on a new floor: (Exclude already overlapped jump truh)
         let collidingPlatform = this._getCollidingPlatform();
         if (canLand && collidingPlatform !== null) {
-          this._currentFallSpeed = 0;
-          
-          //Ensure nothing is grabbed.
-          this._releaseGrabbedPlatform();
           //Register the colliding platform as the floor.
           this._setOnFloor(collidingPlatform);
-        } else if (this._state != this._grabbingPlatform) {
-          //In the air
-          this._canJump = false;
-          if (this._state == this._onFloor) {
-            this._setFalling();
-          }
+        } else if (this._state == this._onFloor) {
+          // don't fall if GrabbingPlatform or OnLadder
+          this._setFalling();
         }
       }
       object.setY(oldY);
@@ -502,7 +494,7 @@ namespace gdjs {
 
       //3) Update the current floor data for the next tick:
       this._updateOverlappedJumpThru();
-      //TODO what about a moving platform, do the same as for grabbing?
+      //TODO what about a moving platforms, remove this condition to do the same as for grabbing?
       if (this._state != this._onLadder) {
         this.checkTransitionOnFloorOrFalling();
       }
@@ -1132,6 +1124,7 @@ namespace gdjs {
         this._floorPlatform = floorPlatform;
         this.updateFloorPosition();
         this._behavior._canJump = true;
+        this._behavior._currentFallSpeed = 0;
       }
 
       leave() {
@@ -1448,6 +1441,7 @@ namespace gdjs {
       enter(grabbedPlatform: PlatformRuntimeBehavior) {
         this._grabbedPlatform = grabbedPlatform;
         this._behavior._canJump = true;
+        this._behavior._currentFallSpeed = 0;
       }
 
       leave() {
@@ -1495,7 +1489,6 @@ namespace gdjs {
   
       beforeMovingY(timeDelta: float, oldX: float) {
         const behavior = this._behavior;
-        behavior._currentFallSpeed = 0;
         this._grabbedPlatformLastX = this._grabbedPlatform.owner.getX();
         this._grabbedPlatformLastY = this._grabbedPlatform.owner.getY();
       }
@@ -1514,6 +1507,7 @@ namespace gdjs {
 
       enter() {
         this._behavior._canJump = true;
+        this._behavior._currentFallSpeed = 0;
       }
 
       leave() {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1096,15 +1096,44 @@ namespace gdjs {
   }
 
   export namespace PlatformerObjectRuntimeBehavior {
+    /**
+     * The object can take 5 states: OnFloor, Falling, Jumping, GrabbingPlatform and OnLadder.
+     * The implementations of this interface hold the specific behaviors and internal state of theses 5 states.
+     * @see PlatformerObjectRuntimeBehavior.doStepPreEvents to understand how the functions are called.
+     */
     export interface State {
+    /**
+     * Called when the object leaves this state.
+     * It's a good place to reset the internal state.
+     * @see OnFloor.enter that is not part of the interface because it take specific parameters.
+     */
       leave(): void;
+      /**
+      * Called before the obstacle search.
+      * The object position may need adjustments to handle external changes.
+      */
       beforeUpdatingObstacles(): void;
+      /**
+      * Check if transition to other states is needed and apply them before moving horizontally.
+      */
       checkTransitionBeforeX(): void;
+      /**
+      * Use _requestedDeltaX and _requestedDeltaY to choose the movement that suite the state before moving horizontally.
+      */
       beforeMovingX(): void;
+      /**
+      * Check if transition to other states is needed and apply them before moving vertically.
+      */
       checkTransitionBeforeY(timeDelta: float): void;
+      /**
+      * Use _requestedDeltaY to choose the movement that suite the state before moving vertically.
+      */
       beforeMovingY(timeDelta: float, oldX: float): void;
     }
 
+    /**
+     * The object is on the floor standing or walking.
+     */
     export class OnFloor implements State {
       private _behavior : PlatformerObjectRuntimeBehavior;
       private _floorPlatform:PlatformRuntimeBehavior | null = null;
@@ -1281,6 +1310,9 @@ namespace gdjs {
       }
     }
 
+    /**
+     * The object is falling.
+     */
     export class Falling implements State {
       private _behavior : PlatformerObjectRuntimeBehavior;
 
@@ -1329,6 +1361,9 @@ namespace gdjs {
       }
     }
 
+    /**
+     * The object is on the ascending part of the jump (otherwise it's falling).
+     */
     export class Jumping implements State {
       private _behavior : PlatformerObjectRuntimeBehavior;
       private _currentJumpSpeed: number = 0;
@@ -1428,6 +1463,9 @@ namespace gdjs {
       }
     }
 
+    /**
+     * The object grabbed the edge of a platform and is standing there.
+     */
     export class GrabbingPlatform implements State {
       private _behavior : PlatformerObjectRuntimeBehavior;
       private _grabbedPlatform: any = null;
@@ -1467,7 +1505,7 @@ namespace gdjs {
       beforeMovingX() {
         const behavior = this._behavior;
         //Shift the object according to the grabbed platform movement.
-          // this._behavior erases any other movement
+        // this._behavior erases any other movement
         behavior._requestedDeltaX =
           this._grabbedPlatform.owner.getX() - this._grabbedPlatformLastX;
         behavior._requestedDeltaY =
@@ -1498,6 +1536,9 @@ namespace gdjs {
       }
     }
 
+    /**
+     * The object grabbed a ladder. It can stand or move in 8 directions.
+     */
     export class OnLadder implements State {
       private _behavior : PlatformerObjectRuntimeBehavior;
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1079,11 +1079,33 @@ namespace gdjs {
     }
 
     /**
-     * Check if the Platformer Object is falling.
+     * Check if the Platformer Object is in the falling state. This is false
+     * if the object is jumping, even if the object is going down after reaching
+     * the jump peak.
      * @returns Returns true if it is falling and false if not.
      */
-    isFalling(): boolean {
+    isFallingWithoutJumping(): boolean {
       return this._state === this._falling;
+    }
+
+    /**
+     * Check if the Platformer Object is "going down", either because it's in the
+     * falling state *or* because it's jumping but reached the jump peak and
+     * is now going down (because the jump speed can't compensate anymore the
+     * falling speed).
+     *
+     * If you want to check if the object is falling outside of a jump (or because
+     * the jump is entirely finished and there is no jump speed applied to the object
+     * anymore), consider using `isFallingWithoutJumping`.
+     *
+     * @returns Returns true if it is "going down" and false if not.
+     */
+    isFalling(): boolean {
+      return (
+        this._state === this._falling ||
+        (this._state === this._jumping &&
+          this._currentFallSpeed > this._jumping.getCurrentJumpSpeed())
+      );
     }
 
     /**

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -44,7 +44,8 @@ namespace gdjs {
     _upKey: boolean = false;
     _downKey: boolean = false;
     _jumpKey: boolean = false;
-    _state: PlatformerObjectRuntimeBehavior.State = PlatformerObjectRuntimeBehavior.State.Falling;
+    _state: PlatformerObjectRuntimeBehavior.State =
+      PlatformerObjectRuntimeBehavior.State.Falling;
 
     /** Platforms near the object, updated with `_updatePotentialCollidingObjects`. */
     _potentialCollidingObjects: Array<gdjs.PlatformRuntimeBehavior>;
@@ -185,7 +186,10 @@ namespace gdjs {
       //0.2) Track changes in object size
 
       //Stick the object to the floor if its height has changed.
-      if (this._state == PlatformerObjectRuntimeBehavior.State.OnFloor && this._oldHeight !== object.getHeight()) {
+      if (
+        this._state == PlatformerObjectRuntimeBehavior.State.OnFloor &&
+        this._oldHeight !== object.getHeight()
+      ) {
         object.setY(
           this._floorLastY -
             object.getHeight() +
@@ -235,7 +239,9 @@ namespace gdjs {
       }
 
       //Shift the object according to the grabbed platform movement.
-      if (this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform) {
+      if (
+        this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform
+      ) {
         // This erases any other movement
         requestedDeltaX =
           this._grabbedPlatform.owner.getX() - this._grabbedPlatformLastX;
@@ -347,9 +353,11 @@ namespace gdjs {
       }
 
       //Fall
-      if (this._state != PlatformerObjectRuntimeBehavior.State.OnFloor &&
-          this._state != PlatformerObjectRuntimeBehavior.State.OnLadder &&
-          this._state != PlatformerObjectRuntimeBehavior.State.GrabbingPlatform) {
+      if (
+        this._state != PlatformerObjectRuntimeBehavior.State.OnFloor &&
+        this._state != PlatformerObjectRuntimeBehavior.State.OnLadder &&
+        this._state != PlatformerObjectRuntimeBehavior.State.GrabbingPlatform
+      ) {
         this._currentFallSpeed += this._gravity * timeDelta;
         if (this._currentFallSpeed > this._maxFallingSpeed) {
           this._currentFallSpeed = this._maxFallingSpeed;
@@ -403,7 +411,8 @@ namespace gdjs {
               true
             )
           ) {
-            this._state = PlatformerObjectRuntimeBehavior.State.GrabbingPlatform;
+            this._state =
+              PlatformerObjectRuntimeBehavior.State.GrabbingPlatform;
             this._grabbedPlatform = collidingPlatform;
             requestedDeltaY = 0;
           } else {
@@ -414,7 +423,10 @@ namespace gdjs {
       this._releaseKey |=
         !this._ignoreDefaultControls &&
         runtimeScene.getGame().getInputManager().isKeyPressed(DOWNKEY);
-      if (this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform && !this._releaseKey) {
+      if (
+        this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform &&
+        !this._releaseKey
+      ) {
         this._canJump = true;
         this._currentJumpSpeed = 0;
         this._currentFallSpeed = 0;
@@ -637,12 +649,12 @@ namespace gdjs {
             this._canJump = true;
             this._currentJumpSpeed = 0;
             this._currentFallSpeed = 0;
-            
+
             //Register the colliding platform as the floor.
             this._floorPlatform = collidingPlatform;
             this._floorLastX = this._floorPlatform.owner.getX();
             this._floorLastY = this._floorPlatform.owner.getY();
-            
+
             //Ensure nothing is grabbed.
             this._releaseGrabbedPlatform();
             this._state = PlatformerObjectRuntimeBehavior.State.OnFloor;
@@ -703,7 +715,9 @@ namespace gdjs {
      * Mark the platformer object has not being grabbing any platform.
      */
     _releaseGrabbedPlatform() {
-      if (this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform) {
+      if (
+        this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform
+      ) {
         this._state = PlatformerObjectRuntimeBehavior.State.Falling;
       }
 
@@ -1230,7 +1244,9 @@ namespace gdjs {
      * @returns Returns true if a platform is grabbed and false if not.
      */
     isGrabbingPlatform(): boolean {
-      return this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform;
+      return (
+        this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform
+      );
     }
 
     /**
@@ -1260,7 +1276,7 @@ namespace gdjs {
       OnFloor,
       Jumping,
       OnLadder,
-      GrabbingPlatform
+      GrabbingPlatform,
     }
   }
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -383,21 +383,18 @@ namespace gdjs {
     }
 
     _setFalling() {
-      console.debug(`${this._state} --> ${this._falling}`);
       this._state.leave();
       this._state = this._falling;
       this._falling.enter();
     }
 
     private _setOnFloor(collidingPlatform: PlatformRuntimeBehavior) {
-      console.debug(`${this._state} --> ${this._onFloor}`);
       this._state.leave();
       this._state = this._onFloor;
       this._onFloor.enter(collidingPlatform);
     }
 
     private _setJumping() {
-      console.debug(`${this._state} --> ${this._jumping}`);
       this._state.leave();
       const from = this._state;
       this._state = this._jumping;
@@ -405,14 +402,12 @@ namespace gdjs {
     }
 
     private _setGrabbingPlatform(grabbedPlatform: PlatformRuntimeBehavior) {
-      console.debug(`${this._state} --> ${this._grabbingPlatform}`);
       this._state.leave();
       this._state = this._grabbingPlatform;
       this._grabbingPlatform.enter(grabbedPlatform);
     }
 
     private _setOnLadder() {
-      console.debug(`${this._state} --> ${this._onLadder}`);
       this._state.leave();
       this._state = this._onLadder;
       this._onLadder.enter();

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -384,7 +384,7 @@ namespace gdjs {
           //Ensure nothing is grabbed.
           this._releaseGrabbedPlatform();
           this._state = PlatformerObjectRuntimeBehavior.State.OnFloor;
-        } else {
+        } else if (this._state != PlatformerObjectRuntimeBehavior.State.GrabbingPlatform) {
           //In the air
           this._canJump = false;
           if (this._state == PlatformerObjectRuntimeBehavior.State.OnFloor) {
@@ -497,16 +497,6 @@ namespace gdjs {
       ) {
         this.checkGrabPlatform();
       }
-      if (
-        this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform &&
-        !this._releaseKey
-      ) {
-        this._canJump = true;
-        this._currentJumpSpeed = 0;
-        this._currentFallSpeed = 0;
-        this._grabbedPlatformLastX = this._grabbedPlatform.owner.getX();
-        this._grabbedPlatformLastY = this._grabbedPlatform.owner.getY();
-      }
       if (this._releaseKey) {
         this._releaseGrabbedPlatform();
       }
@@ -517,6 +507,17 @@ namespace gdjs {
 
     beforeMovingY(timeDelta: float, oldX: float) {
       const object = this.owner;
+      
+      if (
+        this._state == PlatformerObjectRuntimeBehavior.State.GrabbingPlatform &&
+        !this._releaseKey
+      ) {
+        this._canJump = true;
+        this._currentJumpSpeed = 0;
+        this._currentFallSpeed = 0;
+        this._grabbedPlatformLastX = this._grabbedPlatform.owner.getX();
+        this._grabbedPlatformLastY = this._grabbedPlatform.owner.getY();
+      }
 
       if (this._state == PlatformerObjectRuntimeBehavior.State.OnLadder) {
         if (this._upKey) {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -65,7 +65,11 @@ namespace gdjs {
     _requestedDeltaY: float = 0;
     _lastDeltaY: float = 0;
 
-    constructor(runtimeScene, behaviorData, owner) {
+    constructor(
+      runtimeScene: gdjs.RuntimeScene,
+      behaviorData,
+      owner: gdjs.RuntimeObject
+    ) {
       super(runtimeScene, behaviorData, owner);
       this._roundCoordinates = behaviorData.roundCoordinates;
       this._gravity = behaviorData.gravity;
@@ -417,7 +421,7 @@ namespace gdjs {
       );
     }
 
-    doStepPreEvents(runtimeScene) {
+    doStepPreEvents(runtimeScene: gdjs.RuntimeScene) {
       const LEFTKEY = 37;
       const UPKEY = 38;
       const RIGHTKEY = 39;
@@ -517,7 +521,7 @@ namespace gdjs {
       this._lastDeltaY = object.getY() - oldY;
     }
 
-    doStepPostEvents(runtimeScene) {}
+    doStepPostEvents(runtimeScene: gdjs.RuntimeScene) {}
 
     //Scene change is not supported
     /*
@@ -534,7 +538,7 @@ namespace gdjs {
      * @param platform The platform the object is in collision with
      * @param y The value in pixels on Y axis the object wants to move to
      */
-    private _canGrab(platform) {
+    private _canGrab(platform: gdjs.PlatformRuntimeBehavior) {
       const y1 = this.owner.getY() + this._yGrabOffset - this._lastDeltaY;
       const y2 = this.owner.getY() + this._yGrabOffset;
       const platformY = platform.owner.getY() + platform.getYGrabOffset();
@@ -562,7 +566,7 @@ namespace gdjs {
      * @param excludeJumpThrus If set to true, jumpthru platforms are excluded. false if not defined.
      */
     _isCollidingWith(
-      candidates,
+      candidates: gdjs.PlatformRuntimeBehavior[],
       exceptThisOne?: number | null,
       excludeJumpThrus?: boolean
     ) {
@@ -601,7 +605,10 @@ namespace gdjs {
      * @param candidates The platform to be tested for collision
      * @param excludeJumpThrus If set to true, jumpthru platforms are excluded. false if not defined.
      */
-    private _separateFromPlatforms(candidates, excludeJumpThrus) {
+    private _separateFromPlatforms(
+      candidates: gdjs.PlatformRuntimeBehavior[],
+      excludeJumpThrus: boolean
+    ) {
       excludeJumpThrus = !!excludeJumpThrus;
       const objects = gdjs.staticArray(
         PlatformerObjectRuntimeBehavior.prototype._separateFromPlatforms
@@ -729,7 +736,7 @@ namespace gdjs {
       return false;
     }
 
-    _isIn(platformArray, id) {
+    _isIn(platformArray: gdjs.PlatformRuntimeBehavior[], id: integer) {
       for (let i = 0; i < platformArray.length; ++i) {
         if (platformArray[i].owner.id === id) {
           return true;
@@ -741,7 +748,7 @@ namespace gdjs {
     /**
      * Update _potentialCollidingObjects member with platforms near the object.
      */
-    private _updatePotentialCollidingObjects(maxMovementLength) {
+    private _updatePotentialCollidingObjects(maxMovementLength: float) {
       this._manager.getAllPlatformsAround(
         this.owner,
         maxMovementLength,

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -272,7 +272,7 @@ namespace gdjs {
       this._onLadder.enter();
     }
 
-    moveY() {
+    private _moveY() {
       const object = this.owner;
       //Move the object on Y axis
       if (this._requestedDeltaY !== 0) {
@@ -316,19 +316,19 @@ namespace gdjs {
       }
     }
 
-    checkTransitionOnLadder() {
+    _checkTransitionOnLadder() {
       if (this._ladderKey && this._isOverlappingLadder()) {
         this._setOnLadder();
       }
     }
 
-    checkTransitionJumping() {
+    _checkTransitionJumping() {
       if (this._canJump && this._jumpKey) {
         this._setJumping();
       }
     }
 
-    checkGrabPlatform() {
+    _checkGrabPlatform() {
       const object = this.owner;
       let tryGrabbingPlatform = false;
       object.setX(
@@ -374,7 +374,7 @@ namespace gdjs {
       }
     }
 
-    checkTransitionOnFloorOrFalling() {
+    private _checkTransitionOnFloorOrFalling() {
       const object = this.owner;
       //Check if the object is on a floor:
       //In priority, check if the last floor platform is still the floor.
@@ -409,7 +409,7 @@ namespace gdjs {
       object.setY(oldY);
     }
 
-    fall(timeDelta: float) {
+    _fall(timeDelta: float) {
       this._currentFallSpeed += this._gravity * timeDelta;
       if (this._currentFallSpeed > this._maxFallingSpeed) {
         this._currentFallSpeed = this._maxFallingSpeed;
@@ -498,13 +498,13 @@ namespace gdjs {
       this._state.beforeMovingY(timeDelta, oldX);
 
       const oldY = object.getY();
-      this.moveY();
+      this._moveY();
 
       //3) Update the current floor data for the next tick:
       this._updateOverlappedJumpThru();
       //TODO what about a moving platforms, remove this condition to do the same as for grabbing?
       if (this._state !== this._onLadder) {
-        this.checkTransitionOnFloorOrFalling();
+        this._checkTransitionOnFloorOrFalling();
       }
 
       //4) Do not forget to reset pressed keys
@@ -715,7 +715,6 @@ namespace gdjs {
      * Note: _updatePotentialCollidingObjects must have been called before.
      */
     _isOverlappingLadder() {
-      //FIXME put back private
       for (let i = 0; i < this._potentialCollidingObjects.length; ++i) {
         const platform = this._potentialCollidingObjects[i];
         if (
@@ -1212,9 +1211,9 @@ namespace gdjs {
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
       //Go on a ladder
-      behavior.checkTransitionOnLadder();
+      behavior._checkTransitionOnLadder();
       //Jumping
-      behavior.checkTransitionJumping();
+      behavior._checkTransitionJumping();
     }
 
     beforeMovingY(timeDelta: float, oldX: float) {
@@ -1354,19 +1353,19 @@ namespace gdjs {
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
       //Go on a ladder
-      behavior.checkTransitionOnLadder();
+      behavior._checkTransitionOnLadder();
       //Jumping
-      behavior.checkTransitionJumping();
+      behavior._checkTransitionJumping();
 
       //Grabbing a platform
       if (behavior._canGrabPlatforms && behavior._requestedDeltaX !== 0) {
-        behavior.checkGrabPlatform();
+        behavior._checkGrabPlatform();
       }
     }
 
     beforeMovingY(timeDelta: float, oldX: float) {
       //Fall
-      this._behavior.fall(timeDelta);
+      this._behavior._fall(timeDelta);
     }
 
     toString(): String {
@@ -1420,9 +1419,9 @@ namespace gdjs {
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
       //Go on a ladder
-      behavior.checkTransitionOnLadder();
+      behavior._checkTransitionOnLadder();
       //Jumping
-      behavior.checkTransitionJumping();
+      behavior._checkTransitionJumping();
 
       //Grabbing a platform
       if (
@@ -1430,7 +1429,7 @@ namespace gdjs {
         behavior._requestedDeltaX !== 0 &&
         behavior._lastDeltaY >= 0
       ) {
-        behavior.checkGrabPlatform();
+        behavior._checkGrabPlatform();
       }
     }
 
@@ -1439,7 +1438,7 @@ namespace gdjs {
 
       //Fall
       if (!this._jumpingFirstDelta) {
-        behavior.fall(timeDelta);
+        behavior._fall(timeDelta);
       }
       this._jumpingFirstDelta = false;
 
@@ -1519,14 +1518,14 @@ namespace gdjs {
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
       //Go on a ladder
-      behavior.checkTransitionOnLadder();
+      behavior._checkTransitionOnLadder();
 
       if (behavior._releaseKey) {
         behavior._releaseGrabbedPlatform();
       }
 
       //Jumping
-      behavior.checkTransitionJumping();
+      behavior._checkTransitionJumping();
     }
 
     beforeMovingY(timeDelta: float, oldX: float) {
@@ -1571,7 +1570,7 @@ namespace gdjs {
       }
 
       //Jumping
-      behavior.checkTransitionJumping();
+      behavior._checkTransitionJumping();
     }
 
     beforeMovingY(timeDelta: float, oldX: float) {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -151,7 +151,7 @@ namespace gdjs {
       }
 
       //Take deceleration into account only if no key is pressed.
-      if (this._leftKey == this._rightKey) {
+      if (this._leftKey === this._rightKey) {
         const wasPositive = this._currentSpeed > 0;
         this._currentSpeed -=
           this._deceleration * timeDelta * (wasPositive ? 1.0 : -1.0);
@@ -968,7 +968,7 @@ namespace gdjs {
       this._slopeMaxAngle = slopeMaxAngle;
 
       //Avoid rounding errors
-      if (slopeMaxAngle == 45) {
+      if (slopeMaxAngle === 45) {
         this._slopeClimbingFactor = 1;
       } else {
         this._slopeClimbingFactor = Math.tan(

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -461,9 +461,8 @@ namespace gdjs {
       );
       this._updateOverlappedJumpThru();
 
-      this._state.checkTransitionBeforeX();
-
       //1) X axis:
+      this._state.checkTransitionBeforeX();
       this._state.beforeMovingX();
 
       //Ensure the object is not stuck
@@ -475,13 +474,8 @@ namespace gdjs {
       const oldX = object.getX();
       this.moveX();
 
-      //Collided with a wall
-
       //2) Y axis:
       this._state.checkTransitionBeforeY(timeDelta);
-
-      //object.setY(object.getY()-1); //Useless and dangerous
-
       this._state.beforeMovingY(timeDelta, oldX);
 
       const oldY = object.getY();
@@ -504,7 +498,6 @@ namespace gdjs {
 
       //5) Track the movement
       this._hasReallyMoved = Math.abs(object.getX() - oldX) >= 1;
-
       this._lastDeltaY = object.getY() - oldY;
     }
 
@@ -1385,7 +1378,6 @@ namespace gdjs {
   
       beforeMovingY(timeDelta: float, oldX: float) {
         const behavior = this._behavior;
-        const object = behavior.owner;
         
         //Fall
         if (
@@ -1478,29 +1470,15 @@ namespace gdjs {
   
         //Jumping
         behavior.checkTransitionJumping();
-  
-        //Grabbing a platform
-        if (
-          behavior._canGrabPlatforms &&
-          behavior._requestedDeltaX !== 0
-        ) {
-          //TODO useless?
-          behavior.checkGrabPlatform();
-        }
       }
   
       beforeMovingY(timeDelta: float, oldX: float) {
         const behavior = this._behavior;
-        const object = behavior.owner;
         //TODO useless condition?
-        if (
-          !behavior._releaseKey
-        ) {
-          behavior._canJump = true;
-          behavior._currentFallSpeed = 0;
-          this._grabbedPlatformLastX = this._grabbedPlatform.owner.getX();
-          this._grabbedPlatformLastY = this._grabbedPlatform.owner.getY();
-        }
+        behavior._canJump = true;
+        behavior._currentFallSpeed = 0;
+        this._grabbedPlatformLastX = this._grabbedPlatform.owner.getX();
+        this._grabbedPlatformLastY = this._grabbedPlatform.owner.getY();
       }
 
       toString(): String {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -204,7 +204,7 @@ namespace gdjs {
           }
 
           //If on floor: try get up a bit to bypass not perfectly aligned floors.
-          if (this._state == this._onFloor) {
+          if (this._state === this._onFloor) {
             object.setY(object.getY() - 1);
             if (
               !this._isCollidingWith(
@@ -293,7 +293,7 @@ namespace gdjs {
             ))
         ) {
           //Jumpthru = obstacle <=> Only if not already overlapped when going down
-          if (this._state == this._jumping) {
+          if (this._state === this._jumping) {
             this._setFalling();
           }
           if (
@@ -378,7 +378,7 @@ namespace gdjs {
       let oldY = object.getY();
       object.setY(object.getY() + 1);
       if (
-        this._state == this._onFloor &&
+        this._state === this._onFloor &&
         gdjs.RuntimeObject.collisionTest(
           object,
           this._onFloor.getFloorPlatform()!.owner,
@@ -398,7 +398,7 @@ namespace gdjs {
         if (canLand && collidingPlatform !== null) {
           //Register the colliding platform as the floor.
           this._setOnFloor(collidingPlatform);
-        } else if (this._state == this._onFloor) {
+        } else if (this._state === this._onFloor) {
           // don't fall if GrabbingPlatform or OnLadder
           this._setFalling();
         }
@@ -437,7 +437,6 @@ namespace gdjs {
       this._leftKey ||
         (this._leftKey =
           !this._ignoreDefaultControls && inputManager.isKeyPressed(LEFTKEY));
-      // @ts-ignore
       this._rightKey ||
         (this._rightKey =
           !this._ignoreDefaultControls && inputManager.isKeyPressed(RIGHTKEY));
@@ -501,7 +500,7 @@ namespace gdjs {
       //3) Update the current floor data for the next tick:
       this._updateOverlappedJumpThru();
       //TODO what about a moving platforms, remove this condition to do the same as for grabbing?
-      if (this._state != this._onLadder) {
+      if (this._state !== this._onLadder) {
         this.checkTransitionOnFloorOrFalling();
       }
 
@@ -551,7 +550,7 @@ namespace gdjs {
      * Mark the platformer object has not being grabbing any platform.
      */
     _releaseGrabbedPlatform() {
-      if (this._state == this._grabbingPlatform) {
+      if (this._state === this._grabbingPlatform) {
         this._setFalling();
       }
     }
@@ -1052,7 +1051,7 @@ namespace gdjs {
      * @returns Returns true if on the floor and false if not.
      */
     isOnFloor(): boolean {
-      return this._state == this._onFloor;
+      return this._state === this._onFloor;
     }
 
     /**
@@ -1060,7 +1059,7 @@ namespace gdjs {
      * @returns Returns true if on a ladder and false if not.
      */
     isOnLadder(): boolean {
-      return this._state == this._onLadder;
+      return this._state === this._onLadder;
     }
 
     /**
@@ -1068,7 +1067,7 @@ namespace gdjs {
      * @returns Returns true if jumping and false if not.
      */
     isJumping(): boolean {
-      return this._state == this._jumping;
+      return this._state === this._jumping;
     }
 
     /**
@@ -1076,7 +1075,7 @@ namespace gdjs {
      * @returns Returns true if a platform is grabbed and false if not.
      */
     isGrabbingPlatform(): boolean {
-      return this._state == this._grabbingPlatform;
+      return this._state === this._grabbingPlatform;
     }
 
     /**
@@ -1084,7 +1083,7 @@ namespace gdjs {
      * @returns Returns true if it is falling and false if not.
      */
     isFalling(): boolean {
-      return this._state == this._falling;
+      return this._state === this._falling;
     }
 
     /**
@@ -1396,14 +1395,11 @@ namespace gdjs {
         this._timeSinceCurrentJumpStart = 0;
         this._jumpKeyHeldSinceJumpStart = true;
 
-        if (from != behavior._jumping && from != behavior._falling) {
+        if (from !== behavior._jumping && from !== behavior._falling) {
           this._jumpingFirstDelta = true;
         }
 
         behavior._canJump = false;
-
-        //FIXME can't be Jumping and OnFloor at the same time, need a fix and a test
-        //this._isOnFloor = false; If floor is a very steep slope, the object could go into it.
         this._currentJumpSpeed = behavior._jumpSpeed;
         behavior._currentFallSpeed = 0;
       }
@@ -1510,7 +1506,7 @@ namespace gdjs {
       beforeMovingX() {
         const behavior = this._behavior;
         //Shift the object according to the grabbed platform movement.
-        // this._behavior erases any other movement
+        // this erases any other movement
         behavior._requestedDeltaX =
           this._grabbedPlatform.owner.getX() - this._grabbedPlatformLastX;
         behavior._requestedDeltaY =

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -135,7 +135,7 @@ namespace gdjs {
       return true;
     }
 
-    updateSpeed(timeDelta: float): float {
+    private _updateSpeed(timeDelta: float): float {
       //Change the speed according to the player's input.
       // @ts-ignore
       if (this._leftKey) {
@@ -168,7 +168,7 @@ namespace gdjs {
       return this._currentSpeed * timeDelta;
     }
 
-    moveX() {
+    private _moveX() {
       const object = this.owner;
       //Move the object on x axis.
       const oldX = object.getX();
@@ -236,14 +236,14 @@ namespace gdjs {
       this._falling.enter();
     }
 
-    _setOnFloor(collidingPlatform: PlatformRuntimeBehavior) {
+    private _setOnFloor(collidingPlatform: PlatformRuntimeBehavior) {
       console.debug(`${this._state} --> ${this._onFloor}`);
       this._state.leave();
       this._state = this._onFloor;
       this._onFloor.enter(collidingPlatform);
     }
 
-    _setJumping() {
+    private _setJumping() {
       console.debug(`${this._state} --> ${this._jumping}`);
       this._state.leave();
       const from = this._state;
@@ -251,14 +251,14 @@ namespace gdjs {
       this._jumping.enter(from);
     }
 
-    _setGrabbingPlatform(grabbedPlatform: PlatformRuntimeBehavior) {
+    private _setGrabbingPlatform(grabbedPlatform: PlatformRuntimeBehavior) {
       console.debug(`${this._state} --> ${this._grabbingPlatform}`);
       this._state.leave();
       this._state = this._grabbingPlatform;
       this._grabbingPlatform.enter(grabbedPlatform);
     }
 
-    _setOnLadder() {
+    private _setOnLadder() {
       console.debug(`${this._state} --> ${this._onLadder}`);
       this._state.leave();
       this._state = this._onLadder;
@@ -458,7 +458,7 @@ namespace gdjs {
         !this._ignoreDefaultControls &&
         inputManager.isKeyPressed(DOWNKEY));
 
-      this._requestedDeltaX += this.updateSpeed(timeDelta);
+      this._requestedDeltaX += this._updateSpeed(timeDelta);
 
       //0.2) Track changes in object size
       this._state.beforeUpdatingObstacles();
@@ -483,7 +483,7 @@ namespace gdjs {
       //After being unstuck, the object must be able to jump again.
 
       const oldX = object.getX();
-      this.moveX();
+      this._moveX();
 
       //2) Y axis:
       this._state.checkTransitionBeforeY(timeDelta);
@@ -530,7 +530,7 @@ namespace gdjs {
      * @param platform The platform the object is in collision with
      * @param y The value in pixels on Y axis the object wants to move to
      */
-    _canGrab(platform) {
+    private _canGrab(platform) {
       const y1 = this.owner.getY() + this._yGrabOffset - this._lastDeltaY;
       const y2 = this.owner.getY() + this._yGrabOffset;
       const platformY = platform.owner.getY() + platform.getYGrabOffset();
@@ -599,7 +599,7 @@ namespace gdjs {
      * @param candidates The platform to be tested for collision
      * @param excludeJumpThrus If set to true, jumpthru platforms are excluded. false if not defined.
      */
-    _separateFromPlatforms(candidates, excludeJumpThrus) {
+    private _separateFromPlatforms(candidates, excludeJumpThrus) {
       excludeJumpThrus = !!excludeJumpThrus;
       const objects = gdjs.staticArray(
         PlatformerObjectRuntimeBehavior.prototype._separateFromPlatforms
@@ -629,7 +629,7 @@ namespace gdjs {
      * @param candidates The platform to be tested for collision
      * @param exceptTheseOnes The platforms to be excluded from the test
      */
-    _isCollidingWithExcluding(candidates, exceptTheseOnes) {
+    private _isCollidingWithExcluding(candidates, exceptTheseOnes) {
       for (let i = 0; i < candidates.length; ++i) {
         const platform = candidates[i];
         if (exceptTheseOnes && this._isIn(exceptTheseOnes, platform.owner.id)) {
@@ -658,7 +658,7 @@ namespace gdjs {
      * Overlapped jump thru and ladders are excluded.
      * _updatePotentialCollidingObjects and _updateOverlappedJumpThru should have been called before.
      */
-    _getCollidingPlatform() {
+    private _getCollidingPlatform() {
       for (let i = 0; i < this._potentialCollidingObjects.length; ++i) {
         const platform = this._potentialCollidingObjects[i];
         if (

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -113,11 +113,18 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       for (let i = 0; i < 30; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         if (i < 10) expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        if (i < 10)
+          expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+            true
+          );
       }
 
       //Check the platform stopped the platformer object.
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       for (let i = 0; i < 35; ++i) {
@@ -128,6 +135,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getX()).to.be.within(87.5, 87.51);
       expect(object.getY()).to.be(-24.75);
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
 
       for (let i = 0; i < 100; ++i) {
         //Let the speed on X axis go back to 0.
@@ -158,6 +166,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       for (let i = 0; i < 10; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          true
+        );
       }
 
       //Check that the object is falling
@@ -205,6 +216,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getX()).to.be(10);
       expect(object.getY()).to.be.within(-31, -30); // -30 = -10 (platform y) + -20 (object height)
 
@@ -213,12 +227,18 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       };
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getY()).to.be(-19); // -19 = -10 (platform y) + -9 (object height)
 
       for (let i = 0; i < 10; ++i) {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isFalling()).to.be(false);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
       }
       expect(object.getY()).to.be(-19);
       expect(object.getX()).to.be.within(17.638, 17.639);
@@ -239,12 +259,16 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       //Check the object is on the platform
       expect(object.getY()).to.be.within(-31, -30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // move the platform away
       platform.setPosition(-100, -100);
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
     });
   });
 
@@ -301,6 +325,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       //Check the object is on the platform
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // Jump without sustaining
@@ -308,6 +335,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       for (let i = 0; i < 18; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        expect(object.getBehavior('auto1').isFalling()).to.be(false);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
       }
 
       // Check that we reached the maximum height
@@ -321,15 +352,23 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       for (let i = 0; i < 17; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
       }
       // The jump finishes one frame before going back to the floor
       // because the gravity is not applied on the first step.
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isJumping()).to.be(false);
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
       expect(object.getY()).to.be(-31);
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isOnFloor()).to.be(true);
       expect(object.getY()).to.be(-30);
     });
@@ -343,6 +382,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       //Check the object is on the platform
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // Jump with sustaining as much as possible, and
@@ -385,6 +427,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       //Check the object is on the platform
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // Jump with sustaining a bit (5 frames at 60fps = 0.08s), then stop
@@ -416,6 +461,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       runtimeScene.renderAndStep(1000 / 60);
 
       // Then let the object fall
+      expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       for (let i = 0; i < 60; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
@@ -435,6 +484,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // Check the object is on the platform
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // Jump without sustaining
@@ -454,6 +506,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
       }
       // Check that the object didn't grabbed the platform
       expect(object.getX()).to.be.above(
@@ -475,6 +530,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // Check the object is on the platform
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // Jump, reach the top and go down
@@ -487,6 +545,12 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.within(
         topPlatform.getY() - object.getHeight(),
         topPlatform.getY()
+      );
+
+      // Verify the object is in the falling state of the jump:
+      expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
       );
 
       // try to grab the platform
@@ -512,6 +576,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // Check the object is on the platform
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // try to grab the platform
@@ -521,7 +588,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         expect(object.getBehavior('auto1').isOnFloor()).to.be(true);
       }
 
-      // The object is where it could grab the top platform if it where falling.
+      // The object is where it could grab the top platform if it was falling.
       expect(object.getX()).to.be.within(
         topPlatform.getX() - object.getWidth(),
         topPlatform.getX() - object.getWidth() + 2
@@ -605,6 +672,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
       // Check that the jump starts properly, and is not stopped on the jumpthru
@@ -621,13 +691,22 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.within(-61, -60);
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getY()).to.be.within(-67, -66);
+
+      // Verify the object is still jumping
       expect(object.getBehavior('auto1').isJumping()).to.be(true);
+      expect(object.getBehavior('auto1').isFalling()).to.be(false);
 
       // Continue the simulation and check that position is correct in the middle of the jump
       for (let i = 0; i < 20; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
       expect(object.getY()).to.be.within(-89, -88);
+
+      // Verify the object is now considered as falling in its jump:
+      expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
 
       // Continue simulation and check that we arrive on the jumpthru
       for (let i = 0; i < 10; ++i) {
@@ -722,6 +801,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          true
+        );
       }
       object.getBehavior('auto1').simulateRightKey();
       runtimeScene.renderAndStep(1000 / 60);
@@ -754,6 +836,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // Fall and Grab the platform
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
       object.getBehavior('auto1').simulateLadderKey();
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
@@ -1027,6 +1110,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         const lastY = object.getY();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        expect(object.getBehavior('auto1').isFalling()).to.be(false);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
         expect(object.getBehavior('auto1').isMoving()).to.be(true);
         expect(object.getY()).to.be.below(lastY);
       }
@@ -1036,6 +1123,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         const lastY = object.getY();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
         expect(object.getBehavior('auto1').isMoving()).to.be(true);
         expect(object.getY()).to.be.above(lastY);
       }
@@ -1213,6 +1304,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       object.getBehavior('auto1').simulateRightKey();
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
       // and directly on the floor
       object.getBehavior('auto1').simulateRightKey();
       runtimeScene.renderAndStep(1000 / 60);
@@ -1252,6 +1344,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       object.getBehavior('auto1').simulateUpKey();
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
       fall(10);
 
       object.getBehavior('auto1').simulateLadderKey();
@@ -1360,6 +1453,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         const lastY = object.getY();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          true
+        );
         expect(object.getBehavior('auto1').isMoving()).to.be(true);
         expect(object.getY()).to.be.above(lastY);
       }

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -1,4 +1,4 @@
-describe.only('gdjs.PlatformerObjectRuntimeBehavior', function () {
+describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
   const makeTestRuntimeScene = () => {
     const runtimeGame = new gdjs.RuntimeGame({
       variables: [],

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -1306,9 +1306,8 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // try to grab the ladder
       object.getBehavior('auto1').simulateLadderKey();
       runtimeScene.renderAndStep(1000 / 60);
-      // panic mode! (probably a bug)
       expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
-      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
+      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(false);
     });
   });
 

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -1,4 +1,4 @@
-describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
+describe.only('gdjs.PlatformerObjectRuntimeBehavior', function () {
   const makeTestRuntimeScene = () => {
     const runtimeGame = new gdjs.RuntimeGame({
       variables: [],
@@ -450,9 +450,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       );
 
       // try to grab the platform
-      for (let i = 0; i < 30; ++i) {
+      for (let i = 0; i < 20; ++i) {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
+        expect(object.getBehavior('auto1').isJumping()).to.be(true);
       }
       // Check that the object didn't grabbed the platform
       expect(object.getX()).to.be.above(
@@ -717,7 +718,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         topPlatform.getX() - object.getWidth(),
         topPlatform.getY() - 10
       );
-      for (let i = 0; i < 7; ++i) {
+      for (let i = 0; i < 8; ++i) {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
@@ -1295,7 +1296,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         topPlatform.getX() - object.getWidth(),
         topPlatform.getY() - 10
       );
-      for (let i = 0; i < 5; ++i) {
+      for (let i = 0; i < 6; ++i) {
         object.getBehavior('auto1').simulateRightKey();
         fall(1);
       }

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -176,6 +176,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       //Check that the object grabbed the platform
+      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
       expect(object.getX()).to.be.within(
         platform.getX() + platform.getWidth() + 0,
         platform.getX() + platform.getWidth() + 1
@@ -183,11 +184,11 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be(platform.getY());
 
       object.getBehavior('auto1').simulateJumpKey();
+      //Check that the object is jumping
       for (let i = 0; i < 10; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
+        expect(object.getBehavior('auto1').isJumping()).to.be(true);
       }
-
-      //Check that the object is jumping
       expect(object.getY()).to.be.below(platform.getY());
     });
 

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -1060,18 +1060,16 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       stayOnLadder(10);
       climbLadder(14);
       // Check that we reached the maximum height
-      // The player goes a little over the ladder...
-      object.getBehavior('auto1').simulateUpKey();
-      runtimeScene.renderAndStep(1000 / 60);
       const playerAtLadderTop = ladder.getY() - object.getHeight();
       expect(object.getY()).to.be.within(
         playerAtLadderTop - 3,
         playerAtLadderTop
       );
-      expect(object.getBehavior('auto1').isFalling()).to.be(true);
 
+      // The player goes a little over the ladder...
+      object.getBehavior('auto1').simulateUpKey();
       // ...and it falls even if up is pressed
-      for (let i = 0; i < 12; ++i) {
+      for (let i = 0; i < 13; ++i) {
         object.getBehavior('auto1').simulateUpKey();
         fall(1);
       }

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -157,10 +157,11 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       object.getBehavior('auto1').simulateReleaseKey();
       for (let i = 0; i < 10; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
+        expect(object.getBehavior('auto1').isFalling()).to.be(true);
       }
 
       //Check that the object is falling
-      expect(object.getY()).to.be(1.25);
+      expect(object.getY()).to.be(3.75);
     });
 
     it('can grab a platform and jump', function () {


### PR DESCRIPTION
The platformer extension had grown bigger with new features and I think it became hard to follow what it does. The main issue is the multiplication of conditions on the player state in doStepPreEvents(). It makes the reader jump long blocks of code and while doing so, he can easily loose his train of thought.

What I propose:
- Split doStepPreEvents() into Sub-functions to have the big picture of the main loop
- Use the State pattern to keep specific behaviors for a state together
- Use a State interface that enforce transition checks and state actions segregation
- Encapsulate internal state attributes (11 in total)

There were transition checks and state actions that have side effects on each other and sometimes multiples transitions could occur. I did a step by step refactor to move transitions at the beginning. There is an explanation in each commit message on behavior changes (slight or fixes).

The state pattern induces some indirections but less conditions too. I did a performance test (I'll make a PR with some other new test cases). There were no noticeable performance change, but typing give a 120:100 gain.
I understand this is a big risk and I can animate tests with creators after the review if you want.