### PR TITLE
Fix raycast condition not working properly on objects with multiple hitboxes

### DIFF
--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -542,11 +542,11 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
   InsertUnique(includesFiles, "inputmanager.js");
   InsertUnique(includesFiles, "jsonmanager.js");
   InsertUnique(includesFiles, "timemanager.js");
+  InsertUnique(includesFiles, "polygon.js");
   InsertUnique(includesFiles, "runtimeobject.js");
   InsertUnique(includesFiles, "profiler.js");
   InsertUnique(includesFiles, "runtimescene.js");
   InsertUnique(includesFiles, "scenestack.js");
-  InsertUnique(includesFiles, "polygon.js");
   InsertUnique(includesFiles, "force.js");
   InsertUnique(includesFiles, "layer.js");
   InsertUnique(includesFiles, "timer.js");

--- a/GDJS/Runtime/events-tools/objecttools.ts
+++ b/GDJS/Runtime/events-tools/objecttools.ts
@@ -219,11 +219,11 @@ namespace gdjs {
       };
 
       export const hitBoxesCollisionTest = function (
-        objectsLists1,
-        objectsLists2,
-        inverted,
-        runtimeScene,
-        ignoreTouchingEdges
+        objectsLists1: Hashtable<Array<gdjs.RuntimeObject>>,
+        objectsLists2: Hashtable<Array<gdjs.RuntimeObject>>,
+        inverted: boolean,
+        runtimeScene: gdjs.RuntimeScene,
+        ignoreTouchingEdges: boolean
       ) {
         return gdjs.evtTools.object.twoListsTest(
           gdjs.RuntimeObject.collisionTest,
@@ -239,10 +239,10 @@ namespace gdjs {
       };
 
       export const distanceTest = function (
-        objectsLists1,
-        objectsLists2,
-        distance,
-        inverted
+        objectsLists1: Hashtable<Array<gdjs.RuntimeObject>>,
+        objectsLists2: Hashtable<Array<gdjs.RuntimeObject>>,
+        distance: float,
+        inverted: boolean
       ) {
         return gdjs.evtTools.object.twoListsTest(
           gdjs.evtTools.object._distanceBetweenObjects,
@@ -278,10 +278,10 @@ namespace gdjs {
       };
 
       export const movesTowardTest = function (
-        objectsLists1,
-        objectsLists2,
-        tolerance,
-        inverted
+        objectsLists1: Hashtable<Array<gdjs.RuntimeObject>>,
+        objectsLists2: Hashtable<Array<gdjs.RuntimeObject>>,
+        tolerance: float,
+        inverted: boolean
       ) {
         return gdjs.evtTools.object.twoListsTest(
           gdjs.evtTools.object._movesToward,
@@ -403,14 +403,14 @@ namespace gdjs {
       };
 
       export const raycastObject = function (
-        objectsLists,
-        x,
-        y,
-        angle,
-        dist,
-        varX,
-        varY,
-        inverted
+        objectsLists: Hashtable<Array<gdjs.RuntimeObject>>,
+        x: float,
+        y: float,
+        angle: float,
+        dist: float,
+        varX: gdjs.Variable,
+        varY: gdjs.Variable,
+        inverted: boolean
       ) {
         return gdjs.evtTools.object.raycastObjectToPosition(
           objectsLists,
@@ -425,22 +425,22 @@ namespace gdjs {
       };
 
       export const raycastObjectToPosition = function (
-        objectsLists,
-        x,
-        y,
-        endX,
-        endY,
-        varX,
-        varY,
-        inverted
+        objectsLists: Hashtable<Array<gdjs.RuntimeObject>>,
+        x: float,
+        y: float,
+        endX: float,
+        endY: float,
+        varX: gdjs.Variable,
+        varY: gdjs.Variable,
+        inverted: boolean
       ) {
-        let matchObject = null;
+        let matchObject: gdjs.RuntimeObject | null = null;
         let testSqDist = inverted
           ? 0
           : (endX - x) * (endX - x) + (endY - y) * (endY - y);
         let resultX = 0;
         let resultY = 0;
-        const lists = gdjs.staticArray(
+        const lists: RuntimeObject[][] = gdjs.staticArray(
           gdjs.evtTools.object.raycastObjectToPosition
         );
         objectsLists.values(lists);

--- a/GDJS/Runtime/polygon.ts
+++ b/GDJS/Runtime/polygon.ts
@@ -19,6 +19,66 @@ namespace gdjs {
     farSqDist: float;
   };
 
+  /** Build a new object to store collision test results. */
+  const makeNewCollisionTestResult = (): CollisionTestResult => {
+    return { collision: false, move_axis: [0, 0] };
+  };
+
+  /** Build a new object to store raycast test results. */
+  const makeNewRaycastTestResult = (): RaycastTestResult => {
+    return {
+      collision: false,
+      closeX: 0,
+      closeY: 0,
+      closeSqDist: 0,
+      farX: 0,
+      farY: 0,
+      farSqDist: 0,
+    };
+  };
+
+  /**
+   * Arrays and data structure that are (re)used by Polygon.collisionTest to
+   * avoid any allocation.
+   */
+  const collisionTestStatics: {
+    minMaxA: FloatPoint;
+    minMaxB: FloatPoint;
+    edge: FloatPoint;
+    axis: FloatPoint;
+    move_axis: FloatPoint;
+    result: CollisionTestResult;
+  } = {
+    minMaxA: [0, 0],
+    minMaxB: [0, 0],
+    edge: [0, 0],
+    axis: [0, 0],
+    move_axis: [0, 0],
+    result: makeNewCollisionTestResult(),
+  };
+
+  /**
+   * Arrays and data structure that are (re)used by Polygon.raycastTest to
+   * avoid any allocation.
+   */
+  const raycastTestStatics: {
+    p: FloatPoint;
+    q: FloatPoint;
+    r: FloatPoint;
+    s: FloatPoint;
+    deltaQP: FloatPoint;
+    axis: FloatPoint;
+    result: RaycastTestResult;
+  } = {
+    p: [0, 0],
+    q: [0, 0],
+    r: [0, 0],
+    s: [0, 0],
+    deltaQP: [0, 0],
+    axis: [0, 0],
+    result: makeNewRaycastTestResult(),
+  };
+
   /**
    * Polygon represents a polygon which can be used to create collisions masks for RuntimeObject.
    */
@@ -129,11 +189,14 @@ namespace gdjs {
      * Do a collision test between two polygons.
      * Please note that polygons must *convexes*!
      *
+     * You can read the result but do not keep a reference to it as it's a static object
+     * reused between function calls. If you need to keep the results, use `copyCollisionTestResult`.
+     *
      * Uses <a href="http://en.wikipedia.org/wiki/Hyperplane_separation_theorem">Separating Axis Theorem </a>.<br>
      * Based on <a href="http://www.codeproject.com/Articles/15573/2D-Polygon-Collision-Detection">this</a>
      * and <a href="http://stackoverflow.com/questions/5742329/problem-with-collision-response-sat">this</a> article.
      *
-     * @return returnValue.collision is equal to true if polygons are overlapping
+     * @return A collision result. `collision` property is equal to true if polygons are overlapping. Do NOT keep a reference to this.
      * @param p1 The first polygon
      * @param p2 The second polygon
      * @param ignoreTouchingEdges If true, then edges that are touching each other, without the polygons actually overlapping, won't be considered in collision.
@@ -146,9 +209,9 @@ namespace gdjs {
       //Algorithm core :
       p1.computeEdges();
       p2.computeEdges();
-      let edge = Polygon.collisionTestStatics.edge;
-      const move_axis = Polygon.collisionTestStatics.move_axis;
-      const result = Polygon.collisionTestStatics.result;
+      let edge = collisionTestStatics.edge;
+      const move_axis = collisionTestStatics.move_axis;
+      const result = collisionTestStatics.result;
       let minDist = Number.MAX_VALUE;
       edge[0] = 0;
       edge[1] = 0;
@@ -170,14 +233,14 @@ namespace gdjs {
         } else {
           edge = p2.edges[i - len1];
         }
-        const axis = Polygon.collisionTestStatics.axis;
+        const axis = collisionTestStatics.axis;
 
         //Get the axis to which polygons will be projected
         axis[0] = -edge[1];
         axis[1] = edge[0];
         Polygon.normalise(axis);
-        const minMaxA = Polygon.collisionTestStatics.minMaxA;
-        const minMaxB = Polygon.collisionTestStatics.minMaxB;
+        const minMaxA = collisionTestStatics.minMaxA;
+        const minMaxB = collisionTestStatics.minMaxB;
         Polygon.project(
           axis,
           p1,
@@ -227,8 +290,11 @@ namespace gdjs {
     }
 
     /**
-     * Do a raycast test.<br>
-     * Please note that the polygon must be <b>convex</b>!
+     * Do a raycast test.
+     * Please note that the polygon must be **convex**!
+     *
+     * You can read the result but do not keep a reference to it as it's a static object
+     * reused between function calls. If you need to keep the results, use `copyRaycastTestResult`.
      *
      * For some theory, check <a href="https://www.codeproject.com/Tips/862988/Find-the-Intersection-Point-of-Two-Line-Segments">Find the Intersection Point of Two Line Segments</a>.
      *
@@ -237,7 +303,7 @@ namespace gdjs {
      * @param startY The raycast start point Y
      * @param endX The raycast end point X
      * @param endY The raycast end point Y
-     * @return A raycast result with the contact points and distances
+     * @return A raycast result with the contact points and distances. Do NOT keep a reference to this.
      */
     static raycastTest(
       poly: gdjs.Polygon,
@@ -246,16 +312,16 @@ namespace gdjs {
       endX: float,
       endY: float
     ): RaycastTestResult {
-      const result = Polygon.raycastTestStatics.result;
+      const result = raycastTestStatics.result;
       result.collision = false;
       if (poly.vertices.length < 2) {
         return result;
       }
       poly.computeEdges();
-      const p = Polygon.raycastTestStatics.p;
-      const q = Polygon.raycastTestStatics.q;
-      const r = Polygon.raycastTestStatics.r;
-      const s = Polygon.raycastTestStatics.s;
+      const p = raycastTestStatics.p;
+      const q = raycastTestStatics.q;
+      const r = raycastTestStatics.r;
+      const s = raycastTestStatics.s;
       let minSqDist = Number.MAX_VALUE;
 
       // Ray segment: p + t*r, with p = start and r = end - start
@@ -269,7 +335,7 @@ namespace gdjs {
         q[1] = poly.vertices[i][1];
         s[0] = poly.edges[i][0];
         s[1] = poly.edges[i][1];
-        const deltaQP = Polygon.raycastTestStatics.deltaQP;
+        const deltaQP = raycastTestStatics.deltaQP;
         deltaQP[0] = q[0] - p[0];
         deltaQP[1] = q[1] - p[1];
         const crossRS = Polygon.crossProduct(r, s);
@@ -283,7 +349,7 @@ namespace gdjs {
           Math.abs(Polygon.crossProduct(deltaQP, r)) <= 0.0001
         ) {
           // Project the ray and the edge to work on floats, keeping linearity through t
-          const axis = Polygon.raycastTestStatics.axis;
+          const axis = raycastTestStatics.axis;
           axis[0] = r[0];
           axis[1] = r[1];
           Polygon.normalise(axis);
@@ -431,50 +497,40 @@ namespace gdjs {
       return inside;
     }
 
-    // Arrays and data structure that are (re)used by Polygon.collisionTest to
-    // avoid any allocation.
-    private static collisionTestStatics: {
-      minMaxA: FloatPoint;
-      minMaxB: FloatPoint;
-      edge: FloatPoint;
-      axis: FloatPoint;
-      move_axis: FloatPoint;
-      result: CollisionTestResult;
-    } = {
-      minMaxA: [0, 0],
-      minMaxB: [0, 0],
-      edge: [0, 0],
-      axis: [0, 0],
-      move_axis: [0, 0],
-      result: { collision: false, move_axis: [0, 0] },
-    };
+    /**
+     * Copy a `CollisionTestResult` into another one.
+     * Use `gdjs.Polygon.makeNewCollisionTestResult()` to build a new
+     * destination before copying the existing source inside it.
+     */
+    static copyCollisionTestResult(
+      source: CollisionTestResult,
+      dest: CollisionTestResult
+    ) {
+      dest.collision = source.collision;
+      dest.move_axis[0] = source.move_axis[0];
+      dest.move_axis[1] = source.move_axis[1];
+    }
 
-    // Arrays and data structure that are (re)used by Polygon.raycastTest to
-    // avoid any allocation.
-    private static raycastTestStatics: {
-      p: FloatPoint;
-      q: FloatPoint;
-      r: FloatPoint;
-      s: FloatPoint;
-      deltaQP: FloatPoint;
-      axis: FloatPoint;
-      result: RaycastTestResult;
-    } = {
-      p: [0, 0],
-      q: [0, 0],
-      r: [0, 0],
-      s: [0, 0],
-      deltaQP: [0, 0],
-      axis: [0, 0],
-      result: {
-        collision: false,
-        closeX: 0,
-        closeY: 0,
-        closeSqDist: 0,
-        farX: 0,
-        farY: 0,
-        farSqDist: 0,
-      },
-    };
+    static makeNewCollisionTestResult = makeNewCollisionTestResult;
+
+    /**
+     * Copy a `RaycastTestResult` into another one.
+     * Use `gdjs.Polygon.makeNewRaycastTestResult()` to build a new
+     * destination before copying the existing source inside it.
+     */
+    static copyRaycastTestResult(
+      source: RaycastTestResult,
+      dest: RaycastTestResult
+    ) {
+      dest.collision = source.collision;
+      dest.closeX = source.closeX;
+      dest.closeY = source.closeY;
+      dest.closeSqDist = source.closeSqDist;
+      dest.farX = source.farX;
+      dest.farY = source.farY;
+      dest.farSqDist = source.farSqDist;
+    }
+
+    static makeNewRaycastTestResult = makeNewRaycastTestResult;
   }
 }

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -48,9 +48,9 @@ namespace gdjs {
    * {@link RuntimeObject.raycastTest} to avoid any allocation.
    */
   const raycastTestStatics: {
-    result: RaycastTestResult
+    result: RaycastTestResult;
   } = {
-    result: gdjs.Polygon.makeNewRaycastTestResult()
+    result: gdjs.Polygon.makeNewRaycastTestResult(),
   };
 
   /**
@@ -2332,24 +2332,32 @@ namespace gdjs {
       }
 
       // Do a real check if necessary.
-      let testSqDist = closest ? raySqBoundingRadius : 0;
-      const hitBoxes = this.getHitBoxesAround(x, y, endX, endY);
-      for (const hitBox of hitBoxes) {
-        const res = gdjs.Polygon.raycastTest(hitBox, x, y, endX, endY);
-        if (res.collision) {
-          if (closest && res.closeSqDist < testSqDist) {
-            testSqDist = res.closeSqDist;
+      if (closest) {
+        let sqDistMin = raySqBoundingRadius;
+        const hitBoxes = this.getHitBoxesAround(x, y, endX, endY);
+        for (const hitBox of hitBoxes) {
+          const res = gdjs.Polygon.raycastTest(hitBox, x, y, endX, endY);
+          if (res.collision && res.closeSqDist < sqDistMin) {
+            sqDistMin = res.closeSqDist;
             gdjs.Polygon.copyRaycastTestResult(res, result);
-          } else if (
-            !closest &&
-            res.farSqDist > testSqDist &&
+          }
+        }
+      } else {
+        let sqDistMax = 0;
+        const hitBoxes = this.getHitBoxesAround(x, y, endX, endY);
+        for (const hitBox of hitBoxes) {
+          const res = gdjs.Polygon.raycastTest(hitBox, x, y, endX, endY);
+          if (
+            res.collision &&
+            res.farSqDist > sqDistMax &&
             res.farSqDist <= raySqBoundingRadius
           ) {
-            testSqDist = res.farSqDist;
+            sqDistMax = res.farSqDist;
             gdjs.Polygon.copyRaycastTestResult(res, result);
           }
         }
       }
+
       return result;
     }
 

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -2343,7 +2343,7 @@ namespace gdjs {
           }
         }
       } else {
-        let sqDistMax = 0;
+        let sqDistMax = -Number.MAX_VALUE;
         const hitBoxes = this.getHitBoxesAround(x, y, endX, endY);
         for (const hitBox of hitBoxes) {
           const res = gdjs.Polygon.raycastTest(hitBox, x, y, endX, endY);

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -2333,7 +2333,7 @@ namespace gdjs {
 
       // Do a real check if necessary.
       if (closest) {
-        let sqDistMin = raySqBoundingRadius;
+        let sqDistMin = Number.MAX_VALUE;
         const hitBoxes = this.getHitBoxesAround(x, y, endX, endY);
         for (const hitBox of hitBoxes) {
           const res = gdjs.Polygon.raycastTest(hitBox, x, y, endX, endY);

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -44,6 +44,16 @@ namespace gdjs {
   };
 
   /**
+   * Data structure that are (re)used by
+   * {@link RuntimeObject.raycastTest} to avoid any allocation.
+   */
+  const raycastTestStatics: {
+    result: RaycastTestResult
+  } = {
+    result: gdjs.Polygon.makeNewRaycastTestResult()
+  };
+
+  /**
    * Move the object using the results from collisionTest call.
    * This moves the object according to the direction of the longest vector,
    * and projects the others on the orthogonal vector.
@@ -2308,8 +2318,7 @@ namespace gdjs {
       const diffX = this.getDrawableX() + objCenterX - rayCenterWorldX;
       const diffY = this.getDrawableY() + objCenterY - rayCenterWorldY;
 
-      // @ts-ignore
-      let result = gdjs.Polygon.raycastTestStatics.result;
+      let result = raycastTestStatics.result;
       result.collision = false;
       if (
         // As an optimization, avoid computing the square root of the two boundings radius
@@ -2330,16 +2339,14 @@ namespace gdjs {
         if (res.collision) {
           if (closest && res.closeSqDist < testSqDist) {
             testSqDist = res.closeSqDist;
-            result = res;
-          } else {
-            if (
-              !closest &&
-              res.farSqDist > testSqDist &&
-              res.farSqDist <= raySqBoundingRadius
-            ) {
-              testSqDist = res.farSqDist;
-              result = res;
-            }
+            gdjs.Polygon.copyRaycastTestResult(res, result);
+          } else if (
+            !closest &&
+            res.farSqDist > testSqDist &&
+            res.farSqDist <= raySqBoundingRadius
+          ) {
+            testSqDist = res.farSqDist;
+            gdjs.Polygon.copyRaycastTestResult(res, result);
           }
         }
       }

--- a/GDJS/tests/karma.conf.js
+++ b/GDJS/tests/karma.conf.js
@@ -51,11 +51,11 @@ module.exports = function (config) {
       './newIDE/app/resources/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.js',
       './newIDE/app/resources/GDJS/Runtime/jsonmanager.js',
       './newIDE/app/resources/GDJS/Runtime/timemanager.js',
+      './newIDE/app/resources/GDJS/Runtime/polygon.js',
       './newIDE/app/resources/GDJS/Runtime/runtimeobject.js',
       './newIDE/app/resources/GDJS/Runtime/runtimescene.js',
       './newIDE/app/resources/GDJS/Runtime/scenestack.js',
       './newIDE/app/resources/GDJS/Runtime/profiler.js',
-      './newIDE/app/resources/GDJS/Runtime/polygon.js',
       './newIDE/app/resources/GDJS/Runtime/force.js',
       './newIDE/app/resources/GDJS/Runtime/layer.js',
       './newIDE/app/resources/GDJS/Runtime/timer.js',
@@ -120,7 +120,7 @@ module.exports = function (config) {
       './newIDE/app/resources/GDJS/Runtime/Extensions/TileMap/collision/TransformedTileMap.js',
       './newIDE/app/resources/GDJS/Runtime/Extensions/TileMap/helper/TileMapHelper.js',
       './newIDE/app/resources/GDJS/Runtime/Extensions/TileMap/pako/dist/pako.min.js',
-      
+
       // Test extensions:
       './GDJS/tests/tests/Extensions/**.js',
 

--- a/GDJS/tests/tests/Extensions/testspriteruntimeobject.js
+++ b/GDJS/tests/tests/Extensions/testspriteruntimeobject.js
@@ -51,7 +51,7 @@
   }
 
   getRendererObject() {
-    return {};
+    return null;
   }
 
   getWidth() {

--- a/GDJS/tests/tests/runtimeobject.js
+++ b/GDJS/tests/tests/runtimeobject.js
@@ -232,7 +232,7 @@ describe('gdjs.RuntimeObject', () => {
       true
     );
     expect(object1.raycastTest(25, 500, 25, 300 + 20, true).collision).to.be(
-      false
+      true
     );
     expect(object1.raycastTest(25, 500, 25, 300 + 20.1, true).collision).to.be(
       false
@@ -254,7 +254,7 @@ describe('gdjs.RuntimeObject', () => {
       true
     );
     expect(object1.raycastTest(500, 35, 200 + 10, 35, true).collision).to.be(
-      false
+      true
     );
     expect(object1.raycastTest(500, 35, 200 + 10.1, 35, true).collision).to.be(
       false

--- a/GDJS/tests/tests/runtimeobject.js
+++ b/GDJS/tests/tests/runtimeobject.js
@@ -4,7 +4,7 @@
  * See README.md for more information.
  */
 
- describe('gdjs.RuntimeObject', () => {
+describe('gdjs.RuntimeObject', () => {
   const runtimeGame = new gdjs.RuntimeGame({
     variables: [],
     // @ts-ignore TODO: make a function to create an empty game and use it across tests.
@@ -228,11 +228,21 @@
 
     // Vertical raycast, far from the origin, to the edge of the object:
     object1.setPosition(20, 300);
-    expect(object1.raycastTest(25, 500, 25, 300+19, true).collision).to.be(true);
-    expect(object1.raycastTest(25, 500, 25, 300+20, true).collision).to.be(true);
-    expect(object1.raycastTest(25, 500, 25, 300+20.1, true).collision).to.be(false);
-    expect(object1.raycastTest(25, 500, 25, 300+20.5, true).collision).to.be(false);
-    expect(object1.raycastTest(25, 500, 25, 300+21, true).collision).to.be(false);
+    expect(object1.raycastTest(25, 500, 25, 300 + 19, true).collision).to.be(
+      true
+    );
+    expect(object1.raycastTest(25, 500, 25, 300 + 20, true).collision).to.be(
+      false
+    );
+    expect(object1.raycastTest(25, 500, 25, 300 + 20.1, true).collision).to.be(
+      false
+    );
+    expect(object1.raycastTest(25, 500, 25, 300 + 20.5, true).collision).to.be(
+      false
+    );
+    expect(object1.raycastTest(25, 500, 25, 300 + 21, true).collision).to.be(
+      false
+    );
 
     // Horizontal raycast, far from the origin:
     object1.setPosition(200, 30);
@@ -240,14 +250,171 @@
 
     // Horizontal raycast, far from the origin, to the edge of the object:
     object1.setPosition(200, 30);
-    expect(object1.raycastTest(500, 35, 200+9, 35, true).collision).to.be(true);
-    expect(object1.raycastTest(500, 35, 200+10, 35, true).collision).to.be(true);
-    expect(object1.raycastTest(500, 35, 200+10.1, 35, true).collision).to.be(false);
-    expect(object1.raycastTest(500, 35, 200+10.5, 35, true).collision).to.be(false);
-    expect(object1.raycastTest(500, 35, 200+11, 35, true).collision).to.be(false);
+    expect(object1.raycastTest(500, 35, 200 + 9, 35, true).collision).to.be(
+      true
+    );
+    expect(object1.raycastTest(500, 35, 200 + 10, 35, true).collision).to.be(
+      false
+    );
+    expect(object1.raycastTest(500, 35, 200 + 10.1, 35, true).collision).to.be(
+      false
+    );
+    expect(object1.raycastTest(500, 35, 200 + 10.5, 35, true).collision).to.be(
+      false
+    );
+    expect(object1.raycastTest(500, 35, 200 + 11, 35, true).collision).to.be(
+      false
+    );
 
     // Raycast not intersecting with the object
     object1.setPosition(20, 30);
     expect(object1.raycastTest(10, 10, 105, 55, true).collision).to.be(false);
+  });
+
+  it('handles raycast (object with multiple hitboxes)', () => {
+    const objectWithTwoHitboxes = new gdjs.TestSpriteRuntimeObject(
+      runtimeScene,
+      {
+        name: 'objectWithTwoHitboxes',
+        type: '',
+        behaviors: [],
+        effects: [],
+        animations: [
+          {
+            name: 'animation',
+            directions: [
+              {
+                sprites: [
+                  {
+                    originPoint: { x: 0, y: 0 },
+                    centerPoint: { x: 50, y: 50 },
+                    points: [
+                      { name: 'Center', x: 0, y: 0 },
+                      { name: 'Origin', x: 50, y: 50 },
+                    ],
+                    hasCustomCollisionMask: true,
+                    customCollisionMask: [
+                      [
+                        { x: 75, y: 100 },
+                        { x: 0, y: 100 },
+                        { x: 0, y: 25 },
+                      ],
+                      [
+                        { x: 25, y: 0 },
+                        { x: 100, y: 75 },
+                        { x: 100, y: 0 },
+                      ],
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+    );
+    runtimeScene.addObject(objectWithTwoHitboxes);
+    objectWithTwoHitboxes.setUnscaledWidthAndHeight(100, 100);
+    objectWithTwoHitboxes.setCustomWidthAndHeight(100, 100);
+
+    // Ray going through the "tunnel" left by the two triangle hitboxes:
+    objectWithTwoHitboxes.setPosition(0, 0);
+    expect(
+      objectWithTwoHitboxes.raycastTest(0, 0, 300, 300, true).collision
+    ).to.be(false);
+    expect(
+      objectWithTwoHitboxes.raycastTest(0, 10, 300, 300 + 10, true).collision
+    ).to.be(false);
+    expect(
+      objectWithTwoHitboxes.raycastTest(10, 0, 300 + 10, 300, true).collision
+    ).to.be(false);
+
+    const rayCastFromCenterToRightResult = objectWithTwoHitboxes.raycastTest(
+      50,
+      50,
+      300,
+      50,
+      true
+    );
+    expect(rayCastFromCenterToRightResult.collision).to.be(true);
+    expect(rayCastFromCenterToRightResult.closeX).to.be(75);
+    expect(rayCastFromCenterToRightResult.closeY).to.be(50);
+
+    const rayCastFromCenterToRightFarResult = objectWithTwoHitboxes.raycastTest(
+      50,
+      50,
+      300,
+      50,
+      false
+    );
+    expect(rayCastFromCenterToRightFarResult.collision).to.be(true);
+    expect(rayCastFromCenterToRightFarResult.farX).to.be(100);
+    expect(rayCastFromCenterToRightFarResult.farY).to.be(50);
+
+    const rayCastFromCenterToLeftResult = objectWithTwoHitboxes.raycastTest(
+      50,
+      50,
+      -300,
+      50,
+      true
+    );
+    expect(rayCastFromCenterToLeftResult.collision).to.be(true);
+    expect(rayCastFromCenterToLeftResult.closeX).to.be(25);
+    expect(rayCastFromCenterToLeftResult.closeY).to.be(50);
+
+    const rayCastFromCenterToLeftFarResult = objectWithTwoHitboxes.raycastTest(
+      50,
+      50,
+      -300,
+      50,
+      true
+    );
+    expect(rayCastFromCenterToLeftFarResult.collision).to.be(true);
+    expect(rayCastFromCenterToLeftFarResult.farX).to.be(0);
+    expect(rayCastFromCenterToLeftFarResult.farY).to.be(50);
+
+    const rayCastFromMiddleTopResult = objectWithTwoHitboxes.raycastTest(
+      50,
+      -20,
+      50,
+      300,
+      true
+    );
+    expect(rayCastFromMiddleTopResult.collision).to.be(true);
+    expect(rayCastFromMiddleTopResult.closeX).to.be(50);
+    expect(rayCastFromMiddleTopResult.closeY).to.be(0);
+
+    const rayCastFromMiddleTopFarResult = objectWithTwoHitboxes.raycastTest(
+      50,
+      -20,
+      50,
+      300,
+      false
+    );
+    expect(rayCastFromMiddleTopFarResult.collision).to.be(true);
+    expect(rayCastFromMiddleTopFarResult.farX).to.be(50);
+    expect(rayCastFromMiddleTopFarResult.farY).to.be(100);
+
+    const rayCastFromMiddleLeftResult = objectWithTwoHitboxes.raycastTest(
+      -20,
+      50,
+      300,
+      50,
+      true
+    );
+    expect(rayCastFromMiddleLeftResult.collision).to.be(true);
+    expect(rayCastFromMiddleLeftResult.closeX).to.be(0);
+    expect(rayCastFromMiddleLeftResult.closeY).to.be(50);
+
+    const rayCastFromMiddleLeftFarResult = objectWithTwoHitboxes.raycastTest(
+      -20,
+      50,
+      300,
+      50,
+      false
+    );
+    expect(rayCastFromMiddleLeftFarResult.collision).to.be(true);
+    expect(rayCastFromMiddleLeftFarResult.farX).to.be(100);
+    expect(rayCastFromMiddleLeftFarResult.farY).to.be(50);
   });
 });


### PR DESCRIPTION
Fix #3563

TODO:
- Add a test case with an object having two hitboxes.