### PR TITLE
Allow to pass the path to GDJS to the extensions loader

### DIFF
--- a/newIDE/app/src/JsExtensionsLoader/LocalJsExtensionsFinder.js
+++ b/newIDE/app/src/JsExtensionsLoader/LocalJsExtensionsFinder.js
@@ -21,8 +21,8 @@ const checkIfPathHasJsExtensionModule = extensionFolderPath => {
   });
 };
 
-const findJsExtensionModules = ({ filterExamples }) => {
-  return findGDJS().then(({ gdjsRoot }) => {
+const findJsExtensionModules = ({ filterExamples, onFindGDJS }) => {
+  return (onFindGDJS ? onFindGDJS() : findGDJS()).then(({ gdjsRoot }) => {
     const extensionsRoot = path.join(gdjsRoot, 'Runtime', 'Extensions');
     console.info(
       `Searching for JS extensions (file called JsExtension.js) in ${extensionsRoot}...`

--- a/newIDE/app/src/JsExtensionsLoader/LocalJsExtensionsLoader.js
+++ b/newIDE/app/src/JsExtensionsLoader/LocalJsExtensionsLoader.js
@@ -15,6 +15,7 @@ type MakeExtensionsLoaderArguments = {|
   objectsEditorService: typeof ObjectsEditorService,
   objectsRenderingService: typeof ObjectsRenderingService,
   filterExamples: boolean,
+  onFindGDJS?: ?() => Promise<{gdjsRoot: string}>
 |};
 */
 
@@ -29,11 +30,12 @@ module.exports = function makeExtensionsLoader(
     objectsEditorService,
     objectsRenderingService,
     filterExamples,
+    onFindGDJS,
   } /*: MakeExtensionsLoaderArguments*/
 ) /*: JsExtensionsLoader*/ {
   return {
     loadAllExtensions: (_ /*: TranslationFunction */) => {
-      return findJsExtensionModules({ filterExamples }).then(
+      return findJsExtensionModules({ filterExamples, onFindGDJS }).then(
         extensionModulePaths => {
           return Promise.all(
             extensionModulePaths.map(extensionModulePath => {


### PR DESCRIPTION
Useful for third party/external tools.

Don't show in changelog