### PR TITLE
Adding some Particle Emitter properties

### DIFF
--- a/Extensions/ParticleSystem/Extension.cpp
+++ b/Extensions/ParticleSystem/Extension.cpp
@@ -102,6 +102,9 @@ ParticleSystemCppExtension::ParticleSystemCppExtension() {
   conditions["ParticleSystem::EmitterAngle"]
       .SetFunctionName("GetAngle")
       .SetIncludeFile("ParticleSystem/ParticleEmitterObject.h");
+  conditions["ParticleSystem::ParticleType"]
+      .SetFunctionName("GetRendererType")
+      .SetIncludeFile("ParticleSystem/ParticleEmitterObject.h");
   actions["ParticleSystem::EmitterAngleA"]
       .SetFunctionName("SetEmitterAngleA")
       .SetGetter("GetEmitterAngleA")

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration1.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration1.cpp
@@ -122,6 +122,16 @@ void ExtensionSubDeclaration1(gd::ObjectMetadata& obj) {
       .AddParameter("object", _("Object"), "ParticleEmitter")
       .UseStandardRelationalOperatorParameters("number");
 
+  obj.AddCondition("ParticleType",
+                  _("Kind of Particle"),
+                  _("Test the Kind of Particle(Point: 0, Line: 1, or Quad: 2)"),
+                  _("the Particle Kind"),
+                  _("Common"),
+                  "CppPlatform/Extensions/particleSystemicon24.png",
+                  "CppPlatform/Extensions/particleSystemicon16.png")
+      .AddParameter("object", _("Object"), "ParticleEmitter")
+      .UseStandardRelationalOperatorParameters("number");
+
   obj.AddAction("EmitterAngleA",
                 _("Emission angle 1"),
                 _("Change emission angle #1"),

--- a/Extensions/ParticleSystem/JsExtension.cpp
+++ b/Extensions/ParticleSystem/JsExtension.cpp
@@ -51,6 +51,7 @@ class ParticleSystemJsExtension : public gd::PlatformExtension {
         .SetFunctionName("setAngle")
         .SetGetter("getAngle");
     conditions["ParticleSystem::EmitterAngle"].SetFunctionName("getAngle");
+    conditions["ParticleSystem::ParticleType"].SetFunctionName("getRendererType");
     actions["ParticleSystem::EmitterAngleA"]
         .SetFunctionName("setEmitterAngleA")
         .SetGetter("getEmitterAngleA");

--- a/Extensions/ParticleSystem/particleemitterobject.ts
+++ b/Extensions/ParticleSystem/particleemitterobject.ts
@@ -403,6 +403,10 @@ namespace gdjs {
       return (this.angleA + this.angleB) / 2.0;
     }
 
+    getRendererType(): float {
+      return parseInt(this.rendererType, 10) || 0;
+    }
+
     setEmitterAngle(angle): void {
       const oldAngle = this.getEmitterAngle();
       if (angle !== oldAngle) {


### PR DESCRIPTION
It is a rough implementation of the first action(Particles kind) requested in #2225.

Here is how I tested it. I created a particle emitter object and added this condition to the event sheet.
![image](https://user-images.githubusercontent.com/43215292/109922461-617e0000-7ce3-11eb-89bc-2b9d8820d268.png)
It works as expected in the electron app, but the web version shows a black screen. 

I am unable to understand the reason as I didn't make any platform-specific. I need help regarding how to go on from here.