### PR TITLE
Fix bug in theme creation script

### DIFF
--- a/newIDE/app/scripts/create-new-theme.js
+++ b/newIDE/app/scripts/create-new-theme.js
@@ -5,21 +5,26 @@ const fs = require('fs');
 const shell = require('shelljs');
 const readThemeRegistry = require('./lib/ReadThemeRegistry');
 
-let theme = args[2];
-if (!theme) {
+let themeName = args[2];
+if (!themeName) {
   shell.echo('❌ Please enter a theme name');
 }
 
-if (!theme.toLowerCase().endsWith('theme')) {
-  theme = theme + 'Theme';
+if (themeName.toLowerCase().endsWith('theme')) {
+  // Remove unnecessary trailing "Theme" from input
+  // eg: "Foo Bar" => "Foo Bar", "Foo Theme" => "Foo", "FooTheme" => "Foo"
+  const lastIndex = themeName.toLowerCase().lastIndexOf('theme');
+  themeName = themeName.slice(0, lastIndex).trim();
 }
 
-const themeId = theme.replace(/\s+/, '');
+// Remove spaces and append 'Theme' to get full theme identifier
+// eg: "Foo Bar" => "FooBarTheme"
+const themeId = themeName.replace(/\s+/, '') + 'Theme';
 
 
 const dir = path.resolve(__dirname, '../src/UI/Theme/', themeId);
 if (fs.existsSync(dir)) {
-  shell.echo('❌ Theme `' + theme + '` already exists');
+  shell.echo('❌ Theme `' + themeName + '` already exists');
   process.exit(0);
 }
 
@@ -45,7 +50,7 @@ shell.echo('✅ Created index.js');
 const registry = readThemeRegistry()
   .concat({
     id: themeId,
-    name: theme,
+    name: themeName,
   });
 
 const imports =

--- a/newIDE/app/scripts/theme-templates/index.js
+++ b/newIDE/app/scripts/theme-templates/index.js
@@ -1,4 +1,4 @@
-import { createGdevelopTheme } from '../theme';
+import { createGdevelopTheme } from '../CreateTheme';
 
 import styles from './$THEME_IDVariables.json';
 import './$THEME_IDVariables.css';


### PR DESCRIPTION
While trying to create a new theme, I realized that the `create-new-theme.js` script doesn't work correctly:
- In the template `index.js` theme file, `createGdevelopTheme` is wrongly imported from `../theme` (which does not exist in the `Themes` directory) and instead should be imported from `../CreateTheme`. And indeed, creating a new theme with the script leads to Flow compilation errors.
- The script did not create the theme name correctly - user input "Foo Bar" would lead to a theme name "Foo BarTheme" displayed to the end-user.

I've fixed both of the above and tested. New themes show up properly to the end-user and the styling still works.
