### PR TITLE
Add community extensions subsection and warning

### DIFF
--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -106,8 +106,7 @@ const createExtensionReferencePage = async (extension, extensionShortHeader, isC
     (isCommunity ? `<note important>
 This is an extension made by a community member — but not reviewed
 by the GDevelop extension team. As such, we can't guarantee it
-meets all the quality standards of official extensions. It could
-also not be compatible with older GDevelop versions. In case of
+meets all the quality standards of official extensions. In case of
 doubt, contact the author to know more about what the extension
 does or inspect its content before using it.
 </note>\n\n` : '') +


### PR DESCRIPTION
Also fix a "read more" link loop.

The extension I took is probably well made because Arthuro is the author. But, for other extensions, as we don't necessarily do a review of the description, I think it's important to add a warning to keep a good impression on readers.

![image](https://user-images.githubusercontent.com/2611977/192584623-69c0cd61-478d-4b6b-9c4f-cd8747c37054.png)

![image](https://user-images.githubusercontent.com/2611977/192584557-4b5e7405-7147-43db-beeb-e87785954986.png)

![image](https://user-images.githubusercontent.com/2611977/192584594-4bfb831a-268f-49d4-b0ef-3f8f7a174d4e.png)
