### PR TITLE
Feature/display extension username

### DIFF
--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -20,6 +20,7 @@ import { Column, Line } from '../../UI/Grid';
 import { Divider } from '@material-ui/core';
 import { ColumnStackLayout } from '../../UI/Layout';
 import { IconContainer } from '../../UI/IconContainer';
+import { UserPublicProfileChip } from '../../UI/UserPublicProfileChip';
 
 type Props = {|
   extensionShortHeader: ExtensionShortHeader,
@@ -136,7 +137,7 @@ export default class ExtensionInstallDialog extends Component<Props, State> {
             <IconContainer
               alt={extensionShortHeader.fullName}
               src={extensionShortHeader.previewIconUrl}
-              size={48}
+              size={64}
             />
             <Column expand>
               <Text noMargin size="title">
@@ -145,6 +146,12 @@ export default class ExtensionInstallDialog extends Component<Props, State> {
               <Text noMargin size="body2">
                 <Trans>Version {' ' + extensionShortHeader.version}</Trans>
               </Text>
+              <Line>
+                {extensionShortHeader.authors &&
+                  extensionShortHeader.authors.map(author => (
+                    <UserPublicProfileChip user={author} key={author.id} />
+                  ))}
+              </Line>
             </Column>
           </Line>
           <Text noMargin>{extensionShortHeader.shortDescription}</Text>

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionListItem.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionListItem.js
@@ -6,6 +6,7 @@ import Text from '../../UI/Text';
 import { Trans } from '@lingui/macro';
 import { Column, Line } from '../../UI/Grid';
 import { IconContainer } from '../../UI/IconContainer';
+import { UserPublicProfileChip } from '../../UI/UserPublicProfileChip';
 
 const styles = {
   container: {
@@ -43,17 +44,23 @@ export const ExtensionListItem = ({
   return (
     <ButtonBase onClick={onChoose} focusRipple>
       <div style={styles.container} ref={containerRef}>
-        <Line noMargin>
+        <Line>
           <IconContainer
             alt={extensionShortHeader.fullName}
             src={extensionShortHeader.previewIconUrl}
-            size={48}
+            size={64}
           />
           <Column expand>
             <Text noMargin>
               {extensionShortHeader.fullName}{' '}
               {alreadyInstalled && <Trans> (already installed)</Trans>}
             </Text>
+            <Line>
+              {extensionShortHeader.authors &&
+                extensionShortHeader.authors.map(author => (
+                  <UserPublicProfileChip user={author} key={author.id} />
+                ))}
+            </Line>
             <Text noMargin size="body2">
               {extensionShortHeader.shortDescription}
             </Text>

--- a/newIDE/app/src/Profile/User.js
+++ b/newIDE/app/src/Profile/User.js
@@ -1,0 +1,6 @@
+// @flow
+
+export type UserPublicProfile = {|
+  id: string,
+  username: string,
+|};

--- a/newIDE/app/src/UI/Search/ListSearchResults.js
+++ b/newIDE/app/src/UI/Search/ListSearchResults.js
@@ -122,7 +122,13 @@ export const ListSearchResults = <SearchItem>({
 
             return (
               <Grid
-                ref={grid}
+                ref={el => {
+                  if (el) {
+                    // Ensure the grid is recomputed for heights once it is rendered.
+                    el.recomputeGridSize(0, 0);
+                  }
+                  grid.current = el;
+                }}
                 width={width}
                 height={height}
                 columnCount={1}

--- a/newIDE/app/src/UI/UserPublicProfileChip.js
+++ b/newIDE/app/src/UI/UserPublicProfileChip.js
@@ -1,0 +1,27 @@
+// @flow
+import * as React from 'react';
+import Chip from '@material-ui/core/Chip';
+import FaceIcon from '@material-ui/icons/Face';
+import { type UserPublicProfile } from '../Profile/User';
+
+const styles = {
+  chip: {
+    marginRight: 2,
+  },
+};
+
+type Props = {|
+  user: UserPublicProfile,
+|};
+
+export const UserPublicProfileChip = ({ user }: Props) => {
+  return (
+    <Chip
+      icon={<FaceIcon />}
+      size="small"
+      style={styles.chip}
+      label={user.username}
+      key={user.username}
+    />
+  );
+};

--- a/newIDE/app/src/Utils/GDevelopServices/Extension.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Extension.js
@@ -2,9 +2,11 @@
 import axios from 'axios';
 import { GDevelopAssetApi } from './ApiConfigs';
 import semverSatisfies from 'semver/functions/satisfies';
+import { type UserPublicProfile } from '../../Profile/User';
 
 export type ExtensionShortHeader = {|
   shortDescription: string,
+  authors?: Array<UserPublicProfile>,
   extensionNamespace: string,
   fullName: string,
   name: string,
@@ -35,15 +37,6 @@ export type ExtensionsRegistry = {
 };
 
 /**
- * The ExtensionShortHeader returned by the API, with tags being a string
- * (which is kept in the API for compatibility with older GDevelop versions).
- */
-type ExtensionShortHeaderWithTagsAsString = {|
-  ...ExtensionShortHeader,
-  tags: string,
-|};
-
-/**
  * The ExtensionHeader returned by the API, with tags being a string
  * (which is kept in the API for compatibility with older GDevelop versions).
  */
@@ -59,15 +52,6 @@ type ExtensionHeaderWithTagsAsString = {|
 type SerializedExtensionWithTagsAsString = {
   ...SerializedExtension,
   tags: string,
-};
-
-/**
- * The ExtensionsRegistry returned by the API, with tags being a string
- * (which is kept in the API for compatibility with older GDevelop versions).
- */
-type ExtensionsRegistryWithTagsAsString = {
-  ...ExtensionsRegistry,
-  extensionShortHeaders: Array<ExtensionShortHeaderWithTagsAsString>,
 };
 
 /**
@@ -106,19 +90,11 @@ export const getExtensionsRegistry = (): Promise<ExtensionsRegistry> => {
   return axios
     .get(`${GDevelopAssetApi.baseUrl}/extension`)
     .then(response => response.data)
-    .then(({ databaseUrl }) => {
-      if (!databaseUrl) {
-        throw new Error('Unexpected response from the extension endpoint.');
-      }
-
-      return axios.get(databaseUrl);
-    })
-    .then(response => {
-      const data: ExtensionsRegistryWithTagsAsString = response.data;
-
+    .then(({ extensionsDatabase }) => {
       return {
-        ...data,
-        extensionShortHeaders: data.extensionShortHeaders.map(
+        ...extensionsDatabase,
+        // TODO: move this to backend endpoint
+        extensionShortHeaders: extensionsDatabase.extensionShortHeaders.map(
           transformTagsAsStringToTagsAsArray
         ),
       };

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -246,6 +246,7 @@ import {
 } from '../UI/Accordion';
 import ProjectPropertiesDialog from '../ProjectManager/ProjectPropertiesDialog';
 import { LoadingScreenEditor } from '../ProjectManager/LoadingScreenEditor';
+import { UserPublicProfileChip } from '../UI/UserPublicProfileChip';
 
 configureActions({
   depth: 2,
@@ -3955,6 +3956,12 @@ storiesOf('Profile/CreateAccountDialog', module)
         code: 'auth/invalid-email',
       }}
     />
+  ));
+
+storiesOf('UserPublicProfileChip', module)
+  .addDecorator(muiDecorator)
+  .add('default', () => (
+    <UserPublicProfileChip user={{ id: '123', username: 'username' }} />
   ));
 
 storiesOf('LocalNetworkPreviewDialog', module)


### PR DESCRIPTION
Now that the backend returns the list of authors with the extensions database, we are able to display them on the Extensions Search list and on the Extension details popup.

This handles the case where there are no authors.

I also fixed an annoying bug, where the list would not compute the rows height correctly on first render, triggering a jump when scrolling after the next item is displayed.

Preview: 
![Screenshot 2021-09-17 at 10 46 34](https://user-images.githubusercontent.com/4895034/133754150-83d4655c-386c-476b-858e-ad55f24a4b5c.png)
![Screenshot 2021-09-17 at 10 46 08](https://user-images.githubusercontent.com/4895034/133754167-ac8be311-2e04-4428-a9ab-ac001fe160a6.png)
![Screenshot 2021-09-17 at 10 45 30](https://user-images.githubusercontent.com/4895034/133754175-57de1f03-3343-4e42-b921-1ee240a6aaf7.png)


