### PR TITLE
Fix opening up the parameters dialog for object or behaviors expressions having no parameters

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditor.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditor.js
@@ -30,19 +30,18 @@ type Props = {|
 |};
 type State = {||};
 
+export const hasNonCodeOnlyParameters = (
+  expressionMetadata: gdExpressionMetadata
+) =>
+  mapFor(0, expressionMetadata.getParametersCount(), i => {
+    const parameterMetadata = expressionMetadata.getParameter(i);
+    return !parameterMetadata.isCodeOnly();
+  }).filter(isVisible => isVisible).length !== 0;
+
 export default class ExpressionParametersEditor extends React.Component<
   Props,
   State
 > {
-  static getNonCodeOnlyParametersCount(
-    expressionMetadata: gdExpressionMetadata
-  ) {
-    return mapFor(0, expressionMetadata.getParametersCount(), i => {
-      const parameterMetadata = expressionMetadata.getParameter(i);
-      return !parameterMetadata.isCodeOnly();
-    }).filter(isVisible => isVisible).length;
-  }
-
   render() {
     const {
       expressionMetadata,
@@ -97,9 +96,7 @@ export default class ExpressionParametersEditor extends React.Component<
             />
           );
         })}
-        {ExpressionParametersEditor.getNonCodeOnlyParametersCount(
-          expressionMetadata
-        ) === 0 && (
+        {!hasNonCodeOnlyParameters(expressionMetadata) && (
           <EmptyMessage>
             <Trans>There is nothing to configure.</Trans>
           </EmptyMessage>

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -11,6 +11,7 @@ import ExpressionSelector from '../../InstructionEditor/InstructionOrExpressionS
 import ExpressionParametersEditorDialog, {
   type ParameterValues,
 } from './ExpressionParametersEditorDialog';
+import { hasNonCodeOnlyParameters } from './ExpressionParametersEditor';
 import { formatExpressionCall } from './FormatExpressionCall';
 import { type EnumeratedExpressionMetadata } from '../../../InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js';
 import { type ParameterFieldProps } from '../ParameterFieldCommons';
@@ -227,8 +228,7 @@ export default class ExpressionField extends React.Component<Props, State> {
     expressionInfo: EnumeratedExpressionMetadata
   ): boolean => {
     // If there is no parameter to fill for the selected expression, no need to open the dialog.
-    // Non visible parameters (like code only ones) should have already been filtered out.
-    return expressionInfo.parameters.length > 0;
+    return hasNonCodeOnlyParameters(expressionInfo.metadata);
   };
 
   _handleExpressionChosen = (expressionInfo: EnumeratedExpressionMetadata) => {

--- a/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js
@@ -27,6 +27,7 @@ export type EnumeratedExpressionMetadata = {|
   scope: InstructionOrExpressionScope,
   isPrivate: boolean,
   name: string,
+  /** Represents only the visible parameters in the parentheses of the expression. */
   parameters: Array<gdParameterMetadata>,
 |};
 


### PR DESCRIPTION
Fixes #3145 