### PR TITLE
Fix text height

### DIFF
--- a/Extensions/BitmapText/JsExtension.js
+++ b/Extensions/BitmapText/JsExtension.js
@@ -684,9 +684,9 @@ module.exports = {
       }
 
       this._pixiObject.position.x =
-        this._instance.getX() + this._pixiObject.width / 2;
+        this._instance.getX() + this._pixiObject.textWidth / 2;
       this._pixiObject.position.y =
-        this._instance.getY() + this._pixiObject.height / 2;
+        this._instance.getY() + this._pixiObject.textHeight / 2;
       this._pixiObject.rotation = RenderedInstance.toRad(
         this._instance.getAngle()
       );

--- a/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
@@ -149,9 +149,8 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      this._pixiObject.position.x = this._object.x + this._pixiObject.width / 2;
-      this._pixiObject.position.y =
-        this._object.y + this._pixiObject.height / 2;
+      this._pixiObject.position.x = this._object.x + this.getWidth() / 2;
+      this._pixiObject.position.y = this._object.y + this.getHeight() / 2;
     }
 
     updateAngle(): void {
@@ -167,7 +166,7 @@ namespace gdjs {
     }
 
     getHeight(): float {
-      return this._pixiObject.height;
+      return this._pixiObject.textHeight;
     }
   }
   export const BitmapTextRuntimeObjectRenderer = BitmapTextRuntimeObjectPixiRenderer;


### PR DESCRIPTION
When a bitmap text have an empty line the position of the text is wrong.
![image](https://user-images.githubusercontent.com/1670670/119258582-97d46880-bbca-11eb-9fe0-d69fd546fdc2.png)


B110: 
![image](https://user-images.githubusercontent.com/1670670/119258572-8ee39700-bbca-11eb-8a8f-9e910be6c7ed.png)



--- 

This PR: 
![image](https://user-images.githubusercontent.com/1670670/119258579-95720e80-bbca-11eb-8318-183bbce22802.png)



[Source forum](https://forum.gdevelop-app.com/t/newline-in-bitmap-text-object/32712/18)