### PR TITLE
Add an instance render for custom objects

### DIFF
--- a/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
+++ b/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
@@ -44,8 +44,7 @@ const ObjectsRenderingService = {
     'ParticleSystem::ParticleEmitter': RenderedParticleEmitterInstance,
   },
   getThumbnail: function(project: gdProject, object: gdObject) {
-    var objectType = object.getType();
-    console.log(objectType);
+    const objectType = object.getType();
     if (this.renderers.hasOwnProperty(objectType))
       return this.renderers[objectType].getThumbnail(
         project,
@@ -66,7 +65,7 @@ const ObjectsRenderingService = {
     associatedObjectConfiguration: gdObjectConfiguration,
     pixiContainer: any
   ): RenderedInstance {
-    var objectType = associatedObjectConfiguration.getType();
+    const objectType = associatedObjectConfiguration.getType();
     if (this.renderers.hasOwnProperty(objectType))
       return new this.renderers[objectType](
         project,

--- a/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
+++ b/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
@@ -7,6 +7,7 @@ import RenderedTextInstance from './Renderers/RenderedTextInstance';
 import RenderedShapePainterInstance from './Renderers/RenderedShapePainterInstance';
 import RenderedTextEntryInstance from './Renderers/RenderedTextEntryInstance';
 import RenderedParticleEmitterInstance from './Renderers/RenderedParticleEmitterInstance';
+import RenderedCustomObjectInstance from './Renderers/RenderedCustomObjectInstance';
 import PixiResourcesLoader from './PixiResourcesLoader';
 import ResourcesLoader from '../ResourcesLoader';
 import RenderedInstance from './Renderers/RenderedInstance';
@@ -75,6 +76,17 @@ const ObjectsRenderingService = {
         PixiResourcesLoader
       );
     else {
+      if (project.hasEventsBasedObject(objectType)) {
+        return new RenderedCustomObjectInstance(
+          project,
+          layout,
+          instance,
+          associatedObjectConfiguration,
+          pixiContainer,
+          PixiResourcesLoader
+        );
+      }
+
       console.warn(
         `Object with type ${objectType} has no instance renderer registered. Please use registerInstanceRenderer to register your renderer.`
       );

--- a/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
+++ b/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
@@ -45,6 +45,7 @@ const ObjectsRenderingService = {
   },
   getThumbnail: function(project: gdProject, object: gdObject) {
     var objectType = object.getType();
+    console.log(objectType);
     if (this.renderers.hasOwnProperty(objectType))
       return this.renderers[objectType].getThumbnail(
         project,

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -1,0 +1,246 @@
+import RenderedInstance from './RenderedInstance';
+import ObjectsRenderingService from '../ObjectsRenderingService';
+import { mapFor } from '../../Utils/MapFor';
+import * as PIXI from 'pixi.js-legacy';
+
+const gd /* TODO: add flow in this file */ = global.gd;
+
+/**
+ * Renderer for gd.SpriteObject
+ *
+ * @extends RenderedInstance
+ * @class RenderedSpriteInstance
+ * @constructor
+ */
+function RenderedCustomObjectInstance(
+  project,
+  layout,
+  instance,
+  associatedObjectConfiguration,
+  pixiContainer,
+  pixiResourcesLoader
+) {
+  RenderedInstance.call(
+    this,
+    project,
+    layout,
+    instance,
+    associatedObjectConfiguration,
+    pixiContainer,
+    pixiResourcesLoader
+  );
+
+  //Setup the PIXI object:
+  this._pixiObject = new PIXI.Container();
+  this._pixiContainer.addChild(this._pixiObject);
+
+  const customObjectConfiguration = gd.asCustomObjectConfiguration(
+    associatedObjectConfiguration
+  );
+
+  const eventBasedObject = project.hasEventsBasedObject(
+    customObjectConfiguration.getType()
+  )
+    ? project.getEventsBasedObject(customObjectConfiguration.getType())
+    : null;
+
+  this.childrenInstances = [];
+  this.childrenRenderedInstances = eventBasedObject
+    ? mapFor(0, eventBasedObject.getObjectsCount(), i => {
+        const childObject = eventBasedObject.getObjectAt(i);
+        const childObjectConfiguration = customObjectConfiguration.getChildObjectConfiguration(
+          childObject.getName()
+        );
+        const childInstance = new ChildInstance();
+        this.childrenInstances.push(childInstance);
+        return ObjectsRenderingService.createNewInstanceRenderer(
+          project,
+          layout,
+          childInstance,
+          childObjectConfiguration,
+          this._pixiObject
+        );
+      })
+    : [];
+}
+RenderedCustomObjectInstance.prototype = Object.create(
+  RenderedInstance.prototype
+);
+
+/**
+ * Return a URL for thumbnail of the specified object.
+ */
+RenderedCustomObjectInstance.getThumbnail = function(
+  project,
+  resourcesLoader,
+  object
+) {
+  return 'res/unknown32.png';
+};
+
+RenderedCustomObjectInstance.prototype.update = function() {
+  const defaultWidth = this.getDefaultWidth();
+  const defaultHeight = this.getDefaultHeight();
+  const originX = 0;
+  const originY = 0;
+  const centerX = defaultWidth / 2;
+  const centerY = defaultHeight / 2;
+
+  for (let index = 0; index < this.childrenRenderedInstances.length; index++) {
+    const renderedInstance = this.childrenRenderedInstances[index];
+    const childInstance = this.childrenInstances[index];
+    childInstance.x = (defaultWidth - renderedInstance.getDefaultWidth()) / 2;
+    childInstance.y = (defaultHeight - renderedInstance.getDefaultHeight()) / 2;
+    renderedInstance.update();
+  }
+
+  this._pixiObject.pivot.x = centerX;
+  this._pixiObject.pivot.y = centerY;
+  this._pixiObject.rotation = this._shouldNotRotate
+    ? 0
+    : RenderedInstance.toRad(this._instance.getAngle());
+  if (this._instance.hasCustomSize()) {
+    this._pixiObject.scale.x = this._instance.getCustomWidth() / defaultWidth;
+    this._pixiObject.scale.y = this._instance.getCustomHeight() / defaultHeight;
+  } else {
+    this._pixiObject.scale.x = 1;
+    this._pixiObject.scale.y = 1;
+  }
+  this._pixiObject.position.x =
+    this._instance.getX() +
+    (centerX - originX) * Math.abs(this._pixiObject.scale.x);
+  this._pixiObject.position.y =
+    this._instance.getY() +
+    (centerY - originY) * Math.abs(this._pixiObject.scale.y);
+};
+
+RenderedCustomObjectInstance.prototype.getDefaultWidth = function() {
+  let widthMax = 0;
+  for (const instance of this.childrenRenderedInstances) {
+    widthMax = Math.max(widthMax, instance.getDefaultWidth());
+  }
+  return widthMax;
+};
+
+RenderedCustomObjectInstance.prototype.getDefaultHeight = function() {
+  let heightMax = 0;
+  for (const instance of this.childrenRenderedInstances) {
+    heightMax = Math.max(heightMax, instance.getDefaultHeight());
+  }
+  return heightMax;
+};
+
+export default RenderedCustomObjectInstance;
+
+// TODO Make an event-based object instance editor (like the one for the scene)
+// and use real instances instead of this.
+class ChildInstance {
+  x: number;
+  y: number;
+
+  constructor() {
+    this.x = 0;
+    this.y = 0;
+  }
+
+  getX() {
+    return this.x;
+  }
+
+  getY() {
+    return this.y;
+  }
+
+  getAngle() {
+    return 0;
+  }
+
+  setObjectName(name: string) {}
+
+  getObjectName() {
+    return '';
+  }
+
+  setX(x: number) {}
+
+  setY(y: number) {}
+
+  setAngle(angle: number) {}
+
+  isLocked() {
+    return false;
+  }
+
+  setLocked(lock: boolean) {}
+
+  isSealed() {
+    return false;
+  }
+
+  setSealed(seal: boolean) {}
+
+  getZOrder() {
+    return 0;
+  }
+
+  setZOrder(zOrder: number) {}
+
+  getLayer() {
+    return '';
+  }
+
+  setLayer(layer: string) {}
+
+  setHasCustomSize(enable: boolean) {}
+
+  hasCustomSize() {
+    return false;
+  }
+
+  setCustomWidth(width: number) {}
+
+  getCustomWidth() {
+    return 0;
+  }
+
+  setCustomHeight(height: number) {}
+
+  getCustomHeight() {
+    return 0;
+  }
+
+  resetPersistentUuid() {
+    return this;
+  }
+
+  updateCustomProperty(
+    name: string,
+    value: string,
+    project: gdProject,
+    layout: gdLayout
+  ) {}
+
+  getCustomProperties(project: gdProject, layout: gdLayout) {
+    return null;
+  }
+
+  getRawDoubleProperty(name: string) {
+    return 0;
+  }
+
+  getRawStringProperty(name: string) {
+    return '';
+  }
+
+  setRawDoubleProperty(name: string, value: number) {}
+
+  setRawStringProperty(name: string, value: string) {}
+
+  getVariables() {
+    return [];
+  }
+
+  serializeTo(element: gdSerializerElement) {}
+
+  unserializeFrom(element: gdSerializerElement) {}
+}

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -8,7 +8,7 @@ import * as PIXI from 'pixi.js-legacy';
 
 const gd: libGDevelop = global.gd;
 
-// TODO Make an event-based object instance editor (like the one for the scene)
+// TODO EBO Make an event-based object instance editor (like the one for the scene)
 // and use real instances instead of this.
 class ChildInstance {
   x: number;

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -122,7 +122,7 @@ class ChildInstance {
 }
 
 /**
- * Renderer for gd.SpriteObject
+ * Renderer for gd.CustomObject (the class is not exposed to newIDE)
  */
 export default class RenderedCustomObjectInstance extends RenderedInstance {
   childrenInstances: ChildInstance[];

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedIconInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedIconInstance.js
@@ -1,22 +1,21 @@
+// @flow
 import RenderedInstance from './RenderedInstance';
+import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
+import ResourcesLoader from '../../ResourcesLoader';
 import * as PIXI from 'pixi.js-legacy';
 
 /**
  * Create a renderer for an type of object displayed as an icon
- *
- * @extends RenderedInstance
- * @class RenderedIconInstance
- * @constructor
  */
-export default function makeRenderer(iconPath) {
+export default function makeRenderer(iconPath: string) {
   class RenderedIconInstance extends RenderedInstance {
     constructor(
-      project,
-      layout,
-      instance,
-      associatedObjectConfiguration,
-      pixiContainer,
-      pixiResourcesLoader
+      project: gdProject,
+      layout: gdLayout,
+      instance: gdInitialInstance,
+      associatedObjectConfiguration: gdObjectConfiguration,
+      pixiContainer: PIXI.Container,
+      pixiResourcesLoader: Class<PixiResourcesLoader>
     ) {
       super(
         project,
@@ -37,7 +36,11 @@ export default function makeRenderer(iconPath) {
       this._pixiObject.rotation = (this._instance.getAngle() * Math.PI) / 180.0;
     }
 
-    static getThumbnail(project, resourcesLoader, object) {
+    static getThumbnail(
+      project: gdProject,
+      resourcesLoader: Class<ResourcesLoader>,
+      object: gdObject
+    ) {
       return iconPath;
     }
   }

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
@@ -12,7 +12,7 @@ export default class RenderedInstance {
   _instance: gdInitialInstance;
   _associatedObjectConfiguration: gdObjectConfiguration;
   _pixiContainer: PIXI.Container;
-  _pixiResourcesLoader: PixiResourcesLoader;
+  _pixiResourcesLoader: Class<PixiResourcesLoader>;
   _pixiObject: any;
   wasUsed: boolean;
 
@@ -22,7 +22,7 @@ export default class RenderedInstance {
     instance: gdInitialInstance,
     associatedObjectConfiguration: gdObjectConfiguration,
     pixiContainer: PIXI.Container,
-    pixiResourcesLoader: PixiResourcesLoader
+    pixiResourcesLoader: Class<PixiResourcesLoader>
   ) {
     this._pixiObject = null;
     this._instance = instance;

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
@@ -1,419 +1,428 @@
+// @flow
 import RenderedInstance from './RenderedInstance';
+import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
+import ResourcesLoader from '../../ResourcesLoader';
 import * as PIXI from 'pixi.js-legacy';
-const gd /* TODO: add flow in this file */ = global.gd;
+const gd: libGDevelop = global.gd;
+
+type StretchedSprite = PIXI.Sprite | PIXI.TilingSprite;
 
 /**
  * Renderer for gd.PanelSpriteObject
  *
  * Heavily inspired from the GDJS PIXI renderer for PanelSprite objects.
  * TODO: Find a way to factor GDJS objects and IDE instances renderers.
- *
- * @extends RenderedInstance
- * @class RenderedPanelSpriteInstance
- * @constructor
  */
-function RenderedPanelSpriteInstance(
-  project,
-  layout,
-  instance,
-  associatedObjectConfiguration,
-  pixiContainer,
-  pixiResourcesLoader
-) {
-  RenderedInstance.call(
-    this,
-    project,
-    layout,
-    instance,
-    associatedObjectConfiguration,
-    pixiContainer,
-    pixiResourcesLoader
-  );
+export default class RenderedPanelSpriteInstance extends RenderedInstance {
+  _centerSprite: StretchedSprite;
+  _borderSprites: StretchedSprite[];
+  _textureName: string;
+  _width: number;
+  _height: number;
+  _tiled: boolean;
+  _wasRendered: boolean;
 
-  this.makeObjects();
-  this.updateTexture();
-}
-RenderedPanelSpriteInstance.prototype = Object.create(
-  RenderedInstance.prototype
-);
+  constructor(
+    project: gdProject,
+    layout: gdLayout,
+    instance: gdInitialInstance,
+    associatedObjectConfiguration: gdObjectConfiguration,
+    pixiContainer: PIXI.Container,
+    pixiResourcesLoader: Class<PixiResourcesLoader>
+  ) {
+    super(
+      project,
+      layout,
+      instance,
+      associatedObjectConfiguration,
+      pixiContainer,
+      pixiResourcesLoader
+    );
 
-RenderedPanelSpriteInstance.prototype.update = function() {
-  //TODO
-  // if (this._pixiObject.visible && this._wasRendered) {
-  //   this._pixiObject.cacheAsBitmap = true;
-  // }
-  // this._wasRendered = true;
-
-  const panelSprite = gd.asPanelSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  if (panelSprite.isTiled() !== this._tiled) {
     this.makeObjects();
-  }
-  if (panelSprite.getTexture() !== this._textureName) {
     this.updateTexture();
   }
 
-  this.updateAngle();
-  this.updatePosition();
+  update() {
+    //TODO
+    // if (this._pixiObject.visible && this._wasRendered) {
+    //   this._pixiObject.cacheAsBitmap = true;
+    // }
+    // this._wasRendered = true;
 
-  const oldWidth = this._width;
-  const oldHeight = this._height;
-  if (this._instance.hasCustomSize()) {
-    this._width = this._instance.getCustomWidth();
-    this._height = this._instance.getCustomHeight();
-  } else {
-    var tiledSprite = gd.asPanelSpriteConfiguration(
+    const panelSprite = gd.asPanelSpriteConfiguration(
       this._associatedObjectConfiguration
     );
-    this._width = tiledSprite.getWidth();
-    this._height = tiledSprite.getHeight();
+    if (panelSprite.isTiled() !== this._tiled) {
+      this.makeObjects();
+    }
+    if (panelSprite.getTexture() !== this._textureName) {
+      this.updateTexture();
+    }
+
+    this.updateAngle();
+    this.updatePosition();
+
+    const oldWidth = this._width;
+    const oldHeight = this._height;
+    if (this._instance.hasCustomSize()) {
+      this._width = this._instance.getCustomWidth();
+      this._height = this._instance.getCustomHeight();
+    } else {
+      var tiledSprite = gd.asPanelSpriteConfiguration(
+        this._associatedObjectConfiguration
+      );
+      this._width = tiledSprite.getWidth();
+      this._height = tiledSprite.getHeight();
+    }
+
+    if (this._width !== oldWidth || this._height !== oldHeight) {
+      this.updateWidthHeight();
+    }
   }
 
-  if (this._width !== oldWidth || this._height !== oldHeight) {
-    this.updateWidthHeight();
-  }
-};
+  makeObjects() {
+    const panelSprite = gd.asPanelSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    this._textureName = panelSprite.getTexture();
+    const texture = PixiResourcesLoader.getPIXITexture(
+      this._project,
+      this._textureName
+    );
 
-RenderedPanelSpriteInstance.prototype.makeObjects = function() {
-  const panelSprite = gd.asPanelSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  this._textureName = panelSprite.getTexture();
-  const texture = this._pixiResourcesLoader.getPIXITexture(
-    this._project,
-    this._textureName
-  );
+    this._tiled = panelSprite.isTiled();
+    var StretchedSprite = !this._tiled ? PIXI.Sprite : PIXI.TilingSprite;
 
-  this._tiled = panelSprite.isTiled();
-  var StretchedSprite = !this._tiled ? PIXI.Sprite : PIXI.TilingSprite;
+    if (!this._pixiObject) {
+      this._pixiObject = new PIXI.Container();
+      this._pixiContainer.addChild(this._pixiObject);
+    }
+    this._centerSprite = new StretchedSprite(new PIXI.Texture(texture));
+    this._borderSprites = [
+      new StretchedSprite(new PIXI.Texture(texture)), //Right
+      new PIXI.Sprite(texture), //Top-Right
+      new StretchedSprite(new PIXI.Texture(texture)), //Top
+      new PIXI.Sprite(texture), //Top-Left
+      new StretchedSprite(new PIXI.Texture(texture)), //Left
+      new PIXI.Sprite(texture), //Bottom-Left
+      new StretchedSprite(new PIXI.Texture(texture)), //Bottom
+      new PIXI.Sprite(texture), //Bottom-Right
+    ];
 
-  if (!this._pixiObject) {
-    this._pixiObject = new PIXI.Container();
-    this._pixiContainer.addChild(this._pixiObject);
-  }
-  this._centerSprite = new StretchedSprite(new PIXI.Texture(texture));
-  this._borderSprites = [
-    new StretchedSprite(new PIXI.Texture(texture)), //Right
-    new PIXI.Sprite(texture), //Top-Right
-    new StretchedSprite(new PIXI.Texture(texture)), //Top
-    new PIXI.Sprite(texture), //Top-Left
-    new StretchedSprite(new PIXI.Texture(texture)), //Left
-    new PIXI.Sprite(texture), //Bottom-Left
-    new StretchedSprite(new PIXI.Texture(texture)), //Bottom
-    new PIXI.Sprite(texture), //Bottom-Right
-  ];
-
-  this._pixiObject.removeChildren();
-  this._pixiObject.addChild(this._centerSprite);
-  for (var i = 0; i < this._borderSprites.length; ++i) {
-    this._pixiObject.addChild(this._borderSprites[i]);
-  }
-};
-
-RenderedPanelSpriteInstance.prototype.updateAngle = function() {
-  this._pixiObject.rotation = RenderedInstance.toRad(this._instance.getAngle());
-};
-
-RenderedPanelSpriteInstance.prototype.updatePosition = function() {
-  this._pixiObject.x = this._instance.getX() + this._width / 2;
-  this._pixiObject.y = this._instance.getY() + this._height / 2;
-};
-
-RenderedPanelSpriteInstance.prototype._updateLocalPositions = function() {
-  const panelSprite = gd.asPanelSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-
-  this._centerSprite.position.x = panelSprite.getLeftMargin();
-  this._centerSprite.position.y = panelSprite.getTopMargin();
-
-  //Right
-  this._borderSprites[0].position.x =
-    this._width - panelSprite.getRightMargin();
-  this._borderSprites[0].position.y = panelSprite.getTopMargin();
-
-  //Top-right
-  this._borderSprites[1].position.x =
-    this._width - this._borderSprites[1].width;
-  this._borderSprites[1].position.y = 0;
-
-  //Top
-  this._borderSprites[2].position.x = panelSprite.getLeftMargin();
-  this._borderSprites[2].position.y = 0;
-
-  //Top-Left
-  this._borderSprites[3].position.x = 0;
-  this._borderSprites[3].position.y = 0;
-
-  //Left
-  this._borderSprites[4].position.x = 0;
-  this._borderSprites[4].position.y = panelSprite.getTopMargin();
-
-  //Bottom-Left
-  this._borderSprites[5].position.x = 0;
-  this._borderSprites[5].position.y =
-    this._height - this._borderSprites[5].height;
-
-  //Bottom
-  this._borderSprites[6].position.x = panelSprite.getLeftMargin();
-  this._borderSprites[6].position.y =
-    this._height - panelSprite.getBottomMargin();
-
-  //Bottom-Right
-  this._borderSprites[7].position.x =
-    this._width - this._borderSprites[7].width;
-  this._borderSprites[7].position.y =
-    this._height - this._borderSprites[7].height;
-};
-
-RenderedPanelSpriteInstance.prototype._updateSpritesAndTexturesSize = function() {
-  const panelSprite = gd.asPanelSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  this._centerSprite.width = Math.max(
-    this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
-    0
-  );
-  this._centerSprite.height = Math.max(
-    this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
-    0
-  );
-
-  //Right
-  this._borderSprites[0].width = panelSprite.getRightMargin();
-  this._borderSprites[0].height = Math.max(
-    this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
-    0
-  );
-
-  //Top
-  this._borderSprites[2].height = panelSprite.getTopMargin();
-  this._borderSprites[2].width = Math.max(
-    this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
-    0
-  );
-
-  //Left
-  this._borderSprites[4].width = panelSprite.getLeftMargin();
-  this._borderSprites[4].height = Math.max(
-    this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
-    0
-  );
-
-  //Bottom
-  this._borderSprites[6].height = panelSprite.getBottomMargin();
-  this._borderSprites[6].width = Math.max(
-    this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
-    0
-  );
-
-  this._wasRendered = true;
-  this._pixiObject.cacheAsBitmap = false;
-};
-
-RenderedPanelSpriteInstance.prototype.updateTexture = function() {
-  const panelSprite = gd.asPanelSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  this._textureName = panelSprite.getTexture();
-  const texture = this._pixiResourcesLoader.getPIXITexture(
-    this._project,
-    this._textureName
-  );
-
-  if (!texture.baseTexture.valid) {
-    // Post pone texture update if texture is not loaded.
-    texture.once('update', () => this.updateTexture());
-    return;
+    this._pixiObject.removeChildren();
+    this._pixiObject.addChild(this._centerSprite);
+    for (var i = 0; i < this._borderSprites.length; ++i) {
+      this._pixiObject.addChild(this._borderSprites[i]);
+    }
   }
 
-  console.log('Updating PanelSprite instance texture');
-  function makeInsideTexture(rect) {
-    if (rect.width < 0) rect.width = 0;
-    if (rect.height < 0) rect.height = 0;
-    if (rect.x < 0) rect.x = 0;
-    if (rect.y < 0) rect.y = 0;
-    if (rect.x > texture.width) rect.x = texture.width;
-    if (rect.y > texture.height) rect.y = texture.height;
-    if (rect.x + rect.width > texture.width)
-      rect.width = texture.width - rect.x;
-    if (rect.y + rect.height > texture.height)
-      rect.height = texture.height - rect.y;
-
-    return rect;
+  updateAngle() {
+    this._pixiObject.rotation = RenderedInstance.toRad(
+      this._instance.getAngle()
+    );
   }
 
-  this._centerSprite.texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        panelSprite.getLeftMargin(),
-        panelSprite.getTopMargin(),
-        texture.width -
-          panelSprite.getLeftMargin() -
+  updatePosition() {
+    this._pixiObject.x = this._instance.getX() + this._width / 2;
+    this._pixiObject.y = this._instance.getY() + this._height / 2;
+  }
+
+  _updateLocalPositions() {
+    const panelSprite = gd.asPanelSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+
+    this._centerSprite.position.x = panelSprite.getLeftMargin();
+    this._centerSprite.position.y = panelSprite.getTopMargin();
+
+    //Right
+    this._borderSprites[0].position.x =
+      this._width - panelSprite.getRightMargin();
+    this._borderSprites[0].position.y = panelSprite.getTopMargin();
+
+    //Top-right
+    this._borderSprites[1].position.x =
+      this._width - this._borderSprites[1].width;
+    this._borderSprites[1].position.y = 0;
+
+    //Top
+    this._borderSprites[2].position.x = panelSprite.getLeftMargin();
+    this._borderSprites[2].position.y = 0;
+
+    //Top-Left
+    this._borderSprites[3].position.x = 0;
+    this._borderSprites[3].position.y = 0;
+
+    //Left
+    this._borderSprites[4].position.x = 0;
+    this._borderSprites[4].position.y = panelSprite.getTopMargin();
+
+    //Bottom-Left
+    this._borderSprites[5].position.x = 0;
+    this._borderSprites[5].position.y =
+      this._height - this._borderSprites[5].height;
+
+    //Bottom
+    this._borderSprites[6].position.x = panelSprite.getLeftMargin();
+    this._borderSprites[6].position.y =
+      this._height - panelSprite.getBottomMargin();
+
+    //Bottom-Right
+    this._borderSprites[7].position.x =
+      this._width - this._borderSprites[7].width;
+    this._borderSprites[7].position.y =
+      this._height - this._borderSprites[7].height;
+  }
+
+  _updateSpritesAndTexturesSize() {
+    const panelSprite = gd.asPanelSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    this._centerSprite.width = Math.max(
+      this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
+      0
+    );
+    this._centerSprite.height = Math.max(
+      this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
+      0
+    );
+
+    //Right
+    this._borderSprites[0].width = panelSprite.getRightMargin();
+    this._borderSprites[0].height = Math.max(
+      this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
+      0
+    );
+
+    //Top
+    this._borderSprites[2].height = panelSprite.getTopMargin();
+    this._borderSprites[2].width = Math.max(
+      this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
+      0
+    );
+
+    //Left
+    this._borderSprites[4].width = panelSprite.getLeftMargin();
+    this._borderSprites[4].height = Math.max(
+      this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
+      0
+    );
+
+    //Bottom
+    this._borderSprites[6].height = panelSprite.getBottomMargin();
+    this._borderSprites[6].width = Math.max(
+      this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
+      0
+    );
+
+    this._wasRendered = true;
+    this._pixiObject.cacheAsBitmap = false;
+  }
+
+  updateTexture() {
+    const panelSprite = gd.asPanelSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    this._textureName = panelSprite.getTexture();
+    const texture = PixiResourcesLoader.getPIXITexture(
+      this._project,
+      this._textureName
+    );
+
+    if (!texture.baseTexture.valid) {
+      // Post pone texture update if texture is not loaded.
+      texture.once('update', () => this.updateTexture());
+      return;
+    }
+
+    console.log('Updating PanelSprite instance texture');
+    function makeInsideTexture(rect) {
+      if (rect.width < 0) rect.width = 0;
+      if (rect.height < 0) rect.height = 0;
+      if (rect.x < 0) rect.x = 0;
+      if (rect.y < 0) rect.y = 0;
+      if (rect.x > texture.width) rect.x = texture.width;
+      if (rect.y > texture.height) rect.y = texture.height;
+      if (rect.x + rect.width > texture.width)
+        rect.width = texture.width - rect.x;
+      if (rect.y + rect.height > texture.height)
+        rect.height = texture.height - rect.y;
+
+      return rect;
+    }
+
+    this._centerSprite.texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          panelSprite.getLeftMargin(),
+          panelSprite.getTopMargin(),
+          texture.width -
+            panelSprite.getLeftMargin() -
+            panelSprite.getRightMargin(),
+          texture.height -
+            panelSprite.getTopMargin() -
+            panelSprite.getBottomMargin()
+        )
+      )
+    );
+
+    //Right
+    this._borderSprites[0].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          texture.width - panelSprite.getRightMargin(),
+          panelSprite.getTopMargin(),
           panelSprite.getRightMargin(),
-        texture.height -
-          panelSprite.getTopMargin() -
-          panelSprite.getBottomMargin()
+          texture.height -
+            panelSprite.getTopMargin() -
+            panelSprite.getBottomMargin()
+        )
       )
-    )
-  );
+    );
 
-  //Right
-  this._borderSprites[0].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        texture.width - panelSprite.getRightMargin(),
-        panelSprite.getTopMargin(),
-        panelSprite.getRightMargin(),
-        texture.height -
-          panelSprite.getTopMargin() -
-          panelSprite.getBottomMargin()
-      )
-    )
-  );
-
-  //Top-right
-  this._borderSprites[1].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        texture.width - panelSprite.getRightMargin(),
-        0,
-        panelSprite.getRightMargin(),
-        panelSprite.getTopMargin()
-      )
-    )
-  );
-
-  //Top
-  this._borderSprites[2].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        panelSprite.getLeftMargin(),
-        0,
-        texture.width -
-          panelSprite.getLeftMargin() -
+    //Top-right
+    this._borderSprites[1].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          texture.width - panelSprite.getRightMargin(),
+          0,
           panelSprite.getRightMargin(),
-        panelSprite.getTopMargin()
+          panelSprite.getTopMargin()
+        )
       )
-    )
-  );
+    );
 
-  //Top-Left
-  this._borderSprites[3].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        0,
-        0,
-        panelSprite.getLeftMargin(),
-        panelSprite.getTopMargin()
+    //Top
+    this._borderSprites[2].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          panelSprite.getLeftMargin(),
+          0,
+          texture.width -
+            panelSprite.getLeftMargin() -
+            panelSprite.getRightMargin(),
+          panelSprite.getTopMargin()
+        )
       )
-    )
-  );
+    );
 
