### PR TITLE
[P2P] Add a way to check if a connection was successful

### DIFF
--- a/Extensions/P2P/B_p2ptools.ts
+++ b/Extensions/P2P/B_p2ptools.ts
@@ -123,6 +123,11 @@ namespace gdjs {
       let lastError = '';
 
       /**
+       * Set to true if the last connection attempt succeeded.
+       */
+      let lastConnectionSucessful = false;
+
+      /**
        * List of IDs of peers that just disconnected.
        */
       const disconnectedPeers: string[] = [];
@@ -149,6 +154,9 @@ namespace gdjs {
         peer.on('error', (errorMessage) => {
           error = true;
           lastError = errorMessage;
+          if (errorMessage.type === 'peer-unavailable') {
+            lastConnectionSucessful = false;
+          }
         });
         peer.on('connection', (connection) => {
           connection.on('open', () => {
@@ -226,9 +234,59 @@ namespace gdjs {
         if (peer === null) return;
         const connection = peer.connect(id);
         connection.on('open', () => {
+          // See line 158 for the failure case.
+          lastConnectionSucessful = true;
           _onConnection(connection);
         });
       };
+
+      class P2PConnectionTask extends gdjs.AsyncTask {
+        peerConnection: RTCPeerConnection;
+        timeout = 0;
+
+        constructor({ peerConnection }: Peer.DataConnection<NetworkEvent>) {
+          super();
+          this.peerConnection = peerConnection;
+        }
+
+        update(runtimeScene: gdjs.RuntimeScene) {
+          // PeerJS doesn't error when not finding any peer with the good ID,
+          // so if the session establishment stays locked at the same step for 10 seconds,
+          // we assume that this is happening and error out.
+          if (this.peerConnection.signalingState === 'have-local-offer') {
+            this.timeout += runtimeScene.getTimeManager().getElapsedTime();
+            if (this.timeout > 10_000) {
+              lastConnectionSucessful = false;
+              return true;
+            }
+          }
+
+          const connected =
+            this.peerConnection.connectionState !== 'connecting' &&
+            this.peerConnection.connectionState !== 'new';
+
+          if (connected)
+            // Only set it now, so that we can assure that the callback will see the value for this connection.
+            lastConnectionSucessful =
+              this.peerConnection.connectionState === 'connected';
+
+          return connected;
+        }
+      }
+
+      /**
+       * Connects to another p2p client. Asynchronously resolve once the connection either succeeded or failed.
+       * @param id - The other client's ID.
+       */
+      export const connectAsync = (id: string): AsyncTask => {
+        if (peer === null) return new gdjs.ResolvingTask();
+        return new P2PConnectionTask(peer.connect(id));
+      };
+
+      /**
+       * @returns true if the last connection attempt was successful.
+       */
+      export const connectionSucceeded = () => lastConnectionSucessful;
 
       /**
        * Disconnects from another p2p client.

--- a/Extensions/P2P/JsExtension.js
+++ b/Extensions/P2P/JsExtension.js
@@ -123,6 +123,21 @@ module.exports = {
       .setFunctionName('gdjs.evtTools.p2p.onConnection');
 
     extension
+      .addCondition(
+        'ConnectionSucceeded',
+        _('Connection attempt succeeded'),
+        _('Triggers if the last connection attempt was successful.'),
+        _('Connection to peer successful'),
+        '',
+        'JsPlatform/Extensions/p2picon.svg',
+        'JsPlatform/Extensions/p2picon.svg'
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/P2P/A_peer.js')
+      .addIncludeFile('Extensions/P2P/B_p2ptools.js')
+      .setFunctionName('gdjs.evtTools.p2p.connectionSucceeded');
+
+    extension
       .addAction(
         'Connect',
         _('Connect to another client'),
@@ -137,6 +152,23 @@ module.exports = {
       .setIncludeFile('Extensions/P2P/A_peer.js')
       .addIncludeFile('Extensions/P2P/B_p2ptools.js')
       .setFunctionName('gdjs.evtTools.p2p.connect');
+
+    extension
+      .addAction(
+        'ConnectAsync',
+        _('Connect to another client (async)'),
+        _('Connects the current client to another client using its id. Continue executing events after the connection either fails or succeeds.'),
+        _('Start and wait for connection to P2P client _PARAM0_'),
+        '',
+        'JsPlatform/Extensions/p2picon.svg',
+        'JsPlatform/Extensions/p2picon.svg'
+      )
+      .addParameter('string', _('ID of the other client'), '', false)
+      .setAsync()
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/P2P/A_peer.js')
+      .addIncludeFile('Extensions/P2P/B_p2ptools.js')
+      .setFunctionName('gdjs.evtTools.p2p.connectAsync');
 
     extension
       .addAction(

--- a/Extensions/P2P/peerjs.d.ts
+++ b/Extensions/P2P/peerjs.d.ts
@@ -80,7 +80,7 @@ declare class Peer<T> {
    * @param event Event name
    * @param cb Callback Function
    */
-  on(event: 'error', cb: (err: any) => void): void;
+  on(event: 'error', cb: (err: string & { type: string }) => void): void;
   /**
    * Remove event listeners.(EventEmitter3)
    * @param {String} event The event we want to remove.


### PR DESCRIPTION
Adds a condition to see if the last connection attempt succeeded and an async action to await that results (based on #3535).
This is useful to display an error message when a connection failed.

This branch is without the asynchronous code, to keep the changed files readable and reviewable. Use the branch `p2p-async` from my fork, a version with the changes from the async PR, to actually try the feature.