### PR TITLE
Do not select sprite when using mouse middle click to pan in scene editor

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -261,8 +261,9 @@ export default class LayerRenderer {
       renderedInstance._pixiObject.interactive = true;
       gesture.panable(renderedInstance._pixiObject);
       makeDoubleClickable(renderedInstance._pixiObject);
-      renderedInstance._pixiObject.on('click', () => {
-        this.onInstanceClicked(instance);
+      renderedInstance._pixiObject.on('click', event => {
+        if (event.data.originalEvent.button === 0)
+          this.onInstanceClicked(instance);
       });
       renderedInstance._pixiObject.on('doubleclick', () => {
         this.onInstanceDoubleClicked(instance);
@@ -273,12 +274,14 @@ export default class LayerRenderer {
       renderedInstance._pixiObject.on(
         'mousedown',
         (event: PIXI.InteractionEvent) => {
-          const viewPoint = event.data.global;
-          const scenePoint = this.viewPosition.toSceneCoordinates(
-            viewPoint.x,
-            viewPoint.y
-          );
-          this.onDownInstance(instance, scenePoint[0], scenePoint[1]);
+          if (event.data.originalEvent.button === 0) {
+            const viewPoint = event.data.global;
+            const scenePoint = this.viewPosition.toSceneCoordinates(
+              viewPoint.x,
+              viewPoint.y
+            );
+            this.onDownInstance(instance, scenePoint[0], scenePoint[1]);
+          }
         }
       );
       renderedInstance._pixiObject.on('rightclick', interactionEvent => {

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/index.js
@@ -10,6 +10,12 @@ export default class InstancesRenderer {
   layout: gdLayout;
   viewPosition: ViewPosition;
   onInstanceClicked: gdInitialInstance => void;
+  onInstanceRightClicked: ({|
+    offsetX: number,
+    offsetY: number,
+    x: number,
+    y: number,
+  |}) => void;
   onInstanceDoubleClicked: gdInitialInstance => void;
   onOverInstance: gdInitialInstance => void;
   onOutInstance: gdInitialInstance => void;
@@ -30,6 +36,7 @@ export default class InstancesRenderer {
     instances,
     viewPosition,
     onInstanceClicked,
+    onInstanceRightClicked,
     onInstanceDoubleClicked,
     onOverInstance,
     onOutInstance,
@@ -42,6 +49,12 @@ export default class InstancesRenderer {
     layout: gdLayout,
     viewPosition: ViewPosition,
     onInstanceClicked: gdInitialInstance => void,
+    onInstanceRightClicked: ({|
+      offsetX: number,
+      offsetY: number,
+      x: number,
+      y: number,
+    |}) => void,
     onInstanceDoubleClicked: gdInitialInstance => void,
     onOverInstance: gdInitialInstance => void,
     onOutInstance: gdInitialInstance => void,
@@ -54,6 +67,7 @@ export default class InstancesRenderer {
     this.layout = layout;
     this.viewPosition = viewPosition;
     this.onInstanceClicked = onInstanceClicked;
+    this.onInstanceRightClicked = onInstanceRightClicked;
     this.onInstanceDoubleClicked = onInstanceDoubleClicked;
     this.onOverInstance = onOverInstance;
     this.onOutInstance = onOutInstance;
@@ -132,6 +146,7 @@ export default class InstancesRenderer {
           viewPosition: this.viewPosition,
           layer: layer,
           onInstanceClicked: this.onInstanceClicked,
+          onInstanceRightClicked: this.onInstanceRightClicked,
           onInstanceDoubleClicked: this.onInstanceDoubleClicked,
           onOverInstance: this.onOverInstance,
           onOutInstance: this.onOutInstance,

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -152,17 +152,6 @@ export default class InstancesEditor extends Component<Props> {
         this.props.onContextMenu(event.clientX, event.clientY),
     });
 
-    this.pixiRenderer.view.addEventListener('contextmenu', e => {
-      e.preventDefault();
-
-      this.lastContextMenuX = e.offsetX;
-      this.lastContextMenuY = e.offsetY;
-      if (this.props.onContextMenu)
-        this.props.onContextMenu(e.clientX, e.clientY);
-
-      return false;
-    });
-
     this.pixiRenderer.view.onwheel = (event: any) => {
       const zoomFactor = this.getZoomFactor();
       if (this.keyboardShortcuts.shouldZoom()) {
@@ -207,6 +196,22 @@ export default class InstancesEditor extends Component<Props> {
     gesture.panable(this.backgroundArea);
     this.backgroundArea.on('mousedown', event =>
       this._onBackgroundClicked(event.data.global.x, event.data.global.y)
+    );
+    this.backgroundArea.on(
+      'rightclick',
+      (interactionEvent: PIXI.InteractionEvent) => {
+        const {
+          data: { originalEvent: event },
+        } = interactionEvent;
+        this._onInstanceRightClicked({
+          offsetX: event.offsetX,
+          offsetY: event.offsetY,
+          x: event.clientX,
+          y: event.clientY,
+        })
+
+        return false;
+      }
     );
     this.backgroundArea.on('touchstart', event => {
       if (shouldBeHandledByPinch(event.data && event.data.originalEvent)) {
@@ -332,6 +337,7 @@ export default class InstancesEditor extends Component<Props> {
       onDownInstance: this._onDownInstance,
       onOutInstance: this._onOutInstance,
       onInstanceClicked: this._onInstanceClicked,
+      onInstanceRightClicked: this._onInstanceRightClicked,
       onInstanceDoubleClicked: this._onInstanceDoubleClicked,
     });
     this.selectionRectangle = new SelectionRectangle({
@@ -596,6 +602,22 @@ export default class InstancesEditor extends Component<Props> {
 
   _onInstanceClicked = (instance: gdInitialInstance) => {
     this.pixiRenderer.view.focus();
+  };
+
+  _onInstanceRightClicked = ({
+    offsetX,
+    offsetY,
+    x,
+    y,
+  }: {|
+    offsetX: number,
+    offsetY: number,
+    x: number,
+    y: number,
+  |}) => {
+    this.lastContextMenuX = offsetX;
+    this.lastContextMenuY = offsetY;
+    if (this.props.onContextMenu) this.props.onContextMenu(x, y);
   };
 
   _onInstanceDoubleClicked = (instance: gdInitialInstance) => {

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -208,7 +208,7 @@ export default class InstancesEditor extends Component<Props> {
           offsetY: event.offsetY,
           x: event.clientX,
           y: event.clientY,
-        })
+        });
 
         return false;
       }

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -203,7 +203,7 @@ export default class InstancesEditor extends Component<Props> {
         const {
           data: { originalEvent: event },
         } = interactionEvent;
-        this._onInstanceRightClicked({
+        this._onRightClicked({
           offsetX: event.offsetX,
           offsetY: event.offsetY,
           x: event.clientX,
@@ -337,7 +337,7 @@ export default class InstancesEditor extends Component<Props> {
       onDownInstance: this._onDownInstance,
       onOutInstance: this._onOutInstance,
       onInstanceClicked: this._onInstanceClicked,
-      onInstanceRightClicked: this._onInstanceRightClicked,
+      onInstanceRightClicked: this._onRightClicked,
       onInstanceDoubleClicked: this._onInstanceDoubleClicked,
     });
     this.selectionRectangle = new SelectionRectangle({
@@ -604,7 +604,7 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.focus();
   };
 
-  _onInstanceRightClicked = ({
+  _onRightClicked = ({
     offsetX,
     offsetY,
     x,


### PR DESCRIPTION
This PR changes 2 things:

- The first commit propagates right click events to pixi sprites, instead of having the pixi view catching it and handling it. It allows for example the following manipulation:
  - Select Player sprite (left click)
  - Right click on it
  - Edit Player's properties
  - Back to the scene, right click on Enemy sprite
  - Edit Enemy's properties
  => Before that, the context menu when right clicking on the Enemy was referring to the Player. I am not sure a user already reported that but it feels more natural to me.

- The second commit fixes #2278: When you multi select sprites, if you want to use the middle click to pan the scene to select more, if your mid click is on an object, it currently selects it and you lose your previous selection.