### PR TITLE
Allow more freedom on horizontal movements in events sheet

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -5,13 +5,13 @@ import {
   moveNodeAbove,
   moveNodeBelow,
   moveNodeAsSubEvent,
-  isSameDepthAndJustBelow,
+  isJustBelow,
+  isSibling,
 } from './helpers';
 import { type WidthType } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
 import './style.css';
 import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
 import { type DropTargetComponent } from '../../UI/DragAndDrop/DropTarget';
-
 const sharedStyles = {
   dropArea: { zIndex: 1, position: 'absolute' },
   dropIndicator: {
@@ -42,7 +42,7 @@ type TargetPositionStyles = { [position: string]: DropTargetContainerStyle };
 const getTargetPositionStyles = (
   indentWidth: number,
   draggedNodeHeight: number,
-  isDraggedNodeChild: boolean
+  isDraggedNodeSibling: boolean
 ): TargetPositionStyles => ({
   'bottom-left': { left: '0px', bottom: '0px', top: '50%', width: indentWidth },
   'bottom-right': {
@@ -54,13 +54,13 @@ const getTargetPositionStyles = (
   top: { left: '0px', right: '0px', top: '0px', bottom: '50%' },
   bottom: { left: '0px', right: '0px', top: '50%', bottom: '0px' },
   'below-left': {
-    left: isDraggedNodeChild ? '0px' : '10px',
+    left: isDraggedNodeSibling ? '10px' : '0px',
     top: '100%',
     height: draggedNodeHeight,
     width: indentWidth,
   },
   'below-right': {
-    left: isDraggedNodeChild ? `${indentWidth + 10}px` : `${indentWidth}px`,
+    left: isDraggedNodeSibling ? `${indentWidth}px` : `${indentWidth + 10}px`,
     right: '0px',
     top: '100%',
     height: draggedNodeHeight,
@@ -142,7 +142,74 @@ type DropContainerProps = {|
   // Used only for the node just above dragged node if it is an only child,
   // so that drop area covers the whole dragged node's row in height.
   draggedNodeHeight: number,
+  getNodeAtPath: (path: Array<number>) => SortableTreeNode,
 |};
+
+type HorizontalDraggedNodeDropContainerProps = {|
+  node: SortableTreeNode,
+  draggedNode: SortableTreeNode,
+  DnDComponent: DropTargetComponent<SortableTreeNode>,
+  onDrop: (
+    moveFunction: ({
+      targetNode: SortableTreeNode,
+      node: SortableTreeNode,
+    }) => number,
+    node: SortableTreeNode
+  ) => void,
+  activateTargets: boolean,
+
+  getNodeAtPath: (path: Array<number>) => SortableTreeNode,
+  draggedNodeHeight: number,
+  indentWidth: number,
+|};
+
+function HorizontalDraggedNodeDropContainer({
+  DnDComponent,
+  onDrop,
+  activateTargets,
+  getNodeAtPath,
+  node,
+  draggedNode,
+  indentWidth,
+  draggedNodeHeight,
+}: HorizontalDraggedNodeDropContainerProps) {
+  const { depth } = node;
+  // The component should not exist if draggedNode.depth is 0.
+  const depthArray = new Array(depth).fill(0);
+  const parentNodes = depthArray.map((_, depthStep) =>
+    getNodeAtPath(node.nodePath.slice(0, depthStep + 1))
+  );
+  return (
+    <>
+      {new Array(depth).fill(0).map((_, depthStep) => {
+        // Skip so that it does not hinder dragging and so that we don't have to
+        // worry about delaying the drop target activation.
+        if (depthStep === draggedNode.depth) return null;
+        return (
+          <DropTargetContainer
+            key={depthStep}
+            DnDComponent={DnDComponent}
+            onDrop={() => onDrop(moveNodeBelow, parentNodes[depthStep])}
+            canDrop={() => true}
+            style={{
+              dropArea: {
+                top: '100%',
+                bottom: `-${draggedNodeHeight}px`,
+                left: `-${indentWidth * (depth - depthStep)}px`,
+                width: indentWidth,
+              },
+              dropIndicator: {
+                left: `-${indentWidth * (depth - depthStep)}px`,
+                right: '0px',
+                bottom: '-2px',
+              },
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}
 
 /**
  * DropContainer is composed of sub-containers of drop targets that allows us to identify
@@ -158,24 +225,19 @@ export function DropContainer({
   activateTargets,
   windowWidth,
   draggedNodeHeight,
+  getNodeAtPath,
 }: DropContainerProps) {
-  const isDraggedNodesOnlyChild =
-    node.children.length === 1 && node.children[0].key === draggedNode.key;
-  const isDraggedNodeSameDepthAndBelow = isSameDepthAndJustBelow(
-    node,
-    draggedNode
-  );
+  const isDraggedNodeSibling = isSibling(node, draggedNode);
+  const isDraggedNodeJustBelow = isJustBelow(node, draggedNode);
   // We want to allow dropping below if the event has no children OR if the only
   // child of the event is the dragged one.
-  const canDropBelow =
-    !!node.event && (node.children.length === 0 || isDraggedNodesOnlyChild);
   const canHaveSubEvents = !!node.event && node.event.canHaveSubEvents();
 
   const indentWidth = getIndentWidth(windowWidth);
   const dropAreaStyles = getTargetPositionStyles(
     indentWidth,
     draggedNodeHeight,
-    isDraggedNodesOnlyChild
+    isDraggedNodeSibling
   );
   const indicatorStyles = getIndicatorPositionStyles(indentWidth);
   const commonProps = {
@@ -196,7 +258,7 @@ export function DropContainer({
         onDrop={() => onDrop(moveNodeAbove, node)}
         {...commonProps}
       />
-      {canHaveSubEvents && canDropBelow && (
+      {canHaveSubEvents ? (
         <>
           <DropTargetContainer
             style={{
@@ -214,8 +276,8 @@ export function DropContainer({
             onDrop={() => onDrop(moveNodeBelow, node)}
             {...commonProps}
           />
-          {/* Allow dragging left/right to move below or as subevent */}
-          {(isDraggedNodesOnlyChild || isDraggedNodeSameDepthAndBelow) && (
+          {/* Allow dragging left/right just below the current node. */}
+          {isDraggedNodeJustBelow && (
             <>
               <DropTargetContainer
                 style={{
@@ -236,8 +298,7 @@ export function DropContainer({
             </>
           )}
         </>
-      )}
-      {!canHaveSubEvents && canDropBelow && (
+      ) : (
         <DropTargetContainer
           style={{
             dropIndicator: indicatorStyles['bottom'],
@@ -247,14 +308,19 @@ export function DropContainer({
           {...commonProps}
         />
       )}
-      {canHaveSubEvents && !canDropBelow && (
-        <DropTargetContainer
-          style={{
-            dropIndicator: indicatorStyles['bottom-right'],
-            dropArea: dropAreaStyles['bottom'],
-          }}
-          onDrop={() => onDrop(moveNodeAsSubEvent, node)}
-          {...commonProps}
+      {/* This DropContainer allows dragging horizontally, on any depth between
+      0 and the depth of the node just above the dragged one (which has information on
+      its parents). */}
+      {isDraggedNodeJustBelow && (
+        <HorizontalDraggedNodeDropContainer
+          node={node}
+          draggedNode={draggedNode}
+          DnDComponent={DnDComponent}
+          activateTargets={activateTargets}
+          onDrop={onDrop}
+          indentWidth={indentWidth}
+          draggedNodeHeight={draggedNodeHeight}
+          getNodeAtPath={getNodeAtPath}
         />
       )}
     </div>

--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -132,7 +132,7 @@ type DropContainerProps = {|
     moveFunction: ({
       targetNode: SortableTreeNode,
       node: SortableTreeNode,
-    }) => number,
+    }) => void,
     node: SortableTreeNode
   ) => void,
   activateTargets: boolean,
@@ -153,7 +153,7 @@ type HorizontalDraggedNodeDropContainerProps = {|
     moveFunction: ({
       targetNode: SortableTreeNode,
       node: SortableTreeNode,
-    }) => number,
+    }) => void,
     node: SortableTreeNode
   ) => void,
   activateTargets: boolean,

--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -174,11 +174,6 @@ function HorizontalDraggedNodeDropContainer({
   draggedNodeHeight,
 }: HorizontalDraggedNodeDropContainerProps) {
   const { depth } = node;
-  // The component should not exist if draggedNode.depth is 0.
-  const depthArray = new Array(depth).fill(0);
-  const parentNodes = depthArray.map((_, depthStep) =>
-    getNodeAtPath(node.nodePath.slice(0, depthStep + 1))
-  );
   return (
     <>
       {new Array(depth).fill(0).map((_, depthStep) => {
@@ -189,7 +184,12 @@ function HorizontalDraggedNodeDropContainer({
           <DropTargetContainer
             key={depthStep}
             DnDComponent={DnDComponent}
-            onDrop={() => onDrop(moveNodeBelow, parentNodes[depthStep])}
+            onDrop={() =>
+              onDrop(
+                moveNodeBelow,
+                getNodeAtPath(node.nodePath.slice(0, depthStep + 1))
+              )
+            }
             canDrop={() => true}
             style={{
               dropArea: {
@@ -201,6 +201,7 @@ function HorizontalDraggedNodeDropContainer({
               dropIndicator: {
                 left: `-${indentWidth * (depth - depthStep)}px`,
                 right: '0px',
+                // The bottom is set so that the indicator is centered between the events.
                 bottom: '-2px',
               },
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/helpers.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/helpers.js
@@ -5,9 +5,6 @@ export type MoveFunctionArguments = {
   node: SortableTreeNode,
 };
 
-const getRowIndexOfNode = (node: SortableTreeNode) =>
-  node.nodePath[node.nodePath.length - 1];
-
 export const moveEventToEventsList = ({
   targetEventsList,
   movingEvent,
@@ -37,11 +34,6 @@ export const moveNodeAsSubEvent = ({
     initialEventsList: node.eventsList,
     toIndex: 0,
   });
-  const previousRowIndex = getRowIndexOfNode(node);
-  const targetRowIndex = getRowIndexOfNode(targetNode);
-  return previousRowIndex <= targetRowIndex
-    ? targetRowIndex
-    : targetRowIndex + 1;
 };
 
 export const moveNodeBelow = ({ targetNode, node }: MoveFunctionArguments) => {
@@ -56,11 +48,6 @@ export const moveNodeBelow = ({ targetNode, node }: MoveFunctionArguments) => {
     initialEventsList: node.eventsList,
     toIndex,
   });
-  const previousRowIndex = getRowIndexOfNode(node);
-  const targetRowIndex = getRowIndexOfNode(targetNode);
-  return previousRowIndex <= targetRowIndex
-    ? targetRowIndex
-    : targetRowIndex + 1;
 };
 
 export const moveNodeAbove = ({ targetNode, node }: MoveFunctionArguments) => {
@@ -75,11 +62,6 @@ export const moveNodeAbove = ({ targetNode, node }: MoveFunctionArguments) => {
     initialEventsList: node.eventsList,
     toIndex,
   });
-  const previousRowIndex = getRowIndexOfNode(node);
-  const targetRowIndex = getRowIndexOfNode(targetNode);
-  return previousRowIndex <= targetRowIndex
-    ? targetRowIndex - 1
-    : targetRowIndex;
 };
 
 export const isDescendant = (

--- a/newIDE/app/src/EventsSheet/EventsTree/helpers.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/helpers.js
@@ -92,16 +92,35 @@ export const isDescendant = (
   return parentPath.every((pathValue, index) => pathValue === childPath[index]);
 };
 
-export const isSameDepthAndJustBelow = (
+export const isSibling = (nodeA: SortableTreeNode, nodeB: SortableTreeNode) => {
+  if (nodeA.depth !== nodeB.depth) return false;
+  const nodeAPath = nodeA.nodePath;
+  const nodeBPath = nodeB.nodePath;
+  return nodeAPath
+    .slice(0, -1)
+    .every((pathValue, index) => pathValue === nodeBPath[index]);
+};
+
+export const isJustBelow = (
   aboveNode: SortableTreeNode,
   belowNode: SortableTreeNode
 ) => {
-  if (aboveNode.depth !== belowNode.depth) return false;
   const belowNodePath = belowNode.nodePath;
   const aboveNodePath = aboveNode.nodePath;
   if (belowNodePath[belowNodePath.length - 1] === 0) return false;
   return (
     belowNodePath[belowNodePath.length - 1] - 1 ===
     aboveNodePath[aboveNodePath.length - 1]
+  );
+};
+
+export const getNodeAtPath = (
+  path: Array<number>,
+  treeData: Array<SortableTreeNode>
+) => {
+  if (path.length === 1) return treeData[path[0]];
+  return getNodeAtPath(
+    path.slice(0, -1),
+    treeData[path[path.length - 1]].children
   );
 };

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -600,7 +600,10 @@ export default class ThemableEventsTree extends Component<
       });
       const { nodePath, event } = draggedNode;
       this._onEndDrag();
-      // $FlowFixMe - We are confident event is defined because of canDrag.
+      if (!event) {
+        console.warn('EventsSheet: No event found in dragged node.');
+        return;
+      }
       const newRowIndex = this.getEventRow(event);
       this.props.onEventMoved(nodePath[nodePath.length - 1], newRowIndex);
     }
@@ -673,6 +676,10 @@ export default class ThemableEventsTree extends Component<
   };
 
   _onEndDrag = () => {
+    // This method is always called at the end of the drag, regardless of whether
+    // an event was actually dropped. It is also already called in `_onDrop` to update
+    // the event list and compute history. So if draggedNode is null, we want to avoid
+    // recomputing the event list.
     if (this.state.draggedNode) {
       this.setState({ draggedNode: null });
       this._restoreFoldedNodes();

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -5,6 +5,7 @@ import findIndex from 'lodash/findIndex';
 import {
   SortableTreeWithoutDndContext,
   getFlatDataFromTree,
+  getNodeAtPath,
 } from 'react-sortable-tree';
 import { type ConnectDragSource } from 'react-dnd';
 import { mapFor } from '../../Utils/MapFor';
@@ -779,6 +780,13 @@ export default class ThemableEventsTree extends Component<
                   onDrop={this._onDrop}
                   activateTargets={!isDragged && !!this.state.draggedNode}
                   windowWidth={this.props.windowWidth}
+                  getNodeAtPath={path =>
+                    getNodeAtPath({
+                      path,
+                      treeData: this.state.treeData,
+                      getNodeKey,
+                    }).node
+                  }
                 />
               )}
             </div>

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -589,17 +589,20 @@ export default class ThemableEventsTree extends Component<
   };
 
   _onDrop = (
-    moveFunction: MoveFunctionArguments => number,
+    moveFunction: MoveFunctionArguments => void,
     currentNode: SortableTreeNode
   ) => {
     const draggedNode = this.state.draggedNode;
     if (draggedNode) {
-      const nextRowIndex = moveFunction({
+      moveFunction({
         node: draggedNode,
         targetNode: currentNode,
       });
-      const { nodePath } = draggedNode;
-      this.props.onEventMoved(nodePath[nodePath.length - 1], nextRowIndex);
+      const { nodePath, event } = draggedNode;
+      this._onEndDrag();
+      // $FlowFixMe - We are confident event is defined because of canDrag.
+      const newRowIndex = this.getEventRow(event);
+      this.props.onEventMoved(nodePath[nodePath.length - 1], newRowIndex);
     }
   };
 
@@ -670,9 +673,11 @@ export default class ThemableEventsTree extends Component<
   };
 
   _onEndDrag = () => {
-    this.setState({ draggedNode: null });
-    this._restoreFoldedNodes();
-    this.forceEventsUpdate();
+    if (this.state.draggedNode) {
+      this.setState({ draggedNode: null });
+      this._restoreFoldedNodes();
+      this.forceEventsUpdate();
+    }
   };
 
   _renderEvent = ({ node }: { node: SortableTreeNode }) => {


### PR DESCRIPTION
Some things of #3989 requested by @tristanbob 
Change depth by dragging left and right in events sheet


![](https://media.giphy.com/media/tfyjNLLxAoxF5jJbtJ/giphy.gif)


Test it here:
http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/allow-more-freedom-on-horizontal-dnd-in-eventssheet/latest/index.html?path=/story/eventssheet-eventssheet--default-no-scope