### PR TITLE
Make radian or degree explicit in descriptions for angles.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -219,7 +219,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddAction("SetAngle",
                 _("Angle"),
-                _("Change the angle of rotation of an object."),
+                _("Change the angle of rotation of an object (in degrees)."),
                 _("the angle"),
                 _("Angle"),
                 "res/actions/direction24.png",
@@ -998,7 +998,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddExpression("ForceAngle",
                     _("Angle of the sum of forces"),
-                    _("Angle of the sum of forces"),
+                    _("Angle of the sum of forces (in degrees)"),
                     _("Movement using forces"),
                     "res/actions/force.png")
       .AddParameter("object", _("Object"));
@@ -1131,8 +1131,9 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddExpression("AngleToObject",
                     _("Angle between two objects"),
-                    _("Compute the angle between two objects. If you need the "
-                      "angle to an arbitrary position, use AngleToPosition."),
+                    _("Compute the angle between two objects (in degrees). "
+                      "If you need the angle to an arbitrary position, "
+                      "use AngleToPosition."),
                     _("Angle"),
                     "res/actions/position.png")
       .AddParameter("object", _("Object"))
@@ -1165,8 +1166,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
   obj.AddExpression("AngleToPosition",
                     _("Angle between an object and a position"),
                     _("Compute the angle between the object center and a "
-                      "\"target\" position. If you need the angle between two "
-                      "objects, use AngleToObject."),
+                      "\"target\" position (in degrees). If you need the angle "
+                      "between two objects, use AngleToObject."),
                     _("Angle"),
                     "res/actions/position.png")
       .AddParameter("object", _("Object"))

--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -195,7 +195,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
           "number",
           "CameraAngle",
           _("Angle of a camera of a layer"),
-          _("the angle of rotation of a camera"),
+          _("the angle of rotation of a camera (in degrees)"),
           _("the angle of camera (layer: _PARAM3_, camera: _PARAM4_)"),
           "",
           "res/conditions/camera24.png")

--- a/Core/GDCore/Extensions/Builtin/MathematicalToolsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/MathematicalToolsExtension.cpp
@@ -262,7 +262,7 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
       .AddExpression("cos",
                      _("Cosine"),
                      _("Cosine of an angle (in radian). "
-                       "`ToRad` allows to use degrees."),
+                       "If you want to use degrees, use`ToRad`: `sin(ToRad(45))`."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));
@@ -405,7 +405,7 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
       .AddExpression("sin",
                      _("Sine"),
                      _("Sine of an angle (in radian). "
-                       "`ToRad` allows to use degrees."),
+                       "If you want to use degrees, use`ToRad`: `sin(ToRad(45))`."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));
@@ -430,7 +430,7 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
       .AddExpression("tan",
                      _("Tangent"),
                      _("Tangent of an angle (in radian). "
-                       "`ToRad` allows to use degrees."),
+                       "If you want to use degrees, use`ToRad`: `tan(ToRad(45))`."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));

--- a/Core/GDCore/Extensions/Builtin/MathematicalToolsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/MathematicalToolsExtension.cpp
@@ -96,13 +96,13 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
                      _("Difference between two angles"),
                      "",
                      "res/mathfunction.png")
-      .AddParameter("expression", _("First angle"))
-      .AddParameter("expression", _("Second angle"));
+      .AddParameter("expression", _("First angle, in degrees"))
+      .AddParameter("expression", _("Second angle, in degrees"));
 
   extension
       .AddExpression("AngleBetweenPositions",
                      _("Angle between two positions"),
-                     _("Compute the angle between two positions."),
+                     _("Compute the angle between two positions (in degrees)."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("First point X position"))
@@ -159,7 +159,8 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
   extension
       .AddExpression("acos",
                      _("Arccosine"),
-                     _("Arccosine"),
+                     _("Arccosine, return an angle (in radian). "
+                       "`ToDeg` allows to convert it to degrees."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));
@@ -175,7 +176,8 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
   extension
       .AddExpression("asin",
                      _("Arcsine"),
-                     _("Arcsine"),
+                     _("Arcsine, return an angle (in radian). "
+                       "`ToDeg` allows to convert it to degrees."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));
@@ -191,7 +193,8 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
   extension
       .AddExpression("atan",
                      _("Arctangent"),
-                     _("Arctangent"),
+                     _("Arctangent, return an angle (in radian). "
+                       "`ToDeg` allows to convert it to degrees."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));
@@ -258,7 +261,8 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
   extension
       .AddExpression("cos",
                      _("Cosine"),
-                     _("Cosine of a number"),
+                     _("Cosine of an angle (in radian). "
+                       "`ToRad` allows to use degrees."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));
@@ -400,7 +404,8 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
   extension
       .AddExpression("sin",
                      _("Sine"),
-                     _("Sine of a number"),
+                     _("Sine of an angle (in radian). "
+                       "`ToRad` allows to use degrees."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));
@@ -424,7 +429,8 @@ BuiltinExtensionsImplementer::ImplementsMathematicalToolsExtension(
   extension
       .AddExpression("tan",
                      _("Tangent"),
-                     _("Tangent of a number"),
+                     _("Tangent of an angle (in radian). "
+                       "`ToRad` allows to use degrees."),
                      "",
                      "res/mathfunction.png")
       .AddParameter("expression", _("Expression"));


### PR DESCRIPTION
The markdown is not handled, should `"` be used instead?