### PR TITLE
Fix Safari/iOS unable to load some images in the app

### DIFF
--- a/newIDE/app/src/UI/CorsAwareImage.js
+++ b/newIDE/app/src/UI/CorsAwareImage.js
@@ -38,7 +38,6 @@ const addSearchParameterToUrl = (
 export const CorsAwareImage = (props: Props) => (
   <img // eslint-disable-line jsx-a11y/alt-text
     {...props}
-    crossOrigin="anonymous"
     src={
       // To avoid strange/hard to understand CORS issues, we add a dummy parameter.
       // By doing so, we force browser to consider this URL as different than the one traditionally


### PR DESCRIPTION
This needs testing to check that the web-app works properly for these cases.

Thumbnails from examples work properly:
- [ ] on Safari iOS
- [ ] on Safari macOS
- [ ] on Chrome/Firefox as before

Assets are displayed on the asset store:
- [ ] on Safari iOS
- [ ] on Safari macOS
- [ ] on Chrome/Firefox as before

Assets are displayed in the scene editor:
- [ ] on Safari iOS
- [ ] on Safari macOS
- [ ] on Chrome/Firefox as before

Previews run properly:
- [ ] on Safari iOS
- [ ] on Safari macOS
- [ ] on Chrome/Firefox as before

Export run properly:
- [ ] on Safari iOS
- [ ] on Safari macOS
- [ ] on Chrome/Firefox as before