### PR TITLE
Add new lines between functions back in ts files

### DIFF
--- a/Extensions/AdvancedWindow/electron-advancedwindowtools.ts
+++ b/Extensions/AdvancedWindow/electron-advancedwindowtools.ts
@@ -24,12 +24,14 @@ namespace gdjs {
           }
         }
       };
+
       export const isFocused = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isFocused();
         }
         return false;
       };
+
       export const show = function (activate: boolean) {
         if (electronBrowserWindow) {
           if (activate) {
@@ -39,12 +41,14 @@ namespace gdjs {
           }
         }
       };
+
       export const isVisible = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isVisible();
         }
         return false;
       };
+
       export const maximize = function (activate: boolean) {
         if (electronBrowserWindow) {
           if (activate) {
@@ -54,12 +58,14 @@ namespace gdjs {
           }
         }
       };
+
       export const isMaximized = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isMaximized();
         }
         return false;
       };
+
       export const minimize = function (activate: boolean) {
         if (electronBrowserWindow) {
           if (activate) {
@@ -69,89 +75,105 @@ namespace gdjs {
           }
         }
       };
+
       export const isMinimized = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isMinimized();
         }
         return false;
       };
+
       export const enable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setEnabled(activate);
         }
       };
+
       export const isEnabled = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isEnabled();
         }
         return false;
       };
+
       export const setResizable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setResizable(activate);
         }
       };
+
       export const isResizable = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isResizable();
         }
         return false;
       };
+
       export const setMovable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setMovable(activate);
         }
       };
+
       export const isMovable = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isMovable();
         }
         return false;
       };
+
       export const setMaximizable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setMaximizable(activate);
         }
       };
+
       export const isMaximizable = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isMaximizable();
         }
         return false;
       };
+
       export const setMinimizable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setMinimizable(activate);
         }
       };
+
       export const isMinimizable = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isMinimizable();
         }
         return false;
       };
+
       export const setFullScreenable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setFullScreenable(activate);
         }
       };
+
       export const isFullScreenable = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isFullScreenable();
         }
         return false;
       };
+
       export const setClosable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setClosable(activate);
         }
       };
+
       export const isClosable = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isClosable();
         }
         return false;
       };
+
       export const setAlwaysOnTop = function (
         activate: boolean,
         level:
@@ -168,73 +190,86 @@ namespace gdjs {
           electronBrowserWindow.setAlwaysOnTop(activate, level);
         }
       };
+
       export const isAlwaysOnTop = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isAlwaysOnTop();
         }
         return false;
       };
+
       export const setPosition = function (x: float, y: float) {
         if (electronBrowserWindow) {
           // Convert x and y to (32 bit) integers to avoid Electron errors.
           electronBrowserWindow.setPosition(~~x, ~~y);
         }
       };
+
       export const getPositionX = function (): number {
         if (electronBrowserWindow) {
           return electronBrowserWindow.getPosition()[0];
         }
         return 0;
       };
+
       export const getPositionY = function (): number {
         if (electronBrowserWindow) {
           return electronBrowserWindow.getPosition()[1];
         }
         return 0;
       };
+
       export const setKiosk = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setKiosk(activate);
         }
       };
+
       export const isKiosk = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.isKiosk();
         }
         return false;
       };
+
       export const flash = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.flashFrame(activate);
         }
       };
+
       export const setHasShadow = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setHasShadow(activate);
         }
       };
+
       export const hasShadow = function (): boolean {
         if (electronBrowserWindow) {
           return electronBrowserWindow.hasShadow();
         }
         return false;
       };
+
       export const setOpacity = function (opacity: float) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setOpacity(opacity);
         }
       };
+
       export const getOpacity = function (): number {
         if (electronBrowserWindow) {
           return electronBrowserWindow.getOpacity();
         }
         return 1;
       };
+
       export const setContentProtection = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setContentProtection(activate);
         }
       };
