### PR TITLE
Add continuous delivery: automatic macOS and Windows builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,75 @@
-# CircleCI 2.0 configuration file to build GDevelop app running
-# on the Electron runtime (newIDE/electron-app).
+# CircleCI configuration to build GDevelop app running
+# on the Electron runtime (newIDE/electron-app) for macOS and Linux.
+# For Windows, see the appveyor.yml file.
 
-version: 2
+version: 2.1
 jobs:
-  build:
+  build-macos:
+    macos:
+      xcode: 12.5.1
+    steps:
+      - checkout
+
+      # System dependencies (for Emscripten and upload)
+      - run:
+          name: Install dependencies for Emscripten and AWS S3 upload
+          command: brew install cmake && brew install awscli
+
+      - run:
+          name: Install Emscripten (for GDevelop.js)
+          command: git clone https://github.com/juj/emsdk.git && cd emsdk && ./emsdk install 1.39.6 && ./emsdk activate 1.39.6 && cd ..
+
+      # GDevelop.js dependencies
+      - restore_cache:
+          keys:
+            - gd-macos-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}-{{ checksum "GDevelop.js/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - gd-macos-nodejs-dependencies---
+
+      - run:
+          name: Install GDevelop.js dependencies and build it
+          command: cd GDevelop.js && npm install && cd ..
+
+      # Build GDevelop.js (and run tests to ensure it works)
+      - run:
+          name: Build GDevelop.js
+          command: cd GDevelop.js && source ../emsdk/emsdk_env.sh && npm run build && npm test && cd ..
+
+      # GDevelop IDE dependencies (after building GDevelop.js to avoid downloading a pre-built version)
+      - run:
+          name: Install GDevelop IDE dependencies
+          command: cd newIDE/app && npm install && cd ../electron-app && npm install
+
+      - save_cache:
+          paths:
+            - newIDE/electron-app/node_modules
+            - newIDE/app/node_modules
+            - GDevelop.js/node_modules
+          key: gd-macos-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}-{{ checksum "GDevelop.js/package.json" }}
+
+      # Build GDevelop IDE (seems like we need to allow Node.js to use more space than usual)
+      # Note: Code signing is done using CSC_LINK (see https://www.electron.build/code-signing).
+      - run:
+          name: Build GDevelop IDE
+          command: export NODE_OPTIONS="--max-old-space-size=7168" && cd newIDE/electron-app && npm run build -- --mac --publish=never
+
+      - run:
+          name: Clean dist folder to keep only installers/binaries.
+          command: rm -rf "newIDE/electron-app/dist/mac/GDevelop 5.app"
+
+      # Upload artifacts (CircleCI)
+      - store_artifacts:
+          path: newIDE/electron-app/dist
+
+      # Upload artifacts (AWS)
+      - run:
+          name: Deploy to S3 (specific commit)
+          command: aws s3 sync newIDE/electron-app/dist s3://gdevelop-releases/$(git rev-parse --abbrev-ref HEAD)/commit/$(git rev-parse HEAD)/
+      - run:
+          name: Deploy to S3 (latest)
+          command: aws s3 sync newIDE/electron-app/dist s3://gdevelop-releases/$(git rev-parse --abbrev-ref HEAD)/latest/
+
+  build-linux:
     # CircleCI docker workers are failing if they don't have enough memory (no swap)
     resource_class: xlarge
     docker:
@@ -24,25 +90,21 @@ jobs:
           command: git clone https://github.com/juj/emsdk.git && cd emsdk && ./emsdk install 1.39.6 && ./emsdk activate 1.39.6 && cd ..
 
       - run:
-          name: Install Wine for Electron builder
-          command: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt install wine32
-
-      - run:
           name: Install system dependencies for Electron builder
           command: sudo apt install icnsutils && sudo apt install graphicsmagick && sudo apt install rsync
 
       # GDevelop.js dependencies
       - restore_cache:
           keys:
-            - gd-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}-{{ checksum "GDevelop.js/package.json" }}
+            - gd-linux-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}-{{ checksum "GDevelop.js/package.json" }}
             # fallback to using the latest cache if no exact match is found
