### PR TITLE
Reduce size of events in JSON by not writing empty events/sub-instructions arrays

### DIFF
--- a/Core/GDCore/Events/Builtin/ForEachChildVariableEvent.cpp
+++ b/Core/GDCore/Events/Builtin/ForEachChildVariableEvent.cpp
@@ -53,8 +53,10 @@ void ForEachChildVariableEvent::SerializeTo(SerializerElement& element) const {
       conditions, element.AddChild("conditions"));
   gd::EventsListSerialization::SerializeInstructionsTo(
       actions, element.AddChild("actions"));
-  gd::EventsListSerialization::SerializeEventsTo(events,
-                                                 element.AddChild("events"));
+
+  if (!events.IsEmpty())
+    gd::EventsListSerialization::SerializeEventsTo(events,
+                                                  element.AddChild("events"));
 }
 
 void ForEachChildVariableEvent::UnserializeFrom(gd::Project& project,
@@ -66,8 +68,12 @@ void ForEachChildVariableEvent::UnserializeFrom(gd::Project& project,
       project, conditions, element.GetChild("conditions", 0, "Conditions"));
   gd::EventsListSerialization::UnserializeInstructionsFrom(
       project, actions, element.GetChild("actions", 0, "Actions"));
-  gd::EventsListSerialization::UnserializeEventsFrom(
-      project, events, element.GetChild("events", 0, "Events"));
+
+  events.Clear();
+  if (element.HasChild("events", "Events")) {
+    gd::EventsListSerialization::UnserializeEventsFrom(
+        project, events, element.GetChild("events", 0, "Events"));
+  }
 }
 
 }  // namespace gd

--- a/Core/GDCore/Events/Builtin/ForEachEvent.cpp
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.cpp
@@ -74,8 +74,10 @@ void ForEachEvent::SerializeTo(SerializerElement& element) const {
       conditions, element.AddChild("conditions"));
   gd::EventsListSerialization::SerializeInstructionsTo(
       actions, element.AddChild("actions"));
-  gd::EventsListSerialization::SerializeEventsTo(events,
-                                                 element.AddChild("events"));
+
+  if (!events.IsEmpty())
+    gd::EventsListSerialization::SerializeEventsTo(events,
+                                                  element.AddChild("events"));
 }
 
 void ForEachEvent::UnserializeFrom(gd::Project& project,
@@ -86,8 +88,12 @@ void ForEachEvent::UnserializeFrom(gd::Project& project,
       project, conditions, element.GetChild("conditions", 0, "Conditions"));
   gd::EventsListSerialization::UnserializeInstructionsFrom(
       project, actions, element.GetChild("actions", 0, "Actions"));
-  gd::EventsListSerialization::UnserializeEventsFrom(
-      project, events, element.GetChild("events", 0, "Events"));
+
+  events.Clear();
+  if (element.HasChild("events", "Events")) {
+    gd::EventsListSerialization::UnserializeEventsFrom(
+        project, events, element.GetChild("events", 0, "Events"));
+  }
 }
 
 }  // namespace gd

--- a/Core/GDCore/Events/Builtin/RepeatEvent.cpp
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.cpp
@@ -75,8 +75,10 @@ void RepeatEvent::SerializeTo(SerializerElement& element) const {
       conditions, element.AddChild("conditions"));
   gd::EventsListSerialization::SerializeInstructionsTo(
       actions, element.AddChild("actions"));
-  gd::EventsListSerialization::SerializeEventsTo(events,
-                                                 element.AddChild("events"));
+
+  if (!events.IsEmpty())
+    gd::EventsListSerialization::SerializeEventsTo(events,
+                                                  element.AddChild("events"));
 }
 
 void RepeatEvent::UnserializeFrom(gd::Project& project,
@@ -89,8 +91,12 @@ void RepeatEvent::UnserializeFrom(gd::Project& project,
       project, conditions, element.GetChild("conditions", 0, "Conditions"));
   gd::EventsListSerialization::UnserializeInstructionsFrom(
       project, actions, element.GetChild("actions", 0, "Actions"));
-  gd::EventsListSerialization::UnserializeEventsFrom(
-      project, events, element.GetChild("events", 0, "Events"));
+
+  events.Clear();
+  if (element.HasChild("events", "Events")) {
+    gd::EventsListSerialization::UnserializeEventsFrom(
+        project, events, element.GetChild("events", 0, "Events"));
+  }
 }
 
 }  // namespace gd

