### PR TITLE
[P2P] Add warning hint about overriding the Peer ID

### DIFF
--- a/Extensions/P2P/B_p2ptools.ts
+++ b/Extensions/P2P/B_p2ptools.ts
@@ -370,8 +370,9 @@ namespace gdjs {
       export const useDefaultBrokerServer = loadPeerJS;
 
       /**
-       * Overrides the default peer ID. Must be called before connecting to a
-       * broker.
+       * Overrides the default peer ID. Must be called before connecting to a broker.
+       * Overriding the ID may have unwanted consequences. Do not use this feature
+       * unless you really know what you are doing.
        * @param id The peer ID to use when connecting to a broker.
        */
       export const overrideId = (id: string) => {

--- a/newIDE/app/src/Hints/index.js
+++ b/newIDE/app/src/Hints/index.js
@@ -86,6 +86,12 @@ export const getExtraInstructionInformation = (type: string): ?Hint => {
       message: t`Read the wiki page for more info about the dataloss mode.`,
     };
   }
+  if (type === 'P2P::OverrideID') {
+    return {
+      kind: 'warning',
+      message: t`Overriding the ID may have unwanted consequences. Do not use this feature unless you really know what you are doing.`,
+    };
+  }
   if (type.indexOf('P2P::') === 0) {
     return {
       kind: 'warning',


### PR DESCRIPTION
As discussed with @arthuro555 on PR #2598, adding a warning text about not using the `P2P::OverrideID` feature unless you really know what you're doing.

I wasn't really sure about the best practice for the hints - if I should specify an ID or not, etc..