### PR TITLE
Fix the chat in the p2p example

### DIFF
--- a/newIDE/app/resources/examples/p2p-networking/p2p-networking.json
+++ b/newIDE/app/resources/examples/p2p-networking/p2p-networking.json
@@ -11,7 +11,7 @@
     "folderProject": false,
     "orientation": "landscape",
     "packageName": "com.example.multiplayergame",
-    "projectUuid": "4e5a640f-64c8-45c4-97a3-8bf51ce318b1",
+    "projectUuid": "bd20e427-37f0-452d-ba93-372d1563cd4d",
     "scaleMode": "linear",
     "sizeOnStartupMode": "",
     "useDeprecatedZeroAsDefaultZOrder": true,
@@ -189,6 +189,7 @@
         "gridOffsetX": 0,
         "gridOffsetY": 0,
         "gridR": 158,
+        "gridType": "rectangular",
         "gridWidth": 32,
         "snap": true,
         "windowMask": false,
@@ -1405,6 +1406,7 @@
         "gridOffsetX": 0,
         "gridOffsetY": 0,
         "gridR": 158,
+        "gridType": "rectangular",
         "gridWidth": 32,
         "snap": true,
         "windowMask": false,
@@ -2104,6 +2106,7 @@
         "gridOffsetX": 0,
         "gridOffsetY": 0,
         "gridR": 158,
+        "gridType": "rectangular",
         "gridWidth": 32,
         "snap": true,
         "windowMask": false,
@@ -2708,10 +2711,11 @@
         "gridOffsetX": 0,
         "gridOffsetY": 0,
         "gridR": 158,
+        "gridType": "rectangular",
         "gridWidth": 32,
         "snap": true,
         "windowMask": false,
-        "zoomFactor": 0.9168
+        "zoomFactor": 0.869050000000001
       },
       "objectsGroups": [],
       "variables": [
@@ -2719,6 +2723,11 @@
           "name": "textBox",
           "type": "string",
           "value": "~~Begin of conversation~~"
+        },
+        {
+          "name": "textBoxChanged",
+          "type": "boolean",
+          "value": false
         }
       ],
       "instances": [
@@ -2741,25 +2750,9 @@
         {
           "angle": 0,
           "customSize": true,
-          "height": 438,
-          "layer": "",
-          "locked": false,
-          "name": "ChatBox",
-          "persistentUuid": "5f2f3009-7186-4186-b74f-e9c08fefdd04",
-          "width": 664,
-          "x": 76,
-          "y": 66,
-          "zOrder": 2,
-          "numberProperties": [],
-          "stringProperties": [],
-          "initialVariables": []
-        },
-        {
-          "angle": 0,
-          "customSize": true,
           "height": 507,
           "layer": "",
-          "locked": false,
+          "locked": true,
           "name": "ChatBoxSprite",
           "persistentUuid": "51196764-54f8-4094-8155-b9e0e64009f9",
           "width": 724,
@@ -2833,6 +2826,22 @@
           "numberProperties": [],
           "stringProperties": [],
           "initialVariables": []
+        },
+        {
+          "angle": 0,
+          "customSize": true,
+          "height": 205,
+          "layer": "",
+          "locked": false,
+          "name": "ChatBox",
+          "persistentUuid": "da65c15f-034d-43d9-862f-b103969924c0",
+          "width": 664,
+          "x": 76,
+          "y": 60,
+          "zOrder": 2,
+          "numberProperties": [],
+          "stringProperties": [],
+          "initialVariables": []
         }
       ],
       "objects": [
@@ -2856,22 +2865,20 @@
           }
         },
         {
-          "bold": false,
-          "italic": false,
           "name": "ChatBox",
-          "smoothed": true,
           "tags": "",
-          "type": "TextObject::Text",
-          "underlined": false,
+          "type": "BBText::BBText",
           "variables": [],
           "behaviors": [],
-          "string": "~~Begin of conversation~~",
-          "font": "",
-          "characterSize": 15,
-          "color": {
-            "b": 0,
-            "g": 0,
-            "r": 0
+          "content": {
+            "text": "~~Begin of conversation~~",
+            "opacity": 255,
+            "fontSize": 15,
+            "visible": true,
+            "color": "#000000",
+            "fontFamily": "Arial",
+            "align": "left",
+            "wordWrap": true
           }
         },
         {
@@ -3033,69 +3040,6 @@
             {
               "disabled": false,
               "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Handle text entry",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TextEntryObject::String"
-                  },
-                  "parameters": [
-                    "Entry",
-                    "=",
-                    "Sanitizer::trim(Entry.String(), 50)"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
-                    "EntryText",
-                    "=",
-                    "Entry.String()"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Comment",
-              "color": {
-                "b": 109,
-                "g": 230,
-                "r": 255,
-                "textB": 0,
-                "textG": 0,
-                "textR": 0
-              },
-              "comment": "Handle sending",
-              "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
               "type": "BuiltinCommonInstructions::Standard",
               "conditions": [
                 {
@@ -3104,7 +3048,7 @@
                     "value": "Egal"
                   },
                   "parameters": [
-                    "StrLength(Sanitizer::sanitize(Entry.String()))",
+                    "StrLength(Sanitizer::removeNewLines(Sanitizer::sanitize(Entry.String())))",
                     "!=",
                     "0"
                   ],
@@ -3176,12 +3120,12 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "TextObject::String"
+                    "value": "BBText::SetBBText"
                   },
                   "parameters": [
                     "ChatBox",
                     "+",
-                    "NewLine() + \"You: \" + Sanitizer::removeNewLines(Entry.String())"
+                    "NewLine() + \"You: \" + Sanitizer::removeNewLines(Sanitizer::sanitize(Entry.String()))"
                   ],
                   "subInstructions": []
                 },
@@ -3192,7 +3136,7 @@
                   },
                   "parameters": [
                     "\"message\"",
-                    "Entry.String()"
+                    "Sanitizer::removeNewLines(Sanitizer::sanitize(Entry.String()))"
                   ],
                   "subInstructions": []
                 },
