### PR TITLE
Improve Homepage build section

### DIFF
--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -32,6 +32,7 @@ import {
   onCreateFromExampleShortHeader,
   onCreateBlank,
 } from './ProjectCreation/services/LocalCreation';
+import FakeCloudStorageProvider from './ProjectsStorage/FakeCloudStorageProvider';
 
 const gd: libGDevelop = global.gd;
 
@@ -55,7 +56,7 @@ export const create = (authentication: Authentication) => {
           appArguments={appArguments}
           storageProviders={
             // Add Url provider
-            [LocalFileStorageProvider]
+            [LocalFileStorageProvider, FakeCloudStorageProvider]
           }
           defaultStorageProvider={LocalFileStorageProvider}
         >

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection.js
@@ -72,7 +72,9 @@ const BuildSection = ({
   onCreateProject,
   onOpenRecentFile,
 }: Props) => {
-  const { getRecentProjectFiles } = React.useContext(PreferencesContext);
+  const { getRecentProjectFiles, removeRecentProjectFile } = React.useContext(
+    PreferencesContext
+  );
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const contextMenu = React.useRef<?ContextMenuInterface>(null);
   const { showDeleteConfirmation } = useConfirmDialog();
@@ -127,7 +129,7 @@ const BuildSection = ({
     }
   };
 
-  const onDeleteProject = async (
+  const onDeleteCloudProject = async (
     i18n: I18nType,
     { fileMetadata, storageProviderName }: FileMetadataAndStorageProviderName
   ) => {
@@ -160,6 +162,10 @@ const BuildSection = ({
     }
   };
 
+  const onRemoveFromRecentFiles = file => {
+    removeRecentProjectFile(file);
+  };
+
   const buildContextMenu = (
     i18n: I18nType,
     file: ?FileMetadataAndStorageProviderName
@@ -173,7 +179,15 @@ const BuildSection = ({
         { type: 'separator' },
         {
           label: i18n._(t`Delete`),
-          click: () => onDeleteProject(i18n, file),
+          click: () => onDeleteCloudProject(i18n, file),
+        },
+      ]);
+    } else if (file.storageProviderName === 'LocalFile') {
+      actions = actions.concat([
+        { type: 'separator' },
+        {
+          label: i18n._(t`Remove from list`),
+          click: () => onRemoveFromRecentFiles(file),
         },
       ]);
     }

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection.js
@@ -31,6 +31,7 @@ import { showErrorBox } from '../../../UI/Messages/MessageBox';
 import { getRelativeOrAbsoluteDisplayDate } from '../../../Utils/DateDisplay';
 import useForceUpdate from '../../../Utils/UseForceUpdate';
 const electron = optionalRequire('electron');
+const path = optionalRequire('path');
 
 const isWebApp = !electron;
 
@@ -165,10 +166,12 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
       }
     };
 
-    const onRemoveFromRecentFiles = (
-      file: FileMetadataAndStorageProviderName
-    ) => {
-      removeRecentProjectFile(file);
+    const onRemoveFromRecentFiles = removeRecentProjectFile;
+
+    const locateProjectFile = (file: FileMetadataAndStorageProviderName) => {
+      electron.shell.showItemInFolder(
+        path.resolve(file.fileMetadata.fileIdentifier)
+      );
     };
 
     const buildContextMenu = (
@@ -189,6 +192,11 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
         ]);
       } else if (file.storageProviderName === 'LocalFile') {
         actions = actions.concat([
+          {
+            label: i18n._(t`Show in local folder`),
+            click: () => locateProjectFile(file),
+            enabled: !isWebApp,
+          },
           { type: 'separator' },
           {
             label: i18n._(t`Remove from list`),

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection.js
@@ -78,10 +78,6 @@ const BuildSection = ({
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const contextMenu = React.useRef<?ContextMenuInterface>(null);
   const { showDeleteConfirmation } = useConfirmDialog();
-  const [
-    selectedFile,
-    setSelectedFile,
-  ] = React.useState<?FileMetadataAndStorageProviderName>(null);
   const [pendingProject, setPendingProject] = React.useState<?string>(null);
   const windowWidth = useResponsiveWindowWidth();
 
@@ -123,9 +119,8 @@ const BuildSection = ({
     event: MouseEvent,
     file: FileMetadataAndStorageProviderName
   ) => {
-    setSelectedFile(file);
     if (contextMenu.current) {
-      contextMenu.current.open(event.clientX, event.clientY);
+      contextMenu.current.open(event.clientX, event.clientY, { file });
     }
   };
 
@@ -162,7 +157,9 @@ const BuildSection = ({
     }
   };
 
-  const onRemoveFromRecentFiles = file => {
+  const onRemoveFromRecentFiles = (
+    file: FileMetadataAndStorageProviderName
+  ) => {
     removeRecentProjectFile(file);
   };
 
@@ -363,7 +360,9 @@ const BuildSection = ({
           </SectionContainer>
           <ContextMenu
             ref={contextMenu}
-            buildMenuTemplate={_i18n => buildContextMenu(_i18n, selectedFile)}
+            buildMenuTemplate={(_i18n, { file }) =>
+              buildContextMenu(_i18n, file)
+            }
           />
         </>
       )}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -10,7 +10,7 @@ import {
 } from '../../../ProjectCreation/CreateProjectDialog';
 import { type FileMetadataAndStorageProviderName } from '../../../ProjectsStorage';
 import GetStartedSection from './GetStartedSection';
-import BuildSection from './BuildSection';
+import BuildSection, { type BuildSectionInterface } from './BuildSection';
 import LearnSection from './LearnSection';
 import PlaySection from './PlaySection';
 import CommunitySection from './CommunitySection';
@@ -89,6 +89,7 @@ export const HomePage = React.memo<Props>(
         values: { showGetStartedSection },
         setShowGetStartedSection,
       } = React.useContext(PreferencesContext);
+      const buildSectionRef = React.useRef<?BuildSectionInterface>(null);
 
       // Load everything when the user opens the home page, to avoid future loading times.
       React.useEffect(
@@ -108,6 +109,19 @@ export const HomePage = React.memo<Props>(
           }
         },
         [isActive, authenticated, onCloudProjectsChanged]
+      );
+
+      // Refresh build section when homepage becomes active
+      React.useEffect(
+        () => {
+          if (isActive && activeTab === 'build' && buildSectionRef.current) {
+            buildSectionRef.current.forceUpdate();
+          }
+        },
+        // Active tab is excluded from the dependencies because switching tab
+        // mounts and unmounts section, so the data is already up to date.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [isActive]
       );
 
       const getProject = () => {
@@ -159,6 +173,7 @@ export const HomePage = React.memo<Props>(
                   )}
                   {activeTab === 'build' && (
                     <BuildSection
+                      ref={buildSectionRef}
                       project={project}
                       canOpen={canOpen}
                       onOpen={onOpen}

--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -67,7 +67,7 @@ const CreateProjectDialog = ({
   const [isOpening, setIsOpening] = React.useState<boolean>(false);
   const [
     selectedExampleShortHeader,
-    setSelectedExampleShortShortHeader,
+    setSelectedExampleShortHeader,
   ] = React.useState<?ExampleShortHeader>(null);
   const [
     preCreationDialogOpen,
@@ -88,7 +88,7 @@ const CreateProjectDialog = ({
         label={<Trans>Create a blank project</Trans>}
         primary
         onClick={() => {
-          setSelectedExampleShortShortHeader(null);
+          setSelectedExampleShortHeader(null);
           setPreCreationDialogOpen(true);
         }}
       />,
@@ -123,7 +123,7 @@ const CreateProjectDialog = ({
       if (!projectMetadata) return;
 
       setPreCreationDialogOpen(false);
-      setSelectedExampleShortShortHeader(null);
+      setSelectedExampleShortHeader(null);
       onOpen({ ...projectMetadata });
     } finally {
       setIsOpening(false);
@@ -150,7 +150,7 @@ const CreateProjectDialog = ({
                   focusOnMount
                   isOpening={isOpening}
                   onOpen={async (example: ?ExampleShortHeader) => {
-                    setSelectedExampleShortShortHeader(example);
+                    setSelectedExampleShortHeader(example);
                     setPreCreationDialogOpen(true);
                   }}
                 />

--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -87,7 +87,10 @@ const CreateProjectDialog = ({
         id="create-blank-project-button"
         label={<Trans>Create a blank project</Trans>}
         primary
-        onClick={() => setPreCreationDialogOpen(true)}
+        onClick={() => {
+          setSelectedExampleShortShortHeader(null);
+          setPreCreationDialogOpen(true);
+        }}
       />,
     ],
     [onClose, setPreCreationDialogOpen]
@@ -160,6 +163,11 @@ const CreateProjectDialog = ({
               isOpening={isOpening}
               onClose={() => setPreCreationDialogOpen(false)}
               onCreate={projectName => createProject(i18n, projectName)}
+              sourceExampleName={
+                selectedExampleShortHeader
+                  ? selectedExampleShortHeader.name
+                  : undefined
+              }
             />
           )}
         </>

--- a/newIDE/app/src/ProjectCreation/ProjectPreCreationDialog.js
+++ b/newIDE/app/src/ProjectCreation/ProjectPreCreationDialog.js
@@ -23,19 +23,26 @@ type Props = {|
   isOpening?: boolean,
   onClose: () => void,
   onCreate: ProjectCreationSettings => void | Promise<void>,
+  sourceExampleName?: string,
 |};
+
+const generateProjectName = (sourceExampleName: ?string) =>
+  sourceExampleName
+    ? `${generateName()} (${sourceExampleName})`
+    : generateName();
 
 const ProjectPreCreationDialog = ({
   open,
   isOpening,
   onClose,
   onCreate,
+  sourceExampleName,
 }: Props): React.Node => {
   const [projectNameError, setProjectNameError] = React.useState<?React.Node>(
     null
   );
   const [projectName, setProjectName] = React.useState<string>(() =>
-    generateName()
+    generateProjectName(sourceExampleName)
   );
   const [outputPath, setOutputPath] = React.useState<string>(() =>
     app ? findEmptyPathInDefaultFolder(app) : ''
@@ -102,7 +109,9 @@ const ProjectPreCreationDialog = ({
           endAdornment={
             <IconButton
               size="small"
-              onClick={() => setProjectName(generateName())}
+              onClick={() =>
+                setProjectName(generateProjectName(sourceExampleName))
+              }
             >
               <Refresh />
             </IconButton>

--- a/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudProjectOpener.js
+++ b/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudProjectOpener.js
@@ -44,15 +44,15 @@ export const generateOnOpen = (authenticatedUser: AuthenticatedUser) => async (
 |}> => {
   const cloudProjectId = fileMetadata.fileIdentifier;
 
-  onProgress && onProgress((1 / 4) * 100, t`Fetching project metadata`);
+  onProgress && onProgress((1 / 4) * 100, t`Calibrating sensors`);
   const cloudProject = await getCloudProject(authenticatedUser, cloudProjectId);
   if (!cloudProject) throw new Error("Cloud project couldn't be fetched.");
 
-  onProgress && onProgress((2 / 4) * 100, t`Getting cookie`);
+  onProgress && onProgress((2 / 4) * 100, t`Starting engine`);
   await getCredentialsForCloudProject(authenticatedUser, cloudProjectId);
-  onProgress && onProgress((3 / 4) * 100, t`Downloading project`);
+  onProgress && onProgress((3 / 4) * 100, t`Checking tools`);
   const zippedSerializedProject = await getProjectFileAsZipBlob(cloudProject);
-  onProgress && onProgress((4 / 4) * 100, t`Unzipping project`);
+  onProgress && onProgress((4 / 4) * 100, t`Opening portal`);
   const serializedProject = await unzipProject(zippedSerializedProject);
 
   return {

--- a/newIDE/app/src/ProjectsStorage/CloudStorageProvider/index.js
+++ b/newIDE/app/src/ProjectsStorage/CloudStorageProvider/index.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
 import { t } from '@lingui/macro';
-import Cloud from '@material-ui/icons/Cloud';
 import { type StorageProvider } from '../index';
 import {
   generateOnChangeProjectProperty,
@@ -14,6 +13,7 @@ import {
 } from '../../Utils/Window';
 import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 import { generateOnOpen } from './CloudProjectOpener';
+import Cloud from '../../UI/CustomSvgIcons/Cloud';
 
 export default ({
   internalName: 'Cloud',

--- a/newIDE/app/src/ProjectsStorage/FakeCloudStorageProvider/index.js
+++ b/newIDE/app/src/ProjectsStorage/FakeCloudStorageProvider/index.js
@@ -5,7 +5,7 @@ import Cloud from '../../UI/CustomSvgIcons/Cloud';
 import { type StorageProvider, type FileMetadata } from '../index';
 
 /**
- * A storage that is using OneDrive to open and store files.
+ * A storage that is announcing the upcoming Cloud storage on the desktop app.
  */
 const FakeCloudStorageProvider = ({
   internalName: 'FakeCloud',

--- a/newIDE/app/src/ProjectsStorage/FakeCloudStorageProvider/index.js
+++ b/newIDE/app/src/ProjectsStorage/FakeCloudStorageProvider/index.js
@@ -1,0 +1,38 @@
+// @flow
+import { t } from '@lingui/macro';
+import * as React from 'react';
+import { type StorageProvider, type FileMetadata } from '../index';
+import Cloud from '@material-ui/icons/Cloud';
+
+/**
+ * A storage that is using OneDrive to open and store files.
+ */
+const FakeCloudStorageProvider = ({
+  internalName: 'FakeCloud',
+  name: t`GDevelop cloud storage (coming soon)`,
+  disabled: true,
+  renderIcon: () => <Cloud />,
+  createOperations: () => {
+    return {
+      doesInitialOpenRequireUserInteraction: true,
+      onOpen: (
+        fileMetadata: FileMetadata
+      ): Promise<{|
+        content: Object,
+      |}> => {
+        return Promise.reject(new Error('Unimplemented'));
+      },
+      onOpenWithPicker: (): Promise<?FileMetadata> => {
+        return Promise.reject(new Error('Unimplemented'));
+      },
+      onSaveProject: (project: gdProject, fileMetadata: FileMetadata) => {
+        return Promise.reject(new Error('Unimplemented'));
+      },
+      onSaveProjectAs: (project: gdProject, fileMetadata: ?FileMetadata) => {
+        return Promise.reject(new Error('Unimplemented'));
+      },
+    };
+  },
+}: StorageProvider);
+
+export default FakeCloudStorageProvider;

--- a/newIDE/app/src/ProjectsStorage/FakeCloudStorageProvider/index.js
+++ b/newIDE/app/src/ProjectsStorage/FakeCloudStorageProvider/index.js
@@ -1,8 +1,8 @@
 // @flow
 import { t } from '@lingui/macro';
 import * as React from 'react';
+import Cloud from '../../UI/CustomSvgIcons/Cloud';
 import { type StorageProvider, type FileMetadata } from '../index';
-import Cloud from '@material-ui/icons/Cloud';
 
 /**
  * A storage that is using OneDrive to open and store files.

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/index.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/index.js
@@ -26,7 +26,7 @@ import Computer from '../../UI/CustomSvgIcons/Computer';
  */
 export default ({
   internalName: 'LocalFile',
-  name: t`Local file system`,
+  name: t`Your computer`,
   renderIcon: () => <Computer />,
   getFileMetadataFromAppArguments: (appArguments: AppArguments) => {
     if (!appArguments[POSITIONAL_ARGUMENTS_KEY]) return null;

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/index.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/index.js
@@ -1,4 +1,5 @@
 // @flow
+import * as React from 'react';
 import { t } from '@lingui/macro';
 import { type StorageProvider } from '../index';
 import {
@@ -17,6 +18,7 @@ import {
   POSITIONAL_ARGUMENTS_KEY,
 } from '../../Utils/Window';
 import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
+import Computer from '../../UI/CustomSvgIcons/Computer';
 
 /**
  * Use the Electron APIs to provide access to the native
@@ -25,6 +27,7 @@ import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow'
 export default ({
   internalName: 'LocalFile',
   name: t`Local file system`,
+  renderIcon: () => <Computer />,
   getFileMetadataFromAppArguments: (appArguments: AppArguments) => {
     if (!appArguments[POSITIONAL_ARGUMENTS_KEY]) return null;
     if (!appArguments[POSITIONAL_ARGUMENTS_KEY].length) return null;

--- a/newIDE/app/src/UI/CustomSvgIcons/Cloud.js
+++ b/newIDE/app/src/UI/CustomSvgIcons/Cloud.js
@@ -6,9 +6,9 @@ export default React.memo(props => (
     <path
       d="M0.75 8C0.75 9.7949 2.20507 11.25 4 11.25H12C13.7949 11.25 15.25 9.7949 15.25 8C15.25 6.2869 13.9246 4.8834 12.2433 4.759C12.1183 2.5239 10.2663 0.75 8 0.75C5.73368 0.75 3.88168 2.5239 3.75672 4.759C2.07542 4.8834 0.75 6.2869 0.75 8Z"
       stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </SvgIcon>
 ));

--- a/newIDE/app/src/UI/CustomSvgIcons/Cloud.js
+++ b/newIDE/app/src/UI/CustomSvgIcons/Cloud.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export default React.memo(props => (
+  <SvgIcon {...props} viewBox="0 0 16 12" style={{ fill: 'none' }}>
+    <path
+      d="M0.75 8C0.75 9.7949 2.20507 11.25 4 11.25H12C13.7949 11.25 15.25 9.7949 15.25 8C15.25 6.2869 13.9246 4.8834 12.2433 4.759C12.1183 2.5239 10.2663 0.75 8 0.75C5.73368 0.75 3.88168 2.5239 3.75672 4.759C2.07542 4.8834 0.75 6.2869 0.75 8Z"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </SvgIcon>
+));

--- a/newIDE/app/src/UI/CustomSvgIcons/Computer.js
+++ b/newIDE/app/src/UI/CustomSvgIcons/Computer.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export default React.memo(props => (
+  <SvgIcon {...props} viewBox="0 0 16 16" style={{ fill: 'none' }}>
+    <path
+      d="M5.75 11.25C5.75 11.25 6 14.25 4 15.25H12C10 14.25 10.25 11.25 10.25 11.25M5.75 11.25H13.25C14.3546 11.25 15.25 10.3546 15.25 9.25V2.75C15.25 1.64543 14.3546 0.75 13.25 0.75H2.75C1.64543 0.75 0.75 1.64543 0.75 2.75V9.25C0.75 10.3546 1.64543 11.25 2.75 11.25H5.75Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </SvgIcon>
+));


### PR DESCRIPTION
- Add fake cloud storage provider to reassure users that might want to open their cloud projects on the desktop app
- Add options to context menu
- Display project name instead of project path for local projects
- Suggest new project name with example name in parenthesis to remember where does this project comes from

<img width="790" alt="image" src="https://user-images.githubusercontent.com/32449369/181738060-5ca0c8d3-91bc-46c3-a286-207bdadc1101.png">

<img width="839" alt="image" src="https://user-images.githubusercontent.com/32449369/181738160-3819f638-9d3f-49e4-9912-0f047f490a61.png">
