### PR TITLE
[RuntimeObject] Allow grid based object to optimize collision checks

### DIFF
--- a/Extensions/Lighting/lightobstacleruntimebehavior.ts
+++ b/Extensions/Lighting/lightobstacleruntimebehavior.ts
@@ -87,12 +87,16 @@ namespace gdjs {
     _manager: any;
     _registeredInManager: boolean = false;
 
-    constructor(runtimeScene, behaviorData, owner) {
+    constructor(
+      runtimeScene: gdjs.RuntimeScene,
+      behaviorData,
+      owner: gdjs.RuntimeObject
+    ) {
       super(runtimeScene, behaviorData, owner);
       this._manager = LightObstaclesManager.getManager(runtimeScene);
     }
 
-    doStepPreEvents(runtimeScene) {
+    doStepPreEvents(runtimeScene: gdjs.RuntimeScene) {
       // Make sure the obstacle is or is not in the obstacles manager.
       if (!this.activated() && this._registeredInManager) {
         this._manager.removeObstacle(this);

--- a/Extensions/Lighting/lightruntimeobject.ts
+++ b/Extensions/Lighting/lightruntimeobject.ts
@@ -149,10 +149,10 @@ namespace gdjs {
     }
 
     /**
-     * Get the light obstacles manager if objects with the behavior exist, null otherwise.
-     * @returns gdjs.LightObstaclesManager if it exists, otherwise null.
+     * Get the light obstacles manager.
+     * @returns the light obstacles manager.
      */
-    getObstaclesManager(): gdjs.LightObstaclesManager | null {
+    getObstaclesManager(): gdjs.LightObstaclesManager {
       return this._obstaclesManager;
     }
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -770,7 +770,12 @@ namespace gdjs {
         return context;
       }
 
-      for (const hitbox of platformObject.getHitBoxes()) {
+      for (const hitbox of platformObject.getHitBoxesAround(
+        context.ownerMinX,
+        context.headMinY,
+        context.ownerMaxX,
+        context.floorMaxY
+      )) {
         if (hitbox.vertices.length < 3) {
           continue;
         }


### PR DESCRIPTION
This is built over:
* https://github.com/4ian/GDevelop/pull/3236

It adds a new method to get the hitboxes around a given area: `getHitBoxesAround(left: float, top: float, right: float, bottom: float)`
This method is used in collision checks so grid based objects like tile map or marching squares can be optimized.

The only impact on performances is on `separateFromObjects` when another object has more than 4 hitboxes. In this case, the AABB of `this` is calculated to try to get less hit boxes. Objects with a lot of hitboxes will probably be a tile map where optimizations can take place.

It will help to write a PR for this issue (the next thing I will do):
* https://github.com/4ian/GDevelop/issues/2775