### PR TITLE
Fix the camera rounding to work when following objects with even dimensions

### DIFF
--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -85,10 +85,10 @@ namespace gdjs {
         // the sprite one and it changes in which direction sprites are rounded.
         // It makes sprites rounding inconsistent with each other
         // and they seems to move on pixel left and right.
-        this._pixiContainer.position.x = Math.round(
+        this._pixiContainer.position.x = Math.floor(
           this._pixiContainer.position.x
         );
-        this._pixiContainer.position.y = Math.round(
+        this._pixiContainer.position.y = Math.floor(
           this._pixiContainer.position.y
         );
       }

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -85,10 +85,10 @@ namespace gdjs {
         // the sprite one and it changes in which direction sprites are rounded.
         // It makes sprites rounding inconsistent with each other
         // and they seems to move on pixel left and right.
-        this._pixiContainer.position.x = Math.floor(
+        this._pixiContainer.position.x = Math.ceil(
           this._pixiContainer.position.x
         );
-        this._pixiContainer.position.y = Math.floor(
+        this._pixiContainer.position.y = Math.ceil(
           this._pixiContainer.position.y
         );
       }

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -14,6 +14,7 @@ export type AlertMessageIdentifier =
   | 'automatic-lighting-layer'
   | 'object-moved-in-lighting-layer'
   | 'use-non-smoothed-textures'
+  | 'use-pixel-rounding'
   | 'use-nearest-scale-mode'
   | 'maximum-fps-too-low'
   | 'minimum-fps-too-low'
@@ -52,6 +53,10 @@ export const allAlertMessages: Array<{
   {
     key: 'use-non-smoothed-textures',
     label: <Trans>Using non smoothed textures</Trans>,
+  },
+  {
+    key: 'use-pixel-rounding',
+    label: <Trans>Using pixel rounding</Trans>,
   },
   {
     key: 'use-nearest-scale-mode',

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -541,6 +541,17 @@ function ProjectPropertiesDialog(props: Props) {
                     </Trans>
                   </DismissableAlertMessage>
                 )}
+                {pixelsRounding && (
+                  <DismissableAlertMessage
+                    identifier="use-pixel-rounding"
+                    kind="info"
+                  >
+                    <Trans>
+                      To avoid flickering on objects followed by
+                      the camera, use sprites with even dimensions.
+                    </Trans>
+                  </DismissableAlertMessage>
+                )}
 
                 <Text size="title">
                   <Trans>Project files</Trans>


### PR DESCRIPTION
Fix the camera rounding to work when following objects with even dimensions instead of odd ones.

I actually used `ceil` because otherwise, when the character jumps, it seems to move from one pixel on screen.

Direct following
* https://liluo.io/instant-builds/23ae9daf-9240-4ac8-9456-7fd6ce36cb4f?dev=true

Linear following
* https://liluo.io/instant-builds/cb33a8eb-7840-40ae-8622-1722ae730e2c?dev=true


There will be 2 alerts next to each other, but I think it's not an issue.

![image](https://user-images.githubusercontent.com/2611977/160871487-11f31478-1be8-4c9b-9375-7f059f421cf4.png)