-  //Left
-  this._borderSprites[4].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        0,
-        panelSprite.getTopMargin(),
-        panelSprite.getLeftMargin(),
-        texture.height -
-          panelSprite.getTopMargin() -
+    //Top-Left
+    this._borderSprites[3].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          0,
+          0,
+          panelSprite.getLeftMargin(),
+          panelSprite.getTopMargin()
+        )
+      )
+    );
+
+    //Left
+    this._borderSprites[4].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          0,
+          panelSprite.getTopMargin(),
+          panelSprite.getLeftMargin(),
+          texture.height -
+            panelSprite.getTopMargin() -
+            panelSprite.getBottomMargin()
+        )
+      )
+    );
+
+    //Bottom-Left
+    this._borderSprites[5].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          0,
+          texture.height - panelSprite.getBottomMargin(),
+          panelSprite.getLeftMargin(),
           panelSprite.getBottomMargin()
+        )
       )
-    )
-  );
+    );
 
-  //Bottom-Left
-  this._borderSprites[5].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        0,
-        texture.height - panelSprite.getBottomMargin(),
-        panelSprite.getLeftMargin(),
-        panelSprite.getBottomMargin()
+    //Bottom
+    this._borderSprites[6].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          panelSprite.getLeftMargin(),
+          texture.height - panelSprite.getBottomMargin(),
+          texture.width -
+            panelSprite.getLeftMargin() -
+            panelSprite.getRightMargin(),
+          panelSprite.getBottomMargin()
+        )
       )
