### PR TITLE
Add animation and point as string types

### DIFF
--- a/Core/GDCore/Events/Parsers/ExpressionParser2.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.h
@@ -66,6 +66,15 @@ class GD_CORE_API ExpressionParser2 {
     return Start(type, objectName);
   }
 
+  /**
+   * Given an object name (or empty if none) and a behavior name (or empty if none),
+   * return the index of the first parameter that is inside the parenthesis: 
+   * 0, 1 or 2.
+   * 
+   * For example, in an expression like `Object.MyBehavior::Method("hello")`, the
+   * parameter "hello" is the second parameter (the first being by convention Object,
+   * and the second MyBehavior, also by convention).
+   */
   static size_t WrittenParametersFirstIndex(const gd::String &objectName,
                                             const gd::String &behaviorName) {
     // By convention, object is always the first parameter, and behavior the

--- a/Core/GDCore/Events/Parsers/ExpressionParser2.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.h
@@ -66,6 +66,13 @@ class GD_CORE_API ExpressionParser2 {
     return Start(type, objectName);
   }
 
+  static size_t WrittenParametersFirstIndex(const gd::String &objectName,
+                                            const gd::String &behaviorName) {
+    // By convention, object is always the first parameter, and behavior the
+    // second one.
+    return !behaviorName.empty() ? 2 : (!objectName.empty() ? 1 : 0);
+  }
+
  private:
   /** \name Grammar
    * Each method is a part of the grammar.
@@ -998,13 +1005,6 @@ class GD_CORE_API ExpressionParser2 {
     return std::move(RaiseTypeError(message, beginningPosition));
   }
   ///@}
-
-  static size_t WrittenParametersFirstIndex(const gd::String &objectName,
-                                            const gd::String &behaviorName) {
-    // By convention, object is always the first parameter, and behavior the
-    // second one.
-    return !behaviorName.empty() ? 2 : (!objectName.empty() ? 1 : 0);
-  }
 
   gd::String expression;
   std::size_t currentPosition;

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -66,7 +66,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                 "res/actions/animation.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("string", _("Animation name"))
+      .AddParameter("objectAnimationName", _("Animation name"))
       .MarkAsAdvanced();
 
   obj.AddAction(
@@ -230,7 +230,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                    "res/conditions/animation.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("string", _("Animation name"))
+      .AddParameter("objectAnimationName", _("Animation name"))
       .MarkAsAdvanced();
 
   obj.AddCondition(
@@ -455,7 +455,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                     "res/actions/position.png")
       .SetHidden()
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("string", _("Name of the point"), "", true);
+      .AddParameter("objectPointName", _("Name of the point"), "", true);
 
   obj.AddExpression("Y",
                     _("Y position of a point"),
@@ -464,7 +464,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                     "res/actions/position.png")
       .SetHidden()
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("string", _("Name of the point"), "", true);
+      .AddParameter("objectPointName", _("Name of the point"), "", true);
 
   obj.AddExpression("PointX",
                     _("X position of a point"),
@@ -473,7 +473,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                     "res/actions/position.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("string", _("Name of the point"));
+      .AddParameter("objectPointName", _("Name of the point"));
 
   obj.AddExpression("PointY",
                     _("Y position of a point"),
@@ -482,7 +482,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                     "res/actions/position.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("string", _("Name of the point"));
+      .AddParameter("objectPointName", _("Name of the point"));
 
   obj.AddExpression("Direc",
                     _("Direction"),

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
@@ -175,7 +175,8 @@ class GD_CORE_API ParameterMetadata {
    * \brief Return true if the type of the parameter is an expression of the
    * given type.
    * \note If you had a new type of parameter, also add it in the IDE (
-   * see EventsFunctionParametersEditor) and in the EventsCodeGenerator.
+   * see EventsFunctionParametersEditor, ParameterRenderingService
+   * and ExpressionAutocompletion) and in the EventsCodeGenerator.
    */
   static bool IsExpression(const gd::String &type,
                            const gd::String &parameterType) {
@@ -187,7 +188,9 @@ class GD_CORE_API ParameterMetadata {
              parameterType == "color" || parameterType == "file" ||
              parameterType == "joyaxis" ||
              parameterType == "stringWithSelector" ||
-             parameterType == "sceneName";
+             parameterType == "sceneName" ||
+             parameterType == "objectPointName" ||
+             parameterType == "objectAnimationName";
     } else if (type == "variable") {
       return parameterType == "objectvar" || parameterType == "globalvar" ||
              parameterType == "scenevar";

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -14,6 +14,8 @@
 #include "GDCore/Extensions/Metadata/ExpressionMetadata.h"
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/IDE/Events/ExpressionNodeLocationFinder.h"
+#include "GDCore/Events/Parsers/ExpressionParser2.h"
+
 namespace gd {
 class Expression;
 class ObjectsContainer;
@@ -339,13 +341,6 @@ class GD_CORE_API ExpressionCompletionFinder
     // No completions
   }
 
-  static size_t WrittenParametersFirstIndex(const gd::String &objectName,
-                                            const gd::String &behaviorName) {
-    // By convention, object is always the first parameter, and behavior the
-    // second one.
-    return !behaviorName.empty() ? 2 : (!objectName.empty() ? 1 : 0);
-  }
-
   void OnVisitTextNode(TextNode& node) override {
     // Completions are searched in the case the text node is a parameter of a
     // function call.
@@ -364,7 +359,7 @@ class GD_CORE_API ExpressionCompletionFinder
       }
       // Search the parameter metadata index skipping invisible ones.
       size_t visibleParameterIndex = 0;
-      size_t metadataParameterIndex = WrittenParametersFirstIndex(
+      size_t metadataParameterIndex = ExpressionParser2::WrittenParametersFirstIndex(
           functionCall->objectName, functionCall->behaviorName);
 
       const gd::ParameterMetadata* parameterMetadata = nullptr;

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -14,6 +14,7 @@
 #include "GDCore/Extensions/Metadata/ExpressionMetadata.h"
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/IDE/Events/ExpressionNodeLocationFinder.h"
+#include "GDCore/Events/Parsers/ExpressionParser2.h"
 namespace gd {
 class Expression;
 class ObjectsContainer;
@@ -338,6 +339,14 @@ class GD_CORE_API ExpressionCompletionFinder
   void OnVisitNumberNode(NumberNode& node) override {
     // No completions
   }
+
+  static size_t WrittenParametersFirstIndex(const gd::String &objectName,
+                                            const gd::String &behaviorName) {
+    // By convention, object is always the first parameter, and behavior the
+    // second one.
+    return !behaviorName.empty() ? 2 : (!objectName.empty() ? 1 : 0);
+  }
+
   void OnVisitTextNode(TextNode& node) override {
     // Completions are searched in the case the text node is a parameter of a
     // function call.
@@ -355,8 +364,10 @@ class GD_CORE_API ExpressionCompletionFinder
         return;
       }
       // Search the parameter metadata index skipping invisible ones.
-      int visibleParameterIndex = 0;
-      int metadataParameterIndex = 0;
+      size_t visibleParameterIndex = 0;
+      size_t metadataParameterIndex = WrittenParametersFirstIndex(
+          functionCall->objectName, functionCall->behaviorName);
+
       const gd::ParameterMetadata* parameterMetadata = nullptr;
       while (metadataParameterIndex <
              functionCall->expressionMetadata.parameters.size()) {

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -14,7 +14,6 @@
 #include "GDCore/Extensions/Metadata/ExpressionMetadata.h"
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/IDE/Events/ExpressionNodeLocationFinder.h"
-#include "GDCore/Events/Parsers/ExpressionParser2.h"
 namespace gd {
 class Expression;
 class ObjectsContainer;

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -454,6 +454,14 @@ export default class EventsFunctionParametersEditor extends React.Component<
                                   value="trueorfalse"
                                   primaryText={t`True or False (boolean)`}
                                 />
+                                <SelectOption
+                                  value="objectPointName"
+                                  primaryText={t`Object point (text)`}
+                                />
+                                <SelectOption
+                                  value="objectAnimationName"
+                                  primaryText={t`Object animation (text)`}
+                                />
                               </SelectField>
                             )}
                             {gd.ParameterMetadata.isObject(

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.spec.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall.spec.js
@@ -94,6 +94,8 @@ describe('FormatExpressionCall', () => {
     const pointXExpression = filterExpressions(objectsExpressions, 'PointX')[0];
     expect(pointXExpression).not.toBeUndefined();
 
-    expect(getVisibleParameterTypes(pointXExpression)).toEqual(['string']);
+    expect(getVisibleParameterTypes(pointXExpression)).toEqual([
+      'objectPointName',
+    ]);
   });
 });

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -39,7 +39,7 @@ export default class ObjectAnimationNameField extends Component<
       expression,
       parameterIndex,
     });
-    if (!objectName) {
+    if (!objectName || !project) {
       return [];
     }
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -54,12 +54,15 @@ export default class ObjectAnimationNameField extends Component<
     }
 
     return mapFor(0, spriteObject.getAnimationsCount(), index => {
-      const animation = spriteObject.getAnimation(index);
-      return {
+      const animationName = spriteObject.getAnimation(index).getName();
+      return animationName.length > 0 ? animationName : null;
+    })
+      .filter(Boolean)
+      .sort()
+      .map(animationName => ({
         kind: 'Text',
-        completion: `"${animation.getName()}"`,
-      };
-    });
+        completion: `"${animationName}"`,
+      }));
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -1,0 +1,79 @@
+// @flow
+import React, { Component } from 'react';
+import GenericExpressionField from './GenericExpressionField';
+import { type ParameterFieldProps } from './ParameterFieldCommons';
+import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
+import getObjectByName from '../../Utils/GetObjectByName';
+import { getLastObjectParameterValue } from './ParameterMetadataTools';
+import { mapFor } from '../../Utils/MapFor';
+
+const gd: libGDevelop = global.gd;
+
+export default class ObjectAnimationNameField extends Component<
+  ParameterFieldProps,
+  void
+> {
+  _field: ?GenericExpressionField;
+
+  focus() {
+    if (this._field) this._field.focus();
+  }
+
+  getAnimationNames(
+    props: Readonly<any> & Readonly<{ children?: React.ReactNode }>
+  ): Array<ExpressionAutocompletion> {
+    const {
+      project,
+      scope,
+      instructionMetadata,
+      instruction,
+      expressionMetadata,
+      expression,
+      parameterIndex,
+    } = props;
+
+    const objectName = getLastObjectParameterValue({
+      instructionMetadata,
+      instruction,
+      expressionMetadata,
+      expression,
+      parameterIndex,
+    });
+    if (!objectName) {
+      return [];
+    }
+
+    const object = getObjectByName(project, scope.layout, objectName);
+    if (!object) {
+      return [];
+    }
+
+    const spriteObject = gd.asSpriteObject(object);
+    if (!spriteObject) {
+      return [];
+    }
+
+    return mapFor(0, spriteObject.getAnimationsCount(), index => {
+      const animation = spriteObject.getAnimation(index);
+      return {
+        kind: 'Text',
+        completion: `"${animation.getName()}"`,
+      };
+    });
+  }
+
+  render() {
+    return (
+      <GenericExpressionField
+        expressionType="string"
+        onGetAdditionalAutocompletions={expression =>
+          this.getAnimationNames(this.props).filter(
+            ({ completion }) => completion.indexOf(expression) === 0
+          )
+        }
+        ref={field => (this._field = field)}
+        {...this.props}
+      />
+    );
+  }
+}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -19,9 +19,7 @@ export default class ObjectAnimationNameField extends Component<
     if (this._field) this._field.focus();
   }
 
