### PR TITLE
Autocompletion for fields and expressions asking a function parameter name

### DIFF
--- a/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
@@ -83,7 +83,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                     _("Functions"),
                     "res/function24.png",
                     "res/function16.png")
-      .AddParameter("string", "Parameter name")
+      .AddParameter("functionParameterName", "Parameter name")
       .MarkAsAdvanced();
 
   extension
@@ -93,7 +93,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           _("Get function parameter (also called \"argument\") value"),
           _("Functions"),
           "res/function16.png")
-      .AddParameter("string", "Parameter name");
+      .AddParameter("functionParameterName", "Parameter name");
 
   extension
       .AddStrExpression(
@@ -102,7 +102,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           _("Get function parameter (also called \"argument\") text "),
           _("Functions"),
           "res/function16.png")
-      .AddParameter("string", "Parameter name");
+      .AddParameter("functionParameterName", "Parameter name");
 }
 
 }  // namespace gd

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
@@ -194,7 +194,8 @@ class GD_CORE_API ParameterMetadata {
              parameterType == "objectEffectName" ||
              parameterType == "objectEffectParameterName" ||
              parameterType == "objectPointName" ||
-             parameterType == "objectAnimationName";
+             parameterType == "objectAnimationName" ||
+             parameterType == "functionParameterName";
     } else if (type == "variable") {
       return parameterType == "objectvar" || parameterType == "globalvar" ||
              parameterType == "scenevar";

--- a/newIDE/app/src/EventsSheet/ParameterFields/EnumerateFunctionParameters.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/EnumerateFunctionParameters.js
@@ -1,0 +1,15 @@
+// @flow
+import { mapVector } from '../../Utils/MapFor';
+const gd: libGDevelop = global.gd;
+
+export const enumerateParametersUsableInExpressions = (
+  eventsFunction: gdEventsFunction
+): Array<gdParameterMetadata> => {
+  return mapVector(eventsFunction.getParameters(), parameterMetadata =>
+    parameterMetadata.isCodeOnly() ||
+    gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
+    gd.ParameterMetadata.isBehavior(parameterMetadata.getType())
+      ? null
+      : parameterMetadata
+  ).filter(Boolean);
+};

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -1,0 +1,43 @@
+// @flow
+import React, { Component } from 'react';
+import GenericExpressionField from './GenericExpressionField';
+import { enumerateLayouts } from '../../ProjectManager/EnumerateProjectItems';
+import { type ParameterFieldProps } from './ParameterFieldCommons';
+import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
+import { mapVector } from '../../Utils/MapFor';
+import { type EventsScope } from '../../InstructionOrExpression/EventsScope.flow';
+const gd: libGDevelop = global.gd;
+
+export default class FunctionParameterNameField extends Component<
+  ParameterFieldProps,
+  void
+> {
+  _field: ?GenericExpressionField;
+
+  focus() {
+    if (this._field) this._field.focus();
+  }
+
+  render() {
+    const parameterNames: Array<ExpressionAutocompletion> = this.props.scope.eventsFunction
+      ? 
+      mapVector(this.props.scope.eventsFunction.getParameters(),
+        (parameterMetadata) => (parameterMetadata.isCodeOnly() ||
+        gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
+        gd.ParameterMetadata.isBehavior(parameterMetadata.getType())) ? null : { kind: 'Text', completion: `"${parameterMetadata.getName()}"` }).filter(Boolean)
+      : [];
+
+    return (
+      <GenericExpressionField
+        expressionType="string"
+        onGetAdditionalAutocompletions={expression =>
+          parameterNames.filter(
+            ({ completion }) => completion.indexOf(expression) === 0
+          )
+        }
+        ref={field => (this._field = field)}
+        {...this.props}
+      />
+    );
+  }
+}

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -3,8 +3,7 @@ import React, { Component } from 'react';
 import GenericExpressionField from './GenericExpressionField';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
 import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
-import { mapVector } from '../../Utils/MapFor';
-const gd: libGDevelop = global.gd;
+import { enumerateParametersUsableInExpressions } from './EnumerateFunctionParameters';
 
 export default class FunctionParameterNameField extends Component<
   ParameterFieldProps,
@@ -41,15 +40,3 @@ export default class FunctionParameterNameField extends Component<
     );
   }
 }