-    )
-  );
+    );
 
-  //Bottom
-  this._borderSprites[6].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        panelSprite.getLeftMargin(),
-        texture.height - panelSprite.getBottomMargin(),
-        texture.width -
-          panelSprite.getLeftMargin() -
+    //Bottom-Right
+    this._borderSprites[7].texture = new PIXI.Texture(
+      texture,
+      makeInsideTexture(
+        new PIXI.Rectangle(
+          texture.width - panelSprite.getRightMargin(),
+          texture.height - panelSprite.getBottomMargin(),
           panelSprite.getRightMargin(),
-        panelSprite.getBottomMargin()
+          panelSprite.getBottomMargin()
+        )
       )
-    )
-  );
+    );
 
-  //Bottom-Right
-  this._borderSprites[7].texture = new PIXI.Texture(
-    texture,
-    makeInsideTexture(
-      new PIXI.Rectangle(
-        texture.width - panelSprite.getRightMargin(),
-        texture.height - panelSprite.getBottomMargin(),
-        panelSprite.getRightMargin(),
-        panelSprite.getBottomMargin()
-      )
-    )
-  );
+    this._updateSpritesAndTexturesSize();
+    this._updateLocalPositions();
+    this.updatePosition();
+  }
 
-  this._updateSpritesAndTexturesSize();
-  this._updateLocalPositions();
-  this.updatePosition();
-};
+  updateWidthHeight() {
+    this._pixiObject.pivot.x = this._width / 2;
+    this._pixiObject.pivot.y = this._height / 2;
+    this._updateSpritesAndTexturesSize();
+    this._updateLocalPositions();
+    this.updatePosition();
+  }
 
