### PR TITLE
Fix custom object renderer for buttons

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionParametersEditorDialog.js
@@ -5,7 +5,7 @@ import { type EventsScope } from '../../../InstructionOrExpression/EventsScope.f
 import ExpressionParametersEditor from './ExpressionParametersEditor';
 import Dialog, { DialogPrimaryButton } from '../../../UI/Dialog';
 import Text from '../../../UI/Text';
-import { Column, Line } from '../../../UI/Grid';
+import { Column } from '../../../UI/Grid';
 import HelpButton from '../../../UI/HelpButton';
 
 export type ParameterValues = Array<string>;

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -3,6 +3,7 @@ import RenderedInstance from './RenderedInstance';
 import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
 import ResourcesLoader from '../../ResourcesLoader';
 import ObjectsRenderingService from '../ObjectsRenderingService';
+import RenderedTextInstance from './RenderedTextInstance';
 import { mapReverseFor } from '../../Utils/MapFor';
 import * as PIXI from 'pixi.js-legacy';
 
@@ -13,10 +14,16 @@ const gd: libGDevelop = global.gd;
 class ChildInstance {
   x: number;
   y: number;
+  _hasCustomSize: boolean;
+  _customWidth: number;
+  _customHeight: number;
 
   constructor() {
     this.x = 0;
     this.y = 0;
+    this._customWidth = 0;
+    this._customHeight = 0;
+    this._hasCustomSize = false;
   }
 
   getX() {
@@ -67,22 +74,30 @@ class ChildInstance {
 
   setLayer(layer: string) {}
 
-  setHasCustomSize(enable: boolean) {}
+  setHasCustomSize(enable: boolean) {
+    this._hasCustomSize = enable;
+  }
 
   hasCustomSize() {
-    return false;
+    return this._hasCustomSize;
   }
 
-  setCustomWidth(width: number) {}
+  setCustomWidth(width: number) {
+    this._customWidth = width;
+    this._hasCustomSize = true;
+  }
 
   getCustomWidth() {
-    return 0;
+    return this._customWidth;
   }
 
-  setCustomHeight(height: number) {}
+  setCustomHeight(height: number) {
+    this._customHeight = height;
+    this._hasCustomSize = true;
+  }
 
   getCustomHeight() {
-    return 0;
+    return this._customHeight;
   }
 
   resetPersistentUuid() {
@@ -168,7 +183,7 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
           );
           const childInstance = new ChildInstance();
           this.childrenInstances.push(childInstance);
-          return ObjectsRenderingService.createNewInstanceRenderer(
+          const renderer = ObjectsRenderingService.createNewInstanceRenderer(
             project,
             layout,
             // $FlowFixMe Use real object instances.
@@ -176,6 +191,10 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
             childObjectConfiguration,
             this._pixiObject
           );
+          if (renderer instanceof RenderedTextInstance) {
+            renderer._pixiObject.style.align = 'center';
+          }
+          return renderer;
         })
       : [];
   }
@@ -229,6 +248,13 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
     const centerX = defaultWidth / 2;
     const centerY = defaultHeight / 2;
 
+    const width = this._instance.hasCustomSize()
+      ? this._instance.getCustomWidth()
+      : this.getDefaultWidth();
+    const height = this._instance.hasCustomSize()
+      ? this._instance.getCustomHeight()
+      : this.getDefaultHeight();
+
     for (
       let index = 0;
       index < this.childrenRenderedInstances.length;
@@ -236,10 +262,20 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
     ) {
       const renderedInstance = this.childrenRenderedInstances[index];
       const childInstance = this.childrenInstances[index];
-      childInstance.x = (defaultWidth - renderedInstance.getDefaultWidth()) / 2;
-      childInstance.y =
-        (defaultHeight - renderedInstance.getDefaultHeight()) / 2;
+
+      childInstance.x = 0;
+      childInstance.y = 0;
+      childInstance.setCustomWidth(width);
+      childInstance.setCustomHeight(height);
       renderedInstance.update();
+
+      // Center text objects.
+      if (renderedInstance instanceof RenderedTextInstance) {
+        renderedInstance._pixiObject.style.align = 'center';
+        childInstance.x = (width - renderedInstance._pixiObject.width) / 2;
+        childInstance.y = (height - renderedInstance._pixiObject.height) / 2;
+        renderedInstance.update();
+      }
     }
 
     this._pixiObject.pivot.x = centerX;
@@ -247,14 +283,8 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
     this._pixiObject.rotation = RenderedInstance.toRad(
       this._instance.getAngle()
     );
-    if (this._instance.hasCustomSize()) {
-      this._pixiObject.scale.x = this._instance.getCustomWidth() / defaultWidth;
-      this._pixiObject.scale.y =
-        this._instance.getCustomHeight() / defaultHeight;
-    } else {
-      this._pixiObject.scale.x = 1;
-      this._pixiObject.scale.y = 1;
-    }
+    this._pixiObject.scale.x = 1;
+    this._pixiObject.scale.y = 1;
     this._pixiObject.position.x =
       this._instance.getX() +
       (centerX - originX) * Math.abs(this._pixiObject.scale.x);

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -3,7 +3,7 @@ import RenderedInstance from './RenderedInstance';
 import PixiResourcesLoader from '../../ObjectsRendering/PixiResourcesLoader';
 import ResourcesLoader from '../../ResourcesLoader';
 import ObjectsRenderingService from '../ObjectsRenderingService';
-import { mapFor } from '../../Utils/MapFor';
+import { mapReverseFor } from '../../Utils/MapFor';
 import * as PIXI from 'pixi.js-legacy';
 
 const gd: libGDevelop = global.gd;
@@ -161,7 +161,7 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
 
     this.childrenInstances = [];
     this.childrenRenderedInstances = eventBasedObject
-      ? mapFor(0, eventBasedObject.getObjectsCount(), i => {
+      ? mapReverseFor(0, eventBasedObject.getObjectsCount(), i => {
           const childObject = eventBasedObject.getObjectAt(i);
           const childObjectConfiguration = customObjectConfiguration.getChildObjectConfiguration(
             childObject.getName()

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -192,6 +192,7 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
             this._pixiObject
           );
           if (renderer instanceof RenderedTextInstance) {
+            // TODO EBO Remove this line when an alignment property is added to the text object.
             renderer._pixiObject.style.align = 'center';
           }
           return renderer;
@@ -269,13 +270,16 @@ export default class RenderedCustomObjectInstance extends RenderedInstance {
       childInstance.setCustomHeight(height);
       renderedInstance.update();
 
-      // Center text objects.
       if (renderedInstance instanceof RenderedTextInstance) {
+        // TODO EBO Remove this line when an alignment property is added to the text object.
         renderedInstance._pixiObject.style.align = 'center';
-        childInstance.x = (width - renderedInstance._pixiObject.width) / 2;
-        childInstance.y = (height - renderedInstance._pixiObject.height) / 2;
-        renderedInstance.update();
       }
+      // This ensure objects are centered if their dimensions changed from the
+      // custom ones (preferred ones).
+      // For instance, text object dimensions change according to how the text is wrapped.
+      childInstance.x = (width - renderedInstance._pixiObject.width) / 2;
+      childInstance.y = (height - renderedInstance._pixiObject.height) / 2;
+      renderedInstance.update();
     }
 
     this._pixiObject.pivot.x = centerX;


### PR DESCRIPTION
It's not a big extraction, but it's very safe and it will allow to see how buttons resizing works in the IDE with a nightly as I can't manage to build macOS version on the experimental branch.
The bonus is that the button won't appear broken in the IDE of previous GDevelop version when we launch it.