### PR TITLE
[PathFinding] Add movement angle condition and expression

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -206,7 +206,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
            "all of the forces it has."),
          _("Add to _PARAM0_ _PARAM3_ force of _PARAM1_ p/s on X axis and "
            "_PARAM2_ p/s on Y axis"),
-         _("Movement"),
+         _("Movement using forces"),
          "res/actions/force24.png",
          "res/actions/force.png")
 
@@ -222,7 +222,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                   "using the specified angle and length."),
                 _("Add to _PARAM0_ _PARAM3_ force, angle: _PARAM1_ degrees and "
                   "length: _PARAM2_ pixels"),
-                _("Movement"),
+                _("Movement using forces"),
                 "res/actions/force24.png",
                 "res/actions/force.png")
 
@@ -238,7 +238,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add a force to an object to make it move toward a position."),
          _("Move _PARAM0_ toward _PARAM1_;_PARAM2_ with _PARAM4_ force of _PARAM3_ "
            "pixels"),
-         _("Movement"),
+         _("Movement using forces"),
          "res/actions/force24.png",
          "res/actions/force.png")
 
@@ -258,7 +258,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
            "precisely, use the actions in the category \"Position\"."),
          _("Rotate _PARAM0_ around _PARAM1_;_PARAM2_ at _PARAM3_ deg/sec and "
            "_PARAM4_ pixels away"),
-         _("Movement"),
+         _("Movement using forces"),
          "res/actions/forceTourne24.png",
          "res/actions/forceTourne.png")
 
@@ -274,7 +274,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 _("Stop the object"),
                 _("Stop the object by deleting all of its forces."),
                 _("Stop _PARAM0_ (remove all forces)"),
-                _("Movement"),
+                _("Movement using forces"),
                 "res/actions/arreter24.png",
                 "res/actions/arreter.png")
 
@@ -486,10 +486,10 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .SetHidden();  // Inverted "Visible" condition  does the same thing.
 
   obj.AddCondition("Arret",
-                   _("Object is stopped"),
+                   _("Object is stopped (no forces applied on it)"),
                    _("Check if an object is not moving"),
                    _("_PARAM0_ is stopped"),
-                   _("Movement"),
+                   _("Movement using forces"),
                    "res/conditions/arret24.png",
                    "res/conditions/arret.png")
 
@@ -497,10 +497,10 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsAdvanced();
 
   obj.AddCondition("Vitesse",
-                   _("Speed"),
+                   _("Speed (from forces)"),
                    _("Compare the overall speed of an object"),
                    _("the overall speed"),
-                   _("Movement"),
+                   _("Movement using forces"),
                    "res/conditions/vitesse24.png",
                    "res/conditions/vitesse.png")
 
@@ -509,17 +509,18 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .MarkAsAdvanced();
 
   obj.AddCondition("AngleOfDisplacement",
-                   _("Angle of movement"),
-                   _("Compare the angle of displacement of an object"),
-                   _("Angle of displacement of _PARAM0_ is _PARAM1_ (tolerance "
+                   _("Angle of movement (using forces)"),
+                   _("Compare the angle of movement of an object using forces."
+                     " according to the forces."),
+                   _("Angle of movement of _PARAM0_ is _PARAM1_ (tolerance"
                      ": _PARAM2_ degrees)"),
-                   _("Movement"),
+                   _("Movement using forces"),
                    "res/conditions/vitesse24.png",
                    "res/conditions/vitesse.png")
 
       .AddParameter("object", _("Object"))
       .AddParameter("expression", _("Angle, in degrees"))
-      .AddParameter("expression", _("Tolerance"))
+      .AddParameter("expression", _("Tolerance, in degrees"))
       .MarkAsAdvanced();
 
   obj.AddCondition("VarObjet",
@@ -671,7 +672,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add a force to move toward an object"),
          _("Add a force to an object to make it move toward another."),
          _("Move _PARAM0_ toward _PARAM1_ with _PARAM3_ force of _PARAM2_ pixels"),
-         _("Movement"),
+         _("Movement using forces"),
          "res/actions/forceVers24.png",
          "res/actions/forceVers.png")
 
@@ -690,7 +691,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
            "the actions in category \"Position\"."),
          _("Rotate _PARAM0_ around _PARAM1_ at _PARAM2_ deg/sec and _PARAM3_ "
            "pixels away"),
