### PR TITLE
Remove out of label click on checkboxes

### DIFF
--- a/newIDE/app/src/UI/Checkbox.js
+++ b/newIDE/app/src/UI/Checkbox.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from 'react';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import MUICheckbox from '@material-ui/core/Checkbox';
 import { makeStyles } from '@material-ui/core/styles';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormGroup from '@material-ui/core/FormGroup';
+import MUICheckbox from '@material-ui/core/Checkbox';
 
 // Reduce checkbox size to avoid overlapping with other checkboxes.
 const useStyles = makeStyles({
@@ -10,6 +11,12 @@ const useStyles = makeStyles({
     marginLeft: 9,
     marginRight: 9,
     padding: 0,
+  },
+});
+
+const useFormGroupStyles = makeStyles({
+  root: {
+    display: 'block',
   },
 });
 
@@ -36,6 +43,7 @@ type Props = {|
 const Checkbox = (props: Props) => {
   const { onCheck } = props;
   const classes = useStyles();
+  const formGroupClasses = useFormGroupStyles();
   const checkbox = (
     <MUICheckbox
       className={classes.root}
@@ -51,11 +59,13 @@ const Checkbox = (props: Props) => {
     />
   );
   return props.label ? (
-    <FormControlLabel
-      control={checkbox}
-      label={props.label}
-      style={props.style}
-    />
+    <FormGroup classes={formGroupClasses}>
+      <FormControlLabel
+        control={checkbox}
+        label={props.label}
+        style={props.style}
+      />
+    </FormGroup>
   ) : (
     checkbox
   );

--- a/newIDE/app/src/UI/InlineCheckbox.js
+++ b/newIDE/app/src/UI/InlineCheckbox.js
@@ -1,13 +1,21 @@
 // @flow
 import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import Checkbox from '@material-ui/core/Checkbox';
 import Tooltip from '@material-ui/core/Tooltip';
-import { FormGroup, FormHelperText, makeStyles } from '@material-ui/core';
 
 const useLabelStyles = makeStyles({
   root: {
     cursor: 'default',
+  },
+});
+
+const useFormGroupStyles = makeStyles({
+  root: {
+    display: 'block',
   },
 });
 
@@ -35,6 +43,7 @@ const InlineCheckbox = ({
   tooltipOrHelperText,
 }: Props) => {
   const labelClasses = useLabelStyles();
+  const formGroupClasses = useFormGroupStyles();
   const checkbox = (
     <Checkbox
       disabled={disabled}
@@ -48,7 +57,7 @@ const InlineCheckbox = ({
     />
   );
   return label ? (
-    <FormGroup>
+    <FormGroup classes={formGroupClasses}>
       <FormControlLabel
         control={checkbox}
         label={label}


### PR DESCRIPTION
Fixes #4024

Changes from display flex to block for the from group so that the label does not take the whole available space.