### PR TITLE
Improve Dialog Behavior consistency

### DIFF
--- a/newIDE/app/src/AssetStore/AssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/AssetPackDialog.js
@@ -1,0 +1,236 @@
+// @flow
+import * as React from 'react';
+import {
+  type AssetShortHeader,
+  type AssetPack,
+} from '../Utils/GDevelopServices/Asset';
+import Text from '../UI/Text';
+import { t, Trans } from '@lingui/macro';
+import Dialog from '../UI/Dialog';
+import TextButton from '../UI/TextButton';
+import RaisedButton from '../UI/RaisedButton';
+import RaisedButtonWithSplitMenu from '../UI/RaisedButtonWithSplitMenu';
+import { Column, Line } from '../UI/Grid';
+import { LinearProgress } from '@material-ui/core';
+import { installAsset } from './InstallAsset';
+import EventsFunctionsExtensionsContext from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import { useResourceFetcher } from '../ProjectsStorage/ResourceFetcher';
+import { showErrorBox } from '../UI/Messages/MessageBox';
+
+const styles = {
+  linearProgress: {
+    flex: 1,
+  },
+};
+
+type Props = {|
+  assetPack: AssetPack,
+  assetShortHeaders: Array<AssetShortHeader>,
+  addedAssetIds: Array<string>,
+  onClose: () => void,
+  onAssetPackAdded: () => void,
+  project: gdProject,
+  objectsContainer: gdObjectsContainer,
+  events: gdEventsList,
+  onObjectAddedFromAsset: (object: gdObject) => void,
+|};
+
+export const AssetPackDialog = ({
+  assetPack,
+  assetShortHeaders,
+  addedAssetIds,
+  onClose,
+  onAssetPackAdded,
+  project,
+  objectsContainer,
+  events,
+  onObjectAddedFromAsset,
+}: Props) => {
+  const missingAssetShortHeaders = assetShortHeaders.filter(
+    assetShortHeader => !addedAssetIds.includes(assetShortHeader.id)
+  );
+  const allAssetsInstalled = missingAssetShortHeaders.length === 0;
+  const noAssetsInstalled =
+    !allAssetsInstalled &&
+    missingAssetShortHeaders.length === assetShortHeaders.length;
+
+  const resourcesFetcher = useResourceFetcher();
+  const [
+    isAssetPackBeingInstalled,
+    setIsAssetPackBeingInstalled,
+  ] = React.useState<boolean>(false);
+
+  const eventsFunctionsExtensionsState = React.useContext(
+    EventsFunctionsExtensionsContext
+  );
+
+  const onInstallAssetPack = React.useCallback(
+    async (assetShortHeaders: Array<AssetShortHeader>) => {
+      if (!assetShortHeaders || !assetShortHeaders.length) return;
+      setIsAssetPackBeingInstalled(true);
+      try {
+        const installOutputs = await Promise.all(
+          assetShortHeaders.map(assetShortHeader =>
+            installAsset({
+              assetShortHeader,
+              eventsFunctionsExtensionsState,
+              project,
+              objectsContainer,
+              events,
+            })
+          )
+        );
+        installOutputs.forEach(installOutput => {
+          installOutput.createdObjects.forEach(object => {
+            onObjectAddedFromAsset(object);
+          });
+        });
+
+        await resourcesFetcher.ensureResourcesAreFetched(project);
+
+        setIsAssetPackBeingInstalled(false);
+        onAssetPackAdded();
+      } catch (error) {
+        setIsAssetPackBeingInstalled(false);
+        console.error('Error while installing the asset pack', error);
+        showErrorBox({
+          message:
+            'There was an error while installing the asset pack. Verify your internet connection or try again later.',
+          rawError: error,
+          errorId: 'install-asset-pack-error',
+        });
+      }
+    },
+    [
+      resourcesFetcher,
+      eventsFunctionsExtensionsState,
+      project,
+      objectsContainer,
+      events,
+      onObjectAddedFromAsset,
+      onAssetPackAdded,
+    ]
+  );
+
+  const dialogContent = isAssetPackBeingInstalled
+    ? {
+        actionButton: (
+          <TextButton
+            key="loading"
+            label={<Trans>Please wait...</Trans>}
+            disabled
+            onClick={() => {}}
+          />
+        ),
+        onApply: () => {},
+        content: (
+          <>
+            <Text>
+              <Trans>Installing assets...</Trans>
+            </Text>
+            <Line expand>
+              <LinearProgress style={styles.linearProgress} />
+            </Line>
+          </>
+        ),
+      }
+    : allAssetsInstalled
+    ? {
+        actionButton: (
+          <RaisedButton
+            key="install-again"
+            label={<Trans>Install again</Trans>}
+            primary={false}
+            onClick={() => onInstallAssetPack(assetShortHeaders)}
+          />
+        ),
+        onApply: () => {
+          onInstallAssetPack(assetShortHeaders);
+        },
+        content: (
+          <Text>
+            <Trans>
+              You already have this asset pack installed, do you want to add the{' '}
+              {assetShortHeaders.length} assets again?
+            </Trans>
+          </Text>
+        ),
+      }
+    : noAssetsInstalled
+    ? {
+        actionButton: (
+          <RaisedButton
+            key="continue"
+            label={<Trans>Continue</Trans>}
+            primary
+            onClick={() => onInstallAssetPack(assetShortHeaders)}
+          />
+        ),
+        onApply: () => {
+          onInstallAssetPack(assetShortHeaders);
+        },
+        content: (
+          <Text>
+            <Trans>
+              You're about to add {assetShortHeaders.length} assets from the
+              asset pack. Continue?
+            </Trans>
+          </Text>
+        ),
+      }
+    : {
+        actionButton: (
+          <RaisedButtonWithSplitMenu
+            label={<Trans>Install the missing assets</Trans>}
+            key="install-missing"
+            primary
+            onClick={() => {
+              onInstallAssetPack(missingAssetShortHeaders);
+            }}
+            buildMenuTemplate={i18n => [
+              {
+                label: i18n._(t`Install all the assets`),
+                click: () => onInstallAssetPack(assetShortHeaders),
+              },
+            ]}
+          />
+        ),
+        onApply: () => {
+          onInstallAssetPack(missingAssetShortHeaders);
+        },
+        content: (
+          <Text>
+            <Trans>
+              You already have{' '}
+              {assetShortHeaders.length - missingAssetShortHeaders.length}{' '}
+              asset(s) from this pack in your scene. Do you want to add the
+              remaining {missingAssetShortHeaders.length} asset(s)?
+            </Trans>
+          </Text>
+        ),
+      };
+
+  return (
+    <Dialog
+      maxWidth="sm"
+      title={assetPack.name}
+      open
+      onRequestClose={() => {
+        if (!isAssetPackBeingInstalled) onClose();
+      }}
+      cannotBeDismissed
+      actions={[
+        <TextButton
+          key="cancel"
+          label={<Trans>Cancel</Trans>}
+          disabled={isAssetPackBeingInstalled}
+          onClick={onClose}
+        />,
+        dialogContent.actionButton,
+      ]}
+      onApply={dialogContent.onApply}
+    >
+      <Column>{dialogContent.content}</Column>
+    </Dialog>
+  );
+};

