### PR TITLE
Add a button to open events from the scene editor context menu

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
@@ -49,6 +49,7 @@ export type RenderEditorContainerProps = {|
   // Opening other editors:
   onOpenExternalEvents: string => void,
   onOpenLayout: string => void,
+  onOpenEvents: (sceneName: string) => void,
   openInstructionOrExpression: (
     extension: gdPlatformExtension,
     type: string

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
@@ -183,6 +183,7 @@ export class ExternalLayoutEditorContainer extends React.Component<
                 )
               )
             }
+            onOpenEvents={this.props.onOpenEvents}
             onOpenMoreSettings={this.openExternalPropertiesDialog}
             isActive={isActive}
           />

--- a/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
@@ -100,6 +100,7 @@ export class SceneEditorContainer extends React.Component<RenderEditorContainerP
             serializeToJSObject(layout.getAssociatedEditorSettings())
           )
         }
+        onOpenEvents={this.props.onOpenEvents}
         isActive={isActive}
         hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
       />

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -2160,6 +2160,11 @@ const MainFrame = (props: Props) => {
                   projectItemName: editorTab.projectItemName,
                   setPreviewedLayout,
                   onOpenExternalEvents: openExternalEvents,
+                  onOpenEvents: (sceneName: string) =>
+                    openLayout(sceneName, {
+                      openEventsEditor: true,
+                      openSceneEditor: false,
+                    }),
                   previewDebuggerServer,
                   hotReloadPreviewButtonProps,
                   onOpenLayout: name =>

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -112,6 +112,7 @@ type Props = {|
   layout: gdLayout,
   onEditObject?: ?(object: gdObject) => void,
   onOpenMoreSettings?: ?() => void,
+  onOpenEvents: (sceneName: string) => void,
   project: gdProject,
   setToolbar: (?React.Node) => void,
   resourceSources: Array<ResourceSource>,
@@ -1449,9 +1450,14 @@ export default class SceneEditor extends React.Component<Props, State> {
                       this.editObjectByName(this.state.selectedObjectNames[0]),
                     visible: this.state.selectedObjectNames.length > 0,
                   },
+                  { type: 'separator' },
                   {
                     label: i18n._(t`Scene properties`),
                     click: () => this.openSceneProperties(true),
+                  },
+                  {
+                    label: i18n._(t`Open the scene events`),
+                    click: () => this.props.onOpenEvents(layout.getName()),
                   },
                   { type: 'separator' },
                   {


### PR DESCRIPTION
Tested on scene and external layouts.
Should help a tiny bit some people not finding the events tab during their first usage of GDevelop. 