### PR TITLE
Improve publishing flow

### DIFF
--- a/newIDE/app/src/Export/ExportDialog/ExportHome.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportHome.js
@@ -66,7 +66,7 @@ const ExportHome = ({
         <div style={styles.titleContainer}>
           <Line>
             <Text size="title">
-              <Trans>Share with friends</Trans>
+              <Trans>Publish and share with friends on Liluo.io</Trans>
             </Text>
           </Line>
         </div>
@@ -89,7 +89,7 @@ const ExportHome = ({
         <div style={styles.titleContainer}>
           <Line>
             <Text size="title">
-              <Trans>Publish your game</Trans>
+              <Trans>Publish your game on other stores</Trans>
             </Text>
           </Line>
         </div>

--- a/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
+++ b/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
@@ -52,8 +52,8 @@ export const ExplanationHeader = () => (
     <Line>
       <Text align="center">
         <Trans>
-          Generate a unique link to share your game, playable from any computer
-          or mobile phone's browser.
+          Generate a unique link, playable from any computer or mobile phone's
+          browser.
         </Trans>
       </Text>
     </Line>

--- a/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
+++ b/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
@@ -39,6 +39,7 @@ import {
   type Game,
 } from '../../Utils/GDevelopServices/Game';
 import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
+import AlertMessage from '../../UI/AlertMessage';
 
 const styles = {
   icon: {
@@ -85,11 +86,12 @@ export const WebProjectLink = ({
   const exportPending = !errored && exportStep !== '' && exportStep !== 'done';
   const isBuildComplete = build && build.status === 'complete';
   const isBuildPublished = build && game && build.id === game.publicWebBuildId;
+  const gameUrl = getGameUrl(game);
   const buildUrl =
     exportPending || !isBuildComplete
       ? null
       : isBuildPublished
-      ? getGameUrl(game)
+      ? gameUrl
       : getBuildArtifactUrl(build, 's3Key');
 
   const loadGame = React.useCallback(
@@ -286,12 +288,22 @@ export const WebProjectLink = ({
               </Line>
             )}
             {!isBuildPublished && (
-              <Line justifyContent="center">
-                <RaisedButton
-                  label={<Trans>Publish this build to the game's page</Trans>}
-                  onClick={onUpdatePublicBuild}
-                />
-              </Line>
+              <>
+                <Line justifyContent="center">
+                  <RaisedButton
+                    label={<Trans>Publish this build to the game's page</Trans>}
+                    onClick={onUpdatePublicBuild}
+                  />
+                </Line>
+                <Line>
+                  <AlertMessage kind="info">
+                    <Trans>
+                      Your game URL on Liluo hasn't been updated with this
+                      build. You can update it by clicking the button above.
+                    </Trans>
+                  </AlertMessage>
+                </Line>
+              </>
             )}
           </Column>
         ) : (

--- a/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
+++ b/newIDE/app/src/Export/GenericExporters/OnlineWebExport.js
@@ -246,64 +246,77 @@ export const WebProjectLink = ({
               </Line>
             )}
             {isBuildPublished && !navigator.share && (
-              <Line justifyContent="flex-end">
-                <FacebookShareButton
-                  url={buildUrl}
-                  style={styles.icon}
-                  quote={`Try the game I just created with GDevelop.io`}
-                  hashtag="#gdevelop"
-                >
-                  <FacebookIcon size={32} round />
-                </FacebookShareButton>
-                <RedditShareButton
-                  url={buildUrl}
-                  title={`Try the game I just created with r/gdevelop`}
-                  style={styles.icon}
-                >
-                  <RedditIcon size={32} round />
-                </RedditShareButton>
-                <TwitterShareButton
-                  title={`Try the game I just created with GDevelop.io`}
-                  hashtags={['gdevelop']}
-                  url={buildUrl}
-                  style={styles.icon}
-                >
-                  <TwitterIcon size={32} round />
-                </TwitterShareButton>
-                <WhatsappShareButton
-                  title={`Try the game I just created with GDevelop.io`}
-                  url={buildUrl}
-                  style={styles.icon}
-                >
-                  <WhatsappIcon size={32} round />
-                </WhatsappShareButton>
-                <EmailShareButton
-                  subject="My GDevelop game"
-                  body="Try the game I just created with GDevelop.io"
-                  url={buildUrl}
-                  style={styles.icon}
-                >
-                  <EmailIcon size={32} round />
-                </EmailShareButton>
+              <Line justifyContent="space-between">
+                <Column justifyContent="center">
+                  <AlertMessage kind="info">
+                    <Trans>
+                      This link is unique to your game. Show what you made to
+                      the community!
+                    </Trans>
+                  </AlertMessage>
+                </Column>
+                <Column justifyContent="flex-end">
+                  <Line>
+                    <FacebookShareButton
+                      url={buildUrl}
+                      style={styles.icon}
+                      quote={`Try the game I just created with GDevelop.io`}
+                      hashtag="#gdevelop"
+                    >
+                      <FacebookIcon size={32} round />
+                    </FacebookShareButton>
+                    <RedditShareButton
+                      url={buildUrl}
+                      title={`Try the game I just created with r/gdevelop`}
+                      style={styles.icon}
+                    >
+                      <RedditIcon size={32} round />
+                    </RedditShareButton>
+                    <TwitterShareButton
+                      title={`Try the game I just created with GDevelop.io`}
+                      hashtags={['gdevelop']}
+                      url={buildUrl}
+                      style={styles.icon}
+                    >
+                      <TwitterIcon size={32} round />
+                    </TwitterShareButton>
+                    <WhatsappShareButton
+                      title={`Try the game I just created with GDevelop.io`}
+                      url={buildUrl}
+                      style={styles.icon}
+                    >
+                      <WhatsappIcon size={32} round />
+                    </WhatsappShareButton>
+                    <EmailShareButton
+                      subject="My GDevelop game"
+                      body="Try the game I just created with GDevelop.io"
+                      url={buildUrl}
+                      style={styles.icon}
+                    >
+                      <EmailIcon size={32} round />
+                    </EmailShareButton>
+                  </Line>
+                </Column>
               </Line>
             )}
             {!isBuildPublished && (
-              <>
-                <Line justifyContent="center">
-                  <RaisedButton
-                    label={<Trans>Publish this build to the game's page</Trans>}
-                    onClick={onUpdatePublicBuild}
-                  />
-                </Line>
-                <Line>
-                  <AlertMessage kind="info">
-                    <Trans>
-                      Your game URL on Liluo hasn't been updated with this
-                      build. You can update it by clicking the button above.
-                    </Trans>
-                  </AlertMessage>
-                </Line>
-              </>
+              <Line>
+                <AlertMessage
+                  kind="info"
+                  renderRightButton={() => (
+                    <RaisedButton
+                      label={<Trans>Update your game</Trans>}
+                      onClick={onUpdatePublicBuild}
+                    />
+                  )}
+                >
+                  <Trans>
+                    This link is private so you can share it with friends and
+                    testers. When you're ready you can update your Liluo.io game
+                    page.
+                  </Trans>
+                </AlertMessage>
+              </Line>
             )}
           </Column>
         ) : (

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -167,6 +167,29 @@ export const GameDetailsDialog = ({
     }
   };
 
+  const unpublishGame = React.useCallback(
+    async () => {
+      if (!profile) return;
+
+      const { id } = profile;
+      try {
+        setPublicGame(null); // Public game will auto update when game is updated.
+        const updatedGame = await updateGame(
+          getAuthorizationHeader,
+          id,
+          game.id,
+          {
+            publicWebBuildId: null,
+          }
+        );
+        onGameUpdated(updatedGame);
+      } catch (err) {
+        console.error('Unable to update the game', err);
+      }
+    },
+    [game, getAuthorizationHeader, profile, onGameUpdated]
+  );
+
   const authorUsernames =
     publicGame && publicGame.authors
       ? publicGame.authors.map(author => author.username).filter(Boolean)
@@ -275,7 +298,7 @@ export const GameDetailsDialog = ({
                 <FlatButton
                   onClick={() => {
                     const answer = Window.showConfirmDialog(
-                      "Are you sure you want to unregister this game? You won't get access to analytics and metrics, unless you register it again."
+                      "Are you sure you want to unregister this game? \n\nIt will disappear from your games dashboard and you won't get access to analytics, unless you register it again."
                     );
 
                     if (!answer) return;
@@ -285,6 +308,23 @@ export const GameDetailsDialog = ({
                   label={<Trans>Unregister this game</Trans>}
                 />
                 <Spacer />
+                {publicGame.publicWebBuildId && (
+                  <>
+                    <RaisedButton
+                      onClick={() => {
+                        const answer = Window.showConfirmDialog(
+                          'Are you sure you want to unpublish this game? \n\nThis will make your Liluo unique game URL not accessible anymore. \n\nYou can decide anytime to publish it again.'
+                        );
+
+                        if (!answer) return;
+
+                        unpublishGame();
+                      }}
+                      label={<Trans>Unpublish from Liluo</Trans>}
+                    />
+                    <Spacer />
+                  </>
+                )}
                 <RaisedButton
                   primary
                   onClick={() => setIsPublicGamePropertiesDialogOpen(true)}

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -38,6 +38,12 @@ import PlaceholderLoader from '../UI/PlaceholderLoader';
 import PublicGamePropertiesDialog from '../ProjectManager/PublicGamePropertiesDialog';
 import TextField from '../UI/TextField';
 
+const styles = {
+  tableRowStatColumn: {
+    width: 100,
+  },
+};
+
 export type GamesDetailsTab = 'details' | 'builds' | 'analytics';
 
 type Props = {|
@@ -354,6 +360,48 @@ export const GameDetailsDialog = ({
             </PlaceholderError>
           ) : (
             <ColumnStackLayout expand>
+              <Line noMargin alignItems="center">
+                <Text size="title">
+                  <Trans>Consolidated metrics</Trans>
+                </Text>
+                <Spacer />
+                {!publicGame && <CircularProgress size={20} />}
+              </Line>
+              <Table>
+                <TableBody>
+                  <TableRow>
+                    <TableRowColumn>
+                      <Trans>Last week sessions count</Trans>
+                    </TableRowColumn>
+                    <TableRowColumn style={styles.tableRowStatColumn}>
+                      {publicGame &&
+                      publicGame.metrics &&
+                      publicGame.metrics.lastWeekSessionsCount
+                        ? publicGame.metrics.lastWeekSessionsCount
+                        : '-'}
+                    </TableRowColumn>
+                  </TableRow>
+                  <TableRow>
+                    <TableRowColumn>
+                      <Trans>Last year sessions count</Trans>
+                    </TableRowColumn>
+                    <TableRowColumn style={styles.tableRowStatColumn}>
+                      {publicGame &&
+                      publicGame.metrics &&
+                      publicGame.metrics.lastYearSessionsCount
+                        ? publicGame.metrics.lastYearSessionsCount
+                        : '-'}
+                    </TableRowColumn>
+                  </TableRow>
+                </TableBody>
+              </Table>
+              <Line noMargin alignItems="center">
+                <Text size="title">
+                  <Trans>Daily metrics</Trans>
+                </Text>
+                <Spacer />
+                {isGameMetricsLoading && <CircularProgress size={20} />}
+              </Line>
               <Line noMargin>
                 <SelectField
                   fullWidth
@@ -400,20 +448,13 @@ export const GameDetailsDialog = ({
                   </Trans>
                 </AlertMessage>
               ) : null}
-              <Line noMargin alignItems="center">
-                <Text size="title">
-                  <Trans>Main metrics</Trans>
-                </Text>
-                <Spacer />
-                {isGameMetricsLoading && <CircularProgress size={20} />}
-              </Line>
               <Table>
                 <TableBody>
                   <TableRow>
                     <TableRowColumn>
                       <Trans>Players count</Trans>
                     </TableRowColumn>
-                    <TableRowColumn>
+                    <TableRowColumn style={styles.tableRowStatColumn}>
                       {gameRollingMetrics && gameRollingMetrics.players
                         ? gameRollingMetrics.players.d0Players
                         : '-'}
@@ -423,7 +464,7 @@ export const GameDetailsDialog = ({
                     <TableRowColumn>
                       <Trans>Sessions count</Trans>
                     </TableRowColumn>
-                    <TableRowColumn>
+                    <TableRowColumn style={styles.tableRowStatColumn}>
                       {gameRollingMetrics && gameRollingMetrics.sessions
                         ? gameRollingMetrics.sessions.d0Sessions
                         : '-'}
@@ -433,7 +474,7 @@ export const GameDetailsDialog = ({
                     <TableRowColumn>
                       <Trans>New players count</Trans>
                     </TableRowColumn>
-                    <TableRowColumn>
+                    <TableRowColumn style={styles.tableRowStatColumn}>
                       {gameRollingMetrics && gameRollingMetrics.players
                         ? gameRollingMetrics.players.d0NewPlayers
                         : '-'}
@@ -448,13 +489,6 @@ export const GameDetailsDialog = ({
                   metrics for your game.
                 </AlertMessage>
               ) : null}
-              <Line noMargin alignItems="center">
-                <Text size="title">
-                  <Trans>Retention of players</Trans>
-                </Text>
-                <Spacer />
-                {isGameMetricsLoading && <CircularProgress size={20} />}
-              </Line>
               <Table>
                 <TableBody>
                   {[1, 2, 3, 4, 5, 6, 7].map(dayIndex => (
@@ -462,7 +496,7 @@ export const GameDetailsDialog = ({
                       <TableRowColumn>
                         <Trans>Day {dayIndex} retained players</Trans>
                       </TableRowColumn>
-                      <TableRowColumn>
+                      <TableRowColumn style={styles.tableRowStatColumn}>
                         {gameRollingMetrics &&
                         gameRollingMetrics.retention &&
                         gameRollingMetrics.retention[

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -146,7 +146,8 @@ export const GameDetailsDialog = ({
     const { id } = profile;
 
     try {
-      setPublicGame(null); // Public game will auto update when game is updated.
+      // Set public game to null as it will be refetched automatically by the callback above.
+      setPublicGame(null);
       const gameId = project.getProjectUuid();
       const updatedGame = await updateGame(getAuthorizationHeader, id, gameId, {
         authorName: project.getAuthor() || 'Unspecified publisher',
@@ -179,7 +180,8 @@ export const GameDetailsDialog = ({
 
       const { id } = profile;
       try {
-        setPublicGame(null); // Public game will auto update when game is updated.
+        // Set public game to null as it will be refetched automatically by the callback above.
+        setPublicGame(null);
         const updatedGame = await updateGame(
           getAuthorizationHeader,
           id,

--- a/newIDE/app/src/Utils/GDevelopServices/Game.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Game.js
@@ -11,6 +11,10 @@ export type PublicGame = {
   publicWebBuildId?: ?string,
   description?: string,
   authors: Array<UserPublicProfile>,
+  metrics?: {
+    lastWeekSessionsCount: number,
+    lastYearSessionsCount: number,
+  },
 };
 
 export type Game = {


### PR DESCRIPTION
Few suggestions to improve the whole publication / game management flow:

- Add a clearer "unpublish from Liluo" button on the Game in the Dashboard + better warning messages
- Add a message when publishing to indicate that the game URL stays untouched to reassure the user
- Add consolidated metrics analytics on the Game in the dashboard

Few screenshots:

![Screenshot 2022-02-15 at 16 34 59](https://user-images.githubusercontent.com/4895034/154095113-7ee443f6-101b-4702-8c89-bd5fc4befa4e.png)

![image](https://user-images.githubusercontent.com/4895034/154095365-e38dd399-ed61-42d4-8d71-4b7c13cd0c5b.png)

![Screenshot 2022-02-16 at 16 03 46](https://user-images.githubusercontent.com/4895034/154304410-f38f2468-fecd-4e67-b2b9-5ecec90b72d7.png)

![Screenshot 2022-02-16 at 16 04 36](https://user-images.githubusercontent.com/4895034/154304479-a1df963e-6984-4083-b4a9-052b594237dc.png)

![Screenshot 2022-02-15 at 16 29 03](https://user-images.githubusercontent.com/4895034/154095153-1c37ccfd-8f29-482d-b01e-01c342164257.png)

