### PR TITLE
Fix extension documentation links

### DIFF
--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -122,6 +122,7 @@ GDevelop is built in a flexible way. In addition to [[gdevelop5:all-features|cor
         '\n' +
         convertMarkdownToDokuWikiMarkdown(extension.description) +
         '\n' +
+        (helpPageUrl ? `\n[[${helpPageUrl}|Read more...]]\n` : ``) +
         generateExtensionFooterText(extension.fullName);
 
       const extensionReferenceFilePath = path.join(

--- a/newIDE/app/scripts/lib/DokuwikiHelpers.js
+++ b/newIDE/app/scripts/lib/DokuwikiHelpers.js
@@ -18,7 +18,7 @@ const convertMarkdownToDokuWikiMarkdown = markdownText => {
     .replace(/\[(.*?)\]\((.*?)\)/g, (match, linkText, linkUrl) => {
       const url = linkUrl.replace(/^\/+/, '');
       const title = linkText.replace(/^\[(.*?)\]/, '$1');
-      return `{{${url}|${title}}}`;
+      return `[[${url}|${title}]]`;
     })
     // Add a new line before each list, to make sure DokuWiki renders it correctly.
     .replace(/((\n[-\*].*)+)/gm, '\n$1')


### PR DESCRIPTION
It also adds a link from the reference to the extension document.

Example:
```
# Marching Squares (experimental)

{{https://resources.gdevelop-app.com/assets/Icons/peanut-outline.svg?&.png?nolink&48x48 |}}
Allow to build a "scalar field" and draw contour lines of it: useful for fog of wars, liquid effects, paint the ground, etc...

**Authors and contributors** to this community extension: [D8H](https://liluo.io/D8H).

---

It can be helpful for:
  * Liquid effects lik water, blobs or lava ([[https://editor.gdevelop.io/?project=example://marching-squares-liquids|open the project online]])
  * Fog of wars ([[https://editor.gdevelop.io/?project=example://marching-squares-fog-of-war|open the project online]])
  * Platformer with destructible platforms ([[https://editor.gdevelop.io/?project=example://marching-squares-platforms-painter|open the project online]])
  * Dynamically paint territories ([[https://editor.gdevelop.io/?project=example://marching-squares-qix|open the project online]])
  * Top-down relief with physics ([[https://editor.gdevelop.io/?project=example://marching-squares-terraforming|open the project online]])
  * Island generator ([[https://editor.gdevelop.io/?project=example://marching-squares-island-generator|open the project online]])

[[https://wiki.gdevelop.io/gdevelop5/extensions/marching-squares|Read more...]]

---
*This page is an auto-generated reference page about the **Marching Squares (experimental)** extension, made by the community of [[https://gdevelop.io/|GDevelop, the open-source, cross-platform game engine designed for everyone]].* Learn more about [[gdevelop5:extensions|all GDevelop community-made extensions here]].
```