### PR TITLE
[Quick win] Add missing "Audio" category for extensions

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
@@ -209,6 +209,10 @@ export const ExtensionOptionsEditor = ({
                 value: 'Ads',
               },
               {
+                text: 'Audio',
+                value: 'Audio',
+              },
+              {
                 text: 'Advanced',
                 value: 'Advanced',
               },


### PR DESCRIPTION
I was reviewing the Volume Falloff extension and noticed that isn't assigned to the Audio category because this one is missing.

![image](https://user-images.githubusercontent.com/1670670/157544394-e2261fc1-8228-44f9-9de1-2c552f4ff7ab.png)