### PR TITLE
Encode thumbnail URL before sending it to the GDevelop services

### DIFF
--- a/newIDE/app/src/Utils/GDevelopServices/Build.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Build.js
@@ -80,7 +80,11 @@ export const getWebBuildThumbnailUrl = (
   }
   // The exporter put asset files directly in the build folder.
   // It's not factorized with the exporter because it's a temporary solution.
-  return `https://games.gdevelop-app.com/game-${buildId}/${fileName}`;
+  // TODO: Upload the thumbnail separately, so that this URL is not defined by the frontend.
+  const uri = `https://games.gdevelop-app.com/game-${buildId}/${fileName}`;
+  // The backend services encode the file URLs when uploaded, so we need to do the same before saving the value.
+  const encodedUri = encodeURI(uri);
+  return encodedUri;
 };
 
 type UploadOptions = {|


### PR DESCRIPTION
This fixes the case where you would use a thumbnail which has non-conventional characters in the name.
Then the URL saved in the GDevelop services would be different than the actual URL of the thumbnaill.