### PR TITLE
Add Feedback tab

### DIFF
--- a/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
@@ -7,19 +7,21 @@ import { I18n } from '@lingui/react';
 import { Card } from '@material-ui/core';
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 import CheckCircleIcon from '@material-ui/icons//CheckCircle';
+
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 import CardContent from '../../UI/Card/CardContent';
 import Text from '../../UI/Text';
+import { Column, LargeSpacer, Line, Spacer } from '../../UI/Grid';
+import IconButton from '../../UI/IconButton';
+import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
+
+import Rating from './Rating';
 
 import {
   updateComment,
   type Comment,
   type GameRatings,
 } from '../../Utils/GDevelopServices/Play';
-import { ResponsiveLineStackLayout } from '../../UI/Layout';
-import Rating from './Rating';
-import { Column, LargeSpacer, Line, Spacer } from '../../UI/Grid';
-import IconButton from '../../UI/IconButton';
-import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
 import { useDebounce } from '../../Utils/UseDebounce';
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 

--- a/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
@@ -1,0 +1,142 @@
+// @flow
+
+import * as React from 'react';
+import { t, Trans } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+
+import { Card } from '@material-ui/core';
+import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
+import CheckCircleIcon from '@material-ui/icons//CheckCircle';
+import CardContent from '../../UI/Card/CardContent';
+import Text from '../../UI/Text';
+
+import {
+  updateComment,
+  type Comment,
+  type GameRatings,
+} from '../../Utils/GDevelopServices/Play';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
+import Rating from './Rating';
+import { Column, LargeSpacer, Line, Spacer } from '../../UI/Grid';
+import IconButton from '../../UI/IconButton';
+import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
+import { useDebounce } from '../../Utils/UseDebounce';
+import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
+
+const styles = { textComment: { whiteSpace: 'pre-wrap' } };
+
+type Props = {
+  comment: Comment,
+  authenticatedUser: AuthenticatedUser,
+  onUpdateComment: () => ?Promise<void>,
+};
+
+const getRatings = (ratings: ?GameRatings) => {
+  if (!ratings) return null;
+  if (ratings.version === 1) {
+    return [
+      { label: 'Sound', value: ratings.sound },
+      { label: 'Visuals', value: ratings.visuals },
+      { label: 'Fun', value: ratings.fun },
+      { label: 'Ease of use', value: ratings.easeOfUse },
+    ];
+  }
+};
+
+const FeedbackCard = ({
+  comment,
+  authenticatedUser,
+  onUpdateComment,
+}: Props) => {
+  const { getAuthorizationHeader, profile } = authenticatedUser;
+  const ratings = getRatings(comment.ratings);
+  const theme = React.useContext(GDevelopThemeContext);
+
+  const [processed, setProcessed] = React.useState<?boolean>(null);
+
+  const isProcessed = processed === null ? !!comment.processedAt : processed;
+
+  const setProcessedAt = useDebounce(
+    async ({ processed }: { processed: boolean }) => {
+      if (!profile) return;
+      try {
+        await updateComment(getAuthorizationHeader, profile.id, {
+          gameId: comment.gameId,
+          commentId: comment.id,
+          processed: processed,
+        });
+      } catch (error) {
+        console.warn(`Unable to update comment: ${error}`);
+      } finally {
+        await onUpdateComment();
+        setProcessed(null);
+      }
+    },
+    500
+  );
+
+  const onSetProcessed = () => {
+    const newProcessedValue = !(processed === null
+      ? !!comment.processedAt
+      : processed);
+    setProcessed(newProcessedValue);
+    setProcessedAt({
+      processed: newProcessedValue,
+    });
+  };
+
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <Card variant="outlined" style={{ opacity: isProcessed ? '0.5' : '1' }}>
+          <Line noMargin alignItems="start">
+            <Column expand>
+              <CardContent>
+                <Column noMargin>
+                  <Line
+                    noMargin
+                    justifyContent="space-between"
+                    alignItems="start"
+                  >
+                    <Column noMargin>
+                      <Text size="body2">
+                        <Trans>{i18n.date(comment.createdAt)}</Trans>
+                      </Text>
+                      <Text size="body2" noMargin>
+                        {comment.playerName}
+                      </Text>
+                    </Column>
+                  </Line>
+                  {ratings && (
+                    <ResponsiveLineStackLayout noColumnMargin expand>
+                      {ratings.map(rating => (
+                        <Line expand noMargin key={rating.label}>
+                          <Rating label={rating.label} value={rating.value} />
+                          <Spacer />
+                        </Line>
+                      ))}
+                    </ResponsiveLineStackLayout>
+                  )}
+                  <LargeSpacer />
+                  <Text style={styles.textComment}>{comment.text}</Text>
+                </Column>
+              </CardContent>
+            </Column>
+            <IconButton
+              tooltip={isProcessed ? t`Unresolve` : t`Resolve`}
+              onClick={onSetProcessed}
+            >
+              {isProcessed ? (
+                <CheckCircleIcon htmlColor={theme.message.valid} />
+              ) : (
+                <CheckCircleOutlineIcon />
+              )}
+            </IconButton>
+          </Line>
+        </Card>
+      )}
+    </I18n>
+  );
+};
+
+export default FeedbackCard;

--- a/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
@@ -89,7 +89,7 @@ const FeedbackCard = ({ comment, authenticatedUser }: Props) => {
         });
         setProcessed(newProcessedValue);
       } catch (error) {
-        console.error(`Unable to update comment: ${error}`);
+        console.error(`Unable to update comment: `, error);
         showErrorBox({
           message: i18n._(t`Unable to change resolved status of feedback.`),
           rawError: error,

--- a/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
@@ -37,10 +37,22 @@ const getRatings = (ratings: ?GameRatings) => {
   if (!ratings) return null;
   if (ratings.version === 1) {
     return [
-      { label: 'Sound', value: ratings.sound },
-      { label: 'Visuals', value: ratings.visuals },
-      { label: 'Fun', value: ratings.fun },
-      { label: 'Ease of use', value: ratings.easeOfUse },
+      {
+        key: 'rating-sound',
+        label: <Trans>Sound</Trans>,
+        value: ratings.sound,
+      },
+      {
+        key: 'rating-visuals',
+        label: <Trans>Visuals</Trans>,
+        value: ratings.visuals,
+      },
+      { key: 'rating-fun', label: <Trans>Fun</Trans>, value: ratings.fun },
+      {
+        key: 'rating-ease-of-use',
+        label: <Trans>Ease of use</Trans>,
+        value: ratings.easeOfUse,
+      },
     ];
   }
 };
@@ -112,7 +124,7 @@ const FeedbackCard = ({
                   {ratings && (
                     <ResponsiveLineStackLayout noColumnMargin expand>
                       {ratings.map(rating => (
-                        <Line expand noMargin key={rating.label}>
+                        <Line expand noMargin key={rating.key}>
                           <Rating label={rating.label} value={rating.value} />
                           <Spacer />
                         </Line>

--- a/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
@@ -74,7 +74,7 @@ const GameFeedback = ({ authenticatedUser, game }: Props) => {
       <Line>
         {!authenticatedUser.authenticated && (
           <EmptyMessage>
-            <Trans>You need to login first to see your builds.</Trans>
+            <Trans>You need to login first to see your game feedbacks.</Trans>
           </EmptyMessage>
         )}
         {authenticatedUser.authenticated &&

--- a/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
@@ -120,7 +120,6 @@ const GameFeedback = ({ authenticatedUser, game }: Props) => {
                     key={comment.id}
                     comment={comment}
                     authenticatedUser={authenticatedUser}
-                    onUpdateComment={loadFeedbacks}
                   />
                 ))}
               </ColumnStackLayout>

--- a/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
@@ -1,18 +1,20 @@
 // @flow
+import * as React from 'react';
 import { Trans } from '@lingui/macro';
 
-import * as React from 'react';
-import { listComments, type Comment } from '../../Utils/GDevelopServices/Play';
-import { type Game } from '../../Utils/GDevelopServices/Game';
 import { Column, Line } from '../../UI/Grid';
 import EmptyMessage from '../../UI/EmptyMessage';
 import PlaceholderLoader from '../../UI/PlaceholderLoader';
-import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 import Text from '../../UI/Text';
 import { ColumnStackLayout } from '../../UI/Layout';
 import PlaceholderError from '../../UI/PlaceholderError';
-import FeedbackCard from './FeedbackCard';
 import Checkbox from '../../UI/Checkbox';
+
+import FeedbackCard from './FeedbackCard';
+
+import { listComments, type Comment } from '../../Utils/GDevelopServices/Play';
+import { type Game } from '../../Utils/GDevelopServices/Game';
+import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 
 type Props = {|
   authenticatedUser: AuthenticatedUser,

--- a/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/GameFeedback.js
@@ -1,0 +1,133 @@
+// @flow
+import { Trans } from '@lingui/macro';
+
+import * as React from 'react';
+import { listComments, type Comment } from '../../Utils/GDevelopServices/Play';
+import { type Game } from '../../Utils/GDevelopServices/Game';
+import { Column, Line } from '../../UI/Grid';
+import EmptyMessage from '../../UI/EmptyMessage';
+import PlaceholderLoader from '../../UI/PlaceholderLoader';
+import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
+import Text from '../../UI/Text';
+import { ColumnStackLayout } from '../../UI/Layout';
+import PlaceholderError from '../../UI/PlaceholderError';
+import FeedbackCard from './FeedbackCard';
+import Checkbox from '../../UI/Checkbox';
+
+type Props = {|
+  authenticatedUser: AuthenticatedUser,
+  game: Game,
+|};
+
+const RETRIEVED_COMMENT_TYPE = 'FEEDBACK';
+const filterUnsolvedComments = (comments: Array<Comment>) => {
+  return comments.filter((comment: Comment) => !comment.processedAt);
+};
+
+const GameFeedback = ({ authenticatedUser, game }: Props) => {
+  const [showUnsolved, setShowUnsolved] = React.useState(false);
+  const [feedbacks, setFeedbacks] = React.useState<?Array<Comment>>(null);
+  const [isErrored, setIsErrored] = React.useState(false);
+
+  const displayedFeedbacks = feedbacks
+    ? showUnsolved
+      ? filterUnsolvedComments(feedbacks)
+      : feedbacks
+    : null;
+
+  const loadFeedbacks = React.useCallback(
+    async () => {
+      setIsErrored(false);
+      const { getAuthorizationHeader, profile } = authenticatedUser;
+      if (!profile) {
+        setIsErrored(true);
+        return;
+      }
+      try {
+        const feedbacks = await listComments(
+          getAuthorizationHeader,
+          profile.id,
+          {
+            gameId: game.id,
+            type: RETRIEVED_COMMENT_TYPE,
+          }
+        );
+        setFeedbacks(feedbacks);
+      } catch {
+        setIsErrored(true);
+      }
+    },
+    [authenticatedUser, game]
+  );
+
+  React.useEffect(
+    () => {
+      loadFeedbacks();
+    },
+    [loadFeedbacks]
+  );
+
+  return (
+    <Column noMargin expand>
+      <Line>
+        {!authenticatedUser.authenticated && (
+          <EmptyMessage>
+            <Trans>You need to login first to see your builds.</Trans>
+          </EmptyMessage>
+        )}
+        {authenticatedUser.authenticated &&
+          !displayedFeedbacks &&
+          !isErrored && <PlaceholderLoader />}
+        {authenticatedUser.authenticated && isErrored && (
+          <PlaceholderError onRetry={() => {}}>
+            <Text>
+              <Trans>
+                An error occured while retrieving feedbacks for this game.
+              </Trans>
+            </Text>
+          </PlaceholderError>
+        )}
+        {authenticatedUser.authenticated && displayedFeedbacks && (
+          <Column expand>
+            <Column>
+              <Line>
+                <Checkbox
+                  checked={showUnsolved}
+                  onCheck={() => {
+                    setShowUnsolved(!showUnsolved);
+                  }}
+                  label={<Trans>Show unsolved feedbacks only</Trans>}
+                />
+              </Line>
+            </Column>
+            {displayedFeedbacks.length === 0 && (
+              <EmptyMessage>
+                {showUnsolved ? (
+                  <Trans>
+                    You don't have any unsolved feedback for this game.
+                  </Trans>
+                ) : (
+                  <Trans>You don't have any feedback for this game.</Trans>
+                )}
+              </EmptyMessage>
+            )}
+            {displayedFeedbacks.length !== 0 && (
+              <ColumnStackLayout expand>
+                {displayedFeedbacks.map((comment: Comment) => (
+                  <FeedbackCard
+                    key={comment.id}
+                    comment={comment}
+                    authenticatedUser={authenticatedUser}
+                    onUpdateComment={loadFeedbacks}
+                  />
+                ))}
+              </ColumnStackLayout>
+            )}
+          </Column>
+        )}
+      </Line>
+    </Column>
+  );
+};
+
+export default GameFeedback;

--- a/newIDE/app/src/GameDashboard/Feedbacks/Rating.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/Rating.js
@@ -3,14 +3,9 @@
 import * as React from 'react';
 
 import LinearProgress from '@material-ui/core/LinearProgress';
+
 import Text from '../../UI/Text';
-
 import { Column } from '../../UI/Grid';
-import { makeStyles } from '@material-ui/styles';
-
-const useStyles = makeStyles({
-  root: { height: 8, borderRadius: 8 },
-});
 
 type Props = {
   value: number,

--- a/newIDE/app/src/GameDashboard/Feedbacks/Rating.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/Rating.js
@@ -1,0 +1,35 @@
+// @flow
+
+import * as React from 'react';
+
+import LinearProgress from '@material-ui/core/LinearProgress';
+import Text from '../../UI/Text';
+
+import { Column } from '../../UI/Grid';
+import { makeStyles } from '@material-ui/styles';
+
+const useStyles = makeStyles({
+  root: { height: 8, borderRadius: 8 },
+});
+
+type Props = {
+  value: number,
+  label: string,
+};
+
+/* Display a rating between 1 and 10. */
+const Rating = ({ value, label }: Props) => {
+  const classes = useStyles();
+  return (
+    <Column expand noMargin>
+      <Text size="body2">{label}</Text>
+      <LinearProgress
+        variant="determinate"
+        value={value * 10}
+        classes={classes}
+      />
+    </Column>
+  );
+};
+
+export default Rating;

--- a/newIDE/app/src/GameDashboard/Feedbacks/Rating.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/Rating.js
@@ -9,19 +9,18 @@ import { Column } from '../../UI/Grid';
 
 type Props = {
   value: number,
-  label: string,
+  label: React.Node,
 };
 
 /* Display a rating between 1 and 10. */
 const Rating = ({ value, label }: Props) => {
-  const classes = useStyles();
   return (
     <Column expand noMargin>
       <Text size="body2">{label}</Text>
       <LinearProgress
         variant="determinate"
         value={value * 10}
-        classes={classes}
+        style={{ height: 8, borderRadius: 8 }}
       />
     </Column>
   );

--- a/newIDE/app/src/GameDashboard/GameCard.js
+++ b/newIDE/app/src/GameDashboard/GameCard.js
@@ -30,7 +30,8 @@ import {
 } from '../Utils/GDevelopServices/Game';
 import Window from '../Utils/Window';
 import { type GamesDetailsTab } from './GameDetailsDialog';
-import { useDebounce } from '../Utils/UseDebounce';
+import Dialog from '../UI/Dialog';
+import PlaceholderLoader from '../UI/PlaceholderLoader';
 
 type Props = {|
   game: Game,
@@ -39,14 +40,66 @@ type Props = {|
   onUpdateGame: () => Promise<void>,
 |};
 
-type UpdateProperties = {|
-  discoverable?: boolean,
-  acceptsBuildComments?: boolean,
-  acceptsGameComments?: boolean,
-|};
+type TogglableProperties =
+  | 'discoverable'
+  | 'acceptsBuildComments'
+  | 'acceptsGameComments';
 
-const getCurrentState = (gameProperty: ?boolean, pendingState: ?boolean) => {
-  return !!(pendingState === null ? gameProperty : pendingState);
+const getConfirmationMessage = (newProperty: {
+  [key: TogglableProperties]: boolean,
+}) => {
+  console.log(newProperty);
+  const {
+    discoverable,
+    acceptsBuildComments,
+    acceptsGameComments,
+  } = newProperty;
+  if (discoverable !== undefined) {
+    if (discoverable) {
+      return (
+        <Trans>Are you sure you want to make this game discoverable?</Trans>
+      );
+    }
+    if (!discoverable) {
+      return (
+        <Trans>
+          Are you sure you don't want to make this game discoverable anymore?
+        </Trans>
+      );
+    }
+  }
+  if (acceptsBuildComments !== undefined) {
+    if (acceptsBuildComments) {
+      return (
+        <Trans>
+          Are you sure you want to ask for feedbacks on all build pages?
+        </Trans>
+      );
+    }
+    if (!acceptsBuildComments) {
+      return (
+        <Trans>
+          Are you sure you want to stop asking for feedbacks on all build pages?
+        </Trans>
+      );
+    }
+  }
+  if (acceptsGameComments !== undefined) {
+    if (acceptsGameComments) {
+      return (
+        <Trans>
+          Are you sure you want to show a feedback banner on Liluo.io?
+        </Trans>
+      );
+    }
+    if (!acceptsGameComments) {
+      return (
+        <Trans>
+          Are you sure you want to remove the feedback banner on Liluo.io?
+        </Trans>
+      );
+    }
+  }
 };
 
 export const GameCard = ({
@@ -61,66 +114,51 @@ export const GameCard = ({
     Window.openExternalURL(url);
   };
   const [showShareDialog, setShowShareDialog] = React.useState(false);
-  // Those are pending states that are used to limit the number of requests on toggle.
-  const [isDiscoverable, setIsDiscoverable] = React.useState<?boolean>(null);
   const [
-    acceptsBuildComments,
-    setAcceptsBuildComments,
-  ] = React.useState<?boolean>(null);
-  const [
-    acceptsGameComments,
-    setAcceptsGameComments,
-  ] = React.useState<?boolean>(null);
+    showConfirmationDialog,
+    setShowConfirmationDialog,
+  ] = React.useState<?TogglableProperties>(null);
+  const [isEditingProperty, setIsEditingProperty] = React.useState(false);
 
   const { getAuthorizationHeader, profile } = React.useContext(
     AuthenticatedUserContext
   );
 
-  const updateGameProperties = useDebounce(
-    async (parameters: UpdateProperties) => {
-      if (!profile) return;
-      await updateGame(getAuthorizationHeader, profile.id, game.id, {
-        ...parameters,
-      });
-      await onUpdateGame();
-      typeof parameters.discoverable === 'boolean' && setIsDiscoverable(null);
-      typeof parameters.acceptsBuildComments === 'boolean' &&
-        setAcceptsBuildComments(null);
-      typeof parameters.acceptsGameComments === 'boolean' &&
-        setAcceptsGameComments(null);
-    },
-    500
-  );
+  const getNewProperty = (property: ?TogglableProperties) => {
+    switch (property) {
+      case 'discoverable':
+        return { discoverable: !game.discoverable };
+      case 'acceptsBuildComments':
+        return { acceptsBuildComments: !game.acceptsBuildComments };
+      case 'acceptsGameComments':
+        return { acceptsGameComments: !game.acceptsGameComments };
+      default:
+        return null;
+    }
+  };
+  const newProperty = getNewProperty(showConfirmationDialog);
 
-  const onToggleDiscoverable = () => {
-    const currentDiscoverableState = getCurrentState(
-      game.discoverable,
-      isDiscoverable
-    );
-    setIsDiscoverable(!currentDiscoverableState);
-    updateGameProperties({
-      discoverable: !currentDiscoverableState,
-    });
-  };
-  const onToggleAcceptsBuildComments = () => {
-    const currentAcceptsBuildCommentsState = getCurrentState(
-      game.acceptsBuildComments,
-      acceptsBuildComments
-    );
-    setAcceptsBuildComments(!currentAcceptsBuildCommentsState);
-    updateGameProperties({
-      acceptsBuildComments: !currentAcceptsBuildCommentsState,
-    });
-  };
-  const onToggleAcceptsGameComments = () => {
-    const currentAcceptsGameCommentsState = getCurrentState(
-      game.acceptsGameComments,
-      acceptsGameComments
-    );
-    setAcceptsGameComments(!currentAcceptsGameCommentsState);
-    updateGameProperties({
-      acceptsGameComments: !currentAcceptsGameCommentsState,
-    });
+  const onConfirmToggleChanges = async () => {
+    if (!profile || !showConfirmationDialog) return;
+    if (!newProperty) return;
+    setIsEditingProperty(true);
+    try {
+      await updateGame(
+        getAuthorizationHeader,
+        profile.id,
+        game.id,
+        newProperty
+      );
+      await onUpdateGame();
+      setShowConfirmationDialog(null);
+    } catch (error) {
+      console.warn(
+        `Unable to update property ${showConfirmationDialog}`,
+        error
+      );
+    } finally {
+      setIsEditingProperty(false);
+    }
   };
 
   return (
@@ -230,20 +268,16 @@ export const GameCard = ({
                   <Column noMargin justifyContent="flex-start">
                     <Toggle
                       labelPosition="left"
-                      onToggle={onToggleDiscoverable}
-                      toggled={getCurrentState(
-                        game.discoverable,
-                        isDiscoverable
-                      )}
+                      onToggle={() => setShowConfirmationDialog('discoverable')}
+                      toggled={!!game.discoverable}
                       label={<Trans>Make discoverable on Liluo.io</Trans>}
                     />
                     <Toggle
                       labelPosition="left"
-                      onToggle={onToggleAcceptsGameComments}
-                      toggled={getCurrentState(
-                        game.acceptsGameComments,
-                        acceptsGameComments
-                      )}
+                      onToggle={() =>
+                        setShowConfirmationDialog('acceptsGameComments')
+                      }
+                      toggled={!!game.acceptsGameComments}
                       label={
                         <Trans>
                           Show feedback banner on Liluo.io game page
@@ -252,11 +286,10 @@ export const GameCard = ({
                     />
                     <Toggle
                       labelPosition="left"
-                      onToggle={onToggleAcceptsBuildComments}
-                      toggled={getCurrentState(
-                        game.acceptsBuildComments,
-                        acceptsBuildComments
-                      )}
+                      onToggle={() =>
+                        setShowConfirmationDialog('acceptsBuildComments')
+                      }
+                      toggled={!!game.acceptsBuildComments}
                       label={<Trans>Ask for feedback on all build pages</Trans>}
                     />
                   </Column>
@@ -269,6 +302,38 @@ export const GameCard = ({
               game={game}
               onClose={() => setShowShareDialog(false)}
             />
+          )}
+          {showConfirmationDialog && newProperty && (
+            <Dialog
+              open
+              maxWidth="xs"
+              actions={[
+                <FlatButton
+                  key="cancel-toggle-change"
+                  label={<Trans>Cancel</Trans>}
+                  onClick={() => setShowConfirmationDialog(null)}
+                  disabled={isEditingProperty}
+                />,
+                <RaisedButton
+                  key="confirm-toggle-change"
+                  label={<Trans>Confirm</Trans>}
+                  onClick={onConfirmToggleChanges}
+                  disabled={isEditingProperty}
+                />,
+              ]}
+              onApply={onConfirmToggleChanges}
+              cannotBeDismissed={isEditingProperty}
+            >
+              <Column>
+                <Line>
+                  {isEditingProperty ? (
+                    <PlaceholderLoader />
+                  ) : (
+                    <Text>{getConfirmationMessage(newProperty)}</Text>
+                  )}
+                </Line>
+              </Column>
+            </Dialog>
           )}
         </>
       )}

--- a/newIDE/app/src/GameDashboard/GameCard.js
+++ b/newIDE/app/src/GameDashboard/GameCard.js
@@ -166,6 +166,10 @@ export const GameCard = ({
                       click: () => onOpenGameManager('builds'),
                     },
                     {
+                      label: i18n._(t`See feedbacks`),
+                      click: () => onOpenGameManager('feedback'),
+                    },
+                    {
                       label: i18n._(t`Open analytics`),
                       click: () => onOpenGameManager('analytics'),
                     },
@@ -203,7 +207,7 @@ export const GameCard = ({
                       >
                         <FlatButton
                           label={<Trans>Access feedback</Trans>}
-                          onClick={() => {}}
+                          onClick={() => onOpenGameManager('feedback')}
                           disabled={!game.publicWebBuildId}
                         />
                         <RaisedButton

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -43,10 +43,12 @@ import Crown from '../UI/CustomSvgIcons/Crown';
 import { showErrorBox, showWarningBox } from '../UI/Messages/MessageBox';
 import LeaderboardAdmin from './LeaderboardAdmin';
 import { GameAnalyticsPanel } from './GameAnalyticsPanel';
+import GameFeedback from './Feedbacks/GameFeedback';
 
 export type GamesDetailsTab =
   | 'details'
   | 'builds'
+  | 'feedback'
   | 'analytics'
   | 'leaderboards';
 
@@ -334,6 +336,7 @@ export const GameDetailsDialog = ({
           <Tabs value={currentTab} onChange={setCurrentTab}>
             <Tab label={<Trans>Details</Trans>} value="details" />
             <Tab label={<Trans>Builds</Trans>} value="builds" />
+            <Tab label={<Trans>Feedback</Trans>} value="feedback" />
             <Tab label={<Trans>Analytics</Trans>} value="analytics" />
             <Tab label={<Trans>Leaderboards</Trans>} value="leaderboards" />
           </Tabs>
@@ -539,6 +542,9 @@ export const GameDetailsDialog = ({
             ) : null}
             {currentTab === 'analytics' ? (
               <GameAnalyticsPanel game={game} publicGame={publicGame} />
+            ) : null}
+            {currentTab === 'feedback' ? (
+              <GameFeedback authenticatedUser={authenticatedUser} game={game} />
             ) : null}
           </Line>
           {publicGame && project && isPublicGamePropertiesDialogOpen && (

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -298,7 +298,7 @@ export const deleteLeaderboardEntry = async (
 // 2 types of comments. Feedback is private, Review is public.
 export type CommentType = 'FEEDBACK' | 'REVIEW';
 
-export type GameRatingsV1 = {
+export type GameRatings = {
   version: number,
   visuals: number,
   sound: number,
@@ -306,22 +306,18 @@ export type GameRatingsV1 = {
   easeOfUse: number,
 };
 
-export type GameRatings = GameRatingsV1; // Handle future versions of the schema with "| GameRatingsV2"
-
 export type Comment = {
   id: string,
   type: CommentType,
-  gameId: string, // We are always able to link a comment to a game, even if made on a build.
-  buildId?: string, // If defined, the comment is made on a specific build.
+  gameId: string,
+  buildId?: string,
   text: string,
   ratings?: GameRatings,
-  playerId?: string, // Useful in the future, to link a comment to a user.
-  playerName?: string, // For non-authenticated comments.
-  contact?: string, // In order to be able to contact the user.
+  playerId?: string,
+  playerName?: string,
+  contact?: string,
   createdAt: number,
-  updatedAt: number,
-  deletedAt?: number, // For soft delete.
-  processedAt?: number, // For marking comments as resolved/processed.
+  processedAt?: number,
 };
 
 export const listComments = async (

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData.js
@@ -18,6 +18,7 @@ import {
   type Asset,
   type AssetPacks,
 } from '../Utils/GDevelopServices/Asset';
+import { type Comment } from '../Utils/GDevelopServices/Play';
 
 export const indieFirebaseUser: FirebaseUser = {
   uid: 'indie-user',
@@ -999,4 +1000,43 @@ export const fakeAssetPacks: AssetPacks = {
       assetsCount: 287,
     },
   ],
+};
+
+export const commentUnsolved: Comment = {
+  id: 'comment-unsolved-id',
+  type: 'FEEDBACK',
+  gameId: 'game-id',
+  buildId: 'build-id',
+  text:
+    "This is my honest feedback: I think the art is cute. Specially on the screen when it jumps over the chickens. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. ",
+  ratings: {
+    version: 1,
+    visuals: 2,
+    sound: 4,
+    fun: 6,
+    easeOfUse: 8,
+  },
+  playerName: 'playerName', // For non-authenticated comments.
+  createdAt: 1515084391000,
+  updatedAt: 1515084393000,
+};
+
+export const commentSolved: Comment = {
+  id: 'comment-solved-id',
+  type: 'FEEDBACK',
+  gameId: 'game-id',
+  buildId: 'build-id',
+  text:
+    "This is my honest feedback: I think the art is cute. Specially on the screen when it jumps over the chickens. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. ",
+  ratings: {
+    version: 1,
+    visuals: 2,
+    sound: 4,
+    fun: 6,
+    easeOfUse: 8,
+  },
+  playerName: 'playerName', // For non-authenticated comments.
+  createdAt: 1515084391000,
+  updatedAt: 1515084393000,
+  processedAt: 1515084393000,
 };

--- a/newIDE/app/src/stories/componentStories/GameDashboard/Feedback/FeedbackCard.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameDashboard/Feedback/FeedbackCard.stories.js
@@ -21,6 +21,5 @@ export const DefaultFeedbackCard = () => (
   <FeedbackCard
     comment={commentUnsolved}
     authenticatedUser={fakeIndieAuthenticatedUser}
-    onUpdateComment={action('onUpdateComment')}
   />
 );

--- a/newIDE/app/src/stories/componentStories/GameDashboard/Feedback/FeedbackCard.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameDashboard/Feedback/FeedbackCard.stories.js
@@ -1,0 +1,26 @@
+// @flow
+
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+
+import FeedbackCard from '../../../../GameDashboard/Feedbacks/FeedbackCard';
+
+import { fakeIndieAuthenticatedUser } from '../../../../fixtures/GDevelopServicesTestData';
+import { commentUnsolved } from '../../../../fixtures/GDevelopServicesTestData';
+
+export default {
+  title: 'GameDashboard/Feedback/FeedbackCard',
+  component: FeedbackCard,
+  decorators: [muiDecorator, paperDecorator],
+};
+
+export const DefaultFeedbackCard = () => (
+  <FeedbackCard
+    comment={commentUnsolved}
+    authenticatedUser={fakeIndieAuthenticatedUser}
+    onUpdateComment={action('onUpdateComment')}
+  />
+);

--- a/newIDE/app/src/stories/componentStories/GameDashboard/Feedback/GameFeedback.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameDashboard/Feedback/GameFeedback.stories.js
@@ -1,0 +1,84 @@
+// @flow
+
+import * as React from 'react';
+
+import muiDecorator from '../../../ThemeDecorator';
+import paperDecorator from '../../../PaperDecorator';
+
+import GameFeedback from '../../../../GameDashboard/Feedbacks/GameFeedback';
+
+import {
+  commentSolved,
+  commentUnsolved,
+  fakeIndieAuthenticatedUser,
+  game1,
+} from '../../../../fixtures/GDevelopServicesTestData';
+import MockAdapter from 'axios-mock-adapter';
+import Axios from 'axios';
+import { GDevelopPlayApi } from '../../../../Utils/GDevelopServices/ApiConfigs';
+
+export default {
+  title: 'GameDashboard/Feedback/GameFeedback',
+  component: GameFeedback,
+  decorators: [muiDecorator, paperDecorator],
+};
+
+export const DefaultGameFeedback = () => {
+  const mock = new MockAdapter(Axios);
+  mock
+    .onGet(`${GDevelopPlayApi.baseUrl}/game/${game1.id}/comment`)
+    .reply(200, [commentSolved, commentUnsolved])
+    .onAny()
+    .reply(config => {
+      console.error(`Unexpected call to ${config.url} (${config.method})`);
+      return [504, null];
+    });
+  return (
+    <GameFeedback authenticatedUser={fakeIndieAuthenticatedUser} game={game1} />
+  );
+};
+
+export const GameFeedbackOneSolvedComment = () => {
+  const mock = new MockAdapter(Axios);
+  mock
+    .onGet(`${GDevelopPlayApi.baseUrl}/game/${game1.id}/comment`)
+    .reply(200, [commentSolved])
+    .onAny()
+    .reply(config => {
+      console.error(`Unexpected call to ${config.url} (${config.method})`);
+      return [504, null];
+    });
+  return (
+    <GameFeedback authenticatedUser={fakeIndieAuthenticatedUser} game={game1} />
+  );
+};
+
+export const GameFeedbackWithError = () => {
+  const mock = new MockAdapter(Axios);
+  mock
+    .onGet(`${GDevelopPlayApi.baseUrl}/game/${game1.id}/comment`)
+    .reply(500, 'Internal server error')
+    .onAny()
+    .reply(config => {
+      console.error(`Unexpected call to ${config.url} (${config.method})`);
+      return [504, null];
+    });
+  return (
+    <GameFeedback authenticatedUser={fakeIndieAuthenticatedUser} game={game1} />
+  );
+};
+
+export const GameFeedbackEmpty = () => {
+  const mock = new MockAdapter(Axios);
+  mock
+    .onGet(`${GDevelopPlayApi.baseUrl}/game/${game1.id}/comment`)
+    .reply(200, [])
+    .onAny()
+    .reply(config => {
+      console.error(`Unexpected call to ${config.url} (${config.method})`);
+      return [504, null];
+    });
+  return (
+    <GameFeedback authenticatedUser={fakeIndieAuthenticatedUser} game={game1} />
+  );
+};


### PR DESCRIPTION
Continuation of #4045 (split for an easier review)

- Add a tab to review the feedback sent
- Allow user to mark feedback as processed


Note : 
- The build on which the feedback is sent is not yet displayed (it has not much sense until we can customize them)
- We cannot yet filter feedbacks by build (for the same reasons)

<img width="963" alt="image" src="https://user-images.githubusercontent.com/81410437/175544319-eec02f8d-3a70-4d95-bfba-b131dfdb615a.png">


Test the new tab here:
http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/add-feedback-tab/latest/index.html?path=/story/gamedashboard-feedback-gamefeedback--default-game-feedback