### PR TITLE
Fix shortcuts removed by user displayed as default shortcut

### DIFF
--- a/newIDE/app/src/KeyboardShortcuts/ShortcutsList.js
+++ b/newIDE/app/src/KeyboardShortcuts/ShortcutsList.js
@@ -19,6 +19,19 @@ import commandsList, {
 } from '../CommandPalette/CommandsList';
 
 /**
+ * Get shortcut string to be displayed after patching the default
+ * shortcut with user-defined shortcut, if any.
+ */
+const getPatchedShortcutString = (
+  defaultShortcut: string,
+  userShortcut?: string
+) => {
+  // User shortcut can be empty string when user has removed a shortcut,
+  // so we check userShortcut against null/undefined.
+  return userShortcut == null ? defaultShortcut : userShortcut;
+};
+
+/**
  * Sorts all commands into an object keyed by area name, and also creates a
  * reverse mapping from shortcut string to list of commands with that shortcut.
  */
@@ -38,7 +51,10 @@ const sortCommandsIntoAreasAndGetReverseMap = (
       // Add to shortcut-command mapping
       const userShortcut = userShortcutMap[name];
       const defaultShortcut = defaultShortcuts[name] || '';
-      const shortcutString = userShortcut || defaultShortcut;
+      const shortcutString = getPatchedShortcutString(
+        defaultShortcut,
+        userShortcut
+      );
       if (shortcutString === '') return;
       shortcutStringToCommands[shortcutString] = (
         shortcutStringToCommands[shortcutString] || []
@@ -110,7 +126,10 @@ const ShortcutsList = (props: Props) => {
               // Get default and user-set shortcuts
               const userShortcut = props.userShortcutMap[commandName];
               const defaultShortcut = defaultShortcuts[commandName] || '';
-              const shortcutString = userShortcut || defaultShortcut;
+              const shortcutString = getPatchedShortcutString(
+                defaultShortcut,
+                userShortcut
+              );
               const shortcutDisplayName = getShortcutDisplayName(
                 shortcutString
               );
@@ -124,7 +143,7 @@ const ShortcutsList = (props: Props) => {
                   key={commandName}
                   shortcutString={shortcutDisplayName}
                   commandName={commandName}
-                  isDefault={!userShortcut}
+                  isDefault={shortcutString === defaultShortcut}
                   isClashing={hasClash}
                   onEditShortcut={() => setEditedShortcut(commandName)}
                   onResetShortcut={() => resetShortcut(commandName)}


### PR DESCRIPTION
Fixes bug where if a user has removed a keyboard shortcut (via "Remove shortcut" button in the Set Shortcut dialog), the shortcut is removed but the shortcuts pane erroneously displays the default shortcut instead of "No shortcut". 

This was happening because shortcuts removed by the user have a shortcut string of `''`, but the code checked the truthy-ness of the user-defined shortcut to see if it's defined.

Reported on Discord ([message link](https://discord.com/channels/258623956158906368/377571085643677696/942043308929187880)). 