### PR TITLE
[Platformer] Fix: platformer characters can now jump when moving against a wall that is part of the same object as the floor.

### DIFF
--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1715,6 +1715,17 @@ namespace gdjs {
         behavior._overlappedJumpThru.push(this._floorPlatform!);
         behavior._setFalling();
       }
+
+      // It was originally in checkTransitionBeforeY.
+      // The character is ignoring the floor when moving on X to be able to
+      // follow up a slope when moving Y (it enter inside it).
+      // When the current floor and the wall the character is facing is part of
+      // the same instance, the wall is also ignored when moving on X, but the
+      // wall is to high to follow and it is seen as colliding an obstacle
+      // from behind.
+      // Moving against a wall before jumping in this configuration was making
+      // jumps being aborted.
+      behavior._checkTransitionJumping();
     }
 
     beforeMovingX() {
@@ -1723,14 +1734,11 @@ namespace gdjs {
       behavior._requestedDeltaX +=
         this._floorPlatform!.owner.getX() - this._floorLastX;
       // See `beforeUpdatingObstacles` for the logic for the Y axis.
-
-      //Jumping
-      behavior._checkTransitionJumping();
     }
 
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
-      //Go on a ladder
+      // Go on a ladder
       behavior._checkTransitionOnLadder();
     }
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1723,14 +1723,15 @@ namespace gdjs {
       behavior._requestedDeltaX +=
         this._floorPlatform!.owner.getX() - this._floorLastX;
       // See `beforeUpdatingObstacles` for the logic for the Y axis.
+
+      //Jumping
+      behavior._checkTransitionJumping();
     }
 
     checkTransitionBeforeY(timeDelta: float) {
       const behavior = this._behavior;
       //Go on a ladder
       behavior._checkTransitionOnLadder();
-      //Jumping
-      behavior._checkTransitionJumping();
     }
 
     beforeMovingY(timeDelta: float, oldX: float) {

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -1721,7 +1721,7 @@ namespace gdjs {
       // follow up a slope when moving Y (it enter inside it).
       // When the current floor and the wall the character is facing is part of
       // the same instance, the wall is also ignored when moving on X, but the
-      // wall is to high to follow and it is seen as colliding an obstacle
+      // wall is too high to follow and it is seen as colliding an obstacle
       // from behind.
       // Moving against a wall before jumping in this configuration was making
       // jumps being aborted.

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -1606,4 +1606,98 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(object.getY()).to.be(-30);
     });
   });
