### PR TITLE
Allow to choose installation directory in the Windows installer

### DIFF
--- a/newIDE/electron-app/package.json
+++ b/newIDE/electron-app/package.json
@@ -44,6 +44,10 @@
       "executableName": "GDevelop",
       "publish": null
     },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
+    },
     "appx": {
       "publisherDisplayName": "GDevelop game engine",
       "displayName": "GDevelop",


### PR DESCRIPTION
Following discussion ([here, in French](https://twitter.com/Florianrival/status/1524319855339622400)), and more generally feedback from confused users about where GDevelop is installed, this should:
- Show the path before installation - and allow to change it.
- Allow to install machine wide.