### PR TITLE
Ensure the deployment script stops on error

### DIFF
--- a/newIDE/web-app/scripts/deploy.js
+++ b/newIDE/web-app/scripts/deploy.js
@@ -74,12 +74,24 @@ isGitClean()
     }
 
     if (!args['skip-app-build']) {
-      shell.exec('npm run build:app');
+      const output = shell.exec('npm run build:app');
+      if (output.code !== 0) {
+        shell.echo(
+          '❌ Unable to build the app.'
+        );
+        shell.exit(output.code);
+      }
     } else {
       shell.echo('⚠️ Skipping app build.');
     }
     if (!args['skip-gdjs-runtime-deploy']) {
-      shell.exec('npm run deploy:gdjs-runtime');
+      const output = shell.exec('npm run deploy:gdjs-runtime');
+      if (output.code !== 0) {
+        shell.echo(
+          '❌ Unable to build GDJS Runtime.'
+        );
+        shell.exit(output.code);
+      }
     } else {
       shell.echo('⚠️ Skipping GDJS Runtime (and extensions) deployment.');
     }


### PR DESCRIPTION
Prevents deploying the webapp version, without a successful build of the app or the runtime.

Don't show in changelog