### PR TITLE
Allow user to verify their email

### DIFF
--- a/newIDE/app/src/Profile/AuthenticatedUserContext.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserContext.js
@@ -20,6 +20,8 @@ export type AuthenticatedUser = {|
   onEdit: () => void,
   onCreateAccount: () => void,
   onRefreshUserProfile: () => void,
+  onRefreshFirebaseProfile: () => void,
+  onSendEmailVerification: () => void,
   getAuthorizationHeader: () => Promise<string>,
 |};
 
@@ -35,6 +37,8 @@ export const initialAuthenticatedUser = {
   onEdit: () => {},
   onCreateAccount: () => {},
   onRefreshUserProfile: () => {},
+  onRefreshFirebaseProfile: () => {},
+  onSendEmailVerification: () => {},
   getAuthorizationHeader: () => Promise.reject(new Error('Unimplemented')),
 };
 

--- a/newIDE/app/src/Profile/AuthenticatedUserProvider.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserProvider.js
@@ -70,7 +70,7 @@ export default class AuthenticatedUserProvider extends React.Component<
   }
 
   _resetAuthenticatedUser() {
-    this.setState({
+    this.setState(({ authenticatedUser }) => ({
       authenticatedUser: {
         ...initialAuthenticatedUser,
         onLogout: this._doLogout,
@@ -83,40 +83,10 @@ export default class AuthenticatedUserProvider extends React.Component<
         getAuthorizationHeader: () =>
           this.props.authentication.getAuthorizationHeader(),
       },
-    });
+    }));
   }
 
-  _reloadFirebaseProfile = () => {
-    const { authentication } = this.props;
-
-    authentication.getFirebaseUser((err, firebaseUser: ?FirebaseUser) => {
-      if (err && err.unauthenticated) {
-        return this.setState({
-          authenticatedUser: {
-            ...this.state.authenticatedUser,
-            authenticated: false,
-            profile: null,
-            usages: null,
-            limits: null,
-            subscription: null,
-          },
-        });
-      } else if (err || !firebaseUser) {
-        console.log('Unable to fetch user profile', err);
-        return;
-      }
-
-      this.setState({
-        authenticatedUser: {
-          ...this.state.authenticatedUser,
-          authenticated: true,
-          firebaseUser,
-        },
-      });
-    });
-  };
-
-  _fetchUserProfile = () => {
+  _reloadFirebaseProfile = (callback?: FirebaseUser => void) => {
     const { authentication } = this.props;
 
     authentication.getFirebaseUser((err, firebaseUser: ?FirebaseUser) => {
@@ -132,7 +102,7 @@ export default class AuthenticatedUserProvider extends React.Component<
           },
         }));
       } else if (err || !firebaseUser) {
-        console.log('Unable to fetch user profile', err);
+        console.error('Unable to fetch user profile', err);
         return;
       }
 
@@ -145,52 +115,59 @@ export default class AuthenticatedUserProvider extends React.Component<
           },
         }),
         () => {
-          if (!firebaseUser) return;
-
-          authentication
-            .getUserProfile(authentication.getAuthorizationHeader)
-            .then(user =>
-              this.setState(({ authenticatedUser }) => ({
-                authenticatedUser: {
-                  ...authenticatedUser,
-                  profile: user,
-                },
-              }))
-            );
-          getUserUsages(
-            authentication.getAuthorizationHeader,
-            firebaseUser.uid
-          ).then(usages =>
-            this.setState(({ authenticatedUser }) => ({
-              authenticatedUser: {
-                ...authenticatedUser,
-                usages,
-              },
-            }))
-          );
-          getUserSubscription(
-            authentication.getAuthorizationHeader,
-            firebaseUser.uid
-          ).then(subscription =>
-            this.setState(({ authenticatedUser }) => ({
-              authenticatedUser: {
-                ...authenticatedUser,
-                subscription,
-              },
-            }))
-          );
-          getUserLimits(
-            authentication.getAuthorizationHeader,
-            firebaseUser.uid
-          ).then(limits =>
-            this.setState(({ authenticatedUser }) => ({
-              authenticatedUser: {
-                ...authenticatedUser,
-                limits,
-              },
-            }))
-          );
+          if (!firebaseUser || !callback) return;
+          callback(firebaseUser);
         }
