### PR TITLE
Remove misleading descriptions of subscriptions

### DIFF
--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -127,8 +127,9 @@ export class SubscriptionCheckDialog extends React.Component<
             <Star style={styles.icon} />
             <Text style={styles.iconText}>
               <Trans>
-                Having a subscription allows you to use the one-click export and
-                disable the GDevelop splashscreen during loading!
+                Get a subscription to gain more automatic exports and remove the
+                loading screens and this message asking you to get a
+                subscription.
               </Trans>
             </Text>
           </Line>

--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -104,15 +104,14 @@ export class SubscriptionCheckDialog extends React.Component<
         cannotBeDismissed={false}
         onRequestClose={this._closeDialog}
         open={open}
-        title={this.props.title}
+        title={mode === 'try' ? 'We need your support!' : this.props.title}
       >
         <Column noMargin>
           <Line noMargin alignItems="center">
             {mode === 'try' ? (
               <Text>
                 <Trans>
-                  You can try this feature, but if you're using it regularly, we
-                  ask you to get a subscription to GDevelop.
+                  Please get a subscription to keep GDevelop running.
                 </Trans>
               </Text>
             ) : (
@@ -128,9 +127,8 @@ export class SubscriptionCheckDialog extends React.Component<
             <Star style={styles.icon} />
             <Text style={styles.iconText}>
               <Trans>
-                Having a subscription allows you to use the one-click export for
-                Android, Windows, macOS and Linux, launch live previews over
-                wifi, disable the GDevelop splashscreen during loading and more!
+                Having a subscription allows you to use the one-click export and
+                disable the GDevelop splashscreen during loading!
               </Trans>
             </Text>
           </Line>

--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -128,7 +128,7 @@ export class SubscriptionCheckDialog extends React.Component<
             <Text style={styles.iconText}>
               <Trans>
                 Get a subscription to gain more automatic exports and remove the
-                loading screens and this message asking you to get a
+                GDevelop splashscreen and this message asking you to get a
                 subscription.
               </Trans>
             </Text>

--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -127,8 +127,8 @@ export class SubscriptionCheckDialog extends React.Component<
             <Star style={styles.icon} />
             <Text style={styles.iconText}>
               <Trans>
-                Get a subscription to gain more automatic exports and remove the
-                GDevelop splashscreen and this message asking you to get a
+                Get a subscription to gain more one-click exports, remove the
+                GDevelop splashscreen, this message asking you to get a
                 subscription.
               </Trans>
             </Text>

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -188,10 +188,11 @@ export default class SubscriptionDialog extends React.Component<Props, State> {
                       <Line>
                         <Text>
                           <Trans>
-                            Get a subscription to gain more automatic exports.
-                            With a subscription, you're also supporting the
-                            development of GDevelop, which is an open-source
-                            software.
+                            Get a subscription to gain more automatic exports
+                            and remove the loading screens and messages asking
+                            you to get a subscription. With a subscription, you're also
+                            supporting the development of GDevelop, which is an
+                            open-source software.
                           </Trans>
                         </Text>
                       </Line>

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -189,10 +189,10 @@ export default class SubscriptionDialog extends React.Component<Props, State> {
                         <Text>
                           <Trans>
                             Get a subscription to gain more automatic exports
-                            and remove the loading screens and messages asking
-                            you to get a subscription. With a subscription, you're also
-                            supporting the development of GDevelop, which is an
-                            open-source software.
+                            and remove the GDevelop splashscreen and messages
+                            asking you to get a subscription. With a
+                            subscription, you're also supporting the development
+                            of GDevelop, which is an open-source software.
                           </Trans>
                         </Text>
                       </Line>

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -188,11 +188,12 @@ export default class SubscriptionDialog extends React.Component<Props, State> {
                       <Line>
                         <Text>
                           <Trans>
-                            Get a subscription to gain more automatic exports
-                            and remove the GDevelop splashscreen and messages
+                            Get a subscription to gain more one-click exports, 
+                            remove the GDevelop splashscreen and messages
                             asking you to get a subscription. With a
                             subscription, you're also supporting the development
-                            of GDevelop, which is an open-source software.
+                            of GDevelop, which is an open-source software maintained 
+                            by volunteers in their free time.
                           </Trans>
                         </Text>
                       </Line>

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -188,11 +188,10 @@ export default class SubscriptionDialog extends React.Component<Props, State> {
                       <Line>
                         <Text>
                           <Trans>
-                            Get a subscription to package your games for
-                            Android, Windows, macOS and Linux, use live preview
-                            over wifi and more. With a subscription, you're also
-                            supporting the development of GDevelop, which is an
-                            open-source software.
+                            Get a subscription to gain more automatic exports.
+                            With a subscription, you're also supporting the
+                            development of GDevelop, which is an open-source
+                            software.
                           </Trans>
                         </Text>
                       </Line>
@@ -301,7 +300,7 @@ export default class SubscriptionDialog extends React.Component<Props, State> {
                           <Trans>
                             Create a GDevelop account to continue. It's free and
                             you'll be able to access to online services like
-                            one-click build for Android:
+                            one-click builds:
                           </Trans>
                         </Text>
                         <RaisedButton

--- a/newIDE/app/src/Utils/GDevelopServices/Usage.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Usage.js
@@ -57,14 +57,6 @@ export const getSubscriptionPlans = (): Array<PlanDetails> => [
         message: t`One-click packaging for Windows, macOS and Linux up to 70 times a day (every 24 hours).`,
       },
       {
-        message: t`Use Live Preview over Wifi to quickly test your game on mobiles and tablets.`,
-        isLocalAppOnly: true,
-      },
-      {
-        message: t`Use the Debugger to find and solve issues in your games.`,
-        isLocalAppOnly: true,
-      },
-      {
         message: t`Immerse your players by removing GDevelop logo when the game loads.`,
       },
     ],
@@ -81,14 +73,6 @@ export const getSubscriptionPlans = (): Array<PlanDetails> => [
       },
       {
         message: t`One-click packaging for Windows, macOS and Linux up to 10 times a day (every 24 hours).`,
-      },
-      {
-        message: t`Use Live Preview over Wifi to quickly test your game on mobiles and tablets.`,
-        isLocalAppOnly: true,
-      },
-      {
-        message: t`Use the Debugger to find and solve issues in your games.`,
-        isLocalAppOnly: true,
       },
       {
         message: t`Immerse your players by removing GDevelop logo when the game loads`,


### PR DESCRIPTION
The subscriptions related messages have misleading descriptions, making sone free features sound paid. This makes GDevelop look like a freemium software when it isn't, and is just lying and wrong. This PR makes it clear what the subscriptions do exactly.