### PR TITLE
[Platformer] Exclude "potential colliding" platforms that are not actually in the searched area.

### DIFF
--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -965,17 +965,26 @@ namespace gdjs {
      * Update _potentialCollidingObjects member with platforms near the object.
      */
     private _updatePotentialCollidingObjects(maxMovementLength: float) {
+      const object = this.owner;
+
       this._manager.getAllPlatformsAround(
-        this.owner,
+        object,
         maxMovementLength,
         this._potentialCollidingObjects
       );
 
-      // Filter the potential colliding platforms to ensure that the object owning the behavior
-      // is not considered as colliding with itself, in the case that it also has the
-      // platform behavior.
       for (let i = 0; i < this._potentialCollidingObjects.length; ) {
-        if (this._potentialCollidingObjects[i].owner === this.owner) {
+        const platform = this._potentialCollidingObjects[i];
+        if (
+          // Filter the potential colliding platforms to ensure that the object owning the behavior
+          // is not considered as colliding with itself, in the case that it also has the
+          // platform behavior.
+          platform.owner === object ||
+          // Filter platforms that are not in the searched area anymore.
+          // This can happen because platforms are not updated in the RBush before that
+          // characters movement are being processed.
+          !this._manager.isPlatformsAround(platform, object, maxMovementLength)
+        ) {
           this._potentialCollidingObjects.splice(i, 1);
         } else {
           i++;

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -973,18 +973,11 @@ namespace gdjs {
         this._potentialCollidingObjects
       );
 
+      // Filter the potential colliding platforms to ensure that the object owning the behavior
+      // is not considered as colliding with itself, in the case that it also has the
+      // platform behavior.
       for (let i = 0; i < this._potentialCollidingObjects.length; ) {
-        const platform = this._potentialCollidingObjects[i];
-        if (
-          // Filter the potential colliding platforms to ensure that the object owning the behavior
-          // is not considered as colliding with itself, in the case that it also has the
-          // platform behavior.
-          platform.owner === object ||
-          // Filter platforms that are not in the searched area anymore.
-          // This can happen because platforms are not updated in the RBush before that
-          // characters movement are being processed.
-          !this._manager.isPlatformsAround(platform, object, maxMovementLength)
-        ) {
+        if (this._potentialCollidingObjects[i].owner === object) {
           this._potentialCollidingObjects.splice(i, 1);
         } else {
           i++;

--- a/Extensions/PlatformBehavior/platformruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformruntimebehavior.ts
@@ -88,6 +88,26 @@ namespace gdjs {
       result.length = 0;
       result.push.apply(result, nearbyPlatforms);
     }
+
+    /**
+     * Check if the platforms is around the specified object.
+     * @param maxMovementLength The maximum distance, in pixels, the object is going to do.
+     * @return true if the platforms is around the specified object.
+     */
+    isPlatformsAround(
+      platform: gdjs.PlatformRuntimeBehavior,
+      object: gdjs.RuntimeObject,
+      maxMovementLength: number
+    ): boolean {
+      const floorAABB = platform.owner.getAABB();
+      const characterAABB = object.getAABB();
+      return (
+        floorAABB.min[0] <= characterAABB.max[0] + maxMovementLength &&
+        floorAABB.min[1] <= characterAABB.max[1] + maxMovementLength &&
+        floorAABB.max[0] >= characterAABB.min[0] - maxMovementLength &&
+        floorAABB.max[1] >= characterAABB.min[1] - maxMovementLength
+      );
+    }
   }
 
   /**

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
@@ -91,12 +91,12 @@ export default class EventsFunctionExtractorDialog extends React.Component<
     if (eventsFunction) eventsFunction.delete();
   }
 
-  _getFunctionGroupNames = () => {
+  _getFunctionGroupNames = (): Array<string> => {
     const { createNewExtension, extensionName } = this.state;
     if (createNewExtension || !extensionName) {
       return [];
     }
-    const groupNames = [];
+    const groupNames = new Set<string>();
     const { project } = this.props;
     const eventsFunctionsExtension = project.getEventsFunctionsExtension(
       extensionName
@@ -109,11 +109,11 @@ export default class EventsFunctionExtractorDialog extends React.Component<
       const groupName = eventsFunctionsExtension
         .getEventsFunctionAt(index)
         .getGroup();
-      if (groupName && !groupNames.includes(groupName)) {
-        groupNames.push(groupName);
+      if (groupName) {
+        groupNames.add(groupName);
       }
     }
-    return groupNames;
+    return [...groupNames].sort((a, b) => a.localeCompare(b));
   };
 
   render() {


### PR DESCRIPTION
This filters platforms that are not in the searched area anymore. It can happen because platforms are not updated in the RBush before that characters movement are being processed.

The tests pass when merge with:
* https://github.com/4ian/GDevelop/pull/3376


It won't make it up for platforms that should have been found by RBush. So, this PR still stand:
* https://github.com/4ian/GDevelop/pull/2602