--- a/Core/GDCore/Events/Builtin/StandardEvent.cpp
+++ b/Core/GDCore/Events/Builtin/StandardEvent.cpp
@@ -53,8 +53,10 @@ void StandardEvent::SerializeTo(SerializerElement& element) const {
       conditions, element.AddChild("conditions"));
   gd::EventsListSerialization::SerializeInstructionsTo(
       actions, element.AddChild("actions"));
-  gd::EventsListSerialization::SerializeEventsTo(events,
-                                                 element.AddChild("events"));
+
+  if (!events.IsEmpty())
+    gd::EventsListSerialization::SerializeEventsTo(events,
+                                                  element.AddChild("events"));
 }
 
 void StandardEvent::UnserializeFrom(gd::Project& project,

--- a/Core/GDCore/Events/Builtin/WhileEvent.cpp
+++ b/Core/GDCore/Events/Builtin/WhileEvent.cpp
@@ -52,8 +52,10 @@ void WhileEvent::SerializeTo(SerializerElement& element) const {
       conditions, element.AddChild("conditions"));
   gd::EventsListSerialization::SerializeInstructionsTo(
       actions, element.AddChild("actions"));
-  gd::EventsListSerialization::SerializeEventsTo(events,
-                                                 element.AddChild("events"));
+
+  if (!events.IsEmpty())
+    gd::EventsListSerialization::SerializeEventsTo(events,
+                                                  element.AddChild("events"));
 }
 
 void WhileEvent::UnserializeFrom(gd::Project& project,
@@ -68,8 +70,12 @@ void WhileEvent::UnserializeFrom(gd::Project& project,
       project, conditions, element.GetChild("conditions", 0, "Conditions"));
   gd::EventsListSerialization::UnserializeInstructionsFrom(
       project, actions, element.GetChild("actions", 0, "Actions"));
-  gd::EventsListSerialization::UnserializeEventsFrom(
-      project, events, element.GetChild("events", 0, "Events"));
+
+  events.Clear();
+  if (element.HasChild("events", "Events")) {
+    gd::EventsListSerialization::UnserializeEventsFrom(
+        project, events, element.GetChild("events", 0, "Events"));
+  }
 }
 
 }  // namespace gd

--- a/Core/GDCore/Events/Serialization.cpp
+++ b/Core/GDCore/Events/Serialization.cpp
@@ -4,6 +4,7 @@
  * reserved. This project is released under the MIT License.
  */
 #include "GDCore/Events/Serialization.h"
+
 #include "GDCore/CommonTools.h"
 #include "GDCore/Events/Event.h"
 #include "GDCore/Events/EventsList.h"
