### PR TITLE
Allow users to reorder editor tabs

### DIFF
--- a/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
@@ -1,0 +1,158 @@
+// @flow
+import * as React from 'react';
+
+import { makeDragSourceAndDropTarget } from '../../UI/DragAndDrop/DragSourceAndDropTarget';
+import { ScreenTypeMeasurer } from '../../UI/Reponsive/ScreenTypeMeasurer';
+import { ColumnDropIndicator } from './DropIndicator';
+import {
+  type EditorTabsState,
+  type EditorTab,
+  getEditors,
+  getCurrentTabIndex,
+} from './EditorTabsHandler';
+import {
+  ClosableTabs,
+  ClosableTab,
+  type ClosableTabProps,
+} from '../../UI/ClosableTabs';
+
+type DraggableClosableTabsProps = {|
+  hideLabels?: boolean,
+  editorTabs: EditorTabsState,
+  onClickTab: (index: number) => void,
+  onCloseTab: (editor: EditorTab) => void,
+  onCloseOtherTabs: (editor: EditorTab) => void,
+  onCloseAll: () => void,
+  onTabActive: (editor: EditorTab) => void,
+  onDropTab: (fromIndex: number, toIndex: number) => void,
+|};
+
+export function DraggableClosableTabs({
+  hideLabels,
+  editorTabs,
+  onClickTab,
+  onCloseTab,
+  onCloseOtherTabs,
+  onCloseAll,
+  onTabActive,
+  onDropTab,
+}: DraggableClosableTabsProps) {
+  let draggedTabIndex: number | typeof undefined = undefined;
+
+  return (
+    <ClosableTabs hideLabels={hideLabels}>
+      {getEditors(editorTabs).map((editorTab, id) => {
+        const isCurrentTab = getCurrentTabIndex(editorTabs) === id;
+        return (
+          <DraggableClosableTab
+            index={id}
+            label={editorTab.label}
+            key={editorTab.key}
+            id={`tab-${editorTab.key.replace(/\s/g, '-')}`}
+            active={isCurrentTab}
+            onClick={() => onClickTab(id)}
+            onClose={() => onCloseTab(editorTab)}
+            onCloseOthers={() => onCloseOtherTabs(editorTab)}
+            onCloseAll={onCloseAll}
+            onActivated={() => onTabActive(editorTab)}
+            closable={editorTab.closable}
+            onBeginDrag={() => {
+              draggedTabIndex = id;
+              return editorTab;
+            }}
+            onDrop={toIndex => {
+              if (draggedTabIndex !== undefined) {
+                onDropTab(draggedTabIndex, id);
+                draggedTabIndex = undefined;
+              }
+            }}
+          />
+        );
+      })}
+    </ClosableTabs>
+  );
+}
+
+type DraggableClosableTabProps = {|
+  index: number,
+  onBeginDrag: () => EditorTab,
+  onDrop: (toIndex: number) => void,
+  ...ClosableTabProps,
+|};
+
+export function DraggableClosableTab({
+  index,
+  id,
+  active,
+  onClose,
+  onCloseOthers,
+  onCloseAll,
+  label,
+  closable,
+  onClick,
+  onActivated,
+  onBeginDrag,
+  onDrop,
+}: DraggableClosableTabProps) {
+  const DragSourceAndDropTarget = makeDragSourceAndDropTarget<EditorTab>(
+    'draggable-closable-tab'
+  );
+
+  return (
+    <ScreenTypeMeasurer>
+      {screenType => (
+        <DragSourceAndDropTarget
+          beginDrag={onBeginDrag}
+          canDrag={() => {
+            // On touchscreens, we allow DnD on active tab so that user can scroll
+            if (screenType === 'touch' && !active) return false;
+            // We want "Home" tab to stay on the left
+            return index !== 0;
+          }}
+          canDrop={() => true}
+          drop={() => {
+            onDrop(index);
+          }}
+        >
+          {({ connectDragSource, connectDropTarget, isOver, canDrop }) => {
+            // If on a touch screen, setting the whole item to be
+            // draggable would prevent scroll. Set the icon only to be
+            // draggable if the item is not selected. When selected,
+            // set the whole item to be draggable.
+            const canDragOnlyIcon = screenType === 'touch' && !active;
+
+            // Add an extra div because connectDropTarget/connectDragSource can
+            // only be used on native elements
+            const dropTarget = connectDropTarget(
+              <div
+                style={{
+                  display: 'flex',
+                  flexShrink: 0,
+                  // transform: 'translate3d(0,0,0)',
+                }}
+              >
+                <ClosableTab
+                  id={id}
+                  active={active}
+                  onClose={onClose}
+                  onCloseOthers={onCloseOthers}
+                  onCloseAll={onCloseAll}
+                  label={label}
+                  closable={closable}
+                  onClick={onClick}
+                  onActivated={onActivated}
+                  key={id}
+                />
+                {isOver && <ColumnDropIndicator />}
+              </div>
+            );
+
+            if (!dropTarget) return null;
+
+            return canDragOnlyIcon ? dropTarget : connectDragSource(dropTarget);
+          }}
+        </DragSourceAndDropTarget>
+      )}
+    </ScreenTypeMeasurer>
+  );
+}

