### PR TITLE
[PathFinding] Remove the dependency from PathfindingRuntimeBehavior to BehaviorRBushAABB

### DIFF
--- a/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.ts
@@ -83,12 +83,12 @@ namespace gdjs {
       searchArea.maxX = x + radius;
       // @ts-ignore
       searchArea.maxY = y + radius;
-      const nearbyPlatforms: gdjs.BehaviorRBushAABB<
+      const nearbyObstacles: gdjs.BehaviorRBushAABB<
         gdjs.PathfindingObstacleRuntimeBehavior
       >[] = this._obstaclesRBush.search(searchArea);
       result.length = 0;
-      nearbyPlatforms.forEach((nearbyPlatform) =>
-        result.push(nearbyPlatform.behavior)
+      nearbyObstacles.forEach((nearbyObstacle) =>
+        result.push(nearbyObstacle.behavior)
       );
     }
   }

--- a/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.ts
@@ -70,7 +70,7 @@ namespace gdjs {
       x: float,
       y: float,
       radius: float,
-      result: gdjs.BehaviorRBushAABB<gdjs.PathfindingObstacleRuntimeBehavior>[]
+      result: gdjs.PathfindingObstacleRuntimeBehavior[]
     ): any {
       const searchArea = gdjs.staticObject(
         PathfindingObstaclesManager.prototype.getAllObstaclesAround
@@ -83,9 +83,13 @@ namespace gdjs {
       searchArea.maxX = x + radius;
       // @ts-ignore
       searchArea.maxY = y + radius;
-      const nearbyPlatforms = this._obstaclesRBush.search(searchArea);
+      const nearbyPlatforms: gdjs.BehaviorRBushAABB<
+        gdjs.PathfindingObstacleRuntimeBehavior
+      >[] = this._obstaclesRBush.search(searchArea);
       result.length = 0;
-      result.push.apply(result, nearbyPlatforms);
+      nearbyPlatforms.forEach((nearbyPlatform) =>
+        result.push(nearbyPlatform.behavior)
+      );
     }
   }
 

--- a/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingobstacleruntimebehavior.ts
@@ -71,7 +71,7 @@ namespace gdjs {
       y: float,
       radius: float,
       result: gdjs.PathfindingObstacleRuntimeBehavior[]
-    ): any {
+    ): void {
       const searchArea = gdjs.staticObject(
         PathfindingObstaclesManager.prototype.getAllObstaclesAround
       );

--- a/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
@@ -544,9 +544,7 @@ namespace gdjs {
       //An array of nodes sorted by their estimate cost (First node = Lower estimate cost).
       _openNodes: Node[] = [];
       //Used by getNodes to temporarily store obstacles near a position.
-      _closeObstacles: gdjs.BehaviorRBushAABB<
-        PathfindingObstacleRuntimeBehavior
-      >[] = [];
+      _closeObstacles: gdjs.PathfindingObstacleRuntimeBehavior[] = [];
       //Old nodes constructed in a previous search are stored here to avoid temporary objects (see _freeAllNodes method).
       _nodeCache: Node[] = [];
 
@@ -787,7 +785,7 @@ namespace gdjs {
           this._closeObstacles
         );
         for (let k = 0; k < this._closeObstacles.length; ++k) {
-          const obj = this._closeObstacles[k].behavior.owner;
+          const obj = this._closeObstacles[k].owner;
           const topLeftCellX = Math.floor(
             (obj.getDrawableX() - this._rightBorder - this._gridOffsetX) /
               this._cellWidth
@@ -817,13 +815,13 @@ namespace gdjs {
             yPos < bottomRightCellY
           ) {
             objectsOnCell = true;
-            if (this._closeObstacles[k].behavior.isImpassable()) {
+            if (this._closeObstacles[k].isImpassable()) {
               //The cell is impassable, stop here.
               newNode.cost = -1;
               break;
             } else {
               //Superimpose obstacles
-              newNode.cost += this._closeObstacles[k].behavior.getCost();
+              newNode.cost += this._closeObstacles[k].getCost();
             }
           }
         }


### PR DESCRIPTION
Remove the dependency from PathfindingRuntimeBehavior to BehaviorRBushAABB as its an internal usage that PathfindingObstacleRuntimeBehavior should not expose.