### PR TITLE
Make the wheel zoom keeps the mouse in place in the instances editor.

### DIFF
--- a/newIDE/app/src/InstancesEditor/ViewPosition.js
+++ b/newIDE/app/src/InstancesEditor/ViewPosition.js
@@ -48,8 +48,8 @@ export default class ViewPosition {
   toSceneCoordinates = (x: number, y: number): [number, number] => {
     x -= this._width / 2;
     y -= this._height / 2;
-    x /= Math.abs(this._pixiContainer.scale.x);
-    y /= Math.abs(this._pixiContainer.scale.y);
+    x /= Math.abs(this.options.zoomFactor);
+    y /= Math.abs(this.options.zoomFactor);
 
     var viewRotation = 0;
     var tmp = x;
@@ -80,8 +80,8 @@ export default class ViewPosition {
       Math.sin((viewRotation / 180) * Math.PI) * tmp +
       Math.cos((viewRotation / 180) * Math.PI) * y;
 
-    x *= Math.abs(this._pixiContainer.scale.x);
-    y *= Math.abs(this._pixiContainer.scale.y);
+    x *= Math.abs(this.options.zoomFactor);
+    y *= Math.abs(this.options.zoomFactor);
 
     return [x + this._width / 2, y + this._height / 2];
   };

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -158,7 +158,7 @@ export default class InstancesEditor extends Component<Props> {
 
     this.pixiRenderer.view.onwheel = event => {
       if (this.keyboardShortcuts.shouldZoom()) {
-        this.zoomBy(-event.deltaY / 5000);
+        this.zoomOnMouseBy(-event.deltaY / 5000);
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
         this.viewPosition.scrollBy(-event.deltaY / 10, 0);
       } else {
@@ -455,6 +455,16 @@ export default class InstancesEditor extends Component<Props> {
 
   zoomBy(value: number) {
     this.setZoomFactor(this.getZoomFactor() + value);
+  }
+
+  zoomOnMouseBy(value: number) {
+    const beforeZoomCursor = this.getLastCursorSceneCoordinates();
+    this.setZoomFactor(this.getZoomFactor() + value);
+    const afterZoomCursor = this.getLastCursorSceneCoordinates();
+    this.viewPosition.scrollBy(beforeZoomCursor[0] - afterZoomCursor[0], beforeZoomCursor[1] - afterZoomCursor[1]);
+    if (this.props.onViewPositionChanged) {
+      this.props.onViewPositionChanged(this.viewPosition);
+    }
   }
 
   getZoomFactor = () => {

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -158,7 +158,7 @@ export default class InstancesEditor extends Component<Props> {
 
     this.pixiRenderer.view.onwheel = event => {
       if (this.keyboardShortcuts.shouldZoom()) {
-        this.zoomOnMouseBy(-event.deltaY / 5000);
+        this.zoomOnCursorBy(-event.deltaY / 5000);
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
         this.viewPosition.scrollBy(-event.deltaY / 10, 0);
       } else {
@@ -457,11 +457,18 @@ export default class InstancesEditor extends Component<Props> {
     this.setZoomFactor(this.getZoomFactor() + value);
   }
 
-  zoomOnMouseBy(value: number) {
-    const beforeZoomCursor = this.getLastCursorSceneCoordinates();
+  /**
+   * Zoom and scroll so that the cursor stays on the same position scene-wise.
+   */
+  zoomOnCursorBy(value: number) {
+    const beforeZoomCursorPosition = this.getLastCursorSceneCoordinates();
     this.setZoomFactor(this.getZoomFactor() + value);
-    const afterZoomCursor = this.getLastCursorSceneCoordinates();
-    this.viewPosition.scrollBy(beforeZoomCursor[0] - afterZoomCursor[0], beforeZoomCursor[1] - afterZoomCursor[1]);
+    const afterZoomCursorPosition = this.getLastCursorSceneCoordinates();
+    // Compensate for the cursor change in position
+    this.viewPosition.scrollBy(
+      beforeZoomCursorPosition[0] - afterZoomCursorPosition[0],
+      beforeZoomCursorPosition[1] - afterZoomCursorPosition[1]
+    );
     if (this.props.onViewPositionChanged) {
       this.props.onViewPositionChanged(this.viewPosition);
     }


### PR DESCRIPTION
This allows to point an zoom like in Inkscape.

This can save a lot of time when polishing a big level:
* The user adds some decorations to the level
* He jumps to one location by pointing it with the mouse and zoom in
* He adds and adjusts one decoration
* He zooms out to have a level overview
* He points another location and zoom in
* He adds another decoration
* and so on

Without it, the user needs to recenter the view on the target multiple times when zooming in.