### PR TITLE
Decrease build limits correctly after building

### DIFF
--- a/newIDE/app/src/Export/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportLauncher.js
@@ -119,7 +119,10 @@ export default class ExportLauncher extends Component<Props, State> {
     this.buildsWatcher.start({
       authenticatedUser,
       builds: [this.state.build],
-      onBuildUpdated: (build: Build) => this.setState({ build }),
+      onBuildUpdated: (build: Build) => {
+        this.setState({ build });
+        authenticatedUser.onRefreshUserProfile();
+      },
     });
   };
 


### PR DESCRIPTION
Realised that the build limits was never decreasing after a build because we're not fetching the limits again.

We could only do a call to limits, but I thought we might as well get the whole profile (easier technically as well)

https://user-images.githubusercontent.com/4895034/143212101-0fda9594-7867-48e5-a91c-aae6e0506157.mov


