### PR TITLE
Add ability to select default layer for adding objects

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -40,15 +40,21 @@ export default class InstancesAdder {
   _temporaryInstances: Array<gdInitialInstance>;
   _instancesEditorSettings: InstancesEditorSettings;
   _zOrderFinder = new gd.HighestZOrderFinder();
+  _defaultLayer: string;
 
   constructor({ instances, instancesEditorSettings }: Props) {
     this._instances = instances;
     this._instancesEditorSettings = instancesEditorSettings;
     this._temporaryInstances = [];
+    this._defaultLayer = '';
   }
 
   setInstancesEditorSettings(instancesEditorSettings: InstancesEditorSettings) {
     this._instancesEditorSettings = instancesEditorSettings;
+  }
+
+  setDefaultLayer(layerName: string) {
+    this._defaultLayer = layerName;
   }
 
   /**
@@ -69,6 +75,7 @@ export default class InstancesAdder {
       instance.setX(newPos[0]);
       instance.setY(newPos[1]);
       instance.setZOrder(zOrder);
+      if (this._defaultLayer) instance.setLayer(this._defaultLayer);
 
       return instance;
     });
@@ -109,6 +116,7 @@ export default class InstancesAdder {
       instance.setX(newPos[0]);
       instance.setY(newPos[1]);
       instance.setZOrder(zOrder);
+      if (this._defaultLayer) instance.setLayer(this._defaultLayer);
 
       return instance;
     });

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -524,6 +524,10 @@ export default class InstancesEditor extends Component<Props> {
     return this._instancesAdder.addInstances(pos, objectNames);
   };
 
+  setDefaultLayer = (layer: string) => {
+    this._instancesAdder.setDefaultLayer(layer);
+  };
+
   _onMouseMove = (x: number, y: number) => {
     this.lastCursorX = x;
     this.lastCursorY = y;

--- a/newIDE/app/src/UI/EditorMosaic/LayerButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/LayerButton.js
@@ -1,0 +1,38 @@
+// @flow
+import React, { Component } from 'react';
+import { type I18n as I18nType } from '@lingui/core';
+import IconButton from '../IconButton';
+import Layers from '@material-ui/icons/Layers';
+import ElementWithMenu from '../Menu/ElementWithMenu';
+import { type MenuItemTemplate } from '../Menu/Menu.flow';
+
+const styles = {
+  container: {
+    padding: 0,
+    width: 32,
+    height: 32,
+  },
+  icon: {
+    width: 16,
+    height: 16,
+  },
+};
+
+type Props = {|
+  buildMenuTemplate: (i18n: I18nType) => Array<MenuItemTemplate>,
+|};
+
+export default class LayerButton extends Component<Props, {||}> {
+  render() {
+    return (
+      <ElementWithMenu
+        element={
+          <IconButton style={styles.container}>
+            <Layers htmlColor="white" style={styles.icon} />
+          </IconButton>
+        }
+        buildMenuTemplate={this.props.buildMenuTemplate}
+      />
+    );
+  }
+}


### PR DESCRIPTION
This allows the user to select the default layer objects are added to. This is implemented through a menu next to tag selection:

<img width="347" alt="image" src="https://user-images.githubusercontent.com/16108792/154431065-b9927680-35e9-47c8-9d4b-5786d95a1da0.png">

The layer button `newIDE/app/src/UI/EditorMosaic/LayerButton.js` is copied from `newIDE/app/src/UI/EditorMosaic/TagsButton.js`. Between these and the close button there's a bit of code duplication, though I don't think any kind of abstract "MosaicButton" class is necessary.