### PR TITLE
Fix Asset cards text color to be visible on light theme

### DIFF
--- a/newIDE/app/src/AssetStore/AssetCard.js
+++ b/newIDE/app/src/AssetStore/AssetCard.js
@@ -81,10 +81,10 @@ export const AssetCard = ({ assetShortHeader, onOpenDetails, size }: Props) => {
           />
         </div>
         <div style={styles.titleContainer}>
-          <Text noMargin style={styles.title}>
+          <Text noMargin style={styles.title} color="inherit">
             {assetShortHeader.name}
           </Text>
-          <Text noMargin style={styles.title} size="body2">
+          <Text noMargin style={styles.title} size="body2" color="inherit">
             {assetShortHeader.shortDescription}
           </Text>
         </div>

--- a/newIDE/app/src/UI/Text.js
+++ b/newIDE/app/src/UI/Text.js
@@ -11,7 +11,7 @@ type textSize =
   | 'body'
   | 'body2';
 
-type textColor = 'error' | 'primary' | 'secondary';
+type textColor = 'error' | 'primary' | 'secondary' | 'inherit';
 
 type Props = {|
   /** The text to display. */
@@ -80,6 +80,8 @@ const getTextColorFromColor = (color: ?textColor) => {
       return 'textPrimary';
     case 'secondary':
       return 'textSecondary';
+    case 'inherit':
+      return 'inherit';
     default:
       return 'textPrimary';
   }


### PR DESCRIPTION
<img width="1017" alt="Screenshot 2022-07-28 at 12 27 20" src="https://user-images.githubusercontent.com/4895034/181484744-01f54739-a7f7-4c9f-9390-ee3e2ae3574f.png">
<img width="1017" alt="Screenshot 2022-07-28 at 12 27 32" src="https://user-images.githubusercontent.com/4895034/181484758-aaaa3639-a97e-4767-b468-4f103508d1d1.png">
