### PR TITLE
Slightly rework games dashboard

### DIFF
--- a/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
+++ b/newIDE/app/src/GameDashboard/Feedbacks/FeedbackCard.js
@@ -95,7 +95,10 @@ const FeedbackCard = ({
     } catch (error) {
       console.error(`Unable to update comment: `, error);
       showErrorBox({
-        message: i18n._(t`Unable to change resolved status of feedback.`),
+        message:
+          i18n._(t`Unable to change resolved status of feedback.`) +
+          ' ' +
+          i18n._(t`Verify your internet connection or try again later.`),
         rawError: error,
         errorId: 'feedback-card-set-processed-error',
       });

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -496,7 +496,13 @@ export const GameDetailsDialog = ({
                     <FlatButton
                       onClick={() => {
                         const answer = Window.showConfirmDialog(
-                          "Are you sure you want to unregister this game? \n\nIt will disappear from your games dashboard and you won't get access to analytics, unless you register it again."
+                          i18n._(
+                            t`Are you sure you want to unregister this game?`
+                          ) +
+                            '\n\n' +
+                            i18n._(
+                              t`It will disappear from your games dashboard and you won't get access to analytics, unless you register it again.`
+                            )
                         );
 
                         if (!answer) return;


### PR DESCRIPTION
The previous iteration of Games dashboard gave too much importance to Feedback compared to other features, especially Analytics (that have been recently worked on).

- Changed "Access feedback" button to "Manage game" that opens the game's details
- Added an "unregister game" option in the context menu

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/81410437/177523094-911062c1-344e-42e9-accd-35bcdb84ec1f.png">
