### PR TITLE
Split the "Center the camera on an object within limits" in 2 actions

### DIFF
--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -266,6 +266,32 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0")
+      .MarkAsAdvanced()
+      .SetHidden();  // Deprecated
+
+  extension
+      .AddAction(
+          "ClampCamera",
+          _("Move back the camera within bounds"),
+          _("Move back the camera inside the specified bounds."),
+          _("Move back the camera within bounds (left: _PARAM1_, top: _PARAM2_ "
+            "right: _PARAM3_, bottom: _PARAM4_, layer: _PARAM5_, camera: _PARAM6_)"),
+          "",
+          "res/actions/camera24.png",
+          "res/actions/camera.png")
+      .AddCodeOnlyParameter("currentScene", "")
+      .AddParameter("expression",
+                    _("Left bound X Position"))
+      .AddParameter("expression",
+                    _("Top bound Y Position"))
+      .AddParameter("expression",
+                    _("Right bound X Position"))
+      .AddParameter("expression",
+                    _("Bottom bound Y Position"))
+      .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
+      .SetDefaultValue("\"\"")
+      .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .SetDefaultValue("0")
       .MarkAsAdvanced();
 
   extension

--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -236,6 +236,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0");
 
+  // TODO Deprecated: hide this action in a future release.
   extension
       .AddAction(
           "FixCamera",
@@ -266,16 +267,15 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0")
-      .MarkAsAdvanced()
-      .SetHidden();  // Deprecated
+      .MarkAsAdvanced();
 
   extension
       .AddAction(
           "ClampCamera",
-          _("Move back the camera within bounds"),
-          _("Move back the camera inside the specified bounds."),
-          _("Move back the camera within bounds (left: _PARAM1_, top: _PARAM2_ "
-            "right: _PARAM3_, bottom: _PARAM4_, layer: _PARAM5_, camera: _PARAM6_)"),
+          _("Enforce camera boundaries"),
+          _("Enforce camera boundaries by moving the camera back inside specified boundaries."),
+          _("Enforce camera boundaries (left: _PARAM1_, top: _PARAM2_ "
+            "right: _PARAM3_, bottom: _PARAM4_, layer: _PARAM5_)"),
           "",
           "res/actions/camera24.png",
           "res/actions/camera.png")
@@ -299,7 +299,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
           "CentreCamera",
           _("Center the camera on an object"),
           _("Center the camera on the specified object."),
-          _("Center camera on _PARAM1_ (layer: _PARAM3_, camera: _PARAM4_)"),
+          _("Center camera on _PARAM1_ (layer: _PARAM3_)"),
           "",
           "res/actions/camera24.png",
           "res/actions/camera.png")

--- a/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
@@ -73,7 +73,9 @@ CameraExtension::CameraExtension() {
       "gdjs.evtTools.camera.getCameraHeight");
 
   GetAllActions()["FixCamera"].SetFunctionName(
-      "gdjs.evtTools.camera.centerCameraWithinLimits");
+      "gdjs.evtTools.camera.centerCameraWithinLimits");  // Deprecated
+  GetAllActions()["ClampCamera"].SetFunctionName(
+      "gdjs.evtTools.camera.clampCamera");
   GetAllActions()["CentreCamera"].SetFunctionName(
       "gdjs.evtTools.camera.centerCamera");
 

