### PR TITLE
howler-sound-manager: Preload sounds sequentially

### DIFF
--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -761,7 +761,8 @@ namespace gdjs {
         }
       }
 
-      const totalCount = Object.keys(files).length;
+      const filesToLoad = Object.keys(files);
+      const totalCount = filesToLoad.length;
       if (totalCount === 0) return onComplete(totalCount); // Nothing to load.
 
       let loadedCount: integer = 0;
@@ -775,6 +776,7 @@ namespace gdjs {
         if (loadedCount === totalCount) return onComplete(totalCount);
 
         onProgress(loadedCount, totalCount);
+        loadNextFile();
       };
 
       const preloadAudioFile = (
@@ -796,29 +798,30 @@ namespace gdjs {
         );
       };
 
-      for (let file in files) {
-        if (files.hasOwnProperty(file)) {
-          const fileData = files[file][0];
-          if (!fileData.preloadAsSound && !fileData.preloadAsMusic) {
-            onLoad();
-          } else if (fileData.preloadAsSound && fileData.preloadAsMusic) {
-            let loadedOnce = false;
-            const callback = (_, error) => {
-              if (!loadedOnce) {
-                loadedOnce = true;
-                return;
-              }
-              onLoad(_, error);
-            };
+      const loadNextFile = () => {
+        if (!filesToLoad.length) return;
+        const file = filesToLoad.shift()!;
+        const fileData = files[file][0];
+        if (!fileData.preloadAsSound && !fileData.preloadAsMusic) {
+          onLoad();
+        } else if (fileData.preloadAsSound && fileData.preloadAsMusic) {
+          let loadedOnce = false;
+          const callback = (_, error) => {
+            if (!loadedOnce) {
+              loadedOnce = true;
+              return;
+            }
+            onLoad(_, error);
+          };
 
-            preloadAudioFile(file, callback, /* isMusic= */ true);
-            preloadAudioFile(file, callback, /* isMusic= */ false);
-          } else if (fileData.preloadAsSound) {
-            preloadAudioFile(file, onLoad, /* isMusic= */ false);
-          } else if (fileData.preloadAsMusic)
-            preloadAudioFile(file, onLoad, /* isMusic= */ true);
-        }
-      }
+          preloadAudioFile(file, callback, /* isMusic= */ true);
+          preloadAudioFile(file, callback, /* isMusic= */ false);
+        } else if (fileData.preloadAsSound) {
+          preloadAudioFile(file, onLoad, /* isMusic= */ false);
+        } else if (fileData.preloadAsMusic)
+          preloadAudioFile(file, onLoad, /* isMusic= */ true);
+      };
+      loadNextFile();
     }
   }
 


### PR DESCRIPTION
Trying to preload all sounds at once can overwhelm the browser
in case of projects with many big sound files. Load the files
sequentially, the same way images are being preloaded.