### PR TITLE
Don't display objects already in a group as addable

### DIFF
--- a/newIDE/app/src/ObjectGroupEditor/index.js
+++ b/newIDE/app/src/ObjectGroupEditor/index.js
@@ -29,6 +29,7 @@ const ObjectGroupEditor = ({
   onSizeUpdated,
 }: Props) => {
   const [newObjectName, setNewObjectName] = React.useState<string>('');
+  const objectsInGroup = group.getAllObjectsNames().toJSArray();
 
   const removeObject = (objectName: string) => {
     group.removeObject(objectName);
@@ -44,19 +45,16 @@ const ObjectGroupEditor = ({
 
   const renderExplanation = () => {
     let type = undefined;
-    group
-      .getAllObjectsNames()
-      .toJSArray()
-      .forEach(objectName => {
-        const objectType = gd.getTypeOfObject(
-          globalObjectsContainer,
-          objectsContainer,
-          objectName,
-          false
-        );
-        if (type === undefined || objectType === type) type = objectType;
-        else type = '';
-      });
+    objectsInGroup.forEach(objectName => {
+      const objectType = gd.getTypeOfObject(
+        globalObjectsContainer,
+        objectsContainer,
+        objectName,
+        false
+      );
+      if (type === undefined || objectType === type) type = objectType;
+      else type = '';
+    });
 
     let message = '';
     if (type === undefined) {
@@ -98,6 +96,7 @@ const ObjectGroupEditor = ({
             globalObjectsContainer={globalObjectsContainer}
             objectsContainer={objectsContainer}
             value={newObjectName}
+            excludedObjects={objectsInGroup}
             onChange={setNewObjectName}
             onChoose={addObject}
             openOnFocus

--- a/newIDE/app/src/ObjectGroupEditor/index.js
+++ b/newIDE/app/src/ObjectGroupEditor/index.js
@@ -96,7 +96,7 @@ const ObjectGroupEditor = ({
             globalObjectsContainer={globalObjectsContainer}
             objectsContainer={objectsContainer}
             value={newObjectName}
-            excludedObjects={objectsInGroup}
+            excludedObjectOrGroupNames={objectsInGroup}
             onChange={setNewObjectName}
             onChoose={addObject}
             openOnFocus

--- a/newIDE/app/src/ObjectsList/ObjectSelector.js
+++ b/newIDE/app/src/ObjectsList/ObjectSelector.js
@@ -95,6 +95,7 @@ const getObjectsAndGroupsDataSource = ({
   const fullList = [...objects, { type: 'separator' }, ...groups];
   return excludedObjectOrGroupNames
     ? fullList.filter(
+        //$FlowFixMe
         ({ value }) => !excludedObjectOrGroupNames.includes(value)
       )
     : fullList;

--- a/newIDE/app/src/ObjectsList/ObjectSelector.js
+++ b/newIDE/app/src/ObjectsList/ObjectSelector.js
@@ -27,6 +27,9 @@ type Props = {|
 
   noGroups?: boolean,
 
+  /** A list of object names to exclude from the autocomplete list (for exasmple if they have already been selected). */
+  excludedObjects?: Array<string>,
+
   onChoose?: string => void,
   onChange: string => void,
   onRequestClose?: () => void,
@@ -52,12 +55,14 @@ const getObjectsAndGroupsDataSource = ({
   objectsContainer,
   noGroups,
   allowedObjectType,
+  excludedObjects,
 }: {|
   project: ?gdProject,
   globalObjectsContainer: gdObjectsContainer,
   objectsContainer: gdObjectsContainer,
   noGroups: ?boolean,
   allowedObjectType: ?string,
+  excludedObjects: ?Array<string>,
 |}): DataSource => {
   const list = enumerateObjectsAndGroups(
     globalObjectsContainer,
@@ -87,7 +92,10 @@ const getObjectsAndGroupsDataSource = ({
         };
       });
 
-  return [...objects, { type: 'separator' }, ...groups];
+  const fullList = [...objects, { type: 'separator' }, ...groups];
+  return excludedObjects
+    ? fullList.filter(({ value }) => !excludedObjects.includes(value))
+    : fullList;
 };
 
 const checkHasRequiredCapability = ({
@@ -153,6 +161,7 @@ export default class ObjectSelector extends React.Component<Props, {||}> {
       onRequestClose,
       onApply,
       id,
+      excludedObjects,
       ...rest
     } = this.props;
 
@@ -162,6 +171,7 @@ export default class ObjectSelector extends React.Component<Props, {||}> {
       objectsContainer,
       noGroups,
       allowedObjectType,
+      excludedObjects,
     });
     const hasValidChoice =
       objectAndGroups.filter(

--- a/newIDE/app/src/ObjectsList/ObjectSelector.js
+++ b/newIDE/app/src/ObjectsList/ObjectSelector.js
@@ -28,7 +28,7 @@ type Props = {|
   noGroups?: boolean,
 
   /** A list of object names to exclude from the autocomplete list (for exasmple if they have already been selected). */
-  excludedObjects?: Array<string>,
+  excludedObjectOrGroupNames?: Array<string>,
 
   onChoose?: string => void,
   onChange: string => void,
@@ -55,14 +55,14 @@ const getObjectsAndGroupsDataSource = ({
   objectsContainer,
   noGroups,
   allowedObjectType,
-  excludedObjects,
+  excludedObjectOrGroupNames,
 }: {|
   project: ?gdProject,
   globalObjectsContainer: gdObjectsContainer,
   objectsContainer: gdObjectsContainer,
   noGroups: ?boolean,
   allowedObjectType: ?string,
-  excludedObjects: ?Array<string>,
+  excludedObjectOrGroupNames: ?Array<string>,
 |}): DataSource => {
   const list = enumerateObjectsAndGroups(
     globalObjectsContainer,
@@ -93,8 +93,10 @@ const getObjectsAndGroupsDataSource = ({
       });
 
   const fullList = [...objects, { type: 'separator' }, ...groups];
-  return excludedObjects
-    ? fullList.filter(({ value }) => !excludedObjects.includes(value))
+  return excludedObjectOrGroupNames
+    ? fullList.filter(
+        ({ value }) => !excludedObjectOrGroupNames.includes(value)
+      )
     : fullList;
 };
 
@@ -161,7 +163,7 @@ export default class ObjectSelector extends React.Component<Props, {||}> {
       onRequestClose,
       onApply,
       id,
-      excludedObjects,
+      excludedObjectOrGroupNames,
       ...rest
     } = this.props;
 
@@ -171,7 +173,7 @@ export default class ObjectSelector extends React.Component<Props, {||}> {
       objectsContainer,
       noGroups,
       allowedObjectType,
-      excludedObjects,
+      excludedObjectOrGroupNames,
     });
     const hasValidChoice =
       objectAndGroups.filter(


### PR DESCRIPTION
Feature request: https://forum.gdevelop.io/t/remove-already-grouped-objects-from-list/40515?u=arthuro555

Filters already selected objects out of the autocomplete for adding new objects to a group.
This is good since:
- They are useless anyways (not letting one remove or re-add them again).
- We have a clearer list of what objects are left to add in the group, giving less room for overseeing an object that needs to be added.