### PR TITLE
Fix: allow color properties to be used in events.

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -388,11 +388,7 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
     const propertyLabel =
       property.getLabel() || i18n._(t`${propertyName} property`);
 
-    if (
-      propertyType === 'String' ||
-      propertyType === 'Choice' ||
-      propertyType === 'Color'
-    ) {
+    if (propertyType === 'String' || propertyType === 'Choice') {
       addObjectAndBehaviorParameters(
         behaviorMetadata.addStrExpression(
           gd.EventsBasedBehavior.getPropertyExpressionName(propertyName),
@@ -538,6 +534,18 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
         .addParameter('color', i18n._(t`New color to set`), '', false)
         .getCodeExtraInformation()
         .setFunctionName(setterName);
+
+      addObjectAndBehaviorParameters(
+        behaviorMetadata.addStrExpression(
+          gd.EventsBasedBehavior.getPropertyExpressionName(propertyName),
+          propertyLabel,
+          propertyLabel,
+          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
+          getExtensionIconUrl(extension)
+        )
+      )
+        .getCodeExtraInformation()
+        .setFunctionName(getterName);
     }
   });
 };

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -388,7 +388,11 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
     const propertyLabel =
       property.getLabel() || i18n._(t`${propertyName} property`);
 
-    if (propertyType === 'String' || propertyType === 'Choice') {
+    if (
+      propertyType === 'String' ||
+      propertyType === 'Choice' ||
+      propertyType === 'Color'
+    ) {
       addObjectAndBehaviorParameters(
         behaviorMetadata.addStrExpression(
           gd.EventsBasedBehavior.getPropertyExpressionName(propertyName),


### PR DESCRIPTION
The `Color` property type was not considered as a string and the properties could be used in string expressions.

Steps to reproduce:
* Open the fog of war example
* Run the game, the slilders are blue
* Set the thumb color property of the Slider extension to the color type
* Run the game, the sliders are white instead of blue

Related PR: https://github.com/4ian/GDevelop/pull/2980