### PR TITLE
Adapt leaderboard admin to new reset API

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/LeaderboardIdField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LeaderboardIdField.js
@@ -192,6 +192,11 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                 onClose={() => setIsAdminOpen(false)}
                 open={isAdminOpen}
                 project={props.project}
+                leaderboardId={
+                  isCurrentValueInLeaderboardList
+                    ? props.value.replace(/"/g, '')
+                    : undefined
+                }
               />
             )}
           </>

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -68,7 +68,12 @@ import LeaderboardSortOptionsDialog from './LeaderboardSortOptionsDialog';
 import { type LeaderboardSortOption } from '../../Utils/GDevelopServices/Play';
 import { formatScore } from '../../Leaderboard/LeaderboardScoreFormatter';
 
-type Props = {| onLoading: boolean => void, project?: gdProject |};
+type Props = {|
+  onLoading: boolean => void,
+  project?: gdProject,
+  leaderboardIdToSelectAtOpening?: string,
+|};
+
 type ContainerProps = {| ...Props, gameId: string |};
 
 type ApiError = {|
@@ -172,7 +177,11 @@ const getSortOrderText = (currentLeaderboard: Leaderboard) => {
   return <Trans>Higher is better</Trans>;
 };
 
-export const LeaderboardAdmin = ({ onLoading, project }: Props) => {
+export const LeaderboardAdmin = ({
+  onLoading,
+  project,
+  leaderboardIdToSelectAtOpening,
+}: Props) => {
   const isOnline = useOnlineStatus();
   const windowWidth = useResponsiveWindowWidth();
   const [isEditingAppearance, setIsEditingAppearance] = React.useState<boolean>(
@@ -434,6 +443,14 @@ export const LeaderboardAdmin = ({ onLoading, project }: Props) => {
     // This has to be executed on component mount to refresh entries on each admin opening
     // eslint-disable-next-line
   }, []);
+
+  React.useEffect(
+    () => {
+      if (!!leaderboardIdToSelectAtOpening)
+        selectLeaderboard(leaderboardIdToSelectAtOpening);
+    },
+    [leaderboardIdToSelectAtOpening, selectLeaderboard]
+  );
 
   const onCopy = React.useCallback(
     () => {

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -635,7 +635,8 @@ export const LeaderboardAdmin = ({
             {i18n.date(currentLeaderboard.resetLaunchedAt, {
               dateStyle: 'short',
               timeStyle: 'short',
-            })}. Please wait a few minutes...
+            })}
+            . Please wait a few minutes...
           </Trans>
         </Text>
       ) : (

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -635,7 +635,7 @@ export const LeaderboardAdmin = ({
             {i18n.date(currentLeaderboard.resetLaunchedAt, {
               dateStyle: 'short',
               timeStyle: 'short',
-            })}
+            })}. Please wait a few minutes...
           </Trans>
         </Text>
       ) : (

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -337,12 +337,18 @@ export const LeaderboardAdmin = ({ onLoading, project }: Props) => {
       console.error('An error occurred when resetting leaderboard', err);
       setApiError({
         action: 'leaderboardReset',
-        message: (
-          <Trans>
-            An error occurred when resetting the leaderboard, please close the
-            dialog, come back and try again.
-          </Trans>
-        ),
+        message:
+          err.status && err.status === 409 ? (
+            <Trans>
+              This leaderboard is already resetting, please wait a bit, close
+              the dialog, come back and try again.
+            </Trans>
+          ) : (
+            <Trans>
+              An error occurred when resetting the leaderboard, please close the
+              dialog, come back and try again.
+            </Trans>
+          ),
       });
     } finally {
       setIsLoading(false);
@@ -605,7 +611,17 @@ export const LeaderboardAdmin = ({ onLoading, project }: Props) => {
     {
       key: 'startDatetime',
       avatar: <Today />,
-      text: (
+      text: currentLeaderboard.resetLaunchedAt ? (
+        <Text size="body2">
+          <Trans>
+            Reset requested the{' '}
+            {i18n.date(currentLeaderboard.resetLaunchedAt, {
+              dateStyle: 'short',
+              timeStyle: 'short',
+            })}
+          </Trans>
+        </Text>
+      ) : (
         <Tooltip
           title={i18n._(
             t`Date from which entries are taken into account: ${i18n.date(
@@ -633,7 +649,11 @@ export const LeaderboardAdmin = ({ onLoading, project }: Props) => {
           onClick={() => onResetLeaderboard(i18n)}
           tooltip={t`Reset leaderboard`}
           edge="end"
-          disabled={isRequestPending || isEditingName}
+          disabled={
+            isRequestPending ||
+            isEditingName ||
+            !!currentLeaderboard.resetLaunchedAt
+          }
         >
           <Update />
         </IconButton>

--- a/newIDE/app/src/Leaderboard/LeaderboardContext.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardContext.js
@@ -21,7 +21,11 @@ export type LeaderboardState = {|
     name: string,
     sort: LeaderboardSortOption,
   |}) => Promise<?Leaderboard>,
-  listLeaderboards: () => Promise<void>,
+  listLeaderboards: (
+    ?{
+      shouldClearBeforeFetching?: boolean,
+    }
+  ) => Promise<void>,
   selectLeaderboard: (id: string) => void,
   setDisplayOnlyBestEntry: boolean => void,
   updateLeaderboard: (payload: LeaderboardUpdatePayload) => Promise<void>,

--- a/newIDE/app/src/Leaderboard/LeaderboardDialog.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardDialog.js
@@ -11,9 +11,15 @@ type Props = {|
   onClose: () => void,
   open: boolean,
   project: gdProject,
+  leaderboardId?: string,
 |};
 
-const LeaderboardDialog = ({ onClose, open, project }: Props) => {
+const LeaderboardDialog = ({
+  onClose,
+  open,
+  project,
+  leaderboardId,
+}: Props) => {
   const [isLoading, setIsLoading] = React.useState(false);
   return (
     <Dialog
@@ -40,7 +46,11 @@ const LeaderboardDialog = ({ onClose, open, project }: Props) => {
       flexBody
       fullHeight
     >
-      <LeaderboardAdmin onLoading={setIsLoading} project={project} />
+      <LeaderboardAdmin
+        onLoading={setIsLoading}
+        project={project}
+        leaderboardIdToSelectAtOpening={leaderboardId}
+      />
     </Dialog>
   );
 };

--- a/newIDE/app/src/Leaderboard/LeaderboardProvider.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardProvider.js
@@ -208,11 +208,11 @@ const LeaderboardProvider = ({ gameId, children }: Props) => {
   });
 
   const listLeaderboards = React.useCallback(
-    async (shouldNotClearBeforeFetching?: boolean) => {
+    async (options: ?{ shouldClearBeforeFetching?: boolean }) => {
       if (!isListingLeaderboards.current) {
         isListingLeaderboards.current = true;
         try {
-          if (!shouldNotClearBeforeFetching)
+          if (options && options.shouldClearBeforeFetching)
             dispatch({ type: 'SET_LEADERBOARDS', payload: null });
           const fetchedLeaderboards = await listGameActiveLeaderboards(
             authenticatedUser,
@@ -430,7 +430,7 @@ const LeaderboardProvider = ({ gameId, children }: Props) => {
 
   useInterval(
     () => {
-      listLeaderboards(true);
+      listLeaderboards({ shouldClearBeforeFetching: false });
     },
     !leaderboardsByIds ||
       Object.values(leaderboardsByIds).every(

--- a/newIDE/app/src/Leaderboard/LeaderboardProvider.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardProvider.js
@@ -407,6 +407,27 @@ const LeaderboardProvider = ({ gameId, children }: Props) => {
     [currentLeaderboardId, displayOnlyBestEntry, fetchEntries, gameId]
   );
 
+  const previousCurrentLeaderboardId = React.useRef<?string>(null);
+  const previousCurrentLeaderboardResetLaunchedAt = React.useRef<?string>(null);
+
+  React.useEffect(
+    () => {
+      if (
+        previousCurrentLeaderboardId.current === currentLeaderboardId &&
+        !!previousCurrentLeaderboardResetLaunchedAt.current &&
+        !!currentLeaderboard &&
+        !currentLeaderboard.resetLaunchedAt
+      ) {
+        fetchEntries();
+      }
+      previousCurrentLeaderboardId.current = currentLeaderboardId;
+      previousCurrentLeaderboardResetLaunchedAt.current = currentLeaderboard
+        ? currentLeaderboard.resetLaunchedAt
+        : null;
+    },
+    [currentLeaderboard, currentLeaderboardId, fetchEntries]
+  );
+
   useInterval(
     () => {
       listLeaderboards(true);
@@ -414,7 +435,7 @@ const LeaderboardProvider = ({ gameId, children }: Props) => {
     !leaderboardsByIds ||
       Object.values(leaderboardsByIds).every(
         // $FlowFixMe
-        leaderboard => !leaderboard.resetLaunchedAt
+        (leaderboard: Leaderboard) => !leaderboard.resetLaunchedAt
       )
       ? null
       : 5000

--- a/newIDE/app/src/Leaderboard/LeaderboardProvider.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardProvider.js
@@ -71,11 +71,14 @@ const reducer = (state: ReducerState, action: ReducerAction): ReducerState => {
       const primaryLeaderboard = leaderboards.find(
         leaderboard => leaderboard.primary
       );
+      const currentLeaderboardUpdated = state.currentLeaderboard
+        ? leaderboardsByIds[state.currentLeaderboard.id]
+        : undefined;
+      const fallBackLeaderboard =
+        currentLeaderboardUpdated || state.currentLeaderboard;
       const newCurrentLeaderboard = shouldDefineCurrentLeaderboardIfNoneSelected
         ? primaryLeaderboard || leaderboards[0]
-        : (state.currentLeaderboard &&
-            leaderboardsByIds[state.currentLeaderboard.id]) ||
-          state.currentLeaderboard;
+        : fallBackLeaderboard;
       return {
         ...state,
         leaderboardsByIds,
@@ -205,11 +208,12 @@ const LeaderboardProvider = ({ gameId, children }: Props) => {
   });
 
   const listLeaderboards = React.useCallback(
-    async (silent?: boolean) => {
+    async (shouldNotClearBeforeFetching?: boolean) => {
       if (!isListingLeaderboards.current) {
         isListingLeaderboards.current = true;
         try {
-          if (!silent) dispatch({ type: 'SET_LEADERBOARDS', payload: null });
+          if (!shouldNotClearBeforeFetching)
+            dispatch({ type: 'SET_LEADERBOARDS', payload: null });
           const fetchedLeaderboards = await listGameActiveLeaderboards(
             authenticatedUser,
             gameId

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -51,6 +51,7 @@ export type Leaderboard = {|
   visibility: LeaderboardVisibilityOption,
   customizationSettings?: LeaderboardCustomizationSettings,
   primary?: boolean,
+  resetLaunchedAt?: string,
   extremeAllowedScore?: number,
 |};
 


### PR DESCRIPTION
Leaderboard reset API changed to be asynchronous to fix an issue where leaderboards with too many entries would make the backend timeout.

This PR:
- Make the reset trigger an async process
- Silently refreshes leaderboards every 5s when a leaderboard is resetting

Also:
- When one opens the leaderboard admin from the button in a leaderboard id field, the admin is opened with the selected leaderboard displayed (instead of the default leaderboard)