### PR TITLE
Pass down remote to Yarn to fix saving with Electron > 18

### DIFF
--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -110,7 +110,7 @@
     "reload-extensions": "node scripts/import-GDJS-Runtime.js --skip-clean",
     "build-theme-resources": "node scripts/build-theme-resources.js",
     "create-new-theme": "node scripts/create-new-theme.js",
-    "import-zipped-external-editors": "cd scripts && node import-zipped-editor.js piskel 5.0.0-beta82 b8e4d57b160ff93d3680168cd271af795412ea6c4c0da321aee2946345c7fb75 && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.0-beta103 155f6d074dbb025b082ede0f9b6acd55ed293457441f4c55f084c2d27fbda61d"
+    "import-zipped-external-editors": "cd scripts && node import-zipped-editor.js piskel 5.0.0-beta82 b8e4d57b160ff93d3680168cd271af795412ea6c4c0da321aee2946345c7fb75 && node import-zipped-editor.js jfxr 5.0.0-beta55 8ac12b557c2ddba958c6f0d3e0c5df8cf3369a65262dcb90cf5c8a7a7d20bdf6 && node import-zipped-editor.js yarn 5.0.134 155f6d074dbb025b082ede0f9b6acd55ed293457441f4c55f084c2d27fbda61d"
   },
   "eslintConfig": {
     "extends": "react-app",

--- a/newIDE/app/public/external/yarn/yarn-main.js
+++ b/newIDE/app/public/external/yarn/yarn-main.js
@@ -25,6 +25,7 @@ window.addEventListener('yarnReady', e => {
   yarn = e;
   yarn.app.fs = fs;
   yarn.app.electron = electron;
+  yarn.app.remote = remote;
   yarn.data.restoreFromLocalStorage(false);
   ipcRenderer.send('yarn-ready');
 });

--- a/newIDE/app/scripts/import-zipped-editor.js
+++ b/newIDE/app/scripts/import-zipped-editor.js
@@ -4,7 +4,6 @@
  * The zip should be uploaded with one of the git releases (use gitRelease variable for version where you released it)
  */
 var shell = require('shelljs');
-var https = require('follow-redirects').https;
 var fs = require('fs');
 var unzipper = require('unzipper');
 var process = require('process');


### PR DESCRIPTION
Fixes #3952 

Since electron's upgrade, `require('electron').remote` returns undefined.
Unfortunately, the yarn editor we were using was basing itself on the electron passed to the editor to call .remote to get the window.

I've monkey-patched this version to use remote directly, instead of electron.remote and uploaded the package yarn-editor.zip to the 5.0.134 release on github

We will need to rethink how Yarn is used in the app, to avoid these issues in the future (probably upgrade Yarn to latest version)