### PR TITLE
Allow selection of locked objects in the editor

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -84,8 +84,14 @@ export default class InstancesMover {
     this.totalDeltaX += deltaX;
     this.totalDeltaY += deltaY;
 
+    const nonLockedInstances = instances.filter(
+      instance => !instance.isLocked()
+    );
+
     // It will magnet the corner nearest to the grabbing position
-    const initialSelectionAABB = this._getOrCreateSelectionAABB(instances);
+    const initialSelectionAABB = this._getOrCreateSelectionAABB(
+      nonLockedInstances
+    );
     if (!initialSelectionAABB) return;
     const magnetLeft = this._startX < initialSelectionAABB.centerX();
     const magnetTop = this._startY < initialSelectionAABB.centerY();
@@ -122,8 +128,8 @@ export default class InstancesMover {
     const roundedTotalDeltaX = magnetPosition[0] - initialMagnetX;
     const roundedTotalDeltaY = magnetPosition[1] - initialMagnetY;
 
-    for (var i = 0; i < instances.length; i++) {
-      const selectedInstance = instances[i];
+    for (var i = 0; i < nonLockedInstances.length; i++) {
+      const selectedInstance = nonLockedInstances[i];
 
       let initialPosition = this.instancePositions[selectedInstance.ptr];
       if (!initialPosition) {

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -105,7 +105,6 @@ export default class LayerRenderer {
 
       const pixiObject = renderedInstance.getPixiObject();
       if (pixiObject) pixiObject.zOrder = instance.getZOrder();
-      if (pixiObject) pixiObject.interactive = !instance.isLocked();
 
       // "Culling" improves rendering performance of large levels
       const isVisible = this._isInstanceVisible(instance);

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -142,7 +142,13 @@ export default class InstancesResizer {
     this.totalDeltaX += deltaX;
     this.totalDeltaY += deltaY;
 
-    const initialSelectionAABB = this._getOrCreateSelectionAABB(instances);
+    const nonLockedInstances = instances.filter(
+      instance => !instance.isLocked()
+    );
+
+    const initialSelectionAABB = this._getOrCreateSelectionAABB(
+      nonLockedInstances
+    );
     if (!initialSelectionAABB) return;
 
     // Round the grabbed handle position on the grid.
@@ -212,7 +218,7 @@ export default class InstancesResizer {
           initialSelectionAABB.height()
         : flippedTotalDeltaY;
 
-    const hasRotatedInstance = areAnyInstancesNotStraight(instances);
+    const hasRotatedInstance = areAnyInstancesNotStraight(nonLockedInstances);
 
     // Applying a rotation then a scaling can result to
     // an affine transformation with a shear transformation - which we don't want.
@@ -258,8 +264,8 @@ export default class InstancesResizer {
       resizeGrabbingRelativePositions[grabbingLocation][1] *
         initialSelectionAABB.height();
 
-    for (let i = 0; i < instances.length; i++) {
-      const selectedInstance = instances[i];
+    for (let i = 0; i < nonLockedInstances.length; i++) {
+      const selectedInstance = nonLockedInstances[i];
 
       let initialUnrotatedInstanceAABB = this._getOrCreateUnrotatedInstanceAABB(
         selectedInstance

--- a/newIDE/app/src/InstancesEditor/InstancesRotator.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRotator.js
@@ -73,12 +73,20 @@ export default class InstancesRotator {
     deltaY: number,
     proportional: boolean
   ) {
+    const nonLockedInstances = instances.filter(
+      instance => !instance.isLocked()
+    );
+
     if (!this._fixedPointIsUpToDate) {
       this._fixedPointIsUpToDate = true;
       let selectionAABB = new Rectangle();
-      selectionAABB.setRectangle(this._getOrCreateInstanceAABB(instances[0]));
-      for (let i = 1; i < instances.length; i++) {
-        selectionAABB.union(this._getOrCreateInstanceAABB(instances[i]));
+      selectionAABB.setRectangle(
+        this._getOrCreateInstanceAABB(nonLockedInstances[0])
+      );
+      for (let i = 1; i < nonLockedInstances.length; i++) {
+        selectionAABB.union(
+          this._getOrCreateInstanceAABB(nonLockedInstances[i])
+        );
       }
       this._fixedPoint[0] = selectionAABB.centerX();
       this._fixedPoint[1] = selectionAABB.centerY();
@@ -91,8 +99,8 @@ export default class InstancesRotator {
     this.totalDeltaX += deltaX;
     this.totalDeltaY += deltaY;
 
-    for (let i = 0; i < instances.length; i++) {
-      const selectedInstance = instances[i];
+    for (let i = 0; i < nonLockedInstances.length; i++) {
+      const selectedInstance = nonLockedInstances[i];
 
       const initialAABB = this._getOrCreateInstanceAABB(selectedInstance);
       const initialAngle = this._getOrCreateInstanceAngle(selectedInstance);

--- a/newIDE/app/src/InstancesEditor/SelectedInstances.js
+++ b/newIDE/app/src/InstancesEditor/SelectedInstances.js
@@ -200,8 +200,9 @@ export default class SelectedInstances {
     let y1 = 0;
     let x2 = 0;
     let y2 = 0;
+    let initialised = false;
 
-    //Update the selection rectangle of each instance
+    // Update the selection rectangle of each instance.
     for (var i = 0; i < selection.length; i++) {
       if (this.selectedRectangles.length === i) {
         const newRectangle = new PIXI.Graphics();
@@ -218,8 +219,9 @@ export default class SelectedInstances {
       );
 
       this.selectedRectangles[i].clear();
-      this.selectedRectangles[i].beginFill(0x6868e8);
-      this.selectedRectangles[i].lineStyle(1, 0x6868e8, 1);
+      const selectionRectangleColor = instance.isLocked() ? 0xbc5753 : 0x6868e8;
+      this.selectedRectangles[i].beginFill(selectionRectangleColor);
+      this.selectedRectangles[i].lineStyle(1, selectionRectangleColor, 1);
       this.selectedRectangles[i].fill.alpha = 0.3;
       this.selectedRectangles[i].alpha = 0.8;
       this.selectedRectangles[i].drawRect(
@@ -230,11 +232,15 @@ export default class SelectedInstances {
       );
       this.selectedRectangles[i].endFill();
 
-      if (i === 0) {
+      if (instance.isLocked()) {
+        continue;
+      }
+      if (!initialised) {
         x1 = instanceRect.x;
         y1 = instanceRect.y;
         x2 = instanceRect.x + instanceRect.width;
         y2 = instanceRect.y + instanceRect.height;
+        initialised = true;
       } else {
         if (instanceRect.x < x1) x1 = instanceRect.x;
         if (instanceRect.y < y1) y1 = instanceRect.y;
@@ -249,7 +255,9 @@ export default class SelectedInstances {
       this.rectanglesContainer.removeChild(this.selectedRectangles.pop());
     }
 
-    const show = selection.length !== 0;
+    // If there are no unlocked instances, hide the resize buttons.
+    const show =
+      selection.filter(instance => !instance.isLocked()).length !== 0;
 
     // Position the resize buttons.
     for (const grabbingLocation of resizeGrabbingLocationValues) {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -809,9 +809,10 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   deleteSelection = () => {
     const selectedInstances = this.instancesSelection.getSelectedInstances();
-    selectedInstances.map(instance =>
-      this.props.initialInstances.removeInstance(instance)
-    );
+    selectedInstances.forEach(instance => {
+      if (instance.isLocked()) return;
+      this.props.initialInstances.removeInstance(instance);
+    });
 
     this.instancesSelection.clearSelection();
     if (this.editor) this.editor.clearHighlightedInstance();


### PR DESCRIPTION
Addressing #785 

I think that, like suggested in the issue, when an object is locked, and we still allow its selection, but prevent any action done on it, has a better UX overall.
See video for example.

https://user-images.githubusercontent.com/4895034/143222784-4a40ddef-571e-45e5-ab12-5a558145d2f4.mov



