### PR TITLE
Set interactive children to false in runtime scene

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimescene-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimescene-pixi-renderer.ts
@@ -32,6 +32,7 @@ namespace gdjs {
 
       // Contains the layers of the scene (and, optionally, debug PIXI objects).
       this._pixiContainer.sortableChildren = true;
+      this._pixiContainer.interactiveChildren = false;
       this._debugDraw = null;
     }
 


### PR DESCRIPTION
[Untested]

Sets `interactiveChildren` to false on the root container. That tells PIXI not to run a recursive hit test function on the containers children, and may improve perfromance.

I am assuming that since it is recursive, putting it to false on the root container is enough, but if I am wrong the layers renderers may also need to have that property set.

See:
https://pixijs.download/dev/docs/PIXI.Container.html#interactiveChildren
https://github.com/pixijs/pixijs/discussions/8358#discussioncomment-2804783
