### PR TITLE
New variables list improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,20 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "newIDE/app Jest tests (current file)",
+      "program": "${workspaceFolder}/newIDE/app/node_modules/.bin/react-scripts",
+      "args": [
+        "test", "--env=node",
+        "${fileBasenameNoExtension}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "cwd": "${workspaceFolder}/newIDE/app"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "GDevelop.js Jest tests (current file)",
       "program": "${workspaceFolder}/GDevelop.js/node_modules/.bin/jest",
       "args": [

--- a/newIDE/app/src/EventsSheet/ParameterFields/LeaderboardIdField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LeaderboardIdField.js
@@ -8,7 +8,7 @@ import {
   type ParameterFieldProps,
   type ParameterFieldInterface,
 } from './ParameterFieldCommons';
-import SelectField from '../../UI/SelectField';
+import SelectField, { type SelectFieldInterface } from '../../UI/SelectField';
 import SelectOption from '../../UI/SelectOption';
 import { TextFieldWithButtonLayout } from '../../UI/Layout';
 import RaisedButtonWithSplitMenu from '../../UI/RaisedButtonWithSplitMenu';
@@ -57,9 +57,10 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
     const isOnline = useOnlineStatus();
     const leaderboards = useFetchLeaderboards();
     const [isAdminOpen, setIsAdminOpen] = React.useState(false);
-    const inputFieldRef = React.useRef<?(GenericExpressionField | SelectField)>(
-      null
-    );
+    const inputFieldRef = React.useRef<?(
+      | GenericExpressionField
+      | SelectFieldInterface
+    )>(null);
     React.useImperativeHandle(ref, () => ({
       focus: () => {
         if (inputFieldRef.current) {

--- a/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
@@ -4,11 +4,11 @@ import { t } from '@lingui/macro';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
 import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
 import React, { Component } from 'react';
-import SelectField from '../../UI/SelectField';
+import SelectField, { type SelectFieldInterface } from '../../UI/SelectField';
 import SelectOption from '../../UI/SelectOption';
 
 export default class MouseField extends Component<ParameterFieldProps> {
-  _field: ?SelectField;
+  _field: ?SelectFieldInterface;
 
   focus() {
     if (this._field) this._field.focus();

--- a/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/OperatorField.js
@@ -4,7 +4,7 @@ import { t } from '@lingui/macro';
 import React, { Component } from 'react';
 import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
-import SelectField from '../../UI/SelectField';
+import SelectField, { type SelectFieldInterface } from '../../UI/SelectField';
 import SelectOption from '../../UI/SelectOption';
 
 const operatorLabels = {
@@ -23,7 +23,7 @@ const mapTypeToOperators = {
 };
 
 export default class OperatorField extends Component<ParameterFieldProps> {
-  _field: ?SelectField;
+  _field: ?SelectFieldInterface;
   focus() {
     if (this._field && this._field.focus) this._field.focus();
   }

--- a/newIDE/app/src/EventsSheet/ParameterFields/RelationalOperatorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/RelationalOperatorField.js
@@ -4,7 +4,7 @@ import { t } from '@lingui/macro';
 import React, { Component } from 'react';
 import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
-import SelectField from '../../UI/SelectField';
+import SelectField, { type SelectFieldInterface } from '../../UI/SelectField';
 import SelectOption from '../../UI/SelectOption';
 
 const operatorLabels = {
@@ -25,7 +25,7 @@ const mapTypeToOperators: { [string]: Array<string> } = {
 };
 
 export default class RelationalOperatorField extends Component<ParameterFieldProps> {
-  _field: ?SelectField;
+  _field: ?SelectFieldInterface;
   focus() {
     if (this._field && this._field.focus) this._field.focus();
   }

--- a/newIDE/app/src/UI/SelectField.js
+++ b/newIDE/app/src/UI/SelectField.js
@@ -41,7 +41,7 @@ type Props = {|
   hintText?: MessageDescriptor,
 |};
 
-type SelectFieldInterface = {| focus: () => void |};
+export type SelectFieldInterface = {| focus: () => void |};
 
 const INVALID_VALUE = '';
 const stopPropagation = event => event.stopPropagation();

--- a/newIDE/app/src/UI/SelectField.js
+++ b/newIDE/app/src/UI/SelectField.js
@@ -41,6 +41,8 @@ type Props = {|
   hintText?: MessageDescriptor,
 |};
 
+type SelectFieldInterface = {| focus: () => void |};
+
 const INVALID_VALUE = '';
 const stopPropagation = event => event.stopPropagation();
 
@@ -48,15 +50,18 @@ const stopPropagation = event => event.stopPropagation();
  * A select field based on Material-UI select field.
  * To be used with `SelectOption`.
  */
-export default class SelectField extends React.Component<Props, {||}> {
-  _input = React.createRef<HTMLInputElement>();
+const SelectField = React.forwardRef<Props, SelectFieldInterface>(
+  (props, ref) => {
+    const inputRef = React.useRef<?HTMLInputElement>(null);
 
-  focus() {
-    if (this._input.current) this._input.current.focus();
-  }
+    const focus = () => {
+      if (inputRef.current) inputRef.current.focus();
+    };
 
-  render() {
-    const { props } = this;
+    React.useImperativeHandle(ref, () => ({
+      focus,
+    }));
+
     const onChange = props.onChange || undefined;
 
     // Dig into children props to see if the current value is valid or not.
@@ -108,7 +113,7 @@ export default class SelectField extends React.Component<Props, {||}> {
               native: true,
             }}
             style={props.style}
-            inputRef={this._input}
+            inputRef={inputRef}
           >
             {!hasValidValue ? (
               <option value={INVALID_VALUE} disabled>
@@ -123,4 +128,5 @@ export default class SelectField extends React.Component<Props, {||}> {
       </I18n>
     );
   }
-}
+);
+export default SelectField;

--- a/newIDE/app/src/UI/SelectOption.js
+++ b/newIDE/app/src/UI/SelectOption.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { I18n } from '@lingui/react';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
+import { useTheme } from '@material-ui/core/styles';
 
 // We support a subset of the props supported by Material-UI v0.x MenuItem
 // They should be self descriptive - refer to Material UI docs otherwise.
@@ -14,16 +15,25 @@ type Props = {|
 /**
  * A native select option to be used with `SelectField`.
  */
-export default class SelectOption extends React.Component<Props, {||}> {
-  render() {
-    return (
-      <I18n>
-        {({ i18n }) => (
-          <option value={this.props.value} disabled={this.props.disabled}>
-            {i18n._(this.props.primaryText)}
-          </option>
-        )}
-      </I18n>
-    );
-  }
-}
+const SelectOption = (props: Props) => {
+  const muiTheme = useTheme();
+
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <option
+          value={props.value}
+          disabled={props.disabled}
+          style={{
+            color: muiTheme.palette.text.primary,
+            backgroundColor: muiTheme.palette.background.paper,
+          }}
+        >
+          {i18n._(props.primaryText)}
+        </option>
+      )}
+    </I18n>
+  );
+};
+
+export default SelectOption;

--- a/newIDE/app/src/Utils/VariablesUtils.js
+++ b/newIDE/app/src/Utils/VariablesUtils.js
@@ -47,7 +47,7 @@ export const insertInVariablesContainer = (
   name: string,
   serializedVariable: ?any,
   index: ?number
-): string => {
+): { name: string, variable: gdVariable } => {
   const newName = newNameGenerator(
     name,
     name => variablesContainer.has(name),
@@ -59,13 +59,13 @@ export const insertInVariablesContainer = (
   } else {
     newVariable.setString('');
   }
-  variablesContainer.insert(
+  const variable = variablesContainer.insert(
     newName,
     newVariable,
     index || variablesContainer.count()
   );
   newVariable.delete();
-  return newName;
+  return { name: newName, variable };
 };
 
 export const insertInVariableChildrenArray = (

--- a/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.js
+++ b/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.js
@@ -373,7 +373,7 @@ export const generateListOfNodesMatchingSearchInVariablesContainer = (
     return generateListOfNodesMatchingSearchInVariable({
       variable,
       variableName: name,
-      nodeId: prefix ? `${prefix}${name}`: name,
+      nodeId: prefix ? `${prefix}${name}` : name,
       searchText,
       acc: [],
     });

--- a/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.js
+++ b/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.js
@@ -364,7 +364,8 @@ export const generateListOfNodesMatchingSearchInVariable = ({
 
 export const generateListOfNodesMatchingSearchInVariablesContainer = (
   variablesContainer: gdVariablesContainer,
-  searchText: string
+  searchText: string,
+  prefix?: string
 ): Array<string> => {
   return mapFor(0, variablesContainer.count(), index => {
     const variable = variablesContainer.getAt(index);
@@ -372,7 +373,7 @@ export const generateListOfNodesMatchingSearchInVariablesContainer = (
     return generateListOfNodesMatchingSearchInVariable({
       variable,
       variableName: name,
-      nodeId: name,
+      nodeId: prefix ? `${prefix}${name}`: name,
       searchText,
       acc: [],
     });

--- a/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.spec.js
+++ b/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.spec.js
@@ -1,5 +1,6 @@
 // @flow
 import {
+  generateListOfNodesMatchingSearchInVariable,
   getExpandedNodeIdsFromVariablesContainer,
   getVariableContextFromNodeId,
   separator,
@@ -26,13 +27,13 @@ describe('VariableToTreeNodeHandling', () => {
     ├── parent
     │   ├── stringChild
     │   └── arrayChild (folded)
-    │       ├── firstArrayChild
-    │       └── secondArrayChild
+    │       ├── firstArrayChild 35
+    │       └── secondArrayChild false
     └── parent2 (folded)
-        ├── boolChild
+        ├── boolChild true
         └── structureChild
-            ├── firstStructureChild
-            └── secondStructureChild
+            ├── firstStructureChild 'Danger'
+            └── secondStructureChild 'secondStructureChild'
      */
     parent = new gd.Variable();
     parent.castTo('structure');
@@ -64,7 +65,7 @@ describe('VariableToTreeNodeHandling', () => {
     structureChild.castTo('structure');
     structureChild.setFolded(false);
     firstStructureChild = new gd.Variable();
-    firstStructureChild.setString('firstStructureChild');
+    firstStructureChild.setString('Danger');
     structureChild.insertChild('firstStructureChild', firstStructureChild);
     secondStructureChild = new gd.Variable();
     secondStructureChild.setString('secondStructureChild');
@@ -169,6 +170,59 @@ describe('VariableToTreeNodeHandling', () => {
         'parent',
         `parent2${separator}newStructureChildName${separator}firstStructureChild`,
         `parent2${separator}newStructureChildName${separator}firstSecondChild`,
+      ]);
+    });
+  });
+
+  describe('generateListOfNodesMatchingSearchInVariable', () => {
+    test('First variable should be included if name matches', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariable({
+          variable: parent,
+          variableName: 'parent',
+          nodeId: 'parent',
+          searchText: 'parent',
+          acc: [],
+        })
+      ).toEqual(['parent']);
+    });
+    test('Leaf variable in array should be included if value matches', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariable({
+          variable: parent,
+          variableName: 'parent',
+          nodeId: 'parent',
+          searchText: '35',
+          acc: [],
+        })
+      ).toEqual([`parent${separator}arrayChild${separator}0`]);
+    });
+    test('Leaf variable in structure should be included if value matches', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariable({
+          variable: parent2,
+          variableName: 'parent2',
+          nodeId: 'parent2',
+          searchText: 'danger',
+          acc: [],
+        })
+      ).toEqual([
+        `parent2${separator}structureChild${separator}firstStructureChild`,
+      ]);
+    });
+    test('All branches should be included if each variable matches by the name and/or the value', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariable({
+          variable: parent2,
+          variableName: 'parent2',
+          nodeId: 'parent2',
+          searchText: 'structure',
+          acc: [],
+        })
+      ).toEqual([
+        `parent2${separator}structureChild`,
+        `parent2${separator}structureChild${separator}firstStructureChild`,
+        `parent2${separator}structureChild${separator}secondStructureChild`,
       ]);
     });
   });

--- a/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.spec.js
+++ b/newIDE/app/src/VariablesList/VariableToTreeNodeHandling.spec.js
@@ -1,6 +1,7 @@
 // @flow
 import {
   generateListOfNodesMatchingSearchInVariable,
+  generateListOfNodesMatchingSearchInVariablesContainer,
   getExpandedNodeIdsFromVariablesContainer,
   getVariableContextFromNodeId,
   separator,
@@ -185,6 +186,15 @@ describe('VariableToTreeNodeHandling', () => {
           acc: [],
         })
       ).toEqual(['parent']);
+      expect(
+        generateListOfNodesMatchingSearchInVariable({
+          variable: parent2,
+          variableName: 'parent2',
+          nodeId: 'parent2',
+          searchText: 'parent',
+          acc: [],
+        })
+      ).toEqual(['parent2']);
     });
     test('Leaf variable in array should be included if value matches', () => {
       expect(
@@ -220,6 +230,50 @@ describe('VariableToTreeNodeHandling', () => {
           acc: [],
         })
       ).toEqual([
+        `parent2${separator}structureChild`,
+        `parent2${separator}structureChild${separator}firstStructureChild`,
+        `parent2${separator}structureChild${separator}secondStructureChild`,
+      ]);
+    });
+  });
+
+  describe('generateListOfNodesMatchingSearchInVariablesContainer', () => {
+    test('First variable should be included if name matches', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariablesContainer(
+          variablesContainer,
+          'parent'
+        )
+      ).toEqual(['parent', 'parent2']);
+    });
+    test('Leaf variable in array should be included if value matches', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariablesContainer(
+          variablesContainer,
+          '35'
+        )
+      ).toEqual([`parent${separator}arrayChild${separator}0`]);
+    });
+    test('Leaf variable in structure should be included if value matches', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariablesContainer(
+          variablesContainer,
+          'danger'
+        )
+      ).toEqual([
+        `parent2${separator}structureChild${separator}firstStructureChild`,
+      ]);
+    });
+    test('All branches should be included if each variable matches by the name and/or the value', () => {
+      expect(
+        generateListOfNodesMatchingSearchInVariablesContainer(
+          variablesContainer,
+          'child'
+        )
+      ).toEqual([
+        `parent${separator}arrayChild`,
+        `parent${separator}stringChild`,
+        `parent2${separator}boolChild`,
         `parent2${separator}structureChild`,
         `parent2${separator}structureChild${separator}firstStructureChild`,
         `parent2${separator}structureChild${separator}secondStructureChild`,

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -1356,11 +1356,11 @@ const VariablesList = ({ onComputeAllVariableNames, ...props }: Props) => {
             {({ contentRect, measureRef }) => (
               <div
                 ref={measureRef}
-                style={{ flex: 1, display: 'flex' }}
+                style={{ flex: 1, display: 'flex', minHeight: 0 }}
                 onKeyDown={keyboardShortcuts.onKeyDown}
                 onKeyUp={keyboardShortcuts.onKeyUp}
               >
-                <Column expand>
+                <Column expand useFullHeight>
                   {isNarrow ? null : toolbar}
                   {props.variablesContainer.count() === 0 &&
                   (!props.inheritedVariablesContainer ||

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -180,6 +180,11 @@ const VariablesList = ({ onComputeAllVariableNames, ...props }: Props) => {
   const draggedNodeId = React.useRef<?string>(null);
   const forceUpdate = useForceUpdate();
 
+  const DragSourceAndDropTarget = React.useMemo(
+    () => makeDragSourceAndDropTarget('variable-editor'),
+    []
+  );
+
   const triggerSearch = React.useCallback(
     () => {
       let matchingInheritedNodes = [];
@@ -520,11 +525,6 @@ const VariablesList = ({ onComputeAllVariableNames, ...props }: Props) => {
       forceUpdate();
     }
   };
-
-  const DragSourceAndDropTarget = React.useMemo(
-    () => makeDragSourceAndDropTarget('variable-editor'),
-    []
-  );
 
   const canDrop = (nodeId: string): boolean => {
     if (nodeId.startsWith(inheritedPrefix)) return false;

--- a/newIDE/app/src/fixtures/TestProject.js
+++ b/newIDE/app/src/fixtures/TestProject.js
@@ -276,9 +276,9 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
       1
     );
     variable.castTo('structure');
-    variable.getChild('InstanceChild1').setValue(564);
-    variable.getChild('InstanceChild2').setString('Guttentag');
-    variable.getChild('InstanceChild3').setBool(true);
+    variable.getChild('InstanceChild1').setValue(1995);
+    variable.getChild('InstanceChild2').setString('Hallo');
+    variable.getChild('InstanceChild3').setBool(false);
     const arrayVariable = variable.getChild('InstanceChild4');
     arrayVariable.castTo('array');
     arrayVariable.pushNew().setString('Bonjour');


### PR DESCRIPTION
To fix:
- [x] https://github.com/4ian/GDevelop/issues/3927

@Silver-Streak ideas:
- [x] I would recommend docking the copy/paste/delete/undo/search bar at the top, so users don't have to scroll back up if they have a large list of variables.
- [ ] There probably needs to be a copy/paste variable option on the right-click menu. If there is one, I can't seem to activate it (only copy/paste text in a variable name/value seems to work)
- [x] When searching, if the top level of a structure/array is found, the children aren't shown. Not sure if that is intentional or not (or if it should be). Likewise, results that are structures or array cannot be expanded, which feels like it reduces the effectiveness/usefulness of searching somewhat, since I'd have to unsearch and then manually find the structure/array again.
- [ ] Probably needs a right-click "Collapse/Expand this level" option for child variables to collapse/expand all children of the current variable at the level selected.
- [x] When adding a new variable via the "Add variable" button, the window doesn't jump/scroll to it. So the user may not know a variable was created at the bottom of the list and may hit the button a few times. I'd probably recommend jumping to any new variable as the focus, since it was created via a conscious action by the dev clicking the button. 
- [ ] CTRL+A, select all rows.