### PR TITLE
Add a console to the debugger

### DIFF
--- a/Extensions/DebuggerTools/JsExtension.js
+++ b/Extensions/DebuggerTools/JsExtension.js
@@ -89,13 +89,12 @@ module.exports = {
         _('Log a message to the console'),
         _("Logs a message to the debugger's console."),
         _(
-          'Log message _PARAM1_ of type _PARAM2_ to the console in group _PARAM3_'
+          'Log message _PARAM0_ of type _PARAM1_ to the console in group _PARAM2_'
         ),
         _('Debugger Tools'),
         'res/actions/bug32.png',
         'res/actions/bug32.png'
       )
-      .addCodeOnlyParameter('currentScene', '')
       .addParameter('string', 'Message to log', '', false)
       .addParameter(
         'stringWithSelector',

--- a/Extensions/DebuggerTools/JsExtension.js
+++ b/Extensions/DebuggerTools/JsExtension.js
@@ -83,6 +83,33 @@ module.exports = {
       .setIncludeFile('Extensions/DebuggerTools/debuggertools.js')
       .setFunctionName('gdjs.evtTools.debuggerTools.enableDebugDraw');
 
+    extension
+      .addAction(
+        'ConsoleLog',
+        _('Log a message to the console'),
+        _("Logs a message to the debugger's console."),
+        _(
+          'Log message _PARAM1_ of type _PARAM2_ to the console in group _PARAM3_'
+        ),
+        _('Debugger Tools'),
+        'res/actions/bug32.png',
+        'res/actions/bug32.png'
+      )
+      .addCodeOnlyParameter('currentScene', '')
+      .addParameter('string', 'Message to log', '', false)
+      .addParameter(
+        'stringWithSelector',
+        'Message type',
+        '["info", "warning", "error"]',
+        true
+      )
+      .setDefaultValue('info')
+      .addParameter('string', 'Group of messages', '', true)
+      .setDefaultValue('"Default"')
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/DebuggerTools/debuggertools.js')
+      .setFunctionName('gdjs.evtTools.debuggerTools.log');
+
     return extension;
   },
   runExtensionSanityTests: function (

--- a/Extensions/DebuggerTools/debuggertools.ts
+++ b/Extensions/DebuggerTools/debuggertools.ts
@@ -14,6 +14,24 @@ namespace gdjs {
       };
 
       /**
+       * Logs a message to the console.
+       * @param runtimeScene - The current scene.
+       * @param message - The message to log.
+       * @param group - The group of messages it belongs to.
+       * @param type - The type of log (info, warning or error).
+       */
+      export const log = function (
+        runtimeScene: gdjs.RuntimeScene,
+        message: string,
+        type: 'info' | 'warning' | 'error',
+        group: string
+      ) {
+        const game = runtimeScene.getGame();
+        if (game._debuggerClient)
+          game._debuggerClient.log(message, { group, type });
+      };
+
+      /**
        * Enable or disable the debug draw.
        * @param runtimeScene - The current scene.
        * @param enableDebugDraw - true to enable the debug draw, false to disable it.

--- a/Extensions/DebuggerTools/debuggertools.ts
+++ b/Extensions/DebuggerTools/debuggertools.ts
@@ -21,14 +21,11 @@ namespace gdjs {
        * @param type - The type of log (info, warning or error).
        */
       export const log = function (
-        runtimeScene: gdjs.RuntimeScene,
         message: string,
         type: 'info' | 'warning' | 'error',
         group: string
       ) {
-        const game = runtimeScene.getGame();
-        if (game._debuggerClient)
-          game._debuggerClient.log(message, { group, type });
+        gdjs.log(group, message, type);
       };
 
       /**

--- a/GDJS/Runtime/events-tools/storagetools.ts
+++ b/GDJS/Runtime/events-tools/storagetools.ts
@@ -30,11 +30,17 @@ namespace gdjs {
           }
         }
       } catch (error) {
-        console.warn('Unable to get access to the localStorage: ', error);
+        gdjs.log(
+          'Storage extension',
+          'Unable to get access to the localStorage: ' + error,
+          'error'
+        );
       }
       if (!localStorage) {
-        console.warn(
-          "Storage actions won't work as no localStorage was found."
+        gdjs.log(
+          'Storage extension',
+          "Storage actions won't work as no localStorage was found.",
+          'warning'
         );
       }
 
@@ -64,9 +70,13 @@ namespace gdjs {
             serializedString = localStorage.getItem('GDJS_' + name);
           }
         } catch (error) {
-          console.warn(
-            'Unable to load data from localStorage for "' + name + '":',
-            error
+          gdjs.log(
+            'Storage extension',
+            'Unable to load data from localStorage for "' +
+              name +
+              '": ' +
+              error,
+            'warning'
           );
         }
         let jsObject = {};
@@ -75,9 +85,13 @@ namespace gdjs {
             jsObject = JSON.parse(serializedString);
           }
         } catch (error) {
-          console.warn(
-            'Unable to load data from "' + name + '" - data is not valid JSON:',
-            error
+          gdjs.log(
+            'Storage extension',
+            'Unable to load data from "' +
+              name +
+              '" - data is not valid JSON: ' +
+              error,
+            'warning'
           );
         }
         loadedObjects.put(name, jsObject);
@@ -107,9 +121,10 @@ namespace gdjs {
             localStorage.setItem('GDJS_' + name, serializedString);
           }
         } catch (error) {
-          console.warn(
-            'Unable to save data to localStorage for "' + name + '":',
-            error
+          gdjs.log(
+            'Storage extension',
+            'Unable to save data to localStorage for "' + name + '": ' + error,
+            'warning'
           );
         }
         loadedObjects.remove(name);

--- a/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
+++ b/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
@@ -198,13 +198,14 @@ namespace gdjs {
             onFontLoaded(fontFamily, fontResources);
           },
           function (error) {
-            console.error(
+            gdjs.runtimeLog(
               'Error loading font resource "' +
                 fontResources[0].name +
                 '" (file: ' +
                 file +
                 '): ' +
-                (error.message || 'Unknown error')
+                (error.message || 'Unknown error'),
+              'error'
             );
             onFontLoaded(fontFamily, fontResources);
           }

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -502,7 +502,7 @@ namespace gdjs {
     message: string,
     type: 'info' | 'warning' | 'error' = 'info'
   ) => {
-    const logger = _console[type];
+    const logger = _console[type] || _console.info;
     logger(`[${group}] ${message}`);
   };
 

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -311,7 +311,7 @@ namespace gdjs {
    * @private
    */
   export const registerGlobalCallbacks = function (): void {
-    console.warn(
+    gdjs.runtimeLog(
       "You're calling gdjs.registerGlobalCallbacks. This method is now useless and you must not call it anymore."
     );
   };
@@ -344,7 +344,7 @@ namespace gdjs {
     if (name !== undefined && gdjs.objectsTypes.containsKey(name))
       return gdjs.objectsTypes.get(name);
 
-    console.warn('Object type "' + name + '" was not found.');
+    gdjs.runtimeLog('Object type "' + name + '" was not found.', 'warning');
     return gdjs.objectsTypes.get(''); //Create a base empty runtime object.
   };
 
@@ -359,7 +359,7 @@ namespace gdjs {
     if (name !== undefined && gdjs.behaviorsTypes.containsKey(name))
       return gdjs.behaviorsTypes.get(name);
 
-    console.warn('Behavior type "' + name + '" was not found.');
+    gdjs.runtimeLog('Behavior type "' + name + '" was not found.', 'warning');
     return gdjs.behaviorsTypes.get(''); //Create a base empty runtime behavior.
   };
 
@@ -486,6 +486,33 @@ namespace gdjs {
       hex[r[15]]
     );
   };
+
+  const _console = {
+    info: console.log,
+    warning: console.warn,
+    error: console.error,
+  };
+
+  /**
+   * Internal method for logging messages to the JS console or the Debugger if available.
+   * Should be used in engine code or extensions, console.log is fine for JS events.
+   */
+  export let log = (
+    group: string,
+    message: string,
+    type: 'info' | 'warning' | 'error' = 'info'
+  ) => {
+    const logger = _console[type];
+    logger(`[${group}] ${message}`);
+  };
+
+  /**
+   * Shortcut loggin function for the runtime engine code.
+   */
+  export const runtimeLog = (
+    message: string,
+    type: 'info' | 'warning' | 'error' = 'info'
+  ) => log('Engine runtime', message, type);
 }
 
 //Make sure console.warn and console.error are available.

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -8,9 +8,17 @@ namespace gdjs {
   const HowlParameters: HowlOptions = {
     preload: true,
     onplayerror: (_, error) =>
-      console.error("Can't play an audio file: ", error),
+      gdjs.log(
+        'Sound extension',
+        "Can't play an audio file: " + error,
+        'error'
+      ),
     onloaderror: (_, error) =>
-      console.error('Error while loading an audio file: ', error),
+      gdjs.log(
+        'Sound extension',
+        'Error while loading an audio file: ' + error,
+        'error'
+      ),
   };
 
   /**
@@ -682,9 +690,10 @@ namespace gdjs {
       let loadedCount: integer = 0;
       const onLoad = (_?: any, error?: string) => {
         if (error)
-          console.error(
-            'There was an error while loading an audio file:',
-            error
+          gdjs.log(
+            'Sound extension',
+            'There was an error while loading an audio file: ' + error,
+            'error'
           );
 
         loadedCount++;

--- a/GDJS/Runtime/jsonmanager.ts
+++ b/GDJS/Runtime/jsonmanager.ts
@@ -69,7 +69,10 @@ namespace gdjs {
 
       const onLoad: JsonManagerRequestCallback = function (error) {
         if (error) {
-          console.error('Error while preloading a json resource:' + error);
+          gdjs.runtimeLog(
+            'Error while preloading a json resource:' + error,
+            'error'
+          );
         }
         loaded++;
         if (loaded === jsonResources.length) {

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -102,12 +102,13 @@ namespace gdjs {
         effectData.effectType
       );
       if (!filterCreator) {
-        console.log(
+        gdjs.runtimeLog(
           'Filter "' +
             effectData.name +
             '" has an unknown effect type: "' +
             effectData.effectType +
-            '". Was it registered properly? Is the effect type correct?'
+            '". Was it registered properly? Is the effect type correct?',
+          'warning'
         );
         return;
       }

--- a/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
@@ -152,10 +152,12 @@ namespace gdjs {
       }
 
       if (!this._pixiBitmapFontsInUse[bitmapFontInstallKey]) {
-        console.error(
+        gdjs.log(
+          'Bitmap Text',
           'BitmapFont with name ' +
             bitmapFontInstallKey +
-            ' was tried to be released but was never marked as used.'
+            ' was tried to be released but was never marked as used.',
+          'error'
         );
         return;
       }
@@ -176,7 +178,8 @@ namespace gdjs {
           const oldestUnloadedPixiBitmapFontName = this._pixiBitmapFontsToUninstall.shift() as string;
 
           PIXI.BitmapFont.uninstall(oldestUnloadedPixiBitmapFontName);
-          console.log(
+          gdjs.log(
+            'Bitmap Text',
             'Uninstalled BitmapFont "' +
               oldestUnloadedPixiBitmapFontName +
               '" from memory.'
@@ -209,10 +212,12 @@ namespace gdjs {
       // First get the font data:
       const fontData = this._loadedFontsData[bitmapFontResourceName];
       if (!fontData) {
-        console.warn(
+        gdjs.log(
+          'Bitmap Text',
           'Could not find Bitmap Font for resource named "' +
             bitmapFontResourceName +
-            '". The default font will be used.'
+            '". The default font will be used.',
+          'warning'
         );
         return this.getDefaultBitmapFont();
       }
@@ -231,11 +236,13 @@ namespace gdjs {
         this._markBitmapFontAsUsed(bitmapFontInstallKey);
         return bitmapFont;
       } catch (error) {
-        console.warn(
+        gdjs.log(
+          'Bitmap Text',
           'Could not load the Bitmap Font for resource named "' +
             bitmapFontResourceName +
             '". The default font will be used. Error is: ' +
-            error
+            error,
+          'error'
         );
         return this.getDefaultBitmapFont();
       }
@@ -264,11 +271,13 @@ namespace gdjs {
               this._loadedFontsData[bitmapFontResource.name] = fontData;
             })
             .catch((error) => {
-              console.error(
+              gdjs.log(
+                'Bitmap Text',
                 "Can't fetch the bitmap font file " +
                   bitmapFontResource.file +
                   ', error: ' +
-                  error
+                  error,
+                'error'
               );
             })
             .then(() => {

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
@@ -60,10 +60,12 @@ namespace gdjs {
       filterCreator: FilterCreator
     ) {
       if (_filterCreators.hasOwnProperty(filterName)) {
-        console.warn(
+        gdjs.log(
+          'Filters',
           'Filter "' +
             filterName +
-            '" was already registered in gdjs.PixiFiltersTools. Replacing it with the new one.'
+            '" was already registered in gdjs.PixiFiltersTools. Replacing it with the new one.',
+          'warning'
         );
       }
       _filterCreators[filterName] = filterCreator;

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -126,7 +126,7 @@ namespace gdjs {
      */
     loadFromScene(sceneData: LayoutData | null) {
       if (!sceneData) {
-        console.error('loadFromScene was called without a scene');
+        gdjs.runtimeLog('loadFromScene was called without a scene', 'error');
         return;
       }
       if (this._isLoaded) {
@@ -240,10 +240,11 @@ namespace gdjs {
      */
     updateObject(objectData: ObjectData): void {
       if (!this.isObjectRegistered(objectData.name)) {
-        console.warn(
+        gdjs.runtimeLog(
           'Tried to call updateObject for an object that was not registered (' +
             objectData.name +
-            '). Call registerObject first.'
+            '). Call registerObject first.',
+          'warning'
         );
       }
       this._objects.put(objectData.name, objectData);
@@ -435,8 +436,9 @@ namespace gdjs {
       if (module && module.func) {
         this._eventsFunction = module.func;
       } else {
-        console.log(
-          'Warning: no function found for running logic of scene ' + this._name
+        gdjs.runtimeLog(
+          'No function found for running logic of scene ' + this._name,
+          'warning'
         );
         this._eventsFunction = function () {};
       }
@@ -806,7 +808,7 @@ namespace gdjs {
      */
     getObjects(name: string): gdjs.RuntimeObject[] {
       if (!this._instances.containsKey(name)) {
-        console.log(
+        gdjs.runtimeLog(
           'RuntimeScene.getObjects: No instances called "' +
             name +
             '"! Adding it.'
@@ -922,7 +924,10 @@ namespace gdjs {
       if (behaviorSharedData) {
         return behaviorSharedData;
       }
-      console.error("Can't find shared data for behavior with name:", name);
+      gdjs.runtimeLog(
+        "Can't find shared data for behavior with name: " + name,
+        'error'
+      );
       return null;
     }
 

--- a/GDJS/Runtime/scenestack.ts
+++ b/GDJS/Runtime/scenestack.ts
@@ -49,7 +49,10 @@ namespace gdjs {
         } else if (request === gdjs.SceneChangeRequest.CLEAR_SCENES) {
           this.replace(currentScene.getRequestedScene(), true);
         } else {
-          console.error('Unrecognized change in scene stack.');
+          gdjs.runtimeLog(
+            'Unrecognized change in scene stack: ' + request,
+            'error'
+          );
           return false;
         }
       }

--- a/GDJS/Runtime/variable.ts
+++ b/GDJS/Runtime/variable.ts
@@ -167,7 +167,7 @@ namespace gdjs {
       try {
         var obj = JSON.parse(json);
       } catch (e) {
-        gdjs.runtimeLog('Unable to parse JSON: ', json, e);
+        gdjs.runtimeLog('Unable to parse JSON: ' + json + e, 'error');
         return this;
       }
       this.fromJSObject(obj);

--- a/GDJS/Runtime/variable.ts
+++ b/GDJS/Runtime/variable.ts
@@ -111,7 +111,10 @@ namespace gdjs {
         this.setString('null');
       } else if (typeof obj === 'number') {
         if (Number.isNaN(obj)) {
-          console.warn('Variables cannot be set to NaN, setting it to 0.');
+          gdjs.runtimeLog(
+            'Variables cannot be set to NaN, setting it to 0.',
+            'warning'
+          );
           this.setNumber(0);
         } else {
           this.setNumber(obj);
@@ -135,17 +138,23 @@ namespace gdjs {
         this.setString(obj.toString());
       } else if (typeof obj === 'bigint') {
         if (obj > Number.MAX_SAFE_INTEGER)
-          console.warn(
-            'Integers bigger than ' +
+          gdjs.runtimeLog(
+            'Error while converting JS variable to GDevelop variable: Integers bigger than ' +
               Number.MAX_SAFE_INTEGER +
-              " aren't supported by GDevelop variables, it will be reduced to that size."
+              " aren't supported by GDevelop variables, it will be reduced to that size.",
+            'warning'
           );
         // @ts-ignore
         variable.setNumber(parseInt(obj, 10));
       } else if (typeof obj === 'function') {
-        console.error('Error: Impossible to set variable value to a function.');
+        gdjs.runtimeLog(
+          'Error while converting JS variable to GDevelop variable: Impossible to set variable value to a function.'
+        );
       } else {
-        console.error('Cannot identify type of object:', obj);
+        gdjs.runtimeLog(
+          'Error while converting JS variable to GDevelop variable: Cannot identify type of object ' +
+            obj
+        );
       }
       return this;
     }
@@ -158,7 +167,7 @@ namespace gdjs {
       try {
         var obj = JSON.parse(json);
       } catch (e) {
-        console.error('Unable to parse JSON: ', json, e);
+        gdjs.runtimeLog('Unable to parse JSON: ', json, e);
         return this;
       }
       this.fromJSObject(obj);

--- a/newIDE/app/src/Debugger/DebuggerConsole.js
+++ b/newIDE/app/src/Debugger/DebuggerConsole.js
@@ -1,0 +1,100 @@
+import React from 'react';
+
+import { List, CellMeasurer, CellMeasurerCache } from 'react-virtualized';
+import MUIList from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+
+import Checkbox from '../UI/Checkbox';
+
+import InfoIcon from '@material-ui/icons/Info';
+import WarningIcon from '@material-ui/icons/Warning';
+import ErrorIcon from '@material-ui/icons/Error';
+
+export type Log = {
+  message: string,
+  type: 'info' | 'warning' | 'error',
+  group: string,
+  internal: boolean,
+};
+
+const iconMap = {
+  info: <InfoIcon color="primary" />,
+  warning: <WarningIcon color="secondary" />,
+  error: <ErrorIcon color="error" />,
+};
+
+export const DebuggerConsole = ({ logs }: { logs: Array<Logs> }) => {
+  const sizeMeasurer = React.useRef(null);
+  const cache = React.useRef(
+    new CellMeasurerCache({
+      defaultHeight: 45,
+      minHeight: 30,
+      fixedWidth: true,
+    })
+  ).current;
+
+  const [showGroup, _setShowGroup] = React.useState(true);
+  const setShowGroup = (show: boolean) => {
+    _setShowGroup(show);
+    cache.clearAll();
+  };
+
+  return (
+    <>
+      <Checkbox
+        style={{ margin: 10 }}
+        checked={showGroup}
+        label="Show group names"
+        onCheck={(_, value) => setShowGroup(value)}
+      />
+
+      <div
+        style={{
+          position: 'absolute',
+          top: 45,
+          bottom: 0,
+          width: '100%',
+        }}
+        ref={sizeMeasurer}
+      >
+        <MUIList dense={true} style={{ padding: 0 }}>
+          <List
+            autoContainerWidth
+            deferredMeasurementCache={cache}
+            height={
+              sizeMeasurer.current ? sizeMeasurer.current.offsetHeight : 0
+            }
+            width={sizeMeasurer.current ? sizeMeasurer.current.offsetWidth : 0}
+            rowCount={logs.length}
+            rowHeight={cache.rowHeight}
+            rowRenderer={({ index, key, parent, style }) => (
+              <CellMeasurer
+                cache={cache}
+                columnIndex={0}
+                key={key}
+                parent={parent}
+                rowIndex={index}
+              >
+                {({ registerChild }) => (
+                  <ListItem key={key} style={style} ref={registerChild}>
+                    <ListItemIcon>
+                      {iconMap[logs[index].type] || iconMap['info']}
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={logs[index].message}
+                      secondary={
+                        showGroup ? logs[index].group || 'Default' : undefined
+                      }
+                    />
+                  </ListItem>
+                )}
+              </CellMeasurer>
+            )}
+          />
+        </MUIList>
+      </div>
+    </>
+  );
+};

--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -22,6 +22,7 @@ import Flash from '@material-ui/icons/FlashOn';
 import FlashOff from '@material-ui/icons/FlashOff';
 import HelpButton from '../UI/HelpButton';
 import Profiler from './Profiler';
+import { DebuggerConsole } from './DebuggerConsole';
 import { type ProfilerOutput } from '.';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import MiniToolbar from '../UI/MiniToolbar';
@@ -54,7 +55,12 @@ const initialMosaicEditorNodes = {
     second: 'selected-inspector',
     splitPercentage: 25,
   },
-  second: 'profiler',
+  second: {
+    direction: 'row',
+    first: 'profiler',
+    second: 'console',
+    splitPercentage: 25,
+  },
   splitPercentage: 65,
 };
 
@@ -85,6 +91,7 @@ export default class DebuggerContent extends React.Component<Props, State> {
       onStopProfiler,
       profilerOutput,
       profilingInProgress,
+      logs,
     } = this.props;
     const {
       selectedInspector,
@@ -204,6 +211,15 @@ export default class DebuggerContent extends React.Component<Props, State> {
             profilerOutput={profilerOutput}
             profilingInProgress={profilingInProgress}
           />
+        ),
+      },
+      console: {
+        type: 'secondary',
+        title: t`Console`,
+        renderEditor: () => (
+          <Background>
+            <DebuggerConsole logs={logs || []} />
+          </Background>
         ),
       },
     };


### PR DESCRIPTION
Draft console for a console for the debugger.
TODO:
- [ ] Convert some more internal console.log calls to gdjs.log/gdjs.runtimeLog
- [ ] Test further for bugs
- [ ] Add filtering of logs by event group
- [ ] Add toggle console icon to the toolbar
- [ ] Fix bug with contents of the console disappearing until a new log is sent when switching tabs away and back from the debugger
- [ ] ~~Make the text wrap instead of having to scroll~~ **I tried for hours and dind't manage to make that work with react-virtualized**
- [X] Add an action to log to the console to the `DebuggerTools` extension
- [X] Make the list of logs virtualized to prevent the IDE from lagging out
- [X] Monkey-patch console.log to also print to the debugger console
- [X] Add base implementation of console to the IDE and debugger client


I would appreciate feedback on the implementation so far.