### PR TITLE
Introduce stable URLs for games

### DIFF
--- a/newIDE/app/src/Export/BrowserExporters/BrowserCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserCordovaExport.js
@@ -58,6 +58,8 @@ export const browserCordovaExportPipeline: ExportPipeline<
 
   canLaunchBuild: () => true,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: () => <ExplanationHeader />,
 
   renderLaunchButtonLabel: () => <Trans>Package</Trans>,

--- a/newIDE/app/src/Export/BrowserExporters/BrowserElectronExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserElectronExport.js
@@ -58,6 +58,8 @@ export const browserElectronExportPipeline: ExportPipeline<
 
   canLaunchBuild: () => true,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: () => <ExplanationHeader />,
 
   renderLaunchButtonLabel: () => <Trans>Package</Trans>,

--- a/newIDE/app/src/Export/BrowserExporters/BrowserFacebookInstantGamesExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserFacebookInstantGamesExport.js
@@ -57,6 +57,8 @@ export const browserFacebookInstantGamesExportPipeline: ExportPipeline<
 
   canLaunchBuild: () => true,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: () => <ExplanationHeader />,
 
   renderLaunchButtonLabel: () => <Trans>Package</Trans>,

--- a/newIDE/app/src/Export/BrowserExporters/BrowserHTML5Export.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserHTML5Export.js
@@ -68,6 +68,8 @@ export const browserHTML5ExportPipeline: ExportPipeline<
 
   canLaunchBuild: () => true,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: () => <ExplanationHeader />,
 
   renderLaunchButtonLabel: () => <Trans>Export as a HTML5 game</Trans>,

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
@@ -64,7 +64,16 @@ export const browserOnlineCordovaExportPipeline: ExportPipeline<
     signingDialogOpen: false,
   }),
 
-  canLaunchBuild: () => true,
+  // Build can be launched only if just opened the dialog or build errored.
+  canLaunchBuild: (exportState, errored, exportStep) =>
+    errored || exportStep === '',
+
+  // Navigation is enabled when the build is errored or whilst uploading.
+  isNavigationDisabled: (exportStep, errored) =>
+    !errored &&
+    ['register', 'export', 'resources-download', 'compress', 'upload'].includes(
+      exportStep
+    ),
 
   renderHeader: props => <SetupExportHeader {...props} />,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineElectronExport.js
@@ -62,7 +62,16 @@ export const browserOnlineElectronExportPipeline: ExportPipeline<
     targets: ['winExe'],
   }),
 
-  canLaunchBuild: (exportState: ExportState) => !!exportState.targets.length,
+  // Build can be launched only if just opened the dialog or build errored.
+  canLaunchBuild: (exportState, errored, exportStep) =>
+    !!exportState.targets.length && (errored || exportStep === ''),
+
+  // Navigation is enabled when the build is errored or whilst uploading.
+  isNavigationDisabled: (exportStep, errored) =>
+    !errored &&
+    ['register', 'export', 'resources-download', 'compress', 'upload'].includes(
+      exportStep
+    ),
 
   renderHeader: props => <SetupExportHeader {...props} />,
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
@@ -26,6 +26,7 @@ import {
   ExplanationHeader,
   WebProjectLink,
 } from '../GenericExporters/OnlineWebExport';
+import { type BuildStep } from '../Builds/BuildStepsProgress';
 const gd: libGDevelop = global.gd;
 
 type ExportState = null;
@@ -60,14 +61,24 @@ export const browserOnlineWebExportPipeline: ExportPipeline<
 
   getInitialExportState: () => null,
 
-  canLaunchBuild: () => true,
+  // Build can be launched if just opened the dialog or build errored, re-enabled when done.
+  canLaunchBuild: (exportState, errored, exportStep) =>
+    errored || exportStep === '' || exportStep === 'done',
+
+  // Navigation is enabled when the build is errored or if the build is not done.
+  isNavigationDisabled: (exportStep, errored) =>
+    !errored && !['', 'done'].includes(exportStep),
 
   renderHeader: () => <ExplanationHeader />,
 
   renderLaunchButtonLabel: () => <Trans>Generate link</Trans>,
 
