### PR TITLE
Make context menus in scene editor and in object list consistent

### DIFF
--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -14,7 +14,7 @@ import EventTextDialog, {
 import Toolbar from './Toolbar';
 import KeyboardShortcuts from '../UI/KeyboardShortcuts';
 import InlineParameterEditor from './InlineParameterEditor';
-import ContextMenu from '../UI/Menu/ContextMenu';
+import ContextMenu, { type ContextMenuInterface } from '../UI/Menu/ContextMenu';
 import { serializeToJSObject } from '../Utils/Serializer';
 import {
   type HistoryState,
@@ -209,8 +209,8 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     },
   });
 
-  eventContextMenu: ContextMenu;
-  instructionContextMenu: ContextMenu;
+  eventContextMenu: ?ContextMenuInterface;
+  instructionContextMenu: ?ContextMenuInterface;
   addNewEvent: (
     type: string,
     context: ?EventInsertionContext
@@ -642,7 +642,9 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     { type: 'separator' },
     {
       label: i18n._(t`Add New Event Below`),
-      click: () => this.addNewEvent('BuiltinCommonInstructions::Standard'),
+      click: () => {
+        this.addNewEvent('BuiltinCommonInstructions::Standard');
+      },
     },
     {
       label: i18n._(t`Add Sub Event`),
@@ -654,7 +656,9 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       submenu: this.state.allEventsMetadata.map(metadata => {
         return {
           label: metadata.fullName,
-          click: () => this.addNewEvent(metadata.type),
+          click: () => {
+            this.addNewEvent(metadata.type);
+          },
         };
       }),
     },
@@ -730,7 +734,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       },
       () => {
         this.updateToolbar();
-        this.eventContextMenu.open(x, y);
+        if (this.eventContextMenu) this.eventContextMenu.open(x, y);
       }
     );
   };
@@ -751,7 +755,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       },
       () => {
         this.updateToolbar();
-        this.instructionContextMenu.open(x, y);
+        if (this.instructionContextMenu) this.instructionContextMenu.open(x, y);
       }
     );
   };

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -56,7 +56,11 @@ export type InstancesEditorPropsWithoutSizeAndScroll = {|
   onInstancesResized: (instances: Array<gdInitialInstance>) => void,
   onInstancesRotated: (instances: Array<gdInitialInstance>) => void,
   selectedObjectNames: Array<string>,
-  onContextMenu: (x: number, y: number) => void,
+  onContextMenu: (
+    x: number,
+    y: number,
+    ignoreSelectedObjectNamesForContextMenu?: boolean
+  ) => void,
   onCopy: () => void,
   onCut: () => void,
   onPaste: () => void,
@@ -208,6 +212,7 @@ export default class InstancesEditor extends Component<Props> {
           offsetY: event.offsetY,
           x: event.clientX,
           y: event.clientY,
+          ignoreSelectedObjectNamesForContextMenu: true,
         });
 
         return false;
