### PR TITLE
[TopDownMovement] Fix the velocity that was 1e-15 instead of 0

### DIFF
--- a/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js
+++ b/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-describe('gdjs.TopDownMovementRuntimeBehavior', function () {
+describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
   const epsilon = 1 / (2 << 8);
   const topDownName = 'auto1';
 
@@ -99,14 +99,14 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
                 player.getBehavior(topDownName).simulateDownKey();
               }
               runtimeScene.renderAndStep(1000 / 60);
+              expect(
+                player.getBehavior(topDownName).getXVelocity()
+              ).to.be.above(0);
+              expect(player.getBehavior(topDownName).getYVelocity()).to.be(0);
             }
 
             expect(player.getX()).to.be.above(200 + 20);
             expect(player.getY()).to.be(300);
-            expect(player.getBehavior(topDownName).getXVelocity()).to.be.above(
-              0
-            );
-            expect(player.getBehavior(topDownName).getYVelocity()).to.be(0);
           });
 
           it('can move left', function () {
@@ -124,14 +124,14 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
                 player.getBehavior(topDownName).simulateUpKey();
               }
               runtimeScene.renderAndStep(1000 / 60);
+              expect(
+                player.getBehavior(topDownName).getXVelocity()
+              ).to.be.below(0);
+              expect(player.getBehavior(topDownName).getYVelocity()).to.be(0);
             }
 
             expect(player.getX()).to.be.below(200 - 20);
             expect(player.getY()).to.be(300);
-            expect(player.getBehavior(topDownName).getXVelocity()).to.be.below(
-              0
-            );
-            expect(player.getBehavior(topDownName).getYVelocity()).to.be(0);
           });
 
           it('can move down', function () {
@@ -149,14 +149,14 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
                 player.getBehavior(topDownName).simulateLeftKey();
               }
               runtimeScene.renderAndStep(1000 / 60);
+              expect(player.getBehavior(topDownName).getXVelocity()).to.be(0);
+              expect(
+                player.getBehavior(topDownName).getYVelocity()
+              ).to.be.above(0);
             }
 
             expect(player.getX()).to.be(200);
             expect(player.getY()).to.be.above(300 + 20);
-            expect(player.getBehavior(topDownName).getXVelocity()).to.be(0);
-            expect(player.getBehavior(topDownName).getYVelocity()).to.be.above(
-              0
-            );
           });
 
           it('can move up', function () {
@@ -174,14 +174,14 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
                 player.getBehavior(topDownName).simulateLeftKey();
               }
               runtimeScene.renderAndStep(1000 / 60);
+              expect(player.getBehavior(topDownName).getXVelocity()).to.be(0);
+              expect(
+                player.getBehavior(topDownName).getYVelocity()
+              ).to.be.below(0);
             }
 
             expect(player.getX()).to.be(200);
             expect(player.getY()).to.be.below(300 - 20);
-            expect(player.getBehavior(topDownName).getXVelocity()).to.be(0);
-            expect(player.getBehavior(topDownName).getYVelocity()).to.be.below(
-              0
-            );
           });
         });
       });

