### PR TITLE
Clamp opacity value for BBText and Bitmap Text

### DIFF
--- a/Extensions/BBText/bbtextruntimeobject.ts
+++ b/Extensions/BBText/bbtextruntimeobject.ts
@@ -219,6 +219,12 @@ namespace gdjs {
      * @param opacity The new opacity of the object (0-255).
      */
     setOpacity(opacity: float): void {
+      if (opacity < 0) {
+        opacity = 0;
+      }
+      if (opacity > 255) {
+        opacity = 255;
+      }
       this._opacity = opacity;
       this._renderer.updateOpacity();
     }

--- a/Extensions/BitmapText/bitmaptextruntimeobject.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject.ts
@@ -257,6 +257,12 @@ namespace gdjs {
      * @param opacity The new opacity of the object (0-255).
      */
     setOpacity(opacity: float): void {
+      if (opacity < 0) {
+        opacity = 0;
+      }
+      if (opacity > 255) {
+        opacity = 255;
+      }
       this._opacity = opacity;
       this._renderer.updateOpacity();
     }


### PR DESCRIPTION
# Description
Opacity value is not clamped to 0-255 for bitmap text object.
Compare Bitmap Text object to Text object:
![773cfca3f99c55f8cc2c5d2df03a7a34abdf8cc1_2_690x115](https://user-images.githubusercontent.com/1670670/120108833-231fa200-c167-11eb-85d3-1574f8e3a9a9.png)
![f46d22b378739b55968a5dba398b7c4da21e7752](https://user-images.githubusercontent.com/1670670/120108835-2581fc00-c167-11eb-9a5f-525c1f5ab295.png)

# Fix
Add a basic clamp with if[ like on Text object](https://github.com/4ian/GDevelop/blob/master/Extensions/TextObject/textruntimeobject.ts#L186-L195), for Bitmap Text and BBText.

Source: [forum](https://forum.gdevelop-app.com/t/opacity-of-bitmap-text-can-go-beyond-255/33014/3?u=bouh)