### PR TITLE
Switch the order of the buttons

### DIFF
--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -175,6 +175,11 @@ const BehaviorsEditor = (props: Props) => {
             <Accordion key={behaviorName} defaultExpanded>
               <AccordionHeader
                 actions={[
+                  <HelpIcon
+                    key="help"
+                    size="small"
+                    helpPagePath={behaviorMetadata.getHelpPath()}
+                  />,
                   <IconButton
                     key="delete"
                     size="small"
@@ -185,11 +190,6 @@ const BehaviorsEditor = (props: Props) => {
                   >
                     <Delete />
                   </IconButton>,
-                  <HelpIcon
-                    key="help"
-                    size="small"
-                    helpPagePath={behaviorMetadata.getHelpPath()}
-                  />,
                 ]}
               >
                 {iconUrl ? (


### PR DESCRIPTION
Because the buttons remove and help are not aligned with the previous and next behaviors, i've just switched the order.

Before:
![image](https://user-images.githubusercontent.com/1670670/125505066-c8a9a633-4155-4f78-b864-ad8af2c0d17f.png)
