### PR TITLE
Update resources used by pixi on scene editor force update

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
@@ -49,7 +49,11 @@ export class SceneEditorContainer extends React.Component<RenderEditorContainerP
   }
 
   forceUpdateEditor() {
-    if (this.editor) this.editor.forceUpdateObjectsList();
+    const { editor } = this;
+    if (editor) {
+      editor.forceUpdateObjectsList();
+      editor.forceUpdatePixi();
+    }
   }
 
   getLayout(): ?gdLayout {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -923,6 +923,14 @@ export default class SceneEditor extends React.Component<Props, State> {
     if (this._propertiesEditor) this._propertiesEditor.forceUpdate();
   };
 
+  forceUpdatePixi = () => {
+    const { layout } = this.props;
+    const objectsCount = layout.getObjectsCount();
+    for (let index = 0; index < objectsCount; index++) {
+      this.reloadResourcesFor(layout.getObjectAt(index));
+    }
+  };
+
   reloadResourcesFor = (object: gdObject) => {
     const { project } = this.props;
 


### PR DESCRIPTION
Fix #3388. #3549 

@Bouh I had not seen you tagged me in the issue. I used your PR #1724 to fix this bug.
@4ian I added a forced update of Pixi resources when the editor is force updated, that's to say each time the user comes back to the tab I think.

It feels ok regarding the performance:
Using the Isometric starter that can feel a bit loaded, the change of tabs takes 40ms without this pixi reload, and 51ms with.
Maybe I could work a bit more so that this Pixi forced update only takes place on project change.

There's also the issue of the resource not updating if we modify the file outside of GDevelop, but I'm not sure it should be part of this PR.