### PR TITLE
Fix tabs in preference dialog not always on top

### DIFF
--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -74,12 +74,15 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
         <div>
           <Tabs value={currentTab} onChange={setCurrentTab}>
             <Tab label={<Trans>Preferences</Trans>} value="preferences" />
-            <Tab label={<Trans>Hints &amp; explanations</Trans>} value="hints" />
+            <Tab
+              label={<Trans>Hints &amp; explanations</Trans>}
+              value="hints"
+            />
             <Tab label={<Trans>Keyboard Shortcuts</Trans>} value="shortcuts" />
           </Tabs>
-        </div>}
+        </div>
+      }
     >
-      
       {currentTab === 'preferences' && (
         <Column>
           <Text size="title">

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -67,15 +67,19 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
       onRequestClose={onClose}
       cannotBeDismissed={true}
       open
-      title={<Trans>GDevelop Preferences</Trans>}
+      noTitleMargin
       maxWidth="sm"
       noMargin
+      title={
+        <div>
+          <Tabs value={currentTab} onChange={setCurrentTab}>
+            <Tab label={<Trans>Preferences</Trans>} value="preferences" />
+            <Tab label={<Trans>Hints &amp; explanations</Trans>} value="hints" />
+            <Tab label={<Trans>Keyboard Shortcuts</Trans>} value="shortcuts" />
+          </Tabs>
+        </div>}
     >
-      <Tabs value={currentTab} onChange={setCurrentTab}>
-        <Tab label={<Trans>Preferences</Trans>} value="preferences" />
-        <Tab label={<Trans>Hints &amp; explanations</Trans>} value="hints" />
-        <Tab label={<Trans>Keyboard Shortcuts</Trans>} value="shortcuts" />
-      </Tabs>
+      
       {currentTab === 'preferences' && (
         <Column>
           <Text size="title">

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -71,16 +71,11 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
       maxWidth="sm"
       noMargin
       title={
-        <div>
-          <Tabs value={currentTab} onChange={setCurrentTab}>
-            <Tab label={<Trans>Preferences</Trans>} value="preferences" />
-            <Tab
-              label={<Trans>Hints &amp; explanations</Trans>}
-              value="hints"
-            />
-            <Tab label={<Trans>Keyboard Shortcuts</Trans>} value="shortcuts" />
-          </Tabs>
-        </div>
+        <Tabs value={currentTab} onChange={setCurrentTab}>
+          <Tab label={<Trans>Preferences</Trans>} value="preferences" />
+          <Tab label={<Trans>Hints &amp; explanations</Trans>} value="hints" />
+          <Tab label={<Trans>Keyboard Shortcuts</Trans>} value="shortcuts" />
+        </Tabs>
       }
     >
       {currentTab === 'preferences' && (


### PR DESCRIPTION
- Removed the `Preference` Title as no other similar dialogs (project properties, profile) had a title text. All of them had the Tabs as title
- Fix Tabs not always on top. Fixes #3293 

![Pre-comparision](https://user-images.githubusercontent.com/73597906/143669845-5b78ae57-b97a-45df-85d3-f4e8cc429fa8.png)


