### PR TITLE
Text to string for all text related to a string for a variable

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -407,9 +407,9 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .UseStandardOperatorParameters("number");
 
   obj.AddAction("ModVarObjetTxt",
-                _("Text of an object variable"),
-                _("Change the text of an object variable."),
-                _("the text of variable _PARAM1_"),
+                _("String of an object variable"),
+                _("Change the string of an object variable."),
+                _("the string of variable _PARAM1_"),
                 _("Variables"),
                 "res/actions/var24.png",
                 "res/actions/var.png")
@@ -613,9 +613,9 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .UseStandardRelationalOperatorParameters("number");
 
   obj.AddCondition("VarObjetTxt",
-                   _("Text of an object variable"),
-                   _("Compare the text of an object variable."),
-                   _("the text of variable _PARAM1_"),
+                   _("String of an object variable"),
+                   _("Compare the string of an object variable."),
+                   _("the string of variable _PARAM1_"),
                    _("Variables"),
                    "res/conditions/var24.png",
                    "res/conditions/var.png")
@@ -1110,7 +1110,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddStrExpression("VariableString",
                        _("Object variable"),
-                       _("Text of an object variable"),
+                       _("String of an object variable"),
                        _("Variables"),
                        "res/actions/var.png")
       .AddParameter("object", _("Object"))

--- a/Core/GDCore/Extensions/Builtin/VariablesExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/VariablesExtension.cpp
@@ -38,9 +38,9 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
 
   extension
       .AddCondition("VarSceneTxt",
-                    _("Text of a scene variable"),
-                    _("Compare the text of a scene variable."),
-                    _("the text of scene variable _PARAM0_"),
+                    _("String of a scene variable"),
+                    _("Compare the string of a scene variable."),
+                    _("the string of scene variable _PARAM0_"),
                     _("Scene variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
@@ -112,8 +112,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
 
   extension
       .AddCondition("VarGlobalTxt",
-                    _("Text of a global variable"),
-                    _("Compare the text of a global variable."),
+                    _("String of a global variable"),
+                    _("Compare the string of a global variable."),
                     _("the text of the global variable _PARAM0_"),
                     _("Global variables"),
                     "res/conditions/var24.png",
@@ -162,7 +162,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
   extension
       .AddAction("ModVarSceneTxt",
                  _("String of a scene variable"),
-                 _("Modify the text of a scene variable."),
+                 _("Modify the string of a scene variable."),
                  _("the text of scene variable _PARAM0_"),
                  _("Scene variables"),
                  "res/actions/var24.png",
@@ -209,7 +209,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
   extension
       .AddAction("ModVarGlobalTxt",
                  _("String of a global variable"),
-                 _("Modify the text of a global variable."),
+                 _("Modify the string of a global variable."),
                  _("the text of global variable _PARAM0_"),
                  _("Global variables"),
                  "res/actions/var24.png",
@@ -438,8 +438,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
 
   extension
       .AddStrExpression("VariableString",
-                        _("Text of a scene variable"),
-                        _("Text of a scene variable"),
+                        _("String of a scene variable"),
+                        _("String of a scene variable"),
                         _("Scene variables"),
                         "res/actions/var.png")
       .AddParameter("scenevar", _("Variable"));
@@ -454,8 +454,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
 
   extension
       .AddStrExpression("GlobalVariableString",
-                        _("Text of a global variable"),
-                        _("Text of a global variable"),
+                        _("String of a global variable"),
+                        _("String of a global variable"),
                         _("Global variables"),
                         "res/actions/var.png")
       .AddParameter("globalvar", _("Variable"));


### PR DESCRIPTION
Because now in the revamped variable editor we use string.
Close #846
