### PR TITLE
Fix an error log when the new instruction dialog opens.

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -171,6 +171,7 @@ export default function NewInstructionEditorDialog({
 
   const renderInstructionOrObjectSelector = () => (
     <InstructionOrObjectSelector
+      key="instruction-or-object-selector"
       style={styles.fullHeightSelector}
       project={project}
       scope={scope}


### PR DESCRIPTION
It seems the key property was removed by mistake: [Stack.txt](https://github.com/4ian/GDevelop/files/6925723/Stack.txt)
