### PR TITLE
Fix debugger actions being always displayed after first use

### DIFF
--- a/newIDE/app/src/Debugger/index.js
+++ b/newIDE/app/src/Debugger/index.js
@@ -41,7 +41,6 @@ const isUnavoidableLibraryWarning = ({ group, message }: Log): boolean =>
 type Props = {|
   project: gdProject,
   setToolbar: React.Node => void,
-  isActive: boolean,
   previewDebuggerServer: PreviewDebuggerServer,
 |};
 
@@ -79,8 +78,6 @@ export default class Debugger extends React.Component<Props, State> {
   _debuggerLogs: Map<number, LogsManager> = new Map();
 
   updateToolbar() {
-    if (!this.props.isActive) return;
-
     this.props.setToolbar(
       <Toolbar
         onPlay={() => this._play(this.state.selectedId)}
@@ -102,15 +99,7 @@ export default class Debugger extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    if (this.props.isActive) {
-      this._registerServerCallbacks();
-    }
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.isActive && !this.props.isActive) {
-      this._registerServerCallbacks();
-    }
+    this._registerServerCallbacks();
   }
 
   componentWillUnmount() {

--- a/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
@@ -24,9 +24,8 @@ export class DebuggerEditorContainer extends React.Component<
   };
 
   shouldComponentUpdate(nextProps: RenderEditorContainerProps) {
-    // Prevent any update to the editor if the editor is not active,
-    // and so not visible to the user.
-    return nextProps.isActive;
+    // We render updates only if the component is active, or becoming active.
+    return this.props.isActive || nextProps.isActive;
   }
 
   getProject(): ?gdProject {
@@ -75,7 +74,6 @@ export class DebuggerEditorContainer extends React.Component<
         <Debugger
           project={project}
           setToolbar={this.props.setToolbar}
-          isActive={this.props.isActive}
           previewDebuggerServer={previewDebuggerServer}
           ref={editor => (this.editor = editor)}
         />

--- a/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
@@ -24,7 +24,9 @@ export class DebuggerEditorContainer extends React.Component<
   };
 
   shouldComponentUpdate(nextProps: RenderEditorContainerProps) {
-    // We render updates only if the component is active, or becoming active.
+    // We stop updates when the component is inactive.
+    // If it's active, was active or becoming active again we let update propagate.
+    // Especially important to note that when becoming inactive, a "last" update is allowed.
     return this.props.isActive || nextProps.isActive;
   }
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -772,8 +772,8 @@ const MainFrame = (props: Props) => {
     [openProjectManager]
   );
 
-  const setEditorToolbar = (editorToolbar: any) => {
-    if (!toolbar.current) return;
+  const setEditorToolbar = (editorToolbar: any, isCurrentTab = true) => {
+    if (!toolbar.current || !isCurrentTab) return;
 
     toolbar.current.setEditorToolbar(editorToolbar);
   };
@@ -2176,7 +2176,8 @@ const MainFrame = (props: Props) => {
                   extraEditorProps: editorTab.extraEditorProps,
                   project: currentProject,
                   ref: editorRef => (editorTab.editorRef = editorRef),
-                  setToolbar: setEditorToolbar,
+                  setToolbar: editorToolbar =>
+                    setEditorToolbar(editorToolbar, isCurrentTab),
                   onChangeSubscription: () => openSubscriptionDialog(true),
                   projectItemName: editorTab.projectItemName,
                   setPreviewedLayout,


### PR DESCRIPTION
Fixes #3296 

As the top component doesn't re-render when isActive = false, lifecyclemethods of `Debugger/index.js` will not be triggered and isActive will never go from `true` to `false`