### PR TITLE
Make loader screen cover input fields

### DIFF
--- a/Extensions/Leaderboards/leaderboardstools.ts
+++ b/Extensions/Leaderboards/leaderboardstools.ts
@@ -562,8 +562,9 @@ namespace gdjs {
 
               resetLeaderboardDisplayErrorTimeout(runtimeScene);
 
-              _leaderboardViewIframe =
-                computeLeaderboardDisplayingIframe(targetUrl);
+              _leaderboardViewIframe = computeLeaderboardDisplayingIframe(
+                targetUrl
+              );
               if (typeof window !== 'undefined') {
                 _leaderboardViewClosingCallback = (event: MessageEvent) => {
                   receiveMessageFromLeaderboardView(

--- a/Extensions/Leaderboards/leaderboardstools.ts
+++ b/Extensions/Leaderboards/leaderboardstools.ts
@@ -105,6 +105,8 @@ namespace gdjs {
       _loaderContainer.style.width = '100%';
       _loaderContainer.style.justifyContent = 'center';
       _loaderContainer.style.alignItems = 'center';
+      _loaderContainer.style.position = 'absolute';
+      _loaderContainer.style.zIndex = '2';
       const _loader = document.createElement('img');
       _loader.setAttribute('width', '50px');
       _loader.setAttribute(
@@ -560,9 +562,8 @@ namespace gdjs {
 
               resetLeaderboardDisplayErrorTimeout(runtimeScene);
 
-              _leaderboardViewIframe = computeLeaderboardDisplayingIframe(
-                targetUrl
-              );
+              _leaderboardViewIframe =
+                computeLeaderboardDisplayingIframe(targetUrl);
               if (typeof window !== 'undefined') {
                 _leaderboardViewClosingCallback = (event: MessageEvent) => {
                   receiveMessageFromLeaderboardView(

--- a/Extensions/Leaderboards/leaderboardstools.ts
+++ b/Extensions/Leaderboards/leaderboardstools.ts
@@ -105,7 +105,7 @@ namespace gdjs {
       _loaderContainer.style.width = '100%';
       _loaderContainer.style.justifyContent = 'center';
       _loaderContainer.style.alignItems = 'center';
-      _loaderContainer.style.position = 'absolute';
+      _loaderContainer.style.position = 'relative';
       _loaderContainer.style.zIndex = '2';
       const _loader = document.createElement('img');
       _loader.setAttribute('width', '50px');


### PR DESCRIPTION
Do not show in changelog

Fixes input still showing over the loader div
<img width="635" alt="image" src="https://user-images.githubusercontent.com/81410437/164722719-2c9aa492-d077-4adc-91ea-9081a0a38c55.png">
