### PR TITLE
Fix a crash when renaming a child-object

### DIFF
--- a/Core/GDCore/IDE/WholeProjectRefactorer.cpp
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.cpp
@@ -1628,19 +1628,18 @@ void WholeProjectRefactorer::ObjectOrGroupRemovedInEventsFunction(
 
 void WholeProjectRefactorer::ObjectOrGroupRenamedInEventsBasedObject(
     gd::Project& project,
-    gd::EventsBasedObject& eventsBasedObject,
     gd::ObjectsContainer& globalObjectsContainer,
-    gd::ObjectsContainer& objectsContainer,
+    gd::EventsBasedObject& eventsBasedObject,
     const gd::String& oldName,
     const gd::String& newName,
     bool isObjectGroup) {
   for (auto &functionUniquePtr : eventsBasedObject.GetEventsFunctions().GetInternalVector()) {
-    auto function = functionUniquePtr.get();
+    auto *function = functionUniquePtr.get();
     WholeProjectRefactorer::ObjectOrGroupRenamedInEventsFunction(
         project,
         *function,
         globalObjectsContainer,
-        objectsContainer,
+        eventsBasedObject,
         oldName,
         newName,
         isObjectGroup);

--- a/Core/GDCore/IDE/WholeProjectRefactorer.h
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.h
@@ -333,9 +333,8 @@ class GD_CORE_API WholeProjectRefactorer {
    */
   static void ObjectOrGroupRenamedInEventsBasedObject(
       gd::Project& project,
-      gd::EventsBasedObject& eventsBasedObject,
       gd::ObjectsContainer& globalObjectsContainer,
-      gd::ObjectsContainer& objectsContainer,
+      gd::EventsBasedObject& eventsBasedObject,
       const gd::String& oldName,
       const gd::String& newName,
       bool isObjectGroup);

--- a/Core/tests/DummyPlatform.cpp
+++ b/Core/tests/DummyPlatform.cpp
@@ -133,6 +133,18 @@ void SetupProjectWithDummyPlatform(gd::Project& project,
       .SetFunctionName("doSomething");
 
   extension
+      ->AddAction("DoSomethingWithObjects",
+                  "Do something",
+                  "This does something",
+                  "Do something please",
+                  "",
+                  "",
+                  "")
+      .AddParameter("object", _("Object 1 parameter"))
+      .AddParameter("object", _("Object 2 parameter"))
+      .SetFunctionName("doSomethingWithObjects");
+
+  extension
       ->AddAction("DoSomethingWithResources",
                   "Do something with resources",
                   "This does something with resources",

--- a/Core/tests/WholeProjectRefactorer.cpp
+++ b/Core/tests/WholeProjectRefactorer.cpp
@@ -108,18 +108,6 @@ const std::vector<const gd::EventsList *> GetEventsLists(gd::Project &project) {
   return eventLists;
 }
 
-const std::vector<const gd::ObjectsContainer *> GetObjectContainers(gd::Project &project) {
-  std::vector<const gd::ObjectsContainer *> objectContainers;
-  auto &scene = project.GetLayout("Scene");
-  auto &eventsBasedObject =
-      project.GetEventsFunctionsExtension("MyEventsExtension")
-          .GetEventsBasedObjects()
-          .Get("MyOtherEventsBasedObject");
-  objectContainers.push_back(&scene);
-  objectContainers.push_back(&eventsBasedObject);
-  return objectContainers;
-}
-
 const void SetupEvents(gd::EventsList &eventList) {
 
   // Add some free functions usages in events

--- a/Core/tests/WholeProjectRefactorer.cpp
+++ b/Core/tests/WholeProjectRefactorer.cpp
@@ -67,7 +67,9 @@ const gd::String &GetEventFirstActionType(const gd::BaseEvent &event) {
 
 enum TestEvent {
   FreeFunctionAction,
-  FreeFunctionExpression,
+  FreeFunctionWithExpression,
+  FreeFunctionWithObjects,
+  FreeFunctionWithObjectExpression,
 
   BehaviorAction,
   BehaviorPropertyAction,
@@ -106,6 +108,18 @@ const std::vector<const gd::EventsList *> GetEventsLists(gd::Project &project) {
   return eventLists;
 }
 
+const std::vector<const gd::ObjectsContainer *> GetObjectContainers(gd::Project &project) {
+  std::vector<const gd::ObjectsContainer *> objectContainers;
+  auto &scene = project.GetLayout("Scene");
+  auto &eventsBasedObject =
+      project.GetEventsFunctionsExtension("MyEventsExtension")
+          .GetEventsBasedObjects()
+          .Get("MyOtherEventsBasedObject");
+  objectContainers.push_back(&scene);
+  objectContainers.push_back(&eventsBasedObject);
+  return objectContainers;
+}
+
 const void SetupEvents(gd::EventsList &eventList) {
 
   // Add some free functions usages in events
@@ -113,7 +127,7 @@ const void SetupEvents(gd::EventsList &eventList) {
     if (eventList.GetEventsCount() != FreeFunctionAction) {
       throw std::logic_error("Invalid events setup");
     }
-    // Create an event in the layout referring to
+    // Create an event referring to
     // MyEventsExtension::MyEventsFunction
     {
       gd::StandardEvent event;
@@ -128,10 +142,10 @@ const void SetupEvents(gd::EventsList &eventList) {
       eventList.InsertEvent(event);
     }
 
-    if (eventList.GetEventsCount() != FreeFunctionExpression) {
+    if (eventList.GetEventsCount() != FreeFunctionWithExpression) {
       throw std::logic_error("Invalid events setup");
     }
-    // Create an event in the external events referring to
+    // Create an event referring to
     // MyEventsExtension::MyEventsFunctionExpression
     {
       gd::StandardEvent event;
@@ -142,6 +156,38 @@ const void SetupEvents(gd::EventsList &eventList) {
           0,
           gd::Expression(
               "1 + MyEventsExtension::MyEventsFunctionExpression(123, 456)"));
+      event.GetActions().Insert(action);
+      eventList.InsertEvent(event);
+    }
+
+    if (eventList.GetEventsCount() != FreeFunctionWithObjects) {
+      throw std::logic_error("Invalid events setup");
+    }
+    // Create an event referring to objects
+    {
+      gd::StandardEvent event;
+      gd::Instruction action;
+      action.SetType("MyExtension::DoSomethingWithObjects");
+      action.SetParametersCount(2);
+      action.SetParameter(0, gd::Expression("ObjectWithMyBehavior"));
+      action.SetParameter(1, gd::Expression("MyCustomObject"));
+      event.GetActions().Insert(action);
+      eventList.InsertEvent(event);
+    }
+
+    if (eventList.GetEventsCount() != FreeFunctionWithObjectExpression) {
+      throw std::logic_error("Invalid events setup");
+    }
+    // Create an event referring to objects in an expression
+    {
+      gd::StandardEvent event;
+      gd::Instruction action;
+      action.SetType("MyExtension::DoSomething");
+      action.SetParametersCount(1);
+      action.SetParameter(
+          0,
+          gd::Expression(
+              "ObjectWithMyBehavior.GetObjectNumber()"));
       event.GetActions().Insert(action);
       eventList.InsertEvent(event);
     }
@@ -854,6 +900,30 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
       REQUIRE(externalLayout2.GetInitialInstances().HasInstancesOfObject(
                   "GlobalObject3") == true);
     }
+    
+    SECTION("Events") {
+      gd::Project project;
+      gd::Platform platform;
+      SetupProjectWithDummyPlatform(project, platform);
+      auto &eventsExtension = SetupProjectWithEventsFunctionExtension(project);
+
+      auto &layout = project.GetLayout("Scene");
+
+      // Trigger the refactoring after the renaming of an object
+      gd::WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
+          project, layout, "ObjectWithMyBehavior", "RenamedObjectWithMyBehavior",
+          /* isObjectGroup=*/false);
+
+      // Check object name has been renamed in action parameters.
+      REQUIRE(GetEventFirstActionFirstParameterString(
+                  layout.GetEvents().GetEvent(FreeFunctionWithObjects)) ==
+              "RenamedObjectWithMyBehavior");
+
+      // Check object name has been renamed in expressions.
+      REQUIRE(GetEventFirstActionFirstParameterString(
+                  layout.GetEvents().GetEvent(FreeFunctionWithObjectExpression)) ==
+                "RenamedObjectWithMyBehavior.GetObjectNumber()");
+    }
   }
 
   SECTION("Object renamed (in events function)") {
@@ -892,6 +962,43 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
     REQUIRE(objectGroup.Find("Object2") == true);
 
     // Events are not tested
+  }
+
+  SECTION("Object renamed (in events-based object)") {
+    gd::Project project;
+    gd::Platform platform;
+    SetupProjectWithDummyPlatform(project, platform);
+    auto &eventsExtension = SetupProjectWithEventsFunctionExtension(project);
+
+    auto &eventsBasedObject =
+        project.GetEventsFunctionsExtension("MyEventsExtension")
+               .GetEventsBasedObjects()
+               .Get("MyOtherEventsBasedObject");
+
+    // Create the objects container for the events function
+    gd::ObjectsContainer globalObjectsContainer;
+
+    // Trigger the refactoring after the renaming of an object
+    gd::WholeProjectRefactorer::ObjectOrGroupRenamedInEventsBasedObject(
+        project, globalObjectsContainer, eventsBasedObject,
+        "ObjectWithMyBehavior", "RenamedObjectWithMyBehavior",
+        /* isObjectGroup=*/false);
+
+    auto &objectFunctionEvents =
+        eventsBasedObject
+            .GetEventsFunctions()
+            .GetEventsFunction("MyObjectEventsFunction")
+            .GetEvents();
+
+    // Check object name has been renamed in action parameters.
+    REQUIRE(GetEventFirstActionFirstParameterString(
+                objectFunctionEvents.GetEvent(FreeFunctionWithObjects)) ==
+            "RenamedObjectWithMyBehavior");
+
+    // Check object name has been renamed in expressions.
+    REQUIRE(GetEventFirstActionFirstParameterString(
+                objectFunctionEvents.GetEvent(FreeFunctionWithObjectExpression)) ==
+              "RenamedObjectWithMyBehavior.GetObjectNumber()");
   }
 
   SECTION("Object deleted (in events function)") {
@@ -948,7 +1055,7 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
 
       // Check that events function calls in expressions have been renamed
       REQUIRE(GetEventFirstActionFirstParameterString(
-                  eventsList->GetEvent(FreeFunctionExpression)) ==
+                  eventsList->GetEvent(FreeFunctionWithExpression)) ==
               "1 + MyRenamedExtension::MyEventsFunctionExpression(123, 456)");
 
       // Check that the type of the behavior was changed in the behaviors of
@@ -1137,7 +1244,7 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
     for (auto *eventsList : GetEventsLists(project)) {
       // Check that events function calls in expressions have been renamed
       REQUIRE(GetEventFirstActionFirstParameterString(
-                  eventsList->GetEvent(FreeFunctionExpression)) ==
+                  eventsList->GetEvent(FreeFunctionWithExpression)) ==
               "1 + MyEventsExtension::MyRenamedFunctionExpression(123, 456)");
     }
   }
@@ -1177,7 +1284,7 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
     for (auto *eventsList : GetEventsLists(project)) {
       // Check that events function calls in expressions have been updated
       REQUIRE(GetEventFirstActionFirstParameterString(
-                  eventsList->GetEvent(FreeFunctionExpression)) ==
+                  eventsList->GetEvent(FreeFunctionWithExpression)) ==
               "1 + MyEventsExtension::MyEventsFunctionExpression(456, 123)");
     }
   }

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2077,7 +2077,7 @@ interface WholeProjectRefactorer {
     void STATIC_ObjectOrGroupRemovedInLayout([Ref] Project project, [Ref] Layout layout, [Const] DOMString objectName, boolean isObjectGroup, boolean removeEventsAndGroups);
     void STATIC_ObjectOrGroupRenamedInEventsFunction([Ref] Project project, [Ref] EventsFunction eventsFunction, [Ref] ObjectsContainer globalObjectsContainer, [Ref] ObjectsContainer objectsContainer, [Const] DOMString oldName, [Const] DOMString newName, boolean isObjectGroup);
     void STATIC_ObjectOrGroupRemovedInEventsFunction([Ref] Project project, [Ref] EventsFunction eventsFunction, [Ref] ObjectsContainer globalObjectsContainer, [Ref] ObjectsContainer objectsContainer, [Const] DOMString objectName, boolean isObjectGroup, boolean removeEventsAndGroups);
-    void STATIC_ObjectOrGroupRenamedInEventsBasedObject([Ref] Project project, [Ref] EventsBasedObject eventsBasedObject, [Ref] ObjectsContainer globalObjectsContainer, [Ref] ObjectsContainer objectsContainer, [Const] DOMString oldName, [Const] DOMString newName, boolean isObjectGroup);
+    void STATIC_ObjectOrGroupRenamedInEventsBasedObject([Ref] Project project, [Ref] ObjectsContainer globalObjectsContainer, [Ref] EventsBasedObject eventsBasedObject, [Const] DOMString oldName, [Const] DOMString newName, boolean isObjectGroup);
     void STATIC_ObjectOrGroupRemovedInEventsBasedObject([Ref] Project project, [Ref] EventsBasedObject eventsBasedObject, [Ref] ObjectsContainer globalObjectsContainer, [Ref] ObjectsContainer objectsContainer, [Const] DOMString objectName, boolean isObjectGroup, boolean removeEventsAndGroups);
     void STATIC_GlobalObjectOrGroupRenamed([Ref] Project project, [Const] DOMString oldName, [Const] DOMString newName, boolean isObjectGroup);
     void STATIC_GlobalObjectOrGroupRemoved([Ref] Project project, [Const] DOMString objectName, boolean isObjectGroup, boolean removeEventsAndGroups);
@@ -2328,24 +2328,11 @@ interface EventsBasedObject {
     void SerializeTo([Ref] SerializerElement element);
     void UnserializeFrom([Ref] Project project, [Const, Ref] SerializerElement element);
 
-    //Inherited from gd::ObjectsContainer
-    [Ref] gdObject InsertNewObject([Ref] Project project, [Const] DOMString type, [Const] DOMString name, unsigned long pos);
-    [Ref] gdObject InsertObject([Const, Ref] gdObject obj, unsigned long pos);
-    boolean HasObjectNamed([Const] DOMString name);
-    [Ref] gdObject GetObject([Const] DOMString name);
-    [Ref] gdObject GetObjectAt(unsigned long pos);
-    unsigned long GetObjectPosition([Const] DOMString name);
-    void RemoveObject([Const] DOMString name);
-    void SwapObjects(unsigned long first, unsigned long second);
-    void MoveObject(unsigned long oldIndex, unsigned long newIndex);
-    void MoveObjectToAnotherContainer([Const] DOMString name, [Ref] ObjectsContainer newObjectsContainer, unsigned long newPosition);
-    unsigned long GetObjectsCount();
-    [Ref] ObjectGroupsContainer GetObjectGroups();
-
     [Const, Value] DOMString STATIC_GetPropertyActionName([Const] DOMString propertyName);
     [Const, Value] DOMString STATIC_GetPropertyConditionName([Const] DOMString propertyName);
     [Const, Value] DOMString STATIC_GetPropertyExpressionName([Const] DOMString propertyName);
 };
+EventsBasedObject implements ObjectsContainer;
 
 interface EventsBasedObjectsList {
     [Ref] EventsBasedObject InsertNew([Const] DOMString name, unsigned long pos);

--- a/GDevelop.js/types/gdeventsbasedobject.js
+++ b/GDevelop.js/types/gdeventsbasedobject.js
@@ -11,18 +11,6 @@ declare class gdEventsBasedObject extends gdObjectsContainer {
   getPropertyDescriptors(): gdNamedPropertyDescriptorsList;
   serializeTo(element: gdSerializerElement): void;
   unserializeFrom(project: gdProject, element: gdSerializerElement): void;
-  insertNewObject(project: gdProject, type: string, name: string, pos: number): gdObject;
-  insertObject(obj: gdObject, pos: number): gdObject;
-  hasObjectNamed(name: string): boolean;
-  getObject(name: string): gdObject;
-  getObjectAt(pos: number): gdObject;
-  getObjectPosition(name: string): number;
-  removeObject(name: string): void;
-  swapObjects(first: number, second: number): void;
-  moveObject(oldIndex: number, newIndex: number): void;
-  moveObjectToAnotherContainer(name: string, newObjectsContainer: gdObjectsContainer, newPosition: number): void;
-  getObjectsCount(): number;
-  getObjectGroups(): gdObjectGroupsContainer;
   static getPropertyActionName(propertyName: string): string;
   static getPropertyConditionName(propertyName: string): string;
   static getPropertyExpressionName(propertyName: string): string;

--- a/GDevelop.js/types/gdwholeprojectrefactorer.js
+++ b/GDevelop.js/types/gdwholeprojectrefactorer.js
@@ -16,7 +16,7 @@ declare class gdWholeProjectRefactorer {
   static objectOrGroupRemovedInLayout(project: gdProject, layout: gdLayout, objectName: string, isObjectGroup: boolean, removeEventsAndGroups: boolean): void;
   static objectOrGroupRenamedInEventsFunction(project: gdProject, eventsFunction: gdEventsFunction, globalObjectsContainer: gdObjectsContainer, objectsContainer: gdObjectsContainer, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectOrGroupRemovedInEventsFunction(project: gdProject, eventsFunction: gdEventsFunction, globalObjectsContainer: gdObjectsContainer, objectsContainer: gdObjectsContainer, objectName: string, isObjectGroup: boolean, removeEventsAndGroups: boolean): void;
-  static objectOrGroupRenamedInEventsBasedObject(project: gdProject, eventsBasedObject: gdEventsBasedObject, globalObjectsContainer: gdObjectsContainer, objectsContainer: gdObjectsContainer, oldName: string, newName: string, isObjectGroup: boolean): void;
+  static objectOrGroupRenamedInEventsBasedObject(project: gdProject, globalObjectsContainer: gdObjectsContainer, eventsBasedObject: gdEventsBasedObject, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectOrGroupRemovedInEventsBasedObject(project: gdProject, eventsBasedObject: gdEventsBasedObject, globalObjectsContainer: gdObjectsContainer, objectsContainer: gdObjectsContainer, objectName: string, isObjectGroup: boolean, removeEventsAndGroups: boolean): void;
   static globalObjectOrGroupRenamed(project: gdProject, oldName: string, newName: string, isObjectGroup: boolean): void;
   static globalObjectOrGroupRemoved(project: gdProject, objectName: string, isObjectGroup: boolean, removeEventsAndGroups: boolean): void;

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -133,7 +133,6 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
     if (object.getName() !== newName) {
       gd.WholeProjectRefactorer.objectOrGroupRenamedInEventsBasedObject(
         project,
-        eventsBasedObject,
         globalObjectsContainer,
         eventsBasedObject,
         object.getName(),


### PR DESCRIPTION
It adds tests for object renaming in events (layout and event-based object function)