### PR TITLE
Revert RendererInstance parameter for the tile map extension

### DIFF
--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -942,8 +942,7 @@ module.exports = {
       instance,
       associatedObjectConfiguration,
       pixiContainer,
-      pixiResourcesLoader,
-      pixiRenderer
+      pixiResourcesLoader
     ) {
       RenderedInstance.call(
         this,
@@ -952,14 +951,12 @@ module.exports = {
         instance,
         associatedObjectConfiguration,
         pixiContainer,
-        pixiResourcesLoader,
-        pixiRenderer
+        pixiResourcesLoader
       );
 
       // This setting allows tile maps with more than 16K tiles.
       Tilemap.settings.use32bitIndex = true;
-      pixiRenderer.plugins.tilemap =
-        pixiRenderer.plugins.tilemap || new Tilemap.TileRenderer();
+
       this.tileMapPixiObject = new Tilemap.CompositeTilemap();
       this._pixiObject = this.tileMapPixiObject;
 

--- a/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
+++ b/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
@@ -10,7 +10,6 @@ namespace gdjs {
    */
   export class TileMapRuntimeObjectPixiRenderer {
     private _object: any;
-    private _runtimeScene: gdjs.RuntimeScene;
     private _tileMap: TileMapHelper.EditableTileMap | null = null;
 
     private _pixiObject: PIXI.tilemap.CompositeTilemap;
@@ -24,20 +23,9 @@ namespace gdjs {
       runtimeScene: gdjs.RuntimeScene
     ) {
       this._object = runtimeObject;
-      this._runtimeScene = runtimeScene;
-
-      const pixiRenderer = runtimeScene
-        .getGame()
-        .getRenderer()
-        .getPIXIRenderer();
 
       // This setting allows tile maps with more than 16K tiles.
       PIXI.tilemap.settings.use32bitIndex = true;
-      if (pixiRenderer) {
-        pixiRenderer.plugins.tilemap =
-          // @ts-ignore - pixi-tilemap types to be added.
-          pixiRenderer.plugins.tilemap || new PIXI.tilemap.TileRenderer();
-      }
 
       // Load (or reset)
       this._pixiObject = new PIXI.tilemap.CompositeTilemap();

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -41,7 +41,6 @@ export default class LayerRenderer {
 
   renderedInstances: { [number]: RenderedInstance } = {};
   pixiContainer: PIXI.Container;
-  pixiRenderer: PIXI.Renderer;
 
   /** Functor used to render an instance */
   instancesRenderer: gdInitialInstanceJSFunctor;
@@ -65,7 +64,6 @@ export default class LayerRenderer {
     onMoveInstance,
     onMoveInstanceEnd,
     onDownInstance,
-    pixiRenderer,
   }: {
     project: gdProject,
     instances: gdInitialInstancesContainer,
@@ -85,9 +83,7 @@ export default class LayerRenderer {
     onMoveInstance: (gdInitialInstance, number, number) => void,
     onMoveInstanceEnd: void => void,
     onDownInstance: (gdInitialInstance, number, number) => void,
-    pixiRenderer: PIXI.Renderer,
   }) {
-    this.pixiRenderer = pixiRenderer;
     this.project = project;
     this.instances = instances;
     this.layout = layout;
@@ -265,8 +261,7 @@ export default class LayerRenderer {
         this.layout,
         instance,
         associatedObject.getConfiguration(),
-        this.pixiContainer,
-        this.pixiRenderer
+        this.pixiContainer
       );
 
       renderedInstance._pixiObject.interactive = true;

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/index.js
@@ -26,7 +26,6 @@ export default class InstancesRenderer {
   layersRenderers: { [string]: LayerRenderer };
 
   pixiContainer: PIXI.Container;
-  pixiRenderer: PIXI.Renderer;
 
   temporaryRectangle: Rectangle;
   instanceMeasurer: any;
@@ -44,7 +43,6 @@ export default class InstancesRenderer {
     onMoveInstance,
     onMoveInstanceEnd,
     onDownInstance,
-    pixiRenderer,
   }: {
     project: gdProject,
     instances: gdInitialInstancesContainer,
@@ -63,7 +61,6 @@ export default class InstancesRenderer {
     onMoveInstance: (gdInitialInstance, number, number) => void,
     onMoveInstanceEnd: void => void,
     onDownInstance: (gdInitialInstance, number, number) => void,
-    pixiRenderer: PIXI.Renderer,
   }) {
     this.project = project;
     this.instances = instances;
@@ -77,7 +74,6 @@ export default class InstancesRenderer {
     this.onMoveInstance = onMoveInstance;
     this.onMoveInstanceEnd = onMoveInstanceEnd;
     this.onDownInstance = onDownInstance;
-    this.pixiRenderer = pixiRenderer;
 
     this.layersRenderers = {};
 
@@ -148,7 +144,6 @@ export default class InstancesRenderer {
           layout: this.layout,
           instances: this.instances,
           viewPosition: this.viewPosition,
-          pixiRenderer: this.pixiRenderer,
           layer: layer,
           onInstanceClicked: this.onInstanceClicked,
           onInstanceRightClicked: this.onInstanceRightClicked,

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -337,7 +337,6 @@ export default class InstancesEditor extends Component<Props> {
       layout: props.layout,
       instances: props.initialInstances,
       viewPosition: this.viewPosition,
-      pixiRenderer: this.pixiRenderer,
       onOverInstance: this._onOverInstance,
       onMoveInstance: this._onMoveInstance,
       onMoveInstanceEnd: this._onMoveInstanceEnd,

--- a/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
+++ b/newIDE/app/src/ObjectsRendering/ObjectsRenderingService.js
@@ -62,8 +62,7 @@ const ObjectsRenderingService = {
     layout: gdLayout,
     instance: gdInitialInstance,
     associatedObjectConfiguration: gdObjectConfiguration,
-    pixiContainer: any,
-    pixiRenderer: PIXI.Renderer
+    pixiContainer: any
   ): RenderedInstance {
     var objectType = associatedObjectConfiguration.getType();
     if (this.renderers.hasOwnProperty(objectType))
@@ -73,8 +72,7 @@ const ObjectsRenderingService = {
         instance,
         associatedObjectConfiguration,
         pixiContainer,
-        PixiResourcesLoader,
-        pixiRenderer
+        PixiResourcesLoader
       );
     else {
       console.warn(
@@ -86,8 +84,7 @@ const ObjectsRenderingService = {
         instance,
         associatedObjectConfiguration,
         pixiContainer,
-        PixiResourcesLoader,
-        pixiRenderer
+        PixiResourcesLoader
       );
     }
   },


### PR DESCRIPTION
When I did the upgrade I had an issue with the library. I compared several versions and though that the fix done by Blurymind for a previous version was still necessary. Actually, the library already register its plugin and `pixiRenderer.plugins.tilemap` was already set. The line was not harmful, but useless.

I branched it on the commit from:
- https://github.com/4ian/GDevelop/pull/4212

It allows to check the impact of the 2 commits
![image](https://user-images.githubusercontent.com/2611977/188278570-1fb8b897-27fb-4543-87fb-869e4ce18de1.png)
