### PR TITLE
Show warning when accessing builds for a game you don't own

### DIFF
--- a/newIDE/app/src/Export/ExportDialog/index.js
+++ b/newIDE/app/src/Export/ExportDialog/index.js
@@ -13,6 +13,7 @@ import AlertMessage from '../../UI/AlertMessage';
 import { Tab, Tabs } from '../../UI/Tabs';
 import ExportHome from './ExportHome';
 import { getGame, type Game } from '../../Utils/GDevelopServices/Game';
+import { showWarningBox } from '../../UI/Messages/MessageBox';
 
 const styles = {
   icon: { width: 40, height: 40 },
@@ -84,6 +85,16 @@ const ExportDialog = ({
   );
   const onlineStatus = useOnlineStatus();
   const cantExportBecauseOffline = !!allExportersRequireOnline && !onlineStatus;
+
+  const openBuildDialog = () => {
+    if (!game) {
+      showWarningBox(
+        "You are not the owner of this game, so you can't see the builds or publish a build to the game page on Liluo.io."
+      );
+      return;
+    }
+    setBuildsDialogOpen(true);
+  };
 
   const loadGame = React.useCallback(
     async () => {
@@ -164,8 +175,8 @@ const ExportDialog = ({
         <FlatButton
           key="builds"
           label={<Trans>See this game builds</Trans>}
-          onClick={() => setBuildsDialogOpen(true)}
-          disabled={isNavigationDisabled || !game}
+          onClick={openBuildDialog}
+          disabled={isNavigationDisabled}
         />,
       ]}
       open


### PR DESCRIPTION
Addressing #3684 

Instead of showing the whole Dialog and designing an error message if the game cannot be fetched, I went for showing a warning when clicking on the button.
I think it's enough to explain to the user what is happening.

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/4895034/156003899-584eeee4-bdc0-4999-8b27-96ce677041ff.png">
