### PR TITLE
[ShapePainter] Rotation, scaling and fliping

### DIFF
--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -361,7 +361,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
   obj.AddAction("FlipX",
                 _("Flip the object horizontally"),
                 _("Flip the object horizontally"),
-                _("Flip horizontally _PARAM0_ : _PARAM1_"),
+                _("Flip horizontally _PARAM0_: _PARAM1_"),
                 _("Effects"),
                 "res/actions/flipX24.png",
                 "res/actions/flipX.png")
@@ -373,7 +373,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
   obj.AddAction("FlipY",
                 _("Flip the object vertically"),
                 _("Flip the object vertically"),
-                _("Flip vertically _PARAM0_ : _PARAM1_"),
+                _("Flip vertically _PARAM0_: _PARAM1_"),
                 _("Effects"),
                 "res/actions/flipY24.png",
                 "res/actions/flipY.png")

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -669,7 +669,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
   obj.AddAction("FlipX",
                 _("Flip the object horizontally"),
                 _("Flip the object horizontally"),
-                _("Flip horizontally _PARAM0_ : _PARAM1_"),
+                _("Flip horizontally _PARAM0_: _PARAM1_"),
                 _("Effects"),
                 "res/actions/flipX24.png",
                 "res/actions/flipX.png")
@@ -680,7 +680,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
   obj.AddAction("FlipY",
                 _("Flip the object vertically"),
                 _("Flip the object vertically"),
-                _("Flip vertically _PARAM0_ : _PARAM1_"),
+                _("Flip vertically _PARAM0_: _PARAM1_"),
                 _("Effects"),
                 "res/actions/flipY24.png",
                 "res/actions/flipY.png")
@@ -731,7 +731,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
   obj.AddAction("RotationAnchor",
                 _("Center of rotation"),
                 _("Change the center of rotation of an object relatively to the object origin."),
-                _("Change the center of rotation of _PARAM0_ : _PARAM1_; _PARAM2_"),
+                _("Change the center of rotation of _PARAM0_: _PARAM1_; _PARAM2_"),
                 _("Angle"),
                 "res/actions/position24.png",
                 "res/actions/position.png")
@@ -741,7 +741,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .MarkAsAdvanced();
 
   obj.AddExpression("ToDrawingX",
-                    _("X drawing coordinate of a point form the scene"),
+                    _("X drawing coordinate of a point from the scene"),
                     _("X drawing coordinate of a point from the scene"),
                     _("Position"),
                     "res/actions/position.png")
@@ -750,7 +750,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Y scene position"));
 
   obj.AddExpression("ToDrawingY",
-                    _("Y drawing coordinate of a point form the scene"),
+                    _("Y drawing coordinate of a point from the scene"),
                     _("Y drawing coordinate of a point from the scene"),
                     _("Position"),
                     "res/actions/position.png")
@@ -759,7 +759,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Y scene position"));
 
   obj.AddExpression("ToSceneX",
-                    _("X scene coordinate of a point form the drawing"),
+                    _("X scene coordinate of a point from the drawing"),
                     _("X scene coordinate of a point from the drawing"),
                     _("Position"),
                     "res/actions/position.png")
@@ -768,7 +768,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Y drawing position"));
 
   obj.AddExpression("ToSceneY",
-                    _("Y scene coordinate of a point form the drawing"),
+                    _("Y scene coordinate of a point from the drawing"),
                     _("Y scene coordinate of a point from the drawing"),
                     _("Position"),
                     "res/actions/position.png")

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -5,6 +5,7 @@ Copyright (c) 2008-2016 Florian Rival (Florian.Rival@gmail.com)
 This project is released under the MIT License.
 */
 
+#include "GDCore/Extensions/Metadata/MultipleInstructionMetadata.h"
 #include "GDCore/Extensions/PlatformExtension.h"
 #include "GDCore/Tools/Localization.h"
 #include "ShapePainterObject.h"
@@ -643,42 +644,27 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced();
 
-  obj.AddAction("ScaleX",
+  obj.AddExpressionAndConditionAndAction("number",
+                "ScaleX",
                 _("Scale on X axis"),
-                _("Modify the scale of the width of an object."),
+                _("the width's scale of an object"),
                 _("the width's scale"),
                 _("Size"),
-                "res/actions/scale24.png",
-                "res/actions/scale.png")
+                "res/actions/scaleWidth24.png")
       .AddParameter("object", _("Object"), "Drawer")
-      .UseStandardOperatorParameters("number")
+      .UseStandardParameters("number")
       .MarkAsAdvanced();
 
-  obj.AddAction("ScaleY",
+  obj.AddExpressionAndConditionAndAction("number",
+                "ScaleY",
                 _("Scale on Y axis"),
-                _("Modify the scale of the height of an object."),
+                _("the height's scale of an object"),
                 _("the height's scale"),
                 _("Size"),
-                "res/actions/scale24.png",
-                "res/actions/scale.png")
+                "res/actions/scaleHeight24.png")
       .AddParameter("object", _("Object"), "Drawer")
-      .UseStandardOperatorParameters("number")
+      .UseStandardParameters("number")
       .MarkAsAdvanced();
-
-  obj.AddExpression("ScaleX",
-                    _("Scale of the width of an object"),
-                    _("Scale of the width of an object"),
-                    _("Size"),
-                    "res/actions/scaleWidth.png")
-      .AddParameter("object", _("Object"), "Drawer");
-
-  obj.AddExpression("ScaleY",
-                    _("Scale of the height of an object"),
-                    _("Scale of the height of an object"),
-                    _("Size"),
-                    "res/actions/scaleHeight.png")
-      .AddParameter("object", _("Object"), "Drawer");
-
 
   obj.AddAction("FlipX",
                 _("Flip the object horizontally"),

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -702,6 +702,23 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("yesorno", _("Activate flipping"))
       .MarkAsSimple();
 
+  obj.AddCondition("FlippedX",
+                   _("Horizontally flipped"),
+                   _("Check if the object is horizontally flipped"),
+                   _("_PARAM0_ is horizontally flipped"),
+                   _("Effects"),
+                   "res/actions/flipX24.png",
+                   "res/actions/flipX.png")
+      .AddParameter("object", _("Object"), "Drawer");
+
+  obj.AddCondition("FlippedY",
+                   _("Vertically flipped"),
+                   _("Check if the object is vertically flipped"),
+                   _("_PARAM0_ is vertically flipped"),
+                   _("Effects"),
+                   "res/actions/flipY24.png",
+                   "res/actions/flipY.png")
+      .AddParameter("object", _("Object"), "Drawer");
 
   obj.AddAction("Width",
                 _("Width"),

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -632,5 +632,98 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .SetFunctionName("AreCoordinatesRelative")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
+  obj.AddAction("Scale",
+                _("Scale"),
+                _("Modify the scale of the specified object."),
+                _("the scale"),
+                _("Size"),
+                "res/actions/scale24.png",
+                "res/actions/scale.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
+
+  obj.AddAction("ScaleX",
+                _("Scale on X axis"),
+                _("Modify the scale of the width of an object."),
+                _("the width's scale"),
+                _("Size"),
+                "res/actions/scale24.png",
+                "res/actions/scale.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
+
+  obj.AddAction("ScaleY",
+                _("Scale on Y axis"),
+                _("Modify the scale of the height of an object."),
+                _("the height's scale"),
+                _("Size"),
+                "res/actions/scale24.png",
+                "res/actions/scale.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
+
+  obj.AddExpression("ScaleX",
+                    _("Scale of the width of an object"),
+                    _("Scale of the width of an object"),
+                    _("Size"),
+                    "res/actions/scaleWidth.png")
+      .AddParameter("object", _("Object"), "Drawer");
+
+  obj.AddExpression("ScaleY",
+                    _("Scale of the height of an object"),
+                    _("Scale of the height of an object"),
+                    _("Size"),
+                    "res/actions/scaleHeight.png")
+      .AddParameter("object", _("Object"), "Drawer");
+
+
+  obj.AddAction("FlipX",
+                _("Flip the object horizontally"),
+                _("Flip the object horizontally"),
+                _("Flip horizontally _PARAM0_ : _PARAM1_"),
+                _("Effects"),
+                "res/actions/flipX24.png",
+                "res/actions/flipX.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("yesorno", _("Activate flipping"))
+      .MarkAsSimple();
+
+  obj.AddAction("FlipY",
+                _("Flip the object vertically"),
+                _("Flip the object vertically"),
+                _("Flip vertically _PARAM0_ : _PARAM1_"),
+                _("Effects"),
+                "res/actions/flipY24.png",
+                "res/actions/flipY.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("yesorno", _("Activate flipping"))
+      .MarkAsSimple();
+
+
+  obj.AddAction("Width",
+                _("Width"),
+                _("Change the width of an object."),
+                _("the width"),
+                _("Size"),
+                "res/actions/scale24.png",
+                "res/actions/scale.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
+
+  obj.AddAction("Height",
+                _("Height"),
+                _("Change the height of an object."),
+                _("the height"),
+                _("Size"),
+                "res/actions/scale24.png",
+                "res/actions/scale.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
+
 #endif
 }

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -725,5 +725,17 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced();
 
+  obj.AddAction("RotationAnchor",
+                _("Center of rotation"),
+                _("Change the center of rotation of an object relatively to the object origin."),
+                _("Change the center of rotation of _PARAM0_ : _PARAM1_; _PARAM2_"),
+                _("Angle"),
+                "res/actions/position24.png",
+                "res/actions/position.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("expression", _("X position"))
+      .AddParameter("expression", _("Y position"))
+      .MarkAsAdvanced();
+
 #endif
 }

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -754,5 +754,41 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Y position"))
       .MarkAsAdvanced();
 
+  obj.AddExpression("ToDrawingX",
+                    _("X drawing coordinate of a point form the scene"),
+                    _("X drawing coordinate of a point from the scene"),
+                    _("Position"),
+                    "res/actions/position.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("expression", _("X scene position"))
+      .AddParameter("expression", _("Y scene position"));
+
+  obj.AddExpression("ToDrawingY",
+                    _("Y drawing coordinate of a point form the scene"),
+                    _("Y drawing coordinate of a point from the scene"),
+                    _("Position"),
+                    "res/actions/position.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("expression", _("X scene position"))
+      .AddParameter("expression", _("Y scene position"));
+
+  obj.AddExpression("ToSceneX",
+                    _("X scene coordinate of a point form the drawing"),
+                    _("X scene coordinate of a point from the drawing"),
+                    _("Position"),
+                    "res/actions/position.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("expression", _("X drawing position"))
+      .AddParameter("expression", _("Y drawing position"));
+
+  obj.AddExpression("ToSceneY",
+                    _("Y scene coordinate of a point form the drawing"),
+                    _("Y scene coordinate of a point from the drawing"),
+                    _("Position"),
+                    "res/actions/position.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("expression", _("X drawing position"))
+      .AddParameter("expression", _("Y drawing position"));
+
 #endif
 }

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -41,10 +41,10 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
          "res/actions/rectangle.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("expression", _("Top left side: X position"))
-      .AddParameter("expression", _("Top left side: Y position"))
-      .AddParameter("expression", _("Bottom right side: X position"))
-      .AddParameter("expression", _("Bottom right side: Y position"))
+      .AddParameter("expression", _("Left X position"))
+      .AddParameter("expression", _("Top Y position"))
+      .AddParameter("expression", _("Right X position"))
+      .AddParameter("expression", _("Bottom Y position"))
       .SetFunctionName("DrawRectangle")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
 
@@ -132,10 +132,10 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                 "res/actions/roundedRectangle.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .AddParameter("expression", _("Top left side: X position"))
-      .AddParameter("expression", _("Top left side: Y position"))
-      .AddParameter("expression", _("Bottom right side: X position"))
-      .AddParameter("expression", _("Bottom right side: Y position"))
+      .AddParameter("expression", _("Left X position"))
+      .AddParameter("expression", _("Top Y position"))
+      .AddParameter("expression", _("Right X position"))
+      .AddParameter("expression", _("Bottom Y position"))
       .AddParameter("expression", _("Radius (in pixels)"))
       .SetFunctionName("DrawRoundedRectangle")
       .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
@@ -711,7 +711,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                 _("Change the width of an object."),
                 _("the width"),
                 _("Size"),
-                "res/actions/scale24.png",
+                "res/actions/scaleWidth24.png",
                 "res/actions/scale.png")
       .AddParameter("object", _("Object"), "Drawer")
       .UseStandardOperatorParameters("number")
@@ -722,7 +722,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                 _("Change the height of an object."),
                 _("the height"),
                 _("Size"),
-                "res/actions/scale24.png",
+                "res/actions/scaleHeight24.png",
                 "res/actions/scale.png")
       .AddParameter("object", _("Object"), "Drawer")
       .UseStandardOperatorParameters("number")
@@ -738,6 +738,20 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Drawer")
       .AddParameter("expression", _("X position"))
       .AddParameter("expression", _("Y position"))
+      .MarkAsAdvanced();
+
+  obj.AddAction("SetRectangularCollisionMask",
+                _("Collision Mask"),
+                _("Change the collision mask of an object to a rectangle relatively to the object origin."),
+                _("Change the collision mask of _PARAM0_ to a rectangle from _PARAM1_; _PARAM2_ to _PARAM3_; _PARAM4_"),
+                _("Position"),
+                "res/actions/position24.png",
+                "res/actions/position.png")
+      .AddParameter("object", _("Object"), "Drawer")
+      .AddParameter("expression", _("Left X position"))
+      .AddParameter("expression", _("Top Y position"))
+      .AddParameter("expression", _("Right X position"))
+      .AddParameter("expression", _("Bottom Y position"))
       .MarkAsAdvanced();
 
   obj.AddExpression("ToDrawingX",

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -728,7 +728,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced();
 
-  obj.AddAction("RotationAnchor",
+  obj.AddAction("SetRotationCenter",
                 _("Center of rotation"),
                 _("Change the center of rotation of an object relatively to the object origin."),
                 _("Change the center of rotation of _PARAM0_: _PARAM1_; _PARAM2_"),

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -182,6 +182,12 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleY"]
         .SetFunctionName("setScaleY")
         .SetGetter("getScaleY");
+    GetAllConditionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleX"]
+        .SetFunctionName("getScaleX");
+    GetAllConditionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleY"]
+        .SetFunctionName("getScaleY");
     GetAllExpressionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleX"]
         .SetFunctionName("getScaleX");

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -215,6 +215,19 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::RotationAnchor"]
         .SetFunctionName("setRotationAnchor");
 
+    GetAllExpressionsForObject(
+        "PrimitiveDrawing::Drawer")["ToDrawingX"]
+        .SetFunctionName("transformToDrawingX");
+    GetAllExpressionsForObject(
+        "PrimitiveDrawing::Drawer")["ToDrawingY"]
+        .SetFunctionName("transformToDrawingY");
+    GetAllExpressionsForObject(
+        "PrimitiveDrawing::Drawer")["ToSceneX"]
+        .SetFunctionName("transformToSceneX");
+    GetAllExpressionsForObject(
+        "PrimitiveDrawing::Drawer")["ToSceneY"]
+        .SetFunctionName("transformToSceneX");
+
     GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
   };
 };

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -175,11 +175,11 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         .SetFunctionName("setScale")
         .SetGetter("getScale");
     GetAllActionsForObject(
-        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleX"]
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Drawer::SetScaleX"]
         .SetFunctionName("setScaleX")
         .SetGetter("getScaleX");
     GetAllActionsForObject(
-        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleY"]
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Drawer::SetScaleY"]
         .SetFunctionName("setScaleY")
         .SetGetter("getScaleY");
     GetAllConditionsForObject(

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -218,8 +218,8 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         .SetGetter("getHeight");
 
     GetAllActionsForObject(
-        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::RotationAnchor"]
-        .SetFunctionName("setRotationAnchor");
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::SetRotationCenter"]
+        .SetFunctionName("setRotationCenter");
 
     GetAllExpressionsForObject(
         "PrimitiveDrawing::Drawer")["ToDrawingX"]

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -220,6 +220,9 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
     GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::SetRotationCenter"]
         .SetFunctionName("setRotationCenter");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::SetRectangularCollisionMask"]
+        .SetFunctionName("setRectangularCollisionMask");
 
     GetAllExpressionsForObject(
         "PrimitiveDrawing::Drawer")["ToDrawingX"]

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -170,6 +170,39 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::AreCoordinatesRelative"]
         .SetFunctionName("areCoordinatesRelative");
 
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Scale"]
+        .SetFunctionName("setScale")
+        .SetGetter("getScale");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleX"]
+        .SetFunctionName("setScaleX")
+        .SetGetter("getScaleX");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleY"]
+        .SetFunctionName("setScaleY")
+        .SetGetter("getScaleY");
+    GetAllExpressionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleX"]
+        .SetFunctionName("getScaleX");
+    GetAllExpressionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleY"]
+        .SetFunctionName("getScaleY");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FlipX"]
+        .SetFunctionName("flipX");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FlipY"]
+        .SetFunctionName("flipY");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Width"]
+        .SetFunctionName("setWidth")
+        .SetGetter("getWidth");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Height"]
+        .SetFunctionName("setHeight")
+        .SetGetter("getHeight");
+
     GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
   };
 };

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -202,6 +202,9 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Height"]
         .SetFunctionName("setHeight")
         .SetGetter("getHeight");
+    GetAllActionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::RotationAnchor"]
+        .SetFunctionName("setRotationAnchor");
 
     GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
   };

--- a/Extensions/PrimitiveDrawing/JsExtension.cpp
+++ b/Extensions/PrimitiveDrawing/JsExtension.cpp
@@ -188,12 +188,20 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
     GetAllExpressionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::ScaleY"]
         .SetFunctionName("getScaleY");
+
     GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FlipX"]
         .SetFunctionName("flipX");
     GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FlipY"]
         .SetFunctionName("flipY");
+    GetAllConditionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FlippedX"]
+        .SetFunctionName("isFlippedX");
+    GetAllConditionsForObject(
+        "PrimitiveDrawing::Drawer")["PrimitiveDrawing::FlippedY"]
+        .SetFunctionName("isFlippedY");
+
     GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Width"]
         .SetFunctionName("setWidth")
@@ -202,6 +210,7 @@ class PrimitiveDrawingJsExtension : public gd::PlatformExtension {
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::Height"]
         .SetFunctionName("setHeight")
         .SetGetter("getHeight");
+
     GetAllActionsForObject(
         "PrimitiveDrawing::Drawer")["PrimitiveDrawing::RotationAnchor"]
         .SetFunctionName("setRotationAnchor");

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -3,7 +3,10 @@ namespace gdjs {
 
   class ShapePainterRuntimeObjectPixiRenderer {
     _object: gdjs.ShapePainterRuntimeObject;
+    _container: PIXI.Graphics;
     _graphics: PIXI.Graphics;
+    _positionXIsUpToDate = false;
+    _positionYIsUpToDate = false;
 
     constructor(
       runtimeObject: gdjs.ShapePainterRuntimeObject,
@@ -11,10 +14,12 @@ namespace gdjs {
     ) {
       this._object = runtimeObject;
       this._graphics = new PIXI.Graphics();
+      this._container = this._graphics;//new PIXI.Container();
+      //this._container.addChild(this._graphics);
       runtimeScene
         .getLayer('')
         .getRenderer()
-        .addRendererObject(this._graphics, runtimeObject.getZOrder());
+        .addRendererObject(this._container, runtimeObject.getZOrder());
     }
 
     getRendererObject() {
@@ -33,6 +38,7 @@ namespace gdjs {
       );
       this._graphics.drawRect(x1, y1, x2 - x1, y2 - y1);
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawCircle(x: float, y: float, radius: float) {
@@ -43,6 +49,7 @@ namespace gdjs {
       );
       this._graphics.drawCircle(x, y, radius);
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawLine(x1: float, y1: float, x2: float, y2: float, thickness: float) {
@@ -68,6 +75,7 @@ namespace gdjs {
         );
       }
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawLineV2(x1: float, y1: float, x2: float, y2: float, thickness: float) {
@@ -79,6 +87,7 @@ namespace gdjs {
       this._graphics.moveTo(x1, y1);
       this._graphics.lineTo(x2, y2);
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawEllipse(x1: float, y1: float, width: float, height: float) {
@@ -89,6 +98,7 @@ namespace gdjs {
       );
       this._graphics.drawEllipse(x1, y1, width / 2, height / 2);
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawRoundedRectangle(
@@ -106,6 +116,7 @@ namespace gdjs {
       this._graphics.drawRoundedRect(x1, y1, x2 - x1, y2 - y1, radius);
       this._graphics.closePath();
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawStar(
@@ -132,6 +143,7 @@ namespace gdjs {
       );
       this._graphics.closePath();
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawArc(
@@ -164,6 +176,7 @@ namespace gdjs {
         this._graphics.closePath();
       }
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawBezierCurve(
@@ -184,6 +197,7 @@ namespace gdjs {
       this._graphics.moveTo(x1, y1);
       this._graphics.bezierCurveTo(cpX, cpY, cpX2, cpY2, x2, y2);
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawQuadraticCurve(
@@ -202,6 +216,7 @@ namespace gdjs {
       this._graphics.moveTo(x1, y1);
       this._graphics.quadraticCurveTo(cpX, cpY, x2, y2);
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     beginFillPath() {
@@ -213,6 +228,7 @@ namespace gdjs {
 
     endFillPath() {
       this._graphics.endFill();
+      this.invalidateBounds();
     }
 
     drawPathMoveTo(x1: float, y1: float) {
@@ -250,6 +266,7 @@ namespace gdjs {
         gdjs.toRad(endAngle),
         anticlockwise ? true : false
       );
+      this.invalidateBounds();
     }
 
     drawPathQuadraticCurveTo(cpX: float, cpY: float, toX: float, toY: float) {
@@ -258,6 +275,7 @@ namespace gdjs {
 
     closePath() {
       this._graphics.closePath();
+      this.invalidateBounds();
     }
 
     updateOutline(): void {
@@ -268,20 +286,108 @@ namespace gdjs {
       );
     }
 
-    updateXPosition(): void {
-      if (!this._object._absoluteCoordinates) {
-        this._graphics.position.x = this._object.x;
+    invalidateBounds() {
+      this._object.invalidateBounds();
+      this._positionXIsUpToDate = false;
+      this._positionYIsUpToDate = false;
+    }
+
+    updatePositionX(): void {
+      if (this._object._absoluteCoordinates) {
+        this._container.position.x = 0;
       } else {
-        this._graphics.position.x = 0;
+        console.log("setX: " + this._object.x);
+        // GDJS objects relative positions are relative in translation and rotation but not in scale.
+        // Whereas, PIXI containers relative positions are also relative in scale.
+        // This is why the multiplication and division by the scale are needed.
+        this._graphics.pivot.x = this._graphics.getLocalBounds().x + this._object.getCenterX() / this._graphics.scale.x;
+        this._container.position.x = this._object.x + this._graphics.pivot.x * this._graphics.scale.x;
       }
     }
 
-    updateYPosition(): void {
-      if (!this._object._absoluteCoordinates) {
-        this._graphics.position.y = this._object.y;
+    updatePositionY(): void {
+      if (this._object._absoluteCoordinates) {
+        this._container.position.y = 0;
       } else {
-        this._graphics.position.y = 0;
+        this._graphics.pivot.y = this._graphics.getLocalBounds().y + this._object.getCenterY() / this._graphics.scale.y;
+        this._container.position.y = this._object.y + this._graphics.pivot.y * this._graphics.scale.y;
       }
+    }
+    
+    updatePositionIfNeeded() {
+      // Graphics positions can need update when something is drawn.
+      if (!this._positionXIsUpToDate) {
+        this.updatePositionX();
+        this._positionXIsUpToDate = true;
+      }
+      if (!this._positionYIsUpToDate) {
+        this.updatePositionY();
+        this._positionYIsUpToDate = true;
+      }
+    }
+
+    updateAngle(): void {
+      console.log(this._graphics.getLocalBounds());
+      if (this._object._absoluteCoordinates) {
+        this._graphics.angle = 0;
+      }
+      else {
+        this.updatePositionIfNeeded();
+        this._graphics.angle = this._object.angle;
+      }
+    }
+
+    updateScaleX(): void {
+      if (this._object._absoluteCoordinates) {
+        this._container.scale.x = 1;
+      } else {
+        console.log("ScaleX: " + this._object._scaleX);
+        this._container.scale.x = this._object._scaleX;
+      }
+      this.updatePositionX();
+      this.updatePositionY();
+    }
+
+    updateScaleY(): void {
+      if (this._object._absoluteCoordinates) {
+        this._container.scale.y = 1;
+      } else {
+        this._container.scale.y = this._object._scaleY;
+      }
+      this.updatePositionX();
+      this.updatePositionY();
+    }
+    
+    getDrawableX(): float {
+      if (this._object._absoluteCoordinates) {
+        return this._graphics.getLocalBounds().x;
+      }
+      // When new shape are drawn, the bounds of the object can extend.
+      // The object position stays the same but (drawableX; drawableY) can change.
+      return this._object.getX() + this._graphics.getLocalBounds().x * this._graphics.scale.x;
+    }
+
+    getDrawableY(): float {
+      if (this._object._absoluteCoordinates) {
+        return this._graphics.getLocalBounds().y;
+      }
+      return this._object.getY() + this._graphics.getLocalBounds().y * this._graphics.scale.y;
+    }
+
+    getWidth(): float {
+      return this._graphics.width;
+    }
+
+    getHeight(): float {
+      return this._graphics.height;
+    }
+    
+    getUnscaledWidth(): float {
+      return this._graphics.width / this._graphics.scale.x;
+    }
+
+    getUnscaledHeight(): float {
+      return this._graphics.height / this._graphics.scale.y;
     }
   }
 

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -315,8 +315,8 @@ namespace gdjs {
         this._graphics.pivot.x = 0;
         this._graphics.position.x = 0;
       } else {
-        // Make the drawing rotate around the anchor.
-        this._graphics.pivot.x = this._object.getRotationAnchorX();
+        // Make the drawing rotate around the rotation center.
+        this._graphics.pivot.x = this._object.getRotationCenterX();
         // Multiply by the scale to have the scale anchor
         // at the object position instead of the center.
         this._graphics.position.x =
@@ -330,7 +330,7 @@ namespace gdjs {
         this._graphics.pivot.y = 0;
         this._graphics.position.y = 0;
       } else {
-        this._graphics.pivot.y = this._object.getRotationAnchorY();
+        this._graphics.pivot.y = this._object.getRotationCenterY();
         this._graphics.position.y =
           this._object.y +
           this._graphics.pivot.y * Math.abs(this._graphics.scale.y);
@@ -382,8 +382,8 @@ namespace gdjs {
       }
       let localBound = this._graphics.getLocalBounds().left;
       if (this._object._flippedX) {
-        const anchorX = this._object.getRotationAnchorX();
-        localBound = 2 * anchorX - localBound;
+        const rotationCenterX = this._object.getRotationCenterX();
+        localBound = 2 * rotationCenterX - localBound;
       }
       // When new shape are drawn, the bounds of the object can extend.
       // The object position stays the same but (drawableX; drawableY) can change.
@@ -398,8 +398,8 @@ namespace gdjs {
       }
       let localBound = this._graphics.getLocalBounds().top;
       if (this._object._flippedY) {
-        const anchorY = this._object.getRotationAnchorY();
-        localBound = 2 * anchorY - localBound;
+        const rotationCenterY = this._object.getRotationCenterY();
+        localBound = 2 * rotationCenterY - localBound;
       }
       return (
         this._object.getY() + localBound * Math.abs(this._graphics.scale.y)

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -301,11 +301,10 @@ namespace gdjs {
         this._container.position.x = 0;
       } else {
         console.log("setX: " + this._object.x);
+        this._graphics.pivot.x = this._object.getRotationAnchorX();
         // GDJS objects relative positions are relative in translation and rotation but not in scale.
         // Whereas, PIXI containers relative positions are also relative in scale.
-        // This is why the multiplication and division by the scale are needed.
-        const localBound = this._object._flippedX ? this._graphics.getLocalBounds().right : this._graphics.getLocalBounds().left;
-        this._graphics.pivot.x = localBound + this._object.getCenterX() / Math.abs(this._graphics.scale.x);
+        // This is why the scale is used.
         this._container.position.x = this._object.x + this._graphics.pivot.x * Math.abs(this._graphics.scale.x);
       }
     }
@@ -314,14 +313,13 @@ namespace gdjs {
       if (this._object._absoluteCoordinates) {
         this._container.position.y = 0;
       } else {
-        const localBound = this._object._flippedY ? this._graphics.getLocalBounds().bottom : this._graphics.getLocalBounds().top;
-        this._graphics.pivot.y = localBound + this._object.getCenterY() / Math.abs(this._graphics.scale.y);
+        this._graphics.pivot.y = this._object.getRotationAnchorY();
         this._container.position.y = this._object.y + this._graphics.pivot.y * Math.abs(this._graphics.scale.y);
       }
     }
     
     updatePositionIfNeeded() {
-      // Graphics positions can need update when something is drawn.
+      // Graphics positions can need update when shapes are added.
       if (!this._positionXIsUpToDate) {
         this.updatePositionX();
         this._positionXIsUpToDate = true;
@@ -368,7 +366,11 @@ namespace gdjs {
       if (this._object._absoluteCoordinates) {
         return this._graphics.getLocalBounds().x;
       }
-      const localBound = this._object._flippedX ? this._graphics.getLocalBounds().right : this._graphics.getLocalBounds().left;
+      let localBound = this._graphics.getLocalBounds().left;
+      if (this._object._flippedX) {
+        const anchorX = this._object.getRotationAnchorX();
+        localBound = 2 * anchorX - localBound;
+      }
       // When new shape are drawn, the bounds of the object can extend.
       // The object position stays the same but (drawableX; drawableY) can change.
       return this._object.getX() + localBound * Math.abs(this._graphics.scale.x);
@@ -378,7 +380,11 @@ namespace gdjs {
       if (this._object._absoluteCoordinates) {
         return this._graphics.getLocalBounds().y;
       }
-      const localBound = this._object._flippedY ? this._graphics.getLocalBounds().bottom : this._graphics.getLocalBounds().top;
+      let localBound = this._graphics.getLocalBounds().top;
+      if (this._object._flippedY) {
+        const anchorY = this._object.getRotationAnchorY();
+        localBound = 2 * anchorY - localBound;
+      }
       return this._object.getY() + localBound * Math.abs(this._graphics.scale.y);
     }
 
@@ -391,11 +397,25 @@ namespace gdjs {
     }
     
     getUnscaledWidth(): float {
-      return this._graphics.width / this._graphics.scale.x;
+      return this._graphics.getLocalBounds().width;
     }
 
     getUnscaledHeight(): float {
-      return this._graphics.height / this._graphics.scale.y;
+      return this._graphics.getLocalBounds().height;
+    }
+    
+    /**
+     * @returns The drawing origin relatively to the drawable top left corner.
+     */
+    getOriginX() {
+      return - this._graphics.getLocalBounds().left;
+    }
+    
+    /**
+     * @returns The drawing origin relatively to the drawable top left corner.
+     */
+    getOriginY() {
+      return - this._graphics.getLocalBounds().top;
     }
   }
 

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -8,6 +8,8 @@ namespace gdjs {
     _positionXIsUpToDate = false;
     _positionYIsUpToDate = false;
 
+    private static readonly _positionForTransformation: PIXI.IPointData = {x: 0, y: 0};
+
     constructor(
       runtimeObject: gdjs.ShapePainterRuntimeObject,
       runtimeScene: gdjs.RuntimeScene
@@ -416,6 +418,26 @@ namespace gdjs {
      */
     getOriginY() {
       return - this._graphics.getLocalBounds().top;
+    }
+
+    transformToDrawing(point: FloatPoint): FloatPoint {
+      const position = ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
+      position.x = point[0];
+      position.y = point[1];
+      this._graphics.localTransform.applyInverse(position, position);
+      point[0] = position.x;
+      point[1] = position.y;
+      return point;
+    }
+
+    transformToScene(point: FloatPoint): FloatPoint {
+      const position = ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
+      position.x = point[0];
+      position.y = point[1];
+      this._graphics.localTransform.apply(position, position);
+      point[0] = position.x;
+      point[1] = position.y;
+      return point;
     }
   }
 

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -362,6 +362,12 @@ namespace gdjs {
       }
     }
 
+    updateRotationCenter(): void {
+      // The pivot and position depends on the rotation center point.
+      this._positionXIsUpToDate = false;
+      this._positionYIsUpToDate = false;
+    }
+
     updateAngle(): void {
       if (this._object._useAbsoluteCoordinates) {
         this._graphics.angle = 0;
@@ -455,7 +461,6 @@ namespace gdjs {
 
     transformToDrawing(point: FloatPoint): FloatPoint {
       this.updateTransformationIfNeeded();
-      this._graphics.updateTransform();
       const position =
         ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
       position.x = point[0];

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -3,7 +3,6 @@ namespace gdjs {
 
   class ShapePainterRuntimeObjectPixiRenderer {
     _object: gdjs.ShapePainterRuntimeObject;
-    _container: PIXI.Graphics;
     _graphics: PIXI.Graphics;
     _positionXIsUpToDate = false;
     _positionYIsUpToDate = false;
@@ -19,12 +18,11 @@ namespace gdjs {
     ) {
       this._object = runtimeObject;
       this._graphics = new PIXI.Graphics();
-      this._container = this._graphics; //new PIXI.Container();
       //this._container.addChild(this._graphics);
       runtimeScene
         .getLayer('')
         .getRenderer()
-        .addRendererObject(this._container, runtimeObject.getZOrder());
+        .addRendererObject(this._graphics, runtimeObject.getZOrder());
     }
 
     getRendererObject() {
@@ -303,13 +301,13 @@ namespace gdjs {
 
     updatePositionX(): void {
       if (this._object._absoluteCoordinates) {
-        this._container.position.x = 0;
+        this._graphics.position.x = 0;
       } else {
         this._graphics.pivot.x = this._object.getRotationAnchorX();
         // GDJS objects relative positions are relative in translation and rotation but not in scale.
         // Whereas, PIXI containers relative positions are also relative in scale.
         // This is why the scale is used.
-        this._container.position.x =
+        this._graphics.position.x =
           this._object.x +
           this._graphics.pivot.x * Math.abs(this._graphics.scale.x);
       }
@@ -317,10 +315,10 @@ namespace gdjs {
 
     updatePositionY(): void {
       if (this._object._absoluteCoordinates) {
-        this._container.position.y = 0;
+        this._graphics.position.y = 0;
       } else {
         this._graphics.pivot.y = this._object.getRotationAnchorY();
-        this._container.position.y =
+        this._graphics.position.y =
           this._object.y +
           this._graphics.pivot.y * Math.abs(this._graphics.scale.y);
       }
@@ -349,9 +347,9 @@ namespace gdjs {
 
     updateScaleX(): void {
       if (this._object._absoluteCoordinates) {
-        this._container.scale.x = 1;
+        this._graphics.scale.x = 1;
       } else {
-        this._container.scale.x = this._object._scaleX;
+        this._graphics.scale.x = this._object._scaleX;
       }
       this.updatePositionX();
       this.updatePositionY();
@@ -359,9 +357,9 @@ namespace gdjs {
 
     updateScaleY(): void {
       if (this._object._absoluteCoordinates) {
-        this._container.scale.y = 1;
+        this._graphics.scale.y = 1;
       } else {
-        this._container.scale.y = this._object._scaleY;
+        this._graphics.scale.y = this._object._scaleY;
       }
       this.updatePositionX();
       this.updatePositionY();

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -14,6 +14,11 @@ namespace gdjs {
      * this avoids to do it each time.
      */
     _positionYIsUpToDate = false;
+    /**
+     * It allows to use the transformation of the renderer
+     * and compute it only when necessary.
+     */
+    _transformationIsUpToDate = false;
 
     private static readonly _positionForTransformation: PIXI.IPointData = {
       x: 0,
@@ -323,6 +328,7 @@ namespace gdjs {
           this._object.x +
           this._graphics.pivot.x * Math.abs(this._graphics.scale.x);
       }
+      this._transformationIsUpToDate = false;
     }
 
     updatePositionY(): void {
@@ -335,6 +341,7 @@ namespace gdjs {
           this._object.y +
           this._graphics.pivot.y * Math.abs(this._graphics.scale.y);
       }
+      this._transformationIsUpToDate = false;
     }
 
     updatePositionIfNeeded() {
@@ -348,12 +355,20 @@ namespace gdjs {
       }
     }
 
+    updateTransformationIfNeeded() {
+      if (!this._transformationIsUpToDate) {
+        this.updatePositionIfNeeded();
+        this._graphics.updateTransform();
+      }
+    }
+
     updateAngle(): void {
       if (this._object._useAbsoluteCoordinates) {
         this._graphics.angle = 0;
       } else {
         this._graphics.angle = this._object.angle;
       }
+      this._transformationIsUpToDate = false;
     }
 
     updateScaleX(): void {
@@ -364,6 +379,7 @@ namespace gdjs {
       }
       // updatePositionX() uses scale.x
       this._positionXIsUpToDate = false;
+      this._transformationIsUpToDate = false;
     }
 
     updateScaleY(): void {
@@ -374,6 +390,7 @@ namespace gdjs {
       }
       // updatePositionY() uses scale.y
       this._positionYIsUpToDate = false;
+      this._transformationIsUpToDate = false;
     }
 
     getDrawableX(): float {
@@ -437,7 +454,8 @@ namespace gdjs {
     }
 
     transformToDrawing(point: FloatPoint): FloatPoint {
-      this.updatePositionIfNeeded();
+      this.updateTransformationIfNeeded();
+      this._graphics.updateTransform();
       const position =
         ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
       position.x = point[0];
@@ -449,7 +467,7 @@ namespace gdjs {
     }
 
     transformToScene(point: FloatPoint): FloatPoint {
-      this.updatePositionIfNeeded();
+      this.updateTransformationIfNeeded();
       const position =
         ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
       position.x = point[0];

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -360,12 +360,15 @@ namespace gdjs {
         this.updatePositionIfNeeded();
         this._graphics.updateTransform();
       }
+      this._transformationIsUpToDate = true;
     }
 
     updateRotationCenter(): void {
       // The pivot and position depends on the rotation center point.
       this._positionXIsUpToDate = false;
       this._positionYIsUpToDate = false;
+      // The whole transformation changes based on the rotation center point.
+      this._transformationIsUpToDate = false;
     }
 
     updateAngle(): void {

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -15,7 +15,7 @@ namespace gdjs {
      */
     _positionYIsUpToDate = false;
     /**
-     * It allows to use the transformation of the renderer
+     * This allows to use the transformation of the renderer
      * and compute it only when necessary.
      */
     _transformationIsUpToDate = false;
@@ -451,14 +451,14 @@ namespace gdjs {
     /**
      * @returns The drawing origin relatively to the drawable top left corner.
      */
-    getOriginX() {
+    getFrameRelativeOriginX() {
       return -this._graphics.getLocalBounds().left;
     }
 
     /**
      * @returns The drawing origin relatively to the drawable top left corner.
      */
-    getOriginY() {
+    getFrameRelativeOriginY() {
       return -this._graphics.getLocalBounds().top;
     }
 

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -8,7 +8,10 @@ namespace gdjs {
     _positionXIsUpToDate = false;
     _positionYIsUpToDate = false;
 
-    private static readonly _positionForTransformation: PIXI.IPointData = {x: 0, y: 0};
+    private static readonly _positionForTransformation: PIXI.IPointData = {
+      x: 0,
+      y: 0,
+    };
 
     constructor(
       runtimeObject: gdjs.ShapePainterRuntimeObject,
@@ -16,7 +19,7 @@ namespace gdjs {
     ) {
       this._object = runtimeObject;
       this._graphics = new PIXI.Graphics();
-      this._container = this._graphics;//new PIXI.Container();
+      this._container = this._graphics; //new PIXI.Container();
       //this._container.addChild(this._graphics);
       runtimeScene
         .getLayer('')
@@ -302,12 +305,13 @@ namespace gdjs {
       if (this._object._absoluteCoordinates) {
         this._container.position.x = 0;
       } else {
-        console.log("setX: " + this._object.x);
         this._graphics.pivot.x = this._object.getRotationAnchorX();
         // GDJS objects relative positions are relative in translation and rotation but not in scale.
         // Whereas, PIXI containers relative positions are also relative in scale.
         // This is why the scale is used.
-        this._container.position.x = this._object.x + this._graphics.pivot.x * Math.abs(this._graphics.scale.x);
+        this._container.position.x =
+          this._object.x +
+          this._graphics.pivot.x * Math.abs(this._graphics.scale.x);
       }
     }
 
@@ -316,10 +320,12 @@ namespace gdjs {
         this._container.position.y = 0;
       } else {
         this._graphics.pivot.y = this._object.getRotationAnchorY();
-        this._container.position.y = this._object.y + this._graphics.pivot.y * Math.abs(this._graphics.scale.y);
+        this._container.position.y =
+          this._object.y +
+          this._graphics.pivot.y * Math.abs(this._graphics.scale.y);
       }
     }
-    
+
     updatePositionIfNeeded() {
       // Graphics positions can need update when shapes are added.
       if (!this._positionXIsUpToDate) {
@@ -333,11 +339,9 @@ namespace gdjs {
     }
 
     updateAngle(): void {
-      console.log(this._graphics.getLocalBounds());
       if (this._object._absoluteCoordinates) {
         this._graphics.angle = 0;
-      }
-      else {
+      } else {
         this.updatePositionIfNeeded();
         this._graphics.angle = this._object.angle;
       }
@@ -347,7 +351,6 @@ namespace gdjs {
       if (this._object._absoluteCoordinates) {
         this._container.scale.x = 1;
       } else {
-        console.log("ScaleX: " + this._object._scaleX);
         this._container.scale.x = this._object._scaleX;
       }
       this.updatePositionX();
@@ -363,7 +366,7 @@ namespace gdjs {
       this.updatePositionX();
       this.updatePositionY();
     }
-    
+
     getDrawableX(): float {
       if (this._object._absoluteCoordinates) {
         return this._graphics.getLocalBounds().x;
@@ -375,7 +378,9 @@ namespace gdjs {
       }
       // When new shape are drawn, the bounds of the object can extend.
       // The object position stays the same but (drawableX; drawableY) can change.
-      return this._object.getX() + localBound * Math.abs(this._graphics.scale.x);
+      return (
+        this._object.getX() + localBound * Math.abs(this._graphics.scale.x)
+      );
     }
 
     getDrawableY(): float {
@@ -387,7 +392,9 @@ namespace gdjs {
         const anchorY = this._object.getRotationAnchorY();
         localBound = 2 * anchorY - localBound;
       }
-      return this._object.getY() + localBound * Math.abs(this._graphics.scale.y);
+      return (
+        this._object.getY() + localBound * Math.abs(this._graphics.scale.y)
+      );
     }
 
     getWidth(): float {
@@ -397,7 +404,7 @@ namespace gdjs {
     getHeight(): float {
       return this._graphics.height;
     }
-    
+
     getUnscaledWidth(): float {
       return this._graphics.getLocalBounds().width;
     }
@@ -405,23 +412,24 @@ namespace gdjs {
     getUnscaledHeight(): float {
       return this._graphics.getLocalBounds().height;
     }
-    
+
     /**
      * @returns The drawing origin relatively to the drawable top left corner.
      */
     getOriginX() {
-      return - this._graphics.getLocalBounds().left;
+      return -this._graphics.getLocalBounds().left;
     }
-    
+
     /**
      * @returns The drawing origin relatively to the drawable top left corner.
      */
     getOriginY() {
-      return - this._graphics.getLocalBounds().top;
+      return -this._graphics.getLocalBounds().top;
     }
 
     transformToDrawing(point: FloatPoint): FloatPoint {
-      const position = ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
+      const position =
+        ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
       position.x = point[0];
       position.y = point[1];
       this._graphics.localTransform.applyInverse(position, position);
@@ -431,7 +439,8 @@ namespace gdjs {
     }
 
     transformToScene(point: FloatPoint): FloatPoint {
-      const position = ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
+      const position =
+        ShapePainterRuntimeObjectPixiRenderer._positionForTransformation;
       position.x = point[0];
       position.y = point[1];
       this._graphics.localTransform.apply(position, position);

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -292,6 +292,10 @@ namespace gdjs {
       this._positionYIsUpToDate = false;
     }
 
+    updatePreRender(): void {
+      this.updatePositionIfNeeded();
+    }
+
     updatePositionX(): void {
       if (this._object._absoluteCoordinates) {
         this._container.position.x = 0;

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -300,8 +300,9 @@ namespace gdjs {
         // GDJS objects relative positions are relative in translation and rotation but not in scale.
         // Whereas, PIXI containers relative positions are also relative in scale.
         // This is why the multiplication and division by the scale are needed.
-        this._graphics.pivot.x = this._graphics.getLocalBounds().x + this._object.getCenterX() / this._graphics.scale.x;
-        this._container.position.x = this._object.x + this._graphics.pivot.x * this._graphics.scale.x;
+        const localBound = this._object._flippedX ? this._graphics.getLocalBounds().right : this._graphics.getLocalBounds().left;
+        this._graphics.pivot.x = localBound + this._object.getCenterX() / Math.abs(this._graphics.scale.x);
+        this._container.position.x = this._object.x + this._graphics.pivot.x * Math.abs(this._graphics.scale.x);
       }
     }
 
@@ -309,8 +310,9 @@ namespace gdjs {
       if (this._object._absoluteCoordinates) {
         this._container.position.y = 0;
       } else {
-        this._graphics.pivot.y = this._graphics.getLocalBounds().y + this._object.getCenterY() / this._graphics.scale.y;
-        this._container.position.y = this._object.y + this._graphics.pivot.y * this._graphics.scale.y;
+        const localBound = this._object._flippedY ? this._graphics.getLocalBounds().bottom : this._graphics.getLocalBounds().top;
+        this._graphics.pivot.y = localBound + this._object.getCenterY() / Math.abs(this._graphics.scale.y);
+        this._container.position.y = this._object.y + this._graphics.pivot.y * Math.abs(this._graphics.scale.y);
       }
     }
     
@@ -362,16 +364,18 @@ namespace gdjs {
       if (this._object._absoluteCoordinates) {
         return this._graphics.getLocalBounds().x;
       }
+      const localBound = this._object._flippedX ? this._graphics.getLocalBounds().right : this._graphics.getLocalBounds().left;
       // When new shape are drawn, the bounds of the object can extend.
       // The object position stays the same but (drawableX; drawableY) can change.
-      return this._object.getX() + this._graphics.getLocalBounds().x * this._graphics.scale.x;
+      return this._object.getX() + localBound * Math.abs(this._graphics.scale.x);
     }
 
     getDrawableY(): float {
       if (this._object._absoluteCoordinates) {
         return this._graphics.getLocalBounds().y;
       }
-      return this._object.getY() + this._graphics.getLocalBounds().y * this._graphics.scale.y;
+      const localBound = this._object._flippedY ? this._graphics.getLocalBounds().bottom : this._graphics.getLocalBounds().top;
+      return this._object.getY() + localBound * Math.abs(this._graphics.scale.y);
     }
 
     getWidth(): float {

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -26,7 +26,6 @@ namespace gdjs {
     ) {
       this._object = runtimeObject;
       this._graphics = new PIXI.Graphics();
-      //this._container.addChild(this._graphics);
       runtimeScene
         .getLayer('')
         .getRenderer()
@@ -312,13 +311,13 @@ namespace gdjs {
     }
 
     updatePositionX(): void {
-      if (this._object._absoluteCoordinates) {
+      if (this._object._useAbsoluteCoordinates) {
         this._graphics.pivot.x = 0;
         this._graphics.position.x = 0;
       } else {
         // Make the drawing rotate around the anchor.
         this._graphics.pivot.x = this._object.getRotationAnchorX();
-        // Multiply with the scale to have the scale anchor
+        // Multiply by the scale to have the scale anchor
         // at the object position instead of the center.
         this._graphics.position.x =
           this._object.x +
@@ -327,7 +326,7 @@ namespace gdjs {
     }
 
     updatePositionY(): void {
-      if (this._object._absoluteCoordinates) {
+      if (this._object._useAbsoluteCoordinates) {
         this._graphics.pivot.y = 0;
         this._graphics.position.y = 0;
       } else {
@@ -350,7 +349,7 @@ namespace gdjs {
     }
 
     updateAngle(): void {
-      if (this._object._absoluteCoordinates) {
+      if (this._object._useAbsoluteCoordinates) {
         this._graphics.angle = 0;
       } else {
         this._graphics.angle = this._object.angle;
@@ -358,7 +357,7 @@ namespace gdjs {
     }
 
     updateScaleX(): void {
-      if (this._object._absoluteCoordinates) {
+      if (this._object._useAbsoluteCoordinates) {
         this._graphics.scale.x = 1;
       } else {
         this._graphics.scale.x = this._object._scaleX;
@@ -368,7 +367,7 @@ namespace gdjs {
     }
 
     updateScaleY(): void {
-      if (this._object._absoluteCoordinates) {
+      if (this._object._useAbsoluteCoordinates) {
         this._graphics.scale.y = 1;
       } else {
         this._graphics.scale.y = this._object._scaleY;
@@ -378,8 +377,8 @@ namespace gdjs {
     }
 
     getDrawableX(): float {
-      if (this._object._absoluteCoordinates) {
-        return this._graphics.getLocalBounds().x;
+      if (this._object._useAbsoluteCoordinates) {
+        return this._graphics.getLocalBounds().left;
       }
       let localBound = this._graphics.getLocalBounds().left;
       if (this._object._flippedX) {
@@ -394,8 +393,8 @@ namespace gdjs {
     }
 
     getDrawableY(): float {
-      if (this._object._absoluteCoordinates) {
-        return this._graphics.getLocalBounds().y;
+      if (this._object._useAbsoluteCoordinates) {
+        return this._graphics.getLocalBounds().top;
       }
       let localBound = this._graphics.getLocalBounds().top;
       if (this._object._flippedY) {

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -42,6 +42,7 @@ namespace gdjs {
     _blendMode: number = 0;
     _flippedX: boolean = false;
     _flippedY: boolean = false;
+    _customCenter: FloatPoint | null = null;
 
     _fillColor: integer;
     _outlineColor: integer;
@@ -469,6 +470,64 @@ namespace gdjs {
       console.log("center: " + this.getCenterX() + " " + this.getCenterY());
       console.log("getDrawableXY: " + this.getDrawableX() + " " + this.getDrawableY());
       this._renderer.updateAngle();
+    }
+
+    /**
+     * The center of rotation is defined relatively
+     * to the drawing origin (the object position).
+     * This avoid the center to move on the drawing
+     * when new shapes push the bounds.
+     * 
+     * When no custom center is defined, it will move
+     * to stay at the center of the drawable bounds.
+     * 
+     * @param x coordinate of the custom center
+     * @param y coordinate of the custom center
+     */
+    setRotationAnchor(x: float, y: float): void {
+      if (!this._customCenter) {
+        this._customCenter = [0, 0];
+      }
+      this._customCenter[0] = x;
+      this._customCenter[1] = y;
+    }
+
+    /**
+     * @returns The center X relatively to the drawing origin
+     * (where `getCenterX()` is relative to the top left drawable bound).
+     */
+    getRotationAnchorX(): float {
+      return this._customCenter ? this._customCenter[0] : this._renderer.getUnscaledWidth() / 2 - this._renderer.getOriginX();
+    }
+
+    /**
+     * @returns The center Y relatively to the drawing origin
+     * (where `getCenterY()` is relative to the top left drawable bound).
+     */
+    getRotationAnchorY(): float {
+      return this._customCenter ? this._customCenter[1] : this._renderer.getUnscaledHeight() / 2 - this._renderer.getOriginY();
+    }
+
+    getCenterX(): float {
+      if (!this._customCenter) {
+        return super.getCenterX();
+      }
+      let centerX = this._customCenter[0] + (this.getX() - this.getDrawableX()) / Math.abs(this._scaleX);
+      if (this._flippedX) {
+        //centerX = this._renderer.getUnscaledWidth() - centerX;
+      }
+      return centerX * Math.abs(this._scaleX);
+    }
+
+    getCenterY(): float {
+      if (!this._customCenter) {
+        return super.getCenterY();
+      }
+      let centerY = this._customCenter[1] + (this.getY() - this.getDrawableY()) / Math.abs(this._scaleY);
+      if (this._flippedY) {
+        //centerY = this._renderer.getUnscaledHeight() - centerY;
+      }
+      return centerY * Math.abs(this._scaleY);
     }
 
     /**

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -624,6 +624,10 @@ namespace gdjs {
     getHeight(): float {
       return this._renderer.getHeight();
     }
+    
+    updatePreRender(runtimeScene: gdjs.RuntimeScene): void {
+      this._renderer.updatePreRender();
+    }
   }
   gdjs.registerObject(
     'PrimitiveDrawing::Drawer',

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -489,6 +489,7 @@ namespace gdjs {
       }
       this._customCenter[0] = x;
       this._customCenter[1] = y;
+      this._renderer.updateRotationCenter();
     }
 
     /**

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -49,7 +49,7 @@ namespace gdjs {
     _fillOpacity: float;
     _outlineOpacity: float;
     _outlineSize: float;
-    _absoluteCoordinates: boolean;
+    _useAbsoluteCoordinates: boolean;
     _clearBetweenFrames: boolean;
     _renderer: gdjs.ShapePainterRuntimeObjectRenderer;
 
@@ -83,7 +83,7 @@ namespace gdjs {
       this._fillOpacity = shapePainterObjectData.fillOpacity;
       this._outlineOpacity = shapePainterObjectData.outlineOpacity;
       this._outlineSize = shapePainterObjectData.outlineSize;
-      this._absoluteCoordinates = shapePainterObjectData.absoluteCoordinates;
+      this._useAbsoluteCoordinates = shapePainterObjectData.absoluteCoordinates;
       this._clearBetweenFrames = shapePainterObjectData.clearBetweenFrames;
       this._renderer = new gdjs.ShapePainterRuntimeObjectRenderer(
         this,
@@ -142,7 +142,7 @@ namespace gdjs {
       if (
         oldObjectData.absoluteCoordinates !== newObjectData.absoluteCoordinates
       ) {
-        this._absoluteCoordinates = newObjectData.absoluteCoordinates;
+        this._useAbsoluteCoordinates = newObjectData.absoluteCoordinates;
         this._renderer.updatePositionX();
         this._renderer.updatePositionY();
         this._renderer.updateAngle();
@@ -173,7 +173,7 @@ namespace gdjs {
     }
 
     getVisibilityAABB() {
-      return this._absoluteCoordinates ? null : this.getAABB();
+      return this._useAbsoluteCoordinates ? null : this.getAABB();
     }
 
     drawRectangle(x1: float, y1: float, x2: float, y2: float) {
@@ -337,11 +337,11 @@ namespace gdjs {
     }
 
     setCoordinatesRelative(value: boolean): void {
-      this._absoluteCoordinates = !value;
+      this._useAbsoluteCoordinates = !value;
     }
 
     areCoordinatesRelative(): boolean {
-      return !this._absoluteCoordinates;
+      return !this._useAbsoluteCoordinates;
     }
 
     /**
@@ -491,7 +491,7 @@ namespace gdjs {
 
     /**
      * @returns The center X relatively to the drawing origin
-     * (where `getCenterX()` is relative to the top left drawable bound and scaled).
+     * (whereas `getCenterX()` is relative to the top left drawable bound and scaled).
      */
     getRotationAnchorX(): float {
       return this._customCenter
@@ -501,7 +501,7 @@ namespace gdjs {
 
     /**
      * @returns The center Y relatively to the drawing origin
-     * (where `getCenterY()` is relative to the top left drawable bound and scaled).
+     * (whereas `getCenterY()` is relative to the top left drawable bound and scaled).
      */
     getRotationAnchorY(): float {
       return this._customCenter
@@ -532,7 +532,7 @@ namespace gdjs {
     /**
      * Change the width of the object. This changes the scale on X axis of the object.
      *
-     * @param width The new width of the object, in pixels.
+     * @param newWidth The new width of the object, in pixels.
      */
     setWidth(newWidth: float): void {
       const unscaledWidth = this._renderer.getUnscaledWidth();
@@ -544,7 +544,7 @@ namespace gdjs {
     /**
      * Change the height of the object. This changes the scale on Y axis of the object.
      *
-     * @param height The new height of the object, in pixels.
+     * @param newHeight The new height of the object, in pixels.
      */
     setHeight(newHeight: float): void {
       const unscaledHeight = this._renderer.getUnscaledHeight();
@@ -731,7 +731,7 @@ namespace gdjs {
         this.hitBoxes[0].vertices[3][0] = 0 - centerX;
         this.hitBoxes[0].vertices[3][1] = height - centerY;
       }
-      if (!this._absoluteCoordinates) {
+      if (!this._useAbsoluteCoordinates) {
         this.hitBoxes[0].rotate(gdjs.toRad(this.getAngle()));
       }
       this.hitBoxes[0].move(

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -481,7 +481,7 @@ namespace gdjs {
      * @param x coordinate of the custom center
      * @param y coordinate of the custom center
      */
-    setRotationAnchor(x: float, y: float): void {
+    setRotationCenter(x: float, y: float): void {
       if (!this._customCenter) {
         this._customCenter = [0, 0];
       }
@@ -493,7 +493,7 @@ namespace gdjs {
      * @returns The center X relatively to the drawing origin
      * (whereas `getCenterX()` is relative to the top left drawable bound and scaled).
      */
-    getRotationAnchorX(): float {
+    getRotationCenterX(): float {
       return this._customCenter
         ? this._customCenter[0]
         : this._renderer.getUnscaledWidth() / 2 - this._renderer.getOriginX();
@@ -503,7 +503,7 @@ namespace gdjs {
      * @returns The center Y relatively to the drawing origin
      * (whereas `getCenterY()` is relative to the top left drawable bound and scaled).
      */
-    getRotationAnchorY(): float {
+    getRotationCenterY(): float {
       return this._customCenter
         ? this._customCenter[1]
         : this._renderer.getUnscaledHeight() / 2 - this._renderer.getOriginY();

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -629,7 +629,9 @@ namespace gdjs {
      * @return the scale of the object (or the geometric mean of the X and Y scale in case they are different).
      */
     getScale(): number {
-      return this._scaleX === this._scaleY ? this._scaleX : Math.sqrt(this._scaleX * this._scaleY);
+      return this._scaleX === this._scaleY
+        ? this._scaleX
+        : Math.sqrt(this._scaleX * this._scaleY);
     }
 
     /**
@@ -730,7 +732,7 @@ namespace gdjs {
         this.hitBoxes[0].vertices[3][1] = height - centerY;
       }
       if (!this._absoluteCoordinates) {
-      this.hitBoxes[0].rotate(gdjs.toRad(this.getAngle()));
+        this.hitBoxes[0].rotate(gdjs.toRad(this.getAngle()));
       }
       this.hitBoxes[0].move(
         this.getDrawableX() + centerX,

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -515,20 +515,22 @@ namespace gdjs {
       if (!this._customCenter) {
         return super.getCenterX();
       }
-      let centerX =
-        this._customCenter[0] +
-        (this.getX() - this.getDrawableX()) / Math.abs(this._scaleX);
-      return centerX * Math.abs(this._scaleX);
+      return (
+        this._customCenter[0] * Math.abs(this._scaleX) +
+        this.getX() -
+        this.getDrawableX()
+      );
     }
 
     getCenterY(): float {
       if (!this._customCenter) {
         return super.getCenterY();
       }
-      let centerY =
-        this._customCenter[1] +
-        (this.getY() - this.getDrawableY()) / Math.abs(this._scaleY);
-      return centerY * Math.abs(this._scaleY);
+      return (
+        this._customCenter[1] * Math.abs(this._scaleY) +
+        this.getY() -
+        this.getDrawableY()
+      );
     }
 
     /**

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -499,7 +499,8 @@ namespace gdjs {
     getRotationCenterX(): float {
       return this._customCenter
         ? this._customCenter[0]
-        : this._renderer.getUnscaledWidth() / 2 - this._renderer.getOriginX();
+        : this._renderer.getUnscaledWidth() / 2 -
+            this._renderer.getFrameRelativeOriginX();
     }
 
     /**
@@ -509,7 +510,8 @@ namespace gdjs {
     getRotationCenterY(): float {
       return this._customCenter
         ? this._customCenter[1]
-        : this._renderer.getUnscaledHeight() / 2 - this._renderer.getOriginY();
+        : this._renderer.getUnscaledHeight() / 2 -
+            this._renderer.getFrameRelativeOriginY();
     }
 
     getCenterX(): float {

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -53,6 +53,8 @@ namespace gdjs {
     _clearBetweenFrames: boolean;
     _renderer: gdjs.ShapePainterRuntimeObjectRenderer;
 
+    private static readonly _pointForTransformation: FloatPoint = [0, 0];
+
     /**
      * @param runtimeScene The scene the object belongs to.
      * @param shapePainterObjectData The initial properties of the object
@@ -686,6 +688,36 @@ namespace gdjs {
     
     updatePreRender(runtimeScene: gdjs.RuntimeScene): void {
       this._renderer.updatePreRender();
+    }
+
+    transformToDrawing(x: float, y: float) {
+      const point = ShapePainterRuntimeObject._pointForTransformation;
+      point[0] = x;
+      point[1] = y;
+      return this._renderer.transformToDrawing(point);
+    }
+
+    transformToScene(x: float, y: float) {
+      const point = ShapePainterRuntimeObject._pointForTransformation;
+      point[0] = x;
+      point[1] = y;
+      return this._renderer.transformToScene(point);
+    }
+
+    transformToDrawingX(x: float, y: float) {
+      return this.transformToDrawing(x, y)[0];
+    }
+
+    transformToDrawingY(x: float, y: float) {
+      return this.transformToDrawing(x, y)[1];
+    }
+
+    transformToSceneX(x: float, y: float) {
+      return this.transformToScene(x, y)[0];
+    }
+
+    transformToSceneY(x: float, y: float) {
+      return this.transformToScene(x, y)[1];
     }
   }
   gdjs.registerObject(

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -178,8 +178,6 @@ namespace gdjs {
 
     drawRectangle(x1: float, y1: float, x2: float, y2: float) {
       this._renderer.drawRectangle(x1, y1, x2, y2);
-      console.log(this._renderer._graphics.width, this._renderer._graphics.height);
-      console.log(this._renderer._graphics.getLocalBounds());
     }
 
     drawCircle(x: float, y: float, radius: float) {
@@ -451,7 +449,6 @@ namespace gdjs {
       if (x === this.x) {
         return;
       }
-      console.log("SetX");
       super.setX(x);
       this._renderer.updatePositionX();
     }
@@ -469,8 +466,6 @@ namespace gdjs {
         return;
       }
       super.setAngle(angle);
-      console.log("center: " + this.getCenterX() + " " + this.getCenterY());
-      console.log("getDrawableXY: " + this.getDrawableX() + " " + this.getDrawableY());
       this._renderer.updateAngle();
     }
 
@@ -479,10 +474,10 @@ namespace gdjs {
      * to the drawing origin (the object position).
      * This avoid the center to move on the drawing
      * when new shapes push the bounds.
-     * 
+     *
      * When no custom center is defined, it will move
      * to stay at the center of the drawable bounds.
-     * 
+     *
      * @param x coordinate of the custom center
      * @param y coordinate of the custom center
      */
@@ -499,7 +494,9 @@ namespace gdjs {
      * (where `getCenterX()` is relative to the top left drawable bound).
      */
     getRotationAnchorX(): float {
-      return this._customCenter ? this._customCenter[0] : this._renderer.getUnscaledWidth() / 2 - this._renderer.getOriginX();
+      return this._customCenter
+        ? this._customCenter[0]
+        : this._renderer.getUnscaledWidth() / 2 - this._renderer.getOriginX();
     }
 
     /**
@@ -507,14 +504,18 @@ namespace gdjs {
      * (where `getCenterY()` is relative to the top left drawable bound).
      */
     getRotationAnchorY(): float {
-      return this._customCenter ? this._customCenter[1] : this._renderer.getUnscaledHeight() / 2 - this._renderer.getOriginY();
+      return this._customCenter
+        ? this._customCenter[1]
+        : this._renderer.getUnscaledHeight() / 2 - this._renderer.getOriginY();
     }
 
     getCenterX(): float {
       if (!this._customCenter) {
         return super.getCenterX();
       }
-      let centerX = this._customCenter[0] + (this.getX() - this.getDrawableX()) / Math.abs(this._scaleX);
+      let centerX =
+        this._customCenter[0] +
+        (this.getX() - this.getDrawableX()) / Math.abs(this._scaleX);
       if (this._flippedX) {
         //centerX = this._renderer.getUnscaledWidth() - centerX;
       }
@@ -525,7 +526,9 @@ namespace gdjs {
       if (!this._customCenter) {
         return super.getCenterY();
       }
-      let centerY = this._customCenter[1] + (this.getY() - this.getDrawableY()) / Math.abs(this._scaleY);
+      let centerY =
+        this._customCenter[1] +
+        (this.getY() - this.getDrawableY()) / Math.abs(this._scaleY);
       if (this._flippedY) {
         //centerY = this._renderer.getUnscaledHeight() - centerY;
       }
@@ -555,14 +558,13 @@ namespace gdjs {
         this.setScaleY(newHeight / unscaledHeight);
       }
     }
-    
+
     /**
      * Change the scale on X and Y axis of the object.
      *
      * @param newScale The new scale (must be greater than 0).
      */
-     setScale(newScale: float): void {
-      console.log("ScaleX: " + newScale);
+    setScale(newScale: float): void {
       if (newScale < 0) {
         newScale = 0;
       }
@@ -584,7 +586,7 @@ namespace gdjs {
      *
      * @param newScale The new scale (must be greater than 0).
      */
-     setScaleX(newScale: float): void {
+    setScaleX(newScale: float): void {
       if (newScale < 0) {
         newScale = 0;
       }
@@ -665,7 +667,7 @@ namespace gdjs {
     getScaleX(): float {
       return Math.abs(this._scaleX);
     }
-    
+
     invalidateBounds() {
       this.hitBoxesDirty = true;
     }
@@ -685,7 +687,7 @@ namespace gdjs {
     getHeight(): float {
       return this._renderer.getHeight();
     }
-    
+
     updatePreRender(runtimeScene: gdjs.RuntimeScene): void {
       this._renderer.updatePreRender();
     }

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -604,7 +604,7 @@ namespace gdjs {
     getScaleX(): float {
       return Math.abs(this._scaleX);
     }
-
+    
     invalidateBounds() {
       this.hitBoxesDirty = true;
     }

--- a/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
+++ b/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
@@ -1,0 +1,135 @@
+/**
+ * Tests for gdjs.ShapePainterRuntimeObject using a "real" PIXI RuntimeGame with assets.
+ */
+describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)', function () {
+  /**
+   * @param {gdjs.RuntimeScene} runtimeScene
+   */
+  const makeSpriteRuntimeObjectWithCustomHitBox = (runtimeScene) =>
+    new gdjs.ShapePainterRuntimeObject(runtimeScene, {
+      name: 'obj1',
+      type: 'PrimitiveDrawing::Drawer',
+      updateIfNotVisible: false,
+      variables: [],
+      behaviors: [],
+      effects: [],
+      fillColor: { r: 0, g: 0, b: 0 },
+      outlineColor: { r: 0, g: 0, b: 0 },
+      fillOpacity: 255,
+      outlineOpacity: 255,
+      outlineSize: 1,
+      absoluteCoordinates: false,
+      clearBetweenFrames: false,
+    });
+
+  it.only('properly computes bounds of the object (basics)', async () => {
+    const runtimeGame = await gdjs.getPixiRuntimeGameWithAssets();
+    const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
+    runtimeScene.loadFromScene({
+      layers: [{ name: '', visibility: true, effects: [] }],
+      variables: [],
+      behaviorsSharedData: [],
+      objects: [],
+      instances: [],
+    });
+
+    const object = makeSpriteRuntimeObjectWithCustomHitBox(runtimeScene);
+
+    expect(object.getWidth()).to.be(0);
+    expect(object.getHeight()).to.be(0);
+
+    object.drawLineV2(10, 10, 20, 30, 3);
+
+    // Check the automatically computed bounds:
+    expect(object.getDrawableX()).to.be(8.5);
+    expect(object.getDrawableY()).to.be(8.5);
+    expect(object.getWidth()).to.be(13);
+    expect(object.getHeight()).to.be(23);
+
+    // Check the automatic center positioning:
+    expect(object.getCenterXInScene()).to.be(15);
+    expect(object.getCenterYInScene()).to.be(20);
+    expect(object.getCenterX()).to.be(15 - 8.5);
+    expect(object.getCenterY()).to.be(20 - 8.5);
+
+    // Check hit boxes:
+    expect(object.getAABB()).to.eql({
+      min: [8.5, 8.5],
+      max: [8.5 + 13, 8.5 + 23],
+    });
+
+    // Check after scaling (scaling is done from the origin):
+    object.setScale(2);
+    expect(object.getDrawableX()).to.be(17);
+    expect(object.getDrawableY()).to.be(17);
+    expect(object.getWidth()).to.be(13 * 2);
+    expect(object.getHeight()).to.be(23 * 2);
+    expect(object.getAABB()).to.eql({ min: [17, 17], max: [43, 63] });
+
+    // Check after rotating (rotating is done from the center):
+    object.setAngle(45);
+    expect(object.getDrawableX()).to.be(17); // Drawable X/Y is not impacted...
+    expect(object.getDrawableY()).to.be(17);
+    expect(object.getWidth()).to.be(13 * 2); // ...Neither is the size
+    expect(object.getHeight()).to.be(23 * 2);
+    expect(object.getAABB()).to.eql({
+      // The hit boxes/AABB are rotated:
+      min: [4.54415587728429, 14.54415587728429],
+      max: [55.45584412271571, 65.45584412271572],
+    });
+  });
+
+  it.only('properly computes bounds of the object (custom center)', async () => {
+    const runtimeGame = await gdjs.getPixiRuntimeGameWithAssets();
+    const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
+    runtimeScene.loadFromScene({
+      layers: [{ name: '', visibility: true, effects: [] }],
+      variables: [],
+      behaviorsSharedData: [],
+      objects: [],
+      instances: [],
+    });
+
+    const object = makeSpriteRuntimeObjectWithCustomHitBox(runtimeScene);
+
+    expect(object.getWidth()).to.be(0);
+    expect(object.getHeight()).to.be(0);
+
+    object.drawLineV2(10, 10, 20, 30, 3);
+    object.setRotationCenter(10, 9);
+
+    // Check the automatically computed bounds (not impacted by the center):
+    expect(object.getDrawableX()).to.be(8.5);
+    expect(object.getDrawableY()).to.be(8.5);
+    expect(object.getWidth()).to.be(13);
+    expect(object.getHeight()).to.be(23);
+
+    // Check the center positioning:
+    expect(object.getCenterXInScene()).to.be(10);
+    expect(object.getCenterYInScene()).to.be(9);
+    expect(object.getCenterX()).to.be(10 - 8.5);
+    expect(object.getCenterY()).to.be(9 - 8.5);
+
+    // Check hit boxes (not impacted by the center, as no rotation is made):
+    expect(object.getAABB()).to.eql({
+      min: [8.5, 8.5],
+      max: [8.5 + 13, 8.5 + 23],
+    });
+
+    // Check after scaling (scaling is done from the origin):
+    object.setScale(2);
+    expect(object.getDrawableX()).to.be(17);
+    expect(object.getDrawableY()).to.be(17);
+    expect(object.getWidth()).to.be(13 * 2);
+    expect(object.getHeight()).to.be(23 * 2);
+    expect(object.getAABB()).to.eql({ min: [17, 17], max: [43, 63] });
+
+    // Check after rotating (rotating is done from the center):
+    object.setAngle(45);
+    expect(object.getAABB()).to.eql({
+      // The hit boxes/AABB are rotated:
+      min: [-13.941125496954278, 15.17157287525381],
+      max: [36.970562748477136, 66.08326112068524],
+    });
+  });
+});

--- a/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
+++ b/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Tests for gdjs.ShapePainterRuntimeObject using a "real" PIXI RuntimeGame with assets.
  */
@@ -9,7 +11,6 @@ describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)'
     new gdjs.ShapePainterRuntimeObject(runtimeScene, {
       name: 'obj1',
       type: 'PrimitiveDrawing::Drawer',
-      updateIfNotVisible: false,
       variables: [],
       behaviors: [],
       effects: [],
@@ -22,16 +23,40 @@ describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)'
       clearBetweenFrames: false,
     });
 
-  it.only('properly computes bounds of the object (basics)', async () => {
+    /** @param {gdjs.RuntimeScene} runtimeScene */
+  const loadScene = (runtimeScene) => {
+    runtimeScene.loadFromScene({
+        layers: [
+          {
+            name: '',
+            visibility: true,
+            effects: [],
+            cameras: [],
+            ambientLightColorR: 0,
+            ambientLightColorG: 0,
+            ambientLightColorB: 0,
+            isLightingLayer: false,
+            followBaseLayerCamera: true,
+          },
+        ],
+        r: 0,
+        v: 0,
+        b: 0,
+        mangledName: 'Scene1',
+        name: 'Scene1',
+        stopSoundsOnStartup: false,
+        title: '',
+        behaviorsSharedData: [],
+        objects: [],
+        instances: [],
+        variables: [],
+    });
+  }
+
+  it('properly computes bounds of the object (basics)', async () => {
     const runtimeGame = await gdjs.getPixiRuntimeGameWithAssets();
     const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
-    runtimeScene.loadFromScene({
-      layers: [{ name: '', visibility: true, effects: [] }],
-      variables: [],
-      behaviorsSharedData: [],
-      objects: [],
-      instances: [],
-    });
+    loadScene(runtimeScene);
 
     const object = makeSpriteRuntimeObjectWithCustomHitBox(runtimeScene);
 
@@ -79,16 +104,10 @@ describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)'
     });
   });
 
-  it.only('properly computes bounds of the object (custom center)', async () => {
+  it('properly computes bounds of the object (custom center)', async () => {
     const runtimeGame = await gdjs.getPixiRuntimeGameWithAssets();
     const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
-    runtimeScene.loadFromScene({
-      layers: [{ name: '', visibility: true, effects: [] }],
-      variables: [],
-      behaviorsSharedData: [],
-      objects: [],
-      instances: [],
-    });
+    loadScene(runtimeScene);
 
     const object = makeSpriteRuntimeObjectWithCustomHitBox(runtimeScene);
 

--- a/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
+++ b/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
@@ -148,4 +148,38 @@ describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)'
       max: [36.970562748477136, 66.08326112068524],
     });
   });
+
+  it('can transform points', async () => {
+    const runtimeGame = await gdjs.getPixiRuntimeGameWithAssets();
+    const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
+    loadScene(runtimeScene);
+
+    const object = makeSpriteRuntimeObjectWithCustomHitBox(runtimeScene);
+
+    object.drawLineV2(0, 0, 10, 10, 2);
+    expect(object.getWidth()).to.be(12);
+    expect(object.getHeight()).to.be(12);
+
+    // Check changes in position/scale are taken into account:
+    object.setPosition(50, 100);
+    expect(object.transformToScene(10, 20)).to.eql([60, 120]);
+
+    object.setScale(2);
+    expect(object.transformToScene(10, 20)).to.eql([70, 140]);
+
+    // Check rotation with the default center:
+    expect(object.getCenterXInScene()).to.be(60);
+    expect(object.getCenterYInScene()).to.be(110);
+    expect(object.transformToScene(5, 5)).to.eql([60, 110]);
+    expect(object.transformToScene(10, 20)).to.eql([70, 140]);
+
+    object.setAngle(90);
+    expect(object.transformToScene(5, 5)).to.eql([60, 110]);
+    expect(object.transformToScene(10, 20)).to.eql([30, 120]);
+
+    // Check rotation with a custom center:
+    object.setRotationCenter(20, 9);
+    expect(object.transformToScene(10, 20)).to.eql([68, 98]);
+    expect(object.transformToDrawing(68, 98)).to.eql([10, 20]);
+  });
 });

--- a/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
+++ b/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
@@ -147,6 +147,26 @@ describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)'
       min: [-13.941125496954278, 15.17157287525381],
       max: [36.970562748477136, 66.08326112068524],
     });
+
+    // Draw outside of the current bounds.
+    const oldMinX = object.getAABB().min[0];
+    const oldMinY = object.getAABB().min[1];
+    const oldMaxX = object.getAABB().max[0];
+    const oldMaxY = object.getAABB().max[1];
+    const oldCenterX = object.getCenterXInScene();
+    const oldCenterY = object.getCenterYInScene();
+    object.drawLineV2(-10, -10, 21, 31, 3);
+
+    // Check that the center stays the same.
+    expect(object.getCenterXInScene()).to.be(oldCenterX);
+    expect(object.getCenterYInScene()).to.be(oldCenterY);
+
+    // Check that the AABB expands.
+    const newAABB = object.getAABB();
+    expect(newAABB.min[0]).below(oldMinX);
+    expect(newAABB.min[1]).below(oldMinY);
+    expect(newAABB.max[0]).above(oldMaxX);
+    expect(newAABB.max[1]).above(oldMaxY);
   });
 
   it('can transform points', async () => {

--- a/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
+++ b/Extensions/PrimitiveDrawing/tests/shapepainterruntimeobject.pixiruntimegamewithassets.spec.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-/**
- * Tests for gdjs.ShapePainterRuntimeObject using a "real" PIXI RuntimeGame with assets.
- */
 describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)', function () {
   /**
    * @param {gdjs.RuntimeScene} runtimeScene
@@ -23,35 +20,35 @@ describe('gdjs.ShapePainterRuntimeObject (using a PIXI RuntimeGame with assets)'
       clearBetweenFrames: false,
     });
 
-    /** @param {gdjs.RuntimeScene} runtimeScene */
+  /** @param {gdjs.RuntimeScene} runtimeScene */
   const loadScene = (runtimeScene) => {
     runtimeScene.loadFromScene({
-        layers: [
-          {
-            name: '',
-            visibility: true,
-            effects: [],
-            cameras: [],
-            ambientLightColorR: 0,
-            ambientLightColorG: 0,
-            ambientLightColorB: 0,
-            isLightingLayer: false,
-            followBaseLayerCamera: true,
-          },
-        ],
-        r: 0,
-        v: 0,
-        b: 0,
-        mangledName: 'Scene1',
-        name: 'Scene1',
-        stopSoundsOnStartup: false,
-        title: '',
-        behaviorsSharedData: [],
-        objects: [],
-        instances: [],
-        variables: [],
+      layers: [
+        {
+          name: '',
+          visibility: true,
+          effects: [],
+          cameras: [],
+          ambientLightColorR: 0,
+          ambientLightColorG: 0,
+          ambientLightColorB: 0,
+          isLightingLayer: false,
+          followBaseLayerCamera: true,
+        },
+      ],
+      r: 0,
+      v: 0,
+      b: 0,
+      mangledName: 'Scene1',
+      name: 'Scene1',
+      stopSoundsOnStartup: false,
+      title: '',
+      behaviorsSharedData: [],
+      objects: [],
+      instances: [],
+      variables: [],
     });
-  }
+  };
 
   it('properly computes bounds of the object (basics)', async () => {
     const runtimeGame = await gdjs.getPixiRuntimeGameWithAssets();

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -1159,9 +1159,9 @@ namespace gdjs {
     /**
      * Change the width of the object. This changes the scale on X axis of the object.
      *
-     * @param width The new width of the object, in pixels.
+     * @param newWidth The new width of the object, in pixels.
      */
-    setWidth(newWidth): void {
+    setWidth(newWidth: float): void {
       if (this._animationFrameDirty) {
         this._updateAnimationFrame();
       }
@@ -1174,9 +1174,9 @@ namespace gdjs {
     /**
      * Change the height of the object. This changes the scale on Y axis of the object.
      *
-     * @param height The new height of the object, in pixels.
+     * @param newHeight The new height of the object, in pixels.
      */
-    setHeight(newHeight): void {
+    setHeight(newHeight: float): void {
       if (this._animationFrameDirty) {
         this._updateAnimationFrame();
       }

--- a/GDJS/tests/karma.conf.js
+++ b/GDJS/tests/karma.conf.js
@@ -80,6 +80,8 @@ module.exports = function (config) {
       '../../newIDE/app/resources/GDJS/Runtime/Extensions/Lighting/lightobstacleruntimebehavior.js',
       '../../newIDE/app/resources/GDJS/Runtime/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.js',
       '../../newIDE/app/resources/GDJS/Runtime/Extensions/PathfindingBehavior/pathfindingruntimebehavior.js',
+      '../../newIDE/app/resources/GDJS/Runtime/Extensions/PrimitiveDrawing/shapepainterruntimeobject.js',
+      '../../newIDE/app/resources/GDJS/Runtime/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.js',
       '../../newIDE/app/resources/GDJS/Runtime/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.js',
       '../../newIDE/app/resources/GDJS/Runtime/Extensions/TopDownMovementBehavior/topdownobstacleruntimebehavior.js',
       '../../newIDE/app/resources/GDJS/Runtime/Extensions/Firebase/A_firebasejs/*.js',


### PR DESCRIPTION
It allows users to move a shape painter like a sprite.
Extensions can get the relative coordinates to handle mouse events.
![ShapePainterTranformationExpression](https://user-images.githubusercontent.com/2611977/147290848-8b3a1219-90a9-4778-8a4a-71b47481ed47.png)

Test project: https://www.dropbox.com/s/bf8i3ototgwvjqn/ShapePainterTransformationTest.zip?dl=1
Test video: https://user-images.githubusercontent.com/2611977/147290697-6e4108bc-6ccd-4488-9cf4-849b91c51069.mp4


