### PR TITLE
Fix sound is playing condition

### DIFF
--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -107,7 +107,7 @@ namespace gdjs {
      */
     playing(): boolean {
       return (
-        (this._id !== null ? this._howl.playing(this._id) : false) ||
+        (this._id !== null ? this._howl.playing(this._id) : true) ||
         !this.isLoaded() // Loading is considered playing
       );
     }


### PR DESCRIPTION
Fixes #2550 
Between loading and playing the sound, there is a short timeframe where the sound wasn't recognized as being played. As this moment is caused by loading the sound before playing it, it should be considered part of loading and therefore playing the sound.