@@ -232,7 +233,8 @@ void EventsListSerialization::SerializeEventsTo(const EventsList& list,
     const gd::BaseEvent& event = list.GetEvent(j);
     SerializerElement& eventElem = events.AddChild("event");
 
-    if (event.IsDisabled()) eventElem.SetAttribute("disabled", event.IsDisabled());
+    if (event.IsDisabled())
+      eventElem.SetAttribute("disabled", event.IsDisabled());
     if (event.IsFolded()) eventElem.SetAttribute("folded", event.IsFolded());
     eventElem.AddChild("type").SetValue(event.GetType());
 
@@ -340,9 +342,10 @@ void gd::EventsListSerialization::SerializeInstructionsTo(
   instructions.ConsiderAsArrayOf("instruction");
   for (std::size_t k = 0; k < list.size(); k++) {
     SerializerElement& instruction = instructions.AddChild("instruction");
-    instruction.AddChild("type")
-        .SetAttribute("value", list[k].GetType())
-        .SetAttribute("inverted", list[k].IsInverted());
+    instruction.AddChild("type").SetAttribute("value", list[k].GetType());
+
+    if (list[k].IsInverted())
+      instruction.GetChild("type").SetAttribute("inverted", true);
 
     // Parameters
     SerializerElement& parameters = instruction.AddChild("parameters");
@@ -352,9 +355,10 @@ void gd::EventsListSerialization::SerializeInstructionsTo(
           .SetValue(list[k].GetParameter(l).GetPlainString());
 
     // Sub instructions
-    SerializerElement& subInstructions =
-        instruction.AddChild("subInstructions");
-    SerializeInstructionsTo(list[k].GetSubInstructions(), subInstructions);
+    if (!list[k].GetSubInstructions().empty()) {
+      SerializeInstructionsTo(list[k].GetSubInstructions(),
+                              instruction.AddChild("subInstructions"));
+    }
   }
 }
 

--- a/Core/GDCore/Project/Layout.cpp
+++ b/Core/GDCore/Project/Layout.cpp
@@ -54,11 +54,8 @@ Layout::Layout()
       oglFOV(90.0f),
       oglZNear(1.0f),
       oglZFar(500.0f),
-      disableInputWhenNotFocused(true)
-#if defined(GD_IDE_ONLY)
-      ,
+      disableInputWhenNotFocused(true),
       profiler(NULL)
-#endif
 {
   gd::Layer layer;
   layer.SetCameraCount(1);
@@ -332,7 +329,6 @@ void Layout::UnserializeFrom(gd::Project& project,
   disableInputWhenNotFocused =
       element.GetBoolAttribute("disableInputWhenNotFocused");
 
-#if defined(GD_IDE_ONLY)
   editorSettings.UnserializeFrom(
       element.GetChild("uiSettings", 0, "UISettings"));
 
@@ -340,7 +336,6 @@ void Layout::UnserializeFrom(gd::Project& project,
       element.GetChild("objectsGroups", 0, "GroupesObjets"));
   gd::EventsListSerialization::UnserializeEventsFrom(
       project, GetEvents(), element.GetChild("events", 0, "Events"));
-#endif
 
   UnserializeObjectsFrom(project, element.GetChild("objects", 0, "Objets"));
   initialInstances.UnserializeFrom(
@@ -410,13 +405,11 @@ void Layout::Init(const Layout& other) {
         std::unique_ptr<gd::BehaviorContent>(it.second->Clone());
   }
 
-#if defined(GD_IDE_ONLY)
   events = other.events;
   editorSettings = other.editorSettings;
   objectGroups = other.objectGroups;
 
   profiler = other.profiler;
-#endif
 }
 
 std::vector<gd::String> GetHiddenLayers(const Layout& layout) {
@@ -430,7 +423,6 @@ std::vector<gd::String> GetHiddenLayers(const Layout& layout) {
   return hiddenLayers;
 }
 
-#if defined(GD_IDE_ONLY)
 gd::String GD_CORE_API GetTypeOfObject(const gd::ObjectsContainer& project,
                                        const gd::ObjectsContainer& layout,
                                        gd::String name,
@@ -612,6 +604,5 @@ GetBehaviorsOfObject(const gd::ObjectsContainer& project,
 
   return behaviors;
 }
-#endif
 
 }  // namespace gd

--- a/GDevelop.js/__tests__/GDJSAsyncCodeGenerationIntegrationTests.js
+++ b/GDevelop.js/__tests__/GDJSAsyncCodeGenerationIntegrationTests.js
@@ -21,8 +21,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -35,7 +33,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 parameters: ['SuccessVariable', '+', '1'],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -66,8 +63,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -88,7 +83,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 parameters: ['SuccessVariable', '+', '2'],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -125,8 +119,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -143,7 +135,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -191,8 +182,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -219,7 +208,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -276,8 +264,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [
               {
@@ -293,8 +279,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
             ],
             events: [
               {
-                disabled: false,
-                folded: false,
                 type: 'BuiltinCommonInstructions::Standard',
                 conditions: [],
                 actions: [
@@ -314,7 +298,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                     ],
                   },
                 ],
-                events: [],
               },
             ],
           },
@@ -391,8 +374,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -403,8 +384,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
             ],
             events: [
               {
-                disabled: false,
-                folded: false,
                 type: 'BuiltinCommonInstructions::Standard',
                 conditions: [
                   {
@@ -429,7 +408,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                     ],
                   },
                 ],
-                events: [],
               },
             ],
           },
@@ -506,8 +484,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             // Do a first filtering.
             conditions: [
@@ -524,8 +500,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
             ],
             events: [
               {
-                disabled: false,
-                folded: false,
                 type: 'BuiltinCommonInstructions::Standard',
                 // Filter with the more precise condition first.
                 conditions: [
@@ -537,8 +511,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 actions: [],
                 events: [
                   {
-                    disabled: false,
-                    folded: false,
                     type: 'BuiltinCommonInstructions::Standard',
                     // Filter with a less precise condition then.
                     conditions: [
@@ -569,7 +541,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                         ],
                       },
                     ],
-                    events: [],
                   },
                 ],
               },
