### PR TITLE
Add key expressions to "Simulate control" action for TopDown

### DIFF
--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -105,7 +105,9 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
          "res/conditions/keyboard.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .AddParameter("string", _("Key"))
+      .AddParameter("stringWithSelector",
+                    _("Key"),
+                    "[\"Left\", \"Right\", \"Up\", \"Down\"]")
       .MarkAsAdvanced()
       .SetFunctionName("SimulateControl")
       .SetIncludeFile(


### PR DESCRIPTION
Clang format does not seem to be present in the file.
Should that be changed as well?