### PR TITLE
Add errors when zipped file for web is too big

### DIFF
--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
@@ -144,6 +144,7 @@ export const browserOnlineWebExportPipeline: ExportPipeline<
       textFiles,
       basePath: '/export/',
       onProgress: context.updateStepProgress,
+      sizeLimit: 250 * 1024 * 1024,
     });
   },
 

--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineWebExport.js
@@ -144,7 +144,7 @@ export const browserOnlineWebExportPipeline: ExportPipeline<
       textFiles,
       basePath: '/export/',
       onProgress: context.updateStepProgress,
-      sizeLimit: 250 * 1024 * 1024,
+      sizeLimit: 250 * 1000 * 1000,
     });
   },
 

--- a/newIDE/app/src/Export/Builds/BuildCard.js
+++ b/newIDE/app/src/Export/Builds/BuildCard.js
@@ -29,7 +29,7 @@ const formatBuildText = (
     case 'electron-build':
       return <Trans>Windows/macOS/Linux Build</Trans>;
     case 'web-build':
-      return <Trans>Web (upload online) Build</Trans>;
+      return <Trans>Web Build</Trans>;
     default:
       return buildType;
   }
@@ -77,7 +77,7 @@ export const BuildCard = ({
           <Line alignItems="center" noMargin>
             {getIcon(build.type)}
             <Trans>
-              {formatBuildText(build.type)} - <Trans>Last updated on</Trans>{' '}
+              {formatBuildText(build.type)} -{' '}
               {format(build.updatedAt, 'yyyy-MM-dd HH:mm:ss')}
             </Trans>
           </Line>

--- a/newIDE/app/src/Export/Builds/BuildProgressAndActions.js
+++ b/newIDE/app/src/Export/Builds/BuildProgressAndActions.js
@@ -138,8 +138,8 @@ export default ({
     <I18n>
       {({ i18n }) =>
         build.status === 'error' ? (
-          <React.Fragment>
-            <Line alignItems="center" justifyContent="center">
+          <ColumnStackLayout>
+            <Line alignItems="center" justifyContent="flex-end">
               <Text>
                 <Trans>Something wrong happened :(</Trans>
               </Text>
@@ -149,56 +149,60 @@ export default ({
                 onClick={() => onDownload('logsKey')}
               />
             </Line>
-            <Line alignItems="center">
-              <EmptyMessage>
+            <Line alignItems="center" justifyContent="flex-end">
+              <EmptyMessage style={{ justifyContent: 'flex-end' }}>
                 <Trans>
                   Check the logs to see if there is an explanation about what
                   went wrong, or try again later.
                 </Trans>
               </EmptyMessage>
             </Line>
-          </React.Fragment>
+          </ColumnStackLayout>
         ) : build.status === 'pending' ? (
-          <Line alignItems="center" expand justifyContent="center">
-            {(isStillWithinEstimatedTime || hasJustOverrun) && (
-              <>
-                <LinearProgress
-                  style={{ flex: 1 }}
-                  value={
-                    isStillWithinEstimatedTime
-                      ? ((estimatedTime - estimatedRemainingTime) /
-                          estimatedTime) *
-                        100
-                      : 0
-                  }
-                  variant={
-                    isStillWithinEstimatedTime ? 'determinate' : 'indeterminate'
-                  }
-                />
-                <Spacer />
-              </>
-            )}
-            {isStillWithinEstimatedTime && (
-              <Text>
-                <Trans>
-                  ~{Math.round(estimatedRemainingTime / 60)} minutes.
-                </Trans>
-              </Text>
-            )}
-            {hasJustOverrun && (
-              <Text>
-                <Trans>Should finish soon.</Trans>
-              </Text>
-            )}
+          <>
+            <Line alignItems="center" expand justifyContent="center">
+              {(isStillWithinEstimatedTime || hasJustOverrun) && (
+                <>
+                  <LinearProgress
+                    style={{ flex: 1 }}
+                    value={
+                      isStillWithinEstimatedTime
+                        ? ((estimatedTime - estimatedRemainingTime) /
+                            estimatedTime) *
+                          100
+                        : 0
+                    }
+                    variant={
+                      isStillWithinEstimatedTime
+                        ? 'determinate'
+                        : 'indeterminate'
+                    }
+                  />
+                  <Spacer />
+                </>
+              )}
+              {isStillWithinEstimatedTime && (
+                <Text>
+                  <Trans>
+                    ~{Math.round(estimatedRemainingTime / 60)} minutes.
+                  </Trans>
+                </Text>
+              )}
+              {hasJustOverrun && (
+                <Text>
+                  <Trans>Should finish soon.</Trans>
+                </Text>
+              )}
+            </Line>
             {hasTimedOut && (
               <ColumnStackLayout>
-                <Line justifyContent="center">
+                <Line justifyContent="flex-end">
                   <Text>
                     <Trans>Something wrong happened :(</Trans>
                   </Text>
                 </Line>
-                <Line justifyContent="center">
-                  <EmptyMessage>
+                <Line justifyContent="flex-end">
+                  <EmptyMessage style={{ justifyContent: 'flex-end' }}>
                     <Trans>
                       It looks like the build has timed out, please try again.
                     </Trans>
@@ -206,7 +210,7 @@ export default ({
                 </Line>
               </ColumnStackLayout>
             )}
-          </Line>
+          </>
         ) : build.status === 'complete' ? (
           <ColumnStackLayout>
             <Line expand justifyContent="flex-end">

--- a/newIDE/app/src/Export/Builds/BuildsWatcher.js
+++ b/newIDE/app/src/Export/Builds/BuildsWatcher.js
@@ -5,7 +5,7 @@ import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 
 const waitTime = 1500;
 const bulkWaitTime = 5000;
-const maxTimeBeforeIgnoring = 12 * 60 * 60 * 1000; // 12 hours in milliseconds
+const maxTimeBeforeIgnoring = 30 * 60 * 1000; // 30 mins in milliseconds
 
 export default class BuildsWatcher {
   runningWatchers: { [string]: boolean } = {};

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -204,21 +204,25 @@ export default class ExportLauncher extends Component<Props, State> {
     const getErrorMessage = () => {
       switch (this.state.exportStep) {
         case 'export':
-          return t('Error while preparing the exporter.');
-        case 'resources-download':
           return t('Error while exporting the game.');
-        case 'compress':
+        case 'resources-download':
           return t(
             'Error while downloading the game resources. Check your internet connection and that all resources of the game are valid in the Resources editor.'
           );
-        case 'upload':
+        case 'compress':
           return t('Error while compressing the game.');
-        case 'waiting-for-build':
+        case 'upload':
           return t(
             'Error while uploading the game. Check your internet connection or try again later.'
           );
+        case 'waiting-for-build':
+          return t(
+            'Error while building the game. Check the logs of the build for more details.'
+          );
         case 'build':
-          return t('Error while lauching the build of the game.');
+          return t(
+            'Error while building of the game. Check the logs of the build for more details.'
+          );
         default:
           return t(
             'Error while building the game. Try again later. Your internet connection may be slow or one of your resources may be corrupted.'

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -237,8 +237,7 @@ export default class ExportLauncher extends Component<Props, State> {
         });
         showErrorBox({
           message:
-            getErrorMessage() +
-            (err.message ? `\n\nDetails of the error: ${err.message}` : ''),
+            getErrorMessage() + (err.message ? `\n\n${err.message}` : ''),
           rawError: {
             exportStep: this.state.exportStep,
             rawError: err,

--- a/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
+++ b/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
@@ -312,6 +312,6 @@ export const WebProjectLink = ({
 export const onlineWebExporter = {
   key: 'onlinewebexport',
   tabName: 'Web',
-  name: <Trans>Web (upload online)</Trans>,
+  name: <Trans>Web</Trans>,
   helpPage: '/publishing/web',
 };

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
@@ -131,7 +131,7 @@ export const localOnlineWebExportPipeline: ExportPipeline<
     return archiveLocalFolder({
       path: temporaryOutputDir,
       outputFilename: path.join(archiveOutputDir, 'game-archive.zip'),
-      sizeLimit: 250 * 1024 * 1024,
+      sizeLimit: 250 * 1000 * 1000,
     });
   },
 

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineWebExport.js
@@ -131,6 +131,7 @@ export const localOnlineWebExportPipeline: ExportPipeline<
     return archiveLocalFolder({
       path: temporaryOutputDir,
       outputFilename: path.join(archiveOutputDir, 'game-archive.zip'),
+      sizeLimit: 250 * 1024 * 1024,
     });
   },
 

--- a/newIDE/app/src/Utils/BrowserArchiver.js
+++ b/newIDE/app/src/Utils/BrowserArchiver.js
@@ -203,9 +203,13 @@ export const archiveFiles = async ({
                 zipWriter.close((blob: Blob) => {
                   const fileSize = blob.size;
                   if (sizeLimit && fileSize > sizeLimit) {
+                    const roundFileSizeInMb = Math.round(
+                      fileSize / (1000 * 1000)
+                    );
                     reject(
                       new Error(
-                        `Archive is of size ${fileSize} bytes, which is above the limit allowed of ${sizeLimit} bytes.`
+                        `Archive is of size ${roundFileSizeInMb} MB, which is above the limit allowed of ${sizeLimit /
+                          (1000 * 1000)} MB.`
                       )
                     );
                   }

--- a/newIDE/app/src/Utils/BrowserArchiver.js
+++ b/newIDE/app/src/Utils/BrowserArchiver.js
@@ -143,11 +143,13 @@ export const archiveFiles = async ({
   blobFiles,
   basePath,
   onProgress,
+  sizeLimit,
 }: {|
   textFiles: Array<TextFileDescriptor>,
   blobFiles: Array<BlobFileDescriptor>,
   basePath: string,
   onProgress: (count: number, total: number) => void,
+  sizeLimit?: number,
 |}): Promise<Blob> => {
   const zipJs: ZipJs = await initializeZipJs();
 
@@ -199,6 +201,14 @@ export const archiveFiles = async ({
               },
               () => {
                 zipWriter.close((blob: Blob) => {
+                  const fileSize = blob.size;
+                  if (sizeLimit && fileSize > sizeLimit) {
+                    reject(
+                      new Error(
+                        `Archive is of size ${fileSize} bytes, which is above the limit allowed of ${sizeLimit} bytes.`
+                      )
+                    );
+                  }
                   resolve(blob);
                 });
               }

--- a/newIDE/app/src/Utils/LocalArchiver.js
+++ b/newIDE/app/src/Utils/LocalArchiver.js
@@ -12,9 +12,11 @@ const lazyRequireArchiver = optionalLazyRequire('archiver');
 export const archiveLocalFolder = ({
   path,
   outputFilename,
+  sizeLimit,
 }: {|
   path: string,
   outputFilename: string,
+  sizeLimit?: number,
 |}): Promise<string> => {
   const archiver = lazyRequireArchiver();
   return new Promise((resolve, reject) => {
@@ -26,9 +28,17 @@ export const archiveLocalFolder = ({
     });
 
     output.on('close', () => {
+      const fileSize = archive.pointer();
       console.log(
-        `Archive written at ${outputFilename}, ${archive.pointer()} total bytes.`
+        `Archive written at ${outputFilename}, ${fileSize}} total bytes.`
       );
+      if (sizeLimit && fileSize > sizeLimit) {
+        reject(
+          new Error(
+            `Archive is of size ${fileSize} bytes, which is above the limit allowed of ${sizeLimit} bytes.`
+          )
+        );
+      }
       resolve(outputFilename);
     });
 

--- a/newIDE/app/src/Utils/LocalArchiver.js
+++ b/newIDE/app/src/Utils/LocalArchiver.js
@@ -33,9 +33,11 @@ export const archiveLocalFolder = ({
         `Archive written at ${outputFilename}, ${fileSize}} total bytes.`
       );
       if (sizeLimit && fileSize > sizeLimit) {
+        const roundFileSizeInMb = Math.round(fileSize / (1000 * 1000));
         reject(
           new Error(
-            `Archive is of size ${fileSize} bytes, which is above the limit allowed of ${sizeLimit} bytes.`
+            `Archive is of size ${roundFileSizeInMb} MB, which is above the limit allowed of ${sizeLimit /
+              (1000 * 1000)} MB.`
           )
         );
       }


### PR DESCRIPTION
It's been pointed out multiple times that exporting a game sometimes times out.

The goal of this PR is to take a first step towards giving more information to the user about the limitations of the backend services in terms of publishing a game.
This PR only addresses Web Builds and the fact that if the files are too big, then the packaging will not work.
Plus if they are too big, they shouldn't be uploaded to the web, as this will impact the experience, so we can then give them recommendations on how to optimise their assets.

The limit here is set at 250Mb.

Also fixed various design issues in the builds when errored.

Error appearing in the local app:
<img width="334" alt="Screenshot 2022-02-01 at 18 27 30" src="https://user-images.githubusercontent.com/4895034/152135240-98943f72-dd07-4342-b192-5fb21600d4fe.png">

Error appearing in the web app: (size is just for test)
<img width="1008" alt="Screenshot 2022-02-01 at 18 28 25" src="https://user-images.githubusercontent.com/4895034/152021988-846d66ee-7a8f-4e20-b0c3-2a9dd46e6648.png">

If the build is forced, the backend rejects the files too, and the build is errored + message in logs:
<img width="1053" alt="Screenshot 2022-02-01 at 18 28 04" src="https://user-images.githubusercontent.com/4895034/152021983-0d5711b1-53e5-407f-8b2e-7eec1f3059e4.png">
