### PR TITLE
Upgrade TypeScript to version 4.3.2 for GDJS game engine

### DIFF
--- a/GDJS/package-lock.json
+++ b/GDJS/package-lock.json
@@ -2880,9 +2880,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true
     },
     "uc.micro": {

--- a/GDJS/package.json
+++ b/GDJS/package.json
@@ -23,7 +23,7 @@
     "prettier": "2.1.2",
     "recursive-readdir": "^2.2.2",
     "shelljs": "^0.8.4",
-    "typescript": "4.1.3"
+    "typescript": "4.3.2"
   },
   "scripts": {
     "check-types": "tsc",


### PR DESCRIPTION
Only show in developer changelog