### PR TITLE
Add padding option for effects on layers 

### DIFF
--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -130,7 +130,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     const asciiEffect = extension
       .addEffect('Ascii')
@@ -423,7 +423,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     const displacementEffect = extension
       .addEffect('Displacement')
@@ -528,7 +528,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     const glitchEffect = extension
       .addEffect('Glitch')
@@ -703,7 +703,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     const kawaseBlurEffect = extension
       .addEffect('KawaseBlur')
@@ -739,7 +739,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     const lightNightEffect = extension
       .addEffect('LightNight')
@@ -874,7 +874,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     const pixelateEffect = extension
       .addEffect('Pixelate')
@@ -932,7 +932,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     const reflectionEffect = extension
       .addEffect('Reflection')
@@ -1103,7 +1103,7 @@ module.exports = {
       .setValue('20')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
     twistProperties
       .getOrCreate('offsetX')
       .setValue('0.5')
@@ -1147,7 +1147,7 @@ module.exports = {
       .setValue('0')
       .setLabel(_('Padding'))
       .setType('number')
-      .setDescription(_('Padding for filter area'));
+      .setDescription(_('Padding for the visual effect area'));
 
     return extension;
   },

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -125,6 +125,12 @@ module.exports = {
       .setValue('7')
       .setLabel(_('Quality (between 0 and 20)'))
       .setType('number');
+    advancedBloomProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     const asciiEffect = extension
       .addEffect('Ascii')
@@ -412,6 +418,12 @@ module.exports = {
       .setLabel(_('Noise Frequency'))
       .setType('number')
       .setDescription('Number of updates per second (0: no updates)');
+    crtProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     const displacementEffect = extension
       .addEffect('Displacement')
@@ -511,6 +523,12 @@ module.exports = {
       .setValue('false')
       .setLabel(_('Shadow only (shows only the shadow when enabled)'))
       .setType('boolean');
+    dropShadowProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     const glitchEffect = extension
       .addEffect('Glitch')
@@ -680,6 +698,12 @@ module.exports = {
       .setValue('100')
       .setLabel(_('Center Y (between -1000 and 100)'))
       .setType('number');
+    godrayProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     const kawaseBlurEffect = extension
       .addEffect('KawaseBlur')
@@ -710,6 +734,12 @@ module.exports = {
       .setValue('3')
       .setLabel(_('Quality (between 1 and 20)'))
       .setType('number');
+    kawaseBlurProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     const lightNightEffect = extension
       .addEffect('LightNight')
@@ -897,6 +927,12 @@ module.exports = {
       .setValue('0.5')
       .setLabel(_('Center Y (between 0 and 1, 0.5 is image middle)'))
       .setType('number');
+    radialBlurProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     const reflectionEffect = extension
       .addEffect('Reflection')
@@ -1106,6 +1142,12 @@ module.exports = {
       .setValue('0.3')
       .setLabel(_('strength (between 0 and 5)'))
       .setType('number');
+    zoomBlurProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     return extension;
   },

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -839,6 +839,12 @@ module.exports = {
       .setValue('1')
       .setLabel(_('Color of the outline'))
       .setType('color');
+    outlineProperties
+      .getOrCreate('padding')
+      .setValue('0')
+      .setLabel(_('Padding'))
+      .setType('number')
+      .setDescription(_('Padding for filter area'));
 
     const pixelateEffect = extension
       .addEffect('Pixelate')

--- a/Extensions/Effects/advanced-bloom-pixi-filter.ts
+++ b/Extensions/Effects/advanced-bloom-pixi-filter.ts
@@ -17,6 +17,8 @@ namespace gdjs {
         advancedBloomFilter.blur = value;
       } else if (parameterName === 'quality') {
         advancedBloomFilter.quality = value;
+      } else if (parameterName === 'padding') {
+        advancedBloomFilter.padding = value;
       }
     },
     updateStringParameter: function (filter, parameterName, value) {},

--- a/Extensions/Effects/crt-pixi-filter.ts
+++ b/Extensions/Effects/crt-pixi-filter.ts
@@ -42,6 +42,8 @@ namespace gdjs {
         filter.animationSpeed = value;
       } else if (parameterName === 'animationFrequency') {
         filter.animationFrequency = value;
+      } else if (parameterName === 'padding') {
+        filter.padding = value;
       }
     },
     updateStringParameter: function (filter, parameterName, value) {},

--- a/Extensions/Effects/drop-shadow-pixi-filter.ts
+++ b/Extensions/Effects/drop-shadow-pixi-filter.ts
@@ -17,6 +17,8 @@ namespace gdjs {
         dropShadowFilter.distance = value;
       } else if (parameterName === 'rotation') {
         dropShadowFilter.rotation = value;
+      } else if (parameterName === 'padding') {
+        dropShadowFilter.padding = value;
       }
     },
     updateStringParameter: function (filter, parameterName, value) {

--- a/Extensions/Effects/godray-pixi-filter.ts
+++ b/Extensions/Effects/godray-pixi-filter.ts
@@ -26,6 +26,8 @@ namespace gdjs {
         filter.y = value;
       } else if (parameterName === 'animationSpeed') {
         filter.animationSpeed = value;
+      } else if (parameterName === 'padding') {
+        filter.padding = value;
       }
     },
     updateStringParameter: function (filter, parameterName, value) {},

--- a/Extensions/Effects/outline-pixi-filter.ts
+++ b/Extensions/Effects/outline-pixi-filter.ts
@@ -9,6 +9,8 @@ namespace gdjs {
       const outlineFilter = (filter as unknown) as PIXI.filters.OutlineFilter;
       if (parameterName === 'thickness') {
         outlineFilter.thickness = value;
+      } else if (parameterName === 'padding') {
+        outlineFilter.padding = value;
       }
     },
     updateStringParameter: function (filter, parameterName, value) {

--- a/Extensions/Effects/radial-blur-pixi-filter.ts
+++ b/Extensions/Effects/radial-blur-pixi-filter.ts
@@ -33,6 +33,8 @@ namespace gdjs {
       } else if (parameterName === 'centerY') {
         // @ts-ignore - extra properties are stored on the filter.
         radialBlurFilter._centerY = value;
+      } else if (parameterName === 'padding') {
+        radialBlurFilter.padding = value;
       }
     },
     updateStringParameter: function (filter, parameterName, value) {},

--- a/Extensions/Effects/zoom-blur-pixi-filter.ts
+++ b/Extensions/Effects/zoom-blur-pixi-filter.ts
@@ -31,6 +31,8 @@ namespace gdjs {
           0,
           20
         );
+      } else if (parameterName === 'padding') {
+        zoomBlurFilter.padding = value;
       }
     },
     updateStringParameter: function (filter, parameterName, value) {},


### PR DESCRIPTION
# Description

Actually objects and specially objects with a small padding can't render the effect correctly.
@Silver-Streak make me realize that happend specially because he try to break the Bitmap Text object ^^

I tested the effects which had a risk of overflow and I added the padding option.

@HarsimranVirk in the next week this will be an important option on effects for objects, that should if possible done by the engine, like for a blur parameter use this value, multiply by two and ad this value to the padding, something like that what do you think?


![image](https://user-images.githubusercontent.com/1670670/118658164-6df6fc80-b7ec-11eb-9ddb-a8da2d1d7f86.png)
There is also as you can see a issue in the filter area, the effect are applied on a container which wrap the objects on the layer.
See on screen, both objects are on the same layer and there is nothing else, i've added a CRT effect on the layer, the result is limited to the AABB on these objects.
The attemped result would be a CRT effect on the whole screen no ? As user I found it's a weird result that not fulfill my attempt when I use an effect on layers.


# Compare results


With a padding of 100:
![image](https://user-images.githubusercontent.com/1670670/118658420-a4cd1280-b7ec-11eb-875e-29e2225a13a4.png)



Top: padding = 0 (default)
Bottom: padding = 10

![image](https://user-images.githubusercontent.com/1670670/118649496-dab9c900-b7e3-11eb-92cc-e304fce119f0.png)

Another example with advanced bloom on a sprite, top padding=0, bottom padding=100:
![image](https://user-images.githubusercontent.com/1670670/118653893-47cf5d80-b7e8-11eb-8f1c-86d8e7d3178d.png)

A last example with radial blur:
![image](https://user-images.githubusercontent.com/1670670/118660311-5b7dc280-b7ee-11eb-8672-c627e6a8d363.png)


