### PR TITLE
Display all autocompletions in an expression editor (list is not truncated anymore)

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
@@ -232,6 +232,7 @@ type Props = {|
   selectedCompletionIndex: number,
   anchorEl: Element,
   onChoose: (chosenExpressionAutocompletion: ExpressionAutocompletion) => void,
+  onScroll: () => void,
   parameterRenderingService: ParameterRenderingServiceType,
 |};
 
@@ -269,6 +270,7 @@ export default function ExpressionAutocompletionsDisplayer({
   selectedCompletionIndex,
   anchorEl,
   onChoose,
+  onScroll,
   parameterRenderingService,
 }: Props) {
   const scrollView = React.useRef((null: ?ScrollViewInterface));
@@ -302,7 +304,7 @@ export default function ExpressionAutocompletionsDisplayer({
           }
         >
           <Paper variant="outlined" square style={styles.container}>
-            <ScrollView autoHideScrollbar ref={scrollView}>
+            <ScrollView ref={scrollView} onScroll={onScroll}>
               {expressionAutocompletions.map(
                 (expressionAutocompletion, index) => {
                   const isSelected = selectedCompletionIndex === index;
@@ -353,7 +355,7 @@ export default function ExpressionAutocompletionsDisplayer({
               )}
               {remainingCount > 0 && (
                 <Column justifyContent="flex-start">
-                  <Text>And {remainingCount} others...</Text>
+                  <Text>And others...</Text>
                 </Column>
               )}
             </ScrollView>

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
@@ -16,7 +16,10 @@ export const getAutocompletionsInitialState = (): AutocompletionsState => {
   return {
     autocompletions: [],
     selectedCompletionIndex: 0,
-    // BY default, only render some completions.
+    // By default, only render some completions.
+    // This is to avoid rendering a lot (100+) completions,
+    // riskying a lag/frame drops, just for them to be discarded afterwards,
+    // at each keystroke of the user.
     renderEverything: false,
   };
 };

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
@@ -9,28 +9,39 @@ import {
 export type AutocompletionsState = {|
   autocompletions: Array<ExpressionAutocompletion>,
   selectedCompletionIndex: number,
+  renderEverything: boolean,
 |};
 
 export const getAutocompletionsInitialState = (): AutocompletionsState => {
   return {
     autocompletions: [],
     selectedCompletionIndex: 0,
+    // BY default, only render some completions.
+    renderEverything: false,
   };
 };
 
-const MAX_VISIBLE_COUNT = 25;
+/**
+ * The number of completions to be displayed in the DOM by default
+ * when no scroll or key press is made. This allows to quickly display only
+ * a few completions (fast rendering), and render everything only when
+ * the user starts to explore them.
+ */
+const DEFAULT_RENDERED_COUNT = 7;
 
-export const getRemainingCount = (state: AutocompletionsState): number => {
-  return Math.max(0, state.autocompletions.length - MAX_VISIBLE_COUNT);
+export const getNonRenderedCount = (state: AutocompletionsState): number => {
+  if (state.renderEverything) return 0;
+
+  return Math.max(0, state.autocompletions.length - DEFAULT_RENDERED_COUNT);
 };
 
-export const getVisibleAutocompletions = (
+export const getRenderedAutocompletions = (
   state: AutocompletionsState
 ): Array<ExpressionAutocompletion> => {
-  const remainingCount = getRemainingCount(state);
-  return remainingCount === 0
+  const nonRenderedCount = getNonRenderedCount(state);
+  return nonRenderedCount === 0
     ? state.autocompletions
-    : state.autocompletions.slice(0, MAX_VISIBLE_COUNT);
+    : state.autocompletions.slice(0, DEFAULT_RENDERED_COUNT);
 };
 
 export const setNewAutocompletions = (
@@ -48,6 +59,17 @@ export const setNewAutocompletions = (
   return {
     autocompletions,
     selectedCompletionIndex,
+    renderEverything: completionsChanged ? false : state.renderEverything,
+  };
+};
+
+export const handleAutocompletionsScroll = (
+  state: AutocompletionsState
+): AutocompletionsState => {
+  // If there is a scroll, we need to render all the completions.
+  return {
+    ...state,
+    renderEverything: true,
   };
 };
 
@@ -74,27 +96,28 @@ export const handleAutocompletionsKeyDown = (
 
   if (!state.autocompletions.length) return state;
 
-  const visibleAutocompletionsLength = Math.min(
-    MAX_VISIBLE_COUNT,
-    state.autocompletions.length
-  );
-
   if (event.key === 'ArrowDown') {
     event.preventDefault();
 
     return {
       ...state,
+      // If there is a browsing in the autocompletions,
+      // we need to render all the completions.
+      renderEverything: true,
       selectedCompletionIndex:
-        (state.selectedCompletionIndex + 1) % visibleAutocompletionsLength,
+        (state.selectedCompletionIndex + 1) % state.autocompletions.length,
     };
   } else if (event.key === 'ArrowUp') {
     event.preventDefault();
 
     return {
       ...state,
+      // If there is a browsing in the autocompletions,
+      // we need to render all the completions.
+      renderEverything: true,
       selectedCompletionIndex:
-        (visibleAutocompletionsLength + state.selectedCompletionIndex - 1) %
-        visibleAutocompletionsLength,
+        (state.autocompletions.length + state.selectedCompletionIndex - 1) %
+        state.autocompletions.length,
     };
   } else if (shouldCloseOrCancel(event)) {
     // Stop propagation to avoid closing the modal the

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -32,8 +32,9 @@ import {
   getAutocompletionsInitialState,
   setNewAutocompletions,
   handleAutocompletionsKeyDown,
-  getVisibleAutocompletions,
-  getRemainingCount,
+  handleAutocompletionsScroll,
+  getRenderedAutocompletions,
+  getNonRenderedCount,
 } from './ExpressionAutocompletionsHandler';
 import ExpressionAutocompletionsDisplayer from './ExpressionAutocompletionsDisplayer';
 import { ResponsiveWindowMeasurer } from '../../../UI/Reponsive/ResponsiveWindowMeasurer';
@@ -291,6 +292,14 @@ export default class ExpressionField extends React.Component<Props, State> {
         }
       }, 5);
     }, 5);
+  };
+
+  _onExpressionAutocompletionsScroll = () => {
+    if (this.state.autocompletions.renderEverything) return; // Bail out early to avoid changing the state if not needed.
+
+    this.setState({
+      autocompletions: handleAutocompletionsScroll(this.state.autocompletions),
+    });
   };
 
   _insertAutocompletion = (
@@ -560,15 +569,16 @@ export default class ExpressionField extends React.Component<Props, State> {
                   <ExpressionAutocompletionsDisplayer
                     project={project}
                     anchorEl={this._inputElement}
-                    expressionAutocompletions={getVisibleAutocompletions(
+                    expressionAutocompletions={getRenderedAutocompletions(
                       this.state.autocompletions
                     )}
-                    remainingCount={getRemainingCount(
+                    remainingCount={getNonRenderedCount(
                       this.state.autocompletions
                     )}
                     selectedCompletionIndex={
                       this.state.autocompletions.selectedCompletionIndex
                     }
+                    onScroll={this._onExpressionAutocompletionsScroll}
                     onChoose={expressionAutocompletion => {
                       this._insertAutocompletion(expressionAutocompletion);
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -645,6 +645,7 @@ const MainFrame = (props: Props) => {
       preferences,
       eventsFunctionsExtensionsState,
       getStorageProvider,
+      getStorageProviderOperations,
       ensureResourcesAreFetched,
     ]
   );

--- a/newIDE/app/src/UI/ScrollView.js
+++ b/newIDE/app/src/UI/ScrollView.js
@@ -15,6 +15,7 @@ type Props = {|
    */
   autoHideScrollbar?: ?boolean,
   style?: ?Object,
+  onScroll?: () => void,
 |};
 
 export type ScrollViewInterface = {|
@@ -23,7 +24,7 @@ export type ScrollViewInterface = {|
 |};
 
 export default React.forwardRef<Props, ScrollViewInterface>(
-  ({ children, autoHideScrollbar, style }: Props, ref) => {
+  ({ children, autoHideScrollbar, style, onScroll }: Props, ref) => {
     const scrollView = React.useRef((null: ?HTMLDivElement));
     React.useImperativeHandle(ref, () => ({
       /**
@@ -64,6 +65,7 @@ export default React.forwardRef<Props, ScrollViewInterface>(
           overflowY: autoHideScrollbar ? 'auto' : 'scroll',
           ...style,
         }}
+        onScroll={onScroll}
         ref={scrollView}
       >
         {children}

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -2065,6 +2065,7 @@ storiesOf('ExpressionAutcompletionsDisplayer', module)
       onChoose={action('chosen')}
       selectedCompletionIndex={0}
       parameterRenderingService={ParameterRenderingService}
+      onScroll={() => {}}
     />
   ))
   .add('autocompletions (expression selected)', () => (
@@ -2077,6 +2078,7 @@ storiesOf('ExpressionAutcompletionsDisplayer', module)
       onChoose={action('chosen')}
       selectedCompletionIndex={6}
       parameterRenderingService={ParameterRenderingService}
+      onScroll={() => {}}
     />
   ))
   .add('empty autocompletions (because exact expression)', () => (
@@ -2089,6 +2091,7 @@ storiesOf('ExpressionAutcompletionsDisplayer', module)
       onChoose={action('chosen')}
       selectedCompletionIndex={0}
       parameterRenderingService={ParameterRenderingService}
+      onScroll={() => {}}
     />
   ))
   .add('empty autocompletions (nothing shown)', () => (
@@ -2101,6 +2104,7 @@ storiesOf('ExpressionAutcompletionsDisplayer', module)
       onChoose={action('chosen')}
       selectedCompletionIndex={0}
       parameterRenderingService={ParameterRenderingService}
+      onScroll={() => {}}
     />
   ));
 


### PR DESCRIPTION
Fix #3878