-  getAnimationNames(
-    props: ParameterFieldProps
-  ): Array<ExpressionAutocompletion> {
+  getAnimationNames(): Array<ExpressionAutocompletion> {
     const {
       project,
       scope,
@@ -30,7 +28,7 @@ export default class ObjectAnimationNameField extends Component<
       expressionMetadata,
       expression,
       parameterIndex,
-    } = props;
+    } = this.props;
 
     const objectName = getLastObjectParameterValue({
       instructionMetadata,
@@ -48,21 +46,22 @@ export default class ObjectAnimationNameField extends Component<
       return [];
     }
 
-    const spriteObject = gd.asSpriteObject(object);
-    if (!spriteObject) {
-      return [];
+    if (object.getType() === 'Sprite') {
+      const spriteObject = gd.asSpriteObject(object);
+
+      return mapFor(0, spriteObject.getAnimationsCount(), index => {
+        const animationName = spriteObject.getAnimation(index).getName();
+        return animationName.length > 0 ? animationName : null;
+      })
+        .filter(Boolean)
+        .sort()
+        .map(animationName => ({
+          kind: 'Text',
+          completion: `"${animationName}"`,
+        }));
     }
 
-    return mapFor(0, spriteObject.getAnimationsCount(), index => {
-      const animationName = spriteObject.getAnimation(index).getName();
-      return animationName.length > 0 ? animationName : null;
-    })
-      .filter(Boolean)
-      .sort()
-      .map(animationName => ({
-        kind: 'Text',
-        completion: `"${animationName}"`,
-      }));
+    return [];
   }
 
   render() {
@@ -70,7 +69,7 @@ export default class ObjectAnimationNameField extends Component<
       <GenericExpressionField
         expressionType="string"
         onGetAdditionalAutocompletions={expression =>
-          this.getAnimationNames(this.props).filter(
+          this.getAnimationNames().filter(
             ({ completion }) => completion.indexOf(expression) === 0
           )
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -20,7 +20,7 @@ export default class ObjectAnimationNameField extends Component<
   }
 
   getAnimationNames(
-    props: Readonly<any> & Readonly<{ children?: React.ReactNode }>
+    props: ParameterFieldProps
   ): Array<ExpressionAutocompletion> {
     const {
       project,

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
@@ -1,0 +1,78 @@
+// @flow
+import React, { Component } from 'react';
+import GenericExpressionField from './GenericExpressionField';
+import { type ParameterFieldProps } from './ParameterFieldCommons';
+import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
+import getObjectByName from '../../Utils/GetObjectByName';
+import { getLastObjectParameterValue } from './ParameterMetadataTools';
+import { getAllPointNames } from '../../ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper';
+
+const gd: libGDevelop = global.gd;
+
+export default class ObjectPointNameField extends Component<
+  ParameterFieldProps,
+  void
+> {
+  _field: ?GenericExpressionField;
+
+  focus() {
+    if (this._field) this._field.focus();
+  }
+
+  getPointNames(
+    props: Readonly<any> & Readonly<{ children?: React.ReactNode }>
+  ): Array<ExpressionAutocompletion> {
+    const {
+      project,
+      scope,
+      instructionMetadata,
+      instruction,
+      expressionMetadata,
+      expression,
+      parameterIndex,
+    } = props;
+
+    const objectName = getLastObjectParameterValue({
+      instructionMetadata,
+      instruction,
+      expressionMetadata,
+      expression,
+      parameterIndex,
+    });
+    if (!objectName) {
+      return [];
+    }
+
+    const object = getObjectByName(project, scope.layout, objectName);
+    if (!object) {
+      return [];
+    }
+
+    const spriteObject = gd.asSpriteObject(object);
+    if (!spriteObject) {
+      return [];
+    }
+
+    return getAllPointNames(spriteObject).map(pointName => ({
+      kind: 'Text',
+      completion: `"${pointName}"`,
+    }));
+  }
+
+  render() {
+    const pointsNames = this.getPointNames(this.props);
+
+    return (
+      <GenericExpressionField
+        expressionType="string"
+        onGetAdditionalAutocompletions={expression =>
+          pointsNames.filter(
+            ({ completion }) => completion.indexOf(expression) === 0
+          )
+        }
+        ref={field => (this._field = field)}
+        {...this.props}
+      />
+    );
+  }
+}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
@@ -19,7 +19,7 @@ export default class ObjectPointNameField extends Component<
     if (this._field) this._field.focus();
   }
 
-  getPointNames(props: ParameterFieldProps): Array<ExpressionAutocompletion> {
+  getPointNames(): Array<ExpressionAutocompletion> {
     const {
       project,
       scope,
@@ -28,7 +28,7 @@ export default class ObjectPointNameField extends Component<
       expressionMetadata,
       expression,
       parameterIndex,
-    } = props;
+    } = this.props;
 
     const objectName = getLastObjectParameterValue({
       instructionMetadata,
@@ -46,31 +46,30 @@ export default class ObjectPointNameField extends Component<
       return [];
     }
 
-    const spriteObject = gd.asSpriteObject(object);
-    if (!spriteObject) {
-      return [];
+    if (object.getType() === 'Sprite') {
+      const spriteObject = gd.asSpriteObject(object);
+
+      return getAllPointNames(spriteObject)
+        .map(spriteObjectName =>
+          spriteObjectName.length > 0 ? spriteObjectName : null
+        )
+        .filter(Boolean)
+        .sort()
+        .map(pointName => ({
+          kind: 'Text',
+          completion: `"${pointName}"`,
+        }));
     }
 
-    return getAllPointNames(spriteObject)
-      .map(spriteObjectName =>
-        spriteObjectName.length > 0 ? spriteObjectName : null
-      )
-      .filter(Boolean)
-      .sort()
-      .map(pointName => ({
-        kind: 'Text',
-        completion: `"${pointName}"`,
-      }));
+    return [];
   }
 
   render() {
-    const pointsNames = this.getPointNames(this.props);
-
     return (
       <GenericExpressionField
         expressionType="string"
         onGetAdditionalAutocompletions={expression =>
-          pointsNames.filter(
+          this.getPointNames().filter(
             ({ completion }) => completion.indexOf(expression) === 0
           )
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
@@ -19,9 +19,7 @@ export default class ObjectPointNameField extends Component<
     if (this._field) this._field.focus();
   }
 
-  getPointNames(
-    props: Readonly<any> & Readonly<{ children?: React.ReactNode }>
-  ): Array<ExpressionAutocompletion> {
+  getPointNames(props: ParameterFieldProps): Array<ExpressionAutocompletion> {
     const {
       project,
       scope,

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
@@ -53,10 +53,16 @@ export default class ObjectPointNameField extends Component<
       return [];
     }
 
-    return getAllPointNames(spriteObject).map(pointName => ({
-      kind: 'Text',
-      completion: `"${pointName}"`,
-    }));
+    return getAllPointNames(spriteObject)
+      .map(spriteObjectName =>
+        spriteObjectName.length > 0 ? spriteObjectName : null
+      )
+      .filter(Boolean)
+      .sort()
+      .map(pointName => ({
+        kind: 'Text',
+        completion: `"${pointName}"`,
+      }));
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
@@ -37,7 +37,7 @@ export default class ObjectPointNameField extends Component<
       expression,
       parameterIndex,
     });
-    if (!objectName) {
+    if (!objectName || !project) {
       return [];
     }
 

--- a/newIDE/app/src/EventsSheet/ParameterRenderingService.js
+++ b/newIDE/app/src/EventsSheet/ParameterRenderingService.js
@@ -46,6 +46,8 @@ import ForceMultiplierField, {
   renderInlineForceMultiplier,
 } from './ParameterFields/ForceMultiplierField';
 import SceneNameField from './ParameterFields/SceneNameField';
+import ObjectPointNameField from './ParameterFields/ObjectPointNameField';
+import ObjectAnimationNameField from './ParameterFields/ObjectAnimationNameField';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 const gd: libGDevelop = global.gd;
 
@@ -77,6 +79,8 @@ const components = {
   joyaxis: DefaultField, //TODO
   forceMultiplier: ForceMultiplierField,
   sceneName: SceneNameField,
+  objectPointName: ObjectPointNameField,
+  objectAnimationName: ObjectAnimationNameField,
 };
 const inlineRenderers: { [string]: ParameterInlineRenderer } = {
   default: renderInlineDefaultField,
@@ -116,6 +120,8 @@ const userFriendlyTypeName: { [string]: MessageDescriptor } = {
   color: t`Color`,
   forceMultiplier: t`Instant or permanent force`,
   sceneName: t`Scene name`,
+  objectPointName: t`Object point name`,
+  objectAnimationName: t`Object animation name`,
 };
 
 export default {

--- a/newIDE/app/src/ExpressionAutocompletion/ExpressionAutocompletion.spec.js
+++ b/newIDE/app/src/ExpressionAutocompletion/ExpressionAutocompletion.spec.js
@@ -12,7 +12,20 @@ const makeTestContext = () => {
   testLayout.insertNewLayer('Background', 0);
   testLayout.insertNewLayer('Foreground', 0);
 
-  testLayout.insertNewObject(project, 'Sprite', 'MySpriteObject', 0);
+  const object = testLayout.insertNewObject(project, 'Sprite', 'MySpriteObject', 0);
+  const spriteObject = gd.asSpriteObject(object);
+  const point = new gd.Point();
+  point.setName("Head");
+  const sprite = new gd.Sprite();
+  sprite.addPoint(point);
+  const direction = new gd.Direction();
+  direction.addSprite(sprite);
+  const animation = new gd.Animation();
+  animation.setName("Jump");
+  animation.setDirectionsCount(1);
+  animation.setDirection(direction, 0);
+  spriteObject.addAnimation(animation);
+
   const spriteObjectWithBehaviors = testLayout.insertNewObject(
     project,
     'Sprite',
@@ -210,6 +223,38 @@ describe('ExpressionAutocompletion', () => {
           completion: 'PointY',
           addParenthesis: true,
           isExact: false,
+        }),
+      ])
+    );
+  });
+
+  it('can autocomplete object points', () => {
+    const { project, testLayout, parser } = makeTestContext();
+    const scope = { layout: testLayout };
+
+    const expressionNode = parser
+      .parseExpression('number', 'MySpriteObject.PointX("He')
+      .get();
+    const completionDescriptions = gd.ExpressionCompletionFinder.getCompletionDescriptionsFor(
+      expressionNode,
+      24
+    );
+    const autocompletions = getAutocompletionsFromDescriptions(
+      {
+        gd,
+        project: project,
+        globalObjectsContainer: project,
+        objectsContainer: testLayout,
+        scope,
+      },
+      completionDescriptions
+    );
+    expect(autocompletions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          completion: '"Head"',
+          addParameterSeparator: false,
+          addClosingParenthesis: true,
         }),
       ])
     );

--- a/newIDE/app/src/ExpressionAutocompletion/ExpressionAutocompletion.spec.js
+++ b/newIDE/app/src/ExpressionAutocompletion/ExpressionAutocompletion.spec.js
@@ -12,16 +12,21 @@ const makeTestContext = () => {
   testLayout.insertNewLayer('Background', 0);
   testLayout.insertNewLayer('Foreground', 0);
 
-  const object = testLayout.insertNewObject(project, 'Sprite', 'MySpriteObject', 0);
+  const object = testLayout.insertNewObject(
+    project,
+    'Sprite',
+    'MySpriteObject',
+    0
+  );
   const spriteObject = gd.asSpriteObject(object);
   const point = new gd.Point();
-  point.setName("Head");
+  point.setName('Head');
   const sprite = new gd.Sprite();
   sprite.addPoint(point);
   const direction = new gd.Direction();
   direction.addSprite(sprite);
   const animation = new gd.Animation();
-  animation.setName("Jump");
+  animation.setName('Jump');
   animation.setDirectionsCount(1);
   animation.setDirection(direction, 0);
   spriteObject.addAnimation(animation);

--- a/newIDE/app/src/ExpressionAutocompletion/ExpressionAutocompletion.spec.js
+++ b/newIDE/app/src/ExpressionAutocompletion/ExpressionAutocompletion.spec.js
@@ -19,8 +19,7 @@ const makeTestContext = () => {
     0
   );
   const spriteObject = gd.asSpriteObject(object);
-  const point = new gd.Point();
-  point.setName('Head');
+  const point = new gd.Point('Head');
   const sprite = new gd.Sprite();
   sprite.addPoint(point);
   const direction = new gd.Direction();

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -302,9 +302,11 @@ const getAutocompletionsForText = function(
       return [];
     }
 
-    autocompletionTexts = getAllPointNames(spriteObject).map(
-      spriteObjectName => `"${spriteObjectName}"`
-    );
+    autocompletionTexts = getAllPointNames(spriteObject)
+      .map(spriteObjectName =>
+        spriteObjectName.length > 0 ? `"${spriteObjectName}"` : null
+      )
+      .filter(Boolean);
   } else if (type === 'objectAnimationName') {
     const objectName: string = completionDescription.getObjectName();
     if (!objectName) {
@@ -324,13 +326,16 @@ const getAutocompletionsForText = function(
     autocompletionTexts = mapFor(
       0,
       spriteObject.getAnimationsCount(),
-      index => `"${spriteObject.getAnimation(index).getName()}"`
-    );
+      index => {
+        const animationName = spriteObject.getAnimation(index).getName();
+        return animationName.length > 0 ? `"${animationName}"` : null;
+      }
+    ).filter(Boolean);
   }
   // To add missing string types see Core\GDCore\Extensions\Metadata\ParameterMetadata.h
 
-  const filteredTextList = filterStringList(autocompletionTexts, prefix);
-
+  const filteredTextList = filterStringList(autocompletionTexts, prefix).sort();
+  
   const isLastParameter = completionDescription.isLastParameter();
   return filteredTextList.map(text => ({
     kind: 'Text',

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -297,16 +297,17 @@ const getAutocompletionsForText = function(
       return [];
     }
 
-    const spriteObject = gd.asSpriteObject(object);
-    if (!spriteObject) {
+    if (object.getType() === 'Sprite') {
+      const spriteObject = gd.asSpriteObject(object);
+
+      autocompletionTexts = getAllPointNames(spriteObject)
+        .map(spriteObjectName =>
+          spriteObjectName.length > 0 ? `"${spriteObjectName}"` : null
+        )
+        .filter(Boolean);
+    } else {
       return [];
     }
-
-    autocompletionTexts = getAllPointNames(spriteObject)
-      .map(spriteObjectName =>
-        spriteObjectName.length > 0 ? `"${spriteObjectName}"` : null
-      )
-      .filter(Boolean);
   } else if (type === 'objectAnimationName') {
     const objectName: string = completionDescription.getObjectName();
     if (!objectName) {
@@ -318,19 +319,20 @@ const getAutocompletionsForText = function(
       return [];
     }
 
-    const spriteObject = gd.asSpriteObject(object);
-    if (!spriteObject) {
+    if (object.getType() === 'Sprite') {
+      const spriteObject = gd.asSpriteObject(object);
+
+      autocompletionTexts = mapFor(
+        0,
+        spriteObject.getAnimationsCount(),
+        index => {
+          const animationName = spriteObject.getAnimation(index).getName();
+          return animationName.length > 0 ? `"${animationName}"` : null;
+        }
+      ).filter(Boolean);
+    } else {
       return [];
     }
-
-    autocompletionTexts = mapFor(
-      0,
-      spriteObject.getAnimationsCount(),
-      index => {
-        const animationName = spriteObject.getAnimation(index).getName();
-        return animationName.length > 0 ? `"${animationName}"` : null;
-      }
-    ).filter(Boolean);
   }
   // To add missing string types see Core\GDCore\Extensions\Metadata\ParameterMetadata.h
 

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -21,6 +21,10 @@ import {
 import { getVisibleParameterTypes } from '../EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall';
 import { getParameterChoices } from '../EventsSheet/ParameterFields/ParameterMetadataTools';
 import getObjectByName from '../Utils/GetObjectByName';
+import { getAllPointNames } from '../ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper';
+import { mapFor } from '../Utils/MapFor';
+
+const gd: libGDevelop = global.gd;
 
 type BaseExpressionAutocompletion = {|
   completion: string,
@@ -282,6 +286,46 @@ const getAutocompletionsForText = function(
     autocompletionTexts = getParameterChoices(
       completionDescription.getParameterMetadata()
     ).map(autocompletion => autocompletion.completion);
+  } else if (type === 'objectPointName') {
+    const objectName: string = completionDescription.getObjectName();
+    if (!objectName) {
+      return [];
+    }
+
+    const object = getObjectByName(project, scope.layout, objectName);
+    if (!object) {
+      return [];
+    }
+
+    const spriteObject = gd.asSpriteObject(object);
+    if (!spriteObject) {
+      return [];
+    }
+
+    autocompletionTexts = getAllPointNames(spriteObject).map(
+      spriteObjectName => `"${spriteObjectName}"`
+    );
+  } else if (type === 'objectAnimationName') {
+    const objectName: string = completionDescription.getObjectName();
+    if (!objectName) {
+      return [];
+    }
+
+    const object = getObjectByName(project, scope.layout, objectName);
+    if (!object) {
+      return [];
+    }
+
+    const spriteObject = gd.asSpriteObject(object);
+    if (!spriteObject) {
+      return [];
+    }
+
+    autocompletionTexts = mapFor(
+      0,
+      spriteObject.getAnimationsCount(),
+      index => `"${spriteObject.getAnimation(index).getName()}"`
+    );
   }
   // To add missing string types see Core\GDCore\Extensions\Metadata\ParameterMetadata.h
 

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -335,7 +335,7 @@ const getAutocompletionsForText = function(
   // To add missing string types see Core\GDCore\Extensions\Metadata\ParameterMetadata.h
 
   const filteredTextList = filterStringList(autocompletionTexts, prefix).sort();
-  
+
   const isLastParameter = completionDescription.isLastParameter();
   return filteredTextList.map(text => ({
     kind: 'Text',

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper.js
@@ -44,7 +44,6 @@ export const getCurrentElements = (
  * @param {*} object
  */
 export const getAllPointNames = object => {
-  console.log("object: " + object.getName());
   const allPointNames = new Set();
   for (
     let animationIndex = 0;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper.js
@@ -39,6 +39,43 @@ export const getCurrentElements = (
   };
 };
 
+/**
+ * Return all the point names
+ * @param {*} object
+ */
+export const getAllPointNames = object => {
+  console.log("object: " + object.getName());
+  const allPointNames = new Set();
+  for (
+    let animationIndex = 0;
+    animationIndex < object.getAnimationsCount();
+    animationIndex++
+  ) {
+    const animation = object.getAnimation(animationIndex);
+    for (
+      let directionIndex = 0;
+      directionIndex < animation.getDirectionsCount();
+      directionIndex++
+    ) {
+      const direction = animation.getDirection(directionIndex);
+      for (
+        let spriteIndex = 0;
+        spriteIndex < direction.getSpritesCount();
+        spriteIndex++
+      ) {
+        const points = direction
+          .getSprite(spriteIndex)
+          .getAllNonDefaultPoints();
+        for (let pointIndex = 0; pointIndex < points.size(); pointIndex++) {
+          const point = points.at(pointIndex);
+          allPointNames.add(point.getName());
+        }
+      }
+    }
+  }
+  return [...allPointNames];
+};
+
 export const copyPoint = (originalPoint, destinationPoint) => {
   destinationPoint.setX(originalPoint.getX());
   destinationPoint.setY(originalPoint.getY());


### PR DESCRIPTION
* Adds objectAnimationName and objectPointName as subtype for string.
* Update Sprite extension
* Add new fields for autocompletion
* Add expression autocompletion (only for object function: object + string in parameters won't autocompete, but I guess it's too much rare to bother)
* Fix expression autocompletion for object functions

Test Project: https://www.dropbox.com/s/y3xrabgkrnjo9tv/UndefinedVariableTest.zip?dl=1