### PR TITLE
Fix TileSprite being correctly displayed with an offset

### DIFF
--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -76,11 +76,19 @@ namespace gdjs {
     }
 
     updateXOffset(): void {
-      this._tiledSprite.tilePosition.x = -this._object._xOffset;
+      // Known PIXI.js issue, the coordinates should not exceed the width/height of the texture,
+      // otherwise the texture will be pixelated over time.
+      // See https://github.com/pixijs/pixijs/issues/7891#issuecomment-947549553
+      this._tiledSprite.tilePosition.x =
+        -this._object._xOffset % this._tiledSprite.texture.width;
     }
 
     updateYOffset(): void {
-      this._tiledSprite.tilePosition.y = -this._object._yOffset;
+      // Known PIXI.js issue, the coordinates should not exceed the width/height of the texture,
+      // otherwise the texture will be pixelated over time.
+      // See https://github.com/pixijs/pixijs/issues/7891#issuecomment-947549553
+      this._tiledSprite.tilePosition.y =
+        -this._object._yOffset % this._tiledSprite.texture.height;
     }
 
     setColor(rgbColor): void {


### PR DESCRIPTION
Fixes https://github.com/4ian/GDevelop/issues/941

I've briefly looked at this issue again, since we are now using the official `PIXI.TilingSprite`.
The issue still happens on Android.

It actually is a known issue by Pixi.JS (https://github.com/pixijs/pixijs/issues/7891) because of precision issues.
The fix is indeed to only take the remaining part of the offset based on the texture's size.
Looking good now!