+
+  describe('(jump against a wall)', function () {
+    /** @type {gdjs.RuntimeScene} */
+    let runtimeScene;
+    /** @type {gdjs.RuntimeObject} */
+    let object;
+    /** @type {gdjs.PlatformerObjectRuntimeBehavior} */
+    let behavior;
+
+    beforeEach(function () {
+      runtimeScene = makePlatformerTestRuntimeScene();
+
+      // Put a platformer object on a platform
+      object = new gdjs.TestRuntimeObject(runtimeScene, {
+        name: 'obj1',
+        type: '',
+        behaviors: [
+          {
+            type: 'PlatformBehavior::PlatformerObjectBehavior',
+            name: 'auto1',
+            gravity: 1500,
+            maxFallingSpeed: 1500,
+            acceleration: 500,
+            deceleration: 1500,
+            maxSpeed: 500,
+            jumpSpeed: 900,
+            canGrabPlatforms: true,
+            ignoreDefaultControls: true,
+            slopeMaxAngle: 60,
+            jumpSustainTime: 0.2,
+            useLegacyTrajectory: false,
+          },
+        ],
+        effects: [],
+      });
+      behavior = object.getBehavior('auto1');
+      object.setCustomWidthAndHeight(10, 20);
+      runtimeScene.addObject(object);
+      // The object is in the corner of the platform.
+      object.setPosition(80 - 10, 80 - 20);
+
+      // Put a platform.
+    });
+
+    [
+      {
+        wallBeing: 'distinct from the floor',
+        createPlatforms: (runtimeScene) => {
+          const floor = addPlatformObject(runtimeScene);
+          floor.setPosition(0, 80);
+          floor.setCustomWidthAndHeight(100, 20);
+
+          const wall = addPlatformObject(runtimeScene);
+          wall.setPosition(80, 0);
+          wall.setCustomWidthAndHeight(20, 100);
+        },
+      },
+      {
+        wallBeing: 'merged with the floor',
+        createPlatforms: (runtimeScene) => {
+          const platform = addFloorAndWallPlatformObject(runtimeScene);
+          platform.setPosition(0, 0);
+        },
+      },
+    ].forEach(({ wallBeing, createPlatforms }) => {
+      it(`can jump while moving against a wall ${wallBeing}`, function () {
+        createPlatforms(runtimeScene);
+
+        // The object stays on the platform.
+        for (let i = 0; i < 5; ++i) {
+          runtimeScene.renderAndStep(1000 / 60);
+        }
+        expect(object.getY()).to.within(60 - epsilon, 60 + epsilon);
+        expect(behavior.isFalling()).to.be(false);
+        expect(behavior.isFallingWithoutJumping()).to.be(false);
+        expect(behavior.isMoving()).to.be(false);
+
+        // Jump without sustain.
+        behavior.simulateJumpKey();
+        behavior.simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(behavior.isJumping()).to.be(true);
+        // The object is jumping and get higher.
+        for (let i = 0; i < 5; ++i) {
+          const oldY = object.getY();
+          behavior.simulateRightKey();
+          runtimeScene.renderAndStep(1000 / 60);
+          expect(behavior.isJumping()).to.be(true);
+          expect(object.getX()).to.be(80 - 10);
+          expect(object.getY()).to.be.lessThan(oldY);
+        }
+      });
+    });
+  });
 });

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -1646,8 +1646,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       runtimeScene.addObject(object);
       // The object is in the corner of the platform.
       object.setPosition(80 - 10, 80 - 20);
-
-      // Put a platform.
     });
 
     [
@@ -1698,6 +1696,93 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
           expect(object.getY()).to.be.lessThan(oldY);
         }
       });
+    });
+  });
+
+  describe('(jump from slopes)', function () {
+    /** @type {gdjs.RuntimeScene} */
+    let runtimeScene;
+    /** @type {gdjs.RuntimeObject} */
+    let object;
+    /** @type {gdjs.PlatformerObjectRuntimeBehavior} */
+    let behavior;
+
+    beforeEach(function () {
+      runtimeScene = makePlatformerTestRuntimeScene();
+
+      // Put a platformer object on a platform
+      object = new gdjs.TestRuntimeObject(runtimeScene, {
+        name: 'obj1',
+        type: '',
+        behaviors: [
+          {
+            type: 'PlatformBehavior::PlatformerObjectBehavior',
+            name: 'auto1',
+            gravity: 150,
+            maxFallingSpeed: 1500,
+            acceleration: 1000000,
+            deceleration: 1500,
+            maxSpeed: 2000,
+            // This is a very low speed relatively to other properties.
+            // This is not a playable configuration.
+            jumpSpeed: 100,
+            canGrabPlatforms: true,
+            ignoreDefaultControls: true,
+            slopeMaxAngle: 60,
+            jumpSustainTime: 0.2,
+            useLegacyTrajectory: false,
+          },
+        ],
+        effects: [],
+      });
+      behavior = object.getBehavior('auto1');
+      object.setCustomWidthAndHeight(10, 20);
+      runtimeScene.addObject(object);
+      // The object is in the slope.
+      object.setPosition(0, 70);
+
+      const platform = addUpSlopePlatformObject(runtimeScene);
+      platform.setPosition(0, 0);
+    });
+
+    // This is a edge case. The test can be changed if necessary.
+    // Usually characters jump speed is higher than the speed on Y following a
+    // slope.
+    it('can jump while moving up on a slope', function () {
+      // The object stays on the platform.
+      for (let i = 0; i < 5; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      expect(object.getY()).to.within(70, 70 + 1);
+      expect(behavior.isFalling()).to.be(false);
+      expect(behavior.isFallingWithoutJumping()).to.be(false);
+      expect(behavior.isMoving()).to.be(false);
+
+      behavior.simulateRightKey();
+      runtimeScene.renderAndStep(1000 / 60);
+
+      // Jump without sustain.
+      behavior.simulateJumpKey();
+      behavior.simulateRightKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(behavior.isJumping()).to.be(true);
+      // The object is jumping and is kind of sliding on the slope.
+      // This behavior is not expected but it avoid the character to be stuck
+      // into the floor in more common cases.
+      for (let i = 0; i < 19; ++i) {
+        const oldY = object.getY();
+        behavior.simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(behavior.isJumping()).to.be(true);
+        expect(object.getY()).to.be.lessThan(oldY);
+        // As soon as: behavior.getCurrentJumpSpeed() - behavior.getCurrentFallSpeed()
+        // The character is in the falling step of the jump and it can land.
+        expect(behavior.isFalling()).to.be(false);
+      }
+      // The character lands.
+      behavior.simulateRightKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(behavior.isOnFloor()).to.be(true);
     });
   });
 });

