### PR TITLE
[P2P] Allow overriding the Peer client ID

### DIFF
--- a/Extensions/P2P/B_p2ptools.ts
+++ b/Extensions/P2P/B_p2ptools.ts
@@ -82,6 +82,11 @@ namespace gdjs {
       }
 
       /**
+       * The optional peer ID. Only used if explicitly overridden.
+       */
+      let peerId: string | null = null;
+
+      /**
        * The peer to peer configuration.
        */
       let peerConfig: Peer.PeerJSOption = { debug: 1 };
@@ -133,7 +138,11 @@ namespace gdjs {
        */
       const loadPeerJS = () => {
         if (peer !== null) return;
-        peer = new Peer(peerConfig);
+        if (peerId !== null) {
+          peer = new Peer(peerId, peerConfig);
+        } else {
+          peer = new Peer(peerConfig);
+        }
         peer.on('open', () => {
           ready = true;
         });
@@ -359,6 +368,15 @@ namespace gdjs {
        * this server should only be used for quick testing in development.
        */
       export const useDefaultBrokerServer = loadPeerJS;
+
+      /**
+       * Overrides the default peer ID. Must be called before connecting to a
+       * broker.
+       * @param id The peer ID to use when connecting to a broker.
+       */
+      export const overrideId = (id: string) => {
+        peerId = id;
+      };
 
       /**
        * Returns the own current peer ID.

--- a/Extensions/P2P/JsExtension.js
+++ b/Extensions/P2P/JsExtension.js
@@ -171,6 +171,25 @@ module.exports = {
 
     extension
       .addAction(
+        'OverrideID',
+        _('Override the client ID'),
+        _(
+          'Overrides the client ID of the current game instance with a specified ID. ' +
+            'Must be called BEFORE connecting to a broker.'
+        ),
+        _('Override the client ID with _PARAM0_'),
+        _('P2P (experimental)'),
+        'JsPlatform/Extensions/p2picon.svg',
+        'JsPlatform/Extensions/p2picon.svg'
+      )
+      .addParameter('string', _('ID'), '', false)
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/P2P/A_peer.js')
+      .addIncludeFile('Extensions/P2P/B_p2ptools.js')
+      .setFunctionName('gdjs.evtTools.p2p.overrideId');
+
+    extension
+      .addAction(
         'SendToAll',
         _('Trigger event on all connected clients'),
         _('Triggers an event on all connected clients'),


### PR DESCRIPTION
The default behaviour of PeerJS is to generate a UUID for each client that connects to the server. However, it also allows the clients themselves to specify their own ID, which could be useful in some situations.

The typical scenario would be a pretty standard situation, where a player is allowed to "host" a game, and then other players can connect to that instance using a code. A UUID, which is the default, is difficult to share and input, so using something simpler  (such as a 6-digit number or a shorter string) makes it easier to communicate.

Using this patch, a game could generate a simple, but unique, ID for each game (e.g. `639239`), and then specify that as the PeerJS client ID: `P2P::OverrideID('639239')`. Other players can then connect to that peer using the simpler ID.

I specifically avoided using `SetID` as the function name, as this operation isn't really a simple "set" in the traditional sense. It may have some consequences, especially if the ID is not unique enough and you are using the default broker. Thus, I guess one would also only recommend to use this operation when using your own hosted instance of PeerJS. An alternative version could be to include an optional peer ID when using the `UseOwnBroker` function instead.