-         _("Movement"),
+         _("Movement using forces"),
          "res/actions/forceTourne24.png",
          "res/actions/forceTourne.png")
 
@@ -723,7 +724,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 _("Move an object away from another"),
                 _("Move an object away from another, using forces."),
                 _("Move _PARAM0_ away from _PARAM1_ (only _PARAM0_ will move)"),
-                _("Movement"),
+                _("Movement using forces"),
                 "res/actions/ecarter24.png",
                 "res/actions/ecarter.png")
 
@@ -882,37 +883,37 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceX",
-                    _("Average X coordinates of forces"),
-                    _("Average X coordinates of forces"),
-                    _("Movement"),
+                    _("X coordinate of the forces sum"),
+                    _("X coordinate of the forces sum"),
+                    _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceY",
-                    _("Average Y coordinates of forces"),
-                    _("Average Y coordinates of forces"),
-                    _("Movement"),
+                    _("Y coordinate of the forces sum"),
+                    _("Y coordinate of the forces sum"),
+                    _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceAngle",
-                    _("Average angle of the forces"),
-                    _("Average angle of the forces"),
-                    _("Movement"),
+                    _("Angle of the forces sum"),
+                    _("Angle of the forces sum"),
+                    _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceLength",
-                    _("Average length of the forces"),
-                    _("Average length of the forces"),
-                    _("Movement"),
+                    _("Length of the forces sum"),
+                    _("Length of the forces sum"),
+                    _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("Longueur",
                     _("Average length of the forces"),
                     _("Average length of the forces"),
-                    _("Movement"),
+                    _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"))
       .SetHidden();
@@ -1149,7 +1150,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
           _("Moves all objects according to the forces they have. GDevelop "
             "calls this action at the end of the events by default."),
           _("Apply movement to all objects"),
-          _("Movement"),
+          _("Movement using forces"),
           "res/actions/doMove24.png",
           "res/actions/doMove.png")
       .AddCodeOnlyParameter("currentScene", "")
@@ -1157,16 +1158,16 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   extension
       .AddCondition("SeDirige",
-                    _("An object is moving toward another"),
+                    _("An object is moving toward another (using forces)"),
                     _("Check if an object moves toward another.\nThe first "
                       "object must move."),
                     _("_PARAM0_ is moving toward _PARAM1_"),
-                    _("Movement"),
+                    _("Movement using forces"),
                     "res/conditions/sedirige24.png",
                     "res/conditions/sedirige.png")
       .AddParameter("objectList", _("Object"))
       .AddParameter("objectList", _("Object 2"))
-      .AddParameter("expression", _("Angle of tolerance"))
+      .AddParameter("expression", _("Angle of tolerance in degrees"))
       .AddCodeOnlyParameter("conditionInverted", "")
       .MarkAsAdvanced();
 

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -882,36 +882,36 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceX",
-                    _("X coordinate of the forces sum"),
-                    _("X coordinate of the forces sum"),
+                    _("X coordinate of the sum of forces"),
+                    _("X coordinate of the sum of forces"),
                     _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceY",
-                    _("Y coordinate of the forces sum"),
-                    _("Y coordinate of the forces sum"),
+                    _("Y coordinate of the sum of forces"),
+                    _("Y coordinate of the sum of forces"),
                     _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceAngle",
