### PR TITLE
Set up Semaphore 2.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,69 @@
+version: v1.0
+name: Fast tests pipeline (not building GDevelop.js)
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+blocks:
+  - name: Install
+    task:
+      jobs:
+        - name: Checkout and install dependencies
+          commands:
+            - checkout
+            - node -v
+            - cd newIDE/app
+            - npm i
+            - cd ../..
+            - cd GDJS/tests
+            - npm i
+            - cd ../..
+            - cd GDJS
+            - npm i
+            - cd ..
+    dependencies: []
+  - name: Type checks
+    dependencies:
+      - Install
+    task:
+      jobs:
+        - name: GDJS typing and documentation generation
+          commands:
+            - cd GDJS
+            - npm run check-types
+            - npm run generate-doc
+        - name: newIDE typing
+          commands:
+            - cd newIDE/app
+            - npm run flow
+            - cd ../..
+  - name: Auto formatting
+    dependencies:
+      - Install
+    task:
+      jobs:
+        - name: newIDE auto-formatting
+          commands:
+            - cd newIDE/app
+            - npm run check-format
+            - cd ../..
+        - name: GDJS auto-formatting
+          commands:
+            - cd GDJS
+            - npm run check-format
+            - cd ..
+  - name: Tests
+    dependencies:
+      - Install
+    task:
+      jobs:
+        - name: newIDE tests
+          commands:
+            - cd newIDE/app
+            - npm run analyze-test-coverage
+            - cd ../..
+        - name: GDJS tests
+          commands:
+            - cd GDJS
+            - npm run test
+            - cd ../..

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,24 +12,27 @@ blocks:
           commands:
             - checkout
             - node -v
-            - if ! cache has_key newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json); then
-            - '  cd newIDE/app'
-            - '  npm i'
-            - '  cd ../..'
-            - '  cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules'
-            - fi
-            - if ! cache has_key GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json); then
-            - '  cd GDJS'
-            - '  npm i'
-            - '  cd ..'
-            - '  cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules'
-            - fi
-            - if ! cache has_key GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json); then
-            - '  cd GDJS/tests'
-            - '  npm i'
-            - '  cd ../..'
-            - '  cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules'
-            - fi
+            - |-
+              if ! cache has_key newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json); then
+                cd newIDE/app
+                npm i
+                cd ../..
+                cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
+              fi
+            - |-
+              if ! cache has_key GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json); then
+                cd GDJS
+                npm i
+                cd ..
+                cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
+              fi
+            - |-
+              if ! cache has_key GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json); then
+                cd GDJS/tests
+                npm i
+                cd ../..
+                cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
+              fi
     dependencies: []
   - name: Type checks
     dependencies:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,22 +8,28 @@ blocks:
   - name: Install
     task:
       jobs:
-        - name: Checkout and install dependencies
+        - name: Install node_modules and cache them
           commands:
             - checkout
             - node -v
-            - cd newIDE/app
-            - npm i
-            - cd ../..
-            - cd GDJS/tests
-            - npm i
-            - cd ../..
-            - cd GDJS
-            - npm i
-            - cd ..
-            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
-            - cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
-            - cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
+            - 'if ! [ cache has_key newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) ]; then'
+            - '  cd newIDE/app'
+            - '  npm i'
+            - '  cd ../..'
+            - '  cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules'
+            - fi
+            - 'if ! [ cache has_key GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) ]; then'
+            - '  cd GDJS'
+            - '  npm i'
+            - '  cd ..'
+            - '  cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules'
+            - fi
+            - 'if ! [ cache has_key GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) ]; then'
+            - '  cd GDJS/tests'
+            - '  npm i'
+            - '  cd ../..'
+            - '  cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules'
+            - fi
     dependencies: []
   - name: Type checks
     dependencies:
@@ -88,5 +94,6 @@ blocks:
             - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json)
             - cache restore GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json)
             - cd GDJS
+            - npm run build
             - npm run test
             - cd ../..

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,27 +12,24 @@ blocks:
           commands:
             - checkout
             - node -v
-            - |-
-              if ! [ cache has_key newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) ]; then
-                cd newIDE/app
-                npm i
-                cd ../..
-                cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
-              fi
-            - |-
-              if ! [ cache has_key GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) ]; then
-                cd GDJS
-                npm i
-                cd ..
-                cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
-              fi
-            - |-
-              if ! [ cache has_key GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) ]; then
-                cd GDJS/tests
-                npm i
-                cd ../..
-                cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
-              fi
+            - if ! cache has_key newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json); then
+            - '  cd newIDE/app'
+            - '  npm i'
+            - '  cd ../..'
+            - '  cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules'
+            - fi
+            - if ! cache has_key GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json); then
+            - '  cd GDJS'
+            - '  npm i'
+            - '  cd ..'
+            - '  cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules'
+            - fi
+            - if ! cache has_key GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json); then
+            - '  cd GDJS/tests'
+            - '  npm i'
+            - '  cd ../..'
+            - '  cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules'
+            - fi
     dependencies: []
   - name: Type checks
     dependencies:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,24 +12,27 @@ blocks:
           commands:
             - checkout
             - node -v
