### PR TITLE
Scene Editor - Moving instance selected faster with SHIFT

### DIFF
--- a/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
@@ -123,13 +123,13 @@ export default class DeprecatedKeyboardShortcuts {
 
     if (this.onMove) {
       if (evt.which === UP_KEY) {
-        this.onMove(0, -1);
+        this.shiftPressed ? this.onMove(0, -5) : this.onMove(0, -1);
       } else if (evt.which === DOWN_KEY) {
-        this.onMove(0, 1);
+        this.shiftPressed ? this.onMove(0, 5) : this.onMove(0, 1);
       } else if (evt.which === LEFT_KEY) {
-        this.onMove(-1, 0);
+        this.shiftPressed ? this.onMove(-5, 0) : this.onMove(-1, 0);
       } else if (evt.which === RIGHT_KEY) {
-        this.onMove(1, 0);
+        this.shiftPressed ? this.onMove(5, 0) : this.onMove(1, 0);
       }
     }
     if (evt.which === BACKSPACE_KEY || evt.which === DELETE_KEY) {

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -115,13 +115,13 @@ export default class KeyboardShortcuts {
 
     if (onMove) {
       if (evt.which === UP_KEY) {
-        onMove(0, -1);
+        this._shiftPressed ? onMove(0, -5) : onMove(0, -1);
       } else if (evt.which === DOWN_KEY) {
-        onMove(0, 1);
+        this._shiftPressed ? onMove(0, 5) : onMove(0, 1);
       } else if (evt.which === LEFT_KEY) {
-        onMove(-1, 0);
+        this._shiftPressed ? onMove(-5, 0) : onMove(-1, 0);
       } else if (evt.which === RIGHT_KEY) {
-        onMove(1, 0);
+        this._shiftPressed ? onMove(5, 0) : onMove(1, 0);
       }
     }
     if (onDelete && (evt.which === BACKSPACE_KEY || evt.which === DELETE_KEY)) {


### PR DESCRIPTION
As the keyboard shortcuts used are still on the DeprecatedKeyboardShortcuts  class i've made the change on the Deprecated versions used and the new not yet used.

We can't yet use fully the new KeyboardShortcuts class because some fonctions are missing and make crash the app.

fix  #2266