### PR TITLE
Let users define if their game can be played with a keybord, a gamepad or a mobile

### DIFF
--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -37,6 +37,9 @@ import { type PublicGame } from '../Utils/GDevelopServices/Game';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import PublicGamePropertiesDialog from '../ProjectManager/PublicGamePropertiesDialog';
 import TextField from '../UI/TextField';
+import KeyboardIcon from '@material-ui/icons/Keyboard';
+import SportsEsportsIcon from '@material-ui/icons/SportsEsports';
+import SmartphoneIcon from '@material-ui/icons/Smartphone';
 
 const styles = {
   tableRowStatColumn: {
@@ -146,6 +149,7 @@ export const GameDetailsDialog = ({
     const { id } = profile;
 
     try {
+      const { playWithKeyboard, playWithGamepad, playWithMobile } = publicGame;
       // Set public game to null as it will be refetched automatically by the callback above.
       setPublicGame(null);
       const gameId = project.getProjectUuid();
@@ -153,6 +157,9 @@ export const GameDetailsDialog = ({
         authorName: project.getAuthor() || 'Unspecified publisher',
         gameName: project.getName() || 'Untitle game',
         description: project.getDescription() || '',
+        playWithKeyboard,
+        playWithGamepad,
+        playWithMobile,
       });
       const authorAcls = getAclsFromAuthorIds(project.getAuthorIds());
       await setGameUserAcls(getAuthorizationHeader, id, gameId, authorAcls);
@@ -286,6 +293,11 @@ export const GameDetailsDialog = ({
                     </Trans>
                   </Text>
                 </Line>
+              </Line>
+              <Line expand justifyContent="flex-start" alignItems="center">
+                {publicGame.playWithKeyboard && <KeyboardIcon />}
+                {publicGame.playWithGamepad && <SportsEsportsIcon />}
+                {publicGame.playWithMobile && <SmartphoneIcon />}
               </Line>
               <TextField
                 value={publicGame.gameName}

--- a/newIDE/app/src/ProjectManager/PublicGameProperties.js
+++ b/newIDE/app/src/ProjectManager/PublicGameProperties.js
@@ -4,6 +4,7 @@ import { Trans } from '@lingui/macro';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import { UsersAutocomplete } from '../Utils/UsersAutocomplete';
 import { ColumnStackLayout } from '../UI/Layout';
+import Checkbox from '../UI/Checkbox';
 
 type Props = {|
   project: gdProject,
@@ -13,6 +14,12 @@ type Props = {|
   description: ?string,
   setAuthorIds: (string[]) => void,
   authorIds: string[],
+  setPlayableWithKeyboard: boolean => void,
+  playWithKeyboard: boolean,
+  setPlayableWithGamepad: boolean => void,
+  playWithGamepad: boolean,
+  setPlayableWithMobile: boolean => void,
+  playWithMobile: boolean,
 |};
 
 function PublicGameProperties({
@@ -23,6 +30,12 @@ function PublicGameProperties({
   description,
   setAuthorIds,
   authorIds,
+  setPlayableWithKeyboard,
+  playWithKeyboard,
+  setPlayableWithGamepad,
+  playWithGamepad,
+  setPlayableWithMobile,
+  playWithMobile,
 }: Props) {
   return (
     <ColumnStackLayout noMargin>
@@ -55,6 +68,21 @@ function PublicGameProperties({
             example or in the community.
           </Trans>
         }
+      />
+      <Checkbox
+        label={<Trans>Playable with keyboards</Trans>}
+        checked={playWithKeyboard}
+        onCheck={(e, checked) => setPlayableWithKeyboard(checked)}
+      />
+      <Checkbox
+        label={<Trans>Playable with gamepads</Trans>}
+        checked={playWithGamepad}
+        onCheck={(e, checked) => setPlayableWithGamepad(checked)}
+      />
+      <Checkbox
+        label={<Trans>Playable on mobile</Trans>}
+        checked={playWithMobile}
+        onCheck={(e, checked) => setPlayableWithMobile(checked)}
       />
     </ColumnStackLayout>
   );

--- a/newIDE/app/src/ProjectManager/PublicGamePropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/PublicGamePropertiesDialog.js
@@ -33,6 +33,21 @@ function applyPublicPropertiesToProject(
   return displayProjectErrorsBox(t, getProjectPropertiesErrors(t, project));
 }
 
+type PublicGameOnlyProperties = {|
+  playWithKeyboard: boolean,
+  playWithGamepad: boolean,
+  playWithMobile: boolean,
+|};
+
+function applyPublicPropertiesToGame(
+  publicGame: PublicGame,
+  newProperties: PublicGameOnlyProperties
+) {
+  publicGame.playWithKeyboard = newProperties.playWithKeyboard;
+  publicGame.playWithGamepad = newProperties.playWithGamepad;
+  publicGame.playWithMobile = newProperties.playWithMobile;
+}
+
 type Props = {|
   project: gdProject,
   game: PublicGame,
@@ -56,9 +71,24 @@ const PublicGamePropertiesDialog = ({
   const [authorIds, setAuthorIds] = React.useState<string[]>(
     publicGameAuthorIds
   );
+  const [playWithKeyboard, setPlayableWithKeyboard] = React.useState(
+    game.playWithKeyboard
+  );
+  const [playWithGamepad, setPlayableWithGamepad] = React.useState(
+    game.playWithGamepad
+  );
+  const [playWithMobile, setPlayableWithMobile] = React.useState(
+    game.playWithMobile
+  );
+
   if (!open) return null;
 
   const onSave = () => {
+    applyPublicPropertiesToGame(game, {
+      playWithKeyboard,
+      playWithGamepad,
+      playWithMobile,
+    });
     if (
       applyPublicPropertiesToProject(project, {
         name,
@@ -100,6 +130,12 @@ const PublicGamePropertiesDialog = ({
         project={project}
         authorIds={authorIds}
         setAuthorIds={setAuthorIds}
+        setPlayableWithKeyboard={setPlayableWithKeyboard}
+        playWithKeyboard={playWithKeyboard}
+        setPlayableWithGamepad={setPlayableWithGamepad}
+        playWithGamepad={playWithGamepad}
+        setPlayableWithMobile={setPlayableWithMobile}
+        playWithMobile={playWithMobile}
       />
     </Dialog>
   );

--- a/newIDE/app/src/Utils/GDevelopServices/Game.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Game.js
@@ -11,6 +11,9 @@ export type PublicGame = {
   publicWebBuildId?: ?string,
   description?: string,
   authors: Array<?UserPublicProfile>,
+  playWithKeyboard: boolean,
+  playWithGamepad: boolean,
+  playWithMobile: boolean,
   metrics?: {
     lastWeekSessionsCount: number,
     lastYearSessionsCount: number,
@@ -134,11 +137,17 @@ export const updateGame = (
     authorName,
     publicWebBuildId,
     description,
+    playWithKeyboard,
+    playWithGamepad,
+    playWithMobile,
   }: {|
     gameName?: string,
     authorName?: string,
     publicWebBuildId?: ?string,
     description?: string,
+    playWithKeyboard?: boolean,
+    playWithGamepad?: boolean,
+    playWithMobile?: boolean,
   |}
 ): Promise<Game> => {
   return getAuthorizationHeader()
@@ -150,6 +159,9 @@ export const updateGame = (
           authorName,
           publicWebBuildId,
           description,
+          playWithKeyboard,
+          playWithGamepad,
+          playWithMobile,
         },
         {
           params: {


### PR DESCRIPTION
It doesn't store the data in the project, but I'm not against it.

![image](https://user-images.githubusercontent.com/2611977/155010466-8bb384e8-4a36-4677-b65a-753b4d5b4b58.png)

I tried to keep the same layout as in Liluo, but it makes a big empty space.

![image](https://user-images.githubusercontent.com/2611977/155010544-23d4db8f-a5b3-470a-a807-0dfb3de2b24b.png)
