### PR TITLE
Allow to set an empty color property value.

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -528,7 +528,7 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
           getExtensionIconUrl(extension)
         )
       )
-        .useStandardRelationalOperatorParameters('color')
+        .useStandardRelationalOperatorParameters('string')
         .getCodeExtraInformation()
         .setFunctionName(getterName);
 

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -291,9 +291,9 @@ export default class PropertiesEditor extends React.Component<Props, {||}> {
           fullWidth
           color={getFieldValue(this.props.instances, field)}
           onChange={color => {
-            this.props.instances.forEach(i =>
-              setValue(i, rgbOrHexToRGBString(color))
-            );
+            const rgbString =
+              color.length === 0 ? '' : rgbOrHexToRGBString(color);
+            this.props.instances.forEach(i => setValue(i, rgbString));
             this._onInstancesModified(this.props.instances);
           }}
         />


### PR DESCRIPTION
It allows extensions to default on a color when the string is empty (the slider extension use this).

In the slider extension, I changed the optional color properties type from string to color and it works.
* https://github.com/GDevelopApp/GDevelop-extensions/pull/326#issuecomment-1022122724

I fixed the color property condition, the operator type was set to "color", but it seems the generator only handles "string" and "number".

Also see
* https://github.com/4ian/GDevelop/pull/3086
* https://github.com/4ian/GDevelop/issues/2211