### PR TITLE
Add possibility to replace text in text events (Comments and Groups)

### DIFF
--- a/Core/GDCore/Events/Builtin/CommentEvent.cpp
+++ b/Core/GDCore/Events/Builtin/CommentEvent.cpp
@@ -21,6 +21,12 @@ vector<gd::String> CommentEvent::GetAllSearchableStrings() const {
   return allSearchableStrings;
 }
 
+bool CommentEvent::ReplaceAllInSearchableString(
+    std::vector<gd::String> newSearchableString) {
+  SetComment(newSearchableString[0]);
+  return newSearchableString[0] == com1;
+}
+
 void CommentEvent::SerializeTo(SerializerElement &element) const {
   element.AddChild("color")
       .SetAttribute("r", r)

--- a/Core/GDCore/Events/Builtin/CommentEvent.cpp
+++ b/Core/GDCore/Events/Builtin/CommentEvent.cpp
@@ -21,7 +21,7 @@ vector<gd::String> CommentEvent::GetAllSearchableStrings() const {
   return allSearchableStrings;
 }
 
-bool CommentEvent::ReplaceAllInSearchableString(
+bool CommentEvent::ReplaceAllSearchableStrings(
     std::vector<gd::String> newSearchableString) {
   SetComment(newSearchableString[0]);
   return newSearchableString[0] == com1;

--- a/Core/GDCore/Events/Builtin/CommentEvent.h
+++ b/Core/GDCore/Events/Builtin/CommentEvent.h
@@ -47,7 +47,7 @@ class GD_CORE_API CommentEvent : public gd::BaseEvent {
   void SetComment(const gd::String& comment) { com1 = comment; }
 
   virtual std::vector<gd::String> GetAllSearchableStrings() const;
-  virtual bool ReplaceAllInSearchableString(
+  virtual bool ReplaceAllSearchableStrings(
       std::vector<gd::String> newSearchableString);
 
   virtual void SerializeTo(SerializerElement& element) const;

--- a/Core/GDCore/Events/Builtin/CommentEvent.h
+++ b/Core/GDCore/Events/Builtin/CommentEvent.h
@@ -47,6 +47,8 @@ class GD_CORE_API CommentEvent : public gd::BaseEvent {
   void SetComment(const gd::String& comment) { com1 = comment; }
 
   virtual std::vector<gd::String> GetAllSearchableStrings() const;
+  virtual bool ReplaceAllInSearchableString(
+      std::vector<gd::String> newSearchableString);
 
   virtual void SerializeTo(SerializerElement& element) const;
   virtual void UnserializeFrom(gd::Project& project,

--- a/Core/GDCore/Events/Builtin/GroupEvent.cpp
+++ b/Core/GDCore/Events/Builtin/GroupEvent.cpp
@@ -27,7 +27,7 @@ vector<gd::String> GroupEvent::GetAllSearchableStrings() const {
   return allSearchableStrings;
 }
 
-bool GroupEvent::ReplaceAllInSearchableString(
+bool GroupEvent::ReplaceAllSearchableStrings(
     std::vector<gd::String> newSearchableString) {
   SetName(newSearchableString[0]);
   return newSearchableString[0] == name;

--- a/Core/GDCore/Events/Builtin/GroupEvent.cpp
+++ b/Core/GDCore/Events/Builtin/GroupEvent.cpp
@@ -27,6 +27,12 @@ vector<gd::String> GroupEvent::GetAllSearchableStrings() const {
   return allSearchableStrings;
 }
 
+bool GroupEvent::ReplaceAllInSearchableString(
+    std::vector<gd::String> newSearchableString) {
+  SetName(newSearchableString[0]);
+  return newSearchableString[0] == name;
+}
+
 void GroupEvent::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("name", name);
   element.SetAttribute("source", source);
@@ -68,6 +74,5 @@ void GroupEvent::SetBackgroundColor(unsigned int colorR_,
   colorG = colorG_;
   colorB = colorB_;
 }
-
 
 }  // namespace gd

--- a/Core/GDCore/Events/Builtin/GroupEvent.h
+++ b/Core/GDCore/Events/Builtin/GroupEvent.h
@@ -107,6 +107,8 @@ class GD_CORE_API GroupEvent : public gd::BaseEvent {
   virtual gd::EventsList& GetSubEvents() { return events; };
 
   virtual std::vector<gd::String> GetAllSearchableStrings() const;
+  virtual bool ReplaceAllInSearchableString(
+      std::vector<gd::String> newSearchableString);
 
   virtual void SerializeTo(SerializerElement& element) const;
   virtual void UnserializeFrom(gd::Project& project,

--- a/Core/GDCore/Events/Builtin/GroupEvent.h
+++ b/Core/GDCore/Events/Builtin/GroupEvent.h
@@ -107,7 +107,7 @@ class GD_CORE_API GroupEvent : public gd::BaseEvent {
   virtual gd::EventsList& GetSubEvents() { return events; };
 
   virtual std::vector<gd::String> GetAllSearchableStrings() const;
-  virtual bool ReplaceAllInSearchableString(
+  virtual bool ReplaceAllSearchableStrings(
       std::vector<gd::String> newSearchableString);
 
   virtual void SerializeTo(SerializerElement& element) const;

--- a/Core/GDCore/Events/Event.h
+++ b/Core/GDCore/Events/Event.h
@@ -126,12 +126,7 @@ class GD_CORE_API BaseEvent {
     return noSearchableStrings;
   };
 
-  /**
-   * \brief Replace searchable strings with new string vector, return true if
-   * string in event is modified.
-   * \note Used to preprocess or search in the event strings.
-   */
-  virtual bool ReplaceAllInSearchableString(
+  virtual bool ReplaceAllSearchableStrings(
       std::vector<gd::String> newSearchableString) {
     return false;
   };

--- a/Core/GDCore/Events/Event.h
+++ b/Core/GDCore/Events/Event.h
@@ -127,6 +127,16 @@ class GD_CORE_API BaseEvent {
   };
 
   /**
+   * \brief Replace searchable strings with new string vector, return true if
+   * string in event is modified.
+   * \note Used to preprocess or search in the event strings.
+   */
+  virtual bool ReplaceAllInSearchableString(
+      std::vector<gd::String> newSearchableString) {
+    return false;
+  };
+
+  /**
    * \brief Return a list of all expressions of the event, each with their associated metadata.
    * \note Used to preprocess or search in the expressions of the event.
    */

--- a/Core/GDCore/IDE/Events/EventsRefactorer.cpp
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.cpp
@@ -573,7 +573,7 @@ void EventsRefactorer::ReplaceStringInEvents(gd::ObjectsContainer& project,
     }
 
     if (inEventStrings) {
-      bool eventStringModified = ReplaceStringInStringEvent(
+      bool eventStringModified = ReplaceStringInEventSearchableStrings(
           project, layout, events[i], toReplace, newString, matchCase);
     }
 
@@ -684,13 +684,14 @@ bool EventsRefactorer::ReplaceStringInConditions(
   return somethingModified;
 }
 
-bool EventsRefactorer::ReplaceStringInStringEvent(gd::ObjectsContainer& project,
-                                                  gd::ObjectsContainer& layout,
-                                                  gd::BaseEvent& event,
-                                                  gd::String toReplace,
-                                                  gd::String newString,
-                                                  bool matchCase) {
-  vector<gd::String> newStringEvents;
+bool EventsRefactorer::ReplaceStringInEventSearchableStrings(
+    gd::ObjectsContainer& project,
+    gd::ObjectsContainer& layout,
+    gd::BaseEvent& event,
+    gd::String toReplace,
+    gd::String newString,
+    bool matchCase) {
+  vector<gd::String> newEventStrings;
   vector<gd::String> stringEvent = event.GetAllSearchableStrings();
 
   for (std::size_t sNb = 0; sNb < stringEvent.size(); ++sNb) {
@@ -698,10 +699,10 @@ bool EventsRefactorer::ReplaceStringInStringEvent(gd::ObjectsContainer& project,
         matchCase ? stringEvent[sNb].FindAndReplace(toReplace, newString, true)
                   : ReplaceAllOccurencesCaseUnsensitive(
                         stringEvent[sNb], toReplace, newString);
-    newStringEvents.push_back(newStringEvent);
+    newEventStrings.push_back(newStringEvent);
   }
 
-  bool somethingModified = event.ReplaceAllInSearchableString(newStringEvents);
+  bool somethingModified = event.ReplaceAllSearchableStrings(newEventStrings);
 
   return somethingModified;
 }

--- a/Core/GDCore/IDE/Events/EventsRefactorer.cpp
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.cpp
@@ -9,8 +9,6 @@
 #include <memory>
 
 #include "GDCore/CommonTools.h"
-#include "GDCore/Events/Builtin/CommentEvent.h"
-#include "GDCore/Events/Builtin/GroupEvent.h"
 #include "GDCore/Events/Event.h"
 #include "GDCore/Events/EventsList.h"
 #include "GDCore/Events/Parsers/ExpressionParser2.h"
@@ -692,7 +690,7 @@ bool EventsRefactorer::ReplaceStringInStringEvent(gd::ObjectsContainer& project,
                                                   gd::String toReplace,
                                                   gd::String newString,
                                                   bool matchCase) {
-  bool somethingModified = false;
+  vector<gd::String> newStringEvents;
   vector<gd::String> stringEvent = event.GetAllSearchableStrings();
 
   for (std::size_t sNb = 0; sNb < stringEvent.size(); ++sNb) {
@@ -700,18 +698,10 @@ bool EventsRefactorer::ReplaceStringInStringEvent(gd::ObjectsContainer& project,
         matchCase ? stringEvent[sNb].FindAndReplace(toReplace, newString, true)
                   : ReplaceAllOccurencesCaseUnsensitive(
                         stringEvent[sNb], toReplace, newString);
-
-    if (newStringEvent != stringEvent[sNb]) {
-      if (event.GetType() == "BuiltinCommonInstructions::Group") {
-        gd::GroupEvent& groupEvent = dynamic_cast<gd::GroupEvent&>(event);
-        groupEvent.SetName(newStringEvent);
-      } else if (event.GetType() == "BuiltinCommonInstructions::Comment") {
-        gd::CommentEvent& commentEvent = dynamic_cast<gd::CommentEvent&>(event);
-        commentEvent.SetComment(newStringEvent);
-      }
-    }
-    somethingModified = true;
+    newStringEvents.push_back(newStringEvent);
   }
+
+  bool somethingModified = event.ReplaceAllInSearchableString(newStringEvents);
 
   return somethingModified;
 }

--- a/Core/GDCore/IDE/Events/EventsRefactorer.h
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.h
@@ -210,17 +210,18 @@ class GD_CORE_API EventsRefactorer {
                                      bool matchCase);
 
   /**
-   * Replace all occurrences of a gd::String in string events (comments and
-   * groups)
+   * Replace all occurrences of a gd::String in strings of events (for example:
+   * comments and name of groups).
    *
    * \return true if something was modified.
    */
-  static bool ReplaceStringInStringEvent(gd::ObjectsContainer& project,
-                                         gd::ObjectsContainer& layout,
-                                         gd::BaseEvent& stringEvent,
-                                         gd::String toReplace,
-                                         gd::String newString,
-                                         bool matchCase);
+  static bool ReplaceStringInEventSearchableStrings(
+      gd::ObjectsContainer& project,
+      gd::ObjectsContainer& layout,
+      gd::BaseEvent& event,
+      gd::String toReplace,
+      gd::String newString,
+      bool matchCase);
 
   static bool SearchStringInFormattedText(const gd::Platform& platform,
                                           gd::Instruction& instruction,

--- a/Core/GDCore/IDE/Events/EventsRefactorer.h
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.h
@@ -117,7 +117,8 @@ class GD_CORE_API EventsRefactorer {
                                     gd::String newString,
                                     bool matchCase,
                                     bool inConditions,
-                                    bool inActions);
+                                    bool inActions,
+                                    bool inEventString);
 
   virtual ~EventsRefactorer(){};
 
@@ -207,6 +208,19 @@ class GD_CORE_API EventsRefactorer {
                                      gd::String toReplace,
                                      gd::String newString,
                                      bool matchCase);
+
+  /**
+   * Replace all occurrences of a gd::String in string events (comments and
+   * groups)
+   *
+   * \return true if something was modified.
+   */
+  static bool ReplaceStringInStringEvent(gd::ObjectsContainer& project,
+                                         gd::ObjectsContainer& layout,
+                                         gd::BaseEvent& stringEvent,
+                                         gd::String toReplace,
+                                         gd::String newString,
+                                         bool matchCase);
 
   static bool SearchStringInFormattedText(const gd::Platform& platform,
                                           gd::Instruction& instruction,

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1925,7 +1925,7 @@ interface VectorEventsSearchResult {
 interface EventsRefactorer {
     void STATIC_RenameObjectInEvents([Const, Ref] Platform platform, [Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString oldName, [Const] DOMString newName);
     void STATIC_RemoveObjectInEvents([Const, Ref] Platform platform, [Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString name);
-    void STATIC_ReplaceStringInEvents([Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString toReplace, [Const] DOMString newString, boolean matchCase, boolean inConditions, boolean inActions);
+    void STATIC_ReplaceStringInEvents([Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString toReplace, [Const] DOMString newString, boolean matchCase, boolean inConditions, boolean inActions,  boolean inEventStrings);
     [Value] VectorEventsSearchResult STATIC_SearchInEvents([Const, Ref] Platform platform, [Ref] EventsList events, [Const] DOMString search, boolean matchCase, boolean inConditions, boolean inActions, boolean inEventStrings, boolean inEventSentences);
 };
 

--- a/GDevelop.js/types/gdeventsrefactorer.js
+++ b/GDevelop.js/types/gdeventsrefactorer.js
@@ -2,7 +2,7 @@
 declare class gdEventsRefactorer {
   static renameObjectInEvents(platform: gdPlatform, project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, oldName: string, newName: string): void;
   static removeObjectInEvents(platform: gdPlatform, project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, name: string): void;
-  static replaceStringInEvents(project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, toReplace: string, newString: string, matchCase: boolean, inConditions: boolean, inActions: boolean): void;
+  static replaceStringInEvents(project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, toReplace: string, newString: string, matchCase: boolean, inConditions: boolean, inActions: boolean, inEventStrings: boolean): void;
   static searchInEvents(platform: gdPlatform, events: gdEventsList, search: string, matchCase: boolean, inConditions: boolean, inActions: boolean, inEventStrings: boolean, inEventSentences: boolean): gdVectorEventsSearchResult;
   delete(): void;
   ptr: number;

--- a/newIDE/app/src/AssetStore/InstallAsset.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.js
@@ -244,10 +244,10 @@ export const addAssetToProject = async ({
             groupEvent.getSubEvents(),
             parameter.name,
             parameter.defaultValue,
-            true,
-            true,
-            true,
-            false
+            /*matchCase=*/ true,
+            /*inConditions=*/ true,
+            /*inActions=*/ true,
+            /*inEventStrings=*/ false
           );
         });
 

--- a/newIDE/app/src/AssetStore/InstallAsset.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.js
@@ -246,7 +246,8 @@ export const addAssetToProject = async ({
             parameter.defaultValue,
             true,
             true,
-            true
+            true,
+            false
           );
         });
 

--- a/newIDE/app/src/EventsSheet/EventsSearcher.js
+++ b/newIDE/app/src/EventsSheet/EventsSearcher.js
@@ -139,9 +139,8 @@ export default class EventsSearcher extends React.Component<Props, State> {
       replaceText,
       matchCase,
       searchInConditions,
-      searchInActions
-      // TODO: add capability to replace in event strings
-      // searchInEventStrings
+      searchInActions,
+      searchInEventStrings
     );
   };
 


### PR DESCRIPTION
Fixes #3385

Add possibility to replace text in text events like Comments and Groups names

![replace-in-event-text](https://media.giphy.com/media/Splv90JphWxtA3PYrC/giphy.gif)