-
-export const enumerateParametersUsableInExpressions = (
-  eventsFunction: gdEventsFunction
-): gdParameterMetadata[] => {
-  return mapVector(eventsFunction.getParameters(), parameterMetadata =>
-    parameterMetadata.isCodeOnly() ||
-    gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
-    gd.ParameterMetadata.isBehavior(parameterMetadata.getType())
-      ? null
-      : parameterMetadata
-  ).filter(Boolean);
-};

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import GenericExpressionField from './GenericExpressionField';
-import { enumerateLayouts } from '../../ProjectManager/EnumerateProjectItems';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
 import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
 import { mapVector } from '../../Utils/MapFor';

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -4,7 +4,6 @@ import GenericExpressionField from './GenericExpressionField';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
 import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
 import { mapVector } from '../../Utils/MapFor';
-import { type EventsScope } from '../../InstructionOrExpression/EventsScope.flow';
 const gd: libGDevelop = global.gd;
 
 export default class FunctionParameterNameField extends Component<
@@ -18,12 +17,14 @@ export default class FunctionParameterNameField extends Component<
   }
 
   render() {
-    const parameterNames: Array<ExpressionAutocompletion> = this.props.scope.eventsFunction
-      ? 
-      mapVector(this.props.scope.eventsFunction.getParameters(),
-        (parameterMetadata) => (parameterMetadata.isCodeOnly() ||
-        gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
-        gd.ParameterMetadata.isBehavior(parameterMetadata.getType())) ? null : { kind: 'Text', completion: `"${parameterMetadata.getName()}"` }).filter(Boolean)
+    const parameterNames: Array<ExpressionAutocompletion> = this.props.scope
+      .eventsFunction
+      ? enumerateParametersUsableInExpressions(
+          this.props.scope.eventsFunction
+        ).map(parameterMetadata => ({
+          kind: 'Text',
+          completion: `"${parameterMetadata.getName()}"`,
+        }))
       : [];
 
     return (
@@ -40,3 +41,15 @@ export default class FunctionParameterNameField extends Component<
     );
   }
 }
+
+export const enumerateParametersUsableInExpressions = (
+  eventsFunction: gdEventsFunction
+): gdParameterMetadata[] => {
+  return mapVector(eventsFunction.getParameters(), parameterMetadata =>
+    parameterMetadata.isCodeOnly() ||
+    gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
+    gd.ParameterMetadata.isBehavior(parameterMetadata.getType())
+      ? null
+      : parameterMetadata
+  ).filter(Boolean);
+};

--- a/newIDE/app/src/EventsSheet/ParameterRenderingService.js
+++ b/newIDE/app/src/EventsSheet/ParameterRenderingService.js
@@ -52,6 +52,7 @@ import ObjectEffectNameField from './ParameterFields/ObjectEffectNameField';
 import ObjectEffectParameterNameField from './ParameterFields/ObjectEffectParameterNameField';
 import ObjectPointNameField from './ParameterFields/ObjectPointNameField';
 import ObjectAnimationNameField from './ParameterFields/ObjectAnimationNameField';
+import FunctionParameterNameField from './ParameterFields/FunctionParameterNameField';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 const gd: libGDevelop = global.gd;
 
