### PR TITLE
Wording, Remove to Delete

### DIFF
--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -232,7 +232,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
         click: () => this._editName(eventsBasedBehavior),
       },
       {
-        label: i18n._(t`Remove`),
+        label: i18n._(t`Delete`),
         click: () =>
           this._deleteEventsBasedBehavior(eventsBasedBehavior, {
             askForConfirmation: true,

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionDependenciesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionDependenciesEditor.js
@@ -162,7 +162,7 @@ export const ExtensionDependenciesEditor = ({
                     </TableRowColumn>
                     <TableRowColumn>
                       <IconButton
-                        tooltip={t`Remove`}
+                        tooltip={t`Delete`}
                         onClick={() => {
                           eventsFunctionsExtension.removeDependencyAt(index);
                           forceUpdate();

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -293,7 +293,7 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
         click: () => this._togglePrivate(eventsFunction),
       },
       {
-        label: i18n._(t`Remove`),
+        label: i18n._(t`Delete`),
         click: () =>
           this._deleteEventsFunction(eventsFunction, {
             askForConfirmation: true,

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -256,7 +256,7 @@ export default class ResourcesList extends React.Component<Props, State> {
         click: () => this._editName(resource),
       },
       {
-        label: i18n._(t`Remove`),
+        label: i18n._(t`Delete`),
         click: () => this._deleteResource(resource),
       },
       { type: 'separator' },


### PR DESCRIPTION
## Description

**Remove** is used in a few contextual menus while we use **Delete** in most of menus.
![image](https://user-images.githubusercontent.com/1670670/164909370-eb86bd16-ffc7-41ec-a5ad-ab59e50d8751.png)

## Solution

Change **Remove** to **Delete**