### PR TITLE
Select parameter content when editing it form the event sheet

### DIFF
--- a/newIDE/app/src/EventsSheet/InlineParameterEditor.js
+++ b/newIDE/app/src/EventsSheet/InlineParameterEditor.js
@@ -100,7 +100,8 @@ export default class InlineParameterEditor extends React.Component<
       () => {
         // Give a bit of time for the popover to mount itself
         setTimeout(() => {
-          if (this._field && this._field.focus) this._field.focus(true);
+          if (this._field && this._field.focus)
+            this._field.focus(/*selectAll=*/ true);
         }, 10);
       }
     );

--- a/newIDE/app/src/EventsSheet/InlineParameterEditor.js
+++ b/newIDE/app/src/EventsSheet/InlineParameterEditor.js
@@ -100,7 +100,7 @@ export default class InlineParameterEditor extends React.Component<
       () => {
         // Give a bit of time for the popover to mount itself
         setTimeout(() => {
-          if (this._field && this._field.focus) this._field.focus();
+          if (this._field && this._field.focus) this._field.focus(true);
         }, 10);
       }
     );

--- a/newIDE/app/src/EventsSheet/ParameterFields/AudioResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AudioResourceField.js
@@ -12,8 +12,8 @@ export default class AudioResourceField extends Component<
 > {
   _field: ?ResourceSelector;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
@@ -79,8 +79,8 @@ export default class BehaviorField extends React.Component<
       });
   }
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   _getError = (value?: string) => {

--- a/newIDE/app/src/EventsSheet/ParameterFields/BitmapFontResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/BitmapFontResourceField.js
@@ -12,8 +12,8 @@ export default class BitmapFontResourceField extends Component<
 > {
   _field: ?ResourceSelector;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/ColorExpressionField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ColorExpressionField.js
@@ -8,8 +8,8 @@ import { rgbStringAndAlphaToRGBColor } from '../../Utils/ColorTransformer';
 export default class ParameterColorField extends Component<ParameterFieldProps> {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/ExpressionField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ExpressionField.js
@@ -9,8 +9,8 @@ export default class ExpressionField extends Component<
 > {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/FontResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FontResourceField.js
@@ -12,8 +12,8 @@ export default class BitmapFontResourceField extends Component<
 > {
   _field: ?ResourceSelector;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -11,8 +11,8 @@ export default class FunctionParameterNameField extends Component<
 > {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -183,7 +183,6 @@ export default class ExpressionField extends React.Component<Props, State> {
     if (this._field) {
       this._field.focus();
       if (selectAll) {
-        this._inputElement = this._field ? this._field.getInputNode() : null;
         if (this._inputElement) {
           this._inputElement.setSelectionRange(
             0,

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -179,9 +179,18 @@ export default class ExpressionField extends React.Component<Props, State> {
     }
   }
 
-  focus = () => {
+  focus = (selectAll: boolean = false) => {
     if (this._field) {
       this._field.focus();
+      if (selectAll) {
+        this._inputElement = this._field ? this._field.getInputNode() : null;
+        if (this._inputElement) {
+          this._inputElement.setSelectionRange(
+            0,
+            this.props.value.toString().length
+          );
+        }
+      }
       this._enqueueValidation();
     }
   };

--- a/newIDE/app/src/EventsSheet/ParameterFields/JsonResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/JsonResourceField.js
@@ -12,8 +12,8 @@ export default class JsonResourceField extends Component<
 > {
   _field: ?ResourceSelector;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/KeyField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/KeyField.js
@@ -121,8 +121,8 @@ const isKeyValid = (key: string) => keyNames.indexOf(key) !== -1;
 export default class KeyField extends Component<ParameterFieldProps, {||}> {
   _field: ?any;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
@@ -16,8 +16,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function LayerEffectNameField(props: ParameterFieldProps, ref) {
     const field = React.useRef<?GenericExpressionField>(null);
     React.useImperativeHandle(ref, () => ({
-      focus: () => {
-        if (field.current) field.current.focus();
+      focus: (selectAll: boolean = false) => {
+        if (field.current) field.current.focus(selectAll);
       },
     }));
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
@@ -17,8 +17,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function LayerEffectParameterNameField(props: ParameterFieldProps, ref) {
     const field = React.useRef<?GenericExpressionField>(null);
     React.useImperativeHandle(ref, () => ({
-      focus: () => {
-        if (field.current) field.current.focus();
+      focus: (selectAll: boolean = false) => {
+        if (field.current) field.current.focus(selectAll);
       },
     }));
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
@@ -8,8 +8,8 @@ import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
 export default class LayerField extends Component<ParameterFieldProps, {||}> {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -15,8 +15,8 @@ export default class ObjectAnimationNameField extends Component<
 > {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   getAnimationNames(): Array<ExpressionAutocompletion> {

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
@@ -14,8 +14,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function ObjectEffectNameField(props: ParameterFieldProps, ref) {
     const field = React.useRef<?GenericExpressionField>(null);
     React.useImperativeHandle(ref, () => ({
-      focus: () => {
-        if (field.current) field.current.focus();
+      focus: (selectAll: boolean = false) => {
+        if (field.current) field.current.focus(selectAll);
       },
     }));
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
@@ -19,8 +19,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function ObjectEffectParameterNameField(props: ParameterFieldProps, ref) {
     const field = React.useRef<?GenericExpressionField>(null);
     React.useImperativeHandle(ref, () => ({
-      focus: () => {
-        if (field.current) field.current.focus();
+      focus: (selectAll: boolean = false) => {
+        if (field.current) field.current.focus(selectAll);
       },
     }));
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectField.js
@@ -34,8 +34,8 @@ export default class ObjectField extends React.Component<
       : undefined;
   }
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
@@ -15,8 +15,8 @@ export default class ObjectPointNameField extends Component<
 > {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   getPointNames(): Array<ExpressionAutocompletion> {

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
@@ -11,8 +11,8 @@ export default class SceneNameField extends Component<
 > {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringField.js
@@ -6,8 +6,8 @@ import { type ParameterFieldProps } from './ParameterFieldCommons';
 export default class StringField extends Component<ParameterFieldProps, void> {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
@@ -10,8 +10,8 @@ export default class StringWithSelectorField extends Component<
 > {
   _field: ?GenericExpressionField;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -113,8 +113,8 @@ export default class VariableField extends Component<Props, State> {
     });
   }
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/EventsSheet/ParameterFields/VideoResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VideoResourceField.js
@@ -12,8 +12,8 @@ export default class VideoResourceField extends Component<
 > {
   _field: ?ResourceSelector;
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/ObjectsList/ObjectSelector.js
+++ b/newIDE/app/src/ObjectsList/ObjectSelector.js
@@ -133,8 +133,8 @@ export default class ObjectSelector extends React.Component<Props, {||}> {
   // Don't add a componentWillUnmount that would call onChange. This can lead to
   // calling callbacks that would then update a deleted instruction parameters.
 
-  focus() {
-    if (this._field) this._field.focus();
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
   }
 
   render() {

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -66,8 +66,8 @@ export default class ResourceSelector extends React.Component<Props, State> {
   autoCompleteData: DataSource;
   _autoComplete: ?SemiControlledAutoCompleteInterface;
 
-  focus() {
-    if (this._autoComplete) this._autoComplete.focus();
+  focus(selectAll: boolean = false) {
+    if (this._autoComplete) this._autoComplete.focus(selectAll);
   }
 
   componentWillReceiveProps(nextProps: Props) {

--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -58,7 +58,7 @@ type Props = {|
 |};
 
 export type SemiControlledAutoCompleteInterface = {|
-  focus: () => void,
+  focus: (selectAll?: boolean) => void,
   forceInputValueTo: (newValue: string) => void,
 |};
 
@@ -236,8 +236,12 @@ export default React.forwardRef<Props, SemiControlledAutoCompleteInterface>(
     const classes = useStyles();
 
     React.useImperativeHandle(ref, () => ({
-      focus: () => {
-        if (input.current) input.current.focus();
+      focus: (selectAll: boolean = false) => {
+        const { current } = input;
+        if (current) {
+          current.focus();
+          current.setSelectionRange(0, props.value.toString().length);
+        }
       },
       forceInputValueTo: (newValue: string) => {
         if (inputValue !== null) setInputValue(newValue);


### PR DESCRIPTION
Closes #1559
Closes #2111

Used @PascalLadalle suggestion: Select all content to quickly go to either the beginning or the end of the input.

![demo_select_all_parameter](https://user-images.githubusercontent.com/32449369/154449465-d543f588-ffe7-48bf-b838-e71a5fe36676.gif)

