### PR TITLE
[Platformer] Add a condition to check which controls are used.

### DIFF
--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -501,9 +501,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("SimulateControl");
 
     aut.AddScopedCondition("IsUsingControl",
-                  _("Use control"),
-                  _("A control was applied from a default control or a simulate action."),
-                  _("_PARAM0_ uses the _PARAM2_ key"),
+                  _("Control pressed or simulated"),
+                  _("A control was applied from a default control or a simulated by an action."),
+                  _("_PARAM0_ has the _PARAM2_ key pressed or simulated"),
                   _("Controls"),
                   "res/conditions/keyboard24.png",
                   "res/conditions/keyboard.png")

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -500,6 +500,20 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .MarkAsAdvanced()
         .SetFunctionName("SimulateControl");
 
+    aut.AddScopedCondition("IsUsingControl",
+                  _("Use control"),
+                  _("A control was applied from a default control or a simulate action."),
+                  _("_PARAM0_ uses the _PARAM2_ key"),
+                  _("Controls"),
+                  "res/conditions/keyboard24.png",
+                  "res/conditions/keyboard.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .AddParameter("stringWithSelector",
+                    _("Key"),
+                    "[\"Left\", \"Right\", \"Jump\", \"Ladder\", \"Release Ladder\", \"Up\", \"Down\"]")
+        .MarkAsAdvanced();
+
     aut.AddAction("IgnoreDefaultControls",
                   _("Ignore default controls"),
                   _("De/activate the use of default controls.\nIf deactivated, "

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -147,6 +147,8 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
           "simulateReleasePlatformKey");
       autActions["PlatformBehavior::SimulateControl"].SetFunctionName(
           "simulateControl");
+      autConditions["PlatformBehavior::PlatformerObjectBehavior::IsUsingControl"].SetFunctionName(
+          "isUsingControl");
       autActions["PlatformBehavior::IgnoreDefaultControls"].SetFunctionName(
           "ignoreDefaultControls");
     }

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -58,6 +58,18 @@ namespace gdjs {
     _releasePlatformKey: boolean = false;
     _releaseLadderKey: boolean = false;
 
+    // This is useful for extensions that need to know
+    // which keys were pressed and doesn't know the mapping
+    // done by the scene events.
+    private _wasLeftKeyPressed: boolean = false;
+    private _wasRightKeyPressed: boolean = false;
+    private _wasLadderKeyPressed: boolean = false;
+    private _wasUpKeyPressed: boolean = false;
+    private _wasDownKeyPressed: boolean = false;
+    private _wasJumpKeyPressed: boolean = false;
+    private _wasReleasePlatformKeyPressed: boolean = false;
+    private _wasReleaseLadderKeyPressed: boolean = false;
+
     private _state: State;
     _falling: Falling;
     _onFloor: OnFloor;
@@ -235,6 +247,14 @@ namespace gdjs {
         this._checkTransitionOnFloorOrFalling();
       }
 
+      this._wasLeftKeyPressed = this._leftKey;
+      this._wasRightKeyPressed = this._rightKey;
+      this._wasLadderKeyPressed = this._ladderKey;
+      this._wasUpKeyPressed = this._releaseLadderKey;
+      this._wasDownKeyPressed = this._upKey;
+      this._wasJumpKeyPressed = this._downKey;
+      this._wasReleasePlatformKeyPressed = this._releasePlatformKey;
+      this._wasReleaseLadderKeyPressed = this._jumpKey;
       //4) Do not forget to reset pressed keys
       this._leftKey = false;
       this._rightKey = false;
@@ -1005,6 +1025,38 @@ namespace gdjs {
       } else if (input === 'Release Ladder') {
         this._releaseLadderKey = true;
       }
+    }
+
+    /**.
+     * @param input The string expression of the control action [Left,Right,Up,Down,Ladder,Jump,Release,Release Ladder].
+     * @returns true if the key was used from the last `doStepPreEvents` call.
+     */
+    isUsingControl(input: string): boolean {
+      if (input === 'Left') {
+        return this._wasLeftKeyPressed;
+      }
+      if (input === 'Right') {
+        return this._wasRightKeyPressed;
+      }
+      if (input === 'Up') {
+        return this._wasUpKeyPressed;
+      }
+      if (input === 'Down') {
+        return this._wasDownKeyPressed;
+      }
+      if (input === 'Ladder') {
+        return this._wasLadderKeyPressed;
+      }
+      if (input === 'Jump') {
+        return this._wasJumpKeyPressed;
+      }
+      if (input === 'Release') {
+        return this._wasReleasePlatformKeyPressed;
+      }
+      if (input === 'Release Ladder') {
+        return this._wasReleaseLadderKeyPressed;
+      }
+      return false;
     }
 
     /**

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1028,8 +1028,8 @@ namespace gdjs {
     }
 
     /**.
-     * @param input The string expression of the control action [Left,Right,Up,Down,Ladder,Jump,Release,Release Ladder].
-     * @returns true if the key was used from the last `doStepPreEvents` call.
+     * @param input The control to be tested [Left,Right,Up,Down,Ladder,Jump,Release,Release Ladder].
+     * @returns true if the key was used since the last `doStepPreEvents` call.
      */
     isUsingControl(input: string): boolean {
       if (input === 'Left') {


### PR DESCRIPTION
This adds a condition to check which controls are used.

This is useful for extensions that need to know which keys were pressed but doesn't know the mapping done by the scene events (that could use a game-pad...).

This extension review gives more context:
* https://github.com/GDevelopApp/GDevelop-extensions/pull/325#issuecomment-1001016702

I didn't do a release condition because it would have take an extra 8 bytes and extensions can do it by themselves, but it would have been more convenient.
Do you think we should add it?

Test project:
* https://www.dropbox.com/s/3z5fblixwxgdrmq/PlatformerUseControl.zip?dl=1
