### PR TITLE
Improve local IP getting

### DIFF
--- a/newIDE/electron-app/app/Utils/LocalNetworkIpFinder.js
+++ b/newIDE/electron-app/app/Utils/LocalNetworkIpFinder.js
@@ -2,18 +2,12 @@ const os = require('os');
 
 /** @returns {string[]} */
 const getLocalNetworkIps = () => {
-  var interfaces = os.networkInterfaces();
-  var addresses = [];
-  for (var k in interfaces) {
-    for (var k2 in interfaces[k]) {
-      var address = interfaces[k][k2];
-      if (address.family === 'IPv4' && !address.internal) {
-        addresses.push(address.address);
-      }
-    }
-  }
-
-  return addresses;
+  return Object.entries(os.networkInterfaces())
+    .flatMap(([name, interface]) =>
+      name.match(/^(VirtualBox|VMware)/) ? [] : interface
+    )
+    .filter(({ family, internal }) => family === 'IPv4' && !internal)
+    .map(({ address }) => address);
 };
 
 /** @returns {?string} */

--- a/newIDE/electron-app/app/Utils/LocalNetworkIpFinder.js
+++ b/newIDE/electron-app/app/Utils/LocalNetworkIpFinder.js
@@ -3,8 +3,8 @@ const os = require('os');
 /** @returns {string[]} */
 const getLocalNetworkIps = () => {
   return Object.entries(os.networkInterfaces())
-    .flatMap(([name, interface]) =>
-      name.match(/^(VirtualBox|VMware)/) ? [] : interface
+    .flatMap(([name, interfaces]) =>
+      name.match(/^(VirtualBox|VMware)/) ? [] : interfaces
     )
     .filter(({ family, internal }) => family === 'IPv4' && !internal)
     .map(({ address }) => address);


### PR DESCRIPTION
When having virtualization software installed, a computer has fake local network interfaces and gives an unusable local IP. This adds a check to filter out interfaces from common virtualization software. Tested with my own PC that has VirtualBox installed.