### PR TITLE
Fix the "separate" action when there is several obstacles.

### DIFF
--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -1599,35 +1599,36 @@ namespace gdjs {
       objects: RuntimeObject[],
       ignoreTouchingEdges: boolean
     ): boolean {
-      let moved = false;
-      let xMove = 0;
-      let yMove = 0;
+      let moveXArray: Array<float> =
+        RuntimeObject.separateFromObjectsStatics.moveXArray;
+      let moveYArray: Array<float> =
+        RuntimeObject.separateFromObjectsStatics.moveYArray;
+      moveXArray.length = 0;
+      moveYArray.length = 0;
+
       const hitBoxes = this.getHitBoxes();
 
-      //Check if their is a collision with each object
-      for (let i = 0, len = objects.length; i < len; ++i) {
-        if (objects[i].id != this.id) {
-          const otherHitBoxes = objects[i].getHitBoxes();
-          for (let k = 0, lenk = hitBoxes.length; k < lenk; ++k) {
-            for (let l = 0, lenl = otherHitBoxes.length; l < lenl; ++l) {
-              const result = gdjs.Polygon.collisionTest(
-                hitBoxes[k],
-                otherHitBoxes[l],
-                ignoreTouchingEdges
-              );
-              if (result.collision) {
-                xMove += result.move_axis[0];
-                yMove += result.move_axis[1];
-                moved = true;
-              }
+      // Check if their is a collision with each object
+      for (const otherObject of objects) {
+        if (otherObject.id === this.id) {
+          continue;
+        }
+        const otherHitBoxes = otherObject.getHitBoxes();
+        for (const hitBox of hitBoxes) {
+          for (const otherHitBox of otherHitBoxes) {
+            const result = gdjs.Polygon.collisionTest(
+              hitBox,
+              otherHitBox,
+              ignoreTouchingEdges
+            );
+            if (result.collision) {
+              moveXArray.push(result.move_axis[0]);
+              moveYArray.push(result.move_axis[1]);
             }
           }
         }
       }
-
-      //Move according to the results returned by the collision algorithm.
-      this.setPosition(this.getX() + xMove, this.getY() + yMove);
-      return moved;
+      return this._doSeparateFromObjects(moveXArray, moveYArray);
     }
 
     /**
@@ -1640,40 +1641,125 @@ namespace gdjs {
       objectsLists: ObjectsLists,
       ignoreTouchingEdges: boolean
     ): boolean {
-      let moved = false;
-      let xMove = 0;
-      let yMove = 0;
+      let moveXArray: Array<float> =
+        RuntimeObject.separateFromObjectsStatics.moveXArray;
+      let moveYArray: Array<float> =
+        RuntimeObject.separateFromObjectsStatics.moveYArray;
+      moveXArray.length = 0;
+      moveYArray.length = 0;
+
       const hitBoxes = this.getHitBoxes();
+
       for (const name in objectsLists.items) {
         if (objectsLists.items.hasOwnProperty(name)) {
-          const objects = objectsLists.items[name];
+          const otherObjects = objectsLists.items[name];
 
-          //Check if their is a collision with each object
-          for (let i = 0, len = objects.length; i < len; ++i) {
-            if (objects[i].id != this.id) {
-              const otherHitBoxes = objects[i].getHitBoxes();
-              for (let k = 0, lenk = hitBoxes.length; k < lenk; ++k) {
-                for (let l = 0, lenl = otherHitBoxes.length; l < lenl; ++l) {
-                  const result = gdjs.Polygon.collisionTest(
-                    hitBoxes[k],
-                    otherHitBoxes[l],
-                    ignoreTouchingEdges
-                  );
-                  if (result.collision) {
-                    xMove += result.move_axis[0];
-                    yMove += result.move_axis[1];
-                    moved = true;
-                  }
+          // Check if their is a collision with each object
+          for (const otherObject of otherObjects) {
+            if (otherObject.id === this.id) {
+              continue;
+            }
+            const otherHitBoxes = otherObject.getHitBoxes();
+            for (const hitBox of hitBoxes) {
+              for (const otherHitBox of otherHitBoxes) {
+                const result = gdjs.Polygon.collisionTest(
+                  hitBox,
+                  otherHitBox,
+                  ignoreTouchingEdges
+                );
+                if (result.collision) {
+                  moveXArray.push(result.move_axis[0]);
+                  moveYArray.push(result.move_axis[1]);
                 }
               }
             }
           }
         }
       }
+      return this._doSeparateFromObjects(moveXArray, moveYArray);
+    }
 
-      //Move according to the results returned by the collision algorithm.
-      this.setPosition(this.getX() + xMove, this.getY() + yMove);
-      return moved;
+    /**
+     * Separate the object from others objects, using the results from collisionTest call.
+     * @param moveXArray
+     * @param moveYArray
+     * @return true if the object was moved
+     */
+    private _doSeparateFromObjects(
+      moveXArray: Array<float>,
+      moveYArray: Array<float>
+    ): boolean {
+      if (moveXArray.length === 0) {
+        moveXArray.length = 0;
+        moveYArray.length = 0;
+        return false;
+      }
+      if (moveXArray.length === 1) {
+        // Move according to the results returned by the collision algorithm.
+        this.setPosition(
+          this.getX() + moveXArray[0],
+          this.getY() + moveYArray[0]
+        );
+        moveXArray.length = 0;
+        moveYArray.length = 0;
+        return true;
+      }
+
+      // Find the longest vector
+      let distanceSqMax = 0;
+      let distanceMaxIndex = 0;
+      for (let index = 0; index < moveXArray.length; index++) {
+        const moveX = moveXArray[index];
+        const moveY = moveYArray[index];
+
+        const distanceSq = moveX * moveX + moveY * moveY;
+        if (distanceSq > distanceSqMax) {
+          distanceSqMax = distanceSq;
+          distanceMaxIndex = index;
+        }
+      }
+
+      const distanceMax = Math.sqrt(distanceSqMax);
+      // unit vector of the longest vector
+      const uX = moveXArray[distanceMaxIndex] / distanceMax;
+      const uY = moveYArray[distanceMaxIndex] / distanceMax;
+
+      // normal vector of the longest vector
+      const vX = -uY;
+      const vY = uX;
+
+      // Project other vectors on the normal
+      let scalarProductMin = 0;
+      let scalarProductMax = 0;
+      for (let index = 0; index < moveXArray.length; index++) {
+        const moveX = moveXArray[index];
+        const moveY = moveYArray[index];
+
+        const scalarProduct = moveX * vX + moveY * vY;
+        scalarProductMin = Math.min(scalarProductMin, scalarProduct);
+        scalarProductMax = Math.max(scalarProductMax, scalarProduct);
+      }
+
+      // Apply the longest vector
+      let deltaX = moveXArray[distanceMaxIndex];
+      let deltaY = moveYArray[distanceMaxIndex];
+
+      // Apply the longest projected vector if they all are in the same direction
+      // Some projections could have rounding errors,
+      // they are considered negligible under a 1 for 1,000,000 ratio.
+      if ((-scalarProductMin < scalarProductMax / 1048576) !== (scalarProductMax < -scalarProductMin / 1048576)) {
+        if (scalarProductMin !== 0) {
+          deltaX += scalarProductMin * vX;
+          deltaY += scalarProductMin * vY;
+        } else {
+          deltaX += scalarProductMax * vX;
+          deltaY += scalarProductMax * vY;
+        }
+      }
+      this.setPosition(this.getX() + deltaX, this.getY() + deltaY);
+      moveXArray.length = 0;
+      moveYArray.length = 0;
+      return true;
     }
 
     /**
@@ -2157,6 +2243,19 @@ namespace gdjs {
      * @static
      */
     static forcesGarbage: Array<gdjs.Force> = [];
+
+    /**
+     * Arrays and data structure that are (re)used by RuntimeObject.separateFromObjects to
+     * avoid any allocation.
+     * @static
+     */
+    private static separateFromObjectsStatics: {
+      moveXArray: Array<float>;
+      moveYArray: Array<float>;
+    } = {
+      moveXArray: [],
+      moveYArray: [],
+    };
 
     getVariableNumber = RuntimeObject.getVariableNumber;
     returnVariable = RuntimeObject.returnVariable;

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -1747,7 +1747,10 @@ namespace gdjs {
       // Apply the longest projected vector if they all are in the same direction
       // Some projections could have rounding errors,
       // they are considered negligible under a 1 for 1,000,000 ratio.
-      if ((-scalarProductMin < scalarProductMax / 1048576) !== (scalarProductMax < -scalarProductMin / 1048576)) {
+      if (
+        -scalarProductMin < scalarProductMax / 1048576 !==
+        scalarProductMax < -scalarProductMin / 1048576
+      ) {
         if (scalarProductMin !== 0) {
           deltaX += scalarProductMin * vX;
           deltaY += scalarProductMin * vY;

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -41,15 +41,18 @@ namespace gdjs {
 
   /**
    * Move the object using the results from collisionTest call.
+   * This moves the object according to the direction of the longest vector,
+   * and projects the others on the orthogonal vector.
    *
    * See {@link RuntimeObject.separateFromObjects}
    *
-   * @param moveXArray
-   * @param moveYArray
-   * @return true if the object was moved
+   * @param object The object to move.
+   * @param moveXArray The X coordinates of the vectors to move the object.
+   * @param moveYArray The Y coordinates of the vectors to move the object.
+   * @return true if the object was moved.
    */
   const moveFollowingSeparatingVectors = (
-    object: RuntimeObject,
+    object: gdjs.RuntimeObject,
     moveXArray: Array<float>,
     moveYArray: Array<float>
   ): boolean => {

--- a/GDJS/tests/tests/runtimeobject.separateFromObjects.js
+++ b/GDJS/tests/tests/runtimeobject.separateFromObjects.js
@@ -1,0 +1,117 @@
+// @ts-check
+/**
+ * Common tests for gdjs game engine.
+ * See README.md for more information.
+ */
+
+describe('gdjs.RuntimeObject.separateFromObjects', () => {
+  const runtimeGame = new gdjs.RuntimeGame({
+    variables: [],
+    // @ts-ignore TODO: make a function to create an empty game and use it across tests.
+    properties: { windowWidth: 800, windowHeight: 600 },
+    resources: { resources: [] },
+  });
+  const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
+
+  const object = new gdjs.TestRuntimeObject(runtimeScene, {
+    name: 'obj1',
+    type: '',
+    variables: [],
+    behaviors: [],
+    effects: [],
+  });
+  object.setCustomWidthAndHeight(100, 100);
+  object.setCustomCenter(0, 0);
+
+  const obstacle1 = new gdjs.TestRuntimeObject(runtimeScene, {
+    name: 'obj1',
+    type: '',
+    variables: [],
+    behaviors: [],
+    effects: [],
+  });
+  obstacle1.setCustomWidthAndHeight(100, 100);
+  obstacle1.setCustomCenter(0, 0);
+
+  const obstacle2 = new gdjs.TestRuntimeObject(runtimeScene, {
+    name: 'obj1',
+    type: '',
+    variables: [],
+    behaviors: [],
+    effects: [],
+  });
+  obstacle2.setCustomWidthAndHeight(100, 100);
+  obstacle2.setCustomCenter(0, 0);
+
+  it('can be separated from 2 aligned objects', () => {
+    object.setPosition(200, 300);
+    // 2 obstacles on the left
+    obstacle1.setPosition(290, 250);
+    obstacle2.setPosition(290, 350);
+
+    expect(object.separateFromObjects([obstacle1, obstacle2], true)).to.be(
+      true
+    );
+    expect(object.getX()).to.be(190);
+    expect(object.getY()).to.be(300);
+  });
+
+  it('can be separated from 2 not exactly aligned objects', () => {
+    object.setPosition(200, 300);
+    // 2 obstacles on the left
+    obstacle1.setPosition(290, 250);
+    obstacle2.setPosition(295, 350);
+
+    expect(object.separateFromObjects([obstacle1, obstacle2], true)).to.be(
+      true
+    );
+    expect(object.getX()).to.be(190);
+    expect(object.getY()).to.be(300);
+  });
+
+  it('can be separated from 2 objects that form a corner', () => {
+    object.setPosition(200, 300);
+    // 1 obstacle on the top
+    obstacle1.setPosition(250, 220);
+    // 1 obstacle on the left
+    obstacle2.setPosition(290, 250);
+
+    expect(object.separateFromObjects([obstacle1, obstacle2], true)).to.be(
+      true
+    );
+    expect(object.getX()).to.be(190);
+    expect(object.getY()).to.be(320);
+  });
+
+  it('can be separated from 2 rotated objects', () => {
+    object.setPosition(200, 300);
+    // 1 obstacle on the top left corner
+    obstacle1.setPosition(250, 280);
+    obstacle1.setAngle(-45);
+    // 1 obstacle on the bottom left corner
+    obstacle2.setPosition(250, 420);
+    obstacle2.setAngle(-45);
+
+    expect(object.separateFromObjects([obstacle1, obstacle2], true)).to.be(
+      true
+    );
+    expect(object.getX()).to.be(170);
+    expect(object.getY()).to.be(300);
+  });
+
+  it('can be separated from 2 aligned objects when everything is rotated', () => {
+    object.setPosition(240, 350);
+    object.setAngle(-45);
+    // 2 obstacles on the top left
+    obstacle1.setPosition(250, 250);
+    obstacle1.setAngle(-45);
+    obstacle2.setPosition(330, 330);
+    obstacle1.setAngle(-45);
+
+    expect(object.separateFromObjects([obstacle1, obstacle2], true)).to.be(
+      true
+    );
+    expect(object.getX()).to.be.within(224, 225);
+    expect(object.getY()).to.be.within(365, 366);
+  });
+});


### PR DESCRIPTION
## Before the fix
Every vector from the collisionTest are summed. This doesn't work very well when there is more than one obstacle.

![SeparateOld](https://user-images.githubusercontent.com/2611977/141345352-ce6f362e-2d34-46c7-af8e-22b27816aa5a.png)

## After the fix

* It finds the longest vector
* project the other ones on its normal 
* apply the longest vector + the longest projected vector if no conflict (between projected vectors)

The downside is that it use 2 static arrays to store the collisionTest results.

![SeparateFix](https://user-images.githubusercontent.com/2611977/141345307-ec49f63f-1cfc-4929-9471-f5e0ce39e2e4.png)

## Example project
The above screenshots are from the "SeparateCases" scene. There is also the Marching Square platform that is a bit more stable.
* https://www.dropbox.com/s/yhc4rl6955247kp/SeparateExample.zip?dl=1
