### PR TITLE
Improve points and collision masks editors

### DIFF
--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2556,6 +2556,7 @@ interface VectorVector2f {
     [Ref] Vector2f at(unsigned long index);
     void WRAPPED_set(unsigned long index, [Const, Ref] Vector2f pt);
     void FREE_removeFromVectorVector2f(unsigned long index);
+    void FREE_moveVector2fInVector(unsigned long oldIndex, unsigned long newIndex);
     void clear();
 };
 

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -342,6 +342,16 @@ void removeFromVectorVector2f(std::vector<sf::Vector2f> &vec, size_t pos) {
   vec.erase(vec.begin() + pos);
 }
 
+void moveVector2fInVector(std::vector<sf::Vector2f> &vec,
+                 size_t oldIndex,
+                 size_t newIndex) {
+  if (oldIndex >= vec.size() || newIndex >= vec.size()) return;
+
+  auto vector2f = std::move(vec.at(oldIndex));
+  vec.erase(vec.begin() + oldIndex);
+  vec.insert(vec.begin() + newIndex, std::move(vector2f));
+}
+
 void removeFromVectorParameterMetadata(std::vector<gd::ParameterMetadata> &vec,
                                        size_t pos) {
   vec.erase(vec.begin() + pos);

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -3561,10 +3561,16 @@ describe('libGD.js', function () {
         expect(vectorVector2f.at(1).get_x()).toBe(2);
         expect(vectorVector2f.at(2).get_x()).toBe(3);
 
+        gd.moveVector2fInVector(vectorVector2f, 2, 0)
+        expect(vectorVector2f.at(0).get_x()).toBe(3);
+        expect(vectorVector2f.at(1).get_x()).toBe(1);
+        expect(vectorVector2f.at(2).get_x()).toBe(2);
+
         gd.removeFromVectorVector2f(vectorVector2f, 1);
         expect(vectorVector2f.size()).toBe(2);
-        expect(vectorVector2f.at(0).get_x()).toBe(1);
-        expect(vectorVector2f.at(1).get_x()).toBe(3);
+        expect(vectorVector2f.at(0).get_x()).toBe(3);
+        expect(vectorVector2f.at(1).get_x()).toBe(2);
+
 
         vectorVector2f.clear();
         expect(vectorVector2f.size()).toBe(0);

--- a/GDevelop.js/types/gdvectorvector2f.js
+++ b/GDevelop.js/types/gdvectorvector2f.js
@@ -6,6 +6,7 @@ declare class gdVectorVector2f {
   at(index: number): gdVector2f;
   set(index: number, pt: gdVector2f): void;
   removeFromVectorVector2f(index: number): void;
+  moveVector2fInVector(oldIndex: number, newIndex: number): void;
   clear(): void;
   delete(): void;
   ptr: number;

--- a/newIDE/app/src/Leaderboard/LeaderboardScoreFormatter.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardScoreFormatter.js
@@ -4,6 +4,7 @@ import {
   type LeaderboardScoreFormattingTime,
   type LeaderboardScoreFormatting,
 } from '../Utils/GDevelopServices/Play';
+import { roundTo } from '../Utils/Mathematics';
 
 export const orderedTimeUnits = ['hour', 'minute', 'second', 'millisecond'];
 const unitToDivider = {
@@ -46,8 +47,8 @@ export const formatCustomScore = (
   score: number,
   options: LeaderboardScoreFormattingCustom
 ): string => {
-  const roundedScore =
-    Math.round(score * 10 ** options.precision) / 10 ** options.precision;
+  const roundedScore = roundTo(score, options.precision);
+
   return `${options.prefix}${roundedScore.toFixed(
     Math.max(0, options.precision)
   )}${options.suffix}`;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -16,6 +16,7 @@ type Props = {|
   imageHeight: number,
   offsetTop: number,
   offsetLeft: number,
+  highlightedVerticePtr: ?number,
   imageZoomFactor: number,
   onPolygonsUpdated: () => void,
 |};
@@ -128,7 +129,11 @@ const CollisionMasksPreview = (props: Props) => {
             <circle
               onPointerDown={() => onStartDragVertex(vertex)}
               key={`polygon-${i}-vertex-${j}`}
-              fill="rgba(255,0,0,0.75)"
+              fill={
+                vertex.ptr === props.highlightedVerticePtr
+                  ? 'rgba(0,0,255,0.75)'
+                  : 'rgba(255,0,0,0.75)'
+              }
               strokeWidth={1}
               cx={vertex.get_x() * imageZoomFactor}
               cy={vertex.get_y() * imageZoomFactor}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -17,6 +17,8 @@ type Props = {|
   offsetTop: number,
   offsetLeft: number,
   highlightedVerticePtr: ?number,
+  selectedVerticePtr: ?number,
+  onClickVertice: (ptr: ?number) => void,
   imageZoomFactor: number,
   onPolygonsUpdated: () => void,
 |};
@@ -45,8 +47,10 @@ const CollisionMasksPreview = (props: Props) => {
   };
 
   const onEndDragVertex = () => {
-    const draggingWasDone = !!draggedVertex;
-    if (draggingWasDone) props.onPolygonsUpdated();
+    if (!!draggedVertex) {
+      props.onPolygonsUpdated();
+      props.onClickVertice(draggedVertex.ptr);
+    }
     setDraggedVertex(null);
   };
 
@@ -131,6 +135,8 @@ const CollisionMasksPreview = (props: Props) => {
               key={`polygon-${i}-vertex-${j}`}
               fill={
                 vertex.ptr === props.highlightedVerticePtr
+                  ? 'rgba(255,180,0,0.75)'
+                  : vertex.ptr === props.selectedVerticePtr
                   ? 'rgba(0,0,255,0.75)'
                   : 'rgba(255,0,0,0.75)'
               }

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -134,11 +134,16 @@ const CollisionMasksPreview = (props: Props) => {
               onPointerDown={() => onStartDragVertex(vertex)}
               key={`polygon-${i}-vertex-${j}`}
               fill={
-                vertex.ptr === props.highlightedVerticePtr
-                  ? 'rgba(255,180,0,0.75)'
-                  : vertex.ptr === props.selectedVerticePtr
+                vertex.ptr === props.selectedVerticePtr
                   ? 'rgba(0,0,255,0.75)'
                   : 'rgba(255,0,0,0.75)'
+              }
+              stroke={
+                vertex.ptr === props.highlightedVerticePtr
+                  ? vertex.ptr === props.selectedVerticePtr
+                    ? 'white'
+                    : 'black'
+                  : undefined
               }
               strokeWidth={1}
               cx={vertex.get_x() * imageZoomFactor}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
@@ -98,8 +98,8 @@ const VerticesTable = (props: VerticesTableProps) => {
                 dropVertice(current, verticeIndex);
                 draggedVerticeIndex.current = null;
               }}
-              onMouseEnter={() => props.onHoverVertice(vertice.ptr)}
-              onMouseLeave={props.onHoverVertice}
+              onPointerEnter={() => props.onHoverVertice(vertice.ptr)}
+              onPointerLeave={props.onHoverVertice}
               selected={props.selectedVerticePtr === vertice.ptr}
               onClick={() => props.onClickVertice(vertice.ptr)}
               verticeX={vertice.get_x()}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
@@ -35,6 +35,8 @@ type VerticesTableProps = {|
   hasWarning: boolean,
   onUpdated: () => void,
   onHoverVertice: (ptr: ?number) => void,
+  onClickVertice: (ptr: ?number) => void,
+  selectedVerticePtr: ?number,
 
   // Sprite size is useful to make sure polygon vertices
   // are not put outside the sprite bounding box, which is not supported:
@@ -98,6 +100,8 @@ const VerticesTable = (props: VerticesTableProps) => {
               }}
               onMouseEnter={() => props.onHoverVertice(vertice.ptr)}
               onMouseLeave={props.onHoverVertice}
+              selected={props.selectedVerticePtr === vertice.ptr}
+              onClick={() => props.onClickVertice(vertice.ptr)}
               verticeX={vertice.get_x()}
               verticeY={vertice.get_y()}
               onChangeVerticeX={newValue => updateVerticeX(vertice, newValue)}
@@ -141,6 +145,8 @@ type PolygonSectionProps = {|
   onUpdated: () => void,
   onRemove: () => void,
   onHoverVertice: (ptr: ?number) => void,
+  onClickVertice: (ptr: ?number) => void,
+  selectedVerticePtr: ?number,
 
   // Sprite size is useful to make sure polygon vertices
   // are not put outside the sprite bounding box, which is not supported:
@@ -193,6 +199,8 @@ const PolygonSection = (props: PolygonSectionProps) => {
           vertices={vertices}
           hasWarning={!isConvex}
           onHoverVertice={props.onHoverVertice}
+          onClickVertice={props.onClickVertice}
+          selectedVerticePtr={props.selectedVerticePtr}
           onUpdated={props.onUpdated}
           spriteWidth={props.spriteWidth}
           spriteHeight={props.spriteHeight}
@@ -207,6 +215,8 @@ type PolygonsListProps = {|
   onPolygonsUpdated: () => void,
   restoreCollisionMask: () => void,
   onHoverVertice: (ptr: ?number) => void,
+  onClickVertice: (ptr: ?number) => void,
+  selectedVerticePtr: ?number,
 
   // Sprite size is useful to make sure polygon vertices
   // are not put outside the sprite bounding box, which is not supported:
@@ -222,6 +232,8 @@ const PolygonsList = (props: PolygonsListProps) => {
     onPolygonsUpdated,
     restoreCollisionMask,
     onHoverVertice,
+    onClickVertice,
+    selectedVerticePtr,
   } = props;
 
   const addCollisionMask = React.useCallback(
@@ -263,6 +275,8 @@ const PolygonsList = (props: PolygonsListProps) => {
                 onPolygonsUpdated();
               }}
               onHoverVertice={onHoverVertice}
+              onClickVertice={onClickVertice}
+              selectedVerticePtr={selectedVerticePtr}
               spriteWidth={spriteWidth}
               spriteHeight={spriteHeight}
             />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonsList.js
@@ -34,6 +34,7 @@ type VerticesTableProps = {|
   vertices: gdVectorVector2f,
   hasWarning: boolean,
   onUpdated: () => void,
+  onHoverVertice: (ptr: ?number) => void,
 
   // Sprite size is useful to make sure polygon vertices
   // are not put outside the sprite bounding box, which is not supported:
@@ -95,6 +96,8 @@ const VerticesTable = (props: VerticesTableProps) => {
                 dropVertice(current, verticeIndex);
                 draggedVerticeIndex.current = null;
               }}
+              onMouseEnter={() => props.onHoverVertice(vertice.ptr)}
+              onMouseLeave={props.onHoverVertice}
               verticeX={vertice.get_x()}
               verticeY={vertice.get_y()}
               onChangeVerticeX={newValue => updateVerticeX(vertice, newValue)}
@@ -137,6 +140,7 @@ type PolygonSectionProps = {|
   polygon: gdPolygon2d,
   onUpdated: () => void,
   onRemove: () => void,
+  onHoverVertice: (ptr: ?number) => void,
 
   // Sprite size is useful to make sure polygon vertices
   // are not put outside the sprite bounding box, which is not supported:
@@ -188,6 +192,7 @@ const PolygonSection = (props: PolygonSectionProps) => {
         <VerticesTable
           vertices={vertices}
           hasWarning={!isConvex}
+          onHoverVertice={props.onHoverVertice}
           onUpdated={props.onUpdated}
           spriteWidth={props.spriteWidth}
           spriteHeight={props.spriteHeight}
@@ -201,6 +206,7 @@ type PolygonsListProps = {|
   polygons: gdVectorPolygon2d,
   onPolygonsUpdated: () => void,
   restoreCollisionMask: () => void,
+  onHoverVertice: (ptr: ?number) => void,
 
   // Sprite size is useful to make sure polygon vertices
   // are not put outside the sprite bounding box, which is not supported:
@@ -215,6 +221,7 @@ const PolygonsList = (props: PolygonsListProps) => {
     spriteWidth,
     onPolygonsUpdated,
     restoreCollisionMask,
+    onHoverVertice,
   } = props;
 
   const addCollisionMask = React.useCallback(
@@ -255,6 +262,7 @@ const PolygonsList = (props: PolygonsListProps) => {
                 }
                 onPolygonsUpdated();
               }}
+              onHoverVertice={onHoverVertice}
               spriteWidth={spriteWidth}
               spriteHeight={spriteHeight}
             />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -23,8 +23,8 @@ type Props = {|
   verticeY: number,
   onChangeVerticeX: (value: number) => void,
   onChangeVerticeY: (value: number) => void,
-  onMouseEnter: () => void,
-  onMouseLeave: () => void,
+  onPointerEnter: () => void,
+  onPointerLeave: () => void,
   setDragged: () => void,
   drop: () => void,
 |};
@@ -66,8 +66,8 @@ const VerticeRow = ({
                     ? muiTheme.listItem.selectedBackgroundColor
                     : muiTheme.list.itemsBackgroundColor,
                 }}
-                onMouseEnter={props.onMouseEnter}
-                onMouseLeave={props.onMouseLeave}
+                onPointerEnter={props.onPointerEnter}
+                onPointerLeave={props.onPointerLeave}
                 onClick={props.onClick}
               >
                 {connectDragSource(

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -1,22 +1,37 @@
 // @flow
 import React from 'react';
-import { TableRow, TableRowColumn } from '../../../../UI/Table';
+import { TableRowColumn } from '../../../../UI/Table';
 import IconButton from '../../../../UI/IconButton';
 import Delete from '@material-ui/icons/Delete';
 import TextField from '../../../../UI/TextField';
 import styles from './styles';
 import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
+import { makeDragSourceAndDropTarget } from '../../../../UI/DragAndDrop/DragSourceAndDropTarget';
+import { dropIndicatorColor } from '../../../../UI/SortableVirtualizedItemList/DropIndicator';
+import DragHandle from '../../../../UI/DragHandle';
 
 type Props = {|
+  parentVerticeId: string,
   canRemove: boolean,
   onRemove: () => void,
   verticeX: number,
   verticeY: number,
   onChangeVerticeX: (value: number) => void,
   onChangeVerticeY: (value: number) => void,
+  setDragged: () => void,
+  drop: () => void,
 |};
 
-const VerticeRow = ({ verticeX, verticeY, ...props }: Props) => {
+const VerticeRow = ({
+  verticeX,
+  verticeY,
+  parentVerticeId,
+  ...props
+}: Props) => {
+  const DragSourceAndDropTarget = React.useMemo(
+    () => makeDragSourceAndDropTarget(`collision-mask-${parentVerticeId}`),
+    [parentVerticeId]
+  );
   const [verticeXInputValue, setVerticeXInputValue] = React.useState<string>(
     verticeX.toString()
   );
@@ -38,54 +53,79 @@ const VerticeRow = ({ verticeX, verticeY, ...props }: Props) => {
   return (
     <ThemeConsumer>
       {muiTheme => (
-        <TableRow
-          style={{
-            backgroundColor: muiTheme.list.itemsBackgroundColor,
+        <DragSourceAndDropTarget
+          beginDrag={() => {
+            props.setDragged();
+            return {};
+          }}
+          canDrag={() => true}
+          canDrop={() => true}
+          drop={() => {
+            props.drop();
           }}
         >
-          <TableRowColumn />
-          <TableRowColumn style={styles.coordinateColumn}>
-            <TextField
-              margin="none"
-              value={verticeXInputValue}
-              type="number"
-              id="vertice-x"
-              onChange={(e, value) => {
-                setVerticeXInputValue(value);
-                const valueAsNumber = parseFloat(value);
-                if (!isNaN(valueAsNumber)) {
-                  props.onChangeVerticeX(valueAsNumber);
-                }
-              }}
-            />
-          </TableRowColumn>
-          <TableRowColumn style={styles.coordinateColumn}>
-            <TextField
-              margin="none"
-              value={verticeYInputValue}
-              type="number"
-              id="vertice-y"
-              onChange={(e, value) => {
-                setVerticeXInputValue(value);
-                const valueAsNumber = parseFloat(value);
-                if (!isNaN(valueAsNumber)) {
-                  props.onChangeVerticeY(valueAsNumber);
-                }
-              }}
-            />
-          </TableRowColumn>
-          <TableRowColumn style={styles.toolColumn}>
-            {!!props.onRemove && (
-              <IconButton
-                size="small"
-                onClick={props.onRemove}
-                disabled={!props.canRemove}
+          {({ connectDragSource, connectDropTarget, isOver, canDrop }) =>
+            connectDropTarget(
+              <tr
+                className="MuiTableRow-root"
+                style={{ backgroundColor: muiTheme.list.itemsBackgroundColor }}
               >
-                <Delete />
-              </IconButton>
-            )}
-          </TableRowColumn>
-        </TableRow>
+                {connectDragSource(
+                  <td
+                    style={
+                      isOver
+                        ? { borderTop: `2px solid ${dropIndicatorColor}` }
+                        : undefined
+                    }
+                  >
+                    <DragHandle />
+                  </td>
+                )}
+                <TableRowColumn style={styles.coordinateColumn}>
+                  <TextField
+                    margin="none"
+                    value={verticeXInputValue}
+                    type="number"
+                    id="vertice-x"
+                    onChange={(e, value) => {
+                      setVerticeXInputValue(value);
+                      const valueAsNumber = parseFloat(value);
+                      if (!isNaN(valueAsNumber)) {
+                        props.onChangeVerticeX(valueAsNumber);
+                      }
+                    }}
+                  />
+                </TableRowColumn>
+                <TableRowColumn style={styles.coordinateColumn}>
+                  <TextField
+                    margin="none"
+                    value={verticeYInputValue}
+                    type="number"
+                    id="vertice-y"
+                    onChange={(e, value) => {
+                      setVerticeXInputValue(value);
+                      const valueAsNumber = parseFloat(value);
+                      if (!isNaN(valueAsNumber)) {
+                        props.onChangeVerticeY(valueAsNumber);
+                      }
+                    }}
+                  />
+                </TableRowColumn>
+                <TableRowColumn style={styles.toolColumn}>
+                  {!!props.onRemove && (
+                    <IconButton
+                      size="small"
+                      onClick={props.onRemove}
+                      disabled={!props.canRemove}
+                    >
+                      <Delete />
+                    </IconButton>
+                  )}
+                </TableRowColumn>
+              </tr>
+            )
+          }
+        </DragSourceAndDropTarget>
       )}
     </ThemeConsumer>
   );

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -103,7 +103,7 @@ const VerticeRow = ({
                     type="number"
                     id="vertice-y"
                     onChange={(e, value) => {
-                      setVerticeXInputValue(value);
+                      setVerticeYInputValue(value);
                       const valueAsNumber = parseFloat(value);
                       if (!isNaN(valueAsNumber)) {
                         props.onChangeVerticeY(valueAsNumber);

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -17,6 +17,8 @@ type Props = {|
   parentVerticeId: string,
   canRemove: boolean,
   onRemove: () => void,
+  onClick: () => void,
+  selected?: boolean,
   verticeX: number,
   verticeY: number,
   onChangeVerticeX: (value: number) => void,
@@ -59,9 +61,14 @@ const VerticeRow = ({
               // the MUI class name for the component is used.
               <tr
                 className="MuiTableRow-root"
-                style={{ backgroundColor: muiTheme.list.itemsBackgroundColor }}
+                style={{
+                  backgroundColor: props.selected
+                    ? muiTheme.listItem.selectedBackgroundColor
+                    : muiTheme.list.itemsBackgroundColor,
+                }}
                 onMouseEnter={props.onMouseEnter}
                 onMouseLeave={props.onMouseLeave}
+                onClick={props.onClick}
               >
                 {connectDragSource(
                   <td
@@ -77,6 +84,11 @@ const VerticeRow = ({
                 <TableRowColumn style={styles.coordinateColumn}>
                   <SemiControlledTextField
                     margin="none"
+                    inputStyle={
+                      props.selected
+                        ? { color: muiTheme.listItem.selectedTextColor }
+                        : undefined
+                    }
                     value={roundTo(
                       verticeX,
                       VERTICE_COORDINATE_PRECISION
@@ -98,6 +110,11 @@ const VerticeRow = ({
                 <TableRowColumn style={styles.coordinateColumn}>
                   <SemiControlledTextField
                     margin="none"
+                    inputStyle={
+                      props.selected
+                        ? { color: muiTheme.listItem.selectedTextColor }
+                        : undefined
+                    }
                     value={roundTo(
                       verticeY,
                       VERTICE_COORDINATE_PRECISION

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -16,51 +16,79 @@ type Props = {|
   onChangeVerticeY: (value: number) => void,
 |};
 
-const VerticeRow = (props: Props) => (
-  <ThemeConsumer>
-    {muiTheme => (
-      <TableRow
-        style={{
-          backgroundColor: muiTheme.list.itemsBackgroundColor,
-        }}
-      >
-        <TableRowColumn />
-        <TableRowColumn style={styles.coordinateColumn}>
-          <TextField
-            margin="none"
-            value={props.verticeX}
-            type="number"
-            id="vertice-x"
-            onChange={(e, value) =>
-              props.onChangeVerticeX(parseFloat(value || 0))
-            }
-          />
-        </TableRowColumn>
-        <TableRowColumn style={styles.coordinateColumn}>
-          <TextField
-            margin="none"
-            value={props.verticeY}
-            type="number"
-            id="vertice-y"
-            onChange={(e, value) =>
-              props.onChangeVerticeY(parseFloat(value || 0))
-            }
-          />
-        </TableRowColumn>
-        <TableRowColumn style={styles.toolColumn}>
-          {!!props.onRemove && (
-            <IconButton
-              size="small"
-              onClick={props.onRemove}
-              disabled={!props.canRemove}
-            >
-              <Delete />
-            </IconButton>
-          )}
-        </TableRowColumn>
-      </TableRow>
-    )}
-  </ThemeConsumer>
-);
+const VerticeRow = ({ verticeX, verticeY, ...props }: Props) => {
+  const [verticeXInputValue, setVerticeXInputValue] = React.useState<string>(
+    verticeX.toString()
+  );
+  const [verticeYInputValue, setVerticeYInputValue] = React.useState<string>(
+    verticeY.toString()
+  );
+  React.useEffect(
+    () => {
+      setVerticeXInputValue(verticeX.toString());
+    },
+    [verticeX]
+  );
+  React.useEffect(
+    () => {
+      setVerticeYInputValue(verticeY.toString());
+    },
+    [verticeY]
+  );
+  return (
+    <ThemeConsumer>
+      {muiTheme => (
+        <TableRow
+          style={{
+            backgroundColor: muiTheme.list.itemsBackgroundColor,
+          }}
+        >
+          <TableRowColumn />
+          <TableRowColumn style={styles.coordinateColumn}>
+            <TextField
+              margin="none"
+              value={verticeXInputValue}
+              type="number"
+              id="vertice-x"
+              onChange={(e, value) => {
+                setVerticeXInputValue(value);
+                const valueAsNumber = parseFloat(value);
+                if (!isNaN(valueAsNumber)) {
+                  props.onChangeVerticeX(valueAsNumber);
+                }
+              }}
+            />
+          </TableRowColumn>
+          <TableRowColumn style={styles.coordinateColumn}>
+            <TextField
+              margin="none"
+              value={verticeYInputValue}
+              type="number"
+              id="vertice-y"
+              onChange={(e, value) => {
+                setVerticeXInputValue(value);
+                const valueAsNumber = parseFloat(value);
+                if (!isNaN(valueAsNumber)) {
+                  props.onChangeVerticeY(valueAsNumber);
+                }
+              }}
+            />
+          </TableRowColumn>
+          <TableRowColumn style={styles.toolColumn}>
+            {!!props.onRemove && (
+              <IconButton
+                size="small"
+                onClick={props.onRemove}
+                disabled={!props.canRemove}
+              >
+                <Delete />
+              </IconButton>
+            )}
+          </TableRowColumn>
+        </TableRow>
+      )}
+    </ThemeConsumer>
+  );
+};
 
 export default VerticeRow;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -1,14 +1,14 @@
 // @flow
 import React from 'react';
+import Delete from '@material-ui/icons/Delete';
 import { TableRowColumn } from '../../../../UI/Table';
 import IconButton from '../../../../UI/IconButton';
-import Delete from '@material-ui/icons/Delete';
-import TextField from '../../../../UI/TextField';
-import styles from './styles';
+import SemiControlledTextField from '../../../../UI/SemiControlledTextField';
 import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
 import { makeDragSourceAndDropTarget } from '../../../../UI/DragAndDrop/DragSourceAndDropTarget';
 import { dropIndicatorColor } from '../../../../UI/SortableVirtualizedItemList/DropIndicator';
 import DragHandle from '../../../../UI/DragHandle';
+import styles from './styles';
 
 type Props = {|
   parentVerticeId: string,
@@ -34,24 +34,7 @@ const VerticeRow = ({
     () => makeDragSourceAndDropTarget(`collision-mask-${parentVerticeId}`),
     [parentVerticeId]
   );
-  const [verticeXInputValue, setVerticeXInputValue] = React.useState<string>(
-    verticeX.toString()
-  );
-  const [verticeYInputValue, setVerticeYInputValue] = React.useState<string>(
-    verticeY.toString()
-  );
-  React.useEffect(
-    () => {
-      setVerticeXInputValue(verticeX.toString());
-    },
-    [verticeX]
-  );
-  React.useEffect(
-    () => {
-      setVerticeYInputValue(verticeY.toString());
-    },
-    [verticeY]
-  );
+
   return (
     <ThemeConsumer>
       {muiTheme => (
@@ -89,32 +72,38 @@ const VerticeRow = ({
                   </td>
                 )}
                 <TableRowColumn style={styles.coordinateColumn}>
-                  <TextField
+                  <SemiControlledTextField
                     margin="none"
-                    value={verticeXInputValue}
+                    value={verticeX.toString()}
                     type="number"
                     id="vertice-x"
-                    onChange={(e, value) => {
-                      setVerticeXInputValue(value);
+                    onChange={value => {
                       const valueAsNumber = parseFloat(value);
-                      if (!isNaN(valueAsNumber)) {
+                      if (!isNaN(valueAsNumber))
                         props.onChangeVerticeX(valueAsNumber);
-                      }
+                    }}
+                    onBlur={event => {
+                      props.onChangeVerticeX(
+                        parseFloat(event.currentTarget.value) || 0
+                      );
                     }}
                   />
                 </TableRowColumn>
                 <TableRowColumn style={styles.coordinateColumn}>
-                  <TextField
+                  <SemiControlledTextField
                     margin="none"
-                    value={verticeYInputValue}
+                    value={verticeY.toString()}
                     type="number"
                     id="vertice-y"
-                    onChange={(e, value) => {
-                      setVerticeYInputValue(value);
+                    onChange={value => {
                       const valueAsNumber = parseFloat(value);
-                      if (!isNaN(valueAsNumber)) {
+                      if (!isNaN(valueAsNumber))
                         props.onChangeVerticeY(valueAsNumber);
-                      }
+                    }}
+                    onBlur={event => {
+                      props.onChangeVerticeY(
+                        parseFloat(event.currentTarget.value) || 0
+                      );
                     }}
                   />
                 </TableRowColumn>

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -18,6 +18,8 @@ type Props = {|
   verticeY: number,
   onChangeVerticeX: (value: number) => void,
   onChangeVerticeY: (value: number) => void,
+  onMouseEnter: () => void,
+  onMouseLeave: () => void,
   setDragged: () => void,
   drop: () => void,
 |};
@@ -69,6 +71,8 @@ const VerticeRow = ({
               <tr
                 className="MuiTableRow-root"
                 style={{ backgroundColor: muiTheme.list.itemsBackgroundColor }}
+                onMouseEnter={props.onMouseEnter}
+                onMouseLeave={props.onMouseLeave}
               >
                 {connectDragSource(
                   <td

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -9,6 +9,9 @@ import { makeDragSourceAndDropTarget } from '../../../../UI/DragAndDrop/DragSour
 import { dropIndicatorColor } from '../../../../UI/SortableVirtualizedItemList/DropIndicator';
 import DragHandle from '../../../../UI/DragHandle';
 import styles from './styles';
+import { roundTo } from '../../../../Utils/Mathematics';
+
+const VERTICE_COORDINATE_PRECISION = 4;
 
 type Props = {|
   parentVerticeId: string,
@@ -74,7 +77,10 @@ const VerticeRow = ({
                 <TableRowColumn style={styles.coordinateColumn}>
                   <SemiControlledTextField
                     margin="none"
-                    value={verticeX.toString()}
+                    value={roundTo(
+                      verticeX,
+                      VERTICE_COORDINATE_PRECISION
+                    ).toString()}
                     type="number"
                     id="vertice-x"
                     onChange={value => {
@@ -92,7 +98,10 @@ const VerticeRow = ({
                 <TableRowColumn style={styles.coordinateColumn}>
                   <SemiControlledTextField
                     margin="none"
-                    value={verticeY.toString()}
+                    value={roundTo(
+                      verticeY,
+                      VERTICE_COORDINATE_PRECISION
+                    ).toString()}
                     type="number"
                     id="vertice-y"
                     onChange={value => {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/VerticeRow.js
@@ -68,6 +68,9 @@ const VerticeRow = ({
         >
           {({ connectDragSource, connectDropTarget, isOver, canDrop }) =>
             connectDropTarget(
+              // Input of connectDropTarget must be an html element.
+              // So instead of using Material UI table row,
+              // the MUI class name for the component is used.
               <tr
                 className="MuiTableRow-root"
                 style={{ backgroundColor: muiTheme.list.itemsBackgroundColor }}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -54,6 +54,10 @@ const CollisionMasksEditor = (props: Props) => {
     highlightedVerticePtr,
     setHighlightedVerticePtr,
   ] = React.useState<?number>(null);
+  const [
+    selectedVerticePtr,
+    setSelectedVerticePtr,
+  ] = React.useState<?number>(null);
   // Note: these two booleans are set to false to avoid erasing points of other
   // animations/frames (and they will be updated by updateSameCollisionMasksToggles). In
   // theory, they should be set to the appropriate value at their initialization,
@@ -208,6 +212,8 @@ const CollisionMasksEditor = (props: Props) => {
                   polygons={sprite.getCustomCollisionMask()}
                   onPolygonsUpdated={updateCollisionMasks}
                   highlightedVerticePtr={highlightedVerticePtr}
+                  selectedVerticePtr={selectedVerticePtr}
+                  onClickVertice={setSelectedVerticePtr}
                 />
               )
             }
@@ -252,6 +258,8 @@ const CollisionMasksEditor = (props: Props) => {
                 onPolygonsUpdated={updateCollisionMasks}
                 restoreCollisionMask={() => onSetCollisionMaskAutomatic(true)}
                 onHoverVertice={setHighlightedVerticePtr}
+                onClickVertice={setSelectedVerticePtr}
+                selectedVerticePtr={selectedVerticePtr}
                 spriteWidth={spriteWidth}
                 spriteHeight={spriteHeight}
               />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -54,10 +54,9 @@ const CollisionMasksEditor = (props: Props) => {
     highlightedVerticePtr,
     setHighlightedVerticePtr,
   ] = React.useState<?number>(null);
-  const [
-    selectedVerticePtr,
-    setSelectedVerticePtr,
-  ] = React.useState<?number>(null);
+  const [selectedVerticePtr, setSelectedVerticePtr] = React.useState<?number>(
+    null
+  );
   // Note: these two booleans are set to false to avoid erasing points of other
   // animations/frames (and they will be updated by updateSameCollisionMasksToggles). In
   // theory, they should be set to the appropriate value at their initialization,

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -50,7 +50,10 @@ const CollisionMasksEditor = (props: Props) => {
   const [animationIndex, setAnimationIndex] = React.useState(0);
   const [directionIndex, setDirectionIndex] = React.useState(0);
   const [spriteIndex, setSpriteIndex] = React.useState(0);
-
+  const [
+    highlightedVerticePtr,
+    setHighlightedVerticePtr,
+  ] = React.useState<?number>(null);
   // Note: these two booleans are set to false to avoid erasing points of other
   // animations/frames (and they will be updated by updateSameCollisionMasksToggles). In
   // theory, they should be set to the appropriate value at their initialization,
@@ -204,6 +207,7 @@ const CollisionMasksEditor = (props: Props) => {
                   isDefaultBoundingBox={sprite.isCollisionMaskAutomatic()}
                   polygons={sprite.getCustomCollisionMask()}
                   onPolygonsUpdated={updateCollisionMasks}
+                  highlightedVerticePtr={highlightedVerticePtr}
                 />
               )
             }
@@ -247,6 +251,7 @@ const CollisionMasksEditor = (props: Props) => {
                 polygons={sprite.getCustomCollisionMask()}
                 onPolygonsUpdated={updateCollisionMasks}
                 restoreCollisionMask={() => onSetCollisionMaskAutomatic(true)}
+                onHoverVertice={setHighlightedVerticePtr}
                 spriteWidth={spriteWidth}
                 spriteHeight={spriteHeight}
               />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -21,8 +21,8 @@ type Props = {|
   onRemove?: ?(ev: any) => void,
   onEdit?: ?(ev: any) => void,
   onClick: (pointName: string) => void,
-  onMouseEnter: (pointName: ?string) => void,
-  onMouseLeave: (pointName: ?string) => void,
+  onPointerEnter: (pointName: ?string) => void,
+  onPointerLeave: (pointName: ?string) => void,
   selected: boolean,
   pointX: number,
   pointY: number,
@@ -31,119 +31,108 @@ type Props = {|
   isAutomatic?: boolean,
 |};
 
-const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
-  const onLeave = React.useCallback(
-    () => {
-      onMouseLeave(null);
-    },
-    [onMouseLeave]
-  );
-
-  return (
-    <ThemeConsumer>
-      {muiTheme => (
-        <TableRow
-          style={{
-            backgroundColor: props.selected
-              ? muiTheme.listItem.selectedBackgroundColor
-              : muiTheme.list.itemsBackgroundColor,
-          }}
-          onClick={() => props.onClick(props.pointName)}
-          onMouseEnter={() => props.onMouseEnter(props.pointName)}
-          onMouseLeave={onLeave}
-        >
-          <TableRowColumn style={styles.nameColumn}>
-            <TextField
+const PointRow = ({ pointX, pointY, ...props }: Props) => (
+  <ThemeConsumer>
+    {muiTheme => (
+      <TableRow
+        style={{
+          backgroundColor: props.selected
+            ? muiTheme.listItem.selectedBackgroundColor
+            : muiTheme.list.itemsBackgroundColor,
+        }}
+        onClick={() => props.onClick(props.pointName)}
+        onPointerEnter={() => props.onPointerEnter(props.pointName)}
+        onPointerLeave={props.onPointerEnter}
+      >
+        <TableRowColumn style={styles.nameColumn}>
+          <TextField
+            margin="none"
+            inputStyle={
+              props.selected
+                ? { color: muiTheme.listItem.selectedTextColor }
+                : undefined
+            }
+            defaultValue={props.pointName || 'Unnamed point'}
+            id={props.pointName}
+            fullWidth
+            errorText={
+              props.nameError ? 'This name is already taken' : undefined
+            }
+            disabled={!props.onBlur}
+            onBlur={props.onBlur}
+          />
+        </TableRowColumn>
+        <TableRowColumn style={styles.coordinateColumn}>
+          {!props.isAutomatic ? (
+            <SemiControlledTextField
               margin="none"
               inputStyle={
                 props.selected
                   ? { color: muiTheme.listItem.selectedTextColor }
                   : undefined
               }
-              defaultValue={props.pointName || 'Unnamed point'}
-              id={props.pointName}
-              fullWidth
-              errorText={
-                props.nameError ? 'This name is already taken' : undefined
-              }
-              disabled={!props.onBlur}
-              onBlur={props.onBlur}
+              value={roundTo(pointX, POINT_COORDINATE_PRECISION).toString()}
+              type="number"
+              id="point-x"
+              onChange={value => {
+                const valueAsNumber = parseFloat(value);
+                if (!isNaN(valueAsNumber)) props.onChangePointX(valueAsNumber);
+              }}
+              onBlur={event => {
+                props.onChangePointX(
+                  parseFloat(event.currentTarget.value) || 0
+                );
+              }}
             />
-          </TableRowColumn>
-          <TableRowColumn style={styles.coordinateColumn}>
-            {!props.isAutomatic ? (
-              <SemiControlledTextField
-                margin="none"
-                inputStyle={
-                  props.selected
-                    ? { color: muiTheme.listItem.selectedTextColor }
-                    : undefined
-                }
-                value={roundTo(pointX, POINT_COORDINATE_PRECISION).toString()}
-                type="number"
-                id="point-x"
-                onChange={value => {
-                  const valueAsNumber = parseFloat(value);
-                  if (!isNaN(valueAsNumber))
-                    props.onChangePointX(valueAsNumber);
-                }}
-                onBlur={event => {
-                  props.onChangePointX(
-                    parseFloat(event.currentTarget.value) || 0
-                  );
-                }}
-              />
-            ) : (
-              <Text noMargin>
-                <Trans>(auto)</Trans>
-              </Text>
-            )}
-          </TableRowColumn>
-          <TableRowColumn style={styles.coordinateColumn}>
-            {!props.isAutomatic ? (
-              <SemiControlledTextField
-                margin="none"
-                inputStyle={
-                  props.selected
-                    ? { color: muiTheme.listItem.selectedTextColor }
-                    : undefined
-                }
-                value={roundTo(pointY, POINT_COORDINATE_PRECISION).toString()}
-                type="number"
-                id="point-y"
-                onChange={value => {
-                  const valueAsNumber = parseFloat(value);
-                  if (!isNaN(valueAsNumber))
-                    props.onChangePointY(valueAsNumber);
-                }}
-                onBlur={event => {
-                  props.onChangePointY(
-                    parseFloat(event.currentTarget.value) || 0
-                  );
-                }}
-              />
-            ) : (
-              <Text noMargin>
-                <Trans>(auto)</Trans>
-              </Text>
-            )}
-          </TableRowColumn>
-          <TableRowColumn style={styles.toolColumn}>
-            {!!props.onRemove && (
-              <IconButton size="small" onClick={props.onRemove}>
-                <Delete />
-              </IconButton>
-            )}
-            {!!props.onEdit && (
-              <IconButton size="small" onClick={props.onEdit}>
-                <Edit />
-              </IconButton>
-            )}
-          </TableRowColumn>
-        </TableRow>
-      )}
-    </ThemeConsumer>
-  );
-};
+          ) : (
+            <Text noMargin>
+              <Trans>(auto)</Trans>
+            </Text>
+          )}
+        </TableRowColumn>
+        <TableRowColumn style={styles.coordinateColumn}>
+          {!props.isAutomatic ? (
+            <SemiControlledTextField
+              margin="none"
+              inputStyle={
+                props.selected
+                  ? { color: muiTheme.listItem.selectedTextColor }
+                  : undefined
+              }
+              value={roundTo(pointY, POINT_COORDINATE_PRECISION).toString()}
+              type="number"
+              id="point-y"
+              onChange={value => {
+                const valueAsNumber = parseFloat(value);
+                if (!isNaN(valueAsNumber)) props.onChangePointY(valueAsNumber);
+              }}
+              onBlur={event => {
+                props.onChangePointY(
+                  parseFloat(event.currentTarget.value) || 0
+                );
+              }}
+            />
+          ) : (
+            <Text noMargin>
+              <Trans>(auto)</Trans>
+            </Text>
+          )}
+        </TableRowColumn>
+        <TableRowColumn style={styles.toolColumn}>
+          {!!props.onRemove && (
+            <IconButton size="small" onClick={props.onRemove}>
+              <Delete />
+            </IconButton>
+          )}
+          {!!props.onEdit && (
+            <IconButton size="small" onClick={props.onEdit}>
+              <Edit />
+            </IconButton>
+          )}
+        </TableRowColumn>
+      </TableRow>
+    )}
+  </ThemeConsumer>
+);
 
 export default PointRow;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -6,6 +6,7 @@ import IconButton from '../../../../UI/IconButton';
 import Delete from '@material-ui/icons/Delete';
 import Edit from '@material-ui/icons/Edit';
 import TextField from '../../../../UI/TextField';
+import SemiControlledTextField from '../../../../UI/SemiControlledTextField';
 import styles from './styles';
 import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
 import Text from '../../../../UI/Text';
@@ -33,24 +34,6 @@ const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
       onMouseLeave(null);
     },
     [onMouseLeave]
-  );
-  const [pointXInputValue, setPointXInputValue] = React.useState<string>(
-    pointX.toString()
-  );
-  const [pointYInputValue, setPointYInputValue] = React.useState<string>(
-    pointY.toString()
-  );
-  React.useEffect(
-    () => {
-      setPointXInputValue(pointX.toString());
-    },
-    [pointX]
-  );
-  React.useEffect(
-    () => {
-      setPointYInputValue(pointY.toString());
-    },
-    [pointY]
   );
 
   return (
@@ -86,22 +69,25 @@ const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
           </TableRowColumn>
           <TableRowColumn style={styles.coordinateColumn}>
             {!props.isAutomatic ? (
-              <TextField
+              <SemiControlledTextField
                 margin="none"
                 inputStyle={
                   props.selected
                     ? { color: muiTheme.listItem.selectedTextColor }
                     : undefined
                 }
-                value={pointXInputValue}
+                value={pointX.toString()}
                 type="number"
                 id="point-x"
-                onChange={(e, value) => {
-                  setPointXInputValue(value);
+                onChange={value => {
                   const valueAsNumber = parseFloat(value);
-                  if (!isNaN(valueAsNumber)) {
+                  if (!isNaN(valueAsNumber))
                     props.onChangePointX(valueAsNumber);
-                  }
+                }}
+                onBlur={event => {
+                  props.onChangePointX(
+                    parseFloat(event.currentTarget.value) || 0
+                  );
                 }}
               />
             ) : (
@@ -112,22 +98,25 @@ const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
           </TableRowColumn>
           <TableRowColumn style={styles.coordinateColumn}>
             {!props.isAutomatic ? (
-              <TextField
+              <SemiControlledTextField
                 margin="none"
                 inputStyle={
                   props.selected
                     ? { color: muiTheme.listItem.selectedTextColor }
                     : undefined
                 }
-                value={pointYInputValue}
+                value={pointY.toString()}
                 type="number"
                 id="point-y"
-                onChange={(e, value) => {
-                  setPointYInputValue(value);
+                onChange={value => {
                   const valueAsNumber = parseFloat(value);
-                  if (!isNaN(valueAsNumber)) {
+                  if (!isNaN(valueAsNumber))
                     props.onChangePointY(valueAsNumber);
-                  }
+                }}
+                onBlur={event => {
+                  props.onChangePointY(
+                    parseFloat(event.currentTarget.value) || 0
+                  );
                 }}
               />
             ) : (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -27,13 +27,32 @@ type Props = {|
   isAutomatic?: Boolean,
 |};
 
-const PointRow = ({ onMouseLeave, ...props }: Props) => {
+const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
   const onLeave = React.useCallback(
     () => {
       onMouseLeave(null);
     },
     [onMouseLeave]
   );
+  const [pointXInputValue, setPointXInputValue] = React.useState<string>(
+    pointX.toString()
+  );
+  const [pointYInputValue, setPointYInputValue] = React.useState<string>(
+    pointY.toString()
+  );
+  React.useEffect(
+    () => {
+      setPointXInputValue(pointX.toString());
+    },
+    [pointX]
+  );
+  React.useEffect(
+    () => {
+      setPointYInputValue(pointY.toString());
+    },
+    [pointY]
+  );
+
   return (
     <ThemeConsumer>
       {muiTheme => (
@@ -77,12 +96,16 @@ const PointRow = ({ onMouseLeave, ...props }: Props) => {
                     ? { color: muiTheme.listItem.selectedTextColor }
                     : undefined
                 }
-                value={props.pointX}
+                value={pointXInputValue}
                 type="number"
                 id="point-x"
-                onChange={(e, value) =>
-                  props.onChangePointX(parseFloat(value || 0))
-                }
+                onChange={(e, value) => {
+                  setPointXInputValue(value);
+                  const valueAsNumber = parseFloat(value);
+                  if (!isNaN(valueAsNumber)) {
+                    props.onChangePointX(valueAsNumber);
+                  }
+                }}
               />
             ) : (
               <Text noMargin>
@@ -99,12 +122,16 @@ const PointRow = ({ onMouseLeave, ...props }: Props) => {
                     ? { color: muiTheme.listItem.selectedTextColor }
                     : undefined
                 }
-                value={props.pointY}
+                value={pointYInputValue}
                 type="number"
                 id="point-y"
-                onChange={(e, value) =>
-                  props.onChangePointY(parseFloat(value || 0))
-                }
+                onChange={(e, value) => {
+                  setPointYInputValue(value);
+                  const valueAsNumber = parseFloat(value);
+                  if (!isNaN(valueAsNumber)) {
+                    props.onChangePointY(valueAsNumber);
+                  }
+                }}
               />
             ) : (
               <Text noMargin>

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -12,10 +12,10 @@ import Text from '../../../../UI/Text';
 
 type Props = {|
   pointName: string,
-  nameError: boolean,
+  nameError?: boolean,
   onBlur?: (ev: any) => void,
-  onRemove?: (ev: any) => void,
-  onEdit?: (ev: any) => void,
+  onRemove?: ?(ev: any) => void,
+  onEdit?: ?(ev: any) => void,
   onClick: (pointName: string) => void,
   onMouseEnter: (pointName: ?string) => void,
   onMouseLeave: (pointName: ?string) => void,
@@ -24,7 +24,7 @@ type Props = {|
   pointY: number,
   onChangePointX: (value: number) => void,
   onChangePointY: (value: number) => void,
-  isAutomatic?: Boolean,
+  isAutomatic?: boolean,
 |};
 
 const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
@@ -66,10 +66,7 @@ const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
           onMouseEnter={() => props.onMouseEnter(props.pointName)}
           onMouseLeave={onLeave}
         >
-          <TableRowColumn style={styles.handleColumn}>
-            {/* <DragHandle /> Reordering point is not supported for now */}
-          </TableRowColumn>
-          <TableRowColumn>
+          <TableRowColumn style={styles.nameColumn}>
             <TextField
               margin="none"
               inputStyle={

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -16,6 +16,10 @@ type Props = {|
   onBlur?: (ev: any) => void,
   onRemove?: (ev: any) => void,
   onEdit?: (ev: any) => void,
+  onClick: (pointName: string) => void,
+  onMouseEnter: (pointName: ?string) => void,
+  onMouseLeave: (pointName: ?string) => void,
+  selected: boolean,
   pointX: number,
   pointY: number,
   onChangePointX: (value: number) => void,
@@ -23,79 +27,107 @@ type Props = {|
   isAutomatic?: Boolean,
 |};
 
-const PointRow = (props: Props) => (
-  <ThemeConsumer>
-    {muiTheme => (
-      <TableRow
-        style={{
-          backgroundColor: muiTheme.list.itemsBackgroundColor,
-        }}
-      >
-        <TableRowColumn style={styles.handleColumn}>
-          {/* <DragHandle /> Reordering point is not supported for now */}
-        </TableRowColumn>
-        <TableRowColumn>
-          <TextField
-            margin="none"
-            defaultValue={props.pointName || 'Unnamed point'}
-            id={props.pointName}
-            fullWidth
-            errorText={
-              props.nameError ? 'This name is already taken' : undefined
-            }
-            disabled={!props.onBlur}
-            onBlur={props.onBlur}
-          />
-        </TableRowColumn>
-        <TableRowColumn style={styles.coordinateColumn}>
-          {!props.isAutomatic ? (
+const PointRow = ({ onMouseLeave, ...props }: Props) => {
+  const onLeave = React.useCallback(
+    () => {
+      onMouseLeave(null);
+    },
+    [onMouseLeave]
+  );
+  return (
+    <ThemeConsumer>
+      {muiTheme => (
+        <TableRow
+          style={{
+            backgroundColor: props.selected
+              ? muiTheme.listItem.selectedBackgroundColor
+              : muiTheme.list.itemsBackgroundColor,
+          }}
+          onClick={() => props.onClick(props.pointName)}
+          onMouseEnter={() => props.onMouseEnter(props.pointName)}
+          onMouseLeave={onLeave}
+        >
+          <TableRowColumn style={styles.handleColumn}>
+            {/* <DragHandle /> Reordering point is not supported for now */}
+          </TableRowColumn>
+          <TableRowColumn>
             <TextField
               margin="none"
-              value={props.pointX}
-              type="number"
-              id="point-x"
-              onChange={(e, value) =>
-                props.onChangePointX(parseFloat(value || 0))
+              inputStyle={
+                props.selected
+                  ? { color: muiTheme.listItem.selectedTextColor }
+                  : undefined
               }
-            />
-          ) : (
-            <Text noMargin>
-              <Trans>(auto)</Trans>
-            </Text>
-          )}
-        </TableRowColumn>
-        <TableRowColumn style={styles.coordinateColumn}>
-          {!props.isAutomatic ? (
-            <TextField
-              margin="none"
-              value={props.pointY}
-              type="number"
-              id="point-y"
-              onChange={(e, value) =>
-                props.onChangePointY(parseFloat(value || 0))
+              defaultValue={props.pointName || 'Unnamed point'}
+              id={props.pointName}
+              fullWidth
+              errorText={
+                props.nameError ? 'This name is already taken' : undefined
               }
+              disabled={!props.onBlur}
+              onBlur={props.onBlur}
             />
-          ) : (
-            <Text noMargin>
-              <Trans>(auto)</Trans>
-            </Text>
-          )}
-        </TableRowColumn>
-        <TableRowColumn style={styles.toolColumn}>
-          {!!props.onRemove && (
-            <IconButton size="small" onClick={props.onRemove}>
-              <Delete />
-            </IconButton>
-          )}
-          {!!props.onEdit && (
-            <IconButton size="small" onClick={props.onEdit}>
-              <Edit />
-            </IconButton>
-          )}
-        </TableRowColumn>
-      </TableRow>
-    )}
-  </ThemeConsumer>
-);
+          </TableRowColumn>
+          <TableRowColumn style={styles.coordinateColumn}>
+            {!props.isAutomatic ? (
+              <TextField
+                margin="none"
+                inputStyle={
+                  props.selected
+                    ? { color: muiTheme.listItem.selectedTextColor }
+                    : undefined
+                }
+                value={props.pointX}
+                type="number"
+                id="point-x"
+                onChange={(e, value) =>
+                  props.onChangePointX(parseFloat(value || 0))
+                }
+              />
+            ) : (
+              <Text noMargin>
+                <Trans>(auto)</Trans>
+              </Text>
+            )}
+          </TableRowColumn>
+          <TableRowColumn style={styles.coordinateColumn}>
+            {!props.isAutomatic ? (
+              <TextField
+                margin="none"
+                inputStyle={
+                  props.selected
+                    ? { color: muiTheme.listItem.selectedTextColor }
+                    : undefined
+                }
+                value={props.pointY}
+                type="number"
+                id="point-y"
+                onChange={(e, value) =>
+                  props.onChangePointY(parseFloat(value || 0))
+                }
+              />
+            ) : (
+              <Text noMargin>
+                <Trans>(auto)</Trans>
+              </Text>
+            )}
+          </TableRowColumn>
+          <TableRowColumn style={styles.toolColumn}>
+            {!!props.onRemove && (
+              <IconButton size="small" onClick={props.onRemove}>
+                <Delete />
+              </IconButton>
+            )}
+            {!!props.onEdit && (
+              <IconButton size="small" onClick={props.onEdit}>
+                <Edit />
+              </IconButton>
+            )}
+          </TableRowColumn>
+        </TableRow>
+      )}
+    </ThemeConsumer>
+  );
+};
 
 export default PointRow;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointRow.js
@@ -10,6 +10,9 @@ import SemiControlledTextField from '../../../../UI/SemiControlledTextField';
 import styles from './styles';
 import ThemeConsumer from '../../../../UI/Theme/ThemeConsumer';
 import Text from '../../../../UI/Text';
+import { roundTo } from '../../../../Utils/Mathematics';
+
+const POINT_COORDINATE_PRECISION = 4;
 
 type Props = {|
   pointName: string,
@@ -76,7 +79,7 @@ const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
                     ? { color: muiTheme.listItem.selectedTextColor }
                     : undefined
                 }
-                value={pointX.toString()}
+                value={roundTo(pointX, POINT_COORDINATE_PRECISION).toString()}
                 type="number"
                 id="point-x"
                 onChange={value => {
@@ -105,7 +108,7 @@ const PointRow = ({ onMouseLeave, pointX, pointY, ...props }: Props) => {
                     ? { color: muiTheme.listItem.selectedTextColor }
                     : undefined
                 }
-                value={pointY.toString()}
+                value={roundTo(pointY, POINT_COORDINATE_PRECISION).toString()}
                 type="number"
                 id="point-y"
                 onChange={value => {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -214,6 +214,7 @@ const PointsList = (props: PointsListProps) => {
             const point = new gd.Point(name);
             props.pointsContainer.addPoint(point);
             point.delete();
+            props.onSelectPoint(name);
             props.onPointsUpdated();
           }}
         />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -8,7 +8,6 @@ import {
   TableHeader,
   TableHeaderColumn,
   TableRow,
-  TableRowColumn,
 } from '../../../../UI/Table';
 import newNameGenerator from '../../../../Utils/NewNameGenerator';
 import { mapVector } from '../../../../Utils/MapFor';

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -1,5 +1,7 @@
 // @flow
 import * as React from 'react';
+import { Trans } from '@lingui/macro';
+import AddIcon from '@material-ui/icons/Add';
 import {
   Table,
   TableBody,
@@ -8,20 +10,15 @@ import {
   TableRow,
   TableRowColumn,
 } from '../../../../UI/Table';
-import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 import newNameGenerator from '../../../../Utils/NewNameGenerator';
 import { mapVector } from '../../../../Utils/MapFor';
 import Window from '../../../../Utils/Window';
-import styles from './styles';
-import PointRow from './PointRow';
 import useForceUpdate from '../../../../Utils/UseForceUpdate';
 import { Column, Line, Spacer } from '../../../../UI/Grid';
 import RaisedButton from '../../../../UI/RaisedButton';
-import { Trans } from '@lingui/macro';
-import AddIcon from '@material-ui/icons/Add';
+import PointRow from './PointRow';
+import styles from './styles';
 const gd: libGDevelop = global.gd;
-
-const SortablePointRow = SortableElement(PointRow);
 
 type PointsListBodyProps = {|
   pointsContainer: gdSprite,
@@ -76,9 +73,7 @@ const PointsListBody = (props: PointsListBodyProps) => {
     const pointName = point.getName();
 
     return (
-      <SortablePointRow
-        index={i}
-        disabled
+      <PointRow
         key={'point-' + pointName}
         pointX={point.getX()}
         pointY={point.getY()}
@@ -121,8 +116,7 @@ const PointsListBody = (props: PointsListBodyProps) => {
   const centerPoint = pointsContainer.getCenter();
 
   const originRow = (
-    <SortablePointRow
-      index={0}
+    <PointRow
       key={'origin-point-row'}
       pointName="Origin"
       pointX={originPoint.getX()}
@@ -133,12 +127,10 @@ const PointsListBody = (props: PointsListBodyProps) => {
       onMouseLeave={props.onHoverPoint}
       onClick={props.onSelectPoint}
       selected={'Origin' === props.selectedPointName}
-      disabled
     />
   );
   const centerRow = (
-    <SortablePointRow
-      index={1}
+    <PointRow
       key={'center-point-row'}
       pointName="Center"
       isAutomatic={pointsContainer.isDefaultCenterPoint()}
@@ -150,7 +142,6 @@ const PointsListBody = (props: PointsListBodyProps) => {
       onMouseLeave={props.onHoverPoint}
       onClick={props.onSelectPoint}
       selected={'Center' === props.selectedPointName}
-      disabled
       onEdit={
         pointsContainer.isDefaultCenterPoint()
           ? () => {
@@ -173,14 +164,11 @@ const PointsListBody = (props: PointsListBodyProps) => {
   return <TableBody>{[originRow, centerRow, ...pointsRows]}</TableBody>;
 };
 
-const SortablePointsListBody = SortableContainer(PointsListBody);
-SortablePointsListBody.muiName = 'TableBody';
-
 type PointsListProps = {|
   pointsContainer: gdSprite,
   onPointsUpdated: () => void,
-  onHoverPoint: (pointName: string) => void,
-  onSelectPoint: (pointName: string) => void,
+  onHoverPoint: (pointName: ?string) => void,
+  onSelectPoint: (pointName: ?string) => void,
   selectedPointName: ?string,
 |};
 
@@ -190,29 +178,24 @@ const PointsList = (props: PointsListProps) => {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHeaderColumn style={styles.handleColumn} />
-            <TableHeaderColumn>Point name</TableHeaderColumn>
+            <TableHeaderColumn style={styles.nameColumn}>
+              <Trans>Point name</Trans>
+            </TableHeaderColumn>
             <TableHeaderColumn style={styles.coordinateColumn}>
               X
             </TableHeaderColumn>
             <TableHeaderColumn style={styles.coordinateColumn}>
               Y
             </TableHeaderColumn>
-            <TableRowColumn style={styles.toolColumn} />
+            <TableHeaderColumn style={styles.toolColumn} />
           </TableRow>
         </TableHeader>
-        <SortablePointsListBody
+        <PointsListBody
           pointsContainer={props.pointsContainer}
           onHoverPoint={props.onHoverPoint}
           onSelectPoint={props.onSelectPoint}
           selectedPointName={props.selectedPointName}
           onPointsUpdated={props.onPointsUpdated}
-          onSortEnd={({ oldIndex, newIndex }) => {
-            // Reordering points is not supported for now
-          }}
-          helperClass="sortable-helper"
-          useDragHandle
-          lockToContainerEdges
         />
       </Table>
       <Spacer />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -98,8 +98,8 @@ const PointsListBody = (props: PointsListBodyProps) => {
 
           setNameErrors(old => ({ ...old, [pointName]: !success }));
         }}
-        onMouseEnter={props.onHoverPoint}
-        onMouseLeave={props.onHoverPoint}
+        onPointerEnter={props.onHoverPoint}
+        onPointerLeave={props.onHoverPoint}
         onClick={props.onSelectPoint}
         onRemove={() => {
           const answer = Window.showConfirmDialog(
@@ -125,8 +125,8 @@ const PointsListBody = (props: PointsListBodyProps) => {
       pointY={originPoint.getY()}
       onChangePointX={updateOriginPointX}
       onChangePointY={updateOriginPointY}
-      onMouseEnter={props.onHoverPoint}
-      onMouseLeave={props.onHoverPoint}
+      onPointerEnter={props.onHoverPoint}
+      onPointerLeave={props.onHoverPoint}
       onClick={props.onSelectPoint}
       selected={'Origin' === props.selectedPointName}
     />
@@ -140,8 +140,8 @@ const PointsListBody = (props: PointsListBodyProps) => {
       pointY={centerPoint.getY()}
       onChangePointX={updateCenterPointX}
       onChangePointY={updateCenterPointY}
-      onMouseEnter={props.onHoverPoint}
-      onMouseLeave={props.onHoverPoint}
+      onPointerEnter={props.onHoverPoint}
+      onPointerLeave={props.onHoverPoint}
       onClick={props.onSelectPoint}
       selected={'Center' === props.selectedPointName}
       onEdit={

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -26,6 +26,9 @@ const SortablePointRow = SortableElement(PointRow);
 type PointsListBodyProps = {|
   pointsContainer: gdSprite,
   onPointsUpdated: () => void,
+  onHoverPoint: (pointName: ?string) => void,
+  onSelectPoint: (pointName: string) => void,
+  selectedPointName: ?string,
 |};
 
 const PointsListBody = (props: PointsListBodyProps) => {
@@ -82,6 +85,7 @@ const PointsListBody = (props: PointsListBodyProps) => {
         onChangePointX={newValue => updatePointX(point, newValue)}
         onChangePointY={newValue => updatePointY(point, newValue)}
         pointName={pointName}
+        selected={pointName === props.selectedPointName}
         nameError={nameErrors[pointName]}
         onBlur={event => {
           const newName = event.target.value;
@@ -97,6 +101,9 @@ const PointsListBody = (props: PointsListBodyProps) => {
 
           setNameErrors(old => ({ ...old, [pointName]: !success }));
         }}
+        onMouseEnter={props.onHoverPoint}
+        onMouseLeave={props.onHoverPoint}
+        onClick={props.onSelectPoint}
         onRemove={() => {
           const answer = Window.showConfirmDialog(
             "Are you sure you want to remove this point? This can't be undone."
@@ -122,6 +129,10 @@ const PointsListBody = (props: PointsListBodyProps) => {
       pointY={originPoint.getY()}
       onChangePointX={updateOriginPointX}
       onChangePointY={updateOriginPointY}
+      onMouseEnter={props.onHoverPoint}
+      onMouseLeave={props.onHoverPoint}
+      onClick={props.onSelectPoint}
+      selected={'Origin' === props.selectedPointName}
       disabled
     />
   );
@@ -135,6 +146,10 @@ const PointsListBody = (props: PointsListBodyProps) => {
       pointY={centerPoint.getY()}
       onChangePointX={updateCenterPointX}
       onChangePointY={updateCenterPointY}
+      onMouseEnter={props.onHoverPoint}
+      onMouseLeave={props.onHoverPoint}
+      onClick={props.onSelectPoint}
+      selected={'Center' === props.selectedPointName}
       disabled
       onEdit={
         pointsContainer.isDefaultCenterPoint()
@@ -164,6 +179,9 @@ SortablePointsListBody.muiName = 'TableBody';
 type PointsListProps = {|
   pointsContainer: gdSprite,
   onPointsUpdated: () => void,
+  onHoverPoint: (pointName: string) => void,
+  onSelectPoint: (pointName: string) => void,
+  selectedPointName: ?string,
 |};
 
 const PointsList = (props: PointsListProps) => {
@@ -185,6 +203,9 @@ const PointsList = (props: PointsListProps) => {
         </TableHeader>
         <SortablePointsListBody
           pointsContainer={props.pointsContainer}
+          onHoverPoint={props.onHoverPoint}
+          onSelectPoint={props.onSelectPoint}
+          selectedPointName={props.selectedPointName}
           onPointsUpdated={props.onPointsUpdated}
           onSortEnd={({ oldIndex, newIndex }) => {
             // Reordering points is not supported for now

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsList.js
@@ -74,7 +74,7 @@ const PointsListBody = (props: PointsListBodyProps) => {
 
     return (
       <PointRow
-        key={'point-' + pointName}
+        key={'point-' + point.ptr}
         pointX={point.getX()}
         pointY={point.getY()}
         onChangePointX={newValue => updatePointX(point, newValue)}
@@ -91,6 +91,9 @@ const PointsListBody = (props: PointsListBodyProps) => {
             success = false;
           } else {
             point.setName(newName);
+            if (props.selectedPointName === pointName) {
+              props.onSelectPoint(newName);
+            }
             onPointsUpdated();
           }
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
@@ -103,6 +103,7 @@ const PointsPreview = (props: Props) => {
     const draggingWasDone = !!state.draggedPoint;
     if (draggingWasDone) {
       props.onPointsUpdated();
+      // Select point at the end of the drag
       if (state.draggedPointKind && state.draggedPoint) {
         props.onClickPoint(
           getPointName(state.draggedPointKind, state.draggedPoint)

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
@@ -3,11 +3,29 @@ import * as React from 'react';
 import { mapVector } from '../../../../Utils/MapFor';
 import useForceUpdate from '../../../../Utils/UseForceUpdate';
 
+const selectedPointZIndex = 900;
+const highlightedPointZIndex = 1000;
+
 const styles = {
   container: {
     position: 'relative',
     width: '100%',
     height: '100%',
+  },
+  point: {
+    position: 'absolute',
+    transform: 'translate(-6px, -5px)',
+    cursor: 'move',
+  },
+  highlightedPoint: {
+    outline: '1px solid black',
+    background: 'rgba(255, 255, 255, 0.5)',
+    zIndex: highlightedPointZIndex,
+  },
+  selectedPoint: {
+    outline: '1px solid blue',
+    background: 'rgba(255, 255, 255, 0.5)',
+    zIndex: selectedPointZIndex,
   },
 };
 
@@ -18,6 +36,20 @@ const pointKindIdentifiers = {
 };
 type PointKind = 1 | 2 | 3;
 
+const getPointName = (kind: PointKind, point: gdPoint): string =>
+  kind === pointKindIdentifiers.ORIGIN
+    ? 'Origin'
+    : kind === pointKindIdentifiers.CENTER
+    ? 'Center'
+    : point.getName();
+
+const getImageSrc = (kind: PointKind): string =>
+  kind === pointKindIdentifiers.ORIGIN
+    ? 'res/originPoint.png'
+    : kind === pointKindIdentifiers.CENTER
+    ? 'res/centerPoint.png'
+    : 'res/point.png';
+
 type Props = {|
   pointsContainer: gdSprite, // Could potentially be generalized to other things than Sprite in the future.
   imageWidth: number,
@@ -26,6 +58,9 @@ type Props = {|
   offsetLeft: number,
   imageZoomFactor: number,
   onPointsUpdated: () => void,
+  highlightedPointName: ?string,
+  selectedPointName: ?string,
+  onClickPoint: string => void,
 |};
 
 type State = {|
@@ -47,6 +82,8 @@ const PointsPreview = (props: Props) => {
     offsetTop,
     offsetLeft,
     imageZoomFactor,
+    highlightedPointName,
+    selectedPointName,
   } = props;
 
   const forceUpdate = useForceUpdate();
@@ -64,7 +101,14 @@ const PointsPreview = (props: Props) => {
 
   const onEndDragPoint = () => {
     const draggingWasDone = !!state.draggedPoint;
-    if (draggingWasDone) props.onPointsUpdated();
+    if (draggingWasDone) {
+      props.onPointsUpdated();
+      if (state.draggedPointKind && state.draggedPoint) {
+        props.onClickPoint(
+          getPointName(state.draggedPointKind, state.draggedPoint)
+        );
+      }
+    }
     setState({
       draggedPoint: null,
       draggedPointKind: null,
@@ -100,28 +144,20 @@ const PointsPreview = (props: Props) => {
     kind: PointKind,
     point: gdPoint
   ) => {
-    const pointName =
-      kind === pointKindIdentifiers.ORIGIN
-        ? 'Origin'
-        : kind === pointKindIdentifiers.CENTER
-        ? 'Center'
-        : point.getName();
-    const imageSrc =
-      kind === pointKindIdentifiers.ORIGIN
-        ? 'res/originPoint.png'
-        : kind === pointKindIdentifiers.CENTER
-        ? 'res/centerPoint.png'
-        : 'res/point.png';
+    const pointName = getPointName(kind, point);
     return (
       <img
-        src={imageSrc}
+        src={getImageSrc(kind)}
         title={pointName}
         style={{
-          position: 'absolute',
           left: x,
           top: y,
-          transform: 'translate(-6px, -5px)',
-          cursor: 'move',
+          ...styles.point,
+          ...(pointName === selectedPointName
+            ? styles.selectedPoint
+            : pointName === highlightedPointName
+            ? styles.highlightedPoint
+            : null),
         }}
         alt=""
         key={name}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
@@ -50,6 +50,13 @@ const PointsEditor = (props: Props) => {
   const [animationIndex, setAnimationIndex] = React.useState(0);
   const [directionIndex, setDirectionIndex] = React.useState(0);
   const [spriteIndex, setSpriteIndex] = React.useState(0);
+  const [selectedPointName, setSelectedPointName] = React.useState<?string>(
+    null
+  );
+  const [
+    highlightedPointName,
+    setHighlightedPointName,
+  ] = React.useState<?string>(null);
 
   // Note: these two booleans are set to false to avoid erasing points of other
   // animations/frames (and they will be updated by updateSamePointsToggles). In
@@ -178,6 +185,9 @@ const PointsEditor = (props: Props) => {
                   {...overlayProps}
                   pointsContainer={sprite}
                   onPointsUpdated={updatePoints}
+                  selectedPointName={selectedPointName}
+                  highlightedPointName={highlightedPointName}
+                  onClickPoint={setSelectedPointName}
                 />
               )
             }
@@ -220,6 +230,9 @@ const PointsEditor = (props: Props) => {
               <PointsList
                 pointsContainer={sprite}
                 onPointsUpdated={updatePoints}
+                selectedPointName={selectedPointName}
+                onHoverPoint={setHighlightedPointName}
+                onSelectPoint={setSelectedPointName}
               />
             )}
             {!sprite && (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/styles.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/styles.js
@@ -1,15 +1,11 @@
-//TODO: Factor with styles.js from LayersList.
+// @flow
 export default {
-  handleColumn: {
-    width: 24,
-    paddingLeft: 8,
-    paddingRight: 0,
-  },
+  nameColumn: { width: '40%' },
   coordinateColumn: {
-    width: 48,
+    width: 60,
   },
   toolColumn: {
-    width: 48,
+    width: 36,
     height: 32,
   },
 };

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -466,6 +466,7 @@ export default function SpriteEditor({
         <Dialog
           actions={[
             <FlatButton
+              key="close"
               label={<Trans>Close</Trans>}
               primary
               onClick={() => setPointsEditorOpen(false)}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -434,6 +434,7 @@ export default function SpriteEditor({
         <Dialog
           actions={[
             <FlatButton
+              key="close"
               label={<Trans>Close</Trans>}
               primary
               onClick={() => setAdvancedOptionsOpen(false)}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -497,6 +497,7 @@ export default function SpriteEditor({
         <Dialog
           actions={[
             <FlatButton
+              key="close"
               label={<Trans>Close</Trans>}
               primary
               onClick={() => setCollisionMasksEditorOpen(false)}

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -17,6 +17,7 @@ import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
 import CheckeredBackground from '../CheckeredBackground';
 import { getPixelatedImageRendering } from '../../Utils/CssHelpers';
 import { shouldZoom } from '../../UI/KeyboardShortcuts/InteractionKeys';
+import Slider from '../../UI/Slider';
 const gd: libGDevelop = global.gd;
 
 const MARGIN = 50;
@@ -52,6 +53,12 @@ const styles = {
     position: 'relative',
     pointerEvents: 'none',
     margin: MARGIN,
+  },
+  sliderContainer: {
+    maxWidth: 150,
+    width: '100%',
+    display: 'flex',
+    padding: '0 10px',
   },
 };
 
@@ -257,16 +264,28 @@ const ImagePreview = (props: Props) => {
           <Column expand noMargin useFullHeight>
             <MiniToolbar>
               <IconButton
-                onClick={() => zoomBy(+0.2)}
-                tooltip={t`Zoom in (you can also use Ctrl + Mouse wheel)`}
-              >
-                <ZoomIn />
-              </IconButton>
-              <IconButton
                 onClick={() => zoomBy(-0.2)}
                 tooltip={t`Zoom out (you can also use Ctrl + Mouse wheel)`}
               >
                 <ZoomOut />
+              </IconButton>
+              <div style={styles.sliderContainer}>
+                <Slider
+                  min={Math.log10(MIN_ZOOM_FACTOR)}
+                  max={Math.log10(MAX_ZOOM_FACTOR)}
+                  step={0.05}
+                  value={Math.log10(state.imageZoomFactor)}
+                  onChange={value => {
+                    console.log(value);
+                    zoomTo(Math.pow(10, value));
+                  }}
+                />
+              </div>
+              <IconButton
+                onClick={() => zoomBy(+0.2)}
+                tooltip={t`Zoom in (you can also use Ctrl + Mouse wheel)`}
+              >
+                <ZoomIn />
               </IconButton>
               <IconButton
                 onClick={() => zoomTo(1)}

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -16,6 +16,7 @@ import { CorsAwareImage } from '../../UI/CorsAwareImage';
 import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
 import CheckeredBackground from '../CheckeredBackground';
 import { getPixelatedImageRendering } from '../../Utils/CssHelpers';
+import { shouldZoom } from '../../UI/KeyboardShortcuts/InteractionKeys';
 const gd: libGDevelop = global.gd;
 
 const MARGIN = 50;
@@ -262,8 +263,7 @@ const ImagePreview = (props: Props) => {
                 ref={measureRef}
                 onWheel={event => {
                   const { deltaY } = event;
-                  //TODO: Use KeyboardShortcuts
-                  if (event.metaKey || event.ctrlKey) {
+                  if (shouldZoom(event)) {
                     zoomBy(-deltaY / 500);
                     event.preventDefault();
                     event.stopPropagation();

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -158,8 +158,8 @@ const ImagePreview = (props: Props) => {
       zoomFactor = 1;
     } else {
       const idealZoomFactors = [
-        containerWidth / imageWidth,
-        containerHeight / imageHeight,
+        containerWidth / (imageWidth + 2 * MARGIN),
+        containerHeight / (imageHeight + 2 * MARGIN),
       ];
       zoomFactor = getBoundedZoomFactor(Math.min(...idealZoomFactors));
     }

--- a/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
@@ -43,6 +43,13 @@ export const shouldSubmit = (event: SupportedEvent) => {
 };
 
 /**
+ * Check if the user wants to zoom when scrolling.
+ */
+export const shouldZoom = (event: SupportedEvent) => {
+  return (event.metaKey || event.ctrlKey);
+};
+
+/**
  * Check if the user asked to go to the next field.
  * Note that in most case, this should be automatically handled by the browser
  * (or material-ui), and using this should not be needed.

--- a/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
@@ -46,7 +46,7 @@ export const shouldSubmit = (event: SupportedEvent) => {
  * Check if the user wants to zoom when scrolling.
  */
 export const shouldZoom = (event: SupportedEvent) => {
-  return (event.metaKey || event.ctrlKey);
+  return event.metaKey || event.ctrlKey;
 };
 
 /**

--- a/newIDE/app/src/UI/Slider.js
+++ b/newIDE/app/src/UI/Slider.js
@@ -1,0 +1,24 @@
+// @flow
+import * as React from 'react';
+import MuiSlider from '@material-ui/core/Slider';
+
+type Props = {|
+  value: number,
+  min: number,
+  max: number,
+  step: number,
+  onChange: (value: number) => void,
+|};
+
+const Slider = (props: Props) => (
+  <MuiSlider
+    value={props.value}
+    track={false}
+    onChange={(e, newValue) => props.onChange(newValue)}
+    min={props.min}
+    max={props.max}
+    step={props.step}
+  />
+);
+
+export default Slider;

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/DropIndicator.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/DropIndicator.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import ThemeConsumer from '../Theme/ThemeConsumer';
 
-export const dropIndicatorColor = '#18dcf2'
+export const dropIndicatorColor = '#18dcf2';
 
 const styles = {
   dropIndicator: {

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/DropIndicator.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/DropIndicator.js
@@ -2,9 +2,11 @@
 import * as React from 'react';
 import ThemeConsumer from '../Theme/ThemeConsumer';
 
+export const dropIndicatorColor = '#18dcf2'
+
 const styles = {
   dropIndicator: {
-    borderTop: '2px solid #18dcf2',
+    borderTop: `2px solid ${dropIndicatorColor}`,
     height: 0,
     marginTop: '-1px',
     marginBottom: '-1px',

--- a/newIDE/app/src/UI/Table.js
+++ b/newIDE/app/src/UI/Table.js
@@ -73,8 +73,8 @@ type TableRowProps = {|
   style?: {|
     backgroundColor: string,
   |},
-  onMouseEnter?: () => void,
-  onMouseLeave?: () => void,
+  onPointerEnter?: () => void,
+  onPointerLeave?: () => void,
   onClick?: () => void,
 |};
 

--- a/newIDE/app/src/UI/Table.js
+++ b/newIDE/app/src/UI/Table.js
@@ -49,8 +49,10 @@ export class TableHeader extends React.Component<TableHeaderProps, {||}> {
 type TableHeaderColumnProps = {|
   children?: React.Node, // Text of the column
   style?: {|
-    textAlign: 'left' | 'right',
-    paddingRight: number,
+    height?: number,
+    width?: number | string,
+    textAlign?: 'left' | 'right',
+    paddingRight?: number,
   |},
 |};
 
@@ -88,7 +90,8 @@ export class TableRow extends React.Component<TableRowProps, {||}> {
 type TableRowColumnProps = {|
   children?: React.Node, // Content for the cell
   style?: {|
-    width?: number,
+    height?: number,
+    width?: number | string,
     paddingLeft?: number,
     paddingRight?: number,
     textAlign?: string,

--- a/newIDE/app/src/UI/Table.js
+++ b/newIDE/app/src/UI/Table.js
@@ -71,6 +71,9 @@ type TableRowProps = {|
   style?: {|
     backgroundColor: string,
   |},
+  onMouseEnter?: () => void,
+  onMouseLeave?: () => void,
+  onClick?: () => void,
 |};
 
 /**

--- a/newIDE/app/src/Utils/Mathematics.js
+++ b/newIDE/app/src/Utils/Mathematics.js
@@ -1,0 +1,4 @@
+// @flow
+
+export const roundTo = (value: number, precision: number): number =>
+  Math.round(value * Math.pow(10, precision)) / Math.pow(10, precision);

--- a/newIDE/app/src/stories/componentStories/UI/Slider.stories.js
+++ b/newIDE/app/src/stories/componentStories/UI/Slider.stories.js
@@ -1,0 +1,35 @@
+// @flow
+import * as React from 'react';
+import { Trans } from '@lingui/macro';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../ThemeDecorator';
+import paperDecorator from '../../PaperDecorator';
+
+import SliderComponent from '../../../UI/Slider';
+import ValueStateHolder from '../../ValueStateHolder';
+import { Line } from '../../../UI/Grid';
+
+export default {
+  title: 'Slider',
+  component: SliderComponent,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Slider = () => (
+  <ValueStateHolder
+    initialValue={1}
+    render={(value, onChange) => (
+      <SliderComponent
+        onChange={newValue => {
+          action('onChange')(newValue);
+          onChange(newValue);
+        }}
+        value={value}
+        min={-1}
+        max={1}
+        step={0.1}
+      />
+    )}
+  />
+);


### PR DESCRIPTION
## Points editor

- Allow user to erase a coordinate whole value
- Highlight points on the preview
  - for the selected point in the list
  - for the hovered point in the list
- Change Z index of selected and hovered points in the preview
  - to prevent Origin point to cover newly added point for instance
- Take all available space in row

![demo_points_editor](https://user-images.githubusercontent.com/32449369/166878814-a1a2a77e-86b0-44d7-90ba-e809f1339453.gif)

## Collision masks editor

- Allow user to erase a coordinate whole value
- Add possibility to reorder collision masks points

![demo_collision_mask_editor](https://user-images.githubusercontent.com/32449369/166879429-bc7bbf23-9a4c-437c-84d3-9b95f13aa28f.gif)

## Other

- Remove react warnings

## Yet to do

- Fix the behavior that transforms `1.5` in `1.500004572158` that prevents user to fine-tune a value