### PR TITLE
Add actions, conditions and expressions for the object center

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -6,6 +6,7 @@
 #include "AllBuiltinExtensions.h"
 #include "GDCore/Project/Object.h"
 #include "GDCore/Tools/Localization.h"
+#include "GDCore/Extensions/Metadata/MultipleInstructionMetadata.h"
 
 using namespace std;
 namespace gd {
@@ -26,7 +27,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
 #if defined(GD_IDE_ONLY)
   obj.AddCondition("PosX",
-                   _("Compare X position of an object"),
+                   _("X position"),
                    _("Compare the X position of the object."),
                    _("the X position"),
                    _("Position"),
@@ -38,7 +39,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsSimple();
 
   obj.AddAction("MettreX",
-                _("X position of an object"),
+                _("X position"),
                 _("Change the X position of an object."),
                 _("the X position"),
                 _("Position"),
@@ -50,7 +51,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsSimple();
 
   obj.AddCondition("PosY",
-                   _("Compare Y position of an object"),
+                   _("Y position"),
                    _("Compare the Y position of an object."),
                    _("the Y position"),
                    _("Position"),
@@ -62,7 +63,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsSimple();
 
   obj.AddAction("MettreY",
-                _("Y position of an object"),
+                _("Y position"),
                 _("Change the Y position of an object."),
                 _("the Y position"),
                 _("Position"),
@@ -74,7 +75,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsSimple();
 
   obj.AddAction("MettreXY",
-                _("Position of an object"),
+                _("Position"),
                 _("Change the position of an object."),
                 _("Change the position of _PARAM0_: _PARAM1_ _PARAM2_ (x "
                   "axis), _PARAM3_ _PARAM4_ (y axis)"),
@@ -89,8 +90,41 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .AddParameter("expression", _("Y position"))
       .MarkAsSimple();
 
+  obj.AddAction("SetCenter",
+                _("Center position"),
+                _("Change the position of an object, using its center."),
+                _("Change the position of the center of _PARAM0_: _PARAM1_ _PARAM2_ (x "
+                  "axis), _PARAM3_ _PARAM4_ (y axis)"),
+                _("Position/Center"),
+                "res/actions/position24.png",
+                "res/actions/position.png")
+      .AddParameter("object", _("Object"))
+      .AddParameter("operator", _("Modification's sign"))
+      .AddParameter("expression", _("X position"))
+      .AddParameter("operator", _("Modification's sign"))
+      .AddParameter("expression", _("Y position"))
+      .MarkAsSimple();
+
+  obj.AddExpressionAndConditionAndAction("number", "CenterX",
+          _("Center X position"),
+          _("the X position of the center"),
+          _("the X position of the center"),
+          _("Position/Center"),
+          "res/actions/position24.png")
+      .AddParameter("object", _("Object"))
+      .UseStandardParameters("number");
+
+  obj.AddExpressionAndConditionAndAction("number", "CenterY",
+          _("Center Y position"),
+          _("the Y position of the center"),
+          _("the Y position of the center"),
+          _("Position/Center"),
+          "res/actions/position24.png")
+      .AddParameter("object", _("Object"))
+      .UseStandardParameters("number");
+
   obj.AddAction("MettreAutourPos",
-                _("Put an object around a position"),
+                _("Put around a position"),
                 _("Position the center of the given object around a position, "
                   "using the specified angle "
                   "and distance."),
@@ -248,7 +282,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsAdvanced();
 
   obj.AddAction("Delete",
-                _("Delete an object"),
+                _("Delete the object"),
                 _("Delete the specified object."),
                 _("Delete _PARAM0_"),
                 _("Objects"),
@@ -383,7 +417,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddAction("Montre",
                 _("Show"),
-                _("Show the specified object"),
+                _("Show the specified object."),
                 _("Show _PARAM0_"),
                 _("Visibility"),
                 "res/actions/visibilite24.png",
@@ -406,10 +440,10 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsAdvanced();
 
   obj.AddCondition("Plan",
-                   _("Compare Z order"),
+                   _("Z-order"),
                    _("Compare the Z-order of the specified object."),
-                   _("the z Order"),
-                   _("Z order"),
+                   _("the Z-order"),
+                   _("Z-order"),
                    "res/conditions/planicon24.png",
                    "res/conditions/planicon.png")
 
@@ -418,7 +452,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsAdvanced();
 
   obj.AddCondition("Layer",
-                   _("Compare layer"),
+                   _("Current layer"),
                    _("Check if the object is on the specified layer."),
                    _("_PARAM0_ is on layer _PARAM1_"),
                    _("Layer"),
@@ -430,7 +464,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsAdvanced();
 
   obj.AddCondition("Visible",
-                   _("Visibility of an object"),
+                   _("Visibility"),
                    _("Check if an object is visible."),
                    _("_PARAM0_ is visible (not marked as hidden)"),
                    _("Visibility"),
@@ -668,7 +702,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsAdvanced();
 
   obj.AddAction("MettreAutour",
-                _("Put an object around another"),
+                _("Put the object around another"),
                 _("Position an object around another, with the specified angle "
                   "and distance. The center of the objects are used for "
                   "positioning them."),
@@ -711,7 +745,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .AddParameter("objectList", _("Object 2 (won't move)"));
 
   obj.AddAction("SeparateFromObjects",
-                _("Separate two objects"),
+                _("Separate objects"),
                 _("Move an object away from another using their collision "
                   "masks.\nBe sure to call this action on a reasonable number "
                   "of objects\nto avoid slowing down the game."),
@@ -914,15 +948,15 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .SetHidden();
 
   obj.AddExpression("ZOrder",
-                    _("Z order"),
-                    _("Z order of an object"),
+                    _("Z-order"),
+                    _("Z-order of an object"),
                     _("Visibility"),
                     "res/actions/planicon.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("Plan",
-                    _("Z order"),
-                    _("Z order of an object"),
+                    _("Z-order"),
+                    _("Z-order of an object"),
                     _("Visibility"),
                     "res/actions/planicon.png")
       .AddParameter("object", _("Object"))

--- a/Core/GDCore/Extensions/Metadata/ObjectMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ObjectMetadata.cpp
@@ -123,7 +123,10 @@ gd::InstructionMetadata& ObjectMetadata::AddScopedCondition(
     const gd::String& smallicon) {
 #if defined(GD_IDE_ONLY)
   gd::String nameWithNamespace =
-      GetName() + gd::PlatformExtension::GetNamespaceSeparator() + name;
+      GetName().empty()
+          ? name // Don't insert a namespace separator for the base object.
+          : GetName() + gd::PlatformExtension::GetNamespaceSeparator() + name;
+
   conditionsInfos[nameWithNamespace] = InstructionMetadata(extensionNamespace,
                                                            nameWithNamespace,
                                                            fullname,
@@ -148,7 +151,10 @@ gd::InstructionMetadata& ObjectMetadata::AddScopedAction(
     const gd::String& smallicon) {
 #if defined(GD_IDE_ONLY)
   gd::String nameWithNamespace =
-      GetName() + gd::PlatformExtension::GetNamespaceSeparator() + name;
+      GetName().empty()
+          ? name // Don't insert a namespace separator for the base object.
+          : GetName() + gd::PlatformExtension::GetNamespaceSeparator() + name;
+
   actionsInfos[nameWithNamespace] = InstructionMetadata(extensionNamespace,
                                                         nameWithNamespace,
                                                         fullname,

--- a/GDJS/GDJS/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/BaseObjectExtension.cpp
@@ -39,6 +39,14 @@ BaseObjectExtension::BaseObjectExtension() {
       "runtimeobject.js");
   objectConditions["PosY"].SetFunctionName("getY").SetIncludeFile(
       "runtimeobject.js");
+  objectConditions["CenterX"].SetFunctionName("getCenterXInScene");
+  objectConditions["CenterY"].SetFunctionName("getCenterYInScene");
+  objectActions["SetCenterX"]
+      .SetFunctionName("setCenterXInScene")
+      .SetGetter("getCenterXInScene");
+  objectActions["SetCenterY"]
+      .SetFunctionName("setCenterYInScene")
+      .SetGetter("getCenterYInScene");
   objectActions["SetAngle"]
       .SetFunctionName("setAngle")
       .SetGetter("getAngle")
@@ -168,6 +176,8 @@ BaseObjectExtension::BaseObjectExtension() {
 
   objectExpressions["X"].SetFunctionName("getX");
   objectExpressions["Y"].SetFunctionName("getY");
+  objectExpressions["CenterX"].SetFunctionName("getCenterXInScene");
+  objectExpressions["CenterY"].SetFunctionName("getCenterYInScene");
   objectExpressions["ZOrder"].SetFunctionName("getZOrder");
   objectExpressions["Plan"].SetFunctionName("getZOrder");  // Deprecated
   objectExpressions["Width"].SetFunctionName("getWidth");
@@ -203,8 +213,10 @@ BaseObjectExtension::BaseObjectExtension() {
       "getTimerElapsedTimeInSeconds");
   objectStrExpressions["ObjectName"].SetFunctionName("getName");
   objectStrExpressions["Layer"].SetFunctionName("getLayer");
-  objectExpressions["XFromAngleAndDistance"].SetFunctionName("getXFromAngleAndDistance");
-  objectExpressions["YFromAngleAndDistance"].SetFunctionName("getYFromAngleAndDistance");
+  objectExpressions["XFromAngleAndDistance"].SetFunctionName(
+      "getXFromAngleAndDistance");
+  objectExpressions["YFromAngleAndDistance"].SetFunctionName(
+      "getYFromAngleAndDistance");
 
   GetAllActions()["Create"].SetFunctionName(
       "gdjs.evtTools.object.createObjectOnScene");
@@ -290,59 +302,56 @@ BaseObjectExtension::BaseObjectExtension() {
         return "runtimeScene.updateObjectsForces();";
       });
 
+  auto isNotAssignmentOperator = [](const gd::String &op) {
+    return op == "/" || op == "*" || op == "-" || op == "+";
+  };
+
   objectActions["MettreXY"].codeExtraInformation.SetCustomCodeGenerator(
-      [](gd::Instruction &instruction,
-         gd::EventsCodeGenerator &codeGenerator,
-         gd::EventsCodeGenerationContext &context) -> gd::String {
+      [&](gd::Instruction &instruction,
+          gd::EventsCodeGenerator &codeGenerator,
+          gd::EventsCodeGenerationContext &context) -> gd::String {
         gd::String outputCode;
 
-        std::vector<gd::String> realObjects = codeGenerator.ExpandObjectsName(
+        auto realObjects = codeGenerator.ExpandObjectsName(
             instruction.GetParameter(0).GetPlainString(), context);
-        for (std::size_t i = 0; i < realObjects.size(); ++i) {
-          context.SetCurrentObject(realObjects[i]);
-          context.ObjectsListNeeded(realObjects[i]);
+        for (auto &realObjectName : realObjects) {
+          context.SetCurrentObject(realObjectName);
+          context.ObjectsListNeeded(realObjectName);
 
-          gd::String newX, newY;
+          gd::String objectListName =
+              codeGenerator.GetObjectListName(realObjectName, context);
 
           gd::String expression1Code =
               gd::ExpressionCodeGenerator::GenerateExpressionCode(
                   codeGenerator,
                   context,
                   "number",
-                  instruction.GetParameters()[2].GetPlainString());
+                  instruction.GetParameter(2).GetPlainString());
 
           gd::String expression2Code =
               gd::ExpressionCodeGenerator::GenerateExpressionCode(
                   codeGenerator,
                   context,
                   "number",
-                  instruction.GetParameters()[4].GetPlainString());
+                  instruction.GetParameter(4).GetPlainString());
 
           gd::String op1 = instruction.GetParameter(1).GetPlainString();
-          if (op1 == "=" || op1.empty())
-            newX = expression1Code;
-          else if (op1 == "/" || op1 == "*" || op1 == "-" || op1 == "+")
-            newX = codeGenerator.GetObjectListName(realObjects[i], context) +
-                   "[i].getX() " + op1 + expression1Code;
-          else
-            return "";
+          gd::String newX =
+              isNotAssignmentOperator(op1)
+                  ? (objectListName + "[i].getX() " + op1 + expression1Code)
+                  : expression1Code;
+
           gd::String op2 = instruction.GetParameter(3).GetPlainString();
-          if (op2 == "=" || op2.empty())
-            newY = expression2Code;
-          else if (op2 == "/" || op2 == "*" || op2 == "-" || op2 == "+")
-            newY = codeGenerator.GetObjectListName(realObjects[i], context) +
-                   "[i].getY() " + op2 + expression2Code;
-          else
-            return "";
+          gd::String newY =
+              isNotAssignmentOperator(op2)
+                  ? (objectListName + "[i].getY() " + op2 + expression2Code)
+                  : expression2Code;
 
           gd::String call =
-              codeGenerator.GetObjectListName(realObjects[i], context) +
-              "[i].setPosition(" + newX + "," + newY + ")";
+              objectListName + "[i].setPosition(" + newX + "," + newY + ")";
 
-          outputCode +=
-              "for(var i = 0, len = " +
-              codeGenerator.GetObjectListName(realObjects[i], context) +
-              ".length ;i < len;++i) {\n";
+          outputCode += "for(var i = 0, len = " + objectListName +
+                        ".length ;i < len;++i) {\n";
           outputCode += "    " + call + ";\n";
           outputCode += "}\n";
 
@@ -352,48 +361,63 @@ BaseObjectExtension::BaseObjectExtension() {
         return outputCode;
       });
 
-  StripUnimplementedInstructionsAndExpressions();  // Unimplemented things are
-                                                   // listed here:
-  /*
-          obj.AddAction("AddForceTournePos",
-                         _("Add a force so as to move around a position"),
-                         _("Add a force to an object so as it rotates toward a
-     position.\nNote that the moving is not precise, especially if the speed is
-     high.\nTo position an object around a position more precisly, use the
-     actions in the category  \"Position\"."),
-                         _("Rotate _PARAM0_ around _PARAM1_;_PARAM2_ with
-     _PARAM3_�/sec and _PARAM4_ pixels away"),
-                         _("Displacement"),
-                         "res/actions/forceTourne24.png",
-                         "res/actions/forceTourne.png")
+  objectActions["SetCenter"].codeExtraInformation.SetCustomCodeGenerator(
+      [&](gd::Instruction &instruction,
+          gd::EventsCodeGenerator &codeGenerator,
+          gd::EventsCodeGenerationContext &context) -> gd::String {
+        gd::String outputCode;
 
-              .AddParameter("object", _("Object"))
-              .AddParameter("expression", _("X position of the center"))
-              .AddParameter("expression", _("Y position of the center"))
-              .AddParameter("expression", _("Speed ( in Degrees per seconds )"))
-              .AddParameter("expression", _("Distance ( in pixels )"))
-              .AddParameter("expression", _("Damping ( Default : 0 )"))
-              .SetFunctionName("AddForceToMoveAround");
+        auto realObjects = codeGenerator.ExpandObjectsName(
+            instruction.GetParameter(0).GetPlainString(), context);
+        for (auto &realObjectName : realObjects) {
+          context.SetCurrentObject(realObjectName);
+          context.ObjectsListNeeded(realObjectName);
 
-          obj.AddAction("AddForceTourne",
-                         _("Add a force so as to move around an object"),
-                         _("Add a force to an object so as it rotates around
-     another.\nNote that the moving is not precise, especially if the speed is
-     high.\nTo position an object around a position more precisly, use the
-     actions in the category  \"Position\"."),
-                         _("Rotate _PARAM0_ around _PARAM1_ with _PARAM2_�/sec
-     and _PARAM3_ pixels away"),
-                         _("Displacement"),
-                         "res/actions/forceTourne24.png",
-                         "res/actions/forceTourne.png")
+          gd::String objectListName =
+              codeGenerator.GetObjectListName(realObjectName, context);
 
-              .AddParameter("object", _("Object"))
-              .AddParameter("objectPtr", _("Rotate around this object"))
-              .AddParameter("expression", _("Speed ( Degrees per second )"))
-              .AddParameter("expression", _("Distance ( in pixel )"))
-              .AddParameter("expression", _("Damping ( Default : 0 )"))
-              .SetFunctionName("AddForceToMoveAroundObject").SetIncludeFile("GDCpp/Extensions/Builtin/ObjectTools.h");
-  */
+          gd::String expression1Code =
+              gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                  codeGenerator,
+                  context,
+                  "number",
+                  instruction.GetParameter(2).GetPlainString());
+
+          gd::String expression2Code =
+              gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                  codeGenerator,
+                  context,
+                  "number",
+                  instruction.GetParameter(4).GetPlainString());
+
+          gd::String op1 = instruction.GetParameter(1).GetPlainString();
+          gd::String newX = isNotAssignmentOperator(op1)
+                                ? (objectListName + "[i].getCenterXInScene() " +
+                                   op1 + expression1Code)
+                                : expression1Code;
+
+          gd::String op2 = instruction.GetParameter(3).GetPlainString();
+          gd::String newY = isNotAssignmentOperator(op2)
+                                ? (objectListName + "[i].getCenterYInScene() " +
+                                   op2 + expression2Code)
+                                : expression2Code;
+
+          gd::String call = objectListName + "[i].setCenterPositionInScene(" +
+                            newX + "," + newY + ")";
+
+          outputCode += "for(var i = 0, len = " + objectListName +
+                        ".length ;i < len;++i) {\n";
+          outputCode += "    " + call + ";\n";
+          outputCode += "}\n";
+
+          context.SetNoCurrentObject();
+        }
+
+        return outputCode;
+      });
+
+  // "AddForceTournePos" and "AddForceTourne" are deprecated and not implemented
+  StripUnimplementedInstructionsAndExpressions();
 }
 
 }  // namespace gdjs

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -792,6 +792,8 @@ namespace gdjs {
 
     /**
      * Return the X position of the object center, **relative to the object X position** (`getDrawableX`).
+     * Use `getCenterXInScene` to get the position of the center in the scene.
+     *
      * @return the X position of the object center, relative to `getDrawableX()`.
      */
     getCenterX(): float {
@@ -800,10 +802,54 @@ namespace gdjs {
 
     /**
      * Return the Y position of the object center, **relative to the object position** (`getDrawableY`).
+     * Use `getCenterYInScene` to get the position of the center in the scene.
+     *
      * @return the Y position of the object center, relative to `getDrawableY()`.
      */
     getCenterY(): float {
       return this.getHeight() / 2;
+    }
+
+    /**
+     * Return the X position of the object center, **relative to the scene origin**.
+     * @returns the X position of the object center, **relative to the scene origin**.
+     */
+    getCenterXInScene(): float {
+      return this.getDrawableX() + this.getCenterX();
+    }
+
+    /**
+     * Return the Y position of the object center, **relative to the scene origin**.
+     * @returns the Y position of the object center, **relative to the scene origin**.
+     */
+    getCenterYInScene(): float {
+      return this.getDrawableY() + this.getCenterY();
+    }
+
+    /**
+     * Change the object center position in the scene.
+     * @param x The new X position of the center in the scene.
+     * @param y The new Y position of the center in the scene.
+     */
+    setCenterPositionInScene(x: float, y: float): void {
+      this.setX(x + this.x - (this.getDrawableX() + this.getCenterX()));
+      this.setY(y + this.y - (this.getDrawableY() + this.getCenterY()));
+    }
+
+    /**
+     * Change the object center X position in the scene.
+     * @param x The new X position of the center in the scene.
+     */
+    setCenterXInScene(x: float): void {
+      this.setX(x + this.x - (this.getDrawableX() + this.getCenterX()));
+    }
+
+    /**
+     * Change the object center Y position in the scene.
+     * @param x The new Y position of the center in the scene.
+     */
+    setCenterYInScene(y: float): void {
+      this.setY(y + this.y - (this.getDrawableY() + this.getCenterY()));
     }
 
     //Forces :
@@ -1553,20 +1599,8 @@ namespace gdjs {
     ): void {
       const angleInRadians = gdjs.toRad(angleInDegrees);
 
-      // Offset the position by the center, as PutAround* methods should position the center
-      // of the object (just like GetSqDistanceTo, RaycastTest uses center too).
-      this.setX(
-        x +
-          Math.cos(angleInRadians) * distance +
-          this.getX() -
-          (this.getDrawableX() + this.getCenterX())
-      );
-      this.setY(
-        y +
-          Math.sin(angleInRadians) * distance +
-          this.getY() -
-          (this.getDrawableY() + this.getCenterY())
-      );
+      this.setCenterXInScene(x + Math.cos(angleInRadians) * distance);
+      this.setCenterYInScene(y + Math.sin(angleInRadians) * distance);
     }
 
     /**

--- a/newIDE/app/resources/examples/platformer/platformer.json
+++ b/newIDE/app/resources/examples/platformer/platformer.json
@@ -3749,14 +3749,14 @@
             {
               "type": {
                 "inverted": false,
-                "value": "MettreXY"
+                "value": "SetCenter"
               },
               "parameters": [
                 "Player",
                 "=",
-                "PlayerHitBox.X()-12",
+                "PlayerHitBox.CenterX()",
                 "=",
-                "PlayerHitBox.Y()"
+                "PlayerHitBox.CenterY()"
               ],
               "subInstructions": []
             }


### PR DESCRIPTION
Add actions, conditions and expressions to get the position of an object center or set its position using its center. This seems to be a use case that is very common, so it make sense to, exceptionally, enhance the base object actions/conditions :) 

EDIT: also normalize the naming of some actions/conditions that were still using verbs while they are object action/conditions, so don't need it for consistency.