### PR TITLE
Remove useless "Change" prefix in actions full name.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -309,7 +309,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
 
   extension
       .AddAction("ZoomCamera",
-                 _("Change camera zoom"),
+                 _("Camera zoom"),
                  _("Change camera zoom."),
                  _("Change camera zoom to _PARAM1_ (layer: _PARAM2_, camera: "
                    "_PARAM3_)"),
@@ -576,7 +576,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
 
   extension
       .AddAction("SetLayerDefaultZOrder",
-                 _("Change layer default Z order"),
+                 _("Layer default Z order"),
                  _("Change the default Z order set to objects when they are "
                    "created on a layer."),
                  _("Set the default Z order of objects created on _PARAM1_ to "

--- a/Core/GDCore/Extensions/Builtin/SceneExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SceneExtension.cpp
@@ -112,7 +112,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSceneExtension(
 
   extension
       .AddAction("SceneBackground",
-                 _("Change background color"),
+                 _("Background color"),
                  _("Change the background color of the scene."),
                  _("Set background color to _PARAM1_"),
                  "",

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -33,7 +33,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
           .SetCategoryFullName(_("General"));
 
   obj.AddAction("Opacity",
-                _("Change sprite opacity"),
+                _("Sprite opacity"),
                 _("Change the opacity of a Sprite. 0 is fully transparent, 255 "
                   "is opaque (default)."),
                 _("the opacity"),

--- a/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
@@ -136,7 +136,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsTimeExtension(
 
   extension
       .AddAction("ChangeTimeScale",
-                 _("Change time scale"),
+                 _("Time scale"),
                  _("Change the time scale of the scene."),
                  _("Set the time scale of the scene to _PARAM1_"),
                  "",

--- a/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
@@ -55,7 +55,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
 
   extension
       .AddAction("SetWindowMargins",
-                 _("Change the window's margins"),
+                 _("Window's margins"),
                  _("This action changes the margins, in pixels, between the "
                    "game frame and the window borders."),
                  _("Set margins of game window to "
@@ -71,7 +71,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
 
   extension
       .AddAction("SetGameResolutionSize",
-                 _("Change the resolution of the game"),
+                 _("Game resolution"),
                  _("Changes the resolution of the game, effectively changing "
                    "the game area size. This won't change the size of the "
                    "window in which the game is running."),
@@ -117,7 +117,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
 
   extension
       .AddAction("SetGameResolutionResizeMode",
-                 _("Change the game resolution resize mode"),
+                 _("Game resolution resize mode"),
                  _("Set if the width or the height of the game resolution "
                    "should be changed to fit the game window - or if the game "
                    "resolution should not be updated automatically."),
@@ -153,7 +153,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
 
   extension
       .AddAction("SetWindowIcon",
-                 _("Change the window's icon"),
+                 _("Window's icon"),
                  _("This action changes the icon of the game's window."),
                  _("Use _PARAM1_ as the icon for the game's window."),
                  "",
@@ -164,7 +164,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
 
   extension
       .AddAction("SetWindowTitle",
-                 _("Change the window's title"),
+                 _("Window's title"),
                  _("This action changes the title of the game's window."),
                  _("Change window title to _PARAM1_"),
                  "",

--- a/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration3.cpp
@@ -135,7 +135,7 @@ void ExtensionSubDeclaration3(gd::ObjectMetadata& obj) {
       .UseStandardRelationalOperatorParameters("number");
 
   obj.AddAction("Texture",
-                _("Change image (using an expression)"),
+                _("Particle image (using an expression)"),
                 _("Change the image of particles (if displayed)."),
                 _("Change the image of particles of _PARAM0_ to _PARAM1_"),
                 _("Advanced"),
@@ -146,7 +146,7 @@ void ExtensionSubDeclaration3(gd::ObjectMetadata& obj) {
       .SetParameterLongDescription("Indicate the name of the resource");
 
   obj.AddAction("SetTextureFromResource",
-                _("Change image"),
+                _("Particle image"),
                 _("Change the image of particles (if displayed)."),
                 _("Change the image of particles of _PARAM0_ to _PARAM1_"),
                 _("Common"),

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -786,7 +786,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
         std::make_shared<gd::BehaviorsSharedData>());
 
     aut.AddAction("ChangePlatformType",
-                  _("Change platform type"),
+                  _("Platform type"),
                   _("Change the platform type of the object: Platform, "
                     "Jump-Through, or Ladder."),
                   _("Set platform type of _PARAM0_ to _PARAM2_"),

--- a/Extensions/TextObject/Extension.cpp
+++ b/Extensions/TextObject/Extension.cpp
@@ -180,7 +180,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("expression", _("Thickness"));
 
   obj.AddAction("SetShadow",
-                _("Change Shadow"),
+                _("Text shadow"),
                 _("Change the shadow of the text."),
                 _("Change the shadow of _PARAM0_ to color _PARAM1_ distance "
                   "_PARAM2_ blur _PARAM3_ angle _PARAM4_"),
@@ -206,7 +206,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("yesorno", _("Show the shadow"));
 
   obj.AddAction("Opacity",
-                _("Change text opacity"),
+                _("Text opacity"),
                 _("Change the opacity of a Text. 0 is fully transparent, 255 "
                   "is opaque (default)."),
                 _("the opacity"),


### PR DESCRIPTION
I think it important to avoid starting actions full name by "Change" because:
- it doesn't add any information
- make it harder to read and especially to scan because the name is to long and the uppercase letter is not relevant
- It also open the dor to names that looks like sentences which is really bad for scanning.

I've found my self in situations where my review advices were countered by examples from built-in actions which make me lose time arguing. So, I think we should set the example.

Related extensions PR:
- https://github.com/GDevelopApp/GDevelop-extensions/pull/546
- https://github.com/GDevelopApp/GDevelop-extensions/pull/547