### PR TITLE
Allow adding an asset pack

### DIFF
--- a/Core/GDCore/Project/Object.cpp
+++ b/Core/GDCore/Project/Object.cpp
@@ -12,9 +12,7 @@
 #include "GDCore/Project/Layout.h"
 #include "GDCore/Project/Project.h"
 #include "GDCore/Serialization/SerializerElement.h"
-#if defined(GD_IDE_ONLY)
 #include "GDCore/Project/PropertyDescriptor.h"
-#endif
 
 namespace gd {
 
@@ -24,6 +22,7 @@ Object::Object(const gd::String& name_) : name(name_) {}
 
 void Object::Init(const gd::Object& object) {
   name = object.name;
+  assetStoreId = object.assetStoreId;
   type = object.type;
   objectVariables = object.objectVariables;
   tags = object.tags;
@@ -80,7 +79,6 @@ gd::BehaviorContent& Object::AddBehavior(
   return *behaviors[behaviorName];
 }
 
-#if defined(GD_IDE_ONLY)
 std::map<gd::String, gd::PropertyDescriptor> Object::GetProperties() const {
   std::map<gd::String, gd::PropertyDescriptor> nothing;
   return nothing;
@@ -109,11 +107,11 @@ Object::GetInitialInstanceProperties(const gd::InitialInstance& instance,
   std::map<gd::String, gd::PropertyDescriptor> nothing;
   return nothing;
 }
-#endif
 
 void Object::UnserializeFrom(gd::Project& project,
                              const SerializerElement& element) {
   type = element.GetStringAttribute("type");
+  assetStoreId = element.GetStringAttribute("assetStoreId");
   name = element.GetStringAttribute("name", name, "nom");
   tags = element.GetStringAttribute("tags");
 
@@ -184,9 +182,9 @@ void Object::UnserializeFrom(gd::Project& project,
   DoUnserializeFrom(project, element);
 }
 
-#if defined(GD_IDE_ONLY)
 void Object::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("name", GetName());
+  element.SetAttribute("assetStoreId", GetAssetStoreId());
   element.SetAttribute("type", GetType());
   element.SetAttribute("tags", GetTags());
   objectVariables.SerializeTo(element.AddChild("variables"));
@@ -209,6 +207,5 @@ void Object::SerializeTo(SerializerElement& element) const {
 
   DoSerializeTo(element);
 }
-#endif
 
 }  // namespace gd

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -83,6 +83,14 @@ class GD_CORE_API Object {
    */
   const gd::String& GetName() const { return name; };
 
+  /** \brief Change the asset store id of the object.
+   */
+  void SetAssetStoreId(const gd::String& assetStoreIds_) { assetStoreId = assetStoreIds_; };
+
+  /** \brief Return the asset store id of the object.
+   */
+  const gd::String& GetAssetStoreId() const { return assetStoreId; };
+
   /** \brief Change the type of the object.
    */
   void SetType(const gd::String& type_) { type = type_; }
@@ -100,7 +108,6 @@ class GD_CORE_API Object {
   const gd::String& GetTags() const { return tags; }
   ///@}
 
-#if defined(GD_IDE_ONLY)
   /** \name Resources management
    * Members functions related to managing resources used by the object
    */
@@ -186,7 +193,6 @@ class GD_CORE_API Object {
     return false;
   };
     ///@}
-#endif
 
   /** \name Behaviors management
    * Members functions related to behaviors management.
@@ -232,7 +238,6 @@ class GD_CORE_API Object {
    */
   gd::BehaviorContent& AddBehavior(const gd::BehaviorContent& behavior);
 
-#if defined(GD_IDE_ONLY)
   /**
    * \brief Add the behavior of the specified \a type with the specified \a
    * name.
@@ -245,7 +250,6 @@ class GD_CORE_API Object {
   gd::BehaviorContent* AddNewBehavior(gd::Project& project,
                                       const gd::String& type,
                                       const gd::String& name);
-#endif
 
   /**
    * \brief Get a read-only access to the map containing the behaviors with
@@ -296,13 +300,11 @@ class GD_CORE_API Object {
  * Members functions related to serialization of the object
  */
 ///@{
-#if defined(GD_IDE_ONLY)
   /**
    * \brief Serialize the object.
    * \see DoSerializeTo
    */
   void SerializeTo(SerializerElement& element) const;
-#endif
 
   /**
    * \brief Unserialize the object.
@@ -313,6 +315,7 @@ class GD_CORE_API Object {
 
  protected:
   gd::String name;  ///< The full name of the object
+  gd::String assetStoreId;  ///< The ID of the asset it the object comes from the store.
   gd::String type;  ///< Which type is the object. ( To test if we can do
                     ///< something reserved to some objects with it )
   std::map<gd::String, std::unique_ptr<gd::BehaviorContent>>
@@ -331,12 +334,10 @@ class GD_CORE_API Object {
   virtual void DoUnserializeFrom(gd::Project& project,
                                  const SerializerElement& element){};
 
-#if defined(GD_IDE_ONLY)
   /**
    * \brief Derived objects can redefine this method to save custom attributes.
    */
   virtual void DoSerializeTo(SerializerElement& element) const {};
-#endif
 
   /**
    * Initialize object using another object. Used by copy-ctor and assign-op.

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -315,7 +315,7 @@ class GD_CORE_API Object {
 
  protected:
   gd::String name;  ///< The full name of the object
-  gd::String assetStoreId;  ///< The ID of the asset it the object comes from the store.
+  gd::String assetStoreId;  ///< The ID of the asset if the object comes from the store.
   gd::String type;  ///< Which type is the object. ( To test if we can do
                     ///< something reserved to some objects with it )
   std::map<gd::String, std::unique_ptr<gd::BehaviorContent>>

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -85,7 +85,7 @@ class GD_CORE_API Object {
 
   /** \brief Change the asset store id of the object.
    */
-  void SetAssetStoreId(const gd::String& assetStoreIds_) { assetStoreId = assetStoreIds_; };
+  void SetAssetStoreId(const gd::String& assetStoreId_) { assetStoreId = assetStoreId_; };
 
   /** \brief Return the asset store id of the object.
    */

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -552,6 +552,8 @@ interface gdObject {
 
     void SetName([Const] DOMString name);
     [Const, Ref] DOMString GetName();
+    void SetAssetStoreId([Const] DOMString assetStoreId);
+    [Const, Ref] DOMString GetAssetStoreId();
     void SetType([Const] DOMString type);
     [Const, Ref] DOMString GetType();
     void SetTags([Const] DOMString tags);

--- a/GDevelop.js/__tests__/Serializer.js
+++ b/GDevelop.js/__tests__/Serializer.js
@@ -60,6 +60,7 @@ describe('libGD.js object serialization', function() {
       obj.setName('testObject');
       obj.setString('Text of the object, with 官话 characters');
       obj.setTags('inventory, player');
+      obj.setAssetStoreId('1234');
 
       var serializedObject = new gd.SerializerElement();
       obj.serializeTo(serializedObject);
@@ -68,7 +69,7 @@ describe('libGD.js object serialization', function() {
       obj.delete();
 
       expect(jsonObject).toBe(
-        '{"bold":false,"italic":false,"name":"testObject","smoothed":true,"tags":"inventory, player","type":"TextObject::Text","underlined":false,"variables":[],"effects":[],"behaviors":[],"string":"Text of the object, with 官话 characters","font":"","characterSize":20.0,"color":{"b":0,"g":0,"r":0}}'
+        '{"assetStoreId":"1234","bold":false,"italic":false,"name":"testObject","smoothed":true,"tags":"inventory, player","type":"TextObject::Text","underlined":false,"variables":[],"effects":[],"behaviors":[],"string":"Text of the object, with 官话 characters","font":"","characterSize":20.0,"color":{"b":0,"g":0,"r":0}}'
       );
     });
   });

--- a/GDevelop.js/types/gdobject.js
+++ b/GDevelop.js/types/gdobject.js
@@ -4,6 +4,8 @@ declare class gdObject {
   clone(): gdUniquePtrObject;
   setName(name: string): void;
   getName(): string;
+  setAssetStoreId(assetStoreId: string): void;
+  getAssetStoreId(): string;
   setType(type: string): void;
   getType(): string;
   setTags(tags: string): void;

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -257,11 +257,11 @@ export const AssetDetails = ({
                 primary={!isAddedToScene}
                 label={
                   isBeingAddedToScene ? (
-                    <Trans>Adding to scene...</Trans>
+                    <Trans>Adding...</Trans>
                   ) : isAddedToScene ? (
-                    <Trans>Add object again to my scene</Trans>
+                    <Trans>Add again</Trans>
                   ) : (
-                    <Trans>Add object to my scene</Trans>
+                    <Trans>Add to the scene</Trans>
                   )
                 }
                 onClick={onAddAsset}

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -78,8 +78,8 @@ type Props = {|
   assetShortHeader: AssetShortHeader,
   onAdd: () => void,
   onClose: () => void,
-  isAddedToProject: boolean,
-  isBeingAddedToProject: boolean,
+  isAddedToScene: boolean,
+  isBeingAddedToScene: boolean,
 |};
 
 const getObjectAssetResourcesByName = (
@@ -103,8 +103,8 @@ export const AssetDetails = ({
   assetShortHeader,
   onAdd,
   onClose,
-  isAddedToProject,
-  isBeingAddedToProject,
+  isAddedToScene,
+  isBeingAddedToScene,
 }: Props) => {
   const gdevelopTheme = React.useContext(ThemeContext);
   const { authors, licenses } = React.useContext(AssetStoreContext);
@@ -147,7 +147,7 @@ export const AssetDetails = ({
     [loadAsset]
   );
 
-  const canAddAsset = !isBeingAddedToProject && !!asset;
+  const canAddAsset = !isBeingAddedToScene && !!asset;
   const onAddAsset = React.useCallback(
     () => {
       if (canAddAsset) onAdd();
@@ -250,18 +250,18 @@ export const AssetDetails = ({
           </Column>
           <Column alignItems="center" justifyContent="center">
             <LeftLoader
-              isLoading={isBeingAddedToProject || (!asset && !error)}
+              isLoading={isBeingAddedToScene || (!asset && !error)}
               key="install"
             >
               <RaisedButton
-                primary={!isAddedToProject}
+                primary={!isAddedToScene}
                 label={
-                  isBeingAddedToProject ? (
-                    <Trans>Adding to my project...</Trans>
-                  ) : isAddedToProject ? (
-                    <Trans>Add object again to my project</Trans>
+                  isBeingAddedToScene ? (
+                    <Trans>Adding to scene...</Trans>
+                  ) : isAddedToScene ? (
+                    <Trans>Add object again to my scene</Trans>
                   ) : (
-                    <Trans>Add object to my project</Trans>
+                    <Trans>Add object to my scene</Trans>
                   )
                 }
                 onClick={onAddAsset}

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -79,8 +79,8 @@ type Props = {|
   assetShortHeader: AssetShortHeader,
   onAdd: () => void,
   onClose: () => void,
-  canInstall: boolean,
-  isBeingInstalled: boolean,
+  isAddedToProject: boolean,
+  isBeingAddedToProject: boolean,
 |};
 
 const getObjectAssetResourcesByName = (
@@ -105,13 +105,12 @@ export const AssetDetails = ({
   assetShortHeader,
   onAdd,
   onClose,
-  canInstall,
-  isBeingInstalled,
+  isAddedToProject,
+  isBeingAddedToProject,
 }: Props) => {
   const gdevelopTheme = React.useContext(ThemeContext);
   const { authors, licenses } = React.useContext(AssetStoreContext);
   const [asset, setAsset] = React.useState<?Asset>(null);
-  const [isAssetAdded, setIsAssetAdded] = React.useState<boolean>(false);
   const [
     selectedAnimationName,
     setSelectedAnimationName,
@@ -150,14 +149,12 @@ export const AssetDetails = ({
     [loadAsset]
   );
 
-  const canAddAsset =
-    canInstall && !isBeingInstalled && !!asset && !isAssetAdded;
+  const canAddAsset = !isBeingAddedToProject && !!asset;
   const onAddAsset = React.useCallback(
     () => {
       if (canAddAsset) onAdd();
-      setIsAssetAdded(true);
     },
-    [onAdd, canAddAsset, setIsAssetAdded]
+    [onAdd, canAddAsset]
   );
 
   const assetAuthors: ?Array<Author> =
@@ -255,16 +252,16 @@ export const AssetDetails = ({
           </Column>
           <Column alignItems="center" justifyContent="center">
             <LeftLoader
-              isLoading={isBeingInstalled || (!asset && !error)}
+              isLoading={isBeingAddedToProject || (!asset && !error)}
               key="install"
             >
               <RaisedButton
-                primary
+                primary={!isAddedToProject}
                 label={
-                  isBeingInstalled ? (
+                  isBeingAddedToProject ? (
                     <Trans>Adding to my project...</Trans>
-                  ) : isAssetAdded ? (
-                    <Trans>Object added to my project</Trans>
+                  ) : isAddedToProject ? (
+                    <Trans>Add object again to my project</Trans>
                   ) : (
                     <Trans>Add object to my project</Trans>
                   )

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -70,7 +70,6 @@ const makeFirstLetterUppercase = (str: string) =>
 
 type Props = {|
   project: gdProject,
-  layout: ?gdLayout,
   objectsContainer: gdObjectsContainer,
   resourceSources: Array<ResourceSource>,
   resourceExternalEditors: Array<ResourceExternalEditor>,
@@ -97,7 +96,6 @@ const getObjectAssetResourcesByName = (
 
 export const AssetDetails = ({
   project,
-  layout,
   objectsContainer,
   resourceSources,
   resourceExternalEditors,

--- a/newIDE/app/src/AssetStore/AssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/AssetPackDialog.js
@@ -186,14 +186,14 @@ export const AssetPackDialog = ({
       }}
       cannotBeDismissed
       actions={[
-        <FlatButton
+        <TextButton
           key="cancel"
           label={<Trans>Cancel</Trans>}
           disabled={isAssetPackBeingInstalled}
           onClick={onClose}
         />,
         isAssetPackBeingInstalled ? (
-          <FlatButton
+          <TextButton
             key="loading"
             label={<Trans>Please wait...</Trans>}
             disabled

--- a/newIDE/app/src/AssetStore/AssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/AssetPackDialog.js
@@ -112,44 +112,44 @@ export const AssetPackDialog = ({
     ]
   );
 
-  return (
-    <Dialog
-      title={<Trans>{assetPack.name}</Trans>}
-      open
-      cannotBeDismissed
-      actions={[
-        <TextButton
-          key="cancel"
-          label={<Trans>Cancel</Trans>}
-          disabled={isAssetPackBeingInstalled}
-          onClick={onClose}
-        />,
-        // Loading.
-        isAssetPackBeingInstalled ? (
-          <TextButton
-            key="loading"
-            label={<Trans>Please wait...</Trans>}
-            disabled
-            onClick={() => {}}
-          />
-        ) : // All assets already installed.
-        allAssetsInstalled ? (
+  const dialogContent = allAssetsInstalled
+    ? {
+        actionButton: (
           <RaisedButton
             key="install-again"
             label={<Trans>Install again</Trans>}
             primary={false}
             onClick={() => onInstallAssetPack(assetShortHeaders)}
           />
-        ) : // No assets installed.
-        noAssetsInstalled ? (
+        ),
+        onApply: () => onInstallAssetPack(assetShortHeaders),
+        text: (
+          <Trans>
+            You already have this asset pack installed, do you want to add the{' '}
+            {assetShortHeaders.length} assets again?
+          </Trans>
+        ),
+      }
+    : noAssetsInstalled
+    ? {
+        actionButton: (
           <RaisedButton
             key="continue"
             label={<Trans>Continue</Trans>}
             primary
             onClick={() => onInstallAssetPack(assetShortHeaders)}
           />
-        ) : (
-          // Some assets installed.
+        ),
+        onApply: () => onInstallAssetPack(assetShortHeaders),
+        text: (
+          <Trans>
+            You're about to add {assetShortHeaders.length} assets from the asset
+            pack. Continue?
+          </Trans>
+        ),
+      }
+    : {
+        actionButton: (
           <RaisedButtonWithSplitMenu
             label={<Trans>Install the missing assets</Trans>}
             key="install-missing"
@@ -165,12 +165,45 @@ export const AssetPackDialog = ({
             ]}
           />
         ),
-      ]}
-      onApply={() => {
-        noAssetsInstalled
-          ? onInstallAssetPack(assetShortHeaders)
-          : onInstallAssetPack(missingAssetShortHeaders);
+        onApply: () => onInstallAssetPack(missingAssetShortHeaders),
+        text: (
+          <Trans>
+            You already have{' '}
+            {assetShortHeaders.length - missingAssetShortHeaders.length}{' '}
+            asset(s) from this pack in your scene. Do you want to add the
+            remaining {missingAssetShortHeaders.length} asset(s)?
+          </Trans>
+        ),
+      };
+
+  return (
+    <Dialog
+      maxWidth="sm"
+      title={assetPack.name}
+      open
+      onRequestClose={() => {
+        if (!isAssetPackBeingInstalled) onClose();
       }}
+      cannotBeDismissed
+      actions={[
+        <FlatButton
+          key="cancel"
+          label={<Trans>Cancel</Trans>}
+          disabled={isAssetPackBeingInstalled}
+          onClick={onClose}
+        />,
+        isAssetPackBeingInstalled ? (
+          <FlatButton
+            key="loading"
+            label={<Trans>Please wait...</Trans>}
+            disabled
+            onClick={() => {}}
+          />
+        ) : (
+          dialogContent.actionButton
+        ),
+      ]}
+      onApply={dialogContent.onApply}
     >
       <Column>
         {isAssetPackBeingInstalled ? (
@@ -183,26 +216,7 @@ export const AssetPackDialog = ({
             </Line>
           </>
         ) : (
-          <Text>
-            {allAssetsInstalled ? (
-              <Trans>
-                You already have this asset pack installed, do you want to add
-                the {assetShortHeaders.length} assets again?
-              </Trans>
-            ) : noAssetsInstalled ? (
-              <Trans>
-                You're about to add {assetShortHeaders.length} assets from the
-                asset pack. Continue?
-              </Trans>
-            ) : (
-              <Trans>
-                You already have{' '}
-                {assetShortHeaders.length - missingAssetShortHeaders.length}{' '}
-                asset(s) from this pack in your scene. Do you want to add the
-                remaining {missingAssetShortHeaders.length} asset(s)?
-              </Trans>
-            )}
-          </Text>
+          <Text>{dialogContent.text}</Text>
         )}
       </Column>
     </Dialog>

--- a/newIDE/app/src/AssetStore/AssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/AssetPackDialog.js
@@ -112,7 +112,29 @@ export const AssetPackDialog = ({
     ]
   );
 
-  const dialogContent = allAssetsInstalled
+  const dialogContent = isAssetPackBeingInstalled
+    ? {
+        actionButton: (
+          <TextButton
+            key="loading"
+            label={<Trans>Please wait...</Trans>}
+            disabled
+            onClick={() => {}}
+          />
+        ),
+        onApply: () => {},
+        content: (
+          <>
+            <Text>
+              <Trans>Installing assets...</Trans>
+            </Text>
+            <Line expand>
+              <LinearProgress style={styles.linearProgress} />
+            </Line>
+          </>
+        ),
+      }
+    : allAssetsInstalled
     ? {
         actionButton: (
           <RaisedButton
@@ -123,11 +145,13 @@ export const AssetPackDialog = ({
           />
         ),
         onApply: () => onInstallAssetPack(assetShortHeaders),
-        text: (
-          <Trans>
-            You already have this asset pack installed, do you want to add the{' '}
-            {assetShortHeaders.length} assets again?
-          </Trans>
+        content: (
+          <Text>
+            <Trans>
+              You already have this asset pack installed, do you want to add the{' '}
+              {assetShortHeaders.length} assets again?
+            </Trans>
+          </Text>
         ),
       }
     : noAssetsInstalled
@@ -141,11 +165,13 @@ export const AssetPackDialog = ({
           />
         ),
         onApply: () => onInstallAssetPack(assetShortHeaders),
-        text: (
-          <Trans>
-            You're about to add {assetShortHeaders.length} assets from the asset
-            pack. Continue?
-          </Trans>
+        content: (
+          <Text>
+            <Trans>
+              You're about to add {assetShortHeaders.length} assets from the
+              asset pack. Continue?
+            </Trans>
+          </Text>
         ),
       }
     : {
@@ -166,13 +192,15 @@ export const AssetPackDialog = ({
           />
         ),
         onApply: () => onInstallAssetPack(missingAssetShortHeaders),
-        text: (
-          <Trans>
-            You already have{' '}
-            {assetShortHeaders.length - missingAssetShortHeaders.length}{' '}
-            asset(s) from this pack in your scene. Do you want to add the
-            remaining {missingAssetShortHeaders.length} asset(s)?
-          </Trans>
+        content: (
+          <Text>
+            <Trans>
+              You already have{' '}
+              {assetShortHeaders.length - missingAssetShortHeaders.length}{' '}
+              asset(s) from this pack in your scene. Do you want to add the
+              remaining {missingAssetShortHeaders.length} asset(s)?
+            </Trans>
+          </Text>
         ),
       };
 
@@ -192,33 +220,11 @@ export const AssetPackDialog = ({
           disabled={isAssetPackBeingInstalled}
           onClick={onClose}
         />,
-        isAssetPackBeingInstalled ? (
-          <TextButton
-            key="loading"
-            label={<Trans>Please wait...</Trans>}
-            disabled
-            onClick={() => {}}
-          />
-        ) : (
-          dialogContent.actionButton
-        ),
+        dialogContent.actionButton,
       ]}
       onApply={dialogContent.onApply}
     >
-      <Column>
-        {isAssetPackBeingInstalled ? (
-          <>
-            <Text>
-              <Trans>Installing assets...</Trans>
-            </Text>
-            <Line expand>
-              <LinearProgress style={styles.linearProgress} />
-            </Line>
-          </>
-        ) : (
-          <Text>{dialogContent.text}</Text>
-        )}
-      </Column>
+      <Column>{dialogContent.content}</Column>
     </Dialog>
   );
 };

--- a/newIDE/app/src/AssetStore/AssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/AssetPackDialog.js
@@ -1,0 +1,212 @@
+// @flow
+import * as React from 'react';
+import {
+  type AssetShortHeader,
+  type AssetPack,
+} from '../Utils/GDevelopServices/Asset';
+import Text from '../UI/Text';
+import { t, Trans } from '@lingui/macro';
+import Dialog from '../UI/Dialog';
+import TextButton from '../UI/TextButton';
+import RaisedButton from '../UI/RaisedButton';
+import RaisedButtonWithSplitMenu from '../UI/RaisedButtonWithSplitMenu';
+import { Column, Line } from '../UI/Grid';
+import { LinearProgress } from '@material-ui/core';
+import { installAsset } from './InstallAsset';
+import EventsFunctionsExtensionsContext from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import { useResourceFetcher } from '../ProjectsStorage/ResourceFetcher';
+import { showErrorBox } from '../UI/Messages/MessageBox';
+
+const styles = {
+  linearProgress: {
+    flex: 1,
+  },
+};
+
+type Props = {|
+  assetPack: AssetPack,
+  assetShortHeaders: Array<AssetShortHeader>,
+  addedAssetIds: Array<string>,
+  onClose: () => void,
+  onAssetPackAdded: () => void,
+  project: gdProject,
+  objectsContainer: gdObjectsContainer,
+  events: gdEventsList,
+  onObjectAddedFromAsset: (object: gdObject) => void,
+|};
+
+export const AssetPackDialog = ({
+  assetPack,
+  assetShortHeaders,
+  addedAssetIds,
+  onClose,
+  onAssetPackAdded,
+  project,
+  objectsContainer,
+  events,
+  onObjectAddedFromAsset,
+}: Props) => {
+  const missingAssetShortHeaders = assetShortHeaders.filter(
+    assetShortHeader => !addedAssetIds.includes(assetShortHeader.id)
+  );
+
+  const resourcesFetcher = useResourceFetcher();
+  const [
+    isAssetPackBeingInstalled,
+    setIsAssetPackBeingInstalled,
+  ] = React.useState<boolean>(false);
+
+  const eventsFunctionsExtensionsState = React.useContext(
+    EventsFunctionsExtensionsContext
+  );
+
+  const onInstallAssetPack = React.useCallback(
+    async (assetShortHeaders: Array<AssetShortHeader>) => {
+      if (!assetShortHeaders || !assetShortHeaders.length) return;
+      setIsAssetPackBeingInstalled(true);
+      try {
+        const installOutputs = await Promise.all(
+          assetShortHeaders.map(assetShortHeader =>
+            installAsset({
+              assetShortHeader,
+              eventsFunctionsExtensionsState,
+              project,
+              objectsContainer,
+              events,
+            })
+          )
+        );
+        installOutputs.forEach(installOutput => {
+          installOutput.createdObjects.forEach(object => {
+            onObjectAddedFromAsset(object);
+          });
+        });
+
+        await resourcesFetcher.ensureResourcesAreFetched(project);
+
+        setIsAssetPackBeingInstalled(false);
+        onAssetPackAdded();
+      } catch (error) {
+        setIsAssetPackBeingInstalled(false);
+        console.error('Error while installing the asset pack', error);
+        showErrorBox({
+          message:
+            'There was an error while installing the asset pack. Verify your internet connection or try again later.',
+          rawError: error,
+          errorId: 'install-asset-pack-error',
+        });
+      }
+    },
+    [
+      resourcesFetcher,
+      eventsFunctionsExtensionsState,
+      project,
+      objectsContainer,
+      events,
+      onObjectAddedFromAsset,
+      onAssetPackAdded,
+    ]
+  );
+
+  return (
+    <Dialog
+      title={<Trans>{assetPack.name}</Trans>}
+      open
+      cannotBeDismissed
+      actions={[
+        <TextButton
+          key="cancel"
+          label={<Trans>Cancel</Trans>}
+          disabled={isAssetPackBeingInstalled}
+          onClick={onClose}
+        />,
+        // Loading.
+        isAssetPackBeingInstalled && (
+          <TextButton
+            key="loading"
+            label={<Trans>Please wait...</Trans>}
+            disabled
+            onClick={() => {}}
+          />
+        ),
+        // All assets already installed.
+        !isAssetPackBeingInstalled && missingAssetShortHeaders.length === 0 && (
+          <RaisedButton
+            key="install-again"
+            label={<Trans>Install again</Trans>}
+            primary={false}
+            onClick={() => onInstallAssetPack(assetShortHeaders)}
+          />
+        ),
+        // No assets installed.
+        !isAssetPackBeingInstalled &&
+          missingAssetShortHeaders.length === assetShortHeaders.length && (
+            <RaisedButton
+              key="continue"
+              label={<Trans>Continue</Trans>}
+              primary
+              onClick={() => onInstallAssetPack(assetShortHeaders)}
+            />
+          ),
+        // Some assets installed.
+        !isAssetPackBeingInstalled &&
+          missingAssetShortHeaders.length !== 0 &&
+          missingAssetShortHeaders.length !== assetShortHeaders.length && (
+            <RaisedButtonWithSplitMenu
+              label={<Trans>Install the missing assets</Trans>}
+              key="install-missing"
+              primary
+              onClick={() => {
+                onInstallAssetPack(missingAssetShortHeaders);
+              }}
+              buildMenuTemplate={i18n => [
+                {
+                  label: i18n._(t`Install all the assets`),
+                  click: () => onInstallAssetPack(assetShortHeaders),
+                },
+              ]}
+            />
+          ),
+      ]}
+      onApply={() => {
+        missingAssetShortHeaders.length === assetShortHeaders.length
+          ? onInstallAssetPack(assetShortHeaders)
+          : onInstallAssetPack(missingAssetShortHeaders);
+      }}
+    >
+      <Column>
+        {isAssetPackBeingInstalled ? (
+          <>
+            <Text>
+              <Trans>Installing assets...</Trans>
+            </Text>
+            <Line expand>
+              <LinearProgress style={styles.linearProgress} />
+            </Line>
+          </>
+        ) : (
+          <Text>
+            {missingAssetShortHeaders.length === 0 ? (
+              <Trans>
+                You already have this asset pack installed, do you want to add
+                the {assetShortHeaders.length} assets again?
+              </Trans>
+            ) : missingAssetShortHeaders.length === assetShortHeaders.length ? (
+              <Trans>
+                You're about to add {assetShortHeaders.length} assets from the
+                asset pack. Continue?
+              </Trans>
+            ) : (
+              <Trans>
+                You already have{' '}
+                {assetShortHeaders.length - missingAssetShortHeaders.length}{' '}
+                asset(s) from this pack in your scene. Do you want to add the
+                remaining {missingAssetShortHeaders.length} asset(s)?
+              </Trans>
+            )}
+          </Text>
+        )}
+      </Column>
+    </Dialog>
+  );
+};

--- a/newIDE/app/src/AssetStore/AssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/AssetPackDialog.js
@@ -49,6 +49,10 @@ export const AssetPackDialog = ({
   const missingAssetShortHeaders = assetShortHeaders.filter(
     assetShortHeader => !addedAssetIds.includes(assetShortHeader.id)
   );
+  const allAssetsInstalled = missingAssetShortHeaders.length === 0;
+  const noAssetsInstalled =
+    !allAssetsInstalled &&
+    missingAssetShortHeaders.length === assetShortHeaders.length;
 
   const resourcesFetcher = useResourceFetcher();
   const [
@@ -121,55 +125,49 @@ export const AssetPackDialog = ({
           onClick={onClose}
         />,
         // Loading.
-        isAssetPackBeingInstalled && (
+        isAssetPackBeingInstalled ? (
           <TextButton
             key="loading"
             label={<Trans>Please wait...</Trans>}
             disabled
             onClick={() => {}}
           />
-        ),
-        // All assets already installed.
-        !isAssetPackBeingInstalled && missingAssetShortHeaders.length === 0 && (
+        ) : // All assets already installed.
+        allAssetsInstalled ? (
           <RaisedButton
             key="install-again"
             label={<Trans>Install again</Trans>}
             primary={false}
             onClick={() => onInstallAssetPack(assetShortHeaders)}
           />
+        ) : // No assets installed.
+        noAssetsInstalled ? (
+          <RaisedButton
+            key="continue"
+            label={<Trans>Continue</Trans>}
+            primary
+            onClick={() => onInstallAssetPack(assetShortHeaders)}
+          />
+        ) : (
+          // Some assets installed.
+          <RaisedButtonWithSplitMenu
+            label={<Trans>Install the missing assets</Trans>}
+            key="install-missing"
+            primary
+            onClick={() => {
+              onInstallAssetPack(missingAssetShortHeaders);
+            }}
+            buildMenuTemplate={i18n => [
+              {
+                label: i18n._(t`Install all the assets`),
+                click: () => onInstallAssetPack(assetShortHeaders),
+              },
+            ]}
+          />
         ),
-        // No assets installed.
-        !isAssetPackBeingInstalled &&
-          missingAssetShortHeaders.length === assetShortHeaders.length && (
-            <RaisedButton
-              key="continue"
-              label={<Trans>Continue</Trans>}
-              primary
-              onClick={() => onInstallAssetPack(assetShortHeaders)}
-            />
-          ),
-        // Some assets installed.
-        !isAssetPackBeingInstalled &&
-          missingAssetShortHeaders.length !== 0 &&
-          missingAssetShortHeaders.length !== assetShortHeaders.length && (
-            <RaisedButtonWithSplitMenu
-              label={<Trans>Install the missing assets</Trans>}
-              key="install-missing"
-              primary
-              onClick={() => {
-                onInstallAssetPack(missingAssetShortHeaders);
-              }}
-              buildMenuTemplate={i18n => [
-                {
-                  label: i18n._(t`Install all the assets`),
-                  click: () => onInstallAssetPack(assetShortHeaders),
-                },
-              ]}
-            />
-          ),
       ]}
       onApply={() => {
-        missingAssetShortHeaders.length === assetShortHeaders.length
+        noAssetsInstalled
           ? onInstallAssetPack(assetShortHeaders)
           : onInstallAssetPack(missingAssetShortHeaders);
       }}
@@ -186,12 +184,12 @@ export const AssetPackDialog = ({
           </>
         ) : (
           <Text>
-            {missingAssetShortHeaders.length === 0 ? (
+            {allAssetsInstalled ? (
               <Trans>
                 You already have this asset pack installed, do you want to add
                 the {assetShortHeaders.length} assets again?
               </Trans>
-            ) : missingAssetShortHeaders.length === assetShortHeaders.length ? (
+            ) : noAssetsInstalled ? (
               <Trans>
                 You're about to add {assetShortHeaders.length} assets from the
                 asset pack. Continue?

--- a/newIDE/app/src/AssetStore/InstallAsset.js
+++ b/newIDE/app/src/AssetStore/InstallAsset.js
@@ -168,6 +168,7 @@ export const addAssetToProject = async ({
       project
     );
 
+    object.setAssetStoreId(asset.id);
     // The name was overwritten after unserialization.
     object.setName(newName);
 

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -338,31 +338,29 @@ export const AssetStore = ({
                     </Text>
                   ) : (
                     <>
-                      <TextButton
-                        icon={<ArrowBack />}
-                        label={
-                          openedAssetShortHeader ? (
-                            <Trans>Back</Trans>
-                          ) : (
-                            <Trans>Back to discover</Trans>
-                          )
-                        }
-                        primary={false}
-                        onClick={goBack}
-                      />
+                      <Column expand alignItems="flex-start" noMargin>
+                        <TextButton
+                          icon={<ArrowBack />}
+                          label={<Trans>Back</Trans>}
+                          primary={false}
+                          onClick={goBack}
+                        />
+                      </Column>
                       {!!openedAssetPack && !openedAssetShortHeader && (
                         <>
-                          <Text size="title" noMargin>
-                            {openedAssetPack.name}
-                          </Text>
-                          <Column alignItems="center" justifyContent="center">
+                          <Column expand alignItems="center">
+                            <Text size="title" noMargin>
+                              {openedAssetPack.name}
+                            </Text>
+                          </Column>
+                          <Column expand alignItems="flex-end" noMargin>
                             <RaisedButton
                               primary
                               label={
                                 isAssetPackAdded ? (
                                   <Trans>Asset pack added</Trans>
                                 ) : (
-                                  <Trans>Add this pack to my scene</Trans>
+                                  <Trans>Add pack to my scene</Trans>
                                 )
                               }
                               onClick={() =>
@@ -498,40 +496,56 @@ export const AssetStore = ({
                     disabled={isAssetBeingInstalled}
                     onClick={() => setIsAssetPackDialogInstallOpen(false)}
                   />,
-                  searchResultsNotAlreadyAdded.length === 0 ? (
-                    <RaisedButton
-                      key="install-again"
-                      label={<Trans>Install again</Trans>}
-                      primary={false}
-                      disabled={isAssetBeingInstalled}
-                      onClick={() => onInstallAssetPack(searchResults)}
-                    />
-                  ) : searchResultsNotAlreadyAdded.length ===
-                    searchResults.length ? (
-                    <RaisedButton
-                      key="continue"
-                      label={<Trans>Continue</Trans>}
-                      primary
-                      disabled={isAssetBeingInstalled}
-                      onClick={() => onInstallAssetPack(searchResults)}
-                    />
-                  ) : (
-                    <RaisedButtonWithSplitMenu
-                      label={<Trans>Install the missing assets</Trans>}
-                      key="install-missing"
-                      primary
-                      onClick={() =>
-                        onInstallAssetPack(searchResultsNotAlreadyAdded)
-                      }
-                      disabled={isAssetBeingInstalled}
-                      buildMenuTemplate={i18n => [
-                        {
-                          label: i18n._(t`Install all the assets`),
-                          click: () => onInstallAssetPack(searchResults),
-                        },
-                      ]}
+                  // Loading.
+                  isAssetBeingInstalled && (
+                    <TextButton
+                      key="loading"
+                      label={<Trans>Please wait...</Trans>}
+                      disabled
+                      onClick={() => {}}
                     />
                   ),
+                  // All assets already installed.
+                  !isAssetBeingInstalled &&
+                    searchResultsNotAlreadyAdded.length === 0 && (
+                      <RaisedButton
+                        key="install-again"
+                        label={<Trans>Install again</Trans>}
+                        primary={false}
+                        onClick={() => onInstallAssetPack(searchResults)}
+                      />
+                    ),
+                  // No assets installed.
+                  !isAssetBeingInstalled &&
+                    searchResultsNotAlreadyAdded.length ===
+                      searchResults.length && (
+                      <RaisedButton
+                        key="continue"
+                        label={<Trans>Continue</Trans>}
+                        primary
+                        onClick={() => onInstallAssetPack(searchResults)}
+                      />
+                    ),
+                  // Some assets installed.
+                  !isAssetBeingInstalled &&
+                    searchResultsNotAlreadyAdded.length !== 0 &&
+                    searchResultsNotAlreadyAdded.length !==
+                      searchResults.length && (
+                      <RaisedButtonWithSplitMenu
+                        label={<Trans>Install the missing assets</Trans>}
+                        key="install-missing"
+                        primary
+                        onClick={() =>
+                          onInstallAssetPack(searchResultsNotAlreadyAdded)
+                        }
+                        buildMenuTemplate={i18n => [
+                          {
+                            label: i18n._(t`Install all the assets`),
+                            click: () => onInstallAssetPack(searchResults),
+                          },
+                        ]}
+                      />
+                    ),
                 ]}
                 onApply={() =>
                   searchResultsNotAlreadyAdded.length === searchResults.length

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -13,12 +13,16 @@ import {
   sendAssetOpened,
   sendAssetPackOpened,
 } from '../Utils/Analytics/EventSender';
+import RaisedButton from '../UI/RaisedButton';
 import {
   type ResourceSource,
   type ChooseResourceFunction,
 } from '../ResourcesList/ResourceSource';
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
-import { type AssetShortHeader } from '../Utils/GDevelopServices/Asset';
+import {
+  type AssetShortHeader,
+  type AssetPack,
+} from '../Utils/GDevelopServices/Asset';
 import { BoxSearchResults } from '../UI/Search/BoxSearchResults';
 import { type SearchBarInterface } from '../UI/SearchBar';
 import {
@@ -40,11 +44,16 @@ import { installAsset } from './InstallAsset';
 import { useResourceFetcher } from '../ProjectsStorage/ResourceFetcher';
 import { showErrorBox } from '../UI/Messages/MessageBox';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
+import Dialog from '../UI/Dialog';
+import { LinearProgress } from '@material-ui/core';
 
 const styles = {
   searchBar: {
     // TODO: Can we put this in the search bar by default?
     flexShrink: 0,
+  },
+  linearProgress: {
+    flex: 1,
   },
 };
 
@@ -95,14 +104,21 @@ export const AssetStore = ({
 
   const searchBar = React.useRef<?SearchBarInterface>(null);
   const shouldAutofocusSearchbar = useShouldAutofocusSearchbar();
-  const [isFiltersPanelOpen, setIsFiltersPanelOpen] = React.useState(
-    !isOnHomePage && !openedAssetShortHeader
+  const [openedAssetPack, setOpenedAssetPack] = React.useState<?AssetPack>(
+    null
   );
+  const [isFiltersPanelOpen, setIsFiltersPanelOpen] = React.useState(false);
+  const [
+    isAssetPackDialogInstallOpen,
+    setIsAssetPackDialogInstallOpen,
+  ] = React.useState(false);
+  const [isAssetPackAdded, setIsAssetPackAdded] = React.useState(false);
 
   const [
-    assetBeingInstalled,
-    setAssetBeingInstalled,
-  ] = React.useState<?AssetShortHeader>(null);
+    isAssetBeingInstalled,
+    setIsAssetBeingInstalled,
+  ] = React.useState<boolean>(false);
+  const [addedAssetIds, setAddedAssetIds] = React.useState<Array<string>>([]);
 
   const eventsFunctionsExtensionsState = React.useContext(
     EventsFunctionsExtensionsContext
@@ -112,7 +128,7 @@ export const AssetStore = ({
 
   const onInstallAsset = React.useCallback(
     (assetShortHeader: AssetShortHeader) => {
-      setAssetBeingInstalled(assetShortHeader);
+      setIsAssetBeingInstalled(true);
       (async () => {
         try {
           const installOutput = await installAsset({
@@ -127,6 +143,7 @@ export const AssetStore = ({
             name: assetShortHeader.name,
           });
           console.log('Asset successfully installed.');
+          setAddedAssetIds(addedAssetIds.concat(assetShortHeader.id));
 
           installOutput.createdObjects.forEach(object => {
             onObjectAddedFromAsset(object);
@@ -144,7 +161,7 @@ export const AssetStore = ({
           });
         }
 
-        setAssetBeingInstalled(null);
+        setIsAssetBeingInstalled(false);
       })();
     },
     [
@@ -154,12 +171,73 @@ export const AssetStore = ({
       objectsContainer,
       events,
       onObjectAddedFromAsset,
+      addedAssetIds,
+    ]
+  );
+
+  const onInstallAssetPack = React.useCallback(
+    () => {
+      if (!searchResults || !searchResults.length) return;
+      setIsAssetBeingInstalled(true);
+      Promise.all(
+        searchResults.map(assetShortHeader =>
+          installAsset({
+            assetShortHeader,
+            eventsFunctionsExtensionsState,
+            project,
+            objectsContainer,
+            events,
+          })
+        )
+      )
+        .then(installOutputs => {
+          console.log('Asset pack successfully installed.');
+          setIsAssetBeingInstalled(false);
+          setIsAssetPackAdded(true);
+          setAddedAssetIds(
+            addedAssetIds.concat(
+              ...searchResults.map(assetShortHeader => assetShortHeader.id)
+            )
+          );
+
+          setIsAssetPackDialogInstallOpen(false);
+
+          installOutputs.forEach(installOutput => {
+            installOutput.createdObjects.forEach(object => {
+              onObjectAddedFromAsset(object);
+            });
+          });
+
+          return resourcesFetcher.ensureResourcesAreFetched(project);
+        })
+        .catch(error => {
+          console.error('Error while installing the asset pack', error);
+          setIsAssetBeingInstalled(false);
+          showErrorBox({
+            message:
+              'There was an error while installing the asset pack. Verify your internet connection or try again later.',
+            rawError: error,
+            errorId: 'install-asset-pack-error',
+          });
+        });
+    },
+    [
+      resourcesFetcher,
+      eventsFunctionsExtensionsState,
+      project,
+      objectsContainer,
+      events,
+      onObjectAddedFromAsset,
+      searchResults,
+      addedAssetIds,
     ]
   );
 
   const resetToDefault = () => {
     setSearchText('');
     filtersState.setChosenCategory(null);
+    setOpenedAssetPack(null);
+    setIsAssetPackAdded(false);
     setOpenedAssetShortHeader(null);
     clearAllFilters(assetFiltersState);
     setIsFiltersPanelOpen(false);
@@ -179,6 +257,9 @@ export const AssetStore = ({
     };
     filtersState.setChosenCategory(chosenCategory);
 
+    const assetPack = assetPacks.starterPacks.find(pack => pack.tag === tag);
+    setOpenedAssetPack(assetPack);
+
     setIsOnHomePage(false);
     setIsFiltersPanelOpen(true);
   };
@@ -193,8 +274,29 @@ export const AssetStore = ({
     filtersState.setChosenCategory(chosenCategory);
 
     clearAllFilters(assetFiltersState);
+    setOpenedAssetPack(null);
     setOpenedAssetShortHeader(null);
     setIsFiltersPanelOpen(true);
+  };
+
+  // When something is entered in the search bar
+  // we need to ensure we leave the homepage and deselect any pack.
+  const onSearchChange = () => {
+    if (isOnHomePage) setIsOnHomePage(false);
+    if (openedAssetPack) setOpenedAssetPack(null);
+  };
+
+  // When the back button is pressed, if we were on the asset details page,
+  // we just go back to the search,
+  // if we were on the search, we reset everything to go back to the homepage.
+  const goBack = () => {
+    if (openedAssetShortHeader) {
+      // Going back from Asset page to search.
+      setOpenedAssetShortHeader(null);
+    } else {
+      // Going back from search to home.
+      resetToDefault();
+    }
   };
 
   React.useEffect(
@@ -216,44 +318,63 @@ export const AssetStore = ({
                 placeholder={t`Search assets`}
                 value={searchText}
                 onChange={setSearchText}
-                onRequestSearch={() => {
-                  if (isOnHomePage) setIsOnHomePage(false);
-                }}
+                onRequestSearch={onSearchChange}
                 style={styles.searchBar}
                 ref={searchBar}
                 id="asset-store-search-bar"
               />
               {!isOnHomePage && <Spacer />}
-              <Line justifyContent="left" noMargin>
-                {isOnHomePage ? (
-                  <Column>
+              <Column>
+                <Line
+                  justifyContent="space-between"
+                  noMargin
+                  alignItems="center"
+                >
+                  {isOnHomePage ? (
                     <Text size="title">
                       <Trans>Discover</Trans>
                     </Text>
-                  </Column>
-                ) : (
-                  <TextButton
-                    icon={<ArrowBack />}
-                    label={
-                      openedAssetShortHeader ? (
-                        <Trans>Back</Trans>
-                      ) : (
-                        <Trans>Back to discover</Trans>
-                      )
-                    }
-                    primary={false}
-                    onClick={() => {
-                      if (openedAssetShortHeader) {
-                        // Going back from Asset page to search.
-                        setOpenedAssetShortHeader(null);
-                      } else {
-                        // Going back from search to home.
-                        resetToDefault();
-                      }
-                    }}
-                  />
-                )}
-              </Line>
+                  ) : (
+                    <>
+                      <TextButton
+                        icon={<ArrowBack />}
+                        label={
+                          openedAssetShortHeader ? (
+                            <Trans>Back</Trans>
+                          ) : (
+                            <Trans>Back to discover</Trans>
+                          )
+                        }
+                        primary={false}
+                        onClick={goBack}
+                      />
+                      {!!openedAssetPack && !openedAssetShortHeader && (
+                        <>
+                          <Text size="title" noMargin>
+                            {openedAssetPack.name}
+                          </Text>
+                          <Column alignItems="center" justifyContent="center">
+                            <RaisedButton
+                              primary
+                              label={
+                                isAssetPackAdded ? (
+                                  <Trans>Asset pack added</Trans>
+                                ) : (
+                                  <Trans>Add this pack to my project</Trans>
+                                )
+                              }
+                              onClick={() =>
+                                setIsAssetPackDialogInstallOpen(true)
+                              }
+                              disabled={isAssetPackAdded}
+                            />
+                          </Column>
+                        </>
+                      )}
+                    </>
+                  )}
+                </Line>
+              </Column>
               <Line
                 expand
                 overflow={
@@ -304,9 +425,7 @@ export const AssetStore = ({
                         >
                           <AssetStoreFilterPanel
                             assetFiltersState={assetFiltersState}
-                            onChoiceChange={() => {
-                              if (isOnHomePage) setIsOnHomePage(false);
-                            }}
+                            onChoiceChange={onSearchChange}
                           />
                         </Line>
                       </ScrollView>
@@ -357,16 +476,55 @@ export const AssetStore = ({
                     assetShortHeader={openedAssetShortHeader}
                     onAdd={() => onInstallAsset(openedAssetShortHeader)}
                     onClose={() => setOpenedAssetShortHeader(null)}
-                    canInstall={!assetBeingInstalled}
-                    isBeingInstalled={
-                      !!assetBeingInstalled &&
-                      assetBeingInstalled.id === openedAssetShortHeader.id
-                    }
+                    isAddedToProject={addedAssetIds.includes(
+                      openedAssetShortHeader.id
+                    )}
+                    isBeingAddedToProject={isAssetBeingInstalled}
                   />
                 )}
               </Line>
             </Column>
             {resourcesFetcher.renderResourceFetcherDialog()}
+            {isAssetPackDialogInstallOpen && searchResults && openedAssetPack && (
+              <Dialog
+                title={<Trans>{openedAssetPack.name}</Trans>}
+                open
+                actions={[
+                  <TextButton
+                    key="cancel"
+                    label={<Trans>Cancel</Trans>}
+                    onClick={() => setIsAssetPackDialogInstallOpen(false)}
+                  />,
+                  <RaisedButton
+                    key="continue"
+                    label={<Trans>Continue</Trans>}
+                    primary
+                    disabled={isAssetBeingInstalled}
+                    onClick={onInstallAssetPack}
+                  />,
+                ]}
+                onApply={onInstallAssetPack}
+              >
+                <Column>
+                  <Text>
+                    <Trans>
+                      You're about to add {searchResults.length} assets from the
+                      Asset Pack {openedAssetPack.name}. Continue?
+                    </Trans>
+                  </Text>
+                  {isAssetBeingInstalled && (
+                    <>
+                      <Text>
+                        <Trans>Installing assets...</Trans>
+                      </Text>
+                      <Line expand>
+                        <LinearProgress style={styles.linearProgress} />
+                      </Line>
+                    </>
+                  )}
+                </Column>
+              </Dialog>
+            )}
           </>
         )}
       </ResponsiveWindowMeasurer>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -46,6 +46,7 @@ import { showErrorBox } from '../UI/Messages/MessageBox';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import Dialog from '../UI/Dialog';
 import { LinearProgress } from '@material-ui/core';
+import { enumerateObjects } from '../ObjectsList/EnumerateObjects';
 
 const styles = {
   searchBar: {
@@ -118,7 +119,11 @@ export const AssetStore = ({
     isAssetBeingInstalled,
     setIsAssetBeingInstalled,
   ] = React.useState<boolean>(false);
-  const [addedAssetIds, setAddedAssetIds] = React.useState<Array<string>>([]);
+
+  const { containerObjectsList } = enumerateObjects(project, objectsContainer);
+  const addedAssetIds = containerObjectsList
+    .map(({ object }) => object.getAssetStoreId())
+    .filter(Boolean);
 
   const eventsFunctionsExtensionsState = React.useContext(
     EventsFunctionsExtensionsContext
@@ -143,7 +148,6 @@ export const AssetStore = ({
             name: assetShortHeader.name,
           });
           console.log('Asset successfully installed.');
-          setAddedAssetIds(addedAssetIds.concat(assetShortHeader.id));
 
           installOutput.createdObjects.forEach(object => {
             onObjectAddedFromAsset(object);
@@ -171,7 +175,6 @@ export const AssetStore = ({
       objectsContainer,
       events,
       onObjectAddedFromAsset,
-      addedAssetIds,
     ]
   );
 
@@ -194,11 +197,6 @@ export const AssetStore = ({
           console.log('Asset pack successfully installed.');
           setIsAssetBeingInstalled(false);
           setIsAssetPackAdded(true);
-          setAddedAssetIds(
-            addedAssetIds.concat(
-              ...searchResults.map(assetShortHeader => assetShortHeader.id)
-            )
-          );
 
           setIsAssetPackDialogInstallOpen(false);
 
@@ -229,7 +227,6 @@ export const AssetStore = ({
       events,
       onObjectAddedFromAsset,
       searchResults,
-      addedAssetIds,
     ]
   );
 
@@ -468,7 +465,6 @@ export const AssetStore = ({
                 {openedAssetShortHeader && (
                   <AssetDetails
                     project={project}
-                    layout={layout}
                     objectsContainer={objectsContainer}
                     resourceSources={resourceSources}
                     resourceExternalEditors={resourceExternalEditors}

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -44,18 +44,13 @@ import { installAsset } from './InstallAsset';
 import { useResourceFetcher } from '../ProjectsStorage/ResourceFetcher';
 import { showErrorBox } from '../UI/Messages/MessageBox';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
-import Dialog from '../UI/Dialog';
-import { LinearProgress } from '@material-ui/core';
 import { enumerateObjects } from '../ObjectsList/EnumerateObjects';
-import RaisedButtonWithSplitMenu from '../UI/RaisedButtonWithSplitMenu';
+import { AssetPackDialog } from './AssetPackDialog';
 
 const styles = {
   searchBar: {
     // TODO: Can we put this in the search bar by default?
     flexShrink: 0,
-  },
-  linearProgress: {
-    flex: 1,
   },
 };
 
@@ -115,7 +110,6 @@ export const AssetStore = ({
     setIsAssetPackDialogInstallOpen,
   ] = React.useState(false);
   const [isAssetPackAdded, setIsAssetPackAdded] = React.useState(false);
-
   const [
     isAssetBeingInstalled,
     setIsAssetBeingInstalled,
@@ -125,11 +119,6 @@ export const AssetStore = ({
   const addedAssetIds = containerObjectsList
     .map(({ object }) => object.getAssetStoreId())
     .filter(Boolean);
-  const searchResultsNotAlreadyAdded = searchResults
-    ? searchResults.filter(
-        assetShortHeader => !addedAssetIds.includes(assetShortHeader.id)
-      )
-    : [];
 
   const eventsFunctionsExtensionsState = React.useContext(
     EventsFunctionsExtensionsContext
@@ -173,57 +162,6 @@ export const AssetStore = ({
 
         setIsAssetBeingInstalled(false);
       })();
-    },
-    [
-      resourcesFetcher,
-      eventsFunctionsExtensionsState,
-      project,
-      objectsContainer,
-      events,
-      onObjectAddedFromAsset,
-    ]
-  );
-
-  const onInstallAssetPack = React.useCallback(
-    (assetShortHeaders: Array<AssetShortHeader>) => {
-      if (!assetShortHeaders || !assetShortHeaders.length) return;
-      setIsAssetBeingInstalled(true);
-      Promise.all(
-        assetShortHeaders.map(assetShortHeader =>
-          installAsset({
-            assetShortHeader,
-            eventsFunctionsExtensionsState,
-            project,
-            objectsContainer,
-            events,
-          })
-        )
-      )
-        .then(installOutputs => {
-          console.log('Asset pack successfully installed.');
-          setIsAssetBeingInstalled(false);
-          setIsAssetPackAdded(true);
-
-          setIsAssetPackDialogInstallOpen(false);
-
-          installOutputs.forEach(installOutput => {
-            installOutput.createdObjects.forEach(object => {
-              onObjectAddedFromAsset(object);
-            });
-          });
-
-          return resourcesFetcher.ensureResourcesAreFetched(project);
-        })
-        .catch(error => {
-          console.error('Error while installing the asset pack', error);
-          setIsAssetBeingInstalled(false);
-          showErrorBox({
-            message:
-              'There was an error while installing the asset pack. Verify your internet connection or try again later.',
-            rawError: error,
-            errorId: 'install-asset-pack-error',
-          });
-        });
     },
     [
       resourcesFetcher,
@@ -485,111 +423,20 @@ export const AssetStore = ({
             </Column>
             {resourcesFetcher.renderResourceFetcherDialog()}
             {isAssetPackDialogInstallOpen && searchResults && openedAssetPack && (
-              <Dialog
-                title={<Trans>{openedAssetPack.name}</Trans>}
-                open
-                cannotBeDismissed
-                actions={[
-                  <TextButton
-                    key="cancel"
-                    label={<Trans>Cancel</Trans>}
-                    disabled={isAssetBeingInstalled}
-                    onClick={() => setIsAssetPackDialogInstallOpen(false)}
-                  />,
-                  // Loading.
-                  isAssetBeingInstalled && (
-                    <TextButton
-                      key="loading"
-                      label={<Trans>Please wait...</Trans>}
-                      disabled
-                      onClick={() => {}}
-                    />
-                  ),
-                  // All assets already installed.
-                  !isAssetBeingInstalled &&
-                    searchResultsNotAlreadyAdded.length === 0 && (
-                      <RaisedButton
-                        key="install-again"
-                        label={<Trans>Install again</Trans>}
-                        primary={false}
-                        onClick={() => onInstallAssetPack(searchResults)}
-                      />
-                    ),
-                  // No assets installed.
-                  !isAssetBeingInstalled &&
-                    searchResultsNotAlreadyAdded.length ===
-                      searchResults.length && (
-                      <RaisedButton
-                        key="continue"
-                        label={<Trans>Continue</Trans>}
-                        primary
-                        onClick={() => onInstallAssetPack(searchResults)}
-                      />
-                    ),
-                  // Some assets installed.
-                  !isAssetBeingInstalled &&
-                    searchResultsNotAlreadyAdded.length !== 0 &&
-                    searchResultsNotAlreadyAdded.length !==
-                      searchResults.length && (
-                      <RaisedButtonWithSplitMenu
-                        label={<Trans>Install the missing assets</Trans>}
-                        key="install-missing"
-                        primary
-                        onClick={() =>
-                          onInstallAssetPack(searchResultsNotAlreadyAdded)
-                        }
-                        buildMenuTemplate={i18n => [
-                          {
-                            label: i18n._(t`Install all the assets`),
-                            click: () => onInstallAssetPack(searchResults),
-                          },
-                        ]}
-                      />
-                    ),
-                ]}
-                onApply={() =>
-                  searchResultsNotAlreadyAdded.length === searchResults.length
-                    ? onInstallAssetPack(searchResults)
-                    : onInstallAssetPack(searchResultsNotAlreadyAdded)
-                }
-              >
-                <Column>
-                  {isAssetBeingInstalled ? (
-                    <>
-                      <Text>
-                        <Trans>Installing assets...</Trans>
-                      </Text>
-                      <Line expand>
-                        <LinearProgress style={styles.linearProgress} />
-                      </Line>
-                    </>
-                  ) : (
-                    <Text>
-                      {searchResultsNotAlreadyAdded.length === 0 ? (
-                        <Trans>
-                          You already have this asset pack installed, do you
-                          want to add the {searchResults.length} assets again?
-                        </Trans>
-                      ) : searchResultsNotAlreadyAdded.length ===
-                        searchResults.length ? (
-                        <Trans>
-                          You're about to add {searchResults.length} assets from
-                          the asset pack. Continue?
-                        </Trans>
-                      ) : (
-                        <Trans>
-                          You already have{' '}
-                          {searchResults.length -
-                            searchResultsNotAlreadyAdded.length}{' '}
-                          asset(s) from this pack in your scene. Do you want to
-                          add the remaining{' '}
-                          {searchResultsNotAlreadyAdded.length} asset(s)?
-                        </Trans>
-                      )}
-                    </Text>
-                  )}
-                </Column>
-              </Dialog>
+              <AssetPackDialog
+                assetPack={openedAssetPack}
+                assetShortHeaders={searchResults}
+                addedAssetIds={addedAssetIds}
+                onClose={() => setIsAssetPackDialogInstallOpen(false)}
+                onAssetPackAdded={() => {
+                  setIsAssetPackAdded(true);
+                  setIsAssetPackDialogInstallOpen(false);
+                }}
+                project={project}
+                objectsContainer={objectsContainer}
+                events={events}
+                onObjectAddedFromAsset={onObjectAddedFromAsset}
+              />
             )}
           </>
         )}

--- a/newIDE/app/src/UI/Dialog/index.js
+++ b/newIDE/app/src/UI/Dialog/index.js
@@ -67,7 +67,7 @@ type Props = {|
    */
   onApply?: ?() => void,
 
-  cannotBeDismissed?: boolean, // Currently unused.
+  cannotBeDismissed?: boolean, // If set to true, any click outside will not do anything.
 
   children: React.Node, // The content of the dialog
 
@@ -116,6 +116,7 @@ const Dialog = (props: Props) => {
     fullHeight,
     noTitleMargin,
     id,
+    cannotBeDismissed,
   } = props;
 
   const preferences = React.useContext(PreferencesContext);
@@ -151,6 +152,7 @@ const Dialog = (props: Props) => {
       if (reason === 'escapeKeyDown') {
         if (onRequestClose) onRequestClose();
       } else if (reason === 'backdropClick') {
+        if (!!cannotBeDismissed) return;
         if (backdropClickBehavior === 'cancel') {
           if (onRequestClose) onRequestClose();
         } else if (backdropClickBehavior === 'apply') {
@@ -161,7 +163,7 @@ const Dialog = (props: Props) => {
         }
       }
     },
-    [onRequestClose, onApply, backdropClickBehavior]
+    [onRequestClose, onApply, backdropClickBehavior, cannotBeDismissed]
   );
 
   const handleKeyDown = React.useCallback(

--- a/newIDE/app/src/UI/Dialog/index.js
+++ b/newIDE/app/src/UI/Dialog/index.js
@@ -65,9 +65,9 @@ type Props = {|
    * This is not applicable to all dialogs. Some dialogs may have no `onApply` and just a
    * single `onRequestClose`.
    */
-  onApply?: ?() => void,
+  onApply?: ?() => void | Promise<void>,
 
-  cannotBeDismissed?: boolean, // If set to true, any click outside will not do anything.
+  cannotBeDismissed?: boolean, // Currently unused.
 
   children: React.Node, // The content of the dialog
 
@@ -116,7 +116,6 @@ const Dialog = (props: Props) => {
     fullHeight,
     noTitleMargin,
     id,
-    cannotBeDismissed,
   } = props;
 
   const preferences = React.useContext(PreferencesContext);
@@ -152,7 +151,6 @@ const Dialog = (props: Props) => {
       if (reason === 'escapeKeyDown') {
         if (onRequestClose) onRequestClose();
       } else if (reason === 'backdropClick') {
-        if (!!cannotBeDismissed) return;
         if (backdropClickBehavior === 'cancel') {
           if (onRequestClose) onRequestClose();
         } else if (backdropClickBehavior === 'apply') {
@@ -163,7 +161,7 @@ const Dialog = (props: Props) => {
         }
       }
     },
-    [onRequestClose, onApply, backdropClickBehavior, cannotBeDismissed]
+    [onRequestClose, onApply, backdropClickBehavior]
   );
 
   const handleKeyDown = React.useCallback(

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
@@ -19,7 +19,6 @@ export const Default = () => (
   <AssetStoreStateProvider>
     <AssetDetails
       project={testProject.project}
-      layout={testProject.testLayout}
       objectsContainer={testProject.testLayout}
       resourceSources={[]}
       resourceExternalEditors={fakeResourceExternalEditors}
@@ -37,7 +36,6 @@ export const BeingInstalled = () => (
   <AssetStoreStateProvider>
     <AssetDetails
       project={testProject.project}
-      layout={testProject.testLayout}
       objectsContainer={testProject.testLayout}
       resourceSources={[]}
       resourceExternalEditors={fakeResourceExternalEditors}
@@ -55,7 +53,6 @@ export const AddedToProject = () => (
   <AssetStoreStateProvider>
     <AssetDetails
       project={testProject.project}
-      layout={testProject.testLayout}
       objectsContainer={testProject.testLayout}
       resourceSources={[]}
       resourceExternalEditors={fakeResourceExternalEditors}

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { action } from '@storybook/addon-actions';
 
 import muiDecorator from '../../../ThemeDecorator';
 import paperDecorator from '../../../PaperDecorator';
@@ -28,8 +27,8 @@ export const Default = () => (
       assetShortHeader={fakeAssetShortHeader1}
       onAdd={() => {}}
       onClose={() => {}}
-      canInstall={true}
-      isBeingInstalled={false}
+      isAddedToProject={false}
+      isBeingAddedToProject={false}
     />
   </AssetStoreStateProvider>
 );
@@ -46,8 +45,26 @@ export const BeingInstalled = () => (
       assetShortHeader={fakeAssetShortHeader1}
       onAdd={() => {}}
       onClose={() => {}}
-      canInstall={true}
-      isBeingInstalled={true}
+      isAddedToProject={false}
+      isBeingAddedToProject={true}
+    />
+  </AssetStoreStateProvider>
+);
+
+export const AddedToProject = () => (
+  <AssetStoreStateProvider>
+    <AssetDetails
+      project={testProject.project}
+      layout={testProject.testLayout}
+      objectsContainer={testProject.testLayout}
+      resourceSources={[]}
+      resourceExternalEditors={fakeResourceExternalEditors}
+      onTagSelection={() => {}}
+      assetShortHeader={fakeAssetShortHeader1}
+      onAdd={() => {}}
+      onClose={() => {}}
+      isAddedToProject={true}
+      isBeingAddedToProject={false}
     />
   </AssetStoreStateProvider>
 );

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
@@ -26,8 +26,8 @@ export const Default = () => (
       assetShortHeader={fakeAssetShortHeader1}
       onAdd={() => {}}
       onClose={() => {}}
-      isAddedToProject={false}
-      isBeingAddedToProject={false}
+      isAddedToScene={false}
+      isBeingAddedToScene={false}
     />
   </AssetStoreStateProvider>
 );
@@ -43,8 +43,8 @@ export const BeingInstalled = () => (
       assetShortHeader={fakeAssetShortHeader1}
       onAdd={() => {}}
       onClose={() => {}}
-      isAddedToProject={false}
-      isBeingAddedToProject={true}
+      isAddedToScene={false}
+      isBeingAddedToScene={true}
     />
   </AssetStoreStateProvider>
 );
@@ -60,8 +60,8 @@ export const AddedToProject = () => (
       assetShortHeader={fakeAssetShortHeader1}
       onAdd={() => {}}
       onClose={() => {}}
-      isAddedToProject={true}
-      isBeingAddedToProject={false}
+      isAddedToScene={true}
+      isBeingAddedToScene={false}
     />
   </AssetStoreStateProvider>
 );


### PR DESCRIPTION
WIP to improve the asset store to allow few final things:

- when accessing a pack, being able to add the whole pack in one click
- when an asset is added, being able to see that it is already added to the scene (and can be added again)
- from the pack dialog, be able to add the remaining assets, or add all of them

preview:
![Screen Recording 2022-06-01 at 12 16 49](https://user-images.githubusercontent.com/4895034/171382953-f184bba2-4e6f-4c1d-9c84-e2fa03e82766.gif)


