### PR TITLE
Fix previews not loading audio/font/json resources uploaded with the web-app

### DIFF
--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -15,6 +15,20 @@ namespace gdjs {
       logger.error('Error while loading an audio file: ' + error),
   };
 
+  const checkIfCredentialsRequired = (url: string) => {
+    // Any resource stored on the GDevelop Cloud buckets needs the "credentials" of the user,
+    // i.e: its gdevelop.io cookie, to be passed.
+    // Note that this is only useful during previews.
+    if (
+      url.startsWith('https://project-resources.gdevelop.io/') ||
+      url.startsWith('https://project-resources-dev.gdevelop.io/')
+    )
+      return true;
+
+    // For other resources, use the default way of loading resources ("anonymous" or "same-site").
+    return false;
+  };
+
   /**
    * Ensure the volume is between 0 and 1.
    */
@@ -517,6 +531,9 @@ namespace gdjs {
             {
               src: [soundFile],
               html5: isMusic,
+              xhr: {
+                withCredentials: checkIfCredentialsRequired(soundFile),
+              },
               // Cache the sound with no volume. This avoids a bug where it plays at full volume
               // for a split second before setting its correct volume.
               volume: 0,
@@ -551,6 +568,9 @@ namespace gdjs {
           {
             src: [soundFile],
             html5: isMusic,
+            xhr: {
+              withCredentials: checkIfCredentialsRequired(soundFile),
+            },
             // Cache the sound with no volume. This avoids a bug where it plays at full volume
             // for a split second before setting its correct volume.
             volume: 0,
@@ -791,6 +811,9 @@ namespace gdjs {
             onload: onLoadCallback,
             onloaderror: onLoadCallback,
             html5: isMusic,
+            xhr: {
+              withCredentials: checkIfCredentialsRequired(file)
+            },
             // Cache the sound with no volume. This avoids a bug where it plays at full volume
             // for a split second before setting its correct volume.
             volume: 0,
@@ -823,6 +846,7 @@ namespace gdjs {
           // preloading as sound already does a XHR request, hence "else if"
           loadCounter++;
           const sound = new XMLHttpRequest();
+          sound.withCredentials = checkIfCredentialsRequired(file);
           sound.addEventListener('load', callback);
           sound.addEventListener('error', (_) =>
             callback(_, 'XHR error: ' + file)

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -40,7 +40,7 @@ namespace gdjs {
     return null;
   };
 
-  const determineCrossOrigin = (url: string) => {
+  const checkIfCredentialsRequired = (url: string) => {
     // Any resource stored on the GDevelop Cloud buckets needs the "credentials" of the user,
     // i.e: its gdevelop.io cookie, to be passed.
     // Note that this is only useful during previews.
@@ -48,12 +48,10 @@ namespace gdjs {
       url.startsWith('https://project-resources.gdevelop.io/') ||
       url.startsWith('https://project-resources-dev.gdevelop.io/')
     )
-      return 'use-credentials';
+      return true;
 
-    // For other resources, use "anonymous" as done by default by PixiJS. Note that using `false`
-    // to not having `crossorigin` at all would NOT work because the browser would taint the
-    // loaded resource so that it can't be read/used in a canvas (it's only working for display `<img>` on screen).
-    return 'anonymous';
+    // For other resources, use the default way of loading resources ("anonymous" or "same-site").
+    return false;
   };
 
   /**
@@ -134,7 +132,12 @@ namespace gdjs {
       const file = resource.file;
       const texture = PIXI.Texture.from(file, {
         resourceOptions: {
-          crossorigin: determineCrossOrigin(file),
+          // Note that using `false`
+          // to not having `crossorigin` at all would NOT work because the browser would taint the
+          // loaded resource so that it can't be read/used in a canvas (it's only working for display `<img>` on screen).
+          crossorigin: checkIfCredentialsRequired(file)
+            ? 'use-credentials'
+            : 'anonymous',
         },
       }).on('error', (error) => {
         logFileLoadingError(file, error);
@@ -178,7 +181,12 @@ namespace gdjs {
       );
       const texture = PIXI.Texture.from(file, {
         resourceOptions: {
-          crossorigin: determineCrossOrigin(file),
+          // Note that using `false`
+          // to not having `crossorigin` at all would NOT work because the browser would taint the
+          // loaded resource so that it can't be read/used in a canvas (it's only working for display `<img>` on screen).
+          crossorigin: checkIfCredentialsRequired(file)
+            ? 'use-credentials'
+            : 'anonymous',
         },
       }).on('error', (error) => {
         logFileLoadingError(file, error);
@@ -239,7 +247,9 @@ namespace gdjs {
             name: file,
             url: file,
             loadType: PIXI.LoaderResource.LOAD_TYPE.IMAGE,
-            crossOrigin: determineCrossOrigin(file),
+            crossOrigin: checkIfCredentialsRequired(file)
+              ? 'use-credentials'
+              : 'anonymous',
           });
         }
       }


### PR DESCRIPTION
Credentials were not sent for audio, fonts and json.

Manually tested:
- [x] I can upload and play a sound file. It works as a music (HTML5 audio, browser handled) or as a sound (web audio, with an xhr request). It works when preloaded as a music, as a sound or in cache.
- [ ] Font
- [ ] JSON
