### PR TITLE
Add Liluo Link on homepage

### DIFF
--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -272,7 +272,7 @@ export default class AboutDialog extends PureComponent<Props, State> {
             key="website"
             label={<Trans>GDevelop Website</Trans>}
             primary={false}
-            onClick={() => Window.openExternalURL('http://gdevelop-app.com')}
+            onClick={() => Window.openExternalURL('https://gdevelop.io')}
           />,
           <FlatButton
             key="close"

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -403,6 +403,14 @@ export const HomePage = React.memo<Props>(
                           : null
                       }
                       displayItemTitles
+                      additionalAction={
+                        <RaisedButton
+                          label={<Trans>Play on Liluo.io</Trans>}
+                          onClick={() =>
+                            Window.openExternalURL('https://liluo.io')
+                          }
+                        />
+                      }
                       onBrowseAllClick={onOpenGamesShowcase}
                       browseAllLabel={<Trans>Browse all</Trans>}
                       error={

--- a/newIDE/app/src/UI/Carousel.js
+++ b/newIDE/app/src/UI/Carousel.js
@@ -32,6 +32,7 @@ type SkeletonThumbnail = {
 type Props<ThumbnailType> = {|
   title: React.Node,
   items: ?Array<ThumbnailType>,
+  additionalAction?: React.Node,
   onBrowseAllClick?: () => void,
   browseAllLink?: string,
   browseAllLabel: React.Node,
@@ -122,6 +123,7 @@ const useStylesForLeftArrow = makeStyles({
 const Carousel = <ThumbnailType: Thumbnail>({
   title,
   items,
+  additionalAction,
   browseAllLink,
   onBrowseAllClick,
   browseAllLabel,
@@ -369,16 +371,24 @@ const Carousel = <ThumbnailType: Thumbnail>({
           width: `calc(100% - ${2 * arrowWidth}px - ${rightArrowMargin}px)`,
         }}
       >
-        <Line noMargin justifyContent="space-between" alignItems="center">
+        <Line justifyContent="space-between" alignItems="center">
           <Text size="bold-title">{title}</Text>
-          <FlatButton
-            onClick={
-              onBrowseAllClick ||
-              (browseAllLink ? openLinkCallback(browseAllLink) : () => {})
-            }
-            label={browseAllLabel}
-            icon={<ListOutlined />}
-          />
+          <Line>
+            {additionalAction && (
+              <>
+                {additionalAction}
+                <Spacer />
+              </>
+            )}
+            <FlatButton
+              onClick={
+                onBrowseAllClick ||
+                (browseAllLink ? openLinkCallback(browseAllLink) : () => {})
+              }
+              label={browseAllLabel}
+              icon={<ListOutlined />}
+            />
+          </Line>
         </Line>
         {error ? (
           <div style={{ ...styles.error, height: cellHeight }}>


### PR DESCRIPTION
We could also add it in the Games Showcase Dialog, but it's slightly harder, as the Dialog is shared for Examples/Tutorials/Showcase games and already has a button at the bottom to create a blank project, so I feel this would just clutter the space.
Or we need to split the dialogs into 3, to have control over each. (could be a good idea, as the title of the dialog is always "create a new project, even for tutorials & games...)

<img width="1207" alt="image" src="https://user-images.githubusercontent.com/4895034/156601831-56ee02e7-7102-43ae-83ff-41e2afa84279.png">
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/4895034/156602258-82a7efba-91f8-479c-b7eb-f69205aabd7b.png">

