### PR TITLE
Hide advanced parameters and properties from beginners.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -839,6 +839,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                       "edges, but are not overlapping (default: no)"),
                     "",
                     true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("no")
       .MarkAsSimple();
 

--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -40,6 +40,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("0")
       .MarkAsAdvanced();
 
@@ -62,6 +63,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("0")
       .MarkAsAdvanced();
 
@@ -116,6 +118,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("0")
       .MarkAsAdvanced();
 
@@ -234,6 +237,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("0");
 
   // TODO Deprecated: hide this action in a future release.
@@ -262,10 +266,12 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
                     _("Anticipate the movement of the object (yes by default)"),
                     "",
                     true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("yes")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("0")
       .MarkAsAdvanced();
 
@@ -291,6 +297,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("0")
       .MarkAsAdvanced();
 
@@ -309,10 +316,12 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
                     _("Anticipate the movement of the object (yes by default)"),
                     "",
                     true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("yes")
       .AddParameter("layer", _("Layer (base layer if empty)"), "", true)
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
+      .MarkParameterAsAdvanced()
       .SetDefaultValue("0")
       .MarkAsSimple();
 

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
@@ -203,6 +203,18 @@ class GD_CORE_API InstructionMetadata {
   };
 
   /**
+   * \brief Consider that the parameter is harder for a user to understand
+   * and not necessary for common usages.
+   *
+   * \see AddParameter
+   */
+  InstructionMetadata &MarkParameterAsAdvanced() {
+    if (!parameters.empty())
+      parameters.back().MarkAsAdvanced();
+    return *this;
+  };
+
+  /**
    * \brief Add the default parameters for an instruction manipulating the
    * specified type ("string", "number") with the default operators.
    */

