### PR TITLE
Add "simulate stick" action to the top-down behavior

### DIFF
--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -126,6 +126,22 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .SetIncludeFile(
           "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
 
+  aut.AddAction("SimulateStick",
+                _("Simulate stick control"),
+                _("Simulate a stick control."),
+                _("Simulate a stick control for _PARAM0_ with a _PARAM2_ angle and a _PARAM3_ force"),
+                _("Controls"),
+                "res/conditions/keyboard24.png",
+                "res/conditions/keyboard.png")
+      .AddParameter("object", _("Object"))
+      .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
+      .AddParameter("expression", _("Stick rotation"))
+      .AddParameter("expression", _("Stick force"))
+      .MarkAsAdvanced()
+      .SetFunctionName("SimulateStick")
+      .SetIncludeFile(
+          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+
   aut.AddCondition("IsMoving",
                    _("Is moving"),
                    _("Check if the object is moving."),

--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -135,8 +135,8 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                 "res/conditions/keyboard.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("expression", _("Stick rotation"))
-      .AddParameter("expression", _("Stick force"))
+      .AddParameter("expression", _("Stick angle (in degrees)"))
+      .AddParameter("expression", _("Stick force (between 0 and 1)"))
       .MarkAsAdvanced()
       .SetFunctionName("SimulateStick")
       .SetIncludeFile(

--- a/Extensions/TopDownMovementBehavior/JsExtension.cpp
+++ b/Extensions/TopDownMovementBehavior/JsExtension.cpp
@@ -101,6 +101,8 @@ class TopDownMovementBehaviorJsExtension : public gd::PlatformExtension {
         "simulateControl");
     autActions["TopDownMovementBehavior::IgnoreDefaultControls"]
         .SetFunctionName("ignoreDefaultControls");
+    autActions["TopDownMovementBehavior::SimulateStick"].SetFunctionName(
+        "simulateStick");
 
     autExpressions["Acceleration"].SetFunctionName("getAcceleration");
     autExpressions["Deceleration"].SetFunctionName("getDeceleration");

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -39,7 +39,7 @@ namespace gdjs {
     _rightKey: boolean = false;
     _upKey: boolean = false;
     _downKey: boolean = false;
-    private _strickRotation: float = 0;
+    private _stickAngle: float = 0;
     private _stickForce: float = 0;
 
     // @ts-ignore The setter "setViewpoint" is not detected as an affectation.
@@ -111,11 +111,11 @@ namespace gdjs {
     }
 
     setViewpoint(viewpoint: string, customIsometryAngle: float): void {
-      if (viewpoint == 'PixelIsometry') {
+      if (viewpoint === 'PixelIsometry') {
         this._basisTransformation = new IsometryTransformation(Math.atan(0.5));
-      } else if (viewpoint == 'TrueIsometry') {
+      } else if (viewpoint === 'TrueIsometry') {
         this._basisTransformation = new IsometryTransformation(Math.PI / 6);
-      } else if (viewpoint == 'CustomIsometry') {
+      } else if (viewpoint === 'CustomIsometry') {
         this._basisTransformation = new IsometryTransformation(
           (customIsometryAngle * Math.PI) / 180
         );
@@ -290,7 +290,7 @@ namespace gdjs {
       let directionInRad = 0;
       let directionInDeg = 0;
       //Update the speed of the object
-      if (direction != -1) {
+      if (direction !== -1) {
         directionInRad =
           ((direction + this._movementAngleOffset / 45) * Math.PI) / 4.0;
         directionInDeg = direction * 45 + this._movementAngleOffset;
@@ -298,8 +298,8 @@ namespace gdjs {
           this._acceleration * timeDelta * Math.cos(directionInRad);
         this._yVelocity +=
           this._acceleration * timeDelta * Math.sin(directionInRad);
-      } else if (this._stickForce != 0) {
-        directionInDeg = this._strickRotation + this._movementAngleOffset;
+      } else if (this._stickForce !== 0) {
+        directionInDeg = this._stickAngle + this._movementAngleOffset;
         directionInRad = (directionInDeg * Math.PI) / 180;
         const norm = this._acceleration * timeDelta * this._stickForce;
         this._xVelocity += norm * Math.cos(directionInRad);
@@ -337,7 +337,7 @@ namespace gdjs {
       //No acceleration for angular speed for now
 
       //Position object
-      if (this._basisTransformation == null) {
+      if (this._basisTransformation === null) {
         // Top-down viewpoint
         object.setX(object.getX() + this._xVelocity * timeDelta);
         object.setY(object.getY() + this._yVelocity * timeDelta);
@@ -401,8 +401,8 @@ namespace gdjs {
       this._downKey = true;
     }
 
-    simulateStick(strickRotation: float, stickForce: float) {
-      this._strickRotation = strickRotation % 360;
+    simulateStick(stickAngle: float, stickForce: float) {
+      this._stickAngle = stickAngle % 360;
       this._stickForce = Math.max(0, Math.min(1, stickForce));
     }
   }


### PR DESCRIPTION
Can be use with the gamepad extension to give players finer control on top-down movement.
![Stick-topdown](https://user-images.githubusercontent.com/2611977/110870093-114b0300-82cc-11eb-9bfb-afd3f521284a.png)
