### PR TITLE
Change exports to send game id

### DIFF
--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
@@ -153,7 +153,8 @@ export const browserOnlineCordovaExportPipeline: ExportPipeline<
   launchOnlineBuild: (
     exportState: ExportState,
     authenticatedUser: AuthenticatedUser,
-    uploadBucketKey: string
+    uploadBucketKey: string,
+    gameId: string
   ): Promise<Build> => {
     const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
     if (!firebaseUser)
@@ -164,7 +165,8 @@ export const browserOnlineCordovaExportPipeline: ExportPipeline<
       firebaseUser.uid,
       uploadBucketKey,
       exportState.targets,
-      exportState.keystore
+      exportState.keystore,
+      gameId
     );
   },
 };

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
@@ -151,7 +151,8 @@ export const browserOnlineElectronExportPipeline: ExportPipeline<
   launchOnlineBuild: (
     exportState: ExportState,
     authenticatedUser: AuthenticatedUser,
-    uploadBucketKey: string
+    uploadBucketKey: string,
+    gameId: string
   ): Promise<Build> => {
     const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
     if (!firebaseUser)
@@ -161,7 +162,8 @@ export const browserOnlineElectronExportPipeline: ExportPipeline<
       getAuthorizationHeader,
       firebaseUser.uid,
       uploadBucketKey,
-      exportState.targets
+      exportState.targets,
+      gameId
     );
   },
 };

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
@@ -152,12 +152,18 @@ export const browserOnlineWebExportPipeline: ExportPipeline<
   launchOnlineBuild: (
     exportState: ExportState,
     authenticatedUser: AuthenticatedUser,
-    uploadBucketKey: string
+    uploadBucketKey: string,
+    gameId: string
   ): Promise<Build> => {
     const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
     if (!firebaseUser)
       return Promise.reject(new Error('User is not authenticated'));
 
-    return buildWeb(getAuthorizationHeader, firebaseUser.uid, uploadBucketKey);
+    return buildWeb(
+      getAuthorizationHeader,
+      firebaseUser.uid,
+      uploadBucketKey,
+      gameId
+    );
   },
 };

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -260,7 +260,8 @@ export default class ExportLauncher extends Component<Props, State> {
         const build = await launchOnlineBuild(
           this.state.exportState,
           authenticatedUser,
-          uploadBucketKey
+          uploadBucketKey,
+          this.props.project.getProjectUuid()
         );
         setStep('build');
         this.setState({ build }, () => {
@@ -308,15 +309,15 @@ export default class ExportLauncher extends Component<Props, State> {
     } = this.state;
     const { project, authenticatedUser, exportPipeline } = this.props;
     if (!project) return null;
+    const buildPending = !errored && exportStep !== '' && exportStep !== 'done';
+    const buildFinished = !errored && exportStep === 'done';
 
     const getBuildLimit = (authenticatedUser: AuthenticatedUser): ?Limit =>
       authenticatedUser.limits && exportPipeline.onlineBuildType
         ? authenticatedUser.limits[exportPipeline.onlineBuildType]
         : null;
+
     const canLaunchBuild = (authenticatedUser: AuthenticatedUser) => {
-      const buildPending =
-        !errored && exportStep !== '' && exportStep !== 'done';
-      const buildFinished = !errored && exportStep === 'done';
       if (buildPending || buildFinished) return false;
 
       const limit: ?Limit = getBuildLimit(authenticatedUser);
@@ -380,10 +381,7 @@ export default class ExportLauncher extends Component<Props, State> {
           )}
         {authenticatedUser.authenticated &&
           (exportPipeline.renderCustomStepsProgress ? (
-            exportPipeline.renderCustomStepsProgress(
-              build,
-              !!this.state.exportStep && this.state.exportStep !== 'done'
-            )
+            exportPipeline.renderCustomStepsProgress(build, buildPending)
           ) : (
             <Line expand>
               <BuildStepsProgress

--- a/newIDE/app/src/Export/ExportPipeline.flow.js
+++ b/newIDE/app/src/Export/ExportPipeline.flow.js
@@ -78,7 +78,8 @@ export type ExportPipeline<
   launchOnlineBuild?: (
     exportState: ExportState,
     authenticatedUser: AuthenticatedUser,
-    uploadBucketKey: string
+    uploadBucketKey: string,
+    gameId: string
   ) => Promise<Build>,
 
   /**

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
@@ -140,7 +140,8 @@ export const localOnlineCordovaExportPipeline: ExportPipeline<
   launchOnlineBuild: (
     exportState: ExportState,
     authenticatedUser: AuthenticatedUser,
-    uploadBucketKey: string
+    uploadBucketKey: string,
+    gameId: string
   ): Promise<Build> => {
     const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
     if (!firebaseUser)
@@ -151,7 +152,8 @@ export const localOnlineCordovaExportPipeline: ExportPipeline<
       firebaseUser.uid,
       uploadBucketKey,
       exportState.targets,
-      exportState.keystore
+      exportState.keystore,
+      gameId
     );
   },
 };

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
@@ -138,7 +138,8 @@ export const localOnlineElectronExportPipeline: ExportPipeline<
   launchOnlineBuild: (
     exportState: ExportState,
     authenticatedUser: AuthenticatedUser,
-    uploadBucketKey: string
+    uploadBucketKey: string,
+    gameId: string
   ): Promise<Build> => {
     const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
     if (!firebaseUser)
@@ -148,7 +149,8 @@ export const localOnlineElectronExportPipeline: ExportPipeline<
       getAuthorizationHeader,
       firebaseUser.uid,
       uploadBucketKey,
-      exportState.targets
+      exportState.targets,
+      gameId
     );
   },
 };

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
@@ -139,12 +139,18 @@ export const localOnlineWebExportPipeline: ExportPipeline<
   launchOnlineBuild: (
     exportState: ExportState,
     authenticatedUser: AuthenticatedUser,
-    uploadBucketKey: string
+    uploadBucketKey: string,
+    gameId: string
   ): Promise<Build> => {
     const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
     if (!firebaseUser)
       return Promise.reject(new Error('User is not authenticated'));
 
-    return buildWeb(getAuthorizationHeader, firebaseUser.uid, uploadBucketKey);
+    return buildWeb(
+      getAuthorizationHeader,
+      firebaseUser.uid,
+      uploadBucketKey,
+      gameId
+    );
   },
 };

--- a/newIDE/app/src/Utils/GDevelopServices/Build.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Build.js
@@ -15,6 +15,7 @@ export type TargetName =
 
 export type Build = {
   id: string,
+  gameId?: string, // not defined for old builds.
   userId: string,
   bucket?: string,
   logsKey?: string,
@@ -84,26 +85,23 @@ export const buildElectron = (
   getAuthorizationHeader: () => Promise<string>,
   userId: string,
   key: string,
-  targets: Array<TargetName>
+  targets: Array<TargetName>,
+  gameId: string
 ): Promise<Build> => {
   return getAuthorizationHeader()
     .then(authorizationHeader =>
-      axios.post(
-        `${GDevelopBuildApi.baseUrl}/build?userId=${encodeURIComponent(
-          userId
-        )}&key=${encodeURIComponent(
-          key
-        )}&type=electron-build&targets=${encodeURIComponent(
-          targets.join(',')
-        )}`,
-        null,
-        {
-          params: {},
-          headers: {
-            Authorization: authorizationHeader,
-          },
-        }
-      )
+      axios.post(`${GDevelopBuildApi.baseUrl}/build`, null, {
+        params: {
+          userId,
+          key,
+          type: 'electron-build',
+          targets: targets.join(','),
+          gameId,
+        },
+        headers: {
+          Authorization: authorizationHeader,
+        },
+      })
     )
     .then(response => response.data);
 };
@@ -111,22 +109,23 @@ export const buildElectron = (
 export const buildWeb = (
   getAuthorizationHeader: () => Promise<string>,
   userId: string,
-  key: string
+  key: string,
+  gameId: string
 ): Promise<Build> => {
   return getAuthorizationHeader()
     .then(authorizationHeader =>
-      axios.post(
-        `${GDevelopBuildApi.baseUrl}/build?userId=${encodeURIComponent(
-          userId
-        )}&key=${encodeURIComponent(key)}&type=web-build&targets=s3`,
-        null,
-        {
-          params: {},
-          headers: {
-            Authorization: authorizationHeader,
-          },
-        }
-      )
+      axios.post(`${GDevelopBuildApi.baseUrl}/build`, null, {
+        params: {
+          userId,
+          key,
+          type: 'web-build',
+          targets: 's3',
+          gameId,
+        },
+        headers: {
+          Authorization: authorizationHeader,
+        },
+      })
     )
     .then(response => response.data);
 };
@@ -136,23 +135,26 @@ export const buildCordovaAndroid = (
   userId: string,
   key: string,
   targets: Array<TargetName>,
-  keystore: 'old' | 'new'
+  keystore: 'old' | 'new',
+  gameId: string
 ): Promise<Build> => {
   return getAuthorizationHeader()
     .then(authorizationHeader =>
       axios.post(
-        `${GDevelopBuildApi.baseUrl}/build?userId=${encodeURIComponent(
-          userId
-        )}&key=${encodeURIComponent(
-          key
-        )}&type=cordova-build&targets=${encodeURIComponent(targets.join(','))}`,
+        `${GDevelopBuildApi.baseUrl}/build`,
         JSON.stringify({
           signing: {
             keystore,
           },
         }),
         {
-          params: {},
+          params: {
+            userId,
+            key,
+            type: 'cordova-build',
+            targets: targets.join(','),
+            gameId,
+          },
           headers: {
             Authorization: authorizationHeader,
           },

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -261,6 +261,7 @@ export const releaseWithoutDescription: Release = {
 
 export const erroredCordovaBuild: Build = {
   id: 'errored-build-id',
+  gameId: 'errored-game-id',
   status: 'error',
   logsKey: '/fake-error.log',
   createdAt: 1515084391000,
@@ -271,6 +272,7 @@ export const erroredCordovaBuild: Build = {
 
 export const pendingCordovaBuild: Build = {
   id: 'pending-build-id',
+  gameId: 'pending-game-id',
   status: 'pending',
   createdAt: 1515084391000,
   updatedAt: 1515084399000,
@@ -280,6 +282,7 @@ export const pendingCordovaBuild: Build = {
 
 export const pendingElectronBuild: Build = {
   id: 'pending-build-id',
+  gameId: 'pending-game-id',
   status: 'pending',
   createdAt: 1515084391000,
   updatedAt: 1515084399000,
@@ -289,6 +292,7 @@ export const pendingElectronBuild: Build = {
 
 export const completeCordovaBuild: Build = {
   id: 'complete-build-id',
+  gameId: 'complete-game-id',
   createdAt: 1515084391000,
   userId: 'fake-user-id',
   type: 'cordova-build',
@@ -300,6 +304,7 @@ export const completeCordovaBuild: Build = {
 
 export const completeElectronBuild: Build = {
   id: 'complete-build-id',
+  gameId: 'complete-game-id',
   createdAt: 1515084391000,
   userId: 'fake-user-id',
   type: 'electron-build',
@@ -314,6 +319,7 @@ export const completeElectronBuild: Build = {
 
 export const completeWebBuild: Build = {
   id: 'complete-build-id',
+  gameId: 'complete-game-id',
   createdAt: 1515084391000,
   userId: 'fake-user-id',
   type: 'web-build',

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -2573,6 +2573,7 @@ storiesOf('BuildStepsProgress', module)
       exportStep={'build'}
       build={{
         id: 'fake-build-id',
+        gameId: 'game-id',
         userId: 'fake-user-id',
         type: 'electron-build',
         status: 'pending',
@@ -2592,6 +2593,7 @@ storiesOf('BuildStepsProgress', module)
       exportStep={'build'}
       build={{
         id: 'fake-build-id',
+        gameId: 'game-id',
         userId: 'fake-user-id',
         type: 'cordova-build',
         status: 'error',
@@ -2611,6 +2613,7 @@ storiesOf('BuildStepsProgress', module)
       exportStep={'done'}
       build={{
         id: 'fake-build-id',
+        gameId: 'game-id',
         userId: 'fake-user-id',
         type: 'cordova-build',
         status: 'complete',


### PR DESCRIPTION
Do not show in changelog.

Keeping the design choice of having 1 unique link per build, to be able to manage different builds/versions for one single game.
In order to link the builds to a game, we have to send the gameId.