### PR TITLE
Specify if you are updating or reinstalling in the extension store page

### DIFF
--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -24,7 +24,6 @@ import { UserPublicProfileChip } from '../../UI/User/UserPublicProfileChip';
 import RaisedButton from '../../UI/RaisedButton';
 import Window from '../../Utils/Window';
 import { useExtensionUpdate } from './UseExtensionUpdates';
-import { enumerateEventsFunctionsExtensions } from '../../ProjectManager/EnumerateProjectItems';
 
 const getTransformedDescription = (extensionHeader: ExtensionHeader) => {
   if (

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -23,6 +23,8 @@ import { IconContainer } from '../../UI/IconContainer';
 import { UserPublicProfileChip } from '../../UI/User/UserPublicProfileChip';
 import RaisedButton from '../../UI/RaisedButton';
 import Window from '../../Utils/Window';
+import { useExtensionUpdates } from './UseExtensionUpdates';
+import { enumerateEventsFunctionsExtensions } from '../../ProjectManager/EnumerateProjectItems';
 
 const getTransformedDescription = (extensionHeader: ExtensionHeader) => {
   if (
@@ -46,6 +48,7 @@ type Props = {|
   onInstall: () => Promise<void>,
   onEdit?: () => void,
   alreadyInstalled: boolean,
+  project: gdProject,
 |};
 
 const ExtensionInstallDialog = ({
@@ -55,7 +58,13 @@ const ExtensionInstallDialog = ({
   onInstall,
   onEdit,
   alreadyInstalled,
+  project,
 }: Props) => {
+  const installedExtensions = new Set(
+    enumerateEventsFunctionsExtensions(project).map(ext => ext.getName())
+  );
+  const extensionUpdates = useExtensionUpdates(project);
+
   const [error, setError] = React.useState<?Error>(null);
   const [
     extensionHeader,
@@ -117,8 +126,12 @@ const ExtensionInstallDialog = ({
             label={
               !isCompatible ? (
                 <Trans>Not compatible</Trans>
-              ) : alreadyInstalled ? (
-                <Trans>Re-install/update</Trans>
+              ) : installedExtensions.has(extensionShortHeader.name) ? (
+                extensionUpdates.has(extensionShortHeader.name) ? (
+                  <Trans>Update</Trans>
+                ) : (
+                  <Trans>Re-install</Trans>
+                )
               ) : (
                 <Trans>Install in project</Trans>
               )

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -23,7 +23,7 @@ import { IconContainer } from '../../UI/IconContainer';
 import { UserPublicProfileChip } from '../../UI/User/UserPublicProfileChip';
 import RaisedButton from '../../UI/RaisedButton';
 import Window from '../../Utils/Window';
-import { useExtensionUpdates } from './UseExtensionUpdates';
+import { useExtensionUpdate } from './UseExtensionUpdates';
 import { enumerateEventsFunctionsExtensions } from '../../ProjectManager/EnumerateProjectItems';
 
 const getTransformedDescription = (extensionHeader: ExtensionHeader) => {
@@ -47,7 +47,6 @@ type Props = {|
   onClose: () => void,
   onInstall: () => Promise<void>,
   onEdit?: () => void,
-  alreadyInstalled: boolean,
   project: gdProject,
 |};
 
@@ -57,13 +56,12 @@ const ExtensionInstallDialog = ({
   onClose,
   onInstall,
   onEdit,
-  alreadyInstalled,
   project,
 }: Props) => {
-  const installedExtensions = new Set(
-    enumerateEventsFunctionsExtensions(project).map(ext => ext.getName())
+  const alreadyInstalled = project.hasEventsFunctionsExtensionNamed(
+    extensionShortHeader.name
   );
-  const extensionUpdates = useExtensionUpdates(project);
+  const extensionUpdate = useExtensionUpdate(project, extensionShortHeader);
 
   const [error, setError] = React.useState<?Error>(null);
   const [
@@ -126,8 +124,8 @@ const ExtensionInstallDialog = ({
             label={
               !isCompatible ? (
                 <Trans>Not compatible</Trans>
-              ) : installedExtensions.has(extensionShortHeader.name) ? (
-                extensionUpdates.has(extensionShortHeader.name) ? (
+              ) : alreadyInstalled ? (
+                extensionUpdate ? (
                   <Trans>Update</Trans>
                 ) : (
                   <Trans>Re-install</Trans>

--- a/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
@@ -1,0 +1,55 @@
+//@flow
+import { diff } from 'semver/functions/diff';
+import { enumerateEventsFunctionsExtensions } from '../../ProjectManager/EnumerateProjectItems';
+import { ExtensionStoreContext } from './ExtensionStoreContext';
+import { useContext } from 'react';
+
+type UpdateMetadata = {|
+  type: 'patch' | 'minor' | 'major',
+  currentVersion: string,
+  newestVersion: string,
+|};
+type ExtensionUpdates = Map<string, UpdateMetadata>;
+
+export const useExtensionUpdates = (project: gdProject): ExtensionUpdates => {
+  const { extensionShortHeadersByName } = useContext(ExtensionStoreContext);
+  const installedExtensions = enumerateEventsFunctionsExtensions(project);
+
+  const extensionUpdates = new Map<string, UpdateMetadata>();
+
+  for (const localExtension of installedExtensions) {
+    const localExtensionName = localExtension.getName();
+    const extensionHeader = extensionShortHeadersByName[localExtensionName];
+
+    // No header, this is not an extension that exists on the store. Skip it.
+    if (!extensionHeader) continue;
+
+    const currentVersion = localExtension.getVersion();
+    const newestVersion = extensionHeader.version;
+
+    try {
+      const versionDiff = diff(currentVersion, newestVersion);
+      if (['patch', 'minor', 'major'].includes(versionDiff)) {
+        extensionUpdates.set(localExtensionName, {
+          type: versionDiff,
+          currentVersion,
+          newestVersion,
+        });
+      }
+    } catch {
+      // An error will be thrown here only if the version is not in semver.
+      // Simply compare the strings for such extensions.
+      // Note that this is an edge case, the extension repository enforces semver, so this
+      // is only for local extensions that do not respect the best practices.
+      if (currentVersion !== newestVersion)
+        extensionUpdates.set(localExtensionName, {
+          // Use minor as it is the most neutral option
+          type: 'minor',
+          currentVersion,
+          newestVersion,
+        });
+    }
+  }
+
+  return extensionUpdates;
+};

--- a/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
@@ -2,54 +2,93 @@
 import { diff } from 'semver/functions/diff';
 import { enumerateEventsFunctionsExtensions } from '../../ProjectManager/EnumerateProjectItems';
 import { ExtensionStoreContext } from './ExtensionStoreContext';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
+import type { ExtensionShortHeader } from '../../Utils/GDevelopServices/Extension';
 
+type UpdateType = 'patch' | 'minor' | 'major';
 type UpdateMetadata = {|
-  type: 'patch' | 'minor' | 'major',
+  type: UpdateType,
   currentVersion: string,
   newestVersion: string,
 |};
 type ExtensionUpdates = Map<string, UpdateMetadata>;
 
-export const useExtensionUpdates = (project: gdProject): ExtensionUpdates => {
-  const { extensionShortHeadersByName } = useContext(ExtensionStoreContext);
-  const installedExtensions = enumerateEventsFunctionsExtensions(project);
-
-  const extensionUpdates = new Map<string, UpdateMetadata>();
-
-  for (const localExtension of installedExtensions) {
-    const localExtensionName = localExtension.getName();
-    const extensionHeader = extensionShortHeadersByName[localExtensionName];
-
-    // No header, this is not an extension that exists on the store. Skip it.
-    if (!extensionHeader) continue;
-
-    const currentVersion = localExtension.getVersion();
-    const newestVersion = extensionHeader.version;
-
-    try {
-      const versionDiff = diff(currentVersion, newestVersion);
-      if (['patch', 'minor', 'major'].includes(versionDiff)) {
-        extensionUpdates.set(localExtensionName, {
-          type: versionDiff,
-          currentVersion,
-          newestVersion,
-        });
-      }
-    } catch {
-      // An error will be thrown here only if the version is not in semver.
-      // Simply compare the strings for such extensions.
-      // Note that this is an edge case, the extension repository enforces semver, so this
-      // is only for local extensions that do not respect the best practices.
-      if (currentVersion !== newestVersion)
-        extensionUpdates.set(localExtensionName, {
-          // Use minor as it is the most neutral option
-          type: 'minor',
-          currentVersion,
-          newestVersion,
-        });
+const getUpdateMetadataFromVersions = (
+  currentVersion: string,
+  newestVersion: string
+): UpdateMetadata | null => {
+  try {
+    const versionDiff: UpdateType = diff(currentVersion, newestVersion);
+    if (['patch', 'minor', 'major'].includes(versionDiff)) {
+      return {
+        type: versionDiff,
+        currentVersion,
+        newestVersion,
+      };
+    }
+  } catch {
+    // An error will be thrown here only if the version is not in semver.
+    // Simply compare the strings for such extensions.
+    // Note that this is an edge case, the extension repository enforces semver, so this
+    // is only for local extensions that do not respect the best practices.
+    if (currentVersion !== newestVersion) {
+      return {
+        // Use minor as it is the most neutral option
+        type: 'minor',
+        currentVersion,
+        newestVersion,
+      };
     }
   }
 
-  return extensionUpdates;
+  return null;
+};
+
+export const useExtensionUpdate = (
+  project: gdProject,
+  extension: ExtensionShortHeader
+): UpdateMetadata | null => {
+  return useMemo<UpdateMetadata | null>(
+    () =>
+      project.hasEventsFunctionsExtensionNamed(extension.name)
+        ? getUpdateMetadataFromVersions(
+            project.getEventsFunctionsExtension(extension.name).getVersion(),
+            extension.version
+          )
+        : null,
+    [project, extension]
+  );
+};
+
+// TODO: Use this hook to display a visual hint when an installed extension can be updated
+export const useAllExtensionUpdates = (
+  project: gdProject
+): ExtensionUpdates => {
+  const { extensionShortHeadersByName } = useContext(ExtensionStoreContext);
+  return useMemo(
+    () => {
+      const installedExtensions = enumerateEventsFunctionsExtensions(project);
+      const extensionUpdates = new Map<string, UpdateMetadata>();
+
+      for (const localExtension of installedExtensions) {
+        const localExtensionName = localExtension.getName();
+        const extensionHeader = extensionShortHeadersByName[localExtensionName];
+
+        // No header, this is not an extension that exists on the store. Skip it.
+        if (!extensionHeader) continue;
+
+        const currentVersion = localExtension.getVersion();
+        const newestVersion = extensionHeader.version;
+        const updateMetadata = getUpdateMetadataFromVersions(
+          currentVersion,
+          newestVersion
+        );
+        if (updateMetadata)
+          extensionUpdates.set(localExtensionName, updateMetadata);
+      }
+
+      return extensionUpdates;
+    },
+    [project]
+  );
 };

--- a/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
@@ -89,6 +89,6 @@ export const useAllExtensionUpdates = (
 
       return extensionUpdates;
     },
-    [project]
+    [project, extensionShortHeadersByName]
   );
 };

--- a/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
@@ -59,36 +59,3 @@ export const useExtensionUpdate = (
     [project, extension]
   );
 };
-
-// TODO: Use this hook to display a visual hint when an installed extension can be updated
-export const useAllExtensionUpdates = (
-  project: gdProject
-): ExtensionUpdates => {
-  const { extensionShortHeadersByName } = useContext(ExtensionStoreContext);
-  return useMemo(
-    () => {
-      const installedExtensions = enumerateEventsFunctionsExtensions(project);
-      const extensionUpdates = new Map<string, UpdateMetadata>();
-
-      for (const localExtension of installedExtensions) {
-        const localExtensionName = localExtension.getName();
-        const extensionHeader = extensionShortHeadersByName[localExtensionName];
-
-        // No header, this is not an extension that exists on the store. Skip it.
-        if (!extensionHeader) continue;
-
-        const currentVersion = localExtension.getVersion();
-        const newestVersion = extensionHeader.version;
-        const updateMetadata = getUpdateMetadataFromVersions(
-          currentVersion,
-          newestVersion
-        );
-        if (updateMetadata)
-          extensionUpdates.set(localExtensionName, updateMetadata);
-      }
-
-      return extensionUpdates;
-    },
-    [project, extensionShortHeadersByName]
-  );
-};

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -124,9 +124,6 @@ export const ExtensionStore = ({
           project={project}
           isInstalling={isInstalling}
           extensionShortHeader={selectedExtensionShortHeader}
-          alreadyInstalled={project.hasEventsFunctionsExtensionNamed(
-            selectedExtensionShortHeader.name
-          )}
           onInstall={async () => {
             const wasInstalled = await onInstall(selectedExtensionShortHeader);
             if (wasInstalled) setSelectedExtensionShortHeader(null);

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -121,6 +121,7 @@ export const ExtensionStore = ({
       </ResponsiveWindowMeasurer>
       {!!selectedExtensionShortHeader && (
         <ExtensionInstallDialog
+          project={project}
           isInstalling={isInstalling}
           extensionShortHeader={selectedExtensionShortHeader}
           alreadyInstalled={project.hasEventsFunctionsExtensionNamed(

--- a/newIDE/app/src/ProjectManager/InstalledExtensionDetails.js
+++ b/newIDE/app/src/ProjectManager/InstalledExtensionDetails.js
@@ -51,7 +51,6 @@ function InstalledExtensionDetails({
       {({ i18n }) => (
         <ExtensionInstallDialog
           project={project}
-          alreadyInstalled
           isInstalling={isInstalling}
           onClose={onClose}
           onInstall={() => installOrUpdateExtension(i18n)}

--- a/newIDE/app/src/ProjectManager/InstalledExtensionDetails.js
+++ b/newIDE/app/src/ProjectManager/InstalledExtensionDetails.js
@@ -50,6 +50,7 @@ function InstalledExtensionDetails({
     <I18n>
       {({ i18n }) => (
         <ExtensionInstallDialog
+          project={project}
           alreadyInstalled
           isInstalling={isInstalling}
           onClose={onClose}


### PR DESCRIPTION
Adapted from prior work on #3332

Make the update dialogue aware of if you are updating or reinstalling an extension update, and change the button text accordingly.