### PR TITLE
Make extension dependencies only exported when the extension is used

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -106,7 +106,9 @@
         "xstring": "cpp",
         "xtr1common": "cpp",
         "xtree": "cpp",
-        "xutility": "cpp"
+        "xutility": "cpp",
+        "xlocbuf": "cpp",
+        "xlocmes": "cpp"
     },
     "files.exclude": {
         "Binaries/*build*": true,

--- a/Core/GDCore/IDE/ExportedDependencyResolver.h
+++ b/Core/GDCore/IDE/ExportedDependencyResolver.h
@@ -21,7 +21,7 @@ struct DependencyMetadataAndExtension {
   gd::DependencyMetadata &GetDependency() const { return *dependency; };
   gd::PlatformExtension &GetExtension() const { return *extension; };
 
-private:
+ private:
   gd::DependencyMetadata *dependency;
   gd::PlatformExtension *extension;
 };
@@ -31,20 +31,20 @@ private:
  * with a game.
  */
 class ExportedDependencyResolver {
-public:
+ public:
   /**
-   * \brief Return the list of dependencies to be exported for the given project, 
-   * used extensions list and dependency type.
+   * \brief Return the list of dependencies to be exported for the given
+   * project, used extensions list and dependency type.
    *
    * Not all dependencies declared by extensions must be exported: some are only
    * exported when some settings are filled. Then, some others are only exported
    * when some other dependencies are exported (this won't work for more than
    * one level though).
    */
-  static std::vector<DependencyMetadataAndExtension>
-  GetDependenciesFor(const gd::Project &project,
-                     std::set<gd::String> usedExtensions,
-                     const gd::String &dependencyType) {
+  static std::vector<DependencyMetadataAndExtension> GetDependenciesFor(
+      const gd::Project &project,
+      std::set<gd::String> usedExtensions,
+      const gd::String &dependencyType) {
     std::vector<DependencyMetadataAndExtension> dependenciesWithProperType;
     for (const gd::String &extensionName : usedExtensions) {
       auto extension = project.GetCurrentPlatform().GetExtension(extensionName);
@@ -123,4 +123,4 @@ public:
   };
 };
 
-} // namespace gd
+}  // namespace gd

--- a/Core/GDCore/IDE/ExportedDependencyResolver.h
+++ b/Core/GDCore/IDE/ExportedDependencyResolver.h
@@ -14,16 +14,16 @@ namespace gd {
  * \note Both objects must be kept alive, as this is keeping a pointer to them.
  */
 struct DependencyMetadataAndExtension {
-  DependencyMetadataAndExtension(gd::DependencyMetadata& dependency_,
-                                 gd::PlatformExtension& extension_)
+  DependencyMetadataAndExtension(gd::DependencyMetadata &dependency_,
+                                 gd::PlatformExtension &extension_)
       : dependency(&dependency_), extension(&extension_){};
 
-  gd::DependencyMetadata& GetDependency() const { return *dependency; };
-  gd::PlatformExtension& GetExtension() const { return *extension; };
+  gd::DependencyMetadata &GetDependency() const { return *dependency; };
+  gd::PlatformExtension &GetExtension() const { return *extension; };
 
- private:
-  gd::DependencyMetadata* dependency;
-  gd::PlatformExtension* extension;
+private:
+  gd::DependencyMetadata *dependency;
+  gd::PlatformExtension *extension;
 };
 
 /**
@@ -31,22 +31,24 @@ struct DependencyMetadataAndExtension {
  * with a game.
  */
 class ExportedDependencyResolver {
- public:
+public:
   /**
-   * \brief Return the list of dependencies to be exported for the given project
-   * and dependency type.
+   * \brief Return the list of dependencies to be exported for the given project, 
+   * used extensions list and dependency type.
    *
    * Not all dependencies declared by extensions must be exported: some are only
    * exported when some settings are filled. Then, some others are only exported
    * when some other dependencies are exported (this won't work for more than
    * one level though).
    */
-  static std::vector<DependencyMetadataAndExtension> GetDependenciesFor(
-      const gd::Project& project, const gd::String& dependencyType) {
+  static std::vector<DependencyMetadataAndExtension>
+  GetDependenciesFor(const gd::Project &project,
+                     std::set<gd::String> usedExtensions,
+                     const gd::String &dependencyType) {
     std::vector<DependencyMetadataAndExtension> dependenciesWithProperType;
-    for (std::shared_ptr<gd::PlatformExtension> extension :
-         project.GetCurrentPlatform().GetAllPlatformExtensions()) {
-      for (gd::DependencyMetadata& dependency :
+    for (const gd::String &extensionName : usedExtensions) {
+      auto extension = project.GetCurrentPlatform().GetExtension(extensionName);
+      for (gd::DependencyMetadata &dependency :
            extension->GetAllDependencies()) {
         if (dependency.GetDependencyType() == dependencyType) {
           DependencyMetadataAndExtension dependencyMetadataAndExtension(
@@ -60,7 +62,7 @@ class ExportedDependencyResolver {
     // and those that don't require extra settings to be filled.
     std::vector<DependencyMetadataAndExtension> dependenciesWithFilledSettings;
     for (auto dependencyAndExtension : dependenciesWithProperType) {
-      auto& dependency = dependencyAndExtension.GetDependency();
+      auto &dependency = dependencyAndExtension.GetDependency();
       auto extraSettingValues = GetExtensionDependencyExtraSettingValues(
           project, dependencyAndExtension);
 
@@ -73,15 +75,15 @@ class ExportedDependencyResolver {
     // exported (or dependencies that don't require another dependency).
     std::vector<DependencyMetadataAndExtension> exportedDependencies;
     for (auto dependencyAndExtension : dependenciesWithFilledSettings) {
-      auto& dependency = dependencyAndExtension.GetDependency();
-      auto& otherDependencyName =
+      auto &dependency = dependencyAndExtension.GetDependency();
+      auto &otherDependencyName =
           dependency.GetOtherDependencyThatMustBeExported();
       if (otherDependencyName.empty() ||
           std::find_if(
               dependenciesWithFilledSettings.begin(),
               dependenciesWithFilledSettings.end(),
               [&otherDependencyName](
-                  DependencyMetadataAndExtension& otherDependencyAndExtension) {
+                  DependencyMetadataAndExtension &otherDependencyAndExtension) {
                 return otherDependencyAndExtension.GetDependency().GetName() ==
                        otherDependencyName;
               }) != dependenciesWithFilledSettings.end()) {
@@ -98,15 +100,15 @@ class ExportedDependencyResolver {
    */
   static std::map<gd::String, gd::String>
   GetExtensionDependencyExtraSettingValues(
-      const gd::Project& project,
-      const gd::DependencyMetadataAndExtension& dependencyAndExtension) {
+      const gd::Project &project,
+      const gd::DependencyMetadataAndExtension &dependencyAndExtension) {
     std::map<gd::String, gd::String> values;
-    auto& dependency = dependencyAndExtension.GetDependency();
-    const gd::String& extensionName =
+    auto &dependency = dependencyAndExtension.GetDependency();
+    const gd::String &extensionName =
         dependencyAndExtension.GetExtension().GetName();
 
-    for (const auto& extraSetting : dependency.GetAllExtraSettings()) {
-      const gd::String& type = extraSetting.second.GetType();
+    for (const auto &extraSetting : dependency.GetAllExtraSettings()) {
+      const gd::String &type = extraSetting.second.GetType();
       const gd::String extraSettingValue =
           type == "ExtensionProperty"
               ? project.GetExtensionProperties().GetValue(
@@ -121,4 +123,4 @@ class ExportedDependencyResolver {
   };
 };
 
-}  // namespace gd
+} // namespace gd

--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -28,7 +28,7 @@
 #include "GDJS/Events/CodeGeneration/EventsCodeGenerator.h"
 #include "GDJS/IDE/ExporterHelper.h"
 
-#undef CopyFile // Disable an annoying macro
+#undef CopyFile  // Disable an annoying macro
 
 namespace gdjs {
 
@@ -46,15 +46,16 @@ bool Exporter::ExportProjectForPixiPreview(
 }
 
 bool Exporter::ExportWholePixiProject(
-    gd::Project &project, gd::String exportDir,
+    gd::Project &project,
+    gd::String exportDir,
     std::map<gd::String, bool> &exportOptions) {
   ExporterHelper helper(fs, gdjsRoot, codeOutputDir);
   gd::Project exportedProject = project;
 
   auto usedExtensions = gd::UsedExtensionsFinder::ScanProject(project);
 
-  auto exportProject = [this, &exportedProject, &exportOptions,
-                        &helper](gd::String exportDir) {
+  auto exportProject = [this, &exportedProject, &exportOptions, &helper](
+                           gd::String exportDir) {
     bool exportForCordova = exportOptions["exportForCordova"];
     bool exportForFacebookInstantGames =
         exportOptions["exportForFacebookInstantGames"];
@@ -89,16 +90,16 @@ bool Exporter::ExportWholePixiProject(
     helper.ExportEffectIncludes(exportedProject, includesFiles);
 
     // Export events
-    if (!helper.ExportEventsCode(exportedProject, codeOutputDir, includesFiles,
-                                 false)) {
+    if (!helper.ExportEventsCode(
+            exportedProject, codeOutputDir, includesFiles, false)) {
       gd::LogError(_("Error during exporting! Unable to export events:\n") +
                    lastError);
       return false;
     }
 
     // Export source files
-    if (!helper.ExportExternalSourceFiles(exportedProject, codeOutputDir,
-                                          includesFiles)) {
+    if (!helper.ExportExternalSourceFiles(
+            exportedProject, codeOutputDir, includesFiles)) {
       gd::LogError(
           _("Error during exporting! Unable to export source files:\n") +
           lastError);
@@ -111,8 +112,8 @@ bool Exporter::ExportWholePixiProject(
 
     //...and export it
     gd::SerializerElement noRuntimeGameOptions;
-    helper.ExportProjectData(fs, exportedProject, codeOutputDir + "/data.js",
-                             noRuntimeGameOptions);
+    helper.ExportProjectData(
+        fs, exportedProject, codeOutputDir + "/data.js", noRuntimeGameOptions);
     includesFiles.push_back(codeOutputDir + "/data.js");
 
     // Copy all dependencies and the index (or metadata) file.
@@ -125,9 +126,12 @@ bool Exporter::ExportWholePixiProject(
     else if (exportForFacebookInstantGames)
       source = gdjsRoot + "/Runtime/FacebookInstantGames/index.html";
 
-    if (!helper.ExportPixiIndexFile(exportedProject, source, exportDir,
+    if (!helper.ExportPixiIndexFile(exportedProject,
+                                    source,
+                                    exportDir,
                                     includesFiles,
-                                    /*nonRuntimeScriptsCacheBurst=*/0, "")) {
+                                    /*nonRuntimeScriptsCacheBurst=*/0,
+                                    "")) {
       gd::LogError(_("Error during export:\n") + lastError);
       return false;
     }
@@ -139,34 +143,31 @@ bool Exporter::ExportWholePixiProject(
     fs.MkDir(exportDir);
     fs.MkDir(exportDir + "/www");
 
-    if (!exportProject(exportDir + "/www"))
-      return false;
+    if (!exportProject(exportDir + "/www")) return false;
 
     if (!helper.ExportCordovaFiles(exportedProject, exportDir, usedExtensions))
       return false;
   } else if (exportOptions["exportForElectron"]) {
     fs.MkDir(exportDir);
 
-    if (!exportProject(exportDir + "/app"))
-      return false;
+    if (!exportProject(exportDir + "/app")) return false;
 
     if (!helper.ExportElectronFiles(exportedProject, exportDir, usedExtensions))
       return false;
   } else if (exportOptions["exportForFacebookInstantGames"]) {
-    if (!exportProject(exportDir))
-      return false;
+    if (!exportProject(exportDir)) return false;
 
     if (!helper.ExportFacebookInstantGamesFiles(exportedProject, exportDir))
       return false;
   } else {
-    if (!exportProject(exportDir))
-      return false;
+    if (!exportProject(exportDir)) return false;
   }
 
   return true;
 }
 
-bool Exporter::ExportWholeCocos2dProject(gd::Project &project, bool debugMode,
+bool Exporter::ExportWholeCocos2dProject(gd::Project &project,
+                                         bool debugMode,
                                          gd::String exportDir) {
   ExporterHelper helper(fs, gdjsRoot, codeOutputDir);
 
@@ -200,16 +201,16 @@ bool Exporter::ExportWholeCocos2dProject(gd::Project &project, bool debugMode,
   helper.ExportEffectIncludes(exportedProject, includesFiles);
 
   // Export events
-  if (!helper.ExportEventsCode(exportedProject, codeOutputDir, includesFiles,
-                               false)) {
+  if (!helper.ExportEventsCode(
+          exportedProject, codeOutputDir, includesFiles, false)) {
     gd::LogError(_("Error during exporting! Unable to export events:\n") +
                  lastError);
     return false;
   }
 
   // Export source files
-  if (!helper.ExportExternalSourceFiles(exportedProject, codeOutputDir,
-                                        includesFiles)) {
+  if (!helper.ExportExternalSourceFiles(
+          exportedProject, codeOutputDir, includesFiles)) {
     gd::LogError(_("Error during exporting! Unable to export source files:\n") +
                  lastError);
     return false;
@@ -221,16 +222,16 @@ bool Exporter::ExportWholeCocos2dProject(gd::Project &project, bool debugMode,
 
   //...and export it
   gd::SerializerElement noRuntimeGameOptions;
-  helper.ExportProjectData(fs, exportedProject, codeOutputDir + "/data.js",
-                           noRuntimeGameOptions);
+  helper.ExportProjectData(
+      fs, exportedProject, codeOutputDir + "/data.js", noRuntimeGameOptions);
   includesFiles.push_back(codeOutputDir + "/data.js");
 
   // Copy all dependencies and the index (or metadata) file.
   helper.RemoveIncludes(true, false, includesFiles);
   helper.ExportIncludesAndLibs(includesFiles, exportDir + "/src", false);
 
-  if (!helper.ExportCocos2dFiles(project, exportDir, debugMode,
-                                 includesFiles)) {
+  if (!helper.ExportCocos2dFiles(
+          project, exportDir, debugMode, includesFiles)) {
     gd::LogError(_("Error during export:\n") + lastError);
     return false;
   }
@@ -238,4 +239,4 @@ bool Exporter::ExportWholeCocos2dProject(gd::Project &project, bool debugMode,
   return true;
 }
 
-} // namespace gdjs
+}  // namespace gdjs

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -38,7 +38,7 @@
 #include "GDCore/Tools/Log.h"
 #include "GDJS/Events/CodeGeneration/LayoutCodeGenerator.h"
 #include "GDJS/Extensions/JsPlatform.h"
-#undef CopyFile  // Disable an annoying macro
+#undef CopyFile // Disable an annoying macro
 
 namespace {
 double GetTimeNow() {
@@ -56,7 +56,7 @@ double LogTimeSpent(const gd::String &name, double previousTime) {
   std::cout << std::endl;
   return GetTimeNow();
 }
-}  // namespace
+} // namespace
 
 namespace gdjs {
 
@@ -66,8 +66,7 @@ static void InsertUnique(std::vector<gd::String> &container, gd::String str) {
 }
 
 ExporterHelper::ExporterHelper(gd::AbstractFileSystem &fileSystem,
-                               gd::String gdjsRoot_,
-                               gd::String codeOutputDir_)
+                               gd::String gdjsRoot_, gd::String codeOutputDir_)
     : fs(fileSystem), gdjsRoot(gdjsRoot_), codeOutputDir(codeOutputDir_){};
 
 bool ExporterHelper::ExportProjectForPixiPreview(
@@ -113,8 +112,8 @@ bool ExporterHelper::ExportProjectForPixiPreview(
       return false;
 
     // Export source files
-    if (!ExportExternalSourceFiles(
-            exportedProject, codeOutputDir, includesFiles)) {
+    if (!ExportExternalSourceFiles(exportedProject, codeOutputDir,
+                                   includesFiles)) {
       gd::LogError(
           _("Error during exporting! Unable to export source files:\n") +
           lastError);
@@ -159,14 +158,14 @@ bool ExporterHelper::ExportProjectForPixiPreview(
     gd::String scriptSrc = GetExportedIncludeFilename(includeFile);
     scriptFilesElement.AddChild("scriptFile")
         .SetStringAttribute("path", scriptSrc)
-        .SetIntAttribute(
-            "hash",
-            hashIt != options.includeFileHashes.end() ? hashIt->second : 0);
+        .SetIntAttribute("hash", hashIt != options.includeFileHashes.end()
+                                     ? hashIt->second
+                                     : 0);
   }
 
   // Export the project
-  ExportProjectData(
-      fs, exportedProject, codeOutputDir + "/data.js", runtimeGameOptions);
+  ExportProjectData(fs, exportedProject, codeOutputDir + "/data.js",
+                    runtimeGameOptions);
   includesFiles.push_back(codeOutputDir + "/data.js");
 
   previousTime = LogTimeSpent("Project data export", previousTime);
@@ -175,10 +174,8 @@ bool ExporterHelper::ExportProjectForPixiPreview(
   ExportIncludesAndLibs(includesFiles, options.exportPath, true);
 
   // Create the index file
-  if (!ExportPixiIndexFile(exportedProject,
-                           gdjsRoot + "/Runtime/index.html",
-                           options.exportPath,
-                           includesFiles,
+  if (!ExportPixiIndexFile(exportedProject, gdjsRoot + "/Runtime/index.html",
+                           options.exportPath, includesFiles,
                            options.nonRuntimeScriptsCacheBurst,
                            "gdjs.runtimeGameOptions"))
     return false;
@@ -188,9 +185,7 @@ bool ExporterHelper::ExportProjectForPixiPreview(
 }
 
 gd::String ExporterHelper::ExportProjectData(
-    gd::AbstractFileSystem &fs,
-    const gd::Project &project,
-    gd::String filename,
+    gd::AbstractFileSystem &fs, const gd::Project &project, gd::String filename,
     const gd::SerializerElement &runtimeGameOptions) {
   fs.MkDir(fs.DirNameFrom(filename));
 
@@ -202,26 +197,21 @@ gd::String ExporterHelper::ExportProjectData(
       "gdjs.runtimeGameOptions = " +
       gd::Serializer::ToJSON(runtimeGameOptions) + ";\n";
 
-  if (!fs.WriteToFile(filename, output)) return "Unable to write " + filename;
+  if (!fs.WriteToFile(filename, output))
+    return "Unable to write " + filename;
 
   return "";
 }
 
 bool ExporterHelper::ExportPixiIndexFile(
-    const gd::Project &project,
-    gd::String source,
-    gd::String exportDir,
+    const gd::Project &project, gd::String source, gd::String exportDir,
     const std::vector<gd::String> &includesFiles,
-    unsigned int nonRuntimeScriptsCacheBurst,
-    gd::String additionalSpec) {
+    unsigned int nonRuntimeScriptsCacheBurst, gd::String additionalSpec) {
   gd::String str = fs.ReadFile(source);
 
   // Generate the file
-  if (!CompleteIndexFile(str,
-                         exportDir,
-                         includesFiles,
-                         nonRuntimeScriptsCacheBurst,
-                         additionalSpec))
+  if (!CompleteIndexFile(str, exportDir, includesFiles,
+                         nonRuntimeScriptsCacheBurst, additionalSpec))
     return false;
 
   // Write the index.html file
@@ -234,12 +224,13 @@ bool ExporterHelper::ExportPixiIndexFile(
 }
 
 bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
-                                        gd::String exportDir) {
+                                        gd::String exportDir,
+                                        std::set<gd::String> usedExtensions) {
   auto &platformSpecificAssets = project.GetPlatformSpecificAssets();
   auto &resourceManager = project.GetResourcesManager();
-  auto getIconFilename = [&resourceManager, &platformSpecificAssets](
-                             const gd::String &platform,
-                             const gd::String &name) {
+  auto getIconFilename = [&resourceManager,
+                          &platformSpecificAssets](const gd::String &platform,
+                                                   const gd::String &name) {
     const gd::String &file =
         resourceManager.GetResource(platformSpecificAssets.Get(platform, name))
             .GetFile();
@@ -247,12 +238,9 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
   };
 
   auto makeIconsAndroid = [&getIconFilename]() {
-    std::vector<std::pair<gd::String, gd::String>> sizes = {{"36", "ldpi"},
-                                                            {"48", "mdpi"},
-                                                            {"72", "hdpi"},
-                                                            {"96", "xhdpi"},
-                                                            {"144", "xxhdpi"},
-                                                            {"192", "xxxhdpi"}};
+    std::vector<std::pair<gd::String, gd::String>> sizes = {
+        {"36", "ldpi"},  {"48", "mdpi"},    {"72", "hdpi"},
+        {"96", "xhdpi"}, {"144", "xxhdpi"}, {"192", "xxxhdpi"}};
 
     gd::String output;
     for (auto &size : sizes) {
@@ -294,7 +282,8 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
 
   gd::String plugins = "";
   auto dependenciesAndExtensions =
-      gd::ExportedDependencyResolver::GetDependenciesFor(project, "cordova");
+      gd::ExportedDependencyResolver::GetDependenciesFor(
+          project, usedExtensions, "cordova");
   for (auto &dependencyAndExtension : dependenciesAndExtensions) {
     const auto &dependency = dependencyAndExtension.GetDependency();
 
@@ -364,9 +353,7 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
 }
 
 bool ExporterHelper::ExportCocos2dFiles(
-    const gd::Project &project,
-    gd::String exportDir,
-    bool debugMode,
+    const gd::Project &project, gd::String exportDir, bool debugMode,
     const std::vector<gd::String> &includesFiles) {
   if (!fs.CopyFile(gdjsRoot + "/Runtime/Cocos2d/main.js",
                    exportDir + "/main.js")) {
@@ -389,11 +376,8 @@ bool ExporterHelper::ExportCocos2dFiles(
 
     // Generate the file
     std::vector<gd::String> noIncludesInThisFile;
-    if (!CompleteIndexFile(str,
-                           exportDir,
-                           noIncludesInThisFile,
-                           /*nonRuntimeScriptsCacheBurst=*/0,
-                           "")) {
+    if (!CompleteIndexFile(str, exportDir, noIncludesInThisFile,
+                           /*nonRuntimeScriptsCacheBurst=*/0, "")) {
       lastError = "Unable to complete Cocos2d-JS index.html file.";
       return false;
     }
@@ -462,7 +446,8 @@ bool ExporterHelper::ExportFacebookInstantGamesFiles(const gd::Project &project,
 }
 
 bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
-                                         gd::String exportDir) {
+                                         gd::String exportDir,
+                                         std::set<gd::String> usedExtensions) {
   gd::String jsonName =
       gd::Serializer::ToJSON(gd::SerializerElement(project.GetName()));
   gd::String jsonPackageName =
@@ -489,16 +474,16 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
     gd::String packages = "";
 
     auto dependenciesAndExtensions =
-        gd::ExportedDependencyResolver::GetDependenciesFor(project, "npm");
+        gd::ExportedDependencyResolver::GetDependenciesFor(
+            project, usedExtensions, "npm");
     for (auto &dependencyAndExtension : dependenciesAndExtensions) {
       const auto &dependency = dependencyAndExtension.GetDependency();
       if (dependency.GetVersion() == "") {
-        gd::LogError(
-            "Latest Version not available for NPM dependencies, "
-            "dependency " +
-            dependency.GetName() +
-            " is not exported. Please specify a version when calling "
-            "addDependency.");
+        gd::LogError("Latest Version not available for NPM dependencies, "
+                     "dependency " +
+                     dependency.GetName() +
+                     " is not exported. Please specify a version when calling "
+                     "addDependency.");
         continue;
       }
 
@@ -557,12 +542,11 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
 }
 
 bool ExporterHelper::CompleteIndexFile(
-    gd::String &str,
-    gd::String exportDir,
+    gd::String &str, gd::String exportDir,
     const std::vector<gd::String> &includesFiles,
-    unsigned int nonRuntimeScriptsCacheBurst,
-    gd::String additionalSpec) {
-  if (additionalSpec.empty()) additionalSpec = "{}";
+    unsigned int nonRuntimeScriptsCacheBurst, gd::String additionalSpec) {
+  if (additionalSpec.empty())
+    additionalSpec = "{}";
 
   gd::String codeFilesIncludes;
   for (auto &include : includesFiles) {
@@ -591,8 +575,7 @@ bool ExporterHelper::CompleteIndexFile(
   return true;
 }
 
-void ExporterHelper::AddLibsInclude(bool pixiRenderers,
-                                    bool cocosRenderers,
+void ExporterHelper::AddLibsInclude(bool pixiRenderers, bool cocosRenderers,
                                     bool websocketDebuggerClient,
                                     std::vector<gd::String> &includesFiles) {
   // First, do not forget common includes (they must be included before events
@@ -681,8 +664,7 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
   }
 }
 
-void ExporterHelper::RemoveIncludes(bool pixiRenderers,
-                                    bool cocosRenderers,
+void ExporterHelper::RemoveIncludes(bool pixiRenderers, bool cocosRenderers,
                                     std::vector<gd::String> &includesFiles) {
   if (pixiRenderers) {
     for (size_t i = 0; i < includesFiles.size();) {
@@ -713,7 +695,8 @@ bool ExporterHelper::ExportEffectIncludes(
   gd::EffectsCodeGenerator::GenerateEffectsIncludeFiles(
       project.GetCurrentPlatform(), project, effectIncludes);
 
-  for (auto &include : effectIncludes) InsertUnique(includesFiles, include);
+  for (auto &include : effectIncludes)
+    InsertUnique(includesFiles, include);
 
   return true;
 }
@@ -735,7 +718,8 @@ bool ExporterHelper::ExportEventsCode(gd::Project &project,
 
     // Export the code
     if (fs.WriteToFile(filename, eventsOutput)) {
-      for (auto &include : eventsIncludes) InsertUnique(includesFiles, include);
+      for (auto &include : eventsIncludes)
+        InsertUnique(includesFiles, include);
 
       InsertUnique(includesFiles, filename);
     } else {
@@ -748,13 +732,14 @@ bool ExporterHelper::ExportEventsCode(gd::Project &project,
 }
 
 bool ExporterHelper::ExportExternalSourceFiles(
-    gd::Project &project,
-    gd::String outputDir,
+    gd::Project &project, gd::String outputDir,
     std::vector<gd::String> &includesFiles) {
   const auto &allFiles = project.GetAllSourceFiles();
   for (std::size_t i = 0; i < allFiles.size(); ++i) {
-    if (!allFiles[i]) continue;
-    if (allFiles[i]->GetLanguage() != "Javascript") continue;
+    if (!allFiles[i])
+      continue;
+    if (allFiles[i]->GetLanguage() != "Javascript")
+      continue;
 
     gd::SourceFile &file = *allFiles[i];
 
@@ -803,15 +788,13 @@ gd::String ExporterHelper::GetExportedIncludeFilename(
     // for cases where the browser is caching files that are getting
     // overwritten.
     return addSearchParameterToUrl(
-        resolvedInclude,
-        "gdCacheBurst",
+        resolvedInclude, "gdCacheBurst",
         gd::String::From(nonRuntimeScriptsCacheBurst));
   }
 }
 
 bool ExporterHelper::ExportIncludesAndLibs(
-    const std::vector<gd::String> &includesFiles,
-    gd::String exportDir,
+    const std::vector<gd::String> &includesFiles, gd::String exportDir,
     bool exportSourceMaps) {
   for (auto &include : includesFiles) {
     if (!fs.IsAbsolute(include)) {
@@ -821,7 +804,8 @@ bool ExporterHelper::ExportIncludesAndLibs(
       gd::String source = gdjsRoot + "/Runtime/" + include;
       if (fs.FileExists(source)) {
         gd::String path = fs.DirNameFrom(exportDir + "/" + include);
-        if (!fs.DirExists(path)) fs.MkDir(path);
+        if (!fs.DirExists(path))
+          fs.MkDir(path);
 
         fs.CopyFile(source, exportDir + "/" + include);
 
@@ -890,15 +874,13 @@ void ExporterHelper::ExportObjectAndBehaviorsIncludes(
 void ExporterHelper::ExportResources(gd::AbstractFileSystem &fs,
                                      gd::Project &project,
                                      gd::String exportDir) {
-  gd::ProjectResourcesCopier::CopyAllResourcesTo(
-      project, fs, exportDir, true, false, false);
+  gd::ProjectResourcesCopier::CopyAllResourcesTo(project, fs, exportDir, true,
+                                                 false, false);
 }
 
 void ExporterHelper::AddDeprecatedFontFilesToFontResources(
-    gd::AbstractFileSystem &fs,
-    gd::ResourcesManager &resourcesManager,
-    const gd::String &exportDir,
-    gd::String urlPrefix) {
+    gd::AbstractFileSystem &fs, gd::ResourcesManager &resourcesManager,
+    const gd::String &exportDir, gd::String urlPrefix) {
   // Compatibility with GD <= 5.0-beta56
   //
   // Before, fonts were detected by scanning the export folder for .TTF files.
@@ -925,4 +907,4 @@ void ExporterHelper::AddDeprecatedFontFilesToFontResources(
   // end of compatibility code
 }
 
-}  // namespace gdjs
+} // namespace gdjs

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -38,7 +38,7 @@
 #include "GDCore/Tools/Log.h"
 #include "GDJS/Events/CodeGeneration/LayoutCodeGenerator.h"
 #include "GDJS/Extensions/JsPlatform.h"
-#undef CopyFile // Disable an annoying macro
+#undef CopyFile  // Disable an annoying macro
 
 namespace {
 double GetTimeNow() {
@@ -56,7 +56,7 @@ double LogTimeSpent(const gd::String &name, double previousTime) {
   std::cout << std::endl;
   return GetTimeNow();
 }
-} // namespace
+}  // namespace
 
 namespace gdjs {
 
@@ -66,7 +66,8 @@ static void InsertUnique(std::vector<gd::String> &container, gd::String str) {
 }
 
 ExporterHelper::ExporterHelper(gd::AbstractFileSystem &fileSystem,
-                               gd::String gdjsRoot_, gd::String codeOutputDir_)
+                               gd::String gdjsRoot_,
+                               gd::String codeOutputDir_)
     : fs(fileSystem), gdjsRoot(gdjsRoot_), codeOutputDir(codeOutputDir_){};
 
 bool ExporterHelper::ExportProjectForPixiPreview(
@@ -112,8 +113,8 @@ bool ExporterHelper::ExportProjectForPixiPreview(
       return false;
 
     // Export source files
-    if (!ExportExternalSourceFiles(exportedProject, codeOutputDir,
-                                   includesFiles)) {
+    if (!ExportExternalSourceFiles(
+            exportedProject, codeOutputDir, includesFiles)) {
       gd::LogError(
           _("Error during exporting! Unable to export source files:\n") +
           lastError);
@@ -158,14 +159,14 @@ bool ExporterHelper::ExportProjectForPixiPreview(
     gd::String scriptSrc = GetExportedIncludeFilename(includeFile);
     scriptFilesElement.AddChild("scriptFile")
         .SetStringAttribute("path", scriptSrc)
-        .SetIntAttribute("hash", hashIt != options.includeFileHashes.end()
-                                     ? hashIt->second
-                                     : 0);
+        .SetIntAttribute(
+            "hash",
+            hashIt != options.includeFileHashes.end() ? hashIt->second : 0);
   }
 
   // Export the project
-  ExportProjectData(fs, exportedProject, codeOutputDir + "/data.js",
-                    runtimeGameOptions);
+  ExportProjectData(
+      fs, exportedProject, codeOutputDir + "/data.js", runtimeGameOptions);
   includesFiles.push_back(codeOutputDir + "/data.js");
 
   previousTime = LogTimeSpent("Project data export", previousTime);
@@ -174,8 +175,10 @@ bool ExporterHelper::ExportProjectForPixiPreview(
   ExportIncludesAndLibs(includesFiles, options.exportPath, true);
 
   // Create the index file
-  if (!ExportPixiIndexFile(exportedProject, gdjsRoot + "/Runtime/index.html",
-                           options.exportPath, includesFiles,
+  if (!ExportPixiIndexFile(exportedProject,
+                           gdjsRoot + "/Runtime/index.html",
+                           options.exportPath,
+                           includesFiles,
                            options.nonRuntimeScriptsCacheBurst,
                            "gdjs.runtimeGameOptions"))
     return false;
@@ -185,7 +188,9 @@ bool ExporterHelper::ExportProjectForPixiPreview(
 }
 
 gd::String ExporterHelper::ExportProjectData(
-    gd::AbstractFileSystem &fs, const gd::Project &project, gd::String filename,
+    gd::AbstractFileSystem &fs,
+    const gd::Project &project,
+    gd::String filename,
     const gd::SerializerElement &runtimeGameOptions) {
   fs.MkDir(fs.DirNameFrom(filename));
 
@@ -197,21 +202,26 @@ gd::String ExporterHelper::ExportProjectData(
       "gdjs.runtimeGameOptions = " +
       gd::Serializer::ToJSON(runtimeGameOptions) + ";\n";
 
-  if (!fs.WriteToFile(filename, output))
-    return "Unable to write " + filename;
+  if (!fs.WriteToFile(filename, output)) return "Unable to write " + filename;
 
   return "";
 }
 
 bool ExporterHelper::ExportPixiIndexFile(
-    const gd::Project &project, gd::String source, gd::String exportDir,
+    const gd::Project &project,
+    gd::String source,
+    gd::String exportDir,
     const std::vector<gd::String> &includesFiles,
-    unsigned int nonRuntimeScriptsCacheBurst, gd::String additionalSpec) {
+    unsigned int nonRuntimeScriptsCacheBurst,
+    gd::String additionalSpec) {
   gd::String str = fs.ReadFile(source);
 
   // Generate the file
-  if (!CompleteIndexFile(str, exportDir, includesFiles,
-                         nonRuntimeScriptsCacheBurst, additionalSpec))
+  if (!CompleteIndexFile(str,
+                         exportDir,
+                         includesFiles,
+                         nonRuntimeScriptsCacheBurst,
+                         additionalSpec))
     return false;
 
   // Write the index.html file
@@ -228,9 +238,9 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
                                         std::set<gd::String> usedExtensions) {
   auto &platformSpecificAssets = project.GetPlatformSpecificAssets();
   auto &resourceManager = project.GetResourcesManager();
-  auto getIconFilename = [&resourceManager,
-                          &platformSpecificAssets](const gd::String &platform,
-                                                   const gd::String &name) {
+  auto getIconFilename = [&resourceManager, &platformSpecificAssets](
+                             const gd::String &platform,
+                             const gd::String &name) {
     const gd::String &file =
         resourceManager.GetResource(platformSpecificAssets.Get(platform, name))
             .GetFile();
@@ -238,9 +248,12 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
   };
 
   auto makeIconsAndroid = [&getIconFilename]() {
-    std::vector<std::pair<gd::String, gd::String>> sizes = {
-        {"36", "ldpi"},  {"48", "mdpi"},    {"72", "hdpi"},
-        {"96", "xhdpi"}, {"144", "xxhdpi"}, {"192", "xxxhdpi"}};
+    std::vector<std::pair<gd::String, gd::String>> sizes = {{"36", "ldpi"},
+                                                            {"48", "mdpi"},
+                                                            {"72", "hdpi"},
+                                                            {"96", "xhdpi"},
+                                                            {"144", "xxhdpi"},
+                                                            {"192", "xxxhdpi"}};
 
     gd::String output;
     for (auto &size : sizes) {
@@ -353,7 +366,9 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
 }
 
 bool ExporterHelper::ExportCocos2dFiles(
-    const gd::Project &project, gd::String exportDir, bool debugMode,
+    const gd::Project &project,
+    gd::String exportDir,
+    bool debugMode,
     const std::vector<gd::String> &includesFiles) {
   if (!fs.CopyFile(gdjsRoot + "/Runtime/Cocos2d/main.js",
                    exportDir + "/main.js")) {
@@ -376,8 +391,11 @@ bool ExporterHelper::ExportCocos2dFiles(
 
     // Generate the file
     std::vector<gd::String> noIncludesInThisFile;
-    if (!CompleteIndexFile(str, exportDir, noIncludesInThisFile,
-                           /*nonRuntimeScriptsCacheBurst=*/0, "")) {
+    if (!CompleteIndexFile(str,
+                           exportDir,
+                           noIncludesInThisFile,
+                           /*nonRuntimeScriptsCacheBurst=*/0,
+                           "")) {
       lastError = "Unable to complete Cocos2d-JS index.html file.";
       return false;
     }
@@ -479,11 +497,12 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
     for (auto &dependencyAndExtension : dependenciesAndExtensions) {
       const auto &dependency = dependencyAndExtension.GetDependency();
       if (dependency.GetVersion() == "") {
-        gd::LogError("Latest Version not available for NPM dependencies, "
-                     "dependency " +
-                     dependency.GetName() +
-                     " is not exported. Please specify a version when calling "
-                     "addDependency.");
+        gd::LogError(
+            "Latest Version not available for NPM dependencies, "
+            "dependency " +
+            dependency.GetName() +
+            " is not exported. Please specify a version when calling "
+            "addDependency.");
         continue;
       }
 
@@ -542,11 +561,12 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
 }
 
 bool ExporterHelper::CompleteIndexFile(
-    gd::String &str, gd::String exportDir,
+    gd::String &str,
+    gd::String exportDir,
     const std::vector<gd::String> &includesFiles,
-    unsigned int nonRuntimeScriptsCacheBurst, gd::String additionalSpec) {
-  if (additionalSpec.empty())
-    additionalSpec = "{}";
+    unsigned int nonRuntimeScriptsCacheBurst,
+    gd::String additionalSpec) {
+  if (additionalSpec.empty()) additionalSpec = "{}";
 
   gd::String codeFilesIncludes;
   for (auto &include : includesFiles) {
@@ -575,7 +595,8 @@ bool ExporterHelper::CompleteIndexFile(
   return true;
 }
 
-void ExporterHelper::AddLibsInclude(bool pixiRenderers, bool cocosRenderers,
+void ExporterHelper::AddLibsInclude(bool pixiRenderers,
+                                    bool cocosRenderers,
                                     bool websocketDebuggerClient,
                                     std::vector<gd::String> &includesFiles) {
   // First, do not forget common includes (they must be included before events
@@ -664,7 +685,8 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers, bool cocosRenderers,
   }
 }
 
-void ExporterHelper::RemoveIncludes(bool pixiRenderers, bool cocosRenderers,
+void ExporterHelper::RemoveIncludes(bool pixiRenderers,
+                                    bool cocosRenderers,
                                     std::vector<gd::String> &includesFiles) {
   if (pixiRenderers) {
     for (size_t i = 0; i < includesFiles.size();) {
@@ -695,8 +717,7 @@ bool ExporterHelper::ExportEffectIncludes(
   gd::EffectsCodeGenerator::GenerateEffectsIncludeFiles(
       project.GetCurrentPlatform(), project, effectIncludes);
 
-  for (auto &include : effectIncludes)
-    InsertUnique(includesFiles, include);
+  for (auto &include : effectIncludes) InsertUnique(includesFiles, include);
 
   return true;
 }
@@ -718,8 +739,7 @@ bool ExporterHelper::ExportEventsCode(gd::Project &project,
 
     // Export the code
     if (fs.WriteToFile(filename, eventsOutput)) {
-      for (auto &include : eventsIncludes)
-        InsertUnique(includesFiles, include);
+      for (auto &include : eventsIncludes) InsertUnique(includesFiles, include);
 
       InsertUnique(includesFiles, filename);
     } else {
@@ -732,14 +752,13 @@ bool ExporterHelper::ExportEventsCode(gd::Project &project,
 }
 
 bool ExporterHelper::ExportExternalSourceFiles(
-    gd::Project &project, gd::String outputDir,
+    gd::Project &project,
+    gd::String outputDir,
     std::vector<gd::String> &includesFiles) {
   const auto &allFiles = project.GetAllSourceFiles();
   for (std::size_t i = 0; i < allFiles.size(); ++i) {
-    if (!allFiles[i])
-      continue;
-    if (allFiles[i]->GetLanguage() != "Javascript")
-      continue;
+    if (!allFiles[i]) continue;
+    if (allFiles[i]->GetLanguage() != "Javascript") continue;
 
     gd::SourceFile &file = *allFiles[i];
 
@@ -788,13 +807,15 @@ gd::String ExporterHelper::GetExportedIncludeFilename(
     // for cases where the browser is caching files that are getting
     // overwritten.
     return addSearchParameterToUrl(
-        resolvedInclude, "gdCacheBurst",
+        resolvedInclude,
+        "gdCacheBurst",
         gd::String::From(nonRuntimeScriptsCacheBurst));
   }
 }
 
 bool ExporterHelper::ExportIncludesAndLibs(
-    const std::vector<gd::String> &includesFiles, gd::String exportDir,
+    const std::vector<gd::String> &includesFiles,
+    gd::String exportDir,
     bool exportSourceMaps) {
   for (auto &include : includesFiles) {
     if (!fs.IsAbsolute(include)) {
@@ -804,8 +825,7 @@ bool ExporterHelper::ExportIncludesAndLibs(
       gd::String source = gdjsRoot + "/Runtime/" + include;
       if (fs.FileExists(source)) {
         gd::String path = fs.DirNameFrom(exportDir + "/" + include);
-        if (!fs.DirExists(path))
-          fs.MkDir(path);
+        if (!fs.DirExists(path)) fs.MkDir(path);
 
         fs.CopyFile(source, exportDir + "/" + include);
 
@@ -874,13 +894,15 @@ void ExporterHelper::ExportObjectAndBehaviorsIncludes(
 void ExporterHelper::ExportResources(gd::AbstractFileSystem &fs,
                                      gd::Project &project,
                                      gd::String exportDir) {
-  gd::ProjectResourcesCopier::CopyAllResourcesTo(project, fs, exportDir, true,
-                                                 false, false);
+  gd::ProjectResourcesCopier::CopyAllResourcesTo(
+      project, fs, exportDir, true, false, false);
 }
 
 void ExporterHelper::AddDeprecatedFontFilesToFontResources(
-    gd::AbstractFileSystem &fs, gd::ResourcesManager &resourcesManager,
-    const gd::String &exportDir, gd::String urlPrefix) {
+    gd::AbstractFileSystem &fs,
+    gd::ResourcesManager &resourcesManager,
+    const gd::String &exportDir,
+    gd::String urlPrefix) {
   // Compatibility with GD <= 5.0-beta56
   //
   // Before, fonts were detected by scanning the export folder for .TTF files.
@@ -907,4 +929,4 @@ void ExporterHelper::AddDeprecatedFontFilesToFontResources(
   // end of compatibility code
 }
 
-} // namespace gdjs
+}  // namespace gdjs

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -18,7 +18,7 @@ class ExternalLayout;
 class SerializerElement;
 class AbstractFileSystem;
 class ResourcesManager;
-} // namespace gd
+}  // namespace gd
 class wxProgressDialog;
 
 namespace gdjs {
@@ -32,8 +32,10 @@ struct PreviewExportOptions {
    * \param exportPath_ The path in the filesystem where to export the files
    */
   PreviewExportOptions(gd::Project &project_, const gd::String &exportPath_)
-      : project(project_), exportPath(exportPath_),
-        projectDataOnlyExport(false), nonRuntimeScriptsCacheBurst(0){};
+      : project(project_),
+        exportPath(exportPath_),
+        projectDataOnlyExport(false),
+        nonRuntimeScriptsCacheBurst(0){};
 
   /**
    * \brief Set the address of the debugger server that the game should reach
@@ -58,8 +60,8 @@ struct PreviewExportOptions {
    * \brief Set the (optional) external layout to be instanciated in the scene
    * at the beginning of the previewed game.
    */
-  PreviewExportOptions &
-  SetExternalLayoutName(const gd::String &externalLayoutName_) {
+  PreviewExportOptions &SetExternalLayoutName(
+      const gd::String &externalLayoutName_) {
     externalLayoutName = externalLayoutName_;
     return *this;
   }
@@ -109,8 +111,9 @@ struct PreviewExportOptions {
  * game.
  */
 class ExporterHelper {
-public:
-  ExporterHelper(gd::AbstractFileSystem &fileSystem, gd::String gdjsRoot_,
+ public:
+  ExporterHelper(gd::AbstractFileSystem &fileSystem,
+                 gd::String gdjsRoot_,
                  gd::String codeOutputDir);
   virtual ~ExporterHelper(){};
 
@@ -129,10 +132,11 @@ public:
    * in gdjs.runtimeGameOptions \return Empty string if everthing is ok,
    * description of the error otherwise.
    */
-  static gd::String
-  ExportProjectData(gd::AbstractFileSystem &fs, const gd::Project &project,
-                    gd::String filename,
-                    const gd::SerializerElement &runtimeGameOptions);
+  static gd::String ExportProjectData(
+      gd::AbstractFileSystem &fs,
+      const gd::Project &project,
+      gd::String filename,
+      const gd::SerializerElement &runtimeGameOptions);
 
   /**
    * \brief Copy all the resources of the project to to the export directory,
@@ -144,20 +148,23 @@ public:
    * \param progressDlg Optional wxProgressDialog which will be updated with the
    * progress.
    */
-  static void ExportResources(gd::AbstractFileSystem &fs, gd::Project &project,
+  static void ExportResources(gd::AbstractFileSystem &fs,
+                              gd::Project &project,
                               gd::String exportDir);
 
   /**
    * \brief Add libraries files from Pixi.js or Cocos2d to the list of includes.
    */
-  void AddLibsInclude(bool pixiRenderers, bool cocosRenderers,
+  void AddLibsInclude(bool pixiRenderers,
+                      bool cocosRenderers,
                       bool websocketDebuggerClient,
                       std::vector<gd::String> &includesFiles);
 
   /**
    * \brief Remove include files that are Pixi or Cocos2d renderers.
    */
-  void RemoveIncludes(bool pixiRenderers, bool cocosRenderers,
+  void RemoveIncludes(bool pixiRenderers,
+                      bool cocosRenderers,
                       std::vector<gd::String> &includesFiles);
 
   /**
@@ -171,7 +178,8 @@ public:
    * previews only.
    */
   bool ExportIncludesAndLibs(const std::vector<gd::String> &includesFiles,
-                             gd::String exportDir, bool exportSourceMaps);
+                             gd::String exportDir,
+                             bool exportSourceMaps);
 
   /**
    * \brief Generate the events JS code, and save them to the export directory.
@@ -182,7 +190,8 @@ public:
    * includesFiles A reference to a vector that will be filled with JS files to
    * be exported along with the project. ( including "codeX.js" files ).
    */
-  bool ExportEventsCode(gd::Project &project, gd::String outputDir,
+  bool ExportEventsCode(gd::Project &project,
+                        gd::String outputDir,
                         std::vector<gd::String> &includesFiles,
                         bool exportForPreview);
 
@@ -210,7 +219,8 @@ public:
    * with JS files to be exported along with the project. (including
    * "ext-codeX.js" files).
    */
-  bool ExportExternalSourceFiles(gd::Project &project, gd::String outputDir,
+  bool ExportExternalSourceFiles(gd::Project &project,
+                                 gd::String outputDir,
                                  std::vector<gd::String> &includesFiles);
 
   /**
@@ -230,7 +240,8 @@ public:
    * \param additionalSpec JSON string that will be passed to the
    * gdjs.RuntimeGame object.
    */
-  bool ExportPixiIndexFile(const gd::Project &project, gd::String source,
+  bool ExportPixiIndexFile(const gd::Project &project,
+                           gd::String source,
                            gd::String exportDir,
                            const std::vector<gd::String> &includesFiles,
                            unsigned int nonRuntimeScriptsCacheBurst,
@@ -252,7 +263,8 @@ public:
    * surrounded by comments marks will be replaced by the
    * content of this string.
    */
-  bool CompleteIndexFile(gd::String &indexFileContent, gd::String exportDir,
+  bool CompleteIndexFile(gd::String &indexFileContent,
+                         gd::String exportDir,
                          const std::vector<gd::String> &includesFiles,
                          unsigned int nonRuntimeScriptsCacheBurst,
                          gd::String additionalSpec);
@@ -264,13 +276,15 @@ public:
    * \param project The project to be used to generate the configuration file.
    * \param exportDir The directory where the config.xml must be created.
    */
-  bool ExportCordovaFiles(const gd::Project &project, gd::String exportDir,
+  bool ExportCordovaFiles(const gd::Project &project,
+                          gd::String exportDir,
                           std::set<gd::String> usedExtensions);
 
   /**
    * \brief Generate the base Cocos2d files.
    */
-  bool ExportCocos2dFiles(const gd::Project &project, gd::String exportDir,
+  bool ExportCocos2dFiles(const gd::Project &project,
+                          gd::String exportDir,
                           bool debugMode,
                           const std::vector<gd::String> &includesFiles);
 
@@ -281,7 +295,8 @@ public:
    * \param project The project to be used to generate the files.
    * \param exportDir The directory where the files must be created.
    */
-  bool ExportElectronFiles(const gd::Project &project, gd::String exportDir,
+  bool ExportElectronFiles(const gd::Project &project,
+                           gd::String exportDir,
                            std::set<gd::String> usedExtensions);
 
   /**
@@ -307,9 +322,8 @@ public:
    * \brief Given an include file, returns the name of the file to reference
    * in the exported game.
    */
-  gd::String
-  GetExportedIncludeFilename(const gd::String &include,
-                             unsigned int nonRuntimeScriptsCacheBurst = 0);
+  gd::String GetExportedIncludeFilename(
+      const gd::String &include, unsigned int nonRuntimeScriptsCacheBurst = 0);
 
   /**
    * \brief Change the directory where code files are generated.
@@ -321,17 +335,19 @@ public:
   }
 
   static void AddDeprecatedFontFilesToFontResources(
-      gd::AbstractFileSystem &fs, gd::ResourcesManager &resourcesManager,
-      const gd::String &exportDir, gd::String urlPrefix = "");
+      gd::AbstractFileSystem &fs,
+      gd::ResourcesManager &resourcesManager,
+      const gd::String &exportDir,
+      gd::String urlPrefix = "");
 
   gd::AbstractFileSystem
-      &fs; ///< The abstract file system to be used for exportation.
-  gd::String lastError; ///< The last error that occurred.
+      &fs;  ///< The abstract file system to be used for exportation.
+  gd::String lastError;  ///< The last error that occurred.
   gd::String
-      gdjsRoot; ///< The root directory of GDJS, used to copy runtime files.
-  gd::String codeOutputDir; ///< The directory where JS code is outputted. Will
-                            ///< be then copied to the final output directory.
+      gdjsRoot;  ///< The root directory of GDJS, used to copy runtime files.
+  gd::String codeOutputDir;  ///< The directory where JS code is outputted. Will
+                             ///< be then copied to the final output directory.
 };
 
-} // namespace gdjs
-#endif // EXPORTER_HELPER_H
+}  // namespace gdjs
+#endif  // EXPORTER_HELPER_H

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -18,7 +18,7 @@ class ExternalLayout;
 class SerializerElement;
 class AbstractFileSystem;
 class ResourcesManager;
-}  // namespace gd
+} // namespace gd
 class wxProgressDialog;
 
 namespace gdjs {
@@ -32,10 +32,8 @@ struct PreviewExportOptions {
    * \param exportPath_ The path in the filesystem where to export the files
    */
   PreviewExportOptions(gd::Project &project_, const gd::String &exportPath_)
-      : project(project_),
-        exportPath(exportPath_),
-        projectDataOnlyExport(false),
-        nonRuntimeScriptsCacheBurst(0){};
+      : project(project_), exportPath(exportPath_),
+        projectDataOnlyExport(false), nonRuntimeScriptsCacheBurst(0){};
 
   /**
    * \brief Set the address of the debugger server that the game should reach
@@ -60,8 +58,8 @@ struct PreviewExportOptions {
    * \brief Set the (optional) external layout to be instanciated in the scene
    * at the beginning of the previewed game.
    */
-  PreviewExportOptions &SetExternalLayoutName(
-      const gd::String &externalLayoutName_) {
+  PreviewExportOptions &
+  SetExternalLayoutName(const gd::String &externalLayoutName_) {
     externalLayoutName = externalLayoutName_;
     return *this;
   }
@@ -111,9 +109,8 @@ struct PreviewExportOptions {
  * game.
  */
 class ExporterHelper {
- public:
-  ExporterHelper(gd::AbstractFileSystem &fileSystem,
-                 gd::String gdjsRoot_,
+public:
+  ExporterHelper(gd::AbstractFileSystem &fileSystem, gd::String gdjsRoot_,
                  gd::String codeOutputDir);
   virtual ~ExporterHelper(){};
 
@@ -132,11 +129,10 @@ class ExporterHelper {
    * in gdjs.runtimeGameOptions \return Empty string if everthing is ok,
    * description of the error otherwise.
    */
-  static gd::String ExportProjectData(
-      gd::AbstractFileSystem &fs,
-      const gd::Project &project,
-      gd::String filename,
-      const gd::SerializerElement &runtimeGameOptions);
+  static gd::String
+  ExportProjectData(gd::AbstractFileSystem &fs, const gd::Project &project,
+                    gd::String filename,
+                    const gd::SerializerElement &runtimeGameOptions);
 
   /**
    * \brief Copy all the resources of the project to to the export directory,
@@ -148,23 +144,20 @@ class ExporterHelper {
    * \param progressDlg Optional wxProgressDialog which will be updated with the
    * progress.
    */
-  static void ExportResources(gd::AbstractFileSystem &fs,
-                              gd::Project &project,
+  static void ExportResources(gd::AbstractFileSystem &fs, gd::Project &project,
                               gd::String exportDir);
 
   /**
    * \brief Add libraries files from Pixi.js or Cocos2d to the list of includes.
    */
-  void AddLibsInclude(bool pixiRenderers,
-                      bool cocosRenderers,
+  void AddLibsInclude(bool pixiRenderers, bool cocosRenderers,
                       bool websocketDebuggerClient,
                       std::vector<gd::String> &includesFiles);
 
   /**
    * \brief Remove include files that are Pixi or Cocos2d renderers.
    */
-  void RemoveIncludes(bool pixiRenderers,
-                      bool cocosRenderers,
+  void RemoveIncludes(bool pixiRenderers, bool cocosRenderers,
                       std::vector<gd::String> &includesFiles);
 
   /**
@@ -178,8 +171,7 @@ class ExporterHelper {
    * previews only.
    */
   bool ExportIncludesAndLibs(const std::vector<gd::String> &includesFiles,
-                             gd::String exportDir,
-                             bool exportSourceMaps);
+                             gd::String exportDir, bool exportSourceMaps);
 
   /**
    * \brief Generate the events JS code, and save them to the export directory.
@@ -190,8 +182,7 @@ class ExporterHelper {
    * includesFiles A reference to a vector that will be filled with JS files to
    * be exported along with the project. ( including "codeX.js" files ).
    */
-  bool ExportEventsCode(gd::Project &project,
-                        gd::String outputDir,
+  bool ExportEventsCode(gd::Project &project, gd::String outputDir,
                         std::vector<gd::String> &includesFiles,
                         bool exportForPreview);
 
@@ -219,8 +210,7 @@ class ExporterHelper {
    * with JS files to be exported along with the project. (including
    * "ext-codeX.js" files).
    */
-  bool ExportExternalSourceFiles(gd::Project &project,
-                                 gd::String outputDir,
+  bool ExportExternalSourceFiles(gd::Project &project, gd::String outputDir,
                                  std::vector<gd::String> &includesFiles);
 
   /**
@@ -240,8 +230,7 @@ class ExporterHelper {
    * \param additionalSpec JSON string that will be passed to the
    * gdjs.RuntimeGame object.
    */
-  bool ExportPixiIndexFile(const gd::Project &project,
-                           gd::String source,
+  bool ExportPixiIndexFile(const gd::Project &project, gd::String source,
                            gd::String exportDir,
                            const std::vector<gd::String> &includesFiles,
                            unsigned int nonRuntimeScriptsCacheBurst,
@@ -263,8 +252,7 @@ class ExporterHelper {
    * surrounded by comments marks will be replaced by the
    * content of this string.
    */
-  bool CompleteIndexFile(gd::String &indexFileContent,
-                         gd::String exportDir,
+  bool CompleteIndexFile(gd::String &indexFileContent, gd::String exportDir,
                          const std::vector<gd::String> &includesFiles,
                          unsigned int nonRuntimeScriptsCacheBurst,
                          gd::String additionalSpec);
@@ -276,13 +264,13 @@ class ExporterHelper {
    * \param project The project to be used to generate the configuration file.
    * \param exportDir The directory where the config.xml must be created.
    */
-  bool ExportCordovaFiles(const gd::Project &project, gd::String exportDir);
+  bool ExportCordovaFiles(const gd::Project &project, gd::String exportDir,
+                          std::set<gd::String> usedExtensions);
 
   /**
    * \brief Generate the base Cocos2d files.
    */
-  bool ExportCocos2dFiles(const gd::Project &project,
-                          gd::String exportDir,
+  bool ExportCocos2dFiles(const gd::Project &project, gd::String exportDir,
                           bool debugMode,
                           const std::vector<gd::String> &includesFiles);
 
@@ -293,7 +281,8 @@ class ExporterHelper {
    * \param project The project to be used to generate the files.
    * \param exportDir The directory where the files must be created.
    */
-  bool ExportElectronFiles(const gd::Project &project, gd::String exportDir);
+  bool ExportElectronFiles(const gd::Project &project, gd::String exportDir,
+                           std::set<gd::String> usedExtensions);
 
   /**
    * \brief Generate the Facebook Instant Games files for packaging and save it
@@ -318,8 +307,9 @@ class ExporterHelper {
    * \brief Given an include file, returns the name of the file to reference
    * in the exported game.
    */
-  gd::String GetExportedIncludeFilename(
-      const gd::String &include, unsigned int nonRuntimeScriptsCacheBurst = 0);
+  gd::String
+  GetExportedIncludeFilename(const gd::String &include,
+                             unsigned int nonRuntimeScriptsCacheBurst = 0);
 
   /**
    * \brief Change the directory where code files are generated.
@@ -331,19 +321,17 @@ class ExporterHelper {
   }
 
   static void AddDeprecatedFontFilesToFontResources(
-      gd::AbstractFileSystem &fs,
-      gd::ResourcesManager &resourcesManager,
-      const gd::String &exportDir,
-      gd::String urlPrefix = "");
+      gd::AbstractFileSystem &fs, gd::ResourcesManager &resourcesManager,
+      const gd::String &exportDir, gd::String urlPrefix = "");
 
   gd::AbstractFileSystem
-      &fs;  ///< The abstract file system to be used for exportation.
-  gd::String lastError;  ///< The last error that occurred.
+      &fs; ///< The abstract file system to be used for exportation.
+  gd::String lastError; ///< The last error that occurred.
   gd::String
-      gdjsRoot;  ///< The root directory of GDJS, used to copy runtime files.
-  gd::String codeOutputDir;  ///< The directory where JS code is outputted. Will
-                             ///< be then copied to the final output directory.
+      gdjsRoot; ///< The root directory of GDJS, used to copy runtime files.
+  gd::String codeOutputDir; ///< The directory where JS code is outputted. Will
+                            ///< be then copied to the final output directory.
 };
 
-}  // namespace gdjs
-#endif  // EXPORTER_HELPER_H
+} // namespace gdjs
+#endif // EXPORTER_HELPER_H

--- a/GDevelop.js/TestUtils/TestExtensions.js
+++ b/GDevelop.js/TestUtils/TestExtensions.js
@@ -53,6 +53,20 @@ module.exports = {
         )
         .onlyIfSomeExtraSettingsNonEmpty();
 
+      extension
+        .addAction(
+          'ShowInterstitial',
+          'Show interstitial',
+          'Fake action that would show an interstitial screen.',
+          'Show the loaded interstitial',
+          'AdMob',
+          'JsPlatform/Extensions/admobicon24.png',
+          'JsPlatform/Extensions/admobicon16.png'
+        )
+        .getCodeExtraInformation()
+        .setIncludeFile('Extensions/FakeAdMob/admobtools.js')
+        .setFunctionName('gdjs.fakeAdMob.showInterstitial');
+
       platform.addNewExtension(extension);
       extension.delete(); // Release the extension as it was copied inside gd.JsPlatform
     }


### PR DESCRIPTION
Uses the new `gd::UsedExtensionsFinder` to find what extension are used and only export those.