+
       export const setFocusable = function (activate: boolean) {
         if (electronBrowserWindow) {
           electronBrowserWindow.setFocusable(activate);

--- a/Extensions/ExampleJsExtension/examplejsextensiontools.ts
+++ b/Extensions/ExampleJsExtension/examplejsextensiontools.ts
@@ -11,6 +11,7 @@ namespace gdjs {
       export const myConditionFunction = function (number, text) {
         return number <= 10 && text.length < 5;
       };
+
       export const getString = function () {
         return 'Hello World';
       };

--- a/Extensions/FacebookInstantGames/facebookinstantgamestools.ts
+++ b/Extensions/FacebookInstantGames/facebookinstantgamestools.ts
@@ -18,18 +18,21 @@ namespace gdjs {
           supportedAPIs.indexOf('getRewardedVideoAsync') !== -1
         );
       };
+
       export const getPlayerId = function () {
         if (typeof FBInstant === 'undefined') {
           return '';
         }
         return FBInstant.player.getID() || '';
       };
+
       export const getPlayerName = function () {
         if (typeof FBInstant === 'undefined') {
           return '';
         }
         return FBInstant.player.getName() || '';
       };
+
       export const loadPlayerData = function (
         key,
         successVariable,
@@ -49,6 +52,7 @@ namespace gdjs {
             errorVariable.setString(error.message || 'Unknown error');
           });
       };
+
       export const setPlayerData = function (
         key,
         variable,
@@ -71,6 +75,7 @@ namespace gdjs {
             errorVariable.setString(error.message || 'Unknown error');
           });
       };
+
       export const setPlayerScore = function (
         leaderboardName,
         score,
@@ -95,6 +100,7 @@ namespace gdjs {
             errorVariable.setString(error.message || 'Unknown error');
           });
       };
+
       export const getPlayerEntry = function (
         leaderboardName,
         rankVariable,
@@ -124,6 +130,7 @@ namespace gdjs {
             errorVariable.setString(error.message || 'Unknown error');
           });
       };
+
       export const loadInterstitialAd = function (
         adPlacementId,
         errorVariable
@@ -155,6 +162,7 @@ namespace gdjs {
             errorVariable.setString(err.message || 'Unknown error');
           });
       };
+
       export const showInterstitialAd = function (errorVariable) {
         if (typeof FBInstant === 'undefined') {
           return;
@@ -175,9 +183,11 @@ namespace gdjs {
             gdjs.evtTools.facebookInstantGames._preloadedInterstitialLoaded = false;
           });
       };
+
       export const isInterstitialAdReady = function () {
         return gdjs.evtTools.facebookInstantGames._preloadedInterstitialLoaded;
       };
+
       export const loadRewardedVideo = function (adPlacementId, errorVariable) {
         if (typeof FBInstant === 'undefined') {
           return;
@@ -206,6 +216,7 @@ namespace gdjs {
             errorVariable.setString(err.message || 'Unknown error');
           });
       };
+
       export const showRewardedVideo = function (errorVariable) {
         if (typeof FBInstant === 'undefined') {
           return;
@@ -226,6 +237,7 @@ namespace gdjs {
             gdjs.evtTools.facebookInstantGames._preloadedRewardedVideoLoaded = false;
           });
       };
+
       export const isRewardedVideoReady = function () {
         return gdjs.evtTools.facebookInstantGames._preloadedRewardedVideoLoaded;
       };

--- a/Extensions/FileSystem/filesystemtools.ts
+++ b/Extensions/FileSystem/filesystemtools.ts
@@ -24,6 +24,7 @@ namespace gdjs {
       }
       return gdjs.fileSystem._fs;
     };
