### PR TITLE
Increase the NewIDE tests jest timeout

### DIFF
--- a/newIDE/app/src/setupTests.js
+++ b/newIDE/app/src/setupTests.js
@@ -34,3 +34,6 @@ beforeAll(done => {
     done();
   });
 });
+
+// We increase the timeout for CIs (the default 5s can be too low sometimes, as a real browser is involved).
+jest.setTimeout(10000)


### PR DESCRIPTION
Semaphore CI tests were sometimes timing out. Trying to double the timeout of jest to prevent this from happening

Don't show in changelog