### PR TITLE
Prevent variable value to be set to NaN

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,7 +108,8 @@
         "xtree": "cpp",
         "xutility": "cpp",
         "xlocbuf": "cpp",
-        "xlocmes": "cpp"
+        "xlocmes": "cpp",
+        "xmemory0": "cpp"
     },
     "files.exclude": {
         "Binaries/*build*": true,

--- a/Core/GDCore/Project/Variable.cpp
+++ b/Core/GDCore/Project/Variable.cpp
@@ -7,7 +7,6 @@
 #include "GDCore/Project/Variable.h"
 
 #include <sstream>
-#include <cmath>
 
 #include "GDCore/Serialization/SerializerElement.h"
 #include "GDCore/String.h"

--- a/Core/GDCore/Project/Variable.cpp
+++ b/Core/GDCore/Project/Variable.cpp
@@ -91,7 +91,7 @@ double Variable::GetValue() const {
   if (type == Type::Number) {
     return value;
   } else if (type == Type::String) {
-    double retVal = str.To<double>();
+    double retVal = str.empty() ? 0.0 : str.To<double>();
     if(std::isnan(retVal)) retVal = 0.0;
     return retVal;
   } else if (type == Type::Boolean) {

--- a/Core/GDCore/Project/Variable.h
+++ b/Core/GDCore/Project/Variable.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <cmath>
 
 #include "GDCore/String.h"
 namespace gd {
@@ -96,6 +97,8 @@ class GD_CORE_API Variable {
    */
   void SetValue(double val) {
     value = val;
+    // NaN values are not supported by GDevelop nor the serializer.
+    if(std::isnan(value)) value = 0.0;
     type = Type::Number;
   }
 


### PR DESCRIPTION
This prevents setting a variable to NaN. It technically should not be a problem as GetValue transforms a NaN value to return 0.0, but NaN can still break internal methods that use `value` directly in unexpected ways.
Additionally, it caused a weird behavior when converting a string or allowing to have no number until serializing and deserializing again in a variable field.
Before: 

https://user-images.githubusercontent.com/19349038/129705244-462b2d95-cf8a-423c-bc59-54efdce4296c.mp4

After: 

https://user-images.githubusercontent.com/19349038/129705859-40a98b0b-1914-4c25-91c7-15d6583b1901.mp4

