### PR TITLE
Fix scrolling in the instructions editor

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -81,7 +81,6 @@ type Props = {|
 |};
 
 const iconSize = 24;
-const minHeight = 400; // Avoid a super small list in empty scenes. 400 is enough to be displayed on an iPhone SE.
 
 export default class InstructionOrObjectSelector extends React.PureComponent<
   Props,
@@ -232,7 +231,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
               <div
                 style={{
                   backgroundColor: muiTheme.list.itemsBackgroundColor,
-                  minHeight,
+                  minHeight: 0,
                   ...style,
                 }}
               >

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -13,7 +13,6 @@ import InstructionParametersEditor from './InstructionParametersEditor';
 import InstructionOrObjectSelector, {
   type TabName,
 } from './InstructionOrObjectSelector';
-import { Column } from '../../UI/Grid';
 import InstructionOrExpressionSelector from './InstructionOrExpressionSelector';
 import HelpButton from '../../UI/HelpButton';
 import Background from '../../UI/Background';
@@ -199,24 +198,23 @@ export default function NewInstructionEditorDialog({
   );
 
   const renderParameters = () => (
-    <Column expand justifyContent="center" key="parameters">
-      <InstructionParametersEditor
-        project={project}
-        scope={scope}
-        globalObjectsContainer={globalObjectsContainer}
-        objectsContainer={objectsContainer}
-        objectName={chosenObjectName}
-        isCondition={isCondition}
-        instruction={instruction}
-        resourceSources={resourceSources}
-        onChooseResource={onChooseResource}
-        resourceExternalEditors={resourceExternalEditors}
-        openInstructionOrExpression={openInstructionOrExpression}
-        ref={instructionParametersEditor}
-        focusOnMount={!!instructionType}
-        noHelpButton
-      />
-    </Column>
+    <InstructionParametersEditor
+      key="parameters"
+      project={project}
+      scope={scope}
+      globalObjectsContainer={globalObjectsContainer}
+      objectsContainer={objectsContainer}
+      objectName={chosenObjectName}
+      isCondition={isCondition}
+      instruction={instruction}
+      resourceSources={resourceSources}
+      onChooseResource={onChooseResource}
+      resourceExternalEditors={resourceExternalEditors}
+      openInstructionOrExpression={openInstructionOrExpression}
+      ref={instructionParametersEditor}
+      focusOnMount={!!instructionType}
+      noHelpButton
+    />
   );
 
   const renderObjectInstructionSelector = () =>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -171,30 +171,28 @@ export default function NewInstructionEditorDialog({
     : undefined;
 
   const renderInstructionOrObjectSelector = () => (
-    <Background noFullHeight key="instruction-or-object-selector">
-      <InstructionOrObjectSelector
-        style={styles.fullHeightSelector}
-        project={project}
-        scope={scope}
-        currentTab={currentInstructionOrObjectSelectorTab}
-        onChangeTab={setCurrentInstructionOrObjectSelectorTab}
-        globalObjectsContainer={globalObjectsContainer}
-        objectsContainer={objectsContainer}
-        isCondition={isCondition}
-        chosenInstructionType={!chosenObjectName ? instructionType : undefined}
-        onChooseInstruction={(instructionType: string) => {
-          chooseInstruction(instructionType);
-          setStep('parameters');
-        }}
-        chosenObjectName={chosenObjectName}
-        onChooseObject={(chosenObjectName: string) => {
-          chooseObject(chosenObjectName);
-          setStep('object-instructions');
-        }}
-        focusOnMount={!instructionType}
-        onSearchStartOrReset={forceUpdate}
-      />
-    </Background>
+    <InstructionOrObjectSelector
+      style={styles.fullHeightSelector}
+      project={project}
+      scope={scope}
+      currentTab={currentInstructionOrObjectSelectorTab}
+      onChangeTab={setCurrentInstructionOrObjectSelectorTab}
+      globalObjectsContainer={globalObjectsContainer}
+      objectsContainer={objectsContainer}
+      isCondition={isCondition}
+      chosenInstructionType={!chosenObjectName ? instructionType : undefined}
+      onChooseInstruction={(instructionType: string) => {
+        chooseInstruction(instructionType);
+        setStep('parameters');
+      }}
+      chosenObjectName={chosenObjectName}
+      onChooseObject={(chosenObjectName: string) => {
+        chooseObject(chosenObjectName);
+        setStep('object-instructions');
+      }}
+      focusOnMount={!instructionType}
+      onSearchStartOrReset={forceUpdate}
+    />
   );
 
   const renderParameters = () => (
@@ -290,6 +288,9 @@ export default function NewInstructionEditorDialog({
           maxWidth={false}
           noMargin
           flexRowBody
+          fullHeight={
+            true /* Always use full height to avoid a very small dialog when there are not a lot of objects. */
+          }
         >
           <SelectColumns
             columnsRenderer={{

--- a/newIDE/app/src/EventsSheet/InstructionEditor/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/index.js
@@ -18,8 +18,6 @@ const styles = {
   parametersEditor: {
     flex: 2,
     display: 'flex',
-    paddingLeft: 16,
-    paddingRight: 16,
     zIndex: 1, // Put the Paper shadow on the type selector
   },
 };


### PR DESCRIPTION
Fix #2853 and also extra scrollbar on very small screens when choosing an object (or a non object action/condition).

Tested on Chrome/Safari/Firefox with multiple window sizes. 