### PR TITLE
Hide for non desktop the preference for hide the menu bar

### DIFF
--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -284,6 +284,7 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
               }
             />
           </Line>
+          {electron && (
           <Line>
             <Toggle
               onToggle={(e, check) => setIsMenuBarHiddenInPreview(check)}
@@ -292,7 +293,6 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
               label={<Trans>Hide the menu bar in the preview window</Trans>}
             />
           </Line>
-          {electron && (
             <Line>
               <Toggle
                 onToggle={(e, check) => setIsAlwaysOnTopInPreview(check)}

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -285,26 +285,28 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
             />
           </Line>
           {electron && (
-          <Line>
-            <Toggle
-              onToggle={(e, check) => setIsMenuBarHiddenInPreview(check)}
-              toggled={values.isMenuBarHiddenInPreview}
-              labelPosition="right"
-              label={<Trans>Hide the menu bar in the preview window</Trans>}
-            />
-          </Line>
-            <Line>
-              <Toggle
-                onToggle={(e, check) => setIsAlwaysOnTopInPreview(check)}
-                toggled={values.isAlwaysOnTopInPreview}
-                labelPosition="right"
-                label={
-                  <Trans>
-                    Always display the preview window on top of others
-                  </Trans>
-                }
-              />
-            </Line>
+            <>
+              <Line>
+                <Toggle
+                  onToggle={(e, check) => setIsMenuBarHiddenInPreview(check)}
+                  toggled={values.isMenuBarHiddenInPreview}
+                  labelPosition="right"
+                  label={<Trans>Hide the menu bar in the preview window</Trans>}
+                />
+              </Line>
+              <Line>
+                <Toggle
+                  onToggle={(e, check) => setIsAlwaysOnTopInPreview(check)}
+                  toggled={values.isAlwaysOnTopInPreview}
+                  labelPosition="right"
+                  label={
+                    <Trans>
+                      Always display the preview window on top of others
+                    </Trans>
+                  }
+                />
+              </Line>
+            </>
           )}
           {Window.isDev() && (
             <Line>


### PR DESCRIPTION
The preference " hide the menu bar" is visible on web-app but there is no menu bar in web-app.
This pr fix it.

Ready to merge