--- a/GDJS/Runtime/events-tools/cameratools.ts
+++ b/GDJS/Runtime/events-tools/cameratools.ts
@@ -162,7 +162,6 @@ namespace gdjs {
         if (!runtimeScene.hasLayer(layerName) || object == null) {
           return;
         }
-        const layer = runtimeScene.getLayer(layerName);
         let xOffset = 0;
         let yOffset = 0;
         if (anticipateMove && !object.hasNoForces()) {
@@ -172,10 +171,14 @@ namespace gdjs {
           xOffset = objectAverageForce.getX() * elapsedTimeInSeconds;
           yOffset = objectAverageForce.getY() * elapsedTimeInSeconds;
         }
-        layer.setCameraX(object.getDrawableX() + object.getCenterX(), cameraId);
-        layer.setCameraY(object.getDrawableY() + object.getCenterY(), cameraId);
+        const layer = runtimeScene.getLayer(layerName);
+        layer.setCameraX(object.getCenterXInScene() + xOffset, cameraId);
+        layer.setCameraY(object.getCenterYInScene() + yOffset, cameraId);
       };
 
+      /**
+       * @deprecated prefer using centerCamera and clampCamera.
+       */
       export const centerCameraWithinLimits = function (
         runtimeScene: gdjs.RuntimeScene,
         object: gdjs.RuntimeObject | null,
@@ -187,35 +190,49 @@ namespace gdjs {
         layerName: string,
         cameraId: integer
       ) {
-        if (!runtimeScene.hasLayer(layerName) || object == null) {
+        centerCamera(runtimeScene, object, anticipateMove, layerName, cameraId);
+        clampCamera(
+          runtimeScene,
+          left,
+          top,
+          right,
+          bottom,
+          layerName,
+          cameraId
+        );
+      };
+
+      export const clampCamera = function (
+        runtimeScene: gdjs.RuntimeScene,
+        left: float,
+        top: float,
+        right: float,
+        bottom: float,
+        layerName: string,
+        cameraId: integer
+      ) {
+        if (!runtimeScene.hasLayer(layerName)) {
           return;
         }
         const layer = runtimeScene.getLayer(layerName);
-        let xOffset = 0;
-        let yOffset = 0;
-        if (anticipateMove && !object.hasNoForces()) {
-          const objectAverageForce = object.getAverageForce();
-          const elapsedTimeInSeconds =
-            object.getElapsedTime(runtimeScene) / 1000;
-          xOffset = objectAverageForce.getX() * elapsedTimeInSeconds;
-          yOffset = objectAverageForce.getY() * elapsedTimeInSeconds;
-        }
-        let newX = object.getDrawableX() + object.getCenterX() + xOffset;
-        if (newX < left + layer.getCameraWidth(cameraId) / 2) {
-          newX = left + layer.getCameraWidth(cameraId) / 2;
-        }
-        if (newX > right - layer.getCameraWidth(cameraId) / 2) {
-          newX = right - layer.getCameraWidth(cameraId) / 2;
-        }
-        let newY = object.getDrawableY() + object.getCenterY() + yOffset;
-        if (newY < top + layer.getCameraHeight(cameraId) / 2) {
-          newY = top + layer.getCameraHeight(cameraId) / 2;
-        }
-        if (newY > bottom - layer.getCameraHeight(cameraId) / 2) {
-          newY = bottom - layer.getCameraHeight(cameraId) / 2;
-        }
-        layer.setCameraX(newX, cameraId);
-        layer.setCameraY(newY, cameraId);
+        const cameraHalfWidth = layer.getCameraWidth(cameraId) / 2;
+        const cameraHalfHeight = layer.getCameraHeight(cameraId) / 2;
+        layer.setCameraX(
+          gdjs.evtTools.common.clamp(
+            layer.getCameraX(cameraId),
+            left + cameraHalfWidth,
+            right - cameraHalfWidth
+          ),
+          cameraId
+        );
+        layer.setCameraY(
+          gdjs.evtTools.common.clamp(
+            layer.getCameraY(cameraId),
+            top + cameraHalfHeight,
+            bottom - cameraHalfHeight
+          ),
+          cameraId
+        );
       };
 
       /**

--- a/GDJS/Runtime/events-tools/cameratools.ts
+++ b/GDJS/Runtime/events-tools/cameratools.ts
@@ -217,22 +217,33 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const cameraHalfWidth = layer.getCameraWidth(cameraId) / 2;
         const cameraHalfHeight = layer.getCameraHeight(cameraId) / 2;
-        layer.setCameraX(
-          gdjs.evtTools.common.clamp(
-            layer.getCameraX(cameraId),
-            left + cameraHalfWidth,
-            right - cameraHalfWidth
-          ),
-          cameraId
-        );
-        layer.setCameraY(
-          gdjs.evtTools.common.clamp(
-            layer.getCameraY(cameraId),
-            top + cameraHalfHeight,
-            bottom - cameraHalfHeight
-          ),
-          cameraId
-        );
+
+        const centerLeftBound = left + cameraHalfWidth;
+        const centerRightBound = right - cameraHalfWidth;
+        const centerTopBound = top + cameraHalfHeight;
+        const centerBottomBound = bottom - cameraHalfHeight;
+
+        const cameraX =
+          centerLeftBound < centerRightBound
+            ? gdjs.evtTools.common.clamp(
+                layer.getCameraX(cameraId),
+                centerLeftBound,
+                centerRightBound
+              )
+            : // Center on the bounds when they are too small to fit the viewport.
+              (centerLeftBound + centerRightBound) / 2;
+        const cameraY =
+          centerTopBound < centerBottomBound
+            ? gdjs.evtTools.common.clamp(
+                layer.getCameraY(cameraId),
+                centerTopBound,
+                centerBottomBound
+              )
+            : // Center on the bounds when they are too small to fit the viewport.
+              (centerTopBound + centerBottomBound) / 2;
+
+        layer.setCameraX(cameraX, cameraId);
+        layer.setCameraY(cameraY, cameraId);
       };
 
       /**

--- a/newIDE/app/src/Hints/index.js
+++ b/newIDE/app/src/Hints/index.js
@@ -90,6 +90,12 @@ export const getExtraInstructionInformation = (type: string): ?Hint => {
       message: t`To start a timer, don't forget to use the action "Start (or reset) an object timer" in another event.`,
     };
   }
+  if (type === 'FixCamera') {
+    return {
+      kind: 'info',
+      message: t`Please prefer using the new action "Enforce camera boundaries" which is more flexible.`,
+    };
+  }
   if (type === 'BitmapText::Scale') {
     return {
       kind: 'info',


### PR DESCRIPTION
This replace the "Center the camera on an object within limits" by the "Move back the camera within bounds" action. This new action can be used after the "Center the camera on an object" action to get the same effect.

This allow to constraint camera within bounds after any camera movements:
* Drag camera
* Zoom camera
* Smooth following
* ...

Tested on the new platformer example:
* https://www.dropbox.com/s/3hzpx7zemmnu2bi/Platformer_REVIEW.zip?dl=1