+
     export const getDirectoryName = function (fileOrFolderPath: string) {
       const path = gdjs.fileSystem._getPath();
       if (!path) {
@@ -31,6 +32,7 @@ namespace gdjs {
       }
       return path.dirname(fileOrFolderPath);
     };
+
     export const getFileName = function (filePath: string) {
       const path = gdjs.fileSystem._getPath();
       if (!path) {
@@ -38,6 +40,7 @@ namespace gdjs {
       }
       return path.basename(filePath);
     };
+
     export const getExtensionName = function (filePath: string) {
       const path = gdjs.fileSystem._getPath();
       if (!path) {

--- a/Extensions/Inventory/inventorytools.ts
+++ b/Extensions/Inventory/inventorytools.ts
@@ -18,15 +18,19 @@ namespace gdjs {
       export const add = function (runtimeScene, inventoryName, name) {
         return InventoryManager.get(runtimeScene, inventoryName).add(name);
       };
+
       export const remove = function (runtimeScene, inventoryName, name) {
         return InventoryManager.get(runtimeScene, inventoryName).remove(name);
       };
+
       export const count = function (runtimeScene, inventoryName, name) {
         return InventoryManager.get(runtimeScene, inventoryName).count(name);
       };
+
       export const has = function (runtimeScene, inventoryName, name) {
         return InventoryManager.get(runtimeScene, inventoryName).has(name);
       };
+
       export const setMaximum = function (
         runtimeScene,
         inventoryName,
@@ -38,6 +42,7 @@ namespace gdjs {
           maxCount
         );
       };
+
       export const setUnlimited = function (
         runtimeScene,
         inventoryName,
@@ -49,20 +54,24 @@ namespace gdjs {
           enable
         );
       };
+
       export const isFull = function (runtimeScene, inventoryName, name) {
         return InventoryManager.get(runtimeScene, inventoryName).isFull(name);
       };
+
       export const equip = function (runtimeScene, inventoryName, name, equip) {
         return InventoryManager.get(runtimeScene, inventoryName).equip(
           name,
           equip
         );
       };
+
       export const isEquipped = function (runtimeScene, inventoryName, name) {
         return InventoryManager.get(runtimeScene, inventoryName).isEquipped(
           name
         );
       };
+
       export const serializeToVariable = function (
         runtimeScene,
         inventoryName: string,
@@ -81,6 +90,7 @@ namespace gdjs {
           serializedItem.getChild('equipped').setBoolean(item.equipped);
         }
       };
+
       export const unserializeFromVariable = function (
         runtimeScene,
         inventoryName: string,

--- a/Extensions/LinkedObjects/linkedobjects.ts
+++ b/Extensions/LinkedObjects/linkedobjects.ts
@@ -90,6 +90,7 @@ namespace gdjs {
         }
         LinksManager.getManager(runtimeScene).linkObjects(objA, objB);
       };
+
       export const removeLinkBetween = function (
         runtimeScene: gdjs.RuntimeScene,
         objA: gdjs.RuntimeObject,
@@ -100,6 +101,7 @@ namespace gdjs {
         }
         LinksManager.getManager(runtimeScene).removeLinkBetween(objA, objB);
       };
+
       export const removeAllLinksOf = function (
         runtimeScene: gdjs.RuntimeScene,
         objA: gdjs.RuntimeObject
@@ -109,12 +111,14 @@ namespace gdjs {
         }
         LinksManager.getManager(runtimeScene).removeAllLinksOf(objA);
       };
+
       export const _objectIsInList = function (
         obj: gdjs.RuntimeObject,
         linkedObjects: gdjs.RuntimeObject[]
       ) {
         return linkedObjects.indexOf(obj) !== -1;
       };
+
       export const pickObjectsLinkedTo = function (
         runtimeScene: gdjs.RuntimeScene,
         objectsLists: Hashtable<gdjs.RuntimeObject[]>,

--- a/Extensions/Physics2Behavior/physics2tools.ts
+++ b/Extensions/Physics2Behavior/physics2tools.ts
@@ -14,6 +14,7 @@ namespace gdjs {
         behavior
       );
     };
+
     export const setTimeScale = function (objectsLists, behavior, timeScale) {
       const lists = gdjs.staticArray(gdjs.physics2.setTimeScale);
       objectsLists.values(lists);

--- a/Extensions/Shopify/shopifytools.ts
+++ b/Extensions/Shopify/shopifytools.ts
@@ -39,6 +39,7 @@ namespace gdjs {
         const shopifyClient = ShopifyBuy.buildClient(config);
         ShopifyClientsManager.set(runtimeScene, name, shopifyClient);
       };
+
       export const getCheckoutUrlForProduct = function (
         runtimeScene,
         name,

--- a/GDJS/Runtime/events-tools/cameratools.ts
+++ b/GDJS/Runtime/events-tools/cameratools.ts
@@ -17,6 +17,7 @@ namespace gdjs {
         }
         runtimeScene.getLayer(layer).setCameraX(x, cameraId);
       };
+      
       export const setCameraY = function (
         runtimeScene: gdjs.RuntimeScene,
         y: float,
@@ -28,6 +29,7 @@ namespace gdjs {
         }
         runtimeScene.getLayer(layer).setCameraY(y, cameraId);
       };
+
       export const getCameraX = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -38,6 +40,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).getCameraX();
       };
+
       export const getCameraY = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -48,6 +51,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).getCameraY();
       };
+
       export const getCameraWidth = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -58,6 +62,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).getCameraWidth();
       };
+
       export const getCameraHeight = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -68,6 +73,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).getCameraHeight();
       };
+
       export const showLayer = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string
@@ -77,6 +83,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).show(true);
       };
+
       export const hideLayer = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string
@@ -86,6 +93,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).show(false);
       };
+
       export const layerIsVisible = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string
@@ -95,6 +103,7 @@ namespace gdjs {
           runtimeScene.getLayer(layer).isVisible()
         );
       };
