### PR TITLE
Add button in changelog dialog to read on Github to benefit from browser translator

### DIFF
--- a/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
+++ b/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
@@ -7,8 +7,8 @@ import FlatButton from '../../UI/FlatButton';
 import Changelog from '.';
 import Text from '../../UI/Text';
 import useForceUpdate from '../../Utils/UseForceUpdate';
-import { Line } from '../../UI/Grid';
 import Window from '../../Utils/Window';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
 
 type Props = {|
   open: boolean,
@@ -42,7 +42,7 @@ const ChangelogDialog = ({ open, onClose }: Props) => {
       onRequestClose={onClose}
       flexColumnBody
     >
-      <Line noMargin justifyContent="space-between">
+      <ResponsiveLineStackLayout noMargin justifyContent="space-between">
         <Text>
           <Trans>
             GDevelop was upgraded to a new version! Check out the changes.
@@ -52,7 +52,7 @@ const ChangelogDialog = ({ open, onClose }: Props) => {
           label={<Trans>See all the release notes</Trans>}
           onClick={openReleaseNote}
         />
-      </Line>
+      </ResponsiveLineStackLayout>
       <Changelog
         onUpdated={forceUpdate} // Force update to ensure dialog is properly positionned
       />

--- a/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
+++ b/newIDE/app/src/MainFrame/Changelog/ChangelogDialog.js
@@ -7,6 +7,8 @@ import FlatButton from '../../UI/FlatButton';
 import Changelog from '.';
 import Text from '../../UI/Text';
 import useForceUpdate from '../../Utils/UseForceUpdate';
+import { Line } from '../../UI/Grid';
+import Window from '../../Utils/Window';
 
 type Props = {|
   open: boolean,
@@ -19,6 +21,9 @@ const ChangelogDialog = ({ open, onClose }: Props) => {
     // Don't render anything, to avoid in particular sending useless requests.
     return null;
   }
+
+  const openReleaseNote = () =>
+    Window.openExternalURL('https://github.com/4ian/GDevelop/releases');
 
   const actions = [
     <FlatButton
@@ -35,12 +40,19 @@ const ChangelogDialog = ({ open, onClose }: Props) => {
       actions={actions}
       open={open}
       onRequestClose={onClose}
+      flexColumnBody
     >
-      <Text>
-        <Trans>
-          GDevelop was upgraded to a new version! Check out the changes.
-        </Trans>
-      </Text>
+      <Line noMargin justifyContent="space-between">
+        <Text>
+          <Trans>
+            GDevelop was upgraded to a new version! Check out the changes.
+          </Trans>
+        </Text>
+        <FlatButton
+          label={<Trans>See all the release notes</Trans>}
+          onClick={openReleaseNote}
+        />
+      </Line>
       <Changelog
         onUpdated={forceUpdate} // Force update to ensure dialog is properly positionned
       />

--- a/newIDE/app/src/MainFrame/Changelog/ChangelogRenderer.js
+++ b/newIDE/app/src/MainFrame/Changelog/ChangelogRenderer.js
@@ -68,7 +68,7 @@ const ChangelogRenderer = ({ releases, error, currentReleaseName }: Props) => {
     !!currentRelease && hasBreakingChange(currentRelease);
 
   return (
-    <Column>
+    <Column noMargin>
       {currentVersionHasBreakingChange && (
         <AlertMessage kind="warning">
           This version of GDevelop has a breaking change. Please make sure to
@@ -93,7 +93,7 @@ const ChangelogRenderer = ({ releases, error, currentReleaseName }: Props) => {
       )}
       <Line justifyContent="center">
         <FlatButton
-          label={<Trans>See all the releases notes</Trans>}
+          label={<Trans>See all the release notes</Trans>}
           onClick={openReleaseNote}
         />
       </Line>


### PR DESCRIPTION
To answer:
<img width="702" alt="image" src="https://user-images.githubusercontent.com/32449369/187207993-99d3d85b-f3da-4caf-954a-03bff80d281b.png">

<img width="949" alt="image" src="https://user-images.githubusercontent.com/32449369/187208290-34bea8c2-3392-44f1-a9b8-0d35f8857213.png">

I added a button to the ChangelogDialog because it was straightforward.
It could be added to the AboutDialog but we have to decide where to put it, it's less evident.