-RenderedPanelSpriteInstance.prototype.updateWidthHeight = function() {
-  this._pixiObject.pivot.x = this._width / 2;
-  this._pixiObject.pivot.y = this._height / 2;
-  this._updateSpritesAndTexturesSize();
-  this._updateLocalPositions();
-  this.updatePosition();
-};
+  getDefaultWidth() {
+    const panelSprite = gd.asPanelSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    return panelSprite.getWidth();
+  }
 
-RenderedPanelSpriteInstance.prototype.getDefaultWidth = function() {
-  const panelSprite = gd.asPanelSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  return panelSprite.getWidth();
-};
+  getDefaultHeight() {
+    const panelSprite = gd.asPanelSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    return panelSprite.getHeight();
+  }
 
-RenderedPanelSpriteInstance.prototype.getDefaultHeight = function() {
-  const panelSprite = gd.asPanelSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  return panelSprite.getHeight();
-};
+  /**
+   * Return a URL for thumbnail of the specified object.
+   */
+  static getThumbnail(
+    project: gdProject,
+    resourcesLoader: Class<ResourcesLoader>,
+    object: gdObject
+  ) {
+    const panelSprite = gd.asPanelSpriteConfiguration(
+      object.getConfiguration()
+    );
 
-/**
- * Return a URL for thumbnail of the specified object.
- */
-RenderedPanelSpriteInstance.getThumbnail = function(
-  project,
-  resourcesLoader,
-  object
-) {
-  const panelSprite = gd.asPanelSpriteConfiguration(object.getConfiguration());
-
-  return resourcesLoader.getResourceFullUrl(
-    project,
-    panelSprite.getTexture(),
-    {}
-  );
-};
-
-export default RenderedPanelSpriteInstance;
+    return ResourcesLoader.getResourceFullUrl(
+      project,
+      panelSprite.getTexture(),
+      {}
+    );
+  }
+}

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedParticleEmitterInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedParticleEmitterInstance.js
@@ -1,122 +1,117 @@
+// @flow
 import RenderedInstance from './RenderedInstance';
+import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
+import ResourcesLoader from '../../ResourcesLoader';
 import * as PIXI from 'pixi.js-legacy';
 import { rgbToHexNumber } from '../../Utils/ColorTransformer';
-const gd /* TODO: add flow in this file */ = global.gd;
+const gd: libGDevelop = global.gd;
 
 /**
  * Renderer for an ParticleEmitter object.
- *
- * @extends RenderedInstance
- * @class RenderedParticleEmitterInstance
- * @constructor
  */
