### PR TITLE
Increase the GDJS tests Karma timeout

### DIFF
--- a/GDJS/tests/karma.conf.js
+++ b/GDJS/tests/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
     client: {
       mocha: {
         reporter: 'html',
-        timeout: 5000, // Give a bit more time for CIs (the default 2s can be too low sometimes)
+        timeout: 10000, // Give a bit more time for CIs (the default 2s can be too low sometimes, as a real browser is involved).
       },
     },
     files: [


### PR DESCRIPTION
Semaphore CI tests were sometimes timing out, notably the ones involving PixiJS and real resources to load.

Don't show in changelog