### PR TITLE
Add a condition to check if the mouse is inside the window.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
@@ -191,6 +191,17 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsMouseExtension(
   extension.AddDuplicatedExpression("SourisY", "MouseY").SetHidden();
 
   extension
+      .AddCondition("IsMouseInsideCanvas",
+                    _("Mouse is inside the window"),
+                    _("Check if the mouse is inside the window."),
+                    _("The mouse is inside the window"),
+                    "",
+                    "res/conditions/mouse24.png",
+                    "res/conditions/mouse.png")
+      .AddCodeOnlyParameter("currentScene", "")
+      .MarkAsAdvanced();
+
+  extension
       .AddCondition("MouseButtonPressed",
                     _("Mouse button pressed or touch held"),
                     _("Check if the specified mouse button is pressed or "

--- a/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
@@ -192,9 +192,9 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsMouseExtension(
 
   extension
       .AddCondition("IsMouseInsideCanvas",
-                    _("Mouse is inside the window"),
-                    _("Check if the mouse is inside the window."),
-                    _("The mouse is inside the window"),
+                    _("Mouse cursor is inside the window"),
+                    _("Check if the mouse cursor is inside the window."),
+                    _("The mouse cursor is inside the window"),
                     "",
                     "res/conditions/mouse24.png",
                     "res/conditions/mouse.png")

--- a/GDJS/GDJS/Extensions/Builtin/MouseExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/MouseExtension.cpp
@@ -17,6 +17,8 @@ MouseExtension::MouseExtension() {
       "gdjs.evtTools.input.getMouseX");
   GetAllConditions()["MouseY"].SetFunctionName(
       "gdjs.evtTools.input.getMouseY");
+  GetAllConditions()["IsMouseInsideCanvas"].SetFunctionName(
+      "gdjs.evtTools.input.isMouseInsideCanvas");
   GetAllConditions()["SourisX"].SetFunctionName(
       "gdjs.evtTools.input.getMouseX"); // Deprecated
   GetAllConditions()["SourisY"].SetFunctionName(

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -266,6 +266,12 @@ namespace gdjs {
           )[1];
       };
 
+      export const isMouseInsideCanvas = function (
+        runtimeScene: gdjs.RuntimeScene
+      ) {
+        return runtimeScene.getGame().getInputManager().isMouseInsideCanvas();
+      };
+
       export const _cursorIsOnObject = function (obj, runtimeScene) {
         return obj.cursorOnObject(runtimeScene);
       };

--- a/GDJS/Runtime/inputmanager.ts
+++ b/GDJS/Runtime/inputmanager.ts
@@ -366,6 +366,10 @@ namespace gdjs {
       this._touchSimulateMouse = enable;
     }
 
+    isSimulatingMouseWithTouch(): boolean {
+      return this._touchSimulateMouse;
+    }
+
     /**
      * Notify the input manager that the frame ended, so anything that last
      * only for one frame (started/ended touches) should be reset.

--- a/GDJS/Runtime/inputmanager.ts
+++ b/GDJS/Runtime/inputmanager.ts
@@ -28,6 +28,7 @@ namespace gdjs {
     _releasedMouseButtons: Array<boolean>;
     _mouseX: float = 0;
     _mouseY: float = 0;
+    _isMouseInsideCanvas: boolean = true;
     _mouseWheelDelta: float = 0;
     _touches: Hashtable<Touch>;
     //Identifiers of the touches that started during/before the frame.
@@ -191,6 +192,27 @@ namespace gdjs {
      */
     getMouseY(): float {
       return this._mouseY;
+    }
+
+    /**
+     * Should be called when the mouse leave the canvas.
+     */
+    onMouseLeave(): void {
+      this._isMouseInsideCanvas = false;
+    }
+
+    /**
+     * Should be called when the mouse enter the canvas.
+     */
+    onMouseEnter(): void {
+      this._isMouseInsideCanvas = true;
+    }
+
+    /**
+     * @return true when the mouse is inside the canvas.
+     */
+    isMouseInsideCanvas(): boolean {
+      return this._isMouseInsideCanvas;
     }
 
     /**

--- a/GDJS/Runtime/inputmanager.ts
+++ b/GDJS/Runtime/inputmanager.ts
@@ -366,6 +366,9 @@ namespace gdjs {
       this._touchSimulateMouse = enable;
     }
 
+    /**
+     * @returns true if the touch events are used to simulate mouse events.
+     */
     isSimulatingMouseWithTouch(): boolean {
       return this._touchSimulateMouse;
     }

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -571,6 +571,12 @@ namespace gdjs {
         );
         return false;
       };
+      canvas.onmouseleave = function (e) {
+        manager.onMouseLeave();
+      };
+      canvas.onmouseenter = function (e) {
+        manager.onMouseEnter();
+      };
       window.addEventListener(
         'click',
         function (e) {

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -442,7 +442,11 @@ namespace gdjs {
     /**
      * Add the standard events handler.
      */
-    bindStandardEvents(manager, window, document) {
+    bindStandardEvents(
+      manager: gdjs.InputManager,
+      window: Window,
+      document: Document
+    ) {
       const renderer = this._pixiRenderer;
       if (!renderer) return;
       const canvas = renderer.view;
@@ -451,7 +455,7 @@ namespace gdjs {
       //to game coordinates.
       const that = this;
 
-      function getEventPosition(e) {
+      function getEventPosition(e: MouseEvent | Touch) {
         const pos = [e.pageX - canvas.offsetLeft, e.pageY - canvas.offsetTop];
 
         // Handle the fact that the game is stretched to fill the canvas.
@@ -460,6 +464,18 @@ namespace gdjs {
         pos[1] *=
           that._game.getGameResolutionHeight() / (that._canvasHeight || 1);
         return pos;
+      }
+
+      function isInsideCanvas(e: MouseEvent | Touch) {
+        const x = e.pageX - canvas.offsetLeft;
+        const y = e.pageY - canvas.offsetTop;
+
+        return (
+          0 <= x &&
+          x < (that._canvasWidth || 1) &&
+          0 <= y &&
+          y < (that._canvasHeight || 1)
+        );
       }
 
       //Some browsers lacks definition of some variables used to do calculations
@@ -480,6 +496,7 @@ namespace gdjs {
           document.documentElement === undefined ||
           document.documentElement === null
         ) {
+          // @ts-ignore
           document.documentElement = {};
         }
         if (isNaN(document.documentElement.scrollLeft)) {
@@ -612,6 +629,15 @@ namespace gdjs {
           for (let i = 0; i < e.changedTouches.length; ++i) {
             const pos = getEventPosition(e.changedTouches[i]);
             manager.onTouchMove(e.changedTouches[i].identifier, pos[0], pos[1]);
+            // This works because touch events are sent
+            // when they continue outside of the canvas.
+            if (manager.isSimulatingMouseWithTouch()) {
+              if (isInsideCanvas(e.changedTouches[i])) {
+                manager.onMouseEnter();
+              } else {
+                manager.onMouseLeave();
+              }
+            }
           }
         }
       });

--- a/GDJS/tests/tests/inputmanager.js
+++ b/GDJS/tests/tests/inputmanager.js
@@ -90,6 +90,12 @@ describe('gdjs.InputManager', function() {
     expect(
       inputManager.isMouseButtonReleased(gdjs.InputManager.MOUSE_LEFT_BUTTON)
     ).to.be(false);
+    
+    expect(inputManager.isMouseInsideCanvas()).to.be(true);
+    inputManager.onMouseLeave();
+    expect(inputManager.isMouseInsideCanvas()).to.be(false);
+    inputManager.onMouseEnter();
+    expect(inputManager.isMouseInsideCanvas()).to.be(true);
   });
 
   it('should handle touch events', function() {


### PR DESCRIPTION
When the mouse is outside of the canvas GDevelop doesn't update the mouse position and mouse button released (it seems a very hard thing to do). This can cause 2 issues:

1. game creators can't write events to check if the mouse stopped near the canvas edge or left it.
2. game creator can't write events to check if the mouse is released outside of the canvas (PIXI has a mouseupoutside event, maybe it can be possible to have something like it).

## EdgeScrollCamera  extension (1)
* https://github.com/GDevelopApp/GDevelop-extensions/pull/384

Example from Tristan extension with a fix on scrolling up:
* https://liluo.io/games/6fd0cf36-b14b-4180-b7a2-dc5d7613d04a?dev=true
  Try to move the mouse quickly to leave from the bottom. It will often not scroll. Whereas leaving from the top will always scroll.

## QIX example (2)
There is a bug in this game: when leaving the canvas while drawing and releasing the button outside, the game will continue to draw even if the mouse button is not pressed.
* https://d8h.itch.io/quick-impulse-xpansion
With the new condition the drawing could be ended when the mouse leave the canvas.