### PR TITLE
Fix resource refactoring for child-objects.

### DIFF
--- a/Core/GDCore/Project/CustomObjectConfiguration.cpp
+++ b/Core/GDCore/Project/CustomObjectConfiguration.cpp
@@ -216,4 +216,15 @@ void CustomObjectConfiguration::ExposeResources(
       }
     }
   }
+
+  auto objectProperties = std::map<gd::String, gd::PropertyDescriptor>();
+  if (!project->HasEventsBasedObject(GetType())) {
+    return;
+  }
+  const auto &eventsBasedObject = project->GetEventsBasedObject(GetType());
+
+  for (auto& childObject : eventsBasedObject.GetObjects()) {
+    auto &configuration = GetChildObjectConfiguration(childObject->GetName());
+    configuration.ExposeResources(worker);
+  }
 }


### PR DESCRIPTION
Custom objects wasn’t declaring their resource usage, it broke “remove unused resources” for instance.