+
       export const setCameraRotation = function (
         runtimeScene: gdjs.RuntimeScene,
         rotation: float,
@@ -108,6 +117,7 @@ namespace gdjs {
           .getLayer(layer)
           .setCameraRotation(rotation, cameraId);
       };
+
       export const getCameraRotation = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -118,6 +128,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).getCameraRotation(cameraId);
       };
+
       export const getCameraZoom = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -128,6 +139,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).getCameraZoom(cameraId);
       };
+
       export const setCameraZoom = function (
         runtimeScene: gdjs.RuntimeScene,
         newZoom: float,
@@ -139,6 +151,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).setCameraZoom(newZoom, cameraId);
       };
+
       export const centerCamera = function (
         runtimeScene: gdjs.RuntimeScene,
         object: gdjs.RuntimeObject | null,
@@ -162,6 +175,7 @@ namespace gdjs {
         layer.setCameraX(object.getDrawableX() + object.getCenterX(), cameraId);
         layer.setCameraY(object.getDrawableY() + object.getCenterY(), cameraId);
       };
+
       export const centerCameraWithinLimits = function (
         runtimeScene: gdjs.RuntimeScene,
         object: gdjs.RuntimeObject | null,
@@ -309,6 +323,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).isEffectEnabled(effect);
       };
+
       export const setLayerTimeScale = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -319,6 +334,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).setTimeScale(timeScale);
       };
+
       export const getLayerTimeScale = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string
@@ -328,6 +344,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).getTimeScale();
       };
+
       export const setLayerDefaultZOrder = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string,
@@ -338,6 +355,7 @@ namespace gdjs {
         }
         return runtimeScene.getLayer(layer).setDefaultZOrder(defaultZOrder);
       };
+
       export const getLayerDefaultZOrder = function (
         runtimeScene: gdjs.RuntimeScene,
         layer: string

--- a/GDJS/Runtime/events-tools/cameratools.ts
+++ b/GDJS/Runtime/events-tools/cameratools.ts
@@ -17,7 +17,7 @@ namespace gdjs {
         }
         runtimeScene.getLayer(layer).setCameraX(x, cameraId);
       };
