### PR TITLE
Avoid warnings in the console during preview/export by cleaning old C++ include files

### DIFF
--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -31,8 +31,6 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
           .SetCategoryFullName(_("General"));
 
 #if defined(GD_IDE_ONLY)
-  obj.SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
-
   obj.AddAction(
          "Rectangle",
          _("Rectangle"),
@@ -48,8 +46,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Top Y position"))
       .AddParameter("expression", _("Right X position"))
       .AddParameter("expression", _("Bottom Y position"))
-      .SetFunctionName("DrawRectangle")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("DrawRectangle");
 
   obj.AddAction("Circle",
                 _("Circle"),
@@ -64,8 +61,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("X position of center"))
       .AddParameter("expression", _("Y position of center"))
       .AddParameter("expression", _("Radius (in pixels)"))
-      .SetFunctionName("DrawCircle")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("DrawCircle");
 
   obj.AddAction("Line",
                 _("Line"),
@@ -84,8 +80,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("X position of end point"))
       .AddParameter("expression", _("Y position of end point"))
       .AddParameter("expression", _("Thickness (in pixels)"))
-      .SetFunctionName("DrawLine")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("DrawLine");
 
   obj.AddAction("LineV2",
                 _("Line"),
@@ -103,8 +98,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("X position of end point"))
       .AddParameter("expression", _("Y position of end point"))
       .AddParameter("expression", _("Thickness (in pixels)"))
-      .SetFunctionName("drawLineV2")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawLineV2");
 
   obj.AddAction("Ellipse",
                 _("Ellipse"),
@@ -121,8 +115,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Y position of center"))
       .AddParameter("expression", _("The width of the ellipse"))
       .AddParameter("expression", _("The height of the ellipse"))
-      .SetFunctionName("DrawEllipse")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("DrawEllipse");
 
   obj.AddAction("RoundedRectangle",
                 _("Rounded rectangle"),
@@ -140,8 +133,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Right X position"))
       .AddParameter("expression", _("Bottom Y position"))
       .AddParameter("expression", _("Radius (in pixels)"))
-      .SetFunctionName("DrawRoundedRectangle")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("DrawRoundedRectangle");
 
   obj.AddAction(
          "Star",
@@ -163,8 +155,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression",
                     _("Inner radius (in pixels, half radius by default)"))
       .AddParameter("expression", _("Rotation (in degrees)"))
-      .SetFunctionName("DrawStar")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("DrawStar");
 
   obj.AddAction("Arc",
                 _("Arc"),
@@ -187,8 +178,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("End angle of the arc (in degrees)"))
       .AddParameter("yesorno", _("Anticlockwise"))
       .AddParameter("yesorno", _("Close path"))
-      .SetFunctionName("DrawArc")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("DrawArc");
 
   obj.AddAction("BezierCurve",
                 _("Bezier curve"),
@@ -210,8 +200,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Second Control point y"))
       .AddParameter("expression", _("Destination point x"))
       .AddParameter("expression", _("Destination point y"))
-      .SetFunctionName("drawBezierCurve")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawBezierCurve");
 
   obj.AddAction("QuadraticCurve",
                 _("Quadratic curve"),
@@ -230,8 +219,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Control point y"))
       .AddParameter("expression", _("Destination point x"))
       .AddParameter("expression", _("Destination point y"))
-      .SetFunctionName("drawQuadraticCurve")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawQuadraticCurve");
 
   obj.AddAction("BeginFillPath",
                 _("Begin fill path"),
@@ -248,8 +236,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .AddParameter("expression", _("Start drawing x"))
       .AddParameter("expression", _("Start drawing y"))
-      .SetFunctionName("beginFillPath")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("beginFillPath");
 
   obj.AddAction("EndFillPath",
                 _("End fill path"),
@@ -261,8 +248,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                 "res/actions/endFillPath.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("endFillPath")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("endFillPath");
 
   obj.AddAction("MovePathTo",
                 _("Move path drawing position"),
@@ -276,8 +262,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .AddParameter("expression", _("X position of start point"))
       .AddParameter("expression", _("Y position of start point"))
-      .SetFunctionName("drawPathMoveTo")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawPathMoveTo");
 
   obj.AddAction("PathLineTo",
                 _("Path line"),
@@ -294,8 +279,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .AddParameter("expression", _("X position of start point"))
       .AddParameter("expression", _("Y position of start point"))
-      .SetFunctionName("drawPathLineTo")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawPathLineTo");
 
   obj.AddAction("PathBezierCurveTo",
                 _("Path bezier curve"),
@@ -318,8 +302,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Second Control point y"))
       .AddParameter("expression", _("Destination point x"))
       .AddParameter("expression", _("Destination point y"))
-      .SetFunctionName("drawPathBezierCurveTo")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawPathBezierCurveTo");
 
   obj.AddAction("PathArc",
                 _("Path arc"),
@@ -342,8 +325,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Start angle"))
       .AddParameter("expression", _("End angle"))
       .AddParameter("yesorno", _("Anticlockwise"))
-      .SetFunctionName("drawPathArc")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawPathArc");
 
   obj.AddAction("PathQuadraticCurveTo",
                 _("Path quadratic curve"),
@@ -363,8 +345,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Control point y"))
       .AddParameter("expression", _("Destination point x"))
       .AddParameter("expression", _("Destination point y"))
-      .SetFunctionName("drawPathQuadraticCurveTo")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("drawPathQuadraticCurveTo");
 
   obj.AddAction("closePath",
                 _("Close Path"),
@@ -377,8 +358,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                 "res/actions/closePath.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("closePath")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("closePath");
 
   obj.AddScopedAction("ClearShapes",
                       _("Clear shapes"),
@@ -403,8 +383,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .AddParameter("yesorno", _("Clear between each frame"), "", true)
       .SetDefaultValue("yes")
-      .SetFunctionName("SetClearBetweenFrames")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("SetClearBetweenFrames");
 
   obj.AddCondition(
          "ClearBetweenFrames",
@@ -416,8 +395,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
          "res/conditions/visibilite.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("IsClearedBetweenFrames")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("IsClearedBetweenFrames");
 
   obj.AddAction("FillColor",
                 _("Fill color"),
@@ -429,8 +407,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .AddParameter("color", _("Fill color"))
-      .SetFunctionName("SetFillColor")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("SetFillColor");
 
   obj.AddExpression("FillColorRed",
                     _("Filing color red component"),
@@ -438,8 +415,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/actions/color.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetFillColorR")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetFillColorR");
 
   obj.AddExpression("FillColorGreen",
                     _("Filing color green component"),
@@ -447,8 +423,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/actions/color.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetFillColorG")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetFillColorG");
 
   obj.AddExpression("FillColorBlue",
                     _("Filing color blue component"),
@@ -456,8 +431,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/actions/color.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetFillColorB")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetFillColorB");
 
   obj.AddAction("OutlineColor",
                 _("Outline color"),
@@ -469,8 +443,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .AddParameter("color", _("Color"))
-      .SetFunctionName("SetOutlineColor")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("SetOutlineColor");
 
   obj.AddExpression("OutlineColorRed",
                     _("Outline color red component"),
@@ -478,8 +451,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/actions/color.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetOutlineColorR")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetOutlineColorR");
 
   obj.AddExpression("OutlineColorGreen",
                     _("Outline color green component"),
@@ -487,8 +459,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/actions/color.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetOutlineColorG")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetOutlineColorG");
 
   obj.AddExpression("OutlineColorBlue",
                     _("Outline color blue component"),
@@ -496,8 +467,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/actions/color.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetOutlineColorB")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetOutlineColorB");
 
   obj.AddAction("OutlineSize",
                 _("Outline size"),
@@ -510,8 +480,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .UseStandardOperatorParameters("number")
       .SetFunctionName("SetOutlineSize")
-      .SetGetter("GetOutlineSize")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetGetter("GetOutlineSize");
 
   obj.AddCondition("OutlineSize",
                    _("Outline size"),
@@ -523,8 +492,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetOutlineSize")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetOutlineSize");
 
   obj.AddExpression("OutlineSize",
                     _("Outline size"),
@@ -532,8 +500,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/conditions/outlineSize.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetOutlineSize")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetOutlineSize");
 
   obj.AddAction(
          "FillOpacity",
@@ -547,8 +514,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .UseStandardOperatorParameters("number")
       .SetFunctionName("SetFillOpacity")
-      .SetGetter("GetFillOpacity")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetGetter("GetFillOpacity");
 
   obj.AddCondition("FillOpacity",
                    _("Fill opacity"),
@@ -560,8 +526,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetFillOpacity")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetFillOpacity");
 
   obj.AddExpression("FillOpacity",
                     _("Filling opacity"),
@@ -569,8 +534,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/conditions/opacity.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetFillOpacity")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetFillOpacity");
 
   obj.AddAction("OutlineOpacity",
                 _("Outline opacity"),
@@ -583,8 +547,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .UseStandardOperatorParameters("number")
       .SetFunctionName("SetOutlineOpacity")
-      .SetGetter("GetOutlineOpacity")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetGetter("GetOutlineOpacity");
 
   obj.AddCondition("OutlineOpacity",
                    _("Outline opacity"),
@@ -596,8 +559,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetOutlineOpacity")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetOutlineOpacity");
 
   obj.AddExpression("OutlineOpacity",
                     _("Outline opacity"),
@@ -605,8 +567,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
                     "",
                     "res/conditions/opacity.png")
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("GetOutlineOpacity")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("GetOutlineOpacity");
 
   obj.AddAction(
          "UseRelativeCoordinates",
@@ -620,8 +581,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Shape Painter object"), "Drawer")
       .AddParameter("yesorno", _("Use relative coordinates?"), "", false)
       .SetDefaultValue("true")
-      .SetFunctionName("setCoordinatesRelative")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("setCoordinatesRelative");
 
   obj.AddCondition(
          "AreCoordinatesRelative",
@@ -633,8 +593,7 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension& extension) {
          "res/conditions/position.png")
 
       .AddParameter("object", _("Shape Painter object"), "Drawer")
-      .SetFunctionName("AreCoordinatesRelative")
-      .SetIncludeFile("PrimitiveDrawing/ShapePainterObject.h");
+      .SetFunctionName("AreCoordinatesRelative");
 
   obj.AddAction("Scale",
                 _("Scale"),

--- a/Extensions/TextEntryObject/Extension.cpp
+++ b/Extensions/TextEntryObject/Extension.cpp
@@ -29,9 +29,6 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
                                       "CppPlatform/Extensions/textentry.png")
           .SetCategoryFullName(_("Advanced"));
 
-#if defined(GD_IDE_ONLY)
-  obj.SetIncludeFile("TextEntryObject/TextEntryObject.h");
-
   obj.AddAction("String",
                 _("Text in memory"),
                 _("Modify text in memory of the object"),
@@ -43,8 +40,7 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "TextEntry")
       .UseStandardOperatorParameters("string")
       .SetFunctionName("SetString")
-      .SetGetter("GetString")
-      .SetIncludeFile("TextEntryObject/TextEntryObject.h");
+      .SetGetter("GetString");
 
   obj.AddCondition("String",
                    _("Text in memory"),
@@ -56,8 +52,7 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "TextEntry")
       .UseStandardRelationalOperatorParameters("string")
-      .SetFunctionName("GetString")
-      .SetIncludeFile("TextEntryObject/TextEntryObject.h");
+      .SetFunctionName("GetString");
 
   obj.AddAction(
          "Activate",
@@ -71,8 +66,7 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "TextEntry")
       .AddParameter("yesorno", _("Activate"))
-      .SetFunctionName("Activate")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("Activate");
 
   obj.AddCondition("Activated",
                    _("Text input"),
@@ -83,8 +77,7 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
                    "CppPlatform/Extensions/textentryicon.png")
 
       .AddParameter("object", _("Object"), "TextEntry")
-      .SetFunctionName("IsActivated")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("IsActivated");
 
   obj.AddStrExpression("String",
                        _("Text entered with keyboard"),
@@ -92,7 +85,5 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
                        _("Text entered with keyboard"),
                        "res/texteicon.png")
       .AddParameter("object", _("Object"), "TextEntry")
-      .SetFunctionName("GetString")
-      .SetIncludeFile("TextObject/TextObject.h");
-#endif
+      .SetFunctionName("GetString");
 }

--- a/Extensions/TextObject/Extension.cpp
+++ b/Extensions/TextObject/Extension.cpp
@@ -33,9 +33,6 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                                  "CppPlatform/Extensions/texticon.png")
           .SetCategoryFullName(_("Texts"));
 
-#if defined(GD_IDE_ONLY)
-  obj.SetIncludeFile("TextObject/TextObject.h");
-
   obj.AddAction("String",
                 _("Modify the text"),
                 _("Modify the text of a Text object."),
@@ -47,8 +44,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Text")
       .UseStandardOperatorParameters("string")
       .SetFunctionName("SetString")
-      .SetGetter("GetString")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetGetter("GetString");
 
   obj.AddCondition("String",
                    _("Compare the text"),
@@ -60,8 +56,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardRelationalOperatorParameters("string")
-      .SetFunctionName("GetString")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetString");
 
   obj.AddAction("Font",
                 _("Font"),
@@ -73,8 +68,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .AddParameter("police", _("Font"))
-      .SetFunctionName("ChangeFont")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("ChangeFont");
 
   obj.AddCondition("ScaleX",
                    _("Scale on X axis"),
@@ -86,8 +80,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetScaleX")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetScaleX");
 
   obj.AddAction(
          "ScaleX",
@@ -100,8 +93,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardOperatorParameters("number")
-      .SetFunctionName("SetScaleX")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetScaleX");
 
   obj.AddCondition("ScaleY",
                    _("Scale on Y axis"),
@@ -113,8 +105,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetScaleY")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetScaleY");
 
   obj.AddAction(
          "ScaleY",
@@ -127,8 +118,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardOperatorParameters("number")
-      .SetFunctionName("SetScaleY")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetScaleY");
 
   obj.AddAction(
          "Scale",
@@ -141,8 +131,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardOperatorParameters("number")
-      .SetFunctionName("SetScale")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetScale");
 
   obj.AddAction(
          "ChangeColor",
@@ -155,8 +144,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .AddParameter("color", _("Color"))
-      .SetFunctionName("SetColor")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetColor");
 
   obj.AddAction("SetGradient",
                 _("Gradient"),
@@ -229,8 +217,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Text")
       .UseStandardOperatorParameters("number")
       .SetFunctionName("SetOpacity")
-      .SetGetter("GetOpacity")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetGetter("GetOpacity");
 
   obj.AddCondition("Opacity",
                    _("Opacity"),
@@ -243,8 +230,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetOpacity")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetOpacity");
 
   obj.AddAction("SetSmooth",
                 _("Smoothing"),
@@ -256,8 +242,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .AddParameter("yesorno", _("Smooth the text"))
-      .SetFunctionName("SetSmooth")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetSmooth");
 
   obj.AddCondition("Smoothed",
                    _("Smoothing"),
@@ -268,8 +253,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                    "res/conditions/opacity.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("IsSmoothed")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("IsSmoothed");
 
   obj.AddAction("SetBold",
                 _("Bold"),
@@ -281,8 +265,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .AddParameter("yesorno", _("Set bold style"))
-      .SetFunctionName("SetBold")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetBold");
 
   obj.AddCondition("IsBold",
                    _("Bold"),
@@ -293,8 +276,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                    "res/conditions/bold16.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("IsBold")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("IsBold");
 
   obj.AddAction("SetItalic",
                 _("Italic"),
@@ -306,8 +288,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .AddParameter("yesorno", _("Set italic"))
-      .SetFunctionName("SetItalic")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetItalic");
 
   obj.AddCondition("IsItalic",
                    _("Italic"),
@@ -318,8 +299,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                    "res/conditions/italic16.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("IsItalic")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("IsItalic");
 
   obj.AddAction("SetUnderlined",
                 _("Underlined"),
@@ -331,8 +311,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .AddParameter("yesorno", _("Underline"))
-      .SetFunctionName("SetUnderlined")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetUnderlined");
 
   obj.AddCondition("IsUnderlined",
                    _("Underlined"),
@@ -343,8 +322,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                    "res/conditions/underline16.png")
 
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("IsUnderlined")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("IsUnderlined");
 
   obj.AddAction("Angle",
                 _("Angle"),
@@ -357,8 +335,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Text")
       .UseStandardOperatorParameters("number")
       .SetFunctionName("SetAngle")
-      .SetGetter("GetAngle")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetGetter("GetAngle");
 
   obj.AddCondition("Angle",
                    _("Angle"),
@@ -370,8 +347,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
 
       .AddParameter("object", _("Object"), "Text")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetAngle")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetAngle");
 
   obj.AddCondition("Padding",
                    _("Padding"),
@@ -413,8 +389,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                     _("Alignment"),
                     "[\"left\", \"center\", \"right\"]",
                     false)
-      .SetFunctionName("SetTextAlignment")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("SetTextAlignment");
 
   obj.AddCondition("TextAlignment",
                    _("Alignment"),
@@ -485,8 +460,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                     _("Scale"),
                     "res/actions/scaleWidth.png")
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("GetScaleX")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetScaleX");
 
   obj.AddExpression("ScaleY",
                     _("Y Scale of a Text object"),
@@ -494,8 +468,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                     _("Scale"),
                     "res/actions/scaleHeight.png")
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("GetScaleY")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetScaleY");
 
   obj.AddExpression("Opacity",
                     _("Opacity of a Text object"),
@@ -503,8 +476,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                     _("Opacity"),
                     "res/actions/opacity.png")
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("GetOpacity")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetOpacity");
 
   obj.AddExpression("Angle",
                     _("Angle"),
@@ -512,8 +484,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                     _("Rotation"),
                     "res/actions/rotate.png")
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("GetAngle")
-      .SetIncludeFile("TextObject/TextObject.h");
+      .SetFunctionName("GetAngle");
 
   obj.AddExpressionAndConditionAndAction("number",
                                          "FontSize",
@@ -532,7 +503,5 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
   obj.AddStrExpression(
          "String", _("Text"), _("Text"), _("Text"), "res/texteicon.png")
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("GetString")
-      .SetIncludeFile("TextObject/TextObject.h");
-#endif
+      .SetFunctionName("GetString");
 }

--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -35,10 +35,6 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       std::make_shared<gd::BehaviorsSharedData>());
 
 #if defined(GD_IDE_ONLY)
-
-  aut.SetIncludeFile(
-      "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
-
   aut.AddAction("SimulateLeftKey",
                 _("Simulate left key press"),
                 _("Simulate a press of left key."),
@@ -49,9 +45,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .MarkAsAdvanced()
-      .SetFunctionName("SimulateLeftKey")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SimulateLeftKey");
 
   aut.AddAction("SimulateRightKey",
                 _("Simulate right key press"),
@@ -63,9 +57,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .MarkAsAdvanced()
-      .SetFunctionName("SimulateRightKey")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SimulateRightKey");
 
   aut.AddAction("SimulateUpKey",
                 _("Simulate up key press"),
@@ -77,9 +69,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .MarkAsAdvanced()
-      .SetFunctionName("SimulateUpKey")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SimulateUpKey");
 
   aut.AddAction("SimulateDownKey",
                 _("Simulate down key press"),
@@ -91,9 +81,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .MarkAsAdvanced()
-      .SetFunctionName("SimulateDownKey")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SimulateDownKey");
 
   aut.AddAction(
          "SimulateControl",
@@ -109,9 +97,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     _("Key"),
                     "[\"Left\", \"Right\", \"Up\", \"Down\"]")
       .MarkAsAdvanced()
-      .SetFunctionName("SimulateControl")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SimulateControl");
 
   aut.AddAction("IgnoreDefaultControls",
                 _("Ignore default controls"),
@@ -125,9 +111,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .AddParameter("yesorno", _("Ignore controls"))
       .MarkAsAdvanced()
-      .SetFunctionName("IgnoreDefaultControls")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("IgnoreDefaultControls");
 
   aut.AddAction("SimulateStick",
                 _("Simulate stick control"),
@@ -141,9 +125,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Stick angle (in degrees)"))
       .AddParameter("expression", _("Stick force (between 0 and 1)"))
       .MarkAsAdvanced()
-      .SetFunctionName("SimulateStick")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SimulateStick");
 
     aut.AddScopedCondition("IsUsingControl",
                   _("Control pressed or simulated"),
@@ -176,9 +158,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                    "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("IsMoving")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("IsMoving");
 
   aut.AddAction("Acceleration",
                 _("Acceleration"),
@@ -192,9 +172,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetAcceleration")
-      .SetGetter("GetAcceleration")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetGetter("GetAcceleration");
 
   aut.AddCondition("Acceleration",
                    _("Acceleration"),
@@ -207,9 +185,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetAcceleration")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAcceleration");
 
   aut.AddAction("Deceleration",
                 _("Deceleration"),
@@ -223,9 +199,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetDeceleration")
-      .SetGetter("GetDeceleration")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetGetter("GetDeceleration");
 
   aut.AddCondition("Deceleration",
                    _("Deceleration"),
@@ -238,9 +212,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetDeceleration")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetDeceleration");
 
   aut.AddAction("MaxSpeed",
                 _("Maximum speed"),
@@ -253,9 +225,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardOperatorParameters("number")
       .SetFunctionName("SetMaxSpeed")
-      .SetGetter("GetMaxSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetGetter("GetMaxSpeed");
 
   aut.AddCondition("MaxSpeed",
                    _("Maximum speed"),
@@ -268,9 +238,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetMaxSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetMaxSpeed");
 
   aut.AddCondition("Speed",
                    _("Speed"),
@@ -282,9 +250,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
-      .SetFunctionName("GetSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetSpeed");
 
   aut.AddAction("AngularMaxSpeed",
                 _("Angular maximum speed"),
@@ -298,9 +264,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetAngularMaxSpeed")
-      .SetGetter("GetAngularMaxSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetGetter("GetAngularMaxSpeed");
 
   aut.AddCondition("AngularMaxSpeed",
                    _("Angular maximum speed"),
@@ -313,9 +277,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetAngularMaxSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAngularMaxSpeed");
 
   aut.AddAction("AngleOffset",
                 _("Rotation offset"),
@@ -329,9 +291,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters("number")
       .MarkAsAdvanced()
       .SetFunctionName("SetAngleOffset")
-      .SetGetter("GetAngleOffset")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetGetter("GetAngleOffset");
 
   aut.AddCondition(
          "AngleOffset",
@@ -345,9 +305,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetAngleOffset")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAngleOffset");
 
   aut.AddCondition(
          "Angle",
@@ -361,9 +319,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetAngle")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAngle");
 
   aut.AddCondition("XVelocity",
                    _("Speed on X axis"),
@@ -377,9 +333,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetXVelocity")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetXVelocity");
 
   aut.AddCondition("YVelocity",
                    _("Speed on Y axis"),
@@ -393,9 +347,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .UseStandardRelationalOperatorParameters("number")
       .MarkAsAdvanced()
-      .SetFunctionName("GetYVelocity")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetYVelocity");
 
   aut.AddAction("AllowDiagonals",
                 _("Diagonal movement"),
@@ -407,9 +359,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .AddParameter("yesorno", _("Allow?"))
-      .SetFunctionName("SetAllowDiagonals")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SetAllowDiagonals");
 
   aut.AddCondition("DiagonalsAllowed",
                    _("Diagonal movement"),
@@ -421,9 +371,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .MarkAsAdvanced()
-      .SetFunctionName("DiagonalsAllowed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("DiagonalsAllowed");
 
   aut.AddAction("RotateObject",
                 _("Rotate the object"),
@@ -436,9 +384,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .AddParameter("yesorno", _("Rotate object?"))
       .MarkAsAdvanced()
-      .SetFunctionName("SetRotateObject")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("SetRotateObject");
 
   aut.AddCondition(
          "ObjectRotated",
@@ -451,9 +397,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
       .MarkAsAdvanced()
-      .SetFunctionName("IsObjectRotated")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("IsObjectRotated");
 
   aut.AddExpression("Acceleration",
                     _("Acceleration"),
@@ -462,9 +406,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetAcceleration")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAcceleration");
 
   aut.AddExpression("Deceleration",
                     _("Deceleration"),
@@ -473,9 +415,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetDeceleration")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetDeceleration");
 
   aut.AddExpression("MaxSpeed",
                     _("Maximum speed"),
@@ -484,9 +424,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetMaxSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetMaxSpeed");
 
   aut.AddExpression("Speed",
                     _("Speed"),
@@ -495,9 +433,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetSpeed");
 
   aut.AddExpression("AngularMaxSpeed",
                     _("Angular maximum speed"),
@@ -506,9 +442,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetAngularMaxSpeed")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAngularMaxSpeed");
 
   aut.AddExpression("AngleOffset",
                     _("Rotation offset"),
@@ -517,9 +451,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetAngleOffset")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAngleOffset");
 
   aut.AddExpression("Angle",
                     _("Angle of the movement"),
@@ -528,9 +460,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetAngle")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetAngle");
 
   aut.AddExpression("XVelocity",
                     _("Speed on the X axis"),
@@ -539,9 +469,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetXVelocity")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetXVelocity");
 
   aut.AddExpression("YVelocity",
                     _("Speed on the Y axis"),
@@ -550,9 +478,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
                     "CppPlatform/Extensions/topdownmovementicon16.png")
       .AddParameter("object", _("Object"))
       .AddParameter("behavior", _("Behavior"), "TopDownMovementBehavior")
-      .SetFunctionName("GetYVelocity")
-      .SetIncludeFile(
-          "TopDownMovementBehavior/TopDownMovementRuntimeBehavior.h");
+      .SetFunctionName("GetYVelocity");
 
   aut.AddScopedAction("SetVelocityX",
                 _("Speed on the X axis"),


### PR DESCRIPTION
Solve this:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/1280130/176044849-407526ef-542d-4487-b8d0-eaec9ee52c99.png">

Only show in developer changelog