### PR TITLE
Clear authors and publishers when opening project after creation

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1981,6 +1981,8 @@ const MainFrame = (props: Props) => {
 
     currentProject.resetProjectUuid();
     currentProject.setVersion('1.0.0');
+    currentProject.getAuthorIds().clear();
+    currentProject.setAuthor('');
     if (projectName) currentProject.setName(projectName);
     openSceneOrProjectManager({
       currentProject: currentProject,


### PR DESCRIPTION
In particular, remove authors and publishers when creating a new project from an example.