### PR TITLE
Autocompletion for external layout name fields.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/ExternalLayoutsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/ExternalLayoutsExtension.cpp
@@ -33,7 +33,7 @@ BuiltinExtensionsImplementer::ImplementsExternalLayoutsExtension(
                  "res/ribbon_default/externallayout32.png",
                  "res/ribbon_default/externallayout32.png")
       .AddCodeOnlyParameter("currentScene", "")
-      .AddParameter("string", _("Name of the external layout"))
+      .AddParameter("externalLayoutName", _("Name of the external layout"))
       .AddParameter("expression", _("X position of the origin"), "", true)
       .SetDefaultValue("0")
       .AddParameter("expression", _("Y position of the origin"), "", true)

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
@@ -195,7 +195,8 @@ class GD_CORE_API ParameterMetadata {
              parameterType == "objectEffectParameterName" ||
              parameterType == "objectPointName" ||
              parameterType == "objectAnimationName" ||
-             parameterType == "functionParameterName";
+             parameterType == "functionParameterName" ||
+             parameterType == "externalLayoutName";
     } else if (type == "variable") {
       return parameterType == "objectvar" || parameterType == "globalvar" ||
              parameterType == "scenevar";

--- a/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
@@ -1,0 +1,40 @@
+// @flow
+import React, { Component } from 'react';
+import GenericExpressionField from './GenericExpressionField';
+import { enumerateExternalLayouts } from '../../ProjectManager/EnumerateProjectItems';
+import { type ParameterFieldProps } from './ParameterFieldCommons';
+import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
+
+export default class ExternalLayoutNameField extends Component<
+  ParameterFieldProps,
+  void
+> {
+  _field: ?GenericExpressionField;
+
+  focus(selectAll: boolean = false) {
+    if (this._field) this._field.focus(selectAll);
+  }
+
+  render() {
+    const externalLayoutNames: Array<ExpressionAutocompletion> = this.props
+      .project
+      ? enumerateExternalLayouts(this.props.project).map(externalLayout => ({
+          kind: 'Text',
+          completion: `"${externalLayout.getName()}"`,
+        }))
+      : [];
+
+    return (
+      <GenericExpressionField
+        expressionType="string"
+        onGetAdditionalAutocompletions={expression =>
+          externalLayoutNames.filter(
+            ({ completion }) => completion.indexOf(expression) === 0
+          )
+        }
+        ref={field => (this._field = field)}
+        {...this.props}
+      />
+    );
+  }
+}

--- a/newIDE/app/src/EventsSheet/ParameterRenderingService.js
+++ b/newIDE/app/src/EventsSheet/ParameterRenderingService.js
@@ -54,6 +54,7 @@ import ObjectEffectParameterNameField from './ParameterFields/ObjectEffectParame
 import ObjectPointNameField from './ParameterFields/ObjectPointNameField';
 import ObjectAnimationNameField from './ParameterFields/ObjectAnimationNameField';
 import FunctionParameterNameField from './ParameterFields/FunctionParameterNameField';
+import ExternalLayoutNameField from './ParameterFields/ExternalLayoutNameField';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 const gd: libGDevelop = global.gd;
 
@@ -93,6 +94,7 @@ const components = {
   objectPointName: ObjectPointNameField,
   objectAnimationName: ObjectAnimationNameField,
   functionParameterName: FunctionParameterNameField,
+  externalLayoutName: ExternalLayoutNameField,
 };
 const inlineRenderers: { [string]: ParameterInlineRenderer } = {
   default: renderInlineDefaultField,
@@ -140,6 +142,7 @@ const userFriendlyTypeName: { [string]: MessageDescriptor } = {
   objectPointName: t`Object point name`,
   objectAnimationName: t`Object animation name`,
   functionParameterName: t`Parameter name`,
+  externalLayoutName: t`Name of the external layout`,
 };
 
 export default {


### PR DESCRIPTION
It shows every external layouts as the scene asked when creating an external layout is only used for the object list and external layouts can be shared with several scenes.
There is no expression in my knowledge that has an external layout parameter so it's not handled to avoid dead code.

![image](https://user-images.githubusercontent.com/2611977/154741328-77c9ee42-4155-4014-80ea-83f72a0b805f.png)
