### PR TITLE
Add size actions and conditions for sprite and tiled sprite objects

### DIFF
--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -235,7 +235,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced();
 
-  obj.AddAction("ChangeSize",
+  obj.AddAction("SetSize",
                 _("Size"),
                 _("Change the size of an object."),
                 _("Change the size of _PARAM0_: set to _PARAM1_x_PARAM2_"),

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -238,8 +238,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
   obj.AddAction("ChangeSize",
                 _("Size"),
                 _("Change the size of an object."),
-                _("Change the size of _PARAM0_: _PARAM1_ (width) "
-                  ", _PARAM2_ (height)"),
+                _("Change the size of _PARAM0_: set to _PARAM1_x_PARAM2_"),
                 _("Size"),
                 "res/actions/scale24.png",
                 "res/actions/scale.png")

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -199,6 +199,18 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced();
 
+  obj.AddCondition("Width",
+                   _("Width"),
+                   _("Compare the width of a Sprite object."),
+                   _("the width"),
+                   _("Size"),
+                   "res/conditions/scaleWidth24.png",
+                   "res/conditions/scaleWidth.png")
+
+      .AddParameter("object", _("Object"), "Sprite")
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
+
   obj.AddAction("ChangeHeight",
                 _("Height"),
                 _("Change the height of a Sprite object."),
@@ -209,6 +221,32 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
 
       .AddParameter("object", _("Object"), "Sprite")
       .UseStandardOperatorParameters("number")
+      .MarkAsAdvanced();
+
+  obj.AddCondition("Height",
+                   _("Height"),
+                   _("Compare the height of a Sprite object."),
+                   _("the height"),
+                   _("Size"),
+                   "res/conditions/scaleHeight24.png",
+                   "res/conditions/scaleHeight.png")
+
+      .AddParameter("object", _("Object"), "Sprite")
+      .UseStandardRelationalOperatorParameters("number")
+      .MarkAsAdvanced();
+
+  obj.AddAction("ChangeSize",
+                _("Size"),
+                _("Change the size of an object."),
+                _("Change the size of _PARAM0_: _PARAM1_ (width) "
+                  ", _PARAM2_ (height)"),
+                _("Size"),
+                "res/actions/scale24.png",
+                "res/actions/scale.png")
+
+      .AddParameter("object", _("Object"))
+      .AddParameter("expression", _("Width"))
+      .AddParameter("expression", _("Height"))
       .MarkAsAdvanced();
 
   obj.AddCondition(

--- a/Extensions/TiledSpriteObject/Extension.cpp
+++ b/Extensions/TiledSpriteObject/Extension.cpp
@@ -135,7 +135,7 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
       .SetFunctionName("GetHeight")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
-  obj.AddAction("Size",
+  obj.AddAction("SetSize",
                 _("Size"),
                 _("Modify the size of a Tiled Sprite."),
                 _("Change the size of _PARAM0_: set to _PARAM1_x_PARAM2_"),

--- a/Extensions/TiledSpriteObject/Extension.cpp
+++ b/Extensions/TiledSpriteObject/Extension.cpp
@@ -135,6 +135,21 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
       .SetFunctionName("GetHeight")
       .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
 
+  obj.AddAction("Size",
+                _("Size"),
+                _("Modify the size of a Tiled Sprite."),
+                _("Change the size of _PARAM0_: _PARAM1_ (width) "
+                  ", _PARAM2_ (height)"),
+                _("Size"),
+                "res/actions/scale24.png",
+                "res/actions/scale.png")
+
+      .AddParameter("object", _("Object"), "TiledSprite")
+      .AddParameter("expression", _("Width"))
+      .AddParameter("expression", _("Height"))
+      .SetFunctionName("SetSize")
+      .SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
+
   // Deprecated: now available for all objects.
   obj.AddAction("Angle",
                 _("Angle"),

--- a/Extensions/TiledSpriteObject/Extension.cpp
+++ b/Extensions/TiledSpriteObject/Extension.cpp
@@ -138,8 +138,7 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension& extension) {
   obj.AddAction("Size",
                 _("Size"),
                 _("Modify the size of a Tiled Sprite."),
-                _("Change the size of _PARAM0_: _PARAM1_ (width) "
-                  ", _PARAM2_ (height)"),
+                _("Change the size of _PARAM0_: set to _PARAM1_x_PARAM2_"),
                 _("Size"),
                 "res/actions/scale24.png",
                 "res/actions/scale.png")

--- a/Extensions/TiledSpriteObject/JsExtension.cpp
+++ b/Extensions/TiledSpriteObject/JsExtension.cpp
@@ -77,6 +77,11 @@ class TiledSpriteObjectJsExtension : public gd::PlatformExtension {
         .SetFunctionName("getHeight")
         .SetIncludeFile(
             "Extensions/TiledSpriteObject/tiledspriteruntimeobject.js");
+    GetAllActionsForObject(
+        "TiledSpriteObject::TiledSprite")["TiledSpriteObject::Size"]
+        .SetFunctionName("setSize")
+        .SetIncludeFile(
+            "Extensions/TiledSpriteObject/tiledspriteruntimeobject.js");
 
     // Deprecated: now available for all objects.
     GetAllActionsForObject(

--- a/Extensions/TiledSpriteObject/JsExtension.cpp
+++ b/Extensions/TiledSpriteObject/JsExtension.cpp
@@ -78,7 +78,7 @@ class TiledSpriteObjectJsExtension : public gd::PlatformExtension {
         .SetIncludeFile(
             "Extensions/TiledSpriteObject/tiledspriteruntimeobject.js");
     GetAllActionsForObject(
-        "TiledSpriteObject::TiledSprite")["TiledSpriteObject::Size"]
+        "TiledSpriteObject::TiledSprite")["TiledSpriteObject::SetSize"]
         .SetFunctionName("setSize")
         .SetIncludeFile(
             "Extensions/TiledSpriteObject/tiledspriteruntimeobject.js");

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
@@ -163,6 +163,16 @@ namespace gdjs {
     }
 
     /**
+     * Set the size of the Tiled Sprite object.
+     * @param width The new width.
+     * @param height The new height.
+     */
+    setSize(width: float, height: float): void {
+      this.setWidth(width);
+      this.setHeight(height);
+    }
+
+    /**
      * Set the offset on the X-axis when displaying the image of the Tiled Sprite object.
      * @param xOffset The new offset on the X-axis.
      */

--- a/GDJS/GDJS/Extensions/Builtin/SpriteExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/SpriteExtension.cpp
@@ -74,7 +74,7 @@ SpriteExtension::SpriteExtension() {
       .SetFunctionName("setHeight")
       .SetGetter("getHeight");
   spriteConditions["Height"].SetFunctionName("getHeight");
-  spriteActions["ChangeSize"].SetFunctionName("setSize");
+  spriteActions["SetSize"].SetFunctionName("setSize");
   spriteActions["TourneVersPos"].SetFunctionName("rotateTowardPosition");
   spriteActions["TourneVers"].SetFunctionName("turnTowardObject");
   spriteActions["ChangeColor"].SetFunctionName("setColor");

--- a/GDJS/GDJS/Extensions/Builtin/SpriteExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/SpriteExtension.cpp
@@ -69,9 +69,12 @@ SpriteExtension::SpriteExtension() {
   spriteActions["ChangeWidth"]
       .SetFunctionName("setWidth")
       .SetGetter("getWidth");
+  spriteConditions["Width"].SetFunctionName("getWidth");
   spriteActions["ChangeHeight"]
       .SetFunctionName("setHeight")
       .SetGetter("getHeight");
+  spriteConditions["Height"].SetFunctionName("getHeight");
+  spriteActions["ChangeSize"].SetFunctionName("setSize");
   spriteActions["TourneVersPos"].SetFunctionName("rotateTowardPosition");
   spriteActions["TourneVers"].SetFunctionName("turnTowardObject");
   spriteActions["ChangeColor"].SetFunctionName("setColor");

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -1156,20 +1156,6 @@ namespace gdjs {
       return this._renderer.getHeight();
     }
 
-    _setWidth(newWidth: float): void {
-      const unscaledWidth = this._renderer.getUnscaledWidth();
-      if (unscaledWidth !== 0) {
-        this.setScaleX(newWidth / unscaledWidth);
-      }
-    }
-
-    _setHeight(newHeight: float): void {
-      const unscaledHeight = this._renderer.getUnscaledHeight();
-      if (unscaledHeight !== 0) {
-        this.setScaleY(newHeight / unscaledHeight);
-      }
-    }
-
     /**
      * Change the width of the object. This changes the scale on X axis of the object.
      *
@@ -1179,7 +1165,10 @@ namespace gdjs {
       if (this._animationFrameDirty) {
         this._updateAnimationFrame();
       }
-      this._setWidth(newWidth);
+      const unscaledWidth = this._renderer.getUnscaledWidth();
+      if (unscaledWidth !== 0) {
+        this.setScaleX(newWidth / unscaledWidth);
+      }
     }
 
     /**
@@ -1191,7 +1180,10 @@ namespace gdjs {
       if (this._animationFrameDirty) {
         this._updateAnimationFrame();
       }
-      this._setHeight(newHeight);
+      const unscaledHeight = this._renderer.getUnscaledHeight();
+      if (unscaledHeight !== 0) {
+        this.setScaleY(newHeight / unscaledHeight);
+      }
     }
 
     /**
@@ -1201,11 +1193,8 @@ namespace gdjs {
      * @param newHeight The new height of the object, in pixels.
      */
     setSize(newWidth: float, newHeight: float): void {
-      if (this._animationFrameDirty) {
-        this._updateAnimationFrame();
-      }
-      this._setWidth(newWidth);
-      this._setHeight(newHeight);
+      this.setWidth(newWidth);
+      this.setHeight(newHeight);
     }
 
     /**

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -1156,6 +1156,20 @@ namespace gdjs {
       return this._renderer.getHeight();
     }
 
+    _setWidth(newWidth: float): void {
+      const unscaledWidth = this._renderer.getUnscaledWidth();
+      if (unscaledWidth !== 0) {
+        this.setScaleX(newWidth / unscaledWidth);
+      }
+    }
+
+    _setHeight(newHeight: float): void {
+      const unscaledHeight = this._renderer.getUnscaledHeight();
+      if (unscaledHeight !== 0) {
+        this.setScaleY(newHeight / unscaledHeight);
+      }
+    }
+
     /**
      * Change the width of the object. This changes the scale on X axis of the object.
      *
@@ -1165,10 +1179,7 @@ namespace gdjs {
       if (this._animationFrameDirty) {
         this._updateAnimationFrame();
       }
-      const unscaledWidth = this._renderer.getUnscaledWidth();
-      if (unscaledWidth !== 0) {
-        this.setScaleX(newWidth / unscaledWidth);
-      }
+      this._setWidth(newWidth);
     }
 
     /**
@@ -1180,10 +1191,21 @@ namespace gdjs {
       if (this._animationFrameDirty) {
         this._updateAnimationFrame();
       }
-      const unscaledHeight = this._renderer.getUnscaledHeight();
-      if (unscaledHeight !== 0) {
-        this.setScaleY(newHeight / unscaledHeight);
+      this._setHeight(newHeight);
+    }
+
+    /**
+     * Change the size of the object.
+     *
+     * @param newWidth The new width of the object, in pixels.
+     * @param newHeight The new height of the object, in pixels.
+     */
+    setSize(newWidth: float, newHeight: float): void {
+      if (this._animationFrameDirty) {
+        this._updateAnimationFrame();
       }
+      this._setWidth(newWidth);
+      this._setHeight(newHeight);
     }
 
     /**


### PR DESCRIPTION
Closes #3530.

Height and width conditions for Sprite object
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/81410437/157877927-ceabda4e-dfde-49fd-9e23-f62a50d97aac.png">

Size, Height and Width actions for Sprite object
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/81410437/157877369-5bf2d6d5-5844-4426-abf9-43c143ae2c8d.png">

Size action for Tiled Sprite Object
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/81410437/157877787-3c8d2542-d16a-40ea-8168-9e7d65df7514.png">
