### PR TITLE
Tween Scale from center (or named center point) of objects

### DIFF
--- a/Extensions/TweenBehavior/JsExtension.js
+++ b/Extensions/TweenBehavior/JsExtension.js
@@ -327,7 +327,7 @@ module.exports = {
           'Add a tween animation for the object scale (Note: the scale can never be less than 0).'
         ),
         _(
-          'Tween the scale of _PARAM0_ to X-scale: _PARAM3_, Y-scale: _PARAM4_ from center (_PARAM8_) with easing _PARAM5_ over _PARAM6_ms as _PARAM2_'
+          'Tween the scale of _PARAM0_ to X-scale: _PARAM3_, Y-scale: _PARAM4_ (from center: _PARAM8_) with easing _PARAM5_ over _PARAM6_ms as _PARAM2_'
         ),
         _('Scale'),
         'JsPlatform/Extensions/tween_behavior24.png',
@@ -348,12 +348,7 @@ module.exports = {
         false
       )
       .setDefaultValue('no')
-      .addParameter(
-        'yesorno',
-        _('Scale from center of object'),
-        '',
-        false
-      )
+      .addParameter('yesorno', _('Scale from center of object'), '', false)
       .setDefaultValue('no')
       .getCodeExtraInformation()
       .setFunctionName('addObjectScaleTween');
@@ -366,7 +361,7 @@ module.exports = {
           'Add a tween animation for the object X-scale (Note: the scale can never be less than 0).'
         ),
         _(
-          'Tween the X-scale of _PARAM0_ to _PARAM3_ from center (_PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
+          'Tween the X-scale of _PARAM0_ to _PARAM3_ (from center: _PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
         ),
         _('Scale'),
         'JsPlatform/Extensions/tween_behavior24.png',
@@ -386,12 +381,7 @@ module.exports = {
         false
       )
       .setDefaultValue('no')
-      .addParameter(
-        'yesorno',
-        _('Scale from center of object'),
-        '',
-        false
-      )
+      .addParameter('yesorno', _('Scale from center of object'), '', false)
       .setDefaultValue('no')
       .getCodeExtraInformation()
       .setFunctionName('addObjectScaleXTween');
@@ -404,7 +394,7 @@ module.exports = {
           'Add a tween animation for the object Y-scale (Note: the scale can never be less than 0).'
         ),
         _(
-          'Tween the Y-scale of _PARAM0_ to _PARAM3_ from center (_PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
+          'Tween the Y-scale of _PARAM0_ to _PARAM3_ (from center: _PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
         ),
         _('Scale'),
         'JsPlatform/Extensions/tween_behavior24.png',
@@ -424,12 +414,7 @@ module.exports = {
         false
       )
       .setDefaultValue('no')
-      .addParameter(
-        'yesorno',
-        _('Scale from center of object'),
-        '',
-        false
-      )
+      .addParameter('yesorno', _('Scale from center of object'), '', false)
       .setDefaultValue('no')
       .getCodeExtraInformation()
       .setFunctionName('addObjectScaleYTween');

--- a/Extensions/TweenBehavior/JsExtension.js
+++ b/Extensions/TweenBehavior/JsExtension.js
@@ -327,7 +327,7 @@ module.exports = {
           'Add a tween animation for the object scale (Note: the scale can never be less than 0).'
         ),
         _(
-          'Tween the scale of _PARAM0_ to X-scale: _PARAM3_, Y-scale: _PARAM4_ with easing _PARAM5_ over _PARAM6_ms as _PARAM2_'
+          'Tween the scale of _PARAM0_ to X-scale: _PARAM3_, Y-scale: _PARAM4_ from center (_PARAM8_) with easing _PARAM5_ over _PARAM6_ms as _PARAM2_'
         ),
         _('Scale'),
         'JsPlatform/Extensions/tween_behavior24.png',
