### PR TITLE
Improve Scene handling

### DIFF
--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -909,6 +909,7 @@ Project& Project::operator=(const Project& other) {
 
 void Project::Init(const gd::Project& game) {
   name = game.name;
+  firstLayout = game.firstLayout;
   version = game.version;
   windowWidth = game.windowWidth;
   windowHeight = game.windowHeight;

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -634,6 +634,7 @@ void Project::UnserializeFrom(const SerializerElement& element) {
         layoutElement.GetStringAttribute("name", "", "nom"), -1);
     layout.UnserializeFrom(*this, layoutElement);
   }
+  SetFirstLayout(element.GetChild("firstLayout").GetStringValue());
 
   externalEvents.clear();
   const SerializerElement& externalEventsElement =

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1527,7 +1527,10 @@ const MainFrame = (props: Props) => {
       const { currentProject, editorTabs } = newState;
       if (!currentProject) return;
 
-      if (currentProject.getLayoutsCount() === 1) {
+      if (currentProject.getLayoutsCount() <= 1) {
+        if (currentProject.getLayoutsCount() === 0)
+          currentProject.insertNewLayout(i18n._(t`Untitled scene`), 0);
+
         openLayout(
           currentProject.getLayoutAt(0).getName(),
           {
@@ -1547,7 +1550,7 @@ const MainFrame = (props: Props) => {
         });
       }
     },
-    [openLayout, setState]
+    [openLayout, setState, i18n]
   );
 
   const chooseProjectWithStorageProviderPicker = React.useCallback(

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -815,8 +815,9 @@ const MainFrame = (props: Props) => {
   };
 
   const deleteLayout = (layout: gdLayout) => {
+    const { currentProject } = state;
     const { i18n } = props;
-    if (!state.currentProject) return;
+    if (!currentProject) return;
 
     const answer = Window.showConfirmDialog(
       i18n._(
@@ -829,8 +830,9 @@ const MainFrame = (props: Props) => {
       ...state,
       editorTabs: closeLayoutTabs(state.editorTabs, layout),
     })).then(state => {
-      if (state.currentProject)
-        state.currentProject.removeLayout(layout.getName());
+      if (currentProject.getFirstLayout() === layout.getName())
+        currentProject.setFirstLayout('');
+      currentProject.removeLayout(layout.getName());
       _onProjectItemModified();
     });
   };

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -941,11 +941,15 @@ const MainFrame = (props: Props) => {
     }
 
     const layout = currentProject.getLayout(oldName);
+    const shouldChangeProjectFirstLayout =
+      oldName === currentProject.getFirstLayout();
     setState(state => ({
       ...state,
       editorTabs: closeLayoutTabs(state.editorTabs, layout),
     })).then(state => {
       layout.setName(newName);
+      if (shouldChangeProjectFirstLayout)
+        currentProject.setFirstLayout(newName);
       _onProjectItemModified();
     });
   };

--- a/newIDE/app/src/ProjectManager/ProjectManagerItems.js
+++ b/newIDE/app/src/ProjectManager/ProjectManagerItems.js
@@ -79,6 +79,7 @@ export const ProjectStructureItem = (props: ProjectStructureItemProps) => (
 
 type ItemProps = {|
   primaryText: string,
+  textEndAdornment?: React.Node,
   editingName: boolean,
   leftIcon?: ?React.Node,
   onEdit: () => void,
@@ -102,6 +103,7 @@ type ItemProps = {|
 
 export const Item = ({
   primaryText,
+  textEndAdornment,
   editingName,
   leftIcon,
   onEdit,
@@ -152,6 +154,7 @@ export const Item = ({
   ) : (
     <div style={textEllispsisStyle} title={primaryText}>
       {primaryText}
+      {textEndAdornment}
     </div>
   );
 

--- a/newIDE/app/src/ProjectManager/ProjectManagerItems.js
+++ b/newIDE/app/src/ProjectManager/ProjectManagerItems.js
@@ -13,7 +13,7 @@ import TextField, {
   noMarginTextFieldInListItemTopOffset,
 } from '../UI/TextField';
 import { shouldValidate } from '../UI/KeyboardShortcuts/InteractionKeys';
-import { textEllispsisStyle } from '../UI/TextEllipsis';
+import { textEllipsisStyle } from '../UI/TextEllipsis';
 
 import { ExtensionStoreContext } from '../AssetStore/ExtensionStore/ExtensionStoreContext';
 import { type ExtensionShortHeader } from '../Utils/GDevelopServices/Extension';
@@ -155,7 +155,7 @@ export const Item = ({
     <div
       style={{ display: 'inline-flex', width: '100%', alignItems: 'center' }}
     >
-      <span style={textEllispsisStyle} title={primaryText}>
+      <span style={textEllipsisStyle} title={primaryText}>
         {primaryText}
       </span>
       {textEndAdornment && (

--- a/newIDE/app/src/ProjectManager/ProjectManagerItems.js
+++ b/newIDE/app/src/ProjectManager/ProjectManagerItems.js
@@ -152,9 +152,22 @@ export const Item = ({
       style={styles.itemTextField}
     />
   ) : (
-    <div style={textEllispsisStyle} title={primaryText}>
-      {primaryText}
-      {textEndAdornment}
+    <div
+      style={{ display: 'inline-flex', width: '100%', alignItems: 'center' }}
+    >
+      <span style={textEllispsisStyle} title={primaryText}>
+        {primaryText}
+      </span>
+      {textEndAdornment && (
+        <span
+          style={{
+            marginLeft: 5,
+            display: 'flex',
+          }}
+        >
+          {textEndAdornment}
+        </span>
+      )}
     </div>
   );
 

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -736,14 +736,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                                   t`This scene will be used as the start scene.`
                                 )}
                               >
-                                <Flag
-                                  color="disabled"
-                                  fontSize="small"
-                                  style={{
-                                    verticalAlign: 'bottom',
-                                    marginLeft: 5,
-                                  }}
-                                />
+                                <Flag color="disabled" fontSize="small" />
                               </Tooltip>
                             ) : (
                               undefined

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -1,5 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
+import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 import { t } from '@lingui/macro';
 
@@ -261,10 +262,10 @@ export default class ProjectManager extends React.Component<Props, State> {
     this._pasteLayout(index);
   };
 
-  _addLayout = (index: number) => {
+  _addLayout = (index: number, i18n: I18nType) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('Untitled scene', name =>
+    const newName = newNameGenerator(i18n._(t`Untitled scene`), name =>
       project.hasLayoutNamed(name)
     );
     const newLayout = project.insertNewLayout(newName, index + 1);
@@ -283,30 +284,32 @@ export default class ProjectManager extends React.Component<Props, State> {
     this.setState({ editedVariablesLayout: layout });
   };
 
-  _addExternalEvents = (index: number) => {
+  _addExternalEvents = (index: number, i18n: I18nType) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('Untitled external events', name =>
-      project.hasExternalEventsNamed(name)
+    const newName = newNameGenerator(
+      i18n._(t`Untitled external events`),
+      name => project.hasExternalEventsNamed(name)
     );
     project.insertNewExternalEvents(newName, index + 1);
     this._onProjectItemModified();
   };
 
-  _addExternalLayout = (index: number) => {
+  _addExternalLayout = (index: number, i18n: I18nType) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('Untitled external layout', name =>
-      project.hasExternalLayoutNamed(name)
+    const newName = newNameGenerator(
+      i18n._(t`Untitled external layout`),
+      name => project.hasExternalLayoutNamed(name)
     );
     project.insertNewExternalLayout(newName, index + 1);
     this._onProjectItemModified();
   };
 
-  _addEventsFunctionsExtension = (index: number) => {
+  _addEventsFunctionsExtension = (index: number, i18n: I18nType) => {
     const { project } = this.props;
 
-    const newName = newNameGenerator('UntitledExtension', name =>
+    const newName = newNameGenerator(i18n._(t`UntitledExtension`), name =>
       isExtensionNameTaken(name, project)
     );
     project.insertNewEventsFunctionsExtension(newName, index + 1);
@@ -651,501 +654,552 @@ export default class ProjectManager extends React.Component<Props, State> {
     const firstLayoutName = project.getFirstLayout();
 
     return (
-      <div style={styles.container}>
-        <ProjectManagerCommands
-          project={this.props.project}
-          onOpenProjectProperties={this._openProjectProperties}
-          onOpenProjectLoadingScreen={this._openProjectLoadingScreen}
-          onOpenProjectVariables={this._openProjectVariables}
-          onOpenResourcesDialog={this.props.onOpenResources}
-          onOpenPlatformSpecificAssetsDialog={
-            this.props.onOpenPlatformSpecificAssets
-          }
-          onOpenSearchExtensionDialog={this._openSearchExtensionDialog}
-        />
-        <List style={styles.list}>
-          {this._renderMenu()}
-          <ProjectStructureItem
-            primaryText={<Trans>Game settings</Trans>}
-            leftIcon={
-              <ListIcon
-                iconSize={24}
-                isGDevelopIcon
-                src="res/ribbon_default/projectManager32.png"
+      <I18n>
+        {({ i18n }) => (
+          <div style={styles.container}>
+            <ProjectManagerCommands
+              project={this.props.project}
+              onOpenProjectProperties={this._openProjectProperties}
+              onOpenProjectLoadingScreen={this._openProjectLoadingScreen}
+              onOpenProjectVariables={this._openProjectVariables}
+              onOpenResourcesDialog={this.props.onOpenResources}
+              onOpenPlatformSpecificAssetsDialog={
+                this.props.onOpenPlatformSpecificAssets
+              }
+              onOpenSearchExtensionDialog={this._openSearchExtensionDialog}
+            />
+            <List style={styles.list}>
+              {this._renderMenu()}
+              <ProjectStructureItem
+                primaryText={<Trans>Game settings</Trans>}
+                leftIcon={
+                  <ListIcon
+                    iconSize={24}
+                    isGDevelopIcon
+                    src="res/ribbon_default/projectManager32.png"
+                  />
+                }
+                initiallyOpen={false}
+                autoGenerateNestedIndicator={true}
+                indentNestedItems
+                renderNestedItems={() => [
+                  <ListItem
+                    key="properties"
+                    primaryText={<Trans>Properties</Trans>}
+                    leftIcon={<SettingsApplications />}
+                    onClick={this._openProjectProperties}
+                  />,
+                  <ListItem
+                    key="global-variables"
+                    primaryText={<Trans>Global variables</Trans>}
+                    leftIcon={<VariableTree />}
+                    onClick={this._openProjectVariables}
+                  />,
+                  <ListItem
+                    key="icons"
+                    primaryText={<Trans>Icons</Trans>}
+                    leftIcon={<PhotoLibrary />}
+                    onClick={this.props.onOpenPlatformSpecificAssets}
+                  />,
+                  <ListItem
+                    key="resources"
+                    primaryText={<Trans>Resources</Trans>}
+                    leftIcon={<ArtTrack />}
+                    onClick={this.props.onOpenResources}
+                  />,
+                ]}
               />
-            }
-            initiallyOpen={false}
-            autoGenerateNestedIndicator={true}
-            indentNestedItems
-            renderNestedItems={() => [
-              <ListItem
-                key="properties"
-                primaryText={<Trans>Properties</Trans>}
-                leftIcon={<SettingsApplications />}
-                onClick={this._openProjectProperties}
-              />,
-              <ListItem
-                key="global-variables"
-                primaryText={<Trans>Global variables</Trans>}
-                leftIcon={<VariableTree />}
-                onClick={this._openProjectVariables}
-              />,
-              <ListItem
-                key="icons"
-                primaryText={<Trans>Icons</Trans>}
-                leftIcon={<PhotoLibrary />}
-                onClick={this.props.onOpenPlatformSpecificAssets}
-              />,
-              <ListItem
-                key="resources"
-                primaryText={<Trans>Resources</Trans>}
-                leftIcon={<ArtTrack />}
-                onClick={this.props.onOpenResources}
-              />,
-            ]}
-          />
-          <ProjectStructureItem
-            primaryText={<Trans>Scenes</Trans>}
-            leftIcon={
-              <ListIcon
-                iconSize={24}
-                isGDevelopIcon
-                src="res/ribbon_default/sceneadd32.png"
+              <ProjectStructureItem
+                primaryText={<Trans>Scenes</Trans>}
+                leftIcon={
+                  <ListIcon
+                    iconSize={24}
+                    isGDevelopIcon
+                    src="res/ribbon_default/sceneadd32.png"
+                  />
+                }
+                initiallyOpen={true}
+                open={forceOpen}
+                autoGenerateNestedIndicator={!forceOpen}
+                renderNestedItems={() =>
+                  filterProjectItemsList(enumerateLayouts(project), searchText)
+                    .map((layout: gdLayout, i: number) => {
+                      const name = layout.getName();
+                      return (
+                        <Item
+                          key={i}
+                          primaryText={name}
+                          textEndAdornment={
+                            name === firstLayoutName ? (
+                              <Tooltip
+                                title={i18n._(
+                                  t`This scene will be used as the first scene displayed at game launch.`
+                                )}
+                              >
+                                <Flag
+                                  color="disabled"
+                                  fontSize="small"
+                                  style={{
+                                    verticalAlign: 'bottom',
+                                    marginLeft: 5,
+                                  }}
+                                />
+                              </Tooltip>
+                            ) : (
+                              undefined
+                            )
+                          }
+                          editingName={
+                            renamedItemKind === 'layout' &&
+                            renamedItemName === name
+                          }
+                          onEdit={() => this.props.onOpenLayout(name)}
+                          onDelete={() => this.props.onDeleteLayout(layout)}
+                          addLabel={t`Add a New Scene`}
+                          onAdd={() => this._addLayout(i, i18n)}
+                          onRename={newName => {
+                            this.props.onRenameLayout(name, newName);
+                            this._onEditName(null, '');
+                          }}
+                          onEditName={() => this._onEditName('layout', name)}
+                          onCopy={() => this._copyLayout(layout)}
+                          onCut={() => this._cutLayout(layout)}
+                          onPaste={() => this._pasteLayout(i)}
+                          onDuplicate={() => this._duplicateLayout(layout, i)}
+                          canPaste={() => Clipboard.has(LAYOUT_CLIPBOARD_KIND)}
+                          canMoveUp={i !== 0}
+                          onMoveUp={() => this._moveUpLayout(i)}
+                          canMoveDown={i !== project.getLayoutsCount() - 1}
+                          onMoveDown={() => this._moveDownLayout(i)}
+                          buildExtraMenuTemplate={(i18n: I18nType) => [
+                            {
+                              label: i18n._(t`Edit Scene Properties`),
+                              enabled: true,
+                              click: () => this._onOpenLayoutProperties(layout),
+                            },
+                            {
+                              label: i18n._(t`Edit Scene Variables`),
+                              enabled: true,
+                              click: () => this._onOpenLayoutVariables(layout),
+                            },
+                            {
+                              label: i18n._(t`Define as first scene`),
+                              enabled: name !== firstLayoutName,
+                              click: () => this._setProjectFirstLayout(name),
+                            },
+                          ]}
+                        />
+                      );
+                    })
+                    .concat(
+                      <AddListItem
+                        key={'add-scene'}
+                        onClick={() =>
+                          this._addLayout(project.getLayoutsCount(), i18n)
+                        }
+                        primaryText={<Trans>Click to add a scene</Trans>}
+                      />
+                    )
+                }
               />
-            }
-            initiallyOpen={true}
-            open={forceOpen}
-            autoGenerateNestedIndicator={!forceOpen}
-            renderNestedItems={() =>
-              filterProjectItemsList(enumerateLayouts(project), searchText)
-                .map((layout: gdLayout, i: number) => {
-                  const name = layout.getName();
-                  return (
-                    <Item
-                      key={i}
-                      primaryText={name}
-                      textEndAdornment={
-                        name === firstLayoutName ? (
-                          <Tooltip title="This scene will be used as the first scene displayed at game launch.">
-                            <Flag
-                              color="disabled"
-                              fontSize="small"
-                              style={{ verticalAlign: 'bottom', marginLeft: 5 }}
-                            />
-                          </Tooltip>
-                        ) : (
-                          undefined
-                        )
-                      }
-                      editingName={
-                        renamedItemKind === 'layout' && renamedItemName === name
-                      }
-                      onEdit={() => this.props.onOpenLayout(name)}
-                      onDelete={() => this.props.onDeleteLayout(layout)}
-                      addLabel={t`Add a New Scene`}
-                      onAdd={() => this._addLayout(i)}
-                      onRename={newName => {
-                        this.props.onRenameLayout(name, newName);
-                        this._onEditName(null, '');
-                      }}
-                      onEditName={() => this._onEditName('layout', name)}
-                      onCopy={() => this._copyLayout(layout)}
-                      onCut={() => this._cutLayout(layout)}
-                      onPaste={() => this._pasteLayout(i)}
-                      onDuplicate={() => this._duplicateLayout(layout, i)}
-                      canPaste={() => Clipboard.has(LAYOUT_CLIPBOARD_KIND)}
-                      canMoveUp={i !== 0}
-                      onMoveUp={() => this._moveUpLayout(i)}
-                      canMoveDown={i !== project.getLayoutsCount() - 1}
-                      onMoveDown={() => this._moveDownLayout(i)}
-                      buildExtraMenuTemplate={(i18n: I18nType) => [
-                        {
-                          label: i18n._(t`Edit Scene Properties`),
-                          enabled: true,
-                          click: () => this._onOpenLayoutProperties(layout),
-                        },
-                        {
-                          label: i18n._(t`Edit Scene Variables`),
-                          enabled: true,
-                          click: () => this._onOpenLayoutVariables(layout),
-                        },
-                        {
-                          label: i18n._(t`Define as first scene`),
-                          enabled: name !== firstLayoutName,
-                          click: () => this._setProjectFirstLayout(name),
-                        },
-                      ]}
-                    />
+              <ProjectStructureItem
+                primaryText={<Trans>External events</Trans>}
+                leftIcon={
+                  <ListIcon
+                    iconSize={24}
+                    isGDevelopIcon
+                    src="res/ribbon_default/externalevents32.png"
+                  />
+                }
+                initiallyOpen={false}
+                open={forceOpen}
+                autoGenerateNestedIndicator={!forceOpen}
+                renderNestedItems={() =>
+                  filterProjectItemsList(
+                    enumerateExternalEvents(project),
+                    searchText
+                  )
+                    .map((externalEvents, i) => {
+                      const name = externalEvents.getName();
+                      return (
+                        <Item
+                          key={i}
+                          primaryText={name}
+                          editingName={
+                            renamedItemKind === 'external-events' &&
+                            renamedItemName === name
+                          }
+                          onEdit={() => this.props.onOpenExternalEvents(name)}
+                          onDelete={() =>
+                            this.props.onDeleteExternalEvents(externalEvents)
+                          }
+                          addLabel={t`Add New External Events`}
+                          onAdd={() => this._addExternalEvents(i, i18n)}
+                          onRename={newName => {
+                            this.props.onRenameExternalEvents(name, newName);
+                            this._onEditName(null, '');
+                          }}
+                          onEditName={() =>
+                            this._onEditName('external-events', name)
+                          }
+                          onCopy={() =>
+                            this._copyExternalEvents(externalEvents)
+                          }
+                          onCut={() => this._cutExternalEvents(externalEvents)}
+                          onPaste={() => this._pasteExternalEvents(i)}
+                          onDuplicate={() =>
+                            this._duplicateExternalEvents(externalEvents, i)
+                          }
+                          canPaste={() =>
+                            Clipboard.has(EXTERNAL_EVENTS_CLIPBOARD_KIND)
+                          }
+                          canMoveUp={i !== 0}
+                          onMoveUp={() => this._moveUpExternalEvents(i)}
+                          canMoveDown={
+                            i !== project.getExternalEventsCount() - 1
+                          }
+                          onMoveDown={() => this._moveDownExternalEvents(i)}
+                        />
+                      );
+                    })
+                    .concat(
+                      <AddListItem
+                        key={'add-external-events'}
+                        primaryText={
+                          <Trans>Click to add external events</Trans>
+                        }
+                        onClick={() =>
+                          this._addExternalEvents(
+                            project.getExternalEventsCount(),
+                            i18n
+                          )
+                        }
+                      />
+                    )
+                }
+              />
+              <ProjectStructureItem
+                primaryText={<Trans>External layouts</Trans>}
+                leftIcon={
+                  <ListIcon
+                    iconSize={24}
+                    isGDevelopIcon
+                    src="res/ribbon_default/externallayout32.png"
+                  />
+                }
+                initiallyOpen={false}
+                open={forceOpen}
+                autoGenerateNestedIndicator={!forceOpen}
+                renderNestedItems={() =>
+                  filterProjectItemsList(
+                    enumerateExternalLayouts(project),
+                    searchText
+                  )
+                    .map((externalLayout, i) => {
+                      const name = externalLayout.getName();
+                      return (
+                        <Item
+                          key={i}
+                          primaryText={name}
+                          editingName={
+                            renamedItemKind === 'external-layout' &&
+                            renamedItemName === name
+                          }
+                          onEdit={() => this.props.onOpenExternalLayout(name)}
+                          onDelete={() =>
+                            this.props.onDeleteExternalLayout(externalLayout)
+                          }
+                          addLabel={t`Add a New External Layout`}
+                          onAdd={() => this._addExternalLayout(i, i18n)}
+                          onRename={newName => {
+                            this.props.onRenameExternalLayout(name, newName);
+                            this._onEditName(null, '');
+                          }}
+                          onEditName={() =>
+                            this._onEditName('external-layout', name)
+                          }
+                          onCopy={() =>
+                            this._copyExternalLayout(externalLayout)
+                          }
+                          onCut={() => this._cutExternalLayout(externalLayout)}
+                          onPaste={() => this._pasteExternalLayout(i)}
+                          onDuplicate={() =>
+                            this._duplicateExternalLayout(externalLayout, i)
+                          }
+                          canPaste={() =>
+                            Clipboard.has(EXTERNAL_LAYOUT_CLIPBOARD_KIND)
+                          }
+                          canMoveUp={i !== 0}
+                          onMoveUp={() => this._moveUpExternalLayout(i)}
+                          canMoveDown={
+                            i !== project.getExternalLayoutsCount() - 1
+                          }
+                          onMoveDown={() => this._moveDownExternalLayout(i)}
+                        />
+                      );
+                    })
+                    .concat(
+                      <AddListItem
+                        key={'add-external-layout'}
+                        primaryText={
+                          <Trans>Click to add an external layout</Trans>
+                        }
+                        onClick={() =>
+                          this._addExternalLayout(
+                            project.getExternalLayoutsCount(),
+                            i18n
+                          )
+                        }
+                      />
+                    )
+                }
+              />
+              <ProjectStructureItem
+                primaryText={<Trans>Functions/Behaviors</Trans>}
+                error={eventsFunctionsExtensionsError}
+                onRefresh={onReloadEventsFunctionsExtensions}
+                leftIcon={
+                  <ListIcon
+                    iconSize={24}
+                    isGDevelopIcon
+                    src="res/ribbon_default/function32.png"
+                  />
+                }
+                initiallyOpen={false}
+                open={forceOpen}
+                autoGenerateNestedIndicator={
+                  !forceOpen && !eventsFunctionsExtensionsError
+                }
+                renderNestedItems={() =>
+                  filterProjectItemsList(
+                    enumerateEventsFunctionsExtensions(project),
+                    searchText
+                  )
+                    .map((eventsFunctionsExtension, i) => {
+                      const name = eventsFunctionsExtension.getName();
+                      return (
+                        <EventFunctionExtensionItem
+                          key={i}
+                          eventsFunctionsExtension={eventsFunctionsExtension}
+                          isEditingName={
+                            renamedItemKind === 'events-functions-extension' &&
+                            renamedItemName === name
+                          }
+                          onEdit={extensionShortHeadersByName =>
+                            this._onEditEventsFunctionExtensionOrSeeDetails(
+                              extensionShortHeadersByName,
+                              eventsFunctionsExtension,
+                              name
+                            )
+                          }
+                          onDelete={() =>
+                            this.props.onDeleteEventsFunctionsExtension(
+                              eventsFunctionsExtension
+                            )
+                          }
+                          onAdd={() =>
+                            this._addEventsFunctionsExtension(i, i18n)
+                          }
+                          onRename={newName => {
+                            this.props.onRenameEventsFunctionsExtension(
+                              name,
+                              newName
+                            );
+                            this._onEditName(null, '');
+                          }}
+                          onEditName={() =>
+                            this._onEditName('events-functions-extension', name)
+                          }
+                          onCopy={() =>
+                            this._copyEventsFunctionsExtension(
+                              eventsFunctionsExtension
+                            )
+                          }
+                          onCut={() =>
+                            this._cutEventsFunctionsExtension(
+                              eventsFunctionsExtension
+                            )
+                          }
+                          onPaste={() => this._pasteEventsFunctionsExtension(i)}
+                          onDuplicate={() =>
+                            this._duplicateEventsFunctionsExtension(
+                              eventsFunctionsExtension,
+                              i
+                            )
+                          }
+                          canPaste={() =>
+                            Clipboard.has(
+                              EVENTS_FUNCTIONS_EXTENSION_CLIPBOARD_KIND
+                            )
+                          }
+                          canMoveUp={i !== 0}
+                          onMoveUp={() =>
+                            this._moveUpEventsFunctionsExtension(i)
+                          }
+                          canMoveDown={
+                            i !==
+                            project.getEventsFunctionsExtensionsCount() - 1
+                          }
+                          onMoveDown={() =>
+                            this._moveDownEventsFunctionsExtension(i)
+                          }
+                        />
+                      );
+                    })
+                    .concat(
+                      <AddListItem
+                        key={'add-events-functions-extension'}
+                        primaryText={
+                          <Trans>Click to add functions and behaviors</Trans>
+                        }
+                        onClick={() =>
+                          this._addEventsFunctionsExtension(
+                            project.getEventsFunctionsExtensionsCount(),
+                            i18n
+                          )
+                        }
+                      />
+                    )
+                    .concat(
+                      <SearchListItem
+                        key={'extensions-search'}
+                        primaryText={<Trans>Search for new extensions</Trans>}
+                        onClick={this._openSearchExtensionDialog}
+                      />
+                    )
+                }
+              />
+            </List>
+            <SearchBar
+              ref={searchBar => (this._searchBar = searchBar)}
+              value={searchText}
+              onRequestSearch={this._onRequestSearch}
+              onChange={this._onSearchChange}
+            />
+            {this.state.projectVariablesEditorOpen && (
+              <VariablesEditorDialog
+                title={<Trans>Global Variables</Trans>}
+                open
+                variablesContainer={project.getVariables()}
+                onCancel={() =>
+                  this.setState({ projectVariablesEditorOpen: false })
+                }
+                onApply={() => {
+                  if (this.props.unsavedChanges)
+                    this.props.unsavedChanges.triggerUnsavedChanges();
+                  this.setState({ projectVariablesEditorOpen: false });
+                }}
+                emptyExplanationMessage={
+                  <Trans>
+                    Global variables are variables that are shared amongst all
+                    the scenes of the game.
+                  </Trans>
+                }
+                emptyExplanationSecondMessage={
+                  <Trans>
+                    For example, you can have a variable called
+                    UnlockedLevelsCount representing the number of levels
+                    unlocked by the player.
+                  </Trans>
+                }
+                helpPagePath={'/all-features/variables/global-variables'}
+                hotReloadPreviewButtonProps={
+                  this.props.hotReloadPreviewButtonProps
+                }
+                onComputeAllVariableNames={() =>
+                  EventsRootVariablesFinder.findAllGlobalVariables(
+                    project.getCurrentPlatform(),
+                    project
+                  )
+                }
+              />
+            )}
+            {this.state.projectPropertiesDialogOpen && (
+              <ProjectPropertiesDialog
+                open
+                initialTab={this.state.projectPropertiesDialogInitialTab}
+                project={project}
+                onClose={() =>
+                  this.setState({ projectPropertiesDialogOpen: false })
+                }
+                onApply={() => {
+                  if (this.props.unsavedChanges)
+                    this.props.unsavedChanges.triggerUnsavedChanges();
+                  this.setState({ projectPropertiesDialogOpen: false });
+                }}
+                onChangeSubscription={this.props.onChangeSubscription}
+                resourceSources={this.props.resourceSources}
+                onChooseResource={this.props.onChooseResource}
+                resourceExternalEditors={this.props.resourceExternalEditors}
+                hotReloadPreviewButtonProps={
+                  this.props.hotReloadPreviewButtonProps
+                }
+              />
+            )}
+            {!!this.state.editedPropertiesLayout && (
+              <ScenePropertiesDialog
+                open
+                layout={this.state.editedPropertiesLayout}
+                project={this.props.project}
+                onApply={() => {
+                  if (this.props.unsavedChanges)
+                    this.props.unsavedChanges.triggerUnsavedChanges();
+                  this._onOpenLayoutProperties(null);
+                }}
+                onClose={() => this._onOpenLayoutProperties(null)}
+                onEditVariables={() => {
+                  this._onOpenLayoutVariables(
+                    this.state.editedPropertiesLayout
                   );
-                })
-                .concat(
-                  <AddListItem
-                    key={'add-scene'}
-                    onClick={() => this._addLayout(project.getLayoutsCount())}
-                    primaryText={<Trans>Click to add a scene</Trans>}
-                  />
-                )
-            }
-          />
-          <ProjectStructureItem
-            primaryText={<Trans>External events</Trans>}
-            leftIcon={
-              <ListIcon
-                iconSize={24}
-                isGDevelopIcon
-                src="res/ribbon_default/externalevents32.png"
+                  this._onOpenLayoutProperties(null);
+                }}
               />
-            }
-            initiallyOpen={false}
-            open={forceOpen}
-            autoGenerateNestedIndicator={!forceOpen}
-            renderNestedItems={() =>
-              filterProjectItemsList(
-                enumerateExternalEvents(project),
-                searchText
-              )
-                .map((externalEvents, i) => {
-                  const name = externalEvents.getName();
-                  return (
-                    <Item
-                      key={i}
-                      primaryText={name}
-                      editingName={
-                        renamedItemKind === 'external-events' &&
-                        renamedItemName === name
-                      }
-                      onEdit={() => this.props.onOpenExternalEvents(name)}
-                      onDelete={() =>
-                        this.props.onDeleteExternalEvents(externalEvents)
-                      }
-                      addLabel={t`Add New External Events`}
-                      onAdd={() => this._addExternalEvents(i)}
-                      onRename={newName => {
-                        this.props.onRenameExternalEvents(name, newName);
-                        this._onEditName(null, '');
-                      }}
-                      onEditName={() =>
-                        this._onEditName('external-events', name)
-                      }
-                      onCopy={() => this._copyExternalEvents(externalEvents)}
-                      onCut={() => this._cutExternalEvents(externalEvents)}
-                      onPaste={() => this._pasteExternalEvents(i)}
-                      onDuplicate={() =>
-                        this._duplicateExternalEvents(externalEvents, i)
-                      }
-                      canPaste={() =>
-                        Clipboard.has(EXTERNAL_EVENTS_CLIPBOARD_KIND)
-                      }
-                      canMoveUp={i !== 0}
-                      onMoveUp={() => this._moveUpExternalEvents(i)}
-                      canMoveDown={i !== project.getExternalEventsCount() - 1}
-                      onMoveDown={() => this._moveDownExternalEvents(i)}
-                    />
-                  );
-                })
-                .concat(
-                  <AddListItem
-                    key={'add-external-events'}
-                    primaryText={<Trans>Click to add external events</Trans>}
-                    onClick={() =>
-                      this._addExternalEvents(project.getExternalEventsCount())
-                    }
-                  />
-                )
-            }
-          />
-          <ProjectStructureItem
-            primaryText={<Trans>External layouts</Trans>}
-            leftIcon={
-              <ListIcon
-                iconSize={24}
-                isGDevelopIcon
-                src="res/ribbon_default/externallayout32.png"
+            )}
+            {!!this.state.editedVariablesLayout && (
+              <SceneVariablesDialog
+                open
+                project={project}
+                layout={this.state.editedVariablesLayout}
+                onClose={() => this._onOpenLayoutVariables(null)}
+                onApply={() => {
+                  if (this.props.unsavedChanges)
+                    this.props.unsavedChanges.triggerUnsavedChanges();
+                  this._onOpenLayoutVariables(null);
+                }}
+                hotReloadPreviewButtonProps={
+                  this.props.hotReloadPreviewButtonProps
+                }
               />
-            }
-            initiallyOpen={false}
-            open={forceOpen}
-            autoGenerateNestedIndicator={!forceOpen}
-            renderNestedItems={() =>
-              filterProjectItemsList(
-                enumerateExternalLayouts(project),
-                searchText
-              )
-                .map((externalLayout, i) => {
-                  const name = externalLayout.getName();
-                  return (
-                    <Item
-                      key={i}
-                      primaryText={name}
-                      editingName={
-                        renamedItemKind === 'external-layout' &&
-                        renamedItemName === name
-                      }
-                      onEdit={() => this.props.onOpenExternalLayout(name)}
-                      onDelete={() =>
-                        this.props.onDeleteExternalLayout(externalLayout)
-                      }
-                      addLabel={t`Add a New External Layout`}
-                      onAdd={() => this._addExternalLayout(i)}
-                      onRename={newName => {
-                        this.props.onRenameExternalLayout(name, newName);
-                        this._onEditName(null, '');
-                      }}
-                      onEditName={() =>
-                        this._onEditName('external-layout', name)
-                      }
-                      onCopy={() => this._copyExternalLayout(externalLayout)}
-                      onCut={() => this._cutExternalLayout(externalLayout)}
-                      onPaste={() => this._pasteExternalLayout(i)}
-                      onDuplicate={() =>
-                        this._duplicateExternalLayout(externalLayout, i)
-                      }
-                      canPaste={() =>
-                        Clipboard.has(EXTERNAL_LAYOUT_CLIPBOARD_KIND)
-                      }
-                      canMoveUp={i !== 0}
-                      onMoveUp={() => this._moveUpExternalLayout(i)}
-                      canMoveDown={i !== project.getExternalLayoutsCount() - 1}
-                      onMoveDown={() => this._moveDownExternalLayout(i)}
-                    />
-                  );
-                })
-                .concat(
-                  <AddListItem
-                    key={'add-external-layout'}
-                    primaryText={<Trans>Click to add an external layout</Trans>}
-                    onClick={() =>
-                      this._addExternalLayout(project.getExternalLayoutsCount())
-                    }
-                  />
-                )
-            }
-          />
-          <ProjectStructureItem
-            primaryText={<Trans>Functions/Behaviors</Trans>}
-            error={eventsFunctionsExtensionsError}
-            onRefresh={onReloadEventsFunctionsExtensions}
-            leftIcon={
-              <ListIcon
-                iconSize={24}
-                isGDevelopIcon
-                src="res/ribbon_default/function32.png"
+            )}
+            {this.state.extensionsSearchDialogOpen && (
+              <ExtensionsSearchDialog
+                project={project}
+                onClose={() =>
+                  this.setState({ extensionsSearchDialogOpen: false })
+                }
+                onInstallExtension={onInstallExtension}
               />
-            }
-            initiallyOpen={false}
-            open={forceOpen}
-            autoGenerateNestedIndicator={
-              !forceOpen && !eventsFunctionsExtensionsError
-            }
-            renderNestedItems={() =>
-              filterProjectItemsList(
-                enumerateEventsFunctionsExtensions(project),
-                searchText
-              )
-                .map((eventsFunctionsExtension, i) => {
-                  const name = eventsFunctionsExtension.getName();
-                  return (
-                    <EventFunctionExtensionItem
-                      key={i}
-                      eventsFunctionsExtension={eventsFunctionsExtension}
-                      isEditingName={
-                        renamedItemKind === 'events-functions-extension' &&
-                        renamedItemName === name
-                      }
-                      onEdit={extensionShortHeadersByName =>
-                        this._onEditEventsFunctionExtensionOrSeeDetails(
-                          extensionShortHeadersByName,
-                          eventsFunctionsExtension,
-                          name
-                        )
-                      }
-                      onDelete={() =>
-                        this.props.onDeleteEventsFunctionsExtension(
-                          eventsFunctionsExtension
-                        )
-                      }
-                      onAdd={() => this._addEventsFunctionsExtension(i)}
-                      onRename={newName => {
-                        this.props.onRenameEventsFunctionsExtension(
-                          name,
-                          newName
-                        );
-                        this._onEditName(null, '');
-                      }}
-                      onEditName={() =>
-                        this._onEditName('events-functions-extension', name)
-                      }
-                      onCopy={() =>
-                        this._copyEventsFunctionsExtension(
-                          eventsFunctionsExtension
-                        )
-                      }
-                      onCut={() =>
-                        this._cutEventsFunctionsExtension(
-                          eventsFunctionsExtension
-                        )
-                      }
-                      onPaste={() => this._pasteEventsFunctionsExtension(i)}
-                      onDuplicate={() =>
-                        this._duplicateEventsFunctionsExtension(
-                          eventsFunctionsExtension,
-                          i
-                        )
-                      }
-                      canPaste={() =>
-                        Clipboard.has(EVENTS_FUNCTIONS_EXTENSION_CLIPBOARD_KIND)
-                      }
-                      canMoveUp={i !== 0}
-                      onMoveUp={() => this._moveUpEventsFunctionsExtension(i)}
-                      canMoveDown={
-                        i !== project.getEventsFunctionsExtensionsCount() - 1
-                      }
-                      onMoveDown={() =>
-                        this._moveDownEventsFunctionsExtension(i)
-                      }
-                    />
-                  );
-                })
-                .concat(
-                  <AddListItem
-                    key={'add-events-functions-extension'}
-                    primaryText={
-                      <Trans>Click to add functions and behaviors</Trans>
-                    }
-                    onClick={() =>
-                      this._addEventsFunctionsExtension(
-                        project.getEventsFunctionsExtensionsCount()
-                      )
-                    }
-                  />
-                )
-                .concat(
-                  <SearchListItem
-                    key={'extensions-search'}
-                    primaryText={<Trans>Search for new extensions</Trans>}
-                    onClick={this._openSearchExtensionDialog}
-                  />
-                )
-            }
-          />
-        </List>
-        <SearchBar
-          ref={searchBar => (this._searchBar = searchBar)}
-          value={searchText}
-          onRequestSearch={this._onRequestSearch}
-          onChange={this._onSearchChange}
-        />
-        {this.state.projectVariablesEditorOpen && (
-          <VariablesEditorDialog
-            title={<Trans>Global Variables</Trans>}
-            open
-            variablesContainer={project.getVariables()}
-            onCancel={() =>
-              this.setState({ projectVariablesEditorOpen: false })
-            }
-            onApply={() => {
-              if (this.props.unsavedChanges)
-                this.props.unsavedChanges.triggerUnsavedChanges();
-              this.setState({ projectVariablesEditorOpen: false });
-            }}
-            emptyExplanationMessage={
-              <Trans>
-                Global variables are variables that are shared amongst all the
-                scenes of the game.
-              </Trans>
-            }
-            emptyExplanationSecondMessage={
-              <Trans>
-                For example, you can have a variable called UnlockedLevelsCount
-                representing the number of levels unlocked by the player.
-              </Trans>
-            }
-            helpPagePath={'/all-features/variables/global-variables'}
-            hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
-            onComputeAllVariableNames={() =>
-              EventsRootVariablesFinder.findAllGlobalVariables(
-                project.getCurrentPlatform(),
-                project
-              )
-            }
-          />
+            )}
+            {openedExtensionShortHeader && openedExtensionName && (
+              <InstalledExtensionDetails
+                project={project}
+                onClose={() =>
+                  this.setState({
+                    openedExtensionShortHeader: null,
+                    openedExtensionName: null,
+                  })
+                }
+                onOpenEventsFunctionsExtension={
+                  this.props.onOpenEventsFunctionsExtension
+                }
+                extensionShortHeader={openedExtensionShortHeader}
+                extensionName={openedExtensionName}
+                onInstallExtension={onInstallExtension}
+              />
+            )}
+          </div>
         )}
-        {this.state.projectPropertiesDialogOpen && (
-          <ProjectPropertiesDialog
-            open
-            initialTab={this.state.projectPropertiesDialogInitialTab}
-            project={project}
-            onClose={() =>
-              this.setState({ projectPropertiesDialogOpen: false })
-            }
-            onApply={() => {
-              if (this.props.unsavedChanges)
-                this.props.unsavedChanges.triggerUnsavedChanges();
-              this.setState({ projectPropertiesDialogOpen: false });
-            }}
-            onChangeSubscription={this.props.onChangeSubscription}
-            resourceSources={this.props.resourceSources}
-            onChooseResource={this.props.onChooseResource}
-            resourceExternalEditors={this.props.resourceExternalEditors}
-            hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
-          />
-        )}
-        {!!this.state.editedPropertiesLayout && (
-          <ScenePropertiesDialog
-            open
-            layout={this.state.editedPropertiesLayout}
-            project={this.props.project}
-            onApply={() => {
-              if (this.props.unsavedChanges)
-                this.props.unsavedChanges.triggerUnsavedChanges();
-              this._onOpenLayoutProperties(null);
-            }}
-            onClose={() => this._onOpenLayoutProperties(null)}
-            onEditVariables={() => {
-              this._onOpenLayoutVariables(this.state.editedPropertiesLayout);
-              this._onOpenLayoutProperties(null);
-            }}
-          />
-        )}
-        {!!this.state.editedVariablesLayout && (
-          <SceneVariablesDialog
-            open
-            project={project}
-            layout={this.state.editedVariablesLayout}
-            onClose={() => this._onOpenLayoutVariables(null)}
-            onApply={() => {
-              if (this.props.unsavedChanges)
-                this.props.unsavedChanges.triggerUnsavedChanges();
-              this._onOpenLayoutVariables(null);
-            }}
-            hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
-          />
-        )}
-        {this.state.extensionsSearchDialogOpen && (
-          <ExtensionsSearchDialog
-            project={project}
-            onClose={() => this.setState({ extensionsSearchDialogOpen: false })}
-            onInstallExtension={onInstallExtension}
-          />
-        )}
-        {openedExtensionShortHeader && openedExtensionName && (
-          <InstalledExtensionDetails
-            project={project}
-            onClose={() =>
-              this.setState({
-                openedExtensionShortHeader: null,
-                openedExtensionName: null,
-              })
-            }
-            onOpenEventsFunctionsExtension={
-              this.props.onOpenEventsFunctionsExtension
-            }
-            extensionShortHeader={openedExtensionShortHeader}
-            extensionName={openedExtensionName}
-            onInstallExtension={onInstallExtension}
-          />
-        )}
-      </div>
+      </I18n>
     );
   }
 }

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -28,6 +28,7 @@ import {
   unserializeFromJSObject,
 } from '../Utils/Serializer';
 import ExtensionsSearchDialog from '../AssetStore/ExtensionStore/ExtensionsSearchDialog';
+import Flag from '@material-ui/icons/Flag';
 import Close from '@material-ui/icons/Close';
 import SettingsApplications from '@material-ui/icons/SettingsApplications';
 import PhotoLibrary from '@material-ui/icons/PhotoLibrary';
@@ -58,6 +59,7 @@ import {
   ProjectStructureItem,
   EventFunctionExtensionItem,
 } from './ProjectManagerItems';
+import { Tooltip } from '@material-ui/core';
 
 const LAYOUT_CLIPBOARD_KIND = 'Layout';
 const EXTERNAL_LAYOUT_CLIPBOARD_KIND = 'External layout';
@@ -624,6 +626,11 @@ export default class ProjectManager extends React.Component<Props, State> {
       this.props.unsavedChanges.triggerUnsavedChanges();
   };
 
+  _setProjectFirstLayout = (layoutName: string) => {
+    this.props.project.setFirstLayout(layoutName);
+    this.forceUpdate();
+  };
+
   render() {
     const {
       project,
@@ -640,6 +647,8 @@ export default class ProjectManager extends React.Component<Props, State> {
     } = this.state;
 
     const forceOpen = searchText !== '' ? true : undefined;
+
+    const firstLayoutName = project.getFirstLayout();
 
     return (
       <div style={styles.container}>
@@ -715,6 +724,19 @@ export default class ProjectManager extends React.Component<Props, State> {
                     <Item
                       key={i}
                       primaryText={name}
+                      textEndAdornment={
+                        name === firstLayoutName ? (
+                          <Tooltip title="This scene will be used as the first scene displayed at game launch.">
+                            <Flag
+                              color="disabled"
+                              fontSize="small"
+                              style={{ verticalAlign: 'bottom', marginLeft: 5 }}
+                            />
+                          </Tooltip>
+                        ) : (
+                          undefined
+                        )
+                      }
                       editingName={
                         renamedItemKind === 'layout' && renamedItemName === name
                       }
@@ -746,6 +768,11 @@ export default class ProjectManager extends React.Component<Props, State> {
                           label: i18n._(t`Edit Scene Variables`),
                           enabled: true,
                           click: () => this._onOpenLayoutVariables(layout),
+                        },
+                        {
+                          label: i18n._(t`Define as first scene`),
+                          enabled: name !== firstLayoutName,
+                          click: () => this._setProjectFirstLayout(name),
                         },
                       ]}
                     />

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -733,7 +733,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                             name === firstLayoutName ? (
                               <Tooltip
                                 title={i18n._(
-                                  t`This scene will be used as the first scene displayed at game launch.`
+                                  t`This scene will be used as the start scene.`
                                 )}
                               >
                                 <Flag
@@ -783,7 +783,7 @@ export default class ProjectManager extends React.Component<Props, State> {
                               click: () => this._onOpenLayoutVariables(layout),
                             },
                             {
-                              label: i18n._(t`Define as first scene`),
+                              label: i18n._(t`Set as start scene`),
                               enabled: name !== firstLayoutName,
                               click: () => this._setProjectFirstLayout(name),
                             },

--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -19,7 +19,7 @@ import {
   shouldCloseOrCancel,
   shouldSubmit,
 } from './KeyboardShortcuts/InteractionKeys';
-import { textEllispsisStyle } from './TextEllipsis';
+import { textEllipsisStyle } from './TextEllipsis';
 
 type Option =
   | {|
@@ -121,7 +121,7 @@ const makeRenderItem = (i18n: I18nType) => (
       <ListItemText
         style={styles.listItemText}
         primary={
-          <div title={value} style={textEllispsisStyle}>
+          <div title={value} style={textEllipsisStyle}>
             {value}
           </div>
         }

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
@@ -6,7 +6,7 @@ import TextField, { noMarginTextFieldInListItemTopOffset } from '../TextField';
 import ThemeConsumer from '../Theme/ThemeConsumer';
 import { type MenuItemTemplate } from '../Menu/Menu.flow';
 import { shouldValidate } from '../KeyboardShortcuts/InteractionKeys';
-import { textEllispsisStyle } from '../TextEllipsis';
+import { textEllipsisStyle } from '../TextEllipsis';
 
 const styles = {
   textField: {
@@ -83,7 +83,7 @@ class ItemRow<Item> extends React.Component<Props<Item>> {
             <div
               title={typeof itemName === 'string' ? itemName : undefined}
               style={{
-                ...textEllispsisStyle,
+                ...textEllipsisStyle,
                 color: selected
                   ? muiTheme.listItem.selectedTextColor
                   : undefined,

--- a/newIDE/app/src/UI/TextEllipsis.js
+++ b/newIDE/app/src/UI/TextEllipsis.js
@@ -6,7 +6,7 @@
  * where text ellipsis is used (without having yet another component).
  * Please also use a `title` prop on the div to set the text tooltip.
  */
-export const textEllispsisStyle = {
+export const textEllipsisStyle = {
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',


### PR DESCRIPTION
2 improvements in this PR:
- Fixes #3560 (only the main issue - the drag n drop of project manager items will be handled in another PR)
- When creating a blank project, it automatically creates an Untitled Scene and opens it, so that new users will have a step less to create their first game!

![demo_set_first_scene](https://user-images.githubusercontent.com/32449369/151819250-b38c7591-a3da-4d47-95df-09a4b04da1b3.gif)

There's a tooltip on the flag icon that says `This scene will be used as the first scene displayed at game launch.`

---

EDIT:
- Wording has been changed to `Set as start scene` and `This scene will be used as the start scene.`