### PR TITLE
Allow the web-app to use relative resources if found when the project is opened from a public URL

### DIFF
--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/BrowserResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/BrowserResourceFetcher.js
@@ -1,11 +1,41 @@
 // @flow
 import { type ResourceFetcher, type FetchResourcesArgs } from '.';
+import PromisePool from '@supercharge/promise-pool';
+import axios from 'axios';
 
+const isURL = (filename: string) => {
+  return (
+    filename.startsWith('http://') ||
+    filename.startsWith('https://') ||
+    filename.startsWith('ftp://') ||
+    filename.startsWith('blob:') ||
+    filename.startsWith('data:')
+  );
+};
+
+const isFetchableUrl = (filename: string) => {
+  return (
+    filename.startsWith('http://') ||
+    filename.startsWith('https://') ||
+    filename.startsWith('ftp://')
+  );
+};
+
+/**
+ * On the web-app, try to replace relative resource files by a full URL.
+ * The heuristic is: if the project is accessible on a URL, then the resources
+ * must be located next to it.
+ * This is helpful to work on the web-app on a project stored publicly (like on GitHub).
+ */
 const getResourcesToFetch = (project: gdProject): Array<string> => {
-  // Currently, the web-app only supports resources with URLs.
-  // TODO: Detect non URLs resources and explain that it can be opened
-  // only on the desktop app.
-  return [];
+  const resourcesManager = project.getResourcesManager();
+
+  const allResourceNames = resourcesManager.getAllResourceNames().toJSArray();
+  return allResourceNames.filter(resourceName => {
+    const resource = resourcesManager.getResource(resourceName);
+
+    return !isURL(resource.getFile());
+  });
 };
 
 const fetchResources = async ({
@@ -13,9 +43,51 @@ const fetchResources = async ({
   resourceNames,
   onProgress,
 }: FetchResourcesArgs) => {
+  const resourcesManager = project.getResourcesManager();
+  const erroredResources = [];
+  const fetchedResources = [];
+
+  const projectFileUrl = project.getProjectFile();
+  const projectBaseUrl = projectFileUrl.substr(
+    0,
+    projectFileUrl.lastIndexOf('/') + 1
+  );
+  if (!isFetchableUrl(projectBaseUrl)) {
+    // Can't fetch anything relative to this project, because
+    // this project does not have a public URL.
+    return {
+      fetchedResources: [],
+      erroredResources: [],
+    };
+  }
+
+  let fetchedResourcesCount = 0;
+  const resourcesToFetch = getResourcesToFetch(project);
+
+  await PromisePool.withConcurrency(20)
+    .for(resourceNames)
+    .process(async resourceName => {
+      const resource = resourcesManager.getResource(resourceName);
+
+      try {
+        const resourceFullUrl = new URL(resource.getFile(), projectBaseUrl)
+          .href;
+        await axios.get(resourceFullUrl, {
+          timeout: 3000,
+        });
+
+        resource.setFile(resourceFullUrl);
+        fetchedResources.push({ resourceName });
+      } catch (error) {
+        erroredResources.push({ resourceName, error });
+      }
+
+      onProgress(fetchedResourcesCount++, resourcesToFetch.length);
+    });
+
   return {
-    fetchedResources: [],
-    erroredResources: [],
+    fetchedResources,
+    erroredResources,
   };
 };
 

--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/LocalResourceFetcher.js
@@ -17,6 +17,12 @@ const isFetchableUrl = (filename: string) => {
   );
 };
 
+/**
+ * On the desktop app, try to download all URLs into local files, put
+ * next to the project file (in a "assets" directory). This is helpful
+ * to continue working on a game started on the web-app (using public URLs
+ * for resources).
+ */
 const getResourcesToFetch = (project: gdProject): Array<string> => {
   const resourcesManager = project.getResourcesManager();
 

--- a/newIDE/app/src/ProjectsStorage/ResourceFetcher/index.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceFetcher/index.js
@@ -92,10 +92,12 @@ export const ResourceFetcherDialog = ({
           <Text>
             {hasErrors ? (
               <Trans>
-                There were errors when fetching resources for the project.
+                There were errors when fetching resources for the project. You
+                can retry (recommended) or continue despite the errors. In this
+                case, the project will be missing some resources.
               </Trans>
             ) : (
-              <Trans>Resources needed for the project are downloaded...</Trans>
+              <Trans>Resources needed for the project are fetched...</Trans>
             )}
           </Text>
           <LinearProgress variant="determinate" value={progress} />


### PR DESCRIPTION
* For example, this can be useful to open a desktop project stored on a public space like GitHub (using the "raw" raw.githubusercontent.com/... urls given by GitHub)
  **I don't expect this to be common use case**, but this could be useful to quickly test examples that are on a GitHub branch.
  
* Test it locally with a URL like: http://localhost:3000/?project=https://raw.githubusercontent.com/GDevelopApp/GDevelop-examples/main/examples/tappy-plane/tappy-plane.json