-            - gd-nodejs-dependencies---
+            - gd-linux-nodejs-dependencies---
 
       - run:
           name: Install GDevelop.js dependencies and build it
-          command: cd GDevelop.js && sudo npm install -g grunt-cli && npm install && cd ..
+          command: cd GDevelop.js && npm install && cd ..
 
-      # Build GDevelop.js
+      # Build GDevelop.js (and run tests to ensure it works)
       - run:
           name: Build GDevelop.js
           command: cd GDevelop.js && source ../emsdk/emsdk_env.sh && npm run build && npm test && cd ..
@@ -57,16 +119,16 @@ jobs:
             - newIDE/electron-app/node_modules
             - newIDE/app/node_modules
             - GDevelop.js/node_modules
-          key: gd-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}
+          key: gd-linux-nodejs-dependencies-{{ checksum "newIDE/app/package.json" }}-{{ checksum "newIDE/electron-app/package.json" }}-{{ checksum "GDevelop.js/package.json" }}
 
       # Build GDevelop IDE (seems like we need to allow Node.js to use more space than usual)
       - run:
           name: Build GDevelop IDE
-          command: export NODE_OPTIONS="--max-old-space-size=7168" && cd newIDE/electron-app && npm run build -- --mac zip --win --linux tar.gz --publish=never
+          command: export NODE_OPTIONS="--max-old-space-size=7168" && cd newIDE/electron-app && npm run build -- --linux AppImage --publish=never
 
       - run:
           name: Clean dist folder to keep only installers/binaries.
-          command: rm -rf newIDE/electron-app/dist/linux-unpacked && rm -rf newIDE/electron-app/dist/win-unpacked && rm -rf newIDE/electron-app/dist/mac
+          command: rm -rf newIDE/electron-app/dist/linux-unpacked
 
       # Upload artifacts (CircleCI)
       - store_artifacts:
@@ -79,3 +141,20 @@ jobs:
       - run:
           name: Deploy to S3 (latest)
           command: aws s3 sync newIDE/electron-app/dist s3://gdevelop-releases/$(git rev-parse --abbrev-ref HEAD)/latest/
