### PR TITLE
[LinkedObjects] Avoid intersection calculus when nothing is picked

### DIFF
--- a/Extensions/LinkedObjects/linkedobjects.ts
+++ b/Extensions/LinkedObjects/linkedobjects.ts
@@ -23,7 +23,7 @@ namespace gdjs {
       return runtimeScene.linkedObjectsManager;
     }
 
-    getObjectsLinkedWith(objA: gdjs.RuntimeObject) {
+    _getObjectsLinkedWith(objA: gdjs.RuntimeObject) {
       if (!this.links.hasOwnProperty(objA.id)) {
         this.links[objA.id] = new Hashtable<gdjs.RuntimeObject[]>();
       }
@@ -31,7 +31,7 @@ namespace gdjs {
     }
 
     linkObjects(objA: gdjs.RuntimeObject, objB: gdjs.RuntimeObject) {
-      const objALinkedObjectMap = this.getObjectsLinkedWith(objA);
+      const objALinkedObjectMap = this._getObjectsLinkedWith(objA);
       if (!objALinkedObjectMap.containsKey(objB.getName())) {
         objALinkedObjectMap.put(
           objB.getName(),
@@ -42,7 +42,7 @@ namespace gdjs {
       if (objALinkedObjects.indexOf(objB) === -1) {
         objALinkedObjects.push(objB);
       }
-      const objBLinkedObjectMap = this.getObjectsLinkedWith(objB);
+      const objBLinkedObjectMap = this._getObjectsLinkedWith(objB);
       if (!objBLinkedObjectMap.containsKey(objA.getName())) {
         objBLinkedObjectMap.put(
           objA.getName(),
@@ -56,7 +56,7 @@ namespace gdjs {
     }
 
     removeAllLinksOf(obj: gdjs.RuntimeObject) {
-      const linkedObjectMap = this.getObjectsLinkedWith(obj);
+      const linkedObjectMap = this._getObjectsLinkedWith(obj);
 
       for (const linkedObjectName in linkedObjectMap.items) {
         if (linkedObjectMap.containsKey(linkedObjectName)) {
@@ -151,7 +151,7 @@ namespace gdjs {
         }
         const linkedObjectMap = LinksManager.getManager(
           runtimeScene
-        ).getObjectsLinkedWith(obj);
+        )._getObjectsLinkedWith(obj);
 
         let pickedSomething = false;
         const temporaryObjects = gdjs.staticArray(

--- a/Extensions/LinkedObjects/linkedobjects.ts
+++ b/Extensions/LinkedObjects/linkedobjects.ts
@@ -32,7 +32,7 @@ namespace gdjs {
 
     linkObjects(objA: gdjs.RuntimeObject, objB: gdjs.RuntimeObject) {
       const objALinkedObjectMap = this.getObjectsLinkedWith(objA);
-      if (!objALinkedObjectMap.hasOwnProperty(objB.getName())) {
+      if (!objALinkedObjectMap.containsKey(objB.getName())) {
         objALinkedObjectMap.put(
           objB.getName(),
           new Array<gdjs.RuntimeObject>()
@@ -43,7 +43,7 @@ namespace gdjs {
         objALinkedObjects.push(objB);
       }
       const objBLinkedObjectMap = this.getObjectsLinkedWith(objB);
-      if (!objBLinkedObjectMap.hasOwnProperty(objA.getName())) {
+      if (!objBLinkedObjectMap.containsKey(objA.getName())) {
         objBLinkedObjectMap.put(
           objA.getName(),
           new Array<gdjs.RuntimeObject>()
@@ -58,9 +58,10 @@ namespace gdjs {
     removeAllLinksOf(obj: gdjs.RuntimeObject) {
       const linkedObjectMap = this.getObjectsLinkedWith(obj);
 
-      for (const linkedObjectMapItem in linkedObjectMap.items) {
-        if (linkedObjectMap.items.hasOwnProperty(linkedObjectMapItem)) {
-          const objLinkedObjects = linkedObjectMap.items[linkedObjectMapItem];
+      for (const linkedObjectName in linkedObjectMap.items) {
+        if (linkedObjectMap.containsKey(linkedObjectName)) {
+          const objLinkedObjects = linkedObjectMap.get(linkedObjectName);
+
           for (let i = 0; i < objLinkedObjects.length; i++) {
             if (this.links.hasOwnProperty(objLinkedObjects[i].id)) {
               const otherObjList = this.links[objLinkedObjects[i].id].get(
@@ -82,7 +83,7 @@ namespace gdjs {
     removeLinkBetween(objA: gdjs.RuntimeObject, objB: gdjs.RuntimeObject) {
       if (this.links.hasOwnProperty(objA.id)) {
         const map = this.links[objA.id];
-        if (map.hasOwnProperty(objB.getName())) {
+        if (map.containsKey(objB.getName())) {
           const list = map.get(objB.getName());
           const index = list.indexOf(objB);
           if (index !== -1) {
@@ -92,7 +93,7 @@ namespace gdjs {
       }
       if (this.links.hasOwnProperty(objB.id)) {
         const map = this.links[objB.id];
-        if (map.hasOwnProperty(objA.getName())) {
+        if (map.containsKey(objA.getName())) {
           const list = map.get(objA.getName());
           const index = list.indexOf(objA);
           if (index !== -1) {
@@ -140,13 +141,6 @@ namespace gdjs {
         LinksManager.getManager(runtimeScene).removeAllLinksOf(objA);
       };
 
-      export const _objectIsInList = function (
-        obj: gdjs.RuntimeObject,
-        linkedObjects: gdjs.RuntimeObject[]
-      ) {
-        return linkedObjects.indexOf(obj) !== -1;
-      };
-
       export const pickObjectsLinkedTo = function (
         runtimeScene: gdjs.RuntimeScene,
         objectsLists: Hashtable<gdjs.RuntimeObject[]>,
@@ -165,8 +159,8 @@ namespace gdjs {
         );
         for (const objectName in linkedObjectMap.items) {
           if (
-            linkedObjectMap.items.hasOwnProperty(objectName) &&
-            objectsLists.items.hasOwnProperty(objectName)
+            linkedObjectMap.containsKey(objectName) &&
+            objectsLists.containsKey(objectName)
           ) {
             const linkedObjects = linkedObjectMap.items[objectName];
             const pickedObjects = objectsLists.items[objectName];
@@ -176,8 +170,8 @@ namespace gdjs {
               runtimeScene.getObjects(objectName).length
             ) {
               // All the objects were picked, there is no need to make an intersection.
-              pickedObjects.length = 0;
               pickedSomething = pickedSomething || linkedObjects.length > 0;
+              pickedObjects.length = 0;
               pickedObjects.push.apply(pickedObjects, linkedObjects);
             } else {
               temporaryObjects.length = 0;
@@ -186,8 +180,8 @@ namespace gdjs {
                   temporaryObjects.push(otherObject);
                 }
               }
-              pickedObjects.length = 0;
               pickedSomething = pickedSomething || temporaryObjects.length > 0;
+              pickedObjects.length = 0;
               pickedObjects.push.apply(pickedObjects, temporaryObjects);
             }
           }

--- a/Extensions/LinkedObjects/linkedobjects.ts
+++ b/Extensions/LinkedObjects/linkedobjects.ts
@@ -154,39 +154,42 @@ namespace gdjs {
         )._getObjectsLinkedWith(obj);
 
         let pickedSomething = false;
-        const temporaryObjects = gdjs.staticArray(
-          gdjs.evtTools.linkedObjects.pickObjectsLinkedTo
-        );
-        for (const objectName in linkedObjectMap.items) {
-          if (
-            linkedObjectMap.containsKey(objectName) &&
-            objectsLists.containsKey(objectName)
-          ) {
-            const linkedObjects = linkedObjectMap.items[objectName];
+        for (const objectName in objectsLists.items) {
+          if (objectsLists.containsKey(objectName)) {
             const pickedObjects = objectsLists.items[objectName];
 
-            if (
-              pickedObjects.length ===
-              runtimeScene.getObjects(objectName).length
-            ) {
-              // All the objects were picked, there is no need to make an intersection.
-              pickedSomething = pickedSomething || linkedObjects.length > 0;
-              pickedObjects.length = 0;
-              pickedObjects.push.apply(pickedObjects, linkedObjects);
-            } else {
-              temporaryObjects.length = 0;
-              for (const otherObject of linkedObjects) {
-                if (pickedObjects.indexOf(otherObject) >= 0) {
-                  temporaryObjects.push(otherObject);
+            if (linkedObjectMap.containsKey(objectName)) {
+              const linkedObjects = linkedObjectMap.get(objectName);
+              if (
+                pickedObjects.length ===
+                runtimeScene.getObjects(objectName).length
+              ) {
+                // All the objects were picked, there is no need to make an intersection.
+                pickedSomething = pickedSomething || linkedObjects.length > 0;
+                pickedObjects.length = 0;
+                pickedObjects.push.apply(pickedObjects, linkedObjects);
+              } else {
+                const temporaryObjects = gdjs.staticArray(
+                  gdjs.evtTools.linkedObjects.pickObjectsLinkedTo
+                );
+                temporaryObjects.length = 0;
+                for (const otherObject of linkedObjects) {
+                  if (pickedObjects.indexOf(otherObject) >= 0) {
+                    temporaryObjects.push(otherObject);
+                  }
                 }
+                pickedSomething =
+                  pickedSomething || temporaryObjects.length > 0;
+                pickedObjects.length = 0;
+                pickedObjects.push.apply(pickedObjects, temporaryObjects);
+                temporaryObjects.length = 0;
               }
-              pickedSomething = pickedSomething || temporaryObjects.length > 0;
+            } else {
+              // No object is linked for this name
               pickedObjects.length = 0;
-              pickedObjects.push.apply(pickedObjects, temporaryObjects);
             }
           }
         }
-        temporaryObjects.length = 0;
         return pickedSomething;
       };
     }

--- a/Extensions/LinkedObjects/linkedobjects.ts
+++ b/Extensions/LinkedObjects/linkedobjects.ts
@@ -33,10 +33,7 @@ namespace gdjs {
     linkObjects(objA: gdjs.RuntimeObject, objB: gdjs.RuntimeObject) {
       const objALinkedObjectMap = this._getObjectsLinkedWith(objA);
       if (!objALinkedObjectMap.containsKey(objB.getName())) {
-        objALinkedObjectMap.put(
-          objB.getName(),
-          new Array<gdjs.RuntimeObject>()
-        );
+        objALinkedObjectMap.put(objB.getName(), []);
       }
       const objALinkedObjects = objALinkedObjectMap.get(objB.getName());
       if (objALinkedObjects.indexOf(objB) === -1) {
@@ -44,10 +41,7 @@ namespace gdjs {
       }
       const objBLinkedObjectMap = this._getObjectsLinkedWith(objB);
       if (!objBLinkedObjectMap.containsKey(objA.getName())) {
-        objBLinkedObjectMap.put(
-          objA.getName(),
-          new Array<gdjs.RuntimeObject>()
-        );
+        objBLinkedObjectMap.put(objA.getName(), []);
       }
       const objBLinkedObjects = objBLinkedObjectMap.get(objA.getName());
       if (objBLinkedObjects.indexOf(objA) === -1) {
@@ -56,15 +50,18 @@ namespace gdjs {
     }
 
     removeAllLinksOf(obj: gdjs.RuntimeObject) {
+      // Remove the other side of the links
       const linkedObjectMap = this._getObjectsLinkedWith(obj);
-
       for (const linkedObjectName in linkedObjectMap.items) {
         if (linkedObjectMap.containsKey(linkedObjectName)) {
-          const objLinkedObjects = linkedObjectMap.get(linkedObjectName);
+          const linkedObjects = linkedObjectMap.get(linkedObjectName);
 
-          for (let i = 0; i < objLinkedObjects.length; i++) {
-            if (this.links.hasOwnProperty(objLinkedObjects[i].id)) {
-              const otherObjList = this.links[objLinkedObjects[i].id].get(
+          for (let i = 0; i < linkedObjects.length; i++) {
+            // This is the object on the other side of the link
+            // We find obj in its list of linked objects and remove it.
+            const linkedObject = linkedObjects[i];
+            if (this.links.hasOwnProperty(linkedObject.id)) {
+              const otherObjList = this.links[linkedObject.id].get(
                 obj.getName()
               );
               const index = otherObjList.indexOf(obj);
@@ -75,6 +72,7 @@ namespace gdjs {
           }
         }
       }
+      // Remove the links on obj side
       if (this.links.hasOwnProperty(obj.id)) {
         delete this.links[obj.id];
       }

--- a/Extensions/LinkedObjects/tests/linkedobjects.spec.js
+++ b/Extensions/LinkedObjects/tests/linkedobjects.spec.js
@@ -2,11 +2,13 @@
 describe('gdjs.LinksManager', function () {
   var runtimeGame = new gdjs.RuntimeGame({
     variables: [],
+    // @ts-ignore - missing properties.
     properties: { windowWidth: 800, windowHeight: 600 },
     resources: { resources: [] },
   });
   var runtimeScene = new gdjs.RuntimeScene(runtimeGame);
   runtimeScene.loadFromScene({
+    // @ts-ignore - missing properties.
     layers: [{ name: '', visibility: true, effects: [] }],
     variables: [],
     behaviorsSharedData: [],
@@ -16,18 +18,21 @@ describe('gdjs.LinksManager', function () {
 
   var manager = gdjs.LinksManager.getManager(runtimeScene);
 
+  // @ts-ignore - missing properties.
   var object1A = new gdjs.RuntimeObject(runtimeScene, {
     name: 'obj1',
     type: '',
     behaviors: [],
     effects: [],
   });
+  // @ts-ignore - missing properties.
   var object1B = new gdjs.RuntimeObject(runtimeScene, {
     name: 'obj1',
     type: '',
     behaviors: [],
     effects: [],
   });
+  // @ts-ignore - missing properties.
   var object1C = new gdjs.RuntimeObject(runtimeScene, {
     name: 'obj1',
     type: '',
@@ -35,18 +40,22 @@ describe('gdjs.LinksManager', function () {
     effects: [],
   });
 
+  // @ts-ignore - missing properties.
   var object2A = new gdjs.RuntimeObject(runtimeScene, {
     name: 'obj2',
     type: '',
     behaviors: [],
     effects: [],
   });
+
+  // @ts-ignore - missing properties.
   var object2B = new gdjs.RuntimeObject(runtimeScene, {
     name: 'obj2',
     type: '',
     behaviors: [],
     effects: [],
   });
+  // @ts-ignore - missing properties.
   var object2C = new gdjs.RuntimeObject(runtimeScene, {
     name: 'obj2',
     type: '',
@@ -63,7 +72,7 @@ describe('gdjs.LinksManager', function () {
       objectsLists,
       object
     );
-    return pickedSomething ? objectsLists : false;
+    return { pickedSomething, objectsLists };
   };
 
   runtimeScene.addObject(object1A);
@@ -76,51 +85,64 @@ describe('gdjs.LinksManager', function () {
 
   it('can link two objects', function () {
     manager.linkObjects(object1A, object2A);
-
-    let objectsLists = pickObjectsLinkedTo(object1A);
-    expect(objectsLists.get('obj1').length).to.be(0);
-    expect(objectsLists.get('obj2').length).to.be(1);
-    expect(objectsLists.get('obj2')[0]).to.be(object2A);
-
-    objectsLists = pickObjectsLinkedTo(object2A);
-    expect(objectsLists.get('obj1').length).to.be(1);
-    expect(objectsLists.get('obj1')[0]).to.be(object1A);
-    expect(objectsLists.get('obj2').length).to.be(0);
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object1A);
+      expect(pickedSomething).to.be(true);
+      expect(objectsLists.get('obj1').length).to.be(0);
+      expect(objectsLists.get('obj2').length).to.be(1);
+      expect(objectsLists.get('obj2')[0]).to.be(object2A);
+    }
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object2A);
+      expect(pickedSomething).to.be(true);
+      expect(objectsLists.get('obj1').length).to.be(1);
+      expect(objectsLists.get('obj1')[0]).to.be(object1A);
+      expect(objectsLists.get('obj2').length).to.be(0);
+    }
   });
   it('can link more objects', function () {
     manager.linkObjects(object1A, object2A); //Including the same objects as before
     manager.linkObjects(object1A, object2B);
     manager.linkObjects(object1A, object2C);
-
-    let objectsLists = pickObjectsLinkedTo(object1A);
-    expect(objectsLists.get('obj1').length).to.be(0);
-    expect(objectsLists.get('obj2').length).to.be(3);
-
-    objectsLists = pickObjectsLinkedTo(object2C);
-    expect(objectsLists.get('obj1').length).to.be(1);
-    expect(objectsLists.get('obj1')[0]).to.be(object1A);
-    expect(objectsLists.get('obj2').length).to.be(0);
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object1A);
+      expect(pickedSomething).to.be(true);
+      expect(objectsLists.get('obj1').length).to.be(0);
+      expect(objectsLists.get('obj2').length).to.be(3);
+    }
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object2C);
+      expect(pickedSomething).to.be(true);
+      expect(objectsLists.get('obj1').length).to.be(1);
+      expect(objectsLists.get('obj1')[0]).to.be(object1A);
+      expect(objectsLists.get('obj2').length).to.be(0);
+    }
   });
   it('supports removing links', function () {
     manager.removeLinkBetween(object1A, object2B);
-
-    let objectsLists = pickObjectsLinkedTo(object1A);
-    expect(objectsLists.get('obj1').length).to.be(0);
-    expect(objectsLists.get('obj2').length).to.be(2);
-
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object1A);
+      expect(pickedSomething).to.be(true);
+      expect(objectsLists.get('obj1').length).to.be(0);
+      expect(objectsLists.get('obj2').length).to.be(2);
+    }
     manager.linkObjects(object2B, object2C);
     manager.removeAllLinksOf(object1A);
     manager.removeAllLinksOf(object1A);
-
-    objectsLists = pickObjectsLinkedTo(object1A);
-    expect(objectsLists).to.be(false);
-
-    objectsLists = pickObjectsLinkedTo(object2A);
-    expect(objectsLists).to.be(false);
-
-    objectsLists = pickObjectsLinkedTo(object2C);
-    expect(objectsLists.get('obj1').length).to.be(0);
-    expect(objectsLists.get('obj2').length).to.be(1);
-    expect(objectsLists.get('obj2')[0]).to.be(object2B);
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object1A);
+      expect(pickedSomething).to.be(false);
+    }
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object2A);
+      expect(pickedSomething).to.be(false);
+    }
+    {
+      const { pickedSomething, objectsLists } = pickObjectsLinkedTo(object2C);
+      expect(pickedSomething).to.be(true);
+      expect(objectsLists.get('obj1').length).to.be(0);
+      expect(objectsLists.get('obj2').length).to.be(1);
+      expect(objectsLists.get('obj2')[0]).to.be(object2B);
+    }
   });
 });

--- a/Extensions/LinkedObjects/tests/linkedobjects.spec.js
+++ b/Extensions/LinkedObjects/tests/linkedobjects.spec.js
@@ -78,14 +78,14 @@ describe('gdjs.LinksManager', function () {
     manager.linkObjects(object1A, object2A);
 
     let objectsLists = pickObjectsLinkedTo(object1A);
-    expect(objectsLists.get('obj1').length).to.be(3);
+    expect(objectsLists.get('obj1').length).to.be(0);
     expect(objectsLists.get('obj2').length).to.be(1);
     expect(objectsLists.get('obj2')[0]).to.be(object2A);
 
     objectsLists = pickObjectsLinkedTo(object2A);
     expect(objectsLists.get('obj1').length).to.be(1);
     expect(objectsLists.get('obj1')[0]).to.be(object1A);
-    expect(objectsLists.get('obj2').length).to.be(3);
+    expect(objectsLists.get('obj2').length).to.be(0);
   });
   it('can link more objects', function () {
     manager.linkObjects(object1A, object2A); //Including the same objects as before
@@ -93,19 +93,19 @@ describe('gdjs.LinksManager', function () {
     manager.linkObjects(object1A, object2C);
 
     let objectsLists = pickObjectsLinkedTo(object1A);
-    expect(objectsLists.get('obj1').length).to.be(3);
+    expect(objectsLists.get('obj1').length).to.be(0);
     expect(objectsLists.get('obj2').length).to.be(3);
 
     objectsLists = pickObjectsLinkedTo(object2C);
     expect(objectsLists.get('obj1').length).to.be(1);
     expect(objectsLists.get('obj1')[0]).to.be(object1A);
-    expect(objectsLists.get('obj2').length).to.be(3);
+    expect(objectsLists.get('obj2').length).to.be(0);
   });
   it('supports removing links', function () {
     manager.removeLinkBetween(object1A, object2B);
 
     let objectsLists = pickObjectsLinkedTo(object1A);
-    expect(objectsLists.get('obj1').length).to.be(3);
+    expect(objectsLists.get('obj1').length).to.be(0);
     expect(objectsLists.get('obj2').length).to.be(2);
 
     manager.linkObjects(object2B, object2C);

--- a/Extensions/LinkedObjects/tests/linkedobjects.spec.js
+++ b/Extensions/LinkedObjects/tests/linkedobjects.spec.js
@@ -1,3 +1,4 @@
+// @ts-check
 describe('gdjs.LinksManager', function () {
   var runtimeGame = new gdjs.RuntimeGame({
     variables: [],
@@ -35,23 +36,35 @@ describe('gdjs.LinksManager', function () {
   });
 
   var object2A = new gdjs.RuntimeObject(runtimeScene, {
-    name: 'obj1',
+    name: 'obj2',
     type: '',
     behaviors: [],
     effects: [],
   });
   var object2B = new gdjs.RuntimeObject(runtimeScene, {
-    name: 'obj1',
+    name: 'obj2',
     type: '',
     behaviors: [],
     effects: [],
   });
   var object2C = new gdjs.RuntimeObject(runtimeScene, {
-    name: 'obj1',
+    name: 'obj2',
     type: '',
     behaviors: [],
     effects: [],
   });
+
+  var pickObjectsLinkedTo = (object) => {
+    const objectsLists = new Hashtable();
+    objectsLists.put('obj1', [object1A, object1B, object1C]);
+    objectsLists.put('obj2', [object2A, object2B, object2C]);
+    const pickedSomething = gdjs.evtTools.linkedObjects.pickObjectsLinkedTo(
+      runtimeScene,
+      objectsLists,
+      object
+    );
+    return pickedSomething ? objectsLists : false;
+  };
 
   runtimeScene.addObject(object1A);
   runtimeScene.addObject(object1B);
@@ -64,43 +77,50 @@ describe('gdjs.LinksManager', function () {
   it('can link two objects', function () {
     manager.linkObjects(object1A, object2A);
 
-    var linkedObjects = manager.getObjectsLinkedWith(object1A);
-    expect(linkedObjects.length).to.be(1);
-    expect(linkedObjects[0]).to.be(object2A);
+    let objectsLists = pickObjectsLinkedTo(object1A);
+    expect(objectsLists.get('obj1').length).to.be(3);
+    expect(objectsLists.get('obj2').length).to.be(1);
+    expect(objectsLists.get('obj2')[0]).to.be(object2A);
 
-    linkedObjects = manager.getObjectsLinkedWith(object2A);
-    expect(linkedObjects.length).to.be(1);
-    expect(linkedObjects[0]).to.be(object1A);
+    objectsLists = pickObjectsLinkedTo(object2A);
+    expect(objectsLists.get('obj1').length).to.be(1);
+    expect(objectsLists.get('obj1')[0]).to.be(object1A);
+    expect(objectsLists.get('obj2').length).to.be(3);
   });
   it('can link more objects', function () {
     manager.linkObjects(object1A, object2A); //Including the same objects as before
     manager.linkObjects(object1A, object2B);
     manager.linkObjects(object1A, object2C);
 
-    var linkedObjects = manager.getObjectsLinkedWith(object1A);
-    expect(linkedObjects.length).to.be(3);
+    let objectsLists = pickObjectsLinkedTo(object1A);
+    expect(objectsLists.get('obj1').length).to.be(3);
+    expect(objectsLists.get('obj2').length).to.be(3);
 
-    linkedObjects = manager.getObjectsLinkedWith(object2C);
-    expect(linkedObjects.length).to.be(1);
-    expect(linkedObjects[0]).to.be(object1A);
+    objectsLists = pickObjectsLinkedTo(object2C);
+    expect(objectsLists.get('obj1').length).to.be(1);
+    expect(objectsLists.get('obj1')[0]).to.be(object1A);
+    expect(objectsLists.get('obj2').length).to.be(3);
   });
   it('supports removing links', function () {
     manager.removeLinkBetween(object1A, object2B);
-    var linkedObjects = manager.getObjectsLinkedWith(object1A);
-    expect(linkedObjects.length).to.be(2);
+
+    let objectsLists = pickObjectsLinkedTo(object1A);
+    expect(objectsLists.get('obj1').length).to.be(3);
+    expect(objectsLists.get('obj2').length).to.be(2);
 
     manager.linkObjects(object2B, object2C);
     manager.removeAllLinksOf(object1A);
     manager.removeAllLinksOf(object1A);
 
-    linkedObjects = manager.getObjectsLinkedWith(object1A);
-    expect(linkedObjects.length).to.be(0);
+    objectsLists = pickObjectsLinkedTo(object1A);
+    expect(objectsLists).to.be(false);
 
-    linkedObjects = manager.getObjectsLinkedWith(object2A);
-    expect(linkedObjects.length).to.be(0);
+    objectsLists = pickObjectsLinkedTo(object2A);
+    expect(objectsLists).to.be(false);
 
-    linkedObjects = manager.getObjectsLinkedWith(object2C);
-    expect(linkedObjects.length).to.be(1);
-    expect(linkedObjects[0]).to.be(object2B);
+    objectsLists = pickObjectsLinkedTo(object2C);
+    expect(objectsLists.get('obj1').length).to.be(0);
+    expect(objectsLists.get('obj2').length).to.be(1);
+    expect(objectsLists.get('obj2')[0]).to.be(object2B);
   });
 });


### PR DESCRIPTION
## Context
* The link condition is picking objects "ObjectA" that are not constraint by previous conditions.
* The previous picked list of "ObjectA" contains all of them.
* Let's say there is only one "ObjectA" to pick (the common case, I guess).

## Current behavior
* The condition makes an intersection between all the "ObjectA" and the one "ObjectA" to pick.
* The complexity is O(n)

## Expected behavior
* Directly set the picked object list to this one "ObjectA" to pick.
* The complexity is O(1)

## Technical solution
* Aggregate linked objects by type so the list can be copied directly when no object is filtered for this type.

## Side effect
* The picked objects may not be in the same order as before.
  * They will be sorted by first linked.
  * Whereas they were probably sorted by first created.
* The user should not rely on the picked object order but a game that worked by chance could break.
  * For instance,
    * If one object was intended to be links to only one object but was linked to a 2nd one by mistake.
	* They are used in expressions so only the first one is really used.
    * The 2nd one could be used instead.
  * I doubt this is a real issue.

## Performances tests
* On the RTS example, the picking is done 4 times faster.
https://www.dropbox.com/s/f8jmgeupm5dz8xe/RectangularFloodFill.zip?dl=1
  * Before
    ![Before](https://user-images.githubusercontent.com/2611977/131329610-a792aeac-006b-4eac-9458-334e1e9d5169.png)
  * After
    ![EmptyAfter](https://user-images.githubusercontent.com/2611977/131329629-1d5cb0b0-971b-4bc4-a9df-2916a248d20c.png)
