### PR TITLE
Remove useless SetIncludeFile calls in PanelSpriteObject

### DIFF
--- a/Extensions/PanelSpriteObject/JsExtension.cpp
+++ b/Extensions/PanelSpriteObject/JsExtension.cpp
@@ -33,24 +33,16 @@ class PanelSpriteObjectJsExtension : public gd::PlatformExtension {
     GetAllActionsForObject(
         "PanelSpriteObject::PanelSprite")["PanelSpriteObject::SetOpacity"]
         .SetFunctionName("setOpacity")
-        .SetGetter("getOpacity")
-        .SetIncludeFile(
-            "Extensions/PanelSpriteObject/panelspriteruntimeobject.js");
+        .SetGetter("getOpacity");
     GetAllConditionsForObject(
         "PanelSpriteObject::PanelSprite")["PanelSpriteObject::Opacity"]
-        .SetFunctionName("getOpacity")
-        .SetIncludeFile(
-            "Extensions/TiledSpriteObject/panelspriteruntimeobject.js");
+        .SetFunctionName("getOpacity");
     GetAllExpressionsForObject(
         "PanelSpriteObject::PanelSprite")["Opacity"]
-        .SetFunctionName("getOpacity")
-        .SetIncludeFile(
-            "Extensions/TiledSpriteObject/panelspriteruntimeobject.js");
+        .SetFunctionName("getOpacity");
     GetAllActionsForObject(
         "PanelSpriteObject::PanelSprite")["PanelSpriteObject::SetColor"]
-        .SetFunctionName("setColor")
-        .SetIncludeFile(
-            "Extensions/TiledSpriteObject/panelspriteruntimeobject.js");
+        .SetFunctionName("setColor");
 
     GetAllActionsForObject(
         "PanelSpriteObject::PanelSprite")["PanelSpriteObject::Width"]


### PR DESCRIPTION
Most of them had a wrong path anyway.