--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
@@ -120,7 +120,6 @@ export function ExampleDialog({
           />
         </LeftLoader>,
       ]}
-      cannotBeDismissed={false}
       open
       onRequestClose={onClose}
       onApply={onOpenExample}

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -149,9 +149,9 @@ const ExtensionInstallDialog = ({
             ]
           : undefined
       }
-      cannotBeDismissed={false}
       open
       onRequestClose={onClose}
+      onApply={onInstallExtension}
     >
       <ColumnStackLayout expand noMargin>
         {!isCompatible && (

--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionsSearchDialog.js
@@ -126,7 +126,6 @@ export default function ExtensionsSearchDialog({
               />
             ) : null,
           ]}
-          cannotBeDismissed={true}
           flexBody
           open
           noMargin

--- a/newIDE/app/src/AssetStore/NewObjectDialog.js
+++ b/newIDE/app/src/AssetStore/NewObjectDialog.js
@@ -129,7 +129,6 @@ export default function NewObjectDialog({
         />,
       ]}
       onRequestClose={onClose}
-      cannotBeDismissed={false}
       open
       flexBody
       noMargin

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -231,7 +231,6 @@ export default function NewBehaviorDialog({
           ]}
           open
           onRequestClose={onClose}
-          cannotBeDismissed={false}
           flexBody
           noMargin
           fullHeight

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
@@ -43,7 +43,6 @@ export default class EventsBasedBehaviorEditorDialog extends React.Component<
             key={'Apply'}
           />,
         ]}
