### PR TITLE
[Light] Remove the dependency from LightRuntimeObjectPixiRenderer to BehaviorRBushAABB

### DIFF
--- a/Extensions/Lighting/lightobstacleruntimebehavior.ts
+++ b/Extensions/Lighting/lightobstacleruntimebehavior.ts
@@ -54,7 +54,7 @@ namespace gdjs {
       object: gdjs.RuntimeObject,
       radius: number,
       result: gdjs.LightObstacleRuntimeBehavior[]
-    ) {
+    ): void {
       // TODO: This would better be done using the object AABB (getAABB), as (`getCenterX`;`getCenterY`) point
       // is not necessarily in the middle of the object (for sprites for example).
       const x = object.getX();

--- a/Extensions/Lighting/lightobstacleruntimebehavior.ts
+++ b/Extensions/Lighting/lightobstacleruntimebehavior.ts
@@ -53,7 +53,7 @@ namespace gdjs {
     getAllObstaclesAround(
       object: gdjs.RuntimeObject,
       radius: number,
-      result: gdjs.BehaviorRBushAABB<gdjs.LightObstacleRuntimeBehavior>[]
+      result: gdjs.LightObstacleRuntimeBehavior[]
     ) {
       // TODO: This would better be done using the object AABB (getAABB), as (`getCenterX`;`getCenterY`) point
       // is not necessarily in the middle of the object (for sprites for example).
@@ -70,9 +70,13 @@ namespace gdjs {
       searchArea.maxX = x + radius;
       // @ts-ignore
       searchArea.maxY = y + radius;
-      const nearbyObstacles = this._obstacleRBush.search(searchArea);
+      const nearbyObstacles: gdjs.BehaviorRBushAABB<
+        gdjs.LightObstacleRuntimeBehavior
+      >[] = this._obstacleRBush.search(searchArea);
       result.length = 0;
-      result.push.apply(result, nearbyObstacles);
+      nearbyObstacles.forEach((nearbyObstacle) =>
+        result.push(nearbyObstacle.behavior)
+      );
     }
   }
 

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -369,9 +369,7 @@ namespace gdjs {
      * @returns the vertices of mesh.
      */
     _computeLightVertices(): Array<FloatPoint> {
-      const lightObstacles: gdjs.BehaviorRBushAABB<
-        LightObstacleRuntimeBehavior
-      >[] = [];
+      const lightObstacles: gdjs.LightObstacleRuntimeBehavior[] = [];
       if (this._manager) {
         this._manager.getAllObstaclesAround(
           this._object,
@@ -402,9 +400,7 @@ namespace gdjs {
       const obstaclePolygons: Array<gdjs.Polygon> = [];
       obstaclePolygons.push(this._lightBoundingPoly);
       for (let i = 0; i < lightObstacles.length; i++) {
-        const obstacleHitBoxes = lightObstacles[
-          i
-        ].behavior.owner.getHitBoxesAround(
+        const obstacleHitBoxes = lightObstacles[i].owner.getHitBoxesAround(
           searchAreaLeft,
           searchAreaTop,
           searchAreaRight,


### PR DESCRIPTION
Remove the dependency from LightRuntimeObjectPixiRenderer to BehaviorRBushAABB as its an internal usage that LightObstaclesManager should not expose.