### PR TITLE
Allow to go back to previous asset pages.

### DIFF
--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { type FiltersState } from '../UI/Search/FiltersChooser';
 import { type Filters } from '../Utils/GDevelopServices/Filters';
 import {
   type AssetShortHeader,

--- a/newIDE/app/src/AssetStore/AssetStoreNavigator.js
+++ b/newIDE/app/src/AssetStore/AssetStoreNavigator.js
@@ -1,0 +1,151 @@
+// @flow
+import * as React from 'react';
+import { type FiltersState } from '../UI/Search/FiltersChooser';
+import {
+  type AssetShortHeader,
+  type AssetPack,
+} from '../Utils/GDevelopServices/Asset';
+
+export type AssetStorePageState = {|
+  isOnHomePage: boolean,
+  openedAssetPack: ?AssetPack,
+  openedAssetShortHeader: ?AssetShortHeader,
+  filtersState: FiltersState,
+  ignoreTextualSearch: boolean,
+|};
+
+export type NavigationState = {|
+  previousPages: Array<AssetStorePageState>,
+  getCurrentPage: () => AssetStorePageState,
+  backToPreviousPage: () => void,
+  openHome: () => void,
+  clearHistory: () => void,
+  openSearchIfNeeded: () => void,
+  activateTextualSearch: () => void,
+  openTagPage: string => void,
+  openPackPage: AssetPack => void,
+  openDetailPage: AssetShortHeader => void,
+|};
+
+const noFilter: FiltersState = {
+  chosenCategory: null,
+  chosenFilters: new Set(),
+  addFilter: () => {},
+  removeFilter: () => {},
+  setChosenCategory: () => {},
+};
+
+export const assetStoreHomePageState: AssetStorePageState = {
+  isOnHomePage: true,
+  openedAssetShortHeader: null,
+  openedAssetPack: null,
+  filtersState: noFilter,
+  ignoreTextualSearch: false,
+};
+
+const searchPageState: AssetStorePageState = {
+  isOnHomePage: false,
+  openedAssetShortHeader: null,
+  openedAssetPack: null,
+  filtersState: noFilter,
+  ignoreTextualSearch: false,
+};
+
+type AssetStorePageHistory = {|
+  previousPages: Array<AssetStorePageState>,
+|};
+
+export const useNavigation = (): NavigationState => {
+  const [history, setHistory] = React.useState<AssetStorePageHistory>({
+    previousPages: [assetStoreHomePageState],
+  });
+  const previousPages = history.previousPages;
+
+  return {
+    previousPages,
+    getCurrentPage: () => previousPages[previousPages.length - 1],
+    backToPreviousPage: () => {
+      if (previousPages.length > 1) {
+        previousPages.pop();
+        setHistory({ previousPages });
+      }
+    },
+    openHome: () => {
+      previousPages.length = 0;
+      previousPages.push(assetStoreHomePageState);
+      setHistory({ previousPages });
+    },
+    clearHistory: () => {
+      const currentPage = previousPages[previousPages.length - 1];
+      previousPages.length = 0;
+      previousPages.push(assetStoreHomePageState);
+      previousPages.push(currentPage);
+      setHistory({ previousPages });
+    },
+    openSearchIfNeeded: () => {
+      const currentPage = previousPages[previousPages.length - 1];
+      if (currentPage.isOnHomePage || currentPage.openedAssetShortHeader) {
+        previousPages.push(searchPageState);
+        setHistory({ previousPages });
+      }
+    },
+    activateTextualSearch: () => {
+      const currentPage = previousPages[previousPages.length - 1];
+      if (currentPage.isOnHomePage || currentPage.openedAssetShortHeader) {
+        previousPages.push(searchPageState);
+        setHistory({ previousPages });
+      } else if (currentPage.ignoreTextualSearch) {
+        currentPage.ignoreTextualSearch = false;
+        setHistory({ previousPages });
+      }
+    },
+    openTagPage: (tag: string) => {
+      previousPages.push({
+        isOnHomePage: false,
+        openedAssetShortHeader: null,
+        openedAssetPack: null,
+        filtersState: {
+          chosenCategory: {
+            node: { name: tag, allChildrenTags: [], children: [] },
+            parentNodes: [],
+          },
+          chosenFilters: new Set(),
+          addFilter: () => {},
+          removeFilter: () => {},
+          setChosenCategory: () => {},
+        },
+        ignoreTextualSearch: true,
+      });
+      setHistory({ previousPages });
+    },
+    openPackPage: (assetPack: AssetPack) => {
+      previousPages.push({
+        isOnHomePage: false,
+        openedAssetShortHeader: null,
+        openedAssetPack: assetPack,
+        filtersState: {
+          chosenCategory: {
+            node: { name: assetPack.tag, allChildrenTags: [], children: [] },
+            parentNodes: [],
+          },
+          chosenFilters: new Set(),
+          addFilter: () => {},
+          removeFilter: () => {},
+          setChosenCategory: () => {},
+        },
+        ignoreTextualSearch: true,
+      });
+      setHistory({ previousPages });
+    },
+    openDetailPage: (assetShortHeader: AssetShortHeader) => {
+      previousPages.push({
+        isOnHomePage: false,
+        openedAssetShortHeader: assetShortHeader,
+        openedAssetPack: null,
+        filtersState: noFilter,
+        ignoreTextualSearch: true,
+      });
+      setHistory({ previousPages });
+    },
+  };
+};

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -186,10 +186,14 @@ export const AssetStore = ({
     sendAssetPackOpened(tag);
 
     const assetPack = assetPacks.starterPacks.find(pack => pack.tag === tag);
+    if (!assetPack) {
+      // This can't actually happen.
+      return;
+    }
 
-    if (assetPack && assetPack.externalWebLink) {
+    if (assetPack.externalWebLink) {
       Window.openExternalURL(assetPack.externalWebLink);
-    } else if (assetPack) {
+    } else {
       navigationState.openPackPage(assetPack);
       setIsFiltersPanelOpen(true);
     }

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -8,7 +8,6 @@ import DoubleChevronArrow from '../UI/CustomSvgIcons/DoubleChevronArrow';
 import { Column, Line, Spacer } from '../UI/Grid';
 import Background from '../UI/Background';
 import ScrollView from '../UI/ScrollView';
-import Window from '../Utils/Window';
 import {
   sendAssetAddedToProject,
   sendAssetOpened,
@@ -22,7 +21,6 @@ import {
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import {
   type AssetShortHeader,
-  type AssetPack,
 } from '../Utils/GDevelopServices/Asset';
 import { BoxSearchResults } from '../UI/Search/BoxSearchResults';
 import { type SearchBarInterface } from '../UI/SearchBar';

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -189,7 +189,6 @@ export const AssetStore = ({
 
     if (assetPack && assetPack.externalWebLink) {
       Window.openExternalURL(assetPack.externalWebLink);
-      return;
     } else if (assetPack) {
       navigationState.openPackPage(assetPack);
       setIsFiltersPanelOpen(true);

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -47,6 +47,7 @@ import { showErrorBox } from '../UI/Messages/MessageBox';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import { enumerateObjects } from '../ObjectsList/EnumerateObjects';
 import { AssetPackDialog } from './AssetPackDialog';
+import Home from '@material-ui/icons/Home';
 
 const styles = {
   searchBar: {
@@ -83,15 +84,16 @@ export const AssetStore = ({
     searchResults,
     error,
     fetchAssetsAndFilters,
-    filtersState,
-    assetFiltersState,
-    isOnHomePage,
-    setIsOnHomePage,
-    openedAssetShortHeader,
-    setOpenedAssetShortHeader,
+    navigationState,
     searchText,
     setSearchText,
+    assetFiltersState,
   } = React.useContext(AssetStoreContext);
+  const {
+    isOnHomePage,
+    openedAssetPack,
+    openedAssetShortHeader,
+  } = navigationState.getCurrentPage();
 
   React.useEffect(
     () => {
@@ -102,9 +104,6 @@ export const AssetStore = ({
 
   const searchBar = React.useRef<?SearchBarInterface>(null);
   const shouldAutofocusSearchbar = useShouldAutofocusSearchbar();
-  const [openedAssetPack, setOpenedAssetPack] = React.useState<?AssetPack>(
-    null
-  );
   const [isFiltersPanelOpen, setIsFiltersPanelOpen] = React.useState(false);
   const [
     isAssetPackDialogInstallOpen,
@@ -132,7 +131,7 @@ export const AssetStore = ({
       id: assetShortHeader.id,
       name: assetShortHeader.name,
     });
-    setOpenedAssetShortHeader(assetShortHeader);
+    navigationState.openDetailPage(assetShortHeader);
   };
 
   const onInstallAsset = React.useCallback(
@@ -182,17 +181,6 @@ export const AssetStore = ({
     ]
   );
 
-  const resetToDefault = () => {
-    setSearchText('');
-    filtersState.setChosenCategory(null);
-    setOpenedAssetPack(null);
-    setIsAssetPackAdded(false);
-    setOpenedAssetShortHeader(null);
-    clearAllFilters(assetFiltersState);
-    setIsFiltersPanelOpen(false);
-    setIsOnHomePage(true);
-  };
-
   // When a pack is selected from the home page,
   // we set it as the chosen category and open the filters panel.
   const selectPack = (tag: string) => {
@@ -200,59 +188,27 @@ export const AssetStore = ({
 
     sendAssetPackOpened(tag);
 
-    const assetPack = assetPacks.starterPacks.find(
-      assetPack => assetPack.tag === tag
-    );
-    if (assetPack && assetPack.externalWebLink) {
-      Window.openExternalURL(assetPack.externalWebLink);
-      return;
+    const assetPack = assetPacks.starterPacks.find(pack => pack.tag === tag);
+    // This can't actually be false.
+    if (assetPack) {
+      navigationState.openPackPage(assetPack);
     }
 
-    const chosenCategory = {
-      node: { name: tag, allChildrenTags: [], children: [] },
-      parentNodes: [],
-    };
-    filtersState.setChosenCategory(chosenCategory);
-
-    setOpenedAssetPack(assetPack);
-
-    setIsOnHomePage(false);
     setIsFiltersPanelOpen(true);
   };
 
   // When a tag is selected from the asset details page,
   // we set it as the chosen category, clear old filters and open the filters panel.
   const selectTag = (tag: string) => {
-    const chosenCategory = {
-      node: { name: tag, allChildrenTags: [], children: [] },
-      parentNodes: [],
-    };
-    filtersState.setChosenCategory(chosenCategory);
-
-    clearAllFilters(assetFiltersState);
-    setOpenedAssetPack(null);
-    setOpenedAssetShortHeader(null);
-    setIsFiltersPanelOpen(true);
-  };
-
-  // When something is entered in the search bar
-  // we need to ensure we leave the homepage and deselect any pack.
-  const onSearchChange = () => {
-    if (isOnHomePage) setIsOnHomePage(false);
-    if (openedAssetPack) setOpenedAssetPack(null);
-  };
-
-  // When the back button is pressed, if we were on the asset details page,
-  // we just go back to the search,
-  // if we were on the search, we reset everything to go back to the homepage.
-  const goBack = () => {
-    if (openedAssetShortHeader) {
-      // Going back from Asset page to search.
-      setOpenedAssetShortHeader(null);
+    const assetPack =
+      assetPacks && assetPacks.starterPacks.find(pack => pack.tag === tag);
+    if (assetPack) {
+      navigationState.openPackPage(assetPack);
     } else {
-      // Going back from search to home.
-      resetToDefault();
+      navigationState.openTagPage(tag);
     }
+    clearAllFilters(assetFiltersState);
+    setIsFiltersPanelOpen(true);
   };
 
   React.useEffect(
@@ -270,15 +226,37 @@ export const AssetStore = ({
         {windowWidth => (
           <>
             <Column expand noMargin useFullHeight>
-              <SearchBar
-                placeholder={t`Search assets`}
-                value={searchText}
-                onChange={setSearchText}
-                onRequestSearch={onSearchChange}
-                style={styles.searchBar}
-                ref={searchBar}
-                id="asset-store-search-bar"
-              />
+              <Line>
+                <Spacer />
+                <IconButton
+                  key="back-discover"
+                  tooltip={t`Back to discover`}
+                  onClick={() => {
+                    navigationState.openHome();
+                    setIsFiltersPanelOpen(false);
+                    clearAllFilters(assetFiltersState);
+                  }}
+                  size="small"
+                >
+                  <Home />
+                </IconButton>
+                <Column expand useFullHeight>
+                  <SearchBar
+                    placeholder={t`Search assets`}
+                    value={searchText}
+                    onChange={setSearchText}
+                    onRequestSearch={() => {
+                      // Clear the history
+                      navigationState.activateTextualSearch();
+                      navigationState.clearHistory();
+                      setIsFiltersPanelOpen(true);
+                    }}
+                    style={styles.searchBar}
+                    ref={searchBar}
+                    id="asset-store-search-bar"
+                  />
+                </Column>
+              </Line>
               {!isOnHomePage && <Spacer />}
               <Column>
                 <Line
@@ -297,10 +275,16 @@ export const AssetStore = ({
                           icon={<ArrowBack />}
                           label={<Trans>Back</Trans>}
                           primary={false}
-                          onClick={goBack}
+                          onClick={() => {
+                            navigationState.backToPreviousPage();
+                            if (navigationState.getCurrentPage().isOnHomePage) {
+                              clearAllFilters(assetFiltersState);
+                              setIsFiltersPanelOpen(false);
+                            }
+                          }}
                         />
                       </Column>
-                      {!!openedAssetPack && !openedAssetShortHeader && (
+                      {openedAssetPack && (
                         <>
                           <Column expand alignItems="center">
                             <Text size="title" noMargin>
@@ -379,7 +363,9 @@ export const AssetStore = ({
                         >
                           <AssetStoreFilterPanel
                             assetFiltersState={assetFiltersState}
-                            onChoiceChange={onSearchChange}
+                            onChoiceChange={() =>
+                              navigationState.openSearchIfNeeded()
+                            }
                           />
                         </Line>
                       </ScrollView>
@@ -422,7 +408,7 @@ export const AssetStore = ({
                     onTagSelection={selectTag}
                     assetShortHeader={openedAssetShortHeader}
                     onAdd={() => onInstallAsset(openedAssetShortHeader)}
-                    onClose={() => setOpenedAssetShortHeader(null)}
+                    onClose={() => navigationState.backToPreviousPage()}
                     isAddedToScene={addedAssetIds.includes(
                       openedAssetShortHeader.id
                     )}

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -8,6 +8,7 @@ import DoubleChevronArrow from '../UI/CustomSvgIcons/DoubleChevronArrow';
 import { Column, Line, Spacer } from '../UI/Grid';
 import Background from '../UI/Background';
 import ScrollView from '../UI/ScrollView';
+import Window from '../Utils/Window';
 import {
   sendAssetAddedToProject,
   sendAssetOpened,
@@ -19,9 +20,7 @@ import {
   type ChooseResourceFunction,
 } from '../ResourcesList/ResourceSource';
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
-import {
-  type AssetShortHeader,
-} from '../Utils/GDevelopServices/Asset';
+import { type AssetShortHeader } from '../Utils/GDevelopServices/Asset';
 import { BoxSearchResults } from '../UI/Search/BoxSearchResults';
 import { type SearchBarInterface } from '../UI/SearchBar';
 import {
@@ -187,12 +186,14 @@ export const AssetStore = ({
     sendAssetPackOpened(tag);
 
     const assetPack = assetPacks.starterPacks.find(pack => pack.tag === tag);
-    // This can't actually be false.
-    if (assetPack) {
-      navigationState.openPackPage(assetPack);
-    }
 
-    setIsFiltersPanelOpen(true);
+    if (assetPack && assetPack.externalWebLink) {
+      Window.openExternalURL(assetPack.externalWebLink);
+      return;
+    } else if (assetPack) {
+      navigationState.openPackPage(assetPack);
+      setIsFiltersPanelOpen(true);
+    }
   };
 
   // When a tag is selected from the asset details page,


### PR DESCRIPTION
This allows to go back to an asset page after exploring tags.
- The filters and textual search are not part of a page state.
- When an asset pack is opened the textual search is ignored and filters are reset. The textual search is applied again when:
  - its validated
  - the back button is used to go back to the initial search result page.
- The history is reset if a textual search happens to avoid inconsistencies as previous textual researches are not save in the history.