### PR TITLE
Fix/round coordinates checkbox

### DIFF
--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -63,6 +63,7 @@ Project::Project()
       minFPS(20),
       verticalSync(false),
       scaleMode("linear"),
+      pixelsRounding(false),
       adaptGameResolutionAtRuntime(true),
       sizeOnStartupMode("adaptWidth"),
       projectUuid(""),
@@ -528,6 +529,7 @@ void Project::UnserializeFrom(const SerializerElement& element) {
   SetVerticalSyncActivatedByDefault(
       propElement.GetChild("verticalSync").GetValue().GetBool());
   SetScaleMode(propElement.GetStringAttribute("scaleMode", "linear"));
+  SetPixelsRounding(propElement.GetBoolAttribute("pixelsRounding", false));
   SetAdaptGameResolutionAtRuntime(
       propElement.GetBoolAttribute("adaptGameResolutionAtRuntime", false));
   SetSizeOnStartupMode(propElement.GetStringAttribute("sizeOnStartupMode", ""));
@@ -740,6 +742,7 @@ void Project::SerializeTo(SerializerElement& element) const {
   propElement.AddChild("verticalSync")
       .SetValue(IsVerticalSynchronizationEnabledByDefault());
   propElement.SetAttribute("scaleMode", scaleMode);
+  propElement.SetAttribute("pixelsRounding", pixelsRounding);
   propElement.SetAttribute("adaptGameResolutionAtRuntime",
                            adaptGameResolutionAtRuntime);
   propElement.SetAttribute("sizeOnStartupMode", sizeOnStartupMode);
@@ -931,6 +934,7 @@ void Project::Init(const gd::Project& game) {
   minFPS = game.minFPS;
   verticalSync = game.verticalSync;
   scaleMode = game.scaleMode;
+  pixelsRounding = game.pixelsRounding;
   adaptGameResolutionAtRuntime = game.adaptGameResolutionAtRuntime;
   sizeOnStartupMode = game.sizeOnStartupMode;
   projectUuid = game.projectUuid;

--- a/Core/GDCore/Project/Project.h
+++ b/Core/GDCore/Project/Project.h
@@ -277,6 +277,19 @@ class GD_CORE_API Project : public ObjectsContainer {
   void SetScaleMode(const gd::String& scaleMode_) { scaleMode = scaleMode_; }
 
   /**
+   * Return true if pixels rounding option is enabled.
+   */
+  bool GetPixelsRounding() const {
+    return pixelsRounding;
+  }
+
+  /**
+   * Set pixels rounding option to true or false.
+   */
+  void SetPixelsRounding(bool enable) { pixelsRounding = enable; }
+
+
+  /**
    * \brief Return if the project should set 0 as Z-order for objects created
    * from events (which is deprecated) - instead of the highest Z order that was
    * found on each layer when the scene started.
@@ -890,6 +903,7 @@ class GD_CORE_API Project : public ObjectsContainer {
                         ///< are below this number )
   bool verticalSync;    ///< If true, must activate vertical synchronization.
   gd::String scaleMode;
+  bool pixelsRounding; ///< If true, set PIXI's ROUND_PIXELS option to true
   bool adaptGameResolutionAtRuntime;  ///< Should the game resolution be adapted
                                       ///< to the window size at runtime
   gd::String

--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -20,7 +20,6 @@ This project is released under the MIT License.
 
 void PlatformerObjectBehavior::InitializeContent(
     gd::SerializerElement& behaviorContent) {
-  behaviorContent.SetAttribute("roundCoordinates", true);
   behaviorContent.SetAttribute("gravity", 1000);
   behaviorContent.SetAttribute("maxFallingSpeed", 700);
   behaviorContent.SetAttribute("ladderClimbingSpeed", 150);
@@ -80,11 +79,6 @@ PlatformerObjectBehavior::GetProperties(
       gd::String::From(behaviorContent.GetDoubleAttribute("yGrabOffset")));
   properties[_("Grab tolerance on X axis")].SetValue(gd::String::From(
       behaviorContent.GetDoubleAttribute("xGrabTolerance", 10)));
-  properties[_("Round coordinates")]
-      .SetValue(behaviorContent.GetBoolAttribute("roundCoordinates", false)
-                    ? "true"
-                    : "false")
-      .SetType("Boolean");
 
   return properties;
 }
@@ -95,8 +89,6 @@ bool PlatformerObjectBehavior::UpdateProperty(
     const gd::String& value) {
   if (name == _("Default controls"))
     behaviorContent.SetAttribute("ignoreDefaultControls", (value == "0"));
-  else if (name == _("Round coordinates"))
-    behaviorContent.SetAttribute("roundCoordinates", (value == "1"));
   else if (name == _("Can grab platform ledges"))
     behaviorContent.SetAttribute("canGrabPlatforms", (value == "1"));
   else if (name == _("Grab offset on Y axis"))

--- a/Extensions/PlatformBehavior/benchmarks/platformerobjectruntimebehavior.benchmark.js
+++ b/Extensions/PlatformBehavior/benchmarks/platformerobjectruntimebehavior.benchmark.js
@@ -27,7 +27,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior Benchmark', function () {
             ignoreDefaultControls: true,
             slopeMaxAngle: 60,
             jumpSustainTime: 0.2,
-            roundCoordinates: true,
           },
         ],
       });

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -17,7 +17,6 @@ namespace gdjs {
     // platform hitbox left edge is also at X position 10).
     // This parameter "_ignoreTouchingEdges" will be passed to all collision handling functions.
     _ignoreTouchingEdges: boolean = true;
-    _roundCoordinates: boolean;
     _gravity: float;
     private _maxFallingSpeed: float;
     _ladderClimbingSpeed: float;
@@ -72,7 +71,7 @@ namespace gdjs {
       owner: gdjs.RuntimeObject
     ) {
       super(runtimeScene, behaviorData, owner);
-      this._roundCoordinates = behaviorData.roundCoordinates;
+
       this._gravity = behaviorData.gravity;
       this._maxFallingSpeed = behaviorData.maxFallingSpeed;
       this._ladderClimbingSpeed = behaviorData.ladderClimbingSpeed || 150;
@@ -101,11 +100,6 @@ namespace gdjs {
     }
 
     updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
-      if (
-        oldBehaviorData.roundCoordinates !== newBehaviorData.roundCoordinates
-      ) {
-        this._roundCoordinates = newBehaviorData.roundCoordinates;
-      }
       if (oldBehaviorData.gravity !== newBehaviorData.gravity) {
         this.setGravity(newBehaviorData.gravity);
       }
@@ -352,20 +346,20 @@ namespace gdjs {
         //Stop when colliding with an obstacle.
         while (
           (this._requestedDeltaY < 0 &&
+            //Jumpthru = obstacle <=> Never when going up
             this._isCollidingWithOneOf(
               this._potentialCollidingObjects,
               null,
               /*excludeJumpThrus=*/
               true
             )) ||
-          //Jumpthru = obstacle <=> Never when going up
           (this._requestedDeltaY > 0 &&
+            //Jumpthru = obstacle <=> Only if not already overlapped when going down
             this._isCollidingWithOneOfExcluding(
               this._potentialCollidingObjects,
               this._overlappedJumpThru
             ))
         ) {
-          //Jumpthru = obstacle <=> Only if not already overlapped when going down
           if (this._state === this._jumping) {
             this._setFalling();
           }
@@ -1359,11 +1353,7 @@ namespace gdjs {
         //Floor is flat or get down.
         let oldY = object.getY();
         const tentativeStartY = object.getY() + 1;
-        object.setY(
-          behavior._roundCoordinates
-            ? Math.round(tentativeStartY)
-            : tentativeStartY
-        );
+        object.setY(tentativeStartY);
         let step = 0;
         let noMoreOnFloor = false;
         while (

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -471,7 +471,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
             ignoreDefaultControls: true,
             slopeMaxAngle: 60,
             jumpSustainTime: 0.2,
-            roundCoordinates: true,
           },
         ],
         effects: [],
@@ -492,7 +491,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       //Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -511,11 +510,11 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be.within(-180, -179);
+      expect(object.getY()).to.be.within(-181, -180);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-180);
+      expect(object.getY()).to.be(-180.75);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-180, -179);
+      expect(object.getY()).to.be.within(-181, -180);
 
       // Then let the object fall
       for (let i = 0; i < 17; ++i) {
@@ -526,20 +525,15 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           false
         );
       }
