### PR TITLE
Fix export to Android/iOS failing if AdMob id was containing invalid characters

### DIFF
--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -41,23 +41,22 @@
 #undef CopyFile  // Disable an annoying macro
 
 namespace {
-  double GetTimeNow() {
-    #if defined(EMSCRIPTEN)
-    double currentTime = emscripten_get_now();
-    return currentTime;
-    #else
-    return 0;
-    #endif
-  }
-  double GetTimeSpent(double previousTime) {
-    return GetTimeNow() - previousTime;
-  }
-  double LogTimeSpent(const gd::String & name, double previousTime) {
-    gd::LogStatus(name + " took " + gd::String::From(GetTimeSpent(previousTime)) + "ms");
-    std::cout << std::endl;
-    return GetTimeNow();
-  }
+double GetTimeNow() {
+#if defined(EMSCRIPTEN)
+  double currentTime = emscripten_get_now();
+  return currentTime;
+#else
+  return 0;
+#endif
 }
+double GetTimeSpent(double previousTime) { return GetTimeNow() - previousTime; }
+double LogTimeSpent(const gd::String &name, double previousTime) {
+  gd::LogStatus(name + " took " + gd::String::From(GetTimeSpent(previousTime)) +
+                "ms");
+  std::cout << std::endl;
+  return GetTimeNow();
+}
+}  // namespace
 
 namespace gdjs {
 
@@ -300,9 +299,11 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
     const auto &dependency = dependencyAndExtension.GetDependency();
 
     gd::String plugin;
-    plugin += "<plugin name=\"" + dependency.GetExportName();
+    plugin += "<plugin name=\"" +
+              gd::Serializer::ToEscapedXMLString(dependency.GetExportName());
     if (dependency.GetVersion() != "") {
-      plugin += "\" spec=\"" + dependency.GetVersion();
+      plugin += "\" spec=\"" +
+                gd::Serializer::ToEscapedXMLString(dependency.GetVersion());
     }
     plugin += "\">\n";
 
@@ -312,11 +313,14 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
 
     // For Cordova, all settings are considered a plugin variable.
     for (auto &extraSetting : extraSettingValues) {
-      plugin += "\t\t<variable name=\"" + extraSetting.first + "\" value=\"" +
-                extraSetting.second + "\" />\n";
+      plugin += "    <variable name=\"" +
+                gd::Serializer::ToEscapedXMLString(extraSetting.first) +
+                "\" value=\"" +
+                gd::Serializer::ToEscapedXMLString(extraSetting.second) +
+                "\" />\n";
     }
 
-    plugin += "\t</plugin>";
+    plugin += "</plugin>";
 
     plugins += plugin;
   }

--- a/GDevelop.js/TestUtils/FakeAbstractFileSystem.js
+++ b/GDevelop.js/TestUtils/FakeAbstractFileSystem.js
@@ -1,0 +1,66 @@
+const path = require('path');
+
+module.exports = {
+  /**
+   * Create a fake file system to be used in tests. Useful to test
+   * things like exports.
+   * @param {libGDevelop} gd
+   * @param {Record<string, string>} fakeFileContents - Content of files that would be read by the file system.
+   * @returns
+   */
+  makeFakeAbstractFileSystem: (gd, fakeFileContents) => {
+    const fs = new gd.AbstractFileSystemJS();
+    fs.mkDir = fs.clearDir = function () {};
+    fs.getTempDir = function (path) {
+      return '/tmp/';
+    };
+    fs.fileNameFrom = function (fullPath) {
+      return path.posix.basename(fullPath);
+    };
+    fs.dirNameFrom = function (fullPath) {
+      return path.posix.dirname(fullPath);
+    };
+    fs.makeAbsolute = function (relativePath, baseDirectory) {
+      return path.posix.resolve(baseDirectory, relativePath);
+    };
+    fs.makeRelative = function (absolutePath, baseDirectory) {
+      return path.posix.relative(baseDirectory, absolutePath);
+    };
+    fs.isAbsolute = function (fullPath) {
+      return path.posix.isAbsolute(fullPath);
+    };
+    fs.dirExists = function (directoryPath) {
+      return true; // Fake that all directory required exist.
+    };
+    fs.fileExists = function (directoryPath) {
+      return true; // Fake that all files required exist.
+    };
+    fs.readDir = function () {
+      return new gd.VectorString(); // Return nothing, but "readDir" is deprecated anyway.
+    };
+    fs.readFile = function (filePath) {
+      if (!fakeFileContents.hasOwnProperty(filePath)) {
+        throw new Error(
+          `FakeAbstractFileSystem tried to access "${filePath}", but content for this file was not specified.`
+        );
+      }
+      return fakeFileContents[filePath];
+    };
+
+    // In particular, create a mock copyFile, that we can track to verify
+    // files are properly copied.
+    fs.copyFile = jest.fn();
+    fs.copyFile.mockImplementation(function (srcPath, destPath) {
+      return true;
+    });
+
+    fs.writeToFile = jest.fn();
+    fs.writeToFile.mockImplementation(function (filePath, content) {
+      // Uncomment to log what is being written:
+      // console.log('writeToFile called with', filePath, content);
+      return true;
+    });
+
+    return fs;
+  },
+};

