### PR TITLE
Few fixes Asset store and Events drag and drop

### DIFF
--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -3,7 +3,7 @@ import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
 import { Column, Line, Spacer } from '../UI/Grid';
 import Text from '../UI/Text';
-import Chip from '@material-ui/core/Chip';
+import Chip from '../UI/Chip';
 import RaisedButton from '../UI/RaisedButton';
 import {
   type AssetShortHeader,

--- a/newIDE/app/src/AssetStore/AssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/AssetPackDialog.js
@@ -214,12 +214,14 @@ export const AssetPackDialog = ({
       }}
       cannotBeDismissed
       actions={[
-        <TextButton
-          key="cancel"
-          label={<Trans>Cancel</Trans>}
-          disabled={isAssetPackBeingInstalled}
-          onClick={onClose}
-        />,
+        // Installing a pack is not cancelable, so we hide the button while installing.
+        !isAssetPackBeingInstalled ? (
+          <TextButton
+            key="cancel"
+            label={<Trans>Cancel</Trans>}
+            onClick={onClose}
+          />
+        ) : null,
         dialogContent.actionButton,
       ]}
       onApply={dialogContent.onApply}

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -235,8 +235,9 @@ export const AssetStore = ({
                   tooltip={t`Back to discover`}
                   onClick={() => {
                     navigationState.openHome();
-                    setIsFiltersPanelOpen(false);
                     clearAllFilters(assetFiltersState);
+                    setIsFiltersPanelOpen(false);
+                    setIsAssetPackAdded(false);
                   }}
                   size="small"
                 >
@@ -282,6 +283,7 @@ export const AssetStore = ({
                             if (navigationState.getCurrentPage().isOnHomePage) {
                               clearAllFilters(assetFiltersState);
                               setIsFiltersPanelOpen(false);
+                              setIsAssetPackAdded(false);
                             }
                           }}
                         />

--- a/newIDE/app/src/CommandPalette/CommandPalette/AutocompletePicker.js
+++ b/newIDE/app/src/CommandPalette/CommandPalette/AutocompletePicker.js
@@ -9,7 +9,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
-import Chip from '@material-ui/core/Chip';
+import Chip from '../../UI/Chip';
 import TextField from '@material-ui/core/TextField';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import Autocomplete from '@material-ui/lab/Autocomplete';
@@ -19,13 +19,16 @@ import commandsList, { commandAreas } from '../CommandsList';
 import { getShortcutDisplayName } from '../../KeyboardShortcuts';
 
 const useStyles = makeStyles({
-  shortcutChip: {
-    borderRadius: 3,
-  },
   listItemContainer: {
     width: '100%',
   },
 });
+
+const styles = {
+  chip: {
+    borderRadius: 3,
+  },
+};
 
 type Item = NamedCommand | CommandOption;
 
@@ -61,7 +64,7 @@ const AutocompletePicker = (
       const shortcutDisplayName = getShortcutDisplayName(shortcutString);
       return (
         <ListItemSecondaryAction>
-          <Chip className={classes.shortcutChip} label={shortcutDisplayName} />
+          <Chip label={shortcutDisplayName} style={styles.chip} />
         </ListItemSecondaryAction>
       );
     }

--- a/newIDE/app/src/Debugger/DebuggerConsole.js
+++ b/newIDE/app/src/Debugger/DebuggerConsole.js
@@ -10,7 +10,7 @@ import {
 } from 'react-virtualized';
 import useForceUpdate from '../Utils/UseForceUpdate';
 
-import Chip from '@material-ui/core/Chip';
+import Chip from '../UI/Chip';
 
 import { Line, Column, Spacer } from '../UI/Grid';
 import Dialog from '../UI/Dialog';

--- a/newIDE/app/src/EventsSheet/EventsTree/BottomButtons.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/BottomButtons.js
@@ -14,7 +14,7 @@ const styles = {
     cursor: 'pointer',
   },
   dropIndicator: {
-    border: '4px solid black',
+    border: '2px solid black',
     outline: '1px solid white',
   },
 };

--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -17,7 +17,7 @@ const sharedStyles = {
   dropIndicator: {
     position: 'absolute',
     zIndex: 2,
-    border: '4px solid black',
+    border: '2px solid black',
     outline: '1px solid white',
   },
   autoScroll: {
@@ -70,9 +70,9 @@ const getTargetPositionStyles = (
 const getIndicatorPositionStyles = (
   indentWidth: number
 ): TargetPositionStyles => ({
-  bottom: { left: '0px', right: '0px', bottom: '-4px' },
-  'bottom-right': { left: `${indentWidth}px`, right: '0px', bottom: '-4px' },
-  top: { left: '0px', right: '0px', top: '-4px' },
+  bottom: { left: '0px', right: '0px', bottom: '-2px' },
+  'bottom-right': { left: `${indentWidth}px`, right: '0px', bottom: '-2px' },
+  top: { left: '0px', right: '0px', top: '-2px' },
 });
 
 function DropTargetContainer({

--- a/newIDE/app/src/KeyboardShortcuts/ShortcutsListRow.js
+++ b/newIDE/app/src/KeyboardShortcuts/ShortcutsListRow.js
@@ -5,7 +5,7 @@ import { type I18n } from '@lingui/core';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
-import Chip from '@material-ui/core/Chip';
+import Chip from '../UI/Chip';
 import IconButton from '../UI/IconButton';
 import RotateLeftIcon from '@material-ui/icons/RotateLeft';
 import WarningIcon from '@material-ui/icons/Warning';
@@ -43,7 +43,6 @@ const ShortcutsListRow = (props: Props) => {
           style={styles.shortcutChip}
           label={props.shortcutString || <Trans>No shortcut</Trans>}
           onClick={props.onEditShortcut}
-          title={props.i18n._(t`Edit shortcut`)}
           color={props.shortcutString ? 'secondary' : 'default'}
         />
         {!props.isDefault && (

--- a/newIDE/app/src/UI/Chip.js
+++ b/newIDE/app/src/UI/Chip.js
@@ -1,0 +1,42 @@
+// @flow
+import * as React from 'react';
+import MuiChip from '@material-ui/core/Chip';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles({
+  root: {
+    cursor: 'default',
+  },
+});
+
+type Props = {|
+  label?: string | React.Node | void,
+  color?: 'default' | 'primary' | 'secondary',
+  icon?: React.Node,
+  size?: 'small' | 'medium',
+  variant?: 'default' | 'outlined',
+  avatar?: React.Node,
+  style?: Object,
+  onClick?: (() => void) | null,
+  onBlur?: (() => void) | null,
+  onFocus?: (() => void) | null,
+  onDelete?: ((event: any) => void) | null,
+|};
+
+const Chip = (props: Props) => (
+  <MuiChip
+    label={props.label}
+    icon={props.icon}
+    size={props.size}
+    variant={props.variant}
+    avatar={props.avatar}
+    style={props.style}
+    onClick={props.onClick}
+    onBlur={props.onBlur}
+    onFocus={props.onFocus}
+    onDelete={props.onDelete}
+    classes={useStyles()}
+  />
+);
+
+export default Chip;

--- a/newIDE/app/src/UI/Chip.js
+++ b/newIDE/app/src/UI/Chip.js
@@ -7,6 +7,9 @@ const useStyles = makeStyles({
   root: {
     cursor: 'default',
   },
+  deleteIcon: {
+    cursor: 'default', // Hover is enough, no need for a different cursor.
+  },
 });
 
 type Props = {|

--- a/newIDE/app/src/UI/InlineCheckbox.js
+++ b/newIDE/app/src/UI/InlineCheckbox.js
@@ -3,7 +3,13 @@ import * as React from 'react';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Tooltip from '@material-ui/core/Tooltip';
-import { FormGroup, FormHelperText } from '@material-ui/core';
+import { FormGroup, FormHelperText, makeStyles } from '@material-ui/core';
+
+const useLabelStyles = makeStyles({
+  root: {
+    cursor: 'default',
+  },
+});
 
 type Props = {|
   label?: ?React.Node,
@@ -28,6 +34,7 @@ const InlineCheckbox = ({
   checkedIcon,
   tooltipOrHelperText,
 }: Props) => {
+  const labelClasses = useLabelStyles();
   const checkbox = (
     <Checkbox
       disabled={disabled}
@@ -42,7 +49,11 @@ const InlineCheckbox = ({
   );
   return label ? (
     <FormGroup>
-      <FormControlLabel control={checkbox} label={label} />
+      <FormControlLabel
+        control={checkbox}
+        label={label}
+        classes={labelClasses}
+      />
       {tooltipOrHelperText && (
         <FormHelperText>{tooltipOrHelperText}</FormHelperText>
       )}

--- a/newIDE/app/src/UI/SelectField.js
+++ b/newIDE/app/src/UI/SelectField.js
@@ -11,11 +11,13 @@ import { makeStyles } from '@material-ui/core';
 const INVALID_VALUE = '';
 const stopPropagation = event => event.stopPropagation();
 
-const useSelectCenterStyles = makeStyles({
-  root: {
-    textAlign: 'center',
-  },
-});
+const useSelectStyles = textAlign =>
+  makeStyles({
+    root: {
+      textAlign: textAlign || 'left',
+      cursor: 'default',
+    },
+  })();
 
 export type SelectFieldInterface = {| focus: () => void |};
 
@@ -70,7 +72,7 @@ const SelectField = React.forwardRef<Props, SelectFieldInterface>(
     React.useImperativeHandle(ref, () => ({
       focus,
     }));
-    const selectCenterStyles = useSelectCenterStyles();
+    const selectStyles = useSelectStyles(props.textAlign);
 
     const onChange = props.onChange || undefined;
 
@@ -124,7 +126,7 @@ const SelectField = React.forwardRef<Props, SelectFieldInterface>(
             }}
             SelectProps={{
               native: true,
-              classes: props.textAlign === 'center' ? selectCenterStyles : {},
+              classes: selectStyles,
             }}
             style={props.style}
             inputRef={inputRef}

--- a/newIDE/app/src/UI/SemiControlledMultiAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledMultiAutoComplete.js
@@ -4,6 +4,7 @@ import { I18n } from '@lingui/react';
 import TextField from '@material-ui/core/TextField';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 import Autocomplete from '@material-ui/lab/Autocomplete';
+import { makeStyles } from '@material-ui/core';
 
 export type AutocompleteOption = {|
   text: string, // The text displayed
@@ -12,12 +13,14 @@ export type AutocompleteOption = {|
 
 export type DataSource = Array<?AutocompleteOption>;
 
-const styles = {
-  chip: {
-    // Make the chips smaller to fit the input
-    height: 25,
+const useChipStyles = makeStyles({
+  root: {
+    height: 25, // Make the chips smaller to fit the input.
   },
-};
+  deleteIcon: {
+    cursor: 'default', // Hover is enough, no need for a different cursor.
+  },
+});
 
 type Props = {|
   value: Array<AutocompleteOption>,
@@ -36,6 +39,7 @@ type Props = {|
 |};
 
 export default function SemiControlledMultiAutoComplete(props: Props) {
+  const chipStyles = useChipStyles();
   return (
     <I18n>
       {({ i18n }) => (
@@ -72,7 +76,7 @@ export default function SemiControlledMultiAutoComplete(props: Props) {
           fullWidth={props.fullWidth}
           disabled={props.loading}
           ChipProps={{
-            style: styles.chip,
+            classes: chipStyles,
           }}
         />
       )}

--- a/newIDE/app/src/UI/TagChips.js
+++ b/newIDE/app/src/UI/TagChips.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import Chip from '@material-ui/core/Chip';
+import Chip from '../UI/Chip';
 import randomColor from 'randomcolor';
 import { type Tags, removeTag } from '../Utils/TagsHelper';
 

--- a/newIDE/app/src/UI/Theme/DarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DarkTheme/theme.json
@@ -169,7 +169,7 @@
     "drop-indicator": {
       "can-drop": {
         "color": {
-          "value": "{gdevelop.color.dark-blue.value}"
+          "value": "#dddddd"
         }
       },
       "cannot-drop": {

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -181,7 +181,7 @@
     "drop-indicator": {
       "can-drop": {
         "color": {
-          "value": "#4C5361"
+          "value": "#D6DEEC"
         }
       },
       "cannot-drop": {

--- a/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
@@ -179,7 +179,7 @@
     "drop-indicator": {
       "can-drop": {
         "color": {
-          "value": "#4C5361"
+          "value": "#D6DEEC"
         }
       },
       "cannot-drop": {

--- a/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
@@ -169,7 +169,7 @@
     "drop-indicator": {
       "can-drop": {
         "color": {
-          "value": "#047AA6"
+          "value": "#DCDCDC"
         }
       },
       "cannot-drop": {

--- a/newIDE/app/src/UI/Toggle.js
+++ b/newIDE/app/src/UI/Toggle.js
@@ -2,6 +2,13 @@
 import * as React from 'react';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles({
+  root: {
+    cursor: 'default',
+  },
+});
 
 // We support a subset of the props supported by Material-UI v0.x Toggle
 // They should be self descriptive - refer to Material UI docs otherwise.
@@ -20,21 +27,23 @@ type Props = {|
 /**
  * A text field based on Material-UI text field.
  */
-export default class Toggle extends React.Component<Props, {||}> {
-  render() {
-    return (
-      <FormControlLabel
-        control={
-          <Switch
-            checked={this.props.toggled}
-            onChange={event => this.props.onToggle(event, event.target.checked)}
-            color="primary"
-          />
-        }
-        label={this.props.label}
-        disabled={this.props.disabled}
-        style={this.props.style}
-      />
-    );
-  }
-}
+const Toggle = (props: Props) => {
+  const classes = useStyles();
+  return (
+    <FormControlLabel
+      control={
+        <Switch
+          checked={props.toggled}
+          onChange={event => props.onToggle(event, event.target.checked)}
+          color="primary"
+        />
+      }
+      label={props.label}
+      disabled={props.disabled}
+      classes={classes}
+      style={props.style}
+    />
+  );
+};
+
+export default Toggle;

--- a/newIDE/app/src/UI/User/UserChip.js
+++ b/newIDE/app/src/UI/User/UserChip.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Trans } from '@lingui/macro';
 import { makeStyles } from '@material-ui/core';
-import Chip from '@material-ui/core/Chip';
+import Chip from '../../UI/Chip';
 import FaceIcon from '@material-ui/icons/Face';
 import Avatar from '@material-ui/core/Avatar';
 import { type Profile } from '../../Utils/GDevelopServices/Authentication';

--- a/newIDE/app/src/UI/User/UserPublicProfileChip.js
+++ b/newIDE/app/src/UI/User/UserPublicProfileChip.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import Chip from '@material-ui/core/Chip';
+import Chip from '../../UI/Chip';
 import FaceIcon from '@material-ui/icons/Face';
 import { type UserPublicProfileSearch } from '../../Utils/GDevelopServices/User';
 import PublicProfileContext from '../../Profile/PublicProfileContext';


### PR DESCRIPTION
Few fixes listed in #3989 

- Inconsistency of cursor in asset store
- cancel button shown even if not cancelable
- Reset pack disabled for all packs after adding one
- improve style of drop indicator
-

do not show in changelog