### PR TITLE
[Platformer] Allow to automatically grab platform ledges without having to move horizontally.

### DIFF
--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -31,6 +31,7 @@ void PlatformerObjectBehavior::InitializeContent(
   behaviorContent.SetAttribute("ignoreDefaultControls", false);
   behaviorContent.SetAttribute("slopeMaxAngle", 60);
   behaviorContent.SetAttribute("canGrabPlatforms", false);
+  behaviorContent.SetAttribute("canGrabWithoutMoving", true);
   behaviorContent.SetAttribute("yGrabOffset", 0);
   behaviorContent.SetAttribute("xGrabTolerance", 10);
   behaviorContent.SetAttribute("useLegacyTrajectory", false);
@@ -77,6 +78,12 @@ PlatformerObjectBehavior::GetProperties(
                     ? "true"
                     : "false")
       .SetType("Boolean");
+  properties[_("Automatically grab platform ledges without having to move horizontally")]
+      .SetGroup(_("Ledge"))
+      .SetValue(behaviorContent.GetBoolAttribute("canGrabWithoutMoving", false)
+                    ? "true"
+                    : "false")
+      .SetType("Boolean");
   properties[_("Grab offset on Y axis")].SetGroup(_("Ledge")).SetValue(
       gd::String::From(behaviorContent.GetDoubleAttribute("yGrabOffset")));
   properties[_("Grab tolerance on X axis")].SetGroup(_("Ledge")).SetValue(gd::String::From(
@@ -98,6 +105,8 @@ bool PlatformerObjectBehavior::UpdateProperty(
     behaviorContent.SetAttribute("ignoreDefaultControls", (value == "0"));
   else if (name == _("Can grab platform ledges"))
     behaviorContent.SetAttribute("canGrabPlatforms", (value == "1"));
+  else if (name == _("Automatically grab platform ledges without having to move horizontally"))
+    behaviorContent.SetAttribute("canGrabWithoutMoving", (value == "1"));
   else if (name == _("Use frame per second dependent trajectories (deprecated)"))
     behaviorContent.SetAttribute("useLegacyTrajectory", (value == "1"));
   else if (name == _("Grab offset on Y axis"))

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -53,6 +53,7 @@ namespace gdjs {
     _ladderClimbingSpeed: float;
 
     _canGrabPlatforms: boolean;
+    _canGrabWithoutMoving: boolean;
     private _yGrabOffset: any;
     private _xGrabTolerance: any;
 
@@ -66,6 +67,7 @@ namespace gdjs {
     _lastDeltaY: float = 0;
     _currentFallSpeed: float = 0;
     _canJump: boolean = false;
+    _lastDirectionIsLeft: boolean = false;
 
     private _ignoreDefaultControls: boolean;
     private _leftKey: boolean = false;
@@ -123,6 +125,7 @@ namespace gdjs {
       this._maxSpeed = behaviorData.maxSpeed;
       this._jumpSpeed = behaviorData.jumpSpeed;
       this._canGrabPlatforms = behaviorData.canGrabPlatforms || false;
+      this._canGrabWithoutMoving = behaviorData.canGrabWithoutMoving;
       this._yGrabOffset = behaviorData.yGrabOffset || 0;
       this._xGrabTolerance = behaviorData.xGrabTolerance || 10;
       this._jumpSustainTime = behaviorData.jumpSustainTime || 0;
@@ -167,6 +170,12 @@ namespace gdjs {
         oldBehaviorData.canGrabPlatforms !== newBehaviorData.canGrabPlatforms
       ) {
         this.setCanGrabPlatforms(newBehaviorData.canGrabPlatforms);
+      }
+      if (
+        oldBehaviorData.canGrabWithoutMoving !==
+        newBehaviorData.canGrabWithoutMoving
+      ) {
+        this._canGrabWithoutMoving = newBehaviorData.canGrabWithoutMoving;
       }
       if (oldBehaviorData.yGrabOffset !== newBehaviorData.yGrabOffset) {
         this._yGrabOffset = newBehaviorData.yGrabOffset;
@@ -232,6 +241,10 @@ namespace gdjs {
           !this._ignoreDefaultControls && inputManager.isKeyPressed(DOWNKEY));
 
       this._requestedDeltaX += this._updateSpeed(timeDelta);
+
+      if (this._leftKey !== this._rightKey) {
+        this._lastDirectionIsLeft = this._leftKey;
+      }
 
       //0.2) Track changes in object size
       this._state.beforeUpdatingObstacles(timeDelta);
@@ -501,9 +514,10 @@ namespace gdjs {
       let oldX = object.getX();
       object.setX(
         object.getX() +
-          (this._requestedDeltaX > 0
-            ? this._xGrabTolerance
-            : -this._xGrabTolerance)
+          (this._requestedDeltaX < 0 ||
+          (this._requestedDeltaX === 0 && this._lastDirectionIsLeft)
+            ? -this._xGrabTolerance
+            : this._xGrabTolerance)
       );
       const collidingPlatforms: PlatformRuntimeBehavior[] = gdjs.staticArray(
         PlatformerObjectRuntimeBehavior.prototype._checkGrabPlatform
@@ -1878,13 +1892,16 @@ namespace gdjs {
 
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
-      //Go on a ladder
+      // Go on a ladder
       behavior._checkTransitionOnLadder();
-      //Jumping
+      // Jumping
       behavior._checkTransitionJumping();
 
-      //Grabbing a platform
-      if (behavior._canGrabPlatforms && behavior._requestedDeltaX !== 0) {
+      // Grabbing a platform
+      if (
+        behavior._canGrabPlatforms &&
+        (behavior._requestedDeltaX !== 0 || behavior._canGrabWithoutMoving)
+      ) {
         behavior._checkGrabPlatform();
       }
     }
@@ -1948,15 +1965,15 @@ namespace gdjs {
 
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
-      //Go on a ladder
+      // Go on a ladder
       behavior._checkTransitionOnLadder();
-      //Jumping
+      // Jumping
       behavior._checkTransitionJumping();
 
-      //Grabbing a platform
+      // Grabbing a platform
       if (
         behavior._canGrabPlatforms &&
-        behavior._requestedDeltaX !== 0 &&
+        (behavior._requestedDeltaX !== 0 || behavior._canGrabWithoutMoving) &&
         behavior._lastDeltaY >= 0
       ) {
         behavior._checkGrabPlatform();

--- a/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
@@ -34,7 +34,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         object.setPosition(0, -100);
       });
 
-      it('can grab and release a right ledge platform', function () {
+      it('can grab and release the right ledge of a platform', function () {
         // Put a platform.
         const platform = addPlatformObject(runtimeScene);
         platform.setPosition(0, -10);
@@ -72,7 +72,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         expect(object.getY()).to.be.above(0);
       });
 
-      it('can grab and release a left ledge platform', function () {
+      it('can grab and release the left ledge of a platform', function () {
         // Put a platform.
         const platform = addPlatformObject(runtimeScene);
         platform.setPosition(0, -10);
@@ -240,7 +240,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       object.setPosition(0, -100);
     });
 
-    it('can grab without moving and release a right ledge platform', function () {
+    it('can grab without moving and release the right ledge of a platform', function () {
       // Put a platform.
       const platform = addPlatformObject(runtimeScene);
       platform.setPosition(0, -10);
@@ -280,13 +280,13 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.above(0);
     });
 
-    it('can grab without moving and release a left ledge platform', function () {
+    it('can grab without moving and release the left ledge of a platform', function () {
       // Put a platform.
       const platform = addPlatformObject(runtimeScene);
       platform.setPosition(0, -10);
       runtimeScene.renderAndStep(1000 / 60);
 
-      // Put the character near the right ledge of the platform.
+      // Put the character near the left ledge of the platform.
       object.setPosition(
         platform.getX() - object.getWidth() - 2,
         platform.getY() - 10
@@ -318,7 +318,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.above(0);
     });
 
-    it('must not grab automatically a right ledge platform when facing back', function () {
+    it('must not grab automatically the right ledge of a platform when facing back', function () {
       // Put a platform.
       const platform = addPlatformObject(runtimeScene);
       platform.setPosition(0, -10);
@@ -343,13 +343,13 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.greaterThan(platform.getY() + 5);
     });
 
-    it('must not grab automatically a left ledge platform when facing back', function () {
+    it('must not grab automatically the left ledge of a platform when facing back', function () {
       // Put a platform.
       const platform = addPlatformObject(runtimeScene);
       platform.setPosition(0, -10);
       runtimeScene.renderAndStep(1000 / 60);
 
-      // Put the character near the right ledge of the platform.
+      // Put the character near the left ledge of the platform.
       object.setPosition(
         platform.getX() - object.getWidth() - 2,
         platform.getY() - 10

--- a/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/LadderAndCliffPlatformer.spec.js
@@ -1,5 +1,212 @@
 describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
-  describe('(grab platforms)', function () {
+  [true, false].forEach((canGrabWithoutMoving) => {
+    describe(`(grab platforms, canGrabWithoutMoving: ${canGrabWithoutMoving})`, function () {
+      let runtimeScene;
+      let object;
+
+      beforeEach(function () {
+        runtimeScene = makePlatformerTestRuntimeScene();
+
+        // Put a platformer object in the air.
+        object = new gdjs.TestRuntimeObject(runtimeScene, {
+          name: 'obj1',
+          type: '',
+          behaviors: [
+            {
+              type: 'PlatformBehavior::PlatformerObjectBehavior',
+              name: 'auto1',
+              gravity: 900,
+              maxFallingSpeed: 1500,
+              acceleration: 500,
+              deceleration: 1500,
+              maxSpeed: 500,
+              jumpSpeed: 1500,
+              canGrabPlatforms: true,
+              ignoreDefaultControls: true,
+              slopeMaxAngle: 60,
+              canGrabWithoutMoving: canGrabWithoutMoving,
+            },
+          ],
+          effects: [],
+        });
+        object.setCustomWidthAndHeight(10, 20);
+        runtimeScene.addObject(object);
+        object.setPosition(0, -100);
+      });
+
+      it('can grab and release a right ledge platform', function () {
+        // Put a platform.
+        const platform = addPlatformObject(runtimeScene);
+        platform.setPosition(0, -10);
+        runtimeScene.renderAndStep(1000 / 60);
+
+        // Put the character near the right ledge of the platform.
+        object.setPosition(
+          platform.getX() + platform.getWidth() + 2,
+          platform.getY() - 10
+        );
+
+        for (let i = 0; i < 10; ++i) {
+          object.getBehavior('auto1').simulateLeftKey();
+          runtimeScene.renderAndStep(1000 / 60);
+        }
+
+        // The character grabs the platform.
+        expect(object.getX()).to.be.within(
+          platform.getX() + platform.getWidth() + 0,
+          platform.getX() + platform.getWidth() + 1
+        );
+        expect(object.getY()).to.be(platform.getY());
+        expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
+
+        // The character releases the platform.
+        object.getBehavior('auto1').simulateReleasePlatformKey();
+        // The character falls.
+        for (let i = 0; i < 10; ++i) {
+          runtimeScene.renderAndStep(1000 / 60);
+          expect(object.getBehavior('auto1').isFalling()).to.be(true);
+          expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+            true
+          );
+        }
+        expect(object.getY()).to.be.above(0);
+      });
+
+      it('can grab and release a left ledge platform', function () {
+        // Put a platform.
+        const platform = addPlatformObject(runtimeScene);
+        platform.setPosition(0, -10);
+        runtimeScene.renderAndStep(1000 / 60);
+
+        // Put the character near the right ledge of the platform.
+        object.setPosition(
+          platform.getX() - object.getWidth() - 2,
+          platform.getY() - 10
+        );
+
+        for (let i = 0; i < 10; ++i) {
+          object.getBehavior('auto1').simulateRightKey();
+          runtimeScene.renderAndStep(1000 / 60);
+        }
+
+        // The character grabs the platform.
+        expect(object.getX()).to.be.within(
+          platform.getX() - object.getWidth() - 1,
+          platform.getX() - object.getWidth() - 0
+        );
+        expect(object.getY()).to.be(platform.getY());
+        expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
+
+        // The character releases the platform.
+        object.getBehavior('auto1').simulateReleasePlatformKey();
+        // The character falls.
+        for (let i = 0; i < 10; ++i) {
+          runtimeScene.renderAndStep(1000 / 60);
+          expect(object.getBehavior('auto1').isFalling()).to.be(true);
+          expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+            true
+          );
+        }
+        expect(object.getY()).to.be.above(0);
+      });
+
+      [true, false].forEach((addTopPlatformFirst) => {
+        it('can grab every platform when colliding 2', function () {
+          // The 2 platforms will be simultaneously in collision
+          // with the object when it grabs one.
+          let upperPlatform, lowerPlatform;
+          if (addTopPlatformFirst) {
+            upperPlatform = addPlatformObject(runtimeScene);
+            upperPlatform.setPosition(0, -10);
+            upperPlatform.setCustomWidthAndHeight(60, 10);
+
+            lowerPlatform = addPlatformObject(runtimeScene);
+            lowerPlatform.setPosition(0, 0);
+            lowerPlatform.setCustomWidthAndHeight(60, 10);
+          } else {
+            lowerPlatform = addPlatformObject(runtimeScene);
+            lowerPlatform.setPosition(0, 0);
+            lowerPlatform.setCustomWidthAndHeight(60, 10);
+
+            upperPlatform = addPlatformObject(runtimeScene);
+            upperPlatform.setPosition(0, -10);
+            upperPlatform.setCustomWidthAndHeight(60, 10);
+          }
+
+          // Put the object near the right ledge of the platform.
+          object.setPosition(
+            upperPlatform.getX() + upperPlatform.getWidth() + 2,
+            upperPlatform.getY() - 10
+          );
+          runtimeScene.renderAndStep(1000 / 60);
+
+          for (let i = 0; i < 10; ++i) {
+            object.getBehavior('auto1').simulateLeftKey();
+            runtimeScene.renderAndStep(1000 / 60);
+          }
+
+          // Check that the object grabbed the upper platform
+          expect(object.getX()).to.be.within(
+            upperPlatform.getX() + upperPlatform.getWidth() + 0,
+            upperPlatform.getX() + upperPlatform.getWidth() + 1
+          );
+          expect(object.getY()).to.be(upperPlatform.getY());
+          expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
+
+          // Release upper platform
+          object.getBehavior('auto1').simulateReleasePlatformKey();
+          for (let i = 0; i < 10; ++i) {
+            object.getBehavior('auto1').simulateLeftKey();
+            runtimeScene.renderAndStep(1000 / 60);
+          }
+
+          // Check that the object grabbed the lower platform
+          expect(object.getX()).to.be.within(
+            lowerPlatform.getX() + lowerPlatform.getWidth() + 0,
+            lowerPlatform.getX() + lowerPlatform.getWidth() + 1
+          );
+          expect(object.getY()).to.be(lowerPlatform.getY());
+          expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
+        });
+      });
+
+      it('can grab a platform and jump', function () {
+        // Put a platform.
+        platform = addPlatformObject(runtimeScene);
+        platform.setPosition(0, -10);
+        runtimeScene.renderAndStep(1000 / 60);
+
+        //Put the object near the right ledge of the platform.
+        object.setPosition(
+          platform.getX() + platform.getWidth() + 2,
+          platform.getY() - 10
+        );
+
+        for (let i = 0; i < 10; ++i) {
+          object.getBehavior('auto1').simulateLeftKey();
+          runtimeScene.renderAndStep(1000 / 60);
+        }
+
+        //Check that the object grabbed the platform
+        expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
+        expect(object.getX()).to.be.within(
+          platform.getX() + platform.getWidth() + 0,
+          platform.getX() + platform.getWidth() + 1
+        );
+        expect(object.getY()).to.be(platform.getY());
+
+        object.getBehavior('auto1').simulateJumpKey();
+        //Check that the object is jumping
+        for (let i = 0; i < 10; ++i) {
+          runtimeScene.renderAndStep(1000 / 60);
+          expect(object.getBehavior('auto1').isJumping()).to.be(true);
+        }
+        expect(object.getY()).to.be.below(platform.getY());
+      });
+    });
+  });
+
+  describe('(grab platforms, canGrabWithoutMoving: true)', function () {
     let runtimeScene;
     let object;
 
@@ -23,6 +230,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
             canGrabPlatforms: true,
             ignoreDefaultControls: true,
             slopeMaxAngle: 60,
+            canGrabWithoutMoving: true,
           },
         ],
         effects: [],
@@ -32,7 +240,7 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       object.setPosition(0, -100);
     });
 
-    it('can grab, and release, a platform', function () {
+    it('can grab without moving and release a right ledge platform', function () {
       // Put a platform.
       const platform = addPlatformObject(runtimeScene);
       platform.setPosition(0, -10);
@@ -44,17 +252,20 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         platform.getY() - 10
       );
 
-      for (let i = 0; i < 35; ++i) {
-        object.getBehavior('auto1').simulateLeftKey();
+      // The character faces the platform
+      object.getBehavior('auto1').simulateLeftKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(false);
+      for (let i = 0; i < 10; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
       }
-
       // The character grabs the platform.
       expect(object.getX()).to.be.within(
         platform.getX() + platform.getWidth() + 0,
-        platform.getX() + platform.getWidth() + 1
+        platform.getX() + platform.getWidth() + 2
       );
       expect(object.getY()).to.be(platform.getY());
+      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
 
       // The character releases the platform.
       object.getBehavior('auto1').simulateReleasePlatformKey();
@@ -69,98 +280,92 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be.above(0);
     });
 
-    [true, false].forEach((addTopPlatformFirst) => {
-      it('can grab every platform when colliding 2', function () {
-        // The 2 platforms will be simultaneously in collision
-        // with the object when it grabs one.
-        let upperPlatform, lowerPlatform;
-        if (addTopPlatformFirst) {
-          upperPlatform = addPlatformObject(runtimeScene);
-          upperPlatform.setPosition(0, -10);
-          upperPlatform.setCustomWidthAndHeight(60, 10);
-
-          lowerPlatform = addPlatformObject(runtimeScene);
-          lowerPlatform.setPosition(0, 0);
-          lowerPlatform.setCustomWidthAndHeight(60, 10);
-        } else {
-          lowerPlatform = addPlatformObject(runtimeScene);
-          lowerPlatform.setPosition(0, 0);
-          lowerPlatform.setCustomWidthAndHeight(60, 10);
-
-          upperPlatform = addPlatformObject(runtimeScene);
-          upperPlatform.setPosition(0, -10);
-          upperPlatform.setCustomWidthAndHeight(60, 10);
-        }
-
-        // Put the object near the right ledge of the platform.
-        object.setPosition(
-          upperPlatform.getX() + upperPlatform.getWidth() + 2,
-          upperPlatform.getY() - 10
-        );
-        runtimeScene.renderAndStep(1000 / 60);
-
-        for (let i = 0; i < 35; ++i) {
-          object.getBehavior('auto1').simulateLeftKey();
-          runtimeScene.renderAndStep(1000 / 60);
-        }
-
-        // Check that the object grabbed the upper platform
-        expect(object.getX()).to.be.within(
-          upperPlatform.getX() + upperPlatform.getWidth() + 0,
-          upperPlatform.getX() + upperPlatform.getWidth() + 1
-        );
-        expect(object.getY()).to.be(upperPlatform.getY());
-        expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
-
-        // Release upper platform
-        object.getBehavior('auto1').simulateReleasePlatformKey();
-        for (let i = 0; i < 35; ++i) {
-          object.getBehavior('auto1').simulateLeftKey();
-          runtimeScene.renderAndStep(1000 / 60);
-        }
-
-        // Check that the object grabbed the lower platform
-        expect(object.getX()).to.be.within(
-          lowerPlatform.getX() + lowerPlatform.getWidth() + 0,
-          lowerPlatform.getX() + lowerPlatform.getWidth() + 1
-        );
-        expect(object.getY()).to.be(lowerPlatform.getY());
-        expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
-      });
-    });
-
-    it('can grab a platform and jump', function () {
+    it('can grab without moving and release a left ledge platform', function () {
       // Put a platform.
-      platform = addPlatformObject(runtimeScene);
+      const platform = addPlatformObject(runtimeScene);
       platform.setPosition(0, -10);
       runtimeScene.renderAndStep(1000 / 60);
 
-      //Put the object near the right ledge of the platform.
+      // Put the character near the right ledge of the platform.
+      object.setPosition(
+        platform.getX() - object.getWidth() - 2,
+        platform.getY() - 10
+      );
+
+      // The character faces the platform
+      object.getBehavior('auto1').simulateRightKey();
+      for (let i = 0; i < 10; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      // The character grabs the platform.
+      expect(object.getX()).to.be.within(
+        platform.getX() - object.getWidth() - 2,
+        platform.getX() - object.getWidth() - 0
+      );
+      expect(object.getY()).to.be(platform.getY());
+      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
+
+      // The character releases the platform.
+      object.getBehavior('auto1').simulateReleasePlatformKey();
+      // The character falls.
+      for (let i = 0; i < 10; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(object.getBehavior('auto1').isFalling()).to.be(true);
+        expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(
+          true
+        );
+      }
+      expect(object.getY()).to.be.above(0);
+    });
+
+    it('must not grab automatically a right ledge platform when facing back', function () {
+      // Put a platform.
+      const platform = addPlatformObject(runtimeScene);
+      platform.setPosition(0, -10);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      // Put the character near the right ledge of the platform.
       object.setPosition(
         platform.getX() + platform.getWidth() + 2,
         platform.getY() - 10
       );
 
-      for (let i = 0; i < 35; ++i) {
-        object.getBehavior('auto1').simulateLeftKey();
-        runtimeScene.renderAndStep(1000 / 60);
-      }
-
-      //Check that the object grabbed the platform
-      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(true);
-      expect(object.getX()).to.be.within(
-        platform.getX() + platform.getWidth() + 0,
-        platform.getX() + platform.getWidth() + 1
-      );
-      expect(object.getY()).to.be(platform.getY());
-
-      object.getBehavior('auto1').simulateJumpKey();
-      //Check that the object is jumping
+      // The character faces the wrong way
+      object.getBehavior('auto1').simulateRightKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(false);
       for (let i = 0; i < 10; ++i) {
         runtimeScene.renderAndStep(1000 / 60);
-        expect(object.getBehavior('auto1').isJumping()).to.be(true);
       }
-      expect(object.getY()).to.be.below(platform.getY());
+      // The character couldn't grab the platform.
+      expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
+      expect(object.getY()).to.be.greaterThan(platform.getY() + 5);
+    });
+
+    it('must not grab automatically a left ledge platform when facing back', function () {
+      // Put a platform.
+      const platform = addPlatformObject(runtimeScene);
+      platform.setPosition(0, -10);
+      runtimeScene.renderAndStep(1000 / 60);
+
+      // Put the character near the right ledge of the platform.
+      object.setPosition(
+        platform.getX() - object.getWidth() - 2,
+        platform.getY() - 10
+      );
+
+      // The character faces the wrong way
+      object.getBehavior('auto1').simulateLeftKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(object.getBehavior('auto1').isGrabbingPlatform()).to.be(false);
+      for (let i = 0; i < 10; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      // The character couldn't grab the platform.
+      expect(object.getBehavior('auto1').isFalling()).to.be(true);
+      expect(object.getBehavior('auto1').isFallingWithoutJumping()).to.be(true);
+      expect(object.getY()).to.be.greaterThan(platform.getY() + 5);
     });
   });
 


### PR DESCRIPTION
Without this option, players may release the Left or Right key too soon when the character is against the wall for the character to grab the platform.

This is the implementation for the (1) of this ticket:
* https://trello.com/c/zezNvn1J/269-add-an-option-to-automatically-grab-the-ledge-of-platforms

Contrary to this extension, it doesn't automatically move the character to be in range:
* https://github.com/GDevelopApp/GDevelop-extensions/pull/341