### PR TITLE
Fix: instances editor no longer give unnecessary floating positions

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -82,23 +82,21 @@ export default class InstancesMover {
     this.totalDeltaX += deltaX;
     this.totalDeltaY += deltaY;
 
-    let roundedTotalDeltaX;
-    let roundedTotalDeltaY;
-    if (this.options.snap && this.options.grid && !noGridSnap) {
-      // It will magnet the corner nearest to the grabbing position
-      const initialSelectionAABB = this._getOrCreateSelectionAABB(instances);
-      const magnetLeft = this._startX < initialSelectionAABB.centerX();
-      const magnetTop = this._startY < initialSelectionAABB.centerY();
+    // It will magnet the corner nearest to the grabbing position
+    const initialSelectionAABB = this._getOrCreateSelectionAABB(instances);
+    const magnetLeft = this._startX < initialSelectionAABB.centerX();
+    const magnetTop = this._startY < initialSelectionAABB.centerY();
 
-      const initialMagnetX = magnetLeft
-        ? initialSelectionAABB.left
-        : initialSelectionAABB.right;
-      const initialMagnetY = magnetTop
-        ? initialSelectionAABB.top
-        : initialSelectionAABB.bottom;
-      const magnetPosition = this._temporaryPoint;
-      magnetPosition[0] = initialMagnetX + this.totalDeltaX;
-      magnetPosition[1] = initialMagnetY + this.totalDeltaY;
+    const initialMagnetX = magnetLeft
+      ? initialSelectionAABB.left
+      : initialSelectionAABB.right;
+    const initialMagnetY = magnetTop
+      ? initialSelectionAABB.top
+      : initialSelectionAABB.bottom;
+    const magnetPosition = this._temporaryPoint;
+    magnetPosition[0] = initialMagnetX + this.totalDeltaX;
+    magnetPosition[1] = initialMagnetY + this.totalDeltaY;
+    if (this.options.snap && this.options.grid && !noGridSnap) {
       roundPosition(
         magnetPosition,
         this.options.gridWidth,
@@ -107,12 +105,15 @@ export default class InstancesMover {
         this.options.gridOffsetY,
         this.options.gridType
       );
-      roundedTotalDeltaX = magnetPosition[0] - initialMagnetX;
-      roundedTotalDeltaY = magnetPosition[1] - initialMagnetY;
     } else {
-      roundedTotalDeltaX = this.totalDeltaX;
-      roundedTotalDeltaY = this.totalDeltaY;
+      // Without a grid, it's rounded to the nearest pixel
+      // the size might not be round
+      // so the magnet corner is still relevent
+      magnetPosition[0] = Math.round(magnetPosition[0]);
+      magnetPosition[1] = Math.round(magnetPosition[1]);
     }
+    const roundedTotalDeltaX = magnetPosition[0] - initialMagnetX;
+    const roundedTotalDeltaY = magnetPosition[1] - initialMagnetY;
 
     for (var i = 0; i < instances.length; i++) {
       const selectedInstance = instances[i];

--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -106,9 +106,9 @@ export default class InstancesMover {
         this.options.gridType
       );
     } else {
-      // Without a grid, it's rounded to the nearest pixel
-      // the size might not be round
-      // so the magnet corner is still relevent
+      // Without a grid, the position is still rounded to the nearest pixel.
+      // The size of the instance (or selection of instances) might not be round,
+      // so the magnet corner is still relevant.
       magnetPosition[0] = Math.round(magnetPosition[0]);
       magnetPosition[1] = Math.round(magnetPosition[1]);
     }

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -168,8 +168,8 @@ export default class InstancesResizer {
       grabbingPosition[0] = Math.round(grabbingPosition[0]);
       grabbingPosition[1] = Math.round(grabbingPosition[1]);
     }
-    const roundedTotalDeltaX = grabbingPosition[0] - initialGrabbingX;
-    const roundedTotalDeltaY = grabbingPosition[1] - initialGrabbingY;
+    let roundedTotalDeltaX = grabbingPosition[0] - initialGrabbingX;
+    let roundedTotalDeltaY = grabbingPosition[1] - initialGrabbingY;
 
     if (!canMoveOnX(grabbingLocation)) {
       roundedTotalDeltaX = 0;

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -144,19 +144,19 @@ export default class InstancesResizer {
 
     let roundedTotalDeltaX;
     let roundedTotalDeltaY;
+    // Round the grabbed handle position on the grid.
+    const grabbingRelativePosition =
+      resizeGrabbingRelativePositions[grabbingLocation];
+    const initialGrabbingX =
+      initialSelectionAABB.left +
+      initialSelectionAABB.width() * grabbingRelativePosition[0];
+    const initialGrabbingY =
+      initialSelectionAABB.top +
+      initialSelectionAABB.height() * grabbingRelativePosition[1];
+    const grabbingPosition = this._temporaryGrabbingPosition;
+    grabbingPosition[0] = initialGrabbingX + this.totalDeltaX;
+    grabbingPosition[1] = initialGrabbingY + this.totalDeltaY;
     if (this.options.snap && this.options.grid) {
-      // Round the grabbed handle position on the grid.
-      const grabbingRelativePosition =
-        resizeGrabbingRelativePositions[grabbingLocation];
-      const initialGrabbingX =
-        initialSelectionAABB.left +
-        initialSelectionAABB.width() * grabbingRelativePosition[0];
-      const initialGrabbingY =
-        initialSelectionAABB.top +
-        initialSelectionAABB.height() * grabbingRelativePosition[1];
-      const grabbingPosition = this._temporaryGrabbingPosition;
-      grabbingPosition[0] = initialGrabbingX + this.totalDeltaX;
-      grabbingPosition[1] = initialGrabbingY + this.totalDeltaY;
       roundPositionForResizing(
         grabbingPosition,
         this.options.gridWidth,
@@ -165,12 +165,14 @@ export default class InstancesResizer {
         this.options.gridOffsetY,
         this.options.gridType
       );
-      roundedTotalDeltaX = grabbingPosition[0] - initialGrabbingX;
-      roundedTotalDeltaY = grabbingPosition[1] - initialGrabbingY;
     } else {
-      roundedTotalDeltaX = this.totalDeltaX;
-      roundedTotalDeltaY = this.totalDeltaY;
+      // Without a grid, it's rounded to the nearest pixel
+      grabbingPosition[0] = Math.round(grabbingPosition[0]);
+      grabbingPosition[1] = Math.round(grabbingPosition[1]);
     }
+    roundedTotalDeltaX = grabbingPosition[0] - initialGrabbingX;
+    roundedTotalDeltaY = grabbingPosition[1] - initialGrabbingY;
+
     if (!canMoveOnX(grabbingLocation)) {
       roundedTotalDeltaX = 0;
     }

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -142,8 +142,6 @@ export default class InstancesResizer {
 
     const initialSelectionAABB = this._getOrCreateSelectionAABB(instances);
 
-    let roundedTotalDeltaX;
-    let roundedTotalDeltaY;
     // Round the grabbed handle position on the grid.
     const grabbingRelativePosition =
       resizeGrabbingRelativePositions[grabbingLocation];
@@ -170,8 +168,8 @@ export default class InstancesResizer {
       grabbingPosition[0] = Math.round(grabbingPosition[0]);
       grabbingPosition[1] = Math.round(grabbingPosition[1]);
     }
-    roundedTotalDeltaX = grabbingPosition[0] - initialGrabbingX;
-    roundedTotalDeltaY = grabbingPosition[1] - initialGrabbingY;
+    const roundedTotalDeltaX = grabbingPosition[0] - initialGrabbingX;
+    const roundedTotalDeltaY = grabbingPosition[1] - initialGrabbingY;
 
     if (!canMoveOnX(grabbingLocation)) {
       roundedTotalDeltaX = 0;

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -164,7 +164,7 @@ export default class InstancesResizer {
         this.options.gridType
       );
     } else {
-      // Without a grid, it's rounded to the nearest pixel
+      // Without a grid, the position is still rounded to the nearest pixel.
       grabbingPosition[0] = Math.round(grabbingPosition[0]);
       grabbingPosition[1] = Math.round(grabbingPosition[1]);
     }


### PR DESCRIPTION
Moving instances and resizing one instance no longer give floating positions or dimensions on 0° rotated instances.

For 90° rotated instances, I still observe half pixels when width and height parity is different. It's because the center point is not pixel aligned so the rotation gives an AABB with bounds on half pixels.
But this still make the bug a lot less critical.