### PR TITLE
Fix help paths of objects

### DIFF
--- a/Extensions/BitmapText/JsExtension.js
+++ b/Extensions/BitmapText/JsExtension.js
@@ -396,7 +396,7 @@ module.exports = {
     objectsEditorService.registerEditorConfiguration(
       'BitmapText::BitmapTextObject',
       objectsEditorService.getDefaultObjectJsImplementationPropertiesEditor({
-        helpPagePath: '/objects/bitmaptext',
+        helpPagePath: '/objects/bitmap_text',
       })
     );
   },

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -467,7 +467,7 @@ module.exports = {
     objectsEditorService.registerEditorConfiguration(
       'TileMap::TileMap',
       objectsEditorService.getDefaultObjectJsImplementationPropertiesEditor({
-        helpPagePath: '/objects/tile_map_object',
+        helpPagePath: '/objects/tilemap',
       })
     );
   },


### PR DESCRIPTION
Fix path for Tile map and Bitmap Text.
Video help path lead to an empty page but I notified the content creator team to fill the wiki page.