-      // The jump finishes one frame before going back to the floor
-      // because the gravity is not applied on the first step.
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isJumping()).to.be(false);
-      expect(object.getBehavior('auto1').isFalling()).to.be(true);
-      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
-      expect(object.getY()).to.be(-31);
-      runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
       );
       expect(object.getBehavior('auto1').isOnFloor()).to.be(true);
-      expect(object.getY()).to.be(-30);
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getY()).to.be.within(-31, -30);
     });
 
     it('can jump, sustaining the jump', function () {
@@ -549,7 +543,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       //Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -569,9 +563,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check the height reached
-      expect(object.getY()).to.be(-230);
+      expect(object.getY()).to.be(-230.75);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-235);
+      expect(object.getY()).to.be(-235.75);
       for (let i = 0; i < 5; ++i) {
         // Verify that pressing the jump key does not change anything
         object.getBehavior('auto1').simulateJumpKey();
@@ -579,11 +573,11 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be(-247.5);
+      expect(object.getY()).to.be(-248.25);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-247.5);
+      expect(object.getY()).to.be(-248.25);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-247, -246);
+      expect(object.getY()).to.be.within(-248, -247);
 
       // Then let the object fall
       for (let i = 0; i < 60; ++i) {
@@ -599,7 +593,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       //Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -611,7 +605,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         object.getBehavior('auto1').simulateJumpKey();
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object.getY()).to.be.within(-101, -100);
+      expect(object.getY()).to.be.within(-102, -101);
 
       // Stop holding the jump key
       runtimeScene.renderAndStep(1000 / 60);
