### PR TITLE
Add notifications on user chip and achievements

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -41,6 +41,7 @@ import PreferencesContext from '../../Preferences/PreferencesContext';
 import { type FileMetadataAndStorageProviderName } from '../../../ProjectsStorage';
 import generateName from '../../../Utils/ProjectNameGenerator';
 import { sendTutorialOpened } from '../../../Utils/Analytics/EventSender';
+import { arePendingNotifications } from '../../../Utils/Notification';
 
 const electron = optionalRequire('electron');
 const app = electron ? electron.remote.app : null;
@@ -315,6 +316,9 @@ export const HomePage = React.memo<Props>(
                         <UserChip
                           profile={authenticatedUser.profile}
                           onClick={onOpenProfile}
+                          displayNotificationBadge={arePendingNotifications(
+                            authenticatedUser
+                          )}
                         />
                         <ResponsiveLineStackLayout
                           justifyContent="flex-end"

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -41,7 +41,7 @@ import PreferencesContext from '../../Preferences/PreferencesContext';
 import { type FileMetadataAndStorageProviderName } from '../../../ProjectsStorage';
 import generateName from '../../../Utils/ProjectNameGenerator';
 import { sendTutorialOpened } from '../../../Utils/Analytics/EventSender';
-import { arePendingNotifications } from '../../../Utils/Notification';
+import { hasPendingNotifications } from '../../../Utils/Notification';
 
 const electron = optionalRequire('electron');
 const app = electron ? electron.remote.app : null;
@@ -316,7 +316,7 @@ export const HomePage = React.memo<Props>(
                         <UserChip
                           profile={authenticatedUser.profile}
                           onClick={onOpenProfile}
-                          displayNotificationBadge={arePendingNotifications(
+                          displayNotificationBadge={hasPendingNotifications(
                             authenticatedUser
                           )}
                         />

--- a/newIDE/app/src/Profile/Achievement/AchievementList.js
+++ b/newIDE/app/src/Profile/Achievement/AchievementList.js
@@ -6,7 +6,7 @@ import Lock from '@material-ui/icons/Lock';
 
 import { Column, Line } from '../../UI/Grid';
 import Text from '../../UI/Text';
-import Badge from '../../UI/Badge';
+import DotBadge from '../../UI/DotBadge';
 
 import {
   compareAchievements,
@@ -88,7 +88,7 @@ const AchievementList = ({
                     justifyContent="space-between"
                   >
                     <Column justifyContent="center" alignItems="flex-start">
-                      <Badge
+                      <DotBadge
                         color="primary"
                         variant="dot"
                         invisible={
@@ -108,7 +108,7 @@ const AchievementList = ({
                         >
                           {achievementWithBadgeData.name}
                         </Text>
-                      </Badge>
+                      </DotBadge>
                       {displayUnclaimedAchievements && (
                         <Text
                           noMargin

--- a/newIDE/app/src/Profile/Achievement/AchievementList.js
+++ b/newIDE/app/src/Profile/Achievement/AchievementList.js
@@ -75,22 +75,6 @@ const AchievementList = ({
     [badges, achievements, displayUnclaimedAchievements]
   );
 
-  const AchievementNameWrapper = ({
-    achievementWithBadgeData,
-    children,
-  }: {|
-    achievementWithBadgeData: AchievementWithBadgeData,
-    children: React.Node,
-  |}) => {
-    return displayNotifications && achievementWithBadgeData.seen === false ? (
-      <Badge color="primary" variant="dot">
-        {children}
-      </Badge>
-    ) : (
-      <>{children}</>
-    );
-  };
-
   return (
     <Column noMargin>
       <I18n>
@@ -104,8 +88,15 @@ const AchievementList = ({
                     justifyContent="space-between"
                   >
                     <Column justifyContent="center" alignItems="flex-start">
-                      <AchievementNameWrapper
-                        achievementWithBadgeData={achievementWithBadgeData}
+                      <Badge
+                        color="primary"
+                        variant="dot"
+                        invisible={
+                          !(
+                            displayNotifications &&
+                            achievementWithBadgeData.seen === false
+                          )
+                        }
                       >
                         <Text
                           noMargin
@@ -117,7 +108,7 @@ const AchievementList = ({
                         >
                           {achievementWithBadgeData.name}
                         </Text>
-                      </AchievementNameWrapper>
+                      </Badge>
                       {displayUnclaimedAchievements && (
                         <Text
                           noMargin

--- a/newIDE/app/src/Profile/Achievement/AchievementList.js
+++ b/newIDE/app/src/Profile/Achievement/AchievementList.js
@@ -10,7 +10,7 @@ import {
   compareAchievements,
   type Badge,
   type Achievement,
-  type AchievementWithUnlockedDate,
+  type AchievementWithBadgeData,
 } from '../../Utils/GDevelopServices/Badge';
 import ScrollView from '../../UI/ScrollView';
 
@@ -36,9 +36,9 @@ const AchievementList = ({
   displayUnclaimedAchievements,
 }: Props) => {
   const [
-    achievementsWithUnlockedDate,
-    setAchievementsWithUnlockedDate,
-  ] = useState<Array<AchievementWithUnlockedDate>>([]);
+    achievementsWithBadgeData,
+    setAchievementsWithBadgeData,
+  ] = useState<Array<AchievementWithBadgeData>>([]);
 
   useEffect(
     () => {
@@ -47,12 +47,13 @@ const AchievementList = ({
         return acc;
       }, {});
 
-      const achievementsWithDate = achievements.reduce((acc, achievement) => {
+      const achievementsWithBadgeData = achievements.reduce((acc, achievement) => {
         const badge = badgeByAchievementId[achievement.id];
         const hasBadge = !!badge;
         if (hasBadge || (!hasBadge && displayUnclaimedAchievements)) {
           acc.push({
             ...achievement,
+            seen: hasBadge ? badge.seen : undefined,
             unlockedAt: hasBadge ? parseISO(badge.unlockedAt) : null,
           });
         }
@@ -60,9 +61,9 @@ const AchievementList = ({
         return acc;
       }, []);
 
-      achievementsWithDate.sort(compareAchievements);
+      achievementsWithBadgeData.sort(compareAchievements);
 
-      setAchievementsWithUnlockedDate(achievementsWithDate);
+      setAchievementsWithBadgeData(achievementsWithBadgeData);
     },
     [badges, achievements, displayUnclaimedAchievements]
   );
@@ -72,7 +73,7 @@ const AchievementList = ({
       <I18n>
         {({ i18n }) => (
           <ScrollView style={styles.achievementsContainer}>
-            {achievementsWithUnlockedDate.map(
+            {achievementsWithBadgeData.map(
               achievement =>
                 achievement && (
                   <Line key={achievement.id} justifyContent="space-between">

--- a/newIDE/app/src/Profile/Achievement/AchievementList.js
+++ b/newIDE/app/src/Profile/Achievement/AchievementList.js
@@ -80,59 +80,56 @@ const AchievementList = ({
       <I18n>
         {({ i18n }) => (
           <ScrollView style={styles.achievementsContainer}>
-            {achievementsWithBadgeData.map(
-              achievementWithBadgeData =>
-                achievementWithBadgeData && (
-                  <Line
-                    key={achievementWithBadgeData.id}
-                    justifyContent="space-between"
+            {achievementsWithBadgeData.map(achievementWithBadgeData => (
+              <Line
+                key={achievementWithBadgeData.id}
+                justifyContent="space-between"
+              >
+                <Column justifyContent="center" alignItems="flex-start">
+                  <DotBadge
+                    invisible={
+                      !(
+                        displayNotifications &&
+                        achievementWithBadgeData.seen === false
+                      )
+                    }
                   >
-                    <Column justifyContent="center" alignItems="flex-start">
-                      <DotBadge
-                        invisible={
-                          !(
-                            displayNotifications &&
-                            achievementWithBadgeData.seen === false
-                          )
-                        }
-                      >
-                        <Text
-                          noMargin
-                          style={
-                            achievementWithBadgeData.unlockedAt
-                              ? styles.unlockedAchievement
-                              : styles.lockedAchievement
-                          }
-                        >
-                          {achievementWithBadgeData.name}
-                        </Text>
-                      </DotBadge>
-                      {displayUnclaimedAchievements && (
-                        <Text
-                          noMargin
-                          style={
-                            achievementWithBadgeData.unlockedAt
-                              ? styles.unlockedAchievement
-                              : styles.lockedAchievement
-                          }
-                          size="body2"
-                        >
-                          {achievementWithBadgeData.description}
-                        </Text>
-                      )}
-                    </Column>
-                    <Column>
-                      {achievementWithBadgeData.unlockedAt ? (
-                        <Text>
-                          {i18n.date(achievementWithBadgeData.unlockedAt)}
-                        </Text>
-                      ) : (
-                        <Lock style={styles.lockedAchievement} />
-                      )}
-                    </Column>
-                  </Line>
-                )
-            )}
+                    <Text
+                      noMargin
+                      style={
+                        achievementWithBadgeData.unlockedAt
+                          ? styles.unlockedAchievement
+                          : styles.lockedAchievement
+                      }
+                    >
+                      {achievementWithBadgeData.name}
+                    </Text>
+                  </DotBadge>
+                  {displayUnclaimedAchievements && (
+                    <Text
+                      noMargin
+                      style={
+                        achievementWithBadgeData.unlockedAt
+                          ? styles.unlockedAchievement
+                          : styles.lockedAchievement
+                      }
+                      size="body2"
+                    >
+                      {achievementWithBadgeData.description}
+                    </Text>
+                  )}
+                </Column>
+                <Column>
+                  {achievementWithBadgeData.unlockedAt ? (
+                    <Text>
+                      {i18n.date(achievementWithBadgeData.unlockedAt)}
+                    </Text>
+                  ) : (
+                    <Lock style={styles.lockedAchievement} />
+                  )}
+                </Column>
+              </Line>
+            ))}
           </ScrollView>
         )}
       </I18n>

--- a/newIDE/app/src/Profile/Achievement/AchievementList.js
+++ b/newIDE/app/src/Profile/Achievement/AchievementList.js
@@ -1,23 +1,26 @@
 // @flow
-import React, { useEffect, useState } from 'react';
+import * as React from 'react';
 import { I18n } from '@lingui/react';
 import { parseISO } from 'date-fns';
 import Lock from '@material-ui/icons/Lock';
 
 import { Column, Line } from '../../UI/Grid';
 import Text from '../../UI/Text';
+import Badge from '../../UI/Badge';
+
 import {
   compareAchievements,
-  type Badge,
+  type Badge as BadgeType,
   type Achievement,
   type AchievementWithBadgeData,
 } from '../../Utils/GDevelopServices/Badge';
 import ScrollView from '../../UI/ScrollView';
 
 type Props = {|
-  badges: Array<Badge>,
+  badges: Array<BadgeType>,
   achievements: Array<Achievement>,
   displayUnclaimedAchievements: boolean,
+  displayNotifications: boolean,
 |};
 
 const styles = {
@@ -34,32 +37,36 @@ const AchievementList = ({
   badges,
   achievements,
   displayUnclaimedAchievements,
+  displayNotifications,
 }: Props) => {
   const [
     achievementsWithBadgeData,
     setAchievementsWithBadgeData,
-  ] = useState<Array<AchievementWithBadgeData>>([]);
+  ] = React.useState<Array<AchievementWithBadgeData>>([]);
 
-  useEffect(
+  React.useEffect(
     () => {
       const badgeByAchievementId = badges.reduce((acc, badge) => {
         acc[badge.achievementId] = badge;
         return acc;
       }, {});
 
-      const achievementsWithBadgeData = achievements.reduce((acc, achievement) => {
-        const badge = badgeByAchievementId[achievement.id];
-        const hasBadge = !!badge;
-        if (hasBadge || (!hasBadge && displayUnclaimedAchievements)) {
-          acc.push({
-            ...achievement,
-            seen: hasBadge ? badge.seen : undefined,
-            unlockedAt: hasBadge ? parseISO(badge.unlockedAt) : null,
-          });
-        }
+      const achievementsWithBadgeData = achievements.reduce(
+        (acc, achievement) => {
+          const badge = badgeByAchievementId[achievement.id];
+          const hasBadge = !!badge;
+          if (hasBadge || (!hasBadge && displayUnclaimedAchievements)) {
+            acc.push({
+              ...achievement,
+              seen: hasBadge ? badge.seen : undefined,
+              unlockedAt: hasBadge ? parseISO(badge.unlockedAt) : null,
+            });
+          }
 
-        return acc;
-      }, []);
+          return acc;
+        },
+        []
+      );
 
       achievementsWithBadgeData.sort(compareAchievements);
 
@@ -68,43 +75,68 @@ const AchievementList = ({
     [badges, achievements, displayUnclaimedAchievements]
   );
 
+  const AchievementNameWrapper = ({
+    achievementWithBadgeData,
+    children,
+  }: {|
+    achievementWithBadgeData: AchievementWithBadgeData,
+    children: React.Node,
+  |}) => {
+    return displayNotifications && achievementWithBadgeData.seen === false ? (
+      <Badge color="primary" variant="dot">
+        {children}
+      </Badge>
+    ) : (
+      <>{children}</>
+    );
+  };
+
   return (
     <Column noMargin>
       <I18n>
         {({ i18n }) => (
           <ScrollView style={styles.achievementsContainer}>
             {achievementsWithBadgeData.map(
-              achievement =>
-                achievement && (
-                  <Line key={achievement.id} justifyContent="space-between">
-                    <Column justifyContent="center">
-                      <Text
-                        noMargin
-                        style={
-                          achievement.unlockedAt
-                            ? styles.unlockedAchievement
-                            : styles.lockedAchievement
-                        }
+              achievementWithBadgeData =>
+                achievementWithBadgeData && (
+                  <Line
+                    key={achievementWithBadgeData.id}
+                    justifyContent="space-between"
+                  >
+                    <Column justifyContent="center" alignItems="flex-start">
+                      <AchievementNameWrapper
+                        achievementWithBadgeData={achievementWithBadgeData}
                       >
-                        {achievement.name}
-                      </Text>
+                        <Text
+                          noMargin
+                          style={
+                            achievementWithBadgeData.unlockedAt
+                              ? styles.unlockedAchievement
+                              : styles.lockedAchievement
+                          }
+                        >
+                          {achievementWithBadgeData.name}
+                        </Text>
+                      </AchievementNameWrapper>
                       {displayUnclaimedAchievements && (
                         <Text
                           noMargin
                           style={
-                            achievement.unlockedAt
+                            achievementWithBadgeData.unlockedAt
                               ? styles.unlockedAchievement
                               : styles.lockedAchievement
                           }
                           size="body2"
                         >
-                          {achievement.description}
+                          {achievementWithBadgeData.description}
                         </Text>
                       )}
                     </Column>
                     <Column>
-                      {achievement.unlockedAt ? (
-                        <Text>{i18n.date(achievement.unlockedAt)}</Text>
+                      {achievementWithBadgeData.unlockedAt ? (
+                        <Text>
+                          {i18n.date(achievementWithBadgeData.unlockedAt)}
+                        </Text>
                       ) : (
                         <Lock style={styles.lockedAchievement} />
                       )}

--- a/newIDE/app/src/Profile/Achievement/AchievementList.js
+++ b/newIDE/app/src/Profile/Achievement/AchievementList.js
@@ -89,8 +89,6 @@ const AchievementList = ({
                   >
                     <Column justifyContent="center" alignItems="flex-start">
                       <DotBadge
-                        color="primary"
-                        variant="dot"
                         invisible={
                           !(
                             displayNotifications &&

--- a/newIDE/app/src/Profile/Achievement/UserAchievements.js
+++ b/newIDE/app/src/Profile/Achievement/UserAchievements.js
@@ -21,6 +21,7 @@ import PlaceholderLoader from '../../UI/PlaceholderLoader';
 type Props = {|
   badges: ?Array<Badge>,
   displayUnclaimedAchievements: boolean,
+  displayNotifications: boolean,
 |};
 
 const styles = {
@@ -36,7 +37,11 @@ const styles = {
   },
 };
 
-const UserAchievements = ({ badges, displayUnclaimedAchievements }: Props) => {
+const UserAchievements = ({
+  badges,
+  displayUnclaimedAchievements,
+  displayNotifications,
+}: Props) => {
   const [achievements, setAchievements] = useState<?Array<Achievement>>(null);
   const [displayError, setDisplayError] = useState<boolean>(false);
   const windowWidth = useResponsiveWindowWidth();
@@ -100,6 +105,7 @@ const UserAchievements = ({ badges, displayUnclaimedAchievements }: Props) => {
                   badges={badges}
                   achievements={achievements}
                   displayUnclaimedAchievements={displayUnclaimedAchievements}
+                  displayNotifications={displayNotifications}
                 />
               )}
             </div>

--- a/newIDE/app/src/Profile/AuthenticatedUserProfileDetails.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserProfileDetails.js
@@ -10,6 +10,7 @@ import { type AuthenticatedUser } from './AuthenticatedUserContext';
 import { useIsMounted } from '../Utils/UseIsMounted';
 import ProfileDetails from './ProfileDetails';
 import { markBadgesAsSeen } from '../Utils/GDevelopServices/Badge';
+import { useTimeout } from '../Utils/UseTimeout';
 
 type Props = {|
   onEditProfile: () => void,
@@ -38,14 +39,11 @@ const AuthenticatedUserProfileDetails = ({
     [authenticatedUser, isMounted]
   );
 
-  React.useEffect(
-    () => {
-      const timeoutId = setTimeout(() => {
-        markBadgesAsSeen(authenticatedUser);
-      }, 5000);
-      return () => clearTimeout(timeoutId);
-    },
-    [authenticatedUser]
+  useTimeout(
+    React.useMemo(() => () => markBadgesAsSeen(authenticatedUser), [
+      authenticatedUser,
+    ]),
+    5000
   );
 
   return firebaseUser && profile ? (

--- a/newIDE/app/src/Profile/AuthenticatedUserProfileDetails.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserProfileDetails.js
@@ -9,6 +9,7 @@ import AlertMessage from '../UI/AlertMessage';
 import { type AuthenticatedUser } from './AuthenticatedUserContext';
 import { useIsMounted } from '../Utils/UseIsMounted';
 import ProfileDetails from './ProfileDetails';
+import { markBadgesAsSeen } from '../Utils/GDevelopServices/Badge';
 
 type Props = {|
   onEditProfile: () => void,
@@ -35,6 +36,16 @@ const AuthenticatedUserProfileDetails = ({
       }, 3000);
     },
     [authenticatedUser, isMounted]
+  );
+
+  React.useEffect(
+    () => {
+      const timeoutId = setTimeout(() => {
+        markBadgesAsSeen(authenticatedUser);
+      }, 5000);
+      return () => clearTimeout(timeoutId);
+    },
+    [authenticatedUser]
   );
 
   return firebaseUser && profile ? (

--- a/newIDE/app/src/Profile/AuthenticatedUserProfileDetails.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserProfileDetails.js
@@ -40,7 +40,7 @@ const AuthenticatedUserProfileDetails = ({
   );
 
   useTimeout(
-    React.useMemo(() => () => markBadgesAsSeen(authenticatedUser), [
+    React.useCallback(() => markBadgesAsSeen(authenticatedUser), [
       authenticatedUser,
     ]),
     5000

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -91,7 +91,7 @@ const ProfileDetails = ({
             />
           </Line>
           {isAuthenticatedUserProfile && (
-            <ResponsiveLineStackLayout justifyContent="flex-end">
+            <ResponsiveLineStackLayout justifyContent="flex-end" noColumnMargin>
               <RaisedButton
                 label={<Trans>Change my email</Trans>}
                 onClick={onChangeEmail}

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -107,6 +107,7 @@ const ProfileDetails = ({
             <UserAchievements
               badges={badges}
               displayUnclaimedAchievements={!!isAuthenticatedUserProfile}
+              displayNotifications={!!isAuthenticatedUserProfile}
             />
           )}
         </Column>

--- a/newIDE/app/src/UI/Badge.js
+++ b/newIDE/app/src/UI/Badge.js
@@ -6,6 +6,7 @@ type Props = {|
   children: React.Node,
   badgeContent?: React.Node,
   variant?: 'dot',
+  invisible?: boolean,
   color: 'error' | 'primary' | 'secondary' | 'default',
 |};
 

--- a/newIDE/app/src/UI/Badge.js
+++ b/newIDE/app/src/UI/Badge.js
@@ -4,10 +4,11 @@ import MuiBadge from '@material-ui/core/Badge';
 
 type Props = {|
   children: React.Node,
-  badgeContent: React.Node,
+  badgeContent?: React.Node,
+  variant?: 'dot',
   color: 'error' | 'primary' | 'secondary' | 'default',
 |};
 
-export default function Badge(props: Props) {
-  return <MuiBadge {...props} />;
-}
+const Badge = (props: Props) => <MuiBadge {...props} />;
+
+export default Badge;

--- a/newIDE/app/src/UI/Badge.js
+++ b/newIDE/app/src/UI/Badge.js
@@ -1,15 +1,28 @@
 // @flow
 import * as React from 'react';
+import ClassNameMap from '@material-ui/styles';
 import MuiBadge from '@material-ui/core/Badge';
 
 type Props = {|
   children: React.Node,
   badgeContent?: React.Node,
-  variant?: 'dot',
   invisible?: boolean,
   color: 'error' | 'primary' | 'secondary' | 'default',
+  variant?: 'dot',
+  overlap?: 'circle',
+  anchor?: 'topLeft',
+  classes?: ClassNameMap,
 |};
 
-const Badge = (props: Props) => <MuiBadge {...props} />;
+const Badge = ({ anchor, ...otherProps }: Props) => (
+  <MuiBadge
+    anchorOrigin={
+      anchor === 'topLeft'
+        ? { horizontal: 'left', vertical: 'top' }
+        : { horizontal: 'right', vertical: 'top' }
+    }
+    {...otherProps}
+  />
+);
 
 export default Badge;

--- a/newIDE/app/src/UI/Badge.js
+++ b/newIDE/app/src/UI/Badge.js
@@ -1,28 +1,13 @@
 // @flow
 import * as React from 'react';
-import ClassNameMap from '@material-ui/styles';
 import MuiBadge from '@material-ui/core/Badge';
 
 type Props = {|
   children: React.Node,
-  badgeContent?: React.Node,
-  invisible?: boolean,
+  badgeContent: React.Node,
   color: 'error' | 'primary' | 'secondary' | 'default',
-  variant?: 'dot',
-  overlap?: 'circle',
-  anchor?: 'topLeft',
-  classes?: ClassNameMap,
 |};
 
-const Badge = ({ anchor, ...otherProps }: Props) => (
-  <MuiBadge
-    anchorOrigin={
-      anchor === 'topLeft'
-        ? { horizontal: 'left', vertical: 'top' }
-        : { horizontal: 'right', vertical: 'top' }
-    }
-    {...otherProps}
-  />
-);
+const Badge = (props: Props) => <MuiBadge {...props} />;
 
 export default Badge;

--- a/newIDE/app/src/UI/DotBadge.js
+++ b/newIDE/app/src/UI/DotBadge.js
@@ -11,11 +11,7 @@ type Props = {|
 |};
 
 const DotBadge = (props: Props) => (
-  <MuiBadge
-    color="primary"
-    variant="dot"
-    {...props}
-  />
+  <MuiBadge color="primary" variant="dot" {...props} />
 );
 
 export default DotBadge;

--- a/newIDE/app/src/UI/DotBadge.js
+++ b/newIDE/app/src/UI/DotBadge.js
@@ -7,20 +7,14 @@ type Props = {|
   children: React.Node,
   invisible?: boolean,
   overlap?: 'circle',
-  anchor?: 'topLeft',
   classes?: ClassNameMap,
 |};
 
-const DotBadge = ({ anchor, ...otherProps }: Props) => (
+const DotBadge = (props: Props) => (
   <MuiBadge
     color="primary"
     variant="dot"
-    anchorOrigin={
-      anchor === 'topLeft'
-        ? { horizontal: 'left', vertical: 'top' }
-        : { horizontal: 'right', vertical: 'top' }
-    }
-    {...otherProps}
+    {...props}
   />
 );
 

--- a/newIDE/app/src/UI/DotBadge.js
+++ b/newIDE/app/src/UI/DotBadge.js
@@ -1,0 +1,27 @@
+// @flow
+import * as React from 'react';
+import ClassNameMap from '@material-ui/styles';
+import MuiBadge from '@material-ui/core/Badge';
+
+type Props = {|
+  children: React.Node,
+  invisible?: boolean,
+  color: 'primary',
+  variant?: 'dot',
+  overlap?: 'circle',
+  anchor?: 'topLeft',
+  classes?: ClassNameMap,
+|};
+
+const Badge = ({ anchor, ...otherProps }: Props) => (
+  <MuiBadge
+    anchorOrigin={
+      anchor === 'topLeft'
+        ? { horizontal: 'left', vertical: 'top' }
+        : { horizontal: 'right', vertical: 'top' }
+    }
+    {...otherProps}
+  />
+);
+
+export default Badge;

--- a/newIDE/app/src/UI/DotBadge.js
+++ b/newIDE/app/src/UI/DotBadge.js
@@ -6,15 +6,15 @@ import MuiBadge from '@material-ui/core/Badge';
 type Props = {|
   children: React.Node,
   invisible?: boolean,
-  color: 'primary',
-  variant?: 'dot',
   overlap?: 'circle',
   anchor?: 'topLeft',
   classes?: ClassNameMap,
 |};
 
-const Badge = ({ anchor, ...otherProps }: Props) => (
+const DotBadge = ({ anchor, ...otherProps }: Props) => (
   <MuiBadge
+    color="primary"
+    variant="dot"
     anchorOrigin={
       anchor === 'topLeft'
         ? { horizontal: 'left', vertical: 'top' }
@@ -24,4 +24,4 @@ const Badge = ({ anchor, ...otherProps }: Props) => (
   />
 );
 
-export default Badge;
+export default DotBadge;

--- a/newIDE/app/src/UI/User/UserChip.js
+++ b/newIDE/app/src/UI/User/UserChip.js
@@ -16,9 +16,9 @@ type Props = {|
 |};
 
 const useStyles = makeStyles({
-  anchorOriginTopLeftCircle: {
+  anchorOriginTopRightCircle: {
     top: 5,
-    left: 5,
+    right: 5,
   },
 });
 
@@ -28,7 +28,6 @@ const UserChip = ({ profile, onClick, displayNotificationBadge }: Props) => {
     <DotBadge
       overlap="circle"
       invisible={!displayNotificationBadge}
-      anchor="topLeft"
       classes={classes}
     >
       <Chip

--- a/newIDE/app/src/UI/User/UserChip.js
+++ b/newIDE/app/src/UI/User/UserChip.js
@@ -16,6 +16,7 @@ type Props = {|
 |};
 
 const useStyles = makeStyles({
+  root: { flexDirection: 'column' },
   anchorOriginTopRightCircle: {
     top: 5,
     right: 5,

--- a/newIDE/app/src/UI/User/UserChip.js
+++ b/newIDE/app/src/UI/User/UserChip.js
@@ -7,7 +7,7 @@ import FaceIcon from '@material-ui/icons/Face';
 import Avatar from '@material-ui/core/Avatar';
 import { type Profile } from '../../Utils/GDevelopServices/Authentication';
 import { getGravatarUrl } from '../GravatarUrl';
-import Badge from '../Badge';
+import DotBadge from '../DotBadge';
 
 type Props = {|
   profile: ?Profile,
@@ -25,7 +25,7 @@ const useStyles = makeStyles({
 const UserChip = ({ profile, onClick, displayNotificationBadge }: Props) => {
   const classes = useStyles();
   return (
-    <Badge
+    <DotBadge
       color="primary"
       variant="dot"
       overlap="circle"
@@ -54,7 +54,7 @@ const UserChip = ({ profile, onClick, displayNotificationBadge }: Props) => {
         }
         onClick={onClick}
       />
-    </Badge>
+    </DotBadge>
   );
 };
 

--- a/newIDE/app/src/UI/User/UserChip.js
+++ b/newIDE/app/src/UI/User/UserChip.js
@@ -1,40 +1,60 @@
 // @flow
 import * as React from 'react';
 import { Trans } from '@lingui/macro';
+import { makeStyles } from '@material-ui/core';
 import Chip from '@material-ui/core/Chip';
 import FaceIcon from '@material-ui/icons/Face';
 import Avatar from '@material-ui/core/Avatar';
 import { type Profile } from '../../Utils/GDevelopServices/Authentication';
 import { getGravatarUrl } from '../GravatarUrl';
+import Badge from '../Badge';
 
 type Props = {|
   profile: ?Profile,
   onClick: () => void,
+  displayNotificationBadge: boolean,
 |};
 
-const UserChip = ({ profile, onClick }: Props) => {
+const useStyles = makeStyles({
+  anchorOriginTopLeftCircle: {
+    top: 5,
+    left: 5,
+  },
+});
+
+const UserChip = ({ profile, onClick, displayNotificationBadge }: Props) => {
+  const classes = useStyles();
   return (
-    <Chip
-      variant="outlined"
-      avatar={
-        profile ? (
-          <Avatar
-            src={getGravatarUrl(profile.email || '', { size: 30 })}
-            sx={{ width: 30, height: 30 }}
-          />
-        ) : (
-          <FaceIcon />
-        )
-      }
-      label={
-        profile ? (
-          profile.username || profile.email
-        ) : (
-          <Trans>Click to connect</Trans>
-        )
-      }
-      onClick={onClick}
-    />
+    <Badge
+      color="primary"
+      variant="dot"
+      overlap="circle"
+      invisible={!displayNotificationBadge}
+      anchor="topLeft"
+      classes={classes}
+    >
+      <Chip
+        variant="outlined"
+        avatar={
+          profile ? (
+            <Avatar
+              src={getGravatarUrl(profile.email || '', { size: 30 })}
+              sx={{ width: 30, height: 30 }}
+            />
+          ) : (
+            <FaceIcon />
+          )
+        }
+        label={
+          profile ? (
+            profile.username || profile.email
+          ) : (
+            <Trans>Click to connect</Trans>
+          )
+        }
+        onClick={onClick}
+      />
+    </Badge>
   );
 };
 

--- a/newIDE/app/src/UI/User/UserChip.js
+++ b/newIDE/app/src/UI/User/UserChip.js
@@ -26,8 +26,6 @@ const UserChip = ({ profile, onClick, displayNotificationBadge }: Props) => {
   const classes = useStyles();
   return (
     <DotBadge
-      color="primary"
-      variant="dot"
       overlap="circle"
       invisible={!displayNotificationBadge}
       anchor="topLeft"

--- a/newIDE/app/src/Utils/GDevelopServices/Badge.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Badge.js
@@ -28,8 +28,9 @@ export type Achievement = {|
   description: string,
 |};
 
-export type AchievementWithUnlockedDate = {|
+export type AchievementWithBadgeData = {|
   ...Achievement,
+  seen?: boolean,
   unlockedAt: ?Date,
 |};
 
@@ -118,8 +119,8 @@ export const getAchievements = (): Promise<Array<Achievement>> => {
 };
 
 export const compareAchievements = (
-  a: AchievementWithUnlockedDate,
-  b: AchievementWithUnlockedDate
+  a: AchievementWithBadgeData,
+  b: AchievementWithBadgeData
 ) => {
   if (b.unlockedAt && a.unlockedAt) {
     return b.unlockedAt - a.unlockedAt;

--- a/newIDE/app/src/Utils/Notification.js
+++ b/newIDE/app/src/Utils/Notification.js
@@ -1,0 +1,17 @@
+// @flow
+
+import { type AuthenticatedUser } from '../Profile/AuthenticatedUserContext';
+
+export const arePendingNotifications = (
+  authenticatedUser: AuthenticatedUser
+): boolean => {
+  console.log(authenticatedUser.authenticated)
+  if (!authenticatedUser.authenticated) return false;
+
+  const { badges } = authenticatedUser;
+  if (badges && badges.length > 0) {
+    return badges.some(badge => !badge.seen);
+  }
+
+  return false;
+};

--- a/newIDE/app/src/Utils/Notification.js
+++ b/newIDE/app/src/Utils/Notification.js
@@ -5,7 +5,6 @@ import { type AuthenticatedUser } from '../Profile/AuthenticatedUserContext';
 export const arePendingNotifications = (
   authenticatedUser: AuthenticatedUser
 ): boolean => {
-  console.log(authenticatedUser.authenticated)
   if (!authenticatedUser.authenticated) return false;
 
   const { badges } = authenticatedUser;

--- a/newIDE/app/src/Utils/Notification.js
+++ b/newIDE/app/src/Utils/Notification.js
@@ -2,7 +2,7 @@
 
 import { type AuthenticatedUser } from '../Profile/AuthenticatedUserContext';
 
-export const arePendingNotifications = (
+export const hasPendingNotifications = (
   authenticatedUser: AuthenticatedUser
 ): boolean => {
   if (!authenticatedUser.authenticated) return false;

--- a/newIDE/app/src/Utils/UseTimeout.js
+++ b/newIDE/app/src/Utils/UseTimeout.js
@@ -1,0 +1,12 @@
+// @flow
+import { useEffect } from 'react';
+
+export const useTimeout = (callback: any, delay: number) => {
+  useEffect(
+    () => {
+      const id = setTimeout(callback, delay);
+      return () => clearTimeout(id);
+    },
+    [callback, delay]
+  );
+};

--- a/newIDE/app/src/stories/componentStories/ProfileDetails.stories.js
+++ b/newIDE/app/src/stories/componentStories/ProfileDetails.stories.js
@@ -41,12 +41,12 @@ type ArgsTypes = {|
 const badges = [
   {
     achievementId: 'trivial_first-event',
-    seen: false,
+    seen: true,
     unlockedAt: '2020-10-05T11:28:24.864Z',
     userId: 'userId',
   },
   {
-    achievementId: 'game_success_1M-players',
+    achievementId: 'trivial_first-behavior',
     seen: false,
     unlockedAt: '2021-11-15T11:28:24.864Z',
     userId: 'userId',

--- a/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
+++ b/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
@@ -19,9 +19,22 @@ export const SignedUser = () => (
   <UserChip
     profile={indieUserProfile}
     onClick={() => action('click user chip')}
+    displayNotificationBadge={false}
+  />
+);
+
+export const SignedUserWithNotifications = () => (
+  <UserChip
+    profile={indieUserProfile}
+    onClick={() => action('click user chip')}
+    displayNotificationBadge={true}
   />
 );
 
 export const UnsignedUser = () => (
-  <UserChip profile={null} onClick={() => action('click user chip')} />
+  <UserChip
+    profile={null}
+    onClick={() => action('click user chip')}
+    displayNotificationBadge={false}
+  />
 );

--- a/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
+++ b/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
@@ -27,7 +27,7 @@ export default {
       defaultValue: 'Signed in',
       mapping: {
         'Signed in': indieUserProfile,
-        'Anonymous': null,
+        Anonymous: null,
       },
     },
   },

--- a/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
+++ b/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
@@ -6,35 +6,43 @@ import { action } from '@storybook/addon-actions';
 import muiDecorator from '../../ThemeDecorator';
 import paperDecorator from '../../PaperDecorator';
 
-import UserChip from '../../../UI/User/UserChip';
+import UserChipComponent from '../../../UI/User/UserChip';
 import { indieUserProfile } from '../../../fixtures/GDevelopServicesTestData';
+import { type Profile } from '../../../Utils/GDevelopServices/Authentication';
 
 export default {
   title: 'User chips/UserChip',
-  component: UserChip,
+  component: UserChipComponent,
   decorators: [paperDecorator, muiDecorator],
+  argTypes: {
+    withNotifications: {
+      name: 'With notifications',
+      type: { name: 'boolean', required: true },
+      defaultValue: false,
+    },
+    profile: {
+      name: 'User profile',
+      control: { type: 'radio' },
+      options: ['Signed in', 'Unsigned'],
+      defaultValue: 'Signed in',
+      mapping: {
+        'Signed in': indieUserProfile,
+        Unsigned: null,
+      },
+    },
+  },
 };
 
-export const SignedUser = () => (
-  <UserChip
-    profile={indieUserProfile}
+export const UserChip = ({
+  withNotifications,
+  profile,
+}: {|
+  withNotifications: boolean,
+  profile: ?Profile,
+|}) => (
+  <UserChipComponent
+    profile={profile}
     onClick={() => action('click user chip')}
-    displayNotificationBadge={false}
-  />
-);
-
-export const SignedUserWithNotifications = () => (
-  <UserChip
-    profile={indieUserProfile}
-    onClick={() => action('click user chip')}
-    displayNotificationBadge={true}
-  />
-);
-
-export const UnsignedUser = () => (
-  <UserChip
-    profile={null}
-    onClick={() => action('click user chip')}
-    displayNotificationBadge={false}
+    displayNotificationBadge={withNotifications}
   />
 );

--- a/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
+++ b/newIDE/app/src/stories/componentStories/UserChip/UserChip.stories.js
@@ -23,11 +23,11 @@ export default {
     profile: {
       name: 'User profile',
       control: { type: 'radio' },
-      options: ['Signed in', 'Unsigned'],
+      options: ['Signed in', 'Anonymous'],
       defaultValue: 'Signed in',
       mapping: {
         'Signed in': indieUserProfile,
-        Unsigned: null,
+        'Anonymous': null,
       },
     },
   },


### PR DESCRIPTION
Display notification badge on homepage's user chip
![image](https://user-images.githubusercontent.com/32449369/146387690-da90bc82-0dc7-4d4e-9abd-21fc074564bd.png)

Display notification badge on achievement line (and disappear after 5s)
![image](https://user-images.githubusercontent.com/32449369/146385069-06d1aceb-4941-40b4-adbb-ad8f9224a35e.png)

Checked on Safari and Firefox