@@ -337,7 +342,7 @@ export default class InstancesEditor extends Component<Props> {
       onDownInstance: this._onDownInstance,
       onOutInstance: this._onOutInstance,
       onInstanceClicked: this._onInstanceClicked,
-      onInstanceRightClicked: this._onRightClicked,
+      onInstanceRightClicked: this._onRightClickedOnInstance,
       onInstanceDoubleClicked: this._onInstanceDoubleClicked,
     });
     this.selectionRectangle = new SelectionRectangle({
@@ -604,20 +609,40 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.focus();
   };
 
-  _onRightClicked = ({
-    offsetX,
-    offsetY,
-    x,
-    y,
-  }: {|
+  _onRightClickedOnInstance = (coordinates: {|
     offsetX: number,
     offsetY: number,
     x: number,
     y: number,
   |}) => {
+    this._onRightClicked({
+      ...coordinates,
+      ignoreSelectedObjectNamesForContextMenu: false,
+    });
+  };
+
+  _onRightClicked = ({
+    offsetX,
+    offsetY,
+    x,
+    y,
+    ignoreSelectedObjectNamesForContextMenu,
+  }: {|
+    offsetX: number,
+    offsetY: number,
+    x: number,
+    y: number,
+    ignoreSelectedObjectNamesForContextMenu?: boolean,
+  |}) => {
     this.lastContextMenuX = offsetX;
     this.lastContextMenuY = offsetY;
-    if (this.props.onContextMenu) this.props.onContextMenu(x, y);
+    if (this.props.onContextMenu) {
+      const _ignoreSelectedObjectNamesForContextMenu =
+        typeof ignoreSelectedObjectNamesForContextMenu === 'boolean'
+          ? ignoreSelectedObjectNamesForContextMenu
+          : false;
+      this.props.onContextMenu(x, y, _ignoreSelectedObjectNamesForContextMenu);
+    }
   };
 
   _onInstanceDoubleClicked = (instance: gdInitialInstance) => {

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -342,7 +342,7 @@ export default class InstancesEditor extends Component<Props> {
       onDownInstance: this._onDownInstance,
       onOutInstance: this._onOutInstance,
       onInstanceClicked: this._onInstanceClicked,
-      onInstanceRightClicked: this._onRightClickedOnInstance,
+      onInstanceRightClicked: this._onInstanceRightClicked,
       onInstanceDoubleClicked: this._onInstanceDoubleClicked,
     });
     this.selectionRectangle = new SelectionRectangle({
@@ -609,7 +609,7 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.focus();
   };
 
-  _onRightClickedOnInstance = (coordinates: {|
+  _onInstanceRightClicked = (coordinates: {|
     offsetX: number,
     offsetY: number,
     x: number,
@@ -637,11 +637,7 @@ export default class InstancesEditor extends Component<Props> {
     this.lastContextMenuX = offsetX;
     this.lastContextMenuY = offsetY;
     if (this.props.onContextMenu) {
-      const _ignoreSelectedObjectNamesForContextMenu =
-        typeof ignoreSelectedObjectNamesForContextMenu === 'boolean'
-          ? ignoreSelectedObjectNamesForContextMenu
-          : false;
-      this.props.onContextMenu(x, y, _ignoreSelectedObjectNamesForContextMenu);
+      this.props.onContextMenu(x, y, !!ignoreSelectedObjectNamesForContextMenu);
     }
   };
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -17,7 +17,9 @@ import HelpButton from '../../../UI/HelpButton';
 import EmptyMessage from '../../../UI/EmptyMessage';
 import MiniToolbar, { MiniToolbarText } from '../../../UI/MiniToolbar';
 import DragHandle from '../../../UI/DragHandle';
-import ContextMenu from '../../../UI/Menu/ContextMenu';
+import ContextMenu, {
+  type ContextMenuInterface,
+} from '../../../UI/Menu/ContextMenu';
 import { showWarningBox } from '../../../UI/Messages/MessageBox';
 import ResourcesLoader from '../../../ResourcesLoader';
 import PointsEditor from './PointsEditor';
@@ -210,7 +212,7 @@ class AnimationsListContainer extends React.Component<
   state = {
     selectedSprites: {},
   };
-  spriteContextMenu: ?ContextMenu;
+  spriteContextMenu: ?ContextMenuInterface;
 
   onSortEnd = ({ oldIndex, newIndex }) => {
     this.props.spriteObject.moveAnimation(oldIndex, newIndex);

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -27,6 +27,12 @@ import VariablesList from '../VariablesList/index';
 import { sendBehaviorsEditorShown } from '../Utils/Analytics/EventSender';
 const gd: libGDevelop = global.gd;
 
+export type ObjectEditorTab =
+  | 'properties'
+  | 'behaviors'
+  | 'variables'
+  | 'effects';
+
 type Props = {|
   open: boolean,
   object: ?gdObject,
@@ -46,7 +52,7 @@ type Props = {|
   resourceExternalEditors: Array<ResourceExternalEditor>,
   unsavedChanges?: UnsavedChanges,
   onUpdateBehaviorsSharedData: () => void,
-  initialTab: ?string,
+  initialTab: ?ObjectEditorTab,
 
   // Preview:
   hotReloadPreviewButtonProps: HotReloadPreviewButtonProps,
@@ -61,7 +67,7 @@ type InnerDialogProps = {|
 |};
 
 const InnerDialog = (props: InnerDialogProps) => {
-  const [currentTab, setCurrentTab] = React.useState(
+  const [currentTab, setCurrentTab] = React.useState<ObjectEditorTab>(
     props.initialTab || 'properties'
   );
   const [newObjectName, setNewObjectName] = React.useState(props.objectName);

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -474,6 +474,24 @@ export default class ObjectsList extends React.Component<Props, State> {
     );
     return [
       {
+        label: i18n._(t`Copy`),
+        click: () => this._copyObject(objectWithContext),
+      },
+      {
+        label: i18n._(t`Cut`),
+        click: () => this._cutObject(i18n, objectWithContext),
+      },
+      {
+        label: getPasteLabel(objectWithContext.global),
+        enabled: Clipboard.has(CLIPBOARD_KIND),
+        click: () => this._paste(objectWithContext),
+      },
+      {
+        label: i18n._(t`Duplicate`),
+        click: () => this._duplicateObject(objectWithContext),
+      },
+      { type: 'separator' },
+      {
         label: i18n._(t`Edit object`),
         click: () => this.props.onEditObject(object),
       },
@@ -492,6 +510,15 @@ export default class ObjectsList extends React.Component<Props, State> {
       },
       { type: 'separator' },
       {
+        label: i18n._(t`Rename`),
+        click: () => this._editName(objectWithContext),
+      },
+      {
+        label: i18n._(t`Set as a global object`),
+        enabled: !isObjectWithContextGlobal(objectWithContext),
+        click: () => this._setAsGlobalObject(objectWithContext),
+      },
+      {
         label: i18n._(t`Tags`),
         submenu: buildTagsMenuTemplate({
           noTagLabel: 'No tags',
@@ -505,15 +532,6 @@ export default class ObjectsList extends React.Component<Props, State> {
         }),
       },
       {
-        label: i18n._(t`Rename`),
-        click: () => this._editName(objectWithContext),
-      },
-      {
-        label: i18n._(t`Set as a global object`),
-        enabled: !isObjectWithContextGlobal(objectWithContext),
-        click: () => this._setAsGlobalObject(objectWithContext),
-      },
-      {
         label: i18n._(t`Delete`),
         click: () => this._deleteObject(i18n, objectWithContext),
       },
@@ -521,24 +539,6 @@ export default class ObjectsList extends React.Component<Props, State> {
       {
         label: i18n._(t`Add a new object...`),
         click: () => this.onAddNewObject(),
-      },
-      { type: 'separator' },
-      {
-        label: i18n._(t`Copy`),
-        click: () => this._copyObject(objectWithContext),
-      },
-      {
-        label: i18n._(t`Cut`),
-        click: () => this._cutObject(i18n, objectWithContext),
-      },
-      {
-        label: getPasteLabel(objectWithContext.global),
-        enabled: Clipboard.has(CLIPBOARD_KIND),
-        click: () => this._paste(objectWithContext),
-      },
-      {
-        label: i18n._(t`Duplicate`),
-        click: () => this._duplicateObject(objectWithContext),
       },
     ];
   };

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -23,6 +23,7 @@ import {
   filterObjectsList,
   isSameObjectWithContext,
 } from './EnumerateObjects';
+import { type ObjectEditorTab } from '../ObjectEditor/ObjectEditorDialog';
 import type {
   ObjectWithContextList,
   ObjectWithContext,
@@ -121,7 +122,7 @@ type Props = {|
   getAllObjectTags: () => Tags,
   onChangeSelectedObjectTags: SelectedTags => void,
 
-  onEditObject: (object: gdObject, initialTab: ?string) => void,
+  onEditObject: (object: gdObject, initialTab: ?ObjectEditorTab) => void,
   onObjectCreated: gdObject => void,
   onObjectSelected: string => void,
   onObjectPasted?: gdObject => void,

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -127,6 +127,7 @@ type Props = {|
   onObjectSelected: string => void,
   onObjectPasted?: gdObject => void,
   canRenameObject: (newName: string) => boolean,
+  onAddObjectInstance: (objectName: string) => void,
 
   getThumbnail: (project: gdProject, object: Object) => string,
   unsavedChanges?: ?UnsavedChanges,
@@ -535,6 +536,11 @@ export default class ObjectsList extends React.Component<Props, State> {
       {
         label: i18n._(t`Delete`),
         click: () => this._deleteObject(i18n, objectWithContext),
+      },
+      { type: 'separator' },
+      {
+        label: i18n._(t`Add instance to the scene`),
+        click: () => this.props.onAddObjectInstance(object.getName()),
       },
       { type: 'separator' },
       {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -138,6 +138,7 @@ type State = {|
   editedObjectWithContext: ?ObjectWithContext,
   editedObjectInitialTab: ?ObjectEditorTab,
   variablesEditedInstance: ?gdInitialInstance,
+  ignoreSelectedObjectNamesForContextMenu: boolean,
   selectedObjectNames: Array<string>,
   newObjectInstanceSceneCoordinates: ?[number, number],
 
@@ -190,6 +191,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       editedObjectWithContext: null,
       editedObjectInitialTab: 'properties',
       variablesEditedInstance: null,
+      ignoreSelectedObjectNamesForContextMenu: false,
       selectedObjectNames: [],
       newObjectInstanceSceneCoordinates: null,
       editedGroup: null,
@@ -851,13 +853,27 @@ export default class SceneEditor extends React.Component<Props, State> {
     if (this.editor) this.editor.zoomBy(-0.1);
   };
 
-  _onContextMenu = (x: number, y: number) => {
-    if (this.contextMenu) this.contextMenu.open(x, y);
+  _onContextMenu = (
+    x: number,
+    y: number,
+    ignoreSelectedObjectNamesForContextMenu?: boolean = false
+  ) => {
+    if (!ignoreSelectedObjectNamesForContextMenu) {
+      if (this.contextMenu) this.contextMenu.open(x, y);
+    } else {
+      this.setState({ ignoreSelectedObjectNamesForContextMenu: true }, () => {
+        if (this.contextMenu) this.contextMenu.open(x, y);
+        this.setState({ ignoreSelectedObjectNamesForContextMenu: false });
+      });
+    }
   };
 
   buildContextMenu = (i18n: I18nType, layout: gdLayout) => {
     let contextMenuItems = [];
-    if (this.state.selectedObjectNames.length === 0) {
+    if (
+      this.state.ignoreSelectedObjectNamesForContextMenu ||
+      this.state.selectedObjectNames.length === 0
+    ) {
       contextMenuItems = [
         ...contextMenuItems,
         {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -139,7 +139,6 @@ type State = {|
   editedObjectWithContext: ?ObjectWithContext,
   editedObjectInitialTab: ?ObjectEditorTab,
   variablesEditedInstance: ?gdInitialInstance,
-  ignoreSelectedObjectNamesForContextMenu: boolean,
   selectedObjectNames: Array<string>,
   newObjectInstanceSceneCoordinates: ?[number, number],
 
@@ -192,7 +191,6 @@ export default class SceneEditor extends React.Component<Props, State> {
       editedObjectWithContext: null,
       editedObjectInitialTab: 'properties',
       variablesEditedInstance: null,
-      ignoreSelectedObjectNamesForContextMenu: false,
       selectedObjectNames: [],
       newObjectInstanceSceneCoordinates: null,
       editedGroup: null,
@@ -868,20 +866,16 @@ export default class SceneEditor extends React.Component<Props, State> {
     y: number,
     ignoreSelectedObjectNamesForContextMenu?: boolean = false
   ) => {
-    if (!ignoreSelectedObjectNamesForContextMenu) {
-      if (this.contextMenu) this.contextMenu.open(x, y);
-    } else {
-      this.setState({ ignoreSelectedObjectNamesForContextMenu: true }, () => {
-        if (this.contextMenu) this.contextMenu.open(x, y);
-        this.setState({ ignoreSelectedObjectNamesForContextMenu: false });
+    if (this.contextMenu)
+      this.contextMenu.open(x, y, {
+        ignoreSelectedObjectNamesForContextMenu: !!ignoreSelectedObjectNamesForContextMenu,
       });
-    }
   };
 
-  buildContextMenu = (i18n: I18nType, layout: gdLayout) => {
+  buildContextMenu = (i18n: I18nType, layout: gdLayout, options: any) => {
     let contextMenuItems = [];
     if (
-      this.state.ignoreSelectedObjectNamesForContextMenu ||
+      options.ignoreSelectedObjectNamesForContextMenu ||
       this.state.selectedObjectNames.length === 0
     ) {
       contextMenuItems = [
@@ -1594,7 +1588,9 @@ export default class SceneEditor extends React.Component<Props, State> {
               />
               <ContextMenu
                 ref={contextMenu => (this.contextMenu = contextMenu)}
-                buildMenuTemplate={() => this.buildContextMenu(i18n, layout)}
+                buildMenuTemplate={(i18n, buildOptions) =>
+                  this.buildContextMenu(i18n, layout, buildOptions)
+                }
               />
             </React.Fragment>
           )}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -21,6 +21,7 @@ import ObjectGroupEditorDialog from '../ObjectGroupEditor/ObjectGroupEditorDialo
 import InstancesSelection from '../InstancesEditor/InstancesSelection';
 import SetupGridDialog from './SetupGridDialog';
 import ScenePropertiesDialog from './ScenePropertiesDialog';
+import { type ObjectEditorTab } from '../ObjectEditor/ObjectEditorDialog';
 import Toolbar from './Toolbar';
 import {
   serializeToJSObject,
@@ -135,7 +136,7 @@ type State = {|
   editedLayer: ?gdLayer,
   editedLayerInitialTab: 'properties' | 'effects',
   editedObjectWithContext: ?ObjectWithContext,
-  editedObjectInitialTab: ?string,
+  editedObjectInitialTab: ?ObjectEditorTab,
   variablesEditedInstance: ?gdInitialInstance,
   selectedObjectNames: Array<string>,
   newObjectInstanceSceneCoordinates: ?[number, number],
@@ -362,7 +363,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.setState({ layoutVariablesDialogOpen: open });
   };
 
-  editObject = (editedObject: ?gdObject, initialTab: ?string) => {
+  editObject = (editedObject: ?gdObject, initialTab: ?ObjectEditorTab) => {
     const { project } = this.props;
     if (editedObject) {
       this.setState({

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -32,7 +32,7 @@ import Window from '../Utils/Window';
 import FullSizeInstancesEditorWithScrollbars from '../InstancesEditor/FullSizeInstancesEditorWithScrollbars';
 import EditorMosaic from '../UI/EditorMosaic';
 import DismissableInfoBar from '../UI/Messages/DismissableInfoBar';
-import ContextMenu from '../UI/Menu/ContextMenu';
+import ContextMenu, { type ContextMenuInterface } from '../UI/Menu/ContextMenu';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import { shortenString } from '../Utils/StringHelpers';
 import getObjectByName from '../Utils/GetObjectByName';
@@ -168,7 +168,7 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   instancesSelection: InstancesSelection;
   editor: ?InstancesEditor;
-  contextMenu: ?ContextMenu;
+  contextMenu: ?ContextMenuInterface;
   editorMosaic: ?EditorMosaic;
   _objectsList: ?ObjectsList;
   _layersList: ?LayersList;

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1009,21 +1009,17 @@ export default class SceneEditor extends React.Component<Props, State> {
 
     if (!this.editor) return;
 
-    const newInstances = serializedSelection
-      .map(serializedInstance => {
-        const instance = new gd.InitialInstance();
-        unserializeFromJSObject(instance, serializedInstance);
-        return instance;
-      })
-      .map(instance => {
-        instance.setX(instance.getX() + 2 * MOVEMENT_BIG_DELTA);
-        instance.setY(instance.getY() + 2 * MOVEMENT_BIG_DELTA);
-        const newInstance = this.props.initialInstances
-          .insertInitialInstance(instance)
-          .resetPersistentUuid();
-        instance.delete();
-        return newInstance;
-      });
+    const newInstances = serializedSelection.map(serializedInstance => {
+      const instance = new gd.InitialInstance();
+      unserializeFromJSObject(instance, serializedInstance);
+      instance.setX(instance.getX() + 2 * MOVEMENT_BIG_DELTA);
+      instance.setY(instance.getY() + 2 * MOVEMENT_BIG_DELTA);
+      const newInstance = this.props.initialInstances
+        .insertInitialInstance(instance)
+        .resetPersistentUuid();
+      instance.delete();
+      return newInstance;
+    });
     this._onInstancesAdded(newInstances);
     this.instancesSelection.clearSelection();
     this.instancesSelection.selectInstances(newInstances, true);
@@ -1045,21 +1041,17 @@ export default class SceneEditor extends React.Component<Props, State> {
     const y = SafeExtractor.extractNumberProperty(clipboardContent, 'y');
     if (x === null || y === null || instancesContent === null) return;
 
-    const newInstances = instancesContent
-      .map(serializedInstance => {
-        const instance = new gd.InitialInstance();
-        unserializeFromJSObject(instance, serializedInstance);
-        return instance;
-      })
-      .map(instance => {
-        instance.setX(instance.getX() - x + position[0]);
-        instance.setY(instance.getY() - y + position[1]);
-        const newInstance = this.props.initialInstances
-          .insertInitialInstance(instance)
-          .resetPersistentUuid();
-        instance.delete();
-        return newInstance;
-      });
+    const newInstances = instancesContent.map(serializedInstance => {
+      const instance = new gd.InitialInstance();
+      unserializeFromJSObject(instance, serializedInstance);
+      instance.setX(instance.getX() - x + position[0]);
+      instance.setY(instance.getY() - y + position[1]);
+      const newInstance = this.props.initialInstances
+        .insertInitialInstance(instance)
+        .resetPersistentUuid();
+      instance.delete();
+      return newInstance;
+    });
     this._onInstancesAdded(newInstances);
     this.instancesSelection.clearSelection();
     this.instancesSelection.selectInstances(newInstances, true);

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -472,6 +472,15 @@ export default class SceneEditor extends React.Component<Props, State> {
     });
   };
 
+  addInstanceAtTheCenter = (objectName: string) => {
+    const { editor } = this;
+    if (editor)
+      this._addInstance(
+        [editor.grid.viewPosition.viewX, editor.grid.viewPosition.viewY],
+        objectName
+      );
+  };
+
   _addInstance = (pos: [number, number], objectName: string) => {
     if (!objectName || !this.editor) return;
 
@@ -1235,6 +1244,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 onObjectCreated={this._onObjectCreated}
                 onObjectSelected={this._onObjectSelected}
                 onRenameObject={this._onRenameObject}
+                onAddObjectInstance={this.addInstanceAtTheCenter}
                 onObjectPasted={() => this.updateBehaviorsSharedData()}
                 selectedObjectTags={this.state.selectedObjectTags}
                 onChangeSelectedObjectTags={selectedObjectTags =>

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -5,7 +5,7 @@ import React, { Component, useEffect, type Node, useRef } from 'react';
 import Close from '@material-ui/icons/Close';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import ThemeConsumer from './Theme/ThemeConsumer';
-import ContextMenu from './Menu/ContextMenu';
+import ContextMenu, { type ContextMenuInterface } from './Menu/ContextMenu';
 import { useLongTouch } from '../Utils/UseLongTouch';
 
 const styles = {
@@ -135,7 +135,7 @@ export function ClosableTab({
     },
     [active, onActivated]
   );
-  const contextMenu = useRef<ContextMenu>(null);
+  const contextMenu = useRef<?ContextMenuInterface>(null);
 
   const openContextMenu = event => {
     event.stopPropagation();

--- a/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
@@ -1,5 +1,7 @@
 import { isMacLike } from '../../Utils/Platform';
 
+export const MOVEMENT_BIG_DELTA = 5;
+
 const CTRL_KEY = 17;
 const SHIFT_KEY = 16;
 const LEFT_KEY = 37;
@@ -123,13 +125,13 @@ export default class DeprecatedKeyboardShortcuts {
 
     if (this.onMove) {
       if (evt.which === UP_KEY) {
-        this.shiftPressed ? this.onMove(0, -5) : this.onMove(0, -1);
+        this.shiftPressed ? this.onMove(0, -MOVEMENT_BIG_DELTA) : this.onMove(0, -1);
       } else if (evt.which === DOWN_KEY) {
-        this.shiftPressed ? this.onMove(0, 5) : this.onMove(0, 1);
+        this.shiftPressed ? this.onMove(0, MOVEMENT_BIG_DELTA) : this.onMove(0, 1);
       } else if (evt.which === LEFT_KEY) {
-        this.shiftPressed ? this.onMove(-5, 0) : this.onMove(-1, 0);
+        this.shiftPressed ? this.onMove(-MOVEMENT_BIG_DELTA, 0) : this.onMove(-1, 0);
       } else if (evt.which === RIGHT_KEY) {
-        this.shiftPressed ? this.onMove(5, 0) : this.onMove(1, 0);
+        this.shiftPressed ? this.onMove(MOVEMENT_BIG_DELTA, 0) : this.onMove(1, 0);
       }
     }
     if (evt.which === BACKSPACE_KEY || evt.which === DELETE_KEY) {

--- a/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/DeprecatedKeyboardShortcuts.js
@@ -125,13 +125,21 @@ export default class DeprecatedKeyboardShortcuts {
 
     if (this.onMove) {
       if (evt.which === UP_KEY) {
-        this.shiftPressed ? this.onMove(0, -MOVEMENT_BIG_DELTA) : this.onMove(0, -1);
+        this.shiftPressed
+          ? this.onMove(0, -MOVEMENT_BIG_DELTA)
+          : this.onMove(0, -1);
       } else if (evt.which === DOWN_KEY) {
-        this.shiftPressed ? this.onMove(0, MOVEMENT_BIG_DELTA) : this.onMove(0, 1);
+        this.shiftPressed
+          ? this.onMove(0, MOVEMENT_BIG_DELTA)
+          : this.onMove(0, 1);
       } else if (evt.which === LEFT_KEY) {
-        this.shiftPressed ? this.onMove(-MOVEMENT_BIG_DELTA, 0) : this.onMove(-1, 0);
+        this.shiftPressed
+          ? this.onMove(-MOVEMENT_BIG_DELTA, 0)
+          : this.onMove(-1, 0);
       } else if (evt.which === RIGHT_KEY) {
-        this.shiftPressed ? this.onMove(MOVEMENT_BIG_DELTA, 0) : this.onMove(1, 0);
+        this.shiftPressed
+          ? this.onMove(MOVEMENT_BIG_DELTA, 0)
+          : this.onMove(1, 0);
       }
     }
     if (evt.which === BACKSPACE_KEY || evt.which === DELETE_KEY) {

--- a/newIDE/app/src/UI/Menu/ContextMenu.js
+++ b/newIDE/app/src/UI/Menu/ContextMenu.js
@@ -15,17 +15,19 @@ class MaterialUIContextMenu extends React.Component {
       open: false,
       anchorX: 0,
       anchorY: 0,
+      buildOptions: {},
     };
     this.menuImplementation = new MaterialUIMenuImplementation({
       onClose: this._onClose,
     });
   }
 
-  open = (x, y) => {
+  open = (x, y, options) => {
     this.setState(
       {
         anchorX: x,
         anchorY: y,
+        buildOptions: options
       },
       () => {
         this.setState({
@@ -57,7 +59,7 @@ class MaterialUIContextMenu extends React.Component {
             {...this.menuImplementation.getMenuProps()}
           >
             {this.menuImplementation.buildFromTemplate(
-              this.props.buildMenuTemplate(i18n)
+              this.props.buildMenuTemplate(i18n, this.state.buildOptions)
             )}
           </Menu>
         )}
@@ -75,9 +77,9 @@ class ElectronContextMenu extends React.Component {
     this.menuImplementation = new ElectronMenuImplementation();
   }
 
-  open = (x, y) => {
+  open = (x, y, options) => {
     this.menuImplementation.buildFromTemplate(
-      this.props.buildMenuTemplate(this.props.i18n)
+      this.props.buildMenuTemplate(this.props.i18n, options)
     );
     this.menuImplementation.showMenu({
       left: x || 0,
@@ -95,8 +97,8 @@ class ElectronContextMenu extends React.Component {
 const ElectronContextMenuWrapper = React.forwardRef((props, ref) => {
   const electronContextMenu = React.useRef(null);
   React.useImperativeHandle(ref, () => ({
-    open: (x, y) => {
-      if (electronContextMenu.current) electronContextMenu.current.open(x, y);
+    open: (x, y, options) => {
+      if (electronContextMenu.current) electronContextMenu.current.open(x, y, options);
     },
   }));
 

--- a/newIDE/app/src/UI/Menu/ContextMenu.js
+++ b/newIDE/app/src/UI/Menu/ContextMenu.js
@@ -1,6 +1,8 @@
-// TODO: this needs to be flow-typed
+// @flow
 import React from 'react';
 import { I18n } from '@lingui/react';
+import { type I18n as I18nType } from '@lingui/core';
+import { type MenuItemTemplate } from './Menu.flow';
 import Menu from '@material-ui/core/Menu';
 import Fade from '@material-ui/core/Fade';
 import ElectronMenuImplementation from './ElectronMenuImplementation';
@@ -8,80 +10,81 @@ import MaterialUIMenuImplementation from './MaterialUIMenuImplementation';
 import optionalRequire from '../../Utils/OptionalRequire.js';
 const electron = optionalRequire('electron');
 
-class MaterialUIContextMenu extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      open: false,
-      anchorX: 0,
-      anchorY: 0,
-      buildOptions: {},
-    };
-    this.menuImplementation = new MaterialUIMenuImplementation({
-      onClose: this._onClose,
-    });
-  }
+export type ContextMenuInterface = {|
+  open: (x: number, y: number, options: any) => void,
+|};
 
-  open = (x, y, options) => {
-    this.setState(
-      {
-        anchorX: x,
-        anchorY: y,
-        buildOptions: options,
-      },
-      () => {
-        this.setState({
-          open: true,
-        });
-      }
-    );
+type ContextMenuProps = {|
+  buildMenuTemplate: (i18n: I18nType, options: any) => Array<MenuItemTemplate>,
+|};
+
+const MaterialUIContextMenu = React.forwardRef<
+  ContextMenuProps,
+  ContextMenuInterface
+>((props, ref) => {
+  const [anchorPosition, setAnchorPosition] = React.useState<Array<number>>([
+    0,
+    0,
+  ]);
+  const [openMenu, setOpenMenu] = React.useState<boolean>(false);
+  const [buildOptions, setBuildOptions] = React.useState<any>({});
+
+  const menuImplementation = new MaterialUIMenuImplementation({
+    onClose: () => setOpenMenu(false),
+  });
+
+  const open = (x, y, options) => {
+    setAnchorPosition([x, y]);
+    setBuildOptions(options);
+    setOpenMenu(true);
   };
 
-  _onClose = () => {
-    this.setState({
-      open: false,
-    });
-  };
+  React.useImperativeHandle(ref, () => ({
+    open,
+  }));
 
-  render() {
-    return this.state.open ? (
-      <I18n>
-        {({ i18n }) => (
-          <Menu
-            open={this.state.open}
-            anchorPosition={{
-              left: this.state.anchorX,
-              top: this.state.anchorY,
-            }}
-            anchorReference={'anchorPosition'}
-            onClose={this._onClose}
-            TransitionComponent={Fade}
-            {...this.menuImplementation.getMenuProps()}
-          >
-            {this.menuImplementation.buildFromTemplate(
-              this.props.buildMenuTemplate(i18n, this.state.buildOptions)
-            )}
-          </Menu>
-        )}
-      </I18n>
-    ) : // Don't render the menu when it's not opened, as `buildMenuTemplate` could
-    // be running logic to compute some labels or `enabled` flag values - and might
-    // not be prepared to do that when the menu is not opened.
-    null;
-  }
-}
+  return openMenu ? (
+    <I18n>
+      {({ i18n }) => (
+        <Menu
+          open={open}
+          anchorPosition={{
+            left: anchorPosition[0],
+            top: anchorPosition[1],
+          }}
+          anchorReference={'anchorPosition'}
+          onClose={() => setOpenMenu(false)}
+          TransitionComponent={Fade}
+          {...menuImplementation.getMenuProps()}
+        >
+          {menuImplementation.buildFromTemplate(
+            props.buildMenuTemplate(i18n, buildOptions)
+          )}
+        </Menu>
+      )}
+    </I18n>
+  ) : // Don't render the menu when it's not opened, as `buildMenuTemplate` could
+  // be running logic to compute some labels or `enabled` flag values - and might
+  // not be prepared to do that when the menu is not opened.
+  null;
+});
 
-class ElectronContextMenu extends React.Component {
-  constructor(props) {
-    super(props);
-    this.menuImplementation = new ElectronMenuImplementation();
-  }
+type ElectronContextMenuProps = {|
+  ...ContextMenuProps,
+  i18n: I18nType,
+|};
 
-  open = (x, y, options) => {
-    this.menuImplementation.buildFromTemplate(
-      this.props.buildMenuTemplate(this.props.i18n, options)
+const ElectronContextMenu = React.forwardRef<
+  ElectronContextMenuProps,
+  ContextMenuInterface
+>((props, ref) => {
+  const menuImplementation = new ElectronMenuImplementation();
+
+  const open = (x, y, options) => {
+    menuImplementation.buildFromTemplate(
+      props.buildMenuTemplate(props.i18n, options)
     );
-    this.menuImplementation.showMenu({
+    menuImplementation.showMenu({
       left: x || 0,
       top: y || 0,
       width: 0,
@@ -89,13 +92,18 @@ class ElectronContextMenu extends React.Component {
     });
   };
 
-  render() {
-    return null;
-  }
-}
+  React.useImperativeHandle(ref, () => ({
+    open,
+  }));
 
-const ElectronContextMenuWrapper = React.forwardRef((props, ref) => {
-  const electronContextMenu = React.useRef(null);
+  return null;
+});
+
+const ElectronContextMenuWrapper = React.forwardRef<
+  ContextMenuProps,
+  ContextMenuInterface
+>((props, ref) => {
+  const electronContextMenu = React.useRef<?ContextMenuInterface>(null);
   React.useImperativeHandle(ref, () => ({
     open: (x, y, options) => {
       if (electronContextMenu.current)

--- a/newIDE/app/src/UI/Menu/ContextMenu.js
+++ b/newIDE/app/src/UI/Menu/ContextMenu.js
@@ -27,7 +27,7 @@ class MaterialUIContextMenu extends React.Component {
       {
         anchorX: x,
         anchorY: y,
-        buildOptions: options
+        buildOptions: options,
       },
       () => {
         this.setState({
@@ -98,7 +98,8 @@ const ElectronContextMenuWrapper = React.forwardRef((props, ref) => {
   const electronContextMenu = React.useRef(null);
   React.useImperativeHandle(ref, () => ({
     open: (x, y, options) => {
-      if (electronContextMenu.current) electronContextMenu.current.open(x, y, options);
+      if (electronContextMenu.current)
+        electronContextMenu.current.open(x, y, options);
     },
   }));
 

--- a/newIDE/app/src/UI/Menu/ElementWithMenu.js
+++ b/newIDE/app/src/UI/Menu/ElementWithMenu.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { type I18n as I18nType } from '@lingui/core';
 import ReactDOM from 'react-dom';
-import ContextMenu from './ContextMenu';
+import ContextMenu, { type ContextMenuInterface } from './ContextMenu';
 import { type MenuItemTemplate } from './Menu.flow';
 
 type Props = {|
@@ -19,7 +19,7 @@ type State = {||};
  */
 
 export default class ElementWithMenu extends React.Component<Props, State> {
-  _contextMenu: ?ContextMenu;
+  _contextMenu: ?ContextMenuInterface;
   _wrappedElement: ?any;
 
   open = () => {

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -1865,6 +1865,7 @@ storiesOf('UI Building Blocks/ClosableTabs', module)
                     onChooseResource={() => Promise.reject('unimplemented')}
                     resourceExternalEditors={fakeResourceExternalEditors}
                     onEditObject={action('On edit object')}
+                    onAddObjectInstance={action('On add instance to the scene')}
                     selectedObjectNames={[]}
                     selectedObjectTags={[]}
                     onChangeSelectedObjectTags={() => {}}
@@ -3557,6 +3558,7 @@ storiesOf('ObjectsList', module)
             onChooseResource={() => Promise.reject('unimplemented')}
             resourceExternalEditors={fakeResourceExternalEditors}
             onEditObject={action('On edit object')}
+            onAddObjectInstance={action('On add instance to the scene')}
             onObjectCreated={action('On object created')}
             selectedObjectNames={[]}
             selectedObjectTags={[]}
@@ -3586,6 +3588,7 @@ storiesOf('ObjectsList', module)
             onChooseResource={() => Promise.reject('unimplemented')}
             resourceExternalEditors={fakeResourceExternalEditors}
             onEditObject={action('On edit object')}
+            onAddObjectInstance={action('On add instance to the scene')}
             onObjectCreated={action('On object created')}
             selectedObjectNames={[]}
             selectedObjectTags={['Tag1', 'Tag2']}


### PR DESCRIPTION
- Right-click on instance:

  <img width="293" alt="image" src="https://user-images.githubusercontent.com/32449369/156190425-1134c91f-befe-43ca-aaf4-95e53c0513b5.png">

- Right-click on background (even if instance or object is selected):

  <img width="377" alt="image" src="https://user-images.githubusercontent.com/32449369/156190543-098a6be6-2618-4a14-8754-f464b1db070b.png">

- Right-click on object:
  - Action `Add instance to the scene` adds an instance at the center of the scene

  <img width="290" alt="image" src="https://user-images.githubusercontent.com/32449369/156190609-84ac852a-bf32-4c06-aa01-4c4e88809322.png">

- Duplicate action on instances adds duplicates on the lower right side, at the distance of 2 shift+arrow moves:
   
  <img width="247" alt="image" src="https://user-images.githubusercontent.com/32449369/156191049-2e6e09db-5cca-4bd9-933c-7dfe33f7fd98.png">
