### PR TITLE
Move Object variables to Object Editor Dialog

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
@@ -64,10 +64,17 @@ export default class GlobalVariableField extends React.Component<
             }}
             emptyExplanationMessage={
               <Trans>
-                Global variables are variables that are persisted across the
-                scenes during the game.
+                Global variables are variables that are shared amongst all the
+                scenes of the game.
               </Trans>
             }
+            emptyExplanationSecondMessage={
+              <Trans>
+                For example, you can have a variable called UnlockedLevelsCount
+                representing the number of levels unlocked by the player.
+              </Trans>
+            }
+            helpPagePath={'/all-features/variables/global-variables'}
             onComputeAllVariableNames={onComputeAllVariableNames}
           />
         )}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
@@ -89,6 +89,20 @@ export default class ObjectVariableField extends React.Component<
             title={<Trans>Object Variables</Trans>}
             open={this.state.editorOpen}
             variablesContainer={variablesContainer}
+            emptyExplanationMessage={
+              <Trans>
+                When you add variables to an object, any instance of the object
+                put on the scene or created during the game will have these
+                variables attached to it.
+              </Trans>
+            }
+            emptyExplanationSecondMessage={
+              <Trans>
+                For example, you can have a variable called Life representing
+                the health of the object.
+              </Trans>
+            }
+            helpPagePath={'/all-features/variables/object-variables'}
             onComputeAllVariableNames={onComputeAllVariableNames}
             onCancel={() => this.setState({ editorOpen: false })}
             onApply={() => {

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
@@ -76,6 +76,7 @@ export default class SceneVariableField extends React.Component<
                 the current score of the player.
               </Trans>
             }
+            helpPagePath={'/all-features/variables/scene-variables'}
             onComputeAllVariableNames={onComputeAllVariableNames}
           />
         )}

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -26,7 +26,6 @@ type Props = {|
   instances: Array<gdInitialInstance>,
   onEditObjectByName: string => void,
   onInstancesModified?: (Array<gdInitialInstance>) => void,
-  editObjectVariables: (?gdObject) => void,
   editInstanceVariables: gdInitialInstance => void,
   unsavedChanges?: ?UnsavedChanges,
   i18n: I18nType,

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -196,29 +196,27 @@ const InnerDialog = (props: InnerDialogProps) => {
         />
       )}
       {currentTab === 'variables' && (
-        <Column expand noMargin>
-          <VariablesList
-            variablesContainer={props.object.getVariables()}
-            emptyExplanationMessage={
-              <Trans>
-                When you add variables to an object, any instance of the object
-                put on the scene or created during the game will have these
-                variables attached to it.
-              </Trans>
-            }
-            emptyExplanationSecondMessage={
-              <Trans>
-                For example, you can have a variable called Life representing
-                the health of the object.
-              </Trans>
-            }
-            helpPagePath={'/all-features/variables/object-variables'}
-            onSizeUpdated={
-              forceUpdate /*Force update to ensure dialog is properly positioned*/
-            }
-            onComputeAllVariableNames={props.onComputeAllVariableNames}
-          />
-        </Column>
+        <VariablesList
+          variablesContainer={props.object.getVariables()}
+          emptyExplanationMessage={
+            <Trans>
+              When you add variables to an object, any instance of the object
+              put on the scene or created during the game will have these
+              variables attached to it.
+            </Trans>
+          }
+          emptyExplanationSecondMessage={
+            <Trans>
+              For example, you can have a variable called Life representing the
+              health of the object.
+            </Trans>
+          }
+          helpPagePath={'/all-features/variables/object-variables'}
+          onSizeUpdated={
+            forceUpdate /*Force update to ensure dialog is properly positioned*/
+          }
+          onComputeAllVariableNames={props.onComputeAllVariableNames}
+        />
       )}
       {currentTab === 'effects' && (
         <EffectsList

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -197,6 +197,7 @@ const InnerDialog = (props: InnerDialogProps) => {
         />
       )}
       {currentTab === 'variables' && (
+        <Column expand>
         <VariablesList
         variablesContainer={props.object.getVariables()}
         emptyExplanationMessage={
@@ -223,6 +224,7 @@ const InnerDialog = (props: InnerDialogProps) => {
         )}
         
         />
+        </Column>
       )}
       {currentTab === 'effects' && (
         <EffectsList

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -212,6 +212,7 @@ const InnerDialog = (props: InnerDialogProps) => {
                 the health of the object.
               </Trans>
             }
+            helpPagePath={'/all-features/variables/object-variables'}
             onSizeUpdated={
               forceUpdate /*Force update to ensure dialog is properly positioned*/
             }

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -23,13 +23,11 @@ import HotReloadPreviewButton, {
   type HotReloadPreviewButtonProps,
 } from '../HotReload/HotReloadPreviewButton';
 import EffectsList from '../EffectsList';
-import VariablesList from '../VariablesList/index'
-import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
+import VariablesList from '../VariablesList/index';
 
 type Props = {|
   open: boolean,
   object: ?gdObject,
-  variables: ?gdObject.variables,
 
   onApply: () => void,
   onCancel: () => void,
@@ -40,6 +38,7 @@ type Props = {|
 
   // Passed down to object editors:
   project: gdProject,
+  onComputeAllVariableNames: () => Array<string>,
   resourceSources: Array<ResourceSource>,
   onChooseResource: ChooseResourceFunction,
   resourceExternalEditors: Array<ResourceExternalEditor>,
@@ -198,32 +197,26 @@ const InnerDialog = (props: InnerDialogProps) => {
       )}
       {currentTab === 'variables' && (
         <Column expand noMargin>
-        <VariablesList
-        variablesContainer={props.object.getVariables()}
-        emptyExplanationMessage={
-          <Trans>
-            When you add variables to an object, any instance of the object put on the 
-            scene or created during the game will have these variables attached to it.
-          </Trans>
-        }
-        emptyExplanationSecondMessage={
-          <Trans>
-            For example, you can have a variable called 
-            Life representing the health of the object.
-          </Trans>
-        }
-        onSizeUpdated={
-          forceUpdate /*Force update to ensure dialog is properly positioned*/
-        }
-        onComputeAllVariableNames={() =>
-          EventsRootVariablesFinder.findAllObjectVariables(
-            props.project.getCurrentPlatform(),
-            props.project,
-            props.layout,
-            props.object
-        )}
-        
-        />
+          <VariablesList
+            variablesContainer={props.object.getVariables()}
+            emptyExplanationMessage={
+              <Trans>
+                When you add variables to an object, any instance of the object
+                put on the scene or created during the game will have these
+                variables attached to it.
+              </Trans>
+            }
+            emptyExplanationSecondMessage={
+              <Trans>
+                For example, you can have a variable called Life representing
+                the health of the object.
+              </Trans>
+            }
+            onSizeUpdated={
+              forceUpdate /*Force update to ensure dialog is properly positioned*/
+            }
+            onComputeAllVariableNames={props.onComputeAllVariableNames}
+          />
         </Column>
       )}
       {currentTab === 'effects' && (

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -197,7 +197,7 @@ const InnerDialog = (props: InnerDialogProps) => {
         />
       )}
       {currentTab === 'variables' && (
-        <Column expand>
+        <Column expand noMargin>
         <VariablesList
         variablesContainer={props.object.getVariables()}
         emptyExplanationMessage={

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -23,10 +23,13 @@ import HotReloadPreviewButton, {
   type HotReloadPreviewButtonProps,
 } from '../HotReload/HotReloadPreviewButton';
 import EffectsList from '../EffectsList';
+import VariablesList from '../VariablesList/index'
+import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
 
 type Props = {|
   open: boolean,
   object: ?gdObject,
+  variables: ?gdObject.variables,
 
   onApply: () => void,
   onCancel: () => void,
@@ -124,6 +127,11 @@ const InnerDialog = (props: InnerDialogProps) => {
               key={'behaviors'}
             />
             <Tab
+              label={<Trans>Variables</Trans>}
+              value={'variables'}
+              key={'variables'}
+            />
+            <Tab
               label={<Trans>Effects</Trans>}
               value={'effects'}
               key={'effects'}
@@ -186,6 +194,34 @@ const InnerDialog = (props: InnerDialogProps) => {
             forceUpdate /*Force update to ensure dialog is properly positionned*/
           }
           onUpdateBehaviorsSharedData={props.onUpdateBehaviorsSharedData}
+        />
+      )}
+      {currentTab === 'variables' && (
+        <VariablesList
+        variablesContainer={props.object.getVariables()}
+        emptyExplanationMessage={
+          <Trans>
+            When you add variables to an object, any instance of the object put on the 
+            scene or created during the game will have these variables attached to it.
+          </Trans>
+        }
+        emptyExplanationSecondMessage={
+          <Trans>
+            For example, you can have a variable called 
+            Life representing the health of the object.
+          </Trans>
+        }
+        onSizeUpdated={
+          forceUpdate /*Force update to ensure dialog is properly positioned*/
+        }
+        onComputeAllVariableNames={() =>
+          EventsRootVariablesFinder.findAllObjectVariables(
+            props.project.getCurrentPlatform(),
+            props.project,
+            props.layout,
+            props.object
+        )}
+        
         />
       )}
       {currentTab === 'effects' && (

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -10,7 +10,6 @@ import SortableVirtualizedItemList from '../UI/SortableVirtualizedItemList';
 import Background from '../UI/Background';
 import SearchBar from '../UI/SearchBar';
 import NewObjectDialog from '../AssetStore/NewObjectDialog';
-import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import Clipboard, { SafeExtractor } from '../Utils/Clipboard';
 import Window from '../Utils/Window';
@@ -46,7 +45,6 @@ import {
   type ChooseResourceFunction,
 } from '../ResourcesList/ResourceSource';
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
-import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
 
 const styles = {
   listContainer: {
@@ -78,7 +76,6 @@ const getPasteLabel = isGlobalObject => {
 type State = {|
   newObjectDialogOpen: boolean,
   renamedObjectWithContext: ?ObjectWithContext,
-  variablesEditedObject: ?gdObject,
   searchText: string,
   tagEditedObject: ?gdObject,
 |};
@@ -123,7 +120,6 @@ export default class ObjectsList extends React.Component<Props, State> {
   state = {
     newObjectDialogOpen: false,
     renamedObjectWithContext: null,
-    variablesEditedObject: null,
     searchText: '',
     tagEditedObject: null,
   };
@@ -140,7 +136,6 @@ export default class ObjectsList extends React.Component<Props, State> {
       this.state.newObjectDialogOpen !== nextState.newObjectDialogOpen ||
       this.state.renamedObjectWithContext !==
         nextState.renamedObjectWithContext ||
-      this.state.variablesEditedObject !== nextState.variablesEditedObject ||
       this.state.searchText !== nextState.searchText ||
       this.state.tagEditedObject !== nextState.tagEditedObject
     )
@@ -320,12 +315,6 @@ export default class ObjectsList extends React.Component<Props, State> {
     );
   };
 
-  _editVariables = (object: ?gdObject) => {
-    this.setState({
-      variablesEditedObject: object,
-    });
-  };
-
   _rename = (objectWithContext: ObjectWithContext, newName: string) => {
     const { object } = objectWithContext;
     this.setState({
@@ -466,7 +455,7 @@ export default class ObjectsList extends React.Component<Props, State> {
       },
       {
         label: i18n._(t`Edit object variables`),
-        click: () => this._editVariables(object),
+        click: () => this.props.onEditObject(object, 'variables'),
       },
       {
         label: i18n._(t`Edit behaviors`),
@@ -638,43 +627,6 @@ export default class ObjectsList extends React.Component<Props, State> {
             resourceSources={resourceSources}
             onChooseResource={onChooseResource}
             resourceExternalEditors={resourceExternalEditors}
-          />
-        )}
-        {this.state.variablesEditedObject && (
-          <VariablesEditorDialog
-            open
-            variablesContainer={
-              this.state.variablesEditedObject &&
-              this.state.variablesEditedObject.getVariables()
-            }
-            onCancel={() => this._editVariables(null)}
-            onApply={() => this._editVariables(null)}
-            title={<Trans>Object Variables</Trans>}
-            emptyExplanationMessage={
-              <Trans>
-                When you add variables to an object, any instance of the object
-                put on the scene or created during the game will have these
-                variables attached to it.
-              </Trans>
-            }
-            emptyExplanationSecondMessage={
-              <Trans>
-                For example, you can have a variable called Life representing
-                the health of the object.
-              </Trans>
-            }
-            hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
-            onComputeAllVariableNames={() => {
-              const variablesEditedObject = this.state.variablesEditedObject;
-              return layout && variablesEditedObject
-                ? EventsRootVariablesFinder.findAllObjectVariables(
-                    project.getCurrentPlatform(),
-                    project,
-                    layout,
-                    variablesEditedObject
-                  )
-                : [];
-            }}
           />
         )}
         {tagEditedObject && (

--- a/newIDE/app/src/Profile/ContributionsDetails.js
+++ b/newIDE/app/src/Profile/ContributionsDetails.js
@@ -72,6 +72,7 @@ export const ExamplesAccordion = ({
         <Column>
           {examples.map(example => (
             <ContributionLine
+              key={example.name}
               shortDescription={example.shortDescription}
               fullName={example.name}
               previewIconUrl={

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -1183,6 +1183,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                 representing the number of levels unlocked by the player.
               </Trans>
             }
+            helpPagePath={'/all-features/variables/global-variables'}
             hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
             onComputeAllVariableNames={() =>
               EventsRootVariablesFinder.findAllGlobalVariables(

--- a/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
+++ b/newIDE/app/src/SceneEditor/SceneVariablesDialog.js
@@ -34,6 +34,7 @@ export default (props: Props) => {
           current score of the player.
         </Trans>
       }
+      helpPagePath={'/all-features/variables/scene-variables'}
       hotReloadPreviewButtonProps={props.hotReloadPreviewButtonProps}
       onComputeAllVariableNames={() =>
         EventsRootVariablesFinder.findAllLayoutVariables(

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -136,7 +136,6 @@ type State = {|
   editedObjectWithContext: ?ObjectWithContext,
   editedObjectInitialTab: ?string,
   variablesEditedInstance: ?gdInitialInstance,
-  variablesEditedObject: ?gdObject,
   selectedObjectNames: Array<string>,
   newObjectInstanceSceneCoordinates: ?[number, number],
 
@@ -189,7 +188,6 @@ export default class SceneEditor extends React.Component<Props, State> {
       editedObjectWithContext: null,
       editedObjectInitialTab: 'properties',
       variablesEditedInstance: null,
-      variablesEditedObject: null,
       selectedObjectNames: [],
       newObjectInstanceSceneCoordinates: null,
       editedGroup: null,
@@ -357,10 +355,6 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   editInstanceVariables = (instance: ?gdInitialInstance) => {
     this.setState({ variablesEditedInstance: instance });
-  };
-
-  editObjectVariables = (object: ?gdObject) => {
-    this.setState({ variablesEditedObject: object });
   };
 
   editLayoutVariables = (open: boolean = true) => {
@@ -1194,26 +1188,14 @@ export default class SceneEditor extends React.Component<Props, State> {
             resourceSources={resourceSources}
             resourceExternalEditors={resourceExternalEditors}
             onChooseResource={onChooseResource}
-            onComputeAllVariableNames={() => {
-              const variablesEditedInstance = this.state
-                .variablesEditedInstance;
-              if (!variablesEditedInstance) {
-                return [];
-              }
-              const variablesEditedObject = getObjectByName(
+            onComputeAllVariableNames={() =>
+              EventsRootVariablesFinder.findAllObjectVariables(
+                project.getCurrentPlatform(),
                 project,
                 layout,
-                variablesEditedInstance.getObjectName()
-              );
-              return variablesEditedObject
-                ? EventsRootVariablesFinder.findAllObjectVariables(
-                    project.getCurrentPlatform(),
-                    project,
-                    layout,
-                    variablesEditedObject
-                  )
-                : [];
-            }}
+                this.state.editedObjectWithContext.object
+              )
+            }
             onCancel={() => {
               if (this.state.editedObjectWithContext) {
                 this.reloadResourcesFor(
@@ -1331,6 +1313,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 variables of the object.
               </Trans>
             }
+            helpPagePath={'/all-features/variables/instance-variables'}
             title={<Trans>Instance Variables</Trans>}
             onEditObjectVariables={() => {
               if (!this.instancesSelection.hasSelectedInstances()) {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -994,7 +994,6 @@ export default class SceneEditor extends React.Component<Props, State> {
                 layout={layout}
                 instances={selectedInstances}
                 editInstanceVariables={this.editInstanceVariables}
-                editObjectVariables={this.editObjectVariables}
                 onEditObjectByName={this.editObjectByName}
                 onInstancesModified={instances =>
                   this.forceUpdateInstancesList()
@@ -1144,7 +1143,9 @@ export default class SceneEditor extends React.Component<Props, State> {
           project={project}
           layout={layout}
           onEditObject={this.props.onEditObject || this.editObject}
-          onEditObjectVariables={this.editObjectVariables}
+          onEditObjectVariables={object => {
+            this.editObject(object, 'variables');
+          }}
           onOpenSceneProperties={this.openSceneProperties}
           onOpenSceneVariables={this.editLayoutVariables}
           onEditObjectGroup={this.editGroup}
@@ -1188,14 +1189,17 @@ export default class SceneEditor extends React.Component<Props, State> {
             resourceSources={resourceSources}
             resourceExternalEditors={resourceExternalEditors}
             onChooseResource={onChooseResource}
-            onComputeAllVariableNames={() =>
-              EventsRootVariablesFinder.findAllObjectVariables(
+            onComputeAllVariableNames={() => {
+              const { editedObjectWithContext } = this.state;
+              if (!editedObjectWithContext) return [];
+
+              return EventsRootVariablesFinder.findAllObjectVariables(
                 project.getCurrentPlatform(),
                 project,
                 layout,
-                this.state.editedObjectWithContext.object
-              )
-            }
+                editedObjectWithContext.object
+              );
+            }}
             onCancel={() => {
               if (this.state.editedObjectWithContext) {
                 this.reloadResourcesFor(
@@ -1309,7 +1313,7 @@ export default class SceneEditor extends React.Component<Props, State> {
             onApply={() => this.editInstanceVariables(null)}
             emptyExplanationMessage={
               <Trans>
-                Instance variables will override the default values of the
+                Instance variables will overwrite the default values of the
                 variables of the object.
               </Trans>
             }

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1194,14 +1194,26 @@ export default class SceneEditor extends React.Component<Props, State> {
             resourceSources={resourceSources}
             resourceExternalEditors={resourceExternalEditors}
             onChooseResource={onChooseResource}
-            onComputeAllVariableNames={() =>
-              EventsRootVariablesFinder.findAllObjectVariables(
-                project.getCurrentPlatform(),
+            onComputeAllVariableNames={() => {
+              const variablesEditedInstance = this.state
+                .variablesEditedInstance;
+              if (!variablesEditedInstance) {
+                return [];
+              }
+              const variablesEditedObject = getObjectByName(
                 project,
                 layout,
-                this.state.editedObject
-              )
-            }
+                variablesEditedInstance.getObjectName()
+              );
+              return variablesEditedObject
+                ? EventsRootVariablesFinder.findAllObjectVariables(
+                    project.getCurrentPlatform(),
+                    project,
+                    layout,
+                    variablesEditedObject
+                  )
+                : [];
+            }}
             onCancel={() => {
               if (this.state.editedObjectWithContext) {
                 this.reloadResourcesFor(

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1194,6 +1194,14 @@ export default class SceneEditor extends React.Component<Props, State> {
             resourceSources={resourceSources}
             resourceExternalEditors={resourceExternalEditors}
             onChooseResource={onChooseResource}
+            onComputeAllVariableNames={() =>
+              EventsRootVariablesFinder.findAllObjectVariables(
+                project.getCurrentPlatform(),
+                project,
+                layout,
+                this.state.editedObjectWithContext.object
+              )
+            }
             onCancel={() => {
               if (this.state.editedObjectWithContext) {
                 this.reloadResourcesFor(
@@ -1325,7 +1333,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 associatedObjectName
               );
               if (object) {
-                this.editObjectVariables(object);
+                this.editObject(object, 'variables');
                 this.editInstanceVariables(null);
               }
             }}
@@ -1341,37 +1349,6 @@ export default class SceneEditor extends React.Component<Props, State> {
                 layout,
                 variablesEditedInstance.getObjectName()
               );
-              return variablesEditedObject
-                ? EventsRootVariablesFinder.findAllObjectVariables(
-                    project.getCurrentPlatform(),
-                    project,
-                    layout,
-                    variablesEditedObject
-                  )
-                : [];
-            }}
-          />
-        )}
-        {!!this.state.variablesEditedObject && (
-          <VariablesEditorDialog
-            open
-            variablesContainer={
-              this.state.variablesEditedObject &&
-              this.state.variablesEditedObject.getVariables()
-            }
-            onCancel={() => this.editObjectVariables(null)}
-            onApply={() => this.editObjectVariables(null)}
-            emptyExplanationMessage={
-              <Trans>
-                When you add variables to an object, any instance of the object
-                put on the scene or created during the game will have these
-                variables attached to it.
-              </Trans>
-            }
-            title={<Trans>Object Variables</Trans>}
-            hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
-            onComputeAllVariableNames={() => {
-              const variablesEditedObject = this.state.variablesEditedObject;
               return variablesEditedObject
                 ? EventsRootVariablesFinder.findAllObjectVariables(
                     project.getCurrentPlatform(),

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1199,7 +1199,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 project.getCurrentPlatform(),
                 project,
                 layout,
-                this.state.editedObjectWithContext.object
+                this.state.editedObjectWithContext
               )
             }
             onCancel={() => {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1199,7 +1199,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 project.getCurrentPlatform(),
                 project,
                 layout,
-                this.state.editedObjectWithContext
+                this.state.editedObject
               )
             }
             onCancel={() => {

--- a/newIDE/app/src/VariablesList/VariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/VariablesEditorDialog.js
@@ -27,7 +27,6 @@ const VariablesEditorDialog = ({
   onCancel,
   onApply,
   open,
-  onEditObjectVariables,
   title,
   emptyExplanationMessage,
   emptyExplanationSecondMessage,
@@ -63,14 +62,6 @@ const VariablesEditorDialog = ({
       cannotBeDismissed={true}
       onRequestClose={onCancelChanges}
       secondaryActions={[
-        onEditObjectVariables ? (
-          <FlatButton
-            key="edit-object-variables"
-            label={<Trans>Edit Object Variables</Trans>}
-            primary={false}
-            onClick={onEditObjectVariables}
-          />
-        ) : null,
         hotReloadPreviewButtonProps ? (
           <HotReloadPreviewButton
             key="hot-reload-preview-button"

--- a/newIDE/app/src/VariablesList/VariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/VariablesEditorDialog.js
@@ -81,6 +81,8 @@ const VariablesEditorDialog = ({
         ) : null,
       ]}
       title={title}
+      flexBody
+      fullHeight
     >
       <VariablesList
         commitVariableValueOnBlur={

--- a/newIDE/app/src/VariablesList/VariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/VariablesEditorDialog.js
@@ -21,6 +21,7 @@ type Props = {|
   variablesContainer: gdVariablesContainer,
   hotReloadPreviewButtonProps?: ?HotReloadPreviewButtonProps,
   onComputeAllVariableNames: () => Array<string>,
+  helpPagePath: ?string,
 |};
 
 const VariablesEditorDialog = ({
@@ -34,6 +35,7 @@ const VariablesEditorDialog = ({
   variablesContainer,
   hotReloadPreviewButtonProps,
   onComputeAllVariableNames,
+  helpPagePath,
 }: Props) => {
   const forceUpdate = useForceUpdate();
   const onCancelChanges = useSerializableObjectCancelableEditor({
@@ -95,6 +97,7 @@ const VariablesEditorDialog = ({
           forceUpdate /*Force update to ensure dialog is properly positioned*/
         }
         onComputeAllVariableNames={onComputeAllVariableNames}
+        helpPagePath={helpPagePath}
       />
     </Dialog>
   );

--- a/newIDE/app/src/VariablesList/VariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/VariablesEditorDialog.js
@@ -27,6 +27,7 @@ const VariablesEditorDialog = ({
   onCancel,
   onApply,
   open,
+  onEditObjectVariables,
   title,
   emptyExplanationMessage,
   emptyExplanationSecondMessage,
@@ -62,6 +63,14 @@ const VariablesEditorDialog = ({
       cannotBeDismissed={true}
       onRequestClose={onCancelChanges}
       secondaryActions={[
+        onEditObjectVariables ? (
+          <FlatButton
+            key="edit-object-variables"
+            label={<Trans>Edit Object Variables</Trans>}
+            primary={false}
+            onClick={onEditObjectVariables}
+          />
+        ) : null,
         hotReloadPreviewButtonProps ? (
           <HotReloadPreviewButton
             key="hot-reload-preview-button"

--- a/newIDE/app/src/VariablesList/index.js
+++ b/newIDE/app/src/VariablesList/index.js
@@ -3,11 +3,9 @@ import * as React from 'react';
 import flatten from 'lodash/flatten';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import { mapFor } from '../Utils/MapFor';
-import EmptyMessage from '../UI/EmptyMessage';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import VariableRow from './VariableRow';
 import EditVariableRow from './EditVariableRow';
-import styles from './styles';
 import {
   getInitialSelection,
   hasSelection,
@@ -25,13 +23,21 @@ import HelpButton from '../UI/HelpButton';
 import { EmptyPlaceholder } from '../UI/EmptyPlaceholder';
 import { Trans } from '@lingui/macro';
 import Text from '../UI/Text';
+import { Column } from '../UI/Grid';
+import ScrollView from '../UI/ScrollView';
 
 const gd: libGDevelop = global.gd;
 
+const styles = {
+  variablesContainer: {
+    // Somehow ensure the scrollbar is not shown when not needed.
+    marginBottom: 10,
+  },
+};
+
 const SortableVariableRow = SortableElement(VariableRow);
-const SortableAddVariableRow = SortableElement(EditVariableRow);
 const SortableVariablesListBody = SortableContainer(({ children }) => (
-  <div>{children}</div>
+  <div style={styles.variablesContainer}>{children}</div>
 ));
 SortableVariablesListBody.muiName = 'TableBody';
 
@@ -45,7 +51,7 @@ type Props = {|
   emptyExplanationSecondMessage?: React.Node,
   onSizeUpdated?: () => void,
   commitVariableValueOnBlur?: boolean,
-  helpPagePath: ?string,
+  helpPagePath?: ?string,
 |};
 type State = {|
   nameErrors: { [string]: string },
@@ -361,27 +367,6 @@ export default class VariablesList extends React.Component<Props, State> {
     );
   }
 
-  _renderEmpty() {
-    return (
-      !!this.props.emptyExplanationMessage && (
-        <div>
-          <EmptyPlaceholder
-            renderButtons={() => (
-              <HelpButton helpPagePath={this.props.helpPagePath} />
-            )}
-          >
-            <Text>
-              <Trans>{this.props.emptyExplanationMessage}</Trans>
-            </Text>
-            <Text>
-              <Trans>{this.props.emptyExplanationSecondMessage}</Trans>
-            </Text>
-          </EmptyPlaceholder>
-        </div>
-      )
-    );
-  }
-
   render() {
     const { variablesContainer, inheritedVariablesContainer } = this.props;
     if (!variablesContainer) return null;
@@ -422,32 +407,6 @@ export default class VariablesList extends React.Component<Props, State> {
       }
     );
 
-    const editRow = (
-      <SortableAddVariableRow
-        index={0}
-        key={'add-variable-row'}
-        disabled
-        onAdd={() => {
-          const variable = new gd.Variable();
-          variable.setString('');
-          const name = newNameGenerator('Variable', name =>
-            inheritedVariablesContainer
-              ? inheritedVariablesContainer.has(name) ||
-                variablesContainer.has(name)
-              : variablesContainer.has(name)
-          );
-          variablesContainer.insert(name, variable, variablesContainer.count());
-          this.forceUpdate();
-          if (this.props.onSizeUpdated) this.props.onSizeUpdated();
-        }}
-        onCopy={this.copySelection}
-        onPaste={this.paste}
-        onDeleteSelection={this.deleteSelection}
-        hasSelection={hasSelection(this.state.selectedVariables)}
-        hasClipboard={Clipboard.has(CLIPBOARD_KIND)}
-      />
-    );
-
     // Put all variables in the **same** array so that if a variable that was shown
     // as inherited is redefined by the user, React can reconcile the variable rows
     // (VariableRow going from containerInheritedVariablesTree array to
@@ -458,20 +417,63 @@ export default class VariablesList extends React.Component<Props, State> {
     ];
 
     return (
-      <SortableVariablesListBody
-        variablesContainer={this.props.variablesContainer}
-        onSortEnd={({ oldIndex, newIndex }) => {
-          this.props.variablesContainer.move(oldIndex, newIndex);
-          this.forceUpdate();
-        }}
-        helperClass="sortable-helper"
-        useDragHandle
-        lockToContainerEdges
-      >
-        {allVariables}
-        {!allVariables.length && this._renderEmpty()}
-        {editRow}
-      </SortableVariablesListBody>
+      <Column noMargin expand useFullHeight>
+        {allVariables.length ? (
+          <ScrollView autoHideScrollbar>
+            <SortableVariablesListBody
+              variablesContainer={this.props.variablesContainer}
+              onSortEnd={({ oldIndex, newIndex }) => {
+                this.props.variablesContainer.move(oldIndex, newIndex);
+                this.forceUpdate();
+              }}
+              helperClass="sortable-helper"
+              useDragHandle
+              lockToContainerEdges
+            >
+              {allVariables}
+            </SortableVariablesListBody>
+          </ScrollView>
+        ) : !!this.props.emptyExplanationMessage ? (
+          <Column noMargin expand justifyContent="center">
+            <EmptyPlaceholder
+              renderButtons={() => (
+                <HelpButton helpPagePath={this.props.helpPagePath} />
+              )}
+            >
+              <Text>
+                <Trans>{this.props.emptyExplanationMessage}</Trans>
+              </Text>
+              <Text>
+                <Trans>{this.props.emptyExplanationSecondMessage}</Trans>
+              </Text>
+            </EmptyPlaceholder>
+          </Column>
+        ) : null}
+        <EditVariableRow
+          onAdd={() => {
+            const variable = new gd.Variable();
+            variable.setString('');
+            const name = newNameGenerator('Variable', name =>
+              inheritedVariablesContainer
+                ? inheritedVariablesContainer.has(name) ||
+                  variablesContainer.has(name)
+                : variablesContainer.has(name)
+            );
+            variablesContainer.insert(
+              name,
+              variable,
+              variablesContainer.count()
+            );
+            this.forceUpdate();
+            if (this.props.onSizeUpdated) this.props.onSizeUpdated();
+          }}
+          onCopy={this.copySelection}
+          onPaste={this.paste}
+          onDeleteSelection={this.deleteSelection}
+          hasSelection={hasSelection(this.state.selectedVariables)}
+          hasClipboard={Clipboard.has(CLIPBOARD_KIND)}
+        />
+      </Column>
     );
   }
 }

--- a/newIDE/app/src/VariablesList/index.js
+++ b/newIDE/app/src/VariablesList/index.js
@@ -21,6 +21,10 @@ import {
   unserializeFromJSObject,
 } from '../Utils/Serializer';
 import { type VariableOrigin } from './VariablesList.flow';
+import HelpButton from '../UI/HelpButton';
+import { EmptyPlaceholder } from '../UI/EmptyPlaceholder';
+import { Trans } from '@lingui/macro';
+import Text from '../UI/Text';
 
 const gd: libGDevelop = global.gd;
 
@@ -41,6 +45,7 @@ type Props = {|
   emptyExplanationSecondMessage?: React.Node,
   onSizeUpdated?: () => void,
   commitVariableValueOnBlur?: boolean,
+  helpPagePath: ?string,
 |};
 type State = {|
   nameErrors: { [string]: string },
@@ -360,18 +365,18 @@ export default class VariablesList extends React.Component<Props, State> {
     return (
       !!this.props.emptyExplanationMessage && (
         <div>
-          <EmptyMessage
-            style={styles.emptyExplanation}
-            messageStyle={styles.emptyExplanationMessage}
+          <EmptyPlaceholder
+            renderButtons={() => (
+              <HelpButton helpPagePath={this.props.helpPagePath} />
+            )}
           >
-            {this.props.emptyExplanationMessage}
-          </EmptyMessage>
-          <EmptyMessage
-            style={styles.emptyExplanation}
-            messageStyle={styles.emptyExplanationMessage}
-          >
-            {this.props.emptyExplanationSecondMessage}
-          </EmptyMessage>
+            <Text>
+              <Trans>{this.props.emptyExplanationMessage}</Trans>
+            </Text>
+            <Text>
+              <Trans>{this.props.emptyExplanationSecondMessage}</Trans>
+            </Text>
+          </EmptyPlaceholder>
         </div>
       )
     );

--- a/newIDE/app/src/VariablesList/styles.js
+++ b/newIDE/app/src/VariablesList/styles.js
@@ -17,12 +17,6 @@ export default {
     flexShrink: 0,
   },
   indentIconColor: '#DDD', //TODO: Use theme color instead
-  emptyExplanation: {
-    justifyContent: 'flex-start',
-  },
-  emptyExplanationMessage: {
-    textAlign: 'left',
-  },
   fadedButton: {
     opacity: 0.7,
   },

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -3836,7 +3836,6 @@ storiesOf('InstancePropertiesEditor', module)
             layout={testProject.testLayout}
             instances={[testProject.testLayoutInstance1]}
             editInstanceVariables={action('edit instance variables')}
-            editObjectVariables={action('edit object variables')}
             onEditObjectByName={action('edit object')}
           />
         </SerializedObjectDisplay>


### PR DESCRIPTION
Moved Object variables to Object Editor Dialog (#3244)

- [x] Added object variables to object editor
- [x] Update `Edit object variable` action to direct to the new tab
- [x] (Tried) Remove unnessesary code
- [x] Fix VariableList component not taking up all the area

I need help with the last one, the component seems to be moved to the side. I have spent a few days trying to fix it, with no good result (Most likely due to my lack of experience :sweat_smile: ) , it would be great if someone could help find and fix the problem.

EDIT: Fixed it, see next comment
Everything else seems to work perfectly!

![gdghalf](https://user-images.githubusercontent.com/73597906/142652138-c0c206a2-5480-4370-a9a2-ca455a26877e.png)

:)
