### PR TITLE
Fix grid magnet at the object creation when the magnet position is not an integer.

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -122,8 +122,8 @@ export default class InstancesAdder {
   ): Array<gdInitialInstance> => {
     const newPos = roundPositionsToGrid(pos, this._options);
     this._temporaryInstances.forEach(instance => {
-      instance.setX(Math.round(newPos[0]));
-      instance.setY(Math.round(newPos[1]));
+      instance.setX(newPos[0]);
+      instance.setY(newPos[1]);
     });
 
     return this._temporaryInstances;


### PR DESCRIPTION
Pixel isometric grids are normally even so the issue should not happen.
For the city builder example, I used an odd height to show some kind of light grid.
As half the height is #,5 some elements on the grid won't have an integer y position.

The issue happens only when objects are created and not moved. So either it should always be rounded or either never.
I think it should not be rounded because it messes with the grid logic and roundPositionsToGrid() already do it if there is no grid.

Project example:
![InstanceAdderBadRounded](https://user-images.githubusercontent.com/2611977/118375245-d9f51d00-b5c0-11eb-9227-df989b4c5adb.png)
[AdderGridBug.zip](https://github.com/4ian/GDevelop/files/6488006/AdderGridBug.zip)
