### PR TITLE
"Start (or reset) the timer"

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -910,7 +910,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Start (or reset) an object timer"),
          _("Reset the specified object timer, if the timer doesn't exist "
            "it's created and started."),
-         _("Reset the timer _PARAM1_ of _PARAM0_"),
+         _("Start (or reset) the timer _PARAM1_ of _PARAM0_"),
          _("Timers"),
          "res/actions/timer24.png",
          "res/actions/timer.png")

--- a/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
@@ -80,7 +80,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsTimeExtension(
           _("Start (or reset) a scene timer"),
           _("Reset the specified scene timer, if the timer doesn't exist "
             "it's created and started."),
-          _("Reset the timer _PARAM1_"),
+          _("Start (or reset) the timer _PARAM1_"),
           _("Timers and time"),
           "res/actions/timer24.png",
           "res/actions/timer.png")


### PR DESCRIPTION
Change wording to make it match the short description of the action.

Are there any other places this needs to be changed?