### PR TITLE
Add context in search placeholder

### DIFF
--- a/newIDE/app/src/AssetStore/ExampleStore/index.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/index.js
@@ -13,6 +13,7 @@ import { ResponsiveWindowMeasurer } from '../../UI/Reponsive/ResponsiveWindowMea
 import { ExampleDialog } from './ExampleDialog';
 import { type SearchMatch } from '../../UI/Search/UseSearchStructuredItem';
 import { sendExampleDetailsOpened } from '../../Utils/Analytics/EventSender';
+import { t } from '@lingui/macro';
 
 const styles = {
   searchBar: {
@@ -95,6 +96,7 @@ export const ExampleStore = ({ isOpening, onOpen, focusOnMount }: Props) => {
               tagsHandler={tagsHandler}
               tags={filters && filters.defaultTags}
               ref={searchBarRef}
+              placeholder={t`Search examples`}
             />
             <Line
               expand

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -14,6 +14,7 @@ import {
   sendExtensionAddedToProject,
 } from '../../Utils/Analytics/EventSender';
 import useDismissableTutorialMessage from '../../Hints/useDismissableTutorialMessage';
+import { t } from '@lingui/macro';
 
 const styles = {
   searchBar: {
@@ -102,6 +103,7 @@ export const ExtensionStore = ({
               style={styles.searchBar}
               tagsHandler={tagsHandler}
               tags={filters && filters.allTags}
+              placeholder={t`Search extensions`}
             />
             {DismissableTutorialMessage && (
               <Line>

--- a/newIDE/app/src/AssetStore/ResourceStore/index.js
+++ b/newIDE/app/src/AssetStore/ResourceStore/index.js
@@ -11,7 +11,7 @@ import { BoxSearchResults } from '../../UI/Search/BoxSearchResults';
 import { ResourceCard } from './ResourceCard';
 import Subheader from '../../UI/Subheader';
 import { CategoryChooser } from '../../UI/Search/CategoryChooser';
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 
 const styles = {
   searchBar: {
@@ -54,6 +54,7 @@ export const ResourceStore = ({ onChoose, resourceKind }: Props) => {
         onChange={setSearchText}
         onRequestSearch={() => {}}
         style={styles.searchBar}
+        placeholder={t`Search resources`}
       />
       <Line
         expand

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -257,6 +257,7 @@ export default function NewBehaviorDialog({
                   }}
                   onChange={setSearchText}
                   ref={searchBar}
+                  placeholder={t`Search installed behaviors`}
                 />
                 {hasSearchNoResult && (
                   <EmptyMessage>

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -338,6 +338,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
               searchText: text,
             })
           }
+          placeholder={t`Search behaviors`}
         />
       </Background>
     );

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -408,6 +408,7 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
               searchText: text,
             })
           }
+          placeholder={t`Search functions`}
         />
       </Background>
     );

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -394,7 +394,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                   placeholder={
                     isCondition
                       ? t`Search objects or conditions`
-                      : t`Search objects or action`
+                      : t`Search objects or actions`
                   }
                 />
                 {!isSearching && (

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -391,6 +391,11 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                   }
                   style={styles.searchBar}
                   ref={this._searchBar}
+                  placeholder={
+                    isCondition
+                      ? t`Search objects or conditions`
+                      : t`Search objects or action`
+                  }
                 />
                 {!isSearching && (
                   <Tabs value={currentTab} onChange={onChangeTab}>

--- a/newIDE/app/src/GamesShowcase/index.js
+++ b/newIDE/app/src/GamesShowcase/index.js
@@ -9,7 +9,7 @@ import { ListSearchResults } from '../UI/Search/ListSearchResults';
 import { GamesShowcaseContext } from './GamesShowcaseContext';
 import { ShowcasedGameListItem } from './ShowcasedGameListItem';
 import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasurer';
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import Subheader from '../UI/Subheader';
 import { CategoryChooser } from '../UI/Search/CategoryChooser';
 
@@ -52,6 +52,7 @@ export const GamesShowcase = (props: Props) => {
             onChange={setSearchText}
             onRequestSearch={() => {}}
             style={styles.searchBar}
+            placeholder={t`Search games`}
           />
           <Line
             expand

--- a/newIDE/app/src/InstancesEditor/InstancesList/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancesList/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import React, { Component } from 'react';
 import {
   AutoSizer,
@@ -293,6 +293,7 @@ export default class InstancesList extends Component<Props, State> {
               }
               onRequestSearch={this._selectFirstInstance}
               ref={this._searchBar}
+              placeholder={t`Search instances`}
             />
           </div>
         )}

--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -445,6 +445,7 @@ export default class GroupsListContainer extends React.Component<Props, State> {
               searchText: text,
             })
           }
+          placeholder={t`Search object groups`}
         />
       </Background>
     );

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -693,6 +693,7 @@ export default class ObjectsList extends React.Component<Props, State> {
               searchText: text,
             })
           }
+          placeholder={t`Search objects`}
         />
         {this.state.newObjectDialogOpen && (
           <NewObjectDialog

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -1069,6 +1069,7 @@ export default class ProjectManager extends React.Component<Props, State> {
               value={searchText}
               onRequestSearch={this._onRequestSearch}
               onChange={this._onSearchChange}
+              placeholder={t`Search manager`}
             />
             {this.state.projectVariablesEditorOpen && (
               <VariablesEditorDialog

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -1069,7 +1069,7 @@ export default class ProjectManager extends React.Component<Props, State> {
               value={searchText}
               onRequestSearch={this._onRequestSearch}
               onChange={this._onSearchChange}
-              placeholder={t`Search manager`}
+              placeholder={t`Search in project`}
             />
             {this.state.projectVariablesEditorOpen && (
               <VariablesEditorDialog

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -381,6 +381,7 @@ export default class ResourcesList extends React.Component<Props, State> {
               searchText: text,
             })
           }
+          placeholder={t`Search resources`}
         />
       </Background>
     );

--- a/newIDE/app/src/VariablesList/VariablesListToolbar.js
+++ b/newIDE/app/src/VariablesList/VariablesListToolbar.js
@@ -119,7 +119,7 @@ const VariablesListToolbar = (props: Props) => {
           value={props.searchText}
           onRequestSearch={props.onChangeSearchText}
           onChange={props.onChangeSearchText}
-          placeholder={t`Search in variables`}
+          placeholder={t`Search variables`}
         />
       </Column>
       <Column noMargin>


### PR DESCRIPTION
Instead of just having "Search" as placeholder in search bars, we now have the scope of the search.

<img width="742" alt="image" src="https://user-images.githubusercontent.com/81410437/170218767-7708bac8-de82-4c08-b8e5-bf080a485890.png">
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/81410437/170219008-a3c2ffe2-0501-43c5-b13d-5b742ebcc788.png">
