### PR TITLE
Allow event based functions to declare their groups.

### DIFF
--- a/Core/GDCore/Project/EventsFunction.cpp
+++ b/Core/GDCore/Project/EventsFunction.cpp
@@ -17,6 +17,7 @@ void EventsFunction::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("fullName", fullName);
   element.SetAttribute("description", description);
   element.SetAttribute("sentence", sentence);
+  element.SetAttribute("group", group);
   element.SetBoolAttribute("private", isPrivate);
   events.SerializeTo(element.AddChild("events"));
 
@@ -44,6 +45,7 @@ void EventsFunction::UnserializeFrom(gd::Project& project,
   fullName = element.GetStringAttribute("fullName");
   description = element.GetStringAttribute("description");
   sentence = element.GetStringAttribute("sentence");
+  group = element.GetStringAttribute("group");
   isPrivate = element.GetBoolAttribute("private");
   events.UnserializeFrom(project, element.GetChild("events"));
 

--- a/Core/GDCore/Project/EventsFunction.h
+++ b/Core/GDCore/Project/EventsFunction.h
@@ -102,6 +102,19 @@ class GD_CORE_API EventsFunction {
     return *this;
   }
 
+  /**
+   * \brief Get the group of the instruction in the editor.
+   */
+  const gd::String& GetGroup() const { return group; };
+
+  /**
+   * \brief Set the group of the instruction in the editor.
+   */
+  EventsFunction& SetGroup(const gd::String& group_) {
+    group = group_;
+    return *this;
+  }
+
   enum FunctionType { Action, Condition, Expression, StringExpression };
 
   /**
@@ -188,6 +201,7 @@ class GD_CORE_API EventsFunction {
   gd::String fullName;
   gd::String description;
   gd::String sentence;
+  gd::String group;
   gd::EventsList events;
   FunctionType functionType;
   std::vector<gd::ParameterMetadata> parameters;

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2094,6 +2094,8 @@ interface EventsFunction {
     [Const, Ref] DOMString GetFullName();
     [Ref] EventsFunction SetSentence([Const] DOMString sentence);
     [Const, Ref] DOMString GetSentence();
+    [Ref] EventsFunction SetGroup([Const] DOMString group);
+    [Const, Ref] DOMString GetGroup();
     [Ref] EventsFunction SetPrivate(boolean isPrivate);
     boolean IsPrivate();
     [Ref] EventsFunction SetFunctionType(EventsFunction_FunctionType type);

--- a/GDevelop.js/types/gdeventsfunction.js
+++ b/GDevelop.js/types/gdeventsfunction.js
@@ -14,6 +14,8 @@ declare class gdEventsFunction {
   getFullName(): string;
   setSentence(sentence: string): gdEventsFunction;
   getSentence(): string;
+  setGroup(group: string): gdEventsFunction;
+  getGroup(): string;
   setPrivate(isPrivate: boolean): gdEventsFunction;
   isPrivate(): boolean;
   setFunctionType(type: EventsFunction_FunctionType): gdEventsFunction;

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -31,7 +31,7 @@ type Props = {|
   onConfigurationUpdated?: () => void,
   renderConfigurationHeader?: () => React.Node,
   freezeEventsFunctionType?: boolean,
-  functionGroupNames?: string[],
+  getFunctionGroupNames?: () => string[],
 |};
 
 type State = {||};
@@ -117,7 +117,7 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
       helpPagePath,
       renderConfigurationHeader,
       eventsBasedBehavior,
-      functionGroupNames,
+      getFunctionGroupNames,
     } = this.props;
 
     const type = eventsFunction.getFunctionType();
@@ -228,8 +228,8 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
                   this.forceUpdate();
                 }}
                 dataSource={
-                  functionGroupNames
-                    ? functionGroupNames.map(name => ({
+                  getFunctionGroupNames
+                    ? getFunctionGroupNames().map(name => ({
                         text: name,
                         value: name,
                       }))

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -20,6 +20,7 @@ import { getParametersIndexOffset } from '../../EventsFunctionsExtensionsLoader'
 import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 import { ResponsiveLineStackLayout, ColumnStackLayout } from '../../UI/Layout';
 import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
+import SemiControlledAutoComplete from '../../UI/SemiControlledAutoComplete';
 
 const gd: libGDevelop = global.gd;
 
@@ -115,6 +116,7 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
       helpPagePath,
       renderConfigurationHeader,
       eventsBasedBehavior,
+      functionGroupNames,
     } = this.props;
 
     const type = eventsFunction.getFunctionType();
@@ -213,6 +215,30 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
                 fullWidth
               />
             </ResponsiveLineStackLayout>
+            <Line noMargin>
+              <SemiControlledAutoComplete
+                commitOnBlur
+                floatingLabelText={<Trans>Group name</Trans>}
+                hintText={t`Leave it empty to use the default group for this extension.`}
+                fullWidth
+                multiline
+                value={eventsFunction.getGroup()}
+                onChange={text => {
+                  eventsFunction.setGroup(text);
+                  if (onConfigurationUpdated) onConfigurationUpdated();
+                  this.forceUpdate();
+                }}
+                dataSource={
+                  functionGroupNames
+                    ? functionGroupNames.map(name => ({
+                        text: name,
+                        value: name,
+                      }))
+                    : []
+                }
+                openOnFocus={true}
+              />
+            </Line>
             <Line noMargin>
               <SemiControlledTextField
                 commitOnBlur

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -31,6 +31,7 @@ type Props = {|
   onConfigurationUpdated?: () => void,
   renderConfigurationHeader?: () => React.Node,
   freezeEventsFunctionType?: boolean,
+  functionGroupNames: string[],
 |};
 
 type State = {||};

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -31,7 +31,7 @@ type Props = {|
   onConfigurationUpdated?: () => void,
   renderConfigurationHeader?: () => React.Node,
   freezeEventsFunctionType?: boolean,
-  functionGroupNames: string[],
+  functionGroupNames?: string[],
 |};
 
 type State = {||};
@@ -218,11 +218,9 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
             </ResponsiveLineStackLayout>
             <Line noMargin>
               <SemiControlledAutoComplete
-                commitOnBlur
                 floatingLabelText={<Trans>Group name</Trans>}
                 hintText={t`Leave it empty to use the default group for this extension.`}
                 fullWidth
-                multiline
                 value={eventsFunction.getGroup()}
                 onChange={text => {
                   eventsFunction.setGroup(text);

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -41,7 +41,7 @@ type Props = {|
     done: (boolean) => void
   ) => void,
   unsavedChanges?: ?UnsavedChanges,
-  functionGroupNames?: string[],
+  getFunctionGroupNames?: () => string[],
 |};
 
 type TabNames = 'config' | 'parameters' | 'groups';
@@ -162,7 +162,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
       renderConfigurationHeader,
       onMoveFreeEventsParameter,
       onMoveBehaviorEventsParameter,
-      functionGroupNames,
+      getFunctionGroupNames,
     } = this.props;
 
     return (
@@ -191,7 +191,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
                 onConfigurationUpdated={onConfigurationUpdated}
                 renderConfigurationHeader={renderConfigurationHeader}
                 freezeEventsFunctionType={freezeEventsFunctionType}
-                functionGroupNames={functionGroupNames}
+                getFunctionGroupNames={getFunctionGroupNames}
               />
             </Line>
           </ScrollView>

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -41,7 +41,7 @@ type Props = {|
     done: (boolean) => void
   ) => void,
   unsavedChanges?: ?UnsavedChanges,
-  functionGroupNames: string[],
+  functionGroupNames?: string[],
 |};
 
 type TabNames = 'config' | 'parameters' | 'groups';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -41,6 +41,7 @@ type Props = {|
     done: (boolean) => void
   ) => void,
   unsavedChanges?: ?UnsavedChanges,
+  functionGroupNames: string[],
 |};
 
 type TabNames = 'config' | 'parameters' | 'groups';
@@ -161,6 +162,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
       renderConfigurationHeader,
       onMoveFreeEventsParameter,
       onMoveBehaviorEventsParameter,
+      functionGroupNames,
     } = this.props;
 
     return (
@@ -189,6 +191,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
                 onConfigurationUpdated={onConfigurationUpdated}
                 renderConfigurationHeader={renderConfigurationHeader}
                 freezeEventsFunctionType={freezeEventsFunctionType}
+                functionGroupNames={functionGroupNames}
               />
             </Line>
           </ScrollView>

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -621,7 +621,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
   };
 
   _getFunctionGroupNames = () => {
-    const groupNames = [];
+    const groupNames = new Set<String>();
     // Look only in the edited function container because
     // functions from the extension or different behaviors
     // won't use the same groups names.
@@ -637,8 +637,8 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
         const groupName = eventFunctionContainer
           .getEventsFunctionAt(index)
           .getGroup();
-        if (groupName && !groupNames.includes(groupName)) {
-          groupNames.push(groupName);
+        if (groupName) {
+          groupNames.add(groupName);
         }
       }
     } else {
@@ -651,12 +651,12 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
         const groupName = eventsFunctionsExtension
           .getEventsFunctionAt(index)
           .getGroup();
-        if (groupName && !groupNames.includes(groupName)) {
-          groupNames.push(groupName);
+        if (groupName) {
+          groupNames.add(groupName);
         }
       }
     }
-    return groupNames;
+    return [...groupNames].sort((a, b) => a.localeCompare(b));
   };
 
   render() {

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -720,7 +720,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
                       i18n
                     )}
                     unsavedChanges={this.props.unsavedChanges}
-                    functionGroupNames={this._getFunctionGroupNames()}
+                    getFunctionGroupNames={this._getFunctionGroupNames}
                   />
                 ) : (
                   <EmptyMessage>

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -621,7 +621,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
   };
 
   _getFunctionGroupNames = () => {
-    const groupNames = new Set<String>();
+    const groupNames = new Set<string>();
     // Look only in the edited function container because
     // functions from the extension or different behaviors
     // won't use the same groups names.

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -620,6 +620,45 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     }
   };
 
+  _getFunctionGroupNames = () => {
+    const groupNames = [];
+    // Look only in the edited function container because
+    // functions from the extension or different behaviors
+    // won't use the same groups names.
+    // An independent autocompletion is done for each of them.
+    const { selectedEventsBasedBehavior } = this.state;
+    if (selectedEventsBasedBehavior) {
+      const eventFunctionContainer = selectedEventsBasedBehavior.getEventsFunctions();
+      for (
+        let index = 0;
+        index < eventFunctionContainer.getEventsFunctionsCount();
+        index++
+      ) {
+        const groupName = eventFunctionContainer
+          .getEventsFunctionAt(index)
+          .getGroup();
+        if (groupName && !groupNames.includes(groupName)) {
+          groupNames.push(groupName);
+        }
+      }
+    } else {
+      const { eventsFunctionsExtension } = this.props;
+      for (
+        let index = 0;
+        index < eventsFunctionsExtension.getEventsFunctionsCount();
+        index++
+      ) {
+        const groupName = eventsFunctionsExtension
+          .getEventsFunctionAt(index)
+          .getGroup();
+        if (groupName && !groupNames.includes(groupName)) {
+          groupNames.push(groupName);
+        }
+      }
+    }
+    return groupNames;
+  };
+
   render() {
     const { project, eventsFunctionsExtension } = this.props;
     const {
@@ -681,6 +720,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
                       i18n
                     )}
                     unsavedChanges={this.props.unsavedChanges}
+                    functionGroupNames={this._getFunctionGroupNames()}
                   />
                 ) : (
                   <EmptyMessage>

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -620,7 +620,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     }
   };
 
-  _getFunctionGroupNames = () => {
+  _getFunctionGroupNames = (): Array<string> => {
     const groupNames = new Set<string>();
     // Look only in the edited function container because
     // functions from the extension or different behaviors

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -233,7 +233,8 @@ export const declareInstructionOrExpressionMetadata = (
       eventsFunction.getName(),
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
-      eventsFunctionsExtension.getFullName() ||
+      eventsFunction.getGroup() ||
+        eventsFunctionsExtension.getFullName() ||
         eventsFunctionsExtension.getName(),
       getExtensionIconUrl(extension)
     );
@@ -242,7 +243,8 @@ export const declareInstructionOrExpressionMetadata = (
       eventsFunction.getName(),
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
-      eventsFunctionsExtension.getFullName() ||
+      eventsFunction.getGroup() ||
+        eventsFunctionsExtension.getFullName() ||
         eventsFunctionsExtension.getName(),
       getExtensionIconUrl(extension)
     );
@@ -252,7 +254,8 @@ export const declareInstructionOrExpressionMetadata = (
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
       eventsFunction.getSentence(),
-      eventsFunctionsExtension.getFullName() ||
+      eventsFunction.getGroup() ||
+        eventsFunctionsExtension.getFullName() ||
         eventsFunctionsExtension.getName(),
       getExtensionIconUrl(extension),
       getExtensionIconUrl(extension)
@@ -263,7 +266,8 @@ export const declareInstructionOrExpressionMetadata = (
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
       eventsFunction.getSentence(),
-      eventsFunctionsExtension.getFullName() ||
+      eventsFunction.getGroup() ||
+        eventsFunctionsExtension.getFullName() ||
         eventsFunctionsExtension.getName(),
       getExtensionIconUrl(extension),
       getExtensionIconUrl(extension)
@@ -287,7 +291,9 @@ export const declareBehaviorInstructionOrExpressionMetadata = (
       eventsFunction.getName(),
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
-      eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
+      eventsFunction.getGroup() ||
+        eventsBasedBehavior.getFullName() ||
+        eventsBasedBehavior.getName(),
       getExtensionIconUrl(extension)
     );
   } else if (functionType === gd.EventsFunction.StringExpression) {
@@ -295,7 +301,9 @@ export const declareBehaviorInstructionOrExpressionMetadata = (
       eventsFunction.getName(),
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
-      eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
+      eventsFunction.getGroup() ||
+        eventsBasedBehavior.getFullName() ||
+        eventsBasedBehavior.getName(),
       getExtensionIconUrl(extension)
     );
   } else if (functionType === gd.EventsFunction.Condition) {
@@ -307,7 +315,9 @@ export const declareBehaviorInstructionOrExpressionMetadata = (
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
       eventsFunction.getSentence(),
-      eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
+      eventsFunction.getGroup() ||
+        eventsBasedBehavior.getFullName() ||
+        eventsBasedBehavior.getName(),
       getExtensionIconUrl(extension),
       getExtensionIconUrl(extension)
     );
@@ -320,7 +330,9 @@ export const declareBehaviorInstructionOrExpressionMetadata = (
       eventsFunction.getFullName() || eventsFunction.getName(),
       eventsFunction.getDescription() || eventsFunction.getFullName(),
       eventsFunction.getSentence(),
-      eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
+      eventsFunction.getGroup() ||
+        eventsBasedBehavior.getFullName() ||
+        eventsBasedBehavior.getName(),
       getExtensionIconUrl(extension),
       getExtensionIconUrl(extension)
     );

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
@@ -91,6 +91,31 @@ export default class EventsFunctionExtractorDialog extends React.Component<
     if (eventsFunction) eventsFunction.delete();
   }
 
+  _getFunctionGroupNames = () => {
+    const { createNewExtension, extensionName } = this.state;
+    if (createNewExtension || !extensionName) {
+      return [];
+    }
+    const groupNames = [];
+    const { project } = this.props;
+    const eventsFunctionsExtension = project.getEventsFunctionsExtension(
+      extensionName
+    );
+    for (
+      let index = 0;
+      index < eventsFunctionsExtension.getEventsFunctionsCount();
+      index++
+    ) {
+      const groupName = eventsFunctionsExtension
+        .getEventsFunctionAt(index)
+        .getGroup();
+      if (groupName && !groupNames.includes(groupName)) {
+        groupNames.push(groupName);
+      }
+    }
+    return groupNames;
+  };
+
   render() {
     const { project, onClose, onCreate } = this.props;
     const { eventsFunction, extensionName, createNewExtension } = this.state;
@@ -265,6 +290,7 @@ export default class EventsFunctionExtractorDialog extends React.Component<
               this.forceUpdate();
             }}
             freezeEventsFunctionType
+            getFunctionGroupNames={this._getFunctionGroupNames}
           />
           <Spacer />
           <EventsFunctionParametersEditor


### PR DESCRIPTION
It doesn't display the groups in the function list of the extension editor, but it can already be used to make it easier for extension users to find a function.

## Manual tests

### Behavior functions

![FunctionGroupName](https://user-images.githubusercontent.com/2611977/146264230-2348d5ab-f9ec-4250-a0f7-0f678edfb838.png) ![FunctionGroupActions](https://user-images.githubusercontent.com/2611977/146264246-4ba3cc45-c094-4d85-b368-72b043e76ff7.png)

### Extension functions

![ExtensionFunctionGroup](https://user-images.githubusercontent.com/2611977/146285286-aa1a5f2d-b87a-4218-91a0-49c0603ccb63.png) ![ExtensionFunctionGroupActions](https://user-images.githubusercontent.com/2611977/146285298-d4749765-a4d5-481c-a0cb-ad65e31288c9.png)

### Extract function dialog

![ExtractedFunctionGroup](https://user-images.githubusercontent.com/2611977/146285338-7fadbacf-ad1e-4913-9f1e-8bc0ba9f33dc.png)

