### PR TITLE
Prevent debugger server being launched twice, causing a crash

### DIFF
--- a/newIDE/app/src/Debugger/index.js
+++ b/newIDE/app/src/Debugger/index.js
@@ -85,13 +85,13 @@ export default class Debugger extends React.Component<Props, State> {
 
   componentDidMount() {
     if (this.props.isActive) {
-      this._startServer();
+      this._registerServerCallbacks();
     }
   }
 
   componentWillReceiveProps(nextProps: Props) {
     if (nextProps.isActive && !this.props.isActive) {
-      this._startServer();
+      this._registerServerCallbacks();
     }
   }
 
@@ -101,7 +101,7 @@ export default class Debugger extends React.Component<Props, State> {
     }
   }
 
-  _startServer = () => {
+  _registerServerCallbacks = () => {
     const { previewDebuggerServer } = this.props;
     const { unregisterDebuggerServerCallbacks } = this.state;
     if (
@@ -157,7 +157,6 @@ export default class Debugger extends React.Component<Props, State> {
         this._handleMessage(id, parsedMessage);
       },
     });
-    previewDebuggerServer.startServer();
     this.setState({
       unregisterDebuggerServerCallbacks: unregisterCallbacks,
     });


### PR DESCRIPTION
Do not show in changelog

in development environment, the debugger was not working as it was crashing after 5 sec.
In production environment the error was not being shown to the user, but was happening.

The debugger is already launched in the `LocalPreviewLauncher`

![image](https://user-images.githubusercontent.com/4895034/137331244-db527686-8a5a-4d7b-bacf-bdf325c799b8.png)
