### PR TITLE
Send session durations that take into account pauses.

### DIFF
--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -668,7 +668,7 @@ namespace gdjs {
        * The duration that is already sent to the service
        * (in milliseconds).
        **/
-      let sendedDuration = 0;
+      let sentDuration = 0;
       /**
        * The duration that is not yet sent to the service to avoid flooding
        * (in milliseconds).
@@ -738,9 +738,11 @@ namespace gdjs {
         if (notYetSentDuration < 5 * 1000) {
           return;
         }
-        const onlySeconds = Math.floor(notYetSentDuration / 1000) * 1000;
-        sendedDuration += onlySeconds;
-        notYetSentDuration -= onlySeconds;
+        // The backend use seconds for duration.
+        // The milliseconds will stay in notYetSentDuration.
+        const toBeSentDuration = Math.floor(notYetSentDuration / 1000) * 1000;
+        sentDuration += toBeSentDuration;
+        notYetSentDuration -= toBeSentDuration;
 
         navigator.sendBeacon(
           baseUrl + '/session-hit',
@@ -748,7 +750,7 @@ namespace gdjs {
             gameId: this._data.properties.projectUuid,
             playerId: this._playerId,
             sessionId: this._sessionId,
-            duration: Math.floor(sendedDuration / 1000),
+            duration: Math.floor(sentDuration / 1000),
           })
         );
       };

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -664,8 +664,15 @@ namespace gdjs {
       }
       const baseUrl = 'https://api.gdevelop-app.com/analytics';
       this._playerId = this._makePlayerUuid();
+      /**
+       * The duration that is already sent to the service
+       * (in milliseconds).
+       **/
       let sendedDuration = 0;
-      /** The duration that is not yet sent to the service to avoid flooding */
+      /**
+       * The duration that is not yet sent to the service to avoid flooding
+       * (in milliseconds).
+       **/
       let notYetSentDuration = 0;
       /**
        * The last time when duration has been counted


### PR DESCRIPTION
The minimum duration between 2 updates is now 5s instead of 3s.
Also the session duration is no longer sent when the game gets visible again.

# Manual tests
## Switching tabs

* Editor
```
 sendSessionHit: 3066
 visibilitychange: visible
 visibilitychange: hidden
 notYetSentDuration: 1090
 visibilitychange: visible
 visibilitychange: hidden
 notYetSentDuration: 2088
 visibilitychange: visible
 visibilitychange: hidden
 notYetSentDuration: 2934
 visibilitychange: visible
 visibilitychange: hidden
 sendSessionHit: 3603
```

* Service
```
offline: POST /dev/session-hit (λ: session-hit)
{"message":"Received hit","level":"info"}
{"message":"Session found for id=83a504ec-e1c5-4c1a-89f1-1753db6ebfcd","level":"info"}
{"message":"Session updated with duration 168061 seconds.","level":"info"}
offline: (λ: session-hit) RequestId: cl4ms1e2i005k7oeyb9lxcqyz  Duration: 66.58 ms  Billed Duration: 100 ms

offline: POST /dev/session-hit (λ: session-hit)
{"message":"Received hit","level":"info"}
{"message":"Session found for id=83a504ec-e1c5-4c1a-89f1-1753db6ebfcd","level":"info"}
{"message":"Session updated with duration 171664 seconds.","level":"info"}
offline: (λ: session-hit) RequestId: cl4ms1y02005n7oey65w9fep7  Duration: 67.47 ms  Billed Duration: 100 ms
```

## Hidden a long time
* Editor
```
visibilitychange: hidden
notYetSentDuration: 564

...waited a long time here...

visibilitychange: visible
visibilitychange: hidden
notYetSentDuration: 1277
```

* Service
```

```