### PR TITLE
Fix builds timed out being correctly displayed

### DIFF
--- a/newIDE/app/src/Export/Builds/BuildProgressAndActions.js
+++ b/newIDE/app/src/Export/Builds/BuildProgressAndActions.js
@@ -96,11 +96,11 @@ export default ({
     differenceInSeconds(build.updatedAt, Date.now())
   );
   const estimatedRemainingTime = estimatedTime - secondsSinceLastUpdate;
-  const isStillRunning = estimatedRemainingTime > 0;
+  const isStillWithinEstimatedTime = estimatedRemainingTime > 0;
   const hasJustOverrun =
-    estimatedRemainingTime < 0 && estimatedRemainingTime < -estimatedTime;
+    !isStillWithinEstimatedTime && estimatedRemainingTime >= -estimatedTime;
   const hasTimedOut =
-    estimatedRemainingTime < 0 && estimatedRemainingTime > 2 * -estimatedTime;
+    !isStillWithinEstimatedTime && estimatedRemainingTime < -estimatedTime;
 
   const onDownload = (key: BuildArtifactKeyName) => {
     const url = getBuildArtifactUrl(build, key);
@@ -160,23 +160,25 @@ export default ({
           </React.Fragment>
         ) : build.status === 'pending' ? (
           <Line alignItems="center" expand justifyContent="center">
-            {(isStillRunning || hasJustOverrun) && (
+            {(isStillWithinEstimatedTime || hasJustOverrun) && (
               <>
                 <LinearProgress
                   style={{ flex: 1 }}
                   value={
-                    isStillRunning
+                    isStillWithinEstimatedTime
                       ? ((estimatedTime - estimatedRemainingTime) /
                           estimatedTime) *
                         100
                       : 0
                   }
-                  variant={isStillRunning ? 'determinate' : 'indeterminate'}
+                  variant={
+                    isStillWithinEstimatedTime ? 'determinate' : 'indeterminate'
+                  }
                 />
                 <Spacer />
               </>
             )}
-            {isStillRunning && (
+            {isStillWithinEstimatedTime && (
               <Text>
                 <Trans>
                   ~{Math.round(estimatedRemainingTime / 60)} minutes.


### PR DESCRIPTION
Do not show in changelog

I probably did something wrong when I did the last refactoring before merging the feature last time, because I broke the error messages being correctly displayed.
Fixed now.

![image](https://user-images.githubusercontent.com/4895034/151825847-a4947d35-9b51-45c4-9777-5c8366277ac2.png)
