### PR TITLE
Add a newline to boolean long descriptions in the PropertiesEditor

### DIFF
--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -30,6 +30,7 @@ import RaisedButton from '../UI/RaisedButton';
 import UnsavedChangesContext, {
   type UnsavedChanges,
 } from '../MainFrame/UnsavedChangesContext';
+import { Line } from '../UI/Grid';
 
 // An "instance" here is the objects for which properties are shown
 export type Instance = Object; // This could be improved using generics.
@@ -238,7 +239,9 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
               getFieldLabel(this.props.instances, field)
             ) : (
               <React.Fragment>
-                {getFieldLabel(this.props.instances, field)}{' '}
+                <Line noMargin>
+                  {getFieldLabel(this.props.instances, field)}
+                </Line>
                 <FormHelperText style={{ display: 'inline' }}>
                   <MarkdownText source={description} />
                 </FormHelperText>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19349038/114528689-8605ba00-9c49-11eb-993c-7689e9fb1274.png)

After: 
![image](https://user-images.githubusercontent.com/19349038/114528575-6ec6cc80-9c49-11eb-84f6-1654f4f1a688.png)

This allows the long description to be more readable and consistent with all other long descriptions being under the short description.