+      );
+    });
+  };
+
+  _fetchUserProfile = () => {
+    const { authentication } = this.props;
+
+    this._reloadFirebaseProfile((firebaseUser: FirebaseUser) => {
+      authentication
+        .getUserProfile(authentication.getAuthorizationHeader)
+        .then(user =>
+          this.setState(({ authenticatedUser }) => ({
+            authenticatedUser: {
+              ...authenticatedUser,
+              profile: user,
+            },
+          }))
+        );
+      getUserUsages(
+        authentication.getAuthorizationHeader,
+        firebaseUser.uid
+      ).then(usages =>
+        this.setState(({ authenticatedUser }) => ({
+          authenticatedUser: {
+            ...authenticatedUser,
+            usages,
+          },
+        }))
+      );
+      getUserSubscription(
+        authentication.getAuthorizationHeader,
+        firebaseUser.uid
+      ).then(subscription =>
+        this.setState(({ authenticatedUser }) => ({
+          authenticatedUser: {
+            ...authenticatedUser,
+            subscription,
+          },
+        }))
+      );
+      getUserLimits(
+        authentication.getAuthorizationHeader,
+        firebaseUser.uid
+      ).then(limits =>
+        this.setState(({ authenticatedUser }) => ({
+          authenticatedUser: {
+            ...authenticatedUser,
+            limits,
+          },
+        }))
       );
     });
   };

--- a/newIDE/app/src/Profile/EmailVerificationPendingDialog.js
+++ b/newIDE/app/src/Profile/EmailVerificationPendingDialog.js
@@ -50,13 +50,12 @@ export default function EmailVerificationPendingDialog({
           />
         ),
       ]}
-      title={undefined}
       maxWidth="sm"
       cannotBeDismissed={true}
       open
       noMargin
     >
