### PR TITLE
Fix: Set error var to predefined value if web request couldn't be sent

### DIFF
--- a/Core/GDCore/Extensions/Builtin/NetworkExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/NetworkExtension.cpp
@@ -94,9 +94,10 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsNetworkExtension(
           "scenevar", _("Variable where to store the error message"), "", true)
       .SetParameterLongDescription(
           _("Optional, only used if an error occurs. This will contain the "
-            "error message (if request could not be sent) or the [\"status "
-            "code\"](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes), "
-            "if the server returns a status >= 400."))
+            "[\"status code\"](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) "
+            "if the server returns a status >= 400. If the request was not sent "
+            "at all (e.g. no internet or CORS issues), the variable will be set to "
+            "\"REQUEST_NOT_SENT\"."))
       .MarkAsComplex();
 
   extension

--- a/GDJS/Runtime/events-tools/networktools.ts
+++ b/GDJS/Runtime/events-tools/networktools.ts
@@ -34,7 +34,7 @@ namespace gdjs {
             err.currentTarget instanceof XMLHttpRequest &&
             err.currentTarget.status === 0
           ) {
-            errorVar.setString('UNDEFINED');
+            errorVar.setString('REQUEST_NOT_SENT');
           } else {
             errorVar.setString('' + err);
           }

--- a/GDJS/Runtime/events-tools/networktools.ts
+++ b/GDJS/Runtime/events-tools/networktools.ts
@@ -28,7 +28,11 @@ namespace gdjs {
         errorVar: gdjs.Variable
       ) {
         const onError = (err) => {
-          errorVar.setString('' + err);
+          if (err.currentTarget && err.currentTarget.status === 0) {
+            errorVar.setString('UNDEFINED');
+          } else {
+            errorVar.setString('' + err);
+          }
         };
         try {
           const request = new XMLHttpRequest();

--- a/GDJS/Runtime/events-tools/networktools.ts
+++ b/GDJS/Runtime/events-tools/networktools.ts
@@ -28,7 +28,12 @@ namespace gdjs {
         errorVar: gdjs.Variable
       ) {
         const onError = (err) => {
-          if (err.currentTarget && err.currentTarget.status === 0) {
+          if (
+            err instanceof ProgressEvent &&
+            err.currentTarget &&
+            err.currentTarget instanceof XMLHttpRequest &&
+            err.currentTarget.status === 0
+          ) {
             errorVar.setString('UNDEFINED');
           } else {
             errorVar.setString('' + err);


### PR DESCRIPTION
Resolves #2449 