@@ -623,15 +617,15 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be.within(-206, -205);
+      expect(object.getY()).to.be.within(-207, -206);
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getY()).to.be.within(-208, -207);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-208, -207);
+      expect(object.getY()).to.be.within(-209, -208);
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getY()).to.be.within(-208, -207);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-206, -205);
+      expect(object.getY()).to.be.within(-207, -206);
       runtimeScene.renderAndStep(1000 / 60);
 
       // Then let the object fall
@@ -653,7 +647,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
 
       // Check the object is on the platform
       // So at this point, the object could jump
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -681,7 +675,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -728,7 +722,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -775,7 +769,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -821,7 +815,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -867,7 +861,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -886,7 +880,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         topPlatform.getX() - object.getWidth(),
         topPlatform.getX() - object.getWidth() + 2
       );
-      expect(object.getY()).to.be(topPlatform.getY());
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because rounding coordinates (-10 (platform) -20 (object))
       // Check that the object didn't grabbed the platform
       expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(false);
     });
@@ -909,7 +903,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           {
             type: 'PlatformBehavior::PlatformerObjectBehavior',
             name: 'auto1',
-            roundCoordinates: true,
             gravity: 900,
             maxFallingSpeed: 1500,
             acceleration: 500,
@@ -956,7 +949,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       for (let i = 0; i < 5; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.25); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
@@ -1047,7 +1040,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           {
             type: 'PlatformBehavior::PlatformerObjectBehavior',
             name: 'auto1',
-            roundCoordinates: true,
             gravity: 900,
             maxFallingSpeed: maxFallingSpeed,
             acceleration: 500,
@@ -1309,7 +1301,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
             {
               type: 'PlatformBehavior::PlatformerObjectBehavior',
               name: 'auto1',
-              roundCoordinates: false,
               gravity: 900,
               maxFallingSpeed: maxFallingSpeed,
               acceleration: 500,
@@ -1439,7 +1430,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           {
             type: 'PlatformBehavior::PlatformerObjectBehavior',
             name: 'PlatformerObject',
-            roundCoordinates: true,
             gravity: 900,
             maxFallingSpeed: 1500,
             acceleration: 500,
@@ -1469,7 +1459,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           {
             type: 'PlatformBehavior::PlatformerObjectBehavior',
             name: 'PlatformerObject',
-            roundCoordinates: true,
             gravity: 900,
             maxFallingSpeed: 1500,
             acceleration: 500,
@@ -1511,7 +1500,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object2.getY()).to.be(-57.5);
 
       //Check the first object stays on the platform.
-      expect(object.getY()).to.be(-30);
+      expect(object.getY()).to.be(-30.25); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
 
       // Simulate more frames. Check that trying to jump won't do anything.
       for (let i = 0; i < 5; ++i) {
@@ -1520,14 +1509,14 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
       expect(object2.getY()).to.be(-48.75);
       expect(object.getX()).to.be(0);
-      expect(object.getY()).to.be(-30);
+      expect(object.getY()).to.be(-30.25);
 
       // Verify that the first platformer object is moved 1px to the left
       // as the falling platformer object+platform collides with it
       runtimeScene.renderAndStep(1000 / 60);
       expect(object2.getY()).to.be(-46.25);
       expect(object.getX()).to.be(-1);
-      expect(object.getY()).to.be(-30);
+      expect(object.getY()).to.be(-30.25);
 
       // Simulate more frames so that the object reaches the floor
       for (let i = 0; i < 20; ++i) {
@@ -1536,7 +1525,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object2.getX()).to.be(9);
       expect(object2.getY()).to.be(-30);
       expect(object.getX()).to.be(-1);
-      expect(object.getY()).to.be(-30);
+      expect(object.getY()).to.be(-30.25);
 
       // Start a jump for both objects
       object.getBehavior('PlatformerObject').simulateJumpKey();
@@ -1547,7 +1536,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object2.getX()).to.be(9);
       expect(object2.getY()).to.be(-72.5);
       expect(object.getX()).to.be(-1);
-      expect(object.getY()).to.be(-72.5);
+      expect(object.getY()).to.be(-72.75);
 
       // Try to go right for the first object: won't work because the other
       // object is a platform.
@@ -1558,7 +1547,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object2.getX()).to.be(9);
       expect(object2.getY()).to.be.within(-94.2, -94.1);
       expect(object.getX()).to.be(-1);
-      expect(object.getY()).to.be.within(-94.2, -94.1);
+      expect(object.getY()).to.be.within(-94.5, -94.4);
 
       // Try to go right for the first and second object: can do.
       for (let i = 0; i < 3; ++i) {
@@ -1569,7 +1558,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object2.getX()).to.be.within(9.83, 9.84);
       expect(object2.getY()).to.be.within(-101.2, -101.1);
       expect(object.getX()).to.be.within(-0.59, -0.58);
-      expect(object.getY()).to.be.within(-101.2, -101.1);
+      expect(object.getY()).to.be.within(-101.5, -101.4);
 
       // Let the object fall back on the floor.
       for (let i = 0; i < 30; ++i) {
@@ -1608,7 +1597,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
             ignoreDefaultControls: true,
             slopeMaxAngle: 60,
             jumpSustainTime: 0.2,
-            roundCoordinates: true,
           },
         ],
         effects: [],
@@ -1699,7 +1687,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
       }
       //Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
     };
