### PR TITLE
Rework asset store

### DIFF
--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -4,6 +4,7 @@ import { type FiltersState, useFilters } from '../UI/Search/FiltersChooser';
 import { type Filters } from '../Utils/GDevelopServices/Filters';
 import {
   type AssetShortHeader,
+  type AssetPacks,
   type Author,
   type License,
   listAllAssets,
@@ -16,6 +17,7 @@ const defaultSearchText = '';
 
 type AssetStoreState = {|
   filters: ?Filters,
+  assetPacks: ?AssetPacks,
   authors: ?Array<Author>,
   licenses: ?Array<License>,
   searchResults: ?Array<AssetShortHeader>,
@@ -28,6 +30,7 @@ type AssetStoreState = {|
 
 export const AssetStoreContext = React.createContext<AssetStoreState>({
   filters: null,
+  assetPacks: null,
   authors: null,
   licenses: null,
   searchResults: null,
@@ -65,6 +68,7 @@ export const AssetStoreStateProvider = ({
     [string]: AssetShortHeader,
   }>(null);
   const [filters, setFilters] = React.useState<?Filters>(null);
+  const [assetPacks, setAssetPacks] = React.useState<?AssetPacks>(null);
   const [authors, setAuthors] = React.useState<?Array<Author>>(null);
   const [licenses, setLicenses] = React.useState<?Array<License>>(null);
   const [error, setError] = React.useState<?Error>(null);
@@ -84,7 +88,11 @@ export const AssetStoreStateProvider = ({
         isLoading.current = true;
 
         try {
-          const { assetShortHeaders, filters } = await listAllAssets();
+          const {
+            assetShortHeaders,
+            filters,
+            assetPacks,
+          } = await listAllAssets();
           const authors = await listAllAuthors();
           const licenses = await listAllLicenses();
 
@@ -98,6 +106,7 @@ export const AssetStoreStateProvider = ({
           );
           setAssetShortHeadersById(assetShortHeadersById);
           setFilters(filters);
+          setAssetPacks(assetPacks);
           setAuthors(authors);
           setLicenses(licenses);
         } catch (error) {
@@ -143,6 +152,7 @@ export const AssetStoreStateProvider = ({
       searchResults,
       fetchAssetsAndFilters,
       filters,
+      assetPacks,
       authors,
       licenses,
       error,
@@ -154,6 +164,7 @@ export const AssetStoreStateProvider = ({
       searchResults,
       error,
       filters,
+      assetPacks,
       authors,
       licenses,
       searchText,

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -3,7 +3,13 @@ import * as React from 'react';
 import { CorsAwareImage } from '../UI/CorsAwareImage';
 import Text from '../UI/Text';
 import { type AssetPacks } from '../Utils/GDevelopServices/Asset';
-import { GridListTile, GridList, Paper } from '@material-ui/core';
+import {
+  GridListTile,
+  GridList,
+  Paper,
+  makeStyles,
+  createStyles,
+} from '@material-ui/core';
 import { shouldValidate } from '../UI/KeyboardShortcuts/InteractionKeys';
 import { Line, Column } from '../UI/Grid';
 import ScrollView from '../UI/ScrollView';
@@ -32,6 +38,18 @@ const styles = {
   },
 };
 
+const useStylesForGridListItem = makeStyles(theme =>
+  createStyles({
+    root: {
+      '&:focus': {
+        border: `2px solid ${theme.palette.primary.main}`,
+        outline: 'none',
+      },
+      '&:focus-visible': { outline: 'unset' },
+    },
+  })
+);
+
 type Props = {|
   assetPacks: AssetPacks,
   onPackSelection: string => void,
@@ -41,6 +59,7 @@ export const AssetsHome = ({
   assetPacks: { starterPacks },
   onPackSelection,
 }: Props) => {
+  const classesForGridListItem = useStylesForGridListItem();
   return (
     <ThemeConsumer>
       {muiTheme => (
@@ -53,6 +72,7 @@ export const AssetsHome = ({
           >
             {starterPacks.map((pack, index) => (
               <GridListTile
+                classes={classesForGridListItem}
                 key={pack.tag}
                 tabIndex={0}
                 onKeyPress={(

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -16,6 +16,7 @@ import { Line, Column } from '../UI/Grid';
 import ScrollView from '../UI/ScrollView';
 import ThemeConsumer from '../UI/Theme/ThemeConsumer';
 import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
+import ThemeContext from '../UI/Theme/ThemeContext';
 
 const columns = 3;
 const columnsForSmallWindow = 2;
@@ -64,64 +65,57 @@ export const AssetsHome = ({
 }: Props) => {
   const classesForGridListItem = useStylesForGridListItem();
   const windowWidth = useResponsiveWindowWidth();
+  const gdevelopTheme = React.useContext(ThemeContext);
 
   return (
-    <ThemeConsumer>
-      {muiTheme => (
-        <ScrollView>
-          <GridList
-            cols={windowWidth === 'small' ? columnsForSmallWindow : columns}
-            style={styles.grid}
-            cellHeight="auto"
-            spacing={cellSpacing}
+    <ScrollView>
+      <GridList
+        cols={windowWidth === 'small' ? columnsForSmallWindow : columns}
+        style={styles.grid}
+        cellHeight="auto"
+        spacing={cellSpacing}
+      >
+        {starterPacks.map((pack, index) => (
+          <GridListTile
+            classes={classesForGridListItem}
+            key={pack.tag}
+            tabIndex={0}
+            onKeyPress={(
+              event: SyntheticKeyboardEvent<HTMLLIElement>
+            ): void => {
+              if (shouldValidate(event)) {
+                onPackSelection(pack.tag);
+              }
+            }}
+            onClick={() => onPackSelection(pack.tag)}
           >
-            {starterPacks.map((pack, index) => (
-              <GridListTile
-                classes={classesForGridListItem}
-                key={pack.tag}
-                tabIndex={0}
-                onKeyPress={(
-                  event: SyntheticKeyboardEvent<HTMLLIElement>
-                ): void => {
-                  if (shouldValidate(event)) {
-                    onPackSelection(pack.tag);
-                  }
-                }}
-                onClick={() => onPackSelection(pack.tag)}
-              >
-                <Paper
-                  elevation={2}
-                  style={{
-                    ...styles.paper,
-                    backgroundColor: muiTheme.list.itemsBackgroundColor,
-                  }}
-                >
-                  <CorsAwareImage
-                    key={pack.name}
-                    style={styles.previewImage}
-                    src={pack.thumbnailUrl}
-                    alt={pack.name}
-                  />
-                  <Column>
-                    <Line justifyContent="space-between" noMargin>
-                      <Text style={styles.packTitle} size="body2">
-                        {pack.name}
-                      </Text>
-                      <Text
-                        style={styles.packTitle}
-                        color="primary"
-                        size="body2"
-                      >
-                        {pack.assetsCount} <Trans>Assets</Trans>
-                      </Text>
-                    </Line>
-                  </Column>
-                </Paper>
-              </GridListTile>
-            ))}
-          </GridList>
-        </ScrollView>
-      )}
-    </ThemeConsumer>
+            <Paper
+              elevation={2}
+              style={{
+                ...styles.paper,
+                backgroundColor: gdevelopTheme.list.itemsBackgroundColor,
+              }}
+            >
+              <CorsAwareImage
+                key={pack.name}
+                style={styles.previewImage}
+                src={pack.thumbnailUrl}
+                alt={pack.name}
+              />
+              <Column>
+                <Line justifyContent="space-between" noMargin>
+                  <Text style={styles.packTitle} size="body2">
+                    {pack.name}
+                  </Text>
+                  <Text style={styles.packTitle} color="primary" size="body2">
+                    {pack.assetsCount} <Trans>Assets</Trans>
+                  </Text>
+                </Line>
+              </Column>
+            </Paper>
+          </GridListTile>
+        ))}
+      </GridList>
+    </ScrollView>
   );
 };

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -108,7 +108,7 @@ export const AssetsHome = ({
                     {pack.name}
                   </Text>
                   <Text style={styles.packTitle} color="primary" size="body2">
-                    {pack.assetsCount} <Trans>Assets</Trans>
+                    <Trans>{pack.assetsCount} Assets</Trans>
                   </Text>
                 </Line>
               </Column>

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { Trans } from '@lingui/macro';
 import { CorsAwareImage } from '../UI/CorsAwareImage';
 import Text from '../UI/Text';
 import { type AssetPacks } from '../Utils/GDevelopServices/Asset';
@@ -14,8 +15,10 @@ import { shouldValidate } from '../UI/KeyboardShortcuts/InteractionKeys';
 import { Line, Column } from '../UI/Grid';
 import ScrollView from '../UI/ScrollView';
 import ThemeConsumer from '../UI/Theme/ThemeConsumer';
+import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 
 const columns = 3;
+const columnsForSmallWindow = 2;
 const cellSpacing = 2;
 
 const styles = {
@@ -60,12 +63,14 @@ export const AssetsHome = ({
   onPackSelection,
 }: Props) => {
   const classesForGridListItem = useStylesForGridListItem();
+  const windowWidth = useResponsiveWindowWidth();
+
   return (
     <ThemeConsumer>
       {muiTheme => (
         <ScrollView>
           <GridList
-            cols={columns}
+            cols={windowWidth === 'small' ? columnsForSmallWindow : columns}
             style={styles.grid}
             cellHeight="auto"
             spacing={cellSpacing}
@@ -107,7 +112,7 @@ export const AssetsHome = ({
                         color="primary"
                         size="body2"
                       >
-                        {pack.assetsCount} Assets
+                        {pack.assetsCount} <Trans>Assets</Trans>
                       </Text>
                     </Line>
                   </Column>

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -1,0 +1,102 @@
+// @flow
+import * as React from 'react';
+import { CorsAwareImage } from '../UI/CorsAwareImage';
+import Text from '../UI/Text';
+import { type AssetPacks } from '../Utils/GDevelopServices/Asset';
+import { GridListTile, GridList, Paper } from '@material-ui/core';
+import { shouldValidate } from '../UI/KeyboardShortcuts/InteractionKeys';
+import { Line, Column } from '../UI/Grid';
+import ScrollView from '../UI/ScrollView';
+import ThemeConsumer from '../UI/Theme/ThemeConsumer';
+
+const columns = 3;
+const cellSpacing = 2;
+
+const styles = {
+  grid: { marginLeft: 10, marginRight: 10 },
+  previewImage: {
+    width: '100%',
+  },
+  cardContainer: {
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  paper: {
+    margin: 4,
+  },
+  packTitle: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    overflowWrap: 'break-word',
+    whiteSpace: 'nowrap',
+  },
+};
+
+type Props = {|
+  assetPacks: AssetPacks,
+  onPackSelection: string => void,
+|};
+
+export const AssetsHome = ({
+  assetPacks: { starterPacks },
+  onPackSelection,
+}: Props) => {
+  return (
+    <ThemeConsumer>
+      {muiTheme => (
+        <ScrollView>
+          <GridList
+            cols={columns}
+            style={styles.grid}
+            cellHeight="auto"
+            spacing={cellSpacing}
+          >
+            {starterPacks.map((pack, index) => (
+              <GridListTile
+                key={pack.tag}
+                tabIndex={0}
+                onKeyPress={(
+                  event: SyntheticKeyboardEvent<HTMLLIElement>
+                ): void => {
+                  if (shouldValidate(event)) {
+                    onPackSelection(pack.tag);
+                  }
+                }}
+                onClick={() => onPackSelection(pack.tag)}
+              >
+                <Paper
+                  elevation={2}
+                  style={{
+                    ...styles.paper,
+                    backgroundColor: muiTheme.list.itemsBackgroundColor,
+                  }}
+                >
+                  <CorsAwareImage
+                    key={pack.name}
+                    style={styles.previewImage}
+                    src={pack.thumbnailUrl}
+                    alt={pack.name}
+                  />
+                  <Column>
+                    <Line justifyContent="space-between" noMargin>
+                      <Text style={styles.packTitle} size="body2">
+                        {pack.name}
+                      </Text>
+                      <Text
+                        style={styles.packTitle}
+                        color="primary"
+                        size="body2"
+                      >
+                        {pack.assetsCount} Assets
+                      </Text>
+                    </Line>
+                  </Column>
+                </Paper>
+              </GridListTile>
+            ))}
+          </GridList>
+        </ScrollView>
+      )}
+    </ThemeConsumer>
+  );
+};

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -13,7 +13,7 @@ const columns = 3;
 const cellSpacing = 2;
 
 const styles = {
-  grid: { marginLeft: 10, marginRight: 10 },
+  grid: { margin: '0 10px' },
   previewImage: {
     width: '100%',
   },

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -12,7 +12,6 @@ import { type AssetShortHeader } from '../Utils/GDevelopServices/Asset';
 import { BoxSearchResults } from '../UI/Search/BoxSearchResults';
 import { type SearchBarInterface } from '../UI/SearchBar';
 import { FiltersChooser } from '../UI/Search/FiltersChooser';
-import { FilterPanel } from '../UI/Search/FilterPanel';
 import { AssetStoreContext } from './AssetStoreContext';
 import { AssetCard } from './AssetCard';
 import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasurer';

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -84,7 +84,7 @@ export const AssetStore = ({
             placeholder={t`Enter your Search`}
             value={searchText}
             onChange={setSearchText}
-            onRequestSearch={() => {}}
+            onRequestSearch={() => setIsOnHomePage(false)}
             style={styles.searchBar}
             ref={searchBar}
             id="asset-store-search-bar"
@@ -147,6 +147,7 @@ export const AssetStore = ({
                       allItemsLabel={<Trans>All assets</Trans>}
                       allFilters={filters}
                       filtersState={filtersState}
+                      setIsOnHomePage={setIsOnHomePage}
                       error={error}
                     />
                     <Subheader>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -1,7 +1,10 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
+import ArrowBack from '@material-ui/icons/ArrowBack';
+import Tune from '@material-ui/icons/Tune';
 import SearchBar, { useShouldAutofocusSearchbar } from '../UI/SearchBar';
+import DoubleChevronArrow from '../UI/CustomSvgIcons/DoubleChevronArrow';
 import { Column, Line } from '../UI/Grid';
 import Background from '../UI/Background';
 import ScrollView from '../UI/ScrollView';
@@ -14,6 +17,10 @@ import { AssetCard } from './AssetCard';
 import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 import Subheader from '../UI/Subheader';
 import { CategoryChooser } from '../UI/Search/CategoryChooser';
+import { AssetsHome } from './AssetsHome';
+import FlatButton from '../UI/FlatButton';
+import Text from '../UI/Text';
+import IconButton from '../UI/IconButton';
 
 const styles = {
   searchBar: {
@@ -39,6 +46,7 @@ export const AssetStore = ({
 }: Props) => {
   const {
     filters,
+    assetPacks,
     searchResults,
     error,
     fetchAssetsAndFilters,
@@ -56,6 +64,8 @@ export const AssetStore = ({
 
   const searchBar = React.useRef<?SearchBarInterface>(null);
   const shouldAutofocusSearchbar = useShouldAutofocusSearchbar();
+  const [isOnHomePage, setIsOnHomePage] = React.useState(true);
+  const [isFiltersOpen, setIsFiltersOpen] = React.useState(false);
 
   React.useEffect(
     () => {
@@ -71,6 +81,7 @@ export const AssetStore = ({
       {windowWidth => (
         <Column expand noMargin useFullHeight>
           <SearchBar
+            placeholder={t`Enter your Search`}
             value={searchText}
             onChange={setSearchText}
             onRequestSearch={() => {}}
@@ -78,6 +89,24 @@ export const AssetStore = ({
             ref={searchBar}
             id="asset-store-search-bar"
           />
+          <Line justifyContent="left">
+            {isOnHomePage ? (
+              <Column>
+                <Text>Discover</Text>
+              </Column>
+            ) : (
+              <FlatButton
+                icon={<ArrowBack />}
+                label={<Trans>Back to discover</Trans>}
+                primary={false}
+                onClick={() => {
+                  filtersState.setChosenCategory(null);
+                  setIsFiltersOpen(false);
+                  setIsOnHomePage(true);
+                }}
+              />
+            )}
+          </Line>
           <Line
             expand
             overflow={
@@ -87,41 +116,76 @@ export const AssetStore = ({
             <Background
               noFullHeight
               noExpand
-              width={windowWidth === 'small' ? 150 : 250}
+              width={!isFiltersOpen ? 50 : windowWidth === 'small' ? 150 : 250}
             >
-              <ScrollView>
-                <Subheader>
-                  <Trans>Categories</Trans>
-                </Subheader>
-                <CategoryChooser
-                  allItemsLabel={<Trans>All assets</Trans>}
-                  allFilters={filters}
-                  filtersState={filtersState}
-                  error={error}
-                />
-                <Subheader>
-                  <Trans>Filters</Trans>
-                </Subheader>
-                <FiltersChooser
-                  allFilters={filters}
-                  filtersState={filtersState}
-                  error={error}
-                />
-              </ScrollView>
-            </Background>
-            <BoxSearchResults
-              baseSize={128}
-              onRetry={fetchAssetsAndFilters}
-              error={error}
-              searchItems={searchResults}
-              renderSearchItem={(assetShortHeader, size) => (
-                <AssetCard
-                  size={size}
-                  onOpenDetails={() => onOpenDetails(assetShortHeader)}
-                  assetShortHeader={assetShortHeader}
-                />
+              {!isFiltersOpen ? (
+                <Line justifyContent="center">
+                  <IconButton onClick={() => setIsFiltersOpen(true)}>
+                    <Tune />
+                  </IconButton>
+                </Line>
+              ) : (
+                <ScrollView>
+                  <Line justifyContent="space-between" alignItems="center">
+                    <Column>
+                      <Line alignItems="center">
+                        <Tune />
+                        <Subheader>
+                          <Trans>Categories</Trans>
+                        </Subheader>
+                      </Line>
+                    </Column>
+                    <IconButton onClick={() => setIsFiltersOpen(false)}>
+                      <DoubleChevronArrow />
+                    </IconButton>
+                  </Line>
+                  <>
+                    <CategoryChooser
+                      allItemsLabel={<Trans>All assets</Trans>}
+                      allFilters={filters}
+                      filtersState={filtersState}
+                      error={error}
+                    />
+                    <Subheader>
+                      <Trans>Filters</Trans>
+                    </Subheader>
+                    <FiltersChooser
+                      allFilters={filters}
+                      filtersState={filtersState}
+                      error={error}
+                    />
+                  </>
+                </ScrollView>
               )}
-            />
+            </Background>
+            {isOnHomePage && assetPacks ? (
+              <AssetsHome
+                assetPacks={assetPacks}
+                onPackSelection={tag => {
+                  const chosenCategory = {
+                    node: { name: tag, allChildrenTags: [], children: [] },
+                    parentNodes: [],
+                  };
+                  filtersState.setChosenCategory(chosenCategory);
+                  setIsFiltersOpen(true);
+                  setIsOnHomePage(false);
+                }}
+              />
+            ) : (
+              <BoxSearchResults
+                baseSize={128}
+                onRetry={fetchAssetsAndFilters}
+                error={error}
+                searchItems={searchResults}
+                renderSearchItem={(assetShortHeader, size) => (
+                  <AssetCard
+                    size={size}
+                    onOpenDetails={() => onOpenDetails(assetShortHeader)}
+                    assetShortHeader={assetShortHeader}
+                  />
+                )}
+              />
+            )}
           </Line>
         </Column>
       )}

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -12,6 +12,7 @@ import { type AssetShortHeader } from '../Utils/GDevelopServices/Asset';
 import { BoxSearchResults } from '../UI/Search/BoxSearchResults';
 import { type SearchBarInterface } from '../UI/SearchBar';
 import { FiltersChooser } from '../UI/Search/FiltersChooser';
+import { FilterPanel } from '../UI/Search/FilterPanel';
 import { AssetStoreContext } from './AssetStoreContext';
 import { AssetCard } from './AssetCard';
 import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasurer';

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -5,7 +5,7 @@ import ArrowBack from '@material-ui/icons/ArrowBack';
 import Tune from '@material-ui/icons/Tune';
 import SearchBar, { useShouldAutofocusSearchbar } from '../UI/SearchBar';
 import DoubleChevronArrow from '../UI/CustomSvgIcons/DoubleChevronArrow';
-import { Column, Line } from '../UI/Grid';
+import { Column, Line, Spacer } from '../UI/Grid';
 import Background from '../UI/Background';
 import ScrollView from '../UI/ScrollView';
 import { type AssetShortHeader } from '../Utils/GDevelopServices/Asset';
@@ -89,10 +89,11 @@ export const AssetStore = ({
             ref={searchBar}
             id="asset-store-search-bar"
           />
-          <Line justifyContent="left">
+          {!isOnHomePage && <Spacer />}
+          <Line justifyContent="left" noMargin={isOnHomePage}>
             {isOnHomePage ? (
               <Column>
-                <Text>Discover</Text>
+                <Text size="title">Discover</Text>
               </Column>
             ) : (
               <FlatButton

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -147,7 +147,7 @@ export const AssetStore = ({
                       allItemsLabel={<Trans>All assets</Trans>}
                       allFilters={filters}
                       filtersState={filtersState}
-                      setIsOnHomePage={setIsOnHomePage}
+                      onChoiceChange={() => setIsOnHomePage(false)}
                       error={error}
                     />
                     <Subheader>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -93,7 +93,9 @@ export const AssetStore = ({
           <Line justifyContent="left" noMargin={isOnHomePage}>
             {isOnHomePage ? (
               <Column>
-                <Text size="title">Discover</Text>
+                <Text size="title">
+                  <Trans>Discover</Trans>
+                </Text>
               </Column>
             ) : (
               <FlatButton

--- a/newIDE/app/src/UI/CustomSvgIcons/DoubleChevronArrow.js
+++ b/newIDE/app/src/UI/CustomSvgIcons/DoubleChevronArrow.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export default React.memo(props => (
+  <SvgIcon {...props}>
+    <path
+      fill="currentColor"
+      d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z"
+    />
+  </SvgIcon>
+));

--- a/newIDE/app/src/UI/Search/CategoryChooser.js
+++ b/newIDE/app/src/UI/Search/CategoryChooser.js
@@ -51,7 +51,7 @@ type MemoizedTagsTreeProps = {|
   allItemsLabel: React.Node,
   chosenCategory: ?ChosenCategory,
   setChosenCategory: (?ChosenCategory) => void,
-  setIsOnHomePage: boolean => void,
+  setIsOnHomePage?: boolean => void,
   allFilters: Filters,
 |};
 
@@ -70,14 +70,14 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
           : ''
       }
       defaultExpanded={[]}
-      onNodeSelect={() => setIsOnHomePage(false)}
+      onNodeSelect={() => setIsOnHomePage && setIsOnHomePage(false)}
     >
       <TreeItem
         nodeId=""
         label={allItemsLabel}
         onLabelClick={() => {
           setChosenCategory(null);
-          setIsOnHomePage(false);
+          setIsOnHomePage && setIsOnHomePage(false);
         }}
       />
       <TagsTreeItems
@@ -92,7 +92,7 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
 type Props = {|
   allItemsLabel: React.Node,
   filtersState: FiltersState,
-  setIsOnHomePage: boolean => void,
+  setIsOnHomePage?: boolean => void,
   allFilters: ?Filters,
   error: ?Error,
 |};

--- a/newIDE/app/src/UI/Search/CategoryChooser.js
+++ b/newIDE/app/src/UI/Search/CategoryChooser.js
@@ -51,7 +51,7 @@ type MemoizedTagsTreeProps = {|
   allItemsLabel: React.Node,
   chosenCategory: ?ChosenCategory,
   setChosenCategory: (?ChosenCategory) => void,
-  onFilterChange?: () => void,
+  onChoiceChange?: () => void,
   allFilters: Filters,
 |};
 

--- a/newIDE/app/src/UI/Search/CategoryChooser.js
+++ b/newIDE/app/src/UI/Search/CategoryChooser.js
@@ -70,7 +70,7 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
           : ''
       }
       defaultExpanded={[]}
-      onNodeSelect={() => {}}
+      onNodeSelect={() => setIsOnHomePage(false)}
     >
       <TreeItem
         nodeId=""

--- a/newIDE/app/src/UI/Search/CategoryChooser.js
+++ b/newIDE/app/src/UI/Search/CategoryChooser.js
@@ -51,6 +51,7 @@ type MemoizedTagsTreeProps = {|
   allItemsLabel: React.Node,
   chosenCategory: ?ChosenCategory,
   setChosenCategory: (?ChosenCategory) => void,
+  setIsOnHomePage: boolean => void,
   allFilters: Filters,
 |};
 
@@ -58,6 +59,7 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
   allItemsLabel,
   chosenCategory,
   setChosenCategory,
+  setIsOnHomePage,
   allFilters,
 }: MemoizedTagsTreeProps) {
   return (
@@ -73,7 +75,10 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
       <TreeItem
         nodeId=""
         label={allItemsLabel}
-        onLabelClick={() => setChosenCategory(null)}
+        onLabelClick={() => {
+          setChosenCategory(null);
+          setIsOnHomePage(false);
+        }}
       />
       <TagsTreeItems
         tagsTreeNodes={allFilters.tagsTree}
@@ -87,12 +92,14 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
 type Props = {|
   allItemsLabel: React.Node,
   filtersState: FiltersState,
+  setIsOnHomePage: boolean => void,
   allFilters: ?Filters,
   error: ?Error,
 |};
 
 export const CategoryChooser = ({
   filtersState,
+  setIsOnHomePage,
   allFilters,
   error,
   allItemsLabel,
@@ -110,6 +117,7 @@ export const CategoryChooser = ({
       allItemsLabel={allItemsLabel}
       chosenCategory={filtersState.chosenCategory}
       setChosenCategory={filtersState.setChosenCategory}
+      setIsOnHomePage={setIsOnHomePage}
       allFilters={allFilters}
     />
   );

--- a/newIDE/app/src/UI/Search/CategoryChooser.js
+++ b/newIDE/app/src/UI/Search/CategoryChooser.js
@@ -51,7 +51,7 @@ type MemoizedTagsTreeProps = {|
   allItemsLabel: React.Node,
   chosenCategory: ?ChosenCategory,
   setChosenCategory: (?ChosenCategory) => void,
-  setIsOnHomePage?: boolean => void,
+  onFilterChange?: () => void,
   allFilters: Filters,
 |};
 
@@ -59,7 +59,7 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
   allItemsLabel,
   chosenCategory,
   setChosenCategory,
-  setIsOnHomePage,
+  onChoiceChange,
   allFilters,
 }: MemoizedTagsTreeProps) {
   return (
@@ -70,14 +70,14 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
           : ''
       }
       defaultExpanded={[]}
-      onNodeSelect={() => setIsOnHomePage && setIsOnHomePage(false)}
+      onNodeSelect={() => onChoiceChange && onChoiceChange()}
     >
       <TreeItem
         nodeId=""
         label={allItemsLabel}
         onLabelClick={() => {
           setChosenCategory(null);
-          setIsOnHomePage && setIsOnHomePage(false);
+          onChoiceChange && onChoiceChange();
         }}
       />
       <TagsTreeItems
@@ -92,14 +92,14 @@ const MemoizedTagsTree = React.memo<MemoizedTagsTreeProps>(function TagsTree({
 type Props = {|
   allItemsLabel: React.Node,
   filtersState: FiltersState,
-  setIsOnHomePage?: boolean => void,
+  onChoiceChange?: () => void,
   allFilters: ?Filters,
   error: ?Error,
 |};
 
 export const CategoryChooser = ({
   filtersState,
-  setIsOnHomePage,
+  onChoiceChange,
   allFilters,
   error,
   allItemsLabel,
@@ -117,7 +117,7 @@ export const CategoryChooser = ({
       allItemsLabel={allItemsLabel}
       chosenCategory={filtersState.chosenCategory}
       setChosenCategory={filtersState.setChosenCategory}
-      setIsOnHomePage={setIsOnHomePage}
+      onChoiceChange={onChoiceChange}
       allFilters={allFilters}
     />
   );

--- a/newIDE/app/src/UI/Search/UseSearchStructuredItem.js
+++ b/newIDE/app/src/UI/Search/UseSearchStructuredItem.js
@@ -120,7 +120,7 @@ export const useSearchItem = <SearchItem: { tags: Array<string> }>(
   // easing random discovery of items when no search is done.
   const shuffledSearchResults = React.useMemo(
     () => {
-      if (!searchItemsById) return null;
+      if (!searchItemsById || !Object.keys(searchItemsById).length) return null;
 
       return shuffle(
         Object.keys(searchItemsById).map(id => ({

--- a/newIDE/app/src/Utils/GDevelopServices/Asset.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Asset.js
@@ -62,9 +62,21 @@ export type Asset = {|
   objectAssets: Array<ObjectAsset>,
 |};
 
+export type AssetPack = {|
+  name: string,
+  tag: string,
+  thumbnailUrl: string,
+  assetsCount: number,
+|};
+
+export type AssetPacks = {|
+  starterPacks: Array<AssetPack>,
+|};
+
 export type AllAssets = {|
   assetShortHeaders: Array<AssetShortHeader>,
   filters: Filters,
+  assetPacks: AssetPacks,
 |};
 
 export type Resource = {|
@@ -105,16 +117,18 @@ export const listAllAssets = (): Promise<AllAssets> => {
   return axios
     .get(`${GDevelopAssetApi.baseUrl}/asset`)
     .then(response => response.data)
-    .then(({ assetShortHeadersUrl, filtersUrl }) => {
-      if (!assetShortHeadersUrl || !filtersUrl) {
+    .then(({ assetShortHeadersUrl, filtersUrl, assetPacksUrl }) => {
+      if (!assetShortHeadersUrl || !filtersUrl || !assetPacksUrl) {
         throw new Error('Unexpected response from the resource endpoint.');
       }
       return Promise.all([
         axios.get(assetShortHeadersUrl).then(response => response.data),
         axios.get(filtersUrl).then(response => response.data),
-      ]).then(([assetShortHeaders, filters]) => ({
+        axios.get(assetPacksUrl).then(response => response.data),
+      ]).then(([assetShortHeaders, filters, assetPacks]) => ({
         assetShortHeaders,
         filters,
+        assetPacks,
       }));
     });
 };

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetCard.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetCard.stories.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import { AssetCard } from '../../../../AssetStore/AssetCard';
+import { fakeAssetShortHeader1 } from '../../../../fixtures/GDevelopServicesTestData';
+
+export default {
+  title: 'AssetStore/AssetStore/AssetCard',
+  component: AssetCard,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <AssetCard
+    size={128}
+    onOpenDetails={action('onOpenDetails')}
+    assetShortHeader={fakeAssetShortHeader1}
+  />
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
@@ -1,0 +1,55 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import { AssetDetails } from '../../../../AssetStore/AssetDetails';
+import { fakeAssetShortHeader1 } from '../../../../fixtures/GDevelopServicesTestData';
+import { testProject } from '../../../GDevelopJsInitializerDecorator';
+import fakeResourceExternalEditors from '../../../FakeResourceExternalEditors';
+const gd: libGDevelop = global.gd;
+
+export default {
+  title: 'AssetStore/AssetStore/AssetDetails',
+  component: AssetDetails,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <AssetDetails
+    canInstall={true}
+    isBeingInstalled={false}
+    onAdd={action('onAdd')}
+    onClose={action('onClose')}
+    assetShortHeader={fakeAssetShortHeader1}
+    project={testProject.project}
+    objectsContainer={testProject.testLayout}
+    layout={testProject.testLayout}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    onChooseResource={() => {
+      action('onChooseResource');
+      return Promise.reject();
+    }}
+    resourceSources={[]}
+  />
+);
+
+export const BeingInstalled = () => (
+  <AssetDetails
+    canInstall={false}
+    isBeingInstalled={true}
+    onAdd={action('onAdd')}
+    onClose={action('onClose')}
+    assetShortHeader={fakeAssetShortHeader1}
+    project={testProject.project}
+    objectsContainer={testProject.testLayout}
+    layout={testProject.testLayout}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    onChooseResource={() => {
+      action('onChooseResource');
+      return Promise.reject();
+    }}
+    resourceSources={[]}
+  />
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -5,7 +5,6 @@ import { action } from '@storybook/addon-actions';
 import muiDecorator from '../../../ThemeDecorator';
 import paperDecorator from '../../../PaperDecorator';
 import { testProject } from '../../../GDevelopJsInitializerDecorator';
-import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
 import { AssetStoreStateProvider } from '../../../../AssetStore/AssetStoreContext';
 import { AssetStore } from '../../../../AssetStore';
 
@@ -16,14 +15,12 @@ export default {
 };
 
 export const Default = () => (
-  <FixedHeightFlexContainer height={400}>
-    <AssetStoreStateProvider>
-      <AssetStore
-        onOpenDetails={action('onOpenDetails')}
-        events={testProject.testLayout.getEvents()}
-        project={testProject.project}
-        objectsContainer={testProject.testLayout}
-      />
-    </AssetStoreStateProvider>
-  </FixedHeightFlexContainer>
+  <AssetStoreStateProvider>
+    <AssetStore
+      onOpenDetails={action('onOpenDetails')}
+      events={testProject.testLayout.getEvents()}
+      project={testProject.project}
+      objectsContainer={testProject.testLayout}
+    />
+  </AssetStoreStateProvider>
 );

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -1,0 +1,29 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import { testProject } from '../../../GDevelopJsInitializerDecorator';
+import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
+import { AssetStoreStateProvider } from '../../../../AssetStore/AssetStoreContext';
+import { AssetStore } from '../../../../AssetStore';
+
+export default {
+  title: 'AssetStore/AssetStore',
+  component: AssetStore,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <FixedHeightFlexContainer height={400}>
+    <AssetStoreStateProvider>
+      <AssetStore
+        onOpenDetails={action('onOpenDetails')}
+        events={testProject.testLayout.getEvents()}
+        project={testProject.project}
+        objectsContainer={testProject.testLayout}
+      />
+    </AssetStoreStateProvider>
+  </FixedHeightFlexContainer>
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExampleStore/ExampleDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExampleStore/ExampleDialog.stories.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import { ExampleDialog } from '../../../../AssetStore/ExampleStore/ExampleDialog';
+import { exampleFromFutureVersion } from '../../../../fixtures/GDevelopServicesTestData';
+
+export default {
+  title: 'AssetStore/ExampleStore/ExampleDialog',
+  component: ExampleDialog,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const FutureVersion = () => (
+  <ExampleDialog
+    exampleShortHeader={exampleFromFutureVersion}
+    onOpen={action('onOpen')}
+    isOpening={false}
+    onClose={action('onClose')}
+  />
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExampleStore/ExampleStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExampleStore/ExampleStore.stories.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import { ExampleStore } from '../../../../AssetStore/ExampleStore';
+import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
+import { ExampleStoreStateProvider } from '../../../../AssetStore/ExampleStore/ExampleStoreContext';
+
+export default {
+  title: 'AssetStore/ExampleStore',
+  component: ExampleStore,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ExampleStoreStateProvider>
+      <ExampleStore onOpen={action('onOpen')} isOpening={false} />
+    </ExampleStoreStateProvider>
+  </FixedHeightFlexContainer>
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionStore.stories.js
@@ -1,0 +1,55 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import { ExtensionStore } from '../../../../AssetStore/ExtensionStore';
+import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
+import { ExtensionStoreStateProvider } from '../../../../AssetStore/ExtensionStore/ExtensionStoreContext';
+import { testProject } from '../../../GDevelopJsInitializerDecorator';
+
+export default {
+  title: 'AssetStore/ExtensionStore',
+  component: ExtensionStore,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ExtensionStoreStateProvider>
+      <ExtensionStore
+        project={testProject.project}
+        isInstalling={false}
+        onInstall={action('onInstall')}
+        showOnlyWithBehaviors={false}
+      />
+    </ExtensionStoreStateProvider>
+  </FixedHeightFlexContainer>
+);
+
+export const BeingInstalled = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ExtensionStoreStateProvider>
+      <ExtensionStore
+        project={testProject.project}
+        isInstalling={true}
+        onInstall={action('onInstall')}
+        showOnlyWithBehaviors={false}
+      />
+    </ExtensionStoreStateProvider>
+  </FixedHeightFlexContainer>
+);
+
+export const OnlyWithBehaviors = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ExtensionStoreStateProvider>
+      <ExtensionStore
+        project={testProject.project}
+        isInstalling={false}
+        onInstall={action('onInstall')}
+        showOnlyWithBehaviors={true}
+      />
+    </ExtensionStoreStateProvider>
+  </FixedHeightFlexContainer>
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionsSearchDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionsSearchDialog.stories.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import ExtensionsSearchDialog from '../../../../AssetStore/ExtensionStore/ExtensionsSearchDialog';
+import { I18n } from '@lingui/react';
+import EventsFunctionsExtensionsProvider from '../../../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsProvider';
+import { ExtensionStoreStateProvider } from '../../../../AssetStore/ExtensionStore/ExtensionStoreContext';
+import { testProject } from '../../../GDevelopJsInitializerDecorator';
+
+export default {
+  title: 'AssetStore/ExtensionStore/ExtensionSearchDialog',
+  component: ExtensionsSearchDialog,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <I18n>
+    {({ i18n }) => (
+      <EventsFunctionsExtensionsProvider
+        i18n={i18n}
+        makeEventsFunctionCodeWriter={() => null}
+        eventsFunctionsExtensionWriter={null}
+        eventsFunctionsExtensionOpener={null}
+      >
+        <ExtensionStoreStateProvider>
+          <ExtensionsSearchDialog
+            project={testProject.project}
+            onClose={action('on close')}
+            onInstallExtension={action('onInstallExtension')}
+          />
+        </ExtensionStoreStateProvider>
+      </EventsFunctionsExtensionsProvider>
+    )}
+  </I18n>
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/NewObjectDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/NewObjectDialog.stories.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../ThemeDecorator';
+import paperDecorator from '../../PaperDecorator';
+import NewObjectDialog from '../../../AssetStore/NewObjectDialog';
+import { AssetStoreStateProvider } from '../../../AssetStore/AssetStoreContext';
+import { testProject } from '../../GDevelopJsInitializerDecorator';
+import fakeResourceExternalEditors from '../../FakeResourceExternalEditors';
+
+export default {
+  title: 'AssetStore/NewObjectDialog',
+  component: NewObjectDialog,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <AssetStoreStateProvider>
+    <NewObjectDialog
+      project={testProject.project}
+      layout={testProject.testLayout}
+      onClose={action('onClose')}
+      onCreateNewObject={action('onCreateNewObject')}
+      onObjectAddedFromAsset={action('onObjectAddedFromAsset')}
+      events={testProject.testLayout.getEvents()}
+      objectsContainer={testProject.testLayout}
+      resourceExternalEditors={fakeResourceExternalEditors}
+      onChooseResource={() => {
+        action('onChooseResource');
+        return Promise.reject();
+      }}
+      resourceSources={[]}
+    />
+  </AssetStoreStateProvider>
+);

--- a/newIDE/app/src/stories/componentStories/AssetStore/ResourceStore/ResourceStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ResourceStore/ResourceStore.stories.js
@@ -1,0 +1,47 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
+import { ResourceStoreStateProvider } from '../../../../AssetStore/ResourceStore/ResourceStoreContext';
+import { ResourceStore } from '../../../../AssetStore/ResourceStore';
+
+export default {
+  title: 'AssetStore/ResourceStore',
+  component: ResourceStore,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const ImageResource = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ResourceStoreStateProvider>
+      <ResourceStore onChoose={action('onChoose')} resourceKind="image" />
+    </ResourceStoreStateProvider>
+  </FixedHeightFlexContainer>
+);
+
+export const AudioResource = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ResourceStoreStateProvider>
+      <ResourceStore onChoose={action('onChoose')} resourceKind="audio" />
+    </ResourceStoreStateProvider>
+  </FixedHeightFlexContainer>
+);
+
+export const FontResource = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ResourceStoreStateProvider>
+      <ResourceStore onChoose={action('onChoose')} resourceKind="font" />
+    </ResourceStoreStateProvider>
+  </FixedHeightFlexContainer>
+);
+
+export const SvgResource = () => (
+  <FixedHeightFlexContainer height={400}>
+    <ResourceStoreStateProvider>
+      <ResourceStore onChoose={action('onChoose')} resourceKind="svg" />
+    </ResourceStoreStateProvider>
+  </FixedHeightFlexContainer>
+);

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -141,7 +141,6 @@ import EventsBasedBehaviorEditorDialog from '../EventsBasedBehaviorEditor/Events
 import BehaviorTypeSelector from '../BehaviorTypeSelector';
 import ObjectTypeSelector from '../ObjectTypeSelector';
 import NewBehaviorDialog from '../BehaviorsEditor/NewBehaviorDialog';
-import ExtensionsSearchDialog from '../AssetStore/ExtensionStore/ExtensionsSearchDialog';
 import EventsFunctionsExtensionsProvider from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsProvider';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import SemiControlledAutoComplete from '../UI/SemiControlledAutoComplete';
@@ -157,7 +156,6 @@ import SubscriptionPendingDialog from '../Profile/SubscriptionPendingDialog';
 import EmailVerificationPendingDialog from '../Profile/EmailVerificationPendingDialog';
 import Dialog from '../UI/Dialog';
 import MiniToolbar, { MiniToolbarText } from '../UI/MiniToolbar';
-import NewObjectDialog from '../AssetStore/NewObjectDialog';
 import { Column, Line } from '../UI/Grid';
 import DragAndDropTestBed from './DragAndDropTestBed';
 import EditorMosaic from '../UI/EditorMosaic';
@@ -207,20 +205,11 @@ import HotReloadPreviewButton, {
   type HotReloadPreviewButtonProps,
 } from '../HotReload/HotReloadPreviewButton';
 import HotReloadLogsDialog from '../HotReload/HotReloadLogsDialog';
-import { AssetStore } from '../AssetStore';
-import { AssetStoreStateProvider } from '../AssetStore/AssetStoreContext';
 import ScrollView from '../UI/ScrollView';
 import '../UI/Theme/Global/Scrollbar.css';
 import '../UI/Theme/Global/Animation.css';
-import { AssetCard } from '../AssetStore/AssetCard';
-import { AssetDetails } from '../AssetStore/AssetDetails';
-import { ResourceStoreStateProvider } from '../AssetStore/ResourceStore/ResourceStoreContext';
-import { ResourceStore } from '../AssetStore/ResourceStore';
 import { ExampleStoreStateProvider } from '../AssetStore/ExampleStore/ExampleStoreContext';
-import { ExampleStore } from '../AssetStore/ExampleStore';
-import { ExampleDialog } from '../AssetStore/ExampleStore/ExampleDialog';
 import { ExtensionStoreStateProvider } from '../AssetStore/ExtensionStore/ExtensionStoreContext';
-import { ExtensionStore } from '../AssetStore/ExtensionStore';
 import { ResourceFetcherDialog } from '../ProjectsStorage/ResourceFetcher';
 import { GameCard } from '../GameDashboard/GameCard';
 import { GameDetailsDialog } from '../GameDashboard/GameDetailsDialog';
@@ -4565,28 +4554,6 @@ storiesOf('EffectsList', module)
     />
   ));
 
-storiesOf('NewObjectDialog', module)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <AssetStoreStateProvider>
-      <NewObjectDialog
-        project={testProject.project}
-        layout={testProject.testLayout}
-        onClose={action('onClose')}
-        onCreateNewObject={action('onCreateNewObject')}
-        onObjectAddedFromAsset={action('onObjectAddedFromAsset')}
-        events={testProject.testLayout.getEvents()}
-        objectsContainer={testProject.testLayout}
-        resourceExternalEditors={fakeResourceExternalEditors}
-        onChooseResource={() => {
-          action('onChooseResource');
-          return Promise.reject();
-        }}
-        resourceSources={[]}
-      />
-    </AssetStoreStateProvider>
-  ));
-
 storiesOf('CommandPalette', module)
   .addDecorator(muiDecorator)
   .add('commands', () => (
@@ -4690,122 +4657,6 @@ storiesOf('HotReloadLogsDialog', module)
       ]}
       onClose={() => {}}
       onLaunchNewPreview={() => {}}
-    />
-  ));
-
-storiesOf('AssetStore', module)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <FixedHeightFlexContainer height={400}>
-      <AssetStoreStateProvider>
-        <AssetStore
-          onOpenDetails={action('onOpenDetails')}
-          events={testProject.testLayout.getEvents()}
-          project={testProject.project}
-          objectsContainer={testProject.testLayout}
-        />
-      </AssetStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ));
-
-storiesOf('AssetStore/ExampleStore', module)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ExampleStoreStateProvider>
-        <ExampleStore onOpen={action('onOpen')} isOpening={false} />
-      </ExampleStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ));
-storiesOf('AssetStore/ExampleStore/ExampleDialog', module)
-  .addDecorator(muiDecorator)
-  .add('non existing example, from a future version', () => (
-    <ExampleDialog
-      exampleShortHeader={exampleFromFutureVersion}
-      onOpen={action('onOpen')}
-      isOpening={false}
-      onClose={action('onClose')}
-    />
-  ));
-
-storiesOf('AssetStore/ResourceStore', module)
-  .addDecorator(muiDecorator)
-  .add('resourceKind: image', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ResourceStoreStateProvider>
-        <ResourceStore onChoose={action('onChoose')} resourceKind="image" />
-      </ResourceStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ))
-  .add('resourceKind: audio', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ResourceStoreStateProvider>
-        <ResourceStore onChoose={action('onChoose')} resourceKind="audio" />
-      </ResourceStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ))
-  .add('resourceKind: font', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ResourceStoreStateProvider>
-        <ResourceStore onChoose={action('onChoose')} resourceKind="font" />
-      </ResourceStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ))
-  .add('resourceKind: svg (for icons)', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ResourceStoreStateProvider>
-        <ResourceStore onChoose={action('onChoose')} resourceKind="svg" />
-      </ResourceStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ));
-
-storiesOf('AssetStore/AssetCard', module)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <AssetCard
-      size={128}
-      onOpenDetails={action('onOpenDetails')}
-      assetShortHeader={fakeAssetShortHeader1}
-    />
-  ));
-
-storiesOf('AssetStore/AssetDetails', module)
-  .addDecorator(paperDecorator)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <AssetDetails
-      canInstall={true}
-      isBeingInstalled={false}
-      onAdd={action('onAdd')}
-      onClose={action('onClose')}
-      assetShortHeader={fakeAssetShortHeader1}
-      project={testProject.project}
-      objectsContainer={testProject.testLayout}
-      layout={testProject.testLayout}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      onChooseResource={() => {
-        action('onChooseResource');
-        return Promise.reject();
-      }}
-      resourceSources={[]}
-    />
-  ))
-  .add('being installed', () => (
-    <AssetDetails
-      canInstall={false}
-      isBeingInstalled={true}
-      onAdd={action('onAdd')}
-      onClose={action('onClose')}
-      assetShortHeader={fakeAssetShortHeader1}
-      project={testProject.project}
-      objectsContainer={testProject.testLayout}
-      layout={testProject.testLayout}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      onChooseResource={() => {
-        action('onChooseResource');
-        return Promise.reject();
-      }}
-      resourceSources={[]}
     />
   ));
 
@@ -5036,68 +4887,6 @@ storiesOf('GameDashboard/GameDetailsDialog', module)
       </AuthenticatedUserContext.Provider>
     );
   });
-
-storiesOf('AssetStore/ExtensionStore', module)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ExtensionStoreStateProvider>
-        <ExtensionStore
-          project={testProject.project}
-          isInstalling={false}
-          onInstall={action('onInstall')}
-          showOnlyWithBehaviors={false}
-        />
-      </ExtensionStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ))
-  .add('is installing', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ExtensionStoreStateProvider>
-        <ExtensionStore
-          project={testProject.project}
-          isInstalling={true}
-          onInstall={action('onInstall')}
-          showOnlyWithBehaviors={false}
-        />
-      </ExtensionStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ))
-  .add('showOnlyWithBehaviors', () => (
-    <FixedHeightFlexContainer height={400}>
-      <ExtensionStoreStateProvider>
-        <ExtensionStore
-          project={testProject.project}
-          isInstalling={false}
-          onInstall={action('onInstall')}
-          showOnlyWithBehaviors={true}
-        />
-      </ExtensionStoreStateProvider>
-    </FixedHeightFlexContainer>
-  ));
-
-storiesOf('AssetStore/ExtensionsSearchDialog', module)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <I18n>
-      {({ i18n }) => (
-        <EventsFunctionsExtensionsProvider
-          i18n={i18n}
-          makeEventsFunctionCodeWriter={() => null}
-          eventsFunctionsExtensionWriter={null}
-          eventsFunctionsExtensionOpener={null}
-        >
-          <ExtensionStoreStateProvider>
-            <ExtensionsSearchDialog
-              project={testProject.project}
-              onClose={action('on close')}
-              onInstallExtension={action('onInstallExtension')}
-            />
-          </ExtensionStoreStateProvider>
-        </EventsFunctionsExtensionsProvider>
-      )}
-    </I18n>
-  ));
 
 storiesOf('GamesShowcase', module)
   .addDecorator(muiDecorator)


### PR DESCRIPTION
As part of revamping the Asset Store, the first step is to redo the homepage of the asset store, and suggest to creators packs of assets they can import and use easily.

In this PR:

- Moved all stores stories to their own files with a better structure to test easily
- Fixed a bug where the ExtensionStore would show a loader
- Retrieve the Asset Packs from the backend services
- Show the list on the Asset Store homepage, with a folded filters panel
- Redirect to the previous Asset listing on pack selection, filtered on this pack + open the panel

In the future PRs we will probably:

- Rework the Asset Pack Screen to be independent from the listing, with a better view of the assets it contains + previews + allow adding all of them at once
- Rework the filters to be actual filters (size, color, animations, etc...)
- Rework the Asset screen to be more exhaustive about what the asset contains

Few screenshots in different sizes and themes:

![image](https://user-images.githubusercontent.com/4895034/168093065-1960087c-616a-4433-a402-9c168c2f4862.png)
![image](https://user-images.githubusercontent.com/4895034/168093239-1d8c6cf2-6595-4869-a798-c60ab01be1c7.png)
![image](https://user-images.githubusercontent.com/4895034/168093309-a3eeda9c-fa92-4860-ae9e-fed3d17ce1d9.png)
![image](https://user-images.githubusercontent.com/4895034/168093388-a119183d-6b35-49d3-a961-dc1ff5a8d30e.png)