--- a/newIDE/app/src/MainFrame/EditorTabs/DropIndicator.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/DropIndicator.js
@@ -1,0 +1,30 @@
+// @flow
+import * as React from 'react';
+import ThemeConsumer from '../../UI/Theme/ThemeConsumer';
+
+const styles = {
+  columnDropIndicator: {
+    borderRight: '1px solid #18dcf2',
+    borderLeft: '1px solid #18dcf2',
+    width: 7,
+    marginLeft: '-1px',
+    height: '100%',
+    boxSizing: 'border-box',
+  },
+};
+
+export function ColumnDropIndicator() {
+  return (
+    <ThemeConsumer>
+      {gdevelopTheme => (
+        <div
+          style={{
+            ...styles.columnDropIndicator,
+            backgroundColor: gdevelopTheme.closableTabs.selectedBackgroundColor,
+            borderColor: gdevelopTheme.closableTabs.backgroundColor,
+          }}
+        />
+      )}
+    </ThemeConsumer>
+  );
+}

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -1,17 +1,17 @@
 // @flow
 import * as React from 'react';
 import findIndex from 'lodash/findIndex';
-import { EventsEditorContainer } from './EditorContainers/EventsEditorContainer';
-import { DebuggerEditorContainer } from './EditorContainers/DebuggerEditorContainer';
-import { EventsFunctionsExtensionEditorContainer } from './EditorContainers/EventsFunctionsExtensionEditorContainer';
-import { ExternalEventsEditorContainer } from './EditorContainers/ExternalEventsEditorContainer';
-import { ExternalLayoutEditorContainer } from './EditorContainers/ExternalLayoutEditorContainer';
-import { ResourcesEditorContainer } from './EditorContainers/ResourcesEditorContainer';
-import { SceneEditorContainer } from './EditorContainers/SceneEditorContainer';
+import { EventsEditorContainer } from '../EditorContainers/EventsEditorContainer';
+import { DebuggerEditorContainer } from '../EditorContainers/DebuggerEditorContainer';
+import { EventsFunctionsExtensionEditorContainer } from '../EditorContainers/EventsFunctionsExtensionEditorContainer';
+import { ExternalEventsEditorContainer } from '../EditorContainers/ExternalEventsEditorContainer';
+import { ExternalLayoutEditorContainer } from '../EditorContainers/ExternalLayoutEditorContainer';
+import { ResourcesEditorContainer } from '../EditorContainers/ResourcesEditorContainer';
+import { SceneEditorContainer } from '../EditorContainers/SceneEditorContainer';
 import {
   type RenderEditorContainerPropsWithRef,
   type EditorContainerExtraProps,
-} from './EditorContainers/BaseEditor';
+} from '../EditorContainers/BaseEditor';
 
 // Supported editors
 type EditorRef =

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -289,3 +289,24 @@ export const getEventsFunctionsExtensionEditor = (
 
   return null;
 };
+
+export const moveTabToPosition = (
+  editorTabsState: EditorTabsState,
+  fromIndex: number,
+  toIndex: number
+): EditorTabsState => {
+  if (toIndex < fromIndex) toIndex += 1;
+  const currentEditorTabs = [...getEditors(editorTabsState)];
+  const movingTab = currentEditorTabs[fromIndex];
+  currentEditorTabs.splice(fromIndex, 1);
+  currentEditorTabs.splice(toIndex, 0, movingTab);
+
+  let currentTabIndex: number = getCurrentTabIndex(editorTabsState);
+  if (fromIndex === currentTabIndex) currentTabIndex = toIndex;
+  else if (fromIndex < currentTabIndex && toIndex >= currentTabIndex)
+    currentTabIndex -= 1;
+  else if (fromIndex > currentTabIndex && toIndex <= currentTabIndex)
+    currentTabIndex += 1;
+
+  return { editors: currentEditorTabs, currentTab: currentTabIndex };
+};

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -17,11 +17,8 @@ import CloseConfirmDialog from '../UI/CloseConfirmDialog';
 import ProfileDialog from '../Profile/ProfileDialog';
 import Window from '../Utils/Window';
 import { showErrorBox } from '../UI/Messages/MessageBox';
