### PR TITLE
Fix: tilemaps object boxes is now the same as the tilemaps collision mask object boxes.

### DIFF
--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -804,19 +804,16 @@ module.exports = {
         const localPosition = new PIXI.Point();
         this._pixiObject.worldTransform.applyInverse(position, localPosition);
 
-        // Check if the point is inside the object bounds
-        const originalWidth = this._pixiObject.width / this._pixiObject.scale.x;
-        const originalHeight =
-          this._pixiObject.height / this._pixiObject.scale.y;
-
         return (
           localPosition.x >= 0 &&
-          localPosition.x < originalWidth &&
+          localPosition.x < this.width &&
           localPosition.y >= 0 &&
-          localPosition.y < originalHeight
+          localPosition.y < this.height
         );
       };
       this._pixiContainer.addChild(this._pixiObject);
+      this.width = 20;
+      this.height = 20;
       this.update();
       this.updateTileMap();
     }
@@ -892,6 +889,8 @@ module.exports = {
                 return;
               }
 
+              this.width = tileMap.getWidth();
+              this.height = tileMap.getHeight();
               TilemapHelper.PixiTileMapHelper.updatePixiTileMap(
                 this._pixiObject,
                 tileMap,
@@ -955,16 +954,16 @@ module.exports = {
       // Place the center of rotation in the center of the object. Because pivot position in Pixi
       // is in the **local coordinates of the object**, we need to find back the original width
       // and height of the object before scaling (then divide by 2 to find the center)
-      const originalWidth = this._pixiObject.width / this._pixiObject.scale.x;
-      const originalHeight = this._pixiObject.height / this._pixiObject.scale.y;
+      const originalWidth = this.width / this._pixiObject.scale.x;
+      const originalHeight = this.height / this._pixiObject.scale.y;
       this._pixiObject.pivot.x = originalWidth / 2;
       this._pixiObject.pivot.y = originalHeight / 2;
 
       // Modifying the pivot position also has an impact on the transform. The instance (X,Y) position
       // of this object refers to the top-left point, but now in Pixi, as we changed the pivot, the Pixi
       // object (X,Y) position refers to the center. So we add an offset to convert from top-left to center.
-      this._pixiObject.x = this._instance.getX() + this._pixiObject.width / 2;
-      this._pixiObject.y = this._instance.getY() + this._pixiObject.height / 2;
+      this._pixiObject.x = this._instance.getX() + this.width / 2;
+      this._pixiObject.y = this._instance.getY() + this.height / 2;
 
       // Rotation works as intended because we put the pivot in the center
       this._pixiObject.rotation = RenderedInstance.toRad(
@@ -976,14 +975,14 @@ module.exports = {
      * Return the width of the instance, when it's not resized.
      */
     RenderedTileMapInstance.prototype.getDefaultWidth = function () {
-      return this._pixiObject.width / this._pixiObject.scale.x;
+      return this.width / this._pixiObject.scale.x;
     };
 
     /**
      * Return the height of the instance, when it's not resized.
      */
     RenderedTileMapInstance.prototype.getDefaultHeight = function () {
-      return this._pixiObject.height / this._pixiObject.scale.y;
+      return this.height / this._pixiObject.scale.y;
     };
 
     objectsRenderingService.registerInstanceRenderer(

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -954,16 +954,16 @@ module.exports = {
       // Place the center of rotation in the center of the object. Because pivot position in Pixi
       // is in the **local coordinates of the object**, we need to find back the original width
       // and height of the object before scaling (then divide by 2 to find the center)
-      const originalWidth = this.width / this._pixiObject.scale.x;
-      const originalHeight = this.height / this._pixiObject.scale.y;
+      const originalWidth = this.width;
+      const originalHeight = this.height;
       this._pixiObject.pivot.x = originalWidth / 2;
       this._pixiObject.pivot.y = originalHeight / 2;
 
       // Modifying the pivot position also has an impact on the transform. The instance (X,Y) position
       // of this object refers to the top-left point, but now in Pixi, as we changed the pivot, the Pixi
       // object (X,Y) position refers to the center. So we add an offset to convert from top-left to center.
-      this._pixiObject.x = this._instance.getX() + this.width / 2;
-      this._pixiObject.y = this._instance.getY() + this.height / 2;
+      this._pixiObject.x = this._instance.getX() + this._pixiObject.pivot.x * this._pixiObject.scale.x;
+      this._pixiObject.y = this._instance.getY() + this._pixiObject.pivot.y * this._pixiObject.scale.y;
 
       // Rotation works as intended because we put the pivot in the center
       this._pixiObject.rotation = RenderedInstance.toRad(
@@ -1202,16 +1202,16 @@ module.exports = {
       // Place the center of rotation in the center of the object. Because pivot position in Pixi
       // is in the **local coordinates of the object**, we need to find back the original width
       // and height of the object before scaling (then divide by 2 to find the center)
-      const originalWidth = this.width / this._pixiObject.scale.x;
-      const originalHeight = this.height / this._pixiObject.scale.y;
+      const originalWidth = this.width;
+      const originalHeight = this.height;
       this._pixiObject.pivot.x = originalWidth / 2;
       this._pixiObject.pivot.y = originalHeight / 2;
 
       // Modifying the pivot position also has an impact on the transform. The instance (X,Y) position
       // of this object refers to the top-left point, but now in Pixi, as we changed the pivot, the Pixi
       // object (X,Y) position refers to the center. So we add an offset to convert from top-left to center.
-      this._pixiObject.x = this._instance.getX() + this.width / 2;
-      this._pixiObject.y = this._instance.getY() + this.height / 2;
+      this._pixiObject.x = this._instance.getX() + this._pixiObject.pivot.x * this._pixiObject.scale.x;
+      this._pixiObject.y = this._instance.getY() + this._pixiObject.pivot.y * this._pixiObject.scale.y;
 
       // Rotation works as intended because we put the pivot in the center
       this._pixiObject.rotation = RenderedInstance.toRad(

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -944,8 +944,8 @@ module.exports = {
      */
     RenderedTileMapInstance.prototype.update = function () {
       if (this._instance.hasCustomSize()) {
-        this._pixiObject.width = this._instance.getCustomWidth();
-        this._pixiObject.height = this._instance.getCustomHeight();
+        this._pixiObject.scale.x = this._instance.getCustomWidth() / this.width;
+        this._pixiObject.scale.y = this._instance.getCustomHeight() / this.height;
       } else {
         this._pixiObject.scale.x = 1;
         this._pixiObject.scale.y = 1;
@@ -975,14 +975,14 @@ module.exports = {
      * Return the width of the instance, when it's not resized.
      */
     RenderedTileMapInstance.prototype.getDefaultWidth = function () {
-      return this.width / this._pixiObject.scale.x;
+      return this.width;
     };
 
     /**
      * Return the height of the instance, when it's not resized.
      */
     RenderedTileMapInstance.prototype.getDefaultHeight = function () {
-      return this.height / this._pixiObject.scale.y;
+      return this.height;
     };
 
     objectsRenderingService.registerInstanceRenderer(

--- a/Extensions/TileMap/collision/TileMapCollisionMaskRenderer.ts
+++ b/Extensions/TileMap/collision/TileMapCollisionMaskRenderer.ts
@@ -52,36 +52,6 @@ namespace gdjs {
       getRendererObject() {
         return this._graphics;
       }
-
-      setWidth(width: float): void {
-        const tileMap = this._object._collisionTileMap;
-        this._graphics.scale.x = width / tileMap.getWidth();
-        this._graphics.pivot.x = width / 2;
-      }
-
-      setHeight(height: float): void {
-        const tileMap = this._object._collisionTileMap;
-        this._graphics.scale.y = height / tileMap.getHeight();
-        this._graphics.pivot.y = height / 2;
-      }
-
-      getWidth(): float {
-        const tileMap = this._object._collisionTileMap;
-        return tileMap.getWidth() * this._graphics.scale.x;
-      }
-
-      getHeight(): float {
-        const tileMap = this._object._collisionTileMap;
-        return tileMap.getHeight() * this._graphics.scale.y;
-      }
-
-      getScaleX(): float {
-        return this._graphics.scale.x;
-      }
-
-      getScaleY(): float {
-        return this._graphics.scale.y;
-      }
     }
   }
 }

--- a/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
+++ b/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
@@ -213,8 +213,8 @@ namespace gdjs {
       const angleInRadians = (this.angle * Math.PI) / 180;
       transformation.rotateAround(
         angleInRadians,
-        this.getCenterX() * absScaleX,
-        this.getCenterY() * absScaleY
+        this.getCenterX(),
+        this.getCenterY()
       );
 
       // Scale

--- a/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
+++ b/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
@@ -31,6 +31,11 @@ namespace gdjs {
     _outlineOpacity: float;
     _outlineSize: float;
 
+    _width: float;
+    _height: float;
+    _scaleX: float;
+    _scaleY: float;
+
     /**
      * If the owner moves, the hitboxes vertices
      * will have to be transformed again.
@@ -55,6 +60,12 @@ namespace gdjs {
       this._tileMapManager = gdjs.TileMap.TileMapRuntimeManager.getManager(
         runtimeScene
       );
+
+      // The actual size is set when the tile map file is loaded.
+      this._width = 0;
+      this._height = 0;
+      this._scaleX = 1;
+      this._scaleY = 1;
       const editableTileMap = new TileMapHelper.EditableTileMap(
         1,
         1,
@@ -66,6 +77,7 @@ namespace gdjs {
         editableTileMap,
         this._collisionMaskTag
       );
+
       this._renderer = new gdjs.TileMap.TileMapCollisionMaskRenderer(
         this,
         runtimeScene
@@ -152,6 +164,9 @@ namespace gdjs {
             this._collisionTileMap.getAllHitboxes(this._collisionMaskTag)
           );
           this._renderer.redrawCollisionMask();
+
+          this._width = this._collisionTileMap.getWidth() * this._scaleX;
+          this._height = this._collisionTileMap.getHeight() * this._scaleY;
         }
       );
     }
@@ -186,8 +201,8 @@ namespace gdjs {
       }
       const transformation = this._collisionTileMap.getTransformation();
 
-      const absScaleX = Math.abs(this._renderer.getScaleX());
-      const absScaleY = Math.abs(this._renderer.getScaleY());
+      const absScaleX = Math.abs(this._scaleX);
+      const absScaleY = Math.abs(this._scaleY);
 
       transformation.setToIdentity();
 
@@ -441,27 +456,27 @@ namespace gdjs {
     // TODO allow size changes from events?
 
     setWidth(width: float): void {
-      if (this._renderer.getWidth() === width) return;
-
-      this._renderer.setWidth(width);
+      if (this._width === width) return;
+      this._scaleX = width / this._collisionTileMap.getWidth();
+      this._width = width;
       this.hitBoxesDirty = true;
       this._transformationIsUpToDate = false;
     }
 
     setHeight(height: float): void {
-      if (this._renderer.getHeight() === height) return;
-
-      this._renderer.setHeight(height);
+      if (this._height === height) return;
+      this._scaleY = height / this._collisionTileMap.getHeight();
+      this._height = height;
       this.hitBoxesDirty = true;
       this._transformationIsUpToDate = false;
     }
 
     getWidth(): float {
-      return this._renderer.getWidth();
+      return this._width;
     }
 
     getHeight(): float {
-      return this._renderer.getHeight();
+      return this._height;
     }
   }
   gdjs.registerObject(

--- a/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
+++ b/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
@@ -62,18 +62,10 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      const tileMap = this._tileMap;
-      const originalWidth = tileMap ? tileMap.getWidth() : 20;
-      const originalHeight = tileMap ? tileMap.getHeight() : 20;
-
-      this._pixiObject.pivot.x = originalWidth / 2;
-      this._pixiObject.pivot.y = originalHeight / 2;
-
-      const width = this.getWidth();
-      const height = this.getHeight();
-
-      this._pixiObject.position.x = this._object.x + width / 2;
-      this._pixiObject.position.y = this._object.y + height / 2;
+      this._pixiObject.pivot.x = this.getTileMapWidth() / 2;
+      this._pixiObject.pivot.y = this.getTileMapHeight() / 2;
+      this._pixiObject.position.x = this._object.x + this.getWidth() / 2;
+      this._pixiObject.position.y = this._object.y + this.getHeight() / 2;
     }
 
     updateAngle(): void {
@@ -84,30 +76,32 @@ namespace gdjs {
       this._pixiObject.alpha = this._object._opacity / 255;
     }
 
-    setWidth(width: float): void {
+    getTileMapWidth() {
       const tileMap = this._tileMap;
-      const originalHeight = tileMap ? tileMap.getWidth() : 20;
-      this._pixiObject.scale.x = width / originalHeight;
+      return tileMap ? tileMap.getWidth() : 20;
+    }
+
+    getTileMapHeight() {
+      const tileMap = this._tileMap;
+      return tileMap ? tileMap.getHeight() : 20;
+    }
+
+    setWidth(width: float): void {
+      this._pixiObject.scale.x = width / this.getTileMapWidth();
       this._pixiObject.position.x = this._object.x + width / 2;
     }
 
     setHeight(height: float): void {
-      const tileMap = this._tileMap;
-      const originalHeight = tileMap ? tileMap.getHeight() : 20;
-      this._pixiObject.scale.y = height / originalHeight;
+      this._pixiObject.scale.y = height / this.getTileMapHeight();
       this._pixiObject.position.y = this._object.y + height / 2;
     }
 
     getWidth(): float {
-      const tileMap = this._tileMap;
-      const originalWidth = tileMap ? tileMap.getWidth() : 20;
-      return originalWidth * this._pixiObject.scale.x;
+      return this.getTileMapWidth() * this._pixiObject.scale.x;
     }
 
     getHeight(): float {
-      const tileMap = this._tileMap;
-      const originalHeight = tileMap ? tileMap.getHeight() : 20;
-      return originalHeight * this._pixiObject.scale.y;
+      return this.getTileMapHeight() * this._pixiObject.scale.y;
     }
   }
   export const TileMapRuntimeObjectRenderer =

--- a/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
+++ b/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
@@ -9,10 +9,11 @@ namespace gdjs {
    * @class TileMapRuntimeObjectPixiRenderer
    */
   export class TileMapRuntimeObjectPixiRenderer {
-    _object: any;
-    _runtimeScene: gdjs.RuntimeScene;
+    private _object: any;
+    private _runtimeScene: gdjs.RuntimeScene;
+    private _tileMap: TileMapHelper.EditableTileMap | null = null;
 
-    _pixiObject: PIXI.tilemap.CompositeRectTileLayer;
+    private _pixiObject: PIXI.tilemap.CompositeRectTileLayer;
 
     /**
      * @param runtimeObject The object to render
@@ -50,6 +51,7 @@ namespace gdjs {
       tileMap: TileMapHelper.EditableTileMap,
       textureCache: TileMapHelper.TileTextureCache
     ) {
+      this._tileMap = tileMap;
       TileMapHelper.PixiTileMapHelper.updatePixiTileMap(
         this._pixiObject,
         tileMap,
@@ -60,15 +62,16 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      const originalWidth = this._pixiObject.width / this._pixiObject.scale.x;
-      const originalHeight = this._pixiObject.height / this._pixiObject.scale.y;
+      const width = this.getWidth();
+      const height = this.getHeight();
+      const originalWidth = width / this._pixiObject.scale.x;
+      const originalHeight = height / this._pixiObject.scale.y;
       this._pixiObject.pivot.x = originalWidth / 2;
       this._pixiObject.pivot.y = originalHeight / 2;
 
-      this._pixiObject.position.x = this._object.x + this._pixiObject.width / 2;
+      this._pixiObject.position.x = this._object.x + width / 2;
 
-      this._pixiObject.position.y =
-        this._object.y + this._pixiObject.height / 2;
+      this._pixiObject.position.y = this._object.y + height / 2;
     }
 
     updateAngle(): void {
@@ -80,23 +83,29 @@ namespace gdjs {
     }
 
     setWidth(width: float): void {
-      this._pixiObject.width = width / this._pixiObject.scale.x;
+      const tileMap = this._tileMap;
+      const originalHeight = tileMap ? tileMap.getWidth() : 20;
+      this._pixiObject.scale.x = width / originalHeight;
       this._pixiObject.pivot.x = width / 2;
-      this.updatePosition();
     }
 
     setHeight(height: float): void {
-      this._pixiObject.height = height / this._pixiObject.scale.y;
+      const tileMap = this._tileMap;
+      const originalHeight = tileMap ? tileMap.getHeight() : 20;
+      this._pixiObject.scale.y = height / originalHeight;
       this._pixiObject.pivot.y = height / 2;
-      this.updatePosition();
     }
 
     getWidth(): float {
-      return this._pixiObject.width;
+      const tileMap = this._tileMap;
+      const originalWidth = tileMap ? tileMap.getWidth() : 20;
+      return originalWidth * this._pixiObject.scale.x;
     }
 
     getHeight(): float {
-      return this._pixiObject.height;
+      const tileMap = this._tileMap;
+      const originalHeight = tileMap ? tileMap.getHeight() : 20;
+      return originalHeight * this._pixiObject.scale.y;
     }
   }
   export const TileMapRuntimeObjectRenderer =

--- a/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
+++ b/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
@@ -62,15 +62,17 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      const width = this.getWidth();
-      const height = this.getHeight();
-      const originalWidth = width / this._pixiObject.scale.x;
-      const originalHeight = height / this._pixiObject.scale.y;
+      const tileMap = this._tileMap;
+      const originalWidth = tileMap ? tileMap.getWidth() : 20;
+      const originalHeight = tileMap ? tileMap.getHeight() : 20;
+
       this._pixiObject.pivot.x = originalWidth / 2;
       this._pixiObject.pivot.y = originalHeight / 2;
 
-      this._pixiObject.position.x = this._object.x + width / 2;
+      const width = this.getWidth();
+      const height = this.getHeight();
 
+      this._pixiObject.position.x = this._object.x + width / 2;
       this._pixiObject.position.y = this._object.y + height / 2;
     }
 
@@ -86,14 +88,14 @@ namespace gdjs {
       const tileMap = this._tileMap;
       const originalHeight = tileMap ? tileMap.getWidth() : 20;
       this._pixiObject.scale.x = width / originalHeight;
-      this._pixiObject.pivot.x = width / 2;
+      this._pixiObject.position.x = this._object.x + width / 2;
     }
 
     setHeight(height: float): void {
       const tileMap = this._tileMap;
       const originalHeight = tileMap ? tileMap.getHeight() : 20;
       this._pixiObject.scale.y = height / originalHeight;
-      this._pixiObject.pivot.y = height / 2;
+      this._pixiObject.position.y = this._object.y + height / 2;
     }
 
     getWidth(): float {


### PR DESCRIPTION
Tilemaps are no longer cropped automatically, because void spaces could be intended. The right size can be set with Tiled if needed.

It seems that it was already fixed by this PR, but it wasn't merged:
* https://github.com/4ian/GDevelop/pull/2296

## Solution
It relies on the tile map dimensions instead of the render dimensions to avoid bad positioning when there is no tile to draw around the map borders.

## Copping issue
* The crop was probably intended to happen only at right and bottom.

![TileMapVoidSpaceBug](https://user-images.githubusercontent.com/2611977/180447084-dd8b3d4e-c03b-4555-bc17-bc82db417699.png)

## Fix : no cropping
* There is no longer any cropping
![TileMapVoidSpaceFix](https://user-images.githubusercontent.com/2611977/180447169-c8a507f1-8379-4b0b-8311-9606e7d9d659.png)

* It follows what the user chose in Tiled (maybe there is a reason, no judgment)
![TileMapVoidSpaceTile](https://user-images.githubusercontent.com/2611977/180447390-6d1761fd-c508-431f-94d2-e40b511ad9d5.png)

* The collision mask were already using a no cropping strategy because void spaces are very expected
![TileMapCollisionMaskBox](https://user-images.githubusercontent.com/2611977/180447674-57913353-899b-41b1-9d1d-e9fb5746ffb1.png)

* It allow to overlap the tilemap and its collision masks more easily
![TileMapVoidSpaceFixOverview](https://user-images.githubusercontent.com/2611977/180447877-bc9a3ba7-ed07-41a7-a700-25a782fbecc4.png)

## Manual tests

* GDJS
https://user-images.githubusercontent.com/2611977/180506767-744f0127-ce5d-4263-bdbc-becbe25e2875.mp4

* newIDE
https://user-images.githubusercontent.com/2611977/180506817-b0127396-ace7-430b-aa8a-3ab1d36d7998.mp4


