### PR TITLE
Fix #3097 (dialogue variables even if dialogue is not running

### DIFF
--- a/Extensions/DialogueTree/dialoguetools.ts
+++ b/Extensions/DialogueTree/dialoguetools.ts
@@ -739,7 +739,7 @@ namespace gdjs {
    * @param key The name of the variable you want to get the value of
    */
   gdjs.dialogueTree.getVariable = function (key: string) {
-    if (this.dialogueIsRunning && key in this.runner.variables.data) {
+    if (this.runner.variables && key in this.runner.variables.data) {
       return this.runner.variables.get(key);
     }
     return '';
@@ -754,7 +754,7 @@ namespace gdjs {
     key: string,
     value: string | boolean | number
   ) {
-    if (this.dialogueIsRunning && key in this.runner.variables.data) {
+    if (this.runner.variables && key in this.runner.variables.data) {
       return this.runner.variables.get(key) === value;
     }
     return false;


### PR DESCRIPTION
This PR will fix a design discrepancy where setting a dialogue state variable in an action works whether or not the player is in dialogue but getting a dialogue state variable through an expression or condition does not work if the player is not in dialogue.