### PR TITLE
Invalidate hit boxes in TestRuntimeObject setters

### DIFF
--- a/GDJS/tests/tests/Extensions/testruntimeobject.js
+++ b/GDJS/tests/tests/Extensions/testruntimeobject.js
@@ -27,11 +27,13 @@ gdjs.TestRuntimeObject = class TestRuntimeObject extends gdjs.RuntimeObject {
   setCustomWidthAndHeight(customWidth, customHeight) {
     this._customWidth = customWidth;
     this._customHeight = customHeight;
+    this.hitBoxesDirty = true;
   }
 
   setCustomCenter(customCenterX, customCenterY) {
     this._customCenterX = customCenterX;
     this._customCenterY = customCenterY;
+    this.hitBoxesDirty = true;
   }
 
   getRendererObject() {


### PR DESCRIPTION
In the tests a PR (https://github.com/4ian/GDevelop/pull/2153) I had to move an object back and forth for the hit boxes to update after a dimension change.