### PR TITLE
[Platformer] Fix collision detections of platforms that are rotated at runtime.

### DIFF
--- a/Extensions/PlatformBehavior/platformruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformruntimebehavior.ts
@@ -105,6 +105,7 @@ namespace gdjs {
     _oldY: float = 0;
     _oldWidth: float = 0;
     _oldHeight: float = 0;
+    _oldAngle: float = 0;
     _manager: gdjs.PlatformObjectsManager;
     _registeredInManager: boolean = false;
 
@@ -173,7 +174,8 @@ namespace gdjs {
         this._oldX !== this.owner.getX() ||
         this._oldY !== this.owner.getY() ||
         this._oldWidth !== this.owner.getWidth() ||
-        this._oldHeight !== this.owner.getHeight()
+        this._oldHeight !== this.owner.getHeight() ||
+        this._oldAngle !== this.owner.getAngle()
       ) {
         if (this._registeredInManager) {
           this._manager.removePlatform(this);
@@ -183,6 +185,7 @@ namespace gdjs {
         this._oldY = this.owner.getY();
         this._oldWidth = this.owner.getWidth();
         this._oldHeight = this.owner.getHeight();
+        this._oldAngle = this.owner.getAngle();
       }
     }
 

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -474,6 +474,32 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       });
+
+      it.only('can track platform angle changes', function () {
+        // The initial pltaforms AABB are put in RBush.
+        runtimeScene.renderAndStep(1000 / 60);
+
+        // Now change the angle to check that the AABB is updated in RBush.
+        platform.setAngle(90);
+
+        // Put the character above the rotated platform.
+        object.setPosition(
+          platform.getX() + platform.getWidth() / 2,
+          platform.getY() - platform.getWidth() / 2 - object.getHeight() - 10
+        );
+
+        for (let i = 0; i < 15; ++i) {
+          runtimeScene.renderAndStep(1000 / 60);
+        }
+
+        // The character should land on it.
+        expect(object.getBehavior('auto1').isFalling()).to.be(false);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
+        expect(object.getX()).to.be(30);
+        expect(object.getY()).to.be(-44);
+      });
     });
   });
 

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -475,7 +475,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       });
 
-      it.only('can track platform angle changes', function () {
+      it('can track platform angle changes', function () {
         // The initial pltaforms AABB are put in RBush.
         runtimeScene.renderAndStep(1000 / 60);
 

--- a/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
+++ b/Extensions/PlatformBehavior/tests/platformerobjectruntimebehavior.spec.js
@@ -485,7 +485,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         // Put the character above the rotated platform.
         object.setPosition(
           platform.getX() + platform.getWidth() / 2,
-          platform.getY() - platform.getWidth() / 2 - object.getHeight() - 10
+          platform.getY() +
+            (platform.getHeight() - platform.getWidth()) / 2 -
+            object.getHeight() -
+            10
         );
 
         for (let i = 0; i < 15; ++i) {


### PR DESCRIPTION
It fixes:
* https://github.com/4ian/GDevelop/issues/3240

United and checked on the example attached on the issue.