### PR TITLE
Fix buttons layout on mobile in behavior editor

### DIFF
--- a/newIDE/app/src/UI/Accordion.js
+++ b/newIDE/app/src/UI/Accordion.js
@@ -40,7 +40,9 @@ export const AccordionHeader = (props: AccordionHeadProps) => {
         {props.children}
       </div>
       {props.actions && (
-        <div style={{ flexGrow: 0, alignSelf: 'center' }}>{props.actions}</div>
+        <div style={{ flexGrow: 0, flexShrink: 0, alignSelf: 'center' }}>
+          {props.actions}
+        </div>
       )}
     </MUIAccordionSummary>
   );


### PR DESCRIPTION
@arthuro555 mentioned this UI issue [on Discord](https://discord.com/channels/258623956158906368/377571085643677696/933819541258113064) a few days ago. In the behavior editor, on small screens (mobile phones), the buttons in accordion header stack vertically which doesn't look good. Fixed by adding `flexShrink: 0` to the buttons container. Before | After:

![image](https://user-images.githubusercontent.com/18032938/150654175-5e1cf475-d31a-4cca-810b-7942f2f1830a.png)

The second mentioned bug - unscrollable overflow in Physics2 editor on smaller screens - is somewhat unexpected, since I think I did [fix](https://github.com/4ian/GDevelop/pull/2553/commits/99c805d928cd509b94ab8eeeabbce47d146abace) it when I added accordions to the behaviors list, and the file hasn't been changed since. I'll take a look at it.

