### PR TITLE
Allow event-based objects to define a default name for created objects

### DIFF
--- a/Core/GDCore/Project/EventsBasedObject.cpp
+++ b/Core/GDCore/Project/EventsBasedObject.cpp
@@ -23,12 +23,16 @@ EventsBasedObject::EventsBasedObject(const gd::EventsBasedObject &_eventBasedObj
 }
 
 void EventsBasedObject::SerializeTo(SerializerElement& element) const {
+  element.SetAttribute("defaultName", defaultName);
+
   AbstractEventsBasedEntity::SerializeTo(element);
   SerializeObjectsTo(element.AddChild("objects"));
 }
 
 void EventsBasedObject::UnserializeFrom(gd::Project& project,
                                           const SerializerElement& element) {
+  defaultName = element.GetStringAttribute("defaultName");
+
   AbstractEventsBasedEntity::UnserializeFrom(project, element);
   UnserializeObjectsFrom(project, element.GetChild("objects"));
 }

--- a/Core/GDCore/Project/EventsBasedObject.h
+++ b/Core/GDCore/Project/EventsBasedObject.h
@@ -38,6 +38,19 @@ class GD_CORE_API EventsBasedObject: public AbstractEventsBasedEntity, public Ob
    */
   EventsBasedObject* Clone() const { return new EventsBasedObject(*this); };
 
+  /**
+   * \brief Get the default name for created objects.
+   */
+  const gd::String& GetDefaultName() const { return defaultName; };
+
+  /**
+   * \brief Set the default name for created objects.
+   */
+  EventsBasedObject& SetDefaultName(const gd::String& defaultName_) {
+    defaultName = defaultName_;
+    return *this;
+  }
+
   EventsBasedObject& SetDescription(const gd::String& description_) override {
     AbstractEventsBasedEntity::SetDescription(description_);
     return *this;
@@ -65,6 +78,7 @@ class GD_CORE_API EventsBasedObject: public AbstractEventsBasedEntity, public Ob
                        const SerializerElement& element) override;
 
  private:
+  gd::String defaultName;
 };
 
 }  // namespace gd

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2321,6 +2321,8 @@ interface EventsBasedObject {
     [Const, Ref] DOMString GetName();
     [Ref] EventsBasedObject SetFullName([Const] DOMString fullName);
     [Const, Ref] DOMString GetFullName();
+    [Ref] EventsBasedObject SetDefaultName([Const] DOMString defaultName);
+    [Const, Ref] DOMString GetDefaultName();
 
     [Ref] EventsFunctionsContainer GetEventsFunctions();
     [Ref] NamedPropertyDescriptorsList GetPropertyDescriptors();

--- a/GDevelop.js/types/gdeventsbasedobject.js
+++ b/GDevelop.js/types/gdeventsbasedobject.js
@@ -7,6 +7,8 @@ declare class gdEventsBasedObject extends gdObjectsContainer {
   getName(): string;
   setFullName(fullName: string): gdEventsBasedObject;
   getFullName(): string;
+  setDefaultName(defaultName: string): gdEventsBasedObject;
+  getDefaultName(): string;
   getEventsFunctions(): gdEventsFunctionsContainer;
   getPropertyDescriptors(): gdNamedPropertyDescriptorsList;
   serializeTo(element: gdSerializerElement): void;

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -121,17 +121,17 @@ export default class EventsBasedObjectEditor extends React.Component<
                       eventsBasedObject.getName()
                     }
                     onChange={text => {
-                      if (!gd.Project.validateName(text)) {
+                      if (gd.Project.validateName(text)) {
+                        eventsBasedObject.setDefaultName(text);
+                        this.forceUpdate();
+                      } else {
                         showWarningBox(
                           i18n._(
                             t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
                           ),
                           { delayToNextTick: true }
                         );
-                        return false;
                       }
-                      eventsBasedObject.setDefaultName(text);
-                      this.forceUpdate();
                     }}
                     fullWidth
                   />

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -1,6 +1,7 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import { t } from '@lingui/macro';
+import { I18n } from '@lingui/react';
 
 import * as React from 'react';
 import TextField from '../UI/TextField';
@@ -12,6 +13,9 @@ import EventBasedObjectChildrenEditor from './EventBasedObjectChildrenEditor';
 import { ColumnStackLayout } from '../UI/Layout';
 import { Line } from '../UI/Grid';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
+import { showWarningBox } from '../UI/Messages/MessageBox';
+
+const gd: libGDevelop = global.gd;
 
 type TabName = 'configuration' | 'properties' | 'children';
 
@@ -105,21 +109,34 @@ export default class EventsBasedObjectEditor extends React.Component<
                 fullWidth
                 rows={3}
               />
-              <SemiControlledTextField
-                commitOnBlur
-                floatingLabelText={
-                  <Trans>Default name for created objects</Trans>
-                }
-                value={
-                  eventsBasedObject.getDefaultName() ||
-                  eventsBasedObject.getName()
-                }
-                onChange={text => {
-                  eventsBasedObject.setDefaultName(text);
-                  this.forceUpdate();
-                }}
-                fullWidth
-              />
+              <I18n>
+                {({ i18n }) => (
+                  <SemiControlledTextField
+                    commitOnBlur
+                    floatingLabelText={
+                      <Trans>Default name for created objects</Trans>
+                    }
+                    value={
+                      eventsBasedObject.getDefaultName() ||
+                      eventsBasedObject.getName()
+                    }
+                    onChange={text => {
+                      if (!gd.Project.validateName(text)) {
+                        showWarningBox(
+                          i18n._(
+                            t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
+                          ),
+                          { delayToNextTick: true }
+                        );
+                        return false;
+                      }
+                      eventsBasedObject.setDefaultName(text);
+                      this.forceUpdate();
+                    }}
+                    fullWidth
+                  />
+                )}
+              </I18n>
               {eventsBasedObject
                 .getEventsFunctions()
                 .getEventsFunctionsCount() === 0 && (

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -105,6 +105,21 @@ export default class EventsBasedObjectEditor extends React.Component<
                 fullWidth
                 rows={3}
               />
+              <SemiControlledTextField
+                commitOnBlur
+                floatingLabelText={
+                  <Trans>Default name for created objects</Trans>
+                }
+                value={
+                  eventsBasedObject.getDefaultName() ||
+                  eventsBasedObject.getName()
+                }
+                onChange={text => {
+                  eventsBasedObject.setDefaultName(text);
+                  this.forceUpdate();
+                }}
+                fullWidth
+              />
               {eventsBasedObject
                 .getEventsFunctions()
                 .getEventsFunctionsCount() === 0 && (

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -189,8 +189,11 @@ export default class ObjectsList extends React.Component<Props, State> {
       onObjectSelected,
     } = this.props;
 
+    const defaultName = project.hasEventsBasedObject(objectType)
+      ? 'New' + project.getEventsBasedObject(objectType).getDefaultName()
+      : objectTypeToDefaultName[objectType] || 'NewObject';
     const name = newNameGenerator(
-      objectTypeToDefaultName[objectType] || 'NewObject',
+      defaultName,
       name =>
         objectsContainer.hasObjectNamed(name) || project.hasObjectNamed(name)
     );


### PR DESCRIPTION
For instance, for the PanelSpriteButton event-based object, the default name can be "Button".
When users create a new object, it will be called "NewButton" instead of "NewPanelSpriteButton" or "NewObject".