@@ -670,8 +641,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             // Do a first filtering.
             conditions: [
@@ -688,8 +657,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
             ],
             events: [
               {
-                disabled: false,
-                folded: false,
                 type: 'BuiltinCommonInstructions::Standard',
                 // Filter with the more precise condition first.
                 conditions: [
@@ -701,8 +668,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 actions: [],
                 events: [
                   {
-                    disabled: false,
-                    folded: false,
                     type: 'BuiltinCommonInstructions::Standard',
                     // Filter with a less precise condition then.
                     conditions: [
@@ -733,13 +698,10 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                         ],
                       },
                     ],
-                    events: [],
                   },
                   // Add an event to prevent optimisation (reuse of the same objects list)
                   // in the previous event.
                   {
-                    disabled: false,
-                    folded: false,
                     type: 'BuiltinCommonInstructions::Standard',
                     conditions: [
                       {
@@ -753,7 +715,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                       },
                     ],
                     actions: [],
-                    events: [],
                   },
                 ],
               },
@@ -854,8 +815,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -866,8 +825,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
             ],
             events: [
               {
-                disabled: false,
-                folded: false,
                 type: 'BuiltinCommonInstructions::Standard',
                 conditions: [
                   {
@@ -878,8 +835,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 actions: [],
                 events: [
                   {
-                    disabled: false,
-                    folded: false,
                     type: 'BuiltinCommonInstructions::Standard',
                     conditions: [
                       {
@@ -909,13 +864,10 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                         ],
                       },
                     ],
-                    events: [],
                   },
                   // Add an event to prevent optimisation (reuse of the same objects list)
                   // in the previous event.
                   {
-                    disabled: false,
-                    folded: false,
                     type: 'BuiltinCommonInstructions::Standard',
                     conditions: [
                       {
@@ -929,7 +881,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                       },
                     ],
                     actions: [],
-                    events: [],
                   },
                 ],
               },
@@ -1021,8 +972,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -1062,7 +1011,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -1171,8 +1119,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -1203,7 +1149,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -1314,8 +1259,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [
               {
@@ -1360,7 +1303,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -1490,8 +1432,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -1531,7 +1471,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -1690,7 +1629,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -1799,7 +1737,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -1917,7 +1854,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -1997,8 +1933,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [
               {
@@ -2038,7 +1972,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -2148,8 +2081,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [
               {
@@ -2193,7 +2124,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 ],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -2310,8 +2240,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const eventsSerializerElement = gd.Serializer.fromJSON(
         JSON.stringify([
           {
-            disabled: false,
-            folded: false,
             type: 'BuiltinCommonInstructions::Standard',
             conditions: [],
             actions: [
@@ -2336,7 +2264,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                 parameters: ['SuccessVariable', '+', '1'],
               },
             ],
-            events: [],
           },
         ])
       );
@@ -2509,7 +2436,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                     ],
                   },
                 ],
-                events: [],
               },
             ],
           },
@@ -2610,7 +2536,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
               parameters: ['Counter', '=', '0'],
             },
           ],
-          events: [],
         },
         {
           infiniteLoopWarning: true,
@@ -2646,7 +2571,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
               ],
             },
           ],
-          events: [],
         },
       ]);
 
@@ -2728,7 +2652,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
               parameters: ['Counter', '=', '0'],
             },
           ],
-          events: [],
         },
         {
           infiniteLoopWarning: true,
@@ -2775,7 +2698,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                   ],
                 },
               ],
-              events: [],
             },
           ],
         },
@@ -2800,8 +2722,7 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
       const runCompiledEvents = generateCompiledEventsForEventsFunction(
         gd,
         project,
-        eventsFunction,
-        true
+        eventsFunction
       );
 
       eventsFunction.delete();
@@ -2880,7 +2801,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
               ],
             },
           ],
-          events: [],
         },
       ]);
 
@@ -3018,7 +2938,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
               parameters: ['MyOtherParamObject', 'TestVariable', '+', '4'],
             },
           ],
-          events: [],
         },
       ]);
 
@@ -3272,7 +3191,6 @@ describe('libGD.js - GDJS Async Code Generation integration tests', function () 
                     ],
                   },
                 ],
-                events: [],
               },
             ],
           },


### PR DESCRIPTION
Only show in developer changelog