-        cannotBeDismissed={true}
         open
         onRequestClose={onApply}
         title={<Trans>Edit the behavior</Trans>}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/BehaviorMethodSelectorDialog.js
@@ -87,7 +87,6 @@ export default function BehaviorMethodSelectorDialog({
           key={'close'}
         />,
       ]}
-      cannotBeDismissed={false}
       open
       noMargin
       title={<Trans>Choose a new behavior function ("method")</Trans>}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/ExtensionFunctionSelectorDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/ExtensionFunctionSelectorDialog.js
@@ -78,7 +78,6 @@ export default function BehaviorMethodSelectorDialog({
           key={'close'}
         />,
       ]}
-      cannotBeDismissed={false}
       open
       noMargin
       title={<Trans>Choose a new extension function</Trans>}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
@@ -291,7 +291,6 @@ export const ExtensionOptionsEditor = ({
                   }}
                 />,
               ]}
-              cannotBeDismissed={false}
               open
               noMargin
             >

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/index.js
@@ -112,7 +112,6 @@ export default function OptionsEditorDialog({
           key={'close'}
         />,
       ]}
-      cannotBeDismissed={true}
       open={open}
       noTitleMargin
       title={
@@ -147,11 +146,10 @@ export default function OptionsEditorDialog({
               onClick={() => {
                 setExportDialogOpen(false);
               }}
-              key={'close'}
+              key="close"
             />,
           ]}
           open
-          cannotBeDismissed={false}
           onRequestClose={() => {
             setExportDialogOpen(false);
           }}

--- a/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
@@ -71,7 +71,6 @@ export default class EventsContextAnalyzerDialog extends React.Component<
     return (
       <Dialog
         actions={actions}
-        cannotBeDismissed={false}
         open
         onRequestClose={onClose}
       >

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/EventsFunctionExtractorDialog.js
@@ -160,7 +160,7 @@ export default class EventsFunctionExtractorDialog extends React.Component<
             onClick={onApply}
           />,
         ]}
-        cannotBeDismissed={true}
+        cannotBeDismissed
         open
         onRequestClose={onClose}
         noMargin

