### PR TITLE
Make clearer that the publishing is an export

### DIFF
--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -128,6 +128,7 @@ const BehaviorsEditor = (props: Props) => {
             }
             actionLabel={<Trans>Add a behavior</Trans>}
             helpPagePath="/behaviors"
+            actionButtonId="add-behavior-button"
             onAdd={() => setNewBehaviorDialogOpen(true)}
           />
         </Column>

--- a/newIDE/app/src/Export/ExportDialog/ExportHome.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportHome.js
@@ -89,7 +89,7 @@ const ExportHome = ({
         <div style={styles.titleContainer}>
           <Line>
             <Text size="title">
-              <Trans>Publish your game on other stores</Trans>
+              <Trans>Export and publish on other platforms</Trans>
             </Text>
           </Line>
         </div>
@@ -110,7 +110,7 @@ const ExportHome = ({
               </Text>
             </Line>
             <RaisedButton
-              label={<Trans>Publish on stores</Trans>}
+              label={<Trans>Export to other platforms</Trans>}
               onClick={() => {
                 setChosenExporterSection('automated');
                 setChosenExporterKey('webexport');

--- a/newIDE/app/src/UI/EmptyPlaceholder.js
+++ b/newIDE/app/src/UI/EmptyPlaceholder.js
@@ -14,6 +14,7 @@ type Props = {|
   description: React.Node,
   actionLabel: React.Node,
   helpPagePath: string,
+  actionButtonId?: string,
   onAdd: () => void,
 |};
 
@@ -39,12 +40,11 @@ export const EmptyPlaceholder = (props: Props) => (
         <LargeSpacer />
         <ColumnStackLayout alignItems="center" noMargin>
           <RaisedButton
-            key="add-behavior-line"
             label={props.actionLabel}
             primary
             onClick={props.onAdd}
             icon={<Add />}
-            id="add-behavior-button"
+            id={props.actionButtonId}
           />
           <HelpButton
             label={<Trans>Read the doc</Trans>}


### PR DESCRIPTION
And a tiny fix too.

This removes the notion of "stores". I think this is not the last time we rework this, but for now this should avoid people wrongly clicking on "Build manually".

<img width="951" alt="image" src="https://user-images.githubusercontent.com/1280130/157030616-8ef459d1-e874-43a7-af57-ca4fab973b6c.png">

Fixes #3729