### PR TITLE
Sprites are no longer bouncing of one pixel when the camera is moving

### DIFF
--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -13,7 +13,7 @@ namespace gdjs {
   export class LayerPixiRenderer {
     _pixiContainer: PIXI.Container;
 
-    _layer: any;
+    _layer: gdjs.Layer;
     _renderTexture: PIXI.RenderTexture | null = null;
     _lightingSprite: PIXI.Sprite | null = null;
     _runtimeSceneRenderer: any;
@@ -72,10 +72,26 @@ namespace gdjs {
       const centerY =
         this._layer.getCameraX() * zoomFactor * sinValue +
         this._layer.getCameraY() * zoomFactor * cosValue;
-      this._pixiContainer.position.x = -centerX;
-      this._pixiContainer.position.y = -centerY;
-      this._pixiContainer.position.x += this._layer.getWidth() / 2;
-      this._pixiContainer.position.y += this._layer.getHeight() / 2;
+      this._pixiContainer.position.x = this._layer.getWidth() / 2 - centerX;
+      this._pixiContainer.position.y = this._layer.getHeight() / 2 - centerY;
+
+      if (
+        this._layer.getRuntimeScene().getGame().getPixelsRounding() &&
+        (cosValue === 0 || sinValue === 0) &&
+        Number.isInteger(zoomFactor)
+      ) {
+        // Camera rounding is important for pixel perfect games.
+        // Otherwise the camera position fractional part is added to
+        // the sprite one and it changes in which direction sprites are rounded.
+        // It makes sprites rounding inconsistent with each other
+        // and they seems to move on pixel left and right.
+        this._pixiContainer.position.x = Math.round(
+          this._pixiContainer.position.x
+        );
+        this._pixiContainer.position.y = Math.round(
+          this._pixiContainer.position.y
+        );
+      }
     }
 
     updateVisibility(visible: boolean): void {


### PR DESCRIPTION
With pixel perfect mode activated, sprites are no longer bouncing of one pixel when the camera is moving.

## Demo
### Broken one (notice how the character seems to move over grasses)
https://liluo.io/instant-builds/5eccedb0-d30f-4b93-a3ac-bf57e2a0c4e5?dev=true

### Fixed one
https://liluo.io/instant-builds/a950d977-35c9-4137-b9f7-325416993a02?dev=true

## Pixel rounding with float camera position
The grid is the pixels on screen and the small arrows are the sprite rounding

![FloatCamera1](https://user-images.githubusercontent.com/2611977/158473686-c4024b43-1889-4421-905f-cded9811c2ee.png)

When the camera moves from less than one pixel, it changes the direction of the character rounding (in orange), but the platform (in green) stays at the same location on screen. Thus, the character appears to move one pixel to the left in the referential of the platform and it will dance from one pixel right and left.

![FloatCamera2](https://user-images.githubusercontent.com/2611977/158473658-3e10b958-5e50-4402-94c7-f87276159bae.png)