-                    _("Angle of the forces sum"),
-                    _("Angle of the forces sum"),
+                    _("Angle of the sum of forces"),
+                    _("Angle of the sum of forces"),
                     _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("ForceLength",
-                    _("Length of the forces sum"),
-                    _("Length of the forces sum"),
+                    _("Length of the sum of forces"),
+                    _("Length of the sum of forces"),
                     _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
 
   obj.AddExpression("Longueur",
-                    _("Average length of the forces"),
-                    _("Average length of the forces"),
+                    _("Length of the sum of forces"),
+                    _("Length of the sum of forces"),
                     _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"))

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -510,8 +510,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddCondition("AngleOfDisplacement",
                    _("Angle of movement (using forces)"),
-                   _("Compare the angle of movement of an object using forces."
-                     " according to the forces."),
+                   _("Compare the angle of movement of an object according to the forces applied on it."),
                    _("Angle of movement of _PARAM0_ is _PARAM1_ (tolerance"
                      ": _PARAM2_ degrees)"),
                    _("Movement using forces"),
@@ -1167,7 +1166,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                     "res/conditions/sedirige.png")
       .AddParameter("objectList", _("Object"))
       .AddParameter("objectList", _("Object 2"))
-      .AddParameter("expression", _("Angle of tolerance in degrees"))
+      .AddParameter("expression", _("Tolerance, in degrees"))
       .AddCodeOnlyParameter("conditionInverted", "")
       .MarkAsAdvanced();
 

--- a/Extensions/PathfindingBehavior/Extension.cpp
+++ b/Extensions/PathfindingBehavior/Extension.cpp
@@ -228,6 +228,22 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("GetSpeed")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
+    aut.AddScopedCondition("MovementAngleIsAround",
+                          _("Angle of movement"),
+                          _("Compare the angle of displacement of an object"),
+                          _("Angle of displacement of _PARAM0_ is _PARAM2_ (tolerance "
+                              ": _PARAM3_ degrees)"),
+                          _("Path"),
+                         "CppPlatform/Extensions/AStaricon24.png",
+                         "CppPlatform/Extensions/AStaricon16.png")
+
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
+        .AddParameter("expression", _("Angle, in degrees"))
+        .AddParameter("expression", _("Tolerance"))
+        .SetFunctionName("MovementAngleIsAround")
+        .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
+
     aut.AddAction("AngularMaxSpeed",
                   _("Angular maximum speed"),
                   _("Change the maximum angular speed when moving the object"),
@@ -559,13 +575,23 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("GetCellHeight")
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
+    aut.AddExpression("MovementAngle",
+                    _("Angle of movement"),
+                    _("Angle of displacement of an object"),
+                    _("Path"),
+                    "CppPlatform/Extensions/AStaricon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
+        .SetFunctionName("GetMovementAngle")
+        .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
+
     aut.AddExpressionAndConditionAndAction("number",
                       "GridOffsetX",
                       _("Grid X offset"),
                       _("X offset of the virtual grid"),
                       _("X offset of the virtual grid"),
                       _("Virtual grid"),
-                      "CppPlatform/Extensions/AStaricon16.png")
+                      "CppPlatform/Extensions/AStaricon24.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
         .UseStandardParameters("number");
@@ -576,7 +602,7 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
                       _("Y offset of the virtual grid"),
                       _("Y offset of the virtual grid"),
                       _("Virtual grid"),
-                      "CppPlatform/Extensions/AStaricon16.png")
+                      "CppPlatform/Extensions/AStaricon24.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
         .UseStandardParameters("number");

--- a/Extensions/PathfindingBehavior/Extension.cpp
+++ b/Extensions/PathfindingBehavior/Extension.cpp
@@ -215,8 +215,8 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddCondition("Speed",
-                     _("Speed"),
-                     _("Compare the speed of the object on the path"),
+                     _("Speed on its path"),
+                     _("Compare the speed of the object on its path."),
                      _("the speed"),
                      _("Path"),
                      "CppPlatform/Extensions/AStaricon24.png",
@@ -229,9 +229,9 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddScopedCondition("MovementAngleIsAround",
-                          _("Angle of movement"),
-                          _("Compare the angle of displacement of an object"),
-                          _("Angle of displacement of _PARAM0_ is _PARAM2_ (tolerance "
+                          _("Angle of movement on its path"),
+                          _("Compare the angle of movement of an object on its path."),
+                          _("Angle of movement of _PARAM0_ is _PARAM2_ (tolerance"
                               ": _PARAM3_ degrees)"),
                           _("Path"),
                          "CppPlatform/Extensions/AStaricon24.png",
@@ -240,9 +240,7 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
         .AddParameter("expression", _("Angle, in degrees"))
-        .AddParameter("expression", _("Tolerance"))
-        .SetFunctionName("MovementAngleIsAround")
-        .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
+        .AddParameter("expression", _("Tolerance, in degrees"));
 
     aut.AddAction("AngularMaxSpeed",
                   _("Angular maximum speed"),
@@ -576,14 +574,12 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
         .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
 
     aut.AddExpression("MovementAngle",
-                    _("Angle of movement"),
-                    _("Angle of displacement of an object"),
+                    _("Angle of movement on its path"),
+                    _("Angle of movement on its path"),
                     _("Path"),
                     "CppPlatform/Extensions/AStaricon16.png")
         .AddParameter("object", _("Object"))
-        .AddParameter("behavior", _("Behavior"), "PathfindingBehavior")
-        .SetFunctionName("GetMovementAngle")
-        .SetIncludeFile("PathfindingBehavior/PathfindingRuntimeBehavior.h");
+        .AddParameter("behavior", _("Behavior"), "PathfindingBehavior");
 
     aut.AddExpressionAndConditionAndAction("number",
                       "GridOffsetX",

--- a/Extensions/PathfindingBehavior/JsExtension.cpp
+++ b/Extensions/PathfindingBehavior/JsExtension.cpp
@@ -79,6 +79,8 @@ class PathfindingBehaviorJsExtension : public gd::PlatformExtension {
           .SetFunctionName("setSpeed")
           .SetGetter("getSpeed");
       autConditions["PathfindingBehavior::Speed"].SetFunctionName("getSpeed");
+      autConditions["PathfindingBehavior::PathfindingBehavior::MovementAngleIsAround"]
+          .SetFunctionName("movementAngleIsAround");
       autActions["PathfindingBehavior::AngularMaxSpeed"]
           .SetFunctionName("setAngularMaxSpeed")
           .SetGetter("getAngularMaxSpeed");
@@ -118,6 +120,7 @@ class PathfindingBehaviorJsExtension : public gd::PlatformExtension {
       autExpressions["Acceleration"].SetFunctionName("getAcceleration");
       autExpressions["MaxSpeed"].SetFunctionName("getMaxSpeed");
       autExpressions["Speed"].SetFunctionName("getSpeed");
+      autExpressions["MovementAngle"].SetFunctionName("getMovementAngle");
       autExpressions["AngularMaxSpeed"].SetFunctionName("getAngularMaxSpeed");
       autExpressions["AngleOffset"].SetFunctionName("getAngleOffset");
       autExpressions["ExtraBorder"].SetFunctionName("getExtraBorder");

--- a/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
@@ -163,7 +163,7 @@ namespace gdjs {
     }
 
     movementAngleIsAround(degreeAngle: float, tolerance: float) {
-      return Math.abs((this._movementAngle - degreeAngle) % 360) <= tolerance;
+      return gdjs.evtTools.common.angleDifference(this._movementAngle, degreeAngle) <= tolerance;
     }
 
     setAngularMaxSpeed(angularMaxSpeed: float): void {

--- a/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
@@ -34,6 +34,8 @@ namespace gdjs {
     _manager: PathfindingObstaclesManager;
     _searchContext: PathfindingRuntimeBehavior.SearchContext;
 
+    _movementAngle: float = 0;
+
     constructor(
       runtimeScene: gdjs.RuntimeScene,
       behaviorData,
@@ -154,6 +156,14 @@ namespace gdjs {
 
     getSpeed() {
       return this._speed;
+    }
+
+    getMovementAngle() {
+      return this._movementAngle;
+    }
+
+    movementAngleIsAround(degreeAngle: float, tolerance: float) {
+      return Math.abs((this._movementAngle - degreeAngle) % 360) <= tolerance;
     }
 
     setAngularMaxSpeed(angularMaxSpeed: float): void {
@@ -379,6 +389,7 @@ namespace gdjs {
         this._totalSegmentTime = Math.sqrt(pathX * pathX + pathY * pathY);
         this._timeOnSegment = 0;
         this._reachedEnd = false;
+        this._movementAngle = (Math.atan2(pathY, pathX) * 180 / Math.PI + 360) % 360;
       } else {
         this._reachedEnd = true;
         this._speed = 0;


### PR DESCRIPTION
This was asked by users to easily change the animation according to the direction.

2 usages by name or index:
![MovementAngle](https://user-images.githubusercontent.com/2611977/121779967-7dc0f100-cb9e-11eb-9026-61666b5b3222.png)

Test project:
https://www.dropbox.com/s/hqkx917bejz6aav/PathFindingMovementAngleExample.zip?dl=1