### PR TITLE
Disable metrics collection by default

### DIFF
--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -71,7 +71,7 @@ namespace gdjs {
      */
     _debuggerClient: gdjs.IDebuggerClient | null;
     _sessionMetricsInitialized: boolean = false;
-    _disableMetrics: boolean = false;
+    _disableMetrics: boolean = true;
     _isPreview: boolean;
 
     /**
@@ -584,9 +584,6 @@ namespace gdjs {
         }
         return false;
       });
-      setTimeout(() => {
-        this._setupSessionMetrics();
-      }, 10000);
     }
 
     /**


### PR DESCRIPTION
Currently, if a game does not explicitly disable metrics collection, metrics are collected after 10 seconds. This PR instead disables it by default, for 1) privacy 2) legal (GDPR, ToS, etc.) liability.

This only affects the default behaviour. As before, explicitly enabling metrics [triggers immediate collection](https://github.com/4ian/GDevelop/blob/master/GDJS/Runtime/runtimegame.ts#L598).

If game developers are relying on the current behaviour (e.g. to exclude users who close the game quickly from metrics), I could change `_setupSessionMetrics` to keep this delay. Let me know!

Closes #2750.