### PR TITLE
Fix example library error text

### DIFF
--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
@@ -121,7 +121,7 @@ export function ExampleDialog({
           <AlertMessage kind="error">
             <Trans>
               Unfortunately, this example requires a newer version of GDevelop
-              to work. Upgrade GDevelop to be able to open this example.
+              to work. Update GDevelop to be able to open this example.
             </Trans>
           </AlertMessage>
         )}

--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
@@ -121,8 +121,7 @@ export function ExampleDialog({
           <AlertMessage kind="error">
             <Trans>
               Unfortunately, this example requires a newer version of GDevelop
-              to work. Upgrade GDevelop to be able to use this extension in your
-              project.
+              to work. Upgrade GDevelop to be able to open this example.
             </Trans>
           </AlertMessage>
         )}

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -128,7 +128,7 @@ export default class ExtensionInstallDialog extends Component<Props, State> {
             <AlertMessage kind="error">
               <Trans>
                 Unfortunately, this extension requires a newer version of
-                GDevelop to work. Upgrade GDevelop to be able to use this
+                GDevelop to work. Update GDevelop to be able to use this
                 extension in your project.
               </Trans>
             </AlertMessage>


### PR DESCRIPTION
- Fix alert mentioning extensions instead of examples
- Use `Update` instead of `Upgrade`for both example and extension dialog  as upgrade sounded like the user had to get a subscription and `update` is a bit of common in the UI