### PR TITLE
Add One Dark theme for workbench and editor

### DIFF
--- a/newIDE/app/src/CodeEditor/Theme/OneDark.js
+++ b/newIDE/app/src/CodeEditor/Theme/OneDark.js
@@ -1,0 +1,399 @@
+const themeData = {
+  base: 'vs-dark',
+  inherit: true,
+  rules: [
+    {
+      foreground: 'abb2bf',
+      token: 'text',
+    },
+    {
+      foreground: 'abb2bf',
+      token: 'source',
+    },
+    {
+      foreground: 'adb7c9',
+      token: 'variable.parameter.function',
+    },
+    {
+      foreground: '5f697a',
+      fontStyle: ' italic',
+      token: 'comment',
+    },
+    {
+      foreground: '5f697a',
+      fontStyle: ' italic',
+      token: 'punctuation.definition.comment',
+    },
+    {
+      foreground: 'adb7c9',
+      token: 'none',
+    },
+    {
+      foreground: 'adb7c9',
+      token: 'keyword.operator',
+    },
+    {
+      foreground: 'cd74e8',
+      token: 'keyword',
+    },
+    {
+      foreground: 'eb6772',
+      token: 'variable',
+    },
+    {
+      foreground: '5cb3fa',
+      token: 'entity.name.function',
+    },
+    {
+      foreground: '5cb3fa',
+      token: 'meta.require',
+    },
+    {
+      foreground: '5cb3fa',
+      token: 'support.function.any-method',
+    },
+    {
+      foreground: 'f0c678',
+      token: 'support.class',
+    },
+    {
+      foreground: 'f0c678',
+      token: 'entity.name.class',
+    },
+    {
+      foreground: 'f0c678',
+      token: 'entity.name.type.class',
+    },
+    {
+      foreground: 'adb7c9',
+      token: 'meta.class',
+    },
+    {
+      foreground: '5cb3fa',
+      token: 'keyword.other.special-method',
+    },
+    {
+      foreground: 'cd74e8',
+      token: 'storage',
+    },
+    {
+      foreground: '5ebfcc',
+      token: 'support.function',
+    },
+    {
+      foreground: '9acc76',
+      token: 'string',
+    },
+    {
+      foreground: '9acc76',
+      token: 'constant.other.symbol',
+    },
+    {
+      foreground: '9acc76',
+      token: 'entity.other.inherited-class',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'constant.numeric',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'none',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'none',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'constant',
+    },
+    {
+      foreground: 'eb6772',
+      token: 'entity.name.tag',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'entity.other.attribute-name',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'entity.other.attribute-name.id',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'punctuation.definition.entity',
+    },
+    {
+      foreground: 'cd74e8',
+      token: 'meta.selector',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'none',
+    },
+    {
+      foreground: '5cb3fa',
+      token: 'markup.heading punctuation.definition.heading',
+    },
+    {
+      foreground: '5cb3fa',
+      token: 'entity.name.section',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'keyword.other.unit',
+    },
+    {
+      foreground: 'f0c678',
+      token: 'markup.bold',
+    },
+    {
+      foreground: 'f0c678',
+      token: 'punctuation.definition.bold',
+    },
+    {
+      foreground: 'cd74e8',
+      token: 'markup.italic',
+    },
+    {
+      foreground: 'cd74e8',
+      token: 'punctuation.definition.italic',
+    },
+    {
+      foreground: '9acc76',
+      token: 'markup.raw.inline',
+    },
+    {
+      foreground: 'eb6772',
+      token: 'string.other.link',
+    },
+    {
+      foreground: 'eb6772',
+      token: 'punctuation.definition.string.end.markdown',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'meta.link',
+    },
+    {
+      foreground: 'eb6772',
+      token: 'markup.list',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'markup.quote',
+    },
+    {
+      foreground: 'adb7c9',
+      background: '515151',
+      token: 'meta.separator',
+    },
+    {
+      foreground: '9acc76',
+      token: 'markup.inserted',
+    },
+    {
+      foreground: 'eb6772',
+      token: 'markup.deleted',
+    },
+    {
+      foreground: 'cd74e8',
+      token: 'markup.changed',
+    },
+    {
+      foreground: '5ebfcc',
+      token: 'constant.other.color',
+    },
+    {
+      foreground: '5ebfcc',
+      token: 'string.regexp',
+    },
+    {
+      foreground: '5ebfcc',
+      token: 'constant.character.escape',
+    },
+    {
+      foreground: 'c94e42',
+      token: 'punctuation.section.embedded',
+    },
+    {
+      foreground: 'c94e42',
+      token: 'variable.interpolation',
+    },
+    {
+      foreground: 'ffffff',
+      background: 'e05252',
+      token: 'invalid.illegal',
+    },
+    {
+      foreground: '2d2d2d',
+      background: 'f99157',
+      token: 'invalid.broken',
+    },
+    {
+      foreground: '2c323d',
+      background: 'd27b53',
+      token: 'invalid.deprecated',
+    },
+    {
+      foreground: '2c323d',
+      background: '747369',
+      token: 'invalid.unimplemented',
+    },
+    {
+      foreground: 'eb6772',
+      token:
+        'source.json meta.structure.dictionary.json string.quoted.double.json',
+    },
+    {
+      foreground: '9acc76',
+      token:
+        'source.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json',
+    },
+    {
+      foreground: 'eb6772',
+      token:
+        'source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json',
+    },
+    {
+      foreground: '9acc76',
+      token:
+        'source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json',
+    },
+    {
+      foreground: 'cd74e8',
+      token:
+        'text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade',
+    },
+    {
+      foreground: 'cd74e8',
+      token:
+        'text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade',
+    },
+    {
+      foreground: 'db9d63',
+      token:
+        'source.python meta.function.python meta.function.parameters.python variable.parameter.function.python',
+    },
+    {
+      foreground: '5ebfcc',
+      token: 'source.python meta.function-call.python support.type.python',
+    },
+    {
+      foreground: 'cd74e8',
+      token: 'source.python keyword.operator.logical.python',
+    },
+    {
+      foreground: 'f0c678',
+      token:
+        'source.python meta.class.python punctuation.definition.inheritance.begin.python',
+    },
+    {
+      foreground: 'f0c678',
+      token:
+        'source.python meta.class.python punctuation.definition.inheritance.end.python',
+    },
+    {
+      foreground: 'db9d63',
+      token:
+        'source.python meta.function-call.python meta.function-call.arguments.python variable.parameter.function.python',
+    },
+    {
+      foreground: 'db9d63',
+      token:
+        'text.html.basic source.php.embedded.block.html support.constant.std.php',
+    },
+    {
+      foreground: 'f0c678',
+      token:
+        'text.html.basic source.php.embedded.block.html meta.namespace.php entity.name.type.namespace.php',
+    },
+    {
+      foreground: 'db9d63',
+      token: 'source.js meta.function.js support.constant.js',
+    },
+    {
+      foreground: 'cd74e8',
+      token:
+        'text.html.basic` source.php.embedded.block.html constant.other.php',
+    },
+    {
+      foreground: 'db9d63',
+      token:
+        'text.html.basic source.php.embedded.block.html support.other.namespace.php',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'text.tex.latex meta.function.environment.math.latex string.other.math.block.environment.latex meta.definition.label.latex variable.parameter.definition.label.latex',
+    },
+    {
+      foreground: 'cd74e8',
+      fontStyle: ' italic',
+      token: 'text.tex.latex meta.function.emph.latex markup.italic.emph.latex',
+    },
+    {
+      foreground: 'adb7c9',
+      token: 'source.js variable.other.readwrite.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.function-call.with-arguments.js variable.function.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.group.braces.round meta.group.braces.curly meta.function-call.method.without-arguments.js variable.function.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.group.braces.round meta.group.braces.curly variable.other.object.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.group.braces.round meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.group.braces.round meta.group.braces.curly constant.other.object.key.js punctuation.separator.key-value.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.group.braces.round meta.group.braces.curly meta.function-call.method.with-arguments.js variable.function.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.function-call.method.with-arguments.js variable.function.js',
+    },
+    {
+      foreground: 'adb7c9',
+      token:
+        'source.js meta.function-call.method.without-arguments.js variable.function.js',
+    },
+  ],
+  colors: {
+    'editor.foreground': '#6c7079',
+    'editor.background': '#2B303B',
+    'editor.selectionBackground': '#bbccf51b',
+    'editor.inactiveSelectionBackground': '#bbccf51b',
+    'editor.lineHighlightBackground': '#8cc2fc0b',
+    'editorCursor.foreground': '#528bff',
+    'editorWhitespace.foreground': '#747369',
+    'editorIndentGuide.background': '#464c55',
+    'editorIndentGuide.activeBackground': '#464c55',
+    'editor.selectionHighlightBorder': '#bbccf51b',
+  },
+};
+
+export default {
+  name: 'One-Dark',
+  themeName: 'one-dark',
+  themeData,
+};

