### PR TITLE
Fix border on div that represents the frame of an image

### DIFF
--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -249,6 +249,7 @@ const ImagePreview = (props: Props) => {
           height: imageHeight ? imageHeight * imageZoomFactor : undefined,
           visibility: imageLoaded ? undefined : 'hidden', // TODO: Loader
           border: `1px solid ${frameBorderColor}`,
+          boxSizing: 'border-box',
         };
 
         const overlayStyle = {


### PR DESCRIPTION
Fixes #3838

Before

<img width="191" alt="image" src="https://user-images.githubusercontent.com/32449369/168617584-2812eee2-a5af-473a-8d36-e4c22cde42f0.png">

After

<img width="194" alt="image" src="https://user-images.githubusercontent.com/32449369/168617492-46a49b00-33ad-4aba-9145-0cc4c0c121a7.png">
