### PR TITLE
Fix ctrl z for events sheet

### DIFF
--- a/Core/GDCore/Events/Builtin/CommentEvent.cpp
+++ b/Core/GDCore/Events/Builtin/CommentEvent.cpp
@@ -23,8 +23,9 @@ vector<gd::String> CommentEvent::GetAllSearchableStrings() const {
 
 bool CommentEvent::ReplaceAllSearchableStrings(
     std::vector<gd::String> newSearchableString) {
+  bool isCommentModified = newSearchableString[0] != com1;
   SetComment(newSearchableString[0]);
-  return newSearchableString[0] == com1;
+  return isCommentModified;
 }
 
 void CommentEvent::SerializeTo(SerializerElement &element) const {

--- a/Core/GDCore/Events/Builtin/GroupEvent.cpp
+++ b/Core/GDCore/Events/Builtin/GroupEvent.cpp
@@ -29,8 +29,9 @@ vector<gd::String> GroupEvent::GetAllSearchableStrings() const {
 
 bool GroupEvent::ReplaceAllSearchableStrings(
     std::vector<gd::String> newSearchableString) {
+  bool isGroupNameModified = newSearchableString[0] != name;
   SetName(newSearchableString[0]);
-  return newSearchableString[0] == name;
+  return isGroupNameModified;
 }
 
 void GroupEvent::SerializeTo(SerializerElement& element) const {

--- a/Core/GDCore/IDE/Events/EventsRefactorer.h
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.h
@@ -7,6 +7,7 @@
 #define GDCORE_EVENTSREFACTORER_H
 #include <memory>
 #include <vector>
+
 #include "GDCore/Events/Instruction.h"
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/String.h"
@@ -18,7 +19,7 @@ class ExternalEvents;
 class BaseEvent;
 class Instruction;
 typedef std::shared_ptr<gd::BaseEvent> BaseEventSPtr;
-}
+}  // namespace gd
 
 namespace gd {
 
@@ -43,10 +44,11 @@ class GD_CORE_API EventsSearchResult {
   bool IsEventsListValid() const { return eventsList != nullptr; }
 
   /**
-   * \brief Get the events list containing the event pointed by the EventsSearchResult.
-   * \warning Only call this when IsEventsListValid returns true.
+   * \brief Get the events list containing the event pointed by the
+   * EventsSearchResult. \warning Only call this when IsEventsListValid returns
+   * true.
    */
-  const gd::EventsList & GetEventsList() const { return *eventsList; }
+  const gd::EventsList& GetEventsList() const { return *eventsList; }
 
   std::size_t GetPositionInList() const { return positionInList; }
 
@@ -56,7 +58,7 @@ class GD_CORE_API EventsSearchResult {
    * \brief Get the event pointed by the EventsSearchResult.
    * \warning Only call this when IsEventValid returns true.
    */
-  const gd::BaseEvent & GetEvent() const { return *event.lock(); }
+  const gd::BaseEvent& GetEvent() const { return *event.lock(); }
 };
 
 /**
@@ -98,27 +100,31 @@ class GD_CORE_API EventsRefactorer {
    * \return A vector containing EventsSearchResult objects filled with events
    * containing the string
    */
-  static std::vector<EventsSearchResult> SearchInEvents(const gd::Platform& platform,
-                                                        gd::EventsList& events,
-                                                        gd::String search,
-                                                        bool matchCase,
-                                                        bool inConditions,
-                                                        bool inActions,
-                                                        bool inEventStrings,
-                                                        bool inEventSentences);
+  static std::vector<EventsSearchResult> SearchInEvents(
+      const gd::Platform& platform,
+      gd::EventsList& events,
+      gd::String search,
+      bool matchCase,
+      bool inConditions,
+      bool inActions,
+      bool inEventStrings,
+      bool inEventSentences);
 
   /**
    * Replace all occurrences of a gd::String in events
+   *
+   * \return A vector of all events modified.
    */
-  static void ReplaceStringInEvents(gd::ObjectsContainer& project,
-                                    gd::ObjectsContainer& layout,
-                                    gd::EventsList& events,
-                                    gd::String toReplace,
-                                    gd::String newString,
-                                    bool matchCase,
-                                    bool inConditions,
-                                    bool inActions,
-                                    bool inEventString);
+  static std::vector<EventsSearchResult> ReplaceStringInEvents(
+      gd::ObjectsContainer& project,
+      gd::ObjectsContainer& layout,
+      gd::EventsList& events,
+      gd::String toReplace,
+      gd::String newString,
+      bool matchCase,
+      bool inConditions,
+      bool inActions,
+      bool inEventString);
 
   virtual ~EventsRefactorer(){};
 
@@ -148,20 +154,21 @@ class GD_CORE_API EventsRefactorer {
                                        gd::InstructionsList& instructions,
                                        gd::String oldName,
                                        gd::String newName);
-   /**
+  /**
    * Replace all occurrences of an object name by another name in an expression
    * with the specified metadata
    * ( include : objects or objects in math/text expressions ).
    *
    * \return true if something was modified.
    */
-  static bool RenameObjectInEventParameters(const gd::Platform& platform,
-                                            gd::ObjectsContainer& project,
-                                            gd::ObjectsContainer& layout,
-                                            gd::Expression& expression,
-                                            gd::ParameterMetadata parameterMetadata,
-                                            gd::String oldName,
-                                            gd::String newName);
+  static bool RenameObjectInEventParameters(
+      const gd::Platform& platform,
+      gd::ObjectsContainer& project,
+      gd::ObjectsContainer& layout,
+      gd::Expression& expression,
+      gd::ParameterMetadata parameterMetadata,
+      gd::String oldName,
+      gd::String newName);
 
   /**
    * Remove all conditions of the list using an object

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1935,7 +1935,7 @@ interface VectorEventsSearchResult {
 interface EventsRefactorer {
     void STATIC_RenameObjectInEvents([Const, Ref] Platform platform, [Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString oldName, [Const] DOMString newName);
     void STATIC_RemoveObjectInEvents([Const, Ref] Platform platform, [Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString name);
-    void STATIC_ReplaceStringInEvents([Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString toReplace, [Const] DOMString newString, boolean matchCase, boolean inConditions, boolean inActions,  boolean inEventStrings);
+    [Value] VectorEventsSearchResult STATIC_ReplaceStringInEvents([Ref] ObjectsContainer project, [Ref] ObjectsContainer layout, [Ref] EventsList events, [Const] DOMString toReplace, [Const] DOMString newString, boolean matchCase, boolean inConditions, boolean inActions,  boolean inEventStrings);
     [Value] VectorEventsSearchResult STATIC_SearchInEvents([Const, Ref] Platform platform, [Ref] EventsList events, [Const] DOMString search, boolean matchCase, boolean inConditions, boolean inActions, boolean inEventStrings, boolean inEventSentences);
 };
 

--- a/GDevelop.js/types/gdeventsrefactorer.js
+++ b/GDevelop.js/types/gdeventsrefactorer.js
@@ -2,7 +2,7 @@
 declare class gdEventsRefactorer {
   static renameObjectInEvents(platform: gdPlatform, project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, oldName: string, newName: string): void;
   static removeObjectInEvents(platform: gdPlatform, project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, name: string): void;
-  static replaceStringInEvents(project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, toReplace: string, newString: string, matchCase: boolean, inConditions: boolean, inActions: boolean, inEventStrings: boolean): void;
+  static replaceStringInEvents(project: gdObjectsContainer, layout: gdObjectsContainer, events: gdEventsList, toReplace: string, newString: string, matchCase: boolean, inConditions: boolean, inActions: boolean, inEventStrings: boolean): gdVectorEventsSearchResult;
   static searchInEvents(platform: gdPlatform, events: gdEventsList, search: string, matchCase: boolean, inConditions: boolean, inActions: boolean, inEventStrings: boolean, inEventSentences: boolean): gdVectorEventsSearchResult;
   delete(): void;
   ptr: number;

--- a/newIDE/app/src/EventsSheet/EventsSearcher.js
+++ b/newIDE/app/src/EventsSheet/EventsSearcher.js
@@ -40,7 +40,10 @@ type Props = {|
     eventsSearchResultEvents: ?Array<gdBaseEvent>,
     searchFocusOffset: ?number,
     searchInEvents: (SearchInEventsInputs, cb: () => void) => void,
-    replaceInEvents: ReplaceInEventsInputs => void,
+    replaceInEvents: (
+      ReplaceInEventsInputs,
+      cb: () => void
+    ) => ?Array<gdBaseEvent>,
     goToNextSearchResult: () => ?gdBaseEvent,
     goToPreviousSearchResult: () => ?gdBaseEvent,
     clearSearchResults: () => void,
@@ -112,15 +115,37 @@ export default class EventsSearcher extends React.Component<Props, State> {
     });
   };
 
-  _doReplaceInEvents = ({
-    searchInSelection,
-    searchText,
-    replaceText,
-    matchCase,
-    searchInConditions,
-    searchInActions,
-    searchInEventStrings,
-  }: ReplaceInEventsInputs) => {
+  _deduplicateEventSearchResults = (
+    eventsSearchResults: gdVectorEventsSearchResult
+  ) => {
+    const resultEventsWithDuplicates = mapFor(
+      0,
+      eventsSearchResults.size(),
+      i => {
+        const eventsSearchResult = eventsSearchResults.at(i);
+        return eventsSearchResult.isEventValid()
+          ? eventsSearchResult.getEvent()
+          : null;
+      }
+    ).filter(Boolean);
+
+    // Store a list of unique events, because browsing for results in the events
+    // tree is made event by event.
+    return uniqBy<gdBaseEvent>(resultEventsWithDuplicates, event => event.ptr);
+  };
+
+  _doReplaceInEvents = (
+    {
+      searchInSelection,
+      searchText,
+      replaceText,
+      matchCase,
+      searchInConditions,
+      searchInActions,
+      searchInEventStrings,
+    }: ReplaceInEventsInputs,
+    cb: () => void
+  ): ?Array<gdBaseEvent> => {
     const { globalObjectsContainer, objectsContainer, events } = this.props;
 
     if (searchInSelection) {
@@ -131,7 +156,7 @@ export default class EventsSearcher extends React.Component<Props, State> {
     }
     if (!replaceText) return;
 
-    gd.EventsRefactorer.replaceStringInEvents(
+    const modifiedEvents = gd.EventsRefactorer.replaceStringInEvents(
       globalObjectsContainer,
       objectsContainer,
       events,
@@ -142,6 +167,22 @@ export default class EventsSearcher extends React.Component<Props, State> {
       searchInActions,
       searchInEventStrings
     );
+    if (!modifiedEvents) return null;
+
+    if (this.state.eventsSearchResults) {
+      this.state.eventsSearchResults.delete();
+    }
+    this.setState(
+      {
+        eventsSearchResults: modifiedEvents.clone(),
+        searchFocusOffset: null,
+      },
+      () => {
+        this._updateListOfResultEvents();
+        cb();
+      }
+    );
+    return this._deduplicateEventSearchResults(modifiedEvents);
   };
 
   _doSearchInEvents = (
@@ -198,20 +239,11 @@ export default class EventsSearcher extends React.Component<Props, State> {
       return;
     }
 
-    const resultEventsWithDuplicates = mapFor(
-      0,
-      eventsSearchResults.size(),
-      i => {
-        const eventsSearchResult = eventsSearchResults.at(i);
-        return eventsSearchResult.isEventValid()
-          ? eventsSearchResult.getEvent()
-          : null;
-      }
-    ).filter(Boolean);
-
     // Store a list of unique events, because browsing for results in the events
     // tree is made event by event.
-    this._resultEvents = uniqBy(resultEventsWithDuplicates, event => event.ptr);
+    this._resultEvents = this._deduplicateEventSearchResults(
+      eventsSearchResults
+    );
   };
 
   _goToSearchResults = (step: number): ?gdBaseEvent => {

--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -132,7 +132,7 @@ type DropContainerProps = {|
     moveFunction: ({
       targetNode: SortableTreeNode,
       node: SortableTreeNode,
-    }) => void,
+    }) => number,
     node: SortableTreeNode
   ) => void,
   activateTargets: boolean,

--- a/newIDE/app/src/EventsSheet/EventsTree/helpers.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/helpers.js
@@ -34,6 +34,11 @@ export const moveNodeAsSubEvent = ({
     initialEventsList: node.eventsList,
     toIndex: 0,
   });
+  const previousRowIndex = node.nodePath[node.nodePath.length - 1];
+  const targetRowIndex = targetNode.nodePath[targetNode.nodePath.length - 1];
+  return previousRowIndex <= targetRowIndex
+    ? targetRowIndex
+    : targetRowIndex + 1;
 };
 
 export const moveNodeBelow = ({ targetNode, node }: MoveFunctionArguments) => {
@@ -48,6 +53,11 @@ export const moveNodeBelow = ({ targetNode, node }: MoveFunctionArguments) => {
     initialEventsList: node.eventsList,
     toIndex,
   });
+  const previousRowIndex = node.nodePath[node.nodePath.length - 1];
+  const targetRowIndex = targetNode.nodePath[targetNode.nodePath.length - 1];
+  return previousRowIndex <= targetRowIndex
+    ? targetRowIndex
+    : targetRowIndex + 1;
 };
 
 export const moveNodeAbove = ({ targetNode, node }: MoveFunctionArguments) => {
@@ -62,6 +72,11 @@ export const moveNodeAbove = ({ targetNode, node }: MoveFunctionArguments) => {
     initialEventsList: node.eventsList,
     toIndex,
   });
+  const previousRowIndex = node.nodePath[node.nodePath.length - 1];
+  const targetRowIndex = targetNode.nodePath[targetNode.nodePath.length - 1];
+  return previousRowIndex <= targetRowIndex
+    ? targetRowIndex - 1
+    : targetRowIndex;
 };
 
 export const isDescendant = (

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -131,8 +131,6 @@ const SearchPanel = (
   };
 
   const launchReplace = () => {
-    launchSearch();
-
     onReplaceInEvents({
       searchInSelection,
       searchText,

--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -14,6 +14,14 @@ export type InstructionContext = {|
   indexInList: number,
 |};
 
+// Used for history management.
+type EventContainer = {| eventContainer: gdBaseEvent |};
+
+export type InstructionContextWithEventContainer = {
+  ...InstructionContext,
+  ...EventContainer,
+};
+
 export type ParameterContext = {|
   isCondition: boolean,
   instrsList: gdInstructionsList,
@@ -23,6 +31,11 @@ export type ParameterContext = {|
   domEvent?: any,
 |};
 
+export type ParameterContextWithEventContainer = {
+  ...ParameterContext,
+  ...EventContainer,
+};
+
 export type EventContext = {|
   eventsList: gdEventsList,
   event: gdBaseEvent,
@@ -30,7 +43,7 @@ export type EventContext = {|
 |};
 
 export type SelectionState = {
-  selectedInstructions: { [number]: InstructionContext },
+  selectedInstructions: { [number]: InstructionContextWithEventContainer },
   selectedInstructionsLists: { [number]: InstructionsListContext },
   selectedEvents: { [number]: EventContext },
 };
@@ -61,13 +74,23 @@ export const getSelectedInstructions = (
   selection: SelectionState
 ): Array<gdInstruction> => {
   return values(selection.selectedInstructions).map(
-    (instructionContext: InstructionContext) => instructionContext.instruction
+    (instructionContext: InstructionContextWithEventContainer) =>
+      instructionContext.instruction
+  );
+};
+
+export const getSelectedInstructionsEventContainers = (
+  selection: SelectionState
+): Array<gdBaseEvent> => {
+  return values(selection.selectedInstructions).map(
+    (instructionContext: InstructionContextWithEventContainer) =>
+      instructionContext.eventContainer
   );
 };
 
 export const getSelectedInstructionsContexts = (
   selection: SelectionState
-): Array<InstructionContext> => {
+): Array<InstructionContextWithEventContainer> => {
   return values(selection.selectedInstructions);
 };
 
@@ -154,6 +177,7 @@ export const selectEvent = (
 };
 
 export const selectInstruction = (
+  event: gdBaseEvent,
   selection: SelectionState,
   instructionContext: InstructionContext,
   multiSelection: boolean = false
@@ -166,7 +190,7 @@ export const selectInstruction = (
     ...existingSelection,
     selectedInstructions: {
       ...existingSelection.selectedInstructions,
-      [instruction.ptr]: instructionContext,
+      [instruction.ptr]: { ...instructionContext, eventContainer: event },
     },
   };
 };
@@ -188,4 +212,16 @@ export const selectInstructionsList = (
       [instructionsList.ptr]: instructionsListContext,
     },
   };
+};
+
+export const selectEventsAfterHistoryChange = (
+  eventContexts: Array<EventContext>
+) => {
+  let newSelection = getInitialSelection();
+
+  eventContexts.forEach(eventContext => {
+    newSelection.selectedEvents[eventContext.event.ptr] = eventContext;
+  });
+
+  return newSelection;
 };

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -492,7 +492,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
 
   closeEventTextDialog = () => {
     if (this.state.textEditedEvent) {
-      const positions = this._getChangedEventRows(this.state.textEditedEvent);
+      const positions = this._getChangedEventRows([this.state.textEditedEvent]);
       this._saveChangesToHistory('EDIT', {
         previous: positions,
         next: positions,
@@ -1766,7 +1766,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
                 )}
                 {this.state.textEditedEvent && (
                   <EventTextDialog
-                    event={this.state.textEditedEvent.event}
+                    event={this.state.textEditedEvent}
                     onApply={() => {
                       this.closeEventTextDialog();
                     }}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -509,7 +509,11 @@ export default class SceneEditor extends React.Component<Props, State> {
 
     this.setState(
       {
-        history: saveToHistory(this.state.history, this.props.initialInstances),
+        history: saveToHistory(
+          this.state.history,
+          this.props.initialInstances,
+          'ADD'
+        ),
       },
       () => this.updateToolbar()
     );
@@ -532,7 +536,11 @@ export default class SceneEditor extends React.Component<Props, State> {
   _onInstancesMoved = (instances: Array<gdInitialInstance>) => {
     this.setState(
       {
-        history: saveToHistory(this.state.history, this.props.initialInstances),
+        history: saveToHistory(
+          this.state.history,
+          this.props.initialInstances,
+          'EDIT'
+        ),
       },
       () => this.forceUpdatePropertiesEditor()
     );
@@ -541,7 +549,11 @@ export default class SceneEditor extends React.Component<Props, State> {
   _onInstancesResized = (instances: Array<gdInitialInstance>) => {
     this.setState(
       {
-        history: saveToHistory(this.state.history, this.props.initialInstances),
+        history: saveToHistory(
+          this.state.history,
+          this.props.initialInstances,
+          'EDIT'
+        ),
       },
       () => this.forceUpdatePropertiesEditor()
     );
@@ -550,7 +562,11 @@ export default class SceneEditor extends React.Component<Props, State> {
   _onInstancesRotated = (instances: Array<gdInitialInstance>) => {
     this.setState(
       {
-        history: saveToHistory(this.state.history, this.props.initialInstances),
+        history: saveToHistory(
+          this.state.history,
+          this.props.initialInstances,
+          'EDIT'
+        ),
       },
       () => this.forceUpdatePropertiesEditor()
     );
@@ -841,7 +857,11 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.setState(
       {
         selectedObjectNames: [],
-        history: saveToHistory(this.state.history, this.props.initialInstances),
+        history: saveToHistory(
+          this.state.history,
+          this.props.initialInstances,
+          'DELETE'
+        ),
       },
       () => {
         this.updateToolbar();
@@ -1175,10 +1195,12 @@ export default class SceneEditor extends React.Component<Props, State> {
                   canUndo: () => canUndo(this.state.history),
                   canRedo: () => canRedo(this.state.history),
                   saveToHistory: () =>
+                    // TODO: pass actionType as argument of saveToHistory
                     this.setState({
                       history: saveToHistory(
                         this.state.history,
-                        this.props.initialInstances
+                        this.props.initialInstances,
+                        'EDIT'
                       ),
                     }),
                 }}

--- a/newIDE/app/src/Utils/History.js
+++ b/newIDE/app/src/Utils/History.js
@@ -4,64 +4,96 @@ import { serializeToJSObject, unserializeFromJSObject } from './Serializer';
 // Tools function to keep track of the history of changes made
 // on a serializable object from libGD.js
 
+// There are 3 main types of changes:
+// - ADD: the object didn't exist before, and is now created
+// - DELETE: the object existed before, and is now removed
+// - EDIT: the object exists before and after (moved, disabled, changed, rotated, ...)
+export type RevertableActionType = 'ADD' | 'DELETE' | 'EDIT';
+
+export type UndoAction = {|
+  type: RevertableActionType,
+  valueBeforeChange: Object,
+  changeContext: any,
+|};
+
+export type RedoAction = {|
+  type: RevertableActionType,
+  valueAfterChange: Object,
+  changeContext: any,
+|};
+
 export type HistoryState = {|
-  undoHistory: Array<Object>,
-  current: Object,
-  redoHistory: Array<Object>,
+  previousActions: Array<UndoAction>,
+  currentValue: Object,
+  futureActions: Array<RedoAction>,
   maxSize: number,
 |};
 
 /**
- * Return the initial state of the history
- * @param {*} serializableObject
+ * Return the initial state of the history.
+ * We store the current value so we can easily save a new history
+ * without sending the previous value.
  */
 export const getHistoryInitialState = (
   serializableObject: gdSerializable,
-  { historyMaxSize }: { historyMaxSize: number }
+  {
+    historyMaxSize,
+  }: {
+    historyMaxSize: number,
+  }
 ): HistoryState => {
   return {
-    undoHistory: [],
-    current: serializeToJSObject(serializableObject),
-    redoHistory: [],
+    previousActions: [],
+    currentValue: serializeToJSObject(serializableObject),
+    futureActions: [],
     maxSize: historyMaxSize,
   };
 };
 
 /**
  * Return true if redo can be applied for the given history
- * @param {*} history
  */
 export const canRedo = (history: HistoryState): boolean => {
-  return !!history.redoHistory.length;
+  return !!history.futureActions.length;
 };
 
 /**
  * Return true if undo can be applied for the given history
- * @param {*} history
  */
 export const canUndo = (history: HistoryState): boolean => {
-  return !!history.undoHistory.length;
+  return !!history.previousActions.length;
 };
 
 /**
  * Save a new state of the given serializableObject to the history
- * @param {*} history
- * @param {*} serializableObject
  */
 export const saveToHistory = (
   history: HistoryState,
-  serializableObject: gdSerializable
+  newCurrentSerializedValue: gdSerializable,
+  actionType: RevertableActionType,
+  changeContext?: any
 ): HistoryState => {
-  const newUndoHistory = [...history.undoHistory, history.current];
-  if (newUndoHistory.length > history.maxSize) {
-    newUndoHistory.splice(0, newUndoHistory.length - history.maxSize);
+  const newCurrentValue = serializeToJSObject(newCurrentSerializedValue);
+  // Add the current state to the previous actions.
+  const newPreviousActions = [
+    ...history.previousActions,
+    {
+      type: actionType,
+      valueBeforeChange: history.currentValue,
+      changeContext,
+    },
+  ];
+  const newFutureActions = []; // Empty the future actions on save.
+  // If we reach the max size, remove the oldest action.
+  if (newPreviousActions.length > history.maxSize) {
+    newPreviousActions.splice(0, newPreviousActions.length - history.maxSize);
   }
 
   return {
-    undoHistory: newUndoHistory,
-    current: serializeToJSObject(serializableObject),
-    redoHistory: [],
-    maxSize: history.maxSize,
+    ...history,
+    currentValue: newCurrentValue,
+    previousActions: newPreviousActions,
+    futureActions: newFutureActions,
   };
 };
 
@@ -69,32 +101,43 @@ export const saveToHistory = (
  * Update the serializableObject to undo the last changes.
  * /!\ This mutates the serializableObject and there could be objects owned by it
  * deleted or becoming invalid. Be sure to drop/refresh any reference to them.
- *
- * @param {*} history
- * @param {*} serializableObject
  */
 export const undo = (
   history: HistoryState,
   serializableObject: gdSerializable,
   project: ?gdProject = undefined
 ): HistoryState => {
-  if (!history.undoHistory.length) {
+  if (!history.previousActions.length) {
     return history;
   }
 
-  const newCurrent = history.undoHistory[history.undoHistory.length - 1];
+  // Unserialize the events of the previous action and
+  // move the current value to the future actions to allow redo.
+  const previousAction =
+    history.previousActions[history.previousActions.length - 1];
+  const newCurrentValue = previousAction.valueBeforeChange;
   unserializeFromJSObject(
     serializableObject,
-    newCurrent,
+    newCurrentValue,
     'unserializeFrom',
     project
   );
 
+  const newPreviousActions = history.previousActions.slice(0, -1);
+  const newFutureActions = [
+    ...history.futureActions,
+    {
+      type: previousAction.type,
+      changeContext: previousAction.changeContext,
+      valueAfterChange: history.currentValue,
+    },
+  ];
+
   return {
-    undoHistory: history.undoHistory.slice(0, -1),
-    current: newCurrent,
-    redoHistory: [...history.redoHistory, history.current],
-    maxSize: history.maxSize,
+    ...history,
+    previousActions: newPreviousActions,
+    futureActions: newFutureActions,
+    currentValue: newCurrentValue,
   };
 };
 
@@ -102,31 +145,41 @@ export const undo = (
  * Update the serializableObject to undo the last changes.
  * /!\ This mutates the serializableObject and there could be objects owned by it
  * deleted or becoming invalid. Be sure to drop/refresh any reference to them.
- *
- * @param {*} history
- * @param {*} serializableObject
  */
 export const redo = (
   history: HistoryState,
   serializableObject: gdSerializable,
   project: ?gdProject = undefined
 ): HistoryState => {
-  if (!history.redoHistory.length) {
+  if (!history.futureActions.length) {
     return history;
   }
 
-  const newCurrent = history.redoHistory[history.redoHistory.length - 1];
+  // Unserialize the events of the future action and
+  // move the future action to the previous actions to allow undo.
+  const futureAction = history.futureActions[history.futureActions.length - 1];
+  const newCurrentValue = futureAction.valueAfterChange;
   unserializeFromJSObject(
     serializableObject,
-    newCurrent,
+    newCurrentValue,
     'unserializeFrom',
     project
   );
 
+  const newPreviousActions = [
+    ...history.previousActions,
+    {
+      type: futureAction.type,
+      changeContext: futureAction.changeContext,
+      valueBeforeChange: history.currentValue,
+    },
+  ];
+  const newFutureActions = history.futureActions.slice(0, -1);
+
   return {
-    undoHistory: [...history.undoHistory, history.current],
-    current: newCurrent,
-    redoHistory: history.redoHistory.slice(0, -1),
-    maxSize: history.maxSize,
+    ...history,
+    previousActions: newPreviousActions,
+    futureActions: newFutureActions,
+    currentValue: newCurrentValue,
   };
 };

--- a/newIDE/app/src/Utils/History.spec.js
+++ b/newIDE/app/src/Utils/History.spec.js
@@ -1,3 +1,4 @@
+// @flow
 import {
   getHistoryInitialState,
   canRedo,
@@ -15,36 +16,30 @@ describe('History', () => {
 
     gdVariable.setString('Original value');
     let history = getHistoryInitialState(gdVariable, { historyMaxSize: 50 });
-
     expect(canUndo(history)).toBe(false);
     expect(canRedo(history)).toBe(false);
 
     gdVariable.setString('New value 1');
-    history = saveToHistory(history, gdVariable);
-
+    history = saveToHistory(history, gdVariable, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
     gdVariable.setString('New value 2');
-    history = saveToHistory(history, gdVariable);
-
+    history = saveToHistory(history, gdVariable, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
     history = undo(history, gdVariable);
-
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(true);
     expect(gdVariable.getString()).toBe('New value 1');
 
     history = undo(history, gdVariable);
-
     expect(canUndo(history)).toBe(false);
     expect(canRedo(history)).toBe(true);
     expect(gdVariable.getString()).toBe('Original value');
 
     history = redo(history, gdVariable);
-
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(true);
     expect(gdVariable.getString()).toBe('New value 1');
@@ -59,13 +54,12 @@ describe('History', () => {
     expect(canRedo(history)).toBe(false);
 
     testLayout.setWindowDefaultTitle('New name 1');
-    history = saveToHistory(history, testLayout);
-
+    history = saveToHistory(history, testLayout, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
     testLayout.setWindowDefaultTitle('New name 2');
-    history = saveToHistory(history, testLayout);
+    history = saveToHistory(history, testLayout, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
@@ -90,61 +84,51 @@ describe('History', () => {
 
     gdVariable.setString('Original value');
     let history = getHistoryInitialState(gdVariable, { historyMaxSize: 2 });
-
     expect(canUndo(history)).toBe(false);
     expect(canRedo(history)).toBe(false);
 
     gdVariable.setString('New value 1');
-    history = saveToHistory(history, gdVariable);
-
+    history = saveToHistory(history, gdVariable, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
     gdVariable.setString('New value 2');
-    history = saveToHistory(history, gdVariable);
-
+    history = saveToHistory(history, gdVariable, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
     gdVariable.setString('New value 3');
-    history = saveToHistory(history, gdVariable);
-
+    history = saveToHistory(history, gdVariable, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
     history = undo(history, gdVariable);
-
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(true);
     expect(gdVariable.getString()).toBe('New value 2');
 
     history = undo(history, gdVariable);
-
     expect(canUndo(history)).toBe(false);
     expect(canRedo(history)).toBe(true);
     expect(gdVariable.getString()).toBe('New value 1');
 
     history = redo(history, gdVariable);
     history = redo(history, gdVariable);
-
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
     expect(gdVariable.getString()).toBe('New value 3');
 
     gdVariable.setString('New value 4');
-    history = saveToHistory(history, gdVariable);
-
+    history = saveToHistory(history, gdVariable, 'EDIT');
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(false);
 
     history = undo(history, gdVariable);
-
     expect(canUndo(history)).toBe(true);
     expect(canRedo(history)).toBe(true);
     expect(gdVariable.getString()).toBe('New value 3');
 
     history = undo(history, gdVariable);
-
     expect(canUndo(history)).toBe(false);
     expect(canRedo(history)).toBe(true);
     expect(gdVariable.getString()).toBe('New value 2');

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -293,7 +293,8 @@ const VariablesList = ({ onComputeAllVariableNames, ...props }: Props) => {
   const _saveToHistory = () => {
     props.historyHandler
       ? props.historyHandler.saveToHistory()
-      : setHistory(saveToHistory(history, props.variablesContainer));
+      : // TODO: pass actionType as argument of saveToHistory
+        setHistory(saveToHistory(history, props.variablesContainer, 'EDIT'));
   };
 
   const _undo = () => {


### PR DESCRIPTION
- Scrolls to one of the event modified when reverting the change.
- Selects all changed events (technically, it is harder to localise instructions and parameters in the event sheet, which is the reason why I opted for selecting the whole event instead for now).

| Scroll demonstration | Selection demonstration |
| --- | --- |
| ![](https://media.giphy.com/media/3CScYXjDBrl6pxjVld/giphy.gif) | ![](https://media.giphy.com/media/AnB5jPySXclJOY9OJ6/giphy.gif) |

Test it here:
http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/fix-ctrl-z-for-eventssheet/latest/index.html?path=/story/eventssheet--default-no-scope
