### PR TITLE
[Platformer] Add an action to change the current horizontal speed.

### DIFF
--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -619,8 +619,9 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
 
     aut.AddScopedAction("SetCurrentSpeed",
                      _("Current horizontal speed"),
-                     _("Change the current horizontal speed of the object (in pixels per "
-                       "second)."),
+                     _("Change the current horizontal speed of the object "
+                     "(in pixels per second). The object moves to the left "
+                     "with negative values and to the right with positive ones"),
                      _("the current horizontal speed"),
                      _(""),
                      "CppPlatform/Extensions/platformerobjecticon24.png",

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -617,6 +617,19 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         .MarkAsAdvanced()
         .SetFunctionName("GetCurrentJumpSpeed");
 
+    aut.AddScopedAction("SetCurrentSpeed",
+                     _("Current horizontal speed"),
+                     _("Change the current horizontal speed of the object (in pixels per "
+                       "second)."),
+                     _("the current horizontal speed"),
+                     _(""),
+                     "CppPlatform/Extensions/platformerobjecticon24.png",
+                     "CppPlatform/Extensions/platformerobjecticon16.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .UseStandardOperatorParameters("number")
+        .MarkAsAdvanced();
+
     aut.AddCondition("CurrentSpeed",
                      _("Current horizontal speed"),
                      _("Compare the current horizontal speed of the object "

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -114,6 +114,9 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
       autConditions["PlatformBehavior::CurrentFallSpeed"].SetFunctionName(
           "getCurrentFallSpeed");
       autExpressions["CurrentFallSpeed"].SetFunctionName("getCurrentFallSpeed");
+      autActions["PlatformBehavior::PlatformerObjectBehavior::SetCurrentSpeed"]
+          .SetFunctionName("setCurrentSpeed")
+          .SetGetter("getCurrentSpeed");
       autConditions["PlatformBehavior::CurrentSpeed"].SetFunctionName(
           "getCurrentSpeed");
       autExpressions["CurrentSpeed"].SetFunctionName("getCurrentSpeed");

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1194,6 +1194,18 @@ namespace gdjs {
     }
 
     /**
+     * Set the current speed of the Platformer Object.
+     * @param currentSpeed The current speed.
+     */
+    setCurrentSpeed(currentSpeed: float): void {
+      this._currentSpeed = gdjs.evtTools.common.clamp(
+        currentSpeed,
+        -this._maxSpeed,
+        this._maxSpeed
+      );
+    }
+
+    /**
      * Get the current jump speed of the Platformer Object.
      * @returns The current jump speed.
      */


### PR DESCRIPTION
This adds an action to change the current horizontal speed.

It allows to make a dashing that follows the floor and handles collision without any "separate" action.

A merged demo build: https://liluo.io/instant-builds/242e0f29-c0c8-4b9f-9c39-b2ab72cad509?dev=true
* https://github.com/4ian/GDevelop/pull/3537

The demo project: https://www.dropbox.com/s/bcf1qqv27w2i63t/platformer-horizontal-dash.zip?dl=1

![HorizontalDash](https://user-images.githubusercontent.com/2611977/150660235-48b3e026-c7ac-4f54-90a9-7f34fdb6e79a.png)

