### PR TITLE
Prevent calling a user update on every authState change.

### DIFF
--- a/newIDE/app/src/Profile/AuthenticatedUserProvider.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserProvider.js
@@ -65,7 +65,7 @@ export default class AuthenticatedUserProvider extends React.Component<
 
   componentDidMount() {
     this._resetAuthenticatedUser();
-    this.props.authentication.setOnUserChangeCallback(this._fetchUserProfile);
+    this.props.authentication.setOnUserLogoutCallback(this._fetchUserProfile);
     this._fetchUserProfile();
   }
 

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -40,8 +40,8 @@ export default ({ onEditProfile, authenticatedUser }: Props) => {
 
   const loadUserProfile = React.useCallback(
     () => authenticatedUser.onRefreshUserProfile(),
-    // We don't want to fetch again when authenticatedUser changes
-    // Just the first time this page opens.
+    // We don't want to fetch again when authenticatedUser changes,
+    // just the first time this page opens.
     [authenticatedUser.onRefreshUserProfile] // eslint-disable-line react-hooks/exhaustive-deps
   );
 

--- a/newIDE/app/src/Utils/GDevelopServices/Authentication.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Authentication.js
@@ -59,24 +59,26 @@ export default class Authentication {
   firebaseUser: ?FirebaseUser = null;
   user: ?Profile = null;
   auth: Auth;
-  _onUserChangeCallback: ?() => void = null;
+  _onUserLogoutCallback: ?() => void = null;
 
   constructor() {
     const app = initializeApp(GDevelopFirebaseConfig);
     this.auth = getAuth(app);
     onAuthStateChanged(this.auth, user => {
       if (user) {
+        // User has been updated. No need to fetch more info,
+        // this is handled directly by the corresponding actions (edit, signup, login...)
         this.firebaseUser = user;
       } else {
+        // User has logged out.
         this.firebaseUser = null;
+        if (this._onUserLogoutCallback) this._onUserLogoutCallback();
       }
-
-      if (this._onUserChangeCallback) this._onUserChangeCallback();
     });
   }
 
-  setOnUserChangeCallback = (cb: () => void) => {
-    this._onUserChangeCallback = cb;
+  setOnUserLogoutCallback = (cb: () => void) => {
+    this._onUserLogoutCallback = cb;
   };
 
   createFirebaseAccount = (form: RegisterForm): Promise<void> => {


### PR DESCRIPTION
This fixes a race condition where the fetchUser would be called too early, causing a conflict with the signup function while creating the user in the database.

Do not show in changelog