### PR TITLE
Allow signle quotes for text litterals in expressions

### DIFF
--- a/Core/GDCore/Events/Parsers/ExpressionParser2.cpp
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.cpp
@@ -158,15 +158,16 @@ std::unique_ptr<TextNode> ExpressionParser2::ReadText() {
         ExpressionParserLocation(textStartPosition, GetCurrentPosition());
     return text;
   }
+  char matchingQuote = GetCurrentChar();
   SkipChar();
 
   gd::String parsedText = "";
   bool textParsingHasEnded = false;
   bool expectEscapedCharacter = false;
   while (!IsEndReached() && !textParsingHasEnded) {
-    if (GetCurrentChar() == '"') {
+    if (GetCurrentChar() == matchingQuote) {
       if (expectEscapedCharacter) {
-        parsedText += '"';
+        parsedText += GetCurrentChar();
         expectEscapedCharacter = false;
       } else {
         textParsingHasEnded = true;

--- a/Core/GDCore/Events/Parsers/ExpressionParser2.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.h
@@ -829,7 +829,7 @@ class GD_CORE_API ExpressionParser2 {
   }
 
   static bool IsQuote(gd::String::value_type character) {
-    return character == '"';
+    return character == '"' || character == '\'';
   }
 
   static bool IsBracket(gd::String::value_type character) {


### PR DESCRIPTION
This allows for using single quotes for text litterals inside of expressions. For example, where before only `" \" ' hello ' \" "` was accepted, now `' " \' hello \' " '` is too.

This is very useful when working with JSON, where you have no choice but to use double quotes everywhere, and escaping them makes the JSON less readable:

🤮 `"{\"myKey\": \"myValue\"}"`
✅ `'{"myKey": "myValue"}'`