-            - 'if ! [ cache has_key newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) ]; then'
-            - '  cd newIDE/app'
-            - '  npm i'
-            - '  cd ../..'
-            - '  cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules'
-            - fi
-            - 'if ! [ cache has_key GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) ]; then'
-            - '  cd GDJS'
-            - '  npm i'
-            - '  cd ..'
-            - '  cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules'
-            - fi
-            - 'if ! [ cache has_key GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) ]; then'
-            - '  cd GDJS/tests'
-            - '  npm i'
-            - '  cd ../..'
-            - '  cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules'
-            - fi
+            - |-
+              if ! [ cache has_key newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) ]; then
+                cd newIDE/app
+                npm i
+                cd ../..
+                cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
+              fi
+            - |-
+              if ! [ cache has_key GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) ]; then
+                cd GDJS
+                npm i
+                cd ..
+                cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
+              fi
+            - |-
+              if ! [ cache has_key GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) ]; then
+                cd GDJS/tests
+                npm i
+                cd ../..
+                cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
+              fi
     dependencies: []
   - name: Type checks
     dependencies:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Fast tests pipeline (not building GDevelop.js)
+name: Fast tests (not building GDevelop.js - can have false negatives)
 agent:
   machine:
     type: e1-standard-2

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,6 +21,9 @@ blocks:
             - cd GDJS
             - npm i
             - cd ..
+            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
+            - cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
+            - cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
     dependencies: []
   - name: Type checks
     dependencies:
@@ -29,12 +32,18 @@ blocks:
       jobs:
         - name: GDJS typing and documentation generation
           commands:
+            - checkout
+            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
+            - cache restore GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
             - cd GDJS
             - npm run check-types
             - npm run generate-doc
         - name: newIDE typing
           commands:
+            - checkout
+            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
             - cd newIDE/app
+            - npm run postinstall
             - npm run flow
             - cd ../..
   - name: Auto formatting
@@ -44,11 +53,16 @@ blocks:
       jobs:
         - name: newIDE auto-formatting
           commands:
+            - checkout
+            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
             - cd newIDE/app
+            - npm run postinstall
             - npm run check-format
             - cd ../..
         - name: GDJS auto-formatting
           commands:
+            - checkout
+            - cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
             - cd GDJS
             - npm run check-format
             - cd ..
@@ -59,11 +73,17 @@ blocks:
       jobs:
         - name: newIDE tests
           commands:
+            - checkout
+            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
             - cd newIDE/app
+            - npm run postinstall
             - npm run analyze-test-coverage
             - cd ../..
         - name: GDJS tests
           commands:
+            - checkout
+            - cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
+            - cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
             - cd GDJS
             - npm run test
             - cd ../..

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,22 +30,23 @@ blocks:
       - Install
     task:
       jobs:
-        - name: GDJS typing and documentation generation
-          commands:
-            - checkout
-            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
-            - cache restore GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
-            - cd GDJS
-            - npm run check-types
-            - npm run generate-doc
         - name: newIDE typing
           commands:
             - checkout
-            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
+            - cache restore newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json)
+            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json)
             - cd newIDE/app
             - npm run postinstall
             - npm run flow
             - cd ../..
+        - name: GDJS typing and documentation generation
+          commands:
+            - checkout
+            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json)
+            - cache restore GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json)
+            - cd GDJS
+            - npm run check-types
+            - npm run generate-doc
   - name: Auto formatting
     dependencies:
       - Install
@@ -54,7 +55,8 @@ blocks:
         - name: newIDE auto-formatting
           commands:
             - checkout
-            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
+            - cache restore newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json)
+            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json)
             - cd newIDE/app
             - npm run postinstall
             - npm run check-format
@@ -62,7 +64,7 @@ blocks:
         - name: GDJS auto-formatting
           commands:
             - checkout
-            - cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
+            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json)
             - cd GDJS
             - npm run check-format
             - cd ..
@@ -74,7 +76,8 @@ blocks:
         - name: newIDE tests
           commands:
             - checkout
-            - cache store newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json) newIDE/app/node_modules
+            - cache restore newIDE-app-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum newIDE/app/package-lock.json)
+            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json)
             - cd newIDE/app
             - npm run postinstall
             - npm run analyze-test-coverage
@@ -82,8 +85,8 @@ blocks:
         - name: GDJS tests
           commands:
             - checkout
-            - cache store GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json) GDJS/node_modules
-            - cache store GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json) GDJS/tests/node_modules
+            - cache restore GDJS-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/package-lock.json)
+            - cache restore GDJS-tests-node_modules-$SEMAPHORE_GIT_BRANCH-revision-$(checksum GDJS/tests/package-lock.json)
             - cd GDJS
             - npm run test
             - cd ../..


### PR DESCRIPTION
Upgrade to Semaphore CI 2.0 - as the old version stops at Node.js 10 and we will have to upgrade in the future.
Running everything is a ~1min faster (~8min40 -> ~7min20) despite more checkout/installs (but thanks to caching node_modules between builds/jobs - otherwise this adds 1-2min). 
Overall as this is still <10 mins, we can still use this as "fast tests", that may be false negatives when libGD.js changes happened (in which case Travis-CI is to be used as the source of truth, as it's rebuilding everything properly at each build).