--- a/GDevelop.js/TestUtils/TestExtensions.js
+++ b/GDevelop.js/TestUtils/TestExtensions.js
@@ -1,0 +1,60 @@
+// Note: there are also test extensions for the IDE (for the Storybook and for the IDE tests).
+// Search for "TestExtensions.js" in the codebase.
+
+module.exports = {
+  /**
+   * Create dummy extensions into gd.JsPlatform
+   * @param gd The GD instance to use to create the extensions and find the platform.
+   */
+  makeTestExtensions: (gd) => {
+    const platform = gd.JsPlatform.get();
+
+    {
+      const extension = new gd.PlatformExtension();
+      extension
+        .setExtensionInformation(
+          'AdMob',
+          'AdMob',
+          'Some fake extension mimicking the AdMob extension',
+          'Florian Rival',
+          'MIT'
+        )
+        .setExtensionHelpPath('/all-features/admob');
+
+      extension
+        .registerProperty('AdMobAppIdAndroid')
+        .setLabel('AdMob Android App ID')
+        .setDescription('ca-app-pub-XXXXXXXXXXXXXXXX~YYYYYYYYYY')
+        .setType('string');
+
+      extension
+        .registerProperty('AdMobAppIdIos')
+        .setLabel('AdMob iOS App ID')
+        .setDescription('ca-app-pub-XXXXXXXXXXXXXXXX~YYYYYYYYYY')
+        .setType('string');
+
+      extension
+        .addDependency()
+        .setName('AdMob Cordova plugin')
+        .setDependencyType('cordova')
+        .setExportName('gdevelop-cordova-admob-plus')
+        .setVersion('0.43.0')
+        .setExtraSetting(
+          'APP_ID_ANDROID',
+          new gd.PropertyDescriptor('AdMobAppIdAndroid').setType(
+            'ExtensionProperty'
+          )
+        )
+        .setExtraSetting(
+          'APP_ID_IOS',
+          new gd.PropertyDescriptor('AdMobAppIdIos').setType(
+            'ExtensionProperty'
+          )
+        )
+        .onlyIfSomeExtraSettingsNonEmpty();
+
+      platform.addNewExtension(extension);
+      extension.delete(); // Release the extension as it was copied inside gd.JsPlatform
+    }
+  },
+};

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -1,5 +1,8 @@
 const initializeGDevelopJs = require('../../Binaries/embuild/GDevelop.js/libGD.js');
 const path = require('path');
+const {
+  makeFakeAbstractFileSystem,
+} = require('../TestUtils/FakeAbstractFileSystem');
 const extend = require('extend');
 
 describe('libGD.js', function () {
@@ -2374,24 +2377,7 @@ describe('libGD.js', function () {
       project.getResourcesManager().addResource(resource4);
       project.getResourcesManager().addResource(resource5);
 
-      // Create a fake file system
-      const fs = new gd.AbstractFileSystemJS();
-      fs.mkDir = fs.clearDir = function () {};
-      fs.getTempDir = function (path) {
-        return '/tmp/';
-      };
-      fs.fileNameFrom = function (fullpath) {
-        return path.posix.basename(fullpath);
-      };
-      fs.dirNameFrom = function (fullpath) {
-        return path.posix.dirname(fullpath);
-      };
-      fs.makeAbsolute = function (relativePath, baseDirectory) {
-        return path.posix.resolve(baseDirectory, relativePath);
-      };
-      fs.makeRelative = function (absolutePath, baseDirectory) {
-        return path.posix.relative(baseDirectory, absolutePath);
-      };
+      const fs = makeFakeAbstractFileSystem(gd, {});
 
       // Check that ResourcesMergingHelper can update the filenames
       const resourcesMergingHelper = new gd.ResourcesMergingHelper(fs);
@@ -2449,37 +2435,7 @@ describe('libGD.js', function () {
       project.getResourcesManager().addResource(resource4);
       project.getResourcesManager().addResource(resource5);
 
-      // Create a fake file system
-      const fs = new gd.AbstractFileSystemJS();
-      fs.mkDir = fs.clearDir = function () {};
-      fs.getTempDir = function (path) {
-        return '/tmp/';
-      };
-      fs.fileNameFrom = function (fullPath) {
-        return path.posix.basename(fullPath);
-      };
-      fs.dirNameFrom = function (fullPath) {
-        return path.posix.dirname(fullPath);
-      };
-      fs.makeAbsolute = function (relativePath, baseDirectory) {
-        return path.posix.resolve(baseDirectory, relativePath);
-      };
-      fs.makeRelative = function (absolutePath, baseDirectory) {
-        return path.posix.relative(baseDirectory, absolutePath);
-      };
-      fs.isAbsolute = function (fullPath) {
-        return path.posix.isAbsolute(fullPath);
-      };
-      fs.dirExists = function (directoryPath) {
-        return true; // Fake that all directory required exist.
-      };
-
-      // In particular, create a mock copyFile, that we can track to verify
-      // files are properly copied.
-      fs.copyFile = jest.fn();
-      fs.copyFile.mockImplementation(function (srcPath, destPath) {
-        return true;
-      });
+      const fs = makeFakeAbstractFileSystem(gd, {});
 
       // Check that resources can be copied to another folder:
       // * including absolute files.


### PR DESCRIPTION
Also add tests to ensure no regression in the future for exports of some Cordova files.

Note that a user friendly fix would be to add support for "validators" for properties, so that the IDE could warn the user when an invalid string/parameter is entered for a property of the project.