-      
+
       export const setCameraY = function (
         runtimeScene: gdjs.RuntimeScene,
         y: float,

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -179,9 +179,11 @@ namespace gdjs {
       export const anyKeyPressed = function (runtimeScene) {
         return runtimeScene.getGame().getInputManager().anyKeyPressed();
       };
+
       export const anyKeyReleased = function (runtimeScene) {
         return runtimeScene.getGame().getInputManager().anyKeyReleased();
       };
+
       export const isMouseButtonPressed = function (runtimeScene, button) {
         if (button === 'Left') {
           return runtimeScene
@@ -203,6 +205,7 @@ namespace gdjs {
         }
         return false;
       };
+
       export const isMouseButtonReleased = function (runtimeScene, button) {
         if (button === 'Left') {
           return runtimeScene
@@ -224,21 +227,27 @@ namespace gdjs {
         }
         return false;
       };
+
       export const hideCursor = function (runtimeScene) {
         runtimeScene.getRenderer().hideCursor();
       };
+
       export const showCursor = function (runtimeScene) {
         runtimeScene.getRenderer().showCursor();
       };
+
       export const getMouseWheelDelta = function (runtimeScene) {
         return runtimeScene.getGame().getInputManager().getMouseWheelDelta();
       };
+
       export const isScrollingUp = function (runtimeScene) {
         return runtimeScene.getGame().getInputManager().isScrollingUp();
       };
+
       export const isScrollingDown = function (runtimeScene) {
         return runtimeScene.getGame().getInputManager().isScrollingDown();
       };
+
       export const getMouseX = function (runtimeScene, layer, camera) {
         return runtimeScene
           .getLayer(layer)
@@ -247,6 +256,7 @@ namespace gdjs {
             runtimeScene.getGame().getInputManager().getMouseY()
           )[0];
       };
+
       export const getMouseY = function (runtimeScene, layer, camera) {
         return runtimeScene
           .getLayer(layer)
@@ -255,9 +265,11 @@ namespace gdjs {
             runtimeScene.getGame().getInputManager().getMouseY()
           )[1];
       };
+
       export const _cursorIsOnObject = function (obj, runtimeScene) {
         return obj.cursorOnObject(runtimeScene);
       };
+
       export const cursorOnObject = function (
         objectsLists,
         runtimeScene,
@@ -271,6 +283,7 @@ namespace gdjs {
           runtimeScene
         );
       };
+
       export const getTouchX = function (
         runtimeScene,
         identifier,
@@ -284,6 +297,7 @@ namespace gdjs {
             runtimeScene.getGame().getInputManager().getTouchY(identifier)
           )[0];
       };
+
       export const getTouchY = function (
         runtimeScene,
         identifier,
@@ -297,12 +311,15 @@ namespace gdjs {
             runtimeScene.getGame().getInputManager().getTouchY(identifier)
           )[1];
       };
+
       export const getLastTouchId = function () {
         return gdjs.evtTools.input.lastTouchId || 0;
       };
+
       export const getLastEndedTouchId = function () {
         return gdjs.evtTools.input.lastEndedTouchId || 0;
       };
+
       export const popStartedTouch = function (runtimeScene) {
         const startedTouchId = runtimeScene
           .getGame()
@@ -314,6 +331,7 @@ namespace gdjs {
         }
         return false;
       };
+
       export const popEndedTouch = function (runtimeScene) {
         const endedTouchId = runtimeScene
           .getGame()
@@ -325,6 +343,7 @@ namespace gdjs {
         }
         return false;
       };
+
       export const touchSimulateMouse = function (runtimeScene, enable) {
         runtimeScene.getGame().getInputManager().touchSimulateMouse(enable);
       };

--- a/GDJS/Runtime/events-tools/objecttools.ts
+++ b/GDJS/Runtime/events-tools/objecttools.ts
@@ -217,6 +217,7 @@ namespace gdjs {
         }
         arr.length = finalSize;
       };
+
       export const hitBoxesCollisionTest = function (
         objectsLists1,
         objectsLists2,
@@ -232,9 +233,11 @@ namespace gdjs {
           ignoreTouchingEdges
         );
       };
+
       export const _distanceBetweenObjects = function (obj1, obj2, distance) {
         return obj1.getSqDistanceToObject(obj2) <= distance;
       };
+
       export const distanceTest = function (
         objectsLists1,
         objectsLists2,
@@ -249,6 +252,7 @@ namespace gdjs {
           distance * distance
         );
       };
+
       export const _movesToward = function (obj1, obj2, tolerance) {
         if (obj1.hasNoForces()) {
           return false;
@@ -272,6 +276,7 @@ namespace gdjs {
           tolerance / 2
         );
       };
+
       export const movesTowardTest = function (
         objectsLists1,
         objectsLists2,
@@ -286,6 +291,7 @@ namespace gdjs {
           tolerance
         );
       };
+
       export const _turnedToward = function (obj1, obj2, tolerance) {
         let objAngle = Math.atan2(
           obj2.getDrawableY() +
@@ -303,6 +309,7 @@ namespace gdjs {
           tolerance / 2
         );
       };
+
       export const turnedTowardTest = function (
         objectsLists1,
         objectsLists2,
@@ -317,6 +324,7 @@ namespace gdjs {
           tolerance
         );
       };
+
       export const pickAllObjects = function (objectsContext, objectsLists) {
         for (const name in objectsLists.items) {
           if (objectsLists.items.hasOwnProperty(name)) {
@@ -328,6 +336,7 @@ namespace gdjs {
         }
         return true;
       };
+
       export const pickRandomObject = function (runtimeScene, objectsLists) {
         // Compute one many objects we have
         let objectsCount = 0;
@@ -366,6 +375,7 @@ namespace gdjs {
         gdjs.evtTools.object.pickOnly(objectsLists, theChosenOne);
         return true;
       };
+
       export const pickNearestObject = function (objectsLists, x, y, inverted) {
         let bestObject = null;
         let best = 0;
@@ -391,6 +401,7 @@ namespace gdjs {
         gdjs.evtTools.object.pickOnly(objectsLists, bestObject);
         return true;
       };
+
       export const raycastObject = function (
         objectsLists,
         x,
@@ -412,6 +423,7 @@ namespace gdjs {
           inverted
         );
       };
+
       export const raycastObjectToPosition = function (
         objectsLists,
         x,

--- a/GDJS/Runtime/events-tools/runtimescenetools.ts
+++ b/GDJS/Runtime/events-tools/runtimescenetools.ts
@@ -9,12 +9,15 @@ namespace gdjs {
       export const sceneJustBegins = function (runtimeScene) {
         return runtimeScene.getTimeManager().isFirstFrame();
       };
+
       export const sceneJustResumed = function (runtimeScene) {
         return runtimeScene.sceneJustResumed();
       };
+
       export const getSceneName = function (runtimeScene) {
         return runtimeScene.getName();
       };
+
       export const setBackgroundColor = function (runtimeScene, rgbColor) {
         const colors = rgbColor.split(';');
         if (colors.length < 3) {
@@ -26,15 +29,19 @@ namespace gdjs {
           parseInt(colors[2])
         );
       };
+
       export const getElapsedTimeInSeconds = function (runtimeScene) {
         return runtimeScene.getTimeManager().getElapsedTime() / 1000;
       };
+
       export const setTimeScale = function (runtimeScene, timeScale) {
         return runtimeScene.getTimeManager().setTimeScale(timeScale);
       };
+
       export const getTimeScale = function (runtimeScene) {
         return runtimeScene.getTimeManager().getTimeScale();
       };
+
       export const timerElapsedTime = function (
         runtimeScene,
         timeInSeconds,
@@ -49,6 +56,7 @@ namespace gdjs {
           timeManager.getTimer(timerName).getTime() / 1000 >= timeInSeconds
         );
       };
+
       export const timerPaused = function (runtimeScene, timerName) {
         const timeManager = runtimeScene.getTimeManager();
         if (!timeManager.hasTimer(timerName)) {
@@ -56,6 +64,7 @@ namespace gdjs {
         }
         return timeManager.getTimer(timerName).isPaused();
       };
+
       export const resetTimer = function (runtimeScene, timerName) {
         const timeManager = runtimeScene.getTimeManager();
         if (!timeManager.hasTimer(timerName)) {
@@ -64,6 +73,7 @@ namespace gdjs {
           timeManager.getTimer(timerName).reset();
         }
       };
+
       export const pauseTimer = function (runtimeScene, timerName) {
         const timeManager = runtimeScene.getTimeManager();
         if (!timeManager.hasTimer(timerName)) {
@@ -71,6 +81,7 @@ namespace gdjs {
         }
         timeManager.getTimer(timerName).setPaused(true);
       };
+
       export const unpauseTimer = function (runtimeScene, timerName) {
         const timeManager = runtimeScene.getTimeManager();
         if (!timeManager.hasTimer(timerName)) {
@@ -78,10 +89,12 @@ namespace gdjs {
         }
         return timeManager.getTimer(timerName).setPaused(false);
       };
+
       export const removeTimer = function (runtimeScene, timerName) {
         const timeManager = runtimeScene.getTimeManager();
         timeManager.removeTimer(timerName);
       };
+
       export const getTimerElapsedTimeInSeconds = function (
         runtimeScene,
         timerName
@@ -92,9 +105,11 @@ namespace gdjs {
         }
         return timeManager.getTimer(timerName).getTime() / 1000;
       };
+
       export const getTimeFromStartInSeconds = function (runtimeScene) {
         return runtimeScene.getTimeManager().getTimeFromStart() / 1000;
       };
+
       export const getTime = function (runtimeScene, what) {
         if (what === 'timestamp') {
           return Date.now();
@@ -123,6 +138,7 @@ namespace gdjs {
         }
         return 0;
       };
+
       export const replaceScene = function (
         runtimeScene,
         newSceneName,
@@ -138,6 +154,7 @@ namespace gdjs {
           newSceneName
         );
       };
+
       export const pushScene = function (runtimeScene, newSceneName) {
         if (!runtimeScene.getGame().getSceneData(newSceneName)) {
           return;
@@ -147,12 +164,15 @@ namespace gdjs {
           newSceneName
         );
       };
+
       export const popScene = function (runtimeScene) {
         runtimeScene.requestChange(gdjs.SceneChangeRequest.POP_SCENE);
       };
+
       export const stopGame = function (runtimeScene) {
         runtimeScene.requestChange(gdjs.SceneChangeRequest.STOP_GAME);
       };
+
       export const createObjectsFromExternalLayout = function (
         scene,
         externalLayout,

--- a/GDJS/Runtime/events-tools/soundtools.ts
+++ b/GDJS/Runtime/events-tools/soundtools.ts
@@ -11,6 +11,7 @@ namespace gdjs {
       ) {
         return runtimeScene.getSoundManager().getGlobalVolume();
       };
+
       export const setGlobalVolume = function (
         runtimeScene: gdjs.RuntimeScene,
         globalVolume: float
@@ -34,6 +35,7 @@ namespace gdjs {
           .getSoundManager()
           .playSound(soundFile, loop, volume, pitch);
       };
+
       export const playSoundOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         soundFile: string,
@@ -46,6 +48,7 @@ namespace gdjs {
           .getSoundManager()
           .playSoundOnChannel(soundFile, channel, loop, volume, pitch);
       };
+
       export const stopSoundOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -53,6 +56,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         sound && sound.stop();
       };
+
       export const pauseSoundOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -60,6 +64,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         sound && sound.pause();
       };
+
       export const continueSoundOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -69,6 +74,7 @@ namespace gdjs {
           sound.play();
         }
       };
+
       export const isSoundOnChannelPlaying = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -76,6 +82,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         return sound ? sound.playing() : false;
       };
+
       export const isSoundOnChannelPaused = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -83,6 +90,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         return sound ? sound.paused() : false;
       };
+
       export const isSoundOnChannelStopped = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -90,6 +98,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         return sound ? sound.stopped() : true;
       };
+
       export const getSoundOnChannelVolume = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -97,6 +106,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         return sound ? sound.getVolume() * 100 : 100;
       };
+
       export const setSoundOnChannelVolume = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer,
@@ -105,6 +115,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         sound && sound.setVolume(volume / 100);
       };
+
       export const getSoundOnChannelPlayingOffset = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -112,6 +123,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         return sound ? sound.getSeek() : 0;
       };
+
       export const setSoundOnChannelPlayingOffset = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer,
@@ -120,6 +132,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         sound && sound.setSeek(playingOffset);
       };
+
       export const getSoundOnChannelPitch = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -127,6 +140,7 @@ namespace gdjs {
         const sound = runtimeScene.getSoundManager().getSoundOnChannel(channel);
         return sound ? sound.getRate() : 1;
       };
+
       export const setSoundOnChannelPitch = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer,
@@ -164,6 +178,7 @@ namespace gdjs {
           .getSoundManager()
           .playMusic(soundFile, loop, volume, pitch);
       };
+
       export const playMusicOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         soundFile: string,
@@ -176,6 +191,7 @@ namespace gdjs {
           .getSoundManager()
           .playMusicOnChannel(soundFile, channel, loop, volume, pitch);
       };
+
       export const stopMusicOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -183,6 +199,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         music && music.stop();
       };
+
       export const pauseMusicOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -190,6 +207,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         music && music.pause();
       };
+
       export const continueMusicOnChannel = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -199,6 +217,7 @@ namespace gdjs {
           music.play();
         }
       };
+
       export const isMusicOnChannelPlaying = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -206,6 +225,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         return music ? music.playing() : false;
       };
+
       export const isMusicOnChannelPaused = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -213,6 +233,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         return music ? music.paused() : false;
       };
+
       export const isMusicOnChannelStopped = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -220,6 +241,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         return music ? music.stopped() : true;
       };
+
       export const getMusicOnChannelVolume = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -227,6 +249,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         return music ? music.getVolume() * 100 : 100;
       };
+
       export const setMusicOnChannelVolume = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer,
@@ -235,6 +258,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         music && music.setVolume(volume / 100);
       };
+
       export const getMusicOnChannelPlayingOffset = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -242,6 +266,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         return music ? music.getSeek() : 0;
       };
+
       export const setMusicOnChannelPlayingOffset = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer,
@@ -250,6 +275,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         music && music.setSeek(playingOffset);
       };
