### PR TITLE
Fix package URLs crashing the app on web

### DIFF
--- a/newIDE/app/src/Utils/BlobDownloadUrlHolder.js
+++ b/newIDE/app/src/Utils/BlobDownloadUrlHolder.js
@@ -8,27 +8,31 @@ type Props = {
 
 export const BlobDownloadUrlHolder = ({ blob, children }: Props) => {
   const [blobDownloadUrl, setBlobDownloadUrl] = React.useState('');
+  const [stateBlob, setStateBlob] = React.useState(null);
   React.useEffect(
     () => {
-      // Release the existing blob URL, if any.
-      if (blobDownloadUrl) {
-        URL.revokeObjectURL(blobDownloadUrl);
-      }
-
-      if (blob) {
+      // This effect function does not look at the blobDownloadUrl, to avoid infinite loops.
+      // It is only in charge of updating the Url when the blob changes.
+      if (blob && blob !== stateBlob) {
         setBlobDownloadUrl(URL.createObjectURL(blob));
-      } else {
-        setBlobDownloadUrl('');
+        setStateBlob(blob);
       }
+    },
+    [blob, stateBlob]
+  );
 
+  React.useEffect(
+    () => {
+      // This cleanup is called both when the component is unmounted or when an update happens.
+      // This allows releasing the URL when a new one is generated.
+      // See https://reactjs.org/docs/hooks-effect.html#explanation-why-effects-run-on-each-update
       return () => {
-        // Release the blob URL if component is unmounted.
         if (blobDownloadUrl) {
           URL.revokeObjectURL(blobDownloadUrl);
         }
       };
     },
-    [blob, blobDownloadUrl]
+    [blobDownloadUrl]
   );
 
   return children(blobDownloadUrl);

--- a/newIDE/app/src/Utils/BlobDownloadUrlHolder.js
+++ b/newIDE/app/src/Utils/BlobDownloadUrlHolder.js
@@ -8,17 +8,17 @@ type Props = {
 
 export const BlobDownloadUrlHolder = ({ blob, children }: Props) => {
   const [blobDownloadUrl, setBlobDownloadUrl] = React.useState('');
-  const [stateBlob, setStateBlob] = React.useState(null);
+  const [currentBlob, setCurrentBlob] = React.useState<?Blob>(null);
   React.useEffect(
     () => {
       // This effect function does not look at the blobDownloadUrl, to avoid infinite loops.
       // It is only in charge of updating the Url when the blob changes.
-      if (blob && blob !== stateBlob) {
+      if (blob && blob !== currentBlob) {
         setBlobDownloadUrl(URL.createObjectURL(blob));
-        setStateBlob(blob);
+        setCurrentBlob(blob);
       }
     },
-    [blob, stateBlob]
+    [blob, currentBlob]
   );
 
   React.useEffect(


### PR DESCRIPTION
I'm not sure when this got introduced, probably when we refactored the export dialog to be different tabs.