### PR TITLE
Reorganize extensions categories.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -22,6 +22,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
           "object or a position.",
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("Camera")
       .SetExtensionHelpPath("/interface/scene-editor/layers-and-cameras");
   extension.AddInstructionOrExpressionGroupMetadata(_("Layers and cameras"))
       .SetIcon("res/conditions/camera24.png");

--- a/Core/GDCore/Extensions/Builtin/FileExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/FileExtension.cpp
@@ -21,7 +21,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsFileExtension(
           "Florian Rival",
           "Open source (MIT License)")
       .SetExtensionHelpPath("/all-features/storage")
-      .SetCategory("Device");
+      .SetCategory("Advanced");
   extension.AddInstructionOrExpressionGroupMetadata(_("Storage"))
       .SetIcon("res/conditions/fichier24.png");
 

--- a/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/WindowExtension.cpp
@@ -20,6 +20,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsWindowExtension(
           "these features can be applied.",
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("User interface")
       .SetExtensionHelpPath("/all-features/window");
   extension
       .AddInstructionOrExpressionGroupMetadata(

--- a/Extensions/AdvancedWindow/JsExtension.js
+++ b/Extensions/AdvancedWindow/JsExtension.js
@@ -28,7 +28,7 @@ module.exports = {
         'Arthur Pacaud (arthuro555)',
         'MIT'
       )
-      .setCategory('Device');
+      .setCategory('User interface');
     extension
       .addInstructionOrExpressionGroupMetadata(_('Advanced window management'))
       .setIcon('res/actions/window24.png');

--- a/Extensions/AnchorBehavior/Extension.cpp
+++ b/Extensions/AnchorBehavior/Extension.cpp
@@ -17,6 +17,7 @@ void DeclareAnchorBehaviorExtension(gd::PlatformExtension& extension) {
                                _("Anchor objects to the window's bounds."),
                                "Victor Levasseur",
                                "Open source (MIT License)")
+      .SetCategory("User interface")
       .SetExtensionHelpPath("/behaviors/anchor");
 
   gd::BehaviorMetadata& aut = extension.AddBehavior(

--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -33,7 +33,8 @@ module.exports = {
         'Todor Imreorov',
         'Open source (MIT License)'
       )
-      .setExtensionHelpPath('/objects/bbtext');
+      .setExtensionHelpPath('/objects/bbtext')
+      .setCategory('User interface');
 
     var objectBBText = new gd.ObjectJsImplementation();
     // $FlowExpectedError
@@ -168,7 +169,7 @@ module.exports = {
       .addIncludeFile(
         'Extensions/BBText/pixi-multistyle-text/dist/pixi-multistyle-text.umd.js'
       )
-      .setCategoryFullName(_('Texts'));
+      .setCategoryFullName(_('User interface'));
 
     /**
      * Utility function to add both a setter and a getter to a property from a list.

--- a/Extensions/BitmapText/JsExtension.js
+++ b/Extensions/BitmapText/JsExtension.js
@@ -35,7 +35,8 @@ module.exports = {
         'Aurélien Vivet',
         'Open source (MIT License)'
       )
-      .setExtensionHelpPath('/objects/bitmap_text');
+      .setExtensionHelpPath('/objects/bitmap_text')
+      .setCategory('User interface');
 
     const bitmapTextObject = new gd.ObjectJsImplementation();
     // $FlowExpectedError
@@ -171,7 +172,7 @@ module.exports = {
       .addIncludeFile(
         'Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.js'
       )
-      .setCategoryFullName(_('Texts'));
+      .setCategoryFullName(_('User interface'));
 
     object
       .addExpressionAndConditionAndAction(

--- a/Extensions/DestroyOutsideBehavior/Extension.cpp
+++ b/Extensions/DestroyOutsideBehavior/Extension.cpp
@@ -20,6 +20,7 @@ void DeclareDestroyOutsideBehaviorExtension(gd::PlatformExtension& extension) {
                                  "or other short-lived objects."),
                                "Florian Rival",
                                "Open source (MIT License)")
+      .SetCategory("Game mechanic")
       .SetExtensionHelpPath("/behaviors/destroyoutside");
 
   gd::BehaviorMetadata& aut =

--- a/Extensions/DeviceSensors/JsExtension.js
+++ b/Extensions/DeviceSensors/JsExtension.js
@@ -31,7 +31,7 @@ module.exports = {
       "Matthias Meike",
       "Open source (MIT License)"
     ).setExtensionHelpPath("/all-features/device-sensors")
-    .setCategory('Device');
+    .setCategory('Input');
     extension.addInstructionOrExpressionGroupMetadata(_("Device sensors"))
         .setIcon("JsPlatform/Extensions/orientation_active32.png");
 

--- a/Extensions/DeviceVibration/JsExtension.js
+++ b/Extensions/DeviceVibration/JsExtension.js
@@ -35,7 +35,7 @@ module.exports = {
         'Open source (MIT License)'
       )
       .setExtensionHelpPath('/all-features/device-vibration')
-      .setCategory('Device');
+      .setCategory('User interface');
       extension.addInstructionOrExpressionGroupMetadata(_("Device vibration"))
           .setIcon("JsPlatform/Extensions/vibration_start32.png");
 

--- a/Extensions/DialogueTree/JsExtension.js
+++ b/Extensions/DialogueTree/JsExtension.js
@@ -34,7 +34,7 @@ module.exports = {
         'Open source (MIT License)'
       )
       .setExtensionHelpPath('/all-features/dialogue-tree')
-      .setCategory('Advanced');
+      .setCategory('Game mechanic');
     extension
       .addInstructionOrExpressionGroupMetadata(_('Dialogue Tree (experimental)'))
       .setIcon('JsPlatform/Extensions/yarn32.png');

--- a/Extensions/DraggableBehavior/Extension.cpp
+++ b/Extensions/DraggableBehavior/Extension.cpp
@@ -20,6 +20,7 @@ void DeclareDraggableBehaviorExtension(gd::PlatformExtension& extension) {
             "or disable the behavior when needed."),
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("User interface")
       .SetExtensionHelpPath("/behaviors/draggable");
 
   gd::BehaviorMetadata& aut = extension.AddBehavior(

--- a/Extensions/Effects/JsExtension.js
+++ b/Extensions/Effects/JsExtension.js
@@ -31,7 +31,9 @@ module.exports = {
       'Lots of different effects to be used in your game.',
       'Various contributors from PixiJS, PixiJS filters and GDevelop',
       'MIT'
-    ).setExtensionHelpPath('/interface/scene-editor/layer-effects');
+    )
+    .setCategory('Visual effect')
+    .setExtensionHelpPath('/interface/scene-editor/layer-effects');
 
     // ℹ️ You can declare an effect here. Please order the effects by alphabetical order.
     // This file is for common effects that are well-known/"battle-tested". If you have an

--- a/Extensions/FileSystem/JsExtension.js
+++ b/Extensions/FileSystem/JsExtension.js
@@ -34,7 +34,7 @@ module.exports = {
         'Open source (MIT License)'
       )
       .setExtensionHelpPath('/all-features/filesystem')
-      .setCategory('Device');
+      .setCategory('Advanced');
     extension
       .addInstructionOrExpressionGroupMetadata(_('File system'))
       .setIcon('JsPlatform/Extensions/filesystem_create_folder32.png');

--- a/Extensions/Inventory/Extension.cpp
+++ b/Extensions/Inventory/Extension.cpp
@@ -19,7 +19,7 @@ void DeclareInventoryExtension(gd::PlatformExtension& extension) {
       "Florian Rival",
       "Open source (MIT License)")
       .SetExtensionHelpPath("/all-features/inventory")
-      .SetCategory("Advanced");
+      .SetCategory("Game mechanic");
     extension
       .AddInstructionOrExpressionGroupMetadata(_("Inventories"))
       .SetIcon("CppPlatform/Extensions/Inventoryicon.png");

--- a/Extensions/Lighting/JsExtension.js
+++ b/Extensions/Lighting/JsExtension.js
@@ -32,7 +32,8 @@ module.exports = {
       'This provides a light object, and a behavior to mark other objects as being obstacles for the lights. This is a great way to create a special atmosphere to your game, along with effects, make it more realistic or to create gameplays based on lights.',
       'Harsimran Virk',
       'MIT'
-    );
+    )
+    .setCategory('Visual effect');
 
     const lightObstacleBehavior = new gd.BehaviorJsImplementation();
     // $FlowExpectedError - ignore Flow warning as we're creating a behavior
@@ -195,7 +196,7 @@ module.exports = {
       .setIncludeFile('Extensions/Lighting/lightruntimeobject.js')
       .addIncludeFile('Extensions/Lighting/lightruntimeobject-pixi-renderer.js')
       .addIncludeFile('Extensions/Lighting/lightobstacleruntimebehavior.js')
-      .setCategoryFullName(_('Lights'));
+      .setCategoryFullName(_('Visual effect'));
 
     object
       .addAction(

--- a/Extensions/ParticleSystem/Extension.cpp
+++ b/Extensions/ParticleSystem/Extension.cpp
@@ -25,6 +25,7 @@ void DeclareParticleSystemExtension(gd::PlatformExtension& extension) {
           "explosions, magical effects, etc...",
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("Visual effect")
       .SetExtensionHelpPath("/objects/particles_emitter");
 
   // Declaration of all objects available
@@ -37,7 +38,7 @@ void DeclareParticleSystemExtension(gd::PlatformExtension& extension) {
                 _("Displays a large number of small particles to create visual "
                   "effects."),
                 "CppPlatform/Extensions/particleSystemicon.png")
-            .SetCategoryFullName(_("General"));
+            .SetCategoryFullName(_("Visual effect"));
 
     // Declaration is too big to be compiled by GCC in one file, unless you have
     // 4GB+ ram. :/

--- a/Extensions/PathfindingBehavior/Extension.cpp
+++ b/Extensions/PathfindingBehavior/Extension.cpp
@@ -21,6 +21,7 @@ void DeclarePathfindingBehaviorExtension(gd::PlatformExtension& extension) {
           "avoiding obstacles on the way.",
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("Movement")
       .SetExtensionHelpPath("/behaviors/pathfinding");
 
   {

--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -34,7 +34,7 @@ module.exports = {
         'MIT'
       )
       .setExtensionHelpPath('/behaviors/physics2')
-      .setCategory('Advanced');
+      .setCategory('Movement');
     extension
       .addInstructionOrExpressionGroupMetadata(_('Physics Engine 2.0'))
       .setIcon('res/physics32.png');

--- a/Extensions/PhysicsBehavior/Extension.cpp
+++ b/Extensions/PhysicsBehavior/Extension.cpp
@@ -21,6 +21,7 @@ void DeclarePhysicsBehaviorExtension(gd::PlatformExtension& extension) {
                                "This is the old, deprecated physics engine. Prefer to use the Physics Engine 2.0.",
                                "Florian Rival",
                                "Open source (MIT License)")
+      .SetCategory("Movement")
       .SetExtensionHelpPath("/behaviors/physics");
 
   {

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -27,6 +27,7 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
           "could be used.",
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("Movement")
       .SetExtensionHelpPath("/behaviors/platformer");
   extension.AddInstructionOrExpressionGroupMetadata(_("Platform behavior"))
       .SetIcon("CppPlatform/Extensions/platformerobjecticon.png");

--- a/Extensions/Screenshot/JsExtension.js
+++ b/Extensions/Screenshot/JsExtension.js
@@ -34,7 +34,7 @@ module.exports = {
         'Open source (MIT License)'
       )
       .setExtensionHelpPath('/all-features/screenshot')
-      .setCategory('Device');
+      .setCategory('Advanced');
     extension
       .addInstructionOrExpressionGroupMetadata(_('Screenshot'))
       .setIcon('JsPlatform/Extensions/take_screenshot32.png');

--- a/Extensions/SystemInfo/Extension.cpp
+++ b/Extensions/SystemInfo/Extension.cpp
@@ -15,7 +15,7 @@ void DeclareSystemInfoExtension(gd::PlatformExtension& extension) {
       _("Get information about the system and device running the game."),
       "Florian Rival",
       "Open source (MIT License)")
-      .SetCategory("Device");
+      .SetCategory("Advanced");
   extension.AddInstructionOrExpressionGroupMetadata(_("System information"))
       .SetIcon("CppPlatform/Extensions/systeminfoicon.png");
 

--- a/Extensions/TextEntryObject/Extension.cpp
+++ b/Extensions/TextEntryObject/Extension.cpp
@@ -18,6 +18,7 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
             "entered with a keyboard by a player."),
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("User interface")
       .SetExtensionHelpPath("/objects/text_entry");
 
   gd::ObjectMetadata& obj =
@@ -27,7 +28,7 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension& extension) {
                                       _("Invisible object used to get the text "
                                         "entered with the keyboard."),
                                       "CppPlatform/Extensions/textentry.png")
-          .SetCategoryFullName(_("Advanced"));
+          .SetCategoryFullName(_("User interface"));
 
   obj.AddAction("String",
                 _("Text in memory"),

--- a/Extensions/TextInput/JsExtension.js
+++ b/Extensions/TextInput/JsExtension.js
@@ -31,7 +31,8 @@ module.exports = {
       _('A text field the player can type text into.'),
       'Florian Rival',
       'MIT'
-    );
+    )
+    .setCategory('User interface');
 
     const textInputObject = new gd.ObjectJsImplementation();
     // $FlowExpectedError - ignore Flow warning as we're creating an object
@@ -277,7 +278,7 @@ module.exports = {
         'JsPlatform/Extensions/text_input.svg',
         textInputObject
       )
-      .setCategoryFullName(_('Form control'))
+      .setCategoryFullName(_('User interface'))
       .addUnsupportedBaseObjectCapability('effect')
       .setIncludeFile('Extensions/TextInput/textinputruntimeobject.js')
       .addIncludeFile(

--- a/Extensions/TextObject/Extension.cpp
+++ b/Extensions/TextObject/Extension.cpp
@@ -23,6 +23,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                                  "some indicators, menu buttons, dialogues..."),
                                "Florian Rival and Victor Levasseur",
                                "Open source (MIT License)")
+      .SetCategory("User interface")
       .SetExtensionHelpPath("/objects/text");
 
   gd::ObjectMetadata& obj =
@@ -31,7 +32,7 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                                  _("Text"),
                                  _("Displays a text on the screen."),
                                  "CppPlatform/Extensions/texticon.png")
-          .SetCategoryFullName(_("Texts"));
+          .SetCategoryFullName(_("User interface"));
 
   obj.AddAction("String",
                 _("Modify the text"),

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -858,6 +858,7 @@ module.exports = {
         'Todor Imreorov',
         'Open source (MIT License)'
       )
+      .setCategory('Advanced')
       .setExtensionHelpPath('/objects/tilemap');
 
       defineTileMap(extension, _, gd);

--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -20,6 +20,7 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension& extension) {
             "keyboard or using events."),
           "Florian Rival",
           "Open source (MIT License)")
+      .SetCategory("Movement")
       .SetExtensionHelpPath("/behaviors/topdown");
 
   gd::BehaviorMetadata& aut = extension.AddBehavior(

--- a/Extensions/TweenBehavior/JsExtension.js
+++ b/Extensions/TweenBehavior/JsExtension.js
@@ -73,7 +73,10 @@ module.exports = {
         'Matthias Meike, Florian Rival',
         'Open source (MIT License)'
       )
+      .setCategory('Visual effect')
       .setExtensionHelpPath('/behaviors/tween');
+    extension.addInstructionOrExpressionGroupMetadata(_("Tweening"))
+        .setIcon("JsPlatform/Extensions/tween_behavior32.png");
 
     extension
       .addExpression(

--- a/Extensions/Video/JsExtension.js
+++ b/Extensions/Video/JsExtension.js
@@ -33,6 +33,7 @@ module.exports = {
         'Aurélien Vivet',
         'Open source (MIT License)'
       )
+      .setCategory('User interface')
       .setExtensionHelpPath('/objects/video');
 
     var videoObject = new gd.ObjectJsImplementation();
@@ -133,7 +134,7 @@ module.exports = {
       )
       .setIncludeFile('Extensions/Video/videoruntimeobject.js')
       .addIncludeFile('Extensions/Video/videoruntimeobject-pixi-renderer.js')
-      .setCategoryFullName(_('Multimedia'));
+      .setCategoryFullName(_('User interface'));
 
     object
       .addAction(

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
@@ -225,10 +225,6 @@ export const ExtensionOptionsEditor = ({
                 value: 'Camera',
               },
               {
-                text: 'Device',
-                value: 'Device',
-              },
-              {
                 text: 'Input',
                 value: 'Input',
               },


### PR DESCRIPTION
It also fixes the Tween instruction group icon.

The instruction list looks a bit messy because of the additional categories, but they will be filled when extensions are added to a project.

I removed the "Device" category because it's not feature focus.

### Actions

![image](https://user-images.githubusercontent.com/2611977/193305716-f251e3ec-c70a-4597-a30b-eb764681bab7.png)

![image](https://user-images.githubusercontent.com/2611977/193305758-e7e424ac-e4a9-4149-9d06-81bbf44eeae3.png)

### Conditions

![image](https://user-images.githubusercontent.com/2611977/193305893-0959674c-926e-4ac7-b431-8a0e7872bdb1.png)

![image](https://user-images.githubusercontent.com/2611977/193305917-c855f161-dfc6-42db-b8fb-03ad4e9e264b.png)

### Objects

![image](https://user-images.githubusercontent.com/2611977/193305960-2e565bed-de31-4f93-a163-f9d99a9f1a23.png)

![image](https://user-images.githubusercontent.com/2611977/193306814-ac848ea9-a3d8-4061-96bb-d42f2085a649.png)