-      {!isVerified && (
+      {!isVerified ? (
         <Column>
           <Line justifyContent="center" alignItems="center">
             <CircularProgress size={20} />
@@ -73,15 +72,14 @@ export default function EmailVerificationPendingDialog({
             </BackgroundText>
           </Line>
         </Column>
-      )}
-      {isVerified && (
+      ) : (
         <Column>
-          <Line>
+          <Line justifyContent="center" alignItems="center">
+            <VerifiedUser />
+            <Spacer />
             <Text>
               <Trans>Your email is now verified!</Trans>
             </Text>
-            <Spacer />
-            <VerifiedUser />
           </Line>
         </Column>
       )}

--- a/newIDE/app/src/Profile/EmailVerificationPendingDialog.js
+++ b/newIDE/app/src/Profile/EmailVerificationPendingDialog.js
@@ -18,23 +18,23 @@ type Props = {|
   authenticatedUser: AuthenticatedUser,
 |};
 
-export default function SubscriptionPendingDialog({
+export default function EmailVerificationPendingDialog({
   onClose,
   authenticatedUser,
 }: Props) {
-  const hasPlan =
+  const isVerified =
     !!authenticatedUser &&
-    !!authenticatedUser.subscription &&
-    !!authenticatedUser.subscription.planId;
+    !!authenticatedUser.firebaseUser &&
+    !!authenticatedUser.firebaseUser.emailVerified;
   useInterval(
-    () => authenticatedUser.onRefreshUserProfile(),
-    hasPlan ? null : 3900
+    () => authenticatedUser.onRefreshFirebaseProfile(),
+    isVerified ? null : 3900
   );
 
   return (
     <Dialog
       actions={[
-        hasPlan ? (
+        isVerified ? (
           <RaisedButton
             label={<Trans>Done!</Trans>}
             key="close"
@@ -56,67 +56,32 @@ export default function SubscriptionPendingDialog({
       open
       noMargin
     >
-      {!hasPlan && (
+      {!isVerified && (
         <Column>
-          <Line>
-            <Text>
-              <Trans>
-                Thanks for getting a subscription and supporting GDevelop!
-              </Trans>{' '}
-              {'❤️'}
-              <b>
-                <Trans>
-                  Your browser will now open to enter your payment details
-                  (handled securely by Stripe.com).
-                </Trans>
-              </b>
-            </Text>
-          </Line>
           <Line justifyContent="center" alignItems="center">
             <CircularProgress size={20} />
             <Spacer />
-            <Text>Waiting for the subscription confirmation...</Text>
+            <Text>Waiting for the email verification...</Text>
           </Line>
           <Spacer />
           <Line justifyContent="center">
             <BackgroundText>
               <Trans>
-                Once you're done, come back to GDevelop and your account will be
-                upgraded automatically, unlocking the extra exports and online
-                services.
+                Check your inbox and click the link to verify your email address
+                - and come back here when it's done.
               </Trans>
             </BackgroundText>
           </Line>
         </Column>
       )}
-      {hasPlan && (
+      {isVerified && (
         <Column>
           <Line>
             <Text>
-              <Trans>
-                Thanks for getting a subscription and supporting GDevelop!
-              </Trans>{' '}
-              {'❤️'}
+              <Trans>Your email is now verified!</Trans>
             </Text>
-          </Line>
-          <Line justifyContent="center" alignItems="center">
-            <VerifiedUser />
             <Spacer />
-            <Text>
-              <b>
-                <Trans>Your new plan is now activated</Trans>
-              </b>
-            </Text>
-          </Line>
-          <Spacer />
-          <Line justifyContent="center">
-            <BackgroundText>
-              <Trans>
-                Your account is upgraded, with the extra exports and online
-                services. If you wish to change later, come back to your profile
-                and choose another plan.
-              </Trans>
-            </BackgroundText>
+            <VerifiedUser />
           </Line>
         </Column>
       )}

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -4,67 +4,121 @@ import { Trans, t } from '@lingui/macro';
 import * as React from 'react';
 import Avatar from '@material-ui/core/Avatar';
 import { Column, Line, Spacer } from '../UI/Grid';
-import { type Profile } from '../Utils/GDevelopServices/Authentication';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import { getGravatarUrl } from '../UI/GravatarUrl';
 import Text from '../UI/Text';
 import RaisedButton from '../UI/RaisedButton';
 import TextField from '../UI/TextField';
 import { I18n } from '@lingui/react';
+import FlatButton from '../UI/FlatButton';
+import { ColumnStackLayout } from '../UI/Layout';
+import AlertMessage from '../UI/AlertMessage';
+import { type AuthenticatedUser } from './AuthenticatedUserContext';
 
 type Props = {|
-  profile: ?Profile,
   onEditProfile: Function,
+  authenticatedUser: AuthenticatedUser,
 |};
 
-export default ({ profile, onEditProfile }: Props) => {
-  return profile ? (
+export default ({ onEditProfile, authenticatedUser }: Props) => {
+  const profile = authenticatedUser.profile;
+  const firebaseUser = authenticatedUser.firebaseUser;
+  const [emailSent, setEmailSent] = React.useState<boolean>(false);
+  const sendEmail = React.useCallback(
+    () => {
+      authenticatedUser.onSendEmailVerification();
+      setEmailSent(true);
+      setTimeout(() => setEmailSent(false), 3000);
+    },
+    [authenticatedUser]
+  );
+
+  const loadUserProfile = React.useCallback(
+    () => authenticatedUser.onRefreshUserProfile(),
+    [authenticatedUser.onRefreshUserProfile] // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  // Reload user every time the Profile is opened
+  React.useEffect(
+    () => {
+      loadUserProfile();
+    },
+    [loadUserProfile]
+  );
+
+  return firebaseUser && profile ? (
     <I18n>
       {({ i18n }) => (
-        <Column>
-          <Line alignItems="center">
-            <Avatar src={getGravatarUrl(profile.email || '', { size: 40 })} />
-            <Spacer />
-            <Text
-              size="title"
-              style={{
-                opacity: profile.username ? 1.0 : 0.5,
-              }}
+        <ColumnStackLayout noMargin>
+          {firebaseUser && !firebaseUser.emailVerified && (
+            <AlertMessage
+              kind="info"
+              renderRightButton={() => (
+                <FlatButton
+                  label={
+                    emailSent ? (
+                      <Trans>Email sent!</Trans>
+                    ) : (
+                      <Trans>Send it again</Trans>
+                    )
+                  }
+                  onClick={() => sendEmail()}
+                  disabled={emailSent}
+                  primary
+                />
+              )}
             >
-              {profile.username ||
-                i18n._(t`Edit your profile to pick a username!`)}
-            </Text>
-          </Line>
-          <Line>
-            <TextField
-              value={profile.email}
-              readOnly
-              fullWidth
-              floatingLabelText={<Trans>Email</Trans>}
-              floatingLabelFixed={true}
-            />
-          </Line>
-          <Line>
-            <TextField
-              value={profile.description || ''}
-              readOnly
-              fullWidth
-              multiline
-              floatingLabelText={<Trans>Bio</Trans>}
-              floatingLabelFixed={true}
-              hintText={t`No bio defined. Edit your profile to tell us what you are using GDevelop for!`}
-              rows={3}
-              rowsMax={5}
-            />
-          </Line>
-          <Line justifyContent="flex-end">
-            <RaisedButton
-              label={<Trans>Edit my profile</Trans>}
-              primary
-              onClick={onEditProfile}
-            />
-          </Line>
-        </Column>
+              <Trans>
+                It looks like your email is not verified. Click on the link
+                received by email to verify your account. Didn't receive it?
+              </Trans>
+            </AlertMessage>
+          )}
+          <Column>
+            <Line alignItems="center">
+              <Avatar src={getGravatarUrl(profile.email || '', { size: 40 })} />
+              <Spacer />
+              <Text
+                size="title"
+                style={{
+                  opacity: profile.username ? 1.0 : 0.5,
+                }}
+              >
+                {profile.username ||
+                  i18n._(t`Edit your profile to pick a username!`)}
+              </Text>
+            </Line>
+            <Line>
+              <TextField
+                value={profile.email}
+                readOnly
+                fullWidth
+                floatingLabelText={<Trans>Email</Trans>}
+                floatingLabelFixed={true}
+              />
+            </Line>
+            <Line>
+              <TextField
+                value={profile.description || ''}
+                readOnly
+                fullWidth
+                multiline
+                floatingLabelText={<Trans>Bio</Trans>}
+                floatingLabelFixed={true}
+                hintText={t`No bio defined. Edit your profile to tell us what you are using GDevelop for!`}
+                rows={3}
+                rowsMax={5}
+              />
+            </Line>
+            <Line justifyContent="flex-end">
+              <RaisedButton
+                label={<Trans>Edit my profile</Trans>}
+                primary
+                onClick={onEditProfile}
+              />
+            </Line>
+          </Column>
+        </ColumnStackLayout>
       )}
     </I18n>
   ) : (

--- a/newIDE/app/src/Profile/ProfileDialog.js
+++ b/newIDE/app/src/Profile/ProfileDialog.js
@@ -91,7 +91,7 @@ export default class ProfileDialog extends Component<Props, State> {
               (authenticatedUser.authenticated && authenticatedUser.profile ? (
                 <Column noMargin>
                   <ProfileDetails
-                    profile={authenticatedUser.profile}
+                    authenticatedUser={authenticatedUser}
                     onEditProfile={authenticatedUser.onEdit}
                   />
                   <SubscriptionDetails

--- a/newIDE/app/src/Profile/SubscriptionPendingDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionPendingDialog.js
@@ -50,13 +50,12 @@ export default function SubscriptionPendingDialog({
           />
         ),
       ]}
-      title={undefined}
       maxWidth="sm"
       cannotBeDismissed={true}
       open
       noMargin
     >
-      {!hasPlan && (
+      {!hasPlan ? (
         <Column>
           <Line>
             <Text>
@@ -88,8 +87,7 @@ export default function SubscriptionPendingDialog({
             </BackgroundText>
           </Line>
         </Column>
-      )}
-      {hasPlan && (
+      ) : (
         <Column>
           <Line>
             <Text>

--- a/newIDE/app/src/Utils/GDevelopServices/Authentication.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Authentication.js
@@ -9,9 +9,11 @@ import {
   signInWithEmailAndPassword,
   sendPasswordResetEmail,
   signOut,
+  sendEmailVerification,
 } from 'firebase/auth';
 import { GDevelopFirebaseConfig, GDevelopUserApi } from './ApiConfigs';
 import axios from 'axios';
+import { showErrorBox } from '../../UI/Messages/MessageBox';
 
 export type Profile = {
   id: string,
@@ -81,6 +83,7 @@ export default class Authentication {
     return createUserWithEmailAndPassword(this.auth, form.email, form.password)
       .then(userCredentials => {
         this.firebaseUser = userCredentials.user;
+        sendEmailVerification(userCredentials.user);
       })
       .catch(error => {
         console.error('Error while creating firebase account:', error);
@@ -141,8 +144,25 @@ export default class Authentication {
 
   getFirebaseUser = (cb: (any, ?FirebaseUser) => void) => {
     if (!this.isAuthenticated()) return cb({ unauthenticated: true });
+    this.auth.currentUser.reload().then(() => cb(null, this.firebaseUser));
+  };
 
-    cb(null, this.firebaseUser);
+  sendFirebaseEmailVerification = (cb: () => void): Promise<void> => {
+    return this.auth.currentUser.reload().then(() => {
+      if (this.firebaseUser && !this.firebaseUser.emailVerified) {
+        sendEmailVerification(this.auth.currentUser)
+          .then(() => {
+            cb();
+          })
+          .catch((error: Error) => {
+            showErrorBox({
+              message: `Unable to send the email, please try again later.`,
+              rawError: error,
+              errorId: 'email-verification-send-error',
+            });
+          });
+      }
+    });
   };
 
   getUserProfile = (getAuthorizationHeader: () => Promise<string>) => {

--- a/newIDE/app/src/Utils/GDevelopServices/Authentication.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Authentication.js
@@ -144,24 +144,26 @@ export default class Authentication {
 
   getFirebaseUser = (cb: (any, ?FirebaseUser) => void) => {
     if (!this.isAuthenticated()) return cb({ unauthenticated: true });
+    // In order to fetch the latest firebaseUser properties (like emailVerified)
+    // we have to call the reload method.
     this.auth.currentUser.reload().then(() => cb(null, this.firebaseUser));
   };
 
   sendFirebaseEmailVerification = (cb: () => void): Promise<void> => {
     return this.auth.currentUser.reload().then(() => {
-      if (this.firebaseUser && !this.firebaseUser.emailVerified) {
-        sendEmailVerification(this.auth.currentUser)
-          .then(() => {
-            cb();
-          })
-          .catch((error: Error) => {
-            showErrorBox({
-              message: `Unable to send the email, please try again later.`,
-              rawError: error,
-              errorId: 'email-verification-send-error',
-            });
+      if (!this.firebaseUser || this.firebaseUser.emailVerified) return;
+      sendEmailVerification(this.auth.currentUser).then(
+        () => {
+          cb();
+        },
+        (error: Error) => {
+          showErrorBox({
+            message: 'An email has been sent recently, please try again later.',
+            rawError: error,
+            errorId: 'email-verification-send-error',
           });
-      }
+        }
+      );
     });
   };
 

--- a/newIDE/app/src/Utils/UseInterval.js
+++ b/newIDE/app/src/Utils/UseInterval.js
@@ -1,0 +1,27 @@
+// @flow
+import { useEffect, useRef } from 'react';
+
+/**
+ * Creates an interval effect for a callback, with a specified delay.
+ */
+export const useInterval = (callback: Function, delay: number | null) => {
+  const savedCallback = useRef();
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  });
+
+  useEffect(
+    () => {
+      function tick() {
+        if (savedCallback.current) savedCallback.current();
+      }
+
+      if (delay !== null) {
+        let id = setInterval(tick, delay);
+        return () => clearInterval(id);
+      }
+    },
+    [delay]
+  );
+};

--- a/newIDE/app/src/Utils/UseInterval.js
+++ b/newIDE/app/src/Utils/UseInterval.js
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 /**
  * Creates an interval effect for a callback, with a specified delay.
  */
-export const useInterval = (callback: Function, delay: number | null) => {
+export const useInterval = (callback: () => void, delay: number | null) => {
   const savedCallback = useRef();
 
   useEffect(() => {
@@ -18,7 +18,7 @@ export const useInterval = (callback: Function, delay: number | null) => {
       }
 
       if (delay !== null) {
-        let id = setInterval(tick, delay);
+        const id = setInterval(tick, delay);
         return () => clearInterval(id);
       }
     },

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -97,6 +97,12 @@ export const fakeIndieAuthenticatedUser: AuthenticatedUser = {
   onRefreshUserProfile: () => {
     console.info('This should refresh the user profile');
   },
+  onRefreshFirebaseProfile: () => {
+    console.info('This should refresh the firebase profile');
+  },
+  onSendEmailVerification: () => {
+    console.info('This should send the email verification');
+  },
   getAuthorizationHeader: () => Promise.resolve('fake-authorization-header'),
 };
 
@@ -113,6 +119,12 @@ export const fakeNoSubscriptionAuthenticatedUser: AuthenticatedUser = {
   onCreateAccount: () => {},
   onRefreshUserProfile: () => {
     console.info('This should refresh the user profile');
+  },
+  onRefreshFirebaseProfile: () => {
+    console.info('This should refresh the firebase profile');
+  },
+  onSendEmailVerification: () => {
+    console.info('This should send the email verification');
   },
   getAuthorizationHeader: () => Promise.resolve('fake-authorization-header'),
 };
@@ -131,6 +143,12 @@ export const fakeAuthenticatedButLoadingAuthenticatedUser: AuthenticatedUser = {
   onRefreshUserProfile: () => {
     console.info('This should refresh the user profile');
   },
+  onRefreshFirebaseProfile: () => {
+    console.info('This should refresh the firebase profile');
+  },
+  onSendEmailVerification: () => {
+    console.info('This should send the email verification');
+  },
   getAuthorizationHeader: () => Promise.resolve('fake-authorization-header'),
 };
 
@@ -147,6 +165,12 @@ export const fakeNotAuthenticatedAuthenticatedUser: AuthenticatedUser = {
   onCreateAccount: () => {},
   onRefreshUserProfile: () => {
     console.info('This should refresh the user profile');
+  },
+  onRefreshFirebaseProfile: () => {
+    console.info('This should refresh the firebase profile');
+  },
+  onSendEmailVerification: () => {
+    console.info('This should send the email verification');
   },
   getAuthorizationHeader: () => Promise.resolve('fake-authorization-header'),
 };

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -22,6 +22,13 @@ export const indieFirebaseUser: FirebaseUser = {
   uid: 'indie-user',
   providerId: 'fake-provider.com',
   email: 'indie-user@example.com',
+  emailVerified: false,
+};
+
+export const indieVerifiedFirebaseUser: FirebaseUser = {
+  uid: 'indie-user',
+  providerId: 'fake-provider.com',
+  email: 'indie-user@example.com',
   emailVerified: true,
 };
 
@@ -110,6 +117,29 @@ export const fakeNoSubscriptionAuthenticatedUser: AuthenticatedUser = {
   authenticated: true,
   profile: indieUserProfile,
   firebaseUser: indieFirebaseUser,
+  subscription: noSubscription,
+  usages: usagesForIndieUser,
+  limits: limitsForIndieUser,
+  onLogout: () => {},
+  onLogin: () => {},
+  onEdit: () => {},
+  onCreateAccount: () => {},
+  onRefreshUserProfile: () => {
+    console.info('This should refresh the user profile');
+  },
+  onRefreshFirebaseProfile: () => {
+    console.info('This should refresh the firebase profile');
+  },
+  onSendEmailVerification: () => {
+    console.info('This should send the email verification');
+  },
+  getAuthorizationHeader: () => Promise.resolve('fake-authorization-header'),
+};
+
+export const fakeAuthenticatedAndEmailVerifiedUser: AuthenticatedUser = {
+  authenticated: true,
+  profile: indieUserProfile,
+  firebaseUser: indieVerifiedFirebaseUser,
   subscription: noSubscription,
   usages: usagesForIndieUser,
   limits: limitsForIndieUser,

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -91,6 +91,7 @@ import {
   fakeIndieAuthenticatedUser,
   fakeNotAuthenticatedAuthenticatedUser,
   fakeAuthenticatedButLoadingAuthenticatedUser,
+  fakeAuthenticatedAndEmailVerifiedUser,
   release,
   releaseWithBreakingChange,
   releaseWithoutDescription,
@@ -167,6 +168,7 @@ import NewInstructionEditorMenu from '../EventsSheet/InstructionEditor/NewInstru
 import { PopoverButton } from './PopoverButton';
 import EffectsList from '../EffectsList';
 import SubscriptionPendingDialog from '../Profile/SubscriptionPendingDialog';
+import EmailVerificationPendingDialog from '../Profile/EmailVerificationPendingDialog';
 import Dialog from '../UI/Dialog';
 import MiniToolbar, { MiniToolbarText } from '../UI/MiniToolbar';
 import NewObjectDialog from '../AssetStore/NewObjectDialog';
@@ -3951,6 +3953,22 @@ storiesOf('SubscriptionPendingDialog', module)
   .add('authenticated user with subscription', () => (
     <SubscriptionPendingDialog
       authenticatedUser={fakeIndieAuthenticatedUser}
+      onClose={action('on close')}
+    />
+  ));
+
+storiesOf('EmailVerificationPendingDialog', module)
+  .addDecorator(paperDecorator)
+  .addDecorator(muiDecorator)
+  .add('non verified user - loading', () => (
+    <EmailVerificationPendingDialog
+      authenticatedUser={fakeIndieAuthenticatedUser}
+      onClose={action('on close')}
+    />
+  ))
+  .add('verified user', () => (
+    <EmailVerificationPendingDialog
+      authenticatedUser={fakeAuthenticatedAndEmailVerifiedUser}
       onClose={action('on close')}
     />
   ));

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -3876,12 +3876,15 @@ storiesOf('ProfileDetails', module)
   .addDecorator(muiDecorator)
   .add('profile', () => (
     <ProfileDetails
-      profile={indieUserProfile}
+      authenticatedUser={fakeIndieAuthenticatedUser}
       onEditProfile={action('edit profile')}
     />
   ))
   .add('loading', () => (
-    <ProfileDetails profile={null} onEditProfile={action('edit profile')} />
+    <ProfileDetails
+      authenticatedUser={fakeAuthenticatedButLoadingAuthenticatedUser}
+      onEditProfile={action('edit profile')}
+    />
   ));
 
 storiesOf('SubscriptionDetails', module)


### PR DESCRIPTION
Since the creation of user profiles, email didn't need to be verified.
This check is not to block any feature, but rather to ensure the user has selected their correct email, and maybe in the future we can push information to their email if they're willing. (for example, stats on their games)

Tested:

- Verifying email after signup then opening profile -> button not visible
- Verifying email after signup with profile open, then click on "Send it again" -> button disappears without sending email
- Clicking too many times on "send it again" (Firebase "too-many-requests" error) -> message shown to user to wait
- Verifying email via the popup and waiting for the popup to reload the user -> success message
- Verifying email via the popup but closing the popup before verification is done -> button disappears either by reloading the profile or clicking again on the button

![Screenshot 2021-10-04 at 18 07 03](https://user-images.githubusercontent.com/4895034/135886011-6e4bdc27-a46e-4531-9c5a-cd711fa314d9.png)
![Screenshot 2021-10-04 at 18 09 46](https://user-images.githubusercontent.com/4895034/135886178-3db911c5-7b02-4ad6-807e-8df267fd3db3.png)
![Screenshot 2021-10-04 at 18 09 57](https://user-images.githubusercontent.com/4895034/135886184-8a29597f-9407-469b-8568-a820f288c848.png)
![Screenshot 2021-10-05 at 14 36 06](https://user-images.githubusercontent.com/4895034/136025839-fa3d66e0-b855-417b-9eb0-ae4a417e3e10.png)
![Screenshot 2021-10-05 at 10 05 41](https://user-images.githubusercontent.com/4895034/135986383-e3223dbf-369e-4b89-b933-9800101a097d.png)