@@ -1721,7 +1709,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         objectPositionAfterFirstClimb + 22,
         objectPositionAfterFirstClimb + 24
       );
-      climbLadder(24);
+      climbLadder(23);
       // Check that we reached the maximum height
       const playerAtLadderTop = ladder.getY() - object.getHeight();
       expect(object.getY()).to.be.within(
@@ -1869,12 +1857,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
       }
-      // Falling 1 frame
-      object.getBehavior('auto1').simulateRightKey();
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getBehavior('auto1').isFalling()).to.be(true);
-      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
-      // and directly on the floor
+      // falls to the floor
       object.getBehavior('auto1').simulateRightKey();
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isOnFloor()).to.be(true);
@@ -2000,7 +1983,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
             ignoreDefaultControls: true,
             slopeMaxAngle: 60,
             jumpSustainTime: 0.2,
-            roundCoordinates: true,
           },
         ],
         effects: [],
@@ -2045,7 +2027,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
       }
       //Check the object is on the platform
-      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getY()).to.be(-30.75); // not exactly -30 because not rounding coordinates (-10 (platform) -20 (object))
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
     };
@@ -2064,7 +2046,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // walk from the 1st platform to the 2nd one
       walkRight(30);
       expect(object.getX()).to.be.above(platform2.getX());
