### PR TITLE
Fix the cameras position to keep them centered on the object they follow when the game resolution is changed

### DIFF
--- a/GDJS/Runtime/layer.ts
+++ b/GDJS/Runtime/layer.ts
@@ -43,17 +43,22 @@ namespace gdjs {
       oldGameResolutionOriginX: float,
       oldGameResolutionOriginY: float
     ): void {
-      // Adapt position of the camera center as:
-      // * Most cameras following a player/object on the scene will be updating this
-      // in events anyway.
+      // Adapt position of the camera center only if the camera has never moved as:
+      // * When the camera follows a player/object, it will rarely be at the default position.
       // * Cameras not following a player/object are usually UIs which are intuitively
       // expected not to "move". Not adapting the center position would make the camera
       // move from its initial position (which is centered in the screen) - and anchor
       // behavior would behave counterintuitively.
-      this._cameraX +=
-        this._runtimeScene.getViewportOriginX() - oldGameResolutionOriginX;
-      this._cameraY +=
-        this._runtimeScene.getViewportOriginY() - oldGameResolutionOriginY;
+      if (
+        this._cameraX === oldGameResolutionOriginX &&
+        this._cameraY === oldGameResolutionOriginY &&
+        this._zoomFactor === 1
+      ) {
+        this._cameraX +=
+          this._runtimeScene.getViewportOriginX() - oldGameResolutionOriginX;
+        this._cameraY +=
+          this._runtimeScene.getViewportOriginY() - oldGameResolutionOriginY;
+      }
       this._renderer.updatePosition();
     }
 


### PR DESCRIPTION
* https://github.com/4ian/GDevelop/issues/3666

# Changes
- Also fix the camera position for pixel-art games when a zoom and a game resolution change is used to have big pixels

# Examples
* Project: https://www.dropbox.com/s/frf2sjp0718hm9e/ResolutionCameraTest.zip?dl=1

## Example 1 - UI or scrolling?
The scene is 800x600 fill with orange.

![image](https://user-images.githubusercontent.com/2611977/162580660-c40b0a9b-f4d7-4f43-ba03-d9ef09a2ac50.png)

### Camera event disabled
* The camera is at the default position. It's probably an UI layer.
* The camera upper left corner stays at the same position.

![image](https://user-images.githubusercontent.com/2611977/162580687-7c550e58-fc5b-4ed9-9333-17e4fafc974e.png)

### Camera event enabled
* The camera is not at the default position. It's probably a scrolling layer. When a camera following extension is used it will be the case.
* The camera center stays at the same position.

![image](https://user-images.githubusercontent.com/2611977/162580711-60346927-6b54-4774-b866-335a449f00be.png)

## Example 2 - Pixel UI

The camera center doesn't need to be moved by the engine.

![image](https://user-images.githubusercontent.com/2611977/162584941-facc9a0d-0c9f-4129-bc35-1732631364e0.png)

![image](https://user-images.githubusercontent.com/2611977/162584969-a0886645-965e-49f0-aa97-79070d60cd53.png)

![image](https://user-images.githubusercontent.com/2611977/162584979-05f19778-3a7e-4535-a72d-7a2f6a4fd396.png)
