### PR TITLE
Improve overall GDJS typing

### DIFF
--- a/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
@@ -2,8 +2,6 @@
 GDevelop - Pathfinding Behavior Extension
 Copyright (c) 2010-2016 Florian Rival (Florian.Rival@gmail.com)
  */
-type FloatPoint = [number, number];
-
 namespace gdjs {
   /**
    * PathfindingRuntimeBehavior represents a behavior allowing objects to

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -72,7 +72,9 @@ namespace gdjs {
    * Convert a hex color value to an rgb object.
    * @param hex Hex color
    */
-  export const hexNumberToRGB = (hexNumber: number) => {
+  export const hexNumberToRGB = (
+    hexNumber: number
+  ): { r: integer; g: integer; b: integer; a: integer } => {
     return {
       r: (hexNumber >> 16) & 0xff,
       g: (hexNumber >> 8) & 0xff,
@@ -164,7 +166,7 @@ namespace gdjs {
   export const registerObject = function (
     objectTypeName: string,
     Ctor: typeof gdjs.RuntimeObject
-  ) {
+  ): void {
     gdjs.objectsTypes.put(objectTypeName, Ctor);
   };
 
@@ -182,7 +184,7 @@ namespace gdjs {
   export const registerBehavior = function (
     behaviorTypeName: string,
     Ctor: typeof gdjs.RuntimeBehavior
-  ) {
+  ): void {
     gdjs.behaviorsTypes.put(behaviorTypeName, Ctor);
   };
 
@@ -194,7 +196,7 @@ namespace gdjs {
    */
   export const registerFirstRuntimeSceneLoadedCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksFirstRuntimeSceneLoaded.push(callback);
   };
 
@@ -204,7 +206,7 @@ namespace gdjs {
    */
   export const registerRuntimeSceneLoadedCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksRuntimeSceneLoaded.push(callback);
   };
 
@@ -215,7 +217,7 @@ namespace gdjs {
    */
   export const registerRuntimeScenePreEventsCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksRuntimeScenePreEvents.push(callback);
   };
 
@@ -226,7 +228,7 @@ namespace gdjs {
    */
   export const registerRuntimeScenePostEventsCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksRuntimeScenePostEvents.push(callback);
   };
 
@@ -236,7 +238,7 @@ namespace gdjs {
    */
   export const registerRuntimeScenePausedCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksRuntimeScenePaused.push(callback);
   };
 
@@ -246,7 +248,7 @@ namespace gdjs {
    */
   export const registerRuntimeSceneResumedCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksRuntimeSceneResumed.push(callback);
   };
 
@@ -260,7 +262,7 @@ namespace gdjs {
    */
   export const registerRuntimeSceneUnloadingCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksRuntimeSceneUnloading.push(callback);
   };
 
@@ -273,7 +275,7 @@ namespace gdjs {
    */
   export const registerRuntimeSceneUnloadedCallback = function (
     callback: RuntimeSceneCallback
-  ) {
+  ): void {
     gdjs.callbacksRuntimeSceneUnloaded.push(callback);
   };
 
@@ -283,7 +285,7 @@ namespace gdjs {
    */
   export const registerObjectDeletedFromSceneCallback = function (
     callback: RuntimeSceneRuntimeObjectCallback
-  ) {
+  ): void {
     gdjs.callbacksObjectDeletedFromScene.push(callback);
   };
 
@@ -292,7 +294,7 @@ namespace gdjs {
    * @deprecated
    * @private
    */
-  export const registerGlobalCallbacks = function () {
+  export const registerGlobalCallbacks = function (): void {
     console.warn(
       "You're calling gdjs.registerGlobalCallbacks. This method is now useless and you must not call it anymore."
     );
@@ -303,7 +305,7 @@ namespace gdjs {
    *
    * Should only be used for testing - this should never be used at runtime.
    */
-  export const clearGlobalCallbacks = function () {
+  export const clearGlobalCallbacks = function (): void {
     gdjs.callbacksFirstRuntimeSceneLoaded.length = 0;
     gdjs.callbacksRuntimeSceneLoaded.length = 0;
     gdjs.callbacksRuntimeScenePreEvents.length = 0;
@@ -400,7 +402,7 @@ namespace gdjs {
    * @param src The source array
    * @param dst The destination array
    */
-  export const copyArray = function <T>(src: Array<T>, dst: Array<T>) {
+  export const copyArray = function <T>(src: Array<T>, dst: Array<T>): void {
     var len = src.length;
     for (var i = 0; i < len; ++i) {
       dst[i] = src[i];
@@ -408,14 +410,19 @@ namespace gdjs {
     dst.length = len;
   };
 
+  interface MakeUUID {
+    (): string;
+    hex?: string[];
+  }
+
   /**
    * Generate a UUID v4.
    * @returns The generated UUID.
    */
-  export const makeUuid = function (): string {
+  export const makeUuid = <MakeUUID>function (): string {
     // Fallback to non cryptographically secure UUIDs if not supported
     if (typeof crypto === 'undefined' || !crypto.getRandomValues) {
-      const makeMathRandomUuid = (a?: any) => {
+      const makeMathRandomUuid = (a?: any): string => {
         return a
           ? (a ^ ((Math.random() * 16) >> (a / 4))).toString(16)
           : ('' + 1e7 + -1e3 + -4e3 + -8e3 + -1e11).replace(
@@ -427,17 +434,13 @@ namespace gdjs {
       return makeMathRandomUuid();
     }
 
-    // @ts-ignore - TS does not like properties added on functions
     if (!gdjs.makeUuid.hex) {
-      // @ts-ignore - TS does not like properties added on functions
       gdjs.makeUuid.hex = [];
 
       for (var i = 0; i < 256; i++) {
-        // @ts-ignore - TS does not like properties added on functions
         gdjs.makeUuid.hex[i] = (i < 16 ? '0' : '') + i.toString(16);
       }
     }
-    // @ts-ignore - TS does not like properties added on functions
     const hex = gdjs.makeUuid.hex;
 
     var r = crypto.getRandomValues(new Uint8Array(16));

--- a/GDJS/Runtime/inputmanager.ts
+++ b/GDJS/Runtime/inputmanager.ts
@@ -57,7 +57,7 @@ namespace gdjs {
     _getLocationAwareKeyCode(
       keyCode: number,
       location: number | null | undefined
-    ) {
+    ): integer {
       if (location) {
         // If it is a numpad number, do not modify it.
         if (96 <= keyCode && keyCode <= 105) {
@@ -78,7 +78,7 @@ namespace gdjs {
      * @param keyCode The raw key code associated to the key press.
      * @param location The location of the event.
      */
-    onKeyPressed(keyCode: number, location?: number) {
+    onKeyPressed(keyCode: number, location?: number): void {
       const locationAwareKeyCode = this._getLocationAwareKeyCode(
         keyCode,
         location
@@ -94,7 +94,7 @@ namespace gdjs {
      * @param keyCode The raw key code associated to the key release.
      * @param location The location of the event.
      */
-    onKeyReleased(keyCode: number, location?: number) {
+    onKeyReleased(keyCode: number, location?: number): void {
       const locationAwareKeyCode = this._getLocationAwareKeyCode(
         keyCode,
         location
@@ -170,7 +170,7 @@ namespace gdjs {
      * @param x The mouse new X position
      * @param y The mouse new Y position
      */
-    onMouseMove(x: float, y: float) {
+    onMouseMove(x: float, y: float): void {
       this._mouseX = x;
       this._mouseY = y;
     }
@@ -198,7 +198,7 @@ namespace gdjs {
      * @param buttonCode The mouse button code associated to the event.
      * See InputManager.MOUSE_LEFT_BUTTON, InputManager.MOUSE_RIGHT_BUTTON, InputManager.MOUSE_MIDDLE_BUTTON
      */
-    onMouseButtonPressed(buttonCode: number) {
+    onMouseButtonPressed(buttonCode: number): void {
       this._pressedMouseButtons[buttonCode] = true;
       this._releasedMouseButtons[buttonCode] = false;
     }
@@ -207,7 +207,7 @@ namespace gdjs {
      * Should be called whenever a mouse button is released.
      * @param buttonCode The mouse button code associated to the event. (see onMouseButtonPressed)
      */
-    onMouseButtonReleased(buttonCode: number) {
+    onMouseButtonReleased(buttonCode: number): void {
       this._pressedMouseButtons[buttonCode] = false;
       this._releasedMouseButtons[buttonCode] = true;
     }
@@ -238,14 +238,14 @@ namespace gdjs {
      * Should be called whenever the mouse wheel is used
      * @param wheelDelta The mouse wheel delta
      */
-    onMouseWheel(wheelDelta: number) {
+    onMouseWheel(wheelDelta: number): void {
       this._mouseWheelDelta = wheelDelta;
     }
 
     /**
      * Return the mouse wheel delta
      */
-    getMouseWheelDelta() {
+    getMouseWheelDelta(): float {
       return this._mouseWheelDelta;
     }
 
@@ -286,7 +286,7 @@ namespace gdjs {
       return InputManager._allTouchIds;
     }
 
-    onTouchStart(identifier: integer, x, y) {
+    onTouchStart(identifier: integer, x: float, y: float): void {
       this._startedTouches.push(identifier);
       this._touches.put(identifier, { x: x, y: y, justEnded: false });
       if (this._touchSimulateMouse) {
@@ -295,7 +295,7 @@ namespace gdjs {
       }
     }
 
-    onTouchMove(identifier: integer, x, y) {
+    onTouchMove(identifier: integer, x: float, y: float): void {
       const touch = this._touches.get(identifier);
       if (!touch) {
         return;
@@ -307,7 +307,7 @@ namespace gdjs {
       }
     }
 
-    onTouchEnd(identifier) {
+    onTouchEnd(identifier: number): void {
       this._endedTouches.push(identifier);
       if (this._touches.containsKey(identifier)) {
         //Postpone deletion at the end of the frame
@@ -318,15 +318,15 @@ namespace gdjs {
       }
     }
 
-    getStartedTouchIdentifiers() {
+    getStartedTouchIdentifiers(): integer[] {
       return this._startedTouches;
     }
 
-    popStartedTouch() {
+    popStartedTouch(): integer | undefined {
       return this._startedTouches.shift();
     }
 
-    popEndedTouch() {
+    popEndedTouch(): integer | undefined {
       return this._endedTouches.shift();
     }
 
@@ -337,7 +337,7 @@ namespace gdjs {
      * as pressed/released.
      * @param enable true to simulate mouse events, false to disable it.
      */
-    touchSimulateMouse(enable: boolean) {
+    touchSimulateMouse(enable: boolean): void {
       if (enable === undefined) {
         enable = true;
       }
@@ -351,7 +351,7 @@ namespace gdjs {
      * This method should be called in the game loop (see `gdjs.RuntimeGame.startGameLoop`).
      * You don't need to call it otherwise.
      */
-    onFrameEnded() {
+    onFrameEnded(): void {
       //Only clear the ended touches at the end of the frame.
       for (const id in this._touches.items) {
         if (this._touches.items.hasOwnProperty(id)) {

--- a/GDJS/Runtime/jsonmanager.ts
+++ b/GDJS/Runtime/jsonmanager.ts
@@ -25,7 +25,7 @@ namespace gdjs {
    * that loading failed.
    */
   export class JsonManager {
-    _resources: any;
+    _resources: ResourceData[];
 
     _loadedJsons: { [key: string]: Object } = {};
 
@@ -57,7 +57,7 @@ namespace gdjs {
     preloadJsons(
       onProgress: JsonManagerOnProgressCallback,
       onComplete: JsonManagerOnCompleteCallback
-    ) {
+    ): void {
       const resources = this._resources;
       const jsonResources = resources.filter(function (resource) {
         return resource.kind === 'json' && !resource.disablePreload;
@@ -91,7 +91,7 @@ namespace gdjs {
      * @param resourceName The resource pointing to the json file to load.
      * @param callback The callback function called when json is loaded (or an error occured).
      */
-    loadJson(resourceName: string, callback: JsonManagerRequestCallback) {
+    loadJson(resourceName: string, callback: JsonManagerRequestCallback): void {
       const resource = this._resources.find(function (resource) {
         return resource.kind === 'json' && resource.name === resourceName;
       });

--- a/GDJS/Runtime/layer.ts
+++ b/GDJS/Runtime/layer.ts
@@ -28,7 +28,7 @@ namespace gdjs {
     _followBaseLayerCamera: boolean;
     _clearColor: Array<integer>;
 
-    _renderer: any;
+    _renderer: LayerRenderer;
 
     /**
      * @param layerData The data used to initialize the layer
@@ -62,7 +62,7 @@ namespace gdjs {
       }
     }
 
-    getRenderer() {
+    getRenderer(): gdjs.LayerRenderer {
       return this._renderer;
     }
 
@@ -86,7 +86,7 @@ namespace gdjs {
      * Called by the RuntimeScene whenever the game resolution size is changed.
      * Updates the layer width/height and position.
      */
-    onGameResolutionResized() {
+    onGameResolutionResized(): void {
       const oldGameResolutionWidth = this._cachedGameResolutionWidth;
       const oldGameResolutionHeight = this._cachedGameResolutionHeight;
       this._cachedGameResolutionWidth = this._runtimeScene
@@ -120,9 +120,9 @@ namespace gdjs {
 
     /**
      * Called at each frame, after events are run and before rendering.
-     * @param runtimeScene The scene the layer belongs to.
+     * @param [runtimeScene] The scene the layer belongs to.
      */
-    update(runtimeScene: gdjs.RuntimeScene): void {
+    update(runtimeScene?: gdjs.RuntimeScene): void {
       if (this._followBaseLayerCamera) {
         this.followBaseLayer();
       }
@@ -272,7 +272,7 @@ namespace gdjs {
      * @param y The y position, in canvas coordinates.
      * @param cameraId The camera number. Currently ignored.
      */
-    convertCoords(x: float, y: float, cameraId?: integer) {
+    convertCoords(x: float, y: float, cameraId?: integer): FloatPoint {
       x -= this._cachedGameResolutionWidth / 2;
       y -= this._cachedGameResolutionHeight / 2;
       x /= Math.abs(this._zoomFactor);
@@ -288,7 +288,7 @@ namespace gdjs {
       return [x + this.getCameraX(cameraId), y + this.getCameraY(cameraId)];
     }
 
-    convertInverseCoords(x, y, cameraId) {
+    convertInverseCoords(x: float, y: float, cameraId?: integer): FloatPoint {
       x -= this.getCameraX(cameraId);
       y -= this.getCameraY(cameraId);
 
@@ -319,7 +319,7 @@ namespace gdjs {
      * Return the initial effects data for the layer. Only to
      * be used by renderers.
      */
-    getInitialEffectsData() {
+    getInitialEffectsData(): EffectData[] {
       return this._initialEffectsData;
     }
 
@@ -327,7 +327,7 @@ namespace gdjs {
      * Add a new effect, or replace the one with the same name.
      * @param effectData The data of the effect to add.
      */
-    addEffect(effectData: EffectData) {
+    addEffect(effectData: EffectData): void {
       this._renderer.addEffect(effectData);
       for (let name in effectData.doubleParameters) {
         this.setEffectDoubleParameter(
@@ -356,7 +356,7 @@ namespace gdjs {
      * Remove the effect with the specified name
      * @param effectName The name of the effect.
      */
-    removeEffect(effectName: string) {
+    removeEffect(effectName: string): void {
       this._renderer.removeEffect(effectName);
     }
 
@@ -472,7 +472,7 @@ namespace gdjs {
     /**
      * Change the position, rotation and scale (zoom) of the layer camera to be the same as the base layer camera.
      */
-    followBaseLayer() {
+    followBaseLayer(): void {
       const baseLayer = this._runtimeScene.getLayer('');
       this.setCameraX(baseLayer.getCameraX());
       this.setCameraY(baseLayer.getCameraY());

--- a/GDJS/Runtime/oncetriggers.ts
+++ b/GDJS/Runtime/oncetriggers.ts
@@ -9,15 +9,20 @@ namespace gdjs {
    * that are used in events to have conditions that are only valid for one frame in a row.
    */
   export class OnceTriggers {
-    _onceTriggers: any = {};
-    _lastFrameOnceTrigger: any = {};
+    _onceTriggers: Record<number, boolean> = {};
+    _lastFrameOnceTrigger: Record<number, boolean> = {};
 
     /**
      * To be called when events begin so that "Trigger once" conditions
      * are properly handled.
      */
-    startNewFrame() {
-      this._clearObject(this._lastFrameOnceTrigger);
+    startNewFrame(): void {
+      // Clear triggers from 2 frames ago
+      for (const k in this._lastFrameOnceTrigger)
+        if (this._lastFrameOnceTrigger.hasOwnProperty(k))
+          delete this._lastFrameOnceTrigger[k];
+
+      // Move triggers from this frame to last frame
       for (const k in this._onceTriggers) {
         if (this._onceTriggers.hasOwnProperty(k)) {
           this._lastFrameOnceTrigger[k] = this._onceTriggers[k];
@@ -31,17 +36,9 @@ namespace gdjs {
      * this method was not called with the same identifier during the last frame.
      * @param triggerId The identifier of the "Trigger once" condition.
      */
-    triggerOnce(triggerId) {
+    triggerOnce(triggerId: number): boolean {
       this._onceTriggers[triggerId] = true;
       return !this._lastFrameOnceTrigger.hasOwnProperty(triggerId);
-    }
-
-    _clearObject(obj) {
-      for (const k in obj) {
-        if (obj.hasOwnProperty(k)) {
-          delete obj[k];
-        }
-      }
     }
   }
 }

--- a/GDJS/Runtime/oncetriggers.ts
+++ b/GDJS/Runtime/oncetriggers.ts
@@ -9,8 +9,8 @@ namespace gdjs {
    * that are used in events to have conditions that are only valid for one frame in a row.
    */
   export class OnceTriggers {
-    _onceTriggers: Record<number, boolean> = {};
-    _lastFrameOnceTrigger: Record<number, boolean> = {};
+    _onceTriggers: Record<integer, boolean> = {};
+    _lastFrameOnceTrigger: Record<integer, boolean> = {};
 
     /**
      * To be called when events begin so that "Trigger once" conditions
@@ -36,7 +36,7 @@ namespace gdjs {
      * this method was not called with the same identifier during the last frame.
      * @param triggerId The identifier of the "Trigger once" condition.
      */
-    triggerOnce(triggerId: number): boolean {
+    triggerOnce(triggerId: integer): boolean {
       this._onceTriggers[triggerId] = true;
       return !this._lastFrameOnceTrigger.hasOwnProperty(triggerId);
     }

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -10,7 +10,7 @@ namespace gdjs {
   export class LayerPixiRenderer {
     _pixiContainer: any;
 
-    _filters: { [key: string]: gdjs.PixiFiltersTools.Filter } = {};
+    _filters: Record<string, gdjs.PixiFiltersTools.Filter> = {};
     _layer: any;
     _renderTexture: PIXI.RenderTexture | null = null;
     _lightingSprite: PIXI.Sprite | null = null;
@@ -44,11 +44,11 @@ namespace gdjs {
       }
     }
 
-    getRendererObject() {
+    getRendererObject(): PIXI.Container {
       return this._pixiContainer;
     }
 
-    getLightingSprite() {
+    getLightingSprite(): PIXI.Sprite | null {
       return this._lightingSprite;
     }
 
@@ -56,7 +56,7 @@ namespace gdjs {
      * Update the position of the PIXI container. To be called after each change
      * made to position, zoom or rotation of the camera.
      */
-    private updatePosition() {
+    updatePosition(): void {
       const angle = -gdjs.toRad(this._layer.getCameraRotation());
       const zoomFactor = this._layer.getCameraZoom();
       this._pixiContainer.rotation = angle;
@@ -76,7 +76,7 @@ namespace gdjs {
       this._pixiContainer.position.y += this._layer.getHeight() / 2;
     }
 
-    updateVisibility(visible): void {
+    updateVisibility(visible: boolean): void {
       this._pixiContainer.visible = !!visible;
     }
 
@@ -94,7 +94,7 @@ namespace gdjs {
      * Add a new effect, or replace the one with the same name.
      * @param effectData The data of the effect to add.
      */
-    addEffect(effectData: EffectData) {
+    addEffect(effectData: EffectData): void {
       const filterCreator = gdjs.PixiFiltersTools.getFilterCreator(
         effectData.effectType
       );
@@ -129,7 +129,7 @@ namespace gdjs {
      * Remove the effect with the specified name
      * @param effectName The name of the effect.
      */
-    removeEffect(effectName: string) {
+    removeEffect(effectName: string): void {
       const filter = this._filters[effectName];
       if (!filter) {
         return;
@@ -149,7 +149,7 @@ namespace gdjs {
      * @param child The child (PIXI object) to be added.
      * @param zOrder The z order of the associated object.
      */
-    addRendererObject(child, zOrder) {
+    addRendererObject(child, zOrder: integer): void {
       child.zOrder = zOrder;
 
       //Extend the pixi object with a z order.
@@ -169,7 +169,7 @@ namespace gdjs {
      * @param child The child (PIXI object) to be modified.
      * @param newZOrder The z order of the associated object.
      */
-    changeRendererObjectZOrder(child, newZOrder) {
+    changeRendererObjectZOrder(child, newZOrder: integer): void {
       this._pixiContainer.removeChild(child);
       this.addRendererObject(child, newZOrder);
     }
@@ -180,7 +180,7 @@ namespace gdjs {
      *
      * @param child The child (PIXI object) to be removed.
      */
-    removeRendererObject(child) {
+    removeRendererObject(child): void {
       this._pixiContainer.removeChild(child);
     }
 
@@ -282,7 +282,7 @@ namespace gdjs {
      * Updates the render texture, if it exists.
      * Also, render texture is cleared with a specified clear color.
      */
-    _updateRenderTexture() {
+    _updateRenderTexture(): void {
       if (
         !this._pixiRenderer ||
         this._pixiRenderer.type !== PIXI.RENDERER_TYPE.WEBGL
@@ -335,7 +335,7 @@ namespace gdjs {
      * of the layer by a sprite showing this texture.
      * used only in lighting for now as the sprite could have MULTIPLY blend mode.
      */
-    private _replaceContainerWithSprite() {
+    private _replaceContainerWithSprite(): void {
       if (
         !this._pixiRenderer ||
         this._pixiRenderer.type !== PIXI.RENDERER_TYPE.WEBGL
@@ -356,5 +356,6 @@ namespace gdjs {
   }
 
   //Register the class to let the engine use it.
+  export type LayerRenderer = gdjs.LayerPixiRenderer;
   export const LayerRenderer = gdjs.LayerPixiRenderer;
 }

--- a/GDJS/Runtime/polygon.ts
+++ b/GDJS/Runtime/polygon.ts
@@ -4,12 +4,11 @@
  * This project is released under the MIT License.
  */
 namespace gdjs {
-  type FloatPoint = Array<float>;
-
   export type CollisionTestResult = {
     collision: boolean;
     move_axis: FloatPoint;
   };
+
   export type RaycastTestResult = {
     collision: boolean;
     closeX: float;
@@ -104,7 +103,7 @@ namespace gdjs {
       return true;
     }
 
-    computeCenter() {
+    computeCenter(): FloatPoint {
       this.center[0] = 0;
       this.center[1] = 0;
       const len = this.vertices.length;
@@ -212,7 +211,10 @@ namespace gdjs {
       //Ensure move axis is correctly oriented.
       const p1Center = p1.computeCenter();
       const p2Center = p2.computeCenter();
-      const d = [p1Center[0] - p2Center[0], p1Center[1] - p2Center[1]];
+      const d: FloatPoint = [
+        p1Center[0] - p2Center[0],
+        p1Center[1] - p2Center[1],
+      ];
       if (Polygon.dotProduct(d, move_axis) < 0) {
         move_axis[0] = -move_axis[0];
         move_axis[1] = -move_axis[1];
@@ -431,7 +433,14 @@ namespace gdjs {
 
     // Arrays and data structure that are (re)used by Polygon.collisionTest to
     // avoid any allocation.
-    private static collisionTestStatics = {
+    private static collisionTestStatics: {
+      minMaxA: FloatPoint;
+      minMaxB: FloatPoint;
+      edge: FloatPoint;
+      axis: FloatPoint;
+      move_axis: FloatPoint;
+      result: CollisionTestResult;
+    } = {
       minMaxA: [0, 0],
       minMaxB: [0, 0],
       edge: [0, 0],
@@ -442,7 +451,15 @@ namespace gdjs {
 
     // Arrays and data structure that are (re)used by Polygon.raycastTest to
     // avoid any allocation.
-    private static raycastTestStatics = {
+    private static raycastTestStatics: {
+      p: FloatPoint;
+      q: FloatPoint;
+      r: FloatPoint;
+      s: FloatPoint;
+      deltaQP: FloatPoint;
+      axis: FloatPoint;
+      result: RaycastTestResult;
+    } = {
       p: [0, 0],
       q: [0, 0],
       r: [0, 0],

--- a/GDJS/Runtime/profiler.ts
+++ b/GDJS/Runtime/profiler.ts
@@ -35,7 +35,7 @@ namespace gdjs {
     /** The number of frames that have been measured */
     _framesCount: number = 0;
 
-    /** A function to get the current time. If avialable, corresponds to performance.now(). */
+    /** A function to get the current time. If available, corresponds to performance.now(). */
     _getTimeNow: () => float;
 
     constructor() {

--- a/GDJS/Runtime/runtimebehavior.ts
+++ b/GDJS/Runtime/runtimebehavior.ts
@@ -67,7 +67,7 @@ namespace gdjs {
      * Behaviors writers: Please do not redefine this method. Redefine doStepPreEvents instead.
      * @param runtimeScene The runtimeScene owning the object
      */
-    stepPreEvents(runtimeScene: gdjs.RuntimeScene) {
+    stepPreEvents(runtimeScene: gdjs.RuntimeScene): void {
       if (this._activated) {
         const profiler = runtimeScene.getProfiler();
         if (profiler) {
@@ -85,7 +85,7 @@ namespace gdjs {
      * Behaviors writers: Please do not redefine this method. Redefine doStepPreEvents instead.
      * @param runtimeScene The runtimeScene owning the object
      */
-    stepPostEvents(runtimeScene: gdjs.RuntimeScene) {
+    stepPostEvents(runtimeScene: gdjs.RuntimeScene): void {
       if (this._activated) {
         const profiler = runtimeScene.getProfiler();
         if (profiler) {
@@ -102,7 +102,7 @@ namespace gdjs {
      * De/Activate the behavior
      * @param enable true to enable the behavior, false to disable it
      */
-    activate(enable: boolean) {
+    activate(enable: boolean): void {
       if (enable === undefined) {
         enable = true;
       }
@@ -122,12 +122,12 @@ namespace gdjs {
      * object using it was created), after the object is fully initialized (so
      * you can use `this.owner` without risk).
      */
-    onCreated() {}
+    onCreated(): void {}
 
     /**
      * Return true if the behavior is activated
      */
-    activated() {
+    activated(): boolean {
       return this._activated;
     }
 
@@ -135,24 +135,24 @@ namespace gdjs {
      * Reimplement this method to do extra work when the behavior is activated (after
      * it has been deactivated, see `onDeActivate`).
      */
-    onActivate() {}
+    onActivate(): void {}
 
     /**
      * Reimplement this method to do extra work when the behavior is deactivated.
      */
-    onDeActivate() {}
+    onDeActivate(): void {}
 
     /**
      * This method is called each tick before events are done.
      * @param runtimeScene The runtimeScene owning the object
      */
-    doStepPreEvents(runtimeScene: gdjs.RuntimeScene) {}
+    doStepPreEvents(runtimeScene: gdjs.RuntimeScene): void {}
 
     /**
      * This method is called each tick after events are done.
      * @param runtimeScene The runtimeScene owning the object
      */
-    doStepPostEvents(runtimeScene: gdjs.RuntimeScene) {}
+    doStepPostEvents(runtimeScene: gdjs.RuntimeScene): void {}
 
     /**
      * This method is called when the owner of the behavior
@@ -161,14 +161,14 @@ namespace gdjs {
      * hot-reloading only. Otherwise, behaviors are just de-activated,
      * not removed. See `onDeActivate`).
      */
-    onDestroy() {}
+    onDestroy(): void {}
 
     /**
      * This method is called when the owner of the behavior
      * was hot reloaded, so its position, angle, size can have been changed outside
      * of events.
      */
-    onObjectHotReloaded() {}
+    onObjectHotReloaded(): void {}
   }
   gdjs.registerBehavior('', gdjs.RuntimeBehavior);
 }

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -7,9 +7,9 @@ namespace gdjs {
   /** An axis-aligned bounding box. Used to represents a box around an object for example. */
   export type AABB = {
     /** The [x,y] coordinates of the top left point */
-    min: Array<number>;
+    min: FloatPoint;
     /** The [x,y] coordinates of the bottom right point */
-    max: Array<number>;
+    max: FloatPoint;
   };
 
   /**
@@ -42,13 +42,10 @@ namespace gdjs {
     zOrder: integer = 0;
     hidden: boolean = false;
     layer: string = '';
-    protected _nameId: number;
+    protected _nameId: integer;
     protected _livingOnScene: boolean = true;
 
-    /**
-     * @readonly
-     */
-    id: number;
+    readonly id: integer;
     _runtimeScene: gdjs.RuntimeScene;
 
     /**
@@ -122,7 +119,7 @@ namespace gdjs {
      * If you redefine this function, **make sure to call the original method**
      * (`RuntimeObject.prototype.onCreated.call(this);`).
      */
-    onCreated() {
+    onCreated(): void {
       for (let i = 0; i < this._behaviors.length; ++i) {
         this._behaviors[i].onCreated();
       }
@@ -144,7 +141,7 @@ namespace gdjs {
      * need to be set again.
      *
      */
-    reinitialize(objectData: ObjectData) {
+    reinitialize(objectData: ObjectData): void {
       const runtimeScene = this._runtimeScene;
       this.x = 0;
       this.y = 0;
@@ -153,6 +150,7 @@ namespace gdjs {
       this.hidden = false;
       this.layer = '';
       this._livingOnScene = true;
+      //@ts-ignore Reinitialize is like a constructor, it can overwrite the readonly property.
       this.id = runtimeScene.createNewUniqueId();
       this.persistentUuid = null;
       this.pick = false;
@@ -217,7 +215,9 @@ namespace gdjs {
      *
      * @param initialInstanceData The data of the initial instance.
      */
-    extraInitializationFromInitialInstance(initialInstanceData: InstanceData) {}
+    extraInitializationFromInitialInstance(
+      initialInstanceData: InstanceData
+    ): void {}
 
     //Nothing to do.
     /**
@@ -388,7 +388,12 @@ namespace gdjs {
       return this.getY();
     }
 
-    rotateTowardPosition(x, y, speed, scene) {
+    rotateTowardPosition(
+      x: float,
+      y: float,
+      speed: float,
+      scene: gdjs.RuntimeScene
+    ): void {
       this.rotateTowardAngle(
         (Math.atan2(
           y - (this.getDrawableY() + this.getCenterY()),
@@ -401,7 +406,11 @@ namespace gdjs {
       );
     }
 
-    rotateTowardAngle(angle, speed, runtimeScene) {
+    rotateTowardAngle(
+      angle: float,
+      speed: float,
+      runtimeScene: gdjs.RuntimeScene
+    ): void {
       if (speed === 0) {
         this.setAngle(angle);
         return;
@@ -443,7 +452,7 @@ namespace gdjs {
      * @param speed The speed, in degrees per second.
      * @param runtimeScene The scene where the object is displayed.
      */
-    rotate(speed: number, runtimeScene: gdjs.RuntimeScene) {
+    rotate(speed: float, runtimeScene: gdjs.RuntimeScene): void {
       this.setAngle(
         this.getAngle() + (speed * this.getElapsedTime(runtimeScene)) / 1000
       );
@@ -514,7 +523,7 @@ namespace gdjs {
      *
      * @param z The new Z order position of the object
      */
-    setZOrder(z: number): void {
+    setZOrder(z: integer): void {
       if (z === this.zOrder) {
         return;
       }
@@ -562,7 +571,7 @@ namespace gdjs {
      * @return The specified variable
      * @static
      */
-    static returnVariable(variable: gdjs.Variable): any {
+    static returnVariable(variable: gdjs.Variable): gdjs.Variable {
       return variable;
     }
 
@@ -572,7 +581,7 @@ namespace gdjs {
      * @return The string of the specified variable
      * @static
      */
-    static getVariableString(variable): any {
+    static getVariableString(variable: gdjs.Variable): string {
       return variable.getAsString();
     }
 
@@ -582,7 +591,7 @@ namespace gdjs {
      * @return The number of children
      * @static
      */
-    static getVariableChildCount(variable): any {
+    static getVariableChildCount(variable: gdjs.Variable): integer {
       if (variable.isStructure() == false) {
         return 0;
       }
@@ -594,7 +603,7 @@ namespace gdjs {
      * @param variable The variable to be changed
      * @param newValue The value to be set
      */
-    static setVariableNumber(variable, newValue: float) {
+    static setVariableNumber(variable: gdjs.Variable, newValue: float): void {
       variable.setNumber(newValue);
     }
 
@@ -603,7 +612,7 @@ namespace gdjs {
      * @param variable The variable to be changed
      * @param newValue {String} The value to be set
      */
-    static setVariableString(variable, newValue) {
+    static setVariableString(variable: gdjs.Variable, newValue: string) {
       variable.setString(newValue);
     }
 
@@ -615,7 +624,7 @@ namespace gdjs {
     private static variableChildExists(
       variable: gdjs.Variable,
       childName: string
-    ) {
+    ): boolean {
       return variable.hasChild(childName);
     }
 
@@ -627,15 +636,15 @@ namespace gdjs {
     private static variableRemoveChild(
       variable: gdjs.Variable,
       childName: string
-    ) {
-      return variable.removeChild(childName);
+    ): void {
+      variable.removeChild(childName);
     }
 
     /**
      * @static
      * @param variable The variable to be cleared
      */
-    private static variableClearChildren(variable: gdjs.Variable) {
+    private static variableClearChildren(variable: gdjs.Variable): void {
       variable.clearChildren();
     }
 
@@ -755,7 +764,7 @@ namespace gdjs {
      * @param y The y coordinates of the force
      * @param multiplier Set the force multiplier
      */
-    addForce(x: float, y: float, multiplier: integer) {
+    addForce(x: float, y: float, multiplier: integer): void {
       this._forces.push(this._getRecycledForce(x, y, multiplier));
     }
 
@@ -765,7 +774,7 @@ namespace gdjs {
      * @param len The length of the force, in pixels.
      * @param multiplier Set the force multiplier
      */
-    addPolarForce(angle: float, len: number, multiplier: integer) {
+    addPolarForce(angle: float, len: float, multiplier: integer): void {
       const angleInRadians = (angle / 180) * 3.14159;
 
       //TODO: Benchmark with Math.PI
@@ -784,9 +793,9 @@ namespace gdjs {
     addForceTowardPosition(
       x: float,
       y: float,
-      len: number,
+      len: float,
       multiplier: integer
-    ) {
+    ): void {
       const angle = Math.atan2(
         y - (this.getDrawableY() + this.getCenterY()),
         x - (this.getDrawableX() + this.getCenterX())
@@ -805,9 +814,9 @@ namespace gdjs {
      */
     addForceTowardObject(
       object: gdjs.RuntimeObject,
-      len: number,
+      len: float,
       multiplier: integer
-    ) {
+    ): void {
       if (object == null) {
         return;
       }
@@ -822,7 +831,7 @@ namespace gdjs {
     /**
      * Deletes all forces applied on the object
      */
-    clearForces() {
+    clearForces(): void {
       RuntimeObject.forcesGarbage.push.apply(
         RuntimeObject.forcesGarbage,
         this._forces
@@ -842,7 +851,7 @@ namespace gdjs {
      * Called once a step by runtimeScene to update forces magnitudes and
      * remove null ones.
      */
-    updateForces(elapsedTime): void {
+    updateForces(elapsedTime: float): void {
       for (let i = 0; i < this._forces.length; ) {
         const force = this._forces[i];
         const multiplier = force.getMultiplier();
@@ -895,7 +904,7 @@ namespace gdjs {
      * @return true if the difference between the average angle of the forces
      * and the angle parameter is inferior to toleranceInDegrees parameter.
      */
-    averageForceAngleIs(angle: float, toleranceInDegrees: number): boolean {
+    averageForceAngleIs(angle: float, toleranceInDegrees: float): boolean {
       let averageAngle = this.getAverageForce().getAngle();
       if (averageAngle < 0) {
         averageAngle += 360;
@@ -1050,7 +1059,7 @@ namespace gdjs {
     /**
      * Call each behavior stepPreEvents method.
      */
-    stepBehaviorsPreEvents(runtimeScene) {
+    stepBehaviorsPreEvents(runtimeScene): void {
       for (let i = 0, len = this._behaviors.length; i < len; ++i) {
         this._behaviors[i].stepPreEvents(runtimeScene);
       }
@@ -1059,7 +1068,7 @@ namespace gdjs {
     /**
      * Call each behavior stepPostEvents method.
      */
-    stepBehaviorsPostEvents(runtimeScene) {
+    stepBehaviorsPostEvents(runtimeScene): void {
       for (let i = 0, len = this._behaviors.length; i < len; ++i) {
         this._behaviors[i].stepPostEvents(runtimeScene);
       }
@@ -1069,7 +1078,7 @@ namespace gdjs {
      * Called when the object was hot reloaded, to notify behaviors
      * that the object was modified. Useful for behaviors that
      */
-    notifyBehaviorsObjectHotReloaded() {
+    notifyBehaviorsObjectHotReloaded(): void {
       for (let i = 0, len = this._behaviors.length; i < len; ++i) {
         this._behaviors[i].onObjectHotReloaded();
       }
@@ -1085,7 +1094,7 @@ namespace gdjs {
      * @param name {String} The behavior name.
      * @return The behavior with the given name, or undefined.
      */
-    getBehavior(name): gdjs.RuntimeBehavior | null {
+    getBehavior(name: string): gdjs.RuntimeBehavior | null {
       return this._behaviorsTable.get(name);
     }
 
@@ -1094,7 +1103,7 @@ namespace gdjs {
      *
      * @param name {String} The behavior name.
      */
-    hasBehavior(name): boolean {
+    hasBehavior(name: string): boolean {
       return this._behaviorsTable.containsKey(name);
     }
 
@@ -1104,7 +1113,7 @@ namespace gdjs {
      * @param name {String} The behavior name.
      * @param enable {boolean} true to activate the behavior
      */
-    activateBehavior(name, enable) {
+    activateBehavior(name: string, enable: boolean): void {
       if (this._behaviorsTable.containsKey(name)) {
         this._behaviorsTable.get(name).activate(enable);
       }
@@ -1116,7 +1125,7 @@ namespace gdjs {
      * @param name The behavior name.
      * @return true if the behavior is activated.
      */
-    behaviorActivated(name: string): any {
+    behaviorActivated(name: string): boolean {
       if (this._behaviorsTable.containsKey(name)) {
         return this._behaviorsTable.get(name).activated();
       }
@@ -1186,7 +1195,7 @@ namespace gdjs {
      * @param timeInSeconds The time value to check in seconds
      * @return True if the timer exists and its value is greater than or equal than the given time, false otherwise
      */
-    timerElapsedTime(timerName: string, timeInSeconds: number): boolean {
+    timerElapsedTime(timerName: string, timeInSeconds: float): boolean {
       if (!this._timers.containsKey(timerName)) {
         this._timers.put(timerName, new gdjs.Timer(timerName));
         return false;
@@ -1221,7 +1230,7 @@ namespace gdjs {
      * Pause a timer, if the timer doesn't exist it is created
      * @param timerName The timer name
      */
-    pauseTimer(timerName: string) {
+    pauseTimer(timerName: string): void {
       if (!this._timers.containsKey(timerName)) {
         this._timers.put(timerName, new gdjs.Timer(timerName));
       }
@@ -1232,7 +1241,7 @@ namespace gdjs {
      * Unpause a timer, if the timer doesn't exist it is created
      * @param timerName The timer name
      */
-    unpauseTimer(timerName: string) {
+    unpauseTimer(timerName: string): void {
       if (!this._timers.containsKey(timerName)) {
         this._timers.put(timerName, new gdjs.Timer(timerName));
       }
@@ -1243,7 +1252,7 @@ namespace gdjs {
      * Remove a timer
      * @param timerName The timer name
      */
-    removeTimer(timerName: string) {
+    removeTimer(timerName: string): void {
       if (this._timers.containsKey(timerName)) {
         this._timers.remove(timerName);
       }
@@ -1254,7 +1263,7 @@ namespace gdjs {
      * @param timerName The timer name
      * @return The timer elapsed time in seconds, 0 if the timer doesn't exist
      */
-    getTimerElapsedTimeInSeconds(timerName: string): number {
+    getTimerElapsedTimeInSeconds(timerName: string): float {
       if (!this._timers.containsKey(timerName)) {
         return 0;
       }
@@ -1268,7 +1277,10 @@ namespace gdjs {
      * @param ignoreTouchingEdges If true, then edges that are touching each other, without the hitbox polygons actually overlapping, won't be considered in collision.
      * @return true if the object was moved
      */
-    separateFromObjects(objects, ignoreTouchingEdges: boolean): any {
+    separateFromObjects(
+      objects: RuntimeObject[],
+      ignoreTouchingEdges: boolean
+    ): boolean {
       let moved = false;
       let xMove = 0;
       let yMove = 0;
@@ -1306,7 +1318,10 @@ namespace gdjs {
      * @param ignoreTouchingEdges If true, then edges that are touching each other, without the hitbox polygons actually overlapping, won't be considered in collision.
      * @return true if the object was moved
      */
-    separateFromObjectsList(objectsLists, ignoreTouchingEdges: boolean): any {
+    separateFromObjectsList(
+      objectsLists: ObjectsLists,
+      ignoreTouchingEdges: boolean
+    ): boolean {
       let moved = false;
       let xMove = 0;
       let yMove = 0;
@@ -1347,7 +1362,7 @@ namespace gdjs {
      * Get the distance, in pixels, between *the center* of this object and another object.
      * @param otherObject The other object
      */
-    getDistanceToObject(otherObject: gdjs.RuntimeObject) {
+    getDistanceToObject(otherObject: gdjs.RuntimeObject): float {
       return Math.sqrt(this.getSqDistanceToObject(otherObject));
     }
 
@@ -1355,7 +1370,7 @@ namespace gdjs {
      * Get the squared distance, in pixels, between *the center* of this object and another object.
      * @param otherObject The other object
      */
-    getSqDistanceToObject(otherObject: gdjs.RuntimeObject) {
+    getSqDistanceToObject(otherObject: gdjs.RuntimeObject): float {
       if (otherObject === null) {
         return 0;
       }
@@ -1375,7 +1390,7 @@ namespace gdjs {
      * @param targetX Target X position
      * @param targetY Target Y position
      */
-    getDistanceToPosition(targetX: number, targetY: number) {
+    getDistanceToPosition(targetX: float, targetY: float): float {
       return Math.sqrt(this.getSqDistanceToPosition(targetX, targetY));
     }
 
@@ -1384,7 +1399,7 @@ namespace gdjs {
      * @param targetX Target X position
      * @param targetY Target Y position
      */
-    getSqDistanceToPosition(targetX: number, targetY: number) {
+    getSqDistanceToPosition(targetX: float, targetY: float): float {
       const x = this.getDrawableX() + this.getCenterX() - targetX;
       const y = this.getDrawableY() + this.getCenterY() - targetY;
       return x * x + y * y;
@@ -1394,7 +1409,7 @@ namespace gdjs {
      * Get the angle, in degrees, from the *object center* to another object.
      * @param otherObject The other object
      */
-    getAngleToObject(otherObject: gdjs.RuntimeObject) {
+    getAngleToObject(otherObject: gdjs.RuntimeObject): float {
       if (otherObject === null) {
         return 0;
       }
@@ -1414,7 +1429,7 @@ namespace gdjs {
      * @param targetX Target X position
      * @param targetY Target Y position
      */
-    getAngleToPosition(targetX: number, targetY: number) {
+    getAngleToPosition(targetX: float, targetY: float): float {
       const x = this.getDrawableX() + this.getCenterX() - targetX;
       const y = this.getDrawableY() + this.getCenterY() - targetY;
       return (Math.atan2(-y, -x) * 180) / Math.PI;
@@ -1429,7 +1444,12 @@ namespace gdjs {
      * @param distance The distance between the object and the target, in pixels.
      * @param angleInDegrees The angle between the object and the target, in degrees.
      */
-    putAround(x: float, y: float, distance: number, angleInDegrees: number) {
+    putAround(
+      x: float,
+      y: float,
+      distance: float,
+      angleInDegrees: float
+    ): void {
       const angle = (angleInDegrees / 180) * 3.14159;
 
       // Offset the position by the center, as PutAround* methods should position the center
@@ -1456,7 +1476,11 @@ namespace gdjs {
      * @param distance The distance between the object and the target
      * @param angleInDegrees The angle between the object and the target, in degrees.
      */
-    putAroundObject(obj, distance: number, angleInDegrees: number) {
+    putAroundObject(
+      obj: gdjs.RuntimeObject,
+      distance: float,
+      angleInDegrees: float
+    ): void {
       this.putAround(
         obj.getDrawableX() + obj.getCenterX(),
         obj.getDrawableY() + obj.getCenterY(),
@@ -1469,7 +1493,7 @@ namespace gdjs {
      * @deprecated
      * @param objectsLists Tables of objects
      */
-    separateObjectsWithoutForces(objectsLists) {
+    separateObjectsWithoutForces(objectsLists: ObjectsLists): void {
       //Prepare the list of objects to iterate over.
       const objects = gdjs.staticArray(
         RuntimeObject.prototype.separateObjectsWithoutForces
@@ -1512,7 +1536,7 @@ namespace gdjs {
      * @deprecated
      * @param objectsLists Tables of objects
      */
-    separateObjectsWithForces(objectsLists) {
+    separateObjectsWithForces(objectsLists: ObjectsLists): void {
       //Prepare the list of objects to iterate over.
       const objects = gdjs.staticArray(
         RuntimeObject.prototype.separateObjectsWithForces
@@ -1622,10 +1646,16 @@ namespace gdjs {
      * @param y The raycast source Y
      * @param endX The raycast end position X
      * @param endY The raycast end position Y
-     * @param closest {boolean} Get the closest or farthest collision mask result?
+     * @param closest Get the closest or farthest collision mask result?
      * @return A raycast result with the contact points and distances
      */
-    raycastTest(x: float, y: float, endX: number, endY: number, closest): any {
+    raycastTest(
+      x: float,
+      y: float,
+      endX: float,
+      endY: float,
+      closest: boolean
+    ): RaycastTestResult {
       // First check if bounding circles are too far
       const objCenterX = this.getCenterX();
       const objCenterY = this.getCenterY();
@@ -1689,7 +1719,7 @@ namespace gdjs {
      * if you need to pass the mouse or a touch position that you get from gdjs.InputManager.
      *
      */
-    insideObject(x, y) {
+    insideObject(x: float, y: float): boolean {
       if (this.hitBoxesDirty) {
         this.updateHitBoxes();
         this.updateAABB();
@@ -1707,7 +1737,11 @@ namespace gdjs {
      * Check the distance between two objects.
      * @static
      */
-    static distanceTest(obj1, obj2, distance) {
+    static distanceTest(
+      obj1: RuntimeObject,
+      obj2: RuntimeObject,
+      distance: float
+    ): boolean {
       return obj1.getSqDistanceToObject(obj2) <= distance;
     }
 
@@ -1716,7 +1750,7 @@ namespace gdjs {
      *
      * @return true if the cursor, or any touch, is on the object.
      */
-    cursorOnObject(runtimeScene): any {
+    cursorOnObject(runtimeScene: RuntimeScene): boolean {
       const inputManager = runtimeScene.getGame().getInputManager();
       const layer = runtimeScene.getLayer(this.layer);
       const mousePos = layer.convertCoords(
@@ -1745,7 +1779,7 @@ namespace gdjs {
      * @param pointY The point y coordinate.
      * @return true if the point is inside the object collision hitboxes.
      */
-    isCollidingWithPoint(pointX, pointY): boolean {
+    isCollidingWithPoint(pointX: float, pointY: float): boolean {
       const hitBoxes = this.getHitBoxes();
       for (let i = 0; i < this.hitBoxes.length; ++i) {
         if (gdjs.Polygon.isPointInside(hitBoxes[i], pointX, pointY)) {
@@ -1762,7 +1796,7 @@ namespace gdjs {
      *
      * @static
      */
-    static getNameIdentifier(name) {
+    static getNameIdentifier(name: string): integer {
       if (RuntimeObject._identifiers.containsKey(name)) {
         return RuntimeObject._identifiers.get(name);
       }

--- a/GDJS/Runtime/scenestack.ts
+++ b/GDJS/Runtime/scenestack.ts
@@ -22,13 +22,13 @@ namespace gdjs {
      * Useful to notify scene and layers that resolution is changed, as they
      * might be caching it.
      */
-    onGameResolutionResized() {
+    onGameResolutionResized(): void {
       for (let i = 0; i < this._stack.length; ++i) {
         this._stack[i].onGameResolutionResized();
       }
     }
 
-    step(elapsedTime) {
+    step(elapsedTime: float): boolean {
       if (this._stack.length === 0) {
         return false;
       }
@@ -56,7 +56,7 @@ namespace gdjs {
       return true;
     }
 
-    renderWithoutStep() {
+    renderWithoutStep(): boolean {
       if (this._stack.length === 0) {
         return false;
       }
@@ -65,7 +65,7 @@ namespace gdjs {
       return true;
     }
 
-    pop() {
+    pop(): gdjs.RuntimeScene | null {
       if (this._stack.length <= 1) {
         return null;
       }
@@ -89,7 +89,7 @@ namespace gdjs {
      * Pause the scene currently being played and start the new scene that is specified.
      * If `externalLayoutName` is set, also instantiate the objects from this external layout.
      */
-    push(newSceneName: string, externalLayoutName?: string) {
+    push(newSceneName: string, externalLayoutName?: string): gdjs.RuntimeScene {
       // Tell the scene it's being paused
       const currentScene = this._stack[this._stack.length - 1];
       if (currentScene) {
@@ -124,7 +124,7 @@ namespace gdjs {
      * Start the specified scene, replacing the one currently being played.
      * If `clear` is set to true, all running scenes are also removed from the stack of scenes.
      */
-    replace(newSceneName: string, clear?: boolean) {
+    replace(newSceneName: string, clear?: boolean): gdjs.RuntimeScene {
       if (!!clear) {
         // Unload all the scenes
         while (this._stack.length !== 0) {
@@ -148,7 +148,7 @@ namespace gdjs {
     /**
      * Return the current gdjs.RuntimeScene being played, or null if none is run.
      */
-    getCurrentScene() {
+    getCurrentScene(): gdjs.RuntimeScene | null {
       if (this._stack.length === 0) {
         return null;
       }
@@ -158,7 +158,7 @@ namespace gdjs {
     /**
      * Return true if a scene was loaded, false otherwise (i.e: game not yet started).
      */
-    wasFirstSceneLoaded() {
+    wasFirstSceneLoaded(): boolean {
       return this._wasFirstSceneLoaded;
     }
   }

--- a/GDJS/Runtime/timemanager.ts
+++ b/GDJS/Runtime/timemanager.ts
@@ -11,10 +11,10 @@ namespace gdjs {
   export class TimeManager {
     _elapsedTime: float = 0;
     _timeScale: float = 1;
-    _timeFromStart: any;
-    _firstFrame: any;
-    _timers: any;
-    _firstUpdateDone: any;
+    _timeFromStart: float = 0;
+    _firstFrame: boolean = true;
+    _timers: Hashtable<gdjs.Timer> = new Hashtable();
+    _firstUpdateDone: boolean = false;
 
     constructor() {
       this.reset();
@@ -28,7 +28,7 @@ namespace gdjs {
       this._timers = new Hashtable();
     }
 
-    update(elapsedTime, minimumFPS): void {
+    update(elapsedTime: float, minimumFPS: integer): void {
       if (this._firstUpdateDone) {
         this._firstFrame = false;
       }
@@ -70,7 +70,7 @@ namespace gdjs {
      * Get the time since the instanciation of the manager (i.e: since
      * the beginning of the scene most of the time), in milliseconds.
      */
-    getTimeFromStart() {
+    getTimeFromStart(): float {
       return this._timeFromStart;
     }
 
@@ -90,19 +90,19 @@ namespace gdjs {
       return this._elapsedTime;
     }
 
-    addTimer(name) {
+    addTimer(name: string): void {
       this._timers.put(name, new gdjs.Timer(name));
     }
 
-    hasTimer(name): boolean {
+    hasTimer(name: string): boolean {
       return this._timers.containsKey(name);
     }
 
-    getTimer(name) {
+    getTimer(name: string): gdjs.Timer {
       return this._timers.get(name);
     }
 
-    removeTimer(name) {
+    removeTimer(name: string): void {
       if (this._timers.containsKey(name)) {
         this._timers.remove(name);
       }

--- a/GDJS/Runtime/types/global-types.d.ts
+++ b/GDJS/Runtime/types/global-types.d.ts
@@ -10,6 +10,12 @@ declare type integer = number;
 /** A floating point number. Use this instead of `number` to ease future optimizations. */
 declare type float = number;
 
+/** A point in cartesian space. */
+declare type FloatPoint = [number, number];
+
+/** A Hastable with the picked objects lists. */
+declare type ObjectsLists = Hashtable<gdjs.RuntimeObject[]>;
+
 /**
  * Represents the context of the events function (or the behavior method),
  * if any. If the JavaScript code is running in a scene, this will be undefined (so you can't use this in a scene).
@@ -23,9 +29,7 @@ declare type EventsFunctionContext = {
    * You can alter the list and this will alter the objects picked for the next conditions/actions/events.
    * If you don't need this, prefer using `getObjects`.
    */
-  getObjectsLists: (
-    objectName: string
-  ) => Hashtable<Array<gdjs.RuntimeObject>> | null;
+  getObjectsLists: (objectName: string) => ObjectsLists | null;
 
   /**  Get the "real" behavior name, that can be used with `getBehavior`. For example: `object.getBehavior(eventsFunctionContext.getBehaviorName("MyBehavior"))` */
   getBehaviorName: (behaviorName: string) => string;
@@ -44,6 +48,7 @@ declare type EventsFunctionContext = {
 };
 
 declare namespace gdjs {
+  var projectData: ProjectData;
   var runtimeGameOptions: gdjs.RuntimeGameOptions;
 }
 


### PR DESCRIPTION
I might have done too much at once this time 😅 

I added a lot of `: void` to method signatures, as leaving them out implies a return type of `: any`, which might make typescript not spot some bugs if a function is not supposed to return a value.
I also replaced a lot of `{ [key: string]: Type }` with `Record<string, Type>`. There are no changes in the type itself as `Record` is an alias for this but it is way more readable.
I added return types to functions that could already infer it from what is returned as well, to be able to spot bugs if the variable the type is inferred from changes types.

The "major" type changes are in the Profiler and in the Debugger.