### PR TITLE
Rework the behaviors list

### DIFF
--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -51,7 +51,7 @@ const BitGroupEditor = (props: {|
 |}) => {
   return (
     <div style={{ overflowX: 'auto', flex: 1 }}>
-      <ButtonGroup variant="contained" disableElevation fullWidth>
+      <ButtonGroup disableElevation fullWidth>
         {props.bits.map((bit, index) => (
           <Button
             key={index}

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -368,6 +368,12 @@ const Physics2Editor = (props: Props) => {
               resourcesLoader={resourcesLoader}
               fixedHeight={200}
               renderOverlay={overlayProps => {
+                // The result from `getProperties` is temporary, and because this renderOverlay
+                // function can be called outside of the render, we must get the properties again.
+                const properties = behavior.getProperties(
+                  behaviorContent.getContent()
+                );
+
                 return (
                   <ShapePreview
                     shape={properties.get('shape').getValue()}

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -90,7 +90,11 @@ const Physics2Editor = (props: Props) => {
   const masksValues = parseInt(properties.get('masks').getValue(), 10);
 
   return (
-    <Column expand>
+    <Column
+      expand
+      // Avoid overflow on small screens
+      noOverflowParent
+    >
       <Line>
         <SelectField
           key={'bodyType'}

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -88,13 +88,17 @@ const Physics2Editor = (props: Props) => {
 
   const properties = behavior.getProperties(behaviorContent.getContent());
   console.log(
-    properties.get('vertices').getValue(),
-    typeof properties.get('vertices').getValue()
+    'From Physics2 behavior:',
+    behavior.ptr,
+    behaviorContent.ptr,
+    properties.ptr
   );
   const bits = Array(16).fill(null);
   const shape = properties.get('shape').getValue();
   const layersValues = parseInt(properties.get('layers').getValue(), 10);
   const masksValues = parseInt(properties.get('masks').getValue(), 10);
+
+  console.log('Physics2 editor rendered!');
 
   return (
     <Column expand>
@@ -364,10 +368,6 @@ const Physics2Editor = (props: Props) => {
               resourcesLoader={resourcesLoader}
               fixedHeight={200}
               renderOverlay={overlayProps => {
-                console.log(
-                  properties.get('vertices').getValue(),
-                  typeof properties.get('vertices').getValue()
-                );
                 return (
                   <ShapePreview
                     shape={properties.get('shape').getValue()}

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -19,6 +19,8 @@ import DismissableAlertMessage from '../../../UI/DismissableAlertMessage';
 import { ResponsiveLineStackLayout } from '../../../UI/Layout';
 import EmptyMessage from '../../../UI/EmptyMessage';
 import useForceUpdate from '../../../Utils/UseForceUpdate';
+import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
 
 type Props = BehaviorEditorProps;
 
@@ -43,29 +45,24 @@ const NumericProperty = (props: {|
   );
 };
 
-const BitProperty = (props: {|
-  enabled: boolean,
-  propertyName: string,
-  pos: number,
-  spacing: boolean,
-  onUpdate: (enabled: boolean) => void,
+const BitGroupEditor = (props: {|
+  bits: Array<boolean>,
+  onChange: (index: number, value: boolean) => void,
 |}) => {
-  const { enabled, propertyName, pos, spacing, onUpdate } = props;
-
   return (
-    <div style={{ width: spacing ? '7.5%' : '5%' }}>
-      {
-        <Checkbox
-          checked={enabled}
-          onCheck={(e, checked) => onUpdate(checked)}
-        />
-      }
-      {spacing && (
-        <div
-          style={{ width: '33%' }}
-          key={propertyName + '-space' + pos.toString(10)}
-        />
-      )}
+    <div style={{ overflowX: 'auto', flex: 1 }}>
+      <ButtonGroup variant="contained" disableElevation fullWidth>
+        {props.bits.map((bit, index) => (
+          <Button
+            key={index}
+            variant={bit ? 'contained' : 'outlined'}
+            color={bit ? 'primary' : 'default'}
+            onClick={() => props.onChange(index, !bit)}
+          >
+            {index + 1}
+          </Button>
+        ))}
+      </ButtonGroup>
     </div>
   );
 };
@@ -541,50 +538,38 @@ const Physics2Editor = (props: Props) => {
         />
       </ResponsiveLineStackLayout>
       <Line>
-        <Text>{properties.get('layers').getLabel()}</Text>
-        {bits.map((value, index) => {
-          return (
-            <BitProperty
-              enabled={isBitEnabled(layersValues, index)}
-              propertyName={'layers'}
-              pos={index}
-              spacing={index === 7}
-              onUpdate={enabled => {
-                const newValue = enableBit(layersValues, index, enabled);
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'layers',
-                  newValue.toString(10)
-                );
-                forceUpdate();
-              }}
-              key={`layer${index}`}
-            />
-          );
-        })}
+        <Text style={{ marginRight: 10 }}>
+          {properties.get('layers').getLabel()}
+        </Text>
+        <BitGroupEditor
+          bits={bits.map((_, idx) => isBitEnabled(layersValues, idx))}
+          onChange={(index, value) => {
+            const newValue = enableBit(layersValues, index, value);
+            behavior.updateProperty(
+              behaviorContent.getContent(),
+              'layers',
+              newValue.toString(10)
+            );
+            forceUpdate();
+          }}
+        />
       </Line>
       <Line>
-        <Text>{properties.get('masks').getLabel()}</Text>
-        {bits.map((value, index) => {
-          return (
-            <BitProperty
-              enabled={isBitEnabled(masksValues, index)}
-              propertyName={'masks'}
-              pos={index}
-              spacing={index === 7}
-              onUpdate={enabled => {
-                const newValue = enableBit(masksValues, index, enabled);
-                behavior.updateProperty(
-                  behaviorContent.getContent(),
-                  'masks',
-                  newValue.toString(10)
-                );
-                forceUpdate();
-              }}
-              key={`mask${index}`}
-            />
-          );
-        })}
+        <Text style={{ marginRight: 10 }}>
+          {properties.get('masks').getLabel()}
+        </Text>
+        <BitGroupEditor
+          bits={bits.map((_, idx) => isBitEnabled(masksValues, idx))}
+          onChange={(index, value) => {
+            const newValue = enableBit(masksValues, index, value);
+            behavior.updateProperty(
+              behaviorContent.getContent(),
+              'masks',
+              newValue.toString(10)
+            );
+            forceUpdate();
+          }}
+        />
       </Line>
     </Column>
   );

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -87,6 +87,10 @@ const Physics2Editor = (props: Props) => {
   };
 
   const properties = behavior.getProperties(behaviorContent.getContent());
+  console.log(
+    properties.get('vertices').getValue(),
+    typeof properties.get('vertices').getValue()
+  );
   const bits = Array(16).fill(null);
   const shape = properties.get('shape').getValue();
   const layersValues = parseInt(properties.get('layers').getValue(), 10);
@@ -359,43 +363,49 @@ const Physics2Editor = (props: Props) => {
               project={props.project}
               resourcesLoader={resourcesLoader}
               fixedHeight={200}
-              renderOverlay={overlayProps => (
-                <ShapePreview
-                  shape={properties.get('shape').getValue()}
-                  dimensionA={parseFloat(
-                    properties.get('shapeDimensionA').getValue()
-                  )}
-                  dimensionB={parseFloat(
-                    properties.get('shapeDimensionB').getValue()
-                  )}
-                  offsetX={parseFloat(
-                    properties.get('shapeOffsetX').getValue()
-                  )}
-                  offsetY={parseFloat(
-                    properties.get('shapeOffsetY').getValue()
-                  )}
-                  polygonOrigin={properties.get('polygonOrigin').getValue()}
-                  vertices={JSON.parse(properties.get('vertices').getValue())}
-                  width={overlayProps.imageWidth}
-                  height={overlayProps.imageHeight}
-                  frameOffsetTop={overlayProps.offsetTop}
-                  frameOffsetLeft={overlayProps.offsetLeft}
-                  zoomFactor={overlayProps.imageZoomFactor}
-                  onMoveVertex={(index, newX, newY) => {
-                    let vertices = JSON.parse(
-                      properties.get('vertices').getValue()
-                    );
-                    vertices[index].x = newX;
-                    vertices[index].y = newY;
-                    behavior.updateProperty(
-                      behaviorContent.getContent(),
-                      'vertices',
-                      JSON.stringify(vertices)
-                    );
-                    forceUpdate();
-                  }}
-                />
-              )}
+              renderOverlay={overlayProps => {
+                console.log(
+                  properties.get('vertices').getValue(),
+                  typeof properties.get('vertices').getValue()
+                );
+                return (
+                  <ShapePreview
+                    shape={properties.get('shape').getValue()}
+                    dimensionA={parseFloat(
+                      properties.get('shapeDimensionA').getValue()
+                    )}
+                    dimensionB={parseFloat(
+                      properties.get('shapeDimensionB').getValue()
+                    )}
+                    offsetX={parseFloat(
+                      properties.get('shapeOffsetX').getValue()
+                    )}
+                    offsetY={parseFloat(
+                      properties.get('shapeOffsetY').getValue()
+                    )}
+                    polygonOrigin={properties.get('polygonOrigin').getValue()}
+                    vertices={JSON.parse(properties.get('vertices').getValue())}
+                    width={overlayProps.imageWidth}
+                    height={overlayProps.imageHeight}
+                    frameOffsetTop={overlayProps.offsetTop}
+                    frameOffsetLeft={overlayProps.offsetLeft}
+                    zoomFactor={overlayProps.imageZoomFactor}
+                    onMoveVertex={(index, newX, newY) => {
+                      let vertices = JSON.parse(
+                        properties.get('vertices').getValue()
+                      );
+                      vertices[index].x = newX;
+                      vertices[index].y = newY;
+                      behavior.updateProperty(
+                        behaviorContent.getContent(),
+                        'vertices',
+                        JSON.stringify(vertices)
+                      );
+                      forceUpdate();
+                    }}
+                  />
+                );
+              }}
             />
           </div>
         </Line>

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -87,18 +87,10 @@ const Physics2Editor = (props: Props) => {
   };
 
   const properties = behavior.getProperties(behaviorContent.getContent());
-  console.log(
-    'From Physics2 behavior:',
-    behavior.ptr,
-    behaviorContent.ptr,
-    properties.ptr
-  );
   const bits = Array(16).fill(null);
   const shape = properties.get('shape').getValue();
   const layersValues = parseInt(properties.get('layers').getValue(), 10);
   const masksValues = parseInt(properties.get('masks').getValue(), 10);
-
-  console.log('Physics2 editor rendered!');
 
   return (
     <Column expand>

--- a/newIDE/app/src/BehaviorsEditor/EmptyBehaviorsPlaceholder.js
+++ b/newIDE/app/src/BehaviorsEditor/EmptyBehaviorsPlaceholder.js
@@ -1,0 +1,43 @@
+// @flow
+import { Trans } from '@lingui/macro';
+
+import * as React from 'react';
+import HelpButton from '../UI/HelpButton';
+import Text from '../UI/Text';
+import Paper from '@material-ui/core/Paper';
+import { Line, Column } from '../UI/Grid';
+
+const EmptyBehaviorsPlaceholder = () => (
+  <Column alignItems="center">
+    <Paper
+      variant="outlined"
+      style={{
+        maxWidth: '450px',
+        whiteSpace: 'normal',
+      }}
+    >
+      <Column>
+        <Text>
+          <Trans>There are no behaviors here.</Trans>
+        </Text>
+        <Text>
+          <Trans>
+            Behaviors are predefined actions that are assigned to objects.
+            Behaviors can have no or multiple parameters.
+          </Trans>
+        </Text>
+        <Text>
+          <Trans>
+            Add your first behavior using the button "Add a behavior to the
+            object".
+          </Trans>
+        </Text>
+        <Line expand justifyContent="flex-end">
+          <HelpButton helpPagePath="/behaviors" />
+        </Line>
+      </Column>
+    </Paper>
+  </Column>
+);
+
+export default EmptyBehaviorsPlaceholder;

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -76,7 +76,7 @@ const BehaviorsEditor = (props: Props) => {
 
     if (hasBehaviorWithType(type)) {
       const answer = Window.showConfirmDialog(
-        "There is already a behavior of this type attached to the object. It's possible to add again this behavior but it's unusual and may not be always supported properly. Are you sure you want to add again this behavior?"
+        "There is already a behavior of this type attached to the object. It's possible to add this behavior again, but it's unusual and may not be always supported properly. Are you sure you want to add this behavior again?"
       );
 
       if (!answer) return;
@@ -120,62 +120,17 @@ const BehaviorsEditor = (props: Props) => {
 
   return (
     <Column expand>
-      {allBehaviorNames
-        .map((behaviorName, index) => {
-          const behaviorContent = object.getBehavior(behaviorName);
-          const behaviorTypeName = behaviorContent.getTypeName();
-          const behavior = gd.JsPlatform.get().getBehavior(behaviorTypeName);
-          if (isNullPtr(gd, behavior)) {
-            return (
-              <Accordion key={behaviorName} defaultExpanded>
-                <AccordionHeader
-                  actions={[
-                    <IconButton
-                      key="delete"
-                      onClick={ev => {
-                        ev.stopPropagation();
-                        onRemoveBehavior(behaviorName);
-                      }}
-                    >
-                      <Delete />
-                    </IconButton>,
-                  ]}
-                >
-                  <MiniToolbarText>
-                    <Trans>Unknown behavior</Trans>{' '}
-                  </MiniToolbarText>
-                  <Column noMargin expand>
-                    <TextField margin="none" value={behaviorName} disabled />
-                  </Column>
-                </AccordionHeader>
-                <AccordionBody>
-                  <EmptyMessage>
-                    <Trans>
-                      This behavior is unknown. It might be a behavior that was
-                      defined in an extension and that was later removed. You
-                      should delete it.
-                    </Trans>
-                  </EmptyMessage>
-                </AccordionBody>
-              </Accordion>
-            );
-          }
-
-          const BehaviorComponent = BehaviorsEditorService.getEditor(
-            behaviorTypeName
-          );
-          const tutorialHints = getBehaviorTutorialHints(behaviorTypeName);
-          const enabledTutorialHints = tutorialHints.filter(
-            hint => !values.hiddenTutorialHints[hint.identifier]
-          );
-
+      {allBehaviorNames.map((behaviorName, index) => {
+        const behaviorContent = object.getBehavior(behaviorName);
+        const behaviorTypeName = behaviorContent.getTypeName();
+        const behavior = gd.JsPlatform.get().getBehavior(behaviorTypeName);
+        if (isNullPtr(gd, behavior)) {
           return (
             <Accordion key={behaviorName} defaultExpanded>
               <AccordionHeader
                 actions={[
                   <IconButton
                     key="delete"
-                    size="small"
                     onClick={ev => {
                       ev.stopPropagation();
                       onRemoveBehavior(behaviorName);
@@ -183,64 +138,106 @@ const BehaviorsEditor = (props: Props) => {
                   >
                     <Delete />
                   </IconButton>,
-                  <HelpIcon
-                    key="help"
-                    size="small"
-                    helpPagePath={getBehaviorHelpPagePath(behavior)}
-                  />,
                 ]}
               >
                 <MiniToolbarText>
-                  <Trans>Behavior</Trans>{' '}
+                  <Trans>Unknown behavior</Trans>{' '}
                 </MiniToolbarText>
                 <Column noMargin expand>
-                  <TextField
-                    value={behaviorName}
-                    hintText={t`Behavior name`}
-                    margin="none"
-                    fullWidth
-                    disabled
-                    onChange={(e, text) =>
-                      onChangeBehaviorName(behaviorContent, text)
-                    }
-                  />
+                  <TextField margin="none" value={behaviorName} disabled />
                 </Column>
               </AccordionHeader>
               <AccordionBody>
-                <Column expand noMargin>
-                  {enabledTutorialHints.length ? (
-                    <Line>
-                      <ColumnStackLayout expand>
-                        {tutorialHints.map(tutorialHint => (
-                          <DismissableTutorialMessage
-                            key={tutorialHint.identifier}
-                            tutorialHint={tutorialHint}
-                          />
-                        ))}
-                      </ColumnStackLayout>
-                    </Line>
-                  ) : null}
-                  <Line>
-                    <BehaviorComponent
-                      behavior={behavior}
-                      behaviorContent={behaviorContent}
-                      project={project}
-                      resourceSources={props.resourceSources}
-                      onChooseResource={props.onChooseResource}
-                      resourceExternalEditors={props.resourceExternalEditors}
-                    />
-                  </Line>
-                </Column>
+                <EmptyMessage>
+                  <Trans>
+                    This behavior is unknown. It might be a behavior that was
+                    defined in an extension and that was later removed. You
+                    should delete it.
+                  </Trans>
+                </EmptyMessage>
               </AccordionBody>
             </Accordion>
           );
-        })
-        .concat(
-          <AddBehaviorLine
-            key="add-behavior-line"
-            onAdd={() => setNewBehaviorDialogOpen(true)}
-          />
-        )}
+        }
+
+        const BehaviorComponent = BehaviorsEditorService.getEditor(
+          behaviorTypeName
+        );
+        const tutorialHints = getBehaviorTutorialHints(behaviorTypeName);
+        const enabledTutorialHints = tutorialHints.filter(
+          hint => !values.hiddenTutorialHints[hint.identifier]
+        );
+
+        return (
+          <Accordion key={behaviorName} defaultExpanded>
+            <AccordionHeader
+              actions={[
+                <IconButton
+                  key="delete"
+                  size="small"
+                  onClick={ev => {
+                    ev.stopPropagation();
+                    onRemoveBehavior(behaviorName);
+                  }}
+                >
+                  <Delete />
+                </IconButton>,
+                <HelpIcon
+                  key="help"
+                  size="small"
+                  helpPagePath={getBehaviorHelpPagePath(behavior)}
+                />,
+              ]}
+            >
+              <MiniToolbarText>
+                <Trans>Behavior</Trans>{' '}
+              </MiniToolbarText>
+              <Column noMargin expand>
+                <TextField
+                  value={behaviorName}
+                  hintText={t`Behavior name`}
+                  margin="none"
+                  fullWidth
+                  disabled
+                  onChange={(e, text) =>
+                    onChangeBehaviorName(behaviorContent, text)
+                  }
+                />
+              </Column>
+            </AccordionHeader>
+            <AccordionBody>
+              <Column expand noMargin>
+                {enabledTutorialHints.length ? (
+                  <Line>
+                    <ColumnStackLayout expand>
+                      {tutorialHints.map(tutorialHint => (
+                        <DismissableTutorialMessage
+                          key={tutorialHint.identifier}
+                          tutorialHint={tutorialHint}
+                        />
+                      ))}
+                    </ColumnStackLayout>
+                  </Line>
+                ) : null}
+                <Line>
+                  <BehaviorComponent
+                    behavior={behavior}
+                    behaviorContent={behaviorContent}
+                    project={project}
+                    resourceSources={props.resourceSources}
+                    onChooseResource={props.onChooseResource}
+                    resourceExternalEditors={props.resourceExternalEditors}
+                  />
+                </Line>
+              </Column>
+            </AccordionBody>
+          </Accordion>
+        );
+      })}
+      <AddBehaviorLine
+        key="add-behavior-line"
+        onAdd={() => setNewBehaviorDialogOpen(true)}
+      />
       {newBehaviorDialogOpen && (
         <NewBehaviorDialog
           open={newBehaviorDialogOpen}

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -27,6 +27,8 @@ import DismissableTutorialMessage from '../Hints/DismissableTutorialMessage';
 import { ColumnStackLayout } from '../UI/Layout';
 const gd: libGDevelop = global.gd;
 
+// Empty comment - will remove later
+
 const AddBehaviorLine = ({ onAdd }) => (
   <Column>
     <Line justifyContent="flex-end" expand>

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -7,7 +7,7 @@ import Add from '@material-ui/icons/Add';
 import Delete from '@material-ui/icons/Delete';
 import IconButton from '../UI/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
-import MiniToolbar, { MiniToolbarText } from '../UI/MiniToolbar';
+import { MiniToolbarText } from '../UI/MiniToolbar';
 import HelpIcon from '../UI/HelpIcon';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import NewBehaviorDialog from './NewBehaviorDialog';
@@ -124,7 +124,7 @@ const BehaviorsEditor = (props: Props) => {
           const behavior = gd.JsPlatform.get().getBehavior(behaviorTypeName);
           if (isNullPtr(gd, behavior)) {
             return (
-              <Accordion key={index}>
+              <Accordion key={index} defaultExpanded>
                 <AccordionHeader
                   actions={[
                     <IconButton
@@ -164,7 +164,7 @@ const BehaviorsEditor = (props: Props) => {
           const tutorialHints = getBehaviorTutorialHints(behaviorTypeName);
 
           return (
-            <Accordion key={index}>
+            <Accordion key={index} defaultExpanded>
               <AccordionHeader
                 actions={[
                   <IconButton

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -179,6 +179,7 @@ const BehaviorsEditor = (props: Props) => {
                   </IconButton>,
                   <HelpIcon
                     key="help"
+                    size="small"
                     helpPagePath={getBehaviorHelpPagePath(behavior)}
                   />,
                 ]}

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -127,7 +127,7 @@ const BehaviorsEditor = (props: Props) => {
           const behavior = gd.JsPlatform.get().getBehavior(behaviorTypeName);
           if (isNullPtr(gd, behavior)) {
             return (
-              <Accordion key={index} defaultExpanded>
+              <Accordion key={behaviorName} defaultExpanded>
                 <AccordionHeader
                   actions={[
                     <IconButton
@@ -170,7 +170,7 @@ const BehaviorsEditor = (props: Props) => {
           );
 
           return (
-            <Accordion key={index} defaultExpanded>
+            <Accordion key={behaviorName} defaultExpanded>
               <AccordionHeader
                 actions={[
                   <IconButton

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -27,6 +27,7 @@ import DismissableTutorialMessage from '../Hints/DismissableTutorialMessage';
 import { ColumnStackLayout } from '../UI/Layout';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import { Accordion, AccordionHeader, AccordionBody } from '../UI/Accordion';
+import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 const gd: libGDevelop = global.gd;
 
 const AddBehaviorLine = ({ onAdd }) => (
@@ -60,6 +61,8 @@ const BehaviorsEditor = (props: Props) => {
   const { object, project } = props;
   const allBehaviorNames = object.getAllBehaviorNames().toJSArray();
   const forceUpdate = useForceUpdate();
+
+  const { values } = React.useContext(PreferencesContext);
 
   const hasBehaviorWithType = (type: string) => {
     return allBehaviorNames
@@ -162,6 +165,9 @@ const BehaviorsEditor = (props: Props) => {
             behaviorTypeName
           );
           const tutorialHints = getBehaviorTutorialHints(behaviorTypeName);
+          const enabledTutorialHints = tutorialHints.filter(
+            hint => !values.hiddenTutorialHints[hint.identifier]
+          );
 
           return (
             <Accordion key={index} defaultExpanded>
@@ -202,7 +208,7 @@ const BehaviorsEditor = (props: Props) => {
               </AccordionHeader>
               <AccordionBody>
                 <Column expand noMargin>
-                  {tutorialHints.length ? (
+                  {enabledTutorialHints.length ? (
                     <Line>
                       <ColumnStackLayout expand>
                         {tutorialHints.map(tutorialHint => (

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -200,8 +200,8 @@ const BehaviorsEditor = (props: Props) => {
                   />
                 </Column>
               </AccordionHeader>
-              <AccordionBody disableGutters>
-                <Column expand>
+              <AccordionBody>
+                <Column expand noMargin>
                   {tutorialHints.length ? (
                     <Line>
                       <ColumnStackLayout expand>

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -214,7 +214,12 @@ const BehaviorsEditor = (props: Props) => {
               </Column>
             </AccordionHeader>
             <AccordionBody>
-              <Column expand noMargin>
+              <Column
+                expand
+                noMargin
+                // Avoid Physics2 behavior overflow on small screens
+                noOverflowParent
+              >
                 {enabledTutorialHints.length ? (
                   <Line>
                     <ColumnStackLayout expand>

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -26,6 +26,7 @@ import { getBehaviorTutorialHints } from '../Hints';
 import DismissableTutorialMessage from '../Hints/DismissableTutorialMessage';
 import { ColumnStackLayout } from '../UI/Layout';
 import useForceUpdate from '../Utils/UseForceUpdate';
+import { Accordion, AccordionHeader, AccordionBody } from '../UI/Accordion';
 const gd: libGDevelop = global.gd;
 
 const AddBehaviorLine = ({ onAdd }) => (
@@ -115,7 +116,7 @@ const BehaviorsEditor = (props: Props) => {
   };
 
   return (
-    <div>
+    <Column expand>
       {allBehaviorNames
         .map((behaviorName, index) => {
           const behaviorContent = object.getBehavior(behaviorName);
@@ -123,26 +124,37 @@ const BehaviorsEditor = (props: Props) => {
           const behavior = gd.JsPlatform.get().getBehavior(behaviorTypeName);
           if (isNullPtr(gd, behavior)) {
             return (
-              <div key={index}>
-                <MiniToolbar>
+              <Accordion key={index}>
+                <AccordionHeader
+                  actions={[
+                    <IconButton
+                      key="delete"
+                      onClick={ev => {
+                        ev.stopPropagation();
+                        onRemoveBehavior(behaviorName);
+                      }}
+                    >
+                      <Delete />
+                    </IconButton>,
+                  ]}
+                >
                   <MiniToolbarText>
                     <Trans>Unknown behavior</Trans>{' '}
                   </MiniToolbarText>
                   <Column noMargin expand>
                     <TextField margin="none" value={behaviorName} disabled />
                   </Column>
-                  <IconButton onClick={() => onRemoveBehavior(behaviorName)}>
-                    <Delete />
-                  </IconButton>
-                </MiniToolbar>
-                <EmptyMessage>
-                  <Trans>
-                    This behavior is unknown. It might be a behavior that was
-                    defined in an extension and that was later removed. You
-                    should delete it.
-                  </Trans>
-                </EmptyMessage>
-              </div>
+                </AccordionHeader>
+                <AccordionBody>
+                  <EmptyMessage>
+                    <Trans>
+                      This behavior is unknown. It might be a behavior that was
+                      defined in an extension and that was later removed. You
+                      should delete it.
+                    </Trans>
+                  </EmptyMessage>
+                </AccordionBody>
+              </Accordion>
             );
           }
 
@@ -152,8 +164,25 @@ const BehaviorsEditor = (props: Props) => {
           const tutorialHints = getBehaviorTutorialHints(behaviorTypeName);
 
           return (
-            <div key={index}>
-              <MiniToolbar>
+            <Accordion key={index}>
+              <AccordionHeader
+                actions={[
+                  <IconButton
+                    key="delete"
+                    size="small"
+                    onClick={ev => {
+                      ev.stopPropagation();
+                      onRemoveBehavior(behaviorName);
+                    }}
+                  >
+                    <Delete />
+                  </IconButton>,
+                  <HelpIcon
+                    key="help"
+                    helpPagePath={getBehaviorHelpPagePath(behavior)}
+                  />,
+                ]}
+              >
                 <MiniToolbarText>
                   <Trans>Behavior</Trans>{' '}
                 </MiniToolbarText>
@@ -169,34 +198,34 @@ const BehaviorsEditor = (props: Props) => {
                     }
                   />
                 </Column>
-                <IconButton onClick={() => onRemoveBehavior(behaviorName)}>
-                  <Delete />
-                </IconButton>
-                <HelpIcon helpPagePath={getBehaviorHelpPagePath(behavior)} />
-              </MiniToolbar>
-              {tutorialHints.length ? (
-                <Line>
-                  <ColumnStackLayout expand>
-                    {tutorialHints.map(tutorialHint => (
-                      <DismissableTutorialMessage
-                        key={tutorialHint.identifier}
-                        tutorialHint={tutorialHint}
-                      />
-                    ))}
-                  </ColumnStackLayout>
-                </Line>
-              ) : null}
-              <Line>
-                <BehaviorComponent
-                  behavior={behavior}
-                  behaviorContent={behaviorContent}
-                  project={project}
-                  resourceSources={props.resourceSources}
-                  onChooseResource={props.onChooseResource}
-                  resourceExternalEditors={props.resourceExternalEditors}
-                />
-              </Line>
-            </div>
+              </AccordionHeader>
+              <AccordionBody disableGutters>
+                <Column expand>
+                  {tutorialHints.length ? (
+                    <Line>
+                      <ColumnStackLayout expand>
+                        {tutorialHints.map(tutorialHint => (
+                          <DismissableTutorialMessage
+                            key={tutorialHint.identifier}
+                            tutorialHint={tutorialHint}
+                          />
+                        ))}
+                      </ColumnStackLayout>
+                    </Line>
+                  ) : null}
+                  <Line>
+                    <BehaviorComponent
+                      behavior={behavior}
+                      behaviorContent={behaviorContent}
+                      project={project}
+                      resourceSources={props.resourceSources}
+                      onChooseResource={props.onChooseResource}
+                      resourceExternalEditors={props.resourceExternalEditors}
+                    />
+                  </Line>
+                </Column>
+              </AccordionBody>
+            </Accordion>
           );
         })
         .concat(
@@ -214,7 +243,7 @@ const BehaviorsEditor = (props: Props) => {
           project={project}
         />
       )}
-    </div>
+    </Column>
   );
 };
 

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -27,6 +27,7 @@ import DismissableTutorialMessage from '../Hints/DismissableTutorialMessage';
 import { ColumnStackLayout } from '../UI/Layout';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import { Accordion, AccordionHeader, AccordionBody } from '../UI/Accordion';
+import EmptyBehaviorsPlaceholder from './EmptyBehaviorsPlaceholder';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 const gd: libGDevelop = global.gd;
 
@@ -120,6 +121,13 @@ const BehaviorsEditor = (props: Props) => {
 
   return (
     <Column expand>
+      {allBehaviorNames.length === 0 && (
+        <div style={{ height: 300, display: 'flex' }}>
+          <Line expand alignItems="center" justifyContent="center">
+            <EmptyBehaviorsPlaceholder />
+          </Line>
+        </div>
+      )}
       {allBehaviorNames.map((behaviorName, index) => {
         const behaviorContent = object.getBehavior(behaviorName);
         const behaviorTypeName = behaviorContent.getTypeName();

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -111,7 +111,7 @@ const StringSelectorEditor = ({
     <ResponsiveLineStackLayout>
       <Column justifyContent="flex-end" expand>
         {array.map((item, index) => (
-          <Line key={index} justifyContent="flex-end" expand marginSize="5px">
+          <Line key={index} justifyContent="flex-end" expand>
             <SemiControlledTextField
               commitOnBlur
               value={item}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -111,7 +111,7 @@ class Animation extends React.Component<AnimationProps, void> {
         <MiniToolbar>
           <DragHandle />
           <MiniToolbarText>Animation #{id} </MiniToolbarText>
-          <Column expand margin>
+          <Column expand>
             <SemiControlledTextField
               commitOnBlur
               margin="none"

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -104,6 +104,7 @@ const InnerDialog = (props: InnerDialogProps) => {
       cannotBeDismissed={true}
       open={props.open}
       noTitleMargin
+      fullHeight
       title={
         <div>
           <Tabs value={currentTab} onChange={setCurrentTab}>

--- a/newIDE/app/src/UI/Accordion.js
+++ b/newIDE/app/src/UI/Accordion.js
@@ -36,7 +36,9 @@ export const AccordionHeader = (props: AccordionHeadProps) => {
         )
       }
     >
-      <div style={{ flexGrow: 1 }}>{props.children}</div>
+      <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
+        {props.children}
+      </div>
       {props.actions && (
         <div style={{ flexGrow: 0, alignSelf: 'center' }}>{props.actions}</div>
       )}

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -42,6 +42,7 @@ export const Column = (props: {|
   justifyContent?: string,
   expand?: boolean,
   useFullHeight?: boolean,
+  noOverflowParent?: boolean,
 |}) => (
   <div
     style={{
@@ -56,6 +57,11 @@ export const Column = (props: {|
       // all the height (if set to flex: 1) and to *not* grow
       // larger than the parent.
       minHeight: props.useFullHeight ? '0' : undefined,
+      // In some cases, if some flex children cannot contract to
+      // within `Column`, it is possible for Column to overflow
+      // outside its parent. Setting min-width to 0 avoids this.
+      // See: https://stackoverflow.com/a/36247448/6199068
+      minWidth: props.noOverflowParent ? 0 : undefined,
     }}
   >
     {props.children}

--- a/newIDE/app/src/UI/Grid.js
+++ b/newIDE/app/src/UI/Grid.js
@@ -1,4 +1,5 @@
-import React from 'react';
+// @flow
+import * as React from 'react';
 const marginsSize = 4;
 
 /**
@@ -6,7 +7,14 @@ const marginsSize = 4;
  * Check `Layout` first to see if there is already a layout made
  * specifically for your components (like `TextFieldWithButton`).
  */
-export const Line = props => (
+export const Line = (props: {|
+  children?: React.Node,
+  noMargin?: boolean,
+  alignItems?: string,
+  justifyContent?: string,
+  expand?: boolean,
+  overflow?: string,
+|}) => (
   <div
     style={{
       display: 'flex',
@@ -27,7 +35,14 @@ export const Line = props => (
  * Check `Layout` first to see if there is already a layout made
  * specifically for your components (like `TextFieldWithButton`).
  */
-export const Column = props => (
+export const Column = (props: {|
+  children?: React.Node,
+  noMargin?: boolean,
+  alignItems?: string,
+  justifyContent?: string,
+  expand?: boolean,
+  useFullHeight?: boolean,
+|}) => (
   <div
     style={{
       display: 'flex',
@@ -52,7 +67,7 @@ export const Column = props => (
  * Check `Layout` first to see if there is already a layout made
  * specifically for your components (like `TextFieldWithButton`).
  */
-export const Spacer = props => (
+export const Spacer = () => (
   <span
     style={{
       width: marginsSize,

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -182,14 +182,6 @@ export function getMuiOverrides(
         padding: 8,
       },
     },
-    // Avoid double border between buttons in ButtonGroup
-    MuiButtonGroup: {
-      groupedContainedHorizontal: {
-        '&:not(:last-child)': {
-          borderRight: 'none',
-        },
-      },
-    },
   };
 }
 

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -182,6 +182,14 @@ export function getMuiOverrides(
         padding: 8,
       },
     },
+    // Avoid double border between buttons in ButtonGroup
+    MuiButtonGroup: {
+      groupedContainedHorizontal: {
+        '&:not(:last-child)': {
+          borderRight: 'none',
+        },
+      },
+    },
   };
 }
 

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -177,6 +177,11 @@ export function getMuiOverrides(
         padding: 0,
       },
     },
+    MuiAccordionDetails: {
+      root: {
+        padding: 8,
+      },
+    },
   };
 }
 


### PR DESCRIPTION
Related Trello card: https://trello.com/c/Y5B1X0ww

This PR is to rework the behavior list, adding an accordion for each behavior. Panel persistence is also suggested, I'm not very familiar with how to implement that. If there's another IDE configuration setting persisted that is project-specific (and object-specific?), I can probably take a look at that.

As for implementation, the main part is almost trivial now. Accordion is already implemented, just need to move things around in BehaviorsList a bit. I'll get started with this today evening.

EDIT: (sorry for the requested review, forgot to mark this as draft PR)

EDIT: Also, I read somewhere about an alternate UI too (on the forum, maybe) - similar to the asset store, list of behaviors in left pane, and on selecting a behavior the properties appear in the right pane. Not sure which one is more intuitive or productive - I'm not so familiar with the user workflow in GDevelop.