### PR TITLE
Fix wrong type for the color parameter of a light object

### DIFF
--- a/Extensions/Lighting/JsExtension.js
+++ b/Extensions/Lighting/JsExtension.js
@@ -221,7 +221,7 @@ module.exports = {
         'res/actions/color.png'
       )
       .addParameter('object', _('Object'), 'LightObject', false)
-      .addParameter('string', _('Color'), '', false)
+      .addParameter('color', _('Color'), '', false)
       .getCodeExtraInformation()
       .setFunctionName('setColor');
 


### PR DESCRIPTION
Fix #2853 

![image](https://user-images.githubusercontent.com/4895034/127896222-1216790c-ca6b-41bc-a0f6-b134d45e4a9e.png)
