### PR TITLE
Rework events Drag&Drop in events sheet

### DIFF
--- a/newIDE/app/scripts/theme-templates/theme.json
+++ b/newIDE/app/scripts/theme-templates/theme.json
@@ -309,6 +309,14 @@
         }
       }
     },
+    "event-drop-indicator": {
+      "border-color": {
+        "value": "#3c4698"
+      },
+      "outline-color": {
+        "value": "#fff"
+      }
+    },
     "link": {
       "container": {
         "background-color": {

--- a/newIDE/app/src/EventsSheet/EventsTree/ClassNames.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/ClassNames.js
@@ -24,6 +24,8 @@ export const eventsTreeWithSearchResults = 'with-search-results';
 
 export const dropIndicator = 'drop-indicator';
 export const cantDropIndicator = 'cant-drop-indicator';
+export const eventDropIndicator = 'event-drop-indicator';
+export const handle = 'moveHandle';
 
 export const linkContainer = 'link-container';
 

--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -1,0 +1,178 @@
+// @flow
+import * as React from 'react';
+import { getIndentWidth, type SortableTreeNode } from '.';
+import { eventDropIndicator } from './ClassNames';
+import {
+  isDescendant,
+  moveNodeAbove,
+  moveNodeBelow,
+  moveNodeAsSubevent,
+} from './helpers';
+import { type WidthType } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
+import './style.css';
+
+type ContainerPosition = 'top' | 'bottom-left' | 'bottom-right' | 'bottom';
+type IndicatorPosition = 'top' | 'bottom-right' | 'bottom';
+
+const styles = {
+  dropArea: { zIndex: 1, position: 'absolute' },
+  dropIndicator: {
+    position: 'absolute',
+    zIndex: 2,
+  },
+};
+
+const getTargetPositionStyle = (position: ContainerPosition) => {
+  switch (position) {
+    case 'bottom-left':
+      return { left: '0px', bottom: '0px', top: '50%', right: '95%' };
+    case 'bottom-right':
+      return { left: '5%', right: '0px', bottom: '0px', top: '50%' };
+    case 'top':
+      return { left: '0px', right: '0px', top: '0px', bottom: '50%' };
+    case 'bottom':
+      return { left: '0px', right: '0px', top: '50%', bottom: '0px' };
+    default:
+      return {};
+  }
+};
+
+const getIndicatorPositionStyle = (
+  position: IndicatorPosition,
+  indentWidth: number
+) => {
+  switch (position) {
+    case 'bottom':
+      return { left: '0px', right: '0px', bottom: '-3px' };
+    case 'bottom-right':
+      return { left: indentWidth, right: '0px', bottom: '-3px' };
+    case 'top':
+      return { left: '0px', right: '0px', top: '-3px' };
+    default:
+      return {};
+  }
+};
+
+function DropTargetContainer({
+  containerPosition,
+  indicatorPosition,
+  DnDComponent,
+  canDrop,
+  onDrop,
+  indentWidth,
+}: {|
+  containerPosition: ContainerPosition,
+  indicatorPosition: IndicatorPosition,
+  DnDComponent: any,
+  canDrop: () => boolean,
+  onDrop: () => void,
+  indentWidth: number,
+|}) {
+  return (
+    <DnDComponent canDrop={canDrop} drop={onDrop}>
+      {({ isOver, connectDropTarget, canDrop }) => {
+        return connectDropTarget(
+          <div>
+            {/* Drop area */}
+            <div
+              style={{
+                ...styles.dropArea,
+                ...getTargetPositionStyle(containerPosition),
+              }}
+            />
+            {/* Drop indicator */}
+            <div
+              style={{
+                ...styles.dropIndicator,
+                ...getIndicatorPositionStyle(indicatorPosition, indentWidth),
+                visibility: canDrop && isOver ? 'visible' : 'hidden',
+              }}
+              className={eventDropIndicator}
+            />
+          </div>
+        );
+      }}
+    </DnDComponent>
+  );
+}
+
+export default function DropContainer({
+  node,
+  draggedNode,
+  DnDComponent,
+  onDrop,
+  activateTargets,
+  windowWidth,
+}: {|
+  node: SortableTreeNode,
+  draggedNode: ?SortableTreeNode,
+  DnDComponent: any,
+  onDrop: (
+    moveFunction: ({
+      targetNode: SortableTreeNode,
+      node: SortableTreeNode,
+    }) => void,
+    node: SortableTreeNode
+  ) => void,
+  activateTargets: boolean,
+  windowWidth: WidthType,
+|}) {
+  // We want to allow dropping below if the event has no children OR if the only
+  // child of the event is the dragged one.
+  const canDropBelow =
+    node.event &&
+    (node.children.length === 0 ||
+      (node.children.length === 1 && node.children[0] === draggedNode));
+  const canHaveSubevents = node.event && node.event.canHaveSubEvents();
+  const commonProps = {
+    DnDComponent: DnDComponent,
+    canDrop: () => true,
+    indentWidth: getIndentWidth(windowWidth),
+  };
+  return (
+    <div
+      style={{
+        visibility: activateTargets ? 'visible' : 'hidden',
+      }}
+    >
+      <DropTargetContainer
+        containerPosition="top"
+        indicatorPosition="top"
+        onDrop={() => onDrop(moveNodeAbove, node)}
+        {...commonProps}
+      />
+      {canHaveSubevents && canDropBelow && (
+        <>
+          <DropTargetContainer
+            containerPosition="bottom-right"
+            indicatorPosition="bottom-right"
+            onDrop={() => onDrop(moveNodeAsSubevent, node)}
+            {...commonProps}
+          />
+          <DropTargetContainer
+            containerPosition="bottom-left"
+            indicatorPosition="bottom"
+            onDrop={() => onDrop(moveNodeBelow, node)}
+            {...commonProps}
+          />
+        </>
+      )}
+      {!canHaveSubevents && canDropBelow && (
+        <DropTargetContainer
+          containerPosition="bottom"
+          indicatorPosition="bottom"
+          onDrop={() => onDrop(moveNodeBelow, node)}
+          {...commonProps}
+        />
+      )}
+      {canHaveSubevents && !canDropBelow && (
+        <DropTargetContainer
+          containerPosition="bottom"
+          indicatorPosition="bottom-right"
+          onDrop={() => onDrop(moveNodeAsSubevent, node)}
+          {...commonProps}
+        />
+      )}
+    </div>
+  );
+}

--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -2,12 +2,7 @@
 import * as React from 'react';
 import { getIndentWidth, type SortableTreeNode } from '.';
 import { eventDropIndicator } from './ClassNames';
-import {
-  isDescendant,
-  moveNodeAbove,
-  moveNodeBelow,
-  moveNodeAsSubevent,
-} from './helpers';
+import { moveNodeAbove, moveNodeBelow, moveNodeAsSubevent } from './helpers';
 import { type WidthType } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
 import './style.css';
 

--- a/newIDE/app/src/EventsSheet/EventsTree/helpers.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/helpers.js
@@ -1,0 +1,76 @@
+import { type SortableTreeNode } from '.';
+
+export type MoveFunctionArguments = {
+  targetNode: SortableTreeNode,
+  node: SortableTreeNode,
+};
+
+export const moveEventToEventsList = ({
+  targetEventsList,
+  movingEvent,
+  initialEventsList,
+  toIndex,
+}: {
+  targetEventsList: gdEventsList,
+  movingEvent: ?gdBaseEvent,
+  initialEventsList: gdEventsList,
+  toIndex: number,
+}) => {
+  if (!movingEvent) return;
+  initialEventsList.moveEventToAnotherEventsList(
+    movingEvent,
+    targetEventsList,
+    toIndex
+  );
+};
+
+export const moveNodeAsSubevent = ({
+  targetNode,
+  node,
+}: MoveFunctionArguments) => {
+  if (!targetNode.event) return;
+  moveEventToEventsList({
+    targetEventsList: targetNode.event.getSubEvents(),
+    movingEvent: node.event,
+    initialEventsList: node.eventsList,
+    toIndex: 0,
+  });
+};
+
+export const moveNodeBelow = ({ targetNode, node }: MoveFunctionArguments) => {
+  if (!targetNode.event) return;
+  const toIndex =
+    node.indexInList < targetNode.indexInList && node.depth === targetNode.depth
+      ? targetNode.indexInList
+      : targetNode.indexInList + 1;
+  moveEventToEventsList({
+    targetEventsList: targetNode.eventsList,
+    movingEvent: node.event,
+    initialEventsList: node.eventsList,
+    toIndex,
+  });
+};
+
+export const moveNodeAbove = ({ targetNode, node }: MoveFunctionArguments) => {
+  const toIndex =
+    node.indexInList < targetNode.indexInList && node.depth === targetNode.depth
+      ? targetNode.indexInList - 1
+      : targetNode.indexInList;
+  moveEventToEventsList({
+    targetEventsList: targetNode.eventsList,
+    movingEvent: node.event,
+    initialEventsList: node.eventsList,
+    toIndex,
+  });
+};
+
+// Optimises react-sortable-tree isDescendant that processes every children with a .some method.
+export const isDescendant = (
+  olderNode: SortableTreeNode,
+  childrenNode: SortableTreeNode
+) => {
+  const parentPath = olderNode.nodePath;
+  const childrenPath = childrenNode.nodePath;
+  if (childrenNode.depth <= olderNode.depth) return false;
+  return parentPath[olderNode.depth] === childrenPath[olderNode.depth];
+};

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -306,12 +306,12 @@ export default class ThemableEventsTree extends Component<
     eventsSheetEventsDnDType
   );
   DropTarget = makeDropTarget<SortableTreeNode>(eventsSheetEventsDnDType);
-  temporarlyUnfoldedNodes: Array<SortableTreeNode>;
+  temporallyUnfoldedNodes: Array<SortableTreeNode>;
   _hoverTimerId: ?number;
 
   constructor(props: EventsTreeProps) {
     super(props);
-    this.temporarlyUnfoldedNodes = [];
+    this.temporallyUnfoldedNodes = [];
     this.eventsHeightsCache = new EventHeightsCache(this);
     this.state = {
       ...this._eventsToTreeData(props.events),
@@ -568,20 +568,20 @@ export default class ThemableEventsTree extends Component<
     );
   };
 
-  _temporarlyUnfoldNode = (isOverLazy: boolean, node: SortableTreeNode) => {
+  _temporallyUnfoldNode = (isOverLazy: boolean, node: SortableTreeNode) => {
     if (!node.event) return;
 
     const { event: nodeEvent } = node;
 
-    const isNodeTemporarlyUnfolded = !this.temporarlyUnfoldedNodes.some(
+    const isNodeTemporallyUnfolded = !this.temporallyUnfoldedNodes.some(
       foldedNode => foldedNode.event && nodeEvent.ptr === foldedNode.event.ptr
     );
     if (isOverLazy) {
       if (!this._hoverTimerId && !node.expanded) {
         this._hoverTimerId = window.setTimeout(() => {
-          if (node.event && isNodeTemporarlyUnfolded) {
+          if (node.event && isNodeTemporallyUnfolded) {
             nodeEvent.setFolded(false);
-            this.temporarlyUnfoldedNodes.push(node);
+            this.temporallyUnfoldedNodes.push(node);
             this.forceEventsUpdate();
           }
         }, 1000);
@@ -593,11 +593,11 @@ export default class ThemableEventsTree extends Component<
   };
 
   _restoreFoldedNodes = () => {
-    this.temporarlyUnfoldedNodes.forEach(
+    this.temporallyUnfoldedNodes.forEach(
       node => node.event && node.event.setFolded(true)
     );
 
-    this.temporarlyUnfoldedNodes = [];
+    this.temporallyUnfoldedNodes = [];
     this.forceEventsUpdate();
   };
 
@@ -625,7 +625,7 @@ export default class ThemableEventsTree extends Component<
         endDrag={() => this.setState({ draggedNode: null })}
       >
         {({ connectDragSource, connectDropTarget, isOverLazy }) => {
-          this._temporarlyUnfoldNode(isOverLazy, node);
+          this._temporallyUnfoldNode(isOverLazy, node);
 
           const dropTarget = (
             <div

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -2,16 +2,19 @@
 import { Trans } from '@lingui/macro';
 import React, { Component, type Node } from 'react';
 import findIndex from 'lodash/findIndex';
-import {
-  SortableTreeWithoutDndContext,
-  getNodeAtPath,
-} from 'react-sortable-tree';
+import { SortableTreeWithoutDndContext } from 'react-sortable-tree';
+import { type ConnectDragSource } from 'react-dnd';
 import { mapFor } from '../../Utils/MapFor';
 import { getInitialSelection, isEventSelected } from '../SelectionHandler';
 import EventsRenderingService from './EventsRenderingService';
 import EventHeightsCache from './EventHeightsCache';
 import classNames from 'classnames';
-import { eventsTree, eventsTreeWithSearchResults, icon } from './ClassNames';
+import {
+  eventsTree,
+  eventsTreeWithSearchResults,
+  handle,
+  icon,
+} from './ClassNames';
 import {
   type SelectionState,
   type EventContext,
@@ -37,7 +40,13 @@ import { type Preferences } from '../../MainFrame/Preferences/PreferencesContext
 import { type Tutorial } from '../../Utils/GDevelopServices/Tutorial';
 import TutorialMessage from '../../Hints/TutorialMessage';
 import getTutorial from '../../Hints/getTutorial';
+import { makeDragSourceAndDropTarget } from '../../UI/DragAndDrop/DragSourceAndDropTarget';
+import { makeDropTarget } from '../../UI/DragAndDrop/DropTarget';
+import DropContainer from './DropContainer';
+import { isDescendant, type MoveFunctionArguments } from './helpers';
 const gd: libGDevelop = global.gd;
+
+const eventsSheetEventsDnDType = 'events-sheet-events-dnd-type';
 
 const getThumbnail = ObjectsRenderingService.getThumbnail.bind(
   ObjectsRenderingService
@@ -50,13 +59,27 @@ const styles = {
   container: { flex: 1 },
   defaultEventContainer: {
     marginRight: 10,
+    position: 'relative',
   },
   smallEventContainer: {
     marginRight: 0,
+    position: 'relative',
+  },
+  eventComponentContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'stretch',
+    position: 'relative',
+  },
+  handle: {
+    margin: 0.5,
+    flexGrow: 0,
+    flexShrink: 0,
+    cursor: 'move',
   },
 };
 
-const getIndentWidth = (windowWidth: WidthType) =>
+export const getIndentWidth = (windowWidth: WidthType) =>
   windowWidth === 'small' ? smallIndentWidth : defaultIndentWidth;
 const getEventContainerStyle = (windowWidth: WidthType) =>
   windowWidth === 'small'
@@ -95,8 +118,9 @@ type EventsContainerProps = {|
   renderObjectThumbnail: string => Node,
 
   screenType: ScreenType,
-  windowWidth: WidthType,
   eventsSheetHeight: number,
+
+  connectDragSource: ConnectDragSource,
 |};
 
 /**
@@ -134,45 +158,50 @@ class EventContainer extends Component<EventsContainerProps, {||}> {
         ref={container => (this._container = container)}
         onClick={this.props.onEventClick}
         onContextMenu={this._onEventContextMenu}
-        style={getEventContainerStyle(this.props.windowWidth)}
       >
         {EventComponent && (
-          <EventComponent
-            project={project}
-            scope={scope}
-            event={event}
-            globalObjectsContainer={this.props.globalObjectsContainer}
-            objectsContainer={this.props.objectsContainer}
-            selected={isEventSelected(this.props.selection, event)}
-            selection={this.props.selection}
-            leftIndentWidth={this.props.leftIndentWidth}
-            onUpdate={this._onEventUpdated}
-            onAddNewInstruction={this.props.onAddNewInstruction}
-            onPasteInstructions={this.props.onPasteInstructions}
-            onMoveToInstruction={this.props.onMoveToInstruction}
-            onMoveToInstructionsList={this.props.onMoveToInstructionsList}
-            onInstructionClick={this.props.onInstructionClick}
-            onInstructionDoubleClick={this.props.onInstructionDoubleClick}
-            onInstructionContextMenu={this.props.onInstructionContextMenu}
-            onAddInstructionContextMenu={this.props.onAddInstructionContextMenu}
-            onParameterClick={this.props.onParameterClick}
-            onOpenExternalEvents={this.props.onOpenExternalEvents}
-            onOpenLayout={this.props.onOpenLayout}
-            disabled={
-              disabled /* Use disabled (not event.disabled) as it is true if a parent event is disabled*/
-            }
-            renderObjectThumbnail={this.props.renderObjectThumbnail}
-            screenType={this.props.screenType}
-            windowWidth={this.props.windowWidth}
-            eventsSheetHeight={this.props.eventsSheetHeight}
-          />
+          <div style={styles.eventComponentContainer}>
+            {this.props.connectDragSource(
+              <div style={styles.handle} className={handle} />
+            )}
+            <div style={styles.container}>
+              <EventComponent
+                project={project}
+                scope={scope}
+                event={event}
+                globalObjectsContainer={this.props.globalObjectsContainer}
+                objectsContainer={this.props.objectsContainer}
+                selected={isEventSelected(this.props.selection, event)}
+                selection={this.props.selection}
+                leftIndentWidth={this.props.leftIndentWidth}
+                onUpdate={this._onEventUpdated}
+                onAddNewInstruction={this.props.onAddNewInstruction}
+                onPasteInstructions={this.props.onPasteInstructions}
+                onMoveToInstruction={this.props.onMoveToInstruction}
+                onMoveToInstructionsList={this.props.onMoveToInstructionsList}
+                onInstructionClick={this.props.onInstructionClick}
+                onInstructionDoubleClick={this.props.onInstructionDoubleClick}
+                onInstructionContextMenu={this.props.onInstructionContextMenu}
+                onAddInstructionContextMenu={
+                  this.props.onAddInstructionContextMenu
+                }
+                onParameterClick={this.props.onParameterClick}
+                onOpenExternalEvents={this.props.onOpenExternalEvents}
+                onOpenLayout={this.props.onOpenLayout}
+                disabled={
+                  disabled /* Use disabled (not event.disabled) as it is true if a parent event is disabled*/
+                }
+                renderObjectThumbnail={this.props.renderObjectThumbnail}
+                screenType={this.props.screenType}
+                eventsSheetHeight={this.props.eventsSheetHeight}
+              />
+            </div>
+          </div>
         )}
       </div>
     );
   }
 }
-
-const getNodeKey = ({ treeIndex }) => treeIndex;
 
 const SortableTree = ({ className, ...otherProps }) => (
   <ThemeConsumer>
@@ -239,35 +268,54 @@ type EventsTreeProps = {|
 
 // A node displayed by the SortableTree. Almost always represents an
 // event, except for the buttons at the bottom of the sheet.
-type SortableTreeNode = {
+export type SortableTreeNode = {
   eventsList: gdEventsList,
   event: ?gdBaseEvent,
   depth: number,
   disabled: boolean,
   indexInList: number,
+  nodePath: Array<number>,
+  children: Array<any>,
+  expanded: boolean,
 
   // In case of nodes without event (buttons at the bottom of the sheet),
   // use a fixed height.
   fixedHeight?: ?number,
 };
 
+type State = {
+  treeData: Array<any>,
+  flatData: Array<gdBaseEvent>,
+  draggedNode: ?SortableTreeNode,
+};
+
 /**
  * Display a tree of event. Builtin on react-sortable-tree so that event
  * can be drag'n'dropped and events rows are virtualized.
  */
-export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
+export default class ThemableEventsTree extends Component<
+  EventsTreeProps,
+  State
+> {
   static defaultProps = {
     selection: getInitialSelection(),
   };
   _list: ?any;
   eventsHeightsCache: EventHeightsCache;
+  DragSourceAndDropTarget = makeDragSourceAndDropTarget<SortableTreeNode>(
+    eventsSheetEventsDnDType
+  );
+  DropTarget = makeDropTarget<SortableTreeNode>(eventsSheetEventsDnDType);
+  temporarlyUnfoldedNodes: Array<SortableTreeNode>;
+  _hoverTimerId: ?number;
 
   constructor(props: EventsTreeProps) {
     super(props);
-
+    this.temporarlyUnfoldedNodes = [];
     this.eventsHeightsCache = new EventHeightsCache(this);
     this.state = {
       ...this._eventsToTreeData(props.events),
+      draggedNode: null,
     };
   }
 
@@ -359,7 +407,8 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
     eventsList: gdEventsList,
     flatData: Array<gdBaseEvent> = [],
     depth: number = 0,
-    parentDisabled: boolean = false
+    parentDisabled: boolean = false,
+    path: Array<number> = []
   ) => {
     const treeData = mapFor<SortableTreeNode>(
       0,
@@ -369,6 +418,7 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
         flatData.push(event);
 
         const disabled = parentDisabled || event.isDisabled();
+        const currentPath = path.concat(i);
 
         return {
           title: this._renderEvent,
@@ -385,8 +435,12 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
             // Hence it should not contain the folded events.
             !event.isFolded() ? flatData : [],
             depth + 1,
-            disabled
+            disabled,
+            currentPath
           ).treeData,
+          // react-sortable-tree stores path using the node's index in the flattened tree.
+          // We choose to store a path using its index in list to optimise isDescendant function.
+          nodePath: currentPath,
         };
       }
     );
@@ -459,76 +513,33 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
     ].filter(Boolean);
 
     return {
+      // $FlowFixMe - We are confident treeData and extraNodes are both arrays of SortableTreeNode
       treeData: extraNodes.length ? treeData.concat(extraNodes) : treeData,
       flatData,
     };
   };
 
-  _onMoveNode = ({
-    treeData,
-    path,
-    node,
-  }: {
-    treeData: any,
-    path: Array<any>,
-    node: SortableTreeNode,
-  }) => {
-    // Get the moved event and its list from the moved node.
-    const { event, eventsList } = node;
-    if (!event) return;
-
-    // Get the event list where the event should be moved to.
-    const targetPath = path.slice(0, -1);
-    const target = getNodeAtPath({
-      getNodeKey,
-      treeData: treeData,
-      path: targetPath,
-    });
-    const targetNode = target.node;
-    const targetEventsList =
-      targetNode && targetNode.event
-        ? targetNode.event.getSubEvents()
-        : this.props.events;
-    const targetPosition =
-      targetNode && targetNode.children ? targetNode.children.indexOf(node) : 0;
-
-    // Do the move
-    // Note that moveEventToAnotherEventsList does not invalidate the
-    // references to the event in memory - so things refering to this event like the
-    // selection in EventsSheet remain valid. This might not be needed anymore
-    // if events drag'n'drop is reworked to be similar to instructions drag'n'drop.
-    eventsList.moveEventToAnotherEventsList(
-      event,
-      targetEventsList,
-      targetPosition
-    );
-
-    this.forceEventsUpdate();
-    this.props.onEventMoved();
-  };
-
-  _canDrag = ({ node }: { node: ?SortableTreeNode }) => {
+  _canDrag = (node: ?SortableTreeNode) => {
     return !!node && !!node.event;
   };
 
-  _canDrop = ({ nextParent }: { nextParent: ?SortableTreeNode }) => {
-    if (nextParent) {
-      if (nextParent.event) {
-        return nextParent.event.canHaveSubEvents();
-      }
-    }
-
-    // No "nextParent" means that we're trying to drop at the root
-    // of the events tree.
+  _canDrop = (hoveredNode: SortableTreeNode) => {
     return true;
   };
 
-  _canNodeHaveChildren = (node: ?SortableTreeNode) => {
-    if (node && node.event) {
-      return node.event.canHaveSubEvents();
+  _onDrop = (
+    moveFunction: MoveFunctionArguments => void,
+    currentNode: SortableTreeNode
+  ) => {
+    if (this.state.draggedNode) {
+      moveFunction({
+        node: this.state.draggedNode,
+        targetNode: currentNode,
+      });
     }
-
-    return false;
+    this._restoreFoldedNodes();
+    this.forceEventsUpdate();
+    this.props.onEventMoved();
   };
 
   _onVisibilityToggle = ({ node }: { node: SortableTreeNode }) => {
@@ -557,54 +568,132 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
     );
   };
 
+  _temporarlyUnfoldNode = (isOverLazy: boolean, node: SortableTreeNode) => {
+    if (!node.event) return;
+
+    const { event: nodeEvent } = node;
+
+    const isNodeTemporarlyUnfolded = !this.temporarlyUnfoldedNodes.some(
+      foldedNode => foldedNode.event && nodeEvent.ptr === foldedNode.event.ptr
+    );
+    if (isOverLazy) {
+      if (!this._hoverTimerId && !node.expanded) {
+        this._hoverTimerId = window.setTimeout(() => {
+          if (node.event && isNodeTemporarlyUnfolded) {
+            nodeEvent.setFolded(false);
+            this.temporarlyUnfoldedNodes.push(node);
+            this.forceEventsUpdate();
+          }
+        }, 1000);
+      }
+    } else {
+      window.clearTimeout(this._hoverTimerId);
+      this._hoverTimerId = null;
+    }
+  };
+
+  _restoreFoldedNodes = () => {
+    this.temporarlyUnfoldedNodes.forEach(
+      node => node.event && node.event.setFolded(true)
+    );
+
+    this.temporarlyUnfoldedNodes = [];
+    this.forceEventsUpdate();
+  };
+
   _renderEvent = ({ node }: { node: SortableTreeNode }) => {
     const { event, depth, disabled } = node;
     if (!event) return null;
+    const { DragSourceAndDropTarget, DropTarget } = this;
+    const isDragged =
+      !!this.state.draggedNode &&
+      (isDescendant(this.state.draggedNode, node) ||
+        node === this.state.draggedNode);
 
     return (
-      <EventContainer
-        project={this.props.project}
-        scope={this.props.scope}
-        globalObjectsContainer={this.props.globalObjectsContainer}
-        objectsContainer={this.props.objectsContainer}
-        event={event}
-        key={event.ptr}
-        eventsHeightsCache={this.eventsHeightsCache}
-        selection={this.props.selection}
-        leftIndentWidth={depth * getIndentWidth(this.props.windowWidth)}
-        onAddNewInstruction={this.props.onAddNewInstruction}
-        onPasteInstructions={this.props.onPasteInstructions}
-        onMoveToInstruction={this.props.onMoveToInstruction}
-        onMoveToInstructionsList={this.props.onMoveToInstructionsList}
-        onInstructionClick={this.props.onInstructionClick}
-        onInstructionDoubleClick={this.props.onInstructionDoubleClick}
-        onParameterClick={this.props.onParameterClick}
-        onEventClick={() =>
-          this.props.onEventClick({
-            eventsList: node.eventsList,
-            event: event,
-            indexInList: node.indexInList,
-          })
-        }
-        onEventContextMenu={(x, y) =>
-          this.props.onEventContextMenu(x, y, {
-            eventsList: node.eventsList,
-            event: event,
-            indexInList: node.indexInList,
-          })
-        }
-        onInstructionContextMenu={this.props.onInstructionContextMenu}
-        onAddInstructionContextMenu={this.props.onAddInstructionContextMenu}
-        onOpenExternalEvents={this.props.onOpenExternalEvents}
-        onOpenLayout={this.props.onOpenLayout}
-        disabled={
-          disabled /* Use node.disabled (not event.disabled) as it is true if a parent event is disabled*/
-        }
-        renderObjectThumbnail={this._renderObjectThumbnail}
-        screenType={this.props.screenType}
-        windowWidth={this.props.windowWidth}
-        eventsSheetHeight={this.props.eventsSheetHeight}
-      />
+      <DragSourceAndDropTarget
+        beginDrag={() => {
+          this.setState({ draggedNode: node });
+          return node;
+        }}
+        canDrag={() => this._canDrag(node)}
+        canDrop={() => this._canDrop(node)}
+        // Drop operations are handled by DropContainers
+        drop={() => {
+          return;
+        }}
+        endDrag={() => this.setState({ draggedNode: null })}
+      >
+        {({ connectDragSource, connectDropTarget, isOverLazy }) => {
+          this._temporarlyUnfoldNode(isOverLazy, node);
+
+          const dropTarget = (
+            <div
+              style={{
+                opacity: isDragged ? 0.5 : 1,
+                ...getEventContainerStyle(this.props.windowWidth),
+              }}
+            >
+              <EventContainer
+                project={this.props.project}
+                scope={this.props.scope}
+                globalObjectsContainer={this.props.globalObjectsContainer}
+                objectsContainer={this.props.objectsContainer}
+                event={event}
+                key={event.ptr}
+                eventsHeightsCache={this.eventsHeightsCache}
+                selection={this.props.selection}
+                leftIndentWidth={depth * getIndentWidth(this.props.windowWidth)}
+                onAddNewInstruction={this.props.onAddNewInstruction}
+                onPasteInstructions={this.props.onPasteInstructions}
+                onMoveToInstruction={this.props.onMoveToInstruction}
+                onMoveToInstructionsList={this.props.onMoveToInstructionsList}
+                onInstructionClick={this.props.onInstructionClick}
+                onInstructionDoubleClick={this.props.onInstructionDoubleClick}
+                onParameterClick={this.props.onParameterClick}
+                onEventClick={() =>
+                  this.props.onEventClick({
+                    eventsList: node.eventsList,
+                    event: event,
+                    indexInList: node.indexInList,
+                  })
+                }
+                onEventContextMenu={(x, y) =>
+                  this.props.onEventContextMenu(x, y, {
+                    eventsList: node.eventsList,
+                    event: event,
+                    indexInList: node.indexInList,
+                  })
+                }
+                onInstructionContextMenu={this.props.onInstructionContextMenu}
+                onAddInstructionContextMenu={
+                  this.props.onAddInstructionContextMenu
+                }
+                onOpenExternalEvents={this.props.onOpenExternalEvents}
+                onOpenLayout={this.props.onOpenLayout}
+                disabled={
+                  disabled /* Use node.disabled (not event.disabled) as it is true if a parent event is disabled*/
+                }
+                renderObjectThumbnail={this._renderObjectThumbnail}
+                screenType={this.props.screenType}
+                eventsSheetHeight={this.props.eventsSheetHeight}
+                connectDragSource={connectDragSource}
+              />
+              <DropContainer
+                node={node}
+                draggedNode={this.state.draggedNode}
+                DnDComponent={DropTarget}
+                onDrop={this._onDrop}
+                activateTargets={!isDragged && isOverLazy}
+                windowWidth={this.props.windowWidth}
+              />
+            </div>
+          );
+
+          if (!dropTarget) return null;
+          return isDragged ? dropTarget : connectDropTarget(dropTarget);
+        }}
+      </DragSourceAndDropTarget>
     );
   };
 
@@ -646,10 +735,7 @@ export default class ThemableEventsTree extends Component<EventsTreeProps, *> {
           scaffoldBlockPxWidth={getIndentWidth(this.props.windowWidth)}
           onChange={noop}
           onVisibilityToggle={this._onVisibilityToggle}
-          onMoveNode={this._onMoveNode}
-          canDrag={this._canDrag}
-          canDrop={this._canDrop}
-          canNodeHaveChildren={this._canNodeHaveChildren}
+          canDrag={false}
           rowHeight={({ node }: { node: SortableTreeNode }) => {
             if (!node.event) return node.fixedHeight || 0;
 

--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -9,7 +9,7 @@
 /**
  * Draggable handle on the left of an event
  */
-.gd-events-sheet .rst__moveHandle {
+.gd-events-sheet .moveHandle {
     width: 10px;
     border: none;
     box-shadow: none;
@@ -21,7 +21,7 @@
      * Slightly reduce the size of the handle on small screens
      * and phones (where drag'n'drop is not supported anyway).
      */
-    .gd-events-sheet .rst__moveHandle {
+    .gd-events-sheet .moveHandle {
         width: 4px;
     }
 }

--- a/newIDE/app/src/UI/DragAndDrop/DragSourceAndDropTarget.js
+++ b/newIDE/app/src/UI/DragAndDrop/DragSourceAndDropTarget.js
@@ -16,12 +16,14 @@ type Props<DraggedItemType> = {|
     connectDragSource: ConnectDragSource,
     connectDropTarget: ConnectDropTarget,
     isOver: boolean,
+    isOverLazy: boolean,
     canDrop: boolean,
   }) => ?React.Node,
   beginDrag: () => DraggedItemType,
   canDrag?: (item: DraggedItemType) => boolean,
   canDrop: (item: DraggedItemType) => boolean,
   drop: () => void,
+  endDrag?: () => void,
 |};
 
 type DragSourceProps = {|
@@ -31,6 +33,7 @@ type DragSourceProps = {|
 type DropTargetProps = {|
   connectDropTarget: ConnectDropTarget,
   isOver: boolean,
+  isOverLazy: boolean,
   canDrop: boolean,
 |};
 
@@ -52,6 +55,9 @@ export const makeDragSourceAndDropTarget = <DraggedItemType>(
     },
     beginDrag(props: InnerDragSourceAndDropTargetProps<DraggedItemType>) {
       return props.beginDrag();
+    },
+    endDrag(props: Props<DraggedItemType>, monitor: DragSourceMonitor) {
+      if (props.endDrag) props.endDrag();
     },
   };
 
@@ -84,6 +90,7 @@ export const makeDragSourceAndDropTarget = <DraggedItemType>(
     return {
       connectDropTarget: connect.dropTarget(),
       isOver: monitor.isOver({ shallow: true }),
+      isOverLazy: monitor.isOver({ shallow: false }),
       canDrop: monitor.canDrop(),
     };
   }
@@ -94,11 +101,19 @@ export const makeDragSourceAndDropTarget = <DraggedItemType>(
     sourceCollect
   )(
     DropTarget(reactDndType, targetSpec, targetCollect)(
-      ({ children, connectDragSource, connectDropTarget, isOver, canDrop }) => {
+      ({
+        children,
+        connectDragSource,
+        connectDropTarget,
+        isOver,
+        isOverLazy,
+        canDrop,
+      }) => {
         return children({
           connectDragSource,
           connectDropTarget,
           isOver,
+          isOverLazy,
           canDrop,
         });
       }

--- a/newIDE/app/src/UI/Theme/DarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DarkTheme/theme.json
@@ -324,6 +324,14 @@
         }
       }
     },
+    "event-drop-indicator": {
+      "border-color": {
+        "value": "#18dcf2"
+      },
+      "outline-color": {
+        "value": "#fff"
+      }
+    },
     "link": {
       "container": {
         "background-color": {

--- a/newIDE/app/src/UI/Theme/DefaultTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultTheme/theme.json
@@ -325,6 +325,14 @@
         }
       }
     },
+    "event-drop-indicator": {
+      "border-color": {
+        "value": "#3c4698"
+      },
+      "outline-color": {
+        "value": "#fff"
+      }
+    },
     "link": {
       "container": {
         "background-color": {

--- a/newIDE/app/src/UI/Theme/Global/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/Global/EventsSheet.css
@@ -4,10 +4,10 @@
  */
 
 .gd-events-sheet .events-tree {
-    /* Use the fonts provided by the operating system(s) as possible. */
-    /* If you update this font list, be sure to do it in all the other places using fonts in the codebase. */
-    font-family: var(--gdevelop-font-family) !important;
-    background: var(--event-sheet-event-tree-background-color);
+  /* Use the fonts provided by the operating system(s) as possible. */
+  /* If you update this font list, be sure to do it in all the other places using fonts in the codebase. */
+  font-family: var(--gdevelop-font-family) !important;
+  background: var(--event-sheet-event-tree-background-color);
 }
 
 /**
@@ -15,18 +15,18 @@
  * of horizontal scrollbar.
  */
 .gd-events-sheet .rst__virtualScrollOverride {
-    overflow-x: hidden !important;
+  overflow-x: hidden !important;
 }
 
 /**
  * Draggable handle on the left of an event
  */
-.gd-events-sheet .rst__moveHandle {
-    background: var(--event-sheet-rst-move-handle-background-color);
+.gd-events-sheet .moveHandle {
+  background: var(--event-sheet-rst-move-handle-background-color);
 }
 
-.gd-events-sheet .rst__moveHandle:hover {
-    background-color: var(--event-sheet-rst-move-handle-hover-background-color);
+.gd-events-sheet .moveHandle:hover {
+  background-color: var(--event-sheet-rst-move-handle-hover-background-color);
 }
 
 /**
@@ -36,89 +36,89 @@
 .gd-events-sheet .rst__lineFullVertical::after,
 .gd-events-sheet .rst__lineHalfVerticalTop::after,
 .gd-events-sheet .rst__lineHalfVerticalBottom::after {
-    background-color: var(--event-sheet-rst-line-background-color);
+  background-color: var(--event-sheet-rst-line-background-color);
 }
 
 /**
  * Background and default text color of content of an event
  */
 .gd-events-sheet .rst__rowContents {
-    background-color: var(--event-sheet-rst-row-contents-background-color);
-    color: var(--event-sheet-rst-row-contents-color);
+  background-color: var(--event-sheet-rst-row-contents-background-color);
+  color: var(--event-sheet-rst-row-contents-color);
 }
 
 /**
  * Selectable area (instructions)
  */
 .gd-events-sheet .selectable:hover {
-    background-color: var(--event-sheet-selectable-background-color);
+  background-color: var(--event-sheet-selectable-background-color);
 }
 
 .gd-events-sheet .selectable.selected {
-    background-color: var(--event-sheet-selectable-background-color);
-    border: var(--event-sheet-selectable-selected-border) !important;
+  background-color: var(--event-sheet-selectable-background-color);
+  border: var(--event-sheet-selectable-selected-border) !important;
 }
 
 /**
  * Large selectable area (events)
  */
 .gd-events-sheet .large-selectable {
-    border:  var(--event-sheet-selectable-border) !important;
+  border:  var(--event-sheet-selectable-border) !important;
 }
 
 .gd-events-sheet .large-selectable.large-selected {
-    border: var(--event-sheet-selectable-selected-border) !important;
+  border: var(--event-sheet-selectable-selected-border) !important;
 }
 
 /**
  * Conditions and actions containers
  */
 .gd-events-sheet .conditions-container {
-    background: var(--event-sheet-conditions-background-color);
-    border: var(--event-sheet-conditions-border);
-    color: var(--event-sheet-conditions-color);
-    border-right-color: var(--event-sheet-conditions-border-right-color);
-    padding-left: 5px;
-    padding-right: 5px;
-    /* Prevent container to growing outside its parent - and still don't have a ridiculously small size */
-    min-width: 100px;
+  background: var(--event-sheet-conditions-background-color);
+  border: var(--event-sheet-conditions-border);
+  color: var(--event-sheet-conditions-color);
+  border-right-color: var(--event-sheet-conditions-border-right-color);
+  padding-left: 5px;
+  padding-right: 5px;
+  /* Prevent container to growing outside its parent - and still don't have a ridiculously small size */
+  min-width: 100px;
 }
 
 .gd-events-sheet .conditions-container.small-width-container {
-    border-right-color: var(--event-sheet-conditions-border-color);
-    border-bottom-color: var(--event-sheet-conditions-border-color);
+  border-right-color: var(--event-sheet-conditions-border-color);
+  border-bottom-color: var(--event-sheet-conditions-border-color);
 }
 
 .gd-events-sheet .actions-container {
-    background: var(--event-sheet-actions-background-color);
-    color: var(--event-sheet-actions-color);
-    padding-left: 5px;
-    padding-right: 5px;
-    /* Prevent container to growing outside its parent. We don't have a way to prevent an infinitely
+  background: var(--event-sheet-actions-background-color);
+  color: var(--event-sheet-actions-color);
+  padding-left: 5px;
+  padding-right: 5px;
+  /* Prevent container to growing outside its parent. We don't have a way to prevent an infinitely
      * small action column, but responsive design should avoid the problem on small screens. */
-    min-width: 0;
+  min-width: 0;
 }
 
 .gd-events-sheet .actions-container.small-width-container {
-    padding-left: 20px;
+  padding-left: 20px;
 }
 
 .gd-events-sheet .sub-instructions-container {
-    margin-left: 9px;
-    margin-top: 1px;
-    border-right: none;
-    border-left: var(--event-sheet-sub-instructions-border);
+  margin-left: 9px;
+  margin-top: 1px;
+  border-right: none;
+  border-left: var(--event-sheet-sub-instructions-border);
 }
 
 /**
  * Instructions parameters color scheme
  */
 .gd-events-sheet .instruction-parameter {
-    color: var(--event-sheet-instruction-parameter-base-color);
+  color: var(--event-sheet-instruction-parameter-base-color);
 }
 
 .gd-events-sheet .instruction-parameter.expression {
-    color: var(--event-sheet-instruction-parameter-expression-color);
+  color: var(--event-sheet-instruction-parameter-expression-color);
 }
 
 .gd-events-sheet .instruction-parameter.object,
@@ -126,112 +126,120 @@
 .gd-events-sheet .instruction-parameter.objectList,
 .gd-events-sheet .instruction-parameter.objectListOrEmptyIfJustDeclared,
 .gd-events-sheet .instruction-parameter.objectListOrEmptyWithoutPicking {
-    color:var(--event-sheet-instruction-parameter-object-color);
-    font-weight: bold;
+  color:var(--event-sheet-instruction-parameter-object-color);
+  font-weight: bold;
 }
 
 .gd-events-sheet .instruction-parameter.behavior {
-    color: var(--event-sheet-instruction-parameter-behavior-color);
+  color: var(--event-sheet-instruction-parameter-behavior-color);
 }
 
 .gd-events-sheet .instruction-parameter.operator {
-    color: var(--event-sheet-instruction-parameter-operator-color);
+  color: var(--event-sheet-instruction-parameter-operator-color);
 }
 
 .gd-events-sheet .instruction-parameter.objectvar {
-    color: var(--event-sheet-instruction-parameter-var-color);
+  color: var(--event-sheet-instruction-parameter-var-color);
 }
 
 .gd-events-sheet .instruction-parameter.scenevar {
-    color: var(--event-sheet-instruction-parameter-var-color);
+  color: var(--event-sheet-instruction-parameter-var-color);
 }
 
 .gd-events-sheet .instruction-parameter.globalvar {
-    color: var(--event-sheet-instruction-parameter-var-color);
+  color: var(--event-sheet-instruction-parameter-var-color);
 }
 
 .gd-events-sheet .instruction-parameter .instruction-invalid-parameter {
-    color: var(--event-sheet-instruction-parameter-error-color);
-    text-decoration:  var(--event-sheet-instruction-parameter-error-color) underline wavy;
+  color: var(--event-sheet-instruction-parameter-error-color);
+  text-decoration:  var(--event-sheet-instruction-parameter-error-color) underline wavy;
 }
 
 .gd-events-sheet .instruction-parameter .instruction-warning-parameter {
-    color: var(--event-sheet-instruction-parameter-warning-color);
-    text-decoration:  var(--event-sheet-instruction-parameter-warning-color) underline wavy;
+  color: var(--event-sheet-instruction-parameter-warning-color);
+  text-decoration:  var(--event-sheet-instruction-parameter-warning-color) underline wavy;
 }
 
 .gd-events-sheet .instruction-parameter .instruction-missing-parameter {
-    display: inline-flex;
-    background-color: var(--event-sheet-instruction-parameter-error-background-color);
-    border-bottom: 1px dashed  var(--event-sheet-instruction-parameter-error-color);
-    min-width: 25px;
-    min-height: 14px;
+  display: inline-flex;
+  background-color: var(--event-sheet-instruction-parameter-error-background-color);
+  border-bottom: 1px dashed  var(--event-sheet-instruction-parameter-error-color);
+  min-width: 25px;
+  min-height: 14px;
 }
 
 /**
  * Search results highlight
  */
 .gd-events-sheet .with-search-results .rst__rowSearchMatch {
-    outline: none;
+  outline: none;
 }
-.gd-events-sheet .with-search-results .rst__rowSearchMatch .rst__moveHandle {
-    background: var(--event-sheet-events-highlighted-color);
+.gd-events-sheet .with-search-results .rst__rowSearchMatch .moveHandle {
+  background: var(--event-sheet-events-highlighted-color);
 }
-.gd-events-sheet .with-search-results .rst__rowSearchMatch .rst__moveHandle:hover {
-    filter: brightness(120%);
+.gd-events-sheet .with-search-results .rst__rowSearchMatch .moveHandle:hover {
+  filter: brightness(120%);
 }
 .gd-events-sheet .with-search-results .rst__rowSearchMatch .conditions-container {
-    outline: none;
-    background-color: var(--event-sheet-events-highlighted-background-color);
+  outline: none;
+  background-color: var(--event-sheet-events-highlighted-background-color);
 }
 .gd-events-sheet .with-search-results .rst__rowSearchMatch .actions-container {
-    outline: none;
-    background-color: var(--event-sheet-events-highlighted-background-color);
+  outline: none;
+  background-color: var(--event-sheet-events-highlighted-background-color);
 }
 
-.gd-events-sheet .with-search-results .rst__rowSearchFocus .rst__moveHandle {
-    width: 15px;
+.gd-events-sheet .with-search-results .rst__rowSearchFocus .moveHandle {
+  width: 15px;
+}
+
+/**
+* Drag'n'drop indicator (events - instructions)
+*/
+.gd-events-sheet .drop-indicator {
+  border-top: 2px solid var(--event-sheet-drop-indicator-can-drop-border-top-color);
+  height: 0;
+  margin-top: -1px;
+  margin-bottom: -1px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.gd-events-sheet .cant-drop-indicator {
+  border-top: 2px solid var(--event-sheet-drop-indicator-can-drop-border-top-color);
+  height: 0;
+  margin-top: -1px;
+  margin-bottom: -1px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 /**
 * Drag'n'drop indicator (events)
 */
-.gd-events-sheet .drop-indicator {
-    border-top: 2px solid var(--event-sheet-drop-indicator-can-drop-border-top-color);
-    height: 0;
-    margin-top: -1px;
-    margin-bottom: -1px;
-    width: 100%;
-    box-sizing: border-box;
-}
-
-.gd-events-sheet .cant-drop-indicator {
-    border-top: 2px solid var(--event-sheet-drop-indicator-can-drop-border-top-color);
-    height: 0;
-    margin-top: -1px;
-    margin-bottom: -1px;
-    width: 100%;
-    box-sizing: border-box;
+.gd-events-sheet .event-drop-indicator {
+  border: 3px solid var(--event-sheet-event-drop-indicator-border-color);
+  outline: var(--event-sheet-event-drop-indicator-outline-color) solid 1px;
 }
 
 /**
 * Skinning the "Link" event
 */
 .gd-events-sheet .link-container {
-    background: var(--event-sheet-link-container-background-color);
+  background: var(--event-sheet-link-container-background-color);
 }
 .gd-events-sheet-dark-theme .link-container span {
-    color: var(--event-sheet-link-container-color);
+  color: var(--event-sheet-link-container-color);
 }
 
 .gd-events-sheet .link-container .selectable {
-    color: var(--event-sheet-link-selectable-link-color);
-    font-weight: bold;
+  color: var(--event-sheet-link-selectable-link-color);
+  font-weight: bold;
 }
 
 /* Theming icons */
 .gd-events-sheet .icon {
-    padding-right: 2px;
-    width: 16px;
-    height: 16px;
+  padding-right: 2px;
+  width: 16px;
+  height: 16px;
 }

--- a/newIDE/app/src/UI/Theme/NordTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/NordTheme/theme.json
@@ -324,6 +324,14 @@
         }
       }
     },
+    "event-drop-indicator": {
+      "border-color": {
+        "value": "#88C0D0"
+      },
+      "outline-color": {
+        "value": "#fff"
+      }
+    },
     "link": {
       "container": {
         "background-color": {

--- a/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
@@ -334,6 +334,14 @@
         }
       }
     },
+    "event-drop-indicator": {
+      "border-color": {
+        "value": "#E5C07B"
+      },
+      "outline-color": {
+        "value": "#fff"
+      }
+    },
     "link": {
       "container": {
         "background-color": {

--- a/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
@@ -324,6 +324,14 @@
         }
       }
     },
+    "event-drop-indicator": {
+      "border-color": {
+        "value": "#18dcf2"
+      },
+      "outline-color": {
+        "value": "#fff"
+      }
+    },
     "link": {
       "container": {
         "background-color": {


### PR DESCRIPTION
Fixes #1903 
(at least partially)


- Change drop indicator to a slim line between events
- Drop event above/below/as subevent depending on mouse position and event type
- Temporally unfold events when user hovers over them for at least 1 sec while dragging