### PR TITLE
Add price to assets home private asset packs thumbnails and display them in their dialog

### DIFF
--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -7,6 +7,7 @@ import GridList from '@material-ui/core/GridList';
 import Paper from '@material-ui/core/Paper';
 import { CorsAwareImage } from '../UI/CorsAwareImage';
 import Text from '../UI/Text';
+import PriceTag from '../UI/PriceTag';
 import type { AssetPacks, AssetPack } from '../Utils/GDevelopServices/Asset';
 import { type PrivateAssetPackListingData } from '../Utils/GDevelopServices/Shop';
 import { shouldValidate } from '../UI/KeyboardShortcuts/InteractionKeys';
@@ -21,12 +22,19 @@ const cellSpacing = 2;
 
 const styles = {
   grid: { margin: '0 10px' },
+  priceTagContainer: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    cursor: 'default',
+  },
   previewImage: {
     width: '100%',
     // Prevent cumulative layout shift by enforcing
     // the 16:9 ratio.
     aspectRatio: '16 / 9',
     objectFit: 'cover',
+    position: 'relative',
   },
   cardContainer: {
     overflow: 'hidden',
@@ -150,6 +158,9 @@ const PrivateAssetPackTile = ({
           src={assetPack.thumbnailUrls[0]}
           alt={`Preview image of asset pack ${assetPack.name}`}
         />
+        <div style={styles.priceTagContainer}>
+          <PriceTag value={assetPack.prices[0].value} withOverlay />
+        </div>
         <Column>
           <Line justifyContent="space-between" noMargin>
             <Text style={styles.packTitle} size="body2">

--- a/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
@@ -27,7 +27,7 @@ import PublicProfileDialog from '../Profile/PublicProfileDialog';
 import Link from '../UI/Link';
 import Mark from '../UI/CustomSvgIcons/Mark';
 import Cross from '../UI/CustomSvgIcons/Cross';
-import { Paper } from '@material-ui/core';
+import Paper from '@material-ui/core/Paper';
 import ResponsiveImagesGallery from '../UI/ResponsiveImagesGallery';
 import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 
@@ -54,6 +54,10 @@ const contentTypeToMessageDescriptor = {
   font: t`Fonts`,
   audio: t`Audios`,
   partial: t`Other`,
+};
+
+const styles = {
+  disabledText: { opacity: 0.6 },
 };
 
 const PrivateAssetPackDialog = ({
@@ -219,8 +223,15 @@ const PrivateAssetPackDialog = ({
                               </Text>
                             </LineStackLayout>
                             <LineStackLayout noMargin alignItems="center">
-                              <Cross fontSize="small" />
-                              <Text displayInlineAsSpan noMargin>
+                              <Cross
+                                fontSize="small"
+                                style={styles.disabledText}
+                              />
+                              <Text
+                                displayInlineAsSpan
+                                noMargin
+                                style={styles.disabledText}
+                              >
                                 <Trans>Redistribution &amp; reselling</Trans>
                               </Text>
                             </LineStackLayout>

--- a/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
@@ -132,9 +132,7 @@ const PrivateAssetPackDialog = ({
             fullHeight
           >
             {errorText ? (
-              <AlertMessage kind="error">
-                <Text>{errorText}</Text>
-              </AlertMessage>
+              <AlertMessage kind="error">{errorText}</AlertMessage>
             ) : isFetchingDetails ? (
               <>
                 <Text size="title">{name}</Text>

--- a/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
@@ -13,8 +13,12 @@ import PriceTag from '../UI/PriceTag';
 import TextButton from '../UI/TextButton';
 import AlertMessage from '../UI/AlertMessage';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
-import { ColumnStackLayout, ResponsiveLineStackLayout } from '../UI/Layout';
-import { Column, Line, Spacer } from '../UI/Grid';
+import {
+  ColumnStackLayout,
+  ResponsiveLineStackLayout,
+  LineStackLayout,
+} from '../UI/Layout';
+import { Column, Line } from '../UI/Grid';
 import {
   getUserPublicProfile,
   type UserPublicProfile,
@@ -196,34 +200,30 @@ const PrivateAssetPackDialog = ({
                             <Text size="sub-title">
                               <Trans>Licensing</Trans>
                             </Text>
-                            <Line noMargin alignItems="center">
+                            <LineStackLayout noMargin alignItems="center">
                               <Mark fontSize="small" />
-                              <Spacer />
                               <Text displayInlineAsSpan noMargin>
                                 <Trans>Personal projects</Trans>
                               </Text>
-                            </Line>
-                            <Line noMargin alignItems="center">
+                            </LineStackLayout>
+                            <LineStackLayout noMargin alignItems="center">
                               <Mark fontSize="small" />
-                              <Spacer />
                               <Text displayInlineAsSpan noMargin>
                                 <Trans>Professional projects</Trans>
                               </Text>
-                            </Line>
-                            <Line noMargin alignItems="center">
+                            </LineStackLayout>
+                            <LineStackLayout noMargin alignItems="center">
                               <Mark fontSize="small" />
-                              <Spacer />
                               <Text displayInlineAsSpan noMargin>
                                 <Trans>Asset modification</Trans>
                               </Text>
-                            </Line>
-                            <Line noMargin alignItems="center">
+                            </LineStackLayout>
+                            <LineStackLayout noMargin alignItems="center">
                               <Cross fontSize="small" />
-                              <Spacer />
                               <Text displayInlineAsSpan noMargin>
                                 <Trans>Redistribution &amp; reselling</Trans>
                               </Text>
-                            </Line>
+                            </LineStackLayout>
                           </Column>
                         </ResponsiveLineStackLayout>
                       </ColumnStackLayout>

--- a/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
+++ b/newIDE/app/src/AssetStore/PrivateAssetPackDialog.js
@@ -9,11 +9,12 @@ import {
 import Text from '../UI/Text';
 import { t, Trans } from '@lingui/macro';
 import Dialog from '../UI/Dialog';
+import PriceTag from '../UI/PriceTag';
 import TextButton from '../UI/TextButton';
 import AlertMessage from '../UI/AlertMessage';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
-import { ResponsiveLineStackLayout } from '../UI/Layout';
-import { Column, LargeSpacer, Line, Spacer } from '../UI/Grid';
+import { ColumnStackLayout, ResponsiveLineStackLayout } from '../UI/Layout';
+import { Column, Line, Spacer } from '../UI/Grid';
 import {
   getUserPublicProfile,
   type UserPublicProfile,
@@ -52,7 +53,7 @@ const contentTypeToMessageDescriptor = {
 };
 
 const PrivateAssetPackDialog = ({
-  privateAssetPack: { id, name, description, sellerId },
+  privateAssetPack: { id, name, description, sellerId, prices },
   onClose,
 }: Props) => {
   const [
@@ -165,10 +166,11 @@ const PrivateAssetPackDialog = ({
                       variant="outlined"
                       style={{ padding: windowWidth === 'small' ? 20 : 30 }}
                     >
-                      <Column noMargin>
-                        <LargeSpacer /> {/* To be replaced by prices */}
+                      <ColumnStackLayout noMargin useLargeSpacer>
+                        <Line noMargin>
+                          <PriceTag value={prices[0].value} />
+                        </Line>
                         <Text noMargin>{assetPackDetails.longDescription}</Text>
-                        <LargeSpacer />
                         <ResponsiveLineStackLayout noMargin noColumnMargin>
                           <Column noMargin expand>
                             <Text size="sub-title">
@@ -224,7 +226,7 @@ const PrivateAssetPackDialog = ({
                             </Line>
                           </Column>
                         </ResponsiveLineStackLayout>
-                      </Column>
+                      </ColumnStackLayout>
                     </Paper>
                   </Column>
                 </ResponsiveLineStackLayout>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -303,7 +303,7 @@ export const AssetStore = ({ project }: Props) => {
                   />
                 )}
                 {isOnHomePage && error && (
-                  <PlaceholderError>
+                  <PlaceholderError onRetry={fetchAssetsAndFilters}>
                     <AlertMessage kind="error">
                       <Trans>
                         An error occurred when fetching the asset store content.

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -34,6 +34,8 @@ import { AssetDetails } from './AssetDetails';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import Home from '@material-ui/icons/Home';
 import PrivateAssetPackDialog from './PrivateAssetPackDialog';
+import PlaceholderError from '../UI/PlaceholderError';
+import AlertMessage from '../UI/AlertMessage';
 
 type Props = {|
   project: gdProject,
@@ -265,9 +267,9 @@ export const AssetStore = ({ project }: Props) => {
                     )}
                   </Background>
                 )}
-                {isOnHomePage && !(assetPacks && privateAssetPacks) && (
-                  <PlaceholderLoader />
-                )}
+                {isOnHomePage &&
+                  !(assetPacks && privateAssetPacks) &&
+                  !error && <PlaceholderLoader />}
                 {isOnHomePage &&
                   assetPacks &&
                   privateAssetPacks &&
@@ -299,6 +301,16 @@ export const AssetStore = ({ project }: Props) => {
                       />
                     }
                   />
+                )}
+                {isOnHomePage && error && (
+                  <PlaceholderError>
+                    <AlertMessage kind="error">
+                      <Trans>
+                        An error occurred when fetching the asset store content.
+                        Please try again later.
+                      </Trans>
+                    </AlertMessage>
+                  </PlaceholderError>
                 )}
                 {openedAssetShortHeader && (
                   <AssetDetails

--- a/newIDE/app/src/UI/BackgroundText.js
+++ b/newIDE/app/src/UI/BackgroundText.js
@@ -16,6 +16,7 @@ const BackgroundText = (props: Props) => (
       <Typography
         variant="body2"
         align="center"
+        component="div"
         style={{
           opacity: 0.6,
           textShadow: `1px 1px 0px ${muiTheme.emptyMessage.shadowColor}`,

--- a/newIDE/app/src/UI/Layout.js
+++ b/newIDE/app/src/UI/Layout.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Spacer, Line, Column } from './Grid';
+import { Spacer, Line, Column, LargeSpacer } from './Grid';
 import { useResponsiveWindowWidth } from './Reponsive/ResponsiveWindowMeasurer';
 
 type TextFieldWithButtonLayoutProps = {|
@@ -82,6 +82,7 @@ type LineStackLayoutProps = {|
   expand?: boolean,
   noMargin?: boolean,
   children: React.Node,
+  useLargeSpacer?: boolean,
 |};
 
 export const LineStackLayout = ({
@@ -90,6 +91,7 @@ export const LineStackLayout = ({
   expand,
   noMargin,
   children,
+  useLargeSpacer,
 }: LineStackLayoutProps) => {
   let isFirstChild = true;
   return (
@@ -107,7 +109,7 @@ export const LineStackLayout = ({
 
         return (
           <React.Fragment>
-            {addSpacers && <Spacer />}
+            {addSpacers && (useLargeSpacer ? <LargeSpacer /> : <Spacer />)}
             {child}
           </React.Fragment>
         );
@@ -126,6 +128,7 @@ type ResponsiveLineStackLayoutProps = {|
   noColumnMargin?: boolean,
   /** Do not measure window width in case parent component is in smaller component */
   width?: 'small',
+  useLargeSpacer?: boolean,
   children: React.Node,
 |};
 
@@ -136,12 +139,17 @@ export const ResponsiveLineStackLayout = ({
   noMargin,
   noColumnMargin,
   width,
+  useLargeSpacer,
   children,
 }: ResponsiveLineStackLayoutProps) => {
   const windowWidth = useResponsiveWindowWidth();
 
   return (width || windowWidth) === 'small' ? (
-    <ColumnStackLayout noMargin={noMargin || noColumnMargin} expand>
+    <ColumnStackLayout
+      noMargin={noMargin || noColumnMargin}
+      expand
+      useLargeSpacer={useLargeSpacer}
+    >
       {children}
     </ColumnStackLayout>
   ) : (
@@ -150,6 +158,7 @@ export const ResponsiveLineStackLayout = ({
       justifyContent={justifyContent}
       expand={expand}
       noMargin={noMargin}
+      useLargeSpacer={useLargeSpacer}
     >
       {children}
     </LineStackLayout>
@@ -164,6 +173,7 @@ type ColumnStackLayoutProps = {|
   children: React.Node,
   noOverflowParent?: boolean,
   useFullHeight?: boolean,
+  useLargeSpacer?: boolean,
 |};
 
 export const ColumnStackLayout = ({
@@ -174,6 +184,7 @@ export const ColumnStackLayout = ({
   children,
   noOverflowParent,
   useFullHeight,
+  useLargeSpacer,
 }: ColumnStackLayoutProps) => {
   let isFirstChild = true;
   return (
@@ -193,7 +204,7 @@ export const ColumnStackLayout = ({
 
         return (
           <React.Fragment>
-            {addSpacers && <Spacer />}
+            {addSpacers && (useLargeSpacer ? <LargeSpacer /> : <Spacer />)}
             {child}
           </React.Fragment>
         );

--- a/newIDE/app/src/UI/PriceTag.js
+++ b/newIDE/app/src/UI/PriceTag.js
@@ -11,13 +11,18 @@ type Props = {|
   /**
    * To be used when the component is over an element for which
    * we don't control the background (e.g. an image).
-   * This component should logically be invariant to selected theme
-   * when this option is activated
    */
   withOverlay?: boolean,
 |};
 
 const useStyles = makeStyles(theme => {
+  /**
+   * Customize component with overlay:
+   * - for dark themes (light font color on dark background), theme values are used.
+   * - for light themes, we want to keep the same principle (a light font color on
+   *   a dark background) so we override Material UI behavior that would use a dark
+   *   font on a light background.
+   */
   return {
     container: {
       borderRadius: 4,

--- a/newIDE/app/src/UI/PriceTag.js
+++ b/newIDE/app/src/UI/PriceTag.js
@@ -6,7 +6,16 @@ import { I18n } from '@lingui/react';
 import Text from './Text';
 import { makeStyles } from '@material-ui/core';
 
-type Props = {| value: number, transparentBackground: boolean |};
+type Props = {|
+  value: number,
+  /**
+   * To be used when the component is over an element for which
+   * we don't control the background (e.g. an image).
+   * This component should logically be invariant to selected theme
+   * when this option is activated
+   */
+  withOverlay?: boolean,
+|};
 
 const useStyles = makeStyles(theme => {
   return {
@@ -14,22 +23,23 @@ const useStyles = makeStyles(theme => {
       borderRadius: 4,
       padding: '2px 4px',
       backdropFilter: props =>
-        props.transparentBackground ? 'brightness(40%)' : undefined,
+        props.withOverlay ? 'brightness(40%)' : undefined,
       backgroundColor: props =>
-        props.transparentBackground
+        props.withOverlay
           ? undefined
           : theme.palette.background.alternate,
+      color: props => (props.withOverlay ? '#FAFAFA' : undefined),
     },
   };
 });
 
-function PriceTag({ value, transparentBackground }: Props) {
-  const classes = useStyles({ transparentBackground });
+function PriceTag({ value, withOverlay }: Props) {
+  const classes = useStyles({ withOverlay });
   return (
     <I18n>
       {({ i18n }) => (
         <div className={classes.container}>
-          <Text noMargin size="sub-title">
+          <Text noMargin size="sub-title" color="inherit">
             {i18n
               .number(value / 100, {
                 minimumFractionDigits: 2,

--- a/newIDE/app/src/UI/PriceTag.js
+++ b/newIDE/app/src/UI/PriceTag.js
@@ -52,13 +52,13 @@ function PriceTag({ value, withOverlay }: Props) {
       {({ i18n }) => (
         <div className={classes.container}>
           <Text noMargin size="sub-title" color="inherit">
+            €
             {i18n
               .number(value / 100, {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,
               })
               .replace(/\D00$/, '')}
-            EUR
           </Text>
         </div>
       )}

--- a/newIDE/app/src/UI/PriceTag.js
+++ b/newIDE/app/src/UI/PriceTag.js
@@ -1,0 +1,38 @@
+// @flow
+
+import * as React from 'react';
+import { I18n } from '@lingui/react';
+
+import Text from './Text';
+
+type Props = {| value: number |};
+
+const styles = {
+  container: {
+    backdropFilter: 'brightness(80%)',
+    borderRadius: 4,
+    padding: '2px 4px',
+  },
+};
+
+function PriceTag(props: Props) {
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <div style={styles.container}>
+          <Text noMargin size="sub-title">
+            {i18n
+              .number(props.value / 100, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })
+              .replace(/\D00$/, '')}
+            EUR
+          </Text>
+        </div>
+      )}
+    </I18n>
+  );
+}
+
+export default PriceTag;

--- a/newIDE/app/src/UI/PriceTag.js
+++ b/newIDE/app/src/UI/PriceTag.js
@@ -23,12 +23,19 @@ const useStyles = makeStyles(theme => {
       borderRadius: 4,
       padding: '2px 4px',
       backdropFilter: props =>
-        props.withOverlay ? 'brightness(40%)' : undefined,
+        props.withOverlay && theme.palette.type === 'light'
+          ? 'brightness(40%)'
+          : undefined,
       backgroundColor: props =>
-        props.withOverlay
+        props.withOverlay && theme.palette.type === 'light'
           ? undefined
+          : theme.palette.background.alternate.startsWith('#')
+          ? theme.palette.background.alternate + 'BB' // manually add opacity to the background hex color
           : theme.palette.background.alternate,
-      color: props => (props.withOverlay ? '#FAFAFA' : undefined),
+      color: props =>
+        props.withOverlay && theme.palette.type === 'light'
+          ? '#FAFAFA'
+          : undefined,
     },
   };
 });

--- a/newIDE/app/src/UI/PriceTag.js
+++ b/newIDE/app/src/UI/PriceTag.js
@@ -4,25 +4,34 @@ import * as React from 'react';
 import { I18n } from '@lingui/react';
 
 import Text from './Text';
+import { makeStyles } from '@material-ui/core';
 
-type Props = {| value: number |};
+type Props = {| value: number, transparentBackground: boolean |};
 
-const styles = {
-  container: {
-    backdropFilter: 'brightness(80%)',
-    borderRadius: 4,
-    padding: '2px 4px',
-  },
-};
+const useStyles = makeStyles(theme => {
+  return {
+    container: {
+      borderRadius: 4,
+      padding: '2px 4px',
+      backdropFilter: props =>
+        props.transparentBackground ? 'brightness(40%)' : undefined,
+      backgroundColor: props =>
+        props.transparentBackground
+          ? undefined
+          : theme.palette.background.alternate,
+    },
+  };
+});
 
-function PriceTag(props: Props) {
+function PriceTag({ value, transparentBackground }: Props) {
+  const classes = useStyles({ transparentBackground });
   return (
     <I18n>
       {({ i18n }) => (
-        <div style={styles.container}>
+        <div className={classes.container}>
           <Text noMargin size="sub-title">
             {i18n
-              .number(props.value / 100, {
+              .number(value / 100, {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,
               })

--- a/newIDE/app/src/UI/ResponsiveImagesGallery.js
+++ b/newIDE/app/src/UI/ResponsiveImagesGallery.js
@@ -47,6 +47,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
   },
+  disabledText: { opacity: 0.6 },
 };
 
 const GRID_SPACING = 1;
@@ -188,7 +189,7 @@ const ResponsiveImagesGallery = ({
           )}
         </Measure>
         <Line justifyContent="center">
-          <Text noMargin size="body2">
+          <Text noMargin size="body2" style={styles.disabledText}>
             {currentlyViewedImageIndex + 1}/{imagesUrls.length}
           </Text>
         </Line>

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -139,13 +139,13 @@
       "default": {
         "color": {
           "value": "#1D1D26",
-          "comment": "Text/Primary"
+          "comment": "Palette/Grey/100 - Text/Primary"
         }
       },
       "secondary": {
         "color": {
           "value": "#494952",
-          "comment": "Text/Secondary"
+          "comment": "Palette/Grey/70 - Text/ Secondary"
         }
       },
       "disabled": {

--- a/newIDE/app/src/Utils/GDevelopServices/Shop.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Shop.js
@@ -6,6 +6,12 @@ const client = axios.create({
   baseURL: GDevelopShopApi.baseUrl,
 });
 
+type StripePrice = {|
+  value: number,
+  name: 'default',
+  stripePriceId: string,
+|};
+
 export type PrivateAssetPackListingData = {|
   id: string,
   sellerId: string,
@@ -16,6 +22,7 @@ export type PrivateAssetPackListingData = {|
   updatedAt: string,
   createdAt: string,
   thumbnailUrls: string[],
+  prices: StripePrice[],
 |};
 
 export const listListedPrivateAssetPacks = async (): Promise<

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -7,7 +7,8 @@ import paperDecorator from '../../../PaperDecorator';
 import { testProject } from '../../../GDevelopJsInitializerDecorator';
 import { AssetStoreStateProvider } from '../../../../AssetStore/AssetStoreContext';
 import { AssetStore } from '../../../../AssetStore';
-import { fakeAssetPacks } from '../../../../fixtures/GDevelopServicesTestData';
+import { fakeAssetPacks, fakeIndieAuthenticatedUser } from '../../../../fixtures/GDevelopServicesTestData';
+import AuthenticatedUserContext from '../../../../Profile/AuthenticatedUserContext';
 
 export default {
   title: 'AssetStore/AssetStore',
@@ -38,17 +39,21 @@ const apiDataFakePacks = {
 };
 
 export const Default = () => (
-  <AssetStoreStateProvider>
-    <AssetStore project={testProject.project} />
-  </AssetStoreStateProvider>
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <AssetStoreStateProvider>
+      <AssetStore project={testProject.project} />
+    </AssetStoreStateProvider>
+  </AuthenticatedUserContext.Provider>
 );
 Default.decorators = [withMock];
 Default.parameters = apiDataFakePacks;
 
 export const LoadingError = () => (
-  <AssetStoreStateProvider>
-    <AssetStore project={testProject.project} />
-  </AssetStoreStateProvider>
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <AssetStoreStateProvider>
+      <AssetStore project={testProject.project} />
+    </AssetStoreStateProvider>
+  </AuthenticatedUserContext.Provider>
 );
 LoadingError.decorators = [withMock];
 LoadingError.parameters = apiDataServerSideError;

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -7,7 +7,10 @@ import paperDecorator from '../../../PaperDecorator';
 import { testProject } from '../../../GDevelopJsInitializerDecorator';
 import { AssetStoreStateProvider } from '../../../../AssetStore/AssetStoreContext';
 import { AssetStore } from '../../../../AssetStore';
-import { fakeAssetPacks, fakeIndieAuthenticatedUser } from '../../../../fixtures/GDevelopServicesTestData';
+import {
+  fakeAssetPacks,
+  fakeIndieAuthenticatedUser,
+} from '../../../../fixtures/GDevelopServicesTestData';
 import AuthenticatedUserContext from '../../../../Profile/AuthenticatedUserContext';
 
 export default {

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/PrivateAssetPackDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/PrivateAssetPackDialog.stories.js
@@ -31,6 +31,7 @@ const privateAssetPackListingData = {
   listing: 'ASSET_PACK',
   description: '5 assets',
   name: 'French Food',
+  prices: [{ value: 1500, name: 'default', stripePriceId: 'stripePriceId' }],
 };
 
 const sellerPublicProfile = {

--- a/newIDE/app/src/stories/componentStories/UI/Link.stories.js
+++ b/newIDE/app/src/stories/componentStories/UI/Link.stories.js
@@ -10,7 +10,7 @@ import Window from '../../../Utils/Window';
 import { getHelpLink } from '../../../Utils/HelpLink';
 
 export default {
-  title: 'Link',
+  title: 'UI Building Blocks/Link',
   component: Link,
   decorators: [paperDecorator, muiDecorator],
 };

--- a/newIDE/app/src/stories/componentStories/UI/PriceTag.stories.js
+++ b/newIDE/app/src/stories/componentStories/UI/PriceTag.stories.js
@@ -35,7 +35,7 @@ export const Default = () => (
           alignItems: 'flex-start',
         }}
       >
-        <PriceTag value={1200} />
+        <PriceTag value={1200} transparentBackground />
       </div>
     </LineStackLayout>
   </ColumnStackLayout>

--- a/newIDE/app/src/stories/componentStories/UI/PriceTag.stories.js
+++ b/newIDE/app/src/stories/componentStories/UI/PriceTag.stories.js
@@ -1,0 +1,42 @@
+// @flow
+
+import * as React from 'react';
+
+import muiDecorator from '../../ThemeDecorator';
+import paperDecorator from '../../PaperDecorator';
+
+import PriceTag from '../../../UI/PriceTag';
+import { ColumnStackLayout, LineStackLayout } from '../../../UI/Layout';
+
+export default {
+  title: 'UI Building Blocks/PriceTag',
+  component: PriceTag,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <ColumnStackLayout>
+    <LineStackLayout>
+      <PriceTag value={800} />
+      <PriceTag value={850} />
+      <PriceTag value={1200} />
+      <PriceTag value={1225} />
+    </LineStackLayout>
+    <LineStackLayout>
+      <div
+        style={{
+          backgroundSize: 'contain',
+          backgroundImage:
+            "url('https://resources.gdevelop-app.com/assets/Packs/wesxdz skullcup.png?gdUsage=img')",
+          aspectRatio: '16 / 9',
+          height: 200,
+          padding: 10,
+          display: 'flex',
+          alignItems: 'flex-start',
+        }}
+      >
+        <PriceTag value={1200} />
+      </div>
+    </LineStackLayout>
+  </ColumnStackLayout>
+);

--- a/newIDE/app/src/stories/componentStories/UI/PriceTag.stories.js
+++ b/newIDE/app/src/stories/componentStories/UI/PriceTag.stories.js
@@ -35,7 +35,7 @@ export const Default = () => (
           alignItems: 'flex-start',
         }}
       >
-        <PriceTag value={1200} transparentBackground />
+        <PriceTag value={1200} withOverlay />
       </div>
     </LineStackLayout>
   </ColumnStackLayout>


### PR DESCRIPTION
Create a new component to display price => [story](https://gdevelop-storybook.s3.amazonaws.com/add-private-asset-packs-prices/latest/index.html?path=/story/ui-building-blocks-pricetag--default)

<img width="270" alt="image" src="https://user-images.githubusercontent.com/32449369/193596404-4ed3acbf-c374-4895-97f9-2608a73834c0.png">


<img width="1128" alt="image" src="https://user-images.githubusercontent.com/32449369/193592913-18b43fc7-7faa-406b-b252-8363d865d1b1.png">