+
       export const getMusicOnChannelPitch = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer
@@ -257,6 +283,7 @@ namespace gdjs {
         const music = runtimeScene.getSoundManager().getMusicOnChannel(channel);
         return music ? music.getRate() : 1;
       };
+
       export const setMusicOnChannelPitch = function (
         runtimeScene: gdjs.RuntimeScene,
         channel: integer,

--- a/GDJS/Runtime/events-tools/storagetools.ts
+++ b/GDJS/Runtime/events-tools/storagetools.ts
@@ -126,6 +126,7 @@ namespace gdjs {
         }
         return returnValue;
       };
+
       export const clearJSONFile = (name: string) => {
         return loadObject(name, (jsObject) => {
           for (const p in jsObject) {
@@ -136,6 +137,7 @@ namespace gdjs {
           return true;
         });
       };
+
       export const elementExistsInJSONFile = (
         name: string,
         elementPath: string
@@ -152,6 +154,7 @@ namespace gdjs {
           return true;
         });
       };
+
       export const deleteElementFromJSONFile = (
         name: string,
         elementPath: string
@@ -172,6 +175,7 @@ namespace gdjs {
           return true;
         });
       };
+
       export const writeNumberInJSONFile = (
         name: string,
         elementPath: string,
@@ -193,6 +197,7 @@ namespace gdjs {
           return true;
         });
       };
