### PR TITLE
Make sure the object inline popover selects a matching behavior

### DIFF
--- a/newIDE/app/src/EventsSheet/InlineParameterEditor.js
+++ b/newIDE/app/src/EventsSheet/InlineParameterEditor.js
@@ -9,6 +9,7 @@ import {
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import { type EventsScope } from '../InstructionOrExpression/EventsScope.flow';
 import { setupInstructionParameters } from '../InstructionOrExpression/SetupInstructionParameters';
+import { getObjectParameterIndex } from '../InstructionOrExpression/EnumerateInstructions';
 const gd: libGDevelop = global.gd;
 
 type Props = {|
@@ -110,14 +111,20 @@ export default class InlineParameterEditor extends React.Component<
     if (!instruction) return null;
 
     const onRequestClose = () => {
-      if (this.state.instructionMetadata)
+      if (this.state.instructionMetadata) {
+        const objectParameterIndex = getObjectParameterIndex(
+          this.state.instructionMetadata
+        );
         setupInstructionParameters(
           this.props.globalObjectsContainer,
           this.props.objectsContainer,
           instruction,
           this.state.instructionMetadata,
-          instruction.getParameter(this.props.parameterIndex)
+          objectParameterIndex
+            ? instruction.getParameter(objectParameterIndex)
+            : null
         );
+      }
       this.props.onRequestClose();
     };
 

--- a/newIDE/app/src/EventsSheet/InlineParameterEditor.js
+++ b/newIDE/app/src/EventsSheet/InlineParameterEditor.js
@@ -8,6 +8,7 @@ import {
 } from '../ResourcesList/ResourceSource.flow';
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import { type EventsScope } from '../InstructionOrExpression/EventsScope.flow';
+import { setupInstructionParameters } from '../InstructionOrExpression/SetupInstructionParameters';
 const gd: libGDevelop = global.gd;
 
 type Props = {|
@@ -108,13 +109,25 @@ export default class InlineParameterEditor extends React.Component<
     const instruction = this.props.instruction;
     if (!instruction) return null;
 
+    const onRequestClose = () => {
+      if (this.state.instructionMetadata)
+        setupInstructionParameters(
+          this.props.globalObjectsContainer,
+          this.props.objectsContainer,
+          instruction,
+          this.state.instructionMetadata,
+          instruction.getParameter(this.props.parameterIndex)
+        );
+      this.props.onRequestClose();
+    };
+
     const { ParameterComponent } = this.state;
 
     return (
       <InlinePopover
         open={this.props.open}
         anchorEl={this.props.anchorEl}
-        onRequestClose={this.props.onRequestClose}
+        onRequestClose={onRequestClose}
       >
         <ParameterComponent
           instruction={instruction}
@@ -123,7 +136,7 @@ export default class InlineParameterEditor extends React.Component<
           parameterIndex={this.props.parameterIndex}
           value={instruction.getParameter(this.props.parameterIndex)}
           onChange={this.props.onChange}
-          onRequestClose={this.props.onRequestClose}
+          onRequestClose={onRequestClose}
           project={this.props.project}
           scope={this.props.scope}
           globalObjectsContainer={this.props.globalObjectsContainer}


### PR DESCRIPTION
Thanks @Silver-Streak for finding the bug and reporting it on discord.

When selecting an object using the inline popover on a behavior instruction, the behavior parameter is not updated by calling `setupInstructionParameters`. This caused problems like conditions never working when selecting the instruction without an object and setting the object later via the inline popover.