### PR TITLE
[Platformer] Fix the "Is moving" condition by removing the 1 pixel per frame constraint

### DIFF
--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -43,6 +43,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         std::make_shared<PlatformerObjectBehavior>(),
         std::make_shared<gd::BehaviorsSharedData>());
 
+    // Deprecated, use IsMovingEvenALittle instead
     aut.AddCondition("IsMoving",
                      _("Is moving"),
                      _("Check if the object is moving (whether it is on the "
@@ -53,8 +54,21 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
                      "CppPlatform/Extensions/platformerobjecticon.png")
         .AddParameter("object", _("Object"))
         .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .SetHidden()
         .MarkAsSimple()
         .SetFunctionName("IsMoving");
+
+    aut.AddScopedCondition("IsMovingEvenALittle",
+                     _("Is moving"),
+                     _("Check if the object is moving (whether it is on the "
+                       "floor or in the air)."),
+                     _("_PARAM0_ is moving"),
+                     "",
+                     "CppPlatform/Extensions/platformerobjecticon.png",
+                     "CppPlatform/Extensions/platformerobjecticon.png")
+        .AddParameter("object", _("Object"))
+        .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
+        .MarkAsSimple();
 
     aut.AddCondition("IsOnFloor",
                      _("Is on floor"),

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -53,6 +53,8 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
               "PlatformBehavior::PlatformerObjectBehavior");
 
       autConditions["PlatformBehavior::IsMoving"].SetFunctionName("isMoving");
+      autConditions["PlatformBehavior::PlatformerObjectBehavior::IsMovingEvenALittle"]
+          .SetFunctionName("isMovingEvenALittle");
       autConditions["PlatformBehavior::IsOnFloor"].SetFunctionName("isOnFloor");
       autConditions["PlatformBehavior::IsOnLadder"].SetFunctionName(
           "isOnLadder");

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -24,6 +24,11 @@ namespace gdjs {
       isCollidingAnyPlatform: false,
     };
 
+    /**
+     * A very small value compare to 1 pixel, yet very huge compare to rounding errors.
+     */
+    private static readonly epsilon = 2 ** -20;
+
     // Behavior configuration
 
     /** To achieve pixel-perfect precision when positioning object on platform or
@@ -314,8 +319,10 @@ namespace gdjs {
 
       //5) Track the movement
       this._hasReallyMoved =
-        Math.abs(object.getX() - oldX) > 0 ||
-        Math.abs(object.getY() - oldY) > 0;
+        Math.abs(object.getX() - oldX) >
+          PlatformerObjectRuntimeBehavior.epsilon ||
+        Math.abs(object.getY() - oldY) >
+          PlatformerObjectRuntimeBehavior.epsilon;
       this._hasMovedAtLeastOnePixel =
         Math.abs(object.getX() - oldX) >= 1 ||
         Math.abs(object.getY() - oldY) >= 1;

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -107,6 +107,8 @@ namespace gdjs {
     _overlappedJumpThru: Array<gdjs.PlatformRuntimeBehavior>;
 
     private _hasReallyMoved: boolean = false;
+    /** @deprecated use _hasReallyMoved instead */
+    private _hasMovedAtLeastOnePixel: boolean = false;
     private _manager: gdjs.PlatformObjectsManager;
 
     constructor(
@@ -312,6 +314,9 @@ namespace gdjs {
 
       //5) Track the movement
       this._hasReallyMoved =
+        Math.abs(object.getX() - oldX) > 0 ||
+        Math.abs(object.getY() - oldY) > 0;
+      this._hasMovedAtLeastOnePixel =
         Math.abs(object.getX() - oldX) >= 1 ||
         Math.abs(object.getY() - oldY) >= 1;
       this._lastDeltaY = object.getY() - oldY;
@@ -1543,9 +1548,27 @@ namespace gdjs {
 
     /**
      * Check if the Platformer Object is moving.
+     *
+     * When walking or climbing on a ladder,
+     * a speed of less than one pixel per frame won't be detected.
+     *
      * @returns Returns true if it is moving and false if not.
+     * @deprecated use isMovingEvenALittle instead
      */
     isMoving(): boolean {
+      return (
+        (this._hasMovedAtLeastOnePixel &&
+          (this._currentSpeed !== 0 || this._state === this._onLadder)) ||
+        this._jumping.getCurrentJumpSpeed() !== 0 ||
+        this._currentFallSpeed !== 0
+      );
+    }
+
+    /**
+     * Check if the Platformer Object is moving.
+     * @returns Returns true if it is moving and false if not.
+     */
+    isMovingEvenALittle(): boolean {
       return (
         (this._hasReallyMoved &&
           (this._currentSpeed !== 0 || this._state === this._onLadder)) ||


### PR DESCRIPTION
### Context
* A game creator in the forum is having an issue with the "Is moving" condition.
  https://forum.gdevelop.io/t/problems-with-animation-speed-for-plataform-behavior/38470/24
* The game is very low resolution and uses a 60 pixel per second walking speed.
* At about 60 fps, the character moves around 1 pixel per frame (sometimes more, sometimes less).

### Expected behavior
* The "Is moving" condition should be true when the character actually moves even a "little" because "little" is subjective.

### Actual behavior
* The "Is moving" condition is false when the character walks from less than 1 pixel per frame.
* In their game, this result to frequent restart of the walking animation.

### Solution
* The 1 pixel per frame limit is frame rate dependent. Thus, the compatibility can't be kept by adding a minimum speed parameter.
* The existing condition has been made deprecated.
* The new condition doesn't test any minimal speed. Game creators can add another condition for it if they see fit.

The tests could be updated to use the new method.