--- a/Core/GDCore/Extensions/Metadata/MultipleInstructionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/MultipleInstructionMetadata.h
@@ -92,6 +92,18 @@ class GD_CORE_API MultipleInstructionMetadata {
   };
 
   /**
+   * \brief Consider that the parameter is harder for a user to understand
+   * and not necessary for common usages.
+   *
+   * \see AddParameter
+   */
+  MultipleInstructionMetadata &MarkParameterAsAdvanced() {
+    if (condition) condition->MarkParameterAsAdvanced();
+    if (action) action->MarkParameterAsAdvanced();
+    return *this;
+  };
+
+  /**
    * \see gd::InstructionMetadata::SetHidden
    */
   MultipleInstructionMetadata &SetHidden() {

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.cpp
@@ -10,7 +10,7 @@
 
 namespace gd {
 
-ParameterMetadata::ParameterMetadata() : optional(false), codeOnly(false) {}
+ParameterMetadata::ParameterMetadata() : optional(false), codeOnly(false), usageComplexity(5) {}
 
 void ParameterMetadata::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("type", type);
@@ -21,6 +21,7 @@ void ParameterMetadata::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("codeOnly", codeOnly);
   element.SetAttribute("defaultValue", defaultValue);
   element.SetAttribute("name", name);
+  element.SetAttribute("usageComplexity", usageComplexity);
 }
 
 void ParameterMetadata::UnserializeFrom(const SerializerElement& element) {
@@ -33,6 +34,7 @@ void ParameterMetadata::UnserializeFrom(const SerializerElement& element) {
   codeOnly = element.GetBoolAttribute("codeOnly");
   defaultValue = element.GetStringAttribute("defaultValue");
   name = element.GetStringAttribute("name");
+  usageComplexity = element.GetIntAttribute("usageComplexity");
 }
 
 }  // namespace gd

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
@@ -152,6 +152,37 @@ class GD_CORE_API ParameterMetadata {
   }
 
   /**
+   * \brief Consider that the parameter is easy for a user to understand.
+   */
+  ParameterMetadata &MarkAsSimple() {
+    usageComplexity = 2;
+    return *this;
+  }
+
+  /**
+   * \brief Consider that the parameter is harder for a user to understand
+   * than a normal parameter.
+   */
+  ParameterMetadata &MarkAsAdvanced() {
+    usageComplexity = 7;
+    return *this;
+  }
+
+  /**
+   * \brief Consider that the parameter is complex for a user to understand.
+   */
+  ParameterMetadata &MarkAsComplex() {
+    usageComplexity = 9;
+    return *this;
+  }
+
+  /**
+   * \brief Return the usage complexity of this parameter for the user,
+   * from 0 (simple&easy to use) to 10 (complex to understand).
+   */
+  int GetUsageComplexity() const { return usageComplexity; }
+
+  /**
    * \brief Return true if the type of the parameter is "object", "objectPtr" or
    * "objectList".
    *
@@ -235,6 +266,8 @@ class GD_CORE_API ParameterMetadata {
                                ///< optional parameter is empty.
   gd::String name;             ///< The name of the parameter to be used in code
                                ///< generation. Optional.
+  int usageComplexity;  ///< Evaluate the parameter from 0 (simple&easy to
+                        ///< use) to 10 (complex to understand)
 };
 
 }  // namespace gd

--- a/Core/GDCore/Project/PropertyDescriptor.cpp
+++ b/Core/GDCore/Project/PropertyDescriptor.cpp
@@ -27,6 +27,7 @@ void PropertyDescriptor::SerializeTo(SerializerElement& element) const {
     extraInformationElement.AddChild("").SetStringValue(information);
   }
   element.AddChild("hidden").SetBoolValue(hidden);
+  element.AddChild("usageComplexity").SetIntValue(usageComplexity);
 }
 
 void PropertyDescriptor::UnserializeFrom(const SerializerElement& element) {
@@ -47,6 +48,7 @@ void PropertyDescriptor::UnserializeFrom(const SerializerElement& element) {
   hidden = element.HasChild("hidden")
                ? element.GetChild("hidden").GetBoolValue()
                : false;
+  usageComplexity = element.GetChild("usageComplexity").GetIntValue();
 }
 
 void PropertyDescriptor::SerializeValuesTo(SerializerElement& element) const {

--- a/Core/GDCore/Project/PropertyDescriptor.h
+++ b/Core/GDCore/Project/PropertyDescriptor.h
@@ -28,12 +28,12 @@ class GD_CORE_API PropertyDescriptor {
    * \param propertyValue The value of the property.
    */
   PropertyDescriptor(gd::String propertyValue)
-      : currentValue(propertyValue), type("string"), label(""), hidden(false) {}
+      : currentValue(propertyValue), type("string"), label(""), hidden(false), usageComplexity(5) {}
 
   /**
    * \brief Empty constructor creating an empty property to be displayed.
    */
-  PropertyDescriptor() : hidden(false){};
+  PropertyDescriptor() : hidden(false), usageComplexity(5) {};
 
   /**
    * \brief Destructor
@@ -104,6 +104,37 @@ class GD_CORE_API PropertyDescriptor {
     return *this;
   }
 
+  /**
+   * \brief Consider that the property is easy for a user to understand.
+   */
+  PropertyDescriptor &MarkAsSimple() {
+    usageComplexity = 2;
+    return *this;
+  }
+
+  /**
+   * \brief Consider that the property is harder for a user to understand
+   * than a normal property.
+   */
+  PropertyDescriptor &MarkAsAdvanced() {
+    usageComplexity = 7;
+    return *this;
+  }
+
+  /**
+   * \brief Consider that the property is complex for a user to understand.
+   */
+  PropertyDescriptor &MarkAsComplex() {
+    usageComplexity = 9;
+    return *this;
+  }
+
+  /**
+   * \brief Return the usage complexity of this property for the user,
+   * from 0 (simple&easy to use) to 10 (complex to understand).
+   */
+  int GetUsageComplexity() const { return usageComplexity; }
+
   const gd::String& GetValue() const { return currentValue; }
   const gd::String& GetType() const { return type; }
   const gd::String& GetLabel() const { return label; }
@@ -168,6 +199,8 @@ class GD_CORE_API PropertyDescriptor {
                          ///< choices, if a property is a displayed as a combo
                          ///< box.
   bool hidden;
+  int usageComplexity;  ///< Evaluate the parameter from 0 (simple&easy to
+                        ///< use) to 10 (complex to understand)
 };
 
 }  // namespace gd

