### PR TITLE
RuntimeScenePixiRenderer: Wait with showing the cursor until the frame is rendered

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimescene-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimescene-pixi-renderer.ts
@@ -11,6 +11,7 @@ namespace gdjs {
     _debugDraw: PIXI.Graphics | null = null;
     _debugDrawContainer: PIXI.Container | null = null;
     _profilerText: PIXI.Text | null = null;
+    _showCursorAtNextRender: boolean = false;
     _debugDrawRenderedObjectsPoints: Record<
       number,
       {
@@ -59,6 +60,13 @@ namespace gdjs {
       // render the PIXI container of the scene
       this._pixiRenderer.backgroundColor = this._runtimeScene.getBackgroundColor();
       this._pixiRenderer.render(this._pixiContainer);
+
+      // synchronize showing the cursor with rendering (useful to reduce
+      // blinking while switching from in-game cursor)
+      if (this._showCursorAtNextRender) {
+        this._pixiRenderer.view.style.cursor = '';
+        this._showCursorAtNextRender = false;
+      }
     }
 
     _renderProfileText() {
@@ -336,6 +344,7 @@ namespace gdjs {
     }
 
     hideCursor(): void {
+      this._showCursorAtNextRender = false;
       if (!this._pixiRenderer) {
         return;
       }
@@ -343,10 +352,7 @@ namespace gdjs {
     }
 
     showCursor(): void {
-      if (!this._pixiRenderer) {
-        return;
-      }
-      this._pixiRenderer.view.style.cursor = '';
+      this._showCursorAtNextRender = true;
     }
 
     getPIXIContainer() {


### PR DESCRIPTION
This minimizes cursor flicker in games that switch between system cursor and
in-game cursor. If the browser updates cursor status asynchronously and the
rendering takes longer than screen refresh, we could easily end up with two
cursors displayed at once for a short moment.

While the same could be done when hiding the cursor as well, it may be not
a bad idea to do the hiding early anyway, as system cursor can be updated
faster than the browser is able to dispatch events, so hiding it early
minimizes the cases where the cursor jumps back to a previous position
after switching to in-game cursor.