### PR TITLE
Fix 'Not' condition not working with most object conditions

### DIFF
--- a/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -278,7 +278,7 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
               outputCode +=
                   codeGenerator.GenerateBooleanFullName(
                       "condition" + gd::String::From(i) + "IsTrue", context) +
-                  ".val = true;\n";
+                  ".val = false;\n";
             }
 
             for (unsigned int cId = 0; cId < conditions.size(); ++cId) {


### PR DESCRIPTION
The 'Not' condition was giving the variable `IsTrue` a default value of `true`, where it is expected by the default object picking code for that variable to default to be false. It likely wasn't noticed as only some conditions break, the ones that do `if (condition) IsTrue = true;`, not the ones that do `IsTrue = condition` (most of them).

Fixes #3233

Tested with the repro project of #3233 to see if the bug was fixed, and with a previously working object condition, no condition, and a free condition to check for regressions.