@@ -3205,6 +3149,17 @@
                     "Entry",
                     "=",
                     "\"\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "textBoxChanged",
+                    "True"
                   ],
                   "subInstructions": []
                 }
@@ -3220,7 +3175,7 @@
           "colorR": 74,
           "creationTime": 0,
           "disabled": false,
-          "folded": false,
+          "folded": true,
           "name": "Receiving messages",
           "source": "",
           "type": "BuiltinCommonInstructions::Group",
@@ -3246,12 +3201,23 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "TextObject::String"
+                    "value": "BBText::SetBBText"
                   },
                   "parameters": [
                     "ChatBox",
                     "+",
-                    "NewLine() + \"Other: \" + Sanitizer::removeNewLines(P2P::GetEventData(\"message\"))"
+                    "NewLine() + \"Other: \" + Sanitizer::removeNewLines(Sanitizer::sanitize(P2P::GetEventData(\"message\")))"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SetSceneVariableAsBoolean"
+                  },
+                  "parameters": [
+                    "textBoxChanged",
+                    "True"
                   ],
                   "subInstructions": []
                 }
@@ -3284,7 +3250,7 @@
                 "textG": 0,
                 "textR": 0
               },
-              "comment": "Make sure newest message is always visible by removing older messages",
+              "comment": "Make sure newest message is always visible by removing older messages when the text box is updated",
               "comment2": ""
             },
             {
@@ -3295,26 +3261,97 @@
                 {
                   "type": {
                     "inverted": false,
-                    "value": "Egal"
+                    "value": "SceneVariableAsBoolean"
                   },
                   "parameters": [
-                    "Sanitizer::countNewLines(VariableString(textBox))",
-                    ">=",
-                    "28"
+                    "textBoxChanged",
+                    "True"
                   ],
                   "subInstructions": []
                 }
               ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "infiniteLoopWarning": true,
+                  "type": "BuiltinCommonInstructions::While",
+                  "whileConditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "ChatBox.Height()",
+                        ">",
+                        "480"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "BBText::SetBBText"
+                      },
+                      "parameters": [
+                        "ChatBox",
+                        "=",
+                        "Sanitizer::removeFirstLine(ChatBox.GetBBText())"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                }
+              ]
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Display text entry",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
               "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TextEntryObject::String"
+                  },
+                  "parameters": [
+                    "Entry",
+                    "=",
+                    "Sanitizer::removeNewLines(Sanitizer::sanitize(Sanitizer::trim(Entry.String(), 70)))"
+                  ],
+                  "subInstructions": []
+                },
                 {
                   "type": {
                     "inverted": false,
                     "value": "TextObject::String"
                   },
                   "parameters": [
-                    "ChatBox",
+                    "EntryText",
                     "=",
-                    "Sanitizer::removeFirstLine(EntryText.String())"
+                    "Entry.String()"
                   ],
                   "subInstructions": []
                 }
@@ -3381,6 +3418,7 @@
         "gridOffsetX": 0,
         "gridOffsetY": 0,
         "gridR": 158,
+        "gridType": "rectangular",
         "gridWidth": 32,
         "snap": true,
         "windowMask": false,
@@ -3747,7 +3785,7 @@
               "disabled": false,
               "folded": false,
               "type": "BuiltinCommonInstructions::JsCode",
-              "inlineCode": "eventsFunctionContext.returnValue = eventsFunctionContext.getArgument(\"text\").replace(/\\W/g, '');",
+              "inlineCode": "eventsFunctionContext.returnValue = eventsFunctionContext.getArgument(\"text\").replace(/[^a-zA-Z\\d\\s:]/g, '');",
               "parameterObjects": "",
               "useStrict": true,
               "eventsSheetExpanded": false


### PR DESCRIPTION
The chat had inconsistencies in sanitation, and was overflowing out of the screen even though there was an event supposed to prevent that. 