### PR TITLE
Add context to descriptions.

### DIFF
--- a/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
@@ -136,12 +136,13 @@ void ExtensionSubDeclaration3(gd::ObjectMetadata& obj) {
 
   obj.AddAction("Texture",
                 _("Image"),
-                _("Change the image of particles, valid name is the resource name from the resource tab."),
+                _("Change the image of particles ( if displayed )."),
                 _("Change the image of particles of _PARAM0_ to _PARAM1_"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
+      .SetParameterLongDescription(_("Valid name is the resource name used for an asset."))
       .AddParameter("string", _("New image"));
 
   obj.AddCondition(

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
@@ -142,8 +142,8 @@ void ExtensionSubDeclaration3(gd::ObjectMetadata& obj) {
                 "CppPlatform/Extensions/particleSystemicon24.png",
                 "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter")
-      .SetParameterLongDescription(_("Valid name is the resource name used for an asset."))
-      .AddParameter("string", _("New image"));
+      .AddParameter("string", _("New image"))
+      .SetParameterLongDescription(_("Valid name is the resource name used for an asset."));
 
   obj.AddCondition(
          "Texture",

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
@@ -136,7 +136,7 @@ void ExtensionSubDeclaration3(gd::ObjectMetadata& obj) {
 
   obj.AddAction("Texture",
                 _("Image"),
-                _("Change the image of particles ( if displayed )."),
+                _("Change the image of particles, valid name is the resource name from the resource tab."),
                 _("Change the image of particles of _PARAM0_ to _PARAM1_"),
                 _("Common"),
                 "CppPlatform/Extensions/particleSystemicon24.png",

--- a/GDJS/Runtime/pixi-renderers/pixi-effects-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-effects-manager.ts
@@ -14,6 +14,7 @@ namespace gdjs {
     getHeight: () => number;
     getWidth: () => number;
     isLightingLayer?: () => boolean;
+    getName: () => string;
   }
 
   /**
@@ -38,9 +39,11 @@ namespace gdjs {
       );
       if (!filterCreator) {
         console.log(
-          'Effect "' +
+          'Effect: "' +
             effectData.name +
-            '" has an unknown effect type: "' +
+            '", on layer: "' +
+            target.getName()
+            +'", has an unknown effect type: "' +
             effectData.effectType +
             '". Was it registered properly? Is the effect type correct?'
         );

--- a/GDJS/Runtime/pixi-renderers/pixi-effects-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-effects-manager.ts
@@ -42,8 +42,8 @@ namespace gdjs {
           'Effect: "' +
             effectData.name +
             '", on layer: "' +
-            target.getName()
-            +'", has an unknown effect type: "' +
+            target.getName() +
+            '", has an unknown effect type: "' +
             effectData.effectType +
             '". Was it registered properly? Is the effect type correct?'
         );


### PR DESCRIPTION
What is required wasn't clear.
I tested before and It's really the resource name.

Must be the value of the resource name from the resource tab:
![image](https://user-images.githubusercontent.com/1670670/163409665-6f91cbc8-8303-446a-bffb-5f2620a11794.png)
