### PR TITLE
Attempt to remove modal window frame to hide close button on linux

### DIFF
--- a/newIDE/electron-app/app/ModalWindow.js
+++ b/newIDE/electron-app/app/ModalWindow.js
@@ -36,6 +36,10 @@ const loadModalWindow = ({
     backgroundColor,
     modal: true,
     center: true,
+    // Hide top bar to hide close button (needed on Linux) so that
+    // one cannot close the modal window without using Save or Cancel
+    // buttons (and lose work on Piskel for instance) (Workaround for #4245).
+    frame: false,
     webPreferences: {
       webSecurity: false,
       // Allow Node.js API access in renderer process, as long


### PR DESCRIPTION
Workaround for #4245.
Not sure it will work (not using Linux) so we'll wait for next release.