### PR TITLE
Improve resilience of resources fetching of the desktop app

### DIFF
--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.js
@@ -3,6 +3,7 @@ import optionalRequire from '../../Utils/OptionalRequire.js';
 import newNameGenerator from '../../Utils/NewNameGenerator';
 import { type ResourceFetcher, type FetchResourcesArgs } from '.';
 import PromisePool from '@supercharge/promise-pool';
+import { retryIfFailed } from '../../Utils/RetryIfFailed.js';
 const electron = optionalRequire('electron');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
 const fs = optionalRequire('fs-extra');
@@ -44,7 +45,7 @@ const fetchResources = async ({
   let fetchedResourcesCount = 0;
   const resourcesToFetch = getResourcesToFetch(project);
 
-  return PromisePool.withConcurrency(10)
+  return PromisePool.withConcurrency(50)
     .for(resourceNames)
     .process(async resourceName => {
       const resource = resourcesManager.getResource(resourceName);
@@ -62,12 +63,14 @@ const fetchResources = async ({
       downloadedFilePaths.add(newPath);
 
       try {
-        await fs.ensureDir(baseAssetsPath);
-        await ipcRenderer.invoke('local-file-download', url, newPath);
-        resource.setFile(
-          path.relative(projectPath, newPath).replace(/\\/g, '/')
-        );
-        fetchedResources.push({ resourceName });
+        await retryIfFailed({ times: 2 }, async () => {
+          await fs.ensureDir(baseAssetsPath);
+          await ipcRenderer.invoke('local-file-download', url, newPath);
+          resource.setFile(
+            path.relative(projectPath, newPath).replace(/\\/g, '/')
+          );
+          fetchedResources.push({ resourceName });
+        });
       } catch (error) {
         erroredResources.push({ resourceName, error });
       }

--- a/newIDE/app/src/Utils/RetryIfFailed.js
+++ b/newIDE/app/src/Utils/RetryIfFailed.js
@@ -1,0 +1,22 @@
+//@flow
+type Configuration = {| times: number |};
+
+export const retryIfFailed = async <T>(
+  { times }: Configuration,
+  fn: () => Promise<T>
+): Promise<T> => {
+  let tries = 0;
+  let latestError = null;
+  while (tries < times) {
+    tries++;
+    latestError = null;
+    try {
+      const latestReturnValue = await fn();
+      return latestReturnValue;
+    } catch (error) {
+      latestError = error;
+    }
+  }
+
+  throw latestError;
+};


### PR DESCRIPTION
Do more requests at the same time but retry the failing ones.

Don't show in changelog