### PR TITLE
Update supported filetypes for resources

### DIFF
--- a/newIDE/app/src/ResourcesList/ResourceSource.js
+++ b/newIDE/app/src/ResourcesList/ResourceSource.js
@@ -26,7 +26,7 @@ export const allResourceKindsAndMetadata = [
   {
     kind: 'image',
     displayName: t`Image`,
-    fileExtensions: ['png', 'jpg'],
+    fileExtensions: ['png', 'jpg', 'jpeg', 'webp'],
     createNewResource: () => new gd.ImageResource(),
   },
   {
@@ -38,7 +38,7 @@ export const allResourceKindsAndMetadata = [
   {
     kind: 'video',
     displayName: t`Video`,
-    fileExtensions: ['mp4'],
+    fileExtensions: ['mp4', 'webm'],
     createNewResource: () => new gd.VideoResource(),
   },
   {


### PR DESCRIPTION
[Untested]

Adds webm, jpeg and webp as supported formats in the IDE. Those formats are all [already supported by PIXI](https://github.com/pixijs/pixijs/blob/8c666471b8b49fb39b2d6f3f64a283153d337fd7/packages/loaders/src/LoaderResource.ts#L1347), widely used, fast and modern (except JPEG)