### PR TITLE
Set search bars to be rounded in the modern theme

### DIFF
--- a/newIDE/app/src/AssetStore/ExampleStore/index.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/index.js
@@ -15,13 +15,6 @@ import { type SearchMatch } from '../../UI/Search/UseSearchStructuredItem';
 import { sendExampleDetailsOpened } from '../../Utils/Analytics/EventSender';
 import { t } from '@lingui/macro';
 
-const styles = {
-  searchBar: {
-    // TODO: Can we put this in the search bar by default?
-    flexShrink: 0,
-  },
-};
-
 type Props = {|
   isOpening: boolean,
   onOpen: ExampleShortHeader => Promise<void>,
@@ -92,7 +85,7 @@ export const ExampleStore = ({ isOpening, onOpen, focusOnMount }: Props) => {
               value={searchText}
               onChange={setSearchText}
               onRequestSearch={() => {}}
-              style={styles.searchBar}
+              aspect="add-margins-only-if-modern-theme"
               tagsHandler={tagsHandler}
               tags={filters && filters.defaultTags}
               ref={searchBarRef}
@@ -103,6 +96,7 @@ export const ExampleStore = ({ isOpening, onOpen, focusOnMount }: Props) => {
               overflow={
                 'hidden' /* Somehow required on Chrome/Firefox to avoid children growing (but not on Safari) */
               }
+              noMargin
             >
               <ListSearchResults
                 disableAutoTranslate // Search results text highlighting conflicts with dom handling by browser auto-translations features. Disables auto translation to prevent crashes.

--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -16,13 +16,6 @@ import {
 import useDismissableTutorialMessage from '../../Hints/useDismissableTutorialMessage';
 import { t } from '@lingui/macro';
 
-const styles = {
-  searchBar: {
-    // TODO: Can we put this in the search bar by default?
-    flexShrink: 0,
-  },
-};
-
 type Props = {|
   isInstalling: boolean,
   project: gdProject,
@@ -100,7 +93,7 @@ export const ExtensionStore = ({
               value={searchText}
               onChange={setSearchText}
               onRequestSearch={() => {}}
-              style={styles.searchBar}
+              aspect="add-margins-only-if-modern-theme"
               tagsHandler={tagsHandler}
               tags={filters && filters.allTags}
               placeholder={t`Search extensions`}

--- a/newIDE/app/src/AssetStore/ResourceStore/index.js
+++ b/newIDE/app/src/AssetStore/ResourceStore/index.js
@@ -13,13 +13,6 @@ import Subheader from '../../UI/Subheader';
 import { CategoryChooser } from '../../UI/Search/CategoryChooser';
 import { t, Trans } from '@lingui/macro';
 
-const styles = {
-  searchBar: {
-    // TODO: Can we put this in the search bar by default?
-    flexShrink: 0,
-  },
-};
-
 type Props = {
   onChoose: Resource => void,
   resourceKind: string,
@@ -53,7 +46,7 @@ export const ResourceStore = ({ onChoose, resourceKind }: Props) => {
         value={searchText}
         onChange={setSearchText}
         onRequestSearch={() => {}}
-        style={styles.searchBar}
+        aspect="add-margins-only-if-modern-theme"
         placeholder={t`Search resources`}
       />
       <Line

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -46,13 +46,6 @@ import { enumerateObjects } from '../ObjectsList/EnumerateObjects';
 import { AssetPackDialog } from './AssetPackDialog';
 import Home from '@material-ui/icons/Home';
 
-const styles = {
-  searchBar: {
-    // TODO: Can we put this in the search bar by default?
-    flexShrink: 0,
-  },
-};
-
 type Props = {
   project: gdProject,
   objectsContainer: gdObjectsContainer,
@@ -253,7 +246,6 @@ export const AssetStore = ({
                       navigationState.clearHistory();
                       setIsFiltersPanelOpen(true);
                     }}
-                    style={styles.searchBar}
                     ref={searchBar}
                     id="asset-store-search-bar"
                   />

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -255,6 +255,7 @@ export default function NewBehaviorDialog({
                       chooseBehavior(i18n, deprecatedBehaviors[0]);
                     }
                   }}
+                  aspect="add-margins-only-if-modern-theme"
                   onChange={setSearchText}
                   ref={searchBar}
                   placeholder={t`Search installed behaviors`}

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -338,6 +338,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
               searchText: text,
             })
           }
+          aspect="integrated-search-bar"
           placeholder={t`Search behaviors`}
         />
       </Background>

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -408,6 +408,7 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
               searchText: text,
             })
           }
+          aspect="integrated-search-bar"
           placeholder={t`Search functions`}
         />
       </Background>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionSelector/index.js
@@ -31,14 +31,6 @@ import {
 } from '../../../UI/Search/UseSearchStructuredItem';
 const gd: libGDevelop = global.gd;
 
-const styles = {
-  searchBar: {
-    backgroundColor: 'transparent',
-    flexShrink: 0,
-    zIndex: 1, // Put the SearchBar in front of the list, to display the shadow
-  },
-};
-
 const getGroupIconSrc = (key: string) => {
   return gd.JsPlatform.get()
     .getInstructionOrExpressionGroupMetadata(key)
@@ -159,7 +151,7 @@ export default class InstructionOrExpressionSelector<
                 })
               }
               onRequestSearch={onSubmitSearch}
-              style={styles.searchBar}
+              aspect="integrated-search-bar"
               placeholder={
                 searchPlaceholderObjectName
                   ? searchPlaceholderIsCondition

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -63,12 +63,6 @@ import {
 
 const gd: libGDevelop = global.gd;
 
-const styles = {
-  searchBar: {
-    flexShrink: 0,
-  },
-};
-
 const DISPLAYED_INSTRUCTIONS_MAX_LENGTH = 20;
 
 export type TabName = 'objects' | 'free-instructions';
@@ -389,7 +383,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
                   buildMenuTemplate={() =>
                     this._buildObjectTagsMenuTemplate(i18n)
                   }
-                  style={styles.searchBar}
+                  aspect="integrated-search-bar"
                   ref={this._searchBar}
                   placeholder={
                     isCondition

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorMenu.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorMenu.js
@@ -19,7 +19,7 @@ import { type EventsScope } from '../../InstructionOrExpression/EventsScope.flow
 import { SelectColumns } from '../../UI/Reponsive/SelectColumns';
 import useForceUpdate from '../../Utils/UseForceUpdate';
 import { setupInstructionParameters } from '../../InstructionOrExpression/SetupInstructionParameters';
-import FlatButton from '../../UI/FlatButton';
+import TextButton from '../../UI/TextButton';
 import Paste from '../../UI/CustomSvgIcons/Paste';
 import { Line } from '../../UI/Grid';
 
@@ -215,7 +215,7 @@ export default function NewInstructionEditorMenu({
         }}
       />
       <Line noMargin justifyContent="flex-end">
-        <FlatButton
+        <TextButton
           label={
             isCondition ? (
               <Trans>Paste condition(s)</Trans>

--- a/newIDE/app/src/GamesShowcase/index.js
+++ b/newIDE/app/src/GamesShowcase/index.js
@@ -13,13 +13,6 @@ import { t, Trans } from '@lingui/macro';
 import Subheader from '../UI/Subheader';
 import { CategoryChooser } from '../UI/Search/CategoryChooser';
 
-const styles = {
-  searchBar: {
-    // TODO: Can we put this in the search bar by default?
-    flexShrink: 0,
-  },
-};
-
 const getShowcasedGameTitle = (showcasedGame: ShowcasedGame) =>
   showcasedGame.title;
 
@@ -51,7 +44,7 @@ export const GamesShowcase = (props: Props) => {
             value={searchText}
             onChange={setSearchText}
             onRequestSearch={() => {}}
-            style={styles.searchBar}
+            aspect="add-margins-only-if-modern-theme"
             placeholder={t`Search games`}
           />
           <Line
@@ -59,6 +52,7 @@ export const GamesShowcase = (props: Props) => {
             overflow={
               'hidden' /* Somehow required on Chrome/Firefox to avoid children growing (but not on Safari) */
             }
+            noMargin
           >
             <Background
               noFullHeight

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -177,6 +177,7 @@ export default class InstancePropertiesEditor extends React.Component<Props> {
                 <Trans>Instance Variables</Trans>
               </Text>
               <IconButton
+                size="small"
                 onClick={() => {
                   this.props.editInstanceVariables(instance);
                 }}

--- a/newIDE/app/src/InstancesEditor/InstancesList/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancesList/index.js
@@ -294,6 +294,7 @@ export default class InstancesList extends Component<Props, State> {
               onRequestSearch={this._selectFirstInstance}
               ref={this._searchBar}
               placeholder={t`Search instances`}
+              aspect="integrated-search-bar"
             />
           </div>
         )}

--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -445,6 +445,7 @@ export default class GroupsListContainer extends React.Component<Props, State> {
               searchText: text,
             })
           }
+          aspect="integrated-search-bar"
           placeholder={t`Search object groups`}
         />
       </Background>

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -695,6 +695,7 @@ export default class ObjectsList extends React.Component<Props, State> {
               searchText: text,
             })
           }
+          aspect="integrated-search-bar"
           placeholder={t`Search objects`}
         />
         {this.state.newObjectDialogOpen && (

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -1068,6 +1068,7 @@ export default class ProjectManager extends React.Component<Props, State> {
               onRequestSearch={this._onRequestSearch}
               onChange={this._onSearchChange}
               placeholder={t`Search in project`}
+              aspect="integrated-search-bar"
             />
             {this.state.projectVariablesEditorOpen && (
               <VariablesEditorDialog

--- a/newIDE/app/src/ResourcesList/index.js
+++ b/newIDE/app/src/ResourcesList/index.js
@@ -382,6 +382,7 @@ export default class ResourcesList extends React.Component<Props, State> {
             })
           }
           placeholder={t`Search resources`}
+          aspect="integrated-search-bar"
         />
       </Background>
     );

--- a/newIDE/app/src/UI/SearchBar.js
+++ b/newIDE/app/src/UI/SearchBar.js
@@ -16,7 +16,6 @@ import Search from '@material-ui/icons/Search';
 import FilterList from '@material-ui/icons/FilterList';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import ElementWithMenu from './Menu/ElementWithMenu';
-import ThemeConsumer from './Theme/ThemeConsumer';
 import HelpIcon from './HelpIcon';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 import { useScreenType } from './Reponsive/ScreenTypeMeasurer';
@@ -24,6 +23,7 @@ import { shouldValidate } from './KeyboardShortcuts/InteractionKeys';
 import { Column, Line } from './Grid';
 import TagChips from './TagChips';
 import { I18n } from '@lingui/react';
+import GDevelopThemeContext from './Theme/ThemeContext';
 
 type TagsHandler = {|
   remove: string => void,
@@ -41,8 +41,8 @@ type Props = {|
   onChange?: string => void,
   /** Fired when the search icon is clicked. */
   onRequestSearch: string => void,
-  /** Override the inline-styles of the root element. */
-  style?: Object,
+  /** Set if margins should be added or not. */
+  aspect?: 'integrated-search-bar' | 'add-margins-only-if-modern-theme',
   /** The value of the text field. */
   value: string,
   /** The functions needed to interact with the list of tags displayed below search bar. */
@@ -102,7 +102,6 @@ const getStyles = (value: ?string, disabled?: boolean) => {
       width: '100%',
     },
     searchContainer: {
-      top: -1,
       position: 'relative',
       margin: 'auto 8px',
       width: '100%',
@@ -143,8 +142,8 @@ const SearchBar = React.forwardRef<Props, SearchBarInterface>(
       placeholder,
       onChange,
       onRequestSearch,
-      style,
       value: parentValue,
+      aspect,
       tagsHandler,
       tags,
       buildMenuTemplate,
@@ -166,6 +165,12 @@ const SearchBar = React.forwardRef<Props, SearchBarInterface>(
         textField.current.blur();
       }
     };
+
+    const gdevelopTheme = React.useContext(GDevelopThemeContext);
+    const noMargin =
+      aspect === 'add-margins-only-if-modern-theme' && gdevelopTheme.isModern
+        ? false
+        : true;
 
     // This variable represents the content of the input (text field)
     const [value, setValue] = React.useState<string>(parentValue);
@@ -283,119 +288,114 @@ const SearchBar = React.forwardRef<Props, SearchBarInterface>(
     return (
       <I18n>
         {({ i18n }) => (
-          <ThemeConsumer>
-            {muiTheme => (
-              <Column noMargin>
-                <Line noMargin>
-                  <Paper
-                    style={{
-                      backgroundColor: muiTheme.searchBar.backgroundColor,
-                      ...styles.root,
-                      ...style,
-                    }}
-                    square
-                    elevation={1}
-                  >
-                    <div style={styles.searchContainer}>
-                      {tags ? (
-                        <Autocomplete
-                          id={id}
-                          options={tags.slice(0, 30)}
-                          groupBy={options => i18n._(t`Apply a filter`)}
-                          classes={autocompleteStyles}
-                          freeSolo
-                          fullWidth
-                          defaultValue=""
-                          inputValue={value}
-                          value={autocompleteValue}
-                          onChange={handleAutocompleteInput}
-                          onInputChange={handleAutocompleteInputChange}
-                          onKeyPress={handleKeyPressed}
-                          onBlur={handleBlur}
-                          renderOption={option => (
-                            <Typography>{option}</Typography>
-                          )}
-                          renderInput={params => (
-                            <MuiTextField
-                              margin="none"
-                              {...params}
-                              inputRef={textField}
-                              InputProps={{
-                                ...params.InputProps,
-                                disableUnderline: true,
-                                endAdornment: null,
-                                placeholder: i18n._(placeholder || t`Search`),
-                              }}
-                            />
-                          )}
-                        />
-                      ) : (
-                        <TextField
-                          id={id}
+          <Column noMargin={noMargin}>
+            <Line noMargin={noMargin}>
+              <Paper
+                style={{
+                  backgroundColor: gdevelopTheme.searchBar.backgroundColor,
+                  ...styles.root,
+                }}
+                square={
+                  aspect === 'integrated-search-bar' || !gdevelopTheme.isModern
+                }
+                elevation={gdevelopTheme.isModern ? 0 : 1}
+              >
+                <div style={styles.searchContainer}>
+                  {tags ? (
+                    <Autocomplete
+                      id={id}
+                      options={tags.slice(0, 30)}
+                      groupBy={options => i18n._(t`Apply a filter`)}
+                      classes={autocompleteStyles}
+                      freeSolo
+                      fullWidth
+                      defaultValue=""
+                      inputValue={value}
+                      value={autocompleteValue}
+                      onChange={handleAutocompleteInput}
+                      onInputChange={handleAutocompleteInputChange}
+                      onKeyPress={handleKeyPressed}
+                      onBlur={handleBlur}
+                      renderOption={option => <Typography>{option}</Typography>}
+                      renderInput={params => (
+                        <MuiTextField
                           margin="none"
-                          hintText={placeholder || t`Search`}
-                          onBlur={handleBlur}
-                          value={value}
-                          onChange={handleInput}
-                          onKeyUp={handleKeyPressed}
-                          fullWidth
-                          style={styles.input}
-                          underlineShow={false}
-                          disabled={disabled}
-                          ref={textField}
+                          {...params}
+                          inputRef={textField}
+                          InputProps={{
+                            ...params.InputProps,
+                            disableUnderline: true,
+                            endAdornment: null,
+                            placeholder: i18n._(placeholder || t`Search`),
+                          }}
                         />
                       )}
-                    </div>
-                    {buildMenuTemplate && (
-                      <ElementWithMenu
-                        element={
-                          <IconButton
-                            style={styles.iconButtonFilter.style}
-                            disabled={disabled}
-                            size="small"
-                          >
-                            <FilterList />
-                          </IconButton>
-                        }
-                        buildMenuTemplate={buildMenuTemplate}
-                      />
-                    )}
-                    {helpPagePath && (
-                      <HelpIcon
-                        disabled={disabled}
-                        helpPagePath={helpPagePath}
-                        style={styles.iconButtonHelp.style}
-                        size="small"
-                      />
-                    )}
-                    <IconButton
-                      style={styles.iconButtonSearch.style}
-                      disabled={disabled}
-                      size="small"
-                    >
-                      <Search style={styles.iconButtonSearch.iconStyle} />
-                    </IconButton>
-                    <IconButton
-                      onClick={handleCancel}
-                      style={styles.iconButtonClose.style}
-                      disabled={disabled}
-                      size="small"
-                    >
-                      <Close style={styles.iconButtonClose.iconStyle} />
-                    </IconButton>
-                  </Paper>
-                </Line>
-                {tagsHandler && (
-                  <Collapse in={tagsHandler.chosenTags.size > 0}>
-                    <TagChips
-                      tags={Array.from(tagsHandler.chosenTags)}
-                      onRemove={tag => tagsHandler.remove(tag)}
                     />
-                  </Collapse>
+                  ) : (
+                    <TextField
+                      id={id}
+                      margin="none"
+                      hintText={placeholder || t`Search`}
+                      onBlur={handleBlur}
+                      value={value}
+                      onChange={handleInput}
+                      onKeyUp={handleKeyPressed}
+                      fullWidth
+                      style={styles.input}
+                      underlineShow={false}
+                      disabled={disabled}
+                      ref={textField}
+                    />
+                  )}
+                </div>
+                {buildMenuTemplate && (
+                  <ElementWithMenu
+                    element={
+                      <IconButton
+                        style={styles.iconButtonFilter.style}
+                        disabled={disabled}
+                        size="small"
+                      >
+                        <FilterList />
+                      </IconButton>
+                    }
+                    buildMenuTemplate={buildMenuTemplate}
+                  />
                 )}
-              </Column>
+                {helpPagePath && (
+                  <HelpIcon
+                    disabled={disabled}
+                    helpPagePath={helpPagePath}
+                    style={styles.iconButtonHelp.style}
+                    size="small"
+                  />
+                )}
+                <IconButton
+                  style={styles.iconButtonSearch.style}
+                  disabled={disabled}
+                  size="small"
+                >
+                  <Search style={styles.iconButtonSearch.iconStyle} />
+                </IconButton>
+                <IconButton
+                  onClick={handleCancel}
+                  style={styles.iconButtonClose.style}
+                  disabled={disabled}
+                  size="small"
+                >
+                  <Close style={styles.iconButtonClose.iconStyle} />
+                </IconButton>
+              </Paper>
+            </Line>
+            {tagsHandler && (
+              <Collapse in={tagsHandler.chosenTags.size > 0}>
+                <TagChips
+                  tags={Array.from(tagsHandler.chosenTags)}
+                  onRemove={tag => tagsHandler.remove(tag)}
+                />
+              </Collapse>
             )}
-          </ThemeConsumer>
+          </Column>
         )}
       </I18n>
     );


### PR DESCRIPTION
* Search bar have rounding and margins in most dialogs. Margins are better because they are following the asset store design.
* In lists, they stay "integrated" (no rounding, no margins)

<img width="957" alt="image" src="https://user-images.githubusercontent.com/1280130/172152306-af699c48-ab7f-4bfd-9699-a3d9fef61b55.png">
<img width="267" alt="image" src="https://user-images.githubusercontent.com/1280130/172152337-0179e84e-0c1f-45fb-9615-a41f66382b77.png">
<img width="976" alt="image" src="https://user-images.githubusercontent.com/1280130/172152426-b2872a8b-9e07-4633-990f-b5e4328210b2.png">
<img width="998" alt="image" src="https://user-images.githubusercontent.com/1280130/172152456-5c14ce87-90a6-43f6-b22f-3b3e1f552c2b.png">

Also fix an icon that was too big.

Don't show in changelog