### PR TITLE
Add username validation in the create & edit forms

### DIFF
--- a/newIDE/app/src/Profile/CreateAccountDialog.js
+++ b/newIDE/app/src/Profile/CreateAccountDialog.js
@@ -15,6 +15,7 @@ import LeftLoader from '../UI/LeftLoader';
 import BackgroundText from '../UI/BackgroundText';
 import { ColumnStackLayout } from '../UI/Layout';
 import { MarkdownText } from '../UI/MarkdownText';
+import { UsernameField, isUsernameValid } from './UsernameField';
 
 type Props = {|
   onClose: () => void,
@@ -83,7 +84,10 @@ export default class CreateAccountDialog extends Component<Props, State> {
             <RaisedButton
               label={<Trans>Create my account</Trans>}
               primary
-              disabled={createAccountInProgress}
+              disabled={
+                createAccountInProgress ||
+                !isUsernameValid(this.state.form.username, true)
+              }
               onClick={this._onCreateAccount}
             />
           </LeftLoader>,
@@ -109,11 +113,8 @@ export default class CreateAccountDialog extends Component<Props, State> {
               translatableSource={t`By creating an account and using GDevelop, you agree to the [Terms and Conditions](https://gdevelop-app.com/legal/terms-and-conditions). Having an account allows you to export your game on Android or as a Desktop app and it unlocks other services for your project!`}
             />
           </BackgroundText>
-          <TextField
-            autoFocus
+          <UsernameField
             value={this.state.form.username}
-            floatingLabelText={<Trans>Username</Trans>}
-            fullWidth
             onChange={(e, value) => {
               this.setState({
                 form: {
@@ -122,6 +123,7 @@ export default class CreateAccountDialog extends Component<Props, State> {
                 },
               });
             }}
+            allowEmpty
           />
           <TextField
             value={this.state.form.email}

--- a/newIDE/app/src/Profile/EditProfileDialog.js
+++ b/newIDE/app/src/Profile/EditProfileDialog.js
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import FlatButton from '../UI/FlatButton';
 import RaisedButton from '../UI/RaisedButton';
 import Dialog from '../UI/Dialog';
-import TextField from '../UI/TextField';
 import {
   type EditForm,
   type AuthError,
@@ -13,6 +12,11 @@ import {
 } from '../Utils/GDevelopServices/Authentication';
 import LeftLoader from '../UI/LeftLoader';
 import { ColumnStackLayout } from '../UI/Layout';
+import {
+  isUsernameValid,
+  UsernameField,
+  usernameFormatError,
+} from './UsernameField';
 
 type Props = {|
   profile: Profile,
@@ -31,8 +35,7 @@ export const getUsernameErrorText = (error: ?AuthError) => {
 
   if (error.code === 'auth/username-used')
     return 'This username is already used, please pick another one.';
-  if (error.code === 'auth/malformed-username')
-    return 'Please pick a short username with only alphanumeric characters as well as _ and -';
+  if (error.code === 'auth/malformed-username') return usernameFormatError;
   return undefined;
 };
 
@@ -63,7 +66,9 @@ export default class EditDialog extends Component<Props, State> {
           label={<Trans>Save</Trans>}
           primary
           onClick={this._onEdit}
-          disabled={editInProgress}
+          disabled={
+            editInProgress || !isUsernameValid(this.state.form.username)
+          }
         />
       </LeftLoader>,
     ];
@@ -80,12 +85,8 @@ export default class EditDialog extends Component<Props, State> {
         open
       >
         <ColumnStackLayout noMargin>
-          <TextField
-            autoFocus
+          <UsernameField
             value={this.state.form.username}
-            floatingLabelText={<Trans>Username</Trans>}
-            errorText={getUsernameErrorText(error)}
-            fullWidth
             onChange={(e, value) => {
               this.setState({
                 form: {
@@ -94,6 +95,7 @@ export default class EditDialog extends Component<Props, State> {
                 },
               });
             }}
+            errorText={getUsernameErrorText(error)}
           />
         </ColumnStackLayout>
       </Dialog>

--- a/newIDE/app/src/Profile/UsernameField.js
+++ b/newIDE/app/src/Profile/UsernameField.js
@@ -1,0 +1,40 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import * as React from 'react';
+import TextField from '../UI/TextField';
+
+type Props = {|
+  value: string,
+  onChange: Function,
+  errorText?: ?string,
+  allowEmpty?: boolean,
+|};
+
+export const isUsernameValid = (username: string, allowEmpty: ?boolean) => {
+  if (allowEmpty && username === '') return true;
+  return username && /^[\w|-]+$/.test(username) && username.length < 31;
+};
+
+export const usernameFormatError =
+  'Please pick a short username with only alphanumeric characters as well as _ and -';
+
+export const UsernameField = ({
+  value,
+  onChange,
+  errorText,
+  allowEmpty,
+}: Props) => {
+  const getUsernameErrorText = () =>
+    isUsernameValid(value, allowEmpty) ? undefined : usernameFormatError;
+
+  return (
+    <TextField
+      autoFocus
+      value={value}
+      floatingLabelText={<Trans>Username</Trans>}
+      fullWidth
+      onChange={onChange}
+      errorText={getUsernameErrorText() || errorText}
+    />
+  );
+};


### PR DESCRIPTION
Add frontend validation for username field, both in create & edit form.
Empty value still allowed in created form, in case the user doesn't want to set a username for the moment.


![Screenshot 2021-10-01 at 14 04 07](https://user-images.githubusercontent.com/4895034/135616998-d6a1df42-ee7f-41e7-8f2e-f4b10e0d7c77.png)
![Screenshot 2021-10-01 at 14 04 26](https://user-images.githubusercontent.com/4895034/135617002-6bef7b47-6c92-40f9-905d-8a5acc98d4e6.png)

