### PR TITLE
[PathFinding] Add a warn for too long searches.

### DIFF
--- a/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
+++ b/Extensions/PathfindingBehavior/pathfindingruntimebehavior.ts
@@ -648,6 +648,7 @@ namespace gdjs {
         while (this._openNodes.length !== 0) {
           //Make sure we do not search forever.
           if (iterationCount++ > maxIterationCount) {
+            console.warn(`No path was be found after covering ${maxIterationCount} cells.`);
             return false;
           }
 


### PR DESCRIPTION
A user seems to have the issue with a map that have very closed rooms and needs a lot of detours to find a path.
This warning will help to spot this kind of issues.