### PR TITLE
Use the extension name as file name when saving it.

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/index.js
@@ -25,7 +25,7 @@ const exportExtension = (
     return Promise.reject(new Error('Not supported'));
 
   return eventsFunctionsExtensionWriter
-    .chooseEventsFunctionExtensionFile()
+    .chooseEventsFunctionExtensionFile(eventsFunctionsExtension.getName())
     .then(pathOrUrl => {
       if (!pathOrUrl) return;
 

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -29,7 +29,9 @@ const writeJSONFile = (object: Object, filepath: string): Promise<void> => {
 };
 
 export default class LocalEventsFunctionsExtensionWriter {
-  static chooseEventsFunctionExtensionFile = (): Promise<?string> => {
+  static chooseEventsFunctionExtensionFile = (
+    extensionName: string = 'Extension.json'
+  ): Promise<?string> => {
     if (!dialog) return Promise.reject('Not supported');
     const browserWindow = electron.remote.getCurrentWindow();
 
@@ -42,7 +44,7 @@ export default class LocalEventsFunctionsExtensionWriter {
             extensions: ['json'],
           },
         ],
-        defaultPath: 'Extension.json',
+        defaultPath: extensionName,
       })
       .then(({ filePath }) => {
         if (!filePath) return null;

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -30,7 +30,7 @@ const writeJSONFile = (object: Object, filepath: string): Promise<void> => {
 
 export default class LocalEventsFunctionsExtensionWriter {
   static chooseEventsFunctionExtensionFile = (
-    extensionName: string = 'Extension.json'
+    extensionName?: string
   ): Promise<?string> => {
     if (!dialog) return Promise.reject('Not supported');
     const browserWindow = electron.remote.getCurrentWindow();
@@ -44,7 +44,7 @@ export default class LocalEventsFunctionsExtensionWriter {
             extensions: ['json'],
           },
         ],
-        defaultPath: extensionName,
+        defaultPath: extensionName ? extensionName : 'Extension.json',
       })
       .then(({ filePath }) => {
         if (!filePath) return null;

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
@@ -7,7 +7,7 @@ export type EventsFunctionsExtensionOpener = {
 
 export type EventsFunctionsExtensionWriter = {
   chooseEventsFunctionExtensionFile: (
-    extensionName: string
+    extensionName?: string
   ) => Promise<?string>,
   writeEventsFunctionsExtension: (
     extension: gdEventsFunctionsExtension,

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
@@ -6,7 +6,9 @@ export type EventsFunctionsExtensionOpener = {
 };
 
 export type EventsFunctionsExtensionWriter = {
-  chooseEventsFunctionExtensionFile: () => Promise<?string>,
+  chooseEventsFunctionExtensionFile: (
+    extensionName: string
+  ) => Promise<?string>,
   writeEventsFunctionsExtension: (
     extension: gdEventsFunctionsExtension,
     filepath: string


### PR DESCRIPTION
It can save a bit of time when doing changes for an extension review. GDevelop already remember the last folder so it allows to just click on save and commit.