-function RenderedParticleEmitterInstance(
-  project,
-  layout,
-  instance,
-  associatedObjectConfiguration,
-  pixiContainer,
-  pixiResourcesLoader
-) {
-  RenderedInstance.call(
-    this,
-    project,
-    layout,
-    instance,
-    associatedObjectConfiguration,
-    pixiContainer,
-    pixiResourcesLoader
-  );
+export default class RenderedParticleEmitterInstance extends RenderedInstance {
+  constructor(
+    project: gdProject,
+    layout: gdLayout,
+    instance: gdInitialInstance,
+    associatedObjectConfiguration: gdObjectConfiguration,
+    pixiContainer: PIXI.Container,
+    pixiResourcesLoader: Class<PixiResourcesLoader>
+  ) {
+    super(
+      project,
+      layout,
+      instance,
+      associatedObjectConfiguration,
+      pixiContainer,
+      pixiResourcesLoader
+    );
 
-  this._pixiObject = new PIXI.Graphics();
-  this._pixiContainer.addChild(this._pixiObject);
-  this.updateGraphics();
+    this._pixiObject = new PIXI.Graphics();
+    this._pixiContainer.addChild(this._pixiObject);
+    this.updateGraphics();
+  }
+
+  /**
+   * Return a URL for thumbnail of the specified object.
+   */
+  static getThumbnail(
+    project: gdProject,
+    resourcesLoader: Class<ResourcesLoader>,
+    object: gdObject
+  ) {
+    return 'CppPlatform/Extensions/particleSystemicon.png';
+  }
+
+  update() {
+    this._pixiObject.position.x = this._instance.getX();
+    this._pixiObject.position.y = this._instance.getY();
+    this.updateGraphics();
+  }
+
+  /**
+   * Render the preview of the particle emitter according to the setup of the object
+   */
+  updateGraphics() {
+    const particleEmitterConfiguration = gd.asParticleEmitterConfiguration(
+      this._associatedObjectConfiguration
+    );
+
+    this._pixiObject.clear();
+
+    const emitterAngle = (this._instance.getAngle() / 180) * 3.14159;
+    const sprayConeAngle = particleEmitterConfiguration.getConeSprayAngle();
+    const line1Angle = emitterAngle - (sprayConeAngle / 2.0 / 180.0) * 3.14159;
+    const line2Angle = emitterAngle + (sprayConeAngle / 2.0 / 180.0) * 3.14159;
+    const length = 64;
+
+    this._pixiObject.beginFill(0, 0);
+    this._pixiObject.lineStyle(
+      3,
+      rgbToHexNumber(
+        particleEmitterConfiguration.getParticleRed2(),
+        particleEmitterConfiguration.getParticleGreen2(),
+        particleEmitterConfiguration.getParticleBlue2()
+      ),
+      1
+    );
+    this._pixiObject.moveTo(0, 0);
+    this._pixiObject.lineTo(
+      Math.cos(line1Angle) * length,
+      Math.sin(line1Angle) * length
+    );
+    this._pixiObject.moveTo(0, 0);
+    this._pixiObject.lineTo(
+      Math.cos(line2Angle) * length,
+      Math.sin(line2Angle) * length
+    );
+    this._pixiObject.endFill();
+
+    this._pixiObject.lineStyle(0, 0x000000, 1);
+    this._pixiObject.beginFill(
+      rgbToHexNumber(
+        particleEmitterConfiguration.getParticleRed1(),
+        particleEmitterConfiguration.getParticleGreen1(),
+        particleEmitterConfiguration.getParticleBlue1()
+      )
+    );
+    this._pixiObject.drawCircle(0, 0, 8);
+    this._pixiObject.endFill();
+  }
+
+  getDefaultWidth() {
+    return 128;
+  }
+
+  getDefaultHeight() {
+    return 128;
+  }
+
+  getOriginX() {
+    return 64;
+  }
+
+  getOriginY() {
+    return 64;
+  }
 }
-RenderedParticleEmitterInstance.prototype = Object.create(
-  RenderedInstance.prototype
-);
-
-/**
- * Return a URL for thumbnail of the specified object.
- */
-RenderedParticleEmitterInstance.getThumbnail = function(
-  project,
-  resourcesLoader,
-  object
-) {
-  return 'CppPlatform/Extensions/particleSystemicon.png';
-};
-
-RenderedParticleEmitterInstance.prototype.update = function() {
-  this._pixiObject.position.x = this._instance.getX();
-  this._pixiObject.position.y = this._instance.getY();
-  this.updateGraphics();
-};
-
-/**
- * Render the preview of the particle emitter according to the setup of the object
- */
-RenderedParticleEmitterInstance.prototype.updateGraphics = function() {
-  const particleEmitterConfiguration = gd.asParticleEmitterConfiguration(
-    this._associatedObjectConfiguration
-  );
-
-  this._pixiObject.clear();
-
-  const emitterAngle = (this._instance.getAngle() / 180) * 3.14159;
-  const sprayConeAngle = particleEmitterConfiguration.getConeSprayAngle();
-  const line1Angle = emitterAngle - (sprayConeAngle / 2.0 / 180.0) * 3.14159;
-  const line2Angle = emitterAngle + (sprayConeAngle / 2.0 / 180.0) * 3.14159;
-  const length = 64;
-
-  this._pixiObject.beginFill(0, 0);
-  this._pixiObject.lineStyle(
-    3,
-    rgbToHexNumber(
-      particleEmitterConfiguration.getParticleRed2(),
-      particleEmitterConfiguration.getParticleGreen2(),
-      particleEmitterConfiguration.getParticleBlue2()
-    ),
-    1
-  );
-  this._pixiObject.moveTo(0, 0);
-  this._pixiObject.lineTo(
-    Math.cos(line1Angle) * length,
-    Math.sin(line1Angle) * length
-  );
-  this._pixiObject.moveTo(0, 0);
-  this._pixiObject.lineTo(
-    Math.cos(line2Angle) * length,
-    Math.sin(line2Angle) * length
-  );
-  this._pixiObject.endFill();
-
-  this._pixiObject.lineStyle(0, 0x000000, 1);
-  this._pixiObject.beginFill(
-    rgbToHexNumber(
-      particleEmitterConfiguration.getParticleRed1(),
-      particleEmitterConfiguration.getParticleGreen1(),
-      particleEmitterConfiguration.getParticleBlue1()
-    )
-  );
-  this._pixiObject.drawCircle(0, 0, 8);
-  this._pixiObject.endFill();
-};
-
-RenderedParticleEmitterInstance.prototype.getDefaultWidth = function() {
-  return 128;
-};
-
-RenderedParticleEmitterInstance.prototype.getDefaultHeight = function() {
-  return 128;
-};
-
-RenderedParticleEmitterInstance.prototype.getOriginX = function() {
-  return 64;
-};
-
-RenderedParticleEmitterInstance.prototype.getOriginY = function() {
-  return 64;
-};
-
-export default RenderedParticleEmitterInstance;

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedShapePainterInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedShapePainterInstance.js
@@ -1,2 +1,3 @@
+// @flow
 import makeRenderer from './RenderedIconInstance';
 export default makeRenderer('CppPlatform/Extensions/primitivedrawingicon.png');

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
@@ -1,199 +1,207 @@
+// @flow
 import RenderedInstance from './RenderedInstance';
+import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
+import ResourcesLoader from '../../ResourcesLoader';
 import * as PIXI from 'pixi.js-legacy';
-const gd /* TODO: add flow in this file */ = global.gd;
+const gd: libGDevelop = global.gd;
 
 /**
  * Renderer for gd.SpriteObject
- *
- * @extends RenderedInstance
- * @class RenderedSpriteInstance
- * @constructor
  */
-function RenderedSpriteInstance(
-  project,
-  layout,
-  instance,
-  associatedObjectConfiguration,
-  pixiContainer,
-  pixiResourcesLoader
-) {
-  RenderedInstance.call(
-    this,
-    project,
-    layout,
-    instance,
-    associatedObjectConfiguration,
-    pixiContainer,
-    pixiResourcesLoader
-  );
+export default class RenderedSpriteInstance extends RenderedInstance {
+  _renderedAnimation: number;
+  _renderedDirection: number;
+  _centerX: number;
+  _centerY: number;
+  _originX: number;
+  _originY: number;
+  _sprite: ?gdSprite = null;
+  _shouldNotRotate: boolean = false;
 
-  this._renderedAnimation = 0;
-  this._renderedDirection = 0;
-  this._centerX = 0;
-  this._centerY = 0;
-  this._originX = 0;
-  this._originY = 0;
-
-  //Setup the PIXI object:
-  this._pixiObject = new PIXI.Sprite(
-    this._pixiResourcesLoader.getInvalidPIXITexture()
-  );
-  this._pixiContainer.addChild(this._pixiObject);
-  this.updatePIXITextureAndSprite();
-}
-RenderedSpriteInstance.prototype = Object.create(RenderedInstance.prototype);
-
-/**
- * Return a URL for thumbnail of the specified object.
- */
-RenderedSpriteInstance.getThumbnail = function(
-  project,
-  resourcesLoader,
-  object
-) {
-  const spriteConfiguration = gd.asSpriteConfiguration(
-    object.getConfiguration()
-  );
-
-  if (
-    spriteConfiguration.getAnimationsCount() > 0 &&
-    spriteConfiguration.getAnimation(0).getDirectionsCount() > 0 &&
-    spriteConfiguration
-      .getAnimation(0)
-      .getDirection(0)
-      .getSpritesCount() > 0
+  constructor(
+    project: gdProject,
+    layout: gdLayout,
+    instance: gdInitialInstance,
+    associatedObjectConfiguration: gdObjectConfiguration,
+    pixiContainer: PIXI.Container,
+    pixiResourcesLoader: Class<PixiResourcesLoader>
   ) {
-    const imageName = spriteConfiguration
-      .getAnimation(0)
-      .getDirection(0)
-      .getSprite(0)
-      .getImageName();
-    return resourcesLoader.getResourceFullUrl(project, imageName, {});
-  }
+    super(
+      project,
+      layout,
+      instance,
+      associatedObjectConfiguration,
+      pixiContainer,
+      pixiResourcesLoader
+    );
 
-  return 'res/unknown32.png';
-};
-
-RenderedSpriteInstance.prototype.updatePIXISprite = function() {
-  this._pixiObject.anchor.x =
-    this._centerX / this._pixiObject.texture.frame.width;
-  this._pixiObject.anchor.y =
-    this._centerY / this._pixiObject.texture.frame.height;
-  this._pixiObject.rotation = this._shouldNotRotate
-    ? 0
-    : RenderedInstance.toRad(this._instance.getAngle());
-  if (this._instance.hasCustomSize()) {
-    this._pixiObject.scale.x =
-      this._instance.getCustomWidth() / this._pixiObject.texture.frame.width;
-    this._pixiObject.scale.y =
-      this._instance.getCustomHeight() / this._pixiObject.texture.frame.height;
-  } else {
-    this._pixiObject.scale.x = 1;
-    this._pixiObject.scale.y = 1;
-  }
-  this._pixiObject.position.x =
-    this._instance.getX() +
-    (this._centerX - this._originX) * Math.abs(this._pixiObject.scale.x);
-  this._pixiObject.position.y =
-    this._instance.getY() +
-    (this._centerY - this._originY) * Math.abs(this._pixiObject.scale.y);
-};
-
-RenderedSpriteInstance.prototype.updateSprite = function() {
-  this._sprite = null;
-  this._shouldNotRotate = false;
-
-  const spriteConfiguration = gd.asSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  if (spriteConfiguration.hasNoAnimations()) return false;
-
-  this._renderedAnimation = this._instance.getRawDoubleProperty('animation');
-  if (this._renderedAnimation >= spriteConfiguration.getAnimationsCount())
     this._renderedAnimation = 0;
-
-  const animation = spriteConfiguration.getAnimation(this._renderedAnimation);
-  if (animation.hasNoDirections()) return false;
-
-  this._renderedDirection = 0;
-  if (animation.useMultipleDirections()) {
-    let normalizedAngle = Math.floor(this._instance.getAngle()) % 360;
-    if (normalizedAngle < 0) normalizedAngle += 360;
-
-    this._renderedDirection = Math.round(normalizedAngle / 45) % 8;
-  }
-
-  if (this._renderedDirection >= animation.getDirectionsCount())
     this._renderedDirection = 0;
+    this._centerX = 0;
+    this._centerY = 0;
+    this._originX = 0;
+    this._originY = 0;
 
-  const direction = animation.getDirection(this._renderedDirection);
-
-  if (direction.getSpritesCount() === 0) return false;
-
-  this._shouldNotRotate = animation.useMultipleDirections();
-  this._sprite = direction.getSprite(0);
-  return true;
-};
-
-RenderedSpriteInstance.prototype.updatePIXITextureAndSprite = function() {
-  this.updateSprite();
-  if (!this._sprite) return;
-
-  const texture = this._pixiResourcesLoader.getPIXITexture(
-    this._project,
-    this._sprite.getImageName()
-  );
-  this._pixiObject.texture = texture;
-
-  if (!texture.baseTexture.valid) {
-    // Post pone texture update if texture is not loaded.
-    texture.once('update', () => this.updatePIXITextureAndSprite());
-    return;
-  }
-
-  const origin = this._sprite.getOrigin();
-  this._originX = origin.getX();
-  this._originY = origin.getY();
-
-  if (this._sprite.isDefaultCenterPoint()) {
-    this._centerX = texture.width / 2;
-    this._centerY = texture.height / 2;
-  } else {
-    const center = this._sprite.getCenter();
-    this._centerX = center.getX();
-    this._centerY = center.getY();
-  }
-
-  this.updatePIXISprite();
-};
-
-RenderedSpriteInstance.prototype.update = function() {
-  const animation = this._instance.getRawDoubleProperty('animation');
-  if (this._renderedAnimation !== animation) {
+    //Setup the PIXI object:
+    this._pixiObject = new PIXI.Sprite(
+      PixiResourcesLoader.getInvalidPIXITexture()
+    );
+    this._pixiContainer.addChild(this._pixiObject);
     this.updatePIXITextureAndSprite();
-  } else {
+  }
+
+  /**
+   * Return a URL for thumbnail of the specified object.
+   */
+  static getThumbnail(
+    project: gdProject,
+    resourcesLoader: Class<ResourcesLoader>,
+    object: gdObject
+  ): string {
+    const spriteConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    if (
+      spriteConfiguration.getAnimationsCount() > 0 &&
+      spriteConfiguration.getAnimation(0).getDirectionsCount() > 0 &&
+      spriteConfiguration
+        .getAnimation(0)
+        .getDirection(0)
+        .getSpritesCount() > 0
+    ) {
+      const imageName = spriteConfiguration
+        .getAnimation(0)
+        .getDirection(0)
+        .getSprite(0)
+        .getImageName();
+      return ResourcesLoader.getResourceFullUrl(project, imageName, {});
+    }
+
+    return 'res/unknown32.png';
+  }
+
+  updatePIXISprite(): void {
+    this._pixiObject.anchor.x =
+      this._centerX / this._pixiObject.texture.frame.width;
+    this._pixiObject.anchor.y =
+      this._centerY / this._pixiObject.texture.frame.height;
+    this._pixiObject.rotation = this._shouldNotRotate
+      ? 0
+      : RenderedInstance.toRad(this._instance.getAngle());
+    if (this._instance.hasCustomSize()) {
+      this._pixiObject.scale.x =
+        this._instance.getCustomWidth() / this._pixiObject.texture.frame.width;
+      this._pixiObject.scale.y =
+        this._instance.getCustomHeight() /
+        this._pixiObject.texture.frame.height;
+    } else {
+      this._pixiObject.scale.x = 1;
+      this._pixiObject.scale.y = 1;
+    }
+    this._pixiObject.position.x =
+      this._instance.getX() +
+      (this._centerX - this._originX) * Math.abs(this._pixiObject.scale.x);
+    this._pixiObject.position.y =
+      this._instance.getY() +
+      (this._centerY - this._originY) * Math.abs(this._pixiObject.scale.y);
+  }
+
+  updateSprite(): boolean {
+    this._sprite = null;
+    this._shouldNotRotate = false;
+
+    const spriteConfiguration = gd.asSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    if (spriteConfiguration.hasNoAnimations()) return false;
+
+    this._renderedAnimation = this._instance.getRawDoubleProperty('animation');
+    if (this._renderedAnimation >= spriteConfiguration.getAnimationsCount())
+      this._renderedAnimation = 0;
+
+    const animation = spriteConfiguration.getAnimation(this._renderedAnimation);
+    if (animation.hasNoDirections()) return false;
+
+    this._renderedDirection = 0;
+    if (animation.useMultipleDirections()) {
+      let normalizedAngle = Math.floor(this._instance.getAngle()) % 360;
+      if (normalizedAngle < 0) normalizedAngle += 360;
+
+      this._renderedDirection = Math.round(normalizedAngle / 45) % 8;
+    }
+
+    if (this._renderedDirection >= animation.getDirectionsCount())
+      this._renderedDirection = 0;
+
+    const direction = animation.getDirection(this._renderedDirection);
+
+    if (direction.getSpritesCount() === 0) return false;
+
+    this._shouldNotRotate = animation.useMultipleDirections();
+    this._sprite = direction.getSprite(0);
+    return true;
+  }
+
+  updatePIXITextureAndSprite(): void {
+    this.updateSprite();
+    const sprite = this._sprite;
+    if (!sprite) return;
+
+    const texture = PixiResourcesLoader.getPIXITexture(
+      this._project,
+      sprite.getImageName()
+    );
+    this._pixiObject.texture = texture;
+
+    if (!texture.baseTexture.valid) {
+      // Post pone texture update if texture is not loaded.
+      texture.once('update', () => this.updatePIXITextureAndSprite());
+      return;
+    }
+
+    const origin = sprite.getOrigin();
+    this._originX = origin.getX();
+    this._originY = origin.getY();
+
+    if (sprite.isDefaultCenterPoint()) {
+      this._centerX = texture.width / 2;
+      this._centerY = texture.height / 2;
+    } else {
+      const center = sprite.getCenter();
+      this._centerX = center.getX();
+      this._centerY = center.getY();
+    }
+
     this.updatePIXISprite();
   }
-};
 
-RenderedSpriteInstance.prototype.getOriginX = function() {
-  if (!this._sprite || !this._pixiObject) return 0;
+  update(): void {
+    const animation = this._instance.getRawDoubleProperty('animation');
+    if (this._renderedAnimation !== animation) {
+      this.updatePIXITextureAndSprite();
+    } else {
+      this.updatePIXISprite();
+    }
+  }
 
-  return this._sprite.getOrigin().getX() * this._pixiObject.scale.x;
-};
+  getOriginX(): number {
+    if (!this._sprite || !this._pixiObject) return 0;
 
-RenderedSpriteInstance.prototype.getOriginY = function() {
-  if (!this._sprite || !this._pixiObject) return 0;
+    return this._sprite.getOrigin().getX() * this._pixiObject.scale.x;
+  }
 
-  return this._sprite.getOrigin().getY() * this._pixiObject.scale.y;
-};
+  getOriginY(): number {
+    if (!this._sprite || !this._pixiObject) return 0;
 
-RenderedSpriteInstance.prototype.getDefaultWidth = function() {
-  return Math.abs(this._pixiObject.width);
-};
+    return this._sprite.getOrigin().getY() * this._pixiObject.scale.y;
+  }
 
-RenderedSpriteInstance.prototype.getDefaultHeight = function() {
-  return Math.abs(this._pixiObject.height);
-};
+  getDefaultWidth(): number {
+    return Math.abs(this._pixiObject.width);
+  }
 
-export default RenderedSpriteInstance;
+  getDefaultHeight(): number {
+    return Math.abs(this._pixiObject.height);
+  }
+}

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextEntryInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextEntryInstance.js
@@ -1,2 +1,3 @@
+// @flow
 import makeRenderer from './RenderedIconInstance';
 export default makeRenderer('CppPlatform/Extensions/textentry.png');

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -1,142 +1,160 @@
+// @flow
 import RenderedInstance from './RenderedInstance';
+import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
+import ResourcesLoader from '../../ResourcesLoader';
 import * as PIXI from 'pixi.js-legacy';
-const gd /* TODO: add flow in this file */ = global.gd;
+const gd: libGDevelop = global.gd;
 
 /**
  * Renderer for a Text object.
- *
- * @extends RenderedInstance
- * @class RenderedTextInstance
- * @constructor
  */
-function RenderedTextInstance(
-  project,
-  layout,
-  instance,
-  associatedObjectConfiguration,
-  pixiContainer,
-  pixiResourcesLoader
-) {
-  RenderedInstance.call(
-    this,
-    project,
-    layout,
-    instance,
-    associatedObjectConfiguration,
-    pixiContainer,
-    pixiResourcesLoader
-  );
+export default class RenderedTextInstance extends RenderedInstance {
+  _isItalic: boolean = false;
+  _isBold: boolean = false;
+  _characterSize: number = 0;
+  _wrapping: boolean = false;
+  _wrappingWidth: number = 0;
+  _styleFontDirty: boolean = true;
+  _fontName: string = '';
+  _fontFamily: string = '';
+  _colorR: number = 0;
+  _colorG: number = 0;
+  _colorB: number = 0;
 
-  const style = new PIXI.TextStyle({
-    fontFamily: 'Arial',
-    fontSize: 20,
-    align: 'left',
-    padding: 5,
-  });
-
-  //Setup the PIXI object:
-  this._pixiObject = new PIXI.Text('', style);
-  this._pixiObject.anchor.x = 0.5;
-  this._pixiObject.anchor.y = 0.5;
-  this._pixiContainer.addChild(this._pixiObject);
-  this._styleFontDirty = true;
-  this.update();
-}
-RenderedTextInstance.prototype = Object.create(RenderedInstance.prototype);
-
-/**
- * Return a URL for thumbnail of the specified object.
- */
-RenderedTextInstance.getThumbnail = function(project, resourcesLoader, object) {
-  return 'CppPlatform/Extensions/texticon24.png';
-};
-
-RenderedTextInstance.prototype.update = function() {
-  const textObjectConfiguration = gd.asTextObjectConfiguration(
-    this._associatedObjectConfiguration
-  );
-  this._pixiObject.text = textObjectConfiguration.getString();
-
-  //Update style, only if needed to avoid destroying text rendering performances
-  if (
-    textObjectConfiguration.isItalic() !== this._isItalic ||
-    textObjectConfiguration.isBold() !== this._isBold ||
-    textObjectConfiguration.getCharacterSize() !== this._characterSize ||
-    this._instance.hasCustomSize() !== this._wrapping ||
-    (this._instance.getCustomWidth() !== this._wrappingWidth && this._wrapping)
+  constructor(
+    project: gdProject,
+    layout: gdLayout,
+    instance: gdInitialInstance,
+    associatedObjectConfiguration: gdObjectConfiguration,
+    pixiContainer: PIXI.Container,
+    pixiResourcesLoader: Class<PixiResourcesLoader>
   ) {
-    this._isItalic = textObjectConfiguration.isItalic();
-    this._isBold = textObjectConfiguration.isBold();
-    this._characterSize = textObjectConfiguration.getCharacterSize();
-    this._wrapping = this._instance.hasCustomSize();
-    this._wrappingWidth = this._instance.getCustomWidth();
+    super(
+      project,
+      layout,
+      instance,
+      associatedObjectConfiguration,
+      pixiContainer,
+      pixiResourcesLoader
+    );
+
+    const style = new PIXI.TextStyle({
+      fontFamily: 'Arial',
+      fontSize: 20,
+      align: 'left',
+      padding: 5,
+    });
+
+    //Setup the PIXI object:
+    this._pixiObject = new PIXI.Text('', style);
+    this._pixiObject.anchor.x = 0.5;
+    this._pixiObject.anchor.y = 0.5;
+    this._pixiContainer.addChild(this._pixiObject);
     this._styleFontDirty = true;
+    this.update();
   }
 
-  if (this._fontName !== textObjectConfiguration.getFontName()) {
-    //Avoid calling loadFontFamily if the font didn't changed.
-    this._fontName = textObjectConfiguration.getFontName();
-    this._pixiResourcesLoader
-      .loadFontFamily(this._project, textObjectConfiguration.getFontName())
-      .then(fontFamily => {
-        // Once the font is loaded, we can use the given fontFamily.
-        this._fontFamily = fontFamily;
-        this._styleFontDirty = true;
-      })
-      .catch(err => {
-        // Ignore errors
-        console.warn(
-          'Unable to load font family for RenderedTextInstance',
-          err
-        );
-      });
-  }
-
-  if (this._styleFontDirty) {
-    this._pixiObject.style.fontFamily = this._fontFamily || 'Arial';
-    this._pixiObject.style.fontSize = Math.max(1, this._characterSize);
-    this._pixiObject.style.fontStyle = this._isItalic ? 'italic' : 'normal';
-    this._pixiObject.style.fontWeight = this._isBold ? 'bold' : 'normal';
-    this._pixiObject.style.wordWrap = this._wrapping;
-    this._pixiObject.style.wordWrapWidth =
-      this._wrappingWidth <= 1 ? 1 : this._wrappingWidth;
-    this._pixiObject.style.breakWords = true;
-
-    // Manually ask the PIXI object to re-render as we changed a style property
-    // see http://www.html5gamedevs.com/topic/16924-change-text-style-post-render/
-    this._pixiObject.dirty = true;
-    this._styleFontDirty = false;
-  }
-
-  if (
-    textObjectConfiguration.getColorR() !== this._colorR ||
-    textObjectConfiguration.getColorG() !== this._colorG ||
-    textObjectConfiguration.getColorB() !== this._colorB
+  /**
+   * Return a URL for thumbnail of the specified object.
+   */
+  static getThumbnail(
+    project: gdProject,
+    resourcesLoader: Class<ResourcesLoader>,
+    object: gdObject
   ) {
-    this._colorR = textObjectConfiguration.getColorR();
-    this._colorG = textObjectConfiguration.getColorG();
-    this._colorB = textObjectConfiguration.getColorB();
-    this._pixiObject.style.fill =
-      'rgb(' + this._colorR + ',' + this._colorG + ',' + this._colorB + ')';
-
-    // Manually ask the PIXI object to re-render as we changed a style property
-    // see http://www.html5gamedevs.com/topic/16924-change-text-style-post-render/
-    this._pixiObject.dirty = true;
+    return 'CppPlatform/Extensions/texticon24.png';
   }
 
-  this._pixiObject.position.x =
-    this._instance.getX() + this._pixiObject.width / 2;
-  this._pixiObject.position.y =
-    this._instance.getY() + this._pixiObject.height / 2;
-  this._pixiObject.rotation = RenderedInstance.toRad(this._instance.getAngle());
-};
+  update() {
+    const textObjectConfiguration = gd.asTextObjectConfiguration(
+      this._associatedObjectConfiguration
+    );
+    this._pixiObject.text = textObjectConfiguration.getString();
 
-RenderedTextInstance.prototype.getDefaultWidth = function() {
-  return this._pixiObject.width;
-};
+    //Update style, only if needed to avoid destroying text rendering performances
+    if (
+      textObjectConfiguration.isItalic() !== this._isItalic ||
+      textObjectConfiguration.isBold() !== this._isBold ||
+      textObjectConfiguration.getCharacterSize() !== this._characterSize ||
+      this._instance.hasCustomSize() !== this._wrapping ||
+      (this._instance.getCustomWidth() !== this._wrappingWidth &&
+        this._wrapping)
+    ) {
+      this._isItalic = textObjectConfiguration.isItalic();
+      this._isBold = textObjectConfiguration.isBold();
+      this._characterSize = textObjectConfiguration.getCharacterSize();
+      this._wrapping = this._instance.hasCustomSize();
+      this._wrappingWidth = this._instance.getCustomWidth();
+      this._styleFontDirty = true;
+    }
 
-RenderedTextInstance.prototype.getDefaultHeight = function() {
-  return this._pixiObject.height;
-};
+    if (this._fontName !== textObjectConfiguration.getFontName()) {
+      //Avoid calling loadFontFamily if the font didn't changed.
+      this._fontName = textObjectConfiguration.getFontName();
+      PixiResourcesLoader.loadFontFamily(
+        this._project,
+        textObjectConfiguration.getFontName()
+      )
+        .then(fontFamily => {
+          // Once the font is loaded, we can use the given fontFamily.
+          this._fontFamily = fontFamily;
+          this._styleFontDirty = true;
+        })
+        .catch(err => {
+          // Ignore errors
+          console.warn(
+            'Unable to load font family for RenderedTextInstance',
+            err
+          );
+        });
+    }
 
-export default RenderedTextInstance;
+    if (this._styleFontDirty) {
+      this._pixiObject.style.fontFamily = this._fontFamily || 'Arial';
+      this._pixiObject.style.fontSize = Math.max(1, this._characterSize);
+      this._pixiObject.style.fontStyle = this._isItalic ? 'italic' : 'normal';
+      this._pixiObject.style.fontWeight = this._isBold ? 'bold' : 'normal';
+      this._pixiObject.style.wordWrap = this._wrapping;
+      this._pixiObject.style.wordWrapWidth =
+        this._wrappingWidth <= 1 ? 1 : this._wrappingWidth;
+      this._pixiObject.style.breakWords = true;
+
+      // Manually ask the PIXI object to re-render as we changed a style property
+      // see http://www.html5gamedevs.com/topic/16924-change-text-style-post-render/
+      this._pixiObject.dirty = true;
+      this._styleFontDirty = false;
+    }
+
+    if (
+      textObjectConfiguration.getColorR() !== this._colorR ||
+      textObjectConfiguration.getColorG() !== this._colorG ||
+      textObjectConfiguration.getColorB() !== this._colorB
+    ) {
+      this._colorR = textObjectConfiguration.getColorR();
+      this._colorG = textObjectConfiguration.getColorG();
+      this._colorB = textObjectConfiguration.getColorB();
+      this._pixiObject.style.fill =
+        'rgb(' + this._colorR + ',' + this._colorG + ',' + this._colorB + ')';
+
+      // Manually ask the PIXI object to re-render as we changed a style property
+      // see http://www.html5gamedevs.com/topic/16924-change-text-style-post-render/
+      this._pixiObject.dirty = true;
+    }
+
+    this._pixiObject.position.x =
+      this._instance.getX() + this._pixiObject.width / 2;
+    this._pixiObject.position.y =
+      this._instance.getY() + this._pixiObject.height / 2;
+    this._pixiObject.rotation = RenderedInstance.toRad(
+      this._instance.getAngle()
+    );
+  }
+
+  getDefaultWidth() {
+    return this._pixiObject.width;
+  }
+
+  getDefaultHeight() {
+    return this._pixiObject.height;
+  }
+}

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTiledSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTiledSpriteInstance.js
@@ -1,104 +1,105 @@
+// @flow
 import RenderedInstance from './RenderedInstance';
+import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
+import ResourcesLoader from '../../ResourcesLoader';
 import * as PIXI from 'pixi.js-legacy';
-const gd /* TODO: add flow in this file */ = global.gd;
+const gd: libGDevelop = global.gd;
 
 /**
  * Renderer for gd.TiledSpriteObject
- *
- * @extends RenderedInstance
- * @class RenderedTiledSpriteInstance
- * @constructor
  */
-function RenderedTiledSpriteInstance(
-  project,
-  layout,
-  instance,
-  associatedObjectConfiguration,
-  pixiContainer,
-  pixiResourcesLoader
-) {
-  RenderedInstance.call(
-    this,
-    project,
-    layout,
-    instance,
-    associatedObjectConfiguration,
-    pixiContainer,
-    pixiResourcesLoader
-  );
+export default class RenderedTiledSpriteInstance extends RenderedInstance {
+  _texture: PIXI.Texture;
 
-  //Setup the PIXI object:
-  let tiledSprite = gd.asTiledSpriteConfiguration(
-    associatedObjectConfiguration
-  );
-  this._texture = tiledSprite.getTexture();
-  this._pixiObject = new PIXI.TilingSprite(
-    this._pixiResourcesLoader.getPIXITexture(project, tiledSprite.getTexture()),
-    tiledSprite.getWidth(),
-    tiledSprite.getHeight()
-  );
-  this._pixiObject.anchor.x = 0.5;
-  this._pixiObject.anchor.y = 0.5;
-  this._pixiContainer.addChild(this._pixiObject);
-}
-RenderedTiledSpriteInstance.prototype = Object.create(
-  RenderedInstance.prototype
-);
+  constructor(
+    project: gdProject,
+    layout: gdLayout,
+    instance: gdInitialInstance,
+    associatedObjectConfiguration: gdObjectConfiguration,
+    pixiContainer: PIXI.Container,
+    pixiResourcesLoader: Class<PixiResourcesLoader>
+  ) {
+    super(
+      project,
+      layout,
+      instance,
+      associatedObjectConfiguration,
+      pixiContainer,
+      pixiResourcesLoader
+    );
 
-/**
- * Return a URL for thumbnail of the specified object.
- */
-RenderedTiledSpriteInstance.getThumbnail = function(
-  project,
-  resourcesLoader,
-  object
-) {
-  let tiledSprite = gd.asTiledSpriteConfiguration(object.getConfiguration());
-
-  return resourcesLoader.getResourceFullUrl(
-    project,
-    tiledSprite.getTexture(),
-    {}
-  );
-};
-
-RenderedTiledSpriteInstance.prototype.update = function() {
-  let tiledSprite = gd.asTiledSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  if (this._instance.hasCustomSize()) {
-    this._pixiObject.width = this._instance.getCustomWidth();
-    this._pixiObject.height = this._instance.getCustomHeight();
-  } else {
-    this._pixiObject.width = tiledSprite.getWidth();
-    this._pixiObject.height = tiledSprite.getHeight();
+    //Setup the PIXI object:
+    const tiledSprite = gd.asTiledSpriteConfiguration(
+      associatedObjectConfiguration
+    );
+    this._texture = tiledSprite.getTexture();
+    this._pixiObject = new PIXI.TilingSprite(
+      PixiResourcesLoader.getPIXITexture(project, tiledSprite.getTexture()),
+      tiledSprite.getWidth(),
+      tiledSprite.getHeight()
+    );
+    this._pixiObject.anchor.x = 0.5;
+    this._pixiObject.anchor.y = 0.5;
+    this._pixiContainer.addChild(this._pixiObject);
   }
 
-  if (this._texture !== tiledSprite.getTexture()) {
-    this._texture = tiledSprite.getTexture();
-    this._pixiObject.texture = this._pixiResourcesLoader.getPIXITexture(
-      this._project,
-      tiledSprite.getTexture()
+  /**
+   * Return a URL for thumbnail of the specified object.
+   */
+  static getThumbnail(
+    project: gdProject,
+    resourcesLoader: Class<ResourcesLoader>,
+    object: gdObject
+  ) {
+    const tiledSprite = gd.asTiledSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    return ResourcesLoader.getResourceFullUrl(
+      project,
+      tiledSprite.getTexture(),
+      {}
     );
   }
 
-  this._pixiObject.x = this._instance.getX() + this._pixiObject.width / 2;
-  this._pixiObject.y = this._instance.getY() + this._pixiObject.height / 2;
-  this._pixiObject.rotation = RenderedInstance.toRad(this._instance.getAngle());
-};
+  update() {
+    const tiledSprite = gd.asTiledSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    if (this._instance.hasCustomSize()) {
+      this._pixiObject.width = this._instance.getCustomWidth();
+      this._pixiObject.height = this._instance.getCustomHeight();
+    } else {
+      this._pixiObject.width = tiledSprite.getWidth();
+      this._pixiObject.height = tiledSprite.getHeight();
+    }
 
-RenderedTiledSpriteInstance.prototype.getDefaultWidth = function() {
-  let tiledSprite = gd.asTiledSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  return tiledSprite.getWidth();
-};
+    if (this._texture !== tiledSprite.getTexture()) {
+      this._texture = tiledSprite.getTexture();
+      this._pixiObject.texture = PixiResourcesLoader.getPIXITexture(
+        this._project,
+        tiledSprite.getTexture()
+      );
+    }
 
-RenderedTiledSpriteInstance.prototype.getDefaultHeight = function() {
-  let tiledSprite = gd.asTiledSpriteConfiguration(
-    this._associatedObjectConfiguration
-  );
-  return tiledSprite.getHeight();
-};
+    this._pixiObject.x = this._instance.getX() + this._pixiObject.width / 2;
+    this._pixiObject.y = this._instance.getY() + this._pixiObject.height / 2;
+    this._pixiObject.rotation = RenderedInstance.toRad(
+      this._instance.getAngle()
+    );
+  }
 
-export default RenderedTiledSpriteInstance;
+  getDefaultWidth() {
+    const tiledSprite = gd.asTiledSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    return tiledSprite.getWidth();
+  }
+
+  getDefaultHeight() {
+    const tiledSprite = gd.asTiledSpriteConfiguration(
+      this._associatedObjectConfiguration
+    );
+    return tiledSprite.getHeight();
+  }
+}

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedUnknownInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedUnknownInstance.js
@@ -1,59 +1,57 @@
+// @flow
 import RenderedInstance from './RenderedInstance';
+import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
+import ResourcesLoader from '../../ResourcesLoader';
 import * as PIXI from 'pixi.js-legacy';
 
 /**
  * Objects with an unknown type are rendered with a placeholder rectangle.
- *
- * @extends RenderedInstance
- * @class RenderedUnknownInstance
- * @constructor
  */
-function RenderedUnknownInstance(
-  project,
-  layout,
-  instance,
-  associatedObjectConfiguration,
-  pixiContainer,
-  pixiResourcesLoader
-) {
-  RenderedInstance.call(
-    this,
-    project,
-    layout,
-    instance,
-    associatedObjectConfiguration,
-    pixiContainer,
-    pixiResourcesLoader
-  );
+export default class RenderedUnknownInstance extends RenderedInstance {
+  constructor(
+    project: gdProject,
+    layout: gdLayout,
+    instance: gdInitialInstance,
+    associatedObjectConfiguration: gdObjectConfiguration,
+    pixiContainer: PIXI.Container,
+    pixiResourcesLoader: Class<PixiResourcesLoader>
+  ) {
+    super(
+      project,
+      layout,
+      instance,
+      associatedObjectConfiguration,
+      pixiContainer,
+      pixiResourcesLoader
+    );
 
-  //This renderer show a placeholder for the object:
-  this._pixiObject = new PIXI.Graphics();
-  this._pixiContainer.addChild(this._pixiObject);
+    //This renderer show a placeholder for the object:
+    this._pixiObject = new PIXI.Graphics();
+    this._pixiContainer.addChild(this._pixiObject);
 
-  var width = instance.hasCustomSize() ? instance.getCustomWidth() : 32;
-  var height = instance.hasCustomSize() ? instance.getCustomHeight() : 32;
+    const width = instance.hasCustomSize() ? instance.getCustomWidth() : 32;
+    const height = instance.hasCustomSize() ? instance.getCustomHeight() : 32;
 
-  this._pixiObject.beginFill(0x0033ff);
-  this._pixiObject.lineStyle(1, 0xffd900, 1);
-  this._pixiObject.moveTo(0, 0);
-  this._pixiObject.lineTo(width, 0);
-  this._pixiObject.lineTo(width, height);
-  this._pixiObject.lineTo(0, height);
-  this._pixiObject.endFill();
+    this._pixiObject.beginFill(0x0033ff);
+    this._pixiObject.lineStyle(1, 0xffd900, 1);
+    this._pixiObject.moveTo(0, 0);
+    this._pixiObject.lineTo(width, 0);
+    this._pixiObject.lineTo(width, height);
+    this._pixiObject.lineTo(0, height);
+    this._pixiObject.endFill();
+  }
+
+  static getThumbnail(
+    project: gdProject,
+    resourcesLoader: Class<ResourcesLoader>,
+    object: gdObject
+  ) {
+    return 'res/unknown32.png';
+  }
+
+  update() {
+    this._pixiObject.position.x = this._instance.getX();
+    this._pixiObject.position.y = this._instance.getY();
+    this._pixiObject.rotation = (this._instance.getAngle() * Math.PI) / 180.0;
+  }
 }
-RenderedUnknownInstance.prototype = Object.create(RenderedInstance.prototype);
-RenderedUnknownInstance.getThumbnail = function(
-  project,
-  resourcesLoader,
-  object
-) {
-  return 'res/unknown32.png';
-};
-
-RenderedUnknownInstance.prototype.update = function() {
-  this._pixiObject.position.x = this._instance.getX();
-  this._pixiObject.position.y = this._instance.getY();
-  this._pixiObject.rotation = (this._instance.getAngle() * Math.PI) / 180.0;
-};
-
-export default RenderedUnknownInstance;


### PR DESCRIPTION
As there is no instance editor for event-based object yet, it stacks one instance of each child object and centered them. It will give some what good result for an object button.

The entry point is `RenderedCustomObjectInstance`. The other real change is in `ObjectsRenderingService.createNewInstanceRenderer`. Other changes are only type definition.