+
+
+workflows:
+  builds:
+    jobs:
+      - build-macos:
+          filters:
+            branches:
+              only:
+                - master
+                - /experimental-build.*/
+      - build-linux:
+          filters:
+            branches:
+              only:
+                - master
+                - /experimental-build.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+# Travis CI configuration to build and run all tests
+# (and typing/formatting) for the Core, newIDE, GDJS (and even GDCpp).
+#
+# This builds GDevelop.js and store it on a S3 so it can be used to run
+# GDevelop without building it.
+#
+# See also Semaphore CI for quick tests (not building GDevelop.js, so
+# faster but not always reliable).
+
 language: cpp
 sudo: false
 compiler:

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ GDevelop is a full-featured, open-source game development software, allowing to 
 | Create/improve an extension     | Download [Node.js] and follow this [README](newIDE/README-extensions.md).      |
 | Help to translate GDevelop      | Go on the [GDevelop project on Crowdin](https://crowdin.com/project/gdevelop). |
 
-> Are you interested in contributing to GDevelop for the first time? Or want to participate in [Google Summer of Code 2021](https://summerofcode.withgoogle.com/organizations/5586892420022272/)? Take a look at the list of **[good first issues](https://github.com/4ian/GDevelop/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%91%8Cgood+first+issue%22)**, **[good first contributions](https://github.com/4ian/GDevelop/discussions/categories/good-first-contribution)** or the **["🏐 not too hard" cards](https://trello.com/b/qf0lM7k8/gdevelop-roadmap?menu=filter&filter=label:Not%20too%20hard%20%E2%9A%BD%EF%B8%8F)** on the Roadmap.
+> Are you interested in contributing to GDevelop for the first time? Take a look at the list of **[good first issues](https://github.com/4ian/GDevelop/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%91%8Cgood+first+issue%22)**, **[good first contributions](https://github.com/4ian/GDevelop/discussions/categories/good-first-contribution)** or the **["🏐 not too hard" cards](https://trello.com/b/qf0lM7k8/gdevelop-roadmap?menu=filter&filter=label:Not%20too%20hard%20%E2%9A%BD%EF%B8%8F)** on the Roadmap.
 
 ## Overview of the architecture
 
@@ -30,7 +30,7 @@ To learn more about GDevelop Architecture, read the [architecture overview here]
 
 Pre-generated documentation of the Core library, C++ and TypeScript game engines is [available here](https://docs.gdevelop-app.com).
 
-Status of the tests and builds: [![Build status](https://circleci.com/gh/4ian/GDevelop.svg?style=shield)](https://app.circleci.com/pipelines/github/4ian/GDevelop) [![Quick tests status](https://semaphoreci.com/api/v1/4ian/gd/branches/master/shields_badge.svg)](https://semaphoreci.com/4ian/gd) [![All tests Status](https://www.travis-ci.com/4ian/GDevelop.svg?branch=master)](https://www.travis-ci.com/github/4ian/GDevelop) [![Windows Build status](https://ci.appveyor.com/api/projects/status/84uhtdox47xp422x/branch/master?svg=true)](https://ci.appveyor.com/project/4ian/gdevelop/branch/master) [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
+Status of the tests and builds: [![macOS and Linux build status](https://circleci.com/gh/4ian/GDevelop.svg?style=shield)](https://app.circleci.com/pipelines/github/4ian/GDevelop) [![Quick tests status](https://semaphoreci.com/api/v1/4ian/gd/branches/master/shields_badge.svg)](https://semaphoreci.com/4ian/gd) [![All tests status](https://www.travis-ci.com/4ian/GDevelop.svg?branch=master)](https://www.travis-ci.com/github/4ian/GDevelop) [![Windows Build status](https://ci.appveyor.com/api/projects/status/84uhtdox47xp422x/branch/master?svg=true)](https://ci.appveyor.com/project/4ian/gdevelop/branch/master) [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 
 ## Links
 
@@ -61,7 +61,3 @@ Status of the tests and builds: [![Build status](https://circleci.com/gh/4ian/GD
 -   The name, GDevelop, and its logo are the exclusive property of Florian Rival.
 
 Games exported with GDevelop are based on the native and/or HTML5 game engines (see `Core`, `GDCpp` and `GDJS` folders): these engines are distributed under the MIT license so that you can **distribute, sell or do anything** with the games you created with GDevelop. In particular, you are not forced to make your game open source.
-
-[node.js]: https://nodejs.org
-[cmake]: http://www.cmake.org/
-[ninja]: http://martine.github.io/ninja/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,22 @@
+# AppVeyor configuration to build GDevelop app running
+# on the Electron runtime (newIDE/electron-app) for Windows.
+# For macOS and Linux, see the config.yml file.
+
 version: 1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2019
 clone_depth: 5
+# Only build
+branches:
+  only:
+    - master
+    - /experimental-build.*/
 init:
 - ps: ''
 install:
 - ps: Install-Product node 14
-build_script:
+# Build GDevelop.js (and run tests to ensure it works)
 - cmd: >-
     cd GDevelop.js
 
@@ -29,21 +38,34 @@ build_script:
 
     cd ..
 
+# Build GDevelop IDE
+- cmd: >-
     cd newIDE\app
 
     npm install
 
-    cd ..\..
-
-    cd GDJS
-
-    npm install
-
-    cd tests
+    cd ..\electron-app
 
     npm install
 
     cd ..\..
+
+# Package the app for Windows.
+build_script:
+- cmd: >-
+    cd newIDE\electron-app
+
+    node --max-old-space-size=3072 scripts/build.js --win appx --publish=never
+
+    node scripts/build.js --skip-app-build --win nsis --publish=never
+
+    cd ..\..
+
+# Clean dist folder to keep only installers/binaries.
+- cmd: >-
+    DEL /F/Q/S newIDE\electron-app\dist\win-unpacked
+
+# Run a few tests on Windows.
 test_script:
 - cmd: >-
     cd GDevelop.js
@@ -57,5 +79,14 @@ test_script:
     npm test
 
     cd ..\..
-on_finish:
-- ps: ''
+
+artifacts:
+  - path: newIDE\electron-app\dist
+    name: GDevelopWindows
+
+# Upload artifacts (AWS) - configuration is stored on AppVeyor itself.
+deploy:
+  - provider: Environment
+    name: Amazon S3 releases
+  - provider: Environment
+    name: Amazon S3 latest releases

--- a/newIDE/docs/Nightly-Builds-and-continuous-deployment.md
+++ b/newIDE/docs/Nightly-Builds-and-continuous-deployment.md
@@ -1,12 +1,12 @@
 # Nightly Builds and continuous deployment
 
-GDevelop is using CircleCI (a continous deployment/integration service) to automatically build new versions for **every commit on `master`** branch.
+GDevelop is using CircleCI (a continous deployment/integration service) and AppVeyor to automatically build new versions for **every commit on `master`** branch.
 
 You can download these here - **replace XX by the current beta version number**:
 
-- Windows: `https://gdevelop-releases.s3.amazonaws.com/master/latest/GDevelop 5 Setup 5.0.0-betaXX.exe`
-- macOS: `https://gdevelop-releases.s3.amazonaws.com/master/latest/GDevelop 5-5.0.0-betaXX-mac.zip`
-- Linux: `https://gdevelop-releases.s3.amazonaws.com/master/latest/gdevelop-5.0.0-betaXX.tar.gz`
+- Windows: `https://gdevelop-releases.s3.amazonaws.com/master/latest/GDevelop 5 Setup 5.0.0-betaXXX.exe`
+- macOS: `https://gdevelop-releases.s3.amazonaws.com/master/latest/GDevelop 5-5.0.0-betaXXX-mac.zip`
+- Linux: `https://gdevelop-releases.s3.amazonaws.com/master/latest/GDevelop 5-5.0.0-betaXXX.AppImage`
 
 > ⚠️ Be sure to check if the latest build was successfully done: [![Build status](https://circleci.com/gh/4ian/GDevelop.svg?style=shield)](https://app.circleci.com/pipelines/github/4ian/GDevelop). If this icon is not green, wait a bit before downloading the latest version.
 
@@ -27,6 +27,6 @@ You can download these here - **replace XX by the current beta version number**:
 2. Find the hash of the commit. Usually, click on a commit title (in a Pull Requests or in the list of commits of a branch) and read the _hash_ in the URL. For example, for https://github.com/4ian/GDevelop/commit/5c648e3f2b8c444bd99221cea56b92c00cdddddd, the hash is `5c648e3f2b8c444bd99221cea56b92c00cdddddd`.
 3. Download the version built for it (replace XX, THE_BRANCH and THE_COMMIT_HASH):
 
-- Windows: `https://gdevelop-releases.s3.amazonaws.com/THE_BRANCH/commit/THE_COMMIT_HASH/GDevelop 5 Setup 5.0.0-betaXX.exe`
-- macOS: `https://gdevelop-releases.s3.amazonaws.com/THE_BRANCH/commit/THE_COMMIT_HASH/GDevelop 5-5.0.0-betaXX-mac.zip`
-- Linux: `https://gdevelop-releases.s3.amazonaws.com/THE_BRANCH/commit/THE_COMMIT_HASH/gdevelop-5.0.0-betaXX.tar.gz`
+- Windows: `https://gdevelop-releases.s3.amazonaws.com/THE_BRANCH/commit/THE_COMMIT_HASH/GDevelop 5 Setup 5.0.0-betaXXX.exe`
+- macOS: `https://gdevelop-releases.s3.amazonaws.com/THE_BRANCH/commit/THE_COMMIT_HASH/GDevelop 5-5.0.0-betaXXX-mac.zip`
+- Linux: `https://gdevelop-releases.s3.amazonaws.com/THE_BRANCH/commit/THE_COMMIT_HASH/GDevelop 5-5.0.0-betaXXX.AppImage`


### PR DESCRIPTION
* This automatically builds the signed macOS app, the Windows exe and AppX, the Linux AppImage.
* This is only for master and any "experimental-build/xxx" branches.
* Only Travis CI and Semaphore CI are running tests, for all branches.