-      expect(object.getY()).to.be(platform2.getY() - object.getHeight());
+      expect(object.getY()).to.be(-30.75);
     });
 
     it('can walk from a platform to another one that not aligned', function () {
@@ -2082,7 +2064,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // walk from the 1st platform to the 2nd one
       walkRight(30);
       expect(object.getX()).to.be.above(platform2.getX());
-      expect(object.getY()).to.be(platform2.getY() - object.getHeight());
+      expect(object.getY()).to.be(-31.75);
     });
 
     it("can't walk from a platform to another one that is too high", function () {
@@ -2105,7 +2087,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
       // is blocked by the 2nd platform
       expect(object.getX()).to.be(platform2.getX() - object.getWidth());
-      expect(object.getY()).to.be(platform.getY() - object.getHeight());
+      expect(object.getY()).to.be(-30.75);
     });
 
     it('can walk from a platform to another one that is rotated', function () {
@@ -2127,7 +2109,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       platform2.setAngle(-30);
       platform2.setPosition(
         platform.getX() + platform.getWidth() + vertexDeltaX,
-        platform.getY() + vertexDeltaY
+        platform.getY() + vertexDeltaY - 0.5
       );
 
       object.setPosition(30, -32);

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -87,6 +87,11 @@ namespace gdjs {
         this._pixiRenderer.view.style['image-rendering'] = 'pixelated';
       }
 
+      // Handle pixels rounding
+      if (this._game.getPixelsRounding()) {
+        PIXI.settings.ROUND_PIXELS = true;
+      }
+
       //Handle resize
       const that = this;
       window.addEventListener('resize', function () {

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -51,6 +51,7 @@ namespace gdjs {
     _resizeMode: 'adaptWidth' | 'adaptHeight' | string;
     _adaptGameResolutionAtRuntime: boolean;
     _scaleMode: 'linear' | 'nearest';
+    _pixelsRounding: boolean;
     _renderer: RuntimeGameRenderer;
 
     //Game loop management (see startGameLoop method)
@@ -105,6 +106,7 @@ namespace gdjs {
       this._resizeMode = this._data.properties.sizeOnStartupMode;
       this._adaptGameResolutionAtRuntime = this._data.properties.adaptGameResolutionAtRuntime;
       this._scaleMode = data.properties.scaleMode || 'linear';
+      this._pixelsRounding = this._data.properties.pixelsRounding;
       this._renderer = new gdjs.RuntimeGameRenderer(
         this,
         this._options.forceFullscreen || false
@@ -425,6 +427,13 @@ namespace gdjs {
      */
     getScaleMode(): 'linear' | 'nearest' {
       return this._scaleMode;
+    }
+
+    /**
+     * Return if the game is rounding pixels when rendering.
+     */
+    getPixelsRounding(): boolean {
+      return this._pixelsRounding;
     }
 
     /**

--- a/GDJS/Runtime/types/project-data.d.ts
+++ b/GDJS/Runtime/types/project-data.d.ts
@@ -164,6 +164,7 @@ declare interface ProjectPropertiesData {
   packageName: string;
   projectFile: string;
   scaleMode: 'linear' | 'nearest';
+  pixelsRounding: boolean;
   sizeOnStartupMode: string;
   useExternalSourceFiles: boolean;
   version: string;

--- a/GDJS/tests/games/events-based-behaviors/Flash behaviors in Platformer/platformer.json
+++ b/GDJS/tests/games/events-based-behaviors/Flash behaviors in Platformer/platformer.json
@@ -2598,7 +2598,6 @@
               "jumpSpeed": 1000,
               "maxFallingSpeed": 1000,
               "maxSpeed": 250,
-              "roundCoordinates": true,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2677,7 +2676,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 75,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2835,7 +2833,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 400,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/GDJS/tests/games/platformer sandbox/platformer sandbox.json
+++ b/GDJS/tests/games/platformer sandbox/platformer sandbox.json
@@ -1806,7 +1806,6 @@
               "jumpSpeed": 1000,
               "maxFallingSpeed": 1000,
               "maxSpeed": 250,
-              "roundCoordinates": true,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
             }
@@ -1886,7 +1885,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 75,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2046,7 +2044,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 400,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/GDJS/tests/tests-utils/init.pixiruntimegamewithassets.js
+++ b/GDJS/tests/tests-utils/init.pixiruntimegamewithassets.js
@@ -19,6 +19,7 @@ gdjs.getPixiRuntimeGameWithAssets = () => {
       packageName: 'com.gdevelop.integrationtest',
       projectFile: '',
       scaleMode: 'linear',
+      pixelsRounding: false,
       sizeOnStartupMode: 'adaptWidth',
       useExternalSourceFiles: true,
       version: '1.0.0',

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -370,6 +370,8 @@ interface Project {
     void SetAdaptGameResolutionAtRuntime(boolean adaptGameResolutionAtRuntime);
     void SetScaleMode([Const] DOMString scaleMode);
     [Const, Ref] DOMString GetScaleMode();
+    void SetPixelsRounding(boolean pixelsRounding);
+    boolean GetPixelsRounding();
     void SetSizeOnStartupMode([Const] DOMString orientation);
     [Const, Ref] DOMString GetSizeOnStartupMode();
     long GetMaximumFPS();

--- a/GDevelop.js/types/gdproject.js
+++ b/GDevelop.js/types/gdproject.js
@@ -23,6 +23,8 @@ declare class gdProject extends gdObjectsContainer {
   setAdaptGameResolutionAtRuntime(adaptGameResolutionAtRuntime: boolean): void;
   setScaleMode(scaleMode: string): void;
   getScaleMode(): string;
+  setPixelsRounding(pixelsRounding: boolean): void;
+  getPixelsRounding(): boolean;
   setSizeOnStartupMode(orientation: string): void;
   getSizeOnStartupMode(): string;
   getMaximumFPS(): number;

--- a/newIDE/app/resources/examples/platformer/platformer.json
+++ b/newIDE/app/resources/examples/platformer/platformer.json
@@ -2673,7 +2673,6 @@
               "ignoreDefaultControls": false,
               "maxFallingSpeed": 1000,
               "maxSpeed": 250,
-              "roundCoordinates": true,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2754,7 +2753,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 75,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2917,7 +2915,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 400,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -62,6 +62,7 @@ type ProjectProperties = {|
   packageName: string,
   orientation: string,
   scaleMode: string,
+  pixelsRounding: boolean,
   sizeOnStartupMode: string,
   minFPS: number,
   maxFPS: number,
@@ -80,6 +81,7 @@ function loadPropertiesFromProject(project: gdProject): ProjectProperties {
     packageName: project.getPackageName(),
     orientation: project.getOrientation(),
     scaleMode: project.getScaleMode(),
+    pixelsRounding: project.getPixelsRounding(),
     sizeOnStartupMode: project.getSizeOnStartupMode(),
     minFPS: project.getMinimumFPS(),
     maxFPS: project.getMaximumFPS(),
@@ -103,6 +105,7 @@ function applyPropertiesToProject(
     packageName,
     orientation,
     scaleMode,
+    pixelsRounding,
     sizeOnStartupMode,
     minFPS,
     maxFPS,
@@ -117,6 +120,7 @@ function applyPropertiesToProject(
   project.setPackageName(packageName);
   project.setOrientation(orientation);
   project.setScaleMode(scaleMode);
+  project.setPixelsRounding(pixelsRounding);
   project.setSizeOnStartupMode(sizeOnStartupMode);
   project.setMinimumFPS(minFPS);
   project.setMaximumFPS(maxFPS);
@@ -153,6 +157,9 @@ function ProjectPropertiesDialog(props: Props) {
     initialProperties.orientation
   );
   let [scaleMode, setScaleMode] = React.useState(initialProperties.scaleMode);
+  let [pixelsRounding, setPixelsRounding] = React.useState(
+    initialProperties.pixelsRounding
+  );
   let [sizeOnStartupMode, setSizeOnStartupMode] = React.useState(
     initialProperties.sizeOnStartupMode
   );
@@ -194,6 +201,7 @@ function ProjectPropertiesDialog(props: Props) {
         packageName,
         orientation,
         scaleMode,
+        pixelsRounding,
         sizeOnStartupMode,
         minFPS,
         maxFPS,
@@ -483,6 +491,16 @@ function ProjectPropertiesDialog(props: Props) {
                 primaryText={t`Nearest (no antialiasing, good for pixel perfect games)`}
               />
             </SelectField>
+            <Checkbox
+              label={
+                <Trans>
+                  Round pixels when rendering, useful for pixel perfect games.
+                </Trans>
+              }
+              disabled={sizeOnStartupMode === ''}
+              checked={pixelsRounding}
+              onCheck={(e, checked) => setPixelsRounding(checked)}
+            />
             {scaleMode === 'nearest' && (
               <DismissableAlertMessage
                 identifier="use-non-smoothed-textures"

--- a/newIDE/app/src/fixtures/betabox-basics-learning-experience/betabox-basics-learning-experience.json
+++ b/newIDE/app/src/fixtures/betabox-basics-learning-experience/betabox-basics-learning-experience.json
@@ -3200,7 +3200,6 @@
               "jumpSpeed": 1000,
               "maxFallingSpeed": 1000,
               "maxSpeed": 250,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -3481,7 +3480,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 75,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -3640,7 +3638,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 400,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
+++ b/newIDE/app/src/fixtures/dialogue-tree-with-yarn/dialogue-tree-with-yarn.json
@@ -3272,7 +3272,6 @@
               "jumpSpeed": 1000,
               "maxFallingSpeed": 1000,
               "maxSpeed": 250,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -3578,7 +3577,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 75,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -4031,7 +4029,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 400,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/endless-up-runner/endless-up-runner.json
+++ b/newIDE/app/src/fixtures/endless-up-runner/endless-up-runner.json
@@ -1204,7 +1204,6 @@
               "jumpSpeed": 680,
               "maxFallingSpeed": 700,
               "maxSpeed": 160,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/flappy-bird/flappy-bird.json
+++ b/newIDE/app/src/fixtures/flappy-bird/flappy-bird.json
@@ -1647,7 +1647,6 @@
               "jumpSpeed": 350,
               "maxFallingSpeed": 700,
               "maxSpeed": 150,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/geodash/geodash.json
+++ b/newIDE/app/src/fixtures/geodash/geodash.json
@@ -1583,7 +1583,6 @@
               "jumpSpeed": 1200,
               "maxFallingSpeed": 1000,
               "maxSpeed": 300,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2967,7 +2966,6 @@
               "jumpSpeed": 1200,
               "maxFallingSpeed": 1000,
               "maxSpeed": 300,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -4336,7 +4334,6 @@
               "jumpSpeed": 1200,
               "maxFallingSpeed": 1000,
               "maxSpeed": 300,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -5544,7 +5541,6 @@
               "jumpSpeed": 1200,
               "maxFallingSpeed": 1000,
               "maxSpeed": 300,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -6752,7 +6748,6 @@
               "jumpSpeed": 1200,
               "maxFallingSpeed": 1000,
               "maxSpeed": 300,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/pixel-perfect-platform-game/pixel-perfect-platform-game.json
+++ b/newIDE/app/src/fixtures/pixel-perfect-platform-game/pixel-perfect-platform-game.json
@@ -420,7 +420,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 250,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/platformer-with-tilemap/platformer-with-tilemap.json
+++ b/newIDE/app/src/fixtures/platformer-with-tilemap/platformer-with-tilemap.json
@@ -643,7 +643,6 @@
               "gravity": 600,
               "ignoreDefaultControls": false,
               "jumpSustainTime": 0.2,
-              "roundCoordinates": true,
               "slopeMaxAngle": 60,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/platformer/platformer.json
+++ b/newIDE/app/src/fixtures/platformer/platformer.json
@@ -2605,7 +2605,6 @@
               "ignoreDefaultControls": false,
               "maxFallingSpeed": 1000,
               "maxSpeed": 250,
-              "roundCoordinates": true,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2686,7 +2685,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 75,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0
@@ -2849,7 +2847,6 @@
               "jumpSpeed": 600,
               "maxFallingSpeed": 700,
               "maxSpeed": 400,
-              "roundCoordinates": false,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0

--- a/newIDE/app/src/fixtures/screen-shake/screen-shake.json
+++ b/newIDE/app/src/fixtures/screen-shake/screen-shake.json
@@ -785,7 +785,6 @@
               "jumpSpeed": 1000,
               "maxFallingSpeed": 1000,
               "maxSpeed": 250,
-              "roundCoordinates": true,
               "slopeMaxAngle": 0,
               "xGrabTolerance": 10,
               "yGrabOffset": 0


### PR DESCRIPTION
This addresses 2 issues:

- #2664 by removing the object property for the platformer behavior which wasn't working
- #2504 by adding a project property, allowing the user to round the pixels when rendering (using `PIXI.settings.ROUND_PIXELS`)

Tested in the runtime console, by logging `PIXI.settings.ROUND_PIXELS` with the switch on and off.
Tested in multiple test games, no bug encountered