--- a/Extensions/PlatformBehavior/tests/PlatformerTestHelper.js
+++ b/Extensions/PlatformBehavior/tests/PlatformerTestHelper.js
@@ -136,7 +136,7 @@
 
   const addTunnelPlatformObject = (runtimeScene) => {
     const platform = new gdjs.TestSpriteRuntimeObject(runtimeScene, {
-      name: 'slope',
+      name: 'tunnel',
       type: '',
       behaviors: [
         {
@@ -172,6 +172,68 @@
                       { x: 0, y: 300 },
                       { x: 100, y: 300 },
                       { x: 100, y: 200 },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    runtimeScene.addObject(platform);
+    platform.setUnscaledWidthAndHeight(100, 300);
+    platform.setCustomWidthAndHeight(100, 300);
+
+    return platform;
+  };
+
+  /**
+   * @returns A platform with 2 hitboxes that can act as a floor and a wall at
+   * the same time.
+   * It can happen when a tile map collision mask object is used because all
+   * the platforms are part of the same object instance.
+   */
+  const addFloorAndWallPlatformObject = (runtimeScene) => {
+    const platform = new gdjs.TestSpriteRuntimeObject(runtimeScene, {
+      name: 'elbow',
+      type: '',
+      behaviors: [
+        {
+          type: 'PlatformBehavior::PlatformBehavior',
+          name: 'Platform',
+          canBeGrabbed: true,
+        },
+      ],
+      effects: [],
+      animations: [
+        {
+          name: 'animation',
+          directions: [
+            {
+              sprites: [
+                {
+                  originPoint: { x: 0, y: 0 },
+                  centerPoint: { x: 50, y: 50 },
+                  points: [
+                    { name: 'Origin', x: 0, y: 0 },
+                    { name: 'Center', x: 50, y: 50 },
+                  ],
+                  hasCustomCollisionMask: true,
+                  customCollisionMask: [
+                    // Wall
+                    [
+                      { x: 80, y: 0 },
+                      { x: 80, y: 100 },
+                      { x: 100, y: 100 },
+                      { x: 100, y: 0 },
+                    ],
+                    // Floor
+                    [
+                      { x: 0, y: 80 },
+                      { x: 0, y: 100 },
+                      { x: 100, y: 100 },
+                      { x: 100, y: 80 },
                     ],
                   ],
                 },


### PR DESCRIPTION
This could happen when using a tilemap collision mask object and not sustaining the jump.

It's covered by tests but can also be reproduced on this example:
* https://github.com/GDevelopApp/GDevelop-examples/pull/343