### PR TITLE
Fix arrow keys being prevented properly to avoid page scroll when game is focused

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -8,11 +8,11 @@ namespace gdjs {
    * called. This is used to avoid scrolling in a webpage when these keys are pressed
    * in the game.
    */
-  const defaultPreventedKeys = [
-    'ArrowUp',
-    'ArrowDown',
-    'ArrowLeft',
-    'ArrowRight',
+  const defaultPreventedKeyCodes = [
+    37, // ArrowLeft
+    38, // ArrowUp
+    39, // ArrowRight
+    40, // ArrowDown
   ];
 
   /**
@@ -431,14 +431,14 @@ namespace gdjs {
 
       //Keyboard
       document.onkeydown = function (e) {
-        if (defaultPreventedKeys.includes(e.keyCode)) {
+        if (defaultPreventedKeyCodes.includes(e.keyCode)) {
           e.preventDefault();
         }
 
         manager.onKeyPressed(e.keyCode, e.location);
       };
       document.onkeyup = function (e) {
-        if (defaultPreventedKeys.includes(e.keyCode)) {
+        if (defaultPreventedKeyCodes.includes(e.keyCode)) {
           e.preventDefault();
         }
 


### PR DESCRIPTION
Fixes #2834 

I've tried the fix @MechanicalPen suggested in the linked issue and it looks like it was the right idea all along! (if I haven't missed anything?)
It looks like the original fix strategy was good, but it wasn't being called with the right values.
Changing the keys to the keyCodes fixes the issue.

Testing strategy:

I've created a project which:
- has a text & a textentry
- displays the textentry in the text
- detects up & down key and adds temporarily a 0 in the text
(project here: [KeyPress.zip](https://github.com/4ian/GDevelop/files/7587141/KeyPress.zip))


I've exported the project:  https://games.gdevelop-app.com/game-f4a6faea-e69b-4f4b-bd55-4b3e4c708545/index.html

And then embedded it inside an existing iframe of a game (for instance https://www.crimsongames.io/game/a-pixel-adventure-legion-1)
 - Open the Inspector
 - Modify the iframe src property with the link above
 
 The result:
 - text in the textentry is properly displayed
 - when game is not focused, up & down keys scroll the page
 - when game is focused, 0 is added when up & down keys are pressed, page doesn't scroll
 

https://user-images.githubusercontent.com/4895034/143005542-e79a2059-f242-4e9e-8b7a-719b9d6b7126.mov


 