### PR TITLE
Use "Untitled Xxx" instead of "New Xxx" in the project manager for default names

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -789,63 +789,6 @@ const MainFrame = (props: Props) => {
     toolbar.current.setEditorToolbar(editorToolbar);
   };
 
-  const addLayout = () => {
-    const { currentProject } = state;
-    if (!currentProject) return;
-
-    const name = newNameGenerator('New scene', name =>
-      currentProject.hasLayoutNamed(name)
-    );
-    const newLayout = currentProject.insertNewLayout(
-      name,
-      currentProject.getLayoutsCount()
-    );
-    newLayout.updateBehaviorsSharedData(currentProject);
-    _onProjectItemModified();
-  };
-
-  const addExternalLayout = () => {
-    const { currentProject } = state;
-    if (!currentProject) return;
-
-    const name = newNameGenerator('NewExternalLayout', name =>
-      currentProject.hasExternalLayoutNamed(name)
-    );
-    currentProject.insertNewExternalLayout(
-      name,
-      currentProject.getExternalLayoutsCount()
-    );
-    _onProjectItemModified();
-  };
-
-  const addExternalEvents = () => {
-    const { currentProject } = state;
-    if (!currentProject) return;
-
-    const name = newNameGenerator('NewExternalEvents', name =>
-      currentProject.hasExternalEventsNamed(name)
-    );
-    currentProject.insertNewExternalEvents(
-      name,
-      currentProject.getExternalEventsCount()
-    );
-    _onProjectItemModified();
-  };
-
-  const addEventsFunctionsExtension = () => {
-    const { currentProject } = state;
-    if (!currentProject) return;
-
-    const name = newNameGenerator('NewExtension', name =>
-      currentProject.hasEventsFunctionsExtensionNamed(name)
-    );
-    currentProject.insertNewEventsFunctionsExtension(
-      name,
-      currentProject.getEventsFunctionsExtensionsCount()
-    );
-    _onProjectItemModified();
-  };
-
   const onInstallExtension = (extensionShortHeader: ExtensionShortHeader) => {
     const { currentProject } = state;
     if (!currentProject) return;
@@ -2110,10 +2053,6 @@ const MainFrame = (props: Props) => {
             onOpenLayout={openLayout}
             onOpenExternalLayout={openExternalLayout}
             onOpenEventsFunctionsExtension={openEventsFunctionsExtension}
-            onAddLayout={addLayout}
-            onAddExternalLayout={addExternalLayout}
-            onAddEventsFunctionsExtension={addEventsFunctionsExtension}
-            onAddExternalEvents={addExternalEvents}
             onInstallExtension={onInstallExtension}
             onDeleteLayout={deleteLayout}
             onDeleteExternalLayout={deleteExternalLayout}

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -100,10 +100,6 @@ type Props = {|
   onOpenProfile: () => void,
   onOpenGamesDashboard: () => void,
   onOpenResources: () => void,
-  onAddLayout: () => void,
-  onAddExternalEvents: () => void,
-  onAddExternalLayout: () => void,
-  onAddEventsFunctionsExtension: () => void,
   onOpenPlatformSpecificAssets: () => void,
   onChangeSubscription: () => void,
   eventsFunctionsExtensionsError: ?Error,
@@ -266,7 +262,7 @@ export default class ProjectManager extends React.Component<Props, State> {
   _addLayout = (index: number) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('New scene', name =>
+    const newName = newNameGenerator('Untitled scene', name =>
       project.hasLayoutNamed(name)
     );
     const newLayout = project.insertNewLayout(newName, index + 1);
@@ -288,7 +284,7 @@ export default class ProjectManager extends React.Component<Props, State> {
   _addExternalEvents = (index: number) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('NewExternalEvents', name =>
+    const newName = newNameGenerator('Untitled external events', name =>
       project.hasExternalEventsNamed(name)
     );
     project.insertNewExternalEvents(newName, index + 1);
@@ -298,7 +294,7 @@ export default class ProjectManager extends React.Component<Props, State> {
   _addExternalLayout = (index: number) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('NewExternalLayout', name =>
+    const newName = newNameGenerator('Untitled external layout', name =>
       project.hasExternalLayoutNamed(name)
     );
     project.insertNewExternalLayout(newName, index + 1);
@@ -308,7 +304,7 @@ export default class ProjectManager extends React.Component<Props, State> {
   _addEventsFunctionsExtension = (index: number) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('NewExtension', name =>
+    const newName = newNameGenerator('UntitledExtension', name =>
       isExtensionNameTaken(name, project)
     );
     project.insertNewEventsFunctionsExtension(newName, index + 1);
@@ -758,7 +754,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                 .concat(
                   <AddListItem
                     key={'add-scene'}
-                    onClick={this.props.onAddLayout}
+                    onClick={() => this._addLayout(project.getLayoutsCount())}
                     primaryText={<Trans>Click to add a scene</Trans>}
                   />
                 )
@@ -824,7 +820,9 @@ export default class ProjectManager extends React.Component<Props, State> {
                   <AddListItem
                     key={'add-external-events'}
                     primaryText={<Trans>Click to add external events</Trans>}
-                    onClick={this.props.onAddExternalEvents}
+                    onClick={() =>
+                      this._addExternalEvents(project.getExternalEventsCount())
+                    }
                   />
                 )
             }
@@ -889,7 +887,9 @@ export default class ProjectManager extends React.Component<Props, State> {
                   <AddListItem
                     key={'add-external-layout'}
                     primaryText={<Trans>Click to add an external layout</Trans>}
-                    onClick={this.props.onAddExternalLayout}
+                    onClick={() =>
+                      this._addExternalLayout(project.getExternalLayoutsCount())
+                    }
                   />
                 )
             }
@@ -985,7 +985,11 @@ export default class ProjectManager extends React.Component<Props, State> {
                     primaryText={
                       <Trans>Click to add functions and behaviors</Trans>
                     }
-                    onClick={this.props.onAddEventsFunctionsExtension}
+                    onClick={() =>
+                      this._addEventsFunctionsExtension(
+                        project.getEventsFunctionsExtensionsCount()
+                      )
+                    }
                   />
                 )
                 .concat(

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -4573,10 +4573,6 @@ storiesOf('ProjectManager', module)
       onOpenLayout={action('onOpenLayout')}
       onOpenExternalLayout={action('onOpenExternalLayout')}
       onOpenEventsFunctionsExtension={action('onOpenEventsFunctionsExtension')}
-      onAddLayout={action('onAddLayout')}
-      onAddExternalLayout={action('onAddExternalLayout')}
-      onAddEventsFunctionsExtension={action('onAddEventsFunctionsExtension')}
-      onAddExternalEvents={action('onAddExternalEvents')}
       onInstallExtension={action('onInstallExtension')}
       onDeleteLayout={action('onDeleteLayout')}
       onDeleteExternalLayout={action('onDeleteExternalLayout')}
@@ -4618,10 +4614,6 @@ storiesOf('ProjectManager', module)
       onOpenLayout={action('onOpenLayout')}
       onOpenExternalLayout={action('onOpenExternalLayout')}
       onOpenEventsFunctionsExtension={action('onOpenEventsFunctionsExtension')}
-      onAddLayout={action('onAddLayout')}
-      onAddExternalLayout={action('onAddExternalLayout')}
-      onAddEventsFunctionsExtension={action('onAddEventsFunctionsExtension')}
-      onAddExternalEvents={action('onAddExternalEvents')}
       onInstallExtension={action('onInstallExtension')}
       onDeleteLayout={action('onDeleteLayout')}
       onDeleteExternalLayout={action('onDeleteExternalLayout')}


### PR DESCRIPTION
Make it clearer these are items to be renamed, rather than buttons.

Don't show in changelog