### PR TITLE
Clarify object deletion

### DIFF
--- a/newIDE/app/src/MainFrame/Toolbar/PreviewAndPublishButtons.js
+++ b/newIDE/app/src/MainFrame/Toolbar/PreviewAndPublishButtons.js
@@ -119,6 +119,12 @@ export default function PreviewAndPublishButtons({
       previewState,
     ]
   );
+
+  const onClickPreview = event => {
+    if (event.target) event.target.blur();
+    onHotReloadPreview();
+  };
+
   return (
     <React.Fragment>
       <ElementWithMenu
@@ -134,7 +140,7 @@ export default function PreviewAndPublishButtons({
       <ElementWithMenu
         element={
           <FlatButton
-            onClick={onHotReloadPreview}
+            onClick={onClickPreview}
             disabled={!isPreviewEnabled}
             icon={
               <img

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -222,12 +222,14 @@ export default class ObjectsList extends React.Component<Props, State> {
     this.setState({ newObjectDialogOpen: true });
   };
 
-  _deleteObject = (objectWithContext: ObjectWithContext) => {
+  _deleteObject = (i18n: I18nType, objectWithContext: ObjectWithContext) => {
     const { object, global } = objectWithContext;
     const { project, objectsContainer } = this.props;
 
     const answer = Window.showConfirmDialog(
-      "Are you sure you want to remove this object? This can't be undone."
+      i18n._(
+        t`Are you sure you want to remove this object? This can't be undone.`
+      )
     );
     if (!answer) return;
 
@@ -258,9 +260,9 @@ export default class ObjectsList extends React.Component<Props, State> {
     });
   };
 
-  _cutObject = (objectWithContext: ObjectWithContext) => {
+  _cutObject = (i18n: I18nType, objectWithContext: ObjectWithContext) => {
     this._copyObject(objectWithContext);
-    this._deleteObject(objectWithContext);
+    this._deleteObject(i18n, objectWithContext);
   };
 
   _duplicateObject = (objectWithContext: ObjectWithContext) => {
@@ -513,7 +515,7 @@ export default class ObjectsList extends React.Component<Props, State> {
       },
       {
         label: i18n._(t`Delete`),
-        click: () => this._deleteObject(objectWithContext),
+        click: () => this._deleteObject(i18n, objectWithContext),
       },
       { type: 'separator' },
       {
@@ -527,7 +529,7 @@ export default class ObjectsList extends React.Component<Props, State> {
       },
       {
         label: i18n._(t`Cut`),
-        click: () => this._cutObject(objectWithContext),
+        click: () => this._cutObject(i18n, objectWithContext),
       },
       {
         label: getPasteLabel(objectWithContext.global),

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -644,11 +644,14 @@ export default class SceneEditor extends React.Component<Props, State> {
     const { object, global } = objectWithContext;
     const { project, layout } = this.props;
 
-    const answer = Window.showConfirmDialog(
+    const answer = Window.showYesNoCancelDialog(
       i18n._(
         t`Do you want to remove all references to this object in groups and events (actions and conditions using the object)?`
       )
     );
+
+    if (answer === 1) return;
+    const shouldRemoveReferences = answer === 0;
 
     // Unselect instances of the deleted object because these instances
     // will be deleted by gd.WholeProjectRefactorer (and after that, they will
@@ -660,7 +663,7 @@ export default class SceneEditor extends React.Component<Props, State> {
         project,
         object.getName(),
         /* isObjectGroup=*/ false,
-        !!answer
+        shouldRemoveReferences
       );
     } else {
       gd.WholeProjectRefactorer.objectOrGroupRemovedInLayout(
@@ -668,7 +671,7 @@ export default class SceneEditor extends React.Component<Props, State> {
         layout,
         object.getName(),
         /* isObjectGroup=*/ false,
-        !!answer
+        shouldRemoveReferences
       );
     }
 

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -637,7 +637,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     done(true);
   };
 
-  _onDeleteObject = (
+  _onDeleteObject = (i18n: I18nType) => (
     objectWithContext: ObjectWithContext,
     done: boolean => void
   ) => {
@@ -645,7 +645,9 @@ export default class SceneEditor extends React.Component<Props, State> {
     const { project, layout } = this.props;
 
     const answer = Window.showConfirmDialog(
-      'Do you want to remove all references to this object in groups and events (actions and conditions using the object)?'
+      i18n._(
+        t`Do you want to remove all references to this object in groups and events (actions and conditions using the object)?`
+      )
     );
 
     // Unselect instances of the deleted object because these instances
@@ -1090,36 +1092,42 @@ export default class SceneEditor extends React.Component<Props, State> {
           <CloseButton key="close" />,
         ],
         renderEditor: () => (
-          <ObjectsList
-            getThumbnail={ObjectsRenderingService.getThumbnail.bind(
-              ObjectsRenderingService
+          <I18n>
+            {({ i18n }) => (
+              <ObjectsList
+                getThumbnail={ObjectsRenderingService.getThumbnail.bind(
+                  ObjectsRenderingService
+                )}
+                project={project}
+                objectsContainer={layout}
+                layout={layout}
+                events={layout.getEvents()}
+                resourceSources={resourceSources}
+                resourceExternalEditors={resourceExternalEditors}
+                onChooseResource={onChooseResource}
+                selectedObjectNames={this.state.selectedObjectNames}
+                onEditObject={this.props.onEditObject || this.editObject}
+                onDeleteObject={this._onDeleteObject(i18n)}
+                canRenameObject={this._canObjectOrGroupUseNewName}
+                onObjectCreated={this._onObjectCreated}
+                onObjectSelected={this._onObjectSelected}
+                onRenameObject={this._onRenameObject}
+                onObjectPasted={() => this.updateBehaviorsSharedData()}
+                selectedObjectTags={this.state.selectedObjectTags}
+                onChangeSelectedObjectTags={selectedObjectTags =>
+                  this.setState({
+                    selectedObjectTags,
+                  })
+                }
+                getAllObjectTags={this._getAllObjectTags}
+                ref={objectsList => (this._objectsList = objectsList)}
+                unsavedChanges={this.props.unsavedChanges}
+                hotReloadPreviewButtonProps={
+                  this.props.hotReloadPreviewButtonProps
+                }
+              />
             )}
-            project={project}
-            objectsContainer={layout}
-            layout={layout}
-            events={layout.getEvents()}
-            resourceSources={resourceSources}
-            resourceExternalEditors={resourceExternalEditors}
-            onChooseResource={onChooseResource}
-            selectedObjectNames={this.state.selectedObjectNames}
-            onEditObject={this.props.onEditObject || this.editObject}
-            onDeleteObject={this._onDeleteObject}
-            canRenameObject={this._canObjectOrGroupUseNewName}
-            onObjectCreated={this._onObjectCreated}
-            onObjectSelected={this._onObjectSelected}
-            onRenameObject={this._onRenameObject}
-            onObjectPasted={() => this.updateBehaviorsSharedData()}
-            selectedObjectTags={this.state.selectedObjectTags}
-            onChangeSelectedObjectTags={selectedObjectTags =>
-              this.setState({
-                selectedObjectTags,
-              })
-            }
-            getAllObjectTags={this._getAllObjectTags}
-            ref={objectsList => (this._objectsList = objectsList)}
-            unsavedChanges={this.props.unsavedChanges}
-            hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
-          />
+          </I18n>
         ),
       },
       'object-groups-list': {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -650,8 +650,8 @@ export default class SceneEditor extends React.Component<Props, State> {
       )
     );
 
-    if (answer === 1) return;
-    const shouldRemoveReferences = answer === 0;
+    if (answer === 'cancel') return;
+    const shouldRemoveReferences = answer === 'yes';
 
     // Unselect instances of the deleted object because these instances
     // will be deleted by gd.WholeProjectRefactorer (and after that, they will

--- a/newIDE/app/src/Utils/Window.js
+++ b/newIDE/app/src/Utils/Window.js
@@ -167,6 +167,33 @@ export default class Window {
       buttons: ['OK'],
     });
   }
+  /**
+   * @param message
+   * @param type
+   * @returns Index of the button on which the user clicked: 0 for Yes, 1 for Cancel, 2 for No
+   */
+  static showYesNoCancelDialog(
+    message: string,
+    type?: 'none' | 'info' | 'error' | 'question' | 'warning'
+  ): number {
+    if (!dialog || !electron) {
+      // TODO: Find a way to display an alert with 3 buttons (not possible with the 3 native js method confirm, alert and prompt)
+      // eslint-disable-next-line
+      const answer = confirm(message);
+      if (answer) return 0;
+      return 2;
+    }
+
+    const browserWindow = electron.remote.getCurrentWindow();
+    const answer = dialog.showMessageBoxSync(browserWindow, {
+      message,
+      type,
+      cancelId: 1,
+      buttons: ['Yes', 'Cancel', 'No'], // TODO: Check on Windows and Linux how these buttons are displayed.
+      // On Mac, they are displayed vertically in the order Yes, No and Cancel from top to bottom.
+    });
+    return answer;
+  }
 
   static showConfirmDialog(
     message: string,
@@ -181,6 +208,7 @@ export default class Window {
     const answer = dialog.showMessageBoxSync(browserWindow, {
       message,
       type,
+      cancelId: 1,
       buttons: ['OK', 'Cancel'],
     });
     return answer === 0;

--- a/newIDE/app/src/Utils/Window.js
+++ b/newIDE/app/src/Utils/Window.js
@@ -8,6 +8,7 @@ const shell = electron ? electron.shell : null;
 const dialog = electron ? electron.remote.dialog : null;
 
 export type AppArguments = { [string]: any };
+type YesNoCancelDialogChoice = 'yes' | 'no' | 'cancel';
 
 /**
  * The name of the key, in AppArguments, containing the array of
@@ -167,21 +168,17 @@ export default class Window {
       buttons: ['OK'],
     });
   }
-  /**
-   * @param message
-   * @param type
-   * @returns Index of the button on which the user clicked: 0 for Yes, 1 for Cancel, 2 for No
-   */
+
   static showYesNoCancelDialog(
     message: string,
     type?: 'none' | 'info' | 'error' | 'question' | 'warning'
-  ): number {
+  ): YesNoCancelDialogChoice {
     if (!dialog || !electron) {
       // TODO: Find a way to display an alert with 3 buttons (not possible with the 3 native js method confirm, alert and prompt)
       // eslint-disable-next-line
       const answer = confirm(message);
-      if (answer) return 0;
-      return 2;
+      if (answer) return 'yes';
+      return 'no';
     }
 
     const browserWindow = electron.remote.getCurrentWindow();
@@ -192,7 +189,16 @@ export default class Window {
       buttons: ['Yes', 'Cancel', 'No'], // TODO: Check on Windows and Linux how these buttons are displayed.
       // On Mac, they are displayed vertically in the order Yes, No and Cancel from top to bottom.
     });
-    return answer;
+    switch (answer) {
+      case 0:
+        return 'yes';
+      case 1:
+        return 'cancel';
+      case 2:
+        return 'no';
+      default:
+        return 'cancel';
+    }
   }
 
   static showConfirmDialog(


### PR DESCRIPTION
Closes #816

- On desktop apps, now displays the following:
    <img width="577" alt="image" src="https://user-images.githubusercontent.com/32449369/154724882-2c0f6f68-0515-4e08-9e7b-a4c4df539791.png">

  - "Cancel" cancels object removal
  - "Yes" removes instructions mentioning the object
  - "No" does nothing to those instructions
  
- Messages displayed for object deletion are now translated, it could be done for every use of these dialogs.
- TODO: Check how Electron displays the buttons on Windows and Linux, Macos seems to reorder the buttons. Maybe we will have to have a different order depending on the platform.
- Note: on the web app, we still have OK/Cancel buttons. I don't think it is worth spending time on developing our own alert to display 3 buttons.

---

BONUS:
- Remove focus on preview button after clicking it so that when return to the IDE after preview, users can move the scene around with Space+Click