@@ -344,6 +344,13 @@ module.exports = {
       .addParameter(
         'yesorno',
         _('Destroy this object when tween finishes'),
+        '',
+        false
+      )
+      .setDefaultValue('no')
+      .addParameter(
+        'yesorno',
+        _('Scale from center of object'),
         '',
         false
       )
@@ -359,7 +366,7 @@ module.exports = {
           'Add a tween animation for the object X-scale (Note: the scale can never be less than 0).'
         ),
         _(
-          'Tween the X-scale of _PARAM0_ to _PARAM3_ with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
+          'Tween the X-scale of _PARAM0_ to _PARAM3_ from center (_PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
         ),
         _('Scale'),
         'JsPlatform/Extensions/tween_behavior24.png',
@@ -379,6 +386,13 @@ module.exports = {
         false
       )
       .setDefaultValue('no')
+      .addParameter(
+        'yesorno',
+        _('Scale from center of object'),
+        '',
+        false
+      )
+      .setDefaultValue('no')
       .getCodeExtraInformation()
       .setFunctionName('addObjectScaleXTween');
 
@@ -390,7 +404,7 @@ module.exports = {
           'Add a tween animation for the object Y-scale (Note: the scale can never be less than 0).'
         ),
         _(
-          'Tween the Y-scale of _PARAM0_ to _PARAM3_ with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
+          'Tween the Y-scale of _PARAM0_ to _PARAM3_ from center (_PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
         ),
         _('Scale'),
         'JsPlatform/Extensions/tween_behavior24.png',
@@ -406,6 +420,13 @@ module.exports = {
       .addParameter(
         'yesorno',
         _('Destroy this object when tween finishes'),
+        '',
+        false
+      )
+      .setDefaultValue('no')
+      .addParameter(
+        'yesorno',
+        _('Scale from center of object'),
         '',
         false
       )

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -415,6 +415,25 @@ namespace gdjs {
       const newTweenable = TweenRuntimeBehavior.makeNewTweenable(
         this._runtimeScene
       );
+      let stepFunction;
+      if(scaleFromCenterOfObject) {
+        stepFunction = function step(state) {
+          const oldX = that.owner.getCenterXInScene();
+          const oldY = that.owner.getCenterYInScene();
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleX(state.scaleX);
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleY(state.scaleY);
+          that.owner.setCenterPositionInScene(oldX, oldY);
+        }
+      } else {
+        stepFunction = function step(state) {
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleX(state.scaleX);
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleY(state.scaleY);
+        }
+      }
       newTweenable.setConfig({
         from: {
           // @ts-ignore - objects are duck typed
@@ -425,22 +444,7 @@ namespace gdjs {
         to: { scaleX: toScaleX, scaleY: toScaleY },
         duration: durationValue,
         easing: easingValue,
-        step: function step(state) {
-          if(scaleFromCenterOfObject) {
-            const oldX = that.owner.getCenterXInScene();
-            const oldY = that.owner.getCenterYInScene();
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleX(state.scaleX);
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleY(state.scaleY);
-            that.owner.setCenterPositionInScene(oldX, oldY);
-          } else {
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleX(state.scaleX);
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleY(state.scaleY);
-          }
-        },
+        step: stepFunction,
       });
       this._addTween(
         identifier,
@@ -485,23 +489,27 @@ namespace gdjs {
       const newTweenable = TweenRuntimeBehavior.makeNewTweenable(
         this._runtimeScene
       );
+      let stepFunction: { (state: any): void; (state: any): void; };
+      if(scaleFromCenterOfObject) {
+        stepFunction = function step(state) {
+          const oldX = that.owner.getCenterXInScene();
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleX(state.scaleX);
+          that.owner.setCenterXInScene(oldX);
+        }
+      } else {
+        stepFunction = function step(state) {
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleX(state.scaleX);
+        }
+      }
       newTweenable.setConfig({
         // @ts-ignore - objects are duck typed
         from: { scaleX: this.owner.getScaleX() },
         to: { scaleX: toScaleX },
         duration: durationValue,
         easing: easingValue,
-        step: function step(state) {
-          if(scaleFromCenterOfObject) {
-            const oldX = that.owner.getCenterXInScene();
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleX(state.scaleX);
-            that.owner.setCenterXInScene(oldX);
-          } else {
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleX(state.scaleX);
-          }
-        },
+        step: stepFunction,
       });
       this._addTween(
         identifier,
@@ -546,23 +554,27 @@ namespace gdjs {
       const newTweenable = TweenRuntimeBehavior.makeNewTweenable(
         this._runtimeScene
       );
+      let stepFunction: { (state: any): void; (state: any): void; };
+      if(scaleFromCenterOfObject) {
+        stepFunction = function step(state) {
+          const oldY = that.owner.getCenterYInScene();
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleY(state.scaleY);
+          that.owner.setCenterYInScene(oldY);
+        }
+      } else {
+        stepFunction = function step(state) {
+          // @ts-ignore - objects are duck typed
+          that.owner.setScaleY(state.scaleY);
+        }
+      }
       newTweenable.setConfig({
         // @ts-ignore - objects are duck typed
         from: { scaleY: this.owner.getScaleY() },
         to: { scaleY: toScaleY },
         duration: durationValue,
         easing: easingValue,
-        step: function step(state) {
-          if(scaleFromCenterOfObject) {
-            const oldY = that.owner.getCenterYInScene();
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleY(state.scaleY);
-            that.owner.setCenterYInScene(oldY);
-          } else {
-            // @ts-ignore - objects are duck typed
-            that.owner.setScaleY(state.scaleY);
-          }
-        },
+        step: stepFunction,
       });
       this._addTween(
         identifier,

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -489,7 +489,7 @@ namespace gdjs {
       const newTweenable = TweenRuntimeBehavior.makeNewTweenable(
         this._runtimeScene
       );
-      let stepFunction: { (state: any): void; (state: any): void };
+      let stepFunction;
       if (scaleFromCenterOfObject) {
         stepFunction = function step(state) {
           const oldX = that.owner.getCenterXInScene();
@@ -554,7 +554,7 @@ namespace gdjs {
       const newTweenable = TweenRuntimeBehavior.makeNewTweenable(
         this._runtimeScene
       );
-      let stepFunction: { (state: any): void; (state: any): void };
+      let stepFunction;
       if (scaleFromCenterOfObject) {
         stepFunction = function step(state) {
           const oldY = that.owner.getCenterYInScene();

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -381,6 +381,7 @@ namespace gdjs {
      * @param easingValue Type of easing
      * @param durationValue Duration in milliseconds
      * @param destroyObjectWhenFinished Destroy this object when the tween ends
+     * @param scaleFromCenterOfObject Scale the transform from the center of the object (or point that is called center), not the top-left origin
      */
     addObjectScaleTween(
       identifier: string,
@@ -388,7 +389,8 @@ namespace gdjs {
       toScaleY: number,
       easingValue: string,
       durationValue: float,
-      destroyObjectWhenFinished: boolean
+      destroyObjectWhenFinished: boolean, 
+      scaleFromCenterOfObject: boolean
     ) {
       const that = this;
       if (!this._isActive) {
@@ -424,10 +426,20 @@ namespace gdjs {
         duration: durationValue,
         easing: easingValue,
         step: function step(state) {
-          // @ts-ignore - objects are duck typed
-          that.owner.setScaleX(state.scaleX);
-          // @ts-ignore - objects are duck typed
-          that.owner.setScaleY(state.scaleY);
+          if(scaleFromCenterOfObject) {
+            const oldX = that.owner.getCenterXInScene();
+            const oldY = that.owner.getCenterYInScene();
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleX(state.scaleX);
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleY(state.scaleY);
+            that.owner.setCenterPositionInScene(oldX, oldY);
+          } else {
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleX(state.scaleX);
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleY(state.scaleY);
+          }
         },
       });
       this._addTween(
@@ -446,13 +458,15 @@ namespace gdjs {
      * @param easingValue Type of easing
      * @param durationValue Duration in milliseconds
      * @param destroyObjectWhenFinished Destroy this object when the tween ends
+     * @param scaleFromCenterOfObject Scale the transform from the center of the object (or point that is called center), not the top-left origin
      */
     addObjectScaleXTween(
       identifier: string,
       toScaleX: number,
       easingValue: string,
       durationValue: float,
-      destroyObjectWhenFinished: boolean
+      destroyObjectWhenFinished: boolean,
+      scaleFromCenterOfObject: boolean
     ) {
       const that = this;
       if (!this._isActive) {
@@ -478,8 +492,15 @@ namespace gdjs {
         duration: durationValue,
         easing: easingValue,
         step: function step(state) {
-          // @ts-ignore - objects are duck typed
-          that.owner.setScaleX(state.scaleX);
+          if(scaleFromCenterOfObject) {
+            const oldX = that.owner.getCenterXInScene();
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleX(state.scaleX);
+            that.owner.setCenterXInScene(oldX);
+          } else {
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleX(state.scaleX);
+          }
         },
       });
       this._addTween(
@@ -498,13 +519,15 @@ namespace gdjs {
      * @param easingValue Type of easing
      * @param durationValue Duration in milliseconds
      * @param destroyObjectWhenFinished Destroy this object when the tween ends
+     * @param scaleFromCenterOfObject Scale the transform from the center of the object (or point that is called center), not the top-left origin
      */
     addObjectScaleYTween(
       identifier: string,
       toScaleY: number,
       easingValue: string,
       durationValue: float,
-      destroyObjectWhenFinished: boolean
+      destroyObjectWhenFinished: boolean,
+      scaleFromCenterOfObject: boolean
     ) {
       const that = this;
       if (!this._isActive) {
@@ -530,8 +553,15 @@ namespace gdjs {
         duration: durationValue,
         easing: easingValue,
         step: function step(state) {
-          // @ts-ignore - objects are duck typed
-          that.owner.setScaleY(state.scaleY);
+          if(scaleFromCenterOfObject) {
+            const oldY = that.owner.getCenterYInScene();
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleY(state.scaleY);
+            that.owner.setCenterYInScene(oldY);
+          } else {
+            // @ts-ignore - objects are duck typed
+            that.owner.setScaleY(state.scaleY);
+          }
         },
       });
       this._addTween(

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -389,7 +389,7 @@ namespace gdjs {
       toScaleY: number,
       easingValue: string,
       durationValue: float,
-      destroyObjectWhenFinished: boolean, 
+      destroyObjectWhenFinished: boolean,
       scaleFromCenterOfObject: boolean
     ) {
       const that = this;
@@ -416,7 +416,7 @@ namespace gdjs {
         this._runtimeScene
       );
       let stepFunction;
-      if(scaleFromCenterOfObject) {
+      if (scaleFromCenterOfObject) {
         stepFunction = function step(state) {
           const oldX = that.owner.getCenterXInScene();
           const oldY = that.owner.getCenterYInScene();
@@ -425,14 +425,14 @@ namespace gdjs {
           // @ts-ignore - objects are duck typed
           that.owner.setScaleY(state.scaleY);
           that.owner.setCenterPositionInScene(oldX, oldY);
-        }
+        };
       } else {
         stepFunction = function step(state) {
           // @ts-ignore - objects are duck typed
           that.owner.setScaleX(state.scaleX);
           // @ts-ignore - objects are duck typed
           that.owner.setScaleY(state.scaleY);
-        }
+        };
       }
       newTweenable.setConfig({
         from: {
@@ -489,19 +489,19 @@ namespace gdjs {
       const newTweenable = TweenRuntimeBehavior.makeNewTweenable(
         this._runtimeScene
       );
-      let stepFunction: { (state: any): void; (state: any): void; };
-      if(scaleFromCenterOfObject) {
+      let stepFunction: { (state: any): void; (state: any): void };
+      if (scaleFromCenterOfObject) {
         stepFunction = function step(state) {
           const oldX = that.owner.getCenterXInScene();
           // @ts-ignore - objects are duck typed
           that.owner.setScaleX(state.scaleX);
           that.owner.setCenterXInScene(oldX);
-        }
+        };
       } else {
         stepFunction = function step(state) {
           // @ts-ignore - objects are duck typed
           that.owner.setScaleX(state.scaleX);
-        }
+        };
       }
       newTweenable.setConfig({
         // @ts-ignore - objects are duck typed
@@ -554,19 +554,19 @@ namespace gdjs {
       const newTweenable = TweenRuntimeBehavior.makeNewTweenable(
         this._runtimeScene
       );
-      let stepFunction: { (state: any): void; (state: any): void; };
-      if(scaleFromCenterOfObject) {
+      let stepFunction: { (state: any): void; (state: any): void };
+      if (scaleFromCenterOfObject) {
         stepFunction = function step(state) {
           const oldY = that.owner.getCenterYInScene();
           // @ts-ignore - objects are duck typed
           that.owner.setScaleY(state.scaleY);
           that.owner.setCenterYInScene(oldY);
-        }
+        };
       } else {
         stepFunction = function step(state) {
           // @ts-ignore - objects are duck typed
           that.owner.setScaleY(state.scaleY);
-        }
+        };
       }
       newTweenable.setConfig({
         // @ts-ignore - objects are duck typed


### PR DESCRIPTION
When using the scaleXY, scaleX or scaleY tweens, a new yes/no parameter allows you to anchor the object to its center for the scale transform, not the top/left origin. For objects that have the center point moved, this point is the anchor for the transform.
(This is my second attempt at this pull/push request; the first has been closed.)