### PR TITLE
Improve copy pasting instances

### DIFF
--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -902,6 +902,7 @@ export default class SceneEditor extends React.Component<Props, State> {
         instance.delete();
         return newInstance;
       });
+    this._onInstancesAdded(newInstances)
     this.instancesSelection.clearSelection();
     this.instancesSelection.selectInstances(newInstances, true);
   };

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -887,20 +887,23 @@ export default class SceneEditor extends React.Component<Props, State> {
     const y = SafeExtractor.extractNumberProperty(clipboardContent, 'y');
     if (x === null || y === null || instancesContent === null) return;
 
-    instancesContent
+    const newInstances = instancesContent
       .map(serializedInstance => {
         const instance = new gd.InitialInstance();
         unserializeFromJSObject(instance, serializedInstance);
         return instance;
       })
-      .forEach(instance => {
+      .map(instance => {
         instance.setX(instance.getX() - x + position[0]);
         instance.setY(instance.getY() - y + position[1]);
-        this.props.initialInstances
+        const newInstance = this.props.initialInstances
           .insertInitialInstance(instance)
           .resetPersistentUuid();
         instance.delete();
+        return newInstance;
       });
+    this.instancesSelection.clearSelection();
+    this.instancesSelection.selectInstances(newInstances, true);
   };
 
   updateBehaviorsSharedData = () => {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -902,7 +902,7 @@ export default class SceneEditor extends React.Component<Props, State> {
         instance.delete();
         return newInstance;
       });
-    this._onInstancesAdded(newInstances)
+    this._onInstancesAdded(newInstances);
     this.instancesSelection.clearSelection();
     this.instancesSelection.selectInstances(newInstances, true);
   };

--- a/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
@@ -146,10 +146,11 @@ export default class DeprecatedKeyboardShortcuts {
       this.onPaste();
     }
     if (this._isControlPressed() && evt.which === Z_KEY) {
-      this.onUndo();
-    }
-    if (this._isControlPressed() && this.shiftPressed && evt.which === Z_KEY) {
-      this.onRedo();
+      if (this.shiftPressed) {
+        this.onRedo();
+      } else {
+        this.onUndo();
+      }
     }
     if (this._isControlPressed() && evt.which === Y_KEY) {
       this.onRedo();


### PR DESCRIPTION
- When pasting instances on the scene:
  - select the new instances instead of keeping the original instances selected (See https://forum.gdevelop-app.com/t/improve-usability-of-the-scene-editor/21515)
    ![demo_select_pasted](https://user-images.githubusercontent.com/32449369/154664721-4ad4ef50-337d-4dd5-89ce-09a96bd98955.gif)

  - trigger history change
- Fix a bug on redoing with Ctrl+Shift+Z
