### PR TITLE
Add support for displaying external (optionally, paid) asset packs in the Asset Store

### DIFF
--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -112,6 +112,9 @@ export const AssetsHome = ({
                   </Text>
                   <Text style={styles.packTitle} color="primary" size="body2">
                     <Trans>{pack.assetsCount} Assets</Trans>
+                    {pack.userFriendlyPrice
+                      ? ' - ' + pack.userFriendlyPrice
+                      : null}
                   </Text>
                 </Line>
               </Column>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -8,6 +8,7 @@ import DoubleChevronArrow from '../UI/CustomSvgIcons/DoubleChevronArrow';
 import { Column, Line, Spacer } from '../UI/Grid';
 import Background from '../UI/Background';
 import ScrollView from '../UI/ScrollView';
+import Window from '../Utils/Window';
 import {
   sendAssetAddedToProject,
   sendAssetOpened,
@@ -199,13 +200,20 @@ export const AssetStore = ({
 
     sendAssetPackOpened(tag);
 
+    const assetPack = assetPacks.starterPacks.find(
+      assetPack => assetPack.tag === tag
+    );
+    if (assetPack && assetPack.externalWebLink) {
+      Window.openExternalURL(assetPack.externalWebLink);
+      return;
+    }
+
     const chosenCategory = {
       node: { name: tag, allChildrenTags: [], children: [] },
       parentNodes: [],
     };
     filtersState.setChosenCategory(chosenCategory);
 
-    const assetPack = assetPacks.starterPacks.find(pack => pack.tag === tag);
     setOpenedAssetPack(assetPack);
 
     setIsOnHomePage(false);

--- a/newIDE/app/src/Utils/GDevelopServices/Asset.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Asset.js
@@ -74,6 +74,8 @@ export type AssetPack = {|
   tag: string,
   thumbnailUrl: string,
   assetsCount: number,
+  externalWebLink?: ?string,
+  userFriendlyPrice?: ?string,
 |};
 
 export type AssetPacks = {|

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -16,6 +16,7 @@ import { type AuthenticatedUser } from '../Profile/AuthenticatedUserContext';
 import {
   type AssetShortHeader,
   type Asset,
+  type AssetPacks,
 } from '../Utils/GDevelopServices/Asset';
 
 export const indieFirebaseUser: FirebaseUser = {
@@ -900,4 +901,102 @@ export const geometryMonsterExampleShortHeader: ExampleShortHeader = {
     'Health (life points and damages for objects)',
   ],
   gdevelopVersion: '',
+};
+
+export const fakeAssetPacks: AssetPacks = {
+  starterPacks: [
+    {
+      name: 'GDevelop Platformer',
+      tag: 'platformer',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/platformer.png',
+      assetsCount: 16,
+    },
+    {
+      name: 'Space Shooter',
+      tag: 'space shooter',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/space shooter.png',
+      assetsCount: 140,
+    },
+    {
+      name: 'Tanks',
+      tag: 'tank pack',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/tank pack.png',
+      assetsCount: 32,
+    },
+    {
+      name: 'Pixel Adventure',
+      tag: 'pixel adventure pack',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/pixel adventure pack.png',
+      assetsCount: 80,
+    },
+    {
+      name: 'Fake Paid External',
+      tag: 'pirate bomb pack',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/pirate bomb pack.png',
+      assetsCount: 48,
+      externalWebLink: 'https://example.com',
+      userFriendlyPrice: '$4.99',
+    },
+    {
+      name: 'Particles',
+      tag: 'pixel effects pack',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/pixel effects pack.png',
+      assetsCount: 20,
+    },
+    {
+      name: 'Emotes',
+      tag: 'emote',
+      thumbnailUrl: 'https://resources.gdevelop-app.com/assets/Packs/emote.png',
+      assetsCount: 176,
+    },
+    {
+      name: 'Dinosaurus Characters',
+      tag: '24x24 dino characters',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/24x24 dino characters.png',
+      assetsCount: 5,
+    },
+    {
+      name: 'Fake Paid Spinning Items',
+      tag: '16x16 pixel art spinning items',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/16x16 pixel art spinning items.png',
+      assetsCount: 30,
+      userFriendlyPrice: '$4.99',
+    },
+    {
+      name: 'RPG Items #2',
+      tag: '16x16 pixel art rpg items',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/16x16 pixel art rpg items.png',
+      assetsCount: 64,
+    },
+    {
+      name: 'RPG Items',
+      tag: '16x16 rpg item pack',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/16x16 rpg item pack.png',
+      assetsCount: 144,
+    },
+    {
+      name: 'Fantasy Icons',
+      tag: '32x32 fantasy icons pack v2',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/32x32 fantasy icons pack v2.png',
+      assetsCount: 285,
+    },
+    {
+      name: 'On-Screen Controls',
+      tag: 'on-screen controls',
+      thumbnailUrl:
+        'https://resources.gdevelop-app.com/assets/Packs/on-screen controls.png',
+      assetsCount: 287,
+    },
+  ],
 };

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import withMock from 'storybook-addon-mock';
 import { action } from '@storybook/addon-actions';
 
 import muiDecorator from '../../../ThemeDecorator';
@@ -7,11 +8,34 @@ import paperDecorator from '../../../PaperDecorator';
 import { testProject } from '../../../GDevelopJsInitializerDecorator';
 import { AssetStoreStateProvider } from '../../../../AssetStore/AssetStoreContext';
 import { AssetStore } from '../../../../AssetStore';
+import { fakeAssetPacks } from '../../../../fixtures/GDevelopServicesTestData';
 
 export default {
   title: 'AssetStore/AssetStore',
   component: AssetStore,
   decorators: [paperDecorator, muiDecorator],
+};
+
+const apiDataServerSideError = {
+  mockData: [
+    {
+      url: `https://resources.gdevelop-app.com/assets-database/assetPacks.json`,
+      method: 'GET',
+      status: 500,
+      response: { data: 'status' },
+    },
+  ],
+};
+
+const apiDataFakePacks = {
+  mockData: [
+    {
+      url: `https://resources.gdevelop-app.com/assets-database/assetPacks.json`,
+      method: 'GET',
+      status: 200,
+      response: fakeAssetPacks,
+    },
+  ],
 };
 
 export const Default = () => (
@@ -29,3 +53,23 @@ export const Default = () => (
     />
   </AssetStoreStateProvider>
 );
+Default.decorators = [withMock];
+Default.parameters = apiDataFakePacks;
+
+export const LoadingError = () => (
+  <AssetStoreStateProvider>
+    <AssetStore
+      onOpenDetails={action('onOpenDetails')}
+      events={testProject.testLayout.getEvents()}
+      project={testProject.project}
+      layout={testProject.testLayout}
+      onChooseResource={() => Promise.reject('unimplemented')}
+      resourceSources={[]}
+      onObjectAddedFromAsset={() => {}}
+      resourceExternalEditors={[]}
+      objectsContainer={testProject.testLayout}
+    />
+  </AssetStoreStateProvider>
+);
+LoadingError.decorators = [withMock];
+LoadingError.parameters = apiDataServerSideError;


### PR DESCRIPTION
Also improve the Asset store stories by mocking (some) requests

http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/feature/external-asset-packs/latest/index.html?path=/story/assetstore-assetstore--default

<img width="600" alt="image" src="https://user-images.githubusercontent.com/1280130/171863682-f2eaa5fd-007c-4da6-b259-d7ad03259c98.png">
