### PR TITLE
Let game creators define an orientation on mobile for Liluo.io.

### DIFF
--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -159,6 +159,7 @@ export const GameDetailsDialog = ({
         playWithKeyboard: project.isPlayableWithKeyboard(),
         playWithGamepad: project.isPlayableWithGamepad(),
         playWithMobile: project.isPlayableWithMobile(),
+        orientation: project.getOrientation(),
       });
       const authorAcls = getAclsFromAuthorIds(project.getAuthorIds());
       await setGameUserAcls(getAuthorizationHeader, id, gameId, authorAcls);
@@ -319,6 +320,21 @@ export const GameDetailsDialog = ({
                 multiline
                 rows={5}
               />
+              <SelectField
+                disabled
+                fullWidth
+                floatingLabelText={
+                  <Trans>Device orientation (for iOS and Android)</Trans>
+                }
+                value={publicGame.orientation}
+              >
+                <SelectOption
+                  value="default"
+                  primaryText={t`Platform default`}
+                />
+                <SelectOption value="landscape" primaryText={t`Landscape`} />
+                <SelectOption value="portrait" primaryText={t`Portrait`} />
+              </SelectField>
               <Line noMargin justifyContent="flex-end">
                 <FlatButton
                   onClick={() => {

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -300,6 +300,8 @@ function ProjectPropertiesDialog(props: Props) {
                   project={project}
                   authorIds={authorIds}
                   setAuthorIds={setAuthorIds}
+                  orientation={orientation}
+                  setOrientation={setOrientation}
                 />
                 <Text size="title">
                   <Trans>Packaging</Trans>
@@ -499,21 +501,6 @@ function ProjectPropertiesDialog(props: Props) {
                     </Trans>
                   </DismissableAlertMessage>
                 )}
-                <SelectField
-                  fullWidth
-                  floatingLabelText={
-                    <Trans>Device orientation (for iOS and Android)</Trans>
-                  }
-                  value={orientation}
-                  onChange={(e, i, value: string) => setOrientation(value)}
-                >
-                  <SelectOption
-                    value="default"
-                    primaryText={t`Platform default`}
-                  />
-                  <SelectOption value="landscape" primaryText={t`Landscape`} />
-                  <SelectOption value="portrait" primaryText={t`Portrait`} />
-                </SelectField>
                 <SelectField
                   fullWidth
                   floatingLabelText={

--- a/newIDE/app/src/ProjectManager/PublicGameProperties.js
+++ b/newIDE/app/src/ProjectManager/PublicGameProperties.js
@@ -5,6 +5,9 @@ import SemiControlledTextField from '../UI/SemiControlledTextField';
 import { UsersAutocomplete } from '../Utils/UsersAutocomplete';
 import { ColumnStackLayout } from '../UI/Layout';
 import Checkbox from '../UI/Checkbox';
+import SelectField from '../UI/SelectField';
+import SelectOption from '../UI/SelectOption';
+import { t } from '@lingui/macro';
 
 type Props = {|
   project: gdProject,
@@ -20,6 +23,8 @@ type Props = {|
   playWithGamepad?: boolean,
   setPlayableWithMobile?: boolean => void,
   playWithMobile?: boolean,
+  setOrientation?: string => void,
+  orientation?: string,
 |};
 
 function PublicGameProperties({
@@ -36,6 +41,8 @@ function PublicGameProperties({
   playWithGamepad,
   setPlayableWithMobile,
   playWithMobile,
+  setOrientation,
+  orientation,
 }: Props) {
   return (
     <ColumnStackLayout noMargin>
@@ -69,6 +76,18 @@ function PublicGameProperties({
           </Trans>
         }
       />
+      <SelectField
+        fullWidth
+        floatingLabelText={
+          <Trans>Device orientation (for iOS and Android)</Trans>
+        }
+        value={orientation}
+        onChange={(e, i, value: string) => setOrientation(value)}
+      >
+        <SelectOption value="default" primaryText={t`Platform default`} />
+        <SelectOption value="landscape" primaryText={t`Landscape`} />
+        <SelectOption value="portrait" primaryText={t`Portrait`} />
+      </SelectField>
       {// This view is used for public game properties as well as project properties.
       // The following properties are not shown in project properties.
       setPlayableWithKeyboard &&

--- a/newIDE/app/src/ProjectManager/PublicGamePropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/PublicGamePropertiesDialog.js
@@ -22,6 +22,7 @@ type PublicProjectProperties = {|
   playWithKeyboard: boolean,
   playWithGamepad: boolean,
   playWithMobile: boolean,
+  orientation: string,
 |};
 
 function applyPublicPropertiesToProject(
@@ -38,6 +39,7 @@ function applyPublicPropertiesToProject(
   project.setPlayableWithKeyboard(newProperties.playWithKeyboard);
   project.setPlayableWithGamepad(newProperties.playWithGamepad);
   project.setPlayableWithMobile(newProperties.playWithMobile);
+  project.setOrientation(newProperties.orientation);
 
   return displayProjectErrorsBox(t, getProjectPropertiesErrors(t, project));
 }
@@ -74,6 +76,7 @@ const PublicGamePropertiesDialog = ({
   const [playWithMobile, setPlayableWithMobile] = React.useState(
     game.playWithMobile
   );
+  const [orientation, setOrientation] = React.useState(game.orientation);
 
   if (!open) return null;
 
@@ -86,6 +89,7 @@ const PublicGamePropertiesDialog = ({
         playWithKeyboard: !!playWithKeyboard,
         playWithGamepad: !!playWithGamepad,
         playWithMobile: !!playWithMobile,
+        orientation: orientation || 'default',
       })
     )
       onApply();
@@ -128,6 +132,8 @@ const PublicGamePropertiesDialog = ({
         playWithGamepad={playWithGamepad}
         setPlayableWithMobile={setPlayableWithMobile}
         playWithMobile={playWithMobile}
+        setOrientation={setOrientation}
+        orientation={orientation}
       />
     </Dialog>
   );

--- a/newIDE/app/src/Utils/GDevelopServices/Game.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Game.js
@@ -14,6 +14,7 @@ export type PublicGame = {
   playWithKeyboard: boolean,
   playWithGamepad: boolean,
   playWithMobile: boolean,
+  orientation: boolean,
   metrics?: {
     lastWeekSessionsCount: number,
     lastYearSessionsCount: number,
@@ -140,6 +141,7 @@ export const updateGame = (
     playWithKeyboard,
     playWithGamepad,
     playWithMobile,
+    orientation,
   }: {|
     gameName?: string,
     authorName?: string,
@@ -148,6 +150,7 @@ export const updateGame = (
     playWithKeyboard?: boolean,
     playWithGamepad?: boolean,
     playWithMobile?: boolean,
+    orientation?: string,
   |}
 ): Promise<Game> => {
   return getAuthorizationHeader()
@@ -162,6 +165,7 @@ export const updateGame = (
           playWithKeyboard,
           playWithGamepad,
           playWithMobile,
+          orientation,
         },
         {
           params: {


### PR DESCRIPTION
It moves the orientation combobox from project property view to public game property view and send it to the game-api.