### PR TITLE
Search adjustments for instructions

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -179,7 +179,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
       {
         ...sharedFuseConfiguration,
         keys: [
-          { name: 'displayedName', weight: 2 },
+          { name: 'displayedName', weight: 5 },
           { name: 'fullGroupName', weight: 1 },
         ],
       }

--- a/newIDE/app/src/UI/Search/UseSearchStructuredItem.js
+++ b/newIDE/app/src/UI/Search/UseSearchStructuredItem.js
@@ -12,7 +12,6 @@ export const sharedFuseConfiguration = {
   threshold: 0.35,
   includeMatches: true,
   ignoreLocation: true,
-  ignoreFieldNorm: true,
 };
 
 const tuneMatchIndices = (match: SearchMatch, searchText: string) => {
@@ -150,14 +149,13 @@ export const useSearchItem = <SearchItem: { tags: Array<string> }>(
         const newSearchApi = new Fuse(Object.values(searchItemsById), {
           keys: [
             { name: 'name', weight: 2 },
-            { name: 'fullName', weight: 2 },
+            { name: 'fullName', weight: 5 },
             { name: 'shortDescription', weight: 1 },
           ],
           minMatchCharLength: 2,
           threshold: 0.35,
           includeMatches: true,
           ignoreLocation: true,
-          ignoreFieldNorm: true,
         });
 
         const totalTime = performance.now() - startTime;


### PR DESCRIPTION
- Enable weighting based on object size
  - Otherwise, instructions with small names like "Or" will get obscured by other instructions that are seen as better matches as they match the pattern multiple times, for example: 
![image](https://user-images.githubusercontent.com/19349038/156082324-4b6972dc-5d4f-4146-a0a1-3d396cf587a5.png)
- Increase the weight of the name of the instruction, as that name is more natural, while the group will be less commonly used and shared with too many instructions to give good results.
