### PR TITLE
Fix autoPlay on video object

### DIFF
--- a/Extensions/Video/videoruntimeobject-pixi-renderer.ts
+++ b/Extensions/Video/videoruntimeobject-pixi-renderer.ts
@@ -26,7 +26,7 @@ namespace gdjs {
           .getImageManager()
           .getPIXIVideoTexture(this._object._videoResource)
       );
-      this._pixiObject._texture.baseTexture.autoPlay = false;
+      this._pixiObject._texture.baseTexture.resource.autoPlay = false;
 
       // Needed to avoid video not playing/crashing in Chrome/Chromium browsers.
       // See https://github.com/pixijs/pixi.js/issues/5996


### PR DESCRIPTION
Since few beta the autoplay on video object is broken because the option has moved.

#Current
[The autoplay is broken in current beta 108.
](https://editor.gdevelop-app.com/?project=example://video-player
)
#Fix
[The autoplay is now correctly setup on false as before.
](https://games.gdevelop-app.com/game-4840c7a3-f60c-482d-886e-2900ce4e996b/index.html
)
- [x] Tested on desktop with PixiJS v6.0.1