### PR TITLE
Fix light textures sometimes not behaving properly when close to obstacles

### DIFF
--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -546,9 +546,11 @@ namespace gdjs {
   varying vec2 vPos;
 
   void main() {
-      vec2 topleft = vec2(center.x - radius, center.y - radius);
-      vec2 texCoord = (vPos - topleft)/(2.0 * radius);
-      gl_FragColor = vec4(color, 1.0) * texture2D(uSampler, texCoord);
+    vec2 topleft = vec2(center.x - radius, center.y - radius);
+    vec2 texCoord = (vPos - topleft)/(2.0 * radius);
+    gl_FragColor = (texCoord.x > 0.0 && texCoord.x < 1.0 && texCoord.y > 0.0 && texCoord.y < 1.0)
+      ? vec4(color, 1.0) * texture2D(uSampler, texCoord)
+      : vec4(0.0, 0.0, 0.0, 0.0);
   }`;
   }
 


### PR DESCRIPTION
Fixes #3224 

Fixed by not setting the Fragment Color when outside the texture coordinates.
I'm not an GLSL expert though, can this cause issues somewhere else?

![image](https://user-images.githubusercontent.com/4895034/144875113-bf0df19e-b18f-4248-b1b6-e534df983ba9.png)