-import {
-  ClosableTabs,
-  ClosableTab,
-  TabContentContainer,
-} from '../UI/ClosableTabs';
+import { TabContentContainer } from '../UI/ClosableTabs';
+import { DraggableClosableTabs } from './EditorTabs/DraggableEditorTabs';
 import {
   getEditorTabsInitialState,
   openEditorTab,
@@ -42,6 +39,7 @@ import {
   type EditorTab,
   getEventsFunctionsExtensionEditor,
   notifyPreviewWillStart,
+  moveTabToPosition,
 } from './EditorTabs/EditorTabsHandler';
 import { timePromise } from '../Utils/TimeFunction';
 import HelpFinder from '../HelpFinder';
@@ -2139,25 +2137,29 @@ const MainFrame = (props: Props) => {
         }
         previewState={previewState}
       />
-      <ClosableTabs hideLabels={!!props.integratedEditor}>
-        {getEditors(state.editorTabs).map((editorTab, id) => {
-          const isCurrentTab = getCurrentTabIndex(state.editorTabs) === id;
-          return (
-            <ClosableTab
-              label={editorTab.label}
-              key={editorTab.key}
-              id={`tab-${editorTab.key.replace(/\s/g, '-')}`}
-              active={isCurrentTab}
-              onClick={() => _onChangeEditorTab(id)}
-              onClose={() => _onCloseEditorTab(editorTab)}
-              onCloseOthers={() => _onCloseOtherEditorTabs(editorTab)}
-              onCloseAll={_onCloseAllEditorTabs}
-              onActivated={() => _onEditorTabActive(editorTab)}
-              closable={editorTab.closable}
-            />
-          );
-        })}
-      </ClosableTabs>
+      <DraggableClosableTabs
+        hideLabels={!!props.integratedEditor}
+        editorTabs={state.editorTabs}
+        onClickTab={(id: number) => _onChangeEditorTab(id)}
+        onCloseTab={(editorTab: EditorTab) => _onCloseEditorTab(editorTab)}
+        onCloseOtherTabs={(editorTab: EditorTab) =>
+          _onCloseOtherEditorTabs(editorTab)
+        }
+        onCloseAll={_onCloseAllEditorTabs}
+        onTabActive={(editorTab: EditorTab) => _onEditorTabActive(editorTab)}
+        onDropTab={(fromIndex: number, toIndex: number) => {
+          setState(state => {
+            return {
+              ...state,
+              editorTabs: moveTabToPosition(
+                state.editorTabs,
+                fromIndex,
+                toIndex
+              ),
+            };
+          });
+        }}
+      />
       {getEditors(state.editorTabs).map((editorTab, id) => {
         const isCurrentTab = getCurrentTabIndex(state.editorTabs) === id;
         return (

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -42,7 +42,7 @@ import {
   type EditorTab,
   getEventsFunctionsExtensionEditor,
   notifyPreviewWillStart,
-} from './EditorTabsHandler';
+} from './EditorTabs/EditorTabsHandler';
 import { timePromise } from '../Utils/TimeFunction';
 import HelpFinder from '../HelpFinder';
 import { renderDebuggerEditorContainer } from './EditorContainers/DebuggerEditorContainer';

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -100,7 +100,7 @@ export function ClosableTabs({ hideLabels, children }: ClosableTabsProps) {
   );
 }
 
-type ClosableTabProps = {|
+export type ClosableTabProps = {|
   id?: string,
   active: boolean,
   label: Node,
@@ -188,6 +188,9 @@ export function ClosableTab({
                 id={id ? `${id}-button` : undefined}
                 {...longTouchForContextMenuProps}
                 focusRipple
+                // If touch ripple is not disabled, dragged preview will use the size of the ripple
+                // and it will be too big
+                disableTouchRipple
               >
                 <span
                   style={{

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -81,27 +81,23 @@ type ClosableTabsProps = {|
   children: Node,
 |};
 
-export class ClosableTabs extends Component<ClosableTabsProps> {
-  render() {
-    const { hideLabels, children } = this.props;
+export function ClosableTabs({ hideLabels, children }: ClosableTabsProps) {
+  return (
+    <ThemeConsumer>
+      {muiTheme => {
+        const tabItemContainerStyle = {
+          maxWidth: '100%', // Tabs should take all width
+          flexShrink: 0, // Tabs height should never be reduced
+          display: hideLabels ? 'none' : 'flex',
+          flexWrap: 'nowrap', // Single line of tab...
+          overflowX: 'auto', // ...scroll horizontally if needed
+          backgroundColor: muiTheme.closableTabs.containerBackgroundColor,
+        };
 
-    return (
-      <ThemeConsumer>
-        {muiTheme => {
-          const tabItemContainerStyle = {
-            maxWidth: '100%', // Tabs should take all width
-            flexShrink: 0, // Tabs height should never be reduced
-            display: hideLabels ? 'none' : 'flex',
-            flexWrap: 'nowrap', // Single line of tab...
-            overflowX: 'auto', // ...scroll horizontally if needed
-            backgroundColor: muiTheme.closableTabs.containerBackgroundColor,
-          };
-
-          return <div style={tabItemContainerStyle}>{children}</div>;
-        }}
-      </ThemeConsumer>
-    );
-  }
+        return <div style={tabItemContainerStyle}>{children}</div>;
+      }}
+    </ThemeConsumer>
+  );
 }
 
 type ClosableTabProps = {|


### PR DESCRIPTION
Allow users to reorder editor tabs by drag-and-dropping them to wanted position.

![reorder-editor-tabs-with-drag-and-drop](https://media.giphy.com/media/m9LhTIBSEmIKbMmUnE/giphy.gif)

Ripple effect is still displayed on focus (when using Tab to navigate between tabs) but I had to remove it on touch so that the preview image only takes the tab and prevent this from happening : 
![image](https://user-images.githubusercontent.com/81410437/157691884-127e1b2a-3a65-475a-b0bf-63e34ca69a40.png)