--- a/newIDE/app/src/EventsSheet/InstructionEditor/EventTextDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/EventTextDialog.js
@@ -143,7 +143,6 @@ const EventTextDialog = (props: Props) => {
       onApply={onApply}
       title={<Trans>Edit the event text</Trans>}
       onRequestClose={onClose}
-      cannotBeDismissed={true}
       open
       noMargin
       actions={[

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
@@ -71,7 +71,6 @@ export default class InstructionEditorDialog extends React.Component<
         onApply={onSubmit}
         actions={actions}
         open={open}
-        cannotBeDismissed={true}
         onRequestClose={onCancel}
         maxWidth={false}
         flexBody

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -339,7 +339,6 @@ export default function NewInstructionEditorDialog({
         ]}
         open={open}
         onRequestClose={onCancel}
-        cannotBeDismissed={true}
         maxWidth={false}
         noMargin
         flexBody

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
@@ -49,8 +49,8 @@ const ExpressionParametersEditorDialog = ({
 
   return (
     <Dialog
+      onApply={() => onDone(parameterValues)}
       title={<Trans>Enter the expression parameters</Trans>}
-      cannotBeDismissed={true}
       open
       actions={[
         <DialogPrimaryButton

--- a/newIDE/app/src/Export/BrowserExporters/BrowserS3PreviewLauncher/BrowserPreviewErrorDialog.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserS3PreviewLauncher/BrowserPreviewErrorDialog.js
@@ -28,7 +28,6 @@ export default class BrowserPreviewErrorDialog extends Component<Props> {
               />,
             ]}
             title={<Trans>Could not launch the preview</Trans>}
-            cannotBeDismissed={false}
             onRequestClose={onClose}
             open
           >

--- a/newIDE/app/src/Export/BrowserExporters/BrowserS3PreviewLauncher/BrowserPreviewLinkDialog.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserS3PreviewLauncher/BrowserPreviewLinkDialog.js
@@ -56,7 +56,6 @@ export default class BrowserPreviewLinkDialog extends Component<Props> {
               />,
             ]}
             onApply={this._makeOnOpen(i18n)}
-            cannotBeDismissed={true}
             open
           >
             <Line>

--- a/newIDE/app/src/Export/Builds/BuildsDialog.js
+++ b/newIDE/app/src/Export/Builds/BuildsDialog.js
@@ -43,7 +43,6 @@ const BuildsDialog = ({
       secondaryActions={[
         <HelpButton key="help" helpPagePath={'/publishing'} />,
       ]}
-      cannotBeDismissed={false}
       open={open}
       noMargin
     >

--- a/newIDE/app/src/Export/ExportDialog/index.js
+++ b/newIDE/app/src/Export/ExportDialog/index.js
@@ -151,7 +151,6 @@ const ExportDialog = ({
         ) : null
       }
       onRequestClose={onClose}
-      cannotBeDismissed={false}
       actions={[
         chosenExporterSection !== 'home' && (
           <FlatButton

--- a/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/LocalNetworkPreviewDialog.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/LocalNetworkPreviewDialog.js
@@ -54,7 +54,6 @@ export default class LocalNetworkDialog extends React.Component<Props, {}> {
             onClick={onRunPreviewLocally}
           />,
         ]}
-        cannotBeDismissed={true}
         open={open}
         onRequestClose={onClose}
       >

--- a/newIDE/app/src/GameDashboard/PublicGamePropertiesDialog.js
+++ b/newIDE/app/src/GameDashboard/PublicGamePropertiesDialog.js
@@ -143,7 +143,7 @@ export const PublicGamePropertiesDialog = ({
       title={<Trans>Game info</Trans>}
       onRequestClose={onClose}
       actions={actions}
-      cannotBeDismissed={false}
+      onApply={onSave}
       open
     >
       <PublicGameProperties

--- a/newIDE/app/src/HelpFinder/index.js
+++ b/newIDE/app/src/HelpFinder/index.js
@@ -79,7 +79,6 @@ export default class HelpFinder extends React.PureComponent<Props, State> {
             label={<Trans>Browse the documentation</Trans>}
           />,
         ]}
-        cannotBeDismissed={false}
         open={open}
       >
         <DocSearchArea

--- a/newIDE/app/src/HotReload/HotReloadLogsDialog.js
+++ b/newIDE/app/src/HotReload/HotReloadLogsDialog.js
@@ -50,7 +50,6 @@ export default function HotReloadLogsDialog({
         <HelpButton key="help" helpPagePath={'/interface/preview'} />,
       ]}
       open
-      cannotBeDismissed
     >
       <ColumnStackLayout noMargin>
         <Text>

--- a/newIDE/app/src/KeyboardShortcuts/DetectShortcutDialog.js
+++ b/newIDE/app/src/KeyboardShortcuts/DetectShortcutDialog.js
@@ -50,7 +50,7 @@ const DetectShortcutDialog = (props: Props) => {
       open
       title={<Trans>Set shortcut</Trans>}
       onRequestClose={props.onClose}
-      cannotBeDismissed={false}
+      onApply={onApply}
       maxWidth="xs"
       actions={[
         <FlatButton

--- a/newIDE/app/src/LayersList/LayerRemoveDialog.js
+++ b/newIDE/app/src/LayersList/LayerRemoveDialog.js
@@ -61,7 +61,6 @@ export default class VariablesEditorDialog extends Component {
       <Dialog
         title={<Trans>Objects on {this.props.layerRemoved}</Trans>}
         actions={actions}
-        cannotBeDismissed={false}
         open={this.props.open}
         onRequestClose={this.props.onCancel}
       >

--- a/newIDE/app/src/Leaderboard/LeaderboardDialog.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardDialog.js
@@ -32,7 +32,6 @@ const LeaderboardDialog = ({ onClose, open, project }: Props) => {
         />,
       ]}
       open={open}
-      cannotBeDismissed={true}
       onRequestClose={() => {
         if (!isLoading) onClose();
       }}

--- a/newIDE/app/src/MainFrame/AboutDialog.js
+++ b/newIDE/app/src/MainFrame/AboutDialog.js
@@ -282,7 +282,6 @@ export default class AboutDialog extends PureComponent<Props, State> {
           />,
         ]}
         onRequestClose={onClose}
-        cannotBeDismissed={false}
         open={open}
         maxWidth="sm"
         noMargin

--- a/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
+++ b/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
@@ -35,7 +35,6 @@ const ChangelogDialog = ({ open, onClose }: Props) => {
       actions={actions}
       open={open}
       onRequestClose={onClose}
-      cannotBeDismissed={false}
     >
       <Text>
         <Trans>

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalPropertiesDialog.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalPropertiesDialog.js
@@ -76,7 +76,6 @@ export default function ExternalPropertiesDialog({
       open={open}
       title={title}
       onRequestClose={onClose}
-      cannotBeDismissed={false}
       maxWidth="sm"
       onApply={onClick}
     >

--- a/newIDE/app/src/MainFrame/Onboarding/OnboardingDialog.js
+++ b/newIDE/app/src/MainFrame/Onboarding/OnboardingDialog.js
@@ -125,7 +125,7 @@ const OnboardingDialog = () => {
       actions={actions}
       open={open}
       onRequestClose={() => setOpen(false)}
-      cannotBeDismissed={false}
+      onApply={startUserflow}
       maxWidth="xs"
     >
       <ColumnStackLayout noMargin>

--- a/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/LanguageDialog.js
@@ -61,7 +61,6 @@ const LanguageDialog = ({ open, onClose }: Props) => {
               />,
             ]}
             onRequestClose={() => onClose(languageDidChange)}
-            cannotBeDismissed={false}
             open={open}
             title={<Trans>Language</Trans>}
           >

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -69,7 +69,6 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
         />,
       ]}
       onRequestClose={() => onClose(languageDidChange)}
-      cannotBeDismissed={true}
       open
       noTitleMargin
       maxWidth="sm"

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -163,7 +163,6 @@ export default class DirectionTools extends Component<Props, State> {
               />,
             ]}
             noMargin
-            cannotBeDismissed={false}
             onRequestClose={() => this.openPreview(false)}
             open={this.state.previewOpen}
             fullHeight

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -482,7 +482,6 @@ export default function SpriteEditor({
               key="help"
             />,
           ]}
-          cannotBeDismissed={true}
           noMargin
           maxWidth="lg"
           flexBody
@@ -517,7 +516,6 @@ export default function SpriteEditor({
           maxWidth="lg"
           flexBody
           fullHeight
-          cannotBeDismissed={true}
           onRequestClose={() => setCollisionMasksEditorOpen(false)}
           open={collisionMasksEditorOpen}
         >

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -138,7 +138,6 @@ const InnerDialog = (props: InnerDialogProps) => {
       ]}
       noMargin
       onRequestClose={onCancelChanges}
-      cannotBeDismissed={true}
       open={props.open}
       noTitleMargin
       fullHeight

--- a/newIDE/app/src/ObjectGroupEditor/ObjectGroupEditorDialog.js
+++ b/newIDE/app/src/ObjectGroupEditor/ObjectGroupEditorDialog.js
@@ -49,7 +49,6 @@ const ObjectGroupEditorDialog = ({
         />,
       ]}
       noMargin
-      cannotBeDismissed={true}
       onRequestClose={onCancelChanges}
       open
       title={`Edit ${group.getName()} group`}

--- a/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
+++ b/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
@@ -270,7 +270,6 @@ export default class PlatformSpecificAssetsDialog extends React.Component<
         title={<Trans>Project icons</Trans>}
         actions={actions}
         open={this.props.open}
-        cannotBeDismissed={true}
         onRequestClose={this.props.onClose}
       >
         <ColumnStackLayout noMargin>

--- a/newIDE/app/src/Profile/ChangeEmailDialog.js
+++ b/newIDE/app/src/Profile/ChangeEmailDialog.js
@@ -69,7 +69,7 @@ export default class ChangeEmailDialog extends Component<Props, State> {
         }}
         onApply={this._onChangeEmail}
         maxWidth="sm"
-        cannotBeDismissed={true}
+        cannotBeDismissed={changeEmailInProgress}
         open
       >
         <ColumnStackLayout noMargin>

--- a/newIDE/app/src/Profile/CreateAccountDialog.js
+++ b/newIDE/app/src/Profile/CreateAccountDialog.js
@@ -135,7 +135,7 @@ export default class CreateAccountDialog extends Component<Props, State> {
           if (!createAccountInProgress) onClose();
         }}
         maxWidth="sm"
-        cannotBeDismissed={true}
+        cannotBeDismissed={createAccountInProgress}
         open
       >
         <ColumnStackLayout noMargin>

--- a/newIDE/app/src/Profile/EditProfileDialog.js
+++ b/newIDE/app/src/Profile/EditProfileDialog.js
@@ -91,7 +91,7 @@ export default class EditDialog extends Component<Props, State> {
         }}
         maxWidth="sm"
         onApply={this._onEdit}
-        cannotBeDismissed={true}
+        cannotBeDismissed={editInProgress}
         open
       >
         <ColumnStackLayout noMargin>

--- a/newIDE/app/src/Profile/EmailVerificationPendingDialog.js
+++ b/newIDE/app/src/Profile/EmailVerificationPendingDialog.js
@@ -54,7 +54,6 @@ export default function EmailVerificationPendingDialog({
         ),
       ]}
       maxWidth="sm"
-      cannotBeDismissed={true}
       open
       noMargin
     >

--- a/newIDE/app/src/Profile/LoginDialog.js
+++ b/newIDE/app/src/Profile/LoginDialog.js
@@ -107,7 +107,7 @@ export default class LoginDialog extends Component<Props, State> {
           if (!loginInProgress && !forgotPasswordInProgress) onClose();
         }}
         maxWidth="sm"
-        cannotBeDismissed={true}
+        cannotBeDismissed={loginInProgress || forgotPasswordInProgress}
         open
       >
         <ColumnStackLayout noMargin>
@@ -156,7 +156,6 @@ export default class LoginDialog extends Component<Props, State> {
           />
         </ColumnStackLayout>
         <Dialog
-          cannotBeDismissed={true}
           open={resetPasswordDialogOpen}
           title={<Trans>Reset your password</Trans>}
           actions={[

--- a/newIDE/app/src/Profile/ProfileDialog.js
+++ b/newIDE/app/src/Profile/ProfileDialog.js
@@ -77,7 +77,6 @@ const ProfileDialog = ({
         ),
       ]}
       onRequestClose={onClose}
-      cannotBeDismissed={false}
       open={open}
       noMargin
       fullHeight

--- a/newIDE/app/src/Profile/SubscriptionChecker.js
+++ b/newIDE/app/src/Profile/SubscriptionChecker.js
@@ -102,7 +102,6 @@ export class SubscriptionCheckDialog extends React.Component<
             onClick={this._closeDialog}
           />,
         ]}
-        cannotBeDismissed={false}
         onRequestClose={this._closeDialog}
         open={open}
         title={

--- a/newIDE/app/src/Profile/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionDialog.js
@@ -190,7 +190,6 @@ export default class SubscriptionDialog extends React.Component<Props, State> {
                       />,
                     ]}
                     onRequestClose={onClose}
-                    cannotBeDismissed={true}
                     open={open}
                     noMargin
                   >

--- a/newIDE/app/src/Profile/SubscriptionPendingDialog.js
+++ b/newIDE/app/src/Profile/SubscriptionPendingDialog.js
@@ -54,7 +54,6 @@ export default function SubscriptionPendingDialog({
         ),
       ]}
       maxWidth="sm"
-      cannotBeDismissed={true}
       open
       noMargin
     >

--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -183,7 +183,7 @@ const CreateProjectDialog = ({
             title={<Trans>Create a new project</Trans>}
             actions={actions}
             secondaryActions={secondaryActions}
-            cannotBeDismissed={false}
+            onApply={() => setPreCreationDialogOpen(true)}
             onRequestClose={onClose}
             open={open}
             noMargin

--- a/newIDE/app/src/ProjectsStorage/DownloadFileStorageProvider/DownloadSaveAsDialog.js
+++ b/newIDE/app/src/ProjectsStorage/DownloadFileStorageProvider/DownloadSaveAsDialog.js
@@ -64,7 +64,6 @@ export default class DownloadSaveAsDialog extends React.Component<Props> {
       <Dialog
         actions={actions}
         open
-        cannotBeDismissed={false}
         onRequestClose={onDone}
         maxWidth="sm"
       >

--- a/newIDE/app/src/ProjectsStorage/GoogleDriveStorageProvider/GoogleDriveSaveAsDialog.js
+++ b/newIDE/app/src/ProjectsStorage/GoogleDriveStorageProvider/GoogleDriveSaveAsDialog.js
@@ -106,7 +106,7 @@ const GoogleDriveSaveAsDialog = (props: Props) => {
           />
         </LeftLoader>,
       ]}
-      cannotBeDismissed={true}
+      cannotBeDismissed={saving}
       open
       onRequestClose={cancel}
       maxWidth="sm"

--- a/newIDE/app/src/ProjectsStorage/OpenConfirmDialog.js
+++ b/newIDE/app/src/ProjectsStorage/OpenConfirmDialog.js
@@ -35,7 +35,6 @@ export const OpenConfirmDialog = ({
           onClick={onConfirm}
         />,
       ]}
-      cannotBeDismissed={true}
       open
       maxWidth="sm"
     >

--- a/newIDE/app/src/ProjectsStorage/OpenFromStorageProviderDialog.js
+++ b/newIDE/app/src/ProjectsStorage/OpenFromStorageProviderDialog.js
@@ -36,7 +36,6 @@ const OpenFromStorageProviderDialog = ({
               onClick={onClose}
             />,
           ]}
-          cannotBeDismissed={false}
           open
           noMargin
           maxWidth="sm"

--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/index.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/index.js
@@ -82,7 +82,7 @@ export const ResourceFetcherDialog = ({
           key="close"
         />,
       ]}
-      cannotBeDismissed={true}
+      cannotBeDismissed={!hasErrors}
       noMargin
       open
       maxWidth="sm"

--- a/newIDE/app/src/ProjectsStorage/SaveToStorageProviderDialog.js
+++ b/newIDE/app/src/ProjectsStorage/SaveToStorageProviderDialog.js
@@ -32,7 +32,6 @@ const SaveToStorageProviderDialog = ({
               onClick={onClose}
             />,
           ]}
-          cannotBeDismissed={true}
           open
           noMargin
           maxWidth="sm"

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -160,7 +160,6 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
           />,
         ]}
         open={this.props.open}
-        cannotBeDismissed={true}
         onApply={this._onApply}
         onRequestClose={this.props.onClose}
         maxWidth="sm"

--- a/newIDE/app/src/SceneEditor/SetupGridDialog.js
+++ b/newIDE/app/src/SceneEditor/SetupGridDialog.js
@@ -46,7 +46,6 @@ export default function SetupGridDialog(props: Props) {
 
   return (
     <Dialog
-      onApply={props.onApply}
       title={<Trans>Edit Grid Options</Trans>}
       actions={[
         <FlatButton
@@ -62,8 +61,8 @@ export default function SetupGridDialog(props: Props) {
           onClick={props.onApply}
         />,
       ]}
-      cannotBeDismissed={true}
       open
+      onApply={props.onApply}
       onRequestClose={onCancel}
       maxWidth="sm"
       noMargin

--- a/newIDE/app/src/UI/Dialog/index.js
+++ b/newIDE/app/src/UI/Dialog/index.js
@@ -65,7 +65,7 @@ type Props = {|
    * This is not applicable to all dialogs. Some dialogs may have no `onApply` and just a
    * single `onRequestClose`.
    */
-  onApply?: ?() => void,
+  onApply?: ?() => void | Promise<void>,
 
   cannotBeDismissed?: boolean, // Currently unused.
 
@@ -116,6 +116,7 @@ const Dialog = (props: Props) => {
     fullHeight,
     noTitleMargin,
     id,
+    cannotBeDismissed,
   } = props;
 
   const preferences = React.useContext(PreferencesContext);
@@ -148,6 +149,7 @@ const Dialog = (props: Props) => {
 
   const onCloseDialog = React.useCallback(
     (event: any, reason: string) => {
+      if (!!cannotBeDismissed) return;
       if (reason === 'escapeKeyDown') {
         if (onRequestClose) onRequestClose();
       } else if (reason === 'backdropClick') {
@@ -161,7 +163,7 @@ const Dialog = (props: Props) => {
         }
       }
     },
-    [onRequestClose, onApply, backdropClickBehavior]
+    [onRequestClose, onApply, backdropClickBehavior, cannotBeDismissed]
   );
 
   const handleKeyDown = React.useCallback(

--- a/newIDE/app/src/UI/EditTagsDialog.js
+++ b/newIDE/app/src/UI/EditTagsDialog.js
@@ -78,7 +78,6 @@ export default class EditTagsDialog extends React.Component<Props, State> {
             disabled={!this._canEdit()}
           />,
         ]}
-        cannotBeDismissed={false}
         open
         onApply={() => this._onEdit(tags)}
         onRequestClose={onCancel}

--- a/newIDE/app/src/VariablesList/VariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/VariablesEditorDialog.js
@@ -51,7 +51,6 @@ const VariablesEditorDialog = ({
 
   return (
     <Dialog
-      onApply={onApply}
       noMargin
       actions={[
         <FlatButton
@@ -67,7 +66,7 @@ const VariablesEditorDialog = ({
         />,
       ]}
       open={open}
-      cannotBeDismissed={true}
+      onApply={onApply}
       onRequestClose={onCancelChanges}
       secondaryActions={[
         onEditObjectVariables ? (


### PR DESCRIPTION
UX-wise, a Dialog should almost always be dismissable by clicking outside except if:

- the Dialog represents a loading state, you cannot close it until it's finished
- the Dialog can do important changes. There is a risk if you have configured the editor to apply on clicking outside, to do big changes. (ex: create account, refactor events, import asset pack...)

This PR is to apply this behavior to all Dialogs