-  renderCustomStepsProgress: (build: ?Build, loading: boolean) => (
-    <WebProjectLink build={build} loading={loading} />
+  renderCustomStepsProgress: (
+    build: ?Build,
+    errored: boolean,
+    exportStep: BuildStep
+  ) => (
+    <WebProjectLink build={build} errored={errored} exportStep={exportStep} />
   ),
 
   prepareExporter: (

--- a/newIDE/app/src/Export/Builds/BuildCard.js
+++ b/newIDE/app/src/Export/Builds/BuildCard.js
@@ -4,9 +4,21 @@ import * as React from 'react';
 import { differenceInCalendarDays, format } from 'date-fns';
 import { Line } from '../../UI/Grid';
 import { type Build } from '../../Utils/GDevelopServices/Build';
+import { type Game } from '../../Utils/GDevelopServices/Game';
 import { Card, CardActions, CardHeader } from '@material-ui/core';
-import BuildProgress from './BuildProgress';
+import BuildProgressAndActions from './BuildProgressAndActions';
 import EmptyMessage from '../../UI/EmptyMessage';
+import Chrome from '../../UI/CustomSvgIcons/Chrome';
+import PhoneIphone from '@material-ui/icons/PhoneIphone';
+import LaptopMac from '@material-ui/icons/LaptopMac';
+
+const styles = {
+  icon: {
+    height: 30,
+    width: 30,
+    marginRight: 5,
+  },
+};
 
 const formatBuildText = (
   buildType: 'cordova-build' | 'electron-build' | 'web-build'
@@ -23,11 +35,36 @@ const formatBuildText = (
   }
 };
 
+const getIcon = (
+  buildType: 'cordova-build' | 'electron-build' | 'web-build'
+) => {
+  switch (buildType) {
+    case 'cordova-build':
+      return <PhoneIphone style={styles.icon} />;
+    case 'electron-build':
+      return <LaptopMac style={styles.icon} />;
+    case 'web-build':
+      return <Chrome style={styles.icon} />;
+    default:
+      return <Chrome style={styles.icon} />;
+  }
+};
+
 type Props = {|
   build: Build,
+  game?: ?Game,
+  onGameUpdated?: Game => void,
+  gameUpdating: boolean,
+  setGameUpdating: boolean => void,
 |};
 
-export const BuildCard = ({ build }: Props) => {
+export const BuildCard = ({
+  build,
+  game,
+  onGameUpdated,
+  gameUpdating,
+  setGameUpdating,
+}: Props) => {
   const isOld =
     build &&
     build.type !== 'web-build' &&
@@ -38,6 +75,7 @@ export const BuildCard = ({ build }: Props) => {
         title={build.id}
         subheader={
           <Line alignItems="center" noMargin>
+            {getIcon(build.type)}
             <Trans>
               {formatBuildText(build.type)} - <Trans>Last updated on</Trans>{' '}
               {format(build.updatedAt, 'yyyy-MM-dd HH:mm:ss')}
@@ -47,7 +85,15 @@ export const BuildCard = ({ build }: Props) => {
       />
       <CardActions>
         <Line expand noMargin justifyContent="flex-end">
-          {!isOld && <BuildProgress build={build} />}
+          {!isOld && (
+            <BuildProgressAndActions
+              build={build}
+              game={game}
+              onGameUpdated={onGameUpdated}
+              gameUpdating={gameUpdating}
+              setGameUpdating={setGameUpdating}
+            />
+          )}
           {isOld && (
             <EmptyMessage>
               <Trans>

--- a/newIDE/app/src/Export/Builds/BuildCard.js
+++ b/newIDE/app/src/Export/Builds/BuildCard.js
@@ -52,7 +52,7 @@ const getIcon = (
 
 type Props = {|
   build: Build,
-  game?: ?Game,
+  game: Game,
   onGameUpdated?: Game => void,
   gameUpdating: boolean,
   setGameUpdating: boolean => void,

--- a/newIDE/app/src/Export/Builds/BuildStepsProgress.js
+++ b/newIDE/app/src/Export/Builds/BuildStepsProgress.js
@@ -9,11 +9,8 @@ import StepContent from '@material-ui/core/StepContent';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { Line, Spacer, Column } from '../../UI/Grid';
-import BuildProgress from './BuildProgress';
-import {
-  type Build,
-  type BuildArtifactKeyName,
-} from '../../Utils/GDevelopServices/Build';
+import BuildProgressAndActions from './BuildProgressAndActions';
+import { type Build } from '../../Utils/GDevelopServices/Build';
 import EmptyMessage from '../../UI/EmptyMessage';
 import Text from '../../UI/Text';
 import AlertMessage from '../../UI/AlertMessage';
@@ -25,6 +22,7 @@ const styles = {
 
 export type BuildStep =
   | ''
+  | 'register'
   | 'export'
   | 'resources-download'
   | 'compress'
@@ -35,7 +33,6 @@ export type BuildStep =
 
 type Props = {|
   exportStep: BuildStep,
-  onDownload: (key: BuildArtifactKeyName) => void,
   build: ?Build,
   stepMaxProgress: number,
   stepCurrentProgress: number,
@@ -50,17 +47,18 @@ type Props = {|
  */
 export default ({
   exportStep,
-  onDownload,
   build,
   stepMaxProgress,
   stepCurrentProgress,
   errored,
   hasBuildStep,
   showSeeAllMyBuildsExplanation,
-}: Props) => (
-  <Stepper
-    activeStep={
-      exportStep === 'export' || exportStep === 'resources-download'
+}: Props) => {
+  const getActiveStep = React.useCallback(
+    () =>
+      exportStep === 'register' ||
+      exportStep === 'export' ||
+      exportStep === 'resources-download'
         ? 0
         : exportStep === 'compress' || exportStep === 'upload'
         ? 1
@@ -70,128 +68,134 @@ export default ({
         ? hasBuildStep
           ? 2
           : 1
-        : -1
-    }
-    orientation="vertical"
-    style={styles.stepper}
-  >
-    <Step>
-      <StepLabel>
-        <Trans>Game export</Trans>
-      </StepLabel>
-      <StepContent>
-        {errored ? (
-          <AlertMessage kind="error">
-            <Trans>Can't properly export the game.</Trans>{' '}
-            <Trans>
-              Please check your internet connection or try again later.
-            </Trans>
-          </AlertMessage>
-        ) : exportStep === 'resources-download' ? (
-          <Column expand noMargin>
-            <Text>
-              <Trans>Downloading game resources...</Trans>
-            </Text>
-            <Line expand>
-              <LinearProgress
-                style={styles.linearProgress}
-                value={
-                  stepMaxProgress > 0
-                    ? (stepCurrentProgress / stepMaxProgress) * 100
-                    : 0
-                }
-                variant="determinate"
-              />
-            </Line>
-          </Column>
-        ) : (
-          <Column expand noMargin>
-            <Text>
-              <Trans>Export in progress...</Trans>
-            </Text>
-            <Line expand>
-              <LinearProgress style={styles.linearProgress} />
-            </Line>
-          </Column>
-        )}
-      </StepContent>
-    </Step>
-    {hasBuildStep && (
+        : -1,
+    [exportStep, hasBuildStep]
+  );
+
+  return (
+    <Stepper
+      activeStep={getActiveStep()}
+      orientation="vertical"
+      style={styles.stepper}
+    >
       <Step>
         <StepLabel>
-          <Trans>Upload to build service</Trans>
+          <Trans>Game export</Trans>
         </StepLabel>
         <StepContent>
           {errored ? (
             <AlertMessage kind="error">
-              <Trans>Can't upload your game to the build service.</Trans>{' '}
+              <Trans>Can't properly export the game.</Trans>{' '}
               <Trans>
                 Please check your internet connection or try again later.
               </Trans>
             </AlertMessage>
-          ) : exportStep === 'compress' ? (
-            <Line alignItems="center">
-              <CircularProgress size={20} />
-              <Spacer />
+          ) : exportStep === 'resources-download' ? (
+            <Column expand noMargin>
               <Text>
-                <Trans>Compressing before upload...</Trans>
+                <Trans>Downloading game resources...</Trans>
               </Text>
-            </Line>
+              <Line expand>
+                <LinearProgress
+                  style={styles.linearProgress}
+                  value={
+                    stepMaxProgress > 0
+                      ? (stepCurrentProgress / stepMaxProgress) * 100
+                      : 0
+                  }
+                  variant="determinate"
+                />
+              </Line>
+            </Column>
           ) : (
-            <Line alignItems="center" expand>
-              <LinearProgress
-                style={styles.linearProgress}
-                value={
-                  stepMaxProgress > 0
-                    ? (stepCurrentProgress / stepMaxProgress) * 100
-                    : 0
-                }
-                variant="determinate"
-              />
-            </Line>
+            <Column expand noMargin>
+              <Text>
+                <Trans>Export in progress...</Trans>
+              </Text>
+              <Line expand>
+                <LinearProgress style={styles.linearProgress} />
+              </Line>
+            </Column>
           )}
         </StepContent>
       </Step>
-    )}
-    {hasBuildStep && (
-      <Step>
-        <StepLabel>
-          <Trans>Build and download</Trans>
-        </StepLabel>
-        <StepContent>
-          {errored && (
-            <AlertMessage kind="error">
-              <Trans>
-                Build could not start or errored. Please check your internet
-                connection or try again later.
-              </Trans>
-            </AlertMessage>
-          )}
-          {!build && !errored && (
-            <Text>
-              <Trans>Build is starting...</Trans>
-            </Text>
-          )}
-          {build && <BuildProgress build={build} />}
-          {showSeeAllMyBuildsExplanation && (
-            <EmptyMessage>
-              <Trans>
-                If you close this window while the build is being done, you can
-                see its progress and download the game later by clicking on See
-                All My Builds below.
-              </Trans>
-            </EmptyMessage>
-          )}
-        </StepContent>
-      </Step>
-    )}
-    {!hasBuildStep && (
-      <Step>
-        <StepLabel>
-          <Trans>Done</Trans>
-        </StepLabel>
-        <StepContent />
-      </Step>
-    )}
-  </Stepper>
-);
+      {hasBuildStep && (
+        <Step>
+          <StepLabel>
+            <Trans>Upload to build service</Trans>
+          </StepLabel>
+          <StepContent>
+            {errored ? (
+              <AlertMessage kind="error">
+                <Trans>Can't upload your game to the build service.</Trans>{' '}
+                <Trans>
+                  Please check your internet connection or try again later.
+                </Trans>
+              </AlertMessage>
+            ) : exportStep === 'compress' ? (
+              <Line alignItems="center">
+                <CircularProgress size={20} />
+                <Spacer />
+                <Text>
+                  <Trans>Compressing before upload...</Trans>
+                </Text>
+              </Line>
+            ) : (
+              <Line alignItems="center" expand>
+                <LinearProgress
+                  style={styles.linearProgress}
+                  value={
+                    stepMaxProgress > 0
+                      ? (stepCurrentProgress / stepMaxProgress) * 100
+                      : 0
+                  }
+                  variant="determinate"
+                />
+              </Line>
+            )}
+          </StepContent>
+        </Step>
+      )}
+      {hasBuildStep && (
+        <Step>
+          <StepLabel>
+            <Trans>Build and download</Trans>
+          </StepLabel>
+          <StepContent>
+            {errored && (
+              <AlertMessage kind="error">
+                <Trans>
+                  Build could not start or errored. Please check your internet
+                  connection or try again later.
+                </Trans>
+              </AlertMessage>
+            )}
+            {!build && !errored && (
+              <Text>
+                <Trans>Build is starting...</Trans>
+              </Text>
+            )}
+            {build && <BuildProgressAndActions build={build} />}
+            {showSeeAllMyBuildsExplanation && (
+              <EmptyMessage>
+                <Trans>
+                  If you close this window while the build is being done, you
+                  can see its progress and download the game later by clicking
+                  on See All My Builds below.
+                </Trans>
+              </EmptyMessage>
+            )}
+          </StepContent>
+        </Step>
+      )}
+      {!hasBuildStep && (
+        <Step>
+          <StepLabel>
+            <Trans>Done</Trans>
+          </StepLabel>
+          <StepContent />
+        </Step>
+      )}
+    </Stepper>
+  );
+};

--- a/newIDE/app/src/Export/Builds/BuildsDialog.js
+++ b/newIDE/app/src/Export/Builds/BuildsDialog.js
@@ -6,54 +6,26 @@ import Dialog from '../../UI/Dialog';
 import HelpButton from '../../UI/HelpButton';
 import FlatButton from '../../UI/FlatButton';
 import Builds from '.';
-import AuthenticatedUserContext, {
-  type AuthenticatedUser,
-} from '../../Profile/AuthenticatedUserContext';
+import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 import useForceUpdate from '../../Utils/UseForceUpdate';
-import { getGame, type Game } from '../../Utils/GDevelopServices/Game';
+import { type Game } from '../../Utils/GDevelopServices/Game';
 
 type Props = {|
   authenticatedUser: AuthenticatedUser,
-  gameId: string,
+  game: Game,
   open: boolean,
   onClose: () => void,
+  onGameUpdated: () => void,
 |};
 
-const BuildsDialog = ({ authenticatedUser, gameId, open, onClose }: Props) => {
+const BuildsDialog = ({
+  authenticatedUser,
+  game,
+  open,
+  onClose,
+  onGameUpdated,
+}: Props) => {
   const forceUpdate = useForceUpdate();
-  const { getAuthorizationHeader, profile } = React.useContext(
-    AuthenticatedUserContext
-  );
-  const [game, setGame] = React.useState<?Game>(null);
-  const [isGameLoading, setIsGameLoading] = React.useState<boolean>(false);
-
-  const loadGame = React.useCallback(
-    async () => {
-      if (!profile || !gameId) return;
-
-      const { id } = profile;
-      try {
-        setIsGameLoading(true);
-        const game = await getGame(getAuthorizationHeader, id, gameId);
-        setGame(game);
-        setIsGameLoading(false);
-      } catch (err) {
-        setIsGameLoading(false);
-        console.error('Unable to load the game', err);
-      }
-    },
-    [gameId, getAuthorizationHeader, profile]
-  );
-
-  React.useEffect(
-    () => {
-      if (open) {
-        loadGame();
-      }
-    },
-    [loadGame, open]
-  );
-
   if (!open) return null;
 
   return (
@@ -80,8 +52,7 @@ const BuildsDialog = ({ authenticatedUser, gameId, open, onClose }: Props) => {
         onBuildsUpdated={forceUpdate}
         authenticatedUser={authenticatedUser}
         game={game}
-        onGameUpdated={setGame}
-        isGameLoading={isGameLoading}
+        onGameUpdated={onGameUpdated}
       />
     </Dialog>
   );

--- a/newIDE/app/src/Export/Builds/BuildsDialog.js
+++ b/newIDE/app/src/Export/Builds/BuildsDialog.js
@@ -1,12 +1,16 @@
 // @flow
 import { Trans } from '@lingui/macro';
 
-import React, { Component } from 'react';
+import React from 'react';
 import Dialog from '../../UI/Dialog';
 import HelpButton from '../../UI/HelpButton';
 import FlatButton from '../../UI/FlatButton';
 import Builds from '.';
-import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
+import AuthenticatedUserContext, {
+  type AuthenticatedUser,
+} from '../../Profile/AuthenticatedUserContext';
+import useForceUpdate from '../../Utils/UseForceUpdate';
+import { getGame, type Game } from '../../Utils/GDevelopServices/Game';
 
 type Props = {|
   authenticatedUser: AuthenticatedUser,
@@ -14,43 +18,73 @@ type Props = {|
   open: boolean,
   onClose: () => void,
 |};
-type State = {||};
 
-export default class BuildsDialog extends Component<Props, State> {
-  _onBuildsUpdated = () => {
-    // Force the Dialog repositioning
-    this.forceUpdate();
-  };
+const BuildsDialog = ({ authenticatedUser, gameId, open, onClose }: Props) => {
+  const forceUpdate = useForceUpdate();
+  const { getAuthorizationHeader, profile } = React.useContext(
+    AuthenticatedUserContext
+  );
+  const [game, setGame] = React.useState<?Game>(null);
+  const [isGameLoading, setIsGameLoading] = React.useState<boolean>(false);
 
-  render() {
-    const { open, onClose, authenticatedUser, gameId } = this.props;
-    if (!open) return null;
+  const loadGame = React.useCallback(
+    async () => {
+      if (!profile || !gameId) return;
 
-    return (
-      <Dialog
-        title={<Trans>Your game builds</Trans>}
-        onRequestClose={onClose}
-        actions={[
-          <FlatButton
-            label={<Trans>Close</Trans>}
-            key="close"
-            primary={false}
-            onClick={onClose}
-          />,
-        ]}
-        secondaryActions={[
-          <HelpButton key="help" helpPagePath={'/publishing'} />,
-        ]}
-        cannotBeDismissed={false}
-        open={open}
-        noMargin
-      >
-        <Builds
-          onBuildsUpdated={this._onBuildsUpdated}
-          authenticatedUser={authenticatedUser}
-          gameId={gameId}
-        />
-      </Dialog>
-    );
-  }
-}
+      const { id } = profile;
+      try {
+        setIsGameLoading(true);
+        const game = await getGame(getAuthorizationHeader, id, gameId);
+        setGame(game);
+        setIsGameLoading(false);
+      } catch (err) {
+        setIsGameLoading(false);
+        console.error('Unable to load the game', err);
+      }
+    },
+    [gameId, getAuthorizationHeader, profile]
+  );
+
+  React.useEffect(
+    () => {
+      if (open) {
+        loadGame();
+      }
+    },
+    [loadGame, open]
+  );
+
+  if (!open) return null;
+
+  return (
+    <Dialog
+      title={<Trans>Your game builds</Trans>}
+      onRequestClose={onClose}
+      actions={[
+        <FlatButton
+          label={<Trans>Close</Trans>}
+          key="close"
+          primary={false}
+          onClick={onClose}
+        />,
+      ]}
+      secondaryActions={[
+        <HelpButton key="help" helpPagePath={'/publishing'} />,
+      ]}
+      cannotBeDismissed={false}
+      open={open}
+      noMargin
+    >
+      <Builds
+        // Force the Dialog repositioning
+        onBuildsUpdated={forceUpdate}
+        authenticatedUser={authenticatedUser}
+        game={game}
+        onGameUpdated={setGame}
+        isGameLoading={isGameLoading}
+      />
+    </Dialog>
+  );
+};
+
+export default BuildsDialog;

--- a/newIDE/app/src/Export/Builds/BuildsList.js
+++ b/newIDE/app/src/Export/Builds/BuildsList.js
@@ -3,6 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import { type Build } from '../../Utils/GDevelopServices/Build';
+import { type Game } from '../../Utils/GDevelopServices/Game';
 import { Column, Line } from '../../UI/Grid';
 import EmptyMessage from '../../UI/EmptyMessage';
 import PlaceholderLoader from '../../UI/PlaceholderLoader';
@@ -17,9 +18,19 @@ type Props = {|
   authenticatedUser: AuthenticatedUser,
   error: ?Error,
   loadBuilds: () => void,
+  game?: ?Game,
+  onGameUpdated?: Game => void,
 |};
 
-export default ({ builds, authenticatedUser, error, loadBuilds }: Props) => {
+export default ({
+  builds,
+  authenticatedUser,
+  error,
+  loadBuilds,
+  game,
+  onGameUpdated,
+}: Props) => {
+  const [gameUpdating, setGameUpdating] = React.useState(false);
   return (
     <Column noMargin expand>
       <Line>
@@ -55,7 +66,14 @@ export default ({ builds, authenticatedUser, error, loadBuilds }: Props) => {
         {authenticatedUser.authenticated && builds && builds.length !== 0 && (
           <ColumnStackLayout expand>
             {builds.map((build: Build) => (
-              <BuildCard build={build} key={build.id} />
+              <BuildCard
+                build={build}
+                key={build.id}
+                game={game}
+                onGameUpdated={onGameUpdated}
+                gameUpdating={gameUpdating}
+                setGameUpdating={setGameUpdating}
+              />
             ))}
           </ColumnStackLayout>
         )}

--- a/newIDE/app/src/Export/Builds/BuildsList.js
+++ b/newIDE/app/src/Export/Builds/BuildsList.js
@@ -18,7 +18,7 @@ type Props = {|
   authenticatedUser: AuthenticatedUser,
   error: ?Error,
   loadBuilds: () => void,
-  game?: ?Game,
+  game: Game,
   onGameUpdated?: Game => void,
 |};
 

--- a/newIDE/app/src/Export/Builds/index.js
+++ b/newIDE/app/src/Export/Builds/index.js
@@ -9,9 +9,8 @@ import BuildsWatcher from './BuildsWatcher';
 type Props = {|
   onBuildsUpdated?: () => void,
   authenticatedUser: AuthenticatedUser,
-  game?: ?Game,
+  game: Game,
   onGameUpdated?: Game => void,
-  isGameLoading: boolean,
 |};
 type State = {|
   builds: ?Array<Build>,
@@ -26,17 +25,7 @@ export default class Builds extends Component<Props, State> {
   buildsWatcher = new BuildsWatcher();
 
   componentDidMount() {
-    // Do not load the builds if the game is still loading.
-    if (!this.props.isGameLoading) {
-      this._refreshBuilds();
-    }
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    // If the game has been loaded, fetch the builds.
-    if (prevProps.isGameLoading && !this.props.isGameLoading) {
-      this._refreshBuilds();
-    }
+    this._refreshBuilds();
   }
 
   componentWillUnmount() {
@@ -70,10 +59,6 @@ export default class Builds extends Component<Props, State> {
     } = this.props.authenticatedUser;
     if (!firebaseUser) return;
     // Game is not registered yet so return an empty list of builds.
-    if (!this.props.game) {
-      this.setState({ builds: [] });
-      return;
-    }
     const gameId = this.props.game.id;
     this.setState({ builds: null, error: null });
 

--- a/newIDE/app/src/Export/ExportDialog/ExportHome.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportHome.js
@@ -45,6 +45,7 @@ type ExportHomeProps = {|
   authenticatedUser: AuthenticatedUser,
   isNavigationDisabled: boolean,
   setIsNavigationDisabled: (isNavigationDisabled: boolean) => void,
+  onGameUpdated: () => void,
 |};
 
 const ExportHome = ({
@@ -57,6 +58,7 @@ const ExportHome = ({
   authenticatedUser,
   isNavigationDisabled,
   setIsNavigationDisabled,
+  onGameUpdated,
 }: ExportHomeProps) => {
   return (
     <ResponsiveLineStackLayout>
@@ -78,6 +80,7 @@ const ExportHome = ({
             onChangeSubscription={onChangeSubscription}
             authenticatedUser={authenticatedUser}
             setIsNavigationDisabled={setIsNavigationDisabled}
+            onGameUpdated={onGameUpdated}
           />
         </div>
       </ColumnStackLayout>

--- a/newIDE/app/src/Export/ExportDialog/ExportHome.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportHome.js
@@ -43,6 +43,8 @@ type ExportHomeProps = {|
   project: gdProject,
   onChangeSubscription: () => void,
   authenticatedUser: AuthenticatedUser,
+  isNavigationDisabled: boolean,
+  setIsNavigationDisabled: (isNavigationDisabled: boolean) => void,
 |};
 
 const ExportHome = ({
@@ -53,6 +55,8 @@ const ExportHome = ({
   project,
   onChangeSubscription,
   authenticatedUser,
+  isNavigationDisabled,
+  setIsNavigationDisabled,
 }: ExportHomeProps) => {
   return (
     <ResponsiveLineStackLayout>
@@ -73,6 +77,7 @@ const ExportHome = ({
             project={project}
             onChangeSubscription={onChangeSubscription}
             authenticatedUser={authenticatedUser}
+            setIsNavigationDisabled={setIsNavigationDisabled}
           />
         </div>
       </ColumnStackLayout>
@@ -108,6 +113,7 @@ const ExportHome = ({
                 setChosenExporterKey('webexport');
               }}
               primary
+              disabled={isNavigationDisabled}
             />
             <Spacer />
             <FlatButton
@@ -117,6 +123,7 @@ const ExportHome = ({
                 setChosenExporterSection('manual');
                 setChosenExporterKey('webexport');
               }}
+              disabled={isNavigationDisabled}
             />
           </Column>
         </div>

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -24,6 +24,7 @@ import {
   registerGame,
   getGame,
   updateGame,
+  type Game,
 } from '../../Utils/GDevelopServices/Game';
 import { type ExportPipeline } from '../ExportPipeline.flow';
 import { GameRegistration } from '../../GameDashboard/GameRegistration';
@@ -50,6 +51,7 @@ type Props = {|
   authenticatedUser: AuthenticatedUser,
   exportPipeline: ExportPipeline<any, any, any, any, any>,
   setIsNavigationDisabled: (isNavigationDisabled: boolean) => void,
+  onGameUpdated: (game: Game) => void,
 |};
 
 /**
@@ -141,20 +143,23 @@ export default class ExportLauncher extends Component<Props, State> {
     if (profile) {
       const userId = profile.id;
       try {
+        // Try to fetch the game to see if it's registered.
         await getGame(getAuthorizationHeader, userId, gameId);
         // Update the game details to ensure that it is up to date in GDevelop services.
-        await updateGame(getAuthorizationHeader, userId, gameId, {
+        const game = await updateGame(getAuthorizationHeader, userId, gameId, {
           authorName,
           gameName,
         });
+        this.props.onGameUpdated(game);
       } catch (err) {
         if (err.response.status === 404) {
           // If the game is not registered, register it before launching the export.
-          await registerGame(getAuthorizationHeader, userId, {
+          const game = await registerGame(getAuthorizationHeader, userId, {
             gameId,
             authorName,
             gameName,
           });
+          this.props.onGameUpdated(game);
         }
       }
     }

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -5,15 +5,10 @@ import { I18n } from '@lingui/react';
 import { t, Trans } from '@lingui/macro';
 import RaisedButton from '../../UI/RaisedButton';
 import { sendExportLaunched } from '../../Utils/Analytics/EventSender';
-import {
-  type Build,
-  type BuildArtifactKeyName,
-  getBuildArtifactUrl,
-} from '../../Utils/GDevelopServices/Build';
+import { type Build } from '../../Utils/GDevelopServices/Build';
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 import { Column, Line, Spacer } from '../../UI/Grid';
 import { showErrorBox } from '../../UI/Messages/MessageBox';
-import Window from '../../Utils/Window';
 import CreateProfile from '../../Profile/CreateProfile';
 import LimitDisplayer from '../../Profile/LimitDisplayer';
 import {
@@ -54,6 +49,7 @@ type Props = {|
   onChangeSubscription: () => void,
   authenticatedUser: AuthenticatedUser,
   exportPipeline: ExportPipeline<any, any, any, any, any>,
+  setIsNavigationDisabled: (isNavigationDisabled: boolean) => void,
 |};
 
 /**
@@ -86,6 +82,17 @@ export default class ExportLauncher extends Component<Props, State> {
   }
   componentDidUpdate(prevProps: Props, prevState: State) {
     this._setupAchievementHook();
+    if (
+      prevState.exportStep !== this.state.exportStep ||
+      prevState.errored !== this.state.errored
+    ) {
+      this.props.setIsNavigationDisabled(
+        this.props.exportPipeline.isNavigationDisabled(
+          this.state.exportStep,
+          this.state.errored
+        )
+      );
+    }
   }
 
   _setupAchievementHook = () => {
@@ -136,8 +143,7 @@ export default class ExportLauncher extends Component<Props, State> {
       try {
         await getGame(getAuthorizationHeader, userId, gameId);
         // Update the game details to ensure that it is up to date in GDevelop services.
-        await updateGame(getAuthorizationHeader, userId, {
-          gameId,
+        await updateGame(getAuthorizationHeader, userId, gameId, {
           authorName,
           gameName,
         });
@@ -208,10 +214,11 @@ export default class ExportLauncher extends Component<Props, State> {
     const setStep = (step: BuildStep) => this.setState({ exportStep: step });
 
     try {
-      // We do not await for this call, allowing to start building the game in parallel.
-      this.registerAndUpdateGame();
+      setStep('register');
+      // We await for this call, allowing to link the build to the game just registered.
+      await this.registerAndUpdateGame();
     } catch {
-      // Best effort call, we don't prevent building the game.
+      // But if it fails, we don't prevent building the game.
       console.warn('Error while registering the game - ignoring it.');
     }
 
@@ -275,11 +282,6 @@ export default class ExportLauncher extends Component<Props, State> {
     }
   };
 
-  _downloadBuild = (key: BuildArtifactKeyName) => {
-    const url = getBuildArtifactUrl(this.state.build, key);
-    if (url) Window.openExternalURL(url);
-  };
-
   _closeDoneFooter = () =>
     this.setState({
       doneFooterOpen: false,
@@ -305,21 +307,16 @@ export default class ExportLauncher extends Component<Props, State> {
     } = this.state;
     const { project, authenticatedUser, exportPipeline } = this.props;
     if (!project) return null;
-    const buildPending = !errored && exportStep !== '' && exportStep !== 'done';
-    const buildFinished = !errored && exportStep === 'done';
-
     const getBuildLimit = (authenticatedUser: AuthenticatedUser): ?Limit =>
       authenticatedUser.limits && exportPipeline.onlineBuildType
         ? authenticatedUser.limits[exportPipeline.onlineBuildType]
         : null;
 
     const canLaunchBuild = (authenticatedUser: AuthenticatedUser) => {
-      if (buildPending || buildFinished) return false;
-
       const limit: ?Limit = getBuildLimit(authenticatedUser);
       if (limit && limit.limitReached) return false;
 
-      return exportPipeline.canLaunchBuild(exportState);
+      return exportPipeline.canLaunchBuild(exportState, errored, exportStep);
     };
 
     return (
@@ -377,14 +374,13 @@ export default class ExportLauncher extends Component<Props, State> {
           )}
         {authenticatedUser.authenticated &&
           (exportPipeline.renderCustomStepsProgress ? (
-            exportPipeline.renderCustomStepsProgress(build, buildPending)
+            exportPipeline.renderCustomStepsProgress(build, errored, exportStep)
           ) : (
             <Line expand>
               <BuildStepsProgress
                 exportStep={exportStep}
                 hasBuildStep={!!exportPipeline.onlineBuildType}
                 build={build}
-                onDownload={this._downloadBuild}
                 stepMaxProgress={stepMaxProgress}
                 stepCurrentProgress={stepCurrentProgress}
                 errored={errored}

--- a/newIDE/app/src/Export/ExportDialog/index.js
+++ b/newIDE/app/src/Export/ExportDialog/index.js
@@ -69,6 +69,10 @@ const ExportDialog = ({
   const [buildsDialogOpen, setBuildsDialogOpen] = React.useState<boolean>(
     false
   );
+  const [
+    isNavigationDisabled,
+    setIsNavigationDisabled,
+  ] = React.useState<boolean>(false);
   const [chosenExporterKey, setChosenExporterKey] = React.useState<ExporterKey>(
     'onlinewebexport'
   );
@@ -110,6 +114,7 @@ const ExportDialog = ({
               setChosenExporterSection('home');
               setChosenExporterKey('onlinewebexport');
             }}
+            disabled={isNavigationDisabled}
           />
         ),
         <FlatButton
@@ -117,17 +122,17 @@ const ExportDialog = ({
           key="close"
           primary={false}
           onClick={onClose}
+          disabled={isNavigationDisabled}
         />,
       ]}
       secondaryActions={[
         <HelpButton key="help" helpPagePath={exporter.helpPage} />,
-        exporter.key !== 'onlinewebexport' && (
-          <FlatButton
-            key="builds"
-            label={<Trans>See this game builds</Trans>}
-            onClick={() => setBuildsDialogOpen(true)}
-          />
-        ),
+        <FlatButton
+          key="builds"
+          label={<Trans>See this game builds</Trans>}
+          onClick={() => setBuildsDialogOpen(true)}
+          disabled={isNavigationDisabled}
+        />,
       ]}
       open
       noMargin
@@ -149,6 +154,8 @@ const ExportDialog = ({
           project={project}
           onChangeSubscription={onChangeSubscription}
           authenticatedUser={authenticatedUser}
+          isNavigationDisabled={isNavigationDisabled}
+          setIsNavigationDisabled={setIsNavigationDisabled}
         />
       )}
       {chosenExporterSection === 'automated' && (
@@ -158,6 +165,7 @@ const ExportDialog = ({
               label={exporter.tabName}
               value={exporter.key}
               key={exporter.key}
+              disabled={isNavigationDisabled}
             />
           ))}
         </Tabs>
@@ -169,6 +177,7 @@ const ExportDialog = ({
               label={exporter.tabName}
               value={exporter.key}
               key={exporter.key}
+              disabled={isNavigationDisabled}
             />
           ))}
         </Tabs>
@@ -181,6 +190,7 @@ const ExportDialog = ({
             onChangeSubscription={onChangeSubscription}
             authenticatedUser={authenticatedUser}
             key={chosenExporterKey}
+            setIsNavigationDisabled={setIsNavigationDisabled}
           />
         </div>
       )}

--- a/newIDE/app/src/Export/ExportPipeline.flow.js
+++ b/newIDE/app/src/Export/ExportPipeline.flow.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow.js';
 import { type Build } from '../Utils/GDevelopServices/Build';
 import { type AuthenticatedUser } from '../Profile/AuthenticatedUserContext';
+import { type BuildStep } from './Builds/BuildStepsProgress';
 
 export type ExportPipelineContext<ExportState> = {|
   project: gdProject,
@@ -37,9 +38,19 @@ export type ExportPipeline<
 
   renderLaunchButtonLabel: () => React.Node,
 
-  canLaunchBuild: (exportState: ExportState) => boolean,
+  canLaunchBuild: (
+    exportState: ExportState,
+    errored: boolean,
+    exportStep: BuildStep
+  ) => boolean,
 
-  renderCustomStepsProgress?: (build: ?Build, loading: boolean) => React.Node,
+  isNavigationDisabled: (exportStep: BuildStep, errored: boolean) => boolean,
+
+  renderCustomStepsProgress?: (
+    build: ?Build,
+    errored: boolean,
+    exportStep: BuildStep
+  ) => React.Node,
 
   prepareExporter: (
     context: ExportPipelineContext<ExportState>

--- a/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalCordovaExport.js
@@ -52,6 +52,8 @@ export const localCordovaExportPipeline: ExportPipeline<
 
   canLaunchBuild: exportState => !!exportState.outputDir,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: ({ project, exportState, updateExportState }) => (
     <Column noMargin>
       <Line>

--- a/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalElectronExport.js
@@ -52,6 +52,8 @@ export const localElectronExportPipeline: ExportPipeline<
 
   canLaunchBuild: exportState => !!exportState.outputDir,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: ({ project, exportState, updateExportState }) => (
     <Column noMargin>
       <Line>

--- a/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalFacebookInstantGamesExport.js
@@ -61,6 +61,8 @@ export const localFacebookInstantGamesExportPipeline: ExportPipeline<
 
   canLaunchBuild: exportState => !!exportState.archiveOutputFilename,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: ({ project, exportState, updateExportState }) => (
     <Column noMargin>
       <Line>

--- a/newIDE/app/src/Export/LocalExporters/LocalHTML5Export.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalHTML5Export.js
@@ -48,6 +48,8 @@ export const localHTML5ExportPipeline: ExportPipeline<
 
   canLaunchBuild: exportState => !!exportState.outputDir,
 
+  isNavigationDisabled: () => false,
+
   renderHeader: ({ project, exportState, updateExportState }) => (
     <Column noMargin>
       <Line>

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
@@ -58,7 +58,16 @@ export const localOnlineCordovaExportPipeline: ExportPipeline<
     signingDialogOpen: false,
   }),
 
-  canLaunchBuild: () => true,
+  // Build can be launched only if just opened the dialog or build errored.
+  canLaunchBuild: (exportState, errored, exportStep) =>
+    errored || exportStep === '',
+
+  // Navigation is enabled when the build is errored or whilst uploading.
+  isNavigationDisabled: (exportStep, errored) =>
+    !errored &&
+    ['register', 'export', 'resources-download', 'compress', 'upload'].includes(
+      exportStep
+    ),
 
   renderHeader: props => <SetupExportHeader {...props} />,
 

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineElectronExport.js
@@ -56,7 +56,16 @@ export const localOnlineElectronExportPipeline: ExportPipeline<
     targets: ['winExe'],
   }),
 
-  canLaunchBuild: (exportState: ExportState) => !!exportState.targets.length,
+  // Build can be launched only if just opened the dialog or build errored.
+  canLaunchBuild: (exportState, errored, exportStep) =>
+    !!exportState.targets.length && (errored || exportStep === ''),
+
+  // Navigation is enabled when the build is errored or whilst uploading.
+  isNavigationDisabled: (exportStep, errored) =>
+    !errored &&
+    ['register', 'export', 'resources-download', 'compress', 'upload'].includes(
+      exportStep
+    ),
 
   renderHeader: props => <SetupExportHeader {...props} />,
 

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
@@ -17,6 +17,7 @@ import {
   type ExportPipeline,
   type ExportPipelineContext,
 } from '../ExportPipeline.flow';
+import { type BuildStep } from '../Builds/BuildStepsProgress';
 import {
   ExplanationHeader,
   WebProjectLink,
@@ -54,14 +55,24 @@ export const localOnlineWebExportPipeline: ExportPipeline<
 
   getInitialExportState: () => null,
 
-  canLaunchBuild: () => true,
+  // Build can be launched if just opened the dialog or build errored, re-enabled when done.
+  canLaunchBuild: (exportState, errored, exportStep) =>
+    errored || exportStep === '' || exportStep === 'done',
+
+  // Navigation is enabled when the build is errored or if the build is not done.
+  isNavigationDisabled: (exportStep, errored) =>
+    !errored && !['', 'done'].includes(exportStep),
 
   renderHeader: () => <ExplanationHeader />,
 
   renderLaunchButtonLabel: () => <Trans>Generate link</Trans>,
 
-  renderCustomStepsProgress: (build: ?Build, loading: boolean) => (
-    <WebProjectLink build={build} loading={loading} />
+  renderCustomStepsProgress: (
+    build: ?Build,
+    errored: boolean,
+    exportStep: BuildStep
+  ) => (
+    <WebProjectLink build={build} errored={errored} exportStep={exportStep} />
   ),
 
   prepareExporter: (

--- a/newIDE/app/src/GameDashboard/GameCard.js
+++ b/newIDE/app/src/GameDashboard/GameCard.js
@@ -6,10 +6,12 @@ import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
 import { Line, Spacer } from '../UI/Grid';
 import RaisedButton from '../UI/RaisedButton';
-import { type Game } from '../Utils/GDevelopServices/Game';
+import { getGameUrl, type Game } from '../Utils/GDevelopServices/Game';
 import TimelineIcon from '@material-ui/icons/Timeline';
 import MonetizationOnIcon from '@material-ui/icons/MonetizationOn';
 import PlaylistPlayIcon from '@material-ui/icons/PlaylistPlay';
+import { ResponsiveLineStackLayout } from '../UI/Layout';
+import Window from '../Utils/Window';
 
 type Props = {|
   game: Game,
@@ -27,53 +29,64 @@ export const GameCard = ({
   onOpenBuilds,
   onOpenAnalytics,
   onOpenMonetization,
-}: Props) => (
-  <Card key={game.id}>
-    <CardHeader
-      title={game.gameName}
-      subheader={
-        <Line alignItems="center" noMargin>
-          <Trans>
-            Registered on{' '}
-            {format(game.createdAt * 1000 /* TODO */, 'yyyy-MM-dd')}
-          </Trans>
-          {isCurrentGame && (
-            <React.Fragment>
-              <Spacer />
-              <Chip size="small" label={<Trans>Game currently edited</Trans>} />
-            </React.Fragment>
+}: Props) => {
+  const openGameUrl = () => {
+    const url = getGameUrl(game);
+    if (!url) return;
+    Window.openExternalURL(url);
+  };
+
+  return (
+    <Card key={game.id}>
+      <CardHeader
+        title={game.gameName}
+        subheader={
+          <Line alignItems="center" noMargin>
+            <Trans>
+              Registered on{' '}
+              {format(game.createdAt * 1000 /* TODO */, 'yyyy-MM-dd')}
+            </Trans>
+            {isCurrentGame && (
+              <React.Fragment>
+                <Spacer />
+                <Chip
+                  size="small"
+                  label={<Trans>Game currently edited</Trans>}
+                />
+              </React.Fragment>
+            )}
+          </Line>
+        }
+      />
+      <CardActions>
+        <ResponsiveLineStackLayout expand noMargin justifyContent="flex-end">
+          <FlatButton
+            label={<Trans>See details</Trans>}
+            onClick={onOpenDetails}
+          />
+          {game.publicWebBuildId && (
+            <RaisedButton label={<Trans>Open</Trans>} onClick={openGameUrl} />
           )}
-        </Line>
-      }
-    />
-    <CardActions>
-      <Line expand noMargin justifyContent="flex-end">
-        <FlatButton
-          label={<Trans>See details</Trans>}
-          onClick={onOpenDetails}
-        />
-        <Spacer />
-        <RaisedButton
-          primary
-          icon={<PlaylistPlayIcon />}
-          label={<Trans>Builds</Trans>}
-          onClick={onOpenBuilds}
-        />
-        <Spacer />
-        <RaisedButton
-          primary
-          icon={<TimelineIcon />}
-          label={<Trans>Analytics</Trans>}
-          onClick={onOpenAnalytics}
-        />
-        <Spacer />
-        <RaisedButton
-          primary
-          icon={<MonetizationOnIcon />}
-          label={<Trans>Monetization</Trans>}
-          onClick={onOpenMonetization}
-        />
-      </Line>
-    </CardActions>
-  </Card>
-);
+          <RaisedButton
+            primary
+            icon={<PlaylistPlayIcon />}
+            label={<Trans>Builds</Trans>}
+            onClick={onOpenBuilds}
+          />
+          <RaisedButton
+            primary
+            icon={<TimelineIcon />}
+            label={<Trans>Analytics</Trans>}
+            onClick={onOpenAnalytics}
+          />
+          <RaisedButton
+            primary
+            icon={<MonetizationOnIcon />}
+            label={<Trans>Monetization</Trans>}
+            onClick={onOpenMonetization}
+          />
+        </ResponsiveLineStackLayout>
+      </CardActions>
+    </Card>
+  );
+};

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -127,17 +127,20 @@ export const GameDetailsDialog = ({
   );
 
   const updateGameFromProject = async () => {
-    if (!project) return;
-    if (!profile) return;
+    if (!project || !profile) return;
     const { id } = profile;
 
     try {
-      const game = await updateGame(getAuthorizationHeader, id, {
-        authorName: project.getAuthor(),
-        gameId: project.getProjectUuid(),
-        gameName: project.getName(),
-      });
-      onGameUpdated(game);
+      const updatedGame = await updateGame(
+        getAuthorizationHeader,
+        id,
+        project.getProjectUuid(),
+        {
+          authorName: project.getAuthor(),
+          gameName: project.getName(),
+        }
+      );
+      onGameUpdated(updatedGame);
     } catch (error) {
       console.error('Unable to update the game:', error);
     }
@@ -236,7 +239,12 @@ export const GameDetailsDialog = ({
           </ColumnStackLayout>
         ) : null}
         {currentTab === 'builds' ? (
-          <Builds gameId={game.id} authenticatedUser={authenticatedUser} />
+          <Builds
+            game={game}
+            authenticatedUser={authenticatedUser}
+            onGameUpdated={onGameUpdated}
+            isGameLoading={false}
+          />
         ) : null}
         {currentTab === 'analytics' ? (
           gameRollingMetricsError ? (

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -243,7 +243,6 @@ export const GameDetailsDialog = ({
             game={game}
             authenticatedUser={authenticatedUser}
             onGameUpdated={onGameUpdated}
-            isGameLoading={false}
           />
         ) : null}
         {currentTab === 'analytics' ? (

--- a/newIDE/app/src/GameDashboard/GameRegistration.js
+++ b/newIDE/app/src/GameDashboard/GameRegistration.js
@@ -152,9 +152,11 @@ export const GameRegistration = ({
 
   React.useEffect(
     () => {
-      loadGame();
+      if (!game) {
+        loadGame();
+      }
     },
-    [loadGame]
+    [loadGame, game]
   );
 
   return (

--- a/newIDE/app/src/UI/FlatButton.js
+++ b/newIDE/app/src/UI/FlatButton.js
@@ -56,6 +56,7 @@ export default class FlatButton extends React.Component<Props, {||}> {
         color={primary ? 'primary' : 'default'}
         autoFocus={keyboardFocused}
         focusRipple={focusRipple}
+        disabled={disabled}
         {...otherProps}
       >
         {icon}

--- a/newIDE/app/src/UI/Tabs.js
+++ b/newIDE/app/src/UI/Tabs.js
@@ -35,6 +35,7 @@ type TabProps = {|
   label: React.Node,
   value: string,
   tabIndex?: string,
+  disabled?: boolean,
 |};
 
 /**

--- a/newIDE/app/src/Utils/GDevelopServices/ApiConfigs.js
+++ b/newIDE/app/src/Utils/GDevelopServices/ApiConfigs.js
@@ -5,6 +5,10 @@ export const GDevelopGamePreviews = {
   baseUrl: `https://game-previews.gdevelop-app.com/`,
 };
 
+export const GDevelopGamesPlatform = {
+  baseUrl: isDev ? 'http://localhost:3001' : 'https://liluo.io',
+};
+
 export const GDevelopBuildApi = {
   baseUrl: isDev
     ? 'https://69p4m07edd.execute-api.us-east-1.amazonaws.com/dev'

--- a/newIDE/app/src/Utils/GDevelopServices/Build.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Build.js
@@ -1,7 +1,7 @@
 // @flow
 import axios from 'axios';
 import { makeTimestampedId } from '../../Utils/TimestampedId';
-import { GDevelopBuildApi } from './ApiConfigs';
+import { GDevelopBuildApi, GDevelopGamesPlatform } from './ApiConfigs';
 import { getSignedUrl } from './Usage';
 
 export type TargetName =
@@ -52,7 +52,10 @@ export const getBuildArtifactUrl = (
   }
 
   if (keyName === 's3Key') {
-    return `https://games.gdevelop-app.com/${build[keyName]}/index.html`;
+    // New builds have a gameId.
+    return build.gameId
+      ? `${GDevelopGamesPlatform.baseUrl}/instant-builds/${build.id}`
+      : `https://games.gdevelop-app.com/${build[keyName]}/index.html`;
   }
 
   return `https://builds.gdevelop-app.com/${build[keyName]}`;

--- a/newIDE/app/src/Utils/GDevelopServices/Game.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Game.js
@@ -1,6 +1,6 @@
 // @flow
 import axios from 'axios';
-import { GDevelopGameApi } from './ApiConfigs';
+import { GDevelopGameApi, GDevelopGamesPlatform } from './ApiConfigs';
 import { type Filters } from './Filters';
 
 export type Game = {
@@ -8,6 +8,7 @@ export type Game = {
   gameName: string,
   authorName: string,
   createdAt: number,
+  publicWebBuildId?: ?string,
 };
 
 export type ShowcasedGameLink = {
@@ -41,6 +42,11 @@ export type ShowcasedGame = {
 export type AllShowcasedGames = {
   showcasedGames: Array<ShowcasedGame>,
   filters: Filters,
+};
+
+export const getGameUrl = (game: ?Game) => {
+  if (!game) return null;
+  return `${GDevelopGamesPlatform.baseUrl}/games/${game.id}`;
 };
 
 export const listAllShowcasedGames = (): Promise<AllShowcasedGames> => {
@@ -94,17 +100,19 @@ export const registerGame = (
     )
     .then(response => response.data);
 };
+
 export const updateGame = (
   getAuthorizationHeader: () => Promise<string>,
   userId: string,
+  gameId: string,
   {
-    gameId,
     gameName,
     authorName,
+    publicWebBuildId,
   }: {|
-    gameId: string,
-    gameName: string,
-    authorName: string,
+    gameName?: string,
+    authorName?: string,
+    publicWebBuildId?: ?string,
   |}
 ): Promise<Game> => {
   return getAuthorizationHeader()
@@ -114,6 +122,7 @@ export const updateGame = (
         {
           gameName,
           authorName,
+          publicWebBuildId,
         },
         {
           params: {

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -126,7 +126,7 @@ import ChangeEmailDialog from '../Profile/ChangeEmailDialog';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import { SubscriptionCheckDialog } from '../Profile/SubscriptionChecker';
 import DebuggerContent from '../Debugger/DebuggerContent';
-import BuildProgress from '../Export/Builds/BuildProgress';
+import BuildProgressAndActions from '../Export/Builds/BuildProgressAndActions';
 import BuildStepsProgress from '../Export/Builds/BuildStepsProgress';
 import MeasuresTable from '../Debugger/Profiler/MeasuresTable';
 import Profiler from '../Debugger/Profiler';
@@ -2472,7 +2472,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={''}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={0}
       stepCurrentProgress={0}
       errored={false}
@@ -2483,7 +2482,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={''}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={0}
       stepCurrentProgress={0}
       errored={false}
@@ -2494,7 +2492,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'export'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={0}
       stepCurrentProgress={0}
       errored={false}
@@ -2505,7 +2502,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'resources-download'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={27}
       stepCurrentProgress={16}
       errored={false}
@@ -2516,7 +2512,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'export'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={0}
       stepCurrentProgress={0}
       errored={true}
@@ -2527,7 +2522,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'compress'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={0}
       stepCurrentProgress={0}
       errored={false}
@@ -2538,7 +2532,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'upload'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={100}
       stepCurrentProgress={20}
       errored={false}
@@ -2549,7 +2542,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'upload'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={100}
       stepCurrentProgress={20}
       errored
@@ -2560,7 +2552,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'waiting-for-build'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={100}
       stepCurrentProgress={20}
       errored={false}
@@ -2579,7 +2570,6 @@ storiesOf('BuildStepsProgress', module)
         updatedAt: Date.now(),
         createdAt: Date.now(),
       }}
-      onDownload={action('download')}
       stepMaxProgress={100}
       stepCurrentProgress={20}
       errored={false}
@@ -2600,7 +2590,6 @@ storiesOf('BuildStepsProgress', module)
         updatedAt: Date.now(),
         createdAt: Date.now(),
       }}
-      onDownload={action('download')}
       stepMaxProgress={100}
       stepCurrentProgress={20}
       errored
@@ -2621,7 +2610,6 @@ storiesOf('BuildStepsProgress', module)
         updatedAt: Date.now(),
         createdAt: Date.now(),
       }}
-      onDownload={action('download')}
       stepMaxProgress={100}
       stepCurrentProgress={20}
       errored={false}
@@ -2632,7 +2620,6 @@ storiesOf('BuildStepsProgress', module)
     <BuildStepsProgress
       exportStep={'done'}
       build={null}
-      onDownload={action('download')}
       stepMaxProgress={100}
       stepCurrentProgress={20}
       errored={false}
@@ -2640,18 +2627,22 @@ storiesOf('BuildStepsProgress', module)
     />
   ));
 
-storiesOf('BuildProgress', module)
+storiesOf('BuildProgressAndActions', module)
   .addDecorator(paperDecorator)
   .addDecorator(muiDecorator)
-  .add('errored', () => <BuildProgress build={erroredCordovaBuild} />)
+  .add('errored', () => <BuildProgressAndActions build={erroredCordovaBuild} />)
   .add('pending (electron-build)', () => (
-    <BuildProgress build={{ ...pendingElectronBuild, updatedAt: Date.now() }} />
+    <BuildProgressAndActions
+      build={{ ...pendingElectronBuild, updatedAt: Date.now() }}
+    />
   ))
   .add('pending (cordova-build)', () => (
-    <BuildProgress build={{ ...pendingCordovaBuild, updatedAt: Date.now() }} />
+    <BuildProgressAndActions
+      build={{ ...pendingCordovaBuild, updatedAt: Date.now() }}
+    />
   ))
   .add('pending and very old (cordova-build)', () => (
-    <BuildProgress
+    <BuildProgressAndActions
       build={{
         ...pendingCordovaBuild,
         updatedAt: Date.now() - 1000 * 3600 * 24,
@@ -2659,13 +2650,13 @@ storiesOf('BuildProgress', module)
     />
   ))
   .add('complete (cordova-build)', () => (
-    <BuildProgress build={completeCordovaBuild} />
+    <BuildProgressAndActions build={completeCordovaBuild} />
   ))
   .add('complete (electron-build)', () => (
-    <BuildProgress build={completeElectronBuild} />
+    <BuildProgressAndActions build={completeElectronBuild} />
   ))
   .add('complete (web-build)', () => (
-    <BuildProgress build={completeWebBuild} />
+    <BuildProgressAndActions build={completeWebBuild} />
   ));
 
 storiesOf('LocalFolderPicker', module)


### PR DESCRIPTION
This PR does quite a few things (sorry for the mono-commit!)

In summary:
- improved some components readability + optimisation of network calls
- prevent navigating away from the build dialog at critical moments, resulting in confusing the user when the page is reset (while uploading / while building for web)
- improved the builds list accessible from the Export dialog and from the Games dashboard
  - a web build can be promoted as the latest version for the game
  - a web build can also be unpublished
  - the web build url can be opened directly from the list
  - the list of web builds does not expire any more (only the desktop & mobile builds expire after 7 days)
- change the link of the web build to be:
  - either the stable game page link if the build corresponds to the one linked to the game (especially useful for the first build someone creates, automatically linked to the game)
  - or the build link for subsequent builds, with an option to publish easily to the stable game page
- Added a button to open the stable game page from the game dashboard

Few screenshots:

![image](https://user-images.githubusercontent.com/4895034/148243491-24d8f7b5-f6cb-49ae-a24a-3ab4dffb9165.png)
![image](https://user-images.githubusercontent.com/4895034/148243536-65b2cb33-5b17-4dac-9474-ebcb0543fc2f.png)
![image](https://user-images.githubusercontent.com/4895034/148243714-f4e8568e-7465-4b89-a3f1-597f75833e0f.png)
![image](https://user-images.githubusercontent.com/4895034/148243747-10c561ce-1420-49ce-9224-366fd447bc8c.png)
![image](https://user-images.githubusercontent.com/4895034/148243674-867acf05-020e-4d6a-a13b-dfa127d7dcf9.png)
