### PR TITLE
Prevent sending session hits if the session is not correctly created

### DIFF
--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -674,6 +674,14 @@ namespace gdjs {
           },
         }),
       })
+        .then((response) => {
+          // Ensure the session is correctly created to avoid sending hits that will fail.
+          if (!response.ok) {
+            console.error('Error while creating the session', response);
+            throw new Error('Error while creating the session');
+          }
+          return response;
+        })
         .then((response) => response.text())
         .then((returnedSessionId) => {
           sessionId = returnedSessionId;


### PR DESCRIPTION
Do not show in changelog.

The response isn't being checked, meaning that whatever the result is (404, 400, 401...) the text will be considered as the sessionId, resulting in trying to send a hit on a non-existing sessionId.