### PR TITLE
Increase the height of the description text field for extension

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
@@ -178,7 +178,7 @@ export const ExtensionOptionsEditor = ({
             multiline
             fullWidth
             rows={5}
-            rowsMax={5}
+            rowsMax={15}
           />
           <TextField
             floatingLabelText={<Trans>Version</Trans>}


### PR DESCRIPTION
Now edit and read the extension description is easier than scrolling
It was pain during reviews.

After/Before
![image](https://user-images.githubusercontent.com/1670670/131415580-a7b7f7b7-7e60-4a77-99bc-c9f819f86727.png)