--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -88,7 +88,8 @@ PlatformerObjectBehavior::GetProperties(
       .SetValue(behaviorContent.GetBoolAttribute("canGrabWithoutMoving", false)
                     ? "true"
                     : "false")
-      .SetType("Boolean");
+      .SetType("Boolean")
+      .MarkAsAdvanced();
   properties[_("Grab offset on Y axis")]
       .SetGroup(_("Ledge"))
       .SetValue(
@@ -104,13 +105,15 @@ PlatformerObjectBehavior::GetProperties(
       .SetValue(behaviorContent.GetBoolAttribute("useLegacyTrajectory", true)
                     ? "true"
                     : "false")
-      .SetType("Boolean");
+      .SetType("Boolean")
+      .MarkAsComplex();
   properties[_("Can go down from jumpthru platforms")]
       .SetGroup(_("Walk"))
       .SetValue(behaviorContent.GetBoolAttribute("canGoDownFromJumpthru", false)
                     ? "true"
                     : "false")
-      .SetType("Boolean");
+      .SetType("Boolean")
+      .MarkAsAdvanced();
   return properties;
 }
 

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -87,20 +87,23 @@ TopDownMovementBehavior::GetProperties(
       .AddExtraInfo(_("Top-Down"))
       .AddExtraInfo(_("Isometry 2:1 (26.565°)"))
       .AddExtraInfo(_("True Isometry (30°)"))
-      .AddExtraInfo(_("Custom Isometry"));
+      .AddExtraInfo(_("Custom Isometry"))
+      .MarkAsAdvanced();
   properties[_("Custom isometry angle")]
       .SetGroup(_("Viewpoint"))
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("customIsometryAngle")))
       .SetDescription(_("If you choose \"Custom Isometry\", this allows to "
-                        "specify the angle of your isometry projection."));
+                        "specify the angle of your isometry projection."))
+      .MarkAsAdvanced();
   properties[_("Movement angle offset")]
       .SetGroup(_("Viewpoint"))
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("movementAngleOffset")))
       .SetDescription(_(
           "Usually 0, unless you choose an *Isometry* viewpoint in which case "
-          "-45 is recommended."));
+          "-45 is recommended."))
+      .MarkAsAdvanced();
 
   return properties;
 }

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -773,6 +773,11 @@ interface PropertyDescriptor {
     [Ref] VectorString GetExtraInfo();
     [Ref] PropertyDescriptor SetHidden(boolean enable);
     boolean IsHidden();
+    
+    long GetUsageComplexity();
+    [Ref] PropertyDescriptor MarkAsSimple();
+    [Ref] PropertyDescriptor MarkAsAdvanced();
+    [Ref] PropertyDescriptor MarkAsComplex();
 
     void SerializeTo([Ref] SerializerElement element);
     void UnserializeFrom([Const, Ref] SerializerElement element);
@@ -1138,6 +1143,7 @@ interface InstructionMetadata {
     [Ref] InstructionMetadata SetDefaultValue([Const] DOMString defaultValue);
     [Ref] InstructionMetadata SetParameterLongDescription([Const] DOMString longDescription);
     [Ref] InstructionMetadata SetParameterExtraInfo([Const] DOMString extraInfo);
+    [Ref] InstructionMetadata MarkParameterAsAdvanced();
 
     [Ref] InstructionMetadata UseStandardOperatorParameters([Const] DOMString type);
     [Ref] InstructionMetadata UseStandardRelationalOperatorParameters([Const] DOMString type);
@@ -1200,6 +1206,7 @@ interface MultipleInstructionMetadata {
         [Const] DOMString type, [Const] DOMString supplementaryInformation);
     [Ref] MultipleInstructionMetadata SetDefaultValue([Const] DOMString defaultValue);
     [Ref] MultipleInstructionMetadata SetParameterLongDescription([Const] DOMString longDescription);
+    [Ref] MultipleInstructionMetadata MarkParameterAsAdvanced();
 
     [Ref] MultipleInstructionMetadata UseStandardParameters([Const] DOMString type);
 
@@ -1255,6 +1262,10 @@ interface ParameterMetadata {
     [Ref] ParameterMetadata SetCodeOnly(boolean codeOnly_);
     [Const, Ref] DOMString GetDefaultValue();
     [Ref] ParameterMetadata SetDefaultValue([Const] DOMString defaultValue_);
+    [Ref] ParameterMetadata MarkAsSimple();
+    [Ref] ParameterMetadata MarkAsAdvanced();
+    [Ref] ParameterMetadata MarkAsComplex();
+    long GetUsageComplexity();
     boolean STATIC_IsObject([Const] DOMString param);
     boolean STATIC_IsBehavior([Const] DOMString param);
 

--- a/GDevelop.js/types/gdinstructionmetadata.js
+++ b/GDevelop.js/types/gdinstructionmetadata.js
@@ -24,6 +24,7 @@ declare class gdInstructionMetadata {
   setDefaultValue(defaultValue: string): gdInstructionMetadata;
   setParameterLongDescription(longDescription: string): gdInstructionMetadata;
   setParameterExtraInfo(extraInfo: string): gdInstructionMetadata;
+  markParameterAsAdvanced(): gdInstructionMetadata;
   useStandardOperatorParameters(type: string): gdInstructionMetadata;
   useStandardRelationalOperatorParameters(type: string): gdInstructionMetadata;
   setRequiresBaseObjectCapability(capability: string): gdInstructionMetadata;

--- a/GDevelop.js/types/gdmultipleinstructionmetadata.js
+++ b/GDevelop.js/types/gdmultipleinstructionmetadata.js
@@ -4,6 +4,7 @@ declare class gdMultipleInstructionMetadata {
   addCodeOnlyParameter(type: string, supplementaryInformation: string): gdMultipleInstructionMetadata;
   setDefaultValue(defaultValue: string): gdMultipleInstructionMetadata;
   setParameterLongDescription(longDescription: string): gdMultipleInstructionMetadata;
+  markParameterAsAdvanced(): gdMultipleInstructionMetadata;
   useStandardParameters(type: string): gdMultipleInstructionMetadata;
   setHidden(): gdMultipleInstructionMetadata;
   setFunctionName(functionName: string): gdMultipleInstructionMetadata;

--- a/GDevelop.js/types/gdparametermetadata.js
+++ b/GDevelop.js/types/gdparametermetadata.js
@@ -17,6 +17,10 @@ declare class gdParameterMetadata {
   setCodeOnly(codeOnly_: boolean): gdParameterMetadata;
   getDefaultValue(): string;
   setDefaultValue(defaultValue_: string): gdParameterMetadata;
+  markAsSimple(): gdParameterMetadata;
+  markAsAdvanced(): gdParameterMetadata;
+  markAsComplex(): gdParameterMetadata;
+  getUsageComplexity(): number;
   static isObject(param: string): boolean;
   static isBehavior(param: string): boolean;
   serializeTo(element: gdSerializerElement): void;

--- a/GDevelop.js/types/gdpropertydescriptor.js
+++ b/GDevelop.js/types/gdpropertydescriptor.js
@@ -16,6 +16,10 @@ declare class gdPropertyDescriptor {
   getExtraInfo(): gdVectorString;
   setHidden(enable: boolean): gdPropertyDescriptor;
   isHidden(): boolean;
+  getUsageComplexity(): number;
+  markAsSimple(): gdPropertyDescriptor;
+  markAsAdvanced(): gdPropertyDescriptor;
+  markAsComplex(): gdPropertyDescriptor;
   serializeTo(element: gdSerializerElement): void;
   unserializeFrom(element: gdSerializerElement): void;
   serializeValuesTo(element: gdSerializerElement): void;

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -193,6 +193,7 @@ export type PreferencesValues = {|
   isAlwaysOnTopInPreview: boolean,
   backdropClickBehavior: 'nothing' | 'apply' | 'cancel',
   eventsSheetCancelInlineParameter: 'cancel' | 'apply',
+  showAdvancedParametersAndProperties: boolean,
 |};
 
 /**
@@ -251,6 +252,8 @@ export type Preferences = {|
   getIsAlwaysOnTopInPreview: () => boolean,
   setIsAlwaysOnTopInPreview: (enabled: boolean) => void,
   setEventsSheetCancelInlineParameter: (value: string) => void,
+  getShowAdvancedParametersAndProperties: () => boolean,
+  setShowAdvancedParametersAndProperties: (enabled: boolean) => void,
 |};
 
 export const initialPreferences = {
@@ -286,6 +289,7 @@ export const initialPreferences = {
     isAlwaysOnTopInPreview: false,
     backdropClickBehavior: 'nothing',
     eventsSheetCancelInlineParameter: 'apply',
+    showAdvancedParametersAndProperties: false,
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -334,6 +338,8 @@ export const initialPreferences = {
   getIsAlwaysOnTopInPreview: () => true,
   setIsAlwaysOnTopInPreview: () => {},
   setEventsSheetCancelInlineParameter: () => {},
+  getShowAdvancedParametersAndProperties: () => true,
+  setShowAdvancedParametersAndProperties: (enabled: boolean) => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -44,6 +44,7 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
     setAutosaveOnPreview,
     setUseNewInstructionEditorDialog,
     setUseUndefinedVariablesInAutocompletion,
+    setShowAdvancedParametersAndProperties,
     setUseGDJSDevelopmentWatcher,
     setEventsSheetUseAssignmentOperators,
     getDefaultEditorMosaicNode,
@@ -271,6 +272,18 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
                   Suggest names of variables used in events but not declared in
                   the list of variables
                 </Trans>
+              }
+            />
+          </Line>
+          <Line>
+            <Toggle
+              onToggle={(e, check) =>
+                setShowAdvancedParametersAndProperties(check)
+              }
+              toggled={values.showAdvancedParametersAndProperties}
+              labelPosition="right"
+              label={
+                <Trans>Always show advanced parameters and properties</Trans>
               }
             />
           </Line>

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -103,6 +103,12 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     setUseUndefinedVariablesInAutocompletion: this._setUseUndefinedVariablesInAutocompletion.bind(
       this
     ),
+    getShowAdvancedParametersAndProperties: this._getShowAdvancedParametersAndProperties.bind(
+      this
+    ),
+    setShowAdvancedParametersAndProperties: this._setShowAdvancedParametersAndProperties.bind(
+      this
+    ),
     setUseGDJSDevelopmentWatcher: this._setUseGDJSDevelopmentWatcher.bind(this),
     setEventsSheetUseAssignmentOperators: this._setEventsSheetUseAssignmentOperators.bind(
       this
@@ -199,6 +205,26 @@ export default class PreferencesProvider extends React.Component<Props, State> {
         values: {
           ...state.values,
           useUndefinedVariablesInAutocompletion,
+        },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _getShowAdvancedParametersAndProperties(
+    showAdvancedParametersAndProperties: boolean
+  ) {
+    return this.state.values.showAdvancedParametersAndProperties;
+  }
+
+  _setShowAdvancedParametersAndProperties(
+    showAdvancedParametersAndProperties: boolean
+  ) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          showAdvancedParametersAndProperties,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
+++ b/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
@@ -37,6 +37,7 @@ export default (
 
     const propertyDescription = property.getDescription();
     const valueType = property.getType().toLowerCase();
+    const usageComplexity = property.getUsageComplexity();
     const getLabel = (instance: Instance) => {
       const propertyName = getProperties(instance)
         .get(name)
@@ -72,6 +73,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else if (valueType === 'string' || valueType === '') {
@@ -88,6 +90,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else if (valueType === 'boolean') {
@@ -106,6 +109,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else if (valueType === 'choice') {
@@ -128,6 +132,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else if (valueType === 'behavior') {
@@ -160,6 +165,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else if (valueType === 'resource') {
@@ -180,6 +186,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else if (valueType === 'color') {
@@ -196,6 +203,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else if (valueType === 'textarea') {
@@ -212,6 +220,7 @@ export default (
         },
         getLabel,
         getDescription,
+        usageComplexity,
       });
       return null;
     } else {


### PR DESCRIPTION
I made a quick way for advance users to get ride of the beginner mode, but it's probably not be a good practice to replace a button when it's clicked.

![InstructionBasic](https://user-images.githubusercontent.com/2611977/163621183-1de1e859-0896-4bde-a638-f72a05433fbf.png)

![InstructionAdvance](https://user-images.githubusercontent.com/2611977/163621254-8a6882c8-1627-413a-aac8-5149cd127ed9.png)

![BehaviorBasic](https://user-images.githubusercontent.com/2611977/163621303-e84cd93c-393f-4ef8-856a-45765820f15c.png)

![BehaviorAdvance](https://user-images.githubusercontent.com/2611977/163621332-70f542e0-a073-4082-8404-6a64cd6328cf.png)

