### PR TITLE
Set animation to 0 if value is an empty string

### DIFF
--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.cpp
@@ -149,8 +149,9 @@ bool SpriteObject::UpdateInitialInstanceProperty(gd::InitialInstance& position,
                                                  const gd::String& value,
                                                  gd::Project& project,
                                                  gd::Layout& scene) {
-  if (name == _("Animation"))
-    position.SetRawDoubleProperty("animation", value.To<int>());
+  if (name == _("Animation")) {
+    position.SetRawDoubleProperty("animation", value.empty() ? 0 : value.To<int>());
+  }
 
   return true;
 }


### PR DESCRIPTION
Fixes #3518 

@4ian I'm not familiar with the instances properties editor, but I don't know why in `InstancePropertiesEditor._renderInstancesProperties`, in the instanceSchema, `Animation` is set as a string.

EDIT

Maybe because `string` is the fallback if there is no type set.