@@ -89,6 +90,7 @@ const components = {
   objectEffectParameterName: ObjectEffectParameterNameField,
   objectPointName: ObjectPointNameField,
   objectAnimationName: ObjectAnimationNameField,
+  functionParameterName: FunctionParameterNameField,
 };
 const inlineRenderers: { [string]: ParameterInlineRenderer } = {
   default: renderInlineDefaultField,
@@ -134,6 +136,7 @@ const userFriendlyTypeName: { [string]: MessageDescriptor } = {
   objectEffectParameterName: t`Object effect parameter name`,
   objectPointName: t`Object point name`,
   objectAnimationName: t`Object animation name`,
+  functionParameterName: t`Parameter name`,
 };
 
 export default {

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { mapVector } from '../Utils/MapFor';
+import { mapFor, mapVector } from '../Utils/MapFor';
 import {
   enumerateObjectsAndGroups,
   filterObjectsList,
@@ -22,7 +22,7 @@ import { getVisibleParameterTypes } from '../EventsSheet/ParameterFields/Generic
 import { getParameterChoices } from '../EventsSheet/ParameterFields/ParameterMetadataTools';
 import getObjectByName from '../Utils/GetObjectByName';
 import { getAllPointNames } from '../ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper';
-import { mapFor } from '../Utils/MapFor';
+import { enumerateParametersUsableInExpressions } from '../EventsSheet/ParameterFields/FunctionParameterNameField.js';
 
 const gd: libGDevelop = global.gd;
 
@@ -338,13 +338,11 @@ const getAutocompletionsForText = function(
     } else {
       return [];
     }
-  }
-  else if (type === 'functionParameterName') {
+  } else if (type === 'functionParameterName') {
     if (scope.eventsFunction) {
-      autocompletionTexts = mapVector(scope.eventsFunction.getParameters(),
-        (parameterMetadata) => (parameterMetadata.isCodeOnly() ||
-        gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
-        gd.ParameterMetadata.isBehavior(parameterMetadata.getType())) ? null : `"${parameterMetadata.getName()}"`).filter(Boolean);
+      autocompletionTexts = enumerateParametersUsableInExpressions(
+        scope.eventsFunction
+      ).map(parameterMetadata => `"${parameterMetadata.getName()}"`);
     }
   }
   // To add missing string types see Core\GDCore\Extensions\Metadata\ParameterMetadata.h

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -22,7 +22,7 @@ import { getVisibleParameterTypes } from '../EventsSheet/ParameterFields/Generic
 import { getParameterChoices } from '../EventsSheet/ParameterFields/ParameterMetadataTools';
 import getObjectByName from '../Utils/GetObjectByName';
 import { getAllPointNames } from '../ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper';
-import { enumerateParametersUsableInExpressions } from '../EventsSheet/ParameterFields/FunctionParameterNameField';
+import { enumerateParametersUsableInExpressions } from '../EventsSheet/ParameterFields/EnumerateFunctionParameters';
 
 const gd: libGDevelop = global.gd;
 

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -347,7 +347,6 @@ const getAutocompletionsForText = function(
         gd.ParameterMetadata.isBehavior(parameterMetadata.getType())) ? null : `"${parameterMetadata.getName()}"`).filter(Boolean);
     }
   }
-
   // To add missing string types see Core\GDCore\Extensions\Metadata\ParameterMetadata.h
 
   const filteredTextList = filterStringList(autocompletionTexts, prefix).sort();

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -22,7 +22,7 @@ import { getVisibleParameterTypes } from '../EventsSheet/ParameterFields/Generic
 import { getParameterChoices } from '../EventsSheet/ParameterFields/ParameterMetadataTools';
 import getObjectByName from '../Utils/GetObjectByName';
 import { getAllPointNames } from '../ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper';
-import { enumerateParametersUsableInExpressions } from '../EventsSheet/ParameterFields/FunctionParameterNameField.js';
+import { enumerateParametersUsableInExpressions } from '../EventsSheet/ParameterFields/FunctionParameterNameField';
 
 const gd: libGDevelop = global.gd;
 

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -339,6 +339,15 @@ const getAutocompletionsForText = function(
       return [];
     }
   }
+  else if (type === 'functionParameterName') {
+    if (scope.eventsFunction) {
+      autocompletionTexts = mapVector(scope.eventsFunction.getParameters(),
+        (parameterMetadata) => (parameterMetadata.isCodeOnly() ||
+        gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
+        gd.ParameterMetadata.isBehavior(parameterMetadata.getType())) ? null : `"${parameterMetadata.getName()}"`).filter(Boolean);
+    }
+  }
+
   // To add missing string types see Core\GDCore\Extensions\Metadata\ParameterMetadata.h
 
   const filteredTextList = filterStringList(autocompletionTexts, prefix).sort();


### PR DESCRIPTION
I used an expression field. I'm not sure this is really necessary, but it let the user knows when quotes are missing.

![ParameterError](https://user-images.githubusercontent.com/2611977/148815367-10c25f3e-bfa6-4830-ac28-2a688cf93cfe.png)

![ParameterAutocompletion](https://user-images.githubusercontent.com/2611977/148814890-466a1714-2b01-48a2-bcc5-47d07506fb65.png)

