### PR TITLE
Fix resource list not updated when adding some with tab opened

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -31,6 +31,15 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
     // No updates to be done.
   }
 
+  componentDidUpdate(prevProps: RenderEditorContainerProps) {
+    if (
+      this.editor &&
+      this.props.isActive &&
+      prevProps.isActive !== this.props.isActive
+    )
+      this.editor.refreshResourcesList();
+  }
+
   render() {
     const { project } = this.props;
     if (!project) return null;

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -72,6 +72,10 @@ export default class ResourcesEditor extends React.Component<Props, State> {
     selectedResource: null,
   };
 
+  refreshResourcesList() {
+    if (this._resourcesList) this._resourcesList.forceUpdate();
+  }
+
   updateToolbar() {
     this.props.setToolbar(
       <Toolbar

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -45,6 +45,7 @@ type State = {|
   renamedResource: ?gdResource,
   searchText: string,
   resourcesWithErrors: { [string]: '' | 'error' | 'warning' },
+  resourceNamesList: string[],
 |};
 
 type Props = {|
@@ -67,7 +68,16 @@ export default class ResourcesList extends React.Component<Props, State> {
     renamedResource: null,
     searchText: '',
     resourcesWithErrors: {},
+    resourceNamesList: [],
   };
+
+  _shouldListUpdate(project: gdProject) {
+    const projectResourceNames = project
+      .getResourcesManager()
+      .getAllResourceNames()
+      .toJSArray();
+    return this.state.resourceNamesList.length !== projectResourceNames.length;
+  }
 
   shouldComponentUpdate(nextProps: Props, nextState: State) {
     // The component is costly to render, so avoid any re-rendering as much
@@ -82,6 +92,10 @@ export default class ResourcesList extends React.Component<Props, State> {
       this.state.searchText !== nextState.searchText
     )
       return true;
+
+    if (this._shouldListUpdate(nextProps.project)) {
+      return true;
+    }
 
     if (
       this.props.project !== nextProps.project ||
@@ -327,15 +341,26 @@ export default class ResourcesList extends React.Component<Props, State> {
     this.checkMissingPaths();
   }
 
+  componentDidUpdate() {
+    const resourcesManager = this.props.project.getResourcesManager();
+
+    const resourceNamesList = resourcesManager
+      .getAllResourceNames()
+      .toJSArray();
+    this.setState({ resourceNamesList });
+  }
+
   render() {
     const { project, selectedResource, onSelectResource } = this.props;
     const { searchText } = this.state;
 
     const resourcesManager = project.getResourcesManager();
-    const allResourcesList = resourcesManager
+    const resourceNamesList = resourcesManager
       .getAllResourceNames()
-      .toJSArray()
-      .map(resourceName => resourcesManager.getResource(resourceName));
+      .toJSArray();
+    const allResourcesList = resourceNamesList.map(resourceName =>
+      resourcesManager.getResource(resourceName)
+    );
     const filteredList = filterResourcesList(allResourcesList, searchText);
 
     // Force List component to be mounted again if project

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -45,7 +45,6 @@ type State = {|
   renamedResource: ?gdResource,
   searchText: string,
   resourcesWithErrors: { [string]: '' | 'error' | 'warning' },
-  resourceNamesList: string[],
 |};
 
 type Props = {|
@@ -68,16 +67,7 @@ export default class ResourcesList extends React.Component<Props, State> {
     renamedResource: null,
     searchText: '',
     resourcesWithErrors: {},
-    resourceNamesList: [],
   };
-
-  _shouldListUpdate(project: gdProject) {
-    const projectResourceNames = project
-      .getResourcesManager()
-      .getAllResourceNames()
-      .toJSArray();
-    return this.state.resourceNamesList.length !== projectResourceNames.length;
-  }
 
   shouldComponentUpdate(nextProps: Props, nextState: State) {
     // The component is costly to render, so avoid any re-rendering as much
@@ -92,10 +82,6 @@ export default class ResourcesList extends React.Component<Props, State> {
       this.state.searchText !== nextState.searchText
     )
       return true;
-
-    if (this._shouldListUpdate(nextProps.project)) {
-      return true;
-    }
 
     if (
       this.props.project !== nextProps.project ||
@@ -341,26 +327,15 @@ export default class ResourcesList extends React.Component<Props, State> {
     this.checkMissingPaths();
   }
 
-  componentDidUpdate() {
-    const resourcesManager = this.props.project.getResourcesManager();
-
-    const resourceNamesList = resourcesManager
-      .getAllResourceNames()
-      .toJSArray();
-    this.setState({ resourceNamesList });
-  }
-
   render() {
     const { project, selectedResource, onSelectResource } = this.props;
     const { searchText } = this.state;
 
     const resourcesManager = project.getResourcesManager();
-    const resourceNamesList = resourcesManager
+    const allResourcesList = resourcesManager
       .getAllResourceNames()
-      .toJSArray();
-    const allResourcesList = resourceNamesList.map(resourceName =>
-      resourcesManager.getResource(resourceName)
-    );
+      .toJSArray()
+      .map(resourceName => resourcesManager.getResource(resourceName));
     const filteredList = filterResourcesList(allResourcesList, searchText);
 
     // Force List component to be mounted again if project


### PR DESCRIPTION
Partially deals with #2630

Update resource list after adding a resource with resource tab opened. We do not need to close/open the tab again to see resource changes.