### PR TITLE
Add possibility to seal an instance (impossible to select it)

### DIFF
--- a/Core/GDCore/Project/InitialInstance.cpp
+++ b/Core/GDCore/Project/InitialInstance.cpp
@@ -28,6 +28,7 @@ InitialInstance::InitialInstance()
       width(0),
       height(0),
       locked(false),
+      sealed(false),
       persistentUuid(UUID::MakeUuid4()) {}
 
 void InitialInstance::UnserializeFrom(const SerializerElement& element) {

--- a/Core/GDCore/Project/InitialInstance.cpp
+++ b/Core/GDCore/Project/InitialInstance.cpp
@@ -11,9 +11,7 @@
 #include "GDCore/Project/Project.h"
 #include "GDCore/Serialization/SerializerElement.h"
 #include "GDCore/Tools/UUID/UUID.h"
-#if defined(GD_IDE_ONLY)
 #include "GDCore/Project/PropertyDescriptor.h"
-#endif
 
 namespace gd {
 
@@ -44,6 +42,7 @@ void InitialInstance::UnserializeFrom(const SerializerElement& element) {
   SetZOrder(element.GetIntAttribute("zOrder", 0, "plan"));
   SetLayer(element.GetStringAttribute("layer"));
   SetLocked(element.GetBoolAttribute("locked", false));
+  SetSealed(element.GetBoolAttribute("sealed", false));
 
   persistentUuid = element.GetStringAttribute("persistentUuid");
   if (persistentUuid.empty()) ResetPersistentUuid();
@@ -83,7 +82,8 @@ void InitialInstance::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("customSize", HasCustomSize());
   element.SetAttribute("width", GetCustomWidth());
   element.SetAttribute("height", GetCustomHeight());
-  element.SetAttribute("locked", IsLocked());
+  if (IsLocked()) element.SetAttribute("locked", IsLocked());
+  if (IsSealed()) element.SetAttribute("sealed", IsSealed());
 
   if (persistentUuid.empty()) persistentUuid = UUID::MakeUuid4();
   element.SetStringAttribute("persistentUuid", persistentUuid);
@@ -112,7 +112,6 @@ InitialInstance& InitialInstance::ResetPersistentUuid() {
   return *this;
 }
 
-#if defined(GD_IDE_ONLY)
 std::map<gd::String, gd::PropertyDescriptor>
 InitialInstance::GetCustomProperties(gd::Project& project, gd::Layout& layout) {
   // Find an object
@@ -140,7 +139,6 @@ bool InitialInstance::UpdateCustomProperty(const gd::String& name,
 
   return false;
 }
-#endif
 
 double InitialInstance::GetRawDoubleProperty(const gd::String& name) const {
   const auto& it = numberProperties.find(name);

--- a/Core/GDCore/Project/InitialInstance.h
+++ b/Core/GDCore/Project/InitialInstance.h
@@ -145,7 +145,7 @@ class GD_CORE_API InitialInstance {
   bool IsSealed() const { return sealed; };
 
   /**
-   * \brief (Un)lock the initial instance.
+   * \brief (Un)seal the initial instance.
    *
    * An instance which is sealed cannot be selected by clicking on it in a
    * layout editor canvas.

--- a/Core/GDCore/Project/InitialInstance.h
+++ b/Core/GDCore/Project/InitialInstance.h
@@ -127,18 +127,30 @@ class GD_CORE_API InitialInstance {
   void SetCustomHeight(double height_) { height = height_; }
 
   /**
-   * \brief Return true if the instance is locked and cannot be selected by
-   * clicking on it in the IDE.
+   * \brief Return true if the instance is locked and cannot be moved in the IDE.
    */
   bool IsLocked() const { return locked; };
 
   /**
    * \brief (Un)lock the initial instance.
    *
-   * An instance which is locked cannot be selected by clicking on it in a
-   * layout editor canvas.
+   * An instance which is locked cannot be moved with actions in the IDE.
    */
   void SetLocked(bool enable = true) { locked = enable; }
+
+  /**
+   * \brief Return true if the instance cannot be selected by clicking on it
+   * in the IDE (only applies if instance is also locked).
+   */
+  bool IsSealed() const { return sealed; };
+
+  /**
+   * \brief (Un)lock the initial instance.
+   *
+   * An instance which is sealed cannot be selected by clicking on it in a
+   * layout editor canvas.
+   */
+  void SetSealed(bool enable = true) { sealed = enable; }
 
   ///@}
 
@@ -270,6 +282,7 @@ class GD_CORE_API InitialInstance {
   double height;           ///< Object custom height
   gd::VariablesContainer initialVariables;  ///< Instance specific variables
   bool locked;                              ///< True if the instance is locked
+  bool sealed;                              ///< True if the instance is sealed
   mutable gd::String persistentUuid; ///< A persistent random version 4 UUID, useful for hot reloading.
 
   static gd::String*

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -915,6 +915,8 @@ interface InitialInstance {
     void SetAngle(float angle);
     boolean IsLocked();
     void SetLocked(boolean lock);
+    boolean IsSealed();
+    void SetSealed(boolean seal);
     long GetZOrder();
     void SetZOrder(long zOrder);
     [Const, Ref] DOMString GetLayer();

--- a/GDevelop.js/types/gdinitialinstance.js
+++ b/GDevelop.js/types/gdinitialinstance.js
@@ -11,6 +11,8 @@ declare class gdInitialInstance {
   setAngle(angle: number): void;
   isLocked(): boolean;
   setLocked(lock: boolean): void;
+  isSealed(): boolean;
+  setSealed(seal: boolean): void;
   getZOrder(): number;
   setZOrder(zOrder: number): void;
   getLayer(): string;

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -89,6 +89,16 @@ export default class InstancePropertiesEditor extends React.Component<Props> {
         instance.setLocked(newValue),
     },
     {
+      name: this.props.i18n._(t`Prevent selection in the canvas`),
+      valueType: 'boolean',
+      disabled: (instances: gdInitialInstance[]) => {
+        return instances.some(instance => !instance.isLocked());
+      },
+      getValue: (instance: gdInitialInstance) => instance.isSealed(),
+      setValue: (instance: gdInitialInstance, newValue: boolean) =>
+        instance.setSealed(newValue),
+    },
+    {
       name: this.props.i18n._(t`Z Order`),
       valueType: 'number',
       getValue: (instance: gdInitialInstance) => instance.getZOrder(),

--- a/newIDE/app/src/InstancesEditor/InstancesList/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancesList/index.js
@@ -146,9 +146,7 @@ export default class InstancesList extends Component<Props, State> {
       <IconButton
         size="small"
         onClick={() => {
-          console.log("Click")
           if (instance.isSealed()) {
-            console.log("isSealed")
             instance.setSealed(false);
             instance.setLocked(false);
             return;

--- a/newIDE/app/src/InstancesEditor/InstancesList/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancesList/index.js
@@ -16,7 +16,8 @@ import SearchBar, {
 } from '../../UI/SearchBar';
 import Lock from '@material-ui/icons/Lock';
 import LockOpen from '@material-ui/icons/LockOpen';
-const gd /*TODO: add flow in this file */ = global.gd;
+import NotInterested from '@material-ui/icons/NotInterested';
+const gd = global.gd;
 
 type State = {|
   searchText: string,
@@ -136,15 +137,36 @@ export default class InstancesList extends Component<Props, State> {
     }
   };
 
-  _renderLockCell = ({ rowData }: { rowData: RenderedRowInfo }) => {
+  _renderLockCell = ({
+    rowData: { instance },
+  }: {
+    rowData: RenderedRowInfo,
+  }) => {
     return (
       <IconButton
         size="small"
         onClick={() => {
-          rowData.instance.setLocked(!rowData.instance.isLocked());
+          console.log("Click")
+          if (instance.isSealed()) {
+            console.log("isSealed")
+            instance.setSealed(false);
+            instance.setLocked(false);
+            return;
+          }
+          if (instance.isLocked()) {
+            instance.setSealed(true);
+            return;
+          }
+          instance.setLocked(true);
         }}
       >
-        {rowData.instance.isLocked() ? <Lock /> : <LockOpen />}
+        {instance.isLocked() && instance.isSealed() ? (
+          <NotInterested />
+        ) : instance.isLocked() ? (
+          <Lock />
+        ) : (
+          <LockOpen />
+        )}
       </IconButton>
     );
   };

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -109,7 +109,10 @@ export default class LayerRenderer {
     // $FlowFixMe - invoke is not writable
     this.instancesRenderer.invoke = instancePtr => {
       // $FlowFixMe - wrapPointer is not exposed
-      const instance = gd.wrapPointer(instancePtr, gd.InitialInstance);
+      const instance: gdInitialInstance = gd.wrapPointer(
+        instancePtr,
+        gd.InitialInstance
+      );
 
       //Get the "RendereredInstance" object associated to the instance and tell it to update.
       var renderedInstance: ?RenderedInstance = this.getRendererOfInstance(
@@ -122,7 +125,10 @@ export default class LayerRenderer {
 
       // "Culling" improves rendering performance of large levels
       const isVisible = this._isInstanceVisible(instance);
-      if (pixiObject) pixiObject.visible = isVisible;
+      if (pixiObject) {
+        pixiObject.visible = isVisible;
+        pixiObject.interactive = !(instance.isLocked() && instance.isSealed());
+      }
       if (isVisible) renderedInstance.update();
 
       renderedInstance.wasUsed = true;

--- a/newIDE/app/src/InstancesEditor/InstancesSelection.js
+++ b/newIDE/app/src/InstancesEditor/InstancesSelection.js
@@ -27,34 +27,52 @@ export default class InstancesSelection {
     this.selection.length = 0;
   }
 
-  selectInstance(
+  selectInstance({
+    instance,
+    multiSelect,
+    layersVisibility = null,
+    ignoreSeal = false,
+  }: {
     instance: gdInitialInstance,
-    multiselect: boolean,
-    layersVisibility: ?{ [string]: boolean } = null
-  ) {
+    multiSelect: boolean,
+    layersVisibility: ?{ [string]: boolean },
+    ignoreSeal?: boolean,
+  }) {
+    if (!ignoreSeal && instance.isSealed()) return;
     if (this.isInstanceSelected(instance)) {
-      if (multiselect) this.unselectInstance(instance);
+      if (multiSelect) this.unselectInstance(instance);
 
       return;
     }
 
-    if (!multiselect) this.clearSelection();
+    if (!multiSelect) this.clearSelection();
 
     if (!layersVisibility || layersVisibility[instance.getLayer()]) {
       this.selection.push(instance);
     }
   }
 
-  selectInstances(
+  selectInstances({
+    instances,
+    multiSelect,
+    layersVisibility = null,
+    ignoreSeal = false,
+  }: {
     instances: Array<gdInitialInstance>,
-    multiselect: boolean,
-    layersVisibility: ?{ [string]: boolean } = null
-  ) {
-    if (!multiselect) this.clearSelection();
+    multiSelect: boolean,
+    layersVisibility: ?{ [string]: boolean },
+    ignoreSeal?: boolean,
+  }) {
+    if (!multiSelect) this.clearSelection();
 
-    instances.forEach(instance =>
-      this.selectInstance(instance, true, layersVisibility)
-    );
+    instances.forEach(instance => {
+      this.selectInstance({
+        instance,
+        multiSelect: true,
+        layersVisibility,
+        ignoreSeal,
+      });
+    });
   }
 
   unselectInstance(instance: gdInitialInstance) {

--- a/newIDE/app/src/InstancesEditor/InstancesSelection.js
+++ b/newIDE/app/src/InstancesEditor/InstancesSelection.js
@@ -32,12 +32,12 @@ export default class InstancesSelection {
     multiSelect,
     layersVisibility = null,
     ignoreSeal = false,
-  }: {
+  }: {|
     instance: gdInitialInstance,
     multiSelect: boolean,
     layersVisibility: ?{ [string]: boolean },
     ignoreSeal?: boolean,
-  }) {
+  |}) {
     if (!ignoreSeal && instance.isSealed()) return;
     if (this.isInstanceSelected(instance)) {
       if (multiSelect) this.unselectInstance(instance);
@@ -57,12 +57,12 @@ export default class InstancesSelection {
     multiSelect,
     layersVisibility = null,
     ignoreSeal = false,
-  }: {
+  }: {|
     instances: Array<gdInitialInstance>,
     multiSelect: boolean,
     layersVisibility: ?{ [string]: boolean },
     ignoreSeal?: boolean,
-  }) {
+  |}) {
     if (!multiSelect) this.clearSelection();
 
     instances.forEach(instance => {

--- a/newIDE/app/src/InstancesEditor/InstancesSelection.spec.js
+++ b/newIDE/app/src/InstancesEditor/InstancesSelection.spec.js
@@ -22,9 +22,21 @@ describe('InstancesSelection', () => {
     expect(instancesSelection.getSelectedInstances()).toHaveLength(0);
 
     // Select instances, with multiselection activated.
-    instancesSelection.selectInstance(instance1OfObject1, true, null);
-    instancesSelection.selectInstance(instance2OfObject1, true, null);
-    instancesSelection.selectInstance(instance1OfObject2, true, null);
+    instancesSelection.selectInstance({
+      instance: instance1OfObject1,
+      multiSelect: true,
+      layersVisibility: null,
+    });
+    instancesSelection.selectInstance({
+      instance: instance2OfObject1,
+      multiSelect: true,
+      layersVisibility: null,
+    });
+    instancesSelection.selectInstance({
+      instance: instance1OfObject2,
+      multiSelect: true,
+      layersVisibility: null,
+    });
     expect(instancesSelection.hasSelectedInstances()).toBe(true);
     expect(instancesSelection.getSelectedInstances()).toHaveLength(3);
 
@@ -48,7 +60,11 @@ describe('InstancesSelection', () => {
     );
 
     // Unselect by selecting an instance again, with multiselection activated.
-    instancesSelection.selectInstance(instance1OfObject1, true, null);
+    instancesSelection.selectInstance({
+      instance: instance1OfObject1,
+      multiSelect: true,
+      layersVisibility: null,
+    });
     expect(instancesSelection.hasSelectedInstances()).toBe(true);
     expect(instancesSelection.getSelectedInstances()).toHaveLength(2);
     expect(instancesSelection.isInstanceSelected(instance1OfObject1)).toBe(
@@ -94,9 +110,21 @@ describe('InstancesSelection', () => {
     instance3OfObject2.setObjectName('Object2');
 
     // Select instances without multiselection
-    instancesSelection.selectInstance(instance1OfObject1, false, null);
-    instancesSelection.selectInstance(instance2OfObject1, false, null);
-    instancesSelection.selectInstance(instance1OfObject2, false, null);
+    instancesSelection.selectInstance({
+      instance: instance1OfObject1,
+      multiSelect: false,
+      layersVisibility: null,
+    });
+    instancesSelection.selectInstance({
+      instance: instance2OfObject1,
+      multiSelect: false,
+      layersVisibility: null,
+    });
+    instancesSelection.selectInstance({
+      instance: instance1OfObject2,
+      multiSelect: false,
+      layersVisibility: null,
+    });
     expect(instancesSelection.isInstanceSelected(instance1OfObject1)).toBe(
       false
     );
@@ -116,11 +144,11 @@ describe('InstancesSelection', () => {
       false
     );
 
-    instancesSelection.selectInstances(
-      [instance1OfObject1, instance2OfObject1, instance1OfObject2],
-      false,
-      null
-    );
+    instancesSelection.selectInstances({
+      instances: [instance1OfObject1, instance2OfObject1, instance1OfObject2],
+      multiSelect: false,
+      layersVisibility: null,
+    });
     expect(instancesSelection.isInstanceSelected(instance1OfObject1)).toBe(
       true
     );
@@ -163,16 +191,16 @@ describe('InstancesSelection', () => {
     const instance3OfObject2 = new gd.InitialInstance();
     instance3OfObject2.setObjectName('Object2');
 
-    instancesSelection.selectInstances(
-      [
+    instancesSelection.selectInstances({
+      instances: [
         instance1OfObject1,
         instance2OfObject1,
         instance1OfObject2,
         instance3OfObject2,
       ],
-      false,
-      null
-    );
+      multiSelect: false,
+      layersVisibility: null,
+    });
     expect(instancesSelection.isInstanceSelected(instance1OfObject2)).toBe(
       true
     );
@@ -251,16 +279,16 @@ describe('InstancesSelection', () => {
     const instance3OfObject2 = new gd.InitialInstance();
     instance3OfObject2.setObjectName('Object2');
 
-    instancesSelection.selectInstances(
-      [
+    instancesSelection.selectInstances({
+      instances: [
         instance1OfObject1,
         instance2OfObject1,
         instance1OfObject2,
         instance2OfObject2,
       ],
-      false,
-      null
-    );
+      multiSelect: false,
+      layersVisibility: null,
+    });
 
     instancesSelection.unselectInstancesOnLayer('Layer1');
     expect(instancesSelection.hasSelectedInstances()).toBe(true);

--- a/newIDE/app/src/InstancesEditor/InstancesSelection.spec.js
+++ b/newIDE/app/src/InstancesEditor/InstancesSelection.spec.js
@@ -3,6 +3,35 @@ import InstancesSelection from './InstancesSelection';
 const gd: libGDevelop = global.gd;
 
 describe('InstancesSelection', () => {
+  it('does not select a sealed instance', () => {
+    const instancesSelection = new InstancesSelection();
+    const instance1OfObject1 = new gd.InitialInstance();
+    instance1OfObject1.setObjectName('Object1');
+    instance1OfObject1.setSealed(true);
+
+    expect(instancesSelection.hasSelectedInstances()).toBe(false);
+    expect(instancesSelection.getSelectedInstances()).toHaveLength(0);
+
+    instancesSelection.selectInstance({
+      instance: instance1OfObject1,
+      multiSelect: false,
+      layersVisibility: null,
+    });
+
+    expect(instancesSelection.hasSelectedInstances()).toBe(false);
+    expect(instancesSelection.getSelectedInstances()).toHaveLength(0);
+
+    instancesSelection.selectInstance({
+      instance: instance1OfObject1,
+      multiSelect: false,
+      layersVisibility: null,
+      ignoreSeal: true,
+    });
+
+    expect(instancesSelection.hasSelectedInstances()).toBe(true);
+    expect(instancesSelection.getSelectedInstances()).toHaveLength(1);
+  });
+
   it('handles multiselection of instances', () => {
     const instancesSelection = new InstancesSelection();
     const instance1OfObject1 = new gd.InitialInstance();

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -597,11 +597,11 @@ export default class InstancesEditor extends Component<Props> {
     if (this.selectionRectangle.hasStartedSelectionRectangle()) {
       let instancesSelected = this.selectionRectangle.endSelectionRectangle();
 
-      this.props.instancesSelection.selectInstances(
-        instancesSelected,
-        this.keyboardShortcuts.shouldMultiSelect(),
-        this._getLayersVisibility()
-      );
+      this.props.instancesSelection.selectInstances({
+        instances: instancesSelected,
+        multiSelect: this.keyboardShortcuts.shouldMultiSelect(),
+        layersVisibility: this._getLayersVisibility(),
+      });
       instancesSelected = this.props.instancesSelection.getSelectedInstances();
       this.props.onInstancesSelected(instancesSelected);
     }
@@ -671,11 +671,11 @@ export default class InstancesEditor extends Component<Props> {
           .resetPersistentUuid();
       }
     } else {
-      this.props.instancesSelection.selectInstance(
+      this.props.instancesSelection.selectInstance({
         instance,
-        this.keyboardShortcuts.shouldMultiSelect(),
-        this._getLayersVisibility()
-      );
+        multiSelect: this.keyboardShortcuts.shouldMultiSelect(),
+        layersVisibility: this._getLayersVisibility(),
+      });
 
       if (this.props.onInstancesSelected) {
         this.props.onInstancesSelected(

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -43,7 +43,7 @@ export type ValueFieldCommonProperties = {|
   getLabel?: Instance => string,
   getDescription?: Instance => string,
   getExtraDescription?: Instance => string,
-  disabled?: boolean,
+  disabled?: boolean | ((instances: Array<gdInitialInstance>) => boolean),
   onEditButtonClick?: Instance => void,
 |};
 
@@ -169,6 +169,14 @@ const styles = {
   },
 };
 
+const getDisabled = (instances: Instances, field: ValueField): boolean => {
+  return typeof field.disabled === 'boolean'
+    ? field.disabled
+    : typeof field.disabled === 'function'
+    ? field.disabled(instances)
+    : false;
+};
+
 /**
  * Get the value for the given field across all instances.
  * If one of the instances doesn't share the same value, returns the default value.
@@ -290,7 +298,7 @@ const PropertiesEditor = ({
               instances.forEach(i => setValue(i, !!newValue));
               _onInstancesModified(instances);
             }}
-            disabled={field.disabled}
+            disabled={getDisabled(instances, field)}
           />
         );
       } else if (field.valueType === 'number') {
@@ -309,7 +317,7 @@ const PropertiesEditor = ({
             }}
             type="number"
             style={styles.field}
-            disabled={field.disabled}
+            disabled={getDisabled(instances, field)}
           />
         );
       } else if (field.valueType === 'color') {
@@ -366,7 +374,7 @@ const PropertiesEditor = ({
                   _onInstancesModified(instances);
                 }}
                 style={styles.field}
-                disabled={field.disabled}
+                disabled={getDisabled(instances, field)}
               />
             )}
             renderButton={style =>
@@ -434,7 +442,7 @@ const PropertiesEditor = ({
               _onInstancesModified(instances);
             }}
             style={styles.field}
-            disabled={field.disabled}
+            disabled={getDisabled(instances, field)}
           >
             {children}
           </SelectField>

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -581,7 +581,12 @@ export default class SceneEditor extends React.Component<Props, State> {
     instances: Array<gdInitialInstance>,
     multiSelect: boolean
   ) => {
-    this.instancesSelection.selectInstances(instances, multiSelect);
+    this.instancesSelection.selectInstances({
+      instances,
+      multiSelect,
+      layersVisibility: null,
+      ignoreSeal: true,
+    });
 
     if (this.editor) this.editor.centerViewOn(instances);
     this.forceUpdateInstancesList();
@@ -1047,7 +1052,11 @@ export default class SceneEditor extends React.Component<Props, State> {
     });
     this._onInstancesAdded(newInstances);
     this.instancesSelection.clearSelection();
-    this.instancesSelection.selectInstances(newInstances, true);
+    this.instancesSelection.selectInstances({
+      instances: newInstances,
+      multiSelect: true,
+      layersVisibility: null,
+    });
   };
 
   paste = ({ useLastCursorPosition }: CopyCutPasteOptions = {}) => {
@@ -1079,7 +1088,11 @@ export default class SceneEditor extends React.Component<Props, State> {
     });
     this._onInstancesAdded(newInstances);
     this.instancesSelection.clearSelection();
-    this.instancesSelection.selectInstances(newInstances, true);
+    this.instancesSelection.selectInstances({
+      instances: newInstances,
+      multiSelect: true,
+      layersVisibility: null,
+    });
   };
 
   updateBehaviorsSharedData = () => {


### PR DESCRIPTION
To resolve https://forum.gdevelop.io/t/new-lock-ui-option/41304

- Add a new boolean to the instance `sealed`
  - When an instance is sealed, pixi will ignore the pixi instance when mouse is over.
  - When selecting multiple instances with Click => Pan => Release click (rectangle selection), the sealed instances won't be selected.
- Add a new checkbox to control this boolean, enabled only if the instance is already locked
  
  <img width="327" alt="image" src="https://user-images.githubusercontent.com/32449369/183296946-4e4f0115-de2b-489b-95f3-6c788c67fe19.png">

- Make it possible to leave the sealed state from the instance list:

  <img width="439" alt="image" src="https://user-images.githubusercontent.com/32449369/183297056-25510709-af5e-4594-b6a0-5aeff5f90b64.png">