--- a/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js
+++ b/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-describe.only('gdjs.TopDownMovementRuntimeBehavior', function () {
+describe('gdjs.TopDownMovementRuntimeBehavior', function () {
   const epsilon = 1 / (2 << 8);
   const topDownName = 'auto1';
 

--- a/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js
+++ b/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js
@@ -103,6 +103,10 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
 
             expect(player.getX()).to.be.above(200 + 20);
             expect(player.getY()).to.be(300);
+            expect(player.getBehavior(topDownName).getXVelocity()).to.be.above(
+              0
+            );
+            expect(player.getBehavior(topDownName).getYVelocity()).to.be(0);
           });
 
           it('can move left', function () {
@@ -124,6 +128,10 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
 
             expect(player.getX()).to.be.below(200 - 20);
             expect(player.getY()).to.be(300);
+            expect(player.getBehavior(topDownName).getXVelocity()).to.be.below(
+              0
+            );
+            expect(player.getBehavior(topDownName).getYVelocity()).to.be(0);
           });
 
           it('can move down', function () {
@@ -145,6 +153,10 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
 
             expect(player.getX()).to.be(200);
             expect(player.getY()).to.be.above(300 + 20);
+            expect(player.getBehavior(topDownName).getXVelocity()).to.be(0);
+            expect(player.getBehavior(topDownName).getYVelocity()).to.be.above(
+              0
+            );
           });
 
           it('can move up', function () {
@@ -166,6 +178,10 @@ describe('gdjs.TopDownMovementRuntimeBehavior', function () {
 
             expect(player.getX()).to.be(200);
             expect(player.getY()).to.be.below(300 - 20);
+            expect(player.getBehavior(topDownName).getXVelocity()).to.be(0);
+            expect(player.getBehavior(topDownName).getYVelocity()).to.be.below(
+              0
+            );
           });
         });
       });

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -326,16 +326,25 @@ namespace gdjs {
       let directionInDeg = 0;
       const previousVelocityX = this._xVelocity;
       const previousVelocityY = this._yVelocity;
+      let cos = 0;
+      let sin = 0;
 
       // Update the speed of the object:
       if (direction !== -1) {
         directionInRad =
           ((direction + this._movementAngleOffset / 45) * Math.PI) / 4.0;
         directionInDeg = direction * 45 + this._movementAngleOffset;
-        this._xVelocity +=
-          this._acceleration * timeDelta * Math.cos(directionInRad);
-        this._yVelocity +=
-          this._acceleration * timeDelta * Math.sin(directionInRad);
+        // This make the trigo resilient to rounding errors on directionInRad.
+        cos = Math.cos(directionInRad);
+        sin = Math.sin(directionInRad);
+        if (cos === -1 || cos === 1) {
+          sin = 0;
+        }
+        if (sin === -1 || sin === 1) {
+          cos = 0;
+        }
+        this._xVelocity += this._acceleration * timeDelta * cos;
+        this._yVelocity += this._acceleration * timeDelta * sin;
       } else if (this._stickForce !== 0) {
         if (!this._allowDiagonals) {
           this._stickAngle = 90 * Math.floor((this._stickAngle + 45) / 90);
@@ -343,8 +352,17 @@ namespace gdjs {
         directionInDeg = this._stickAngle + this._movementAngleOffset;
         directionInRad = (directionInDeg * Math.PI) / 180;
         const norm = this._acceleration * timeDelta * this._stickForce;
-        this._xVelocity += norm * Math.cos(directionInRad);
-        this._yVelocity += norm * Math.sin(directionInRad);
+        // This make the trigo resilient to rounding errors on directionInRad.
+        cos = Math.cos(directionInRad);
+        sin = Math.sin(directionInRad);
+        if (cos === -1 || cos === 1) {
+          sin = 0;
+        }
+        if (sin === -1 || sin === 1) {
+          cos = 0;
+        }
+        this._xVelocity += norm * cos;
+        this._yVelocity += norm * sin;
 
         this._stickForce = 0;
       } else if (this._yVelocity !== 0 || this._xVelocity !== 0) {
@@ -352,10 +370,17 @@ namespace gdjs {
         directionInDeg = (directionInRad * 180.0) / Math.PI;
         const xVelocityWasPositive = this._xVelocity >= 0;
         const yVelocityWasPositive = this._yVelocity >= 0;
-        this._xVelocity -=
-          this._deceleration * timeDelta * Math.cos(directionInRad);
-        this._yVelocity -=
-          this._deceleration * timeDelta * Math.sin(directionInRad);
+        // This make the trigo resilient to rounding errors on directionInRad.
+        cos = Math.cos(directionInRad);
+        sin = Math.sin(directionInRad);
+        if (cos === -1 || cos === 1) {
+          sin = 0;
+        }
+        if (sin === -1 || sin === 1) {
+          cos = 0;
+        }
+        this._xVelocity -= this._deceleration * timeDelta * cos;
+        this._yVelocity -= this._deceleration * timeDelta * sin;
         if (this._xVelocity > 0 !== xVelocityWasPositive) {
           this._xVelocity = 0;
         }
@@ -366,8 +391,8 @@ namespace gdjs {
       const squaredSpeed =
         this._xVelocity * this._xVelocity + this._yVelocity * this._yVelocity;
       if (squaredSpeed > this._maxSpeed * this._maxSpeed) {
-        this._xVelocity = this._maxSpeed * Math.cos(directionInRad);
-        this._yVelocity = this._maxSpeed * Math.sin(directionInRad);
+        this._xVelocity = this._maxSpeed * cos;
+        this._yVelocity = this._maxSpeed * sin;
       }
 
       // No acceleration for angular speed for now.

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -322,11 +322,14 @@ namespace gdjs {
 
       const object = this.owner;
       const timeDelta = this.owner.getElapsedTime(runtimeScene) / 1000;
-      let directionInRad = 0;
-      let directionInDeg = 0;
       const previousVelocityX = this._xVelocity;
       const previousVelocityY = this._yVelocity;
-      let cos = 0;
+      // These 4 values are not actually used.
+      // JavaScript doesn't allow to declare
+      // variables without assigning them a value.
+      let directionInRad = 0;
+      let directionInDeg = 0;
+      let cos = 1;
       let sin = 0;
 
       // Update the speed of the object:
@@ -334,7 +337,7 @@ namespace gdjs {
         directionInRad =
           ((direction + this._movementAngleOffset / 45) * Math.PI) / 4.0;
         directionInDeg = direction * 45 + this._movementAngleOffset;
-        // This make the trigo resilient to rounding errors on directionInRad.
+        // This makes the trigo resilient to rounding errors on directionInRad.
         cos = Math.cos(directionInRad);
         sin = Math.sin(directionInRad);
         if (cos === -1 || cos === 1) {
@@ -352,7 +355,7 @@ namespace gdjs {
         directionInDeg = this._stickAngle + this._movementAngleOffset;
         directionInRad = (directionInDeg * Math.PI) / 180;
         const norm = this._acceleration * timeDelta * this._stickForce;
-        // This make the trigo resilient to rounding errors on directionInRad.
+        // This makes the trigo resilient to rounding errors on directionInRad.
         cos = Math.cos(directionInRad);
         sin = Math.sin(directionInRad);
         if (cos === -1 || cos === 1) {
@@ -370,7 +373,7 @@ namespace gdjs {
         directionInDeg = (directionInRad * 180.0) / Math.PI;
         const xVelocityWasPositive = this._xVelocity >= 0;
         const yVelocityWasPositive = this._yVelocity >= 0;
-        // This make the trigo resilient to rounding errors on directionInRad.
+        // This makes the trigo resilient to rounding errors on directionInRad.
         cos = Math.cos(directionInRad);
         sin = Math.sin(directionInRad);
         if (cos === -1 || cos === 1) {


### PR DESCRIPTION
It fixes the velocity that was 1e-14 instead of 0 when going strictly vertically or horizontally.

```
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: 1key) can move left FAILED
        Error: expected 1.6328623988631378e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:134:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: 1key) can move down FAILED
        Error: expected 8.164311994315689e-15 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:156:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: 1key) can move up FAILED
        Error: expected -2.4492935982947077e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:181:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: 3keys) can move left FAILED
        Error: expected 1.6328623988631378e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:134:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: 3keys) can move down FAILED
        Error: expected 8.164311994315689e-15 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:156:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: 3keys) can move up FAILED
        Error: expected -2.4492935982947077e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:181:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: stick) can move left FAILED
        Error: expected 1.6328623988631378e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:134:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: stick) can move down FAILED
        Error: expected 8.164311994315689e-15 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:156:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: true, inputMethod: stick) can move up FAILED
        Error: expected -2.4492935982947077e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:181:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: 1key) can move left FAILED
        Error: expected 1.6328623988631378e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:134:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: 1key) can move down FAILED
        Error: expected 8.164311994315689e-15 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:156:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: 1key) can move up FAILED
        Error: expected -2.4492935982947077e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:181:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: 3keys) can move left FAILED
        Error: expected 1.6328623988631378e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:134:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: 3keys) can move down FAILED
        Error: expected 8.164311994315689e-15 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:156:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: 3keys) can move up FAILED
        Error: expected -2.4492935982947077e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:181:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: stick) can move left FAILED
        Error: expected 1.6328623988631378e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:134:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: stick) can move down FAILED
        Error: expected 8.164311994315689e-15 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:156:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0) gdjs.TopDownMovementRuntimeBehavior (allowDiagonals: false, inputMethod: stick) can move up FAILED
        Error: expected -2.4492935982947077e-14 to equal 0
            at Assertion.assert (node_modules/expect.js/index.js:96:13)
            at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
            at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
            at context.<anonymous> (C:/WorkspaceGDevelop/GDevelop/Extensions/TopDownMovementBehavior/tests/topdownmovementbehavior.spec.js:181:71)
HeadlessChrome 100.0.4896 (Windows 10.0.0): Executed 54 of 54 (18 FAILED) (0.019 secs / 0.014 secs) 
```