### PR TITLE
[Platformer] Add a frame rate independent movement mode.

### DIFF
--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -33,6 +33,7 @@ void PlatformerObjectBehavior::InitializeContent(
   behaviorContent.SetAttribute("canGrabPlatforms", false);
   behaviorContent.SetAttribute("yGrabOffset", 0);
   behaviorContent.SetAttribute("xGrabTolerance", 10);
+  behaviorContent.SetAttribute("useLegacyTrajectory", false);
 }
 
 #if defined(GD_IDE_ONLY)
@@ -80,6 +81,12 @@ PlatformerObjectBehavior::GetProperties(
       gd::String::From(behaviorContent.GetDoubleAttribute("yGrabOffset")));
   properties[_("Grab tolerance on X axis")].SetGroup(_("Ledge")).SetValue(gd::String::From(
       behaviorContent.GetDoubleAttribute("xGrabTolerance", 10)));
+  properties[_("Use frame per second dependent trajectories (deprecated)")]
+      .SetGroup(_("Jump"))
+      .SetValue(behaviorContent.GetBoolAttribute("useLegacyTrajectory", true)
+                    ? "true"
+                    : "false")
+      .SetType("Boolean");
   return properties;
 }
 
@@ -91,6 +98,8 @@ bool PlatformerObjectBehavior::UpdateProperty(
     behaviorContent.SetAttribute("ignoreDefaultControls", (value == "0"));
   else if (name == _("Can grab platform ledges"))
     behaviorContent.SetAttribute("canGrabPlatforms", (value == "1"));
+  else if (name == _("Use frame per second dependent trajectories (deprecated)"))
+    behaviorContent.SetAttribute("useLegacyTrajectory", (value == "1"));
   else if (name == _("Grab offset on Y axis"))
     behaviorContent.SetAttribute("yGrabOffset", value.To<double>());
   else {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1890,7 +1890,9 @@ namespace gdjs {
         behavior._requestedDeltaY -= previousJumpSpeed * timeDelta;
 
         // Fall
-        // This is arbitrary. It used to not be obvious.
+        // The condition is a legacy thing.
+        // There is no actual reason not to fall at 1st frame.
+        // Before a refactoring, it used to not be this obvious.
         if (!this._jumpingFirstDelta) {
           behavior._fall(timeDelta);
         }

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -290,16 +290,6 @@ namespace gdjs {
         Math.abs(object.getX() - oldX) >= 1 ||
         Math.abs(object.getY() - oldY) >= 1;
       this._lastDeltaY = object.getY() - oldY;
-
-      console.log(
-        this._state +
-          ' ' +
-          object.getX() +
-          ' ' +
-          object.getY() +
-          '\tJump: ' +
-          this._jumping._currentJumpSpeed
-      );
     }
 
     doStepPostEvents(runtimeScene: gdjs.RuntimeScene) {}
@@ -611,10 +601,13 @@ namespace gdjs {
       const y1 = this.owner.getY() + this._yGrabOffset - this._lastDeltaY;
       const y2 = this.owner.getY() + this._yGrabOffset;
       const platformY = platform.owner.getY() + platform.getYGrabOffset();
+      // This must be inclusive for at least one position.
+      // Otherwise, if the character is at the exact position,
+      // it could not be able to grab the platform at any frame.
       return (
         platform.canBeGrabbed() &&
-        ((y1 < platformY && platformY < y2) ||
-          (y2 < platformY && platformY < y1))
+        ((y1 < platformY && platformY <= y2) ||
+          (y2 <= platformY && platformY < y1))
       );
     }
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -306,6 +306,7 @@ namespace gdjs {
     doStepPostEvents(runtimeScene: gdjs.RuntimeScene) {}
 
     private _updateSpeed(timeDelta: float): float {
+      const previousSpeed = this._currentSpeed;
       //Change the speed according to the player's input.
       // @ts-ignore
       if (this._leftKey) {
@@ -335,7 +336,7 @@ namespace gdjs {
       if (this._currentSpeed < -this._maxSpeed) {
         this._currentSpeed = -this._maxSpeed;
       }
-      return this._currentSpeed * timeDelta;
+      return ((this._currentSpeed + previousSpeed) * timeDelta) / 2;
     }
 
     /**

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -124,7 +124,6 @@ namespace gdjs {
       this._jumpSustainTime = behaviorData.jumpSustainTime || 0;
       this._ignoreDefaultControls = behaviorData.ignoreDefaultControls;
       this._useLegacyTrajectory = behaviorData.useLegacyTrajectory;
-      console.log('useLegacyTrajectory:' + this._useLegacyTrajectory);
       this._slopeMaxAngle = 0;
       this.setSlopeMaxAngle(behaviorData.slopeMaxAngle);
 
@@ -589,7 +588,7 @@ namespace gdjs {
         this._requestedDeltaY += this._currentFallSpeed * timeDelta;
       } else {
         this._requestedDeltaY +=
-          ((this._currentFallSpeed + previousFallSpeed) * timeDelta) / 2;
+          ((this._currentFallSpeed + previousFallSpeed) / 2) * timeDelta;
       }
     }
 
@@ -1901,7 +1900,7 @@ namespace gdjs {
         }
       } else {
         behavior._requestedDeltaY +=
-          ((-previousJumpSpeed - this._currentJumpSpeed) * timeDelta) / 2;
+          ((-previousJumpSpeed - this._currentJumpSpeed) / 2) * timeDelta;
 
         //Fall
         behavior._fall(timeDelta);

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -325,6 +325,7 @@ namespace gdjs {
       if (this._currentSpeed < -this._maxSpeed) {
         this._currentSpeed = -this._maxSpeed;
       }
+      // Use Verlet integration.
       return ((this._currentSpeed + previousSpeed) * timeDelta) / 2;
     }
 
@@ -577,6 +578,7 @@ namespace gdjs {
       if (this._useLegacyTrajectory) {
         this._requestedDeltaY += this._currentFallSpeed * timeDelta;
       } else {
+        // Use Verlet integration.
         this._requestedDeltaY +=
           ((this._currentFallSpeed + previousFallSpeed) / 2) * timeDelta;
       }
@@ -1887,15 +1889,17 @@ namespace gdjs {
       if (this._behavior._useLegacyTrajectory) {
         behavior._requestedDeltaY -= previousJumpSpeed * timeDelta;
 
-        //Fall
+        // Fall
+        // This is arbitrary. It used to not be obvious.
         if (!this._jumpingFirstDelta) {
           behavior._fall(timeDelta);
         }
       } else {
+        // Use Verlet integration.
         behavior._requestedDeltaY +=
           ((-previousJumpSpeed - this._currentJumpSpeed) / 2) * timeDelta;
 
-        //Fall
+        // Fall
         behavior._fall(timeDelta);
       }
       this._jumpingFirstDelta = false;

--- a/Extensions/PlatformBehavior/tests/FlatFloorPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/FlatFloorPlatformer.spec.js
@@ -1,5 +1,5 @@
 describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
-  const epsilon = 1 / (2 << 8);
+  const epsilon = 1 / (2 << 16);
   [0, 60].forEach((slopeMaxAngle) => {
     describe(`(walk on flat floors, slopeMaxAngle: ${slopeMaxAngle}°)`, function () {
       let runtimeScene;

--- a/Extensions/PlatformBehavior/tests/FlatFloorPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/FlatFloorPlatformer.spec.js
@@ -384,7 +384,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       });
 
       it('can track object height changes', function () {
-        //Put the object near the right ledge of the platform.
+        // Put the character near the right ledge of the platform.
         object.setPosition(
           platform.getX() + 10,
           platform.getY() - object.getHeight() + 1
@@ -399,16 +399,19 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           false
         );
         expect(object.getX()).to.be(10);
-        expect(object.getY()).to.be.within(-31, -30); // -30 = -10 (platform y) + -20 (object height)
+        expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
 
+        // Make the platform under the character feet smaller.
         object.setCustomWidthAndHeight(object.getWidth(), 9);
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isFalling()).to.be(false);
         expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
           false
         );
+        // The character follows it.
         expect(object.getY()).to.be(-19); // -19 = -10 (platform y) + -9 (object height)
 
+        // The character walks on the platform.
         for (let i = 0; i < 10; ++i) {
           object.getBehavior('auto1').simulateRightKey();
           runtimeScene.renderAndStep(1000 / 60);
@@ -418,10 +421,12 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           );
         }
         expect(object.getY()).to.be(-19);
-        expect(object.getX()).to.be.within(17.638, 17.639);
+        expect(object.getX()).to.be.above(16);
 
+        // Make the platform under the character feet bigger.
         object.setCustomWidthAndHeight(object.getWidth(), 20);
         runtimeScene.renderAndStep(1000 / 60);
+        // The character follows it.
         expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       });
 

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -176,6 +176,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
         // Jump with sustaining 1/10 of second
+        // A jump will at least sustain one frame,
+        // because the jump key is pressed.
+        // To have the same sustain time for each fps,
+        // we use their greatest common divisor: 10.
         for (let i = 0; i < framesPerSecond / 10; ++i) {
           object.getBehavior('auto1').simulateJumpKey();
           runtimeScene.renderAndStep(1000 / framesPerSecond);
@@ -183,7 +187,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         expect(object.getY()).to.be.within(-112.5 - epsilon, -112.5 + epsilon);
 
         // Jump without sustaining
-        for (let i = 0; i < (framesPerSecond * 2.5) / 10 - 1; ++i) {
+        for (let i = 0; i < framesPerSecond / 4 - 1; ++i) {
           runtimeScene.renderAndStep(1000 / framesPerSecond);
           expect(object.getBehavior('auto1').isJumping()).to.be(true);
           expect(object.getBehavior('auto1').isFalling()).to.be(false);
@@ -230,13 +234,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     });
   });
 
-  // TODO Use Verlet integration instead of Euler method.
-  // This is a comparison of jumping over the frame per second.
-  //       fps, max height
-  // -  30 fps, 165 pixel
-  // -  60 fps, 150 pixel
-  // - 120 fps, 142.5 pixel
-  describe('(jump at 120 fps)', function () {
+  // The legacy trajectory calculus uses Euler method instead of Verlet integration.
+  // In this mode, the character is jumping higher at lower frame rates.
+  describe('(FPS dependent trajectory: 120 fps)', function () {
     let runtimeScene;
     let object;
     let platform;
@@ -282,7 +282,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 120);
       }
 
-      //Check the object is on the platform
+      // Check the object is on the platform
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
@@ -313,7 +313,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getY()).to.be(-210);
 
-      // Then let the object fall
+      // Then, let the object fall.
       for (let i = 0; i < 120 / 3; ++i) {
         runtimeScene.renderAndStep(1000 / 120);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
@@ -332,7 +332,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     });
   });
 
-  describe('(jump at 60 fps)', function () {
+  describe('(FPS dependent trajectory: 60 fps)', function () {
     let runtimeScene;
     let object;
     let platform;
@@ -430,7 +430,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     });
   });
 
-  describe('(jump at 30 fps)', function () {
+  describe('(FPS dependent trajectory: 30 fps)', function () {
     let runtimeScene;
     let object;
     let platform;

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -116,113 +116,111 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     });
   });
 
-  describe.only(`(FPS independent trajectory)`, function () {
-    [20, 30, 60, 120].forEach((framesPerSecond) => {
-      describe(`(FPS independent trajectory: ${framesPerSecond} fps)`, function () {
-        let runtimeScene;
-        let object;
-        let platform;
+  [20, 30, 60, 120].forEach((framesPerSecond) => {
+    describe(`(FPS independent trajectory: ${framesPerSecond} fps)`, function () {
+      let runtimeScene;
+      let object;
+      let platform;
 
-        beforeEach(function () {
-          runtimeScene = makePlatformerTestRuntimeScene(1000 / framesPerSecond);
+      beforeEach(function () {
+        runtimeScene = makePlatformerTestRuntimeScene(1000 / framesPerSecond);
 
-          // Put a platformer object on a platform
-          object = new gdjs.TestRuntimeObject(runtimeScene, {
-            name: 'obj1',
-            type: '',
-            behaviors: [
-              {
-                type: 'PlatformBehavior::PlatformerObjectBehavior',
-                name: 'auto1',
-                gravity: 1500,
-                maxFallingSpeed: 1500,
-                acceleration: 500,
-                deceleration: 1500,
-                maxSpeed: 500,
-                jumpSpeed: 900,
-                canGrabPlatforms: true,
-                ignoreDefaultControls: true,
-                slopeMaxAngle: 60,
-                jumpSustainTime: 0.2,
-                useLegacyTrajectory: false,
-              },
-            ],
-            effects: [],
-          });
-          object.setCustomWidthAndHeight(10, 20);
-          runtimeScene.addObject(object);
-          object.setPosition(0, -32);
-
-          // Put a platform.
-          platform = addPlatformObject(runtimeScene);
-          platform.setPosition(0, -10);
+        // Put a platformer object on a platform
+        object = new gdjs.TestRuntimeObject(runtimeScene, {
+          name: 'obj1',
+          type: '',
+          behaviors: [
+            {
+              type: 'PlatformBehavior::PlatformerObjectBehavior',
+              name: 'auto1',
+              gravity: 1500,
+              maxFallingSpeed: 1500,
+              acceleration: 500,
+              deceleration: 1500,
+              maxSpeed: 500,
+              jumpSpeed: 900,
+              canGrabPlatforms: true,
+              ignoreDefaultControls: true,
+              slopeMaxAngle: 60,
+              jumpSustainTime: 0.2,
+              useLegacyTrajectory: false,
+            },
+          ],
+          effects: [],
         });
+        object.setCustomWidthAndHeight(10, 20);
+        runtimeScene.addObject(object);
+        object.setPosition(0, -32);
 
-        it('can jump', function () {
-          // Ensure the object falls on the platform
-          for (let i = 0; i < framesPerSecond / 6; ++i) {
-            runtimeScene.renderAndStep(1000 / framesPerSecond);
-          }
+        // Put a platform.
+        platform = addPlatformObject(runtimeScene);
+        platform.setPosition(0, -10);
+      });
 
-          //Check the object is on the platform
-          expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      it('can jump', function () {
+        // Ensure the object falls on the platform
+        for (let i = 0; i < framesPerSecond / 6; ++i) {
+          runtimeScene.renderAndStep(1000 / framesPerSecond);
+        }
+
+        //Check the object is on the platform
+        expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+        expect(object.getBehavior('auto1').isFalling()).to.be(false);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
+        expect(object.getBehavior('auto1').isMoving()).to.be(false);
+
+        // Jump with sustaining 1/10 of second
+        for (let i = 0; i < framesPerSecond / 10; ++i) {
+          object.getBehavior('auto1').simulateJumpKey();
+          runtimeScene.renderAndStep(1000 / framesPerSecond);
+        }
+
+        // Jump without sustaining
+        for (let i = 0; i < (framesPerSecond * 2.5) / 10 - 1; ++i) {
+          runtimeScene.renderAndStep(1000 / framesPerSecond);
+          expect(object.getBehavior('auto1').isJumping()).to.be(true);
           expect(object.getBehavior('auto1').isFalling()).to.be(false);
           expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
             false
           );
-          expect(object.getBehavior('auto1').isMoving()).to.be(false);
+        }
 
-          // Jump with sustaining 1/10 of second
-          for (let i = 0; i < framesPerSecond / 10; ++i) {
-            object.getBehavior('auto1').simulateJumpKey();
-            runtimeScene.renderAndStep(1000 / framesPerSecond);
-          }
-
-          // Jump without sustaining
-          for (let i = 0; i < (framesPerSecond * 2.5) / 10 - 1; ++i) {
-            runtimeScene.renderAndStep(1000 / framesPerSecond);
-            expect(object.getBehavior('auto1').isJumping()).to.be(true);
-            expect(object.getBehavior('auto1').isFalling()).to.be(false);
-            expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
-              false
-            );
-          }
-
-          // Check that we reached the maximum height
-          expect(object.getY()).to.be.above(-206.25);
-          // At 30 fps, the maximum value is between 2 frames.
-          if (framesPerSecond !== 30) {
-            runtimeScene.renderAndStep(1000 / framesPerSecond);
-            expect(object.getY()).to.be.within(
-              -206.25 - epsilon,
-              -206.25 + epsilon
-            );
-          }
+        // Check that we reached the maximum height
+        expect(object.getY()).to.be.above(-206.25);
+        // At 30 fps, the maximum value is between 2 frames.
+        if (framesPerSecond !== 30) {
           runtimeScene.renderAndStep(1000 / framesPerSecond);
-          expect(object.getY()).to.be.above(-206.25);
+          expect(object.getY()).to.be.within(
+            -206.25 - epsilon,
+            -206.25 + epsilon
+          );
+        }
+        runtimeScene.renderAndStep(1000 / framesPerSecond);
+        expect(object.getY()).to.be.above(-206.25);
 
-          // Then let the object fall
-          for (let i = 0; i < framesPerSecond / 3 - 2; ++i) {
-            runtimeScene.renderAndStep(1000 / framesPerSecond);
-            expect(object.getBehavior('auto1').isJumping()).to.be(true);
-            expect(object.getBehavior('auto1').isFalling()).to.be(true);
-            expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
-              false
-            );
-          }
-          // The landing happens 1 or 2 frames sooner for some fps.
-          // This is expected as a collision is involved.
+        // Then let the object fall
+        for (let i = 0; i < framesPerSecond / 3 - 2; ++i) {
           runtimeScene.renderAndStep(1000 / framesPerSecond);
-          runtimeScene.renderAndStep(1000 / framesPerSecond);
-
-          runtimeScene.renderAndStep(1000 / framesPerSecond);
-          expect(object.getBehavior('auto1').isFalling()).to.be(false);
+          expect(object.getBehavior('auto1').isJumping()).to.be(true);
+          expect(object.getBehavior('auto1').isFalling()).to.be(true);
           expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
             false
           );
-          expect(object.getBehavior('auto1').isOnFloor()).to.be(true);
-          expect(object.getY()).to.be(-30);
-        });
+        }
+        // The landing happens 1 or 2 frames sooner for some fps.
+        // This is expected as a collision is involved.
+        runtimeScene.renderAndStep(1000 / framesPerSecond);
+        runtimeScene.renderAndStep(1000 / framesPerSecond);
+
+        runtimeScene.renderAndStep(1000 / framesPerSecond);
+        expect(object.getBehavior('auto1').isFalling()).to.be(false);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
+        expect(object.getBehavior('auto1').isOnFloor()).to.be(true);
+        expect(object.getY()).to.be(-30);
       });
     });
   });

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -40,16 +40,19 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     });
 
     it('can fall when in the air', function () {
-      for (let i = 0; i < 30; ++i) {
+      // The character falls.
+      for (let i = 0; i < 10; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
-        if (i < 10) expect(object.getBehavior('auto1').isFalling()).to.be(true);
-        if (i < 10)
-          expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
-            true
-          );
+        expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          true
+        );
+      }
+      for (let i = 0; i < 20; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
       }
 
-      //Check the platform stopped the platformer object.
+      // The platform stopped the character.
       expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
       expect(object.getBehavior('auto1').isFalling()).to.be(false);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
@@ -57,20 +60,21 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
+      // The character walk out of the platform. 
       for (let i = 0; i < 35; ++i) {
-        //Check that the platformer object can fall.
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object.getX()).to.be.within(87.5, 87.51);
-      expect(object.getY()).to.be(-24.75);
+      expect(object.getX()).to.be.above(84);
+      expect(object.getY()).to.be(-26.875);
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
 
-      for (let i = 0; i < 100; ++i) {
-        //Let the speed on X axis go back to 0.
+      // Let the speed on X axis go back to 0.
+      for (let i = 0; i < 50; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
+      expect(object.getBehavior('auto1').getCurrentSpeed()).to.be(0);
     });
 
     it('falls when a platform is moved away', function () {
@@ -176,6 +180,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           object.getBehavior('auto1').simulateJumpKey();
           runtimeScene.renderAndStep(1000 / framesPerSecond);
         }
+        expect(object.getY()).to.be.within(
+          -112.5 - epsilon,
+          -112.5 + epsilon
+        );
 
         // Jump without sustaining
         for (let i = 0; i < (framesPerSecond * 2.5) / 10 - 1; ++i) {
@@ -273,7 +281,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
 
     it('can jump', function () {
       // Ensure the object falls on the platform
-      for (let i = 0; i < 20; ++i) {
+      for (let i = 0; i < 120 / 6; ++i) {
         runtimeScene.renderAndStep(1000 / 120);
       }
 
@@ -285,9 +293,15 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
+      // Jump with sustaining 1/10 of second
+      for (let i = 0; i < 120 / 10; ++i) {
+        object.getBehavior('auto1').simulateJumpKey();
+        runtimeScene.renderAndStep(1000 / 120);
+      }
+      expect(object.getY()).to.be(-113.125);
+      
       // Jump without sustaining
-      object.getBehavior('auto1').simulateJumpKey();
-      for (let i = 0; i < 36; ++i) {
+      for (let i = 0; i < 120 / 4; ++i) {
         runtimeScene.renderAndStep(1000 / 120);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(false);
@@ -297,14 +311,13 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be.within(-172.4, -172);
+      expect(object.getY()).to.be(-210);
+      // The maximum is between these 2 frames
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-172.5);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-172.4, -172);
+      expect(object.getY()).to.be(-210);
 
       // Then let the object fall
-      for (let i = 0; i < 35; ++i) {
+      for (let i = 0; i < 120 / 3; ++i) {
         runtimeScene.renderAndStep(1000 / 120);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
@@ -376,9 +389,16 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
+      // Jump with sustaining 1/10 of second
+      for (let i = 0; i < 60 / 10; ++i) {
+        object.getBehavior('auto1').simulateJumpKey();
+        runtimeScene.renderAndStep(1000 / 120);
+      }
+      expect(object.getY()).to.be(-113.75);
+
       // Jump without sustaining
       object.getBehavior('auto1').simulateJumpKey();
-      for (let i = 0; i < 18; ++i) {
+      for (let i = 0; i < 60 / 4; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(false);
@@ -388,14 +408,14 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be.within(-180, -179);
+      expect(object.getY()).to.be.above(-220);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-180);
+      expect(object.getY()).to.be(-220);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-180, -179);
+      expect(object.getY()).to.be.above(-220);
 
       // Then let the object fall
-      for (let i = 0; i < 17; ++i) {
+      for (let i = 0; i < 60 / 3; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
@@ -467,9 +487,16 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
+      // Jump with sustaining 1/10 of second
+      for (let i = 0; i < 30 / 10; ++i) {
+        object.getBehavior('auto1').simulateJumpKey();
+        runtimeScene.renderAndStep(1000 / 120);
+      }
+      expect(object.getY()).to.be(-115);
+
       // Jump without sustaining
       object.getBehavior('auto1').simulateJumpKey();
-      for (let i = 0; i < 9; ++i) {
+      for (let i = 0; i < 30 / 4; ++i) {
         runtimeScene.renderAndStep(1000 / 30);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(false);
@@ -479,14 +506,13 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be.within(-194, -193);
+      expect(object.getY()).to.be(-233 - 1/3);
+      // The maximum is between these 2 frames
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-195);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-194, -193);
+      expect(object.getY()).to.be(-233 - 1/3);
 
       // Then let the object fall
-      for (let i = 0; i < 8; ++i) {
+      for (let i = 0; i < 30 / 3; ++i) {
         runtimeScene.renderAndStep(1000 / 30);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
@@ -570,21 +596,21 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check the height reached
-      expect(object.getY()).to.be(-230);
+      expect(object.getY()).to.be.within(-225 - epsilon, -225 + epsilon);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-235);
-      for (let i = 0; i < 5; ++i) {
+      expect(object.getY()).to.be.within(-229.583 - epsilon, -229.583 + epsilon);
+      for (let i = 0; i < 4; ++i) {
         // Verify that pressing the jump key does not change anything
         object.getBehavior('auto1').simulateJumpKey();
         runtimeScene.renderAndStep(1000 / 60);
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be(-247.5);
+      expect(object.getY()).to.be.above(-240);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-247.5);
+      expect(object.getY()).to.be.within(-240 - epsilon, -240 + epsilon);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-247, -246);
+      expect(object.getY()).to.be.above(-240);
 
       // Then let the object fall
       for (let i = 0; i < 60; ++i) {
@@ -612,7 +638,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         object.getBehavior('auto1').simulateJumpKey();
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object.getY()).to.be.within(-101, -100);
+      expect(object.getY()).to.be.within(-100, -99);
 
       // Stop holding the jump key
       runtimeScene.renderAndStep(1000 / 60);
@@ -624,23 +650,20 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be.within(-206, -205);
+      expect(object.getY()).to.be.above(-199.791 + epsilon);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-208, -207);
+      expect(object.getY()).to.be.within(-199.791 - epsilon, -199.791 + epsilon);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-208, -207);
+      expect(object.getY()).to.be.within(-199.791 - epsilon, -199.791 + epsilon);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-208, -207);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-206, -205);
-      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getY()).to.be.above(-199.791 + epsilon);
 
       // Then let the object fall
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
       expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
         false
       );
-      for (let i = 0; i < 60; ++i) {
+      for (let i = 0; i < 20; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
       expect(object.getY()).to.be(-30);
@@ -831,7 +854,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
 
       // Jump, reach the top and go down
       object.getBehavior('auto1').simulateJumpKey();
-      for (let i = 0; i < 30; ++i) {
+      for (let i = 0; i < 29; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
       }
@@ -951,7 +974,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     });
 
     it('can jump through a jumpthru and land', function () {
-      jumpthru.setPosition(0, -33);
+      jumpthru.setPosition(0, -32);
       //Check the platform stopped the platformer object.
       for (let i = 0; i < 5; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
@@ -968,15 +991,15 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getY()).to.be.within(-39, -38);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-47, -46);
+      expect(object.getY()).to.be.within(-46, -45);
       runtimeScene.renderAndStep(1000 / 60);
-      // At this step, the object is almost on the jumpthru (-53 + 20 (object height) = -33 (jump thru Y position)),
+      // At this step, the object is almost on the jumpthru (-52 + 20 (object height) = -32 (jump thru Y position)),
       // but the object should not stop.
-      expect(object.getY()).to.be.within(-54, -53);
+      expect(object.getY()).to.be.within(-53, -52);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-61, -60);
+      expect(object.getY()).to.be.within(-60, -59);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-67, -66);
+      expect(object.getY()).to.be.within(-66, -65);
 
       // Verify the object is still jumping
       expect(object.getBehavior('auto1').isJumping()).to.be(true);
@@ -986,7 +1009,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       for (let i = 0; i < 20; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object.getY()).to.be.within(-89, -88);
+      expect(object.getY()).to.be.within(-83, -82);
 
       // Verify the object is now considered as falling in its jump:
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
@@ -1008,7 +1031,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     it('can jump right under a jumpthru without landing', function () {
       // A big one because the object jump to the right.
       jumpthru.setCustomWidthAndHeight(600, 20);
-      const highestJumpY = -104; // actually -103.6
+      const highestJumpY = -100; // actually -99.41666666666661
       // Right above the maximum reach by jumping
       jumpthru.setPosition(0, highestJumpY + object.getHeight());
 
@@ -1025,13 +1048,14 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
 
       // The object jumps.
       object.getBehavior('auto1').simulateJumpKey();
-      for (let i = 0; i < 17; ++i) {
+      for (let i = 0; i < 16; ++i) {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(false);
       }
       // The object is at the highest of the jump.
+      runtimeScene.renderAndStep(1000 / 60);
       expect(object.getY()).to.be.within(highestJumpY, highestJumpY + 1);
 
       // The object starts to fall.
@@ -1051,10 +1075,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.above(-85);
     });
 
-    it('can jump right above a jumpthru and landing', function () {
+    it.only('can jump right above a jumpthru and landing', function () {
       // A big one because the object jump to the right.
       jumpthru.setCustomWidthAndHeight(600, 20);
-      const highestJumpY = -104; // actually -103.6
+      const highestJumpY = -99.41666666666661;
       // Right above the maximum reach by jumping
       jumpthru.setPosition(0, highestJumpY + 1 + object.getHeight());
 
@@ -1071,14 +1095,15 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
 
       // The object jumps.
       object.getBehavior('auto1').simulateJumpKey();
-      for (let i = 0; i < 17; ++i) {
+      for (let i = 0; i < 16; ++i) {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isJumping()).to.be(true);
         expect(object.getBehavior('auto1').isFalling()).to.be(false);
       }
       // The object is at the highest of the jump.
-      expect(object.getY()).to.be.within(highestJumpY, highestJumpY + 1);
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getY()).to.be.within(highestJumpY - epsilon, highestJumpY + epsilon);
 
       // The object landed on the jumpthru.
       object.getBehavior('auto1').simulateRightKey();

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -1,5 +1,5 @@
 describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
-  const epsilon = 1 / (2 << 8);
+  const epsilon = 1 / (2 << 16);
   describe('(falling)', function () {
     let runtimeScene;
     let object;
@@ -60,7 +60,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       );
       expect(object.getBehavior('auto1').isMoving()).to.be(false);
 
-      // The character walk out of the platform. 
+      // The character walk out of the platform.
       for (let i = 0; i < 35; ++i) {
         object.getBehavior('auto1').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
@@ -180,10 +180,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           object.getBehavior('auto1').simulateJumpKey();
           runtimeScene.renderAndStep(1000 / framesPerSecond);
         }
-        expect(object.getY()).to.be.within(
-          -112.5 - epsilon,
-          -112.5 + epsilon
-        );
+        expect(object.getY()).to.be.within(-112.5 - epsilon, -112.5 + epsilon);
 
         // Jump without sustaining
         for (let i = 0; i < (framesPerSecond * 2.5) / 10 - 1; ++i) {
@@ -299,7 +296,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 120);
       }
       expect(object.getY()).to.be(-113.125);
-      
+
       // Jump without sustaining
       for (let i = 0; i < 120 / 4; ++i) {
         runtimeScene.renderAndStep(1000 / 120);
@@ -506,10 +503,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be(-233 - 1/3);
+      expect(object.getY()).to.be(-233 - 1 / 3);
       // The maximum is between these 2 frames
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be(-233 - 1/3);
+      expect(object.getY()).to.be(-233 - 1 / 3);
 
       // Then let the object fall
       for (let i = 0; i < 30 / 3; ++i) {
@@ -598,7 +595,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // Check the height reached
       expect(object.getY()).to.be.within(-225 - epsilon, -225 + epsilon);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-229.583 - epsilon, -229.583 + epsilon);
+      expect(object.getY()).to.be.within(
+        -229.5833333333333 - epsilon,
+        -229.5833333333333 + epsilon
+      );
       for (let i = 0; i < 4; ++i) {
         // Verify that pressing the jump key does not change anything
         object.getBehavior('auto1').simulateJumpKey();
@@ -650,13 +650,19 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
 
       // Check that we reached the maximum height
-      expect(object.getY()).to.be.above(-199.791 + epsilon);
+      expect(object.getY()).to.be.above(-199.7916666666666 + epsilon);
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-199.791 - epsilon, -199.791 + epsilon);
+      expect(object.getY()).to.be.within(
+        -199.7916666666666 - epsilon,
+        -199.7916666666666 + epsilon
+      );
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(-199.791 - epsilon, -199.791 + epsilon);
+      expect(object.getY()).to.be.within(
+        -199.7916666666666 - epsilon,
+        -199.7916666666666 + epsilon
+      );
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.above(-199.791 + epsilon);
+      expect(object.getY()).to.be.above(-199.7916666666666 + epsilon);
 
       // Then let the object fall
       expect(object.getBehavior('auto1').isFalling()).to.be(true);
@@ -1031,9 +1037,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     it('can jump right under a jumpthru without landing', function () {
       // A big one because the object jump to the right.
       jumpthru.setCustomWidthAndHeight(600, 20);
-      const highestJumpY = -100; // actually -99.41666666666661
+      const highestJumpY = -99.41666666666661;
       // Right above the maximum reach by jumping
-      jumpthru.setPosition(0, highestJumpY + object.getHeight());
+      jumpthru.setPosition(0, Math.floor(highestJumpY) + object.getHeight());
 
       // The object landed on the platform.
       for (let i = 0; i < 5; ++i) {
@@ -1056,7 +1062,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
       // The object is at the highest of the jump.
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(highestJumpY, highestJumpY + 1);
+      expect(object.getY()).to.be.within(
+        highestJumpY - epsilon,
+        highestJumpY + epsilon
+      );
 
       // The object starts to fall.
       object.getBehavior('auto1').simulateRightKey();
@@ -1075,12 +1084,12 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.above(-85);
     });
 
-    it.only('can jump right above a jumpthru and landing', function () {
+    it('can jump right above a jumpthru and landing', function () {
       // A big one because the object jump to the right.
       jumpthru.setCustomWidthAndHeight(600, 20);
       const highestJumpY = -99.41666666666661;
       // Right above the maximum reach by jumping
-      jumpthru.setPosition(0, highestJumpY + 1 + object.getHeight());
+      jumpthru.setPosition(0, Math.ceil(highestJumpY) + object.getHeight());
 
       // The object landed on the platform.
       for (let i = 0; i < 5; ++i) {
@@ -1103,7 +1112,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       }
       // The object is at the highest of the jump.
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getY()).to.be.within(highestJumpY - epsilon, highestJumpY + epsilon);
+      expect(object.getY()).to.be.within(
+        highestJumpY - epsilon,
+        highestJumpY + epsilon
+      );
 
       // The object landed on the jumpthru.
       object.getBehavior('auto1').simulateRightKey();
@@ -1138,7 +1150,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
     });
   });
 
-  describe('and gdjs.PlatformRuntimeBehavior at same time', function () {
+  describe('and gdjs.PlatformRuntimeBehavior at same time - ', function () {
     let runtimeScene;
     let object;
     let platform;
@@ -1212,38 +1224,45 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       object2.setPosition(9, -60);
     });
 
-    it('can jump through the jumpthru', function () {
-      // Check that the second object falls (it's not stopped by itself)
+    it('can move', function () {
+      // The 2nd object falls (it's not stopped by itself).
       expect(object2.getY()).to.be(-60);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object2.getY()).to.be(-59.75);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object2.getY()).to.be(-59.25);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object2.getY()).to.be(-58.5);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object2.getY()).to.be(-57.5);
+      for (let i = 0; i < 4; i++) {
+        const previousY = object2.getY();
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(object2.getY()).to.be.above(previousY);
+        expect(object2.getBehavior('PlatformerObject').isFalling()).to.be(true);
+      }
+      expect(object2.getY()).to.be(-58);
 
-      //Check the first object stays on the platform.
+      // The 1st object stays on the platform.
       expect(object.getY()).to.be(-30);
 
-      // Simulate more frames. Check that trying to jump won't do anything.
-      for (let i = 0; i < 5; ++i) {
+      // The 2nd object can't jump on itself.
+      for (let i = 0; i < 4; ++i) {
         object2.getBehavior('PlatformerObject').simulateJumpKey();
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object2.getY()).to.be(-48.75);
+      expect(object2.getY()).to.be.below(object.getY() - object2.getHeight());
       expect(object.getX()).to.be(0);
       expect(object.getY()).to.be(-30);
-
-      // Verify that the first platformer object is moved 1px to the left
-      // as the falling platformer object+platform collides with it
+      // At the 1st frame of collision, the result depends on execution order.
+      // The effect on the 1st object is not tested.
       runtimeScene.renderAndStep(1000 / 60);
-      expect(object2.getY()).to.be(-46.25);
+      expect(object2.getY()).to.be.above(object.getY() - object2.getHeight());
+
+      // 1st the object can be pushed down, when the intersection height < 1.
+      runtimeScene.renderAndStep(1000 / 60);
+      // The falling platformer object+platform collides with the 1st object.
+      // The 1st object moves 1px to the left.
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object2.getY()).to.be.above(
+        object.getY() - object2.getHeight() + 1
+      );
       expect(object.getX()).to.be(-1);
       expect(object.getY()).to.be(-30);
 
-      // Simulate more frames so that the object reaches the floor
+      // The 2nd object reaches the floor.
       for (let i = 0; i < 20; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
@@ -1259,9 +1278,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
       }
       expect(object2.getX()).to.be(9);
-      expect(object2.getY()).to.be(-72.5);
+      expect(object2.getY()).to.be.below(-70);
       expect(object.getX()).to.be(-1);
-      expect(object.getY()).to.be(-72.5);
+      expect(object.getY()).to.be.below(-70);
 
       // Try to go right for the first object: won't work because the other
       // object is a platform.
@@ -1270,9 +1289,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
       }
       expect(object2.getX()).to.be(9);
-      expect(object2.getY()).to.be.within(-94.2, -94.1);
+      expect(object2.getY()).to.be.below(-90);
       expect(object.getX()).to.be(-1);
-      expect(object.getY()).to.be.within(-94.2, -94.1);
+      expect(object.getY()).to.be.below(-90);
 
       // Try to go right for the first and second object: can do.
       for (let i = 0; i < 3; ++i) {
@@ -1280,18 +1299,18 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         object2.getBehavior('PlatformerObject').simulateRightKey();
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object2.getX()).to.be.within(9.83, 9.84);
-      expect(object2.getY()).to.be.within(-101.2, -101.1);
-      expect(object.getX()).to.be.within(-0.59, -0.58);
-      expect(object.getY()).to.be.within(-101.2, -101.1);
+      expect(object2.getX()).to.be.above(9.5);
+      expect(object2.getY()).to.be.below(-95);
+      expect(object.getX()).to.be.above(-0.8);
+      expect(object.getY()).to.be.below(-95);
 
       // Let the object fall back on the floor.
-      for (let i = 0; i < 30; ++i) {
+      for (let i = 0; i < 20; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
-      expect(object2.getX()).to.be.within(9.83, 9.84);
+      expect(object2.getX()).to.be.above(9.5);
       expect(object2.getY()).to.be(-30);
-      expect(object.getX()).to.be.within(-0.59, -0.58);
+      expect(object.getX()).to.be.above(-0.8);
       expect(object.getY()).to.be(-30);
     });
   });

--- a/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
@@ -434,7 +434,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // Here, if we had pressed Right the character would have been falling.
       runtimeScene.renderAndStep(1000 / 60);
       expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
-      // Now, it fells.
+      // Now, it falls.
       fall(5);
     });
 

--- a/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
@@ -1,4 +1,4 @@
-describe.only('gdjs.PlatformerObjectRuntimeBehavior', function () {
+describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
   describe('(grab platforms)', function () {
     let runtimeScene;
     let object;

--- a/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
@@ -1,4 +1,4 @@
-describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
+describe.only('gdjs.PlatformerObjectRuntimeBehavior', function () {
   describe('(grab platforms)', function () {
     let runtimeScene;
     let object;
@@ -38,7 +38,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       platform.setPosition(0, -10);
       runtimeScene.renderAndStep(1000 / 60);
 
-      //Put the object near the right ledge of the platform.
+      // Put the character near the right ledge of the platform.
       object.setPosition(
         platform.getX() + platform.getWidth() + 2,
         platform.getY() - 10
@@ -49,14 +49,16 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
       }
 
-      //Check that the object grabbed the platform
+      // The character grabs the platform.
       expect(object.getX()).to.be.within(
         platform.getX() + platform.getWidth() + 0,
         platform.getX() + platform.getWidth() + 1
       );
       expect(object.getY()).to.be(platform.getY());
 
+      // The character releases the platform.
       object.getBehavior('auto1').simulateReleasePlatformKey();
+      // The character falls.
       for (let i = 0; i < 10; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isFalling()).to.be(true);
@@ -64,9 +66,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           true
         );
       }
-
-      //Check that the object is falling
-      expect(object.getY()).to.be(3.75);
+      expect(object.getY()).to.be.above(0);
     });
 
     [true, false].forEach((addTopPlatformFirst) => {
@@ -302,7 +302,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         objectPositionAfterFirstClimb + 20,
         objectPositionAfterFirstClimb + 21
       );
-      climbLadder(24);
+      climbLadder(23);
       // Check that we reached the maximum height
       const playerAtLadderTop = ladder.getY() - object.getHeight();
       expect(object.getY()).to.be.within(
@@ -355,7 +355,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
 
       // Jump
       object.getBehavior('auto1').simulateJumpKey();
-      for (let i = 0; i < 19; ++i) {
+      for (let i = 0; i < 18; ++i) {
         jumpAndAscend(1);
       }
 
@@ -407,10 +407,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // and grab the 2nd one, even if still ascending
       object.getBehavior('auto1').simulateLadderKey();
       // still moves a little because of inertia
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
-      runtimeScene.renderAndStep(1000 / 60);
-      expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
+      for (let i = 0; i < 3; i++) {
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
+      }
       stayOnLadder(1);
     });
 
@@ -431,6 +431,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
         expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
       }
+      // Here, if we had pressed Right the character would have been falling.
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getBehavior('auto1').isOnLadder()).to.be(true);
+      // Now, it fells.
       fall(5);
     });
 

--- a/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
@@ -298,9 +298,9 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       releaseLadder(10);
       object.getBehavior('auto1').simulateLadderKey();
       expect(object.getY()).to.be.within(
-        // gravity is 1500, 10 frames falling ~ 23px
-        objectPositionAfterFirstClimb + 22,
-        objectPositionAfterFirstClimb + 24
+        // gravity is 1500, 10 frames falling ~ 21px
+        objectPositionAfterFirstClimb + 20,
+        objectPositionAfterFirstClimb + 21
       );
       climbLadder(24);
       // Check that we reached the maximum height

--- a/Extensions/PlatformBehavior/tests/MovingPlatformPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/MovingPlatformPlatformer.spec.js
@@ -1,5 +1,5 @@
 describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
-  const epsilon = 1 / (2 << 8);
+  const epsilon = 1 / (2 << 16);
 
   describe('(moving platforms)', function () {
     let runtimeScene;

--- a/Extensions/PlatformBehavior/tests/SlopePlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/SlopePlatformer.spec.js
@@ -359,7 +359,10 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           fallOnPlatform(10);
 
           // Walk from the 1st platform to the 2nd one.
-          walkRight(30);
+          // The floor detection can't round it to 30
+          // because the character bottom is 50 with rounding error
+          // 29.999999999999996 + 20 = 50
+          walkRight(29.999999999999996);
           expect(object.getX()).to.be.above(platform.getX());
           // Gone downward following the 2nd platform.
           expect(object.getY()).to.be(platform.getY() - object.getHeight());

--- a/Extensions/PlatformBehavior/tests/SlopePlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/SlopePlatformer.spec.js
@@ -1,5 +1,5 @@
 describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
-  const epsilon = 1 / (2 << 8);
+  const epsilon = 1 / (2 << 16);
 
   describe('(walk on slopes)', function () {
     let runtimeScene;
@@ -359,13 +359,16 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           fallOnPlatform(10);
 
           // Walk from the 1st platform to the 2nd one.
+          walkRight(30);
+          expect(object.getX()).to.be.above(platform.getX());
+          // Gone downward following the 2nd platform.
           // The floor detection can't round it to 30
           // because the character bottom is 50 with rounding error
           // 29.999999999999996 + 20 = 50
-          walkRight(29.999999999999996);
-          expect(object.getX()).to.be.above(platform.getX());
-          // Gone downward following the 2nd platform.
-          expect(object.getY()).to.be(platform.getY() - object.getHeight());
+          expect(object.getY()).to.be.within(
+            platform.getY() - object.getHeight() - epsilon,
+            platform.getY() - object.getHeight() + epsilon
+          );
         });
       });
 


### PR DESCRIPTION
This uses a Verlet integration.
* https://github.com/4ian/GDevelop/discussions/3405

It also fix the ledge grabbing: when the character is on exactly on right Y, it can now grab.
It add tests to check that the trajectory is the same on different frame rate for jump/fall and walking.

The existing tests have been adapted to this new mode. Only the basic jump test uses the legacy mode. I think it allows to check that the legacy mode works without having to maintain 2 test suites. But, if you want to reduce regression risk during the transition, I can add the old suite in a legacy folder.

I sometimes made tests less constraint. This is to only check what is really matter for the test to help readability and make them easier to maintain.