### PR TITLE
Allow rounding pixels when rendering on a project level

### DIFF
--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -63,6 +63,7 @@ Project::Project()
       minFPS(20),
       verticalSync(false),
       scaleMode("linear"),
+      pixelsRounding(false),
       adaptGameResolutionAtRuntime(true),
       sizeOnStartupMode("adaptWidth"),
       projectUuid(""),
@@ -528,6 +529,7 @@ void Project::UnserializeFrom(const SerializerElement& element) {
   SetVerticalSyncActivatedByDefault(
       propElement.GetChild("verticalSync").GetValue().GetBool());
   SetScaleMode(propElement.GetStringAttribute("scaleMode", "linear"));
+  SetPixelsRounding(propElement.GetBoolAttribute("pixelsRounding", false));
   SetAdaptGameResolutionAtRuntime(
       propElement.GetBoolAttribute("adaptGameResolutionAtRuntime", false));
   SetSizeOnStartupMode(propElement.GetStringAttribute("sizeOnStartupMode", ""));
@@ -740,6 +742,7 @@ void Project::SerializeTo(SerializerElement& element) const {
   propElement.AddChild("verticalSync")
       .SetValue(IsVerticalSynchronizationEnabledByDefault());
   propElement.SetAttribute("scaleMode", scaleMode);
+  propElement.SetAttribute("pixelsRounding", pixelsRounding);
   propElement.SetAttribute("adaptGameResolutionAtRuntime",
                            adaptGameResolutionAtRuntime);
   propElement.SetAttribute("sizeOnStartupMode", sizeOnStartupMode);
@@ -931,6 +934,7 @@ void Project::Init(const gd::Project& game) {
   minFPS = game.minFPS;
   verticalSync = game.verticalSync;
   scaleMode = game.scaleMode;
+  pixelsRounding = game.pixelsRounding;
   adaptGameResolutionAtRuntime = game.adaptGameResolutionAtRuntime;
   sizeOnStartupMode = game.sizeOnStartupMode;
   projectUuid = game.projectUuid;

--- a/Core/GDCore/Project/Project.h
+++ b/Core/GDCore/Project/Project.h
@@ -277,6 +277,19 @@ class GD_CORE_API Project : public ObjectsContainer {
   void SetScaleMode(const gd::String& scaleMode_) { scaleMode = scaleMode_; }
 
   /**
+   * Return true if pixels rounding option is enabled.
+   */
+  bool GetPixelsRounding() const {
+    return pixelsRounding;
+  }
+
+  /**
+   * Set pixels rounding option to true or false.
+   */
+  void SetPixelsRounding(bool enable) { pixelsRounding = enable; }
+
+
+  /**
    * \brief Return if the project should set 0 as Z-order for objects created
    * from events (which is deprecated) - instead of the highest Z order that was
    * found on each layer when the scene started.
@@ -890,6 +903,8 @@ class GD_CORE_API Project : public ObjectsContainer {
                         ///< are below this number )
   bool verticalSync;    ///< If true, must activate vertical synchronization.
   gd::String scaleMode;
+  bool pixelsRounding; ///< If true, the rendering should stop pixel interpolation 
+                       ///< of rendered objects.
   bool adaptGameResolutionAtRuntime;  ///< Should the game resolution be adapted
                                       ///< to the window size at runtime
   gd::String

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -87,6 +87,11 @@ namespace gdjs {
         this._pixiRenderer.view.style['image-rendering'] = 'pixelated';
       }
 
+      // Handle pixels rounding
+      if (this._game.getPixelsRounding()) {
+        PIXI.settings.ROUND_PIXELS = true;
+      }
+
       //Handle resize
       const that = this;
       window.addEventListener('resize', function () {

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -51,6 +51,7 @@ namespace gdjs {
     _resizeMode: 'adaptWidth' | 'adaptHeight' | string;
     _adaptGameResolutionAtRuntime: boolean;
     _scaleMode: 'linear' | 'nearest';
+    _pixelsRounding: boolean;
     _renderer: RuntimeGameRenderer;
 
     //Game loop management (see startGameLoop method)
@@ -105,6 +106,7 @@ namespace gdjs {
       this._resizeMode = this._data.properties.sizeOnStartupMode;
       this._adaptGameResolutionAtRuntime = this._data.properties.adaptGameResolutionAtRuntime;
       this._scaleMode = data.properties.scaleMode || 'linear';
+      this._pixelsRounding = this._data.properties.pixelsRounding;
       this._renderer = new gdjs.RuntimeGameRenderer(
         this,
         this._options.forceFullscreen || false
@@ -425,6 +427,13 @@ namespace gdjs {
      */
     getScaleMode(): 'linear' | 'nearest' {
       return this._scaleMode;
+    }
+
+    /**
+     * Return if the game is rounding pixels when rendering.
+     */
+    getPixelsRounding(): boolean {
+      return this._pixelsRounding;
     }
 
     /**

--- a/GDJS/Runtime/types/project-data.d.ts
+++ b/GDJS/Runtime/types/project-data.d.ts
@@ -164,6 +164,7 @@ declare interface ProjectPropertiesData {
   packageName: string;
   projectFile: string;
   scaleMode: 'linear' | 'nearest';
+  pixelsRounding: boolean;
   sizeOnStartupMode: string;
   useExternalSourceFiles: boolean;
   version: string;

--- a/GDJS/tests/tests-utils/init.pixiruntimegamewithassets.js
+++ b/GDJS/tests/tests-utils/init.pixiruntimegamewithassets.js
@@ -19,6 +19,7 @@ gdjs.getPixiRuntimeGameWithAssets = () => {
       packageName: 'com.gdevelop.integrationtest',
       projectFile: '',
       scaleMode: 'linear',
+      pixelsRounding: false,
       sizeOnStartupMode: 'adaptWidth',
       useExternalSourceFiles: true,
       version: '1.0.0',

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -370,6 +370,8 @@ interface Project {
     void SetAdaptGameResolutionAtRuntime(boolean adaptGameResolutionAtRuntime);
     void SetScaleMode([Const] DOMString scaleMode);
     [Const, Ref] DOMString GetScaleMode();
+    void SetPixelsRounding(boolean pixelsRounding);
+    boolean GetPixelsRounding();
     void SetSizeOnStartupMode([Const] DOMString orientation);
     [Const, Ref] DOMString GetSizeOnStartupMode();
     long GetMaximumFPS();

--- a/GDevelop.js/types/gdproject.js
+++ b/GDevelop.js/types/gdproject.js
@@ -23,6 +23,8 @@ declare class gdProject extends gdObjectsContainer {
   setAdaptGameResolutionAtRuntime(adaptGameResolutionAtRuntime: boolean): void;
   setScaleMode(scaleMode: string): void;
   getScaleMode(): string;
+  setPixelsRounding(pixelsRounding: boolean): void;
+  getPixelsRounding(): boolean;
   setSizeOnStartupMode(orientation: string): void;
   getSizeOnStartupMode(): string;
   getMaximumFPS(): number;

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -62,6 +62,7 @@ type ProjectProperties = {|
   packageName: string,
   orientation: string,
   scaleMode: string,
+  pixelsRounding: boolean,
   sizeOnStartupMode: string,
   minFPS: number,
   maxFPS: number,
@@ -80,6 +81,7 @@ function loadPropertiesFromProject(project: gdProject): ProjectProperties {
     packageName: project.getPackageName(),
     orientation: project.getOrientation(),
     scaleMode: project.getScaleMode(),
+    pixelsRounding: project.getPixelsRounding(),
     sizeOnStartupMode: project.getSizeOnStartupMode(),
     minFPS: project.getMinimumFPS(),
     maxFPS: project.getMaximumFPS(),
@@ -103,6 +105,7 @@ function applyPropertiesToProject(
     packageName,
     orientation,
     scaleMode,
+    pixelsRounding,
     sizeOnStartupMode,
     minFPS,
     maxFPS,
@@ -117,6 +120,7 @@ function applyPropertiesToProject(
   project.setPackageName(packageName);
   project.setOrientation(orientation);
   project.setScaleMode(scaleMode);
+  project.setPixelsRounding(pixelsRounding);
   project.setSizeOnStartupMode(sizeOnStartupMode);
   project.setMinimumFPS(minFPS);
   project.setMaximumFPS(maxFPS);
@@ -153,6 +157,9 @@ function ProjectPropertiesDialog(props: Props) {
     initialProperties.orientation
   );
   let [scaleMode, setScaleMode] = React.useState(initialProperties.scaleMode);
+  let [pixelsRounding, setPixelsRounding] = React.useState(
+    initialProperties.pixelsRounding
+  );
   let [sizeOnStartupMode, setSizeOnStartupMode] = React.useState(
     initialProperties.sizeOnStartupMode
   );
@@ -194,6 +201,7 @@ function ProjectPropertiesDialog(props: Props) {
         packageName,
         orientation,
         scaleMode,
+        pixelsRounding,
         sizeOnStartupMode,
         minFPS,
         maxFPS,
@@ -483,6 +491,15 @@ function ProjectPropertiesDialog(props: Props) {
                 primaryText={t`Nearest (no antialiasing, good for pixel perfect games)`}
               />
             </SelectField>
+            <Checkbox
+              label={
+                <Trans>
+                  Round pixels when rendering, useful for pixel perfect games.
+                </Trans>
+              }
+              checked={pixelsRounding}
+              onCheck={(e, checked) => setPixelsRounding(checked)}
+            />
             {scaleMode === 'nearest' && (
               <DismissableAlertMessage
                 identifier="use-non-smoothed-textures"


### PR DESCRIPTION
Addresses #2504 

![image](https://user-images.githubusercontent.com/4895034/130574458-b1821f6f-c3f1-4ea7-bd1f-02a1357e3ff1.png)

Tested in the runtime console, by logging PIXI.settings.ROUND_PIXELS with the switch on and off.
Tested in multiple test games, no bug encountered
