### PR TITLE
Disable autocomplete for Text Input objects and add 5px padding left

### DIFF
--- a/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
@@ -47,6 +47,8 @@ namespace gdjs {
       const isTextArea = this._object.getInputType() === 'text area';
       this._input = document.createElement(isTextArea ? 'textarea' : 'input');
       this._input.style.border = '1px solid black';
+      this._input.autocomplete = 'off';
+      this._input.style.paddingLeft = '5px';
       this._input.style.borderRadius = '0px';
       this._input.style.backgroundColor = 'white';
       this._input.style.position = 'absolute';


### PR DESCRIPTION
Close https://github.com/GDevelopApp/GDevelop-games-platform/issues/88

+ Add 5 px padding on left because this depend of the browser, and the text is too much stuck on left for now.