### PR TITLE
Add actions to change the tile map dimensions

### DIFF
--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -206,7 +206,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .addParameter('jsonResource', _('Tilemap JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('isTilemapJsonFile');
@@ -223,7 +223,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .addParameter('jsonResource', _('Tilemap JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('setTilemapJsonFile');
@@ -238,7 +238,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .addParameter('jsonResource', _('Tileset JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('isTilesetJsonFile');
@@ -255,7 +255,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .addParameter('jsonResource', _('Tileset JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('setTilesetJsonFile');
@@ -270,7 +270,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .addParameter(
       'stringWithSelector',
       _('Display mode'),
@@ -290,7 +290,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .addParameter(
       'stringWithSelector',
       _('Display mode'),
@@ -310,7 +310,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .useStandardRelationalOperatorParameters('number')
     .getCodeExtraInformation()
     .setFunctionName('getLayerIndex');
@@ -325,7 +325,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .useStandardOperatorParameters('number')
     .getCodeExtraInformation()
     .setFunctionName('setLayerIndex')
@@ -339,7 +339,7 @@ const defineTileMap = function (
       '',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .getCodeExtraInformation()
     .setFunctionName('getLayerIndex');
 
@@ -353,7 +353,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .useStandardRelationalOperatorParameters('number')
     .getCodeExtraInformation()
     .setFunctionName('getAnimationSpeedScale');
@@ -368,7 +368,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .useStandardOperatorParameters('number')
     .getCodeExtraInformation()
     .setFunctionName('setAnimationSpeedScale')
@@ -382,7 +382,7 @@ const defineTileMap = function (
       '',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .getCodeExtraInformation()
     .setFunctionName('getAnimationSpeedScale');
 
@@ -396,7 +396,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .useStandardRelationalOperatorParameters('number')
     .getCodeExtraInformation()
     .setFunctionName('getAnimationFps');
@@ -411,7 +411,7 @@ const defineTileMap = function (
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .useStandardOperatorParameters('number')
     .getCodeExtraInformation()
     .setFunctionName('setAnimationFps')
@@ -425,9 +425,89 @@ const defineTileMap = function (
       '',
       'JsPlatform/Extensions/tile_map.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map'), 'TileMap', false)
     .getCodeExtraInformation()
     .setFunctionName('getAnimationFps');
+
+  object.addAction(
+    "Scale",
+    _("Scale"),
+    _("Modify the scale of the specified object."),
+    _("the scale"),
+    _("Size"),
+    "res/actions/scale24.png",
+    "res/actions/scale.png"
+  )
+  .addParameter('object', _('Tile map'), 'TileMap', false)
+  .useStandardOperatorParameters("number")
+  .markAsAdvanced()
+  .getCodeExtraInformation()
+  .setFunctionName('setScale');
+
+object
+  .addExpressionAndConditionAndAction(
+    "number",
+    "ScaleX",
+    _("Scale on X axis"),
+    _("the width's scale of an object"),
+    _("the width's scale"),
+    _("Size"),
+    "res/actions/scaleWidth24.png"
+  )
+  .addParameter('object', _('Tile map'), 'TileMap', false)
+  .useStandardParameters("number")
+  .markAsAdvanced()
+  .setFunctionName('setScaleX')
+  .setGetter('getScaleX');
+
+object
+  .addExpressionAndConditionAndAction(
+    "number",
+    "ScaleY",
+    _("Scale on Y axis"),
+    _("the height's scale of an object"),
+    _("the height's scale"),
+    _("Size"),
+    "res/actions/scaleHeight24.png"
+  )
+  .addParameter('object', _('Tile map'), 'TileMap', false)
+  .useStandardParameters("number")
+  .markAsAdvanced()
+  .setFunctionName('setScaleY')
+  .setGetter('getScaleY');
+
+  object
+    .addAction(
+      "Width",
+      _("Width"),
+      _("Change the width of an object."),
+      _("the width"),
+      _("Size"),
+      "res/actions/scaleWidth24.png",
+      "res/actions/scale.png"
+    )
+    .addParameter('object', _('Tile map'), 'TileMap', false)
+    .useStandardOperatorParameters("number")
+    .markAsAdvanced()
+    .getCodeExtraInformation()
+    .setFunctionName('setWidth');
+
+  object
+    .addAction(
+      "Height",
+      _("Height"),
+      _("Change the height of an object."),
+      _("the height"),
+      _("Size"),
+      "res/actions/scaleHeight24.png",
+      "res/actions/scale.png"
+    )
+    .addParameter('object', _('Tile map'), 'TileMap', false)
+    .useStandardOperatorParameters("number")
+    .markAsAdvanced()
+    .getCodeExtraInformation()
+    .setFunctionName('setHeight');
+
 };
 
 const defineCollisionMask = function (
@@ -628,7 +708,7 @@ const defineCollisionMask = function (
       'JsPlatform/Extensions/tile_map_collision_mask24.svg',
       'JsPlatform/Extensions/tile_map_collision_mask32.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
     .addParameter('jsonResource', _('Tilemap JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('isTilemapJsonFile');
@@ -645,7 +725,7 @@ const defineCollisionMask = function (
       'JsPlatform/Extensions/tile_map_collision_mask24.svg',
       'JsPlatform/Extensions/tile_map_collision_mask32.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
     .addParameter('jsonResource', _('Tilemap JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('setTilemapJsonFile');
@@ -660,7 +740,7 @@ const defineCollisionMask = function (
       'JsPlatform/Extensions/tile_map_collision_mask24.svg',
       'JsPlatform/Extensions/tile_map_collision_mask32.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
     .addParameter('jsonResource', _('Tileset JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('isTilesetJsonFile');
@@ -677,10 +757,90 @@ const defineCollisionMask = function (
       'JsPlatform/Extensions/tile_map_collision_mask24.svg',
       'JsPlatform/Extensions/tile_map_collision_mask32.svg'
     )
-    .addParameter('object', 'TileMap', 'TileMap', false)
+    .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
     .addParameter('jsonResource', _('Tileset JSON file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('setTilesetJsonFile');
+
+    object.addAction(
+      "Scale",
+      _("Scale"),
+      _("Modify the scale of the specified object."),
+      _("the scale"),
+      _("Size"),
+      "res/actions/scale24.png",
+      "res/actions/scale.png"
+    )
+    .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
+    .useStandardOperatorParameters("number")
+    .markAsAdvanced()
+    .getCodeExtraInformation()
+    .setFunctionName('setScale');
+  
+  object
+    .addExpressionAndConditionAndAction(
+      "number",
+      "ScaleX",
+      _("Scale on X axis"),
+      _("the width's scale of an object"),
+      _("the width's scale"),
+      _("Size"),
+      "res/actions/scaleWidth24.png"
+    )
+    .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
+    .useStandardParameters("number")
+    .markAsAdvanced()
+    .setFunctionName('setScaleX')
+    .setGetter('getScaleX');
+
+  object
+    .addExpressionAndConditionAndAction(
+      "number",
+      "ScaleY",
+      _("Scale on Y axis"),
+      _("the height's scale of an object"),
+      _("the height's scale"),
+      _("Size"),
+      "res/actions/scaleHeight24.png"
+    )
+    .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
+    .useStandardParameters("number")
+    .markAsAdvanced()
+    .setFunctionName('setScaleY')
+    .setGetter('getScaleY');
+
+    object
+      .addAction(
+        "Width",
+        _("Width"),
+        _("Change the width of an object."),
+        _("the width"),
+        _("Size"),
+        "res/actions/scaleWidth24.png",
+        "res/actions/scale.png"
+      )
+      .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
+      .useStandardOperatorParameters("number")
+      .markAsAdvanced()
+      .getCodeExtraInformation()
+      .setFunctionName('setWidth');
+  
+    object
+      .addAction(
+        "Height",
+        _("Height"),
+        _("Change the height of an object."),
+        _("the height"),
+        _("Size"),
+        "res/actions/scaleHeight24.png",
+        "res/actions/scale.png"
+      )
+      .addParameter('object', _('Tile map collision mask'), 'CollisionMask', false)
+      .useStandardOperatorParameters("number")
+      .markAsAdvanced()
+      .getCodeExtraInformation()
+      .setFunctionName('setHeight');
+  
 };
 
 module.exports = {

--- a/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
+++ b/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
@@ -453,20 +453,72 @@ namespace gdjs {
       this._transformationIsUpToDate = false;
     }
 
-    // TODO allow size changes from events?
-
+    /**
+     * Change the width of the object. This changes the scale on X axis of the object.
+     *
+     * @param width The new width of the object, in pixels.
+     */
     setWidth(width: float): void {
-      if (this._width === width) return;
+      if (this._width === width) {
+        return;
+      }
       this._scaleX = width / this._collisionTileMap.getWidth();
       this._width = width;
       this.hitBoxesDirty = true;
       this._transformationIsUpToDate = false;
     }
 
+    /**
+     * Change the height of the object. This changes the scale on Y axis of the object.
+     *
+     * @param height The new height of the object, in pixels.
+     */
     setHeight(height: float): void {
-      if (this._height === height) return;
+      if (this._height === height) {
+        return;
+      }
       this._scaleY = height / this._collisionTileMap.getHeight();
       this._height = height;
+      this.hitBoxesDirty = true;
+      this._transformationIsUpToDate = false;
+    }
+
+    /**
+     * Change the scale on X and Y axis of the object.
+     *
+     * @param scale The new scale (must be greater than 0).
+     */
+    setScale(scale: float): void {
+      this.setScaleX(scale);
+      this.setScaleY(scale);
+    }
+
+    /**
+     * Change the scale on X axis of the object (changing its width).
+     *
+     * @param scaleX The new scale (must be greater than 0).
+     */
+    setScaleX(scaleX: float): void {
+      if (this._scaleX === scaleX) {
+        return;
+      }
+      this._scaleX = scaleX;
+      this._width = scaleX * this._collisionTileMap.getWidth();
+      this.hitBoxesDirty = true;
+      this._transformationIsUpToDate = false;
+    }
+
+    /**
+     * Change the scale on Y axis of the object (changing its width).
+     *
+     * @param scaleY The new scale (must be greater than 0).
+     */
+    setScaleY(scaleY: float): void {
+      if (this._scaleY === scaleY) {
+        return;
+      }
+      this._scaleY = scaleY;
+      this._height = scaleY * this._collisionTileMap.getHeight();
       this.hitBoxesDirty = true;
       this._transformationIsUpToDate = false;
     }
@@ -477,6 +529,14 @@ namespace gdjs {
 
     getHeight(): float {
       return this._height;
+    }
+
+    getScaleX(): float {
+      return this._scaleX;
+    }
+
+    getScaleY(): float {
+      return this._scaleY;
     }
   }
   gdjs.registerObject(

--- a/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
+++ b/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
@@ -499,6 +499,9 @@ namespace gdjs {
      * @param scaleX The new scale (must be greater than 0).
      */
     setScaleX(scaleX: float): void {
+      if (scaleX < 0) {
+        scaleX = 0;
+      }
       if (this._scaleX === scaleX) {
         return;
       }
@@ -514,6 +517,9 @@ namespace gdjs {
      * @param scaleY The new scale (must be greater than 0).
      */
     setScaleY(scaleY: float): void {
+      if (scaleY < 0) {
+        scaleY = 0;
+      }
       if (this._scaleY === scaleY) {
         return;
       }

--- a/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
+++ b/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
@@ -96,12 +96,32 @@ namespace gdjs {
       this._pixiObject.position.y = this._object.y + height / 2;
     }
 
+    setScaleX(scaleX: float): void {
+      this._pixiObject.scale.x = scaleX;
+      const width = scaleX * this.getTileMapWidth();
+      this._pixiObject.position.x = this._object.x + width / 2;
+    }
+
+    setScaleY(scaleY: float): void {
+      this._pixiObject.scale.y = scaleY;
+      const height = scaleY * this.getTileMapHeight();
+      this._pixiObject.position.y = this._object.y + height / 2;
+    }
+
     getWidth(): float {
       return this.getTileMapWidth() * this._pixiObject.scale.x;
     }
 
     getHeight(): float {
       return this.getTileMapHeight() * this._pixiObject.scale.y;
+    }
+
+    getScaleX(): float {
+      return this._pixiObject.scale.x;
+    }
+
+    getScaleY(): float {
+      return this._pixiObject.scale.y;
     }
   }
   export const TileMapRuntimeObjectRenderer =

--- a/Extensions/TileMap/tilemapruntimeobject.ts
+++ b/Extensions/TileMap/tilemapruntimeobject.ts
@@ -212,17 +212,61 @@ namespace gdjs {
       return this._animationSpeedScale;
     }
 
+    /**
+     * Change the width of the object. This changes the scale on X axis of the object.
+     *
+     * @param width The new width of the object, in pixels.
+     */
     setWidth(width: float): void {
-      if (this._renderer.getWidth() === width) return;
+      if (this.getWidth() === width) return;
 
       this._renderer.setWidth(width);
       this.hitBoxesDirty = true;
     }
 
+    /**
+     * Change the height of the object. This changes the scale on Y axis of the object.
+     *
+     * @param height The new height of the object, in pixels.
+     */
     setHeight(height: float): void {
-      if (this._renderer.getHeight() === height) return;
+      if (this.getHeight() === height) return;
 
       this._renderer.setHeight(height);
+      this.hitBoxesDirty = true;
+    }
+
+    /**
+     * Change the scale on X and Y axis of the object.
+     *
+     * @param scale The new scale (must be greater than 0).
+     */
+    setScale(scale: float): void {
+      this.setScaleX(scale);
+      this.setScaleY(scale);
+    }
+
+    /**
+     * Change the scale on X axis of the object (changing its width).
+     *
+     * @param scaleX The new scale (must be greater than 0).
+     */
+    setScaleX(scaleX: float): void {
+      if (this.getScaleX() === scaleX) return;
+
+      this._renderer.setScaleX(scaleX);
+      this.hitBoxesDirty = true;
+    }
+
+    /**
+     * Change the scale on Y axis of the object (changing its width).
+     *
+     * @param scaleY The new scale (must be greater than 0).
+     */
+    setScaleY(scaleY: float): void {
+      if (this.getScaleY() === scaleY) return;
+
+      this._renderer.setScaleY(scaleY);
       this.hitBoxesDirty = true;
     }
 
@@ -263,6 +307,14 @@ namespace gdjs {
 
     getHeight(): float {
       return this._renderer.getHeight();
+    }
+
+    getScaleX(): float {
+      return this._renderer.getScaleX();
+    }
+
+    getScaleY(): float {
+      return this._renderer.getScaleY();
     }
   }
   gdjs.registerObject('TileMap::TileMap', gdjs.TileMapRuntimeObject);

--- a/Extensions/TileMap/tilemapruntimeobject.ts
+++ b/Extensions/TileMap/tilemapruntimeobject.ts
@@ -252,6 +252,9 @@ namespace gdjs {
      * @param scaleX The new scale (must be greater than 0).
      */
     setScaleX(scaleX: float): void {
+      if (scaleX < 0) {
+        scaleX = 0;
+      }
       if (this.getScaleX() === scaleX) return;
 
       this._renderer.setScaleX(scaleX);
@@ -264,6 +267,9 @@ namespace gdjs {
      * @param scaleY The new scale (must be greater than 0).
      */
     setScaleY(scaleY: float): void {
+      if (scaleY < 0) {
+        scaleY = 0;
+      }
       if (this.getScaleY() === scaleY) return;
 
       this._renderer.setScaleY(scaleY);


### PR DESCRIPTION
It also
* fix all the collision mask object functions that were expecting a tile map object 
* mark the tile map object parameter for the translation.

(the small offset that can be seen on platforms in red is because the top pixel of the tile is not part of the mask to give a bit of depth)

https://user-images.githubusercontent.com/2611977/180818526-207085de-e51b-4c45-b118-862667e3bcbf.mp4

