### PR TITLE
[Platformer] Add actions to allow to dash toward the ground.

### DIFF
--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -372,6 +372,19 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior");
 
+    aut.AddScopedAction(
+           "AbortJump",
+           _("Abort jump"),
+           _("Abort the current jump. This action doesn't have any effect "
+             "when the character is not jumping."),
+           _("Abort the current jump of _PARAM0_"),
+           _(""),
+           "CppPlatform/Extensions/platformerobjecticon24.png",
+           "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .AddParameter("yesorno", _("Stop the object vertically"));
+
     aut.AddCondition("CanJump",
                      _("Can jump"),
                      _("Check if the object can jump."),
@@ -552,6 +565,21 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
         .MarkAsSimple()
         .SetFunctionName("canGrabPlatforms");
+
+    aut.AddScopedAction(
+           "SetCurrentFallSpeed",
+           _("Current falling speed"),
+           _("Change the current falling speed of the object (in pixels per "
+             "second). This action doesn't have any effect when the character "
+             "is not falling without jumping."),
+           _("the current falling speed"),
+           _(""),
+           "CppPlatform/Extensions/platformerobjecticon24.png",
+           "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .UseStandardOperatorParameters("number")
+        .MarkAsAdvanced();
 
     aut.AddCondition(
            "CurrentFallSpeed",

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -377,7 +377,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
            _("Abort jump"),
            _("Abort the current jump. This action doesn't have any effect "
              "when the character is not jumping."),
-           _("Abort the current jump of _PARAM0_"),
+           _("Abort the current jump of _PARAM0_ (and stop the object vertically: _PARAM2_)"),
            _(""),
            "CppPlatform/Extensions/platformerobjecticon24.png",
            "CppPlatform/Extensions/platformerobjecticon16.png")

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -571,7 +571,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
            _("Current falling speed"),
            _("Change the current falling speed of the object (in pixels per "
              "second). This action doesn't have any effect when the character "
-             "is not falling without jumping."),
+             "is not falling or is in the first phase of a jump."),
            _("the current falling speed"),
            _(""),
            "CppPlatform/Extensions/platformerobjecticon24.png",

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -108,6 +108,9 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
           .SetFunctionName("setJumpSustainTime")
           .SetGetter("getJumpSustainTime");
       autExpressions["JumpSustainTime"].SetFunctionName("getJumpSustainTime");
+      autActions["PlatformBehavior::PlatformerObjectBehavior::SetCurrentFallSpeed"]
+          .SetFunctionName("setCurrentFallSpeed")
+          .SetGetter("getCurrentFallSpeed");
       autConditions["PlatformBehavior::CurrentFallSpeed"].SetFunctionName(
           "getCurrentFallSpeed");
       autExpressions["CurrentFallSpeed"].SetFunctionName("getCurrentFallSpeed");
@@ -124,6 +127,7 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
       autExpressions["CurrentJumpSpeed"].SetFunctionName("getCurrentJumpSpeed");
       autActions["PlatformBehavior::SetCanJump"].SetFunctionName("setCanJump");
       autActions["PlatformBehavior::PlatformerObjectBehavior::SetCanNotAirJump"].SetFunctionName("setCanNotAirJump");
+      autActions["PlatformBehavior::PlatformerObjectBehavior::AbortJump"].SetFunctionName("abortJump");
       autConditions["PlatformBehavior::CanJump"].SetFunctionName(
           "canJump");
       autActions["PlatformBehavior::SimulateLeftKey"].SetFunctionName(

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1326,6 +1326,35 @@ namespace gdjs {
     }
 
     /**
+     * Abort the current jump.
+     *
+     * When the character is not in the jumping state this method has no effect.
+     */
+    abortJump(resetFallingSpeed: boolean): void {
+      if (this._state === this._jumping) {
+        if (resetFallingSpeed) {
+          this._currentFallSpeed = 0;
+        }
+        this._setFalling();
+      }
+    }
+
+    /**
+     * Set the current fall speed.
+     *
+     * When the character is not in the falling state this method has no effect.
+     */
+    setCurrentFallSpeed(currentFallSpeed: float) {
+      if (this._state === this._falling) {
+        this._currentFallSpeed = gdjs.evtTools.common.clamp(
+          currentFallSpeed,
+          0,
+          this._maxFallingSpeed
+        );
+      }
+    }
+
+    /**
      * Set if the Platformer Object can grab platforms.
      * @param enable Enable / Disable grabbing of platforms.
      */


### PR DESCRIPTION
This adds
* an action to abort a jump
* an action to change the current falling speed when falling and not jumping.

It allows to make a dashing toward the ground like in Dead Cells.

In the abort action, I put a boolean parameter to keep the current falling speed or not. But, I think it might be better to always set the falling speed to 0 when aborting a jump because user probably won't understand where the falling speed comes from.

A merged demo build: https://liluo.io/instant-builds/242e0f29-c0c8-4b9f-9c39-b2ab72cad509?dev=true
* https://github.com/4ian/GDevelop/pull/3539

The demo project: https://www.dropbox.com/s/exajqjrd4j92pzj/platformer-vertical-dash.zip?dl=1

Note: in the events, I should have put the max speed action before the speed action because it's capped. We could not cap it to avoid this kind of issue but in this case the speed expression can be greater than the max speed expression which might not be great either.
![VerticalDash](https://user-images.githubusercontent.com/2611977/150654139-e6054c83-6e4a-4b60-84a7-6295c4065e84.png)
