### PR TITLE
Add a button to export custom objects

### DIFF
--- a/Core/GDCore/Project/EffectsContainer.h
+++ b/Core/GDCore/Project/EffectsContainer.h
@@ -110,6 +110,11 @@ class GD_CORE_API EffectsContainer {
    */
   void UnserializeFrom(const SerializerElement& element);
 
+  /**
+   * \brief Clear all effects of the container.
+   */
+  inline void Clear() { effects.clear(); }
+
  private:
   std::vector<std::shared_ptr<gd::Effect>> effects;
   static Effect badEffect;

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -768,6 +768,7 @@ interface EffectsContainer {
   void RemoveEffect([Const] DOMString name);
   void SwapEffects(unsigned long firstEffectIndex, unsigned long secondEffectIndex);
   void MoveEffect(unsigned long oldIndex, unsigned long newIndex);
+  void Clear();
 
   void SerializeTo([Ref] SerializerElement element);
   void UnserializeFrom([Const, Ref] SerializerElement element);

--- a/GDevelop.js/types/gdeffectscontainer.js
+++ b/GDevelop.js/types/gdeffectscontainer.js
@@ -11,6 +11,7 @@ declare class gdEffectsContainer {
   removeEffect(name: string): void;
   swapEffects(firstEffectIndex: number, secondEffectIndex: number): void;
   moveEffect(oldIndex: number, newIndex: number): void;
+  clear(): void;
   serializeTo(element: gdSerializerElement): void;
   unserializeFrom(element: gdSerializerElement): void;
   delete(): void;

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -5,7 +5,7 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
 import { Line } from '../UI/Grid';
-import ObjectsList from '../ObjectsList';
+import ObjectsList, { type ObjectsListInterface } from '../ObjectsList';
 import ObjectsRenderingService from '../ObjectsRendering/ObjectsRenderingService';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import type { ObjectWithContext } from '../ObjectsList/EnumerateObjects';
@@ -34,7 +34,7 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
   Props,
   State
 > {
-  _objectsList: ?ObjectsList;
+  _objectsList: ?ObjectsListInterface;
 
   state = {
     editedObjectWithContext: null,
@@ -218,7 +218,7 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 selectedObjectNames={this.state.selectedObjectNames}
                 onEditObject={this.editObject}
                 // Don't allow export as there is no assets.
-                onExportObject={null}
+                onExportObject={() => {}}
                 onDeleteObject={this._onDeleteObject(i18n)}
                 canRenameObject={newName =>
                   this._canObjectOrGroupUseNewName(newName, i18n)
@@ -235,7 +235,10 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 selectedObjectTags={[]}
                 onChangeSelectedObjectTags={selectedObjectTags => {}}
                 getAllObjectTags={() => []}
-                ref={objectsList => (this._objectsList = objectsList)}
+                ref={
+                  // $FlowFixMe Make this component functional.
+                  objectsList => (this._objectsList = objectsList)
+                }
                 unsavedChanges={null}
                 // TODO EBO Hide the preview button or implement it.
                 // Note that it will be hard to do hot reload as extensions need

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -217,6 +217,8 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 onChooseResource={() => Promise.resolve([])}
                 selectedObjectNames={this.state.selectedObjectNames}
                 onEditObject={this.editObject}
+                // Don't allow export as there is no assets.
+                onExportObject={null}
                 onDeleteObject={this._onDeleteObject(i18n)}
                 canRenameObject={newName =>
                   this._canObjectOrGroupUseNewName(newName, i18n)

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionExporterDialog.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionExporterDialog.js
@@ -1,54 +1,54 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import React from 'react';
-import FlatButton from '../UI/FlatButton';
-import Dialog from '../UI/Dialog';
-import HelpButton from '../UI/HelpButton';
-import { Column, Line } from '../UI/Grid';
+import FlatButton from '../../UI/FlatButton';
+import Dialog from '../../UI/Dialog';
+import HelpButton from '../../UI/HelpButton';
+import { Column, Line } from '../../UI/Grid';
 import CloudUpload from '@material-ui/icons/CloudUpload';
-import { ResponsiveLineStackLayout } from '../UI/Layout';
-import RaisedButton from '../UI/RaisedButton';
-import Text from '../UI/Text';
+import { ResponsiveLineStackLayout } from '../../UI/Layout';
+import RaisedButton from '../../UI/RaisedButton';
+import Text from '../../UI/Text';
 import EventsFunctionsExtensionsContext, {
   type EventsFunctionsExtensionsState,
-} from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
-import Window from '../Utils/Window';
+} from '../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import Window from '../../Utils/Window';
 
-const exportCustomObject = async (
+const exportExtension = async (
   eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
-  customObject: gdObject
+  eventsFunctionsExtension: gdEventsFunctionsExtension
 ) => {
   const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
   if (!eventsFunctionsExtensionWriter) {
     // This won't happen in practice because this view can't be reached from the web-app.
     throw new Error(
-      "The object can't be exported because it's not supported by the web-app."
+      "The extension can't be exported because it's not supported by the web-app."
     );
   }
-  const pathOrUrl = await eventsFunctionsExtensionWriter.chooseCustomObjectFile(
-    customObject.getName()
+  const pathOrUrl = await eventsFunctionsExtensionWriter.chooseEventsFunctionExtensionFile(
+    eventsFunctionsExtension.getName()
   );
 
   if (!pathOrUrl) return;
 
-  await eventsFunctionsExtensionWriter.writeCustomObject(
-    customObject,
+  await eventsFunctionsExtensionWriter.writeEventsFunctionsExtension(
+    eventsFunctionsExtension,
     pathOrUrl
   );
 };
 
 const openGitHubIssue = () => {
   Window.openExternalURL(
-    'https://github.com/4ian/GDevelop/issues/new?assignees=&labels=%F0%9F%93%A6+Asset+Store+submission&template=--asset-store-submission.md&title='
+    'https://github.com/GDevelopApp/GDevelop-extensions/issues/new?assignees=&labels=%E2%9C%A8+New+extension&template=new-extension.yml&title=New+extension%3A+%3Ctitle%3E'
   );
 };
 
 type Props = {|
-  object: gdObject,
+  eventsFunctionsExtension: gdEventsFunctionsExtension,
   onClose: () => void,
 |};
 
-const ObjectExporterDialog = (props: Props) => {
+const ExtensionExporterDialog = (props: Props) => {
   const eventsFunctionsExtensionsState = React.useContext(
     EventsFunctionsExtensionsContext
   );
@@ -81,8 +81,10 @@ const ObjectExporterDialog = (props: Props) => {
         <Line>
           <Text>
             <Trans>
-              You can export the object to a file to submit it to the asset
-              store.
+              You can export the extension to a file to easily import it in
+              another project. If your extension is providing useful and
+              reusable functions or behaviors, consider sharing it with the
+              GDevelop community!
             </Trans>
           </Text>
         </Line>
@@ -92,11 +94,14 @@ const ObjectExporterDialog = (props: Props) => {
             primary
             label={<Trans>Export to a file</Trans>}
             onClick={() => {
-              exportCustomObject(eventsFunctionsExtensionsState, props.object);
+              exportExtension(
+                eventsFunctionsExtensionsState,
+                props.eventsFunctionsExtension
+              );
             }}
           />
           <FlatButton
-            label={<Trans>Submit objects to the community</Trans>}
+            label={<Trans>Submit extension to the community</Trans>}
             onClick={openGitHubIssue}
           />
         </ResponsiveLineStackLayout>
@@ -105,4 +110,4 @@ const ObjectExporterDialog = (props: Props) => {
   );
 };
 
-export default ObjectExporterDialog;
+export default ExtensionExporterDialog;

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/index.js
@@ -4,43 +4,12 @@ import * as React from 'react';
 import Dialog from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
 import CloudUpload from '@material-ui/icons/CloudUpload';
-import { Column, Line } from '../../UI/Grid';
 import HelpButton from '../../UI/HelpButton';
-import EventsFunctionsExtensionsContext, {
-  type EventsFunctionsExtensionsState,
-} from '../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
-import RaisedButton from '../../UI/RaisedButton';
-import Window from '../../Utils/Window';
-import Text from '../../UI/Text';
+import EventsFunctionsExtensionsContext from '../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
 import { ExtensionOptionsEditor } from './ExtensionOptionsEditor';
 import { Tab, Tabs } from '../../UI/Tabs';
 import { ExtensionDependenciesEditor } from './ExtensionDependenciesEditor';
-import { LineStackLayout } from '../../UI/Layout';
-
-const exportExtension = (
-  eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
-  eventsFunctionsExtension: gdEventsFunctionsExtension
-) => {
-  const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
-  if (!eventsFunctionsExtensionWriter)
-    return Promise.reject(new Error('Not supported'));
-
-  return eventsFunctionsExtensionWriter
-    .chooseEventsFunctionExtensionFile(eventsFunctionsExtension.getName())
-    .then(pathOrUrl => {
-      if (!pathOrUrl) return;
-
-      eventsFunctionsExtensionWriter
-        .writeEventsFunctionsExtension(eventsFunctionsExtension, pathOrUrl)
-        .then();
-    });
-};
-
-const openGitHubIssue = () => {
-  Window.openExternalURL(
-    'https://github.com/GDevelopApp/GDevelop-extensions/issues/new?assignees=&labels=%E2%9C%A8+New+extension&template=new-extension.yml&title=New+extension%3A+%3Ctitle%3E'
-  );
-};
+import ExtensionExporterDialog from './ExtensionExporterDialog';
 
 type TabName = 'options' | 'dependencies';
 
@@ -114,55 +83,10 @@ export default function OptionsEditorDialog({
         />
       )}
       {exportDialogOpen && (
-        <Dialog
-          secondaryActions={[
-            <HelpButton key="help" helpPagePath="/extensions/share" />,
-          ]}
-          actions={[
-            <FlatButton
-              label={<Trans>Close</Trans>}
-              keyboardFocused={true}
-              onClick={() => {
-                setExportDialogOpen(false);
-              }}
-              key="close"
-            />,
-          ]}
-          open
-          onRequestClose={() => {
-            setExportDialogOpen(false);
-          }}
-        >
-          <Column expand>
-            <Line>
-              <Text>
-                <Trans>
-                  You can export the extension to a file to easily import it in
-                  another project. If your extension is providing useful and
-                  reusable functions or behaviors, consider sharing it with the
-                  GDevelop community!
-                </Trans>
-              </Text>
-            </Line>
-            <LineStackLayout>
-              <RaisedButton
-                icon={<CloudUpload />}
-                primary
-                label={<Trans>Export to a file</Trans>}
-                onClick={() => {
-                  exportExtension(
-                    eventsFunctionsExtensionsState,
-                    eventsFunctionsExtension
-                  );
-                }}
-              />
-              <FlatButton
-                label={<Trans>Submit extension to the community</Trans>}
-                onClick={openGitHubIssue}
-              />
-            </LineStackLayout>
-          </Column>
-        </Dialog>
+        <ExtensionExporterDialog
+          eventsFunctionsExtension={eventsFunctionsExtension}
+          onClose={() => setExportDialogOpen(false)}
+        />
       )}
     </Dialog>
   );

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -88,12 +88,11 @@ export default class LocalEventsFunctionsExtensionWriter {
     customObject: gdObject,
     filepath: string
   ): Promise<void> => {
-    const exportedObject = customObject.clone();
+    const exportedObject = customObject.clone().get();
     exportedObject.setTags('');
     exportedObject.getVariables().clear();
     exportedObject.getEffects().clear();
     exportedObject
-      .get()
       .getAllBehaviorNames()
       .toJSArray()
       .forEach(name => exportedObject.removeBehavior(name));

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -93,6 +93,7 @@ export default class LocalEventsFunctionsExtensionWriter {
     exportedObject.getVariables().clear();
     exportedObject.getEffects().clear();
     exportedObject
+      .get()
       .getAllBehaviorNames()
       .toJSArray()
       .forEach(name => exportedObject.removeBehavior(name));

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -99,7 +99,6 @@ export default class LocalEventsFunctionsExtensionWriter {
       .toJSArray()
       .forEach(name => exportedObject.removeBehavior(name));
     const serializedObject = serializeToJSObject(exportedObject);
-    exportedObject.delete();
     return writeJSONFile(serializedObject, filepath).catch(err => {
       console.error('Unable to write the object:', err);
       throw err;

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -88,6 +88,8 @@ export default class LocalEventsFunctionsExtensionWriter {
     customObject: gdObject,
     filepath: string
   ): Promise<void> => {
+    // TODO Fix the memory crash
+    // I think the clone method is bugged, it doesn't keep the Configuration.
     const exportedObject = customObject.clone().get();
     exportedObject.setTags('');
     exportedObject.getVariables().clear();
@@ -96,7 +98,7 @@ export default class LocalEventsFunctionsExtensionWriter {
       .getAllBehaviorNames()
       .toJSArray()
       .forEach(name => exportedObject.removeBehavior(name));
-    const serializedObject = serializeToJSObject(customObject);
+    const serializedObject = serializeToJSObject(exportedObject);
     exportedObject.delete();
     return writeJSONFile(serializedObject, filepath).catch(err => {
       console.error('Unable to write the object:', err);

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -88,8 +88,6 @@ export default class LocalEventsFunctionsExtensionWriter {
     customObject: gdObject,
     filepath: string
   ): Promise<void> => {
-    // TODO Fix the memory crash
-    // I think the clone method is bugged, it doesn't keep the Configuration.
     const exportedObject = customObject.clone().get();
     exportedObject.setTags('');
     exportedObject.getVariables().clear();

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -44,7 +44,7 @@ export default class LocalEventsFunctionsExtensionWriter {
             extensions: ['json'],
           },
         ],
-        defaultPath: extensionName ? extensionName : 'Extension.json',
+        defaultPath: extensionName || 'Extension.json',
       })
       .then(({ filePath }) => {
         if (!filePath) return null;
@@ -59,6 +59,47 @@ export default class LocalEventsFunctionsExtensionWriter {
     const serializedObject = serializeToJSObject(extension);
     return writeJSONFile(serializedObject, filepath).catch(err => {
       console.error('Unable to write the events function extension:', err);
+      throw err;
+    });
+  };
+
+  static chooseCustomObjectFile = (objectName?: string): Promise<?string> => {
+    if (!dialog) return Promise.reject('Not supported');
+    const browserWindow = remote.getCurrentWindow();
+
+    return dialog
+      .showSaveDialog(browserWindow, {
+        title: 'Export an object of the project',
+        filters: [
+          {
+            name: 'GDevelop 5 "events based" extension',
+            extensions: ['json'],
+          },
+        ],
+        defaultPath: objectName || 'Object.json',
+      })
+      .then(({ filePath }) => {
+        if (!filePath) return null;
+        return filePath;
+      });
+  };
+
+  static writeCustomObject = (
+    customObject: gdObject,
+    filepath: string
+  ): Promise<void> => {
+    const exportedObject = customObject.clone();
+    exportedObject.setTags('');
+    exportedObject.getVariables().clear();
+    exportedObject.getEffects().clear();
+    exportedObject
+      .getAllBehaviorNames()
+      .toJSArray()
+      .forEach(name => exportedObject.removeBehavior(name));
+    const serializedObject = serializeToJSObject(customObject);
+    exportedObject.delete();
+    return writeJSONFile(serializedObject, filepath).catch(err => {
+      console.error('Unable to write the object:', err);
       throw err;
     });
   };

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter.js
@@ -72,11 +72,11 @@ export default class LocalEventsFunctionsExtensionWriter {
         title: 'Export an object of the project',
         filters: [
           {
-            name: 'GDevelop 5 "events based" extension',
-            extensions: ['json'],
+            name: 'GDevelop 5 object configuration',
+            extensions: ['gdo'],
           },
         ],
-        defaultPath: objectName || 'Object.json',
+        defaultPath: objectName || 'Object',
       })
       .then(({ filePath }) => {
         if (!filePath) return null;

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
@@ -13,4 +13,6 @@ export type EventsFunctionsExtensionWriter = {
     extension: gdEventsFunctionsExtension,
     filepath: string
   ) => Promise<void>,
+  chooseCustomObjectFile: (objectName?: string) => Promise<?string>,
+  writeCustomObject: (extension: gdObject, filepath: string) => Promise<void>,
 };

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -26,41 +26,8 @@ import EffectsList from '../EffectsList';
 import VariablesList from '../VariablesList/VariablesList';
 import { sendBehaviorsEditorShown } from '../Utils/Analytics/EventSender';
 import useDismissableTutorialMessage from '../Hints/useDismissableTutorialMessage';
-import CloudUpload from '@material-ui/icons/CloudUpload';
-import { LineStackLayout } from '../UI/Layout';
-import RaisedButton from '../UI/RaisedButton';
-import Text from '../UI/Text';
-import EventsFunctionsExtensionsContext, {
-  type EventsFunctionsExtensionsState,
-} from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
-import Window from '../Utils/Window';
 
 const gd: libGDevelop = global.gd;
-
-const exportCustomObject = (
-  eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
-  customObject: gdObject
-) => {
-  const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
-  if (!eventsFunctionsExtensionWriter)
-    return Promise.reject(new Error('Not supported'));
-
-  return eventsFunctionsExtensionWriter
-    .chooseCustomObjectFile(customObject.getName())
-    .then(pathOrUrl => {
-      if (!pathOrUrl) return;
-
-      eventsFunctionsExtensionWriter
-        .writeCustomObject(customObject, pathOrUrl)
-        .then();
-    });
-};
-
-const openGitHubIssue = () => {
-  Window.openExternalURL(
-    'https://github.com/4ian/GDevelop/issues/new?assignees=&labels=%F0%9F%93%A6+Asset+Store+submission&template=--asset-store-submission.md&title='
-  );
-};
 
 export type ObjectEditorTab =
   | 'properties'
@@ -102,16 +69,10 @@ type InnerDialogProps = {|
 |};
 
 const InnerDialog = (props: InnerDialogProps) => {
-  const eventsFunctionsExtensionsState = React.useContext(
-    EventsFunctionsExtensionsContext
-  );
-  const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
-
   const [currentTab, setCurrentTab] = React.useState<ObjectEditorTab>(
     props.initialTab || 'properties'
   );
   const [newObjectName, setNewObjectName] = React.useState(props.objectName);
-  const [exportDialogOpen, setExportDialogOpen] = React.useState(false);
   const forceUpdate = useForceUpdate();
   const onCancelChanges = useSerializableObjectCancelableEditor({
     serializableObject: props.object,
@@ -171,17 +132,6 @@ const InnerDialog = (props: InnerDialogProps) => {
       ]}
       secondaryActions={[
         <HelpButton key="help-button" helpPagePath={props.helpPagePath} />,
-        eventsFunctionsExtensionWriter &&
-        props.project.hasEventsBasedObject(props.object.getType()) ? (
-          <FlatButton
-            leftIcon={<CloudUpload />}
-            key="export"
-            label={<Trans>Export object</Trans>}
-            onClick={() => {
-              setExportDialogOpen(true);
-            }}
-          />
-        ) : null,
         <HotReloadPreviewButton
           key="hot-reload-preview-button"
           {...props.hotReloadPreviewButtonProps}
@@ -319,58 +269,6 @@ const InnerDialog = (props: InnerDialogProps) => {
             forceUpdate /*Force update to ensure dialog is properly positionned*/
           }
         />
-      )}
-      {exportDialogOpen && (
-        <Dialog
-          secondaryActions={[
-            <HelpButton
-              key="help"
-              helpPagePath="/community/contribute-to-the-assets-store"
-            />,
-          ]}
-          actions={[
-            <FlatButton
-              label={<Trans>Close</Trans>}
-              keyboardFocused={true}
-              onClick={() => {
-                setExportDialogOpen(false);
-              }}
-              key="close"
-            />,
-          ]}
-          open
-          onRequestClose={() => {
-            setExportDialogOpen(false);
-          }}
-        >
-          <Column expand>
-            <Line>
-              <Text>
-                <Trans>
-                  You can export the object to a file to submit it for the asset
-                  store.
-                </Trans>
-              </Text>
-            </Line>
-            <LineStackLayout>
-              <RaisedButton
-                icon={<CloudUpload />}
-                primary
-                label={<Trans>Export to a file</Trans>}
-                onClick={() => {
-                  exportCustomObject(
-                    eventsFunctionsExtensionsState,
-                    props.object
-                  );
-                }}
-              />
-              <FlatButton
-                label={<Trans>Submit objects to the community</Trans>}
-                onClick={openGitHubIssue}
-              />
-            </LineStackLayout>
-          </Column>
-        </Dialog>
       )}
     </Dialog>
   );

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -26,7 +26,41 @@ import EffectsList from '../EffectsList';
 import VariablesList from '../VariablesList/VariablesList';
 import { sendBehaviorsEditorShown } from '../Utils/Analytics/EventSender';
 import useDismissableTutorialMessage from '../Hints/useDismissableTutorialMessage';
+import CloudUpload from '@material-ui/icons/CloudUpload';
+import { LineStackLayout } from '../UI/Layout';
+import RaisedButton from '../UI/RaisedButton';
+import Text from '../UI/Text';
+import EventsFunctionsExtensionsContext, {
+  type EventsFunctionsExtensionsState,
+} from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import Window from '../Utils/Window';
+
 const gd: libGDevelop = global.gd;
+
+const exportCustomObject = (
+  eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
+  customObject: gdObject
+) => {
+  const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
+  if (!eventsFunctionsExtensionWriter)
+    return Promise.reject(new Error('Not supported'));
+
+  return eventsFunctionsExtensionWriter
+    .chooseCustomObjectFile(customObject.getName())
+    .then(pathOrUrl => {
+      if (!pathOrUrl) return;
+
+      eventsFunctionsExtensionWriter
+        .writeCustomObject(customObject, pathOrUrl)
+        .then();
+    });
+};
+
+const openGitHubIssue = () => {
+  Window.openExternalURL(
+    'https://github.com/4ian/GDevelop/issues/new?assignees=&labels=%F0%9F%93%A6+Asset+Store+submission&template=--asset-store-submission.md&title='
+  );
+};
 
 export type ObjectEditorTab =
   | 'properties'
@@ -68,10 +102,16 @@ type InnerDialogProps = {|
 |};
 
 const InnerDialog = (props: InnerDialogProps) => {
+  const eventsFunctionsExtensionsState = React.useContext(
+    EventsFunctionsExtensionsContext
+  );
+  const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
+
   const [currentTab, setCurrentTab] = React.useState<ObjectEditorTab>(
     props.initialTab || 'properties'
   );
   const [newObjectName, setNewObjectName] = React.useState(props.objectName);
+  const [exportDialogOpen, setExportDialogOpen] = React.useState(false);
   const forceUpdate = useForceUpdate();
   const onCancelChanges = useSerializableObjectCancelableEditor({
     serializableObject: props.object,
@@ -131,6 +171,17 @@ const InnerDialog = (props: InnerDialogProps) => {
       ]}
       secondaryActions={[
         <HelpButton key="help-button" helpPagePath={props.helpPagePath} />,
+        eventsFunctionsExtensionWriter &&
+        props.project.hasEventsBasedObject(props.object.getType()) ? (
+          <FlatButton
+            leftIcon={<CloudUpload />}
+            key="export"
+            label={<Trans>Export object</Trans>}
+            onClick={() => {
+              setExportDialogOpen(true);
+            }}
+          />
+        ) : null,
         <HotReloadPreviewButton
           key="hot-reload-preview-button"
           {...props.hotReloadPreviewButtonProps}
@@ -268,6 +319,58 @@ const InnerDialog = (props: InnerDialogProps) => {
             forceUpdate /*Force update to ensure dialog is properly positionned*/
           }
         />
+      )}
+      {exportDialogOpen && (
+        <Dialog
+          secondaryActions={[
+            <HelpButton
+              key="help"
+              helpPagePath="/community/contribute-to-the-assets-store"
+            />,
+          ]}
+          actions={[
+            <FlatButton
+              label={<Trans>Close</Trans>}
+              keyboardFocused={true}
+              onClick={() => {
+                setExportDialogOpen(false);
+              }}
+              key="close"
+            />,
+          ]}
+          open
+          onRequestClose={() => {
+            setExportDialogOpen(false);
+          }}
+        >
+          <Column expand>
+            <Line>
+              <Text>
+                <Trans>
+                  You can export the object to a file to submit it for the asset
+                  store.
+                </Trans>
+              </Text>
+            </Line>
+            <LineStackLayout>
+              <RaisedButton
+                icon={<CloudUpload />}
+                primary
+                label={<Trans>Export to a file</Trans>}
+                onClick={() => {
+                  exportCustomObject(
+                    eventsFunctionsExtensionsState,
+                    props.object
+                  );
+                }}
+              />
+              <FlatButton
+                label={<Trans>Submit objects to the community</Trans>}
+                onClick={openGitHubIssue}
+              />
+            </LineStackLayout>
+          </Column>
+        </Dialog>
       )}
     </Dialog>
   );

--- a/newIDE/app/src/ObjectEditor/ObjectExporterDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectExporterDialog.js
@@ -44,7 +44,7 @@ type Props = {|
   onClose: () => void,
 |};
 
-export const ObjectExporterDialog = (props: Props) => {
+const ObjectExporterDialog = (props: Props) => {
   const eventsFunctionsExtensionsState = React.useContext(
     EventsFunctionsExtensionsContext
   );
@@ -99,3 +99,5 @@ export const ObjectExporterDialog = (props: Props) => {
     </Dialog>
   );
 };
+
+export default ObjectExporterDialog;

--- a/newIDE/app/src/ObjectEditor/ObjectExporterDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectExporterDialog.js
@@ -1,0 +1,101 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import React from 'react';
+import FlatButton from '../UI/FlatButton';
+import Dialog from '../UI/Dialog';
+import HelpButton from '../UI/HelpButton';
+import { Column, Line } from '../UI/Grid';
+import CloudUpload from '@material-ui/icons/CloudUpload';
+import { LineStackLayout } from '../UI/Layout';
+import RaisedButton from '../UI/RaisedButton';
+import Text from '../UI/Text';
+import EventsFunctionsExtensionsContext, {
+  type EventsFunctionsExtensionsState,
+} from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import Window from '../Utils/Window';
+
+const exportCustomObject = (
+  eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
+  customObject: gdObject
+) => {
+  const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
+  if (!eventsFunctionsExtensionWriter)
+    return Promise.reject(new Error('Not supported'));
+
+  return eventsFunctionsExtensionWriter
+    .chooseCustomObjectFile(customObject.getName())
+    .then(pathOrUrl => {
+      if (!pathOrUrl) return;
+
+      eventsFunctionsExtensionWriter
+        .writeCustomObject(customObject, pathOrUrl)
+        .then();
+    });
+};
+
+const openGitHubIssue = () => {
+  Window.openExternalURL(
+    'https://github.com/4ian/GDevelop/issues/new?assignees=&labels=%F0%9F%93%A6+Asset+Store+submission&template=--asset-store-submission.md&title='
+  );
+};
+
+type Props = {|
+  object: gdObject,
+  onClose: () => void,
+|};
+
+export const ObjectExporterDialog = (props: Props) => {
+  const eventsFunctionsExtensionsState = React.useContext(
+    EventsFunctionsExtensionsContext
+  );
+
+  return (
+    <Dialog
+      secondaryActions={[
+        <HelpButton
+          key="help"
+          helpPagePath="/community/contribute-to-the-assets-store"
+        />,
+      ]}
+      actions={[
+        <FlatButton
+          label={<Trans>Close</Trans>}
+          keyboardFocused={true}
+          onClick={() => {
+            props.onClose();
+          }}
+          key="close"
+        />,
+      ]}
+      open
+      onRequestClose={() => {
+        props.onClose();
+      }}
+    >
+      <Column expand>
+        <Line>
+          <Text>
+            <Trans>
+              You can export the object to a file to submit it for the asset
+              store.
+            </Trans>
+          </Text>
+        </Line>
+        <LineStackLayout>
+          <RaisedButton
+            icon={<CloudUpload />}
+            primary
+            label={<Trans>Export to a file</Trans>}
+            onClick={() => {
+              exportCustomObject(eventsFunctionsExtensionsState, props.object);
+            }}
+          />
+          <FlatButton
+            label={<Trans>Submit objects to the community</Trans>}
+            onClick={openGitHubIssue}
+          />
+        </LineStackLayout>
+      </Column>
+    </Dialog>
+  );
+};

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -129,7 +129,7 @@ type Props = {|
   onChangeSelectedObjectTags: SelectedTags => void,
 
   onEditObject: (object: gdObject, initialTab: ?ObjectEditorTab) => void,
-  onExportObject?: (object: gdObject) => void,
+  onExportObject: ?(object: gdObject) => void,
   onObjectCreated: gdObject => void,
   onObjectSelected: string => void,
   onObjectPasted?: gdObject => void,

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -48,6 +48,8 @@ import {
 import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
 import { getInstanceCountInLayoutForObject } from '../Utils/Layout';
+import EventsFunctionsExtensionsContext from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import useForceUpdate from '../Utils/UseForceUpdate';
 
 const gd: libGDevelop = global.gd;
 
@@ -96,11 +98,10 @@ const getPasteLabel = (i18n: I18nType, isGlobalObject: boolean) => {
     : i18n._(t`Paste ${clipboardObjectName}`);
 };
 
-type State = {|
-  newObjectDialogOpen: boolean,
-  renamedObjectWithContext: ?ObjectWithContext,
-  searchText: string,
-  tagEditedObject: ?gdObject,
+export type ObjectsListInterface = {|
+  forceUpdateList: () => void,
+  openNewObjectDialog: () => void,
+  closeNewObjectDialog: () => void,
 |};
 
 type Props = {|
@@ -129,7 +130,7 @@ type Props = {|
   onChangeSelectedObjectTags: SelectedTags => void,
 
   onEditObject: (object: gdObject, initialTab: ?ObjectEditorTab) => void,
-  onExportObject: ?(object: gdObject) => void,
+  onExportObject: (object: gdObject) => void,
   onObjectCreated: gdObject => void,
   onObjectSelected: string => void,
   onObjectPasted?: gdObject => void,
@@ -144,537 +145,615 @@ type Props = {|
   hotReloadPreviewButtonProps: HotReloadPreviewButtonProps,
 |};
 
-export default class ObjectsList extends React.Component<Props, State> {
-  sortableList: ?SortableVirtualizedItemList<ObjectWithContext>;
-  _displayedObjectWithContextsList: ObjectWithContextList = [];
-  state = {
-    newObjectDialogOpen: false,
-    renamedObjectWithContext: null,
-    searchText: '',
-    tagEditedObject: null,
-  };
-
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
-    // The component is costly to render, so avoid any re-rendering as much
-    // as possible.
-    // We make the assumption that no changes to objects list is made outside
-    // from the component.
-    // If a change is made, the component won't notice it: you have to manually
-    // call forceUpdate.
-
-    if (
-      this.state.newObjectDialogOpen !== nextState.newObjectDialogOpen ||
-      this.state.renamedObjectWithContext !==
-        nextState.renamedObjectWithContext ||
-      this.state.searchText !== nextState.searchText ||
-      this.state.tagEditedObject !== nextState.tagEditedObject
-    )
-      return true;
-
-    if (
-      this.props.selectedObjectNames !== nextProps.selectedObjectNames ||
-      this.props.selectedObjectTags !== nextProps.selectedObjectTags
-    )
-      return true;
-
-    if (
-      this.props.project !== nextProps.project ||
-      this.props.objectsContainer !== nextProps.objectsContainer
-    )
-      return true;
-
-    return false;
-  }
-
-  addObject = (objectType: string) => {
-    const {
-      project,
-      objectsContainer,
-      onEditObject,
-      onObjectCreated,
-      onObjectSelected,
-    } = this.props;
-
-    const defaultName = project.hasEventsBasedObject(objectType)
-      ? 'New' + project.getEventsBasedObject(objectType).getDefaultName()
-      : objectTypeToDefaultName[objectType] || 'NewObject';
-    const name = newNameGenerator(
-      defaultName,
-      name =>
-        objectsContainer.hasObjectNamed(name) || project.hasObjectNamed(name)
-    );
-
-    const object = objectsContainer.insertNewObject(
-      project,
-      objectType,
-      name,
-      objectsContainer.getObjectsCount()
-    );
-    object.setTags(getStringFromTags(this.props.selectedObjectTags));
-
-    this.setState(
-      {
-        newObjectDialogOpen: false,
-      },
-      () => {
-        if (onEditObject) {
-          onEditObject(object);
-          onObjectCreated(object);
-          onObjectSelected(name);
-        }
-      }
-    );
-  };
-
-  _onObjectAddedFromAsset = (object: gdObject) => {
-    const { onObjectCreated } = this.props;
-
-    object.setTags(getStringFromTags(this.props.selectedObjectTags));
-    onObjectCreated(object);
-
-    this.forceUpdateList();
-  };
-
-  onAddNewObject = () => {
-    this.setState({ newObjectDialogOpen: true });
-  };
-
-  _deleteObject = (i18n: I18nType, objectWithContext: ObjectWithContext) => {
-    const { object, global } = objectWithContext;
-    const { project, objectsContainer } = this.props;
-
-    const answer = Window.showConfirmDialog(
-      i18n._(
-        t`Are you sure you want to remove this object? This can't be undone.`
-      )
-    );
-    if (!answer) return;
-
-    // It's important to call onDeleteObject, because the parent might
-    // have to do some refactoring/clean up work before the object is deleted
-    // (typically, the SceneEditor will remove instances refering to the object,
-    // leading to the removal of their renderer - which can keep a reference to
-    // the object).
-    this.props.onDeleteObject(objectWithContext, doRemove => {
-      if (!doRemove) return;
-
-      if (global) {
-        project.removeObject(object.getName());
-      } else {
-        objectsContainer.removeObject(object.getName());
-      }
-
-      this._onObjectModified(false);
-    });
-  };
-
-  _copyObject = (objectWithContext: ObjectWithContext) => {
-    const { object } = objectWithContext;
-    Clipboard.set(CLIPBOARD_KIND, {
-      type: object.getType(),
-      name: object.getName(),
-      object: serializeToJSObject(object),
-    });
-  };
-
-  _cutObject = (i18n: I18nType, objectWithContext: ObjectWithContext) => {
-    this._copyObject(objectWithContext);
-    this._deleteObject(i18n, objectWithContext);
-  };
-
-  _duplicateObject = (objectWithContext: ObjectWithContext) => {
-    this._copyObject(objectWithContext);
-    this._pasteAndRename(objectWithContext);
-  };
-
-  _pasteAndRename = (objectWithContext: ObjectWithContext) => {
-    this._editName(this._paste(objectWithContext));
-  };
-
-  _paste = (objectWithContext: ObjectWithContext): ?ObjectWithContext => {
-    if (!Clipboard.has(CLIPBOARD_KIND)) return null;
-
-    const { object: pasteObject, global } = objectWithContext;
-    const clipboardContent = Clipboard.get(CLIPBOARD_KIND);
-    const copiedObject = SafeExtractor.extractObjectProperty(
-      clipboardContent,
-      'object'
-    );
-    const name = SafeExtractor.extractStringProperty(clipboardContent, 'name');
-    const type = SafeExtractor.extractStringProperty(clipboardContent, 'type');
-    if (!name || !type || !copiedObject) return;
-
-    const { project, objectsContainer, onObjectPasted } = this.props;
-
-    const newName = newNameGenerator(
-      name,
-      name =>
-        objectsContainer.hasObjectNamed(name) || project.hasObjectNamed(name),
-      ''
-    );
-
-    const newObject = global
-      ? project.insertNewObject(
-          project,
-          type,
-          newName,
-          project.getObjectPosition(pasteObject.getName()) + 1
-        )
-      : objectsContainer.insertNewObject(
-          project,
-          type,
-          newName,
-          objectsContainer.getObjectPosition(pasteObject.getName()) + 1
-        );
-
-    unserializeFromJSObject(
-      newObject,
-      copiedObject,
-      'unserializeFrom',
-      project
-    );
-    newObject.setName(newName); // Unserialization has overwritten the name.
-
-    this._onObjectModified(false);
-    if (onObjectPasted) onObjectPasted(newObject);
-
-    return { object: newObject, global };
-  };
-
-  _editName = (objectWithContext: ?ObjectWithContext) => {
-    this.setState(
-      {
-        renamedObjectWithContext: objectWithContext,
-      },
-      () => {
-        if (this.sortableList) this.sortableList.forceUpdateGrid();
-      }
-    );
-  };
-
-  _rename = (objectWithContext: ObjectWithContext, newName: string) => {
-    const { object } = objectWithContext;
-    this.setState({
-      renamedObjectWithContext: null,
-    });
-
-    if (getObjectWithContextName(objectWithContext) === newName) return;
-
-    if (this.props.canRenameObject(newName)) {
-      this.props.onRenameObject(objectWithContext, newName, doRename => {
-        if (!doRename) return;
-
-        object.setName(newName);
-        this._onObjectModified(false);
-      });
-    }
-  };
-
-  _canMoveSelectionTo = (destinationObjectWithContext: ObjectWithContext) => {
-    // Check if at least one element in the selection can be moved.
-    const selectedObjectsWithContext = this._displayedObjectWithContextsList.filter(
-      objectWithContext =>
-        this.props.selectedObjectNames.indexOf(
-          objectWithContext.object.getName()
-        ) !== -1
-    );
-    if (
-      selectedObjectsWithContext.every(
-        selectedObject =>
-          selectedObject.global === destinationObjectWithContext.global
-      )
-    ) {
-      return true;
-    }
-
-    const displayedGlobalObjectsWithContext = this._displayedObjectWithContextsList.filter(
-      objectWithContext => objectWithContext.global
-    );
-
-    if (
-      selectedObjectsWithContext.every(
-        selectedObject => !selectedObject.global
-      ) &&
-      destinationObjectWithContext.global &&
-      displayedGlobalObjectsWithContext.indexOf(
-        destinationObjectWithContext
-      ) === 0
-    ) {
-      return true;
-    }
-    return false;
-  };
-
-  _moveSelectionTo = (destinationObjectWithContext: ObjectWithContext) => {
-    const { project, objectsContainer } = this.props;
-
-    const displayedGlobalObjectsWithContext = this._displayedObjectWithContextsList.filter(
-      objectWithContext => objectWithContext.global
-    );
-    const displayedLocalObjectsWithContext = this._displayedObjectWithContextsList.filter(
-      objectWithContext => !objectWithContext.global
-    );
-
-    const isDestinationItemFirstItemOfGlobalDisplayedList =
-      destinationObjectWithContext.global &&
-      displayedGlobalObjectsWithContext.indexOf(
-        destinationObjectWithContext
-      ) === 0;
-
-    const selectedObjectsWithContext = this._displayedObjectWithContextsList.filter(
-      objectWithContext =>
-        this.props.selectedObjectNames.indexOf(
-          objectWithContext.object.getName()
-        ) !== -1
-    );
-    selectedObjectsWithContext.forEach(movedObjectWithContext => {
-      let container: gdObjectsContainer;
-      let fromIndex: number;
-      let toIndex: number;
-      if (
-        movedObjectWithContext.global === destinationObjectWithContext.global
-      ) {
-        container = destinationObjectWithContext.global
-          ? project
-          : objectsContainer;
-
-        fromIndex = container.getObjectPosition(
-          movedObjectWithContext.object.getName()
-        );
-        toIndex = container.getObjectPosition(
-          destinationObjectWithContext.object.getName()
-        );
-      } else if (
-        !movedObjectWithContext.global &&
-        isDestinationItemFirstItemOfGlobalDisplayedList
-      ) {
-        container = objectsContainer;
-        fromIndex = container.getObjectPosition(
-          movedObjectWithContext.object.getName()
-        );
-        toIndex = !this.state.searchText
-          ? container.getObjectsCount()
-          : container.getObjectPosition(
-              displayedLocalObjectsWithContext[
-                displayedLocalObjectsWithContext.length - 1
-              ].object.getName()
-            ) + 1;
-      } else {
-        return;
-      }
-      if (toIndex > fromIndex) toIndex -= 1;
-      container.moveObject(fromIndex, toIndex);
-    });
-    this._onObjectModified(true);
-  };
-
-  _setAsGlobalObject = (objectWithContext: ObjectWithContext) => {
-    const { object } = objectWithContext;
-    const { project, objectsContainer } = this.props;
-
-    const objectName: string = object.getName();
-    if (!objectsContainer.hasObjectNamed(objectName)) return;
-
-    if (project.hasObjectNamed(objectName)) {
-      showWarningBox(
-        'A global object with this name already exists. Please change the object name before setting it as a global object',
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
-    const answer = Window.showConfirmDialog(
-      "This object will be loaded and available in all the scenes. This is only recommended for objects that you reuse a lot and can't be undone. Make this object global?"
-    );
-    if (!answer) return;
-
-    // It's safe to call moveObjectToAnotherContainer because it does not invalidate the
-    // references to the object in memory - so other editors like InstancesRenderer can
-    // continue to work.
-    objectsContainer.moveObjectToAnotherContainer(
-      objectName,
-      project,
-      project.getObjectsCount()
-    );
-    this._onObjectModified(true);
-  };
-
-  forceUpdateList = () => {
-    this.forceUpdate();
-    if (this.sortableList) this.sortableList.forceUpdateGrid();
-  };
-
-  _openEditTagDialog = (tagEditedObject: ?gdObject) => {
-    this.setState({
-      tagEditedObject,
-    });
-  };
-
-  _changeObjectTags = (object: gdObject, tags: Tags) => {
-    object.setTags(getStringFromTags(tags));
-
-    // Force update the list as it's possible that user removed a tag
-    // from an object, that should then not be shown anymore in the list.
-    this._onObjectModified(true);
-  };
-
-  _selectObject = (objectWithContext: ?ObjectWithContext) => {
-    this.props.onObjectSelected(
-      objectWithContext ? objectWithContext.object.getName() : ''
-    );
-  };
-
-  _getObjectThumbnail = (objectWithContext: ObjectWithContext) =>
-    this.props.getThumbnail(
-      this.props.project,
-      objectWithContext.object.getConfiguration()
-    );
-
-  _renderObjectMenuTemplate = (i18n: I18nType) => (
-    objectWithContext: ObjectWithContext,
-    index: number
-  ) => {
-    const { object } = objectWithContext;
-    const { layout, onSelectAllInstancesOfObjectInLayout } = this.props;
-    const instanceCountOnScene = layout
-      ? getInstanceCountInLayoutForObject(layout, object.getName())
-      : undefined;
-
-    const objectMetadata = gd.MetadataProvider.getObjectMetadata(
-      this.props.project.getCurrentPlatform(),
-      object.getType()
-    );
-    return [
-      {
-        label: i18n._(t`Copy`),
-        click: () => this._copyObject(objectWithContext),
-      },
-      {
-        label: i18n._(t`Cut`),
-        click: () => this._cutObject(i18n, objectWithContext),
-      },
-      {
-        label: getPasteLabel(i18n, objectWithContext.global),
-        enabled: Clipboard.has(CLIPBOARD_KIND),
-        click: () => this._paste(objectWithContext),
-      },
-      {
-        label: i18n._(t`Duplicate`),
-        click: () => this._duplicateObject(objectWithContext),
-      },
-      { type: 'separator' },
-      {
-        label: i18n._(t`Edit object`),
-        click: () => this.props.onEditObject(object),
-      },
-      {
-        label: i18n._(t`Edit object variables`),
-        click: () => this.props.onEditObject(object, 'variables'),
-      },
-      {
-        label: i18n._(t`Edit behaviors`),
-        click: () => this.props.onEditObject(object, 'behaviors'),
-      },
-      {
-        label: i18n._(t`Edit effects`),
-        click: () => this.props.onEditObject(object, 'effects'),
-        enabled: !objectMetadata.isUnsupportedBaseObjectCapability('effect'),
-      },
-      this.props.onExportObject &&
-      this.props.project.hasEventsBasedObject(object.getType())
-        ? {
-            label: i18n._(t`Export object`),
-            click: () =>
-              this.props.onExportObject && this.props.onExportObject(object),
-          }
-        : null,
-      { type: 'separator' },
-      {
-        label: i18n._(t`Rename`),
-        click: () => this._editName(objectWithContext),
-      },
-      {
-        label: i18n._(t`Set as global object`),
-        enabled: !isObjectWithContextGlobal(objectWithContext),
-        click: () => this._setAsGlobalObject(objectWithContext),
-      },
-      {
-        label: i18n._(t`Tags`),
-        submenu: buildTagsMenuTemplate({
-          noTagLabel: 'No tags',
-          getAllTags: this.props.getAllObjectTags,
-          selectedTags: getTagsFromString(object.getTags()),
-          onChange: objectTags => {
-            this._changeObjectTags(object, objectTags);
-          },
-          editTagsLabel: 'Add/edit tags...',
-          onEditTags: () => this._openEditTagDialog(object),
-        }),
-      },
-      {
-        label: i18n._(t`Delete`),
-        click: () => this._deleteObject(i18n, objectWithContext),
-      },
-      { type: 'separator' },
-      {
-        label: i18n._(t`Add instance to the scene`),
-        click: () => this.props.onAddObjectInstance(object.getName()),
-      },
-      instanceCountOnScene !== undefined && onSelectAllInstancesOfObjectInLayout
-        ? {
-            label: i18n._(
-              t`Select instances on scene (${instanceCountOnScene})`
-            ),
-            click: () => onSelectAllInstancesOfObjectInLayout(object.getName()),
-            enabled: instanceCountOnScene > 0,
-          }
-        : undefined,
-      { type: 'separator' },
-      {
-        label: i18n._(t`Add a new object...`),
-        click: () => this.onAddNewObject(),
-      },
-    ].filter(Boolean);
-  };
-
-  _onObjectModified = (shouldForceUpdateList: boolean) => {
-    if (this.props.unsavedChanges)
-      this.props.unsavedChanges.triggerUnsavedChanges();
-
-    if (shouldForceUpdateList) this.forceUpdateList();
-    else this.forceUpdate();
-  };
-
-  render() {
-    const {
+const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
+  (
+    {
       project,
       layout,
       objectsContainer,
       resourceSources,
       onChooseResource,
       resourceExternalEditors,
-      selectedObjectTags,
       onFetchNewlyAddedResources,
+      onSelectAllInstancesOfObjectInLayout,
+      onDeleteObject,
+      onRenameObject,
+      selectedObjectNames,
       canInstallPrivateAsset,
-    } = this.props;
-    const { searchText, tagEditedObject } = this.state;
+
+      selectedObjectTags,
+      getAllObjectTags,
+      onChangeSelectedObjectTags,
+
+      onEditObject,
+      onExportObject,
+      onObjectCreated,
+      onObjectSelected,
+      onObjectPasted,
+      canRenameObject,
+      onAddObjectInstance,
+
+      getThumbnail,
+      unsavedChanges,
+      hotReloadPreviewButtonProps,
+    }: Props,
+    ref
+  ) => {
+    const sortableList = React.useRef<?SortableVirtualizedItemList<ObjectWithContext>>(
+      null
+    );
+
+    const forceUpdate = useForceUpdate();
+
+    const forceUpdateList = React.useCallback(
+      () => {
+        forceUpdate();
+        if (sortableList.current) sortableList.current.forceUpdateGrid();
+      },
+      [forceUpdate]
+    );
+
+    const [newObjectDialogOpen, setNewObjectDialogOpen] = React.useState(false);
+
+    React.useImperativeHandle(ref, () => ({
+      forceUpdateList: () => {
+        forceUpdate();
+        if (sortableList.current) sortableList.current.forceUpdateGrid();
+      },
+      openNewObjectDialog: () => {
+        setNewObjectDialogOpen(true);
+      },
+      closeNewObjectDialog: () => {
+        setNewObjectDialogOpen(false);
+      },
+    }));
+
+    const [
+      renamedObjectWithContext,
+      setRenamedObjectWithContext,
+    ] = React.useState<?ObjectWithContext>(null);
+    const [searchText, setSearchText] = React.useState('');
+    const [tagEditedObject, setTagEditedObject] = React.useState<?gdObject>(
+      null
+    );
+
+    const addObject = React.useCallback(
+      (objectType: string) => {
+        const defaultName = project.hasEventsBasedObject(objectType)
+          ? 'New' + project.getEventsBasedObject(objectType).getDefaultName()
+          : objectTypeToDefaultName[objectType] || 'NewObject';
+        const name = newNameGenerator(
+          defaultName,
+          name =>
+            objectsContainer.hasObjectNamed(name) ||
+            project.hasObjectNamed(name)
+        );
+
+        const object = objectsContainer.insertNewObject(
+          project,
+          objectType,
+          name,
+          objectsContainer.getObjectsCount()
+        );
+        object.setTags(getStringFromTags(selectedObjectTags));
+
+        setNewObjectDialogOpen(false);
+        // TODO Should it be called later?
+        if (onEditObject) {
+          onEditObject(object);
+          onObjectCreated(object);
+          onObjectSelected(name);
+        }
+      },
+      [
+        project,
+        objectsContainer,
+        selectedObjectTags,
+        onEditObject,
+        onObjectCreated,
+        onObjectSelected,
+      ]
+    );
+
+    const onObjectAddedFromAsset = React.useCallback(
+      (object: gdObject) => {
+        object.setTags(getStringFromTags(selectedObjectTags));
+        onObjectCreated(object);
+
+        forceUpdateList();
+      },
+      [forceUpdateList, onObjectCreated, selectedObjectTags]
+    );
+
+    const onAddNewObject = React.useCallback(() => {
+      setNewObjectDialogOpen(true);
+    }, []);
+
+    const onObjectModified = React.useCallback(
+      (shouldForceUpdateList: boolean) => {
+        if (unsavedChanges) unsavedChanges.triggerUnsavedChanges();
+
+        if (shouldForceUpdateList) forceUpdateList();
+        else forceUpdate();
+      },
+      [forceUpdate, forceUpdateList, unsavedChanges]
+    );
+
+    const deleteObject = React.useCallback(
+      (i18n: I18nType, objectWithContext: ObjectWithContext) => {
+        const { object, global } = objectWithContext;
+
+        const answer = Window.showConfirmDialog(
+          i18n._(
+            t`Are you sure you want to remove this object? This can't be undone.`
+          )
+        );
+        if (!answer) return;
+
+        // It's important to call onDeleteObject, because the parent might
+        // have to do some refactoring/clean up work before the object is deleted
+        // (typically, the SceneEditor will remove instances refering to the object,
+        // leading to the removal of their renderer - which can keep a reference to
+        // the object).
+        onDeleteObject(objectWithContext, doRemove => {
+          if (!doRemove) return;
+
+          if (global) {
+            project.removeObject(object.getName());
+          } else {
+            objectsContainer.removeObject(object.getName());
+          }
+
+          onObjectModified(false);
+        });
+      },
+      [objectsContainer, onDeleteObject, onObjectModified, project]
+    );
+
+    const copyObject = React.useCallback(
+      (objectWithContext: ObjectWithContext) => {
+        const { object } = objectWithContext;
+        Clipboard.set(CLIPBOARD_KIND, {
+          type: object.getType(),
+          name: object.getName(),
+          object: serializeToJSObject(object),
+        });
+      },
+      []
+    );
+
+    const cutObject = React.useCallback(
+      (i18n: I18nType, objectWithContext: ObjectWithContext) => {
+        copyObject(objectWithContext);
+        deleteObject(i18n, objectWithContext);
+      },
+      [copyObject, deleteObject]
+    );
+
+    const paste = React.useCallback(
+      (objectWithContext: ObjectWithContext): ?ObjectWithContext => {
+        if (!Clipboard.has(CLIPBOARD_KIND)) return null;
+
+        const { object: pasteObject, global } = objectWithContext;
+        const clipboardContent = Clipboard.get(CLIPBOARD_KIND);
+        const copiedObject = SafeExtractor.extractObjectProperty(
+          clipboardContent,
+          'object'
+        );
+        const name = SafeExtractor.extractStringProperty(
+          clipboardContent,
+          'name'
+        );
+        const type = SafeExtractor.extractStringProperty(
+          clipboardContent,
+          'type'
+        );
+        if (!name || !type || !copiedObject) return;
+
+        const newName = newNameGenerator(
+          name,
+          name =>
+            objectsContainer.hasObjectNamed(name) ||
+            project.hasObjectNamed(name),
+          ''
+        );
+
+        const newObject = global
+          ? project.insertNewObject(
+              project,
+              type,
+              newName,
+              project.getObjectPosition(pasteObject.getName()) + 1
+            )
+          : objectsContainer.insertNewObject(
+              project,
+              type,
+              newName,
+              objectsContainer.getObjectPosition(pasteObject.getName()) + 1
+            );
+
+        unserializeFromJSObject(
+          newObject,
+          copiedObject,
+          'unserializeFrom',
+          project
+        );
+        newObject.setName(newName); // Unserialization has overwritten the name.
+
+        onObjectModified(false);
+        if (onObjectPasted) onObjectPasted(newObject);
+
+        return { object: newObject, global };
+      },
+      [objectsContainer, onObjectModified, onObjectPasted, project]
+    );
+
+    const editName = React.useCallback(
+      (objectWithContext: ?ObjectWithContext) => {
+        setRenamedObjectWithContext(objectWithContext);
+        // TODO Should it be called later?
+        if (sortableList.current) sortableList.current.forceUpdateGrid();
+      },
+      []
+    );
+
+    const pasteAndRename = React.useCallback(
+      (objectWithContext: ObjectWithContext) => {
+        editName(paste(objectWithContext));
+      },
+      [editName, paste]
+    );
+
+    const duplicateObject = React.useCallback(
+      (objectWithContext: ObjectWithContext) => {
+        copyObject(objectWithContext);
+        pasteAndRename(objectWithContext);
+      },
+      [copyObject, pasteAndRename]
+    );
+
+    const rename = React.useCallback(
+      (objectWithContext: ObjectWithContext, newName: string) => {
+        const { object } = objectWithContext;
+        setRenamedObjectWithContext(null);
+
+        if (getObjectWithContextName(objectWithContext) === newName) return;
+
+        if (canRenameObject(newName)) {
+          onRenameObject(objectWithContext, newName, doRename => {
+            if (!doRename) return;
+
+            object.setName(newName);
+            onObjectModified(false);
+          });
+        }
+      },
+      [canRenameObject, onObjectModified, onRenameObject]
+    );
 
     const lists = enumerateObjects(project, objectsContainer);
-    this._displayedObjectWithContextsList = filterObjectsList(
+    const displayedObjectWithContextsList = filterObjectsList(
       lists.allObjectsList,
       {
         searchText,
         selectedTags: selectedObjectTags,
       }
     );
-    const selectedObjects = this._displayedObjectWithContextsList.filter(
+    const selectedObjects = displayedObjectWithContextsList.filter(
       objectWithContext =>
-        this.props.selectedObjectNames.indexOf(
-          objectWithContext.object.getName()
-        ) !== -1
+        selectedObjectNames.indexOf(objectWithContext.object.getName()) !== -1
     );
-    const renamedObjectWithContext = this._displayedObjectWithContextsList.find(
-      isSameObjectWithContext(this.state.renamedObjectWithContext)
+    const displayedRenamedObjectWithContext = displayedObjectWithContextsList.find(
+      isSameObjectWithContext(renamedObjectWithContext)
+    );
+
+    const canMoveSelectionTo = React.useCallback(
+      (destinationObjectWithContext: ObjectWithContext) => {
+        // Check if at least one element in the selection can be moved.
+        const selectedObjectsWithContext = displayedObjectWithContextsList.filter(
+          objectWithContext =>
+            selectedObjectNames.indexOf(objectWithContext.object.getName()) !==
+            -1
+        );
+        if (
+          selectedObjectsWithContext.every(
+            selectedObject =>
+              selectedObject.global === destinationObjectWithContext.global
+          )
+        ) {
+          return true;
+        }
+
+        const displayedGlobalObjectsWithContext = displayedObjectWithContextsList.filter(
+          objectWithContext => objectWithContext.global
+        );
+
+        if (
+          selectedObjectsWithContext.every(
+            selectedObject => !selectedObject.global
+          ) &&
+          destinationObjectWithContext.global &&
+          displayedGlobalObjectsWithContext.indexOf(
+            destinationObjectWithContext
+          ) === 0
+        ) {
+          return true;
+        }
+        return false;
+      },
+      [displayedObjectWithContextsList, selectedObjectNames]
+    );
+
+    const moveSelectionTo = React.useCallback(
+      (destinationObjectWithContext: ObjectWithContext) => {
+        const displayedGlobalObjectsWithContext = displayedObjectWithContextsList.filter(
+          objectWithContext => objectWithContext.global
+        );
+        const displayedLocalObjectsWithContext = displayedObjectWithContextsList.filter(
+          objectWithContext => !objectWithContext.global
+        );
+
+        const isDestinationItemFirstItemOfGlobalDisplayedList =
+          destinationObjectWithContext.global &&
+          displayedGlobalObjectsWithContext.indexOf(
+            destinationObjectWithContext
+          ) === 0;
+
+        const selectedObjectsWithContext = displayedObjectWithContextsList.filter(
+          objectWithContext =>
+            selectedObjectNames.indexOf(objectWithContext.object.getName()) !==
+            -1
+        );
+        selectedObjectsWithContext.forEach(movedObjectWithContext => {
+          let container: gdObjectsContainer;
+          let fromIndex: number;
+          let toIndex: number;
+          if (
+            movedObjectWithContext.global ===
+            destinationObjectWithContext.global
+          ) {
+            container = destinationObjectWithContext.global
+              ? project
+              : objectsContainer;
+
+            fromIndex = container.getObjectPosition(
+              movedObjectWithContext.object.getName()
+            );
+            toIndex = container.getObjectPosition(
+              destinationObjectWithContext.object.getName()
+            );
+          } else if (
+            !movedObjectWithContext.global &&
+            isDestinationItemFirstItemOfGlobalDisplayedList
+          ) {
+            container = objectsContainer;
+            fromIndex = container.getObjectPosition(
+              movedObjectWithContext.object.getName()
+            );
+            toIndex = !searchText
+              ? container.getObjectsCount()
+              : container.getObjectPosition(
+                  displayedLocalObjectsWithContext[
+                    displayedLocalObjectsWithContext.length - 1
+                  ].object.getName()
+                ) + 1;
+          } else {
+            return;
+          }
+          if (toIndex > fromIndex) toIndex -= 1;
+          container.moveObject(fromIndex, toIndex);
+        });
+        onObjectModified(true);
+      },
+      [
+        displayedObjectWithContextsList,
+        objectsContainer,
+        onObjectModified,
+        project,
+        searchText,
+        selectedObjectNames,
+      ]
+    );
+
+    const setAsGlobalObject = React.useCallback(
+      (objectWithContext: ObjectWithContext) => {
+        const { object } = objectWithContext;
+
+        const objectName: string = object.getName();
+        if (!objectsContainer.hasObjectNamed(objectName)) return;
+
+        if (project.hasObjectNamed(objectName)) {
+          showWarningBox(
+            'A global object with this name already exists. Please change the object name before setting it as a global object',
+            { delayToNextTick: true }
+          );
+          return;
+        }
+
+        const answer = Window.showConfirmDialog(
+          "This object will be loaded and available in all the scenes. This is only recommended for objects that you reuse a lot and can't be undone. Make this object global?"
+        );
+        if (!answer) return;
+
+        // It's safe to call moveObjectToAnotherContainer because it does not invalidate the
+        // references to the object in memory - so other editors like InstancesRenderer can
+        // continue to work.
+        objectsContainer.moveObjectToAnotherContainer(
+          objectName,
+          project,
+          project.getObjectsCount()
+        );
+        onObjectModified(true);
+      },
+      [objectsContainer, onObjectModified, project]
+    );
+
+    const openEditTagDialog = React.useCallback(
+      (tagEditedObject: ?gdObject) => {
+        setTagEditedObject(tagEditedObject);
+      },
+      []
+    );
+
+    const changeObjectTags = React.useCallback(
+      (object: gdObject, tags: Tags) => {
+        object.setTags(getStringFromTags(tags));
+
+        // Force update the list as it's possible that user removed a tag
+        // from an object, that should then not be shown anymore in the list.
+        onObjectModified(true);
+      },
+      [onObjectModified]
+    );
+
+    const selectObject = React.useCallback(
+      (objectWithContext: ?ObjectWithContext) => {
+        onObjectSelected(
+          objectWithContext ? objectWithContext.object.getName() : ''
+        );
+      },
+      [onObjectSelected]
+    );
+
+    const getObjectThumbnail = React.useCallback(
+      (objectWithContext: ObjectWithContext) =>
+        getThumbnail(project, objectWithContext.object.getConfiguration()),
+      [getThumbnail, project]
+    );
+
+    const eventsFunctionsExtensionsState = React.useContext(
+      EventsFunctionsExtensionsContext
+    );
+    const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
+
+    const renderObjectMenuTemplate = React.useCallback(
+      (i18n: I18nType) => (
+        objectWithContext: ObjectWithContext,
+        index: number
+      ) => {
+        const { object } = objectWithContext;
+        const instanceCountOnScene = layout
+          ? getInstanceCountInLayoutForObject(layout, object.getName())
+          : undefined;
+
+        const objectMetadata = gd.MetadataProvider.getObjectMetadata(
+          project.getCurrentPlatform(),
+          object.getType()
+        );
+        return [
+          {
+            label: i18n._(t`Copy`),
+            click: () => copyObject(objectWithContext),
+          },
+          {
+            label: i18n._(t`Cut`),
+            click: () => cutObject(i18n, objectWithContext),
+          },
+          {
+            label: getPasteLabel(i18n, objectWithContext.global),
+            enabled: Clipboard.has(CLIPBOARD_KIND),
+            click: () => paste(objectWithContext),
+          },
+          {
+            label: i18n._(t`Duplicate`),
+            click: () => duplicateObject(objectWithContext),
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Edit object`),
+            click: () => onEditObject(object),
+          },
+          {
+            label: i18n._(t`Edit object variables`),
+            click: () => onEditObject(object, 'variables'),
+          },
+          {
+            label: i18n._(t`Edit behaviors`),
+            click: () => onEditObject(object, 'behaviors'),
+          },
+          {
+            label: i18n._(t`Edit effects`),
+            click: () => onEditObject(object, 'effects'),
+            enabled: !objectMetadata.isUnsupportedBaseObjectCapability(
+              'effect'
+            ),
+          },
+          eventsFunctionsExtensionWriter &&
+          project.hasEventsBasedObject(object.getType())
+            ? {
+                label: i18n._(t`Export object`),
+                click: () => onExportObject && onExportObject(object),
+              }
+            : null,
+          { type: 'separator' },
+          {
+            label: i18n._(t`Rename`),
+            click: () => editName(objectWithContext),
+          },
+          {
+            label: i18n._(t`Set as global object`),
+            enabled: !isObjectWithContextGlobal(objectWithContext),
+            click: () => setAsGlobalObject(objectWithContext),
+          },
+          {
+            label: i18n._(t`Tags`),
+            submenu: buildTagsMenuTemplate({
+              noTagLabel: 'No tags',
+              getAllTags: getAllObjectTags,
+              selectedTags: getTagsFromString(object.getTags()),
+              onChange: objectTags => {
+                changeObjectTags(object, objectTags);
+              },
+              editTagsLabel: 'Add/edit tags...',
+              onEditTags: () => openEditTagDialog(object),
+            }),
+          },
+          {
+            label: i18n._(t`Delete`),
+            click: () => deleteObject(i18n, objectWithContext),
+          },
+          { type: 'separator' },
+          {
+            label: i18n._(t`Add instance to the scene`),
+            click: () => onAddObjectInstance(object.getName()),
+          },
+          instanceCountOnScene !== undefined &&
+          onSelectAllInstancesOfObjectInLayout
+            ? {
+                label: i18n._(
+                  t`Select instances on scene (${instanceCountOnScene})`
+                ),
+                click: () =>
+                  onSelectAllInstancesOfObjectInLayout(object.getName()),
+                enabled: instanceCountOnScene > 0,
+              }
+            : undefined,
+          { type: 'separator' },
+          {
+            label: i18n._(t`Add a new object...`),
+            click: onAddNewObject,
+          },
+        ].filter(Boolean);
+      },
+      [
+        changeObjectTags,
+        copyObject,
+        cutObject,
+        deleteObject,
+        duplicateObject,
+        editName,
+        getAllObjectTags,
+        layout,
+        onAddNewObject,
+        onAddObjectInstance,
+        onEditObject,
+        onExportObject,
+        onSelectAllInstancesOfObjectInLayout,
+        openEditTagDialog,
+        paste,
+        project,
+        setAsGlobalObject,
+      ]
     );
 
     // Force List component to be mounted again if project or objectsContainer
@@ -682,11 +761,13 @@ export default class ObjectsList extends React.Component<Props, State> {
     // crash the app.
     const listKey = project.ptr + ';' + objectsContainer.ptr;
 
+    const screenType = useScreenType();
+
     return (
       <Background maxWidth>
         <TagChips
-          tags={this.props.selectedObjectTags}
-          onChange={this.props.onChangeSelectedObjectTags}
+          tags={selectedObjectTags}
+          onChange={onChangeSelectedObjectTags}
         />
         <div style={styles.listContainer}>
           <AutoSizer>
@@ -695,30 +776,30 @@ export default class ObjectsList extends React.Component<Props, State> {
                 {({ i18n }) => (
                   <SortableVirtualizedItemList
                     key={listKey}
-                    ref={sortableList => (this.sortableList = sortableList)}
-                    fullList={this._displayedObjectWithContextsList}
+                    ref={sortableList}
+                    fullList={displayedObjectWithContextsList}
                     width={width}
                     height={height}
                     getItemName={getObjectWithContextName}
-                    getItemThumbnail={this._getObjectThumbnail}
+                    getItemThumbnail={getObjectThumbnail}
                     getItemId={(objectWithContext, index) => {
                       return 'object-item-' + index;
                     }}
                     isItemBold={isObjectWithContextGlobal}
                     onEditItem={objectWithContext =>
-                      this.props.onEditObject(objectWithContext.object)
+                      onEditObject(objectWithContext.object)
                     }
-                    onAddNewItem={this.onAddNewObject}
+                    onAddNewItem={onAddNewObject}
                     addNewItemLabel={<Trans>Add a new object</Trans>}
                     addNewItemId="add-new-object-button"
                     selectedItems={selectedObjects}
-                    onItemSelected={this._selectObject}
-                    renamedItem={renamedObjectWithContext}
-                    onRename={this._rename}
-                    buildMenuTemplate={this._renderObjectMenuTemplate(i18n)}
-                    onMoveSelectionToItem={this._moveSelectionTo}
-                    canMoveSelectionToItem={this._canMoveSelectionTo}
-                    scaleUpItemIconWhenSelected={useScreenType() === 'touch'}
+                    onItemSelected={selectObject}
+                    renamedItem={displayedRenamedObjectWithContext}
+                    onRename={rename}
+                    buildMenuTemplate={renderObjectMenuTemplate(i18n)}
+                    onMoveSelectionToItem={moveSelectionTo}
+                    canMoveSelectionToItem={canMoveSelectionTo}
+                    scaleUpItemIconWhenSelected={screenType === 'touch'}
                     reactDndType={objectWithContextReactDndType}
                   />
                 )}
@@ -729,23 +810,15 @@ export default class ObjectsList extends React.Component<Props, State> {
         <SearchBar
           value={searchText}
           onRequestSearch={() => {}}
-          onChange={text =>
-            this.setState({
-              searchText: text,
-            })
-          }
+          onChange={text => setSearchText(text)}
           aspect="integrated-search-bar"
           placeholder={t`Search objects`}
         />
-        {this.state.newObjectDialogOpen && (
+        {newObjectDialogOpen && (
           <NewObjectDialog
-            onClose={() =>
-              this.setState({
-                newObjectDialogOpen: false,
-              })
-            }
-            onCreateNewObject={this.addObject}
-            onObjectAddedFromAsset={this._onObjectAddedFromAsset}
+            onClose={() => setNewObjectDialogOpen(false)}
+            onCreateNewObject={addObject}
+            onObjectAddedFromAsset={onObjectAddedFromAsset}
             project={project}
             layout={layout}
             objectsContainer={objectsContainer}
@@ -760,13 +833,27 @@ export default class ObjectsList extends React.Component<Props, State> {
           <EditTagsDialog
             tagsString={tagEditedObject.getTags()}
             onEdit={tags => {
-              this._changeObjectTags(tagEditedObject, tags);
-              this._openEditTagDialog(null);
+              changeObjectTags(tagEditedObject, tags);
+              openEditTagDialog(null);
             }}
-            onCancel={() => this._openEditTagDialog(null)}
+            onCancel={() => openEditTagDialog(null)}
           />
         )}
       </Background>
     );
   }
-}
+);
+
+const areEqual = (prevProps: Props, nextProps: Props): boolean =>
+  // The component is costly to render, so avoid any re-rendering as much
+  // as possible.
+  // We make the assumption that no changes to objects list is made outside
+  // from the component.
+  // If a change is made, the component won't notice it: you have to manually
+  // call forceUpdate.
+  prevProps.selectedObjectNames === nextProps.selectedObjectNames &&
+  prevProps.selectedObjectTags === nextProps.selectedObjectTags &&
+  prevProps.project === nextProps.project &&
+  prevProps.objectsContainer === nextProps.objectsContainer;
+
+export default React.memo<Props>(ObjectsList, areEqual);

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -129,6 +129,7 @@ type Props = {|
   onChangeSelectedObjectTags: SelectedTags => void,
 
   onEditObject: (object: gdObject, initialTab: ?ObjectEditorTab) => void,
+  onExportObject?: (object: gdObject) => void,
   onObjectCreated: gdObject => void,
   onObjectSelected: string => void,
   onObjectPasted?: gdObject => void,
@@ -579,6 +580,14 @@ export default class ObjectsList extends React.Component<Props, State> {
         click: () => this.props.onEditObject(object, 'effects'),
         enabled: !objectMetadata.isUnsupportedBaseObjectCapability('effect'),
       },
+      this.props.onExportObject &&
+      this.props.project.hasEventsBasedObject(object.getType())
+        ? {
+            label: i18n._(t`Export object`),
+            click: () =>
+              this.props.onExportObject && this.props.onExportObject(object),
+          }
+        : null,
       { type: 'separator' },
       {
         label: i18n._(t`Rename`),

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -17,7 +17,7 @@ import LayerRemoveDialog from '../LayersList/LayerRemoveDialog';
 import LayerEditorDialog from '../LayersList/LayerEditorDialog';
 import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
 import ObjectEditorDialog from '../ObjectEditor/ObjectEditorDialog';
-import { ObjectExporterDialog } from '../ObjectEditor/ObjectExporterDialog';
+import ObjectExporterDialog from '../ObjectEditor/ObjectExporterDialog';
 import ObjectGroupEditorDialog from '../ObjectGroupEditor/ObjectGroupEditorDialog';
 import InstancesSelection from '../InstancesEditor/InstancesSelection';
 import SetupGridDialog from './SetupGridDialog';
@@ -78,6 +78,7 @@ import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
 import { MOVEMENT_BIG_DELTA } from '../UI/KeyboardShortcuts';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
 import { getInstancesInLayoutForObject } from '../Utils/Layout';
+import EventsFunctionsExtensionsContext from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
 
 const gd: libGDevelop = global.gd;
 
@@ -1262,6 +1263,11 @@ export default class SceneEditor extends React.Component<Props, State> {
       ? getObjectByName(project, layout, variablesEditedAssociatedObjectName)
       : null;
 
+    const eventsFunctionsExtensionsState = React.useContext(
+      EventsFunctionsExtensionsContext
+    );
+    const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
+
     const editors = {
       properties: {
         type: 'secondary',
@@ -1406,7 +1412,9 @@ export default class SceneEditor extends React.Component<Props, State> {
                 selectedObjectNames={this.state.selectedObjectNames}
                 canInstallPrivateAsset={this.props.canInstallPrivateAsset}
                 onEditObject={this.props.onEditObject || this.editObject}
-                onExportObject={this.exportObject}
+                onExportObject={
+                  eventsFunctionsExtensionWriter ? this.exportObject : null
+                }
                 onDeleteObject={this._onDeleteObject(i18n)}
                 canRenameObject={newName =>
                   this._canObjectOrGroupUseNewName(newName, i18n)

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -6,7 +6,7 @@ import { t } from '@lingui/macro';
 
 import * as React from 'react';
 import uniq from 'lodash/uniq';
-import ObjectsList from '../ObjectsList';
+import ObjectsList, { type ObjectsListInterface } from '../ObjectsList';
 import ObjectGroupsList from '../ObjectGroupsList';
 import ObjectsRenderingService from '../ObjectsRendering/ObjectsRenderingService';
 import InstancesEditor from '../InstancesEditor';
@@ -78,7 +78,6 @@ import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
 import { MOVEMENT_BIG_DELTA } from '../UI/KeyboardShortcuts';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
 import { getInstancesInLayoutForObject } from '../Utils/Layout';
-import EventsFunctionsExtensionsContext from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
 
 const gd: libGDevelop = global.gd;
 
@@ -177,7 +176,7 @@ export default class SceneEditor extends React.Component<Props, State> {
   editor: ?InstancesEditor;
   contextMenu: ?ContextMenuInterface;
   editorMosaic: ?EditorMosaic;
-  _objectsList: ?ObjectsList;
+  _objectsList: ?ObjectsListInterface;
   _layersList: ?LayersList;
   _propertiesEditor: ?InstancePropertiesEditor;
   _instancesList: ?InstancesList;
@@ -481,8 +480,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       newObjectInstanceSceneCoordinates: this.editor.getLastCursorSceneCoordinates(),
     });
 
-    if (this._objectsList)
-      this._objectsList.setState({ newObjectDialogOpen: true });
+    if (this._objectsList) this._objectsList.openNewObjectDialog();
   };
 
   _onAddInstanceUnderCursor = () => {
@@ -1263,11 +1261,6 @@ export default class SceneEditor extends React.Component<Props, State> {
       ? getObjectByName(project, layout, variablesEditedAssociatedObjectName)
       : null;
 
-    const eventsFunctionsExtensionsState = React.useContext(
-      EventsFunctionsExtensionsContext
-    );
-    const eventsFunctionsExtensionWriter = eventsFunctionsExtensionsState.getEventsFunctionsExtensionWriter();
-
     const editors = {
       properties: {
         type: 'secondary',
@@ -1412,9 +1405,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 selectedObjectNames={this.state.selectedObjectNames}
                 canInstallPrivateAsset={this.props.canInstallPrivateAsset}
                 onEditObject={this.props.onEditObject || this.editObject}
-                onExportObject={
-                  eventsFunctionsExtensionWriter ? this.exportObject : null
-                }
+                onExportObject={this.exportObject}
                 onDeleteObject={this._onDeleteObject(i18n)}
                 canRenameObject={newName =>
                   this._canObjectOrGroupUseNewName(newName, i18n)
@@ -1431,7 +1422,10 @@ export default class SceneEditor extends React.Component<Props, State> {
                   })
                 }
                 getAllObjectTags={this._getAllObjectTags}
-                ref={objectsList => (this._objectsList = objectsList)}
+                ref={
+                  // $FlowFixMe Make this component functional.
+                  objectsList => (this._objectsList = objectsList)
+                }
                 unsavedChanges={this.props.unsavedChanges}
                 hotReloadPreviewButtonProps={
                   this.props.hotReloadPreviewButtonProps

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -17,6 +17,7 @@ import LayerRemoveDialog from '../LayersList/LayerRemoveDialog';
 import LayerEditorDialog from '../LayersList/LayerEditorDialog';
 import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
 import ObjectEditorDialog from '../ObjectEditor/ObjectEditorDialog';
+import { ObjectExporterDialog } from '../ObjectEditor/ObjectExporterDialog';
 import ObjectGroupEditorDialog from '../ObjectGroupEditor/ObjectGroupEditorDialog';
 import InstancesSelection from '../InstancesEditor/InstancesSelection';
 import SetupGridDialog from './SetupGridDialog';
@@ -140,6 +141,7 @@ type State = {|
   layerRemoved: ?string,
   editedLayer: ?gdLayer,
   editedLayerInitialTab: 'properties' | 'effects',
+  exportedObjectWithContext: ?ObjectWithContext,
   editedObjectWithContext: ?ObjectWithContext,
   editedObjectInitialTab: ?ObjectEditorTab,
   variablesEditedInstance: ?gdInitialInstance,
@@ -192,6 +194,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       layerRemoved: null,
       editedLayer: null,
       editedLayerInitialTab: 'properties',
+      exportedObjectWithContext: null,
       editedObjectWithContext: null,
       editedObjectInitialTab: 'properties',
       variablesEditedInstance: null,
@@ -381,6 +384,22 @@ export default class SceneEditor extends React.Component<Props, State> {
       this.setState({
         editedObjectWithContext: null,
         editedObjectInitialTab: 'properties',
+      });
+    }
+  };
+
+  exportObject = (editedObject: ?gdObject) => {
+    if (editedObject) {
+      this.setState({
+        exportedObjectWithContext: {
+          object: editedObject,
+          // It's not important for the export.
+          global: false,
+        },
+      });
+    } else {
+      this.setState({
+        exportedObjectWithContext: null,
       });
     }
   };
@@ -1387,6 +1406,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 selectedObjectNames={this.state.selectedObjectNames}
                 canInstallPrivateAsset={this.props.canInstallPrivateAsset}
                 onEditObject={this.props.onEditObject || this.editObject}
+                onExportObject={this.exportObject}
                 onDeleteObject={this._onDeleteObject(i18n)}
                 canRenameObject={newName =>
                   this._canObjectOrGroupUseNewName(newName, i18n)
@@ -1542,6 +1562,14 @@ export default class SceneEditor extends React.Component<Props, State> {
             </React.Fragment>
           )}
         </I18n>
+        {this.state.exportedObjectWithContext && (
+          <ObjectExporterDialog
+            object={this.state.exportedObjectWithContext.object}
+            onClose={() => {
+              this.exportObject(null);
+            }}
+          />
+        )}
         {!!this.state.editedGroup && (
           <ObjectGroupEditorDialog
             project={project}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -141,7 +141,7 @@ type State = {|
   layerRemoved: ?string,
   editedLayer: ?gdLayer,
   editedLayerInitialTab: 'properties' | 'effects',
-  exportedObjectWithContext: ?ObjectWithContext,
+  exportedObject: ?gdObject,
   editedObjectWithContext: ?ObjectWithContext,
   editedObjectInitialTab: ?ObjectEditorTab,
   variablesEditedInstance: ?gdInitialInstance,
@@ -194,7 +194,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       layerRemoved: null,
       editedLayer: null,
       editedLayerInitialTab: 'properties',
-      exportedObjectWithContext: null,
+      exportedObject: null,
       editedObjectWithContext: null,
       editedObjectInitialTab: 'properties',
       variablesEditedInstance: null,
@@ -388,18 +388,14 @@ export default class SceneEditor extends React.Component<Props, State> {
     }
   };
 
-  exportObject = (editedObject: ?gdObject) => {
-    if (editedObject) {
+  openObjectExporterDialog = (object: ?gdObject) => {
+    if (object) {
       this.setState({
-        exportedObjectWithContext: {
-          object: editedObject,
-          // It's not important for the export.
-          global: false,
-        },
+        exportedObject: object,
       });
     } else {
       this.setState({
-        exportedObjectWithContext: null,
+        exportedObject: null,
       });
     }
   };
@@ -1405,7 +1401,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 selectedObjectNames={this.state.selectedObjectNames}
                 canInstallPrivateAsset={this.props.canInstallPrivateAsset}
                 onEditObject={this.props.onEditObject || this.editObject}
-                onExportObject={this.exportObject}
+                onExportObject={this.openObjectExporterDialog}
                 onDeleteObject={this._onDeleteObject(i18n)}
                 canRenameObject={newName =>
                   this._canObjectOrGroupUseNewName(newName, i18n)
@@ -1564,11 +1560,11 @@ export default class SceneEditor extends React.Component<Props, State> {
             </React.Fragment>
           )}
         </I18n>
-        {this.state.exportedObjectWithContext && (
+        {this.state.exportedObject && (
           <ObjectExporterDialog
-            object={this.state.exportedObjectWithContext.object}
+            object={this.state.exportedObject}
             onClose={() => {
-              this.exportObject(null);
+              this.openObjectExporterDialog(null);
             }}
           />
         )}

--- a/newIDE/app/src/Utils/UseForceUpdate.js
+++ b/newIDE/app/src/Utils/UseForceUpdate.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 
+// https://reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
 export default function useForceUpdate() {
   const [, updateState] = React.useState();
   const forceUpdate = React.useCallback(() => updateState({}), []);

--- a/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
+++ b/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
@@ -268,6 +268,7 @@ export const WithObjectsList = () => (
                   onChooseResource={() => Promise.reject('unimplemented')}
                   resourceExternalEditors={fakeResourceExternalEditors}
                   onEditObject={action('On edit object')}
+                  onExportObject={action('On export object')}
                   onAddObjectInstance={action('On add instance to the scene')}
                   selectedObjectNames={[]}
                   selectedObjectTags={[]}

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectExporterDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectExporterDialog.stories.js
@@ -1,0 +1,43 @@
+// @flow
+
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+// Keep first as it creates the `global.gd` object:
+import { testProject } from '../../GDevelopJsInitializerDecorator';
+
+import muiDecorator from '../../ThemeDecorator';
+import paperDecorator from '../../PaperDecorator';
+import ObjectExporterDialog from '../../../ObjectEditor/ObjectExporterDialog';
+import EventsFunctionsExtensionsContext from '../../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import LocalEventsFunctionsExtensionWriter from '../../../EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter';
+import LocalEventsFunctionsExtensionOpener from '../../../EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionOpener';
+
+export default {
+  title: 'LayoutEditor/ObjectExporterDialog',
+  component: ObjectExporterDialog,
+  decorators: [muiDecorator, paperDecorator],
+};
+
+const fakeEventsFunctionsExtensionsContext = {
+  loadProjectEventsFunctionsExtensions: async project => {},
+  unloadProjectEventsFunctionsExtensions: project => {},
+  unloadProjectEventsFunctionsExtension: (project, extensionName) => {},
+  reloadProjectEventsFunctionsExtensions: async project => {},
+  getEventsFunctionsExtensionWriter: () => LocalEventsFunctionsExtensionWriter,
+  getEventsFunctionsExtensionOpener: () => LocalEventsFunctionsExtensionOpener,
+  ensureLoadFinished: async () => {},
+  getIncludeFileHashs: () => ({}),
+  eventsFunctionsExtensionsError: null,
+};
+
+export const Default = () => (
+  <EventsFunctionsExtensionsContext.Provider
+    value={fakeEventsFunctionsExtensionsContext}
+  >
+    <ObjectExporterDialog
+      object={testProject.customObject}
+      onClose={() => action('Close the dialog')}
+    />
+  </EventsFunctionsExtensionsContext.Provider>
+);

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
@@ -33,6 +33,7 @@ export const Default = () => (
           onChooseResource={() => Promise.reject('unimplemented')}
           resourceExternalEditors={fakeResourceExternalEditors}
           onEditObject={action('On edit object')}
+          onExportObject={action('On export object')}
           onAddObjectInstance={action('On add instance to the scene')}
           onObjectCreated={action('On object created')}
           selectedObjectNames={[]}
@@ -65,6 +66,7 @@ export const WithTags = () => (
           onChooseResource={() => Promise.reject('unimplemented')}
           resourceExternalEditors={fakeResourceExternalEditors}
           onEditObject={action('On edit object')}
+          onExportObject={action('On export object')}
           onAddObjectInstance={action('On add instance to the scene')}
           onObjectCreated={action('On object created')}
           selectedObjectNames={[]}

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
@@ -4,9 +4,7 @@ import { action } from '@storybook/addon-actions';
 import muiDecorator from '../../ThemeDecorator';
 import paperDecorator from '../../PaperDecorator';
 import themeDecorator from '../../ThemeDecorator';
-import GDevelopJsInitializerDecorator, {
-  testProject,
-} from '../../GDevelopJsInitializerDecorator';
+import { testProject } from '../../GDevelopJsInitializerDecorator';
 import EffectsList from '../../../EffectsList';
 import DragAndDropContextProvider from '../../../UI/DragAndDrop/DragAndDropContextProvider';
 import FixedHeightFlexContainer from '../../FixedHeightFlexContainer';

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/ObjectEditorDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/ObjectEditorDialog.stories.js
@@ -9,9 +9,6 @@ import { testProject } from '../../GDevelopJsInitializerDecorator';
 import muiDecorator from '../../ThemeDecorator';
 import ObjectEditorDialog from '../../../ObjectEditor/ObjectEditorDialog';
 import fakeResourceExternalEditors from '../../FakeResourceExternalEditors';
-import EventsFunctionsExtensionsContext from '../../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
-import LocalEventsFunctionsExtensionWriter from '../../../EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter';
-import LocalEventsFunctionsExtensionOpener from '../../../EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionOpener';
 
 export default {
   title: 'ObjectEditor/ObjectEditorDialog',
@@ -19,68 +16,48 @@ export default {
   decorators: [muiDecorator],
 };
 
-const eventsFunctionsExtensionsContext = {
-  loadProjectEventsFunctionsExtensions: async project => {},
-  unloadProjectEventsFunctionsExtensions: project => {},
-  unloadProjectEventsFunctionsExtension: (project, extensionName) => {},
-  reloadProjectEventsFunctionsExtensions: async project => {},
-  getEventsFunctionsExtensionWriter: () => LocalEventsFunctionsExtensionWriter,
-  getEventsFunctionsExtensionOpener: () => LocalEventsFunctionsExtensionOpener,
-  ensureLoadFinished: async () => {},
-  getIncludeFileHashs: () => ({}),
-  eventsFunctionsExtensionsError: null,
-};
-
 export const CustomObject = () => (
-  <EventsFunctionsExtensionsContext.Provider
-    value={eventsFunctionsExtensionsContext}
-  >
-    <ObjectEditorDialog
-      open={true}
-      object={testProject.customObject}
-      onApply={() => action('Apply changes')}
-      onCancel={() => action('Cancel changes')}
-      onRename={() => action('Rename object')}
-      canRenameObject={name => true}
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={source => action('Choose resource from source', source)}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      onComputeAllVariableNames={() => []}
-      onUpdateBehaviorsSharedData={() => {}}
-      initialTab={null}
-      hotReloadPreviewButtonProps={{
-        hasPreviewsRunning: false,
-        launchProjectDataOnlyPreview: () => action('Hot-reload'),
-        launchProjectWithLoadingScreenPreview: () => action('Reload'),
-      }}
-    />
-  </EventsFunctionsExtensionsContext.Provider>
+  <ObjectEditorDialog
+    open={true}
+    object={testProject.customObject}
+    onApply={() => action('Apply changes')}
+    onCancel={() => action('Cancel changes')}
+    onRename={() => action('Rename object')}
+    canRenameObject={name => true}
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={source => action('Choose resource from source', source)}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    onComputeAllVariableNames={() => []}
+    onUpdateBehaviorsSharedData={() => {}}
+    initialTab={null}
+    hotReloadPreviewButtonProps={{
+      hasPreviewsRunning: false,
+      launchProjectDataOnlyPreview: () => action('Hot-reload'),
+      launchProjectWithLoadingScreenPreview: () => action('Reload'),
+    }}
+  />
 );
 
 export const StandardObject = () => (
-  <EventsFunctionsExtensionsContext.Provider
-    value={eventsFunctionsExtensionsContext}
-  >
-    <ObjectEditorDialog
-      open={true}
-      object={testProject.panelSpriteObject}
-      onApply={() => action('Apply changes')}
-      onCancel={() => action('Cancel changes')}
-      onRename={() => action('Rename object')}
-      canRenameObject={name => true}
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={source => action('Choose resource from source', source)}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      onComputeAllVariableNames={() => []}
-      onUpdateBehaviorsSharedData={() => {}}
-      initialTab={null}
-      hotReloadPreviewButtonProps={{
-        hasPreviewsRunning: false,
-        launchProjectDataOnlyPreview: () => action('Hot-reload'),
-        launchProjectWithLoadingScreenPreview: () => action('Reload'),
-      }}
-    />
-  </EventsFunctionsExtensionsContext.Provider>
+  <ObjectEditorDialog
+    open={true}
+    object={testProject.panelSpriteObject}
+    onApply={() => action('Apply changes')}
+    onCancel={() => action('Cancel changes')}
+    onRename={() => action('Rename object')}
+    canRenameObject={name => true}
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={source => action('Choose resource from source', source)}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    onComputeAllVariableNames={() => []}
+    onUpdateBehaviorsSharedData={() => {}}
+    initialTab={null}
+    hotReloadPreviewButtonProps={{
+      hasPreviewsRunning: false,
+      launchProjectDataOnlyPreview: () => action('Hot-reload'),
+      launchProjectWithLoadingScreenPreview: () => action('Reload'),
+    }}
+  />
 );


### PR DESCRIPTION
* There is the custom object `MyButton` in this list, the "export" action is only in the contextual menu of this object.
http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/custom-object-export/latest/index.html?path=/story/layouteditor-objectslist--default

* It shows this dialog
http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/custom-object-export/latest/index.html?path=/story/layouteditor-objectexporterdialog--default

The export button is not working because it's not supported from a browser. The "export" action from the contextual menu should not show either in practice but it's forced by the story by setting `onExportObject` (see: https://github.com/4ian/GDevelop/pull/4363#discussion_r994540816).