### PR TITLE
Increase shader precision, allowing lights to be displayed correctly on iOS

### DIFF
--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -509,7 +509,7 @@ namespace gdjs {
 
     static _defaultIndexBuffer = new Uint16Array([0, 1, 2, 0, 2, 3]);
     static defaultVertexShader = `
-  precision mediump float;
+  precision highp float;
   attribute vec2 aVertexPosition;
 
   uniform mat3 translationMatrix;
@@ -521,7 +521,7 @@ namespace gdjs {
       gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
   }`;
     static defaultFragmentShader = `
-  precision mediump float;
+  precision highp float;
   uniform vec2 center;
   uniform float radius;
   uniform vec3 color;
@@ -535,7 +535,7 @@ namespace gdjs {
       gl_FragColor = vec4(color*intensity, 1.0);
   }`;
     static texturedFragmentShader = `
-  precision mediump float;
+  precision highp float;
   uniform vec2 center;
   uniform float radius;
   uniform vec3 color;


### PR DESCRIPTION
Fixes #1990 