### PR TITLE
Fix Physics2 behavior overflowing on small screens

### DIFF
--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -109,7 +109,7 @@ const BehaviorsEditor = (props: Props) => {
   };
 
   return (
-    <Column noMargin expand useFullHeight>
+    <Column noMargin expand useFullHeight noOverflowParent>
       {allBehaviorNames.length === 0 ? (
         <Column noMargin expand justifyContent="center">
           <EmptyBehaviorsPlaceholder />


### PR DESCRIPTION
The Physics2 behavior was overflowing on small screens (mobile devices), due to the bit group editors for layers and masks. This issue resurfaced after `flexBody` was added to the Object Editor dialog (commit 24c13e1022ba95496ad3f58f3a50dc21e77a22b2) - this caused an intermediate `Column` to overflow for the bit group editors. Fixed by adding `noOverflowParent` to this Column, same as the [fix done earlier](https://github.com/4ian/GDevelop/pull/2553#issuecomment-822405794).