### PR TITLE
Show typing errors of object parameters directly on the event sheet.

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -188,10 +188,19 @@ const Instruction = (props: Props) => {
               .getParameter(parameterIndex)
               .getPlainString();
             expressionIsValid =
-              globalObjectsContainer.hasObjectNamed(objectOrGroupName) ||
-              objectsContainer.hasObjectNamed(objectOrGroupName) ||
-              globalObjectsContainer.getObjectGroups().has(objectOrGroupName) ||
-              objectsContainer.getObjectGroups().has(objectOrGroupName);
+              (globalObjectsContainer.hasObjectNamed(objectOrGroupName) ||
+                objectsContainer.hasObjectNamed(objectOrGroupName) ||
+                globalObjectsContainer
+                  .getObjectGroups()
+                  .has(objectOrGroupName) ||
+                objectsContainer.getObjectGroups().has(objectOrGroupName)) &&
+              (!parameterMetadata.getExtraInfo() ||
+                gd.getTypeOfObject(
+                  globalObjectsContainer,
+                  objectsContainer,
+                  objectOrGroupName,
+                  false
+                ) === parameterMetadata.getExtraInfo());
           }
 
           return (


### PR DESCRIPTION
The error was already shown in the instruction editor but not directly on the sheet.
![image](https://user-images.githubusercontent.com/2611977/179971142-3e854295-e9ab-4dcd-a115-12fd14f69a49.png)

It took less time to implement than what I've wasted because of an oversight.