### PR TITLE
[Platformer] Add a parameter "try to preserve the current speed" to the "max falling speed" action.

### DIFF
--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -171,6 +171,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .UseStandardOperatorParameters("number")
+        .AddParameter("yesorno", _("Try to preserve the current speed"))
         .MarkAsAdvanced()
         .SetFunctionName("SetMaxFallingSpeed")
         .SetGetter("GetMaxFallingSpeed");
@@ -206,9 +207,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddCondition("Acceleration",
                      _("Acceleration"),
-                     _("Compare the acceleration of the object (in pixels per "
+                     _("Compare the horizontal acceleration of the object (in pixels per "
                        "second per second)."),
-                     _("the acceleration"),
+                     _("the horizontal acceleration"),
                      _("Options"),
                      "CppPlatform/Extensions/platformerobjecticon24.png",
                      "CppPlatform/Extensions/platformerobjecticon16.png")
@@ -220,9 +221,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddAction("Acceleration",
                   _("Acceleration"),
-                  _("Change the acceleration of an object (in pixels per "
+                  _("Change the horizontal acceleration of an object (in pixels per "
                     "second per second)."),
-                  _("the acceleration"),
+                  _("the horizontal acceleration"),
                   _("Options"),
                   "CppPlatform/Extensions/platformerobjecticon24.png",
                   "CppPlatform/Extensions/platformerobjecticon16.png")
@@ -235,9 +236,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddCondition("Deceleration",
                      _("Deceleration"),
-                     _("Compare the deceleration of the object (in pixels per "
+                     _("Compare the horizontal deceleration of the object (in pixels per "
                        "second per second)."),
-                     _("the deceleration"),
+                     _("the horizontal deceleration"),
                      _("Options"),
                      "CppPlatform/Extensions/platformerobjecticon24.png",
                      "CppPlatform/Extensions/platformerobjecticon16.png")
@@ -249,9 +250,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddAction("Deceleration",
                   _("Deceleration"),
-                  _("Change the deceleration of an object (in pixels per "
+                  _("Change the horizontal deceleration of an object (in pixels per "
                     "second per second)."),
-                  _("the deceleration"),
+                  _("the horizontal deceleration"),
                   _("Options"),
                   "CppPlatform/Extensions/platformerobjecticon24.png",
                   "CppPlatform/Extensions/platformerobjecticon16.png")
@@ -264,9 +265,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddCondition(
            "MaxSpeed",
-           _("Maximum speed"),
-           _("Compare the maximum speed of the object (in pixels per second)."),
-           _("the maximum speed"),
+           _("Maximum horizontal speed"),
+           _("Compare the maximum horizontal speed of the object (in pixels per second)."),
+           _("the maximum horizontal speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
@@ -277,9 +278,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddAction(
            "MaxSpeed",
-           _("Maximum speed"),
-           _("Change the maximum speed of an object (in pixels per second)."),
-           _("the maximum speed"),
+           _("Maximum horizontal speed"),
+           _("Change the maximum horizontal speed of an object (in pixels per second)."),
+           _("the maximum horizontal speed"),
            _("Options"),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")
@@ -584,10 +585,10 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("GetCurrentJumpSpeed");
 
     aut.AddCondition("CurrentSpeed",
-                     _("Current speed"),
-                     _("Compare the current speed of the object (in pixels per "
+                     _("Current horizontal speed"),
+                     _("Compare the current horizontal speed of the object (in pixels per "
                        "second)."),
-                     _("the current speed"),
+                     _("the current horizontal speed"),
                      _(""),
                      "CppPlatform/Extensions/platformerobjecticon24.png",
                      "CppPlatform/Extensions/platformerobjecticon16.png")
@@ -626,7 +627,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddExpression("Acceleration",
                       _("Acceleration"),
-                      _("Acceleration"),
+                      _("Horizontal acceleration"),
                       _("Options"),
                       "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
@@ -635,7 +636,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddExpression("Deceleration",
                       _("Deceleration"),
-                      _("Deceleration"),
+                      _("Horizontal deceleration"),
                       _("Options"),
                       "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
@@ -643,8 +644,8 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("GetDeceleration");
 
     aut.AddExpression("MaxSpeed",
-                      _("Maximum speed"),
-                      _("Maximum speed"),
+                      _("Maximum horizontal speed"),
+                      _("Maximum horizontal speed"),
                       _("Options"),
                       "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))
@@ -679,8 +680,8 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .SetFunctionName("GetCurrentFallSpeed");
 
     aut.AddExpression("CurrentSpeed",
-                      _("Current speed"),
-                      _("Current speed"),
+                      _("Current horizontal speed"),
+                      _("Current horizontal speed"),
                       _(""),
                       "CppPlatform/Extensions/platformerobjecticon16.png")
         .AddParameter("object", _("Object"))

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -171,7 +171,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .UseStandardOperatorParameters("number")
-        .AddParameter("yesorno", _("Try to preserve the current speed"))
+        .AddParameter("yesorno", _("If jumping, try to preserve the current speed in the air"))
         .MarkAsAdvanced()
         .SetFunctionName("SetMaxFallingSpeed")
         .SetGetter("GetMaxFallingSpeed");

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1870,7 +1870,7 @@ namespace gdjs {
     }
 
     setCurrentJumpSpeed(currentJumpSpeed: number) {
-      return (this._currentJumpSpeed = currentJumpSpeed);
+      this._currentJumpSpeed = currentJumpSpeed;
     }
 
     enter(from: State) {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1228,7 +1228,22 @@ namespace gdjs {
      * Set the maximum falling speed of the Platformer Object.
      * @param maxFallingSpeed The maximum falling speed.
      */
-    setMaxFallingSpeed(maxFallingSpeed: float): void {
+    setMaxFallingSpeed(
+      maxFallingSpeed: float,
+      tryToKeepSpeed: boolean = false
+    ): void {
+      if (tryToKeepSpeed && this._state === this._jumping) {
+        const fallingSpeedOverflow = this._currentFallSpeed - maxFallingSpeed;
+        if (fallingSpeedOverflow > 0) {
+          this._currentFallSpeed -= fallingSpeedOverflow;
+          this._jumping.setCurrentJumpSpeed(
+            Math.max(
+              0,
+              this._jumping.getCurrentJumpSpeed() - fallingSpeedOverflow
+            )
+          );
+        }
+      }
       this._maxFallingSpeed = maxFallingSpeed;
     }
 
@@ -1849,6 +1864,10 @@ namespace gdjs {
 
     getCurrentJumpSpeed() {
       return this._currentJumpSpeed;
+    }
+
+    setCurrentJumpSpeed(currentJumpSpeed: number) {
+      return (this._currentJumpSpeed = currentJumpSpeed);
     }
 
     enter(from: State) {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1227,12 +1227,15 @@ namespace gdjs {
     /**
      * Set the maximum falling speed of the Platformer Object.
      * @param maxFallingSpeed The maximum falling speed.
+     * @param tryToPreserveAirSpeed If true and if jumping, tune the current jump speed to preserve the overall speed in the air.
      */
     setMaxFallingSpeed(
       maxFallingSpeed: float,
-      tryToKeepSpeed: boolean = false
+      tryToPreserveAirSpeed: boolean = false
     ): void {
-      if (tryToKeepSpeed && this._state === this._jumping) {
+      if (tryToPreserveAirSpeed && this._state === this._jumping) {
+        // If the falling speed is too high compared to the new max falling speed,
+        // reduce it and adapt the jump speed to preserve the overall vertical speed.
         const fallingSpeedOverflow = this._currentFallSpeed - maxFallingSpeed;
         if (fallingSpeedOverflow > 0) {
           this._currentFallSpeed -= fallingSpeedOverflow;

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -943,6 +943,93 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       // Check that the object didn't grabbed the platform
       expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(false);
     });
+
+    const goToJumpPeak = () => {
+      // Ensure the object falls on the platform
+      for (let i = 0; i < 60 / 6; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+
+      //Check the object is on the platform
+      expect(object.getY()).to.be(-30); // -30 = -10 (platform y) + -20 (object height)
+      expect(object.getBehavior('auto1').isFalling()).to.be(false);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+        false
+      );
+      expect(object.getBehavior('auto1').isMoving()).to.be(false);
+
+      // Jump with sustaining 1/10 of second
+      // A jump will at least sustain one frame,
+      // because the jump key is pressed.
+      // To have the same sustain time for each fps,
+      // we use their greatest common divisor: 10.
+      for (let i = 0; i < 60 / 10; ++i) {
+        object.getBehavior('auto1').simulateJumpKey();
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      expect(object.getY()).to.be.within(-112.5 - epsilon, -112.5 + epsilon);
+
+      // Jump without sustaining
+      for (let i = 0; i < 60 / 4 - 1; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        expect(object.getBehavior('auto1').isFalling()).to.be(false);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
+      }
+
+      // Check that we reached the maximum height
+      expect(object.getY()).to.be.above(-206.25);
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getY()).to.be.within(-206.25 - epsilon, -206.25 + epsilon);
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getY()).to.be.above(-206.25);
+    };
+
+    it('can change the maximum falling speed without changing the vertical speed', function () {
+      goToJumpPeak();
+
+      // Change the maximum falling speed from 550 to 200 (for instance, for a gliding mode)
+      const previousFallSpeed = object
+        .getBehavior('auto1')
+        .getCurrentFallSpeed();
+      const previousJumpSpeed = object
+        .getBehavior('auto1')
+        .getCurrentJumpSpeed();
+      object.getBehavior('auto1').setMaxFallingSpeed(200, true);
+      runtimeScene.renderAndStep(1000 / 60);
+      // The character speed stays the same (25 is the acceleration).
+      // The jump speed is reduced as much as the falling speed.
+      expect(object.getBehavior('auto1').getCurrentFallSpeed()).to.be(
+        previousFallSpeed - 350
+      );
+      expect(object.getBehavior('auto1').getCurrentJumpSpeed()).to.be(
+        previousJumpSpeed - 350 - 25
+      );
+    });
+
+    it('can change the maximum falling speed and avoid changing the vertical speed too much', function () {
+      goToJumpPeak();
+      // Then let the object fall a bit
+      for (let i = 0; i < 15; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          false
+        );
+      }
+
+      // Change the maximum falling speed from 550 to 200 (for instance, for a gliding mode)
+      expect(object.getBehavior('auto1').getCurrentFallSpeed()).to.be(925);
+      expect(object.getBehavior('auto1').getCurrentJumpSpeed()).to.be(125);
+      object.getBehavior('auto1').setMaxFallingSpeed(200, true);
+      runtimeScene.renderAndStep(1000 / 60);
+      // The character jump speed is set to 0 to reduce the speed gap.
+      expect(object.getBehavior('auto1').getCurrentFallSpeed()).to.be(200);
+      expect(object.getBehavior('auto1').getCurrentJumpSpeed()).to.be(0);
+    });
   });
 
   describe('(jumpthru)', function () {

--- a/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
@@ -301,8 +301,8 @@ describe('EnumerateExpressions', () => {
     // $FlowFixMe
     expect(allExpressionsTree['Platform Behavior']).toMatchObject({
       Options: {
-        'Maximum speed': {
-          displayedName: 'Maximum speed',
+        'Maximum horizontal speed': {
+          displayedName: 'Maximum horizontal speed',
           fullGroupName: 'Platform Behavior/Options',
           iconFilename: 'CppPlatform/Extensions/platformerobjecticon16.png',
           isPrivate: false,


### PR DESCRIPTION
This is used by this extension (with JS) to avoid the object to move back up when the wall sliding is activated (max falling speed is reduced):
* https://github.com/GDevelopApp/GDevelop-extensions/pull/325

It also makes explicit when speed, acceleration and deceleration are horizontal.