--- a/newIDE/app/src/CodeEditor/Theme/index.js
+++ b/newIDE/app/src/CodeEditor/Theme/index.js
@@ -7,6 +7,7 @@ import SolarizedLight from './SolarizedLight';
 import VibrantInk from './VibrantInk';
 import GitHub from './GitHub';
 import NordDark from './NordDark';
+import OneDark from './OneDark';
 
 type CodeEditorTheme = {|
   name: string,
@@ -37,6 +38,7 @@ const themes: Array<CodeEditorTheme> = [
   TomorrowNight,
   VibrantInk,
   NordDark,
+  OneDark,
 ];
 
 export const getAllThemes = () => themes;

--- a/newIDE/app/src/UI/Theme/OneDarkTheme/index.js
+++ b/newIDE/app/src/UI/Theme/OneDarkTheme/index.js
@@ -1,0 +1,11 @@
+import { createGdevelopTheme } from '../CreateTheme';
+
+import styles from './OneDarkThemeVariables.json';
+import './OneDarkThemeVariables.css';
+
+export default createGdevelopTheme(
+  styles,
+  'OneDarkTheme',
+  'dark',
+  'hue-rotate(-10deg) saturate(50%)'
+);

--- a/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
@@ -1,0 +1,406 @@
+{
+  "theme": {
+    "primary": {
+      "color": {
+        "value": "#61AFEF"
+      },
+      "text-contrast-color": {
+        "value": "#FFFFFF"
+      }
+    },
+    "secondary": {
+      "color": {
+        "value": "#D6DEEC"
+      },
+      "text-contrast-color": {
+        "value": "#282C34"
+      }
+    },
+    "surface": {
+      "window": {
+        "background-color": {
+          "value": "#21252B"
+        }
+      },
+      "canvas": {
+        "background-color": {
+          "value": "#282C34"
+        }
+      },
+      "alternate-canvas": {
+        "background-color": {
+          "value": "#3E4452"
+        }
+      }
+    },
+    "selection": {
+      "background-color": {
+        "value": "#3E4452"
+      },
+      "color": {
+        "value": "#D6DEEC"
+      }
+    },
+    "text": {
+      "default": {
+        "color": {
+          "value": "#D6DEEC"
+        }
+      },
+      "secondary": {
+        "color": {
+          "value": "#ABB2BF"
+        }
+      },
+      "disabled": {
+        "color": {
+          "value": "#9AA1AD"
+        }
+      },
+      "contrast": {
+        "color": {
+          "value": "#D6DEEC"
+        }
+      }
+    },
+    "message": {
+      "warning": {
+        "color": {
+          "value": "#E5C07B"
+        }
+      },
+      "error": {
+        "color": {
+          "value": "#E06C75"
+        }
+      },
+      "valid": {
+        "color": {
+          "value": "#98C379"
+        }
+      },
+      "empty-shadow": {
+        "color": {
+          "value": "transparent"
+        }
+      }
+    },
+    "toolbar-separator": {
+      "color": {
+        "value": "#3E4452"
+      }
+    },
+    "closable-tabs": {
+      "default": {
+        "background-color": {
+          "value": "#21252B"
+        },
+        "color": {
+          "value": "#D6DEEC"
+        }
+      },
+      "selected": {
+        "background-color": {
+          "value": "#4C5361"
+        },
+        "color": {
+          "value": "#D6DEEC"
+        }
+      }
+    },
+    "list-item": {
+      "group": {
+        "text": {
+          "color": {
+            "value": "#ABB2BF"
+          }
+        },
+        "text-deprecated": {
+          "color": {
+            "value": "#9AA1AD"
+          }
+        }
+      },
+      "separator": {
+        "color": {
+          "value": "#3E4452"
+        }
+      },
+      "warning": {
+        "color": {
+          "value": "#E5C07B"
+        }
+      },
+      "error": {
+        "color": {
+          "value": "#E06C75"
+        }
+      }
+    },
+    "right-icon": {
+      "color": {
+        "value": "#FFFFFF"
+      }
+    },
+    "palette": {
+      "black": {
+        "value": "#6E2A2A"
+      },
+      "white": {
+        "value": "#D6DEEC"
+      }
+    }
+  },
+  "input": {
+    "border-bottom": {
+      "color": {
+        "value": "#D6DEEC"
+      }
+    }
+  },
+  "tabs": {
+    "background-color": {
+      "value": "#4C5361"
+    }
+  },
+  "event-sheet": {
+    "event-tree": {
+      "background-color": {
+        "value": "#282C34"
+      }
+    },
+    "rst": {
+      "move-handle": {
+        "background-color": {
+          "value": "#3E4452"
+        }
+      },
+      "move-handle-hover": {
+        "background-color": {
+          "value": "#6C7D96"
+        }
+      },
+      "line": {
+        "background-color": {
+          "value": "#ABB2BF"
+        }
+      },
+      "row-contents": {
+        "background-color": {
+          "value": "#282C34"
+        },
+        "color": {
+          "value": "#D6DEEC"
+        }
+      },
+      "row-search": {
+        "border-color": {
+          "value": "#18DCF2"
+        },
+        "border-left-width-match": {
+          "value": "3px"
+        },
+        "border-left-width-focus": {
+          "value": "5px"
+        }
+      }
+    },
+    "rst-with-results": {
+      "background-color": {
+        "value": "#D3D3D3"
+      },
+      "border": {
+        "value": "1px #D3D3D3 solid"
+      }
+    },
+    "selectable": {
+      "background-color": {
+        "value": "rgba(0, 0, 0, 0.1)"
+      },
+      "border": {
+        "value": "1px #282C34 solid"
+      },
+      "selected-border": {
+        "value": "1px #4AB0E4 dashed"
+      }
+    },
+    "conditions": {
+      "background-color": {
+        "value": "#3E4452"
+      },
+      "border-color": {
+        "value": "#3E4452"
+      },
+      "border": {
+        "value": "1px #3E4452 solid"
+      },
+      "color": {
+        "value": "rgb(209, 209, 209)"
+      },
+      "border-right-color": {
+        "value": "#494949"
+      },
+      "border-bottom-color": {
+        "value": "black"
+      }
+    },
+    "actions": {
+      "background-color": {
+        "value": "#282C34"
+      },
+      "color": {
+        "value": "#D6DEEC"
+      }
+    },
+    "sub-instructions": {
+      "border-color": {
+        "value": "#282C34"
+      },
+      "border": {
+        "value": "1px #282C34 solid"
+      }
+    },
+    "instruction-parameter": {
+      "base": {
+        "color": {
+          "value": "#98C379"
+        }
+      },
+      "expression": {
+        "color": {
+          "value": "#E5C07B"
+        }
+      },
+      "object": {
+        "color": {
+          "value": "#C678DD"
+        }
+      },
+      "behavior": {
+        "color": {
+          "value": "#E09563"
+        }
+      },
+      "operator": {
+        "color": {
+          "value": "#B77CFF"
+        }
+      },
+      "var": {
+        "color": {
+          "value": "#56B6C2"
+        }
+      },
+      "error": {
+        "color": {
+          "value": "#E06C75"
+        },
+        "background-color": {
+          "value": "#E06C7544"
+        }
+      }
+    },
+    "drop-indicator": {
+      "can-drop": {
+        "border-top-color": {
+          "value": "#61AFEF"
+        }
+      },
+      "cannot-drop": {
+        "border-top-color": {
+          "value": "#E06C75"
+        }
+      }
+    },
+    "link": {
+      "container": {
+        "background-color": {
+          "value": "#3E4452"
+        },
+        "color": {
+          "value": "#D6DEEC"
+        }
+      },
+      "selectable-link": {
+        "color": {
+          "value": "#C678DD"
+        }
+      }
+    }
+  },
+  "markdown": {
+    "blockquote": {
+      "border-left": {
+        "color": {
+          "value": "rgba(221, 221, 221, 0.6)"
+        }
+      }
+    },
+    "link": {
+      "color": {
+        "value": "rgb(221, 221, 221)"
+      }
+    }
+  },
+  "mosaic": {
+    "title": {
+      "color": {
+        "value": "#FFFFFF"
+      }
+    },
+    "layout": {
+      "border-color": {
+        "value": "#3E4452"
+      },
+      "background-color": {
+        "value": "#21252B"
+      }
+    },
+    "toolbar": {
+      "background-color": {
+        "value": "#4C5361"
+      },
+      "color": {
+        "value": "#D6DEEC"
+      },
+      "border-color-hover": {
+        "value": "#D6DEEC"
+      }
+    }
+  },
+  "table": {
+    "border": {
+      "color": {
+        "value": "#282C34"
+      }
+    },
+    "text": {
+      "color": {
+        "value": "#ABB2BF"
+      },
+      "color-header": {
+        "value": "#D6DEEC"
+      }
+    },
+    "row": {
+      "odd": {
+        "background-color": {
+          "value": "#282C34"
+        }
+      },
+      "even": {
+        "background-color": {
+          "value": "#21252B"
+        }
+      },
+      "selected": {
+        "background-color": {
+          "value": "#3E4452"
+        },
+        "color": {
+          "value": "#D6DEEC"
+        }
+      }
+    }
+  }
+}

--- a/newIDE/app/src/UI/Theme/ThemeRegistry.js
+++ b/newIDE/app/src/UI/Theme/ThemeRegistry.js
@@ -7,9 +7,9 @@ import OneDarkTheme from './OneDarkTheme';
 
 /*eslint no-useless-computed-key: "off"*/
 export const themes = {
-    ['GDevelop default']: DefaultTheme,
-    ['Dark']: DarkTheme,
-    ['Nord']: NordTheme,
-    ['Solarized Dark']: SolarizedDarkTheme,
-    ['One Dark']: OneDarkTheme,
+  ['GDevelop default']: DefaultTheme,
+  ['Dark']: DarkTheme,
+  ['Nord']: NordTheme,
+  ['Solarized Dark']: SolarizedDarkTheme,
+  ['One Dark']: OneDarkTheme,
 };

--- a/newIDE/app/src/UI/Theme/ThemeRegistry.js
+++ b/newIDE/app/src/UI/Theme/ThemeRegistry.js
@@ -3,11 +3,13 @@ import DefaultTheme from './DefaultTheme';
 import DarkTheme from './DarkTheme';
 import NordTheme from './NordTheme';
 import SolarizedDarkTheme from './SolarizedDarkTheme';
+import OneDarkTheme from './OneDarkTheme';
 
 /*eslint no-useless-computed-key: "off"*/
 export const themes = {
-  ['GDevelop default']: DefaultTheme,
-  ['Dark']: DarkTheme,
-  ['Nord']: NordTheme,
-  ['Solarized Dark']: SolarizedDarkTheme,
+    ['GDevelop default']: DefaultTheme,
+    ['Dark']: DarkTheme,
+    ['Nord']: NordTheme,
+    ['Solarized Dark']: SolarizedDarkTheme,
+    ['One Dark']: OneDarkTheme,
 };


### PR DESCRIPTION
This PR adds the One Dark theme for both the IDE and the code editor. It's a quite popular theme, originally used in Atom, recently added as an alternative dark mode option on GitHub and has been ported to almost every popular themeable app. Here are some screenshots:

![start-page](https://user-images.githubusercontent.com/18032938/112731220-f3340280-8f5b-11eb-9f7e-64e145bee4e1.png)
![scene-editor](https://user-images.githubusercontent.com/18032938/112731217-f202d580-8f5b-11eb-98ea-96aeb2c2a239.png)
![event-sheet](https://user-images.githubusercontent.com/18032938/112731215-f0d1a880-8f5b-11eb-9aaf-5e5a8a5be718.png)

The base color palette used for this theme is picked up from https://github.com/joshdick/onedark.vim (there is no "official" One Dark website or color palette available). Auxiliary shades of black and white have been picked up from One Dark screenshots :D 
![color-palette](https://raw.githubusercontent.com/joshdick/onedark.vim/master/img/color_reference.png),

Suggestions welcome!