+
       export const writeStringInJSONFile = (
         name: string,
         elementPath: string,
@@ -214,6 +219,7 @@ namespace gdjs {
           return true;
         });
       };
+
       export const readNumberFromJSONFile = (
         name: string,
         elementPath: string,
@@ -239,6 +245,7 @@ namespace gdjs {
           return true;
         });
       };
+
       export const readStringFromJSONFile = (
         name: string,
         elementPath: string,

--- a/GDJS/Runtime/events-tools/windowtools.ts
+++ b/GDJS/Runtime/events-tools/windowtools.ts
@@ -21,6 +21,7 @@ namespace gdjs {
           .getRenderer()
           .setMargins(top, right, bottom, left);
       };
+
       export const setFullScreen = function (
         runtimeScene: gdjs.RuntimeScene,
         enable: boolean,
@@ -29,11 +30,13 @@ namespace gdjs {
         runtimeScene.getGame().getRenderer().keepAspectRatio(keepAspectRatio);
         runtimeScene.getGame().getRenderer().setFullScreen(enable);
       };
+
       export const isFullScreen = function (
         runtimeScene: gdjs.RuntimeScene
       ): boolean {
         return runtimeScene.getGame().getRenderer().isFullScreen();
       };
+
       export const setWindowSize = function (
         runtimeScene: gdjs.RuntimeScene,
         width: float,
@@ -45,9 +48,11 @@ namespace gdjs {
           runtimeScene.getGame().setGameResolutionSize(width, height);
         }
       };
+
       export const centerWindow = function (runtimeScene: gdjs.RuntimeScene) {
         runtimeScene.getGame().getRenderer().centerWindow();
       };
+
       export const setGameResolutionSize = function (
         runtimeScene: gdjs.RuntimeScene,
         width: float,
@@ -55,29 +60,34 @@ namespace gdjs {
       ) {
         runtimeScene.getGame().setGameResolutionSize(width, height);
       };
+
       export const setGameResolutionResizeMode = function (
         runtimeScene: gdjs.RuntimeScene,
         resizeMode: string
       ) {
         runtimeScene.getGame().setGameResolutionResizeMode(resizeMode);
       };
+
       export const setAdaptGameResolutionAtRuntime = function (
         runtimeScene: gdjs.RuntimeScene,
         enable: boolean
       ) {
         runtimeScene.getGame().setAdaptGameResolutionAtRuntime(enable);
       };
+
       export const setWindowTitle = function (
         runtimeScene: gdjs.RuntimeScene,
         title: string
       ) {
         runtimeScene.getGame().getRenderer().setWindowTitle(title);
       };
+
       export const getWindowTitle = function (
         runtimeScene: gdjs.RuntimeScene
       ): string {
         return runtimeScene.getGame().getRenderer().getWindowTitle();
       };
+
       export const getWindowInnerWidth = function (): number {
         if (
           gdjs.RuntimeGameRenderer &&
@@ -88,6 +98,7 @@ namespace gdjs {
         // @ts-ignore
         return typeof window !== 'undefined' ? window.innerWidth : 800;
       };
+
       export const getWindowInnerHeight = function (): number {
         if (
           gdjs.RuntimeGameRenderer &&
@@ -98,16 +109,19 @@ namespace gdjs {
         // @ts-ignore
         return typeof window !== 'undefined' ? window.innerHeight : 800;
       };
+
       export const getGameResolutionWidth = function (
         runtimeScene: gdjs.RuntimeScene
       ): number {
         return runtimeScene.getGame().getGameResolutionWidth();
       };
+
       export const getGameResolutionHeight = function (
         runtimeScene: gdjs.RuntimeScene
       ): number {
         return runtimeScene.getGame().getGameResolutionHeight();
       };
+
       export const openURL = function (
         url: string,
         runtimeScene: gdjs.RuntimeScene

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
@@ -5,6 +5,7 @@ namespace gdjs {
     export const clampValue = function (value, min, max) {
       return Math.max(min, Math.min(max, value));
     };
+
     export const clampKernelSize = function (value, min, max) {
       const len = Math.round((max - min) / 2 + 1);
       const arr = new Array(len);


### PR DESCRIPTION
When switching over to ts, the codemod removed a lot of newlines in the ts files. I used this simple regex on the GDJS Runtime and Extensions folder from vscode to add them back:
![image](https://user-images.githubusercontent.com/19349038/127996678-e24ce532-20b4-4ddb-b63a-5ef9d9b923f2.png)

This makes the code way more readable.