### PR TITLE
Fix hitboxes of some objects not properly updated when some objects were resized

### DIFF
--- a/Extensions/BBText/bbtextruntimeobject.ts
+++ b/Extensions/BBText/bbtextruntimeobject.ts
@@ -242,8 +242,11 @@ namespace gdjs {
      * @param width The new width in pixels.
      */
     setWrappingWidth(width: float): void {
+      if (this._wrappingWidth === width) return;
+
       this._wrappingWidth = width;
       this._renderer.updateWrappingWidth();
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -253,12 +256,15 @@ namespace gdjs {
       return this._wrappingWidth;
     }
 
-    setWordWrap(wordWrap): void {
+    setWordWrap(wordWrap: boolean): void {
+      if (this._wordWrap === wordWrap) return;
+
       this._wordWrap = wordWrap;
       this._renderer.updateWordWrap();
+      this.hitBoxesDirty = true;
     }
 
-    getWordWrap(wordWrap) {
+    getWordWrap() {
       return this._wordWrap;
     }
 

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-cocos-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-cocos-renderer.ts
@@ -10,6 +10,8 @@ namespace gdjs {
     _leftSpriteShader: any;
     _bottomSpriteShader: any;
     _convertYPosition: any;
+    _textureWidth = 0;
+    _textureHeight = 0;
 
     constructor(runtimeObject, runtimeScene, textureName, tiled) {
       this._object = runtimeObject;
@@ -203,11 +205,12 @@ namespace gdjs {
 
     setTexture(textureName, runtimeScene): void {
       const obj = this._object;
-      const that = this;
       const texture = runtimeScene
         .getGame()
         .getImageManager()
         .getTexture(textureName);
+      this._textureWidth = texture.pixelsWidth;
+      this._textureHeight = texture.pixelsHeight;
 
       function makeInsideTexture(rect) {
         //TODO
@@ -386,6 +389,14 @@ namespace gdjs {
       this._updateSpritesAndTexturesSize();
       this._updateLocalPositions();
       this.updatePosition();
+    }
+
+    getTextureWidth() {
+      return this._textureWidth;
+    }
+
+    getTextureHeight() {
+      return this._textureHeight;
     }
   }
   // @ts-ignore - Register the class to let the engine use it.

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
@@ -6,6 +6,8 @@ namespace gdjs {
     _borderSprites: any;
     _alpha: float;
     _wasRendered: boolean = false;
+    _textureWidth = 0;
+    _textureHeight = 0;
 
     constructor(
       runtimeObject: gdjs.PanelSpriteRuntimeObject,
@@ -185,6 +187,8 @@ namespace gdjs {
         .getGame()
         .getImageManager()
         .getPIXITexture(textureName);
+      this._textureWidth = texture.width;
+      this._textureHeight = texture.height;
 
       function makeInsideTexture(rect) {
         //TODO
@@ -367,7 +371,16 @@ namespace gdjs {
         Math.floor(rgb[2] * 255)
       );
     }
+
+    getTextureWidth() {
+      return this._textureWidth;
+    }
+
+    getTextureHeight() {
+      return this._textureHeight;
+    }
   }
 
   export const PanelSpriteRuntimeObjectRenderer = PanelSpriteRuntimeObjectPixiRenderer;
+  export type PanelSpriteRuntimeObjectRenderer = PanelSpriteRuntimeObjectPixiRenderer;
 }

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
@@ -33,11 +33,13 @@ namespace gdjs {
     _tBorder: integer;
     _bBorder: integer;
     _tiled: boolean;
-    _width: float;
-    _height: float;
     opacity: float = 255;
 
-    // @ts-ignore
+    // Width and height can be stored because they do not depend on the
+    // size of the texture being used (contrary to most objects).
+    _width: float;
+    _height: float;
+
     _renderer: gdjs.PanelSpriteRuntimeObjectRenderer;
 
     /**
@@ -112,7 +114,9 @@ namespace gdjs {
 
     onDestroyFromScene(runtimeScene): void {
       super.onDestroyFromScene(runtimeScene);
+      // @ts-ignore
       if (this._renderer.onDestroy) {
+        // @ts-ignore
         this._renderer.onDestroy();
       }
     }
@@ -188,8 +192,11 @@ namespace gdjs {
      * @param width The new width in pixels.
      */
     setWidth(width: float): void {
+      if (this._width === width) return;
+
       this._width = width;
       this._renderer.updateWidth();
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -197,8 +204,11 @@ namespace gdjs {
      * @param height The new height in pixels.
      */
     setHeight(height: float): void {
+      if (this._height === height) return;
+
       this._height = height;
       this._renderer.updateHeight();
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -240,6 +250,54 @@ namespace gdjs {
      */
     getColor(): string {
       return this._renderer.getColor();
+    }
+
+    // Implement support for get/set scale:
+
+    /**
+     * Get scale of the tiled sprite object.
+     */
+    getScale(): float {
+      return (this.getScaleX() + this.getScaleY()) / 2.0;
+    }
+
+    /**
+     * Get x-scale of the tiled sprite object.
+     */
+    getScaleX(): float {
+      return this._width / this._renderer.getTextureWidth();
+    }
+
+    /**
+     * Get y-scale of the tiled sprite object.
+     */
+    getScaleY(): float {
+      return this._height / this._renderer.getTextureHeight();
+    }
+
+    /**
+     * Set the tiled sprite object scale.
+     * @param newScale The new scale for the tiled sprite object.
+     */
+    setScale(newScale: float): void {
+      this.setWidth(this._renderer.getTextureWidth() * newScale);
+      this.setHeight(this._renderer.getTextureHeight() * newScale);
+    }
+
+    /**
+     * Set the tiled sprite object x-scale.
+     * @param newScale The new x-scale for the tiled sprite object.
+     */
+    setScaleX(newScale: float): void {
+      this.setWidth(this._renderer.getTextureWidth() * newScale);
+    }
+
+    /**
+     * Set the tiled sprite object y-scale.
+     * @param newScale The new y-scale for the tiled sprite object.
+     */
+    setScaleY(newScale: float): void {
+      this.setHeight(this._renderer.getTextureHeight() * newScale);
     }
   }
   gdjs.registerObject(

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -55,11 +55,12 @@ namespace gdjs {
     _shadowBlur: integer = 1;
     _shadowAngle: float = 0;
     _padding: integer = 5;
-    _scaleX: number = 1;
-    _scaleY: number = 1;
     _str: string;
     _renderer: gdjs.TextRuntimeObjectRenderer;
-    hitBoxesDirty: any;
+
+    // We can store the scale as nothing else can change it.
+    _scaleX: number = 1;
+    _scaleY: number = 1;
 
     /**
      * @param runtimeScene The scene the object belongs to.
@@ -305,14 +306,14 @@ namespace gdjs {
      * Get x-scale of the text.
      */
     getScaleX(): float {
-      return this._renderer.getScaleX();
+      return this._scaleX;
     }
 
     /**
      * Get y-scale of the text.
      */
     getScaleY(): float {
-      return this._renderer.getScaleY();
+      return this._scaleY;
     }
 
     /**
@@ -320,9 +321,12 @@ namespace gdjs {
      * @param newScale The new scale for the text object.
      */
     setScale(newScale: float): void {
+      if (this._scaleX === newScale && this._scaleY === newScale) return;
+
       this._scaleX = newScale;
       this._scaleY = newScale;
       this._renderer.setScale(newScale);
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -330,8 +334,11 @@ namespace gdjs {
      * @param newScale The new x-scale for the text object.
      */
     setScaleX(newScale: float): void {
+      if (this._scaleX === newScale) return;
+
       this._scaleX = newScale;
       this._renderer.setScaleX(newScale);
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -339,15 +346,18 @@ namespace gdjs {
      * @param newScale The new y-scale for the text object.
      */
     setScaleY(newScale: float): void {
+      if (this._scaleY === newScale) return;
+
       this._scaleY = newScale;
       this._renderer.setScaleY(newScale);
+      this.hitBoxesDirty = true;
     }
 
     /**
      * Change the text color.
      * @param color color as a "R;G;B" string, for example: "255;0;0"
      */
-    setColor(str): void {
+    setColor(str: string): void {
       const color = str.split(';');
       if (color.length < 3) {
         return;
@@ -363,7 +373,7 @@ namespace gdjs {
      * Get the text color.
      * @return The color as a "R;G;B" string, for example: "255;0;0"
      */
-    getColor(str): string {
+    getColor(): string {
       return this._color[0] + ';' + this._color[1] + ';' + this._color[2];
     }
 
@@ -396,8 +406,11 @@ namespace gdjs {
      * @param enable true to enable word wrapping, false to disable it.
      */
     setWrapping(enable: boolean): void {
+      if (this._wrapping === enable) return;
+
       this._wrapping = enable;
       this._renderer.updateStyle();
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -415,8 +428,11 @@ namespace gdjs {
       if (width <= 1) {
         width = 1;
       }
+      if (this._wrappingWidth === width) return;
+
       this._wrappingWidth = width;
       this._renderer.updateStyle();
+      this.hitBoxesDirty = true;
     }
 
     /**

--- a/Extensions/TileMap/tilemapruntimeobject.ts
+++ b/Extensions/TileMap/tilemapruntimeobject.ts
@@ -185,7 +185,10 @@ namespace gdjs {
      * @param width The new width.
      */
     setWidth(width: float): void {
+      if (this._renderer.getWidth() === width) return;
+
       this._renderer.setWidth(width);
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -193,7 +196,10 @@ namespace gdjs {
      * @param height The new height.
      */
     setHeight(height: float): void {
+      if (this._renderer.getHeight() === height) return;
+
       this._renderer.setHeight(height);
+      this.hitBoxesDirty = true;
     }
 
     /**

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-cocos-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-cocos-renderer.ts
@@ -142,6 +142,14 @@ namespace gdjs {
       this.updatePosition();
     }
 
+    getTextureWidth() {
+      return this._cachedTextureWidth;
+    }
+
+    getTextureHeight() {
+      return this._cachedTextureHeight;
+    }
+
     updateXOffset(): void {
       this._updateTextureRect();
     }

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -107,43 +107,12 @@ namespace gdjs {
       );
     }
 
-    /**
-     * Get x-scale of the tiled sprite object.
-     */
-    getScaleX(): float {
-      return this._tiledSprite.scale.x;
+    getTextureWidth() {
+      return this._tiledSprite.texture.width;
     }
 
-    /**
-     * Get y-scale of the tiled sprite object.
-     */
-    getScaleY(): float {
-      return this._tiledSprite.scale.y;
-    }
-
-    /**
-     * Set the tiled sprite object scale.
-     * @param newScale The new scale for the object.
-     */
-    setScale(newScale: float): void {
-      this._tiledSprite.scale.x = newScale;
-      this._tiledSprite.scale.y = newScale;
-    }
-
-    /**
-     * Set the tiled sprite object x-scale.
-     * @param newScale The new x-scale for the object.
-     */
-    setScaleX(newScale: float): void {
-      this._tiledSprite.scale.x = newScale;
-    }
-
-    /**
-     * Set the tiled sprite object y-scale.
-     * @param newScale The new y-scale for the object.
-     */
-    setScaleY(newScale: float): void {
-      this._tiledSprite.scale.y = newScale;
+    getTextureHeight() {
+      return this._tiledSprite.texture.height;
     }
   }
 

--- a/Extensions/Video/videoruntimeobject.ts
+++ b/Extensions/Video/videoruntimeobject.ts
@@ -150,7 +150,10 @@ namespace gdjs {
      * @param width The new width in pixels.
      */
     setWidth(width: float): void {
+      if (this._renderer.getWidth() === width) return;
+
       this._renderer.setWidth(width);
+      this.hitBoxesDirty = true;
     }
 
     /**
@@ -158,7 +161,10 @@ namespace gdjs {
      * @param height The new height in pixels.
      */
     setHeight(height: float): void {
+      if (this._renderer.getHeight() === height) return;
+
       this._renderer.setHeight(height);
+      this.hitBoxesDirty = true;
     }
 
     /**


### PR DESCRIPTION
* This includes BBText, Text, Tilemap, Tiled Sprite, Panel Sprite and the Video objects.
* Also add support for tweening the scale of a Panel Sprite object.


Fix #2280