### PR TITLE
Add UID parameter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,7 +108,8 @@
         "xtree": "cpp",
         "xutility": "cpp",
         "xlocbuf": "cpp",
-        "xlocmes": "cpp"
+        "xlocmes": "cpp",
+        "xmemory0": "cpp"
     },
     "files.exclude": {
         "Binaries/*build*": true,

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -17,6 +17,7 @@
 #include "GDCore/Project/Layout.h"
 #include "GDCore/Project/ObjectsContainer.h"
 #include "GDCore/Project/Project.h"
+#include "GDCore/Tools/UUID/UUID.h"
 
 using namespace std;
 
@@ -623,6 +624,9 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
   // Code only parameter type
   else if (metadata.type == "inlineCode") {
     argOutput += metadata.supplementaryInformation;
+  } else if(metadata.type == "uid") {
+    // GenerateSingleUsageUniqueIdFor would be better, but wouldn't work with expressions.
+    argOutput += ConvertToStringExplicit(gd::UUID::MakeUuid4());
   } else {
     // Try supplementary types if provided
     if (supplementaryParametersTypes) {

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.h
@@ -127,6 +127,7 @@ class GD_CORE_API EventsCodeGenerator {
       const std::vector<gd::Expression>& parameters,
       const std::vector<gd::ParameterMetadata>& parametersInfo,
       EventsCodeGenerationContext& context,
+      std::function<gd::String()> uidGenerator,
       std::vector<std::pair<gd::String, gd::String> >*
           supplementaryParametersTypes = 0);
 
@@ -487,6 +488,7 @@ class GD_CORE_API EventsCodeGenerator {
       const gd::ParameterMetadata& metadata,
       gd::EventsCodeGenerationContext& context,
       const gd::String& lastObjectName,
+      std::function<gd::String()> uidGenerator,
       std::vector<std::pair<gd::String, gd::String> >*
           supplementaryParametersTypes);
 

--- a/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
@@ -328,6 +328,8 @@ gd::String ExpressionCodeGenerator::GenerateParametersCodes(
                                                parameterMetadata,
                                                context,
                                                "",
+                                               // UIDs are not supported by expressions
+                                               []() { return "Unsupported by expressions"; },
                                                nullptr);
     }
   }

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -878,6 +878,7 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
     const gd::ParameterMetadata& metadata,
     gd::EventsCodeGenerationContext& context,
     const gd::String& lastObjectName,
+    std::function<gd::String()> uidGenerator,
     std::vector<std::pair<gd::String, gd::String> >*
         supplementaryParametersTypes) {
   gd::String argOutput;
@@ -903,6 +904,7 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
         metadata,
         context,
         lastObjectName,
+        uidGenerator,
         supplementaryParametersTypes);
 
   return argOutput;

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
@@ -176,6 +176,7 @@ class EventsCodeGenerator : public gd::EventsCodeGenerator {
       const gd::ParameterMetadata& metadata,
       gd::EventsCodeGenerationContext& context,
       const gd::String& lastObjectName,
+      std::function<gd::String()> uidGenerator,
       std::vector<std::pair<gd::String, gd::String> >*
           supplementaryParametersTypes);
 

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -29,6 +29,7 @@ import Delete from '@material-ui/icons/Delete';
 import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
 import { ColumnStackLayout, ResponsiveLineStackLayout } from '../../UI/Layout';
 import { getLastObjectParameterObjectType } from '../../EventsSheet/ParameterFields/ParameterMetadataTools';
+import { isCodeOnlyType } from '../../EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers';
 
 const gd: libGDevelop = global.gd;
 
@@ -306,6 +307,12 @@ export default class EventsFunctionParametersEditor extends React.Component<
         !!this.state.longDescriptionShownIndexes[index]
       );
     };
+    const isParameterLabelShown = (parameter, index): boolean => {
+      if (!isParameterDescriptionAndTypeShown(index)) return false;
+
+      // Code only parameter aren't displayed, they don't have a label.
+      return !isCodeOnlyType(parameter.getType());
+    };
     const parametersIndexOffset = getParametersIndexOffset(
       !!eventsBasedBehavior
     );
@@ -462,6 +469,10 @@ export default class EventsFunctionParametersEditor extends React.Component<
                                   value="objectAnimationName"
                                   primaryText={t`Object animation (text)`}
                                 />
+                                <SelectOption
+                                  value="uid"
+                                  primaryText={t`Unique event ID (text)`}
+                                />
                               </SelectField>
                             )}
                             {gd.ParameterMetadata.isObject(
@@ -504,7 +515,7 @@ export default class EventsFunctionParametersEditor extends React.Component<
                               }}
                             />
                           )}
-                          {isParameterDescriptionAndTypeShown(i) && (
+                          {isParameterLabelShown(parameter, i) && (
                             <SemiControlledTextField
                               commitOnBlur
                               floatingLabelText={<Trans>Label</Trans>}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -20,6 +20,7 @@ import { getParametersIndexOffset } from '../../EventsFunctionsExtensionsLoader'
 import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 import { ResponsiveLineStackLayout, ColumnStackLayout } from '../../UI/Layout';
 import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
+import { isCodeOnlyType } from '../../EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers';
 
 const gd: libGDevelop = global.gd;
 
@@ -58,9 +59,11 @@ const getSentenceErrorText = (
   const missingParameters = mapVector(
     eventsFunction.getParameters(),
     (parameter, index) => {
-      if (gd.ParameterMetadata.isBehavior(parameter.getType())) {
-        return null; // Behaviors are usually not shown in sentences.
-      }
+      if (
+        gd.ParameterMetadata.isBehavior(parameter.getType()) ||
+        isCodeOnlyType(parameter.getType())
+      )
+        return null; // Behaviors and code only parameters are usually not shown in sentences.
 
       const expectedString = `_PARAM${index + parametersIndexOffset}_`;
       if (sentence.indexOf(expectedString) === -1) return expectedString;

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -493,6 +493,8 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
   });
 };
 
+export const isCodeOnlyType = (type: string) => type === 'uid';
+
 /**
  * Add to the instruction (action/condition) or expression the parameters
  * expected by the events function.
@@ -504,7 +506,7 @@ export const declareEventsFunctionParameters = (
   mapVector(
     eventsFunction.getParameters(),
     (parameter: gdParameterMetadata) => {
-      if (!parameter.isCodeOnly()) {
+      if (!parameter.isCodeOnly() && !isCodeOnlyType(parameter.getType())) {
         instructionOrExpression.addParameter(
           parameter.getType(),
           parameter.getDescription(),


### PR DESCRIPTION
Adds a UID parameter, which generates for each parameter generation a different UID. This allows to identify one specific usage of a function, like in the trigger once. This can allow to make powerful extensions, like "Wait X seconds", "Conditions executed X times in X amount of times" (for double/triple/whatever click or key press for example)...

Example:

https://user-images.githubusercontent.com/19349038/125647400-a033bdfd-0fe6-4403-a1e9-5e0dc25a371b.mp4

[WaitX.zip](https://github.com/4ian/GDevelop/files/6817147/WaitX.zip)