### PR TITLE
Upgrade Admob so that it works with the latest Android SDK

### DIFF
--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -58,7 +58,7 @@ module.exports = {
       .setName('AdMob Cordova plugin')
       .setDependencyType('cordova')
       .setExportName('gdevelop-cordova-admob-plus')
-      .setVersion('0.43.0')
+      .setVersion('0.44.0')
       .setExtraSetting(
         'APP_ID_ANDROID',
         new gd.PropertyDescriptor('AdMobAppIdAndroid').setType(


### PR DESCRIPTION
The build service is being upgraded to use the latest Android SDK (API level 32) as required by the Play Store. This needs to also update the Cordova Admob plugin to work around a crash due to an old google ads service using a dependency crashing when targeting this API level.