### PR TITLE
prevented a bug of endless include loop that could have broken the compiler

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -709,6 +709,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
                 project={project}
                 scope={{
                   layout: null,
+                  externalEvents: null,
                   eventsFunctionsExtension,
                   eventsBasedBehavior: selectedEventsBasedBehavior,
                   eventsFunction: selectedEventsFunction,

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
@@ -9,8 +9,11 @@ import SemiControlledAutoComplete, {
   type DataSource,
 } from '../../../../UI/SemiControlledAutoComplete';
 
-const getList = (currentSceneName: string, project: ?gdProject): DataSource => {
-  if (!project) {
+const getList = (
+  currentSceneName: ?string,
+  project: ?gdProject
+): DataSource => {
+  if (!project || !currentSceneName) {
     return [];
   }
 
@@ -36,7 +39,7 @@ type Props = {|
   isInline?: boolean,
   onRequestClose?: () => void,
   onApply?: () => void,
-  sceneName: string,
+  sceneName?: string,
 |};
 
 export default class ExternalEventsAutoComplete extends React.Component<

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
@@ -27,7 +27,7 @@ const getList = (
     }));
 
   const layouts = enumerateLayouts(project)
-    .filter(layout => layout.getName() !== currentSceneName || externalEvents)
+    .filter(layout => layout.getName() !== currentSceneName)
     .map(layout => ({
       text: layout.getName(),
       value: layout.getName(),

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
@@ -8,7 +8,7 @@ import SemiControlledAutoComplete, {
   type DataSource,
 } from '../../../../UI/SemiControlledAutoComplete';
 
-const getList = (project: ?gdProject): DataSource => {
+const getList = (currentSceneName: string, project: ?gdProject): DataSource => {
   if (!project) {
     return [];
   }
@@ -19,10 +19,12 @@ const getList = (project: ?gdProject): DataSource => {
       value: externalEvents.getName(),
     })
   );
-  const layouts = enumerateLayouts(project).map(layout => ({
-    text: layout.getName(),
-    value: layout.getName(),
-  }));
+  const layouts = enumerateLayouts(project)
+    .filter(layout => layout.getName() !== currentSceneName)
+    .map(layout => ({
+      text: layout.getName(),
+      value: layout.getName(),
+    }));
   return [...externalEvents, { type: 'separator' }, ...layouts];
 };
 
@@ -53,6 +55,7 @@ export default class ExternalEventsAutoComplete extends React.Component<
       onApply,
       isInline,
       project,
+      sceneName,
     } = this.props;
 
     return (
@@ -64,7 +67,7 @@ export default class ExternalEventsAutoComplete extends React.Component<
         onChange={onChange}
         onRequestClose={onRequestClose}
         onApply={onApply}
-        dataSource={getList(project)}
+        dataSource={getList(sceneName, project)}
         openOnFocus={!isInline}
         ref={field => (this._field = field)}
       />

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
@@ -1,5 +1,4 @@
 // @flow
-import { string } from 'prop-types';
 import * as React from 'react';
 import {
   enumerateLayouts,
@@ -11,24 +10,29 @@ import SemiControlledAutoComplete, {
 
 const getList = (
   currentSceneName: ?string,
+  currentExternalEventName: ?string,
   project: ?gdProject
 ): DataSource => {
   if (!project || !currentSceneName) {
     return [];
   }
 
-  const externalEvents = enumerateExternalEvents(project).map(
-    externalEvents => ({
+  const externalEvents = enumerateExternalEvents(project)
+    .filter(
+      externalEvents => externalEvents.getName() !== currentExternalEventName
+    )
+    .map(externalEvents => ({
       text: externalEvents.getName(),
       value: externalEvents.getName(),
-    })
-  );
+    }));
+
   const layouts = enumerateLayouts(project)
-    .filter(layout => layout.getName() !== currentSceneName)
+    .filter(layout => layout.getName() !== currentSceneName || externalEvents)
     .map(layout => ({
       text: layout.getName(),
       value: layout.getName(),
     }));
+
   return [...externalEvents, { type: 'separator' }, ...layouts];
 };
 
@@ -40,6 +44,7 @@ type Props = {|
   onRequestClose?: () => void,
   onApply?: () => void,
   sceneName?: string,
+  externalEventsName?: string,
 |};
 
 export default class ExternalEventsAutoComplete extends React.Component<
@@ -61,6 +66,7 @@ export default class ExternalEventsAutoComplete extends React.Component<
       isInline,
       project,
       sceneName,
+      externalEventsName,
     } = this.props;
 
     return (
@@ -72,7 +78,7 @@ export default class ExternalEventsAutoComplete extends React.Component<
         onChange={onChange}
         onRequestClose={onRequestClose}
         onApply={onApply}
-        dataSource={getList(sceneName, project)}
+        dataSource={getList(sceneName, externalEventsName, project)}
         openOnFocus={!isInline}
         ref={field => (this._field = field)}
       />

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete.js
@@ -1,4 +1,5 @@
 // @flow
+import { string } from 'prop-types';
 import * as React from 'react';
 import {
   enumerateLayouts,
@@ -35,6 +36,7 @@ type Props = {|
   isInline?: boolean,
   onRequestClose?: () => void,
   onApply?: () => void,
+  sceneName: string,
 |};
 
 export default class ExternalEventsAutoComplete extends React.Component<

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
@@ -175,6 +175,7 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
               <ExternalEventsAutoComplete
                 project={this.props.project}
                 value={target}
+                sceneName={this.props.scope.layout.getName()}
                 onChange={text => {
                   linkEvent.setTarget(text);
                   this.props.onUpdate();

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
@@ -156,7 +156,7 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
                 tabIndex={0}
               >
                 {target || (
-                  <Trans>{`<Enter the name of external events>`}</Trans>
+                  <Trans>{`<Enter the name of external events/scene>`}</Trans>
                 )}
               </i>
             </span>
@@ -178,6 +178,11 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
                 sceneName={
                   this.props.scope.layout
                     ? this.props.scope.layout.getName()
+                    : undefined
+                }
+                externalEventsName={
+                  this.props.scope.externalEvents
+                    ? this.props.scope.externalEvents.getName()
                     : undefined
                 }
                 onChange={text => {

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
@@ -175,7 +175,7 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
               <ExternalEventsAutoComplete
                 project={this.props.project}
                 value={target}
-                sceneName={this.props.scope.layout.getName()}
+                sceneName={this.props.scope.layout ? this.props.scope.layout.getName() : ""}
                 onChange={text => {
                   linkEvent.setTarget(text);
                   this.props.onUpdate();

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
@@ -156,7 +156,7 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
                 tabIndex={0}
               >
                 {target || (
-                  <Trans>{`<Enter the name of external events/scene>`}</Trans>
+                  <Trans>{`<Enter the name of external events>`}</Trans>
                 )}
               </i>
             </span>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
@@ -175,7 +175,11 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
               <ExternalEventsAutoComplete
                 project={this.props.project}
                 value={target}
-                sceneName={this.props.scope.layout ? this.props.scope.layout.getName() : ""}
+                sceneName={
+                  this.props.scope.layout
+                    ? this.props.scope.layout.getName()
+                    : ''
+                }
                 onChange={text => {
                   linkEvent.setTarget(text);
                   this.props.onUpdate();

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/LinkEvent/index.js
@@ -178,7 +178,7 @@ export default class LinkEvent extends React.Component<EventRendererProps, *> {
                 sceneName={
                   this.props.scope.layout
                     ? this.props.scope.layout.getName()
-                    : ''
+                    : undefined
                 }
                 onChange={text => {
                   linkEvent.setTarget(text);

--- a/newIDE/app/src/InstructionOrExpression/EventsScope.flow.js
+++ b/newIDE/app/src/InstructionOrExpression/EventsScope.flow.js
@@ -6,6 +6,7 @@
 // will be visible).
 export type EventsScope = {|
   layout?: ?gdLayout,
+  externalEvents?: ?gdExternalEvents,
   eventsFunctionsExtension?: gdEventsFunctionsExtension,
   eventsBasedBehavior?: ?gdEventsBasedBehavior,
   eventsFunction?: gdEventsFunction,

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
@@ -133,6 +133,7 @@ export class ExternalEventsEditorContainer extends React.Component<
             project={project}
             scope={{
               layout,
+              externalEvents,
             }}
             globalObjectsContainer={project}
             objectsContainer={layout}

--- a/newIDE/electron-app/app/package-lock.json
+++ b/newIDE/electron-app/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gdevelop",
-  "version": "5.0.0-beta108",
+  "version": "5.0.120",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# Introduction
Hi ! I have **prevented** a bug that ~~was not in the issues~~ was reported by me #3186 but that I discovered and that could have broken the GDevelop compiler.
# Explaining the bug
You could i**nclude the events of a scene into itself** and creating a **endless loop** of including events wich **lock gdevelop when previewing** the game. Here is an example :
![example image](https://user-images.githubusercontent.com/61246500/140584261-eb2af307-cd94-44b9-aec9-c078eb1cfdd3.png)
_("Inclure les évenements de [...]" =  "Include events from [...]")_
 # How I prevented it
I **modified the renderer for the event link system** so it will not let users do this bug.
Maybe we should also modify the core of the engine to disallow a selfincluding scene but for now it's a good start.

