### PR TITLE
Update the discord invite URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ Status of the tests and builds: [![Build status](https://circleci.com/gh/4ian/GD
 
 ### Community
 
--   [GDevelop forums](https://forum.gdevelop-app.com) and [Discord chat](https://discord.gg/rjdYHvj).
+-   [GDevelop forums](https://forum.gdevelop-app.com) and [Discord chat](https://discord.gg/gdevelop).
 -   [GDevelop homepage](https://gdevelop-app.com)
 -   [GDevelop wiki (documentation)](http://wiki.compilgames.net/doku.php/gdevelop5/start)
 -   Help translate GDevelop in your language: [GDevelop project on Crowdin](https://crowdin.com/project/gdevelop).

--- a/newIDE/app/src/MainFrame/EditorContainers/StartPage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/StartPage/index.js
@@ -201,7 +201,7 @@ export class StartPage extends React.Component<Props, {||}> {
                     <IconButton
                       className="icon-discord"
                       onClick={() =>
-                        Window.openExternalURL('https://discord.gg/rjdYHvj')
+                        Window.openExternalURL('https://discord.gg/gdevelop')
                       }
                       tooltip={t`GDevelop on Discord`}
                     />

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -229,7 +229,7 @@ const buildAndSendMenuTemplate = (
       },
       {
         label: i18n._(t`Community Discord Chat`),
-        onClickOpenLink: 'https://discord.gg/rjdYHvj',
+        onClickOpenLink: 'https://discord.gg/gdevelop',
       },
       { type: 'separator' },
       {


### PR DESCRIPTION
Discord just turned on [vanity url for our server](https://github.com/discord/discord-open-source/pull/250#issuecomment-813603559). This PR replaces occurrence of the old invite with the new one (https://discord.gg/gdevelop).