### PR TITLE
[Stuck] Cast object condition

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.h
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerationContext.h
@@ -5,10 +5,12 @@
  */
 #ifndef EVENTSCODEGENERATIONCONTEXT_H
 #define EVENTSCODEGENERATIONCONTEXT_H
+#include "GDCore/Project/ObjectsContainer.h"
+#include "GDCore/String.h"
 #include <map>
 #include <memory>
 #include <set>
-#include "GDCore/String.h"
+
 
 namespace gd {
 
@@ -26,18 +28,15 @@ namespace gd {
 class GD_CORE_API EventsCodeGenerationContext {
   friend class EventsCodeGenerator;
 
- public:
+public:
   /**
    * Default constructor. You may want to call InheritsFrom just after.
    * \param maxDepthLevel Optional pointer to an unsigned integer that will be
    * updated to contain the maximal scope depth reached.
    */
-  EventsCodeGenerationContext(unsigned int* maxDepthLevel_ = nullptr)
-      : contextDepth(0),
-        customConditionDepth(0),
-        maxDepthLevel(maxDepthLevel_),
-        parent(NULL),
-        reuseExplicitlyForbidden(false){};
+  EventsCodeGenerationContext(unsigned int *maxDepthLevel_ = nullptr)
+      : contextDepth(0), customConditionDepth(0), maxDepthLevel(maxDepthLevel_),
+        parent(NULL), reuseExplicitlyForbidden(false){};
   virtual ~EventsCodeGenerationContext(){};
 
   /**
@@ -45,7 +44,7 @@ class GD_CORE_API EventsCodeGenerationContext {
    * another one. The child will then for example not declare again objects
    * already declared by its parent.
    */
-  void InheritsFrom(const EventsCodeGenerationContext& parent);
+  void InheritsFrom(const EventsCodeGenerationContext &parent);
 
   /**
    * \brief As InheritsFrom, mark the context as being the child of another one,
@@ -53,7 +52,7 @@ class GD_CORE_API EventsCodeGenerationContext {
    *
    * Used for example for optimizing the last event of a list.
    */
-  void Reuse(const EventsCodeGenerationContext& parent);
+  void Reuse(const EventsCodeGenerationContext &parent);
 
   /**
    * \brief Forbid any optimization that would reuse and modify the object list
@@ -85,12 +84,12 @@ class GD_CORE_API EventsCodeGenerationContext {
    * \return A pointer to the parent context, or NULL if the context has no
    * parent.
    */
-  const EventsCodeGenerationContext* GetParentContext() const { return parent; }
+  const EventsCodeGenerationContext *GetParentContext() const { return parent; }
 
   /**
    * Mark the object has being the object being handled by the instruction
    */
-  void SetCurrentObject(const gd::String& objectName) {
+  void SetCurrentObject(const gd::String &objectName) {
     currentObject = objectName;
   };
 
@@ -102,7 +101,7 @@ class GD_CORE_API EventsCodeGenerationContext {
   /**
    * Get the object being handled by the instruction
    */
-  const gd::String& GetCurrentObject() const { return currentObject; };
+  const gd::String &GetCurrentObject() const { return currentObject; };
 
   /**
    * \brief Call this when an instruction in the event needs an objects list.
@@ -111,7 +110,7 @@ class GD_CORE_API EventsCodeGenerationContext {
    * it is requested, unless there is already an object list with this name
    * (i.e. `ObjectAlreadyDeclared(objectName)` returns true).
    */
-  void ObjectsListNeeded(const gd::String& objectName);
+  void ObjectsListNeeded(const gd::String &objectName);
 
   /**
    * Call this when an instruction in the event needs an empty objects list
@@ -121,7 +120,7 @@ class GD_CORE_API EventsCodeGenerationContext {
    * from the scene. If there is already an objects list with this name, no new
    * list will be declared again.
    */
-  void ObjectsListWithoutPickingNeeded(const gd::String& objectName);
+  void ObjectsListWithoutPickingNeeded(const gd::String &objectName);
 
   /**
    * Call this when an instruction in the event needs an empty object list,
@@ -131,13 +130,13 @@ class GD_CORE_API EventsCodeGenerationContext {
    * from the scene. If there is already an object list with this name, it won't
    * be used to initialize the new list, which will remain empty.
    */
-  void EmptyObjectsListNeeded(const gd::String& objectName);
+  void EmptyObjectsListNeeded(const gd::String &objectName);
 
   /**
    * Return true if an object list has already been declared (or is going to be
    * declared).
    */
-  bool ObjectAlreadyDeclared(const gd::String& objectName) const {
+  bool ObjectAlreadyDeclared(const gd::String &objectName) const {
     return (alreadyDeclaredObjectsLists.find(objectName) !=
             alreadyDeclaredObjectsLists.end());
   };
@@ -145,7 +144,7 @@ class GD_CORE_API EventsCodeGenerationContext {
   /**
    * \brief Consider that \a objectName is now declared in the context.
    */
-  void SetObjectDeclared(const gd::String& objectName) {
+  void SetObjectDeclared(const gd::String &objectName) {
     alreadyDeclaredObjectsLists.insert(objectName);
   }
 
@@ -158,7 +157,7 @@ class GD_CORE_API EventsCodeGenerationContext {
   /**
    * Return the objects lists which will be declared by the current context
    */
-  const std::set<gd::String>& GetObjectsListsToBeDeclared() const {
+  const std::set<gd::String> &GetObjectsListsToBeDeclared() const {
     return objectsListsToBeDeclared;
   };
 
@@ -166,8 +165,8 @@ class GD_CORE_API EventsCodeGenerationContext {
    * Return the objects lists which will be will be declared, without filling
    * them with objects from the scene.
    */
-  const std::set<gd::String>& GetObjectsListsToBeDeclaredWithoutPicking()
-      const {
+  const std::set<gd::String> &
+  GetObjectsListsToBeDeclaredWithoutPicking() const {
     return objectsListsWithoutPickingToBeDeclared;
   };
 
@@ -176,7 +175,7 @@ class GD_CORE_API EventsCodeGenerationContext {
    * filling them with objects from the scene and without copying any previously
    * declared objects list.
    */
-  const std::set<gd::String>& GetObjectsListsToBeDeclaredEmpty() const {
+  const std::set<gd::String> &GetObjectsListsToBeDeclaredEmpty() const {
     return emptyObjectsListsToBeDeclared;
   };
 
@@ -184,7 +183,7 @@ class GD_CORE_API EventsCodeGenerationContext {
    * Return the objects lists which are already declared and can be used in the
    * current context without declaration.
    */
-  const std::set<gd::String>& GetObjectsListsAlreadyDeclared() const {
+  const std::set<gd::String> &GetObjectsListsAlreadyDeclared() const {
     return alreadyDeclaredObjectsLists;
   };
 
@@ -195,8 +194,8 @@ class GD_CORE_API EventsCodeGenerationContext {
    * If \a objectName is needed in this context, it will return the depth of
    * this context.
    */
-  unsigned int GetLastDepthObjectListWasNeeded(
-      const gd::String& objectName) const;
+  unsigned int
+  GetLastDepthObjectListWasNeeded(const gd::String &objectName) const;
 
   /**
    * \brief Check if twos context have the same list for an object.
@@ -204,8 +203,8 @@ class GD_CORE_API EventsCodeGenerationContext {
    * This can be the case when a context is reusing the lists of another (see
    * gd::EventsCodeGenerationContext::Reuse).
    */
-  bool IsSameObjectsList(const gd::String& objectName,
-                         const EventsCodeGenerationContext& otherContext) const;
+  bool IsSameObjectsList(const gd::String &objectName,
+                         const EventsCodeGenerationContext &otherContext) const;
 
   /**
    * \brief Called when a custom condition code is generated.
@@ -227,14 +226,31 @@ class GD_CORE_API EventsCodeGenerationContext {
    */
   size_t GetCurrentConditionDepth() const { return customConditionDepth; }
 
- private:
+  /**
+   * \brief Get the type of an object.
+   *
+   * This will return the casted type if the type was casted.
+   */
+  gd::String GetTypeOfObject(const gd::ObjectsContainer &project,
+                                    const gd::ObjectsContainer &layout,
+                                    const gd::String &objectName);
+
+  /**
+   * \brief Marks an object as of a specified type for the current context and
+   * child contexts.
+   */
+  void CastObjectTo(const gd::String &objectName, const gd::String &type) {
+    castedObjects[objectName] = type;
+  };
+
+private:
   /**
    * \brief Returns true if the given object is already going to be declared
    * (either as a traditional objects list, or one without picking, or one
    * empty).
    *
    */
-  bool IsToBeDeclared(const gd::String& objectName) {
+  bool IsToBeDeclared(const gd::String &objectName) {
     return objectsListsToBeDeclared.find(objectName) !=
                objectsListsToBeDeclared.end() ||
            objectsListsWithoutPickingToBeDeclared.find(objectName) !=
@@ -244,38 +260,39 @@ class GD_CORE_API EventsCodeGenerationContext {
   };
 
   std::set<gd::String>
-      alreadyDeclaredObjectsLists;  ///< Objects lists already needed in a
-                                    ///< parent context.
+      alreadyDeclaredObjectsLists; ///< Objects lists already needed in a
+                                   ///< parent context.
+  std::set<gd::String> objectsListsToBeDeclared; ///< Objects lists that will be
+                                                 ///< declared in this context.
   std::set<gd::String>
-      objectsListsToBeDeclared;  ///< Objects lists that will be declared in
-                                 ///< this context.
+      objectsListsWithoutPickingToBeDeclared; ///< Objects lists that will be
+                                              ///< declared in this context,
+                                              ///< but not filled with scene's
+                                              ///< objects.
   std::set<gd::String>
-      objectsListsWithoutPickingToBeDeclared;  ///< Objects lists that will be
-                                               ///< declared in this context,
-                                               ///< but not filled with scene's
-                                               ///< objects.
-  std::set<gd::String>
-      emptyObjectsListsToBeDeclared;  ///< Objects lists that will be
-                                      ///< declared in this context,
-                                      ///< but not filled with scene's
-                                      ///< objects and not filled with any
-                                      ///< previously existing objects list.
+      emptyObjectsListsToBeDeclared; ///< Objects lists that will be
+                                     ///< declared in this context,
+                                     ///< but not filled with scene's
+                                     ///< objects and not filled with any
+                                     ///< previously existing objects list.
   std::map<gd::String, unsigned int>
-      depthOfLastUse;  ///< The context depth when an object was last used.
+      depthOfLastUse; ///< The context depth when an object was last used.
+  std::map<gd::String, gd::String>
+      castedObjects; ///< The casted objects and their new type.
   gd::String
-      currentObject;  ///< The object being used by an action or condition.
-  unsigned int contextDepth;  ///< The depth of the context : 0 for a newly
-                              ///< created context, n+1 for any context
-                              ///< inheriting from context with depth n.
+      currentObject; ///< The object being used by an action or condition.
+  unsigned int contextDepth; ///< The depth of the context : 0 for a newly
+                             ///< created context, n+1 for any context
+                             ///< inheriting from context with depth n.
   unsigned int
-      customConditionDepth;  ///< The depth of the conditions being generated.
-  unsigned int* maxDepthLevel;  ///< A pointer to a unsigned int updated with
-                                ///< the maximum depth reached.
-  const EventsCodeGenerationContext*
-      parent;  ///< The parent of the current context. Can be NULL.
-  bool reuseExplicitlyForbidden;  ///< If set to true, forbid children context
-                                  ///< to reuse this one without inheriting.
+      customConditionDepth;    ///< The depth of the conditions being generated.
+  unsigned int *maxDepthLevel; ///< A pointer to a unsigned int updated with
+                               ///< the maximum depth reached.
+  const EventsCodeGenerationContext
+      *parent; ///< The parent of the current context. Can be NULL.
+  bool reuseExplicitlyForbidden; ///< If set to true, forbid children context
+                                 ///< to reuse this one without inheriting.
 };
 
-}  // namespace gd
-#endif  // EVENTSCODEGENERATIONCONTEXT_H
+} // namespace gd
+#endif // EVENTSCODEGENERATIONCONTEXT_H

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -302,7 +302,7 @@ gd::String EventsCodeGenerator::GenerateConditionCode(
         condition.SetParameter(pNb, gd::Expression(""));
         condition.SetType("");
       } else if (!instrInfos.parameters[pNb].supplementaryInformation.empty() &&
-                 gd::GetTypeOfObject(GetGlobalObjectsAndGroups(),
+                 context.GetTypeOfObject(GetGlobalObjectsAndGroups(),
                                      GetObjectsAndGroups(),
                                      objectInParameter) !=
                      instrInfos.parameters[pNb].supplementaryInformation) {
@@ -314,7 +314,7 @@ gd::String EventsCodeGenerator::GenerateConditionCode(
 
   if (instrInfos.IsObjectInstruction()) {
     gd::String objectName = condition.GetParameter(0).GetPlainString();
-    gd::String objectType = gd::GetTypeOfObject(
+    gd::String objectType = context.GetTypeOfObject(
         GetGlobalObjectsAndGroups(), GetObjectsAndGroups(), objectName);
     if (!objectName.empty() && !instrInfos.parameters.empty()) {
       std::vector<gd::String> realObjects =
@@ -469,7 +469,7 @@ gd::String EventsCodeGenerator::GenerateActionCode(
         action.SetParameter(pNb, gd::Expression(""));
         action.SetType("");
       } else if (!instrInfos.parameters[pNb].supplementaryInformation.empty() &&
-                 gd::GetTypeOfObject(GetGlobalObjectsAndGroups(),
+                 context.GetTypeOfObject(GetGlobalObjectsAndGroups(),
                                      GetObjectsAndGroups(),
                                      objectInParameter) !=
                      instrInfos.parameters[pNb].supplementaryInformation) {
@@ -482,7 +482,7 @@ gd::String EventsCodeGenerator::GenerateActionCode(
   // Call free function first if available
   if (instrInfos.IsObjectInstruction()) {
     gd::String objectName = action.GetParameter(0).GetPlainString();
-    gd::String objectType = gd::GetTypeOfObject(
+    gd::String objectType = context.GetTypeOfObject(
         GetGlobalObjectsAndGroups(), GetObjectsAndGroups(), objectName);
 
     if (!instrInfos.parameters.empty()) {

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -605,13 +605,11 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
     argOutput = "\"" + argOutput + "\"";
   } else if (ParameterMetadata::IsBehavior(metadata.type)) {
     argOutput = GenerateGetBehaviorNameCode(parameter);
-  } else if (metadata.type == "key") {
-    argOutput = "\"" + ConvertToString(parameter) + "\"";
   } else if (metadata.type == "password" || metadata.type == "musicfile" ||
-             metadata.type == "soundfile" || metadata.type == "police") {
-    argOutput = "\"" + ConvertToString(parameter) + "\"";
-  } else if (metadata.type == "mouse") {
-    argOutput = "\"" + ConvertToString(parameter) + "\"";
+             metadata.type == "soundfile" || metadata.type == "police" ||
+             metadata.type == "key" || metadata.type == "mouse" ||
+             metadata.type == "objectType") {
+    argOutput = ConvertToStringExplicit(parameter);
   } else if (metadata.type == "yesorno") {
     argOutput += (parameter == "yes" || parameter == "oui") ? GenerateTrue()
                                                             : GenerateFalse();

--- a/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
@@ -214,7 +214,7 @@ gd::String ExpressionCodeGenerator::GenerateObjectFunctionCode(
   for (std::size_t i = 0; i < realObjects.size(); ++i) {
     context.ObjectsListNeeded(realObjects[i]);
 
-    gd::String objectType = gd::GetTypeOfObject(
+    gd::String objectType = context.GetTypeOfObject(
         globalObjectsAndGroups, objectsAndGroups, realObjects[i]);
     const ObjectMetadata& objInfo = MetadataProvider::GetObjectMetadata(
         codeGenerator.GetPlatform(), objectType);

--- a/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
@@ -93,7 +93,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                     _("Object _PARAM0_ is of type _PARAM1_"), _("Other"),
                     "res/function24.png", "res/function16.png")
       .AddParameter("object", "The object to check the type from")
-      .AddParameter("string", "Type to check for")
+      .AddParameter("objectType", "Type to check for")
       .MarkAsAdvanced();
 #endif
 }

--- a/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
@@ -10,23 +10,18 @@ using namespace std;
 namespace gd {
 
 void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
-    gd::PlatformExtension& extension) {
+    gd::PlatformExtension &extension) {
   extension.SetExtensionInformation(
-      "BuiltinAdvanced",
-      _("Advanced control features"),
-      _("Advanced control features to be used in events."),
-      "Florian Rival",
+      "BuiltinAdvanced", _("Advanced control features"),
+      _("Advanced control features to be used in events."), "Florian Rival",
       "Open source (MIT License)");
 
 #if defined(GD_IDE_ONLY)
   extension
-      .AddCondition("Toujours",
-                    _("Always"),
+      .AddCondition("Toujours", _("Always"),
                     _("This condition always returns true (or always false, if "
                       "the condition is inverted)."),
-                    _("Always"),
-                    _("Other"),
-                    "res/conditions/toujours24.png",
+                    _("Always"), _("Other"), "res/conditions/toujours24.png",
                     "res/conditions/toujours.png")
       .SetHelpPath("/all-features/advanced-conditions")
       .AddCodeOnlyParameter("conditionInverted", "")
@@ -34,41 +29,32 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
 
   extension
       .AddAction(
-          "SetReturnNumber",
-          _("Set number return value"),
+          "SetReturnNumber", _("Set number return value"),
           _("Set the return value of the events function to the specified "
             "number (to be used with \"Expression\" functions)."),
-          _("Set return value to number _PARAM0_"),
-          _("Functions"),
-          "res/function24.png",
-          "res/function16.png")
+          _("Set return value to number _PARAM0_"), _("Functions"),
+          "res/function24.png", "res/function16.png")
       .SetHelpPath("/events/functions/return")
       .AddParameter("expression", "The number to be returned")
       .MarkAsAdvanced();
 
   extension
       .AddAction(
-          "SetReturnString",
-          _("Set text return value"),
+          "SetReturnString", _("Set text return value"),
           _("Set the return value of the events function to the specified text "
             "(to be used with \"String Expression\" functions)."),
-          _("Set return value to text _PARAM0_"),
-          _("Functions"),
-          "res/function24.png",
-          "res/function16.png")
+          _("Set return value to text _PARAM0_"), _("Functions"),
+          "res/function24.png", "res/function16.png")
       .SetHelpPath("/events/functions/return")
       .AddParameter("string", "The text to be returned")
       .MarkAsAdvanced();
 
   extension
-      .AddAction("SetReturnBoolean",
-                 _("Set condition return value"),
+      .AddAction("SetReturnBoolean", _("Set condition return value"),
                  _("Set the return value of the Condition events function to "
                    "either true (condition will pass) or false."),
                  _("Set return value of the condition to _PARAM0_"),
-                 _("Functions"),
-                 "res/function24.png",
-                 "res/function16.png")
+                 _("Functions"), "res/function24.png", "res/function16.png")
       .SetHelpPath("/events/functions/return")
       .AddParameter("trueorfalse", "Should the condition be true or false?")
       .MarkAsAdvanced();
@@ -80,31 +66,36 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                       "\"argument\") is set to True or Yes. If the argument is "
                       "a string, an empty string is considered as \"false\". "
                       "If it's a number, 0 is considered as \"false\"."),
-                    _("Parameter _PARAM0_ is true"),
-                    _("Functions"),
-                    "res/function24.png",
-                    "res/function16.png")
+                    _("Parameter _PARAM0_ is true"), _("Functions"),
+                    "res/function24.png", "res/function16.png")
       .AddParameter("string", "Parameter name")
       .MarkAsAdvanced();
 
   extension
       .AddExpression(
-          "GetArgumentAsNumber",
-          _("Get function parameter value"),
+          "GetArgumentAsNumber", _("Get function parameter value"),
           _("Get function parameter (also called \"argument\") value"),
-          _("Functions"),
-          "res/function16.png")
+          _("Functions"), "res/function16.png")
       .AddParameter("string", "Parameter name");
 
   extension
       .AddStrExpression(
-          "GetArgumentAsString",
-          _("Get function parameter text"),
+          "GetArgumentAsString", _("Get function parameter text"),
           _("Get function parameter (also called \"argument\") text "),
-          _("Functions"),
-          "res/function16.png")
+          _("Functions"), "res/function16.png")
       .AddParameter("string", "Parameter name");
+
+  extension
+      .AddCondition("CastTo", _("Check object type"),
+                    _("Checks if an object os of a given type. This allows to "
+                      "use object type specific instructions on objects "
+                      "(groups) with an unknown type."),
+                    _("Object _PARAM0_ is of type _PARAM1_"), _("Other"),
+                    "res/function24.png", "res/function16.png")
+      .AddParameter("object", "The object to check the type from")
+      .AddParameter("string", "Type to check for")
+      .MarkAsAdvanced();
 #endif
 }
 
-}  // namespace gd
+} // namespace gd

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectTypeField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectTypeField.js
@@ -1,0 +1,45 @@
+// @flow
+import { t } from '@lingui/macro';
+import React, { Component } from 'react';
+import { type ParameterFieldProps } from './ParameterFieldCommons';
+import SelectField from '../../UI/SelectField';
+import SelectOption from '../../UI/SelectOption';
+import { enumerateObjectTypes } from '../../ObjectsList/EnumerateObjects';
+
+export default class ObjectTypeField extends Component<ParameterFieldProps> {
+  _field: ?SelectField;
+
+  focus() {
+    if (this._field && this._field.focus) this._field.focus();
+  }
+
+  render() {
+    const { parameterMetadata } = this.props;
+    const description = parameterMetadata
+      ? parameterMetadata.getDescription()
+      : undefined;
+
+    return (
+      <SelectField
+        margin={this.props.isInline ? 'none' : 'dense'}
+        fullWidth
+        floatingLabelText={description}
+        helperMarkdownText={
+          parameterMetadata ? parameterMetadata.getLongDescription() : undefined
+        }
+        value={this.props.value}
+        onChange={(e, i, value: string) => this.props.onChange(value)}
+        ref={field => (this._field = field)}
+        hintText={t`Choose an object type`}
+      >
+        {enumerateObjectTypes(this.props.project).map(({ fullName, name }) => (
+          <SelectOption key={name} value={name} primaryText={fullName} />
+        ))}
+      </SelectField>
+    );
+  }
+}
+
+export const renderInlineObjectType = ({
+  value,
+}: ParameterInlineRendererProps) => value || 'Base object';

--- a/newIDE/app/src/EventsSheet/ParameterRenderingService.js
+++ b/newIDE/app/src/EventsSheet/ParameterRenderingService.js
@@ -49,6 +49,9 @@ import SceneNameField from './ParameterFields/SceneNameField';
 import ObjectPointNameField from './ParameterFields/ObjectPointNameField';
 import ObjectAnimationNameField from './ParameterFields/ObjectAnimationNameField';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
+import ObjectTypeField, {
+  renderInlineObjectType,
+} from './ParameterFields/ObjectTypeField';
 const gd: libGDevelop = global.gd;
 
 const components = {
@@ -81,6 +84,7 @@ const components = {
   sceneName: SceneNameField,
   objectPointName: ObjectPointNameField,
   objectAnimationName: ObjectAnimationNameField,
+  objectType: ObjectTypeField,
 };
 const inlineRenderers: { [string]: ParameterInlineRenderer } = {
   default: renderInlineDefaultField,
@@ -95,6 +99,7 @@ const inlineRenderers: { [string]: ParameterInlineRenderer } = {
   trueorfalse: renderInlineTrueFalse,
   operator: renderInlineOperator,
   relationalOperator: renderInlineRelationalOperator,
+  objectType: renderInlineObjectType,
 };
 const userFriendlyTypeName: { [string]: MessageDescriptor } = {
   mouse: t`Mouse button`,


### PR DESCRIPTION
Adds a condition to check for an object type. If it is true, GDevelop will consider the object in the the following conditions, actions and subevents as of that type. It is useful when the type of the object is not known, like in custom behaviors that accept any objects or objects groups with objects of multiple types. 

Discussion: https://github.com/4ian/GDevelop/discussions/2643
Test project: 
[test.zip](https://github.com/4ian/GDevelop/files/6764904/test.zip)


TODO:
- [X] Create the condition with custom code generator
- [X] Make the CodeGenerationContext able to override an object type
- [x] Add a ObjectType parameter
- [ ] Make the IDE aware of the type change for usages after that condition