### PR TITLE
Add subsections for extensions categories in the Wiki

### DIFF
--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -14,7 +14,6 @@ const {
   improperlyFormattedHelpPaths,
 } = require('./lib/WikiHelpLink');
 const { convertMarkdownToDokuWikiMarkdown } = require('./lib/DokuwikiHelpers');
-const { table } = require('console');
 
 const extensionShortHeadersUrl =
   'https://api.gdevelop-app.com/asset/extension-short-header';
@@ -178,14 +177,12 @@ const getAllExtensionsSections = (extensionsAndExtensionShortHeaders) => {
   let extensionSectionsContent = "";
   const extensionsByCategory = sortKeys(group(extensionsAndExtensionShortHeaders, getExtensionCategory));
   for (const category in extensionsByCategory) {
-    if (Object.hasOwnProperty.call(extensionsByCategory, category)) {
       const extensions = extensionsByCategory[category];
 
       extensionSectionsContent += `### ${category}\n\n`;
       for (const { extension, extensionShortHeader } of extensions) {
         extensionSectionsContent += getExtensionSection(extension, extensionShortHeader);
       }
-    }
   }
   return extensionSectionsContent;
 }

--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -106,8 +106,7 @@ const createExtensionReferencePage = async (extension, extensionShortHeader, isC
     (isCommunity ? `<note important>
 This is an extension made by a community member — but not reviewed
 by the GDevelop extension team. As such, we can't guarantee it
-meets all the quality standards of official extensions. It could
-also not be compatible with older GDevelop versions. In case of
+meets all the quality standards of official extensions. In case of
 doubt, contact the author to know more about what the extension
 does or inspect its content before using it.
 </note>\n\n` : '') +

--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -85,7 +85,7 @@ const getAllExtensionAndExtensionShortHeaders = async () => {
   return extensions;
 };
 
-const group = (array, getKey) => {
+const groupBy = (array, getKey) => {
   const table = {};
   for (const element of array) {
     const key = getKey(element);
@@ -150,7 +150,7 @@ does or inspect its content before using it.
   console.info(`ℹ️ File generated: ${extensionReferenceFilePath}`);
 };
 
-const getExtensionSection = (extension, extensionShortHeader) => {
+const generateExtensionSection = (extension, extensionShortHeader) => {
   const folderName = getExtensionFolderName(extension.name);
   const referencePageUrl = `${gdevelopWikiUrlRoot}/extensions/${folderName}/reference`;
   const helpPageUrl = getHelpLink(extension.helpPath) || referencePageUrl;
@@ -171,9 +171,9 @@ const getExtensionSection = (extension, extensionShortHeader) => {
     '\n\n');
 };
 
-const getAllExtensionsSections = (extensionsAndExtensionShortHeaders) => {
+const generateAllExtensionsSections = (extensionsAndExtensionShortHeaders) => {
   let extensionSectionsContent = "";
-  const extensionsByCategory = sortKeys(group(
+  const extensionsByCategory = sortKeys(groupBy(
       extensionsAndExtensionShortHeaders,
       pair => pair.extension.category || 'General'));
   for (const category in extensionsByCategory) {
@@ -181,7 +181,7 @@ const getAllExtensionsSections = (extensionsAndExtensionShortHeaders) => {
 
       extensionSectionsContent += `### ${category}\n\n`;
       for (const { extension, extensionShortHeader } of extensions) {
-        extensionSectionsContent += getExtensionSection(extension, extensionShortHeader);
+        extensionSectionsContent += generateExtensionSection(extension, extensionShortHeader);
       }
   }
   return extensionSectionsContent;
@@ -214,7 +214,7 @@ GDevelop is built in a flexible way. In addition to [[gdevelop5:all-features|cor
     } of reviewedExtensionsAndExtensionShortHeaders) {
       await createExtensionReferencePage(extension, extensionShortHeader, false);
     }
-    indexPageContent += getAllExtensionsSections(reviewedExtensionsAndExtensionShortHeaders);
+    indexPageContent += generateAllExtensionsSections(reviewedExtensionsAndExtensionShortHeaders);
 
     indexPageContent += `## Community extensions
 
@@ -231,7 +231,7 @@ does or inspect its content before using it.
     } of communityExtensionsAndExtensionShortHeaders) {
       await createExtensionReferencePage(extension, extensionShortHeader, true);
     }
-    indexPageContent += getAllExtensionsSections(communityExtensionsAndExtensionShortHeaders);
+    indexPageContent += generateAllExtensionsSections(communityExtensionsAndExtensionShortHeaders);
 
     indexPageContent += `
 ## Make your own extension

--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -107,8 +107,6 @@ const sortKeys = (table) => {
   return sortedTable;
 }
 
-const getExtensionCategory = pair => pair.extension.category || 'General';
-
 const createExtensionReferencePage = async (extension, extensionShortHeader, isCommunity) => {
   const folderName = getExtensionFolderName(extension.name);
   const referencePageUrl = `${gdevelopWikiUrlRoot}/extensions/${folderName}/reference`;
@@ -175,7 +173,9 @@ const getExtensionSection = (extension, extensionShortHeader) => {
 
 const getAllExtensionsSections = (extensionsAndExtensionShortHeaders) => {
   let extensionSectionsContent = "";
-  const extensionsByCategory = sortKeys(group(extensionsAndExtensionShortHeaders, getExtensionCategory));
+  const extensionsByCategory = sortKeys(group(
+      extensionsAndExtensionShortHeaders,
+      pair => pair.extension.category || 'General'));
   for (const category in extensionsByCategory) {
       const extensions = extensionsByCategory[category];
 


### PR DESCRIPTION
Built over:
- https://github.com/4ian/GDevelop/pull/4330

It handles any category we will add.
Categories are sorted alphabetically.
General is the default category.

Extensions are h4, they no longer appear on the index. This could be an issue.

![image](https://user-images.githubusercontent.com/2611977/192774586-2cd5e1ee-43ae-46fb-b59d-6d30f38b56ae.png)
