### PR TITLE
Asset store: Pixelate pixel art assets in viewer & make it bigger

### DIFF
--- a/newIDE/app/src/AssetStore/AssetCard.js
+++ b/newIDE/app/src/AssetStore/AssetCard.js
@@ -19,6 +19,11 @@ const styles = {
     verticalAlign: 'middle',
     pointerEvents: 'none',
   },
+  previewImagePixelated: {
+    width: '-webkit-fill-available',
+    imageRendering: 'pixelated',
+    padding: 15,
+  },
   icon: {
     color: '#fff',
   },
@@ -51,6 +56,14 @@ type Props = {|
   onOpenDetails: () => void,
 |};
 
+const isPixelArt = assetShortHeader => {
+  let returnValue = false;
+  assetShortHeader.tags.map(tag => {
+    if (tag.toLowerCase() === 'pixel art') returnValue = true;
+  });
+  return returnValue;
+};
+
 export const AssetCard = ({ assetShortHeader, onOpenDetails, size }: Props) => {
   return (
     <ButtonBase onClick={onOpenDetails} focusRipple>
@@ -59,11 +72,20 @@ export const AssetCard = ({ assetShortHeader, onOpenDetails, size }: Props) => {
           <CheckeredBackground />
           <CorsAwareImage
             key={assetShortHeader.previewImageUrls[0]}
-            style={{
-              ...styles.previewImage,
-              maxWidth: 128 - 2 * paddingSize,
-              maxHeight: 128 - 2 * paddingSize,
-            }}
+            style={
+              isPixelArt(assetShortHeader)
+                ? {
+                    ...styles.previewImage,
+                    ...styles.previewImagePixelated,
+                    maxWidth: 128 - 2 * paddingSize,
+                    maxHeight: 128 - 2 * paddingSize,
+                  }
+                : {
+                    ...styles.previewImage,
+                    maxWidth: 128 - 2 * paddingSize,
+                    maxHeight: 128 - 2 * paddingSize,
+                  }
+            }
             src={assetShortHeader.previewImageUrls[0]}
             alt={assetShortHeader.name}
           />

--- a/newIDE/app/src/AssetStore/AssetCard.js
+++ b/newIDE/app/src/AssetStore/AssetCard.js
@@ -24,10 +24,7 @@ const styles = {
   },
   previewImagePixelated: {
     width: '100%',
-    imageRendering: '-moz-crisp-edges',
-    imageRendering: '-webkit-optimize-contrast',
-    imageRendering: '-webkit-crisp-edges',
-    imageRendering: 'pixelated',
+    imageRendering: '-moz-crisp-edges' || 'pixelated', // TODO to check
     padding: 15,
   },
   icon: {

--- a/newIDE/app/src/AssetStore/AssetCard.js
+++ b/newIDE/app/src/AssetStore/AssetCard.js
@@ -4,6 +4,7 @@ import {
   type AssetShortHeader,
   isPixelArt,
 } from '../Utils/GDevelopServices/Asset';
+import { getPixelatedImageRendering } from '../Utils/CssHelpers';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Text from '../UI/Text';
 import { CorsAwareImage } from '../UI/CorsAwareImage';
@@ -24,7 +25,7 @@ const styles = {
   },
   previewImagePixelated: {
     width: '100%',
-    imageRendering: '-moz-crisp-edges' || 'pixelated', // TODO to check
+    imageRendering: getPixelatedImageRendering(),
     padding: 15,
   },
   icon: {

--- a/newIDE/app/src/AssetStore/AssetCard.js
+++ b/newIDE/app/src/AssetStore/AssetCard.js
@@ -1,6 +1,9 @@
 // @flow
 import * as React from 'react';
-import { type AssetShortHeader } from '../Utils/GDevelopServices/Asset';
+import {
+  type AssetShortHeader,
+  isPixelArt,
+} from '../Utils/GDevelopServices/Asset';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Text from '../UI/Text';
 import { CorsAwareImage } from '../UI/CorsAwareImage';
@@ -20,7 +23,10 @@ const styles = {
     pointerEvents: 'none',
   },
   previewImagePixelated: {
-    width: '-webkit-fill-available',
+    width: '100%',
+    imageRendering: '-moz-crisp-edges',
+    imageRendering: '-webkit-optimize-contrast',
+    imageRendering: '-webkit-crisp-edges',
     imageRendering: 'pixelated',
     padding: 15,
   },
@@ -56,14 +62,6 @@ type Props = {|
   onOpenDetails: () => void,
 |};
 
-const isPixelArt = assetShortHeader => {
-  let returnValue = false;
-  assetShortHeader.tags.map(tag => {
-    if (tag.toLowerCase() === 'pixel art') returnValue = true;
-  });
-  return returnValue;
-};
-
 export const AssetCard = ({ assetShortHeader, onOpenDetails, size }: Props) => {
   return (
     <ButtonBase onClick={onOpenDetails} focusRipple>
@@ -72,20 +70,14 @@ export const AssetCard = ({ assetShortHeader, onOpenDetails, size }: Props) => {
           <CheckeredBackground />
           <CorsAwareImage
             key={assetShortHeader.previewImageUrls[0]}
-            style={
-              isPixelArt(assetShortHeader)
-                ? {
-                    ...styles.previewImage,
-                    ...styles.previewImagePixelated,
-                    maxWidth: 128 - 2 * paddingSize,
-                    maxHeight: 128 - 2 * paddingSize,
-                  }
-                : {
-                    ...styles.previewImage,
-                    maxWidth: 128 - 2 * paddingSize,
-                    maxHeight: 128 - 2 * paddingSize,
-                  }
-            }
+            style={{
+              maxWidth: 128 - 2 * paddingSize,
+              maxHeight: 128 - 2 * paddingSize,
+              ...styles.previewImage,
+              ...(isPixelArt(assetShortHeader)
+                ? styles.previewImagePixelated
+                : undefined),
+            }}
             src={assetShortHeader.previewImageUrls[0]}
             alt={assetShortHeader.name}
           />

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -10,6 +10,7 @@ import {
   type Asset,
   type Author,
   getAsset,
+  isPixelArt,
 } from '../Utils/GDevelopServices/Asset';
 import LeftLoader from '../UI/LeftLoader';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
@@ -33,10 +34,8 @@ import CheckeredBackground from '../ResourcesList/CheckeredBackground';
 const styles = {
   previewImagePixelated: {
     width: '100%',
-    imageRendering: '-moz-crisp-edges',
-    imageRendering: '-webkit-optimize-contrast',
-    imageRendering: '-webkit-crisp-edges',
-    imageRendering: 'pixelated',
+    imageRendering:
+      '-moz-crisp-edges -webkit-optimize-contrast -webkit-crisp-edges pixelated', // TODO not working, need to check if we can do that
     padding: 15,
   },
   previewBackground: {
@@ -80,14 +79,6 @@ type Props = {|
   canInstall: boolean,
   isBeingInstalled: boolean,
 |};
-
-const isPixelArt = assetShortHeader => {
-  let returnValue = false;
-  assetShortHeader.tags.map(tag => {
-    if (tag.toLowerCase() === 'pixel art') returnValue = true;
-  });
-  return returnValue;
-};
 
 export const AssetDetails = ({
   project,

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -12,6 +12,7 @@ import {
   getAsset,
   isPixelArt,
 } from '../Utils/GDevelopServices/Asset';
+import { getPixelatedImageRendering } from '../Utils/CssHelpers';
 import LeftLoader from '../UI/LeftLoader';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import PlaceholderError from '../UI/PlaceholderError';
@@ -34,8 +35,7 @@ import CheckeredBackground from '../ResourcesList/CheckeredBackground';
 const styles = {
   previewImagePixelated: {
     width: '100%',
-    imageRendering:
-      '-moz-crisp-edges -webkit-optimize-contrast -webkit-crisp-edges pixelated', // TODO not working, need to check if we can do that
+    imageRendering: getPixelatedImageRendering(),
     padding: 15,
   },
   previewBackground: {

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -31,6 +31,11 @@ import Window from '../Utils/Window';
 import CheckeredBackground from '../ResourcesList/CheckeredBackground';
 
 const styles = {
+  previewImagePixelated: {
+    width: '-webkit-fill-available',
+    imageRendering: 'pixelated',
+    padding: 15,
+  },
   previewBackground: {
     position: 'relative',
     display: 'flex',
@@ -72,6 +77,14 @@ type Props = {|
   canInstall: boolean,
   isBeingInstalled: boolean,
 |};
+
+const isPixelArt = assetShortHeader => {
+  let returnValue = false;
+  assetShortHeader.tags.map(tag => {
+    if (tag.toLowerCase() === 'pixel art') returnValue = true;
+  });
+  return returnValue;
+};
 
 export const AssetDetails = ({
   project,
@@ -159,7 +172,16 @@ export const AssetDetails = ({
               >
                 <CheckeredBackground />
                 <CorsAwareImage
-                  style={styles.previewImage}
+                  style={
+                    isPixelArt(assetShortHeader)
+                      ? {
+                          ...styles.previewImage,
+                          ...styles.previewImagePixelated,
+                        }
+                      : {
+                          ...styles.previewImage,
+                        }
+                  }
                   src={assetShortHeader.previewImageUrls[0]}
                   alt={assetShortHeader.name}
                 />

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -32,7 +32,10 @@ import CheckeredBackground from '../ResourcesList/CheckeredBackground';
 
 const styles = {
   previewImagePixelated: {
-    width: '-webkit-fill-available',
+    width: '100%',
+    imageRendering: '-moz-crisp-edges',
+    imageRendering: '-webkit-optimize-contrast',
+    imageRendering: '-webkit-crisp-edges',
     imageRendering: 'pixelated',
     padding: 15,
   },
@@ -172,16 +175,12 @@ export const AssetDetails = ({
               >
                 <CheckeredBackground />
                 <CorsAwareImage
-                  style={
-                    isPixelArt(assetShortHeader)
-                      ? {
-                          ...styles.previewImage,
-                          ...styles.previewImagePixelated,
-                        }
-                      : {
-                          ...styles.previewImage,
-                        }
-                  }
+                  style={{
+                    ...styles.previewImage,
+                    ...(isPixelArt(assetShortHeader)
+                      ? styles.previewImagePixelated
+                      : undefined),
+                  }}
                   src={assetShortHeader.previewImageUrls[0]}
                   alt={assetShortHeader.name}
                 />

--- a/newIDE/app/src/Utils/CssHelpers.js
+++ b/newIDE/app/src/Utils/CssHelpers.js
@@ -3,7 +3,7 @@ let pixelatedImageRenderingValue: ?string = null;
 export const getPixelatedImageRendering = (): string => {
   if (pixelatedImageRenderingValue) return pixelatedImageRenderingValue;
 
-  return (pixelatedImageRenderingValue = CSS.supports(
+  return (pixelatedImageRenderingValue = global.CSS.supports(
     'image-rendering: crisp-edges'
   )
     ? 'crisp-edges'

--- a/newIDE/app/src/Utils/CssHelpers.js
+++ b/newIDE/app/src/Utils/CssHelpers.js
@@ -1,0 +1,11 @@
+// @flow
+let pixelatedImageRenderingValue: ?string = null;
+export const getPixelatedImageRendering = (): string => {
+  if (pixelatedImageRenderingValue) return pixelatedImageRenderingValue;
+
+  return (pixelatedImageRenderingValue = CSS.supports(
+    'image-rendering: crisp-edges'
+  )
+    ? 'crisp-edges'
+    : 'pixelated');
+};

--- a/newIDE/app/src/Utils/GDevelopServices/Asset.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Asset.js
@@ -232,3 +232,11 @@ export const listAllLicenses = (): Promise<Array<License>> => {
     })
     .then(response => response.data);
 };
+
+export const isPixelArt = (assetShortHeader: AssetShortHeader) => {
+  let returnValue = false;
+  assetShortHeader.tags.some(tag => {
+    if (tag.toLowerCase() === 'pixel art') returnValue = true;
+  });
+  return returnValue;
+};

--- a/newIDE/app/src/Utils/GDevelopServices/Asset.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Asset.js
@@ -234,9 +234,7 @@ export const listAllLicenses = (): Promise<Array<License>> => {
 };
 
 export const isPixelArt = (assetShortHeader: AssetShortHeader) => {
-  let returnValue = false;
-  assetShortHeader.tags.some(tag => {
-    if (tag.toLowerCase() === 'pixel art') returnValue = true;
+  return assetShortHeader.tags.some(tag => {
+    return tag.toLowerCase() === 'pixel art';
   });
-  return returnValue;
 };


### PR DESCRIPTION
Make all assets with **pixel art** tag bigger and pixelated in the viewer.

Assets from **Grafxkid** are not tagged with **pixel art** and should be.
@Entr0py404 I think you can add an option in your editor to tag assets as pixel art with a checkbox, if isn't already done :)

## Before
![image](https://user-images.githubusercontent.com/1670670/126880148-97c02ede-a55a-43bf-a314-4e43589139e1.png)

## After
![image](https://user-images.githubusercontent.com/1670670/126880056-7cf1f368-9e3d-486f-b123-51864276fc1c.png)

![image](https://user-images.githubusercontent.com/1670670/126880061-c6cc7035-21f0-4749-b44d-cf799625f05c.png)

