### PR TITLE
Fix issues with npm install and npm version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 # For Windows, see the appveyor.yml file.
 
 version: 2.1
-orbs: 
+orbs:
   aws-cli: circleci/aws-cli@2.0.6
 jobs:
   build-macos:
@@ -33,7 +33,7 @@ jobs:
             - gd-macos-nodejs-dependencies---
 
       - run:
-          name: Install GDevelop.js dependencies and build it
+          name: Install GDevelop.js dependencies
           command: cd GDevelop.js && npm install && cd ..
 
       # Build GDevelop.js (and run tests to ensure it works)
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Install dependencies for Emscripten
           command: sudo apt-get update && sudo apt install cmake
-          
+
       - run:
          name: Install Python3 dependencies for Emscripten
          command: sudo apt install python-is-python3 python3-distutils -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ cache:
   directories:
     - $HOME/.npm
 
-env:
-  global:
-    - GCC_VERSION="4.8"
-
 services:
   # Virtual Framebuffer 'fake' X server for SFML
   - xvfb
@@ -40,7 +36,6 @@ addons:
     # Build dependencies:
     - cmake
     - p7zip-full
-    - g++-4.8
     # SFML dependencies:
     - libopenal-dev
     - libjpeg-dev
@@ -60,10 +55,8 @@ before_install:
   - sudo dpkg --force-all -i libstdc++6
 
 install:
-# Ensure we use a recent version of Node.js (and npm)
+# Ensure we use a recent version of Node.js (and npm).
   - nvm install v16 && nvm use v16
-#Get the correct version of gcc/g++
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
 #Compile the tests only for GDCore
   - mkdir .build-tests
   - cd .build-tests
@@ -72,21 +65,17 @@ install:
   - cd ..
 # Install Emscripten (for GDevelop.js)
   - git clone https://github.com/juj/emsdk.git
-  - cd emsdk
-  - ./emsdk install 1.39.6
-  - ./emsdk activate 1.39.6
-  - source ./emsdk_env.sh
-  - cd ..
-# Install GDevelop.js dependencies and compile it
-  - cd GDevelop.js
-  - npm install -g grunt-cli
-  - npm install
-  - npm run build
-  - cd ..
-#Install newIDE tests dependencies
+  - cd emsdk && ./emsdk install 1.39.6 && ./emsdk activate 1.39.6 && cd ..
+# Install GDevelop.js dependencies
+  - cd GDevelop.js && npm install && cd ..
+# Build GDevelop.js
+# (in a subshell to avoid Emscripten polluting the Node.js and npm version for the rest of the build)
+  - (set -e; cd GDevelop.js && source ../emsdk/emsdk_env.sh && npm run build && cd ..)
+# Install newIDE tests dependencies
+  - npm -v
   - cd newIDE/app && npm install
   - cd ../..
-#Install GDJS tests dependencies
+# Install GDJS tests dependencies
   - cd GDJS && npm install && cd tests && npm install
   - cd ../..
 

--- a/GDevelop.js/Readme.md
+++ b/GDevelop.js/Readme.md
@@ -29,6 +29,8 @@ This is the port of GDevelop core classes to WebAssembly+JavaScript. This allows
     npm run build
 ```
 
+> ⚠️ If the npm install fails, relaunch it in a different terminal using a recent Node.js and npm version (to avoid using the old npm version from Emscripten).
+
 > ℹ️ Output is created in _/path/to/GD/Binaries/embuild/GDevelop.js/_ and also copied to GDevelop 5 IDE (`newIDE` folder).
 
 -> ⏱ The linking (last step) of the build can be made a few seconds faster by specifying `-- --dev`. Be sure to remove it before building a release version, as this disable "link-time optimizations" of the generated WebAssembly module.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,13 @@ branches:
 init:
 - ps: ''
 install:
-- ps: Install-Product node 14
-# Build GDevelop.js (and run tests to ensure it works)
+- ps: Install-Product node 16
+# Build GDevelop.js (and run tests to ensure it works).
+# (in a subshell to avoid Emscripten polluting the Node.js and npm version for the rest of the build)
 - cmd: >-
     cd GDevelop.js
+
+    npm -v && npm install
 
     git clone https://github.com/juj/emsdk.git
 
@@ -26,31 +29,23 @@ install:
 
     emsdk install 1.39.6
 
-    emsdk activate 1.39.6
+    CMD /C "emsdk activate 1.39.6 && cd .. && npm run build"
 
-    emsdk_env.bat
-
-    cd ..
-
-    npm install
-
-    npm run build
-
-    cd ..
+    cd ..\..
 
 # Build GDevelop IDE
 - cmd: >-
     cd newIDE\app
 
-    npm install
+    npm -v && npm install
 
     cd ..\electron-app
 
-    npm install
+    npm -v && npm install
 
     cd ..\..
 
-# Package the app for Windows (and sign it with the certificate set in environment variables). 
+# Package the app for Windows (and sign it with the certificate set in environment variables).
 # Don't sign the appx (it will be signed by the Microsoft Store).
 build_script:
 - ps: >-


### PR DESCRIPTION
- Remove useless GCC 4.8 on Travis
- Use a subshell to compile GDevelop.js and use Node.js 16/npm v8 for all npm installs (Travis, AppVeyor). The subshell avoids Emscripten to pollute the environment with an old Node.js/npm version that has issue during the npm install. CircleCi was already good.