### PR TITLE
Fix crash on empty while event

### DIFF
--- a/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -347,11 +347,18 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
       [](gd::BaseEvent& event_,
          gd::EventsCodeGenerator& codeGenerator,
          gd::EventsCodeGenerationContext& parentContext) {
-        gd::String outputCode;
         gd::WhileEvent& event = dynamic_cast<gd::WhileEvent&>(event_);
 
-        // Context is "reset" each time the event is repeated (i.e. objects are
-        // picked again)
+        // Prevent code generation if there are no conditions, as this would
+        // get the game stuck in a never ending loop.
+        if (event.GetWhileConditions().empty())
+          return gd::String(
+              "\n// While event not generated to prevent a crash\n");
+       
+        gd::String outputCode;
+
+        // Context is "reset" each time the event is repeated (i.e. objects
+        // are picked again)
         gd::EventsCodeGenerationContext context;
         context.InheritsFrom(parentContext);
         context.ForbidReuse();
@@ -459,10 +466,12 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
         // Define references to variables (if they exist)
         if (keyIteratorExists)
           outputCode +=
-              "const $KEY_ITERATOR_REFERENCE = $KEY_ITERATOR_VARIABLE_ACCESSOR;\n";
+              "const $KEY_ITERATOR_REFERENCE = "
+              "$KEY_ITERATOR_VARIABLE_ACCESSOR;\n";
         if (valueIteratorExists)
           outputCode +=
-              "const $VALUE_ITERATOR_REFERENCE = $VALUE_ITERATOR_VARIABLE_ACCESSOR;\n";
+              "const $VALUE_ITERATOR_REFERENCE = "
+              "$VALUE_ITERATOR_VARIABLE_ACCESSOR;\n";
         outputCode +=
             "const $ITERABLE_REFERENCE = $ITERABLE_VARIABLE_ACCESSOR;\n";
 

--- a/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -349,11 +349,15 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
          gd::EventsCodeGenerationContext& parentContext) {
         gd::WhileEvent& event = dynamic_cast<gd::WhileEvent&>(event_);
 
-        // Prevent code generation if there are no conditions, as this would
+        // Prevent code generation if the event is empty, as this would
         // get the game stuck in a never ending loop.
-        if (event.GetWhileConditions().empty())
+        if (
+          event.GetWhileConditions().empty() && 
+          event.GetConditions().empty() && 
+          event.GetActions().empty()
+        )
           return gd::String(
-              "\n// While event not generated to prevent a crash\n");
+              "\n// While event not generated to prevent an infinite loop.\n");
        
         gd::String outputCode;
 


### PR DESCRIPTION
Fixes #2437 

Doesn't generate while events without any conditions as it is impossible to break out of them and crashes the game. If you really wish to crash the game, you can still put the always condition in the while event.