### PR TITLE
Fix same points set to true for an instant

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
@@ -51,9 +51,9 @@ const PointsEditor = (props: Props) => {
   const [directionIndex, setDirectionIndex] = React.useState(0);
   const [spriteIndex, setSpriteIndex] = React.useState(0);
   const [samePointsForAnimations, setSamePointsForAnimations] = React.useState(
-    true
+    false
   );
-  const [samePointsForSprites, setSamePointsForSprites] = React.useState(true);
+  const [samePointsForSprites, setSamePointsForSprites] = React.useState(false);
   const forceUpdate = useForceUpdate();
 
   const spriteObject = gd.asSpriteObject(props.object);


### PR DESCRIPTION
Fixes #2631.
This bug stemmed from refactoring PointsEditor to a functional component - change in the component lifecycle meant that the default true values for React states `samePointsForAnimations` and `samePointsForSprites` were used for the first `updatePoints` call.

Right now I've just added a simple fix - the default values are now `false`. So that instant where the values are not set to the correct values does not have any side effects. An ideal fix would safeguard the component against the transient state, I haven't tried that yet.