### PR TITLE
Discover extensions and behaviors from action or condition list

### DIFF
--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionListItem.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionListItem.js
@@ -9,11 +9,13 @@ import { IconContainer } from '../../UI/IconContainer';
 import { UserPublicProfileChip } from '../../UI/User/UserPublicProfileChip';
 
 const styles = {
+  button: { width: '100%' },
   container: {
     display: 'flex',
     textAlign: 'left',
     overflow: 'hidden',
     padding: 8,
+    width: '100%',
   },
 };
 
@@ -42,7 +44,7 @@ export const ExtensionListItem = ({
   });
 
   return (
-    <ButtonBase onClick={onChoose} focusRipple>
+    <ButtonBase onClick={onChoose} focusRipple style={styles.button}>
       <div style={styles.container} ref={containerRef}>
         <Line>
           <IconContainer

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -13,7 +13,6 @@ import DismissableInfoBar from '../../UI/Messages/DismissableInfoBar';
 import { type ExtensionShortHeader } from '../../Utils/GDevelopServices/Extension';
 import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
 import {
-  ACHIEVEMENT_FEATURE_FLAG,
   addCreateBadgePreHookIfNotClaimed,
   TRIVIAL_FIRST_EXTENSION,
 } from '../../Utils/GDevelopServices/Badge';
@@ -43,13 +42,11 @@ export default function ExtensionsSearchDialog({
   );
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
 
-  const installDisplayedExtension = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_EXTENSION,
-        installExtension
-      )
-    : installExtension;
+  const installDisplayedExtension = addCreateBadgePreHookIfNotClaimed(
+    authenticatedUser,
+    TRIVIAL_FIRST_EXTENSION,
+    installExtension
+  );
 
   const eventsFunctionsExtensionOpener = eventsFunctionsExtensionsState.getEventsFunctionsExtensionOpener();
 

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -22,7 +22,7 @@ type Props = {|
   project: gdProject,
   onClose: () => void,
   onInstallExtension: ExtensionShortHeader => void,
-  onExtensionInstalled?: ExtensionShortHeader => void,
+  onExtensionInstalled?: (extensionShortHeader?: ExtensionShortHeader) => void,
 |};
 
 /**
@@ -82,6 +82,9 @@ export default function ExtensionsSearchDialog({
                       eventsFunctionsExtensionsState,
                       project
                     );
+                    if (wasExtensionImported && onExtensionInstalled)
+                      onExtensionInstalled();
+
                     setExtensionWasInstalled(wasExtensionImported);
                     setIsInstalling(false);
                   })();

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -22,6 +22,7 @@ type Props = {|
   project: gdProject,
   onClose: () => void,
   onInstallExtension: ExtensionShortHeader => void,
+  onExtensionInstalled?: ExtensionShortHeader => void,
 |};
 
 /**
@@ -31,6 +32,7 @@ export default function ExtensionsSearchDialog({
   project,
   onClose,
   onInstallExtension,
+  onExtensionInstalled,
 }: Props) {
   const [isInstalling, setIsInstalling] = React.useState(false);
   const [extensionWasInstalled, setExtensionWasInstalled] = React.useState(
@@ -105,6 +107,8 @@ export default function ExtensionsSearchDialog({
                 eventsFunctionsExtensionsState,
                 extensionShortHeader
               );
+              if (wasExtensionInstalled && onExtensionInstalled)
+                onExtensionInstalled(extensionShortHeader);
 
               setExtensionWasInstalled(wasExtensionInstalled);
               setIsInstalling(false);

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -31,6 +31,13 @@ import EventsFunctionsExtensionsContext from '../EventsFunctionsExtensionsLoader
 import { installExtension } from '../AssetStore/ExtensionStore/InstallExtension';
 import DismissableInfoBar from '../UI/Messages/DismissableInfoBar';
 import ScrollView, { type ScrollViewInterface } from '../UI/ScrollView';
+import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
+import {
+  ACHIEVEMENT_FEATURE_FLAG,
+  addCreateBadgePreHookIfNotClaimed,
+  TRIVIAL_FIRST_BEHAVIOR,
+  TRIVIAL_FIRST_EXTENSION,
+} from '../Utils/GDevelopServices/Badge';
 
 const styles = {
   disabledItem: { opacity: 0.6 },
@@ -89,6 +96,15 @@ export default function NewBehaviorDialog({
   const eventsFunctionsExtensionsState = React.useContext(
     EventsFunctionsExtensionsContext
   );
+  const authenticatedUser = React.useContext(AuthenticatedUserContext);
+
+  const installDisplayedExtension = ACHIEVEMENT_FEATURE_FLAG
+    ? addCreateBadgePreHookIfNotClaimed(
+        authenticatedUser,
+        TRIVIAL_FIRST_EXTENSION,
+        installExtension
+      )
+    : installExtension;
 
   const platform = project.getCurrentPlatform();
   const behaviorMetadata: Array<EnumeratedBehaviorMetadata> = React.useMemo(
@@ -126,7 +142,7 @@ export default function NewBehaviorDialog({
     ({ type }) => !!deprecatedBehaviorsInformation[type]
   );
 
-  const chooseBehavior = (
+  const _chooseBehavior = (
     i18n: I18nType,
     { type, defaultName }: EnumeratedBehaviorMetadata
   ) => {
@@ -136,6 +152,13 @@ export default function NewBehaviorDialog({
 
     return onChoose(type, defaultName);
   };
+  const chooseBehavior = ACHIEVEMENT_FEATURE_FLAG
+    ? addCreateBadgePreHookIfNotClaimed(
+        authenticatedUser,
+        TRIVIAL_FIRST_BEHAVIOR,
+        _chooseBehavior
+      )
+    : _chooseBehavior;
 
   const canBehaviorBeUsed = (behaviorMetadata: EnumeratedBehaviorMetadata) => {
     // An empty object type means the base object, i.e: any object.
@@ -263,12 +286,12 @@ export default function NewBehaviorDialog({
               </React.Fragment>
             )}
             {currentTab === 'search' && (
-              <ExtensionStore // TODO
+              <ExtensionStore
                 project={project}
                 isInstalling={isInstalling}
                 onInstall={async extensionShortHeader => {
                   setIsInstalling(true);
-                  const wasExtensionInstalled = await installExtension(
+                  const wasExtensionInstalled = await installDisplayedExtension(
                     i18n,
                     project,
                     eventsFunctionsExtensionsState,

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -33,7 +33,6 @@ import DismissableInfoBar from '../UI/Messages/DismissableInfoBar';
 import ScrollView, { type ScrollViewInterface } from '../UI/ScrollView';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import {
-  ACHIEVEMENT_FEATURE_FLAG,
   addCreateBadgePreHookIfNotClaimed,
   TRIVIAL_FIRST_BEHAVIOR,
   TRIVIAL_FIRST_EXTENSION,
@@ -106,13 +105,11 @@ export default function NewBehaviorDialog({
   );
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
 
-  const installDisplayedExtension = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_EXTENSION,
-        installExtension
-      )
-    : installExtension;
+  const installDisplayedExtension = addCreateBadgePreHookIfNotClaimed(
+    authenticatedUser,
+    TRIVIAL_FIRST_EXTENSION,
+    installExtension
+  );
 
   const platform = project.getCurrentPlatform();
   const behaviorMetadata: Array<EnumeratedBehaviorMetadata> = React.useMemo(
@@ -160,13 +157,11 @@ export default function NewBehaviorDialog({
 
     return onChoose(type, defaultName);
   };
-  const chooseBehavior = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_BEHAVIOR,
-        _chooseBehavior
-      )
-    : _chooseBehavior;
+  const chooseBehavior = addCreateBadgePreHookIfNotClaimed(
+    authenticatedUser,
+    TRIVIAL_FIRST_BEHAVIOR,
+    _chooseBehavior
+  );
 
   const isAmongObjectBehaviors = (
     behaviorMetadata: EnumeratedBehaviorMetadata

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -161,7 +161,9 @@ export default function NewBehaviorDialog({
               onClick={onClose}
             />,
           ]}
-          secondaryActions={[<HelpButton helpPagePath="/behaviors" key="help" />]}
+          secondaryActions={[
+            <HelpButton helpPagePath="/behaviors" key="help" />,
+          ]}
           open
           cannotBeDismissed={false}
           flexBody

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 
@@ -44,11 +44,15 @@ const styles = {
 };
 
 const BehaviorListItem = ({
+  i18n,
   behaviorMetadata,
+  alreadyInstalled,
   onClick,
   disabled,
 }: {|
+  i18n: I18nType,
   behaviorMetadata: EnumeratedBehaviorMetadata,
+  alreadyInstalled: boolean,
   onClick: () => void,
   disabled: boolean,
 |}) => (
@@ -61,7 +65,9 @@ const BehaviorListItem = ({
       />
     }
     key={behaviorMetadata.type}
-    primaryText={behaviorMetadata.fullName}
+    primaryText={`${behaviorMetadata.fullName} ${
+      alreadyInstalled ? i18n._(t`(already added to this object)`) : ''
+    }`}
     secondaryText={behaviorMetadata.description}
     secondaryTextLines={2}
     onClick={onClick}
@@ -73,6 +79,7 @@ const BehaviorListItem = ({
 type Props = {|
   project: gdProject,
   objectType: string,
+  objectBehaviorsTypes: Array<string>,
   open: boolean,
   onClose: () => void,
   onChoose: (type: string, defaultName: string) => void,
@@ -84,6 +91,7 @@ export default function NewBehaviorDialog({
   onClose,
   onChoose,
   objectType,
+  objectBehaviorsTypes,
 }: Props) {
   const [showDeprecated, setShowDeprecated] = React.useState(false);
   const [searchText, setSearchText] = React.useState('');
@@ -160,11 +168,16 @@ export default function NewBehaviorDialog({
       )
     : _chooseBehavior;
 
+  const isAmongObjectBehaviors = (
+    behaviorMetadata: EnumeratedBehaviorMetadata
+  ) => objectBehaviorsTypes.includes(behaviorMetadata.type);
+
   const canBehaviorBeUsed = (behaviorMetadata: EnumeratedBehaviorMetadata) => {
     // An empty object type means the base object, i.e: any object.
     return (
-      behaviorMetadata.objectType === '' ||
-      behaviorMetadata.objectType === objectType
+      (behaviorMetadata.objectType === '' ||
+        behaviorMetadata.objectType === objectType) &&
+      !isAmongObjectBehaviors(behaviorMetadata)
     );
   };
 
@@ -226,8 +239,12 @@ export default function NewBehaviorDialog({
                   <List>
                     {behaviors.map((behaviorMetadata, index) => (
                       <BehaviorListItem
+                        i18n={i18n}
                         key={index}
                         behaviorMetadata={behaviorMetadata}
+                        alreadyInstalled={isAmongObjectBehaviors(
+                          behaviorMetadata
+                        )}
                         onClick={() => chooseBehavior(i18n, behaviorMetadata)}
                         disabled={!canBehaviorBeUsed(behaviorMetadata)}
                       />
@@ -240,8 +257,12 @@ export default function NewBehaviorDialog({
                     {showDeprecated &&
                       deprecatedBehaviors.map((behaviorMetadata, index) => (
                         <BehaviorListItem
+                          i18n={i18n}
                           key={index}
                           behaviorMetadata={behaviorMetadata}
+                          alreadyInstalled={isAmongObjectBehaviors(
+                            behaviorMetadata
+                          )}
                           onClick={() => chooseBehavior(i18n, behaviorMetadata)}
                           disabled={!canBehaviorBeUsed(behaviorMetadata)}
                         />

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -161,7 +161,7 @@ export default function NewBehaviorDialog({
               onClick={onClose}
             />,
           ]}
-          secondaryActions={[<HelpButton helpPagePath="/behaviors" />]}
+          secondaryActions={[<HelpButton helpPagePath="/behaviors" key="help" />]}
           open
           cannotBeDismissed={false}
           flexBody

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -28,7 +28,10 @@ import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import ScrollView from '../UI/ScrollView';
 import { IconContainer } from '../UI/IconContainer';
 import { getBehaviorTutorialIds } from '../Utils/GDevelopServices/Tutorial';
-import { addBehaviorToObject } from '../Utils/Behavior';
+import {
+  addBehaviorToObject,
+  listObjectBehaviorsTypes,
+} from '../Utils/Behavior';
 
 const gd: libGDevelop = global.gd;
 
@@ -256,6 +259,7 @@ const BehaviorsEditor = (props: Props) => {
         <NewBehaviorDialog
           open={newBehaviorDialogOpen}
           objectType={object.getType()}
+          objectBehaviorsTypes={listObjectBehaviorsTypes(object)}
           onClose={() => setNewBehaviorDialogOpen(false)}
           onChoose={addBehavior}
           project={project}

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -9,7 +9,6 @@ import IconButton from '../UI/IconButton';
 import EmptyMessage from '../UI/EmptyMessage';
 import { MiniToolbarText } from '../UI/MiniToolbar';
 import HelpIcon from '../UI/HelpIcon';
-import newNameGenerator from '../Utils/NewNameGenerator';
 import NewBehaviorDialog from './NewBehaviorDialog';
 import BehaviorsEditorService from './BehaviorsEditorService';
 import Window from '../Utils/Window';
@@ -35,6 +34,7 @@ import {
 } from '../Utils/GDevelopServices/Badge';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import { getBehaviorTutorialIds } from '../Utils/GDevelopServices/Tutorial';
+import { addBehaviorToObject } from '../Utils/Behavior';
 
 const gd: libGDevelop = global.gd;
 
@@ -60,33 +60,10 @@ const BehaviorsEditor = (props: Props) => {
 
   const { values } = React.useContext(PreferencesContext);
 
-  const hasBehaviorWithType = (type: string) => {
-    return allBehaviorNames
-      .map(behaviorName => object.getBehavior(behaviorName))
-      .map(behavior => behavior.getTypeName())
-      .filter(behaviorType => behaviorType === type).length;
-  };
-
   const _addBehavior = (type: string, defaultName: string) => {
     setNewBehaviorDialogOpen(false);
 
-    if (hasBehaviorWithType(type)) {
-      const answer = Window.showConfirmDialog(
-        "There is already a behavior of this type attached to the object. It's possible to add this behavior again, but it's unusual and may not be always supported properly. Are you sure you want to add this behavior again?"
-      );
-
-      if (!answer) return;
-    }
-
-    const name = newNameGenerator(defaultName, name =>
-      object.hasBehaviorNamed(name)
-    );
-    gd.WholeProjectRefactorer.addBehaviorAndRequiredBehaviors(
-      project,
-      object,
-      type,
-      name
-    );
+    addBehaviorToObject(project, object, type, defaultName);
 
     forceUpdate();
     if (props.onSizeUpdated) props.onSizeUpdated();

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -27,12 +27,6 @@ import EmptyBehaviorsPlaceholder from './EmptyBehaviorsPlaceholder';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import ScrollView from '../UI/ScrollView';
 import { IconContainer } from '../UI/IconContainer';
-import {
-  ACHIEVEMENT_FEATURE_FLAG,
-  addCreateBadgePreHookIfNotClaimed,
-  TRIVIAL_FIRST_BEHAVIOR,
-} from '../Utils/GDevelopServices/Badge';
-import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import { getBehaviorTutorialIds } from '../Utils/GDevelopServices/Tutorial';
 import { addBehaviorToObject } from '../Utils/Behavior';
 
@@ -52,7 +46,6 @@ const BehaviorsEditor = (props: Props) => {
   const [newBehaviorDialogOpen, setNewBehaviorDialogOpen] = React.useState(
     false
   );
-  const authenticatedUser = React.useContext(AuthenticatedUserContext);
 
   const { object, project } = props;
   const allBehaviorNames = object.getAllBehaviorNames().toJSArray();
@@ -60,7 +53,7 @@ const BehaviorsEditor = (props: Props) => {
 
   const { values } = React.useContext(PreferencesContext);
 
-  const _addBehavior = (type: string, defaultName: string) => {
+  const addBehavior = (type: string, defaultName: string) => {
     setNewBehaviorDialogOpen(false);
 
     addBehaviorToObject(project, object, type, defaultName);
@@ -69,14 +62,6 @@ const BehaviorsEditor = (props: Props) => {
     if (props.onSizeUpdated) props.onSizeUpdated();
     props.onUpdateBehaviorsSharedData();
   };
-
-  const addBehavior = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_BEHAVIOR,
-        _addBehavior
-      )
-    : _addBehavior;
 
   const onChangeBehaviorName = (
     behaviorContent: gdBehaviorContent,

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -57,9 +57,14 @@ const BehaviorsEditor = (props: Props) => {
   const { values } = React.useContext(PreferencesContext);
 
   const addBehavior = (type: string, defaultName: string) => {
-    setNewBehaviorDialogOpen(false);
+    const wasBehaviorAdded = addBehaviorToObject(
+      project,
+      object,
+      type,
+      defaultName
+    );
 
-    addBehaviorToObject(project, object, type, defaultName);
+    if (wasBehaviorAdded) setNewBehaviorDialogOpen(false);
 
     forceUpdate();
     if (props.onSizeUpdated) props.onSizeUpdated();

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -35,7 +35,6 @@ import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEd
 import ScrollView from '../UI/ScrollView';
 import { EmptyEffectsPlaceholder } from './EmptyEffectsPlaceholder';
 import {
-  ACHIEVEMENT_FEATURE_FLAG,
   addCreateBadgePreHookIfNotClaimed,
   TRIVIAL_FIRST_EFFECT,
 } from '../Utils/GDevelopServices/Badge';
@@ -93,13 +92,11 @@ export default function EffectsList(props: Props) {
     onEffectsUpdated();
   };
 
-  const addEffect = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_EFFECT,
-        _addEffect
-      )
-    : _addEffect;
+  const addEffect = addCreateBadgePreHookIfNotClaimed(
+    authenticatedUser,
+    TRIVIAL_FIRST_EFFECT,
+    _addEffect
+  );
 
   const removeEffect = (name: string) => {
     effectsContainer.removeEffect(name);

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
@@ -139,7 +139,10 @@ export default class EventsFunctionExtractorDialog extends React.Component<
         onApply={onApply}
         title={<Trans>Extract the events in a function</Trans>}
         secondaryActions={[
-          <HelpButton helpPagePath="/events/functions/extract-events" key="help" />,
+          <HelpButton
+            helpPagePath="/events/functions/extract-events"
+            key="help"
+          />,
         ]}
         actions={[
           <FlatButton

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
@@ -139,7 +139,7 @@ export default class EventsFunctionExtractorDialog extends React.Component<
         onApply={onApply}
         title={<Trans>Extract the events in a function</Trans>}
         secondaryActions={[
-          <HelpButton helpPagePath="/events/functions/extract-events" />,
+          <HelpButton helpPagePath="/events/functions/extract-events" key="help" />,
         ]}
         actions={[
           <FlatButton

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -2,6 +2,7 @@
 import { Trans } from '@lingui/macro';
 import { t } from '@lingui/macro';
 import * as React from 'react';
+import Add from '@material-ui/icons/Add';
 import { List, type ListItemRefType } from '../../../UI/List';
 import SearchBar, { useShouldAutofocusSearchbar } from '../../../UI/SearchBar';
 import { type EnumeratedInstructionOrExpressionMetadata } from '../../../InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js';
@@ -16,6 +17,7 @@ import { renderInstructionOrExpressionTree } from '../SelectorListItems/Selector
 import EmptyMessage from '../../../UI/EmptyMessage';
 import ScrollView, { type ScrollViewInterface } from '../../../UI/ScrollView';
 import { Line } from '../../../UI/Grid';
+import RaisedButton from '../../../UI/RaisedButton';
 import { getInstructionListItemValue } from '../SelectorListItems/Keys';
 
 const styles = {
@@ -137,23 +139,25 @@ export default class InstructionOrExpressionSelector<
             >
               {hasResults && (
                 <List>
-                  {searchText
-                    ? displayedInstructionsList.map(
-                        enumeratedInstructionOrExpressionMetadata =>
-                          renderInstructionOrExpressionListItem({
-                            instructionOrExpressionMetadata: enumeratedInstructionOrExpressionMetadata,
-                            iconSize: iconSize,
-                            onClick: () =>
-                              onChoose(
-                                enumeratedInstructionOrExpressionMetadata.type,
-                                enumeratedInstructionOrExpressionMetadata
-                              ),
-                            selectedValue: getInstructionListItemValue(
-                              selectedType
+                  {searchText ? (
+                    displayedInstructionsList.map(
+                      enumeratedInstructionOrExpressionMetadata =>
+                        renderInstructionOrExpressionListItem({
+                          instructionOrExpressionMetadata: enumeratedInstructionOrExpressionMetadata,
+                          iconSize: iconSize,
+                          onClick: () =>
+                            onChoose(
+                              enumeratedInstructionOrExpressionMetadata.type,
+                              enumeratedInstructionOrExpressionMetadata
                             ),
-                          })
-                      )
-                    : renderInstructionOrExpressionTree({
+                          selectedValue: getInstructionListItemValue(
+                            selectedType
+                          ),
+                        })
+                    )
+                  ) : (
+                    <>
+                      {renderInstructionOrExpressionTree({
                         instructionTreeNode: instructionsInfoTree,
                         iconSize,
                         onChoose,
@@ -164,6 +168,18 @@ export default class InstructionOrExpressionSelector<
                         initiallyOpenedPath: this.initialInstructionTypePath,
                         selectedItemRef: this._selectedItem,
                       })}
+                      <Line justifyContent="center">
+                        <RaisedButton
+                          primary
+                          icon={<Add />}
+                          onClick={() => {
+                            console.log('onClickMoreBehaviors');
+                          }}
+                          label={<Trans>Add new behavior</Trans>}
+                        />
+                      </Line>
+                    </>
+                  )}
                 </List>
               )}
               {!hasResults && (

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -176,7 +176,7 @@ export default class InstructionOrExpressionSelector<
                             primary
                             icon={<Add />}
                             onClick={onClickMore}
-                            label={<Trans>Add new behavior</Trans>}
+                            label={<Trans>Add a new behavior to the object</Trans>}
                           />
                         </Line>
                       )}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -40,6 +40,7 @@ type Props<T> = {|
   searchPlaceholderIsCondition?: ?boolean,
   helpPagePath?: ?string,
   style?: Object,
+  onClickMore: () => void,
 |};
 type State<T> = {|
   searchText: string,
@@ -90,6 +91,7 @@ export default class InstructionOrExpressionSelector<
       useSubheaders,
       helpPagePath,
       style,
+      onClickMore,
     } = this.props;
     const { searchText } = this.state;
     const displayedInstructionsList: Array<T> = searchText
@@ -172,9 +174,7 @@ export default class InstructionOrExpressionSelector<
                         <RaisedButton
                           primary
                           icon={<Add />}
-                          onClick={() => {
-                            console.log('onClickMoreBehaviors');
-                          }}
+                          onClick={onClickMore}
                           label={<Trans>Add new behavior</Trans>}
                         />
                       </Line>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -19,6 +19,7 @@ import ScrollView, { type ScrollViewInterface } from '../../../UI/ScrollView';
 import { Line } from '../../../UI/Grid';
 import RaisedButton from '../../../UI/RaisedButton';
 import { getInstructionListItemValue } from '../SelectorListItems/Keys';
+import { ResponsiveLineStackLayout } from '../../../UI/Layout';
 
 const styles = {
   searchBar: {
@@ -171,14 +172,14 @@ export default class InstructionOrExpressionSelector<
                         selectedItemRef: this._selectedItem,
                       })}
                       {onClickMore && (
-                        <Line justifyContent="center">
+                        <ResponsiveLineStackLayout justifyContent="center">
                           <RaisedButton
                             primary
                             icon={<Add />}
                             onClick={onClickMore}
                             label={<Trans>Add a new behavior to the object</Trans>}
                           />
-                        </Line>
+                        </ResponsiveLineStackLayout>
                       )}
                     </>
                   )}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -40,7 +40,7 @@ type Props<T> = {|
   searchPlaceholderIsCondition?: ?boolean,
   helpPagePath?: ?string,
   style?: Object,
-  onClickMore: () => void,
+  onClickMore?: () => void,
 |};
 type State<T> = {|
   searchText: string,
@@ -170,14 +170,16 @@ export default class InstructionOrExpressionSelector<
                         initiallyOpenedPath: this.initialInstructionTypePath,
                         selectedItemRef: this._selectedItem,
                       })}
-                      <Line justifyContent="center">
-                        <RaisedButton
-                          primary
-                          icon={<Add />}
-                          onClick={onClickMore}
-                          label={<Trans>Add new behavior</Trans>}
-                        />
-                      </Line>
+                      {onClickMore && (
+                        <Line justifyContent="center">
+                          <RaisedButton
+                            primary
+                            icon={<Add />}
+                            onClick={onClickMore}
+                            label={<Trans>Add new behavior</Trans>}
+                          />
+                        </Line>
+                      )}
                     </>
                   )}
                 </List>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -177,7 +177,9 @@ export default class InstructionOrExpressionSelector<
                             primary
                             icon={<Add />}
                             onClick={onClickMore}
-                            label={<Trans>Add a new behavior to the object</Trans>}
+                            label={
+                              <Trans>Add a new behavior to the object</Trans>
+                            }
                           />
                         </ResponsiveLineStackLayout>
                       )}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -108,6 +108,15 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
     this.props.chosenInstructionType
   );
 
+  update = () => {
+    this.freeInstructionsInfo = filterEnumeratedInstructionOrExpressionMetadataByScope(
+      enumerateFreeInstructions(this.props.isCondition),
+      this.props.scope
+    );
+    this.freeInstructionsInfoTree = createTree(this.freeInstructionsInfo);
+    this.forceUpdate();
+  };
+
   // All the instructions, to be used when searching, so that the search is done
   // across all the instructions (including object and behaviors instructions).
   allInstructionsInfo: Array<EnumeratedInstructionMetadata> = filterEnumeratedInstructionOrExpressionMetadataByScope(

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -81,6 +81,7 @@ type Props = {|
   onChooseObject: (objectName: string) => void,
   onSearchStartOrReset?: () => void,
   style?: Object,
+  onClickMore: () => void,
 |};
 
 const iconSize = 24;
@@ -168,6 +169,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
       currentTab,
       onChangeTab,
       onSearchStartOrReset,
+      onClickMore,
     } = this.props;
     const { searchText, selectedObjectTags } = this.state;
 
@@ -378,7 +380,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                             <RaisedButton
                               primary
                               icon={<Add />}
-                              onClick={() => console.log('onClickMore')}
+                              onClick={onClickMore}
                               label={<Trans>Search new extensions</Trans>}
                             />
                           </Line>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -108,7 +108,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
     this.props.chosenInstructionType
   );
 
-  update = () => {
+  reEnumerateInstructions = () => {
     this.freeInstructionsInfo = filterEnumeratedInstructionOrExpressionMetadataByScope(
       enumerateFreeInstructions(this.props.isCondition),
       this.props.scope

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -81,7 +81,7 @@ type Props = {|
   onChooseObject: (objectName: string) => void,
   onSearchStartOrReset?: () => void,
   style?: Object,
-  onClickMore: () => void,
+  onClickMore?: () => void,
 |};
 
 const iconSize = 24;
@@ -385,14 +385,16 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                               .initialInstructionTypePath,
                             selectedItemRef: this._selectedItem,
                           })}
-                          <Line justifyContent="center">
-                            <RaisedButton
-                              primary
-                              icon={<Add />}
-                              onClick={onClickMore}
-                              label={<Trans>Search new extensions</Trans>}
-                            />
-                          </Line>
+                          {onClickMore && (
+                            <Line justifyContent="center">
+                              <RaisedButton
+                                primary
+                                icon={<Add />}
+                                onClick={onClickMore}
+                                label={<Trans>Search new extensions</Trans>}
+                              />
+                            </Line>
+                          )}
                         </>
                       )}
                       {remainingResultsCount > 0 && (

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -391,7 +391,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                                 primary
                                 icon={<Add />}
                                 onClick={onClickMore}
-                                label={<Trans>Search new extensions</Trans>}
+                                label={<Trans>Add a new extension to the project</Trans>}
                               />
                             </Line>
                           )}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -5,6 +5,7 @@ import { type I18n as I18nType } from '@lingui/core';
 import { t } from '@lingui/macro';
 
 import * as React from 'react';
+import Add from '@material-ui/icons/Add';
 import {
   createTree,
   type InstructionOrExpressionTreeNode,
@@ -33,6 +34,8 @@ import {
   enumerateObjects,
 } from '../../ObjectsList/EnumerateObjects';
 import TagChips from '../../UI/TagChips';
+import RaisedButton from '../../UI/RaisedButton';
+import { Line } from '../../UI/Grid';
 import { renderGroupObjectsListItem } from './SelectorListItems/SelectorGroupObjectsListItem';
 import { renderObjectListItem } from './SelectorListItems/SelectorObjectListItem';
 import { renderInstructionOrExpressionListItem } from './SelectorListItems/SelectorInstructionOrExpressionListItem';
@@ -356,18 +359,31 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                               : undefined,
                           })
                         )}
-                      {!isSearching &&
-                        currentTab === 'free-instructions' &&
-                        renderInstructionOrExpressionTree({
-                          instructionTreeNode: this.freeInstructionsInfoTree,
-                          onChoose: onChooseInstruction,
-                          iconSize,
-                          selectedValue: chosenInstructionType
-                            ? getInstructionListItemValue(chosenInstructionType)
-                            : undefined,
-                          initiallyOpenedPath: this.initialInstructionTypePath,
-                          selectedItemRef: this._selectedItem,
-                        })}
+                      {!isSearching && currentTab === 'free-instructions' && (
+                        <>
+                          {renderInstructionOrExpressionTree({
+                            instructionTreeNode: this.freeInstructionsInfoTree,
+                            onChoose: onChooseInstruction,
+                            iconSize,
+                            selectedValue: chosenInstructionType
+                              ? getInstructionListItemValue(
+                                  chosenInstructionType
+                                )
+                              : undefined,
+                            initiallyOpenedPath: this
+                              .initialInstructionTypePath,
+                            selectedItemRef: this._selectedItem,
+                          })}
+                          <Line justifyContent="center">
+                            <RaisedButton
+                              primary
+                              icon={<Add />}
+                              onClick={() => console.log('onClickMore')}
+                              label={<Trans>Search new extensions</Trans>}
+                            />
+                          </Line>
+                        </>
+                      )}
                       {remainingResultsCount > 0 && (
                         <ListItem
                           primaryText={

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -35,7 +35,7 @@ import {
 } from '../../ObjectsList/EnumerateObjects';
 import TagChips from '../../UI/TagChips';
 import RaisedButton from '../../UI/RaisedButton';
-import { Line } from '../../UI/Grid';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 import { renderGroupObjectsListItem } from './SelectorListItems/SelectorGroupObjectsListItem';
 import { renderObjectListItem } from './SelectorListItems/SelectorObjectListItem';
 import { renderInstructionOrExpressionListItem } from './SelectorListItems/SelectorInstructionOrExpressionListItem';
@@ -386,14 +386,24 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                             selectedItemRef: this._selectedItem,
                           })}
                           {onClickMore && (
-                            <Line justifyContent="center">
+                            <ResponsiveLineStackLayout justifyContent="center">
                               <RaisedButton
                                 primary
                                 icon={<Add />}
                                 onClick={onClickMore}
-                                label={<Trans>Add a new extension to the project</Trans>}
+                                label={
+                                  isCondition ? (
+                                    <Trans>
+                                      Search for new conditions in extensions
+                                    </Trans>
+                                  ) : (
+                                    <Trans>
+                                      Search for new actions in extensions
+                                    </Trans>
+                                  )
+                                }
                               />
-                            </Line>
+                            </ResponsiveLineStackLayout>
                           )}
                         </>
                       )}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -28,12 +28,6 @@ import {
 import NewBehaviorDialog from '../../BehaviorsEditor/NewBehaviorDialog';
 import useForceUpdate from '../../Utils/UseForceUpdate';
 import getObjectByName from '../../Utils/GetObjectByName';
-import {
-  ACHIEVEMENT_FEATURE_FLAG,
-  addCreateBadgePreHookIfNotClaimed,
-  TRIVIAL_FIRST_BEHAVIOR,
-} from '../../Utils/GDevelopServices/Badge';
-import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
 import { addBehaviorToObject } from '../../Utils/Behavior';
 import ExtensionsSearchDialog from '../../AssetStore/ExtensionStore/ExtensionsSearchDialog';
 
@@ -155,7 +149,6 @@ export default function NewInstructionEditorDialog({
     newExtensionDialogOpen,
     setNewExtensionDialogOpen,
   ] = React.useState<boolean>(false);
-  const authenticatedUser = React.useContext(AuthenticatedUserContext);
 
   // Handle the back button
   const stepBackFrom = (origin: StepName, windowWidth: WidthType) => {
@@ -171,7 +164,7 @@ export default function NewInstructionEditorDialog({
     }
   };
 
-  const _addBehavior = (type: string, defaultName: string) => {
+  const addBehavior = (type: string, defaultName: string) => {
     if (!chosenObject) return;
     setNewBehaviorDialogOpen(false);
 
@@ -180,14 +173,6 @@ export default function NewInstructionEditorDialog({
     // Re-choose the same object to force recomputation of chosenObjectInstructionsInfoTree
     chooseObject(chosenObject.getName());
   };
-
-  const addBehavior = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_BEHAVIOR,
-        _addBehavior
-      )
-    : _addBehavior;
 
   const onAddExtension = () => {
     setNewExtensionDialogOpen(false);

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -28,7 +28,10 @@ import {
 import NewBehaviorDialog from '../../BehaviorsEditor/NewBehaviorDialog';
 import useForceUpdate from '../../Utils/UseForceUpdate';
 import getObjectByName from '../../Utils/GetObjectByName';
-import { addBehaviorToObject } from '../../Utils/Behavior';
+import {
+  addBehaviorToObject,
+  listObjectBehaviorsTypes,
+} from '../../Utils/Behavior';
 import ExtensionsSearchDialog from '../../AssetStore/ExtensionStore/ExtensionsSearchDialog';
 
 const styles = {
@@ -372,6 +375,7 @@ export default function NewInstructionEditorDialog({
           project={project}
           open={newBehaviorDialogOpen}
           objectType={chosenObject.getType()}
+          objectBehaviorsTypes={listObjectBehaviorsTypes(chosenObject)}
           onClose={() => setNewBehaviorDialogOpen(false)}
           onChoose={addBehavior}
         />

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -178,7 +178,10 @@ export default function NewInstructionEditorDialog({
     );
 
     if (wasBehaviorAdded) setNewBehaviorDialogOpen(false);
+
     // Re-choose the same object to force recomputation of chosenObjectInstructionsInfoTree
+    // This is not done automatically because a change in the object behaviors
+    // is not detected by React at this level.
     chooseObject(chosenObject.getName());
   };
 

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -35,6 +35,7 @@ import {
 } from '../../Utils/GDevelopServices/Badge';
 import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
 import { addBehaviorToObject } from '../../Utils/Behavior';
+import ExtensionsSearchDialog from '../../AssetStore/ExtensionStore/ExtensionsSearchDialog';
 
 const styles = {
   fullHeightSelector: {
@@ -147,6 +148,10 @@ export default function NewInstructionEditorDialog({
     newBehaviorDialogOpen,
     setNewBehaviorDialogOpen,
   ] = React.useState<boolean>(false);
+  const [
+    newExtensionDialogOpen,
+    setNewExtensionDialogOpen,
+  ] = React.useState<boolean>(false);
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
 
   // Handle the back button
@@ -170,7 +175,7 @@ export default function NewInstructionEditorDialog({
     addBehaviorToObject(project, chosenObject, type, defaultName);
 
     // Re-choose the same object to force recomputation of chosenObjectInstructionsInfoTree
-    chooseObject(chosenObject.getName())
+    chooseObject(chosenObject.getName());
   };
 
   const addBehavior = ACHIEVEMENT_FEATURE_FLAG
@@ -180,6 +185,10 @@ export default function NewInstructionEditorDialog({
         _addBehavior
       )
     : _addBehavior;
+
+  const onAddExtension = () => {
+    setNewExtensionDialogOpen(false);
+  };
 
   // Focus the parameters when showing them
   const instructionParametersEditor = React.useRef(
@@ -228,6 +237,7 @@ export default function NewInstructionEditorDialog({
       }}
       focusOnMount={!instructionType}
       onSearchStartOrReset={forceUpdate}
+      onClickMore={() => setNewExtensionDialogOpen(true)}
     />
   );
 
@@ -373,6 +383,14 @@ export default function NewInstructionEditorDialog({
           objectType={chosenObject.getType()}
           onClose={() => setNewBehaviorDialogOpen(false)}
           onChoose={addBehavior}
+        />
+      )}
+      {newExtensionDialogOpen && (
+        <ExtensionsSearchDialog
+          project={project}
+          onClose={() => setNewExtensionDialogOpen(false)}
+          onInstallExtension={() => {}}
+          onExtensionInstalled={onAddExtension}
         />
       )}
     </>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -25,7 +25,16 @@ import {
   useNewInstructionEditor,
   getInstructionMetadata,
 } from './NewInstructionEditor';
+import NewBehaviorDialog from '../../BehaviorsEditor/NewBehaviorDialog';
 import useForceUpdate from '../../Utils/UseForceUpdate';
+import getObjectByName from '../../Utils/GetObjectByName';
+import {
+  ACHIEVEMENT_FEATURE_FLAG,
+  addCreateBadgePreHookIfNotClaimed,
+  TRIVIAL_FIRST_BEHAVIOR,
+} from '../../Utils/GDevelopServices/Badge';
+import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
+import { addBehaviorToObject } from '../../Utils/Behavior';
 
 const styles = {
   fullHeightSelector: {
@@ -122,6 +131,9 @@ export default function NewInstructionEditorDialog({
   } = newInstructionEditorSetters;
   const hasObjectChosen =
     !!chosenObjectInstructionsInfo && !!chosenObjectInstructionsInfoTree;
+  const chosenObject = chosenObjectName
+    ? getObjectByName(project, scope.layout, chosenObjectName)
+    : null;
   const [step, setStep] = React.useState(() =>
     getInitialStepName(isNewInstruction)
   );
@@ -131,6 +143,11 @@ export default function NewInstructionEditorDialog({
   ] = React.useState(() => getInitialTab(isNewInstruction, hasObjectChosen));
   const windowWidth = useResponsiveWindowWidth();
   const instructionType: string = instruction.getType();
+  const [
+    newBehaviorDialogOpen,
+    setNewBehaviorDialogOpen,
+  ] = React.useState<boolean>(false);
+  const authenticatedUser = React.useContext(AuthenticatedUserContext);
 
   // Handle the back button
   const stepBackFrom = (origin: StepName, windowWidth: WidthType) => {
@@ -145,6 +162,24 @@ export default function NewInstructionEditorDialog({
       setStep('object-or-free-instructions');
     }
   };
+
+  const _addBehavior = (type: string, defaultName: string) => {
+    if (!chosenObject) return;
+    setNewBehaviorDialogOpen(false);
+
+    addBehaviorToObject(project, chosenObject, type, defaultName);
+
+    // Re-choose the same object to force recomputation of chosenObjectInstructionsInfoTree
+    chooseObject(chosenObject.getName())
+  };
+
+  const addBehavior = ACHIEVEMENT_FEATURE_FLAG
+    ? addCreateBadgePreHookIfNotClaimed(
+        authenticatedUser,
+        TRIVIAL_FIRST_BEHAVIOR,
+        _addBehavior
+      )
+    : _addBehavior;
 
   // Focus the parameters when showing them
   const instructionParametersEditor = React.useRef(
@@ -233,101 +268,113 @@ export default function NewInstructionEditorDialog({
         focusOnMount={!instructionType}
         searchPlaceholderObjectName={chosenObjectName}
         searchPlaceholderIsCondition={isCondition}
+        onClickMore={() => setNewBehaviorDialogOpen(true)}
       />
     ) : null;
 
   return (
-    <Dialog
-      onApply={instructionType ? onSubmit : null}
-      actions={[
-        <FlatButton
-          label={<Trans>Cancel</Trans>}
-          primary={false}
-          onClick={onCancel}
-          key="cancel"
-        />,
-        <FlatButton
-          label={<Trans>Ok</Trans>}
-          primary={true}
-          keyboardFocused={false}
-          disabled={!instructionType}
-          onClick={onSubmit}
-          key="ok"
-        />,
-      ]}
-      secondaryActions={[
-        windowWidth !== 'large' && step !== 'object-or-free-instructions' ? (
+    <>
+      <Dialog
+        onApply={instructionType ? onSubmit : null}
+        actions={[
           <FlatButton
-            label={<Trans>Back</Trans>}
+            label={<Trans>Cancel</Trans>}
             primary={false}
-            onClick={() => stepBackFrom(step, windowWidth)}
-            key="back"
-          />
-        ) : null,
-        <HelpButton
-          key="help"
-          helpPagePath={instructionHelpPage || '/events'}
-          label={
-            !instructionHelpPage ||
-            (windowWidth === 'small' ||
-              step === 'object-or-free-instructions') ? (
-              <Trans>Help</Trans>
-            ) : isCondition ? (
-              <Trans>Help for this condition</Trans>
-            ) : (
-              <Trans>Help for this action</Trans>
-            )
-          }
-        />,
-      ]}
-      open={open}
-      onRequestClose={onCancel}
-      cannotBeDismissed={true}
-      maxWidth={false}
-      noMargin
-      flexRowBody
-      fullHeight={
-        true /* Always use full height to avoid a very small dialog when there are not a lot of objects. */
-      }
-    >
-      <SelectColumns
-        columnsRenderer={{
-          'instruction-or-object-selector': renderInstructionOrObjectSelector,
-          'object-instruction-selector': renderObjectInstructionSelector,
-          parameters: renderParameters,
-        }}
-        getColumns={() => {
-          if (windowWidth === 'large') {
-            if (chosenObjectName) {
-              return [
-                'instruction-or-object-selector',
-                'object-instruction-selector',
-                'parameters',
-              ];
-            } else {
-              return ['instruction-or-object-selector', 'parameters'];
+            onClick={onCancel}
+            key="cancel"
+          />,
+          <FlatButton
+            label={<Trans>Ok</Trans>}
+            primary={true}
+            keyboardFocused={false}
+            disabled={!instructionType}
+            onClick={onSubmit}
+            key="ok"
+          />,
+        ]}
+        secondaryActions={[
+          windowWidth !== 'large' && step !== 'object-or-free-instructions' ? (
+            <FlatButton
+              label={<Trans>Back</Trans>}
+              primary={false}
+              onClick={() => stepBackFrom(step, windowWidth)}
+              key="back"
+            />
+          ) : null,
+          <HelpButton
+            key="help"
+            helpPagePath={instructionHelpPage || '/events'}
+            label={
+              !instructionHelpPage ||
+              (windowWidth === 'small' ||
+                step === 'object-or-free-instructions') ? (
+                <Trans>Help</Trans>
+              ) : isCondition ? (
+                <Trans>Help for this condition</Trans>
+              ) : (
+                <Trans>Help for this action</Trans>
+              )
             }
-          } else if (windowWidth === 'medium') {
-            if (step === 'object-or-free-instructions') {
-              return ['instruction-or-object-selector'];
-            } else {
+          />,
+        ]}
+        open={open}
+        onRequestClose={onCancel}
+        cannotBeDismissed={true}
+        maxWidth={false}
+        noMargin
+        flexRowBody
+        fullHeight={
+          true /* Always use full height to avoid a very small dialog when there are not a lot of objects. */
+        }
+      >
+        <SelectColumns
+          columnsRenderer={{
+            'instruction-or-object-selector': renderInstructionOrObjectSelector,
+            'object-instruction-selector': renderObjectInstructionSelector,
+            parameters: renderParameters,
+          }}
+          getColumns={() => {
+            if (windowWidth === 'large') {
               if (chosenObjectName) {
-                return ['object-instruction-selector', 'parameters'];
+                return [
+                  'instruction-or-object-selector',
+                  'object-instruction-selector',
+                  'parameters',
+                ];
+              } else {
+                return ['instruction-or-object-selector', 'parameters'];
+              }
+            } else if (windowWidth === 'medium') {
+              if (step === 'object-or-free-instructions') {
+                return ['instruction-or-object-selector'];
+              } else {
+                if (chosenObjectName) {
+                  return ['object-instruction-selector', 'parameters'];
+                } else {
+                  return ['parameters'];
+                }
+              }
+            } else {
+              if (step === 'object-or-free-instructions') {
+                return ['instruction-or-object-selector'];
+              } else if (step === 'object-instructions') {
+                return ['object-instruction-selector'];
               } else {
                 return ['parameters'];
               }
             }
-          } else {
-            if (step === 'object-or-free-instructions') {
-              return ['instruction-or-object-selector'];
-            } else if (step === 'object-instructions') {
-              return ['object-instruction-selector'];
-            } else {
-              return ['parameters'];
-            }
-          }
-        }}
-      />
-    </Dialog>
+          }}
+        />
+      </Dialog>
+      {newBehaviorDialogOpen && chosenObject && (
+        <NewBehaviorDialog
+          project={project}
+          open={newBehaviorDialogOpen}
+          objectType={chosenObject.getType()}
+          onClose={() => setNewBehaviorDialogOpen(false)}
+          onChoose={addBehavior}
+        />
+      )}
+    </>
   );
 }

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -135,6 +135,9 @@ export default function NewInstructionEditorDialog({
   const chosenObject = chosenObjectName
     ? getObjectByName(project, scope.layout, chosenObjectName)
     : null;
+  const freeInstructionComponentRef = React.useRef<?InstructionOrObjectSelector>(
+    null
+  );
   const [step, setStep] = React.useState(() =>
     getInitialStepName(isNewInstruction)
   );
@@ -188,6 +191,8 @@ export default function NewInstructionEditorDialog({
 
   const onAddExtension = () => {
     setNewExtensionDialogOpen(false);
+    freeInstructionComponentRef.current &&
+      freeInstructionComponentRef.current.update();
   };
 
   // Focus the parameters when showing them
@@ -220,6 +225,7 @@ export default function NewInstructionEditorDialog({
       style={styles.fullHeightSelector}
       project={project}
       scope={scope}
+      ref={freeInstructionComponentRef}
       currentTab={currentInstructionOrObjectSelectorTab}
       onChangeTab={setCurrentInstructionOrObjectSelectorTab}
       globalObjectsContainer={globalObjectsContainer}

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -185,10 +185,10 @@ export default function NewInstructionEditorDialog({
     chooseObject(chosenObject.getName());
   };
 
-  const onAddExtension = () => {
+  const onExtensionInstalled = () => {
     setNewExtensionDialogOpen(false);
     freeInstructionComponentRef.current &&
-      freeInstructionComponentRef.current.update();
+      freeInstructionComponentRef.current.reEnumerateInstructions();
   };
 
   // Focus the parameters when showing them
@@ -393,7 +393,7 @@ export default function NewInstructionEditorDialog({
           project={project}
           onClose={() => setNewExtensionDialogOpen(false)}
           onInstallExtension={() => {}}
-          onExtensionInstalled={onAddExtension}
+          onExtensionInstalled={onExtensionInstalled}
         />
       )}
     </>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -169,10 +169,15 @@ export default function NewInstructionEditorDialog({
 
   const addBehavior = (type: string, defaultName: string) => {
     if (!chosenObject) return;
-    setNewBehaviorDialogOpen(false);
 
-    addBehaviorToObject(project, chosenObject, type, defaultName);
+    const wasBehaviorAdded = addBehaviorToObject(
+      project,
+      chosenObject,
+      type,
+      defaultName
+    );
 
+    if (wasBehaviorAdded) setNewBehaviorDialogOpen(false);
     // Re-choose the same object to force recomputation of chosenObjectInstructionsInfoTree
     chooseObject(chosenObject.getName());
   };

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -90,7 +90,6 @@ import AuthenticatedUserContext, {
 import {
   addCreateBadgePreHookIfNotClaimed,
   TRIVIAL_FIRST_EVENT,
-  ACHIEVEMENT_FEATURE_FLAG,
 } from '../Utils/GDevelopServices/Badge';
 const gd: libGDevelop = global.gd;
 
@@ -258,15 +257,11 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
 
   constructor(props: ComponentProps) {
     super(props);
-    if (ACHIEVEMENT_FEATURE_FLAG) {
-      this.addNewEvent = addCreateBadgePreHookIfNotClaimed(
-        this.props.authenticatedUser,
-        TRIVIAL_FIRST_EVENT,
-        this._addNewEvent
-      );
-    } else {
-      this.addNewEvent = this._addNewEvent;
-    }
+    this.addNewEvent = addCreateBadgePreHookIfNotClaimed(
+      this.props.authenticatedUser,
+      TRIVIAL_FIRST_EVENT,
+      this._addNewEvent
+    );
   }
 
   componentDidMount() {
@@ -274,15 +269,12 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
   }
 
   componentDidUpdate(prevProps: ComponentProps, prevState: State) {
-    if (ACHIEVEMENT_FEATURE_FLAG) {
-      this.addNewEvent = addCreateBadgePreHookIfNotClaimed(
-        this.props.authenticatedUser,
-        TRIVIAL_FIRST_EVENT,
-        this._addNewEvent
-      );
-    } else {
-      this.addNewEvent = this._addNewEvent;
-    }
+    this.addNewEvent = addCreateBadgePreHookIfNotClaimed(
+      this.props.authenticatedUser,
+      TRIVIAL_FIRST_EVENT,
+      this._addNewEvent
+    );
+
     if (this.state.history !== prevState.history)
       if (this.props.unsavedChanges)
         this.props.unsavedChanges.triggerUnsavedChanges();

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -34,7 +34,6 @@ import { type ExportPipeline } from '../ExportPipeline.flow';
 import { GameRegistration } from '../../GameDashboard/GameRegistration';
 import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
 import {
-  ACHIEVEMENT_FEATURE_FLAG,
   addCreateBadgePreHookIfNotClaimed,
   TRIVIAL_FIRST_WEB_EXPORT,
 } from '../../Utils/GDevelopServices/Badge';
@@ -90,10 +89,7 @@ export default class ExportLauncher extends Component<Props, State> {
   }
 
   _setupAchievementHook = () => {
-    if (
-      ACHIEVEMENT_FEATURE_FLAG &&
-      this.props.exportPipeline.name.includes('web')
-    ) {
+    if (this.props.exportPipeline.name.includes('web')) {
       this.launchWholeExport = addCreateBadgePreHookIfNotClaimed(
         this.props.authenticatedUser,
         TRIVIAL_FIRST_WEB_EXPORT,

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -129,7 +129,6 @@ import { findAndLogProjectPreviewErrors } from '../Utils/ProjectErrorsChecker';
 import { renameResourcesInProject } from '../ResourcesList/ResourceUtils';
 import { NewResourceDialog } from '../ResourcesList/NewResourceDialog';
 import {
-  ACHIEVEMENT_FEATURE_FLAG,
   addCreateBadgePreHookIfNotClaimed,
   TRIVIAL_FIRST_DEBUG,
   TRIVIAL_FIRST_PREVIEW,
@@ -1281,13 +1280,11 @@ const MainFrame = (props: Props) => {
     ]
   );
 
-  const launchPreview = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_PREVIEW,
-        _launchPreview
-      )
-    : _launchPreview;
+  const launchPreview = addCreateBadgePreHookIfNotClaimed(
+    authenticatedUser,
+    TRIVIAL_FIRST_PREVIEW,
+    _launchPreview
+  );
 
   const launchNewPreview = React.useCallback(
     () => launchPreview({ networkPreview: false }),
@@ -1455,13 +1452,11 @@ const MainFrame = (props: Props) => {
     [i18n, setState]
   );
 
-  const openDebugger = ACHIEVEMENT_FEATURE_FLAG
-    ? addCreateBadgePreHookIfNotClaimed(
-        authenticatedUser,
-        TRIVIAL_FIRST_DEBUG,
-        _openDebugger
-      )
-    : _openDebugger;
+  const openDebugger = addCreateBadgePreHookIfNotClaimed(
+    authenticatedUser,
+    TRIVIAL_FIRST_DEBUG,
+    _openDebugger
+  );
 
   const launchDebuggerAndPreview = React.useCallback(
     () => {

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -13,10 +13,7 @@ import { I18n } from '@lingui/react';
 import PlaceholderError from '../UI/PlaceholderError';
 import RaisedButton from '../UI/RaisedButton';
 import UserAchievements from './Achievement/UserAchievements';
-import {
-  ACHIEVEMENT_FEATURE_FLAG,
-  type Badge,
-} from '../Utils/GDevelopServices/Badge';
+import { type Badge } from '../Utils/GDevelopServices/Badge';
 
 type DisplayedProfile = {
   +email?: string,
@@ -103,13 +100,11 @@ const ProfileDetails = ({
               />
             </ResponsiveLineStackLayout>
           )}
-          {ACHIEVEMENT_FEATURE_FLAG && (
-            <UserAchievements
-              badges={badges}
-              displayUnclaimedAchievements={!!isAuthenticatedUserProfile}
-              displayNotifications={!!isAuthenticatedUserProfile}
-            />
-          )}
+          <UserAchievements
+            badges={badges}
+            displayUnclaimedAchievements={!!isAuthenticatedUserProfile}
+            displayNotifications={!!isAuthenticatedUserProfile}
+          />
         </Column>
       )}
     </I18n>

--- a/newIDE/app/src/Utils/Behavior.js
+++ b/newIDE/app/src/Utils/Behavior.js
@@ -1,0 +1,39 @@
+// @flow
+import newNameGenerator from './NewNameGenerator';
+import Window from './Window';
+
+const gd: libGDevelop = global.gd;
+
+export const hasBehaviorWithType = (object: gdObject, type: string) => {
+  const allBehaviorNames = object.getAllBehaviorNames().toJSArray();
+
+  return allBehaviorNames
+    .map(behaviorName => object.getBehavior(behaviorName))
+    .map(behavior => behavior.getTypeName())
+    .filter(behaviorType => behaviorType === type).length;
+};
+
+export const addBehaviorToObject = (
+  project: gdProject,
+  object: gdObject,
+  type: string,
+  defaultName: string
+) => {
+  if (hasBehaviorWithType(object, type)) {
+    const answer = Window.showConfirmDialog(
+      "There is already a behavior of this type attached to the object. It's possible to add this behavior again, but it's unusual and may not be always supported properly. Are you sure you want to add this behavior again?"
+    );
+
+    if (!answer) return;
+  }
+
+  const name = newNameGenerator(defaultName, name =>
+    object.hasBehaviorNamed(name)
+  );
+  gd.WholeProjectRefactorer.addBehaviorAndRequiredBehaviors(
+    project,
+    object,
+    type,
+    name
+  );
+};

--- a/newIDE/app/src/Utils/Behavior.js
+++ b/newIDE/app/src/Utils/Behavior.js
@@ -4,14 +4,13 @@ import Window from './Window';
 
 const gd: libGDevelop = global.gd;
 
-export const hasBehaviorWithType = (object: gdObject, type: string) => {
-  const allBehaviorNames = object.getAllBehaviorNames().toJSArray();
-
-  return allBehaviorNames
-    .map(behaviorName => object.getBehavior(behaviorName))
-    .map(behavior => behavior.getTypeName())
-    .filter(behaviorType => behaviorType === type).length;
-};
+export const hasBehaviorWithType = (object: gdObject, type: string) =>
+  object
+    .getAllBehaviorNames()
+    .toJSArray()
+    .filter(
+      behaviorName => object.getBehavior(behaviorName).getTypeName() === type
+    ).length;
 
 export const addBehaviorToObject = (
   project: gdProject,

--- a/newIDE/app/src/Utils/Behavior.js
+++ b/newIDE/app/src/Utils/Behavior.js
@@ -20,7 +20,7 @@ export const addBehaviorToObject = (
 ): boolean => {
   if (hasBehaviorWithType(object, type)) {
     const answer = Window.showConfirmDialog(
-      "There is already a behavior of this type attached to the object. It's possible to add this behavior again, but it's unusual and may not be always supported properly. Are you sure you want to add this behavior again?"
+      "There is already a behavior of this type attached to the object. It's possible to add this behavior again, but it's unusual and may not always be supported properly. Are you sure you want to add this behavior again?"
     );
 
     if (!answer) return false;

--- a/newIDE/app/src/Utils/Behavior.js
+++ b/newIDE/app/src/Utils/Behavior.js
@@ -17,13 +17,13 @@ export const addBehaviorToObject = (
   object: gdObject,
   type: string,
   defaultName: string
-) => {
+): boolean => {
   if (hasBehaviorWithType(object, type)) {
     const answer = Window.showConfirmDialog(
       "There is already a behavior of this type attached to the object. It's possible to add this behavior again, but it's unusual and may not be always supported properly. Are you sure you want to add this behavior again?"
     );
 
-    if (!answer) return;
+    if (!answer) return false;
   }
 
   const name = newNameGenerator(defaultName, name =>
@@ -35,6 +35,7 @@ export const addBehaviorToObject = (
     type,
     name
   );
+  return true;
 };
 
 export const listObjectBehaviorsTypes = (object: gdObject): Array<string> =>

--- a/newIDE/app/src/Utils/Behavior.js
+++ b/newIDE/app/src/Utils/Behavior.js
@@ -37,3 +37,9 @@ export const addBehaviorToObject = (
     name
   );
 };
+
+export const listObjectBehaviorsTypes = (object: gdObject): Array<string> =>
+  object
+    .getAllBehaviorNames()
+    .toJSArray()
+    .map(behaviorName => object.getBehavior(behaviorName).getTypeName());

--- a/newIDE/app/src/Utils/GDevelopServices/Badge.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Badge.js
@@ -4,8 +4,6 @@ import { GDevelopUserApi } from './ApiConfigs';
 
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 
-export const ACHIEVEMENT_FEATURE_FLAG = true;
-
 export const TRIVIAL_FIRST_EVENT = 'trivial_first-event';
 export const TRIVIAL_FIRST_BEHAVIOR = 'trivial_first-behavior';
 export const TRIVIAL_FIRST_PREVIEW = 'trivial_first-preview';

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -3311,6 +3311,7 @@ storiesOf('InstructionOrObjectSelector', module)
             chosenObjectName={null}
             onChooseObject={action('choose object')}
             focusOnMount
+            onClickMore={action('See new behaviors')}
           />
         </FixedHeightFlexContainer>
       )}
@@ -3335,6 +3336,7 @@ storiesOf('InstructionOrObjectSelector', module)
             chosenObjectName={'MySpriteObject'}
             onChooseObject={action('choose object')}
             focusOnMount
+            onClickMore={action('See new behaviors')}
           />
         </FixedHeightFlexContainer>
       )}

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -4816,6 +4816,10 @@ storiesOf('NewBehaviorDialog', module)
         objectType={'Sprite'}
         onClose={action('on close')}
         onChoose={action('on choose')}
+        objectBehaviorsTypes={[
+          'DestroyOutsideBehavior::DestroyOutside',
+          'PlatformBehavior::PlatformBehavior',
+        ]}
       />
     </ExtensionStoreStateProvider>
   ));


### PR DESCRIPTION
Add buttons in actions/conditions list to open the NewBehavior dialog or the ExtensionsSearch dialog, depending if an object is selected.

![demo_add_extension_on_the_fly](https://user-images.githubusercontent.com/32449369/148102823-8fbb4d40-9e73-4e24-8227-6bfd8f950d5a.gif)

I think that the wording of the buttons can be better : "Discover other actions/conditions in behaviors/extensions" or something like that?