### PR TITLE
Add notion of origin to extensions

### DIFF
--- a/Core/GDCore/Project/EventsFunctionsExtension.cpp
+++ b/Core/GDCore/Project/EventsFunctionsExtension.cpp
@@ -3,7 +3,6 @@
  * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights
  * reserved. This project is released under the MIT License.
  */
-#if defined(GD_IDE_ONLY)
 #include "EventsFunctionsExtension.h"
 
 #include "EventsBasedBehavior.h"
@@ -138,5 +137,3 @@ bool EventsFunctionsExtension::IsExtensionLifecycleEventsFunction(
 }
 
 }  // namespace gd
-
-#endif

--- a/Core/GDCore/Project/EventsFunctionsExtension.cpp
+++ b/Core/GDCore/Project/EventsFunctionsExtension.cpp
@@ -50,6 +50,11 @@ void EventsFunctionsExtension::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("description", description);
   element.SetAttribute("name", name);
   element.SetAttribute("fullName", fullName);
+  if (!originName.empty() || !originIdentifier.empty()) {
+    element.AddChild("origin")
+        .SetAttribute("name", originName)
+        .SetAttribute("identifier", originIdentifier);
+  }
   auto& tagsElement = element.AddChild("tags");
   tagsElement.ConsiderAsArray();
   for (const auto& tag : tags) {
@@ -86,6 +91,14 @@ void EventsFunctionsExtension::UnserializeFrom(
   previewIconUrl = element.GetStringAttribute("previewIconUrl");
   iconUrl = element.GetStringAttribute("iconUrl");
   helpPath = element.GetStringAttribute("helpPath");
+
+  if (element.HasChild("origin")) {
+    gd::String originName =
+        element.GetChild("origin").GetStringAttribute("name", "");
+    gd::String originIdentifier =
+        element.GetChild("origin").GetStringAttribute("identifier", "");
+    SetOrigin(originName, originIdentifier);
+  }
 
   tags.clear();
   auto& tagsElement = element.GetChild("tags");

--- a/Core/GDCore/Project/EventsFunctionsExtension.h
+++ b/Core/GDCore/Project/EventsFunctionsExtension.h
@@ -139,6 +139,12 @@ class GD_CORE_API EventsFunctionsExtension : public EventsFunctionsContainer {
     return eventsBasedBehaviors;
   }
 
+  /**
+   * \brief Sets an extension origin. This method is not present since the beginning
+   * so the projects created before that will have extensions installed from the store
+   * without an origin. Keep that in mind when creating features that rely on an
+   * extension's origin.
+   */
   virtual void SetOrigin(const gd::String& originName_, const gd::String& originIdentifier_) {
     originName = originName_;
     originIdentifier = originIdentifier_;

--- a/Core/GDCore/Project/EventsFunctionsExtension.h
+++ b/Core/GDCore/Project/EventsFunctionsExtension.h
@@ -3,7 +3,6 @@
  * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights
  * reserved. This project is released under the MIT License.
  */
-#if defined(GD_IDE_ONLY)
 #ifndef GDCORE_EVENTSFUNCTIONEXTENSION_H
 #define GDCORE_EVENTSFUNCTIONEXTENSION_H
 
@@ -236,4 +235,3 @@ class GD_CORE_API EventsFunctionsExtension : public EventsFunctionsContainer {
 }  // namespace gd
 
 #endif  // GDCORE_EVENTSFUNCTIONEXTENSION_H
-#endif

--- a/Core/GDCore/Project/EventsFunctionsExtension.h
+++ b/Core/GDCore/Project/EventsFunctionsExtension.h
@@ -140,19 +140,21 @@ class GD_CORE_API EventsFunctionsExtension : public EventsFunctionsContainer {
   }
 
   /**
-   * \brief Sets an extension origin. This method is not present since the beginning
-   * so the projects created before that will have extensions installed from the store
-   * without an origin. Keep that in mind when creating features that rely on an
-   * extension's origin.
+   * \brief Sets an extension origin. This method is not present since the
+   * beginning so the projects created before that will have extensions
+   * installed from the store without an origin. Keep that in mind when creating
+   * features that rely on an extension's origin.
    */
-  virtual void SetOrigin(const gd::String& originName_, const gd::String& originIdentifier_) {
+  virtual void SetOrigin(const gd::String& originName_,
+                         const gd::String& originIdentifier_) {
     originName = originName_;
     originIdentifier = originIdentifier_;
   }
 
   virtual const gd::String& GetOriginName() const { return originName; }
-  virtual const gd::String& GetOriginIdentifier() const { return originIdentifier; }
-
+  virtual const gd::String& GetOriginIdentifier() const {
+    return originIdentifier;
+  }
 
   /** \name Dependencies
    */

--- a/Core/GDCore/Project/EventsFunctionsExtension.h
+++ b/Core/GDCore/Project/EventsFunctionsExtension.h
@@ -139,6 +139,15 @@ class GD_CORE_API EventsFunctionsExtension : public EventsFunctionsContainer {
     return eventsBasedBehaviors;
   }
 
+  virtual void SetOrigin(const gd::String& originName_, const gd::String& originIdentifier_) {
+    originName = originName_;
+    originIdentifier = originIdentifier_;
+  }
+
+  virtual const gd::String& GetOriginName() const { return originName; }
+  virtual const gd::String& GetOriginIdentifier() const { return originIdentifier; }
+
+
   /** \name Dependencies
    */
   ///@{
@@ -225,6 +234,8 @@ class GD_CORE_API EventsFunctionsExtension : public EventsFunctionsContainer {
   std::vector<gd::String> authorIds;
   gd::String author;
   gd::String previewIconUrl;
+  gd::String originName;
+  gd::String originIdentifier;
   gd::String iconUrl;
   gd::String helpPath;  ///< The relative path to the help for this extension in
                         ///< the documentation (or an absolute URL).

--- a/Core/GDCore/Project/ResourcesManager.cpp
+++ b/Core/GDCore/Project/ResourcesManager.cpp
@@ -24,12 +24,9 @@ gd::String Resource::badStr;
 
 Resource ResourcesManager::badResource;
 gd::String ResourcesManager::badResourceName;
-#if defined(GD_IDE_ONLY)
 ResourceFolder ResourcesManager::badFolder;
 Resource ResourceFolder::badResource;
-#endif
 
-#if defined(GD_IDE_ONLY)
 void ResourceFolder::Init(const ResourceFolder& other) {
   name = other.name;
 
@@ -38,19 +35,16 @@ void ResourceFolder::Init(const ResourceFolder& other) {
     resources.push_back(std::shared_ptr<Resource>(other.resources[i]->Clone()));
   }
 }
-#endif
 
 void ResourcesManager::Init(const ResourcesManager& other) {
   resources.clear();
   for (std::size_t i = 0; i < other.resources.size(); ++i) {
     resources.push_back(std::shared_ptr<Resource>(other.resources[i]->Clone()));
   }
-#if defined(GD_IDE_ONLY)
   folders.clear();
   for (std::size_t i = 0; i < other.folders.size(); ++i) {
     folders.push_back(other.folders[i]);
   }
-#endif
 }
 
 Resource& ResourcesManager::GetResource(const gd::String& name) {
@@ -147,7 +141,6 @@ std::vector<gd::String> ResourcesManager::FindFilesNotInResources(
   return filesNotInResources;
 }
 
-#if defined(GD_IDE_ONLY)
 std::map<gd::String, gd::PropertyDescriptor> Resource::GetProperties() const {
   std::map<gd::String, gd::PropertyDescriptor> nothing;
   return nothing;
@@ -443,9 +436,7 @@ void ResourcesManager::RemoveResource(const gd::String& name) {
   for (std::size_t i = 0; i < folders.size(); ++i)
     folders[i].RemoveResource(name);
 }
-#endif
 
-#if defined(GD_IDE_ONLY)
 void ResourceFolder::UnserializeFrom(const SerializerElement& element,
                                      gd::ResourcesManager& parentManager) {
   name = element.GetStringAttribute("name");
@@ -470,7 +461,6 @@ void ResourceFolder::SerializeTo(SerializerElement& element) const {
         .SetAttribute("name", resources[i]->GetName());
   }
 }
-#endif
 
 void ResourcesManager::UnserializeFrom(const SerializerElement& element) {
   resources.clear();
@@ -500,7 +490,6 @@ void ResourcesManager::UnserializeFrom(const SerializerElement& element) {
     resources.push_back(resource);
   }
 
-#if defined(GD_IDE_ONLY)
   folders.clear();
   const SerializerElement& resourcesFoldersElement =
       element.GetChild("resourceFolders", 0, "ResourceFolders");
@@ -511,10 +500,8 @@ void ResourcesManager::UnserializeFrom(const SerializerElement& element) {
 
     folders.push_back(folder);
   }
-#endif
 }
 
-#if defined(GD_IDE_ONLY)
 void ResourcesManager::SerializeTo(SerializerElement& element) const {
   SerializerElement& resourcesElement = element.AddChild("resources");
   resourcesElement.ConsiderAsArrayOf("resource");
@@ -543,7 +530,6 @@ void ResourcesManager::SerializeTo(SerializerElement& element) const {
   for (std::size_t i = 0; i < folders.size(); ++i)
     folders[i].SerializeTo(resourcesFoldersElement.AddChild("folder"));
 }
-#endif
 
 void ImageResource::SetFile(const gd::String& newFile) {
   file = newFile;
@@ -560,14 +546,12 @@ void ImageResource::UnserializeFrom(const SerializerElement& element) {
   SetFile(element.GetStringAttribute("file"));
 }
 
-#if defined(GD_IDE_ONLY)
 void ImageResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("alwaysLoaded", alwaysLoaded);
   element.SetAttribute("smoothed", smooth);
   element.SetAttribute("userAdded", IsUserAdded());
   element.SetAttribute("file", GetFile());
 }
-#endif
 
 void AudioResource::SetFile(const gd::String& newFile) {
   file = newFile;
@@ -584,14 +568,12 @@ void AudioResource::UnserializeFrom(const SerializerElement& element) {
   SetPreloadAsSound(element.GetBoolAttribute("preloadAsSound"));
 }
 
-#if defined(GD_IDE_ONLY)
 void AudioResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("userAdded", IsUserAdded());
   element.SetAttribute("file", GetFile());
   element.SetAttribute("preloadAsMusic", PreloadAsMusic());
   element.SetAttribute("preloadAsSound", PreloadAsSound());
 }
-#endif
 
 void FontResource::SetFile(const gd::String& newFile) {
   file = newFile;
@@ -606,12 +588,10 @@ void FontResource::UnserializeFrom(const SerializerElement& element) {
   SetFile(element.GetStringAttribute("file"));
 }
 
-#if defined(GD_IDE_ONLY)
 void FontResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("userAdded", IsUserAdded());
   element.SetAttribute("file", GetFile());
 }
-#endif
 
 void VideoResource::SetFile(const gd::String& newFile) {
   file = newFile;
@@ -626,12 +606,10 @@ void VideoResource::UnserializeFrom(const SerializerElement& element) {
   SetFile(element.GetStringAttribute("file"));
 }
 
-#if defined(GD_IDE_ONLY)
 void VideoResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("userAdded", IsUserAdded());
   element.SetAttribute("file", GetFile());
 }
-#endif
 
 void JsonResource::SetFile(const gd::String& newFile) {
   file = newFile;
@@ -647,7 +625,6 @@ void JsonResource::UnserializeFrom(const SerializerElement& element) {
   DisablePreload(element.GetBoolAttribute("disablePreload", false));
 }
 
-#if defined(GD_IDE_ONLY)
 void JsonResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("userAdded", IsUserAdded());
   element.SetAttribute("file", GetFile());
@@ -672,7 +649,6 @@ bool JsonResource::UpdateProperty(const gd::String& name,
   return true;
 }
 
-#endif
 
 void BitmapFontResource::SetFile(const gd::String& newFile) {
   file = newFile;
@@ -687,14 +663,11 @@ void BitmapFontResource::UnserializeFrom(const SerializerElement& element) {
   SetFile(element.GetStringAttribute("file"));
 }
 
-#if defined(GD_IDE_ONLY)
 void BitmapFontResource::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("userAdded", IsUserAdded());
   element.SetAttribute("file", GetFile());
 }
-#endif
 
-#if defined(GD_IDE_ONLY)
 ResourceFolder::ResourceFolder(const ResourceFolder& other) { Init(other); }
 
 ResourceFolder& ResourceFolder::operator=(const ResourceFolder& other) {
@@ -702,7 +675,6 @@ ResourceFolder& ResourceFolder::operator=(const ResourceFolder& other) {
 
   return *this;
 }
-#endif
 
 ResourcesManager::ResourcesManager(const ResourcesManager& other) {
   Init(other);

--- a/Core/GDCore/Project/ResourcesManager.h
+++ b/Core/GDCore/Project/ResourcesManager.h
@@ -104,7 +104,6 @@ class GD_CORE_API Resource {
    */
   virtual const gd::String& GetMetadata() const { return metadata; }
 
-#if defined(GD_IDE_ONLY)
   /** \name Resources properties
    * Reading and updating resources properties
    */
@@ -136,7 +135,6 @@ class GD_CORE_API Resource {
     return false;
   };
 ///@}
-#endif
 
   /**
    * \brief Serialize the object
@@ -186,7 +184,6 @@ class GD_CORE_API ImageResource : public Resource {
    */
   virtual void SetFile(const gd::String& newFile) override;
 
-#if defined(GD_IDE_ONLY)
   virtual bool UseFile() override { return true; }
 
   std::map<gd::String, gd::PropertyDescriptor> GetProperties() const override;
@@ -196,7 +193,6 @@ class GD_CORE_API ImageResource : public Resource {
    * \brief Serialize the object
    */
   void SerializeTo(SerializerElement& element) const override;
-#endif
 
   /**
    * \brief Unserialize the objectt.
@@ -238,14 +234,12 @@ class GD_CORE_API AudioResource : public Resource {
   virtual const gd::String& GetFile() const override { return file; };
   virtual void SetFile(const gd::String& newFile) override;
 
-#if defined(GD_IDE_ONLY)
   virtual bool UseFile() override { return true; }
 
   std::map<gd::String, gd::PropertyDescriptor> GetProperties() const override;
   bool UpdateProperty(const gd::String& name, const gd::String& value) override;
 
   void SerializeTo(SerializerElement& element) const override;
-#endif
 
   void UnserializeFrom(const SerializerElement& element) override;
 
@@ -292,10 +286,8 @@ class GD_CORE_API FontResource : public Resource {
   virtual const gd::String& GetFile() const override { return file; };
   virtual void SetFile(const gd::String& newFile) override;
 
-#if defined(GD_IDE_ONLY)
   virtual bool UseFile() override { return true; }
   void SerializeTo(SerializerElement& element) const override;
-#endif
 
   void UnserializeFrom(const SerializerElement& element) override;
 
@@ -320,10 +312,8 @@ class GD_CORE_API VideoResource : public Resource {
   virtual const gd::String& GetFile() const override { return file; };
   virtual void SetFile(const gd::String& newFile) override;
 
-#if defined(GD_IDE_ONLY)
   virtual bool UseFile() override { return true; }
   void SerializeTo(SerializerElement& element) const override;
-#endif
 
   void UnserializeFrom(const SerializerElement& element) override;
 
@@ -348,14 +338,12 @@ class GD_CORE_API JsonResource : public Resource {
   virtual const gd::String& GetFile() const override { return file; };
   virtual void SetFile(const gd::String& newFile) override;
 
-#if defined(GD_IDE_ONLY)
   virtual bool UseFile() override { return true; }
 
   std::map<gd::String, gd::PropertyDescriptor> GetProperties() const override;
   bool UpdateProperty(const gd::String& name, const gd::String& value) override;
 
   void SerializeTo(SerializerElement& element) const override;
-#endif
 
   void UnserializeFrom(const SerializerElement& element) override;
 
@@ -391,10 +379,8 @@ class GD_CORE_API BitmapFontResource : public Resource {
   virtual const gd::String& GetFile() const override { return file; };
   virtual void SetFile(const gd::String& newFile) override;
 
-#if defined(GD_IDE_ONLY)
   virtual bool UseFile() override { return true; }
   void SerializeTo(SerializerElement& element) const override;
-#endif
 
   void UnserializeFrom(const SerializerElement& element) override;
 
@@ -463,7 +449,6 @@ class GD_CORE_API ResourcesManager {
    */
   std::vector<gd::String> FindFilesNotInResources(const std::vector<gd::String>& filesToCheck) const;
 
-#if defined(GD_IDE_ONLY)
   /**
    * \brief Return a (smart) pointer to a resource.
    */
@@ -557,7 +542,6 @@ class GD_CORE_API ResourcesManager {
    * \brief Serialize the object
    */
   void SerializeTo(SerializerElement& element) const;
-#endif
 
   /**
    * \brief Unserialize the objectt.
@@ -568,18 +552,13 @@ class GD_CORE_API ResourcesManager {
   void Init(const ResourcesManager& other);
 
   std::vector<std::shared_ptr<Resource> > resources;
-#if defined(GD_IDE_ONLY)
   std::vector<ResourceFolder> folders;
-#endif
 
-#if defined(GD_IDE_ONLY)
   static ResourceFolder badFolder;
-#endif
   static Resource badResource;
   static gd::String badResourceName;
 };
 
-#if defined(GD_IDE_ONLY)
 class GD_CORE_API ResourceFolder {
  public:
   ResourceFolder(){};
@@ -654,7 +633,6 @@ class GD_CORE_API ResourceFolder {
   void Init(const ResourceFolder& other);
   static Resource badResource;
 };
-#endif
 
 }  // namespace gd
 

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2204,6 +2204,10 @@ interface EventsFunctionsExtension {
     [Const, Ref] DOMString GetIconUrl();
     [Ref] EventsFunctionsExtension SetHelpPath([Const] DOMString helpPath);
     [Const, Ref] DOMString GetHelpPath();
+    void SetOrigin([Const] DOMString originName, [Const] DOMString originIdentifier);
+    [Const, Ref] DOMString GetOriginName();
+    [Const, Ref] DOMString GetOriginIdentifier();
+
 
     [Ref] DependencyMetadata AddDependency();
     void RemoveDependencyAt(unsigned long index);

--- a/GDevelop.js/types/gdeventsfunctionsextension.js
+++ b/GDevelop.js/types/gdeventsfunctionsextension.js
@@ -23,6 +23,9 @@ declare class gdEventsFunctionsExtension extends gdEventsFunctionsContainer {
   getIconUrl(): string;
   setHelpPath(helpPath: string): gdEventsFunctionsExtension;
   getHelpPath(): string;
+  setOrigin(originName: string, originIdentifier: string): void;
+  getOriginName(): string;
+  getOriginIdentifier(): string;
   addDependency(): gdDependencyMetadata;
   removeDependencyAt(index: number): void;
   getAllDependencies(): gdVectorDependencyMetadata;

--- a/newIDE/app/src/AssetStore/ExtensionStore/InstallExtension.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/InstallExtension.js
@@ -71,7 +71,8 @@ export const importExtension = async (
     await addSerializedExtensionsToProject(
       eventsFunctionsExtensionsState,
       project,
-      [serializedExtension]
+      [serializedExtension],
+      false
     );
     return true;
   } catch (rawError) {

--- a/newIDE/app/src/AssetStore/InstallAsset.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.js
@@ -419,6 +419,11 @@ export const addSerializedExtensionsToProject = (
       'unserializeFrom',
       project
     );
+
+    if (serializedExtension.url) {
+      // extensions with url field are extensions that come from the store.
+      newEventsFunctionsExtension.setOrigin('extensions-store', serializedExtension.name)
+    }
   });
 
   return eventsFunctionsExtensionsState.loadProjectEventsFunctionsExtensions(

--- a/newIDE/app/src/AssetStore/InstallAsset.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.js
@@ -400,7 +400,8 @@ export const downloadExtensions = async (
 export const addSerializedExtensionsToProject = (
   eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
   project: gdProject,
-  serializedExtensions: Array<SerializedExtension>
+  serializedExtensions: Array<SerializedExtension>,
+  fromExtensionStore: boolean = true
 ): Promise<void> => {
   serializedExtensions.forEach(serializedExtension => {
     const { name } = serializedExtension;
@@ -420,12 +421,8 @@ export const addSerializedExtensionsToProject = (
       project
     );
 
-    if (serializedExtension.url) {
-      // extensions with url field are extensions that come from the store.
-      newEventsFunctionsExtension.setOrigin(
-        'gdevelop-extension-store',
-        serializedExtension.name
-      );
+    if (fromExtensionStore) {
+      newEventsFunctionsExtension.setOrigin('gdevelop-extension-store', name);
     }
   });
 

--- a/newIDE/app/src/AssetStore/InstallAsset.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.js
@@ -422,7 +422,10 @@ export const addSerializedExtensionsToProject = (
 
     if (serializedExtension.url) {
       // extensions with url field are extensions that come from the store.
-      newEventsFunctionsExtension.setOrigin('extensions-store', serializedExtension.name)
+      newEventsFunctionsExtension.setOrigin(
+        'extensions-store',
+        serializedExtension.name
+      );
     }
   });
 

--- a/newIDE/app/src/AssetStore/InstallAsset.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.js
@@ -423,7 +423,7 @@ export const addSerializedExtensionsToProject = (
     if (serializedExtension.url) {
       // extensions with url field are extensions that come from the store.
       newEventsFunctionsExtension.setOrigin(
-        'extensions-store',
+        'gdevelop-extension-store',
         serializedExtension.name
       );
     }

--- a/newIDE/app/src/AssetStore/InstallAsset.spec.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.spec.js
@@ -1,6 +1,7 @@
 // @flow
 import {
   addAssetToProject,
+  addSerializedExtensionsToProject,
   getRequiredBehaviorsFromAsset,
   filterMissingBehaviors,
   downloadExtensions,
@@ -19,6 +20,8 @@ import {
   fakeAssetWithFlashBehaviorCustomizations1,
   fakeAssetWithEventCustomizationsAndFlashExtension1,
   flashExtensionShortHeader,
+  flashExtensionSerializedExtension,
+  customExtensionSerializedExtension,
   fireBulletExtensionShortHeader,
   fakeAssetWithEventCustomizationsAndUnknownExtension1,
 } from '../fixtures/GDevelopServicesTestData';
@@ -482,6 +485,72 @@ describe('InstallAsset', () => {
       await expect(downloadExtensions(['FakeExtension'])).rejects.toMatchObject(
         { message: 'Fake error' }
       );
+    });
+  });
+
+  describe('addSerializedExtensionsToProject', () => {
+    const mockEventsFunctionsExtensionsState: EventsFunctionsExtensionsState = {
+      eventsFunctionsExtensionsError: null,
+      loadProjectEventsFunctionsExtensions: () => Promise.resolve(),
+      unloadProjectEventsFunctionsExtensions: () => {},
+      reloadProjectEventsFunctionsExtensions: () => Promise.resolve(),
+      unloadProjectEventsFunctionsExtension: () => {},
+      getEventsFunctionsExtensionWriter: () => null,
+      getEventsFunctionsExtensionOpener: () => null,
+      ensureLoadFinished: () => Promise.resolve(),
+      getIncludeFileHashs: () => ({}),
+    };
+
+    it('adds an extension with origin set if serialized extension has url', () => {
+      makeTestExtensions(gd);
+      const { project } = makeTestProject(gd);
+      addSerializedExtensionsToProject(
+        mockEventsFunctionsExtensionsState,
+        project,
+        [flashExtensionSerializedExtension]
+      );
+
+      expect(
+        project.hasEventsFunctionsExtensionNamed(
+          flashExtensionSerializedExtension.name
+        )
+      ).toBe(true);
+      expect(
+        project
+          .getEventsFunctionsExtension(flashExtensionSerializedExtension.name)
+          .getOriginName()
+      ).toEqual('gdevelop-extension-store');
+      expect(
+        project
+          .getEventsFunctionsExtension(flashExtensionSerializedExtension.name)
+          .getOriginIdentifier()
+      ).toEqual(flashExtensionSerializedExtension.name);
+    });
+
+    it('adds an extension with origin not set if serialized extension does not have url', () => {
+      makeTestExtensions(gd);
+      const { project } = makeTestProject(gd);
+      addSerializedExtensionsToProject(
+        mockEventsFunctionsExtensionsState,
+        project,
+        [customExtensionSerializedExtension]
+      );
+
+      expect(
+        project.hasEventsFunctionsExtensionNamed(
+          customExtensionSerializedExtension.name
+        )
+      ).toBe(true);
+      expect(
+        project
+          .getEventsFunctionsExtension(customExtensionSerializedExtension.name)
+          .getOriginName()
+      ).toEqual('');
+      expect(
+        project
+          .getEventsFunctionsExtension(customExtensionSerializedExtension.name)
+          .getOriginIdentifier()
+      ).toEqual('');
     });
   });
 

--- a/newIDE/app/src/AssetStore/InstallAsset.spec.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.spec.js
@@ -20,8 +20,6 @@ import {
   fakeAssetWithFlashBehaviorCustomizations1,
   fakeAssetWithEventCustomizationsAndFlashExtension1,
   flashExtensionShortHeader,
-  flashExtensionSerializedExtension,
-  customExtensionSerializedExtension,
   fireBulletExtensionShortHeader,
   fakeAssetWithEventCustomizationsAndUnknownExtension1,
 } from '../fixtures/GDevelopServicesTestData';
@@ -501,30 +499,30 @@ describe('InstallAsset', () => {
       getIncludeFileHashs: () => ({}),
     };
 
+    const serializedExtension = { name: 'ExtensionName' };
+
     it('adds an extension with origin set if it comes from the store', () => {
       makeTestExtensions(gd);
       const { project } = makeTestProject(gd);
       addSerializedExtensionsToProject(
         mockEventsFunctionsExtensionsState,
         project,
-        [flashExtensionSerializedExtension]
+        [serializedExtension]
       );
 
       expect(
-        project.hasEventsFunctionsExtensionNamed(
-          flashExtensionSerializedExtension.name
-        )
+        project.hasEventsFunctionsExtensionNamed(serializedExtension.name)
       ).toBe(true);
       expect(
         project
-          .getEventsFunctionsExtension(flashExtensionSerializedExtension.name)
+          .getEventsFunctionsExtension(serializedExtension.name)
           .getOriginName()
       ).toEqual('gdevelop-extension-store');
       expect(
         project
-          .getEventsFunctionsExtension(flashExtensionSerializedExtension.name)
+          .getEventsFunctionsExtension(serializedExtension.name)
           .getOriginIdentifier()
-      ).toEqual(flashExtensionSerializedExtension.name);
+      ).toEqual(serializedExtension.name);
     });
 
     it("adds an extension with origin not set if it doesn't come from the store", () => {
@@ -533,23 +531,21 @@ describe('InstallAsset', () => {
       addSerializedExtensionsToProject(
         mockEventsFunctionsExtensionsState,
         project,
-        [customExtensionSerializedExtension],
+        [serializedExtension],
         false
       );
 
       expect(
-        project.hasEventsFunctionsExtensionNamed(
-          customExtensionSerializedExtension.name
-        )
+        project.hasEventsFunctionsExtensionNamed(serializedExtension.name)
       ).toBe(true);
       expect(
         project
-          .getEventsFunctionsExtension(customExtensionSerializedExtension.name)
+          .getEventsFunctionsExtension(serializedExtension.name)
           .getOriginName()
       ).toEqual('');
       expect(
         project
-          .getEventsFunctionsExtension(customExtensionSerializedExtension.name)
+          .getEventsFunctionsExtension(serializedExtension.name)
           .getOriginIdentifier()
       ).toEqual('');
     });

--- a/newIDE/app/src/AssetStore/InstallAsset.spec.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.spec.js
@@ -501,7 +501,7 @@ describe('InstallAsset', () => {
       getIncludeFileHashs: () => ({}),
     };
 
-    it('adds an extension with origin set if serialized extension has url', () => {
+    it('adds an extension with origin set if it comes from the store', () => {
       makeTestExtensions(gd);
       const { project } = makeTestProject(gd);
       addSerializedExtensionsToProject(
@@ -527,13 +527,14 @@ describe('InstallAsset', () => {
       ).toEqual(flashExtensionSerializedExtension.name);
     });
 
-    it('adds an extension with origin not set if serialized extension does not have url', () => {
+    it("adds an extension with origin not set if it doesn't come from the store", () => {
       makeTestExtensions(gd);
       const { project } = makeTestProject(gd);
       addSerializedExtensionsToProject(
         mockEventsFunctionsExtensionsState,
         project,
-        [customExtensionSerializedExtension]
+        [customExtensionSerializedExtension],
+        false
       );
 
       expect(

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -8,7 +8,10 @@ import { User as FirebaseUser } from 'firebase/auth';
 import { type Profile } from '../Utils/GDevelopServices/Authentication';
 import { type Release } from '../Utils/GDevelopServices/Release';
 import { type Build } from '../Utils/GDevelopServices/Build';
-import { type ExtensionShortHeader } from '../Utils/GDevelopServices/Extension';
+import {
+  type ExtensionShortHeader,
+  type SerializedExtension,
+} from '../Utils/GDevelopServices/Extension';
 import { type ExampleShortHeader } from '../Utils/GDevelopServices/Example';
 import { type Game, type ShowcasedGame } from '../Utils/GDevelopServices/Game';
 import { type GameMetrics } from '../Utils/GDevelopServices/Analytics';
@@ -721,6 +724,31 @@ export const flashExtensionShortHeader: ExtensionShortHeader = {
   previewIconUrl: 'http://example.com/icon.svg',
   eventsBasedBehaviorsCount: 1,
   eventsFunctionsCount: 0,
+};
+
+export const flashExtensionSerializedExtension: SerializedExtension = {
+  ...flashExtensionShortHeader,
+  helpPath: 'Extension/helpPath.html',
+  description:
+    'Make the object flash (blink) for a period of time, so that it is alternately visible and invisible. After adding this to an object, you have to trigger the effect by using the flash action.',
+  iconUrl:
+    'https://resources.gdevelop-app.com/assets/Icons/flash-outline.svg?gdUsage=img',
+};
+
+// $FlowFixMe - SerializedExtension does not reflect what a custom extension can be (i.e. no url)
+export const customExtensionSerializedExtension: SerializedExtension = {
+  shortDescription: 'My custom extension',
+  extensionNamespace: '',
+  fullName: 'CustomExtension',
+  name: 'CustomExtension',
+  version: '1.0.0',
+  headerUrl: '',
+  tags: ['damage', 'custom'],
+  previewIconUrl: '',
+  helpPath: '',
+  authorIds: ['tVUYpNMz1AfsbzJtxUEpPTuu4Mn1'],
+  description: 'This is my custom extension, it is great.',
+  iconUrl: '',
 };
 
 export const game1: Game = {

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -726,31 +726,6 @@ export const flashExtensionShortHeader: ExtensionShortHeader = {
   eventsFunctionsCount: 0,
 };
 
-export const flashExtensionSerializedExtension: SerializedExtension = {
-  ...flashExtensionShortHeader,
-  helpPath: 'Extension/helpPath.html',
-  description:
-    'Make the object flash (blink) for a period of time, so that it is alternately visible and invisible. After adding this to an object, you have to trigger the effect by using the flash action.',
-  iconUrl:
-    'https://resources.gdevelop-app.com/assets/Icons/flash-outline.svg?gdUsage=img',
-};
-
-// $FlowFixMe - SerializedExtension does not reflect what a custom extension can be (i.e. no url)
-export const customExtensionSerializedExtension: SerializedExtension = {
-  shortDescription: 'My custom extension',
-  extensionNamespace: '',
-  fullName: 'CustomExtension',
-  name: 'CustomExtension',
-  version: '1.0.0',
-  headerUrl: '',
-  tags: ['damage', 'custom'],
-  previewIconUrl: '',
-  helpPath: '',
-  authorIds: ['tVUYpNMz1AfsbzJtxUEpPTuu4Mn1'],
-  description: 'This is my custom extension, it is great.',
-  iconUrl: '',
-};
-
 export const game1: Game = {
   id: 'fake-game1-id',
   authorName: 'My company',


### PR DESCRIPTION
Do not show in changelog.

Will allow to have a different behavior depending on the origin of the extension (`extensions-store` or else)