### PR TITLE
Add warnings when updating an extension with breaking changes

### DIFF
--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import React from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
@@ -47,6 +47,7 @@ type Props = {|
   onInstall: () => Promise<void>,
   onEdit?: () => void,
   project: gdProject,
+  i18n: I18nType,
 |};
 
 const ExtensionInstallDialog = ({
@@ -56,6 +57,7 @@ const ExtensionInstallDialog = ({
   onInstall,
   onEdit,
   project,
+  i18n,
 }: Props) => {
   const alreadyInstalled = project.hasEventsFunctionsExtensionNamed(
     extensionShortHeader.name
@@ -94,18 +96,29 @@ const ExtensionInstallDialog = ({
   const onInstallExtension = React.useCallback(
     () => {
       if (canInstallExtension) {
-        if (alreadyInstalled) {
-          const answer = Window.showConfirmDialog(
-            'This extension is already in your project, this will install the latest version. You may have to do some adaptations to make sure your game still works. Do you want to continue?'
-          );
-          if (!answer) return;
-          onInstall();
-        } else {
-          onInstall();
+        if (extensionUpdate) {
+          if (extensionUpdate.type === 'major') {
+            const answer = Window.showConfirmDialog(
+              i18n._(
+                t`This extension update contains a breaking change. You will have to do some adaptations to make sure your game still works. We advise to back up your game before proceeding. Do you want to continue?`
+              )
+            );
+            if (!answer) return;
+          }
+
+          if (extensionUpdate.type === 'unknown') {
+            const answer = Window.showConfirmDialog(
+              i18n._(
+                t`The latest version will be installed, but it isn't indicated whether this update includes breaking changes. You may have to do some adaptations to make sure your game still works. We advise to back up your game before proceeding. Do you want to continue?`
+              )
+            );
+            if (!answer) return;
+          }
         }
+        onInstall();
       }
     },
-    [onInstall, canInstallExtension, alreadyInstalled]
+    [onInstall, canInstallExtension, extensionUpdate, i18n]
   );
 
   return (
@@ -118,6 +131,7 @@ const ExtensionInstallDialog = ({
           onClick={onClose}
           disabled={isInstalling}
         />,
+
         <LeftLoader isLoading={isInstalling} key="install">
           <RaisedButton
             label={

--- a/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/UseExtensionUpdates.js
@@ -1,9 +1,9 @@
 //@flow
-import { diff } from 'semver/functions/diff';
+import diff from 'semver/functions/diff';
 import { useMemo } from 'react';
 import type { ExtensionShortHeader } from '../../Utils/GDevelopServices/Extension';
 
-type UpdateType = 'patch' | 'minor' | 'major';
+type UpdateType = 'patch' | 'minor' | 'major' | 'unknown';
 type UpdateMetadata = {|
   type: UpdateType,
   currentVersion: string,
@@ -30,8 +30,7 @@ const getUpdateMetadataFromVersions = (
     // is only for local extensions that do not respect the best practices.
     if (currentVersion !== newestVersion) {
       return {
-        // Use minor as it is the most neutral option
-        type: 'minor',
+        type: 'unknown',
         currentVersion,
         newestVersion,
       };

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { I18n } from '@lingui/react';
 import SearchBar from '../../UI/SearchBar';
 import { Column } from '../../UI/Grid';
 import { type ExtensionShortHeader } from '../../Utils/GDevelopServices/Extension';
@@ -119,18 +120,25 @@ export const ExtensionStore = ({
           </Column>
         )}
       </ResponsiveWindowMeasurer>
-      {!!selectedExtensionShortHeader && (
-        <ExtensionInstallDialog
-          project={project}
-          isInstalling={isInstalling}
-          extensionShortHeader={selectedExtensionShortHeader}
-          onInstall={async () => {
-            const wasInstalled = await onInstall(selectedExtensionShortHeader);
-            if (wasInstalled) setSelectedExtensionShortHeader(null);
-          }}
-          onClose={() => setSelectedExtensionShortHeader(null)}
-        />
-      )}
+      <I18n>
+        {({ i18n }) =>
+          !!selectedExtensionShortHeader && (
+            <ExtensionInstallDialog
+              project={project}
+              isInstalling={isInstalling}
+              extensionShortHeader={selectedExtensionShortHeader}
+              onInstall={async () => {
+                const wasInstalled = await onInstall(
+                  selectedExtensionShortHeader
+                );
+                if (wasInstalled) setSelectedExtensionShortHeader(null);
+              }}
+              onClose={() => setSelectedExtensionShortHeader(null)}
+              i18n={i18n}
+            />
+          )
+        }
+      </I18n>
     </React.Fragment>
   );
 };

--- a/newIDE/app/src/ProjectManager/InstalledExtensionDetails.js
+++ b/newIDE/app/src/ProjectManager/InstalledExtensionDetails.js
@@ -59,6 +59,7 @@ function InstalledExtensionDetails({
             onOpenEventsFunctionsExtension(extensionName);
             onClose();
           }}
+          i18n={i18n}
         />
       )}
     </I18n>


### PR DESCRIPTION
The warning messages are now clearer, translatable, and only shown if the update type is unknown or breaking (major).