### PR TITLE
Add D as shortcut to toggle disabled event

### DIFF
--- a/newIDE/app/src/CommandPalette/CommandsList.js
+++ b/newIDE/app/src/CommandPalette/CommandsList.js
@@ -52,6 +52,7 @@ export type CommandName =
   | 'ADD_STANDARD_EVENT'
   | 'ADD_SUBEVENT'
   | 'ADD_COMMENT_EVENT'
+  | 'TOGGLE_EVENT'
   | 'CHOOSE_AND_ADD_EVENT'
   | 'EVENTS_EDITOR_UNDO'
   | 'EVENTS_EDITOR_REDO'
@@ -279,6 +280,7 @@ const commandsList: { [CommandName]: CommandMetadata } = {
     displayText: t`Add a sub-event to the selected event`,
   },
   ADD_COMMENT_EVENT: { area: 'EVENTS', displayText: t`Add a comment` },
+  TOGGLE_EVENT: { area: 'EVENTS', displayText: t`Toggle disabled event` },
   CHOOSE_AND_ADD_EVENT: {
     area: 'EVENTS',
     displayText: t`Choose and add an event...`,

--- a/newIDE/app/src/CommandPalette/CommandsList.js
+++ b/newIDE/app/src/CommandPalette/CommandsList.js
@@ -52,7 +52,7 @@ export type CommandName =
   | 'ADD_STANDARD_EVENT'
   | 'ADD_SUBEVENT'
   | 'ADD_COMMENT_EVENT'
-  | 'TOGGLE_EVENT'
+  | 'TOGGLE_EVENT_DISABLED'
   | 'CHOOSE_AND_ADD_EVENT'
   | 'EVENTS_EDITOR_UNDO'
   | 'EVENTS_EDITOR_REDO'
@@ -280,7 +280,7 @@ const commandsList: { [CommandName]: CommandMetadata } = {
     displayText: t`Add a sub-event to the selected event`,
   },
   ADD_COMMENT_EVENT: { area: 'EVENTS', displayText: t`Add a comment` },
-  TOGGLE_EVENT: { area: 'EVENTS', displayText: t`Toggle disabled event` },
+  TOGGLE_EVENT_DISABLED: { area: 'EVENTS', displayText: t`Toggle disabled event` },
   CHOOSE_AND_ADD_EVENT: {
     area: 'EVENTS',
     displayText: t`Choose and add an event...`,

--- a/newIDE/app/src/CommandPalette/CommandsList.js
+++ b/newIDE/app/src/CommandPalette/CommandsList.js
@@ -280,7 +280,10 @@ const commandsList: { [CommandName]: CommandMetadata } = {
     displayText: t`Add a sub-event to the selected event`,
   },
   ADD_COMMENT_EVENT: { area: 'EVENTS', displayText: t`Add a comment` },
-  TOGGLE_EVENT_DISABLED: { area: 'EVENTS', displayText: t`Toggle disabled event` },
+  TOGGLE_EVENT_DISABLED: {
+    area: 'EVENTS',
+    displayText: t`Toggle disabled event`,
+  },
   CHOOSE_AND_ADD_EVENT: {
     area: 'EVENTS',
     displayText: t`Choose and add an event...`,

--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -48,11 +48,6 @@ export class Toolbar extends PureComponent<Props> {
             src="res/ribbon_default/commentaireadd32.png"
             tooltip={t`Add a comment`}
           />
-          <ToolbarIcon
-            onClick={this.props.onToggleDisabledEvent}
-            src="res/ribbon_default/subeventadd32.png"
-            tooltip={t`Toggle disabled selected event`}
-          />
           <ElementWithMenu
             element={
               <ToolbarIcon

--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -16,6 +16,7 @@ type Props = {|
   allEventsMetadata: Array<EventMetadata>,
   onAddEvent: (eventType: string) => Array<gdBaseEvent>,
   onToggleDisabledEvent: () => void,
+  canToggleEventDisabled: boolean,
   onRemove: () => void,
   canRemove: boolean,
   undo: () => void,

--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -15,6 +15,7 @@ type Props = {|
   onAddCommentEvent: () => void,
   allEventsMetadata: Array<EventMetadata>,
   onAddEvent: (eventType: string) => Array<gdBaseEvent>,
+  onToggleDisabledEvent: () => void,
   onRemove: () => void,
   canRemove: boolean,
   undo: () => void,
@@ -46,6 +47,11 @@ export class Toolbar extends PureComponent<Props> {
             onClick={this.props.onAddCommentEvent}
             src="res/ribbon_default/commentaireadd32.png"
             tooltip={t`Add a comment`}
+          />
+          <ToolbarIcon
+            onClick={this.props.onToggleDisabledEvent}
+            src="res/ribbon_default/subeventadd32.png"
+            tooltip={t`Toggle disabled selected event`}
           />
           <ElementWithMenu
             element={

--- a/newIDE/app/src/EventsSheet/ToolbarCommands.js
+++ b/newIDE/app/src/EventsSheet/ToolbarCommands.js
@@ -14,6 +14,7 @@ type Props = {|
   allEventsMetadata: Array<EventMetadata>,
   onAddEvent: (eventType: string) => Array<gdBaseEvent>,
   onToggleDisabledEvent: () => void,
+  canToggleEventDisabled: boolean,
   onRemove: () => void,
   canRemove: boolean,
   undo: () => void,
@@ -39,7 +40,7 @@ const ToolbarCommands = (props: Props) => {
     handler: props.onAddCommentEvent,
   });
 
-  useCommand('TOGGLE_EVENT_DISABLED', true, {
+  useCommand('TOGGLE_EVENT_DISABLED', props.canToggleEventDisabled, {
     handler: props.onToggleDisabledEvent,
   });
 

--- a/newIDE/app/src/EventsSheet/ToolbarCommands.js
+++ b/newIDE/app/src/EventsSheet/ToolbarCommands.js
@@ -13,6 +13,7 @@ type Props = {|
   onAddCommentEvent: () => void,
   allEventsMetadata: Array<EventMetadata>,
   onAddEvent: (eventType: string) => Array<gdBaseEvent>,
+  onToggleDisabledEvent: () => void,
   onRemove: () => void,
   canRemove: boolean,
   undo: () => void,
@@ -36,6 +37,10 @@ const ToolbarCommands = (props: Props) => {
 
   useCommand('ADD_COMMENT_EVENT', true, {
     handler: props.onAddCommentEvent,
+  });
+
+  useCommand('TOGGLE_EVENT', true, {
+    handler: props.onToggleDisabledEvent,
   });
 
   useCommandWithOptions('CHOOSE_AND_ADD_EVENT', true, {

--- a/newIDE/app/src/EventsSheet/ToolbarCommands.js
+++ b/newIDE/app/src/EventsSheet/ToolbarCommands.js
@@ -39,7 +39,7 @@ const ToolbarCommands = (props: Props) => {
     handler: props.onAddCommentEvent,
   });
 
-  useCommand('TOGGLE_EVENT', true, {
+  useCommand('TOGGLE_EVENT_DISABLED', true, {
     handler: props.onToggleDisabledEvent,
   });
 

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -290,6 +290,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
         onAddStandardEvent={this._addStandardEvent}
         onAddSubEvent={this.addSubEvents}
         canAddSubEvent={hasEventSelected(this.state.selection)}
+        canToggleEventDisabled={hasEventSelected(this.state.selection)}
         onAddCommentEvent={this._addCommentEvent}
         onAddEvent={this.addNewEvent}
         onToggleDisabledEvent={this.toggleDisabled}

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -13,6 +13,7 @@ import EventTextDialog, {
 } from './InstructionEditor/EventTextDialog';
 import Toolbar from './Toolbar';
 import KeyboardShortcuts from '../UI/KeyboardShortcuts';
+import { getShortcutDisplayName } from '../KeyboardShortcuts';
 import InlineParameterEditor from './InlineParameterEditor';
 import ContextMenu, { type ContextMenuInterface } from '../UI/Menu/ContextMenu';
 import { serializeToJSObject } from '../Utils/Serializer';
@@ -639,7 +640,11 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       label: i18n._(t`Toggle disabled`),
       click: () => this.toggleDisabled(),
       enabled: this._selectionCanToggleDisabled(),
-      accelerator: 'D',
+      accelerator: getShortcutDisplayName(
+        this.props.preferences.values.userShortcutMap[
+          'TOGGLE_EVENT_DISABLED'
+        ] || 'KeyD'
+      ),
     },
     { type: 'separator' },
     {
@@ -833,12 +838,18 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
   };
 
   toggleDisabled = () => {
-    getSelectedEvents(this.state.selection).forEach(event =>
-      event.setDisabled(!event.isDisabled())
-    );
-    this._saveChangesToHistory(() => {
-      if (this._eventsTree) this._eventsTree.forceEventsUpdate();
+    let shouldBeSaved = false;
+    getSelectedEvents(this.state.selection).forEach(event => {
+      if (event.isExecutable()) {
+        event.setDisabled(!event.isDisabled());
+        shouldBeSaved = true;
+      }
     });
+    if (shouldBeSaved) {
+      this._saveChangesToHistory(() => {
+        if (this._eventsTree) this._eventsTree.forceEventsUpdate();
+      });
+    }
   };
 
   deleteSelection = ({

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -291,6 +291,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
         canAddSubEvent={hasEventSelected(this.state.selection)}
         onAddCommentEvent={this._addCommentEvent}
         onAddEvent={this.addNewEvent}
+        onToggleDisabledEvent={this.toggleDisabled}
         canRemove={hasSomethingSelected(this.state.selection)}
         onRemove={this.deleteSelection}
         canUndo={canUndo(this.state.history)}
@@ -638,6 +639,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       label: i18n._(t`Toggle disabled`),
       click: () => this.toggleDisabled(),
       enabled: this._selectionCanToggleDisabled(),
+      accelerator: 'D',
     },
     { type: 'separator' },
     {

--- a/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
+++ b/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
@@ -51,6 +51,7 @@ const defaultShortcuts: ShortcutMap = {
   ADD_STANDARD_EVENT: 'Shift+KeyA',
   ADD_SUBEVENT: 'Shift+KeyD',
   ADD_COMMENT_EVENT: '',
+  TOGGLE_EVENT: 'KeyD',
   CHOOSE_AND_ADD_EVENT: 'Shift+KeyW',
   OPEN_EXTENSION_SETTINGS: '',
 };

--- a/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
+++ b/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
@@ -51,7 +51,7 @@ const defaultShortcuts: ShortcutMap = {
   ADD_STANDARD_EVENT: 'Shift+KeyA',
   ADD_SUBEVENT: 'Shift+KeyD',
   ADD_COMMENT_EVENT: '',
-  TOGGLE_EVENT: 'KeyD',
+  TOGGLE_EVENT_DISABLED: 'KeyD',
   CHOOSE_AND_ADD_EVENT: 'Shift+KeyW',
   OPEN_EXTENSION_SETTINGS: '',
 };


### PR DESCRIPTION
- [x] D allow to toggle disabled event.
- [x] Added in command palette.
- [x] Added in shortcut settings.

One problem persist, I can make it works when I edit the shortcut with another key, but the shortcut shown in the context menu isn't the key setup in settings.

I choose D because CTRL+D is used by the browser, and SHIFT+D is already used in GDevelop to add a sub-event.
Also CTRL+D is generally uised to duplicate in other software so D is the best choice and intuitive.
