### PR TITLE
Variable autocompletion in expressions

### DIFF
--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -76,12 +76,14 @@ struct ExpressionCompletionDescription {
       const gd::String& type_,
       const gd::String& prefix_,
       size_t replacementStartPosition_,
-      size_t replacementEndPosition_) {
+      size_t replacementEndPosition_,
+      const gd::String& objectName_ = "") {
     return ExpressionCompletionDescription(Variable,
                                            type_,
                                            prefix_,
                                            replacementStartPosition_,
-                                           replacementEndPosition_);
+                                           replacementEndPosition_,
+                                           objectName_);
   }
 
   /**
@@ -397,7 +399,8 @@ class GD_CORE_API ExpressionCompletionFinder
         node.type,
         node.name,
         node.location.GetStartPosition(),
-        node.location.GetEndPosition()));
+        node.location.GetEndPosition(),
+        node.objectName));
   }
   void OnVisitVariableAccessorNode(VariableAccessorNode& node) override {
     // No completions

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
@@ -346,7 +346,8 @@ export default function ExpressionAutocompletionsDisplayer({
                     ? selectedAutocompletionElement
                     : undefined;
 
-                  return expressionAutocompletion.kind === 'Text' ? (
+                  return expressionAutocompletion.kind === 'Text' ||
+                    expressionAutocompletion.kind === 'Variable' ? (
                     <DisplayedTextAutocompletion
                       key={index}
                       expressionAutocompletion={expressionAutocompletion}

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -46,6 +46,10 @@ export type ExpressionAutocompletion =
     |}
   | {|
       ...BaseExpressionAutocompletion,
+      kind: 'Variable',
+    |}
+  | {|
+      ...BaseExpressionAutocompletion,
       object?: gdObject,
       kind: 'Object',
     |}
@@ -339,7 +343,7 @@ const getAutocompletionsForVariable = function(
   const filteredVariablesList = filterStringList(definedVariableNames, prefix);
 
   return filteredVariablesList.map(variableName => ({
-    kind: 'Text',
+    kind: 'Variable',
     completion: variableName,
     replacementStartPosition: completionDescription.getReplacementStartPosition(),
     replacementEndPosition: completionDescription.getReplacementEndPosition(),

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -302,15 +302,22 @@ const getAutocompletionsForVariable = function(
   const type: string = completionDescription.getType();
   const objectName: string = completionDescription.getObjectName();
   const { project, scope } = expressionAutocompletionContext;
+  const layout = scope.layout;
 
   let variablesContainer: gdVariablesContainer;
   if (type === 'globalvar') {
+    if (!project) {
+      // No variable completion
+      return [];
+    }
     variablesContainer = project.getVariables();
   } else if (type === 'scenevar') {
-    const layout = scope.layout;
+    if (!layout) {
+      // No variable completion
+      return [];
+    }
     variablesContainer = layout.getVariables();
   } else if (type === 'objectvar') {
-    const layout = scope.layout;
     const object = getObjectByName(project, layout, objectName);
     if (!object) {
       // No variable completion for unknown objet


### PR DESCRIPTION
This is committed over: https://github.com/4ian/GDevelop/pull/2702

I didn't find an easy way to use undefined variables without having them calculated at every input so I revert it. I'll create an issue for it.