### PR TITLE
Fix Folder being set for both Examples and Starters

### DIFF
--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -12,6 +12,11 @@ import { type StorageProvider, type FileMetadata } from '../ProjectsStorage';
 import { GamesShowcase } from '../GamesShowcase';
 import Window from '../Utils/Window';
 import PublishIcon from '@material-ui/icons/Publish';
+import { findEmptyPath } from './LocalPathFinder';
+import optionalRequire from '../Utils/OptionalRequire.js';
+const path = optionalRequire('path');
+const electron = optionalRequire('electron');
+const app = electron ? electron.remote.app : null;
 
 type State = {|
   currentTab: 'starters' | 'examples' | 'tutorials' | 'games-showcase',
@@ -42,7 +47,9 @@ type Props = {|
 export default class CreateProjectDialog extends React.Component<Props, State> {
   state = {
     currentTab: this.props.initialTab,
-    outputPath: '',
+    outputPath: app
+      ? findEmptyPath(path.join(app.getPath('documents'), 'GDevelop projects'))
+      : '',
   };
 
   _onChangeTab = (

--- a/newIDE/app/src/ProjectCreation/LocalStarters.js
+++ b/newIDE/app/src/ProjectCreation/LocalStarters.js
@@ -17,10 +17,7 @@ import ListIcon from '../UI/ListIcon';
 import { showGameFileCreationError } from './LocalExamples';
 import { type StorageProvider, type FileMetadata } from '../ProjectsStorage';
 import LocalFileStorageProvider from '../ProjectsStorage/LocalFileStorageProvider';
-import { findEmptyPath } from './LocalPathFinder';
 const path = optionalRequire('path');
-const electron = optionalRequire('electron');
-const app = electron ? electron.remote.app : null;
 var fs = optionalRequire('fs-extra');
 const gd: libGDevelop = global.gd;
 
@@ -80,16 +77,6 @@ export default class LocalStarters extends Component<Props, State> {
       fileIdentifier: filePath,
     });
     sendNewGameCreated('');
-  }
-
-  componentDidMount() {
-    if (this.props.outputPath === '')
-      if (path && app)
-        this.props.onChangeOutputPath(
-          findEmptyPath(
-            path.join(app.getPath('documents'), 'GDevelop projects')
-          )
-        );
   }
 
   render() {


### PR DESCRIPTION
Fixes #3089 

Moved the logic to the `CreateProjectDialog` level rather than the `LocalStarters` only

![image](https://user-images.githubusercontent.com/4895034/134691419-be707e5f-b5d5-4a49-a6dc-01fcc63c2157.png)
