### PR TITLE
Fix asset thumbnail having a wrong size when navigating the Asset store

### DIFF
--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -129,6 +129,8 @@ export const AssetDetails = ({
     () => {
       (async () => {
         try {
+          // Reinitialise asset to trigger a loader and recalculate all parameters. (for instance zoom)
+          setAsset(null);
           const loadedAsset = await getAsset(assetShortHeader);
           setAsset(loadedAsset);
           if (loadedAsset.objectType === 'sprite') {

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -38,6 +38,7 @@ import EmptyMessage from '../UI/EmptyMessage';
 import { BoxSearchResults } from '../UI/Search/BoxSearchResults';
 
 const FIXED_HEIGHT = 250;
+const FIXED_WIDTH = 300;
 
 const styles = {
   previewBackground: {
@@ -46,7 +47,7 @@ const styles = {
     justifyContent: 'center',
     alignItems: 'center',
     padding: 10,
-    width: 300,
+    width: FIXED_WIDTH,
     height: FIXED_HEIGHT,
   },
   chip: {
@@ -298,43 +299,44 @@ export const AssetDetails = ({
         </Line>
         <ResponsiveLineStackLayout noMargin>
           <Column>
-            <div style={styles.previewBackground}>
-              {asset ? (
-                <>
-                  {asset.objectType === 'sprite' &&
-                    animationResources &&
-                    direction && (
-                      <AnimationPreview
-                        resourceNames={animationResources.map(
-                          ({ name }) => name
-                        )}
-                        getImageResourceSource={(resourceName: string) => {
-                          const resource = assetResources[resourceName];
-                          return resource ? resource.file : '';
-                        }}
-                        isImageResourceSmooth={() => isImageResourceSmooth}
-                        project={project}
-                        timeBetweenFrames={direction.timeBetweenFrames}
-                        isLooping // Always loop in the asset store.
-                        hideCheckeredBackground
-                        hideControls
-                        initialZoom={140 / Math.max(asset.width, asset.height)}
-                        fixedHeight={FIXED_HEIGHT}
-                      />
-                    )}
-                  {(asset.objectType === 'tiled' ||
-                    asset.objectType === '9patch') && (
+            {asset ? (
+              <>
+                {asset.objectType === 'sprite' &&
+                  animationResources &&
+                  direction && (
+                    <AnimationPreview
+                      resourceNames={animationResources.map(({ name }) => name)}
+                      getImageResourceSource={(resourceName: string) => {
+                        const resource = assetResources[resourceName];
+                        return resource ? resource.file : '';
+                      }}
+                      isImageResourceSmooth={() => isImageResourceSmooth}
+                      project={project}
+                      timeBetweenFrames={direction.timeBetweenFrames}
+                      isLooping // Always loop in the asset store.
+                      hideCheckeredBackground
+                      hideControls
+                      initialZoom={140 / Math.max(asset.width, asset.height)}
+                      fixedHeight={FIXED_HEIGHT}
+                      fixedWidth={FIXED_WIDTH}
+                    />
+                  )}
+                {(asset.objectType === 'tiled' ||
+                  asset.objectType === '9patch') && (
+                  <div style={styles.previewBackground}>
                     <CorsAwareImage
                       style={styles.previewImage}
                       src={asset.previewImageUrls[0]}
                       alt={asset.name}
                     />
-                  )}
-                </>
-              ) : (
+                  </div>
+                )}
+              </>
+            ) : (
+              <div style={styles.previewBackground}>
                 <PlaceholderLoader />
-              )}
-            </div>
+              </div>
+            )}
             {assetAnimations &&
               assetAnimations.length > 1 &&
               typeof selectedAnimationName === 'string' && (

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview/index.js
@@ -36,6 +36,7 @@ type Props = {|
   hideControls?: boolean,
   initialZoom?: number,
   fixedHeight?: number,
+  fixedWidth?: number,
 |};
 
 const AnimationPreview = ({
@@ -50,6 +51,7 @@ const AnimationPreview = ({
   hideControls,
   initialZoom,
   fixedHeight,
+  fixedWidth,
 }: Props) => {
   const forceUdpate = useForceUpdate();
 
@@ -171,6 +173,7 @@ const AnimationPreview = ({
         hideCheckeredBackground={hideCheckeredBackground}
         hideControls={hideControls}
         fixedHeight={fixedHeight}
+        fixedWidth={fixedWidth}
       />
       {!hideControls && (
         <LineStackLayout noMargin alignItems="center">

--- a/newIDE/app/src/UI/Search/BoxSearchResults.js
+++ b/newIDE/app/src/UI/Search/BoxSearchResults.js
@@ -63,8 +63,6 @@ export const BoxSearchResults = <SearchItem>({
       <div style={styles.container}>
         <AutoSizer>
           {({ width, height }) => {
-            if (!width || !height) return null;
-
             const columnCount = Math.max(Math.floor((width - 5) / baseSize), 1);
             const columnWidth = Math.max(Math.floor(width / columnCount), 30);
             const rowCount = Math.max(


### PR DESCRIPTION
This fixes a few things:

- when going back from one asset to the other, we reset the asset to allow setting the zoom again + seeing a loader
- when the screen is really small, the search results were not displayed at all and couldn't be accessed
- when an asset loads, sometimes a scroll is seen and the image jumps


https://user-images.githubusercontent.com/4895034/173111248-f5001da4-82c5-4981-a474-7da6c75f7744.mov

