### PR TITLE
[SpriteRuntimeObject] Optimize custom hitboxes vertices transformations.

### DIFF
--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -551,6 +551,7 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
   InsertUnique(includesFiles, "oncetriggers.js");
   InsertUnique(includesFiles, "runtimebehavior.js");
   InsertUnique(includesFiles, "spriteruntimeobject.js");
+  InsertUnique(includesFiles, "affinetransformation.js");
 
   // Common includes for events only.
   InsertUnique(includesFiles, "events-tools/commontools.js");

--- a/GDJS/Runtime/affinetransformation.ts
+++ b/GDJS/Runtime/affinetransformation.ts
@@ -1,0 +1,285 @@
+namespace gdjs {
+  export class AffineTransformation {
+    private a: float;
+    private b: float;
+    private c: float;
+    private d: float;
+    private e: float;
+    private f: float;
+
+    constructor() {
+      // | a b c |   | 1 0 0 |
+      // | d e f | = | 0 1 0 |
+      // | 0 0 1 |   | 0 0 1 |
+      this.a = 1;
+      this.b = 0;
+      this.c = 0;
+      this.d = 0;
+      this.e = 1;
+      this.f = 0;
+    }
+
+    setToIdentity() {
+      // | a b c |   | 1 0 0 |
+      // | d e f | = | 0 1 0 |
+      // | 0 0 1 |   | 0 0 1 |
+      this.a = 1;
+      this.b = 0;
+      this.c = 0;
+      this.d = 0;
+      this.e = 1;
+      this.f = 0;
+    }
+
+    isIdentity(): boolean {
+      return (
+        this.a === 1 &&
+        this.b === 0 &&
+        this.c === 0 &&
+        this.d === 0 &&
+        this.e === 1 &&
+        this.f === 0
+      );
+    }
+
+    equals(other: AffineTransformation): boolean {
+      return (
+        this === other ||
+        (this.a === other.a &&
+          this.b === other.b &&
+          this.c === other.c &&
+          this.d === other.d &&
+          this.e === other.e &&
+          this.f === other.f)
+      );
+    }
+
+    nearlyEquals(other: AffineTransformation, epsilon: float): boolean {
+      return (
+        this === other ||
+        (gdjs.nearlyEqual(this.a, other.a, epsilon) &&
+          gdjs.nearlyEqual(this.b, other.b, epsilon) &&
+          gdjs.nearlyEqual(this.c, other.c, epsilon) &&
+          gdjs.nearlyEqual(this.d, other.d, epsilon) &&
+          gdjs.nearlyEqual(this.e, other.e, epsilon) &&
+          gdjs.nearlyEqual(this.f, other.f, epsilon))
+      );
+    }
+
+    setToTranslation(tx: float, ty: float) {
+      // | a b c |   | 1 0 tx |
+      // | d e f | = | 0 1 ty |
+      // | 0 0 1 |   | 0 0 1  |
+      this.a = 1;
+      this.b = 0;
+      this.c = tx;
+      this.d = 0;
+      this.e = 1;
+      this.f = ty;
+    }
+
+    translate(tx: float, ty: float) {
+      //       1 0 tx
+      //       0 1 ty
+      //       0 0 1
+      // a b c
+      // d e f
+      // 0 0 1
+      const c = tx * this.a + ty * this.b + this.c;
+      const f = tx * this.d + ty * this.e + this.f;
+
+      this.c = c;
+      this.f = f;
+    }
+
+    setToScale(sx: float, sy: float) {
+      // | a b c |   | sx 0  0 |
+      // | d e f | = | 0  sy 0 |
+      // | 0 0 1 |   | 0  0  1 |
+      this.a = sx;
+      this.b = 0;
+      this.c = 0;
+      this.d = 0;
+      this.e = sy;
+      this.f = 0;
+    }
+
+    scale(sx: float, sy: float) {
+      //       sx 0  0
+      //       0  sy 0
+      //       0  0  1
+      // a b c
+      // d e f
+      // 0 0 1
+      const a = sx * this.a;
+      const b = sy * this.b;
+      const d = sx * this.d;
+      const e = sy * this.e;
+
+      this.a = a;
+      this.b = b;
+      this.d = d;
+      this.e = e;
+    }
+
+    setToRotation(theta: float) {
+      let cost = Math.cos(theta);
+      let sint = Math.sin(theta);
+
+      // Avoid rounding errors around 0.
+      if (cost === -1 || cost === 1) {
+        sint = 0;
+      }
+      if (sint === -1 || sint === 1) {
+        cost = 0;
+      }
+
+      // | a b c |   | cost -sint 0 |
+      // | d e f | = | sint  cost 0 |
+      // | 0 0 1 |   |  0     0   1 |
+      this.a = cost;
+      this.b = -sint;
+      this.c = 0;
+      this.d = sint;
+      this.e = cost;
+      this.f = 0;
+    }
+
+    rotate(theta: float) {
+      let cost = Math.cos(theta);
+      let sint = Math.sin(theta);
+
+      // Avoid rounding errors around 0.
+      if (cost === -1 || cost === 1) {
+        sint = 0;
+      }
+      if (sint === -1 || sint === 1) {
+        cost = 0;
+      }
+
+      //       cost -sint 0
+      //       sint  cost 0
+      //        0     0   1
+      // a b c
+      // d e f
+      // 0 0 1
+      const a = cost * this.a + sint * this.b;
+      const b = -sint * this.a + cost * this.b;
+      const d = cost * this.d + sint * this.e;
+      const e = -sint * this.d + cost * this.e;
+
+      this.a = a;
+      this.b = b;
+      this.d = d;
+      this.e = e;
+    }
+
+    setToRotationAround(theta: float, anchorX: float, anchorY: float) {
+      let cost = Math.cos(theta);
+      let sint = Math.sin(theta);
+
+      // Avoid rounding errors around 0.
+      if (cost === -1 || cost === 1) {
+        sint = 0;
+      }
+      if (sint === -1 || sint === 1) {
+        cost = 0;
+      }
+
+      // | a b c |   | cost -sint x-x*cost+y*sint |
+      // | d e f | = | sint  cost y-x*sint-y*cost |
+      // | 0 0 1 |   |  0     0          1        |
+      this.a = cost;
+      this.b = -sint;
+      this.c = anchorX - anchorX * cost + anchorY * sint;
+      this.d = sint;
+      this.e = cost;
+      this.f = anchorY - anchorX * sint + anchorY * cost;
+    }
+
+    rotateAround(theta: float, anchorX: float, anchorY: float) {
+      this.translate(anchorX, anchorY);
+      this.rotate(theta);
+      // First: translate anchor to origin
+      this.translate(-anchorX, -anchorY);
+    }
+
+    setToFlipX(anchorX: float) {
+      // | a b c |   | -1  0 2x |
+      // | d e f | = |  0  1  0 |
+      // | 0 0 1 |   |  0  0  1 |
+      this.a = -1;
+      this.b = 0;
+      this.c = 2 * anchorX;
+      this.d = 0;
+      this.e = 1;
+      this.f = 0;
+    }
+
+    flipX(anchorX: float) {
+      this.translate(anchorX, 0);
+      this.scale(-1, 1);
+      // First: translate anchor to origin
+      this.translate(-anchorX, 0);
+    }
+
+    setToFlipY(anchorY: float) {
+      // | a b c |   | 1  0  0 |
+      // | d e f | = | 0 -1 2x |
+      // | 0 0 1 |   | 0  0  1 |
+      this.a = 1;
+      this.b = 0;
+      this.c = 0;
+      this.d = 0;
+      this.e = -1;
+      this.f = 2 * anchorY;
+    }
+
+    flipY(anchorY: float) {
+      this.translate(0, anchorY);
+      this.scale(1, -1);
+      // First: translate anchor to origin
+      this.translate(0, -anchorY);
+    }
+
+    concatenate(other: AffineTransformation) {
+      //       a b c
+      //       d e f
+      //       0 0 1
+      // a b c
+      // d e f
+      // 0 0 1
+      const a = this.a * other.a + this.b * other.d;
+      const b = this.a * other.b + this.b * other.e;
+      const c = this.a * other.c + this.b * other.f + this.c;
+
+      const d = this.d * other.a + this.e * other.d;
+      const e = this.d * other.b + this.e * other.e;
+      const f = this.d * other.c + this.e * other.f + this.f;
+
+      this.a = a;
+      this.b = b;
+      this.c = c;
+      this.d = d;
+      this.e = e;
+      this.f = f;
+    }
+
+    transform(source: FloatPoint, destination: FloatPoint) {
+      //       x
+      //       y
+      //       1
+      // a b c
+      // d e f
+      // 0 0 1
+      const x = this.a * source[0] + this.b * source[1] + this.c;
+      const y = this.d * source[0] + this.e * source[1] + this.f;
+      destination[0] = x;
+      destination[1] = y;
+    }
+
+    toString() {
+      return `[[${this.a} ${this.b} ${this.c}] [${this.d} ${this.e} ${this.f}]]`;
+    }
+  }
+}

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -511,6 +511,31 @@ namespace gdjs {
       hex[r[15]]
     );
   };
+
+  /**
+   * See https://floating-point-gui.de/errors/comparison/
+   * @param a
+   * @param b
+   * @param epsilon the relative margin error
+   * @returns true when a and b are within a relative margin error.
+   */
+  export const nearlyEqual = (a: float, b: float, epsilon: float): boolean => {
+    const absA = Math.abs(a);
+    const absB = Math.abs(b);
+    const diff = Math.abs(a - b);
+
+    if (a === b) {
+      // shortcut, handles infinities
+      return true;
+    } else if (a == 0 || b == 0 || absA + absB < Number.EPSILON) {
+      // a or b is zero or both are extremely close to it
+      // relative error is less meaningful here
+      return diff < epsilon * Number.EPSILON;
+    } else {
+      // use relative error
+      return diff / Math.min(absA + absB, Number.MAX_VALUE) < epsilon;
+    }
+  };
 }
 
 //Make sure console.warn and console.error are available.

--- a/GDJS/tests/karma.conf.js
+++ b/GDJS/tests/karma.conf.js
@@ -67,6 +67,7 @@ module.exports = function (config) {
       '../../newIDE/app/resources/GDJS/Runtime/events-tools/stringtools.js',
       '../../newIDE/app/resources/GDJS/Runtime/events-tools/windowtools.js',
       '../../newIDE/app/resources/GDJS/Runtime/debugger-client/hot-reloader.js',
+      '../../newIDE/app/resources/GDJS/Runtime/affinetransformation.js',
 
       //Extensions:
       '../../newIDE/app/resources/GDJS/Runtime/Extensions/DraggableBehavior/draggableruntimebehavior.js',

--- a/GDJS/tests/tests/affinetransformation.spec.js
+++ b/GDJS/tests/tests/affinetransformation.spec.js
@@ -1,0 +1,58 @@
+describe('gdjs.AffineTransformation', function () {
+  const epsilon = 1 / (2 << 16);
+
+  it('can conserve identity through identity', function () {
+    const identityA = new gdjs.AffineTransformation();
+    const identityB = new gdjs.AffineTransformation();
+
+    expect(identityA.equals(identityB)).to.be(true);
+
+    identityB.setToIdentity();
+    expect(identityA.equals(identityB)).to.be(true);
+
+    identityB.concatenate(identityA);
+    expect(identityA.equals(identityB)).to.be(true);
+  });
+
+  it('can compose translations', function () {
+    const translationA = new gdjs.AffineTransformation();
+    translationA.setToTranslation(12 + 45, 67 + 89);
+
+    const translationB = new gdjs.AffineTransformation();
+    translationB.setToTranslation(12, 67);
+    translationB.translate(45, 89);
+
+    expect(translationA.equals(translationB)).to.be(true);
+  });
+
+  it('can compose rotations', function () {
+    const rotationA = new gdjs.AffineTransformation();
+    rotationA.setToRotation(Math.PI / 3 + Math.PI / 2);
+
+    const rotationB = new gdjs.AffineTransformation();
+    rotationB.setToRotation(Math.PI / 3);
+    rotationB.rotate(Math.PI / 2);
+
+    expect(rotationA.nearlyEquals(rotationB, epsilon)).to.be(true);
+  });
+
+  it('can do exact 90° rotation transformations', function () {
+    const rotationA = new gdjs.AffineTransformation();
+    rotationA.setToRotation(90 * Math.PI / 180);
+
+    const result = [10, 5];
+    rotationA.transform(result, result);
+    expect(result).to.eql([-5, 10]);
+  });
+
+  it('can compose scales', function () {
+    const scaleA = new gdjs.AffineTransformation();
+    scaleA.setToScale(2 * 4, 3 * 5);
+
+    const scaleB = new gdjs.AffineTransformation();
+    scaleB.setToScale(2, 3);
+    scaleB.scale(4, 5);
+
+    expect(scaleA.equals(scaleB)).to.be(true);
+  });
+});


### PR DESCRIPTION
Each time a point is transformed, the current implementation do a lot of calculus to apply an affine transformation.

https://github.com/4ian/GDevelop/blob/bc606ed1be28275624678dd7c6bcc192c2da846d/GDJS/Runtime/spriteruntimeobject.ts#L847-L883

The affine transformation can be calculated only once and reused for each point transformation:
```
    private _transformToGlobal(x: float, y: float, result: number[]) {
      result.length = 2;
      result[0] = x;
      result[1] = y;
      // @ts-ignore It's a FloatPoint at this point.
      this.getAffineTransformation().transform(result, result);
    }
```
```
    transform(source: FloatPoint, destination: FloatPoint) {
      //       x
      //       y
      //       1
      // a b c
      // d e f
      // 0 0 1
      const x = this.a * source[0] + this.b * source[1] + this.c;
      const y = this.d * source[0] + this.e * source[1] + this.f;
      destination[0] = x;
      destination[1] = y;
    }
```

Using the `AffineTransformation` class also make the code easier to follow (once used to the composition order).

It needs more tests and more features on `AffineTransformation`, but I wanted your view on this.

I couldn't find any library that allows incitation-free affine transformation so I started to implement this one.