### PR TITLE
Make Builds list consistent across the app

### DIFF
--- a/newIDE/app/src/Export/Builds/BuildCard.js
+++ b/newIDE/app/src/Export/Builds/BuildCard.js
@@ -1,0 +1,63 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import * as React from 'react';
+import { differenceInCalendarDays, format } from 'date-fns';
+import { Line } from '../../UI/Grid';
+import { type Build } from '../../Utils/GDevelopServices/Build';
+import { Card, CardActions, CardHeader } from '@material-ui/core';
+import BuildProgress from './BuildProgress';
+import EmptyMessage from '../../UI/EmptyMessage';
+
+const formatBuildText = (
+  buildType: 'cordova-build' | 'electron-build' | 'web-build'
+) => {
+  switch (buildType) {
+    case 'cordova-build':
+      return <Trans>Android Build</Trans>;
+    case 'electron-build':
+      return <Trans>Windows/macOS/Linux Build</Trans>;
+    case 'web-build':
+      return <Trans>Web (upload online) Build</Trans>;
+    default:
+      return buildType;
+  }
+};
+
+type Props = {|
+  build: Build,
+|};
+
+export const BuildCard = ({ build }: Props) => {
+  const isOld =
+    build &&
+    build.type !== 'web-build' &&
+    differenceInCalendarDays(Date.now(), build.updatedAt) > 6;
+  return (
+    <Card>
+      <CardHeader
+        title={build.id}
+        subheader={
+          <Line alignItems="center" noMargin>
+            <Trans>
+              {formatBuildText(build.type)} - <Trans>Last updated on</Trans>{' '}
+              {format(build.updatedAt, 'yyyy-MM-dd HH:mm:ss')}
+            </Trans>
+          </Line>
+        }
+      />
+      <CardActions>
+        <Line expand noMargin justifyContent="flex-end">
+          {!isOld && <BuildProgress build={build} />}
+          {isOld && (
+            <EmptyMessage>
+              <Trans>
+                This build is old and the generated games can't be downloaded
+                anymore.
+              </Trans>
+            </EmptyMessage>
+          )}
+        </Line>
+      </CardActions>
+    </Card>
+  );
+};

--- a/newIDE/app/src/Export/Builds/BuildProgress.js
+++ b/newIDE/app/src/Export/Builds/BuildProgress.js
@@ -11,9 +11,12 @@ import differenceInSeconds from 'date-fns/differenceInSeconds';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import Text from '../../UI/Text';
 import {
+  getBuildArtifactUrl,
   type Build,
   type BuildArtifactKeyName,
 } from '../../Utils/GDevelopServices/Build';
+import Window from '../../Utils/Window';
+import { ColumnStackLayout } from '../../UI/Layout';
 
 const buildTypesConfig = {
   'cordova-build': {
@@ -65,14 +68,13 @@ const buttons = [
 
 type Props = {|
   build: Build,
-  onDownload: (key: BuildArtifactKeyName) => void,
 |};
 
 /**
  * Show an estimate of the progress of a build or the button
  * to download the artifacts.
  */
-export default ({ build, onDownload }: Props) => {
+export default ({ build }: Props) => {
   const config = buildTypesConfig[build.type];
   const secondsSinceLastUpdate = Math.abs(
     differenceInSeconds(build.updatedAt, Date.now())
@@ -81,6 +83,11 @@ export default ({ build, onDownload }: Props) => {
     config ? config.estimatedTimeInSeconds(build) - secondsSinceLastUpdate : 0,
     0
   );
+
+  const onDownload = (key: BuildArtifactKeyName) => {
+    const url = getBuildArtifactUrl(build, key);
+    if (url) Window.openExternalURL(url);
+  };
 
   return (
     <I18n>
@@ -136,8 +143,8 @@ export default ({ build, onDownload }: Props) => {
             )}
           </Line>
         ) : build.status === 'complete' ? (
-          <React.Fragment>
-            <Line expand>
+          <ColumnStackLayout>
+            <Line expand justifyContent="flex-end">
               {buttons
                 .filter(button => !!build[button.key])
                 .map((button, index) => (
@@ -155,10 +162,12 @@ export default ({ build, onDownload }: Props) => {
                 onClick={() => onDownload('logsKey')}
               />
             </Line>
-            <Line expand>
-              {config && <Text>{config.completeDescription}</Text>}
-            </Line>
-          </React.Fragment>
+            {config && config.completeDescription && (
+              <Line expand justifyContent="flex-end">
+                <Text>{config.completeDescription}</Text>
+              </Line>
+            )}
+          </ColumnStackLayout>
         ) : (
           <Line>
             <Trans>Unknown status</Trans>

--- a/newIDE/app/src/Export/Builds/BuildStepsProgress.js
+++ b/newIDE/app/src/Export/Builds/BuildStepsProgress.js
@@ -172,7 +172,7 @@ export default ({
               <Trans>Build is starting...</Trans>
             </Text>
           )}
-          {build && <BuildProgress build={build} onDownload={onDownload} />}
+          {build && <BuildProgress build={build} />}
           {showSeeAllMyBuildsExplanation && (
             <EmptyMessage>
               <Trans>

--- a/newIDE/app/src/Export/Builds/BuildsDialog.js
+++ b/newIDE/app/src/Export/Builds/BuildsDialog.js
@@ -10,6 +10,7 @@ import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 
 type Props = {|
   authenticatedUser: AuthenticatedUser,
+  gameId: string,
   open: boolean,
   onClose: () => void,
 |};
@@ -22,12 +23,12 @@ export default class BuildsDialog extends Component<Props, State> {
   };
 
   render() {
-    const { open, onClose, authenticatedUser } = this.props;
+    const { open, onClose, authenticatedUser, gameId } = this.props;
     if (!open) return null;
 
     return (
       <Dialog
-        title={<Trans>All your builds</Trans>}
+        title={<Trans>Your game builds</Trans>}
         onRequestClose={onClose}
         actions={[
           <FlatButton
@@ -47,6 +48,7 @@ export default class BuildsDialog extends Component<Props, State> {
         <Builds
           onBuildsUpdated={this._onBuildsUpdated}
           authenticatedUser={authenticatedUser}
+          gameId={gameId}
         />
       </Dialog>
     );

--- a/newIDE/app/src/Export/Builds/BuildsList.js
+++ b/newIDE/app/src/Export/Builds/BuildsList.js
@@ -2,106 +2,62 @@
 import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
-import Paper from '@material-ui/core/Paper';
-import {
-  type Build,
-  type BuildArtifactKeyName,
-} from '../../Utils/GDevelopServices/Build';
+import { type Build } from '../../Utils/GDevelopServices/Build';
 import { Column, Line } from '../../UI/Grid';
 import EmptyMessage from '../../UI/EmptyMessage';
 import PlaceholderLoader from '../../UI/PlaceholderLoader';
-import BuildProgress from './BuildProgress';
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
-import format from 'date-fns/format';
-import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
 import Text from '../../UI/Text';
+import { ColumnStackLayout } from '../../UI/Layout';
+import { BuildCard } from './BuildCard';
+import PlaceholderError from '../../UI/PlaceholderError';
 
 type Props = {|
   builds: ?Array<Build>,
   authenticatedUser: AuthenticatedUser,
-  onDownload: (build: Build, key: BuildArtifactKeyName) => void,
+  error: ?Error,
+  loadBuilds: () => void,
 |};
 
-const styles = {
-  buildContainer: {
-    padding: 10,
-  },
-};
-
-const formatBuildText = (
-  buildType: 'cordova-build' | 'electron-build' | 'web-build'
-) => {
-  switch (buildType) {
-    case 'cordova-build':
-      return <Trans>Android Build</Trans>;
-    case 'electron-build':
-      return <Trans>Windows/macOS/Linux Build</Trans>;
-    case 'web-build':
-      return <Trans>Web (upload online) Build</Trans>;
-    default:
-      return buildType;
-  }
-};
-
-export default ({ builds, authenticatedUser, onDownload }: Props) => {
+export default ({ builds, authenticatedUser, error, loadBuilds }: Props) => {
   return (
     <Column noMargin expand>
       <Line>
         <Column>
           <EmptyMessage>
             <Trans>
-              This is the list of builds that you've done. Note that you can
-              download games generated during the last 7 days, after which they
-              are removed.
+              This is the list of builds that you've done for this game. Note
+              that builds for mobile and desktop are available for 7 days, after
+              which they are removed.
             </Trans>
           </EmptyMessage>
         </Column>
       </Line>
       <Line>
-        {!authenticatedUser.authenticated ? (
+        {!authenticatedUser.authenticated && (
           <EmptyMessage>
             <Trans>You need to login first to see your builds.</Trans>
           </EmptyMessage>
-        ) : !builds ? (
+        )}
+        {authenticatedUser.authenticated && !builds && !error && (
           <PlaceholderLoader />
-        ) : builds.length === 0 ? (
+        )}
+        {authenticatedUser.authenticated && error && (
+          <PlaceholderError onRetry={loadBuilds}>
+            <Text>{error.message}</Text>
+          </PlaceholderError>
+        )}
+        {authenticatedUser.authenticated && builds && builds.length === 0 && (
           <EmptyMessage>
-            <Trans>
-              You don't have any builds on the online services for now.
-            </Trans>
+            <Trans>You don't have any builds for this game.</Trans>
           </EmptyMessage>
-        ) : (
-          <Column noMargin expand>
-            {builds.map((build: Build) => {
-              const isOld =
-                build &&
-                differenceInCalendarDays(Date.now(), build.updatedAt) > 6;
-
-              return (
-                <Paper style={styles.buildContainer} key={build.id}>
-                  <Text>
-                    {formatBuildText(build.type)} -{' '}
-                    <Trans>Last updated on</Trans>{' '}
-                    {format(build.updatedAt, 'yyyy-MM-dd HH:mm:ss')}
-                  </Text>
-                  {!isOld && (
-                    <BuildProgress
-                      build={build}
-                      onDownload={key => onDownload(build, key)}
-                    />
-                  )}
-                  {isOld && (
-                    <EmptyMessage>
-                      <Trans>
-                        This build is old and the generated games can't be
-                        downloaded anymore.
-                      </Trans>
-                    </EmptyMessage>
-                  )}
-                </Paper>
-              );
-            })}
-          </Column>
+        )}
+        {authenticatedUser.authenticated && builds && builds.length !== 0 && (
+          <ColumnStackLayout expand>
+            {builds.map((build: Build) => (
+              <BuildCard build={build} key={build.id} />
+            ))}
+          </ColumnStackLayout>
         )}
       </Line>
     </Column>

--- a/newIDE/app/src/Export/Builds/index.js
+++ b/newIDE/app/src/Export/Builds/index.js
@@ -2,26 +2,23 @@
 import React, { Component } from 'react';
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 import BuildsList from './BuildsList';
-import {
-  getBuilds,
-  type Build,
-  type BuildArtifactKeyName,
-  getBuildArtifactUrl,
-} from '../../Utils/GDevelopServices/Build';
-import Window from '../../Utils/Window';
+import { getBuilds, type Build } from '../../Utils/GDevelopServices/Build';
 import BuildsWatcher from './BuildsWatcher';
 
 type Props = {|
-  onBuildsUpdated: ?() => void,
+  onBuildsUpdated?: () => void,
   authenticatedUser: AuthenticatedUser,
+  gameId: string,
 |};
 type State = {|
   builds: ?Array<Build>,
+  error: ?Error,
 |};
 
 export default class Builds extends Component<Props, State> {
   state = {
     builds: null,
+    error: null,
   };
   buildsWatcher = new BuildsWatcher();
 
@@ -59,8 +56,9 @@ export default class Builds extends Component<Props, State> {
       firebaseUser,
     } = this.props.authenticatedUser;
     if (!firebaseUser) return;
+    this.setState({ builds: null, error: null });
 
-    getBuilds(getAuthorizationHeader, firebaseUser.uid).then(
+    getBuilds(getAuthorizationHeader, firebaseUser.uid, this.props.gameId).then(
       builds => {
         this.setState(
           {
@@ -73,14 +71,13 @@ export default class Builds extends Component<Props, State> {
         );
       },
       () => {
-        //TODO: Handle error
+        this.setState({
+          error: new Error(
+            'There was an issue getting the game builds, verify your internet connection or try again later.'
+          ),
+        });
       }
     );
-  };
-
-  _download = (build: Build, key: BuildArtifactKeyName) => {
-    const url = getBuildArtifactUrl(build, key);
-    if (url) Window.openExternalURL(url);
   };
 
   render() {
@@ -88,7 +85,8 @@ export default class Builds extends Component<Props, State> {
       <BuildsList
         builds={this.state.builds}
         authenticatedUser={this.props.authenticatedUser}
-        onDownload={this._download}
+        error={this.state.error}
+        loadBuilds={this._refreshBuilds}
       />
     );
   }

--- a/newIDE/app/src/Export/ExportDialog/index.js
+++ b/newIDE/app/src/Export/ExportDialog/index.js
@@ -124,7 +124,7 @@ const ExportDialog = ({
         exporter.key !== 'onlinewebexport' && (
           <FlatButton
             key="builds"
-            label={<Trans>See all my builds</Trans>}
+            label={<Trans>See this game builds</Trans>}
             onClick={() => setBuildsDialogOpen(true)}
           />
         ),
@@ -188,6 +188,7 @@ const ExportDialog = ({
         open={buildsDialogOpen}
         onClose={() => setBuildsDialogOpen(false)}
         authenticatedUser={authenticatedUser}
+        gameId={project.getProjectUuid()}
       />
     </Dialog>
   );

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -2643,23 +2643,12 @@ storiesOf('BuildStepsProgress', module)
 storiesOf('BuildProgress', module)
   .addDecorator(paperDecorator)
   .addDecorator(muiDecorator)
-  .add('errored', () => (
-    <BuildProgress
-      build={erroredCordovaBuild}
-      onDownload={action('download')}
-    />
-  ))
+  .add('errored', () => <BuildProgress build={erroredCordovaBuild} />)
   .add('pending (electron-build)', () => (
-    <BuildProgress
-      build={{ ...pendingElectronBuild, updatedAt: Date.now() }}
-      onDownload={action('download')}
-    />
+    <BuildProgress build={{ ...pendingElectronBuild, updatedAt: Date.now() }} />
   ))
   .add('pending (cordova-build)', () => (
-    <BuildProgress
-      build={{ ...pendingCordovaBuild, updatedAt: Date.now() }}
-      onDownload={action('download')}
-    />
+    <BuildProgress build={{ ...pendingCordovaBuild, updatedAt: Date.now() }} />
   ))
   .add('pending and very old (cordova-build)', () => (
     <BuildProgress
@@ -2667,23 +2656,16 @@ storiesOf('BuildProgress', module)
         ...pendingCordovaBuild,
         updatedAt: Date.now() - 1000 * 3600 * 24,
       }}
-      onDownload={action('download')}
     />
   ))
   .add('complete (cordova-build)', () => (
-    <BuildProgress
-      build={completeCordovaBuild}
-      onDownload={action('download')}
-    />
+    <BuildProgress build={completeCordovaBuild} />
   ))
   .add('complete (electron-build)', () => (
-    <BuildProgress
-      build={completeElectronBuild}
-      onDownload={action('download')}
-    />
+    <BuildProgress build={completeElectronBuild} />
   ))
   .add('complete (web-build)', () => (
-    <BuildProgress build={completeWebBuild} onDownload={action('download')} />
+    <BuildProgress build={completeWebBuild} />
   ));
 
 storiesOf('LocalFolderPicker', module)


### PR DESCRIPTION
Refacto to use the builds service in the games dashboard + improve styling & error management a bit

In Export dialog
![image](https://user-images.githubusercontent.com/4895034/147497737-816392cd-f7ff-480d-aa99-0f1718bab893.png)


In Games dashboard
![image](https://user-images.githubusercontent.com/4895034/147497756-77887b0d-a9e2-46e8-af17-bbe5a482dc4d.png)

