### PR TITLE
Cancel default behavior from browsers when keyboard is used

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -411,9 +411,11 @@ namespace gdjs {
       //Keyboard
       document.onkeydown = function (e) {
         manager.onKeyPressed(e.keyCode, e.location);
+        e.preventDefault();
       };
       document.onkeyup = function (e) {
         manager.onKeyReleased(e.keyCode, e.location);
+        e.preventDefault();
       };
 
       //Mouse


### PR DESCRIPTION
## Description
Add preventDefault() on keyboard events. For fix problems with game in iframe like on itch.io, this has been also reported by users,[ and recently this guys.](https://forum.gdevelop-app.com/t/arrow-keys-on-html-embedded-game/32265)

## Test
[You can test the change here ](https://witly.fr/test/test.html) with a top down behavior, use the arrow keys for moving, the default action of arrow keys is prevented.
The default keyboard event is prevented inly when the focus is on the game, the scroll continue if you focus the rest of the page.

## Question

~This preventDefault was present in past? if this has been removed, you remember why?~
