### PR TITLE
Add WebManifest generation to builds

### DIFF
--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -121,6 +121,11 @@ bool Exporter::ExportWholePixiProject(
         fs, exportedProject, codeOutputDir + "/data.js", noRuntimeGameOptions);
     includesFiles.push_back(codeOutputDir + "/data.js");
 
+    // Export a WebManifest with project metadata
+    if (!fs.WriteToFile(exportDir + "/manifest.webmanifest",
+                        helper.GenerateWebManifest(exportedProject)))
+      gd::LogError("Unable to export WebManifest!");
+
     helper.ExportIncludesAndLibs(includesFiles, exportDir, false);
 
     gd::String source = gdjsRoot + "/Runtime/index.html";

--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -124,7 +124,7 @@ bool Exporter::ExportWholePixiProject(
     // Export a WebManifest with project metadata
     if (!fs.WriteToFile(exportDir + "/manifest.webmanifest",
                         helper.GenerateWebManifest(exportedProject)))
-      gd::LogError("Unable to export WebManifest!");
+      gd::LogError("Unable to export WebManifest.");
 
     helper.ExportIncludesAndLibs(includesFiles, exportDir, false);
 

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -904,6 +904,7 @@ const gd::String ExporterHelper::GenerateWebManifest(
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "black",
+  "categories": ["games", "entertainment"],
   "icons": {ICONS}
 })webmanifest")
       .FindAndReplace("{NAME}", project.GetName())

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -858,28 +858,28 @@ const gd::String ExporterHelper::GenerateWebManifest(
 
   {
     std::map<int, gd::String> resourcesForSizes;
-    const auto FileNameForIcon = [&project](const gd::String &platform,
-                                            const int size) {
-      return project.GetPlatformSpecificAssets().Has(
-                 platform, "icon-" + gd::String::From(size))
+    const auto getFileNameForIcon = [&project](const gd::String &platform,
+                                               const int size) {
+      const gd::String iconName = "icon-" + gd::String::From(size);
+      return project.GetPlatformSpecificAssets().Has(platform, iconName)
                  ? project.GetResourcesManager()
                        .GetResource(project.GetPlatformSpecificAssets().Get(
-                           platform, "icon-" + gd::String::From(size)))
+                           platform, iconName))
                        .GetFile()
                  : "";
     };
 
     for (const int size : IOS_ICONS_SIZES) {
-      const auto iconFile = FileNameForIcon("ios", size);
+      const auto iconFile = getFileNameForIcon("ios", size);
       if (!iconFile.empty()) resourcesForSizes[size] = iconFile;
     };
 
     for (const int size : ANDROID_ICONS_SIZES) {
-      const auto iconFile = FileNameForIcon("android", size);
+      const auto iconFile = getFileNameForIcon("android", size);
       if (!iconFile.empty()) resourcesForSizes[size] = iconFile;
     };
 
-    const auto desktopIconFile = FileNameForIcon("desktop", 512);
+    const auto desktopIconFile = getFileNameForIcon("desktop", 512);
     if (!desktopIconFile.empty()) resourcesForSizes[512] = desktopIconFile;
 
     for (const auto &sizeAndFile : resourcesForSizes) {

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -9,6 +9,7 @@
 #include <emscripten.h>
 #endif
 #include <algorithm>
+#include <array>
 #include <fstream>
 #include <functional>
 #include <sstream>
@@ -843,5 +844,74 @@ void ExporterHelper::AddDeprecatedFontFilesToFontResources(
   }
   // end of compatibility code
 }
+
+const std::array<int, 20> IOS_ICONS_SIZES = {
+    180, 60,  120, 76, 152, 40, 80, 57,  114, 72,
+    144, 167, 29,  58, 87,  50, 20, 100, 167, 1024,
+};
+const std::array<int, 6> ANDROID_ICONS_SIZES = {36, 48, 72, 96, 144, 192};
+
+const gd::String ExporterHelper::GenerateWebManifest(
+    const gd::Project &project) {
+  const gd::String &orientation = project.GetOrientation();
+  gd::String icons = "[";
+
+  {
+    std::map<int, gd::String> resourcesForSizes;
+    const auto FileNameForIcon = [&project](const gd::String &platform,
+                                            const int size) {
+      return project.GetPlatformSpecificAssets().Has(
+                 platform, "icon-" + gd::String::From(size))
+                 ? project.GetResourcesManager()
+                       .GetResource(project.GetPlatformSpecificAssets().Get(
+                           platform, "icon-" + gd::String::From(size)))
+                       .GetFile()
+                 : "";
+    };
+
+    for (const int size : IOS_ICONS_SIZES) {
+      const auto iconFile = FileNameForIcon("ios", size);
+      if (!iconFile.empty()) resourcesForSizes[size] = iconFile;
+    };
+
+    for (const int size : ANDROID_ICONS_SIZES) {
+      const auto iconFile = FileNameForIcon("android", size);
+      if (!iconFile.empty()) resourcesForSizes[size] = iconFile;
+    };
+
+    const auto desktopIconFile = FileNameForIcon("desktop", 512);
+    if (!desktopIconFile.empty()) resourcesForSizes[512] = desktopIconFile;
+
+    for (const auto &sizeAndFile : resourcesForSizes) {
+      icons +=
+          gd::String(R"({
+        "src": "{FILE}",
+        "sizes": "{SIZE}x{SIZE}" 
+      },)")
+              .FindAndReplace("{SIZE}", gd::String::From(sizeAndFile.first))
+              .FindAndReplace("{FILE}", sizeAndFile.second);
+    }
+  }
+
+  icons = icons.RightTrim(",") + "]";
+
+  return gd::String(R"webmanifest({
+  "name": "{NAME}",
+  "short_name": "{NAME}",
+  "id": "{PACKAGE_ID}",
+  "description": "{DESCRIPTION}",
+  "orientation": "{ORIENTATION}",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "black",
+  "icons": {ICONS}
+})webmanifest")
+      .FindAndReplace("{NAME}", project.GetName())
+      .FindAndReplace("{PACKAGE_ID}", project.GetPackageName())
+      .FindAndReplace("{DESCRIPTION}", project.GetDescription())
+      .FindAndReplace("{ORIENTATION}",
+                      orientation == "default" ? "any" : orientation)
+      .FindAndReplace("{ICONS}", icons);
+};
 
 }  // namespace gdjs

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -117,11 +117,12 @@ struct PreviewExportOptions {
 
   /**
    * Set the path to use for the game engine to require "@electron/remote".
-   * This is because the preview is run in a folder without any node_module, but this
-   * is still required for now for some features.
-   * This should be removed once the dependency to "@electron/remote" is removed.
+   * This is because the preview is run in a folder without any node_module, but
+   * this is still required for now for some features. This should be removed
+   * once the dependency to "@electron/remote" is removed.
    */
-  PreviewExportOptions &SetElectronRemoteRequirePath(const gd::String& electronRemoteRequirePath_) {
+  PreviewExportOptions &SetElectronRemoteRequirePath(
+      const gd::String &electronRemoteRequirePath_) {
     electronRemoteRequirePath = electronRemoteRequirePath_;
     return *this;
   }
@@ -302,6 +303,15 @@ class ExporterHelper {
                          const std::vector<gd::String> &includesFiles,
                          unsigned int nonRuntimeScriptsCacheBurst,
                          gd::String additionalSpec);
+
+  /**
+   * \brief Generates a WebManifest, a metadata file that allow to make the
+   * exported game a working PWA.
+   *
+   * \param project The project containing the game properties to generate the
+   * manifest from.
+   */
+  const gd::String GenerateWebManifest(const gd::Project &project);
 
   /**
    * \brief Generate the Cordova configuration file and save it to the export

--- a/GDJS/Runtime/index.html
+++ b/GDJS/Runtime/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8"/>
+    <link rel="manifest" href="manifest.webmanifest">
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
A first baby step towards making the exported games working PWAs 💪 Generates a WebManifest from project data.  

The WebManifest is only made for builds, not previews, since:
1. A preview shouldn't be installable
2. The manifest isn't working there anyways, as icons links are not allowed to be file URLs


As a follow-up, we could add support for the following fields that require being added to the project properties first:
- Background color
- Theme color
- Short name
- Screenshots
- Language

Those properties could also be useful for liluo 😉 