### PR TITLE
Select copied element on behaviors and functions lists

### DIFF
--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -214,6 +214,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
 
     this._onEventsBasedBehaviorModified();
     this.props.onSelectEventsBasedBehavior(newEventsBasedBehavior);
+    this._editName(newEventsBasedBehavior)
   };
 
   _renderEventsBasedBehaviorMenuTemplate = (i18n: I18nType) => (

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -213,6 +213,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
     newEventsBasedBehavior.setName(newName);
 
     this._onEventsBasedBehaviorModified();
+    this.props.onSelectEventsBasedBehavior(newEventsBasedBehavior);
   };
 
   _renderEventsBasedBehaviorMenuTemplate = (i18n: I18nType) => (

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -268,6 +268,7 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
 
     this._onEventsFunctionModified();
     this.props.onSelectEventsFunction(newEventsFunction);
+    this._editName(newEventsFunction);
   };
 
   _onEventsFunctionModified() {

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -267,6 +267,7 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
     this.props.onEventsFunctionAdded(newEventsFunction);
 
     this._onEventsFunctionModified();
+    this.props.onSelectEventsFunction(newEventsFunction);
   };
 
   _onEventsFunctionModified() {


### PR DESCRIPTION
It could be nice to have the function inserted after the copied one but this is another story. I wanted to keep this PR very tiny.

![image](https://user-images.githubusercontent.com/2611977/177507412-99658aef-bfc0-46fa-bba5-1fc53f0fcbbe.png)

### User story
* I want to add a new action to change a property
* I duplicate an existing action to have less work to do
* In most UI I know, the copied element of a list is selected. So, I edit the selected function which is not the one I should edit.
* I rename the new action. Usually, at this point I realize my mistake and I have start from scratch.
* But sometimes, I don't and this happens:
  * https://github.com/GDevelopApp/GDevelop-extensions/issues/484