### PR TITLE
Get Game categories from backend allowing more flexibility for jams

### DIFF
--- a/newIDE/app/src/GameDashboard/PublicGameProperties.js
+++ b/newIDE/app/src/GameDashboard/PublicGameProperties.js
@@ -10,8 +10,9 @@ import SelectOption from '../UI/SelectOption';
 import { t } from '@lingui/macro';
 import SemiControlledMultiAutoComplete from '../UI/SemiControlledMultiAutoComplete';
 import {
-  allGameCategories,
   getCategoryName,
+  getGameCategories,
+  type GameCategory,
 } from '../Utils/GDevelopServices/Game';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import { I18n } from '@lingui/react';
@@ -117,6 +118,22 @@ export function PublicGameProperties({
   const hasValidGameSlug =
     hasGameSlug && (profile && userSlug !== profile.username);
 
+  const [allGameCategories, setAllGameCategories] = React.useState<
+    GameCategory[]
+  >([]);
+
+  const fetchGameCategories = React.useCallback(async () => {
+    const categories = await getGameCategories();
+    setAllGameCategories(categories);
+  }, []);
+
+  React.useEffect(
+    () => {
+      fetchGameCategories();
+    },
+    [fetchGameCategories]
+  );
+
   return (
     <I18n>
       {({ i18n }) => (
@@ -177,12 +194,14 @@ export function PublicGameProperties({
                     }
                   }}
                   dataSource={allGameCategories.map(category => ({
-                    value: category,
-                    text: getCategoryName(category, i18n),
+                    value: category.name,
+                    text: getCategoryName(category.name, i18n),
+                    disabled: category.type === 'admin-only',
                   }))}
                   fullWidth
                   optionsLimit={4}
-                  loading={disabled}
+                  disabled={disabled}
+                  loading={allGameCategories.length === 0}
                 />
               )}
               {setDiscoverable && (

--- a/newIDE/app/src/UI/SemiControlledMultiAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledMultiAutoComplete.js
@@ -9,6 +9,7 @@ import { makeStyles } from '@material-ui/core';
 export type AutocompleteOption = {|
   text: string, // The text displayed
   value: string, // The internal value selected
+  disabled?: boolean, // If the option is disabled by default
 |};
 
 export type DataSource = Array<?AutocompleteOption>;
@@ -35,6 +36,7 @@ type Props = {|
   fullWidth?: boolean,
   error?: ?string,
   loading?: boolean,
+  disabled?: boolean,
   optionsLimit?: number, // Allow limiting the number of options by disabling the autocomplete.
 |};
 
@@ -52,6 +54,7 @@ export default function SemiControlledMultiAutoComplete(props: Props) {
           options={props.dataSource}
           getOptionLabel={(option: AutocompleteOption) => option.text}
           getOptionDisabled={(option: AutocompleteOption) =>
+            option.disabled ||
             !!props.value.find(
               element => element && element.value === option.value
             ) ||
@@ -71,11 +74,11 @@ export default function SemiControlledMultiAutoComplete(props: Props) {
               helperText={props.error || props.helperText}
               variant="filled"
               error={!!props.error}
-              disabled={props.loading}
+              disabled={props.disabled || props.loading}
             />
           )}
           fullWidth={props.fullWidth}
-          disabled={props.loading}
+          disabled={props.disabled || props.loading}
           ChipProps={{
             classes: chipStyles,
           }}

--- a/newIDE/app/src/Utils/GDevelopServices/Game.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Game.js
@@ -41,6 +41,11 @@ export type Game = {
   displayAdsOnGamePage?: boolean,
 };
 
+export type GameCategory = {
+  name: string,
+  type: 'user-defined' | 'admin-only',
+};
+
 export type GameSlug = {
   username: string,
   gameSlug: string,
@@ -84,25 +89,9 @@ export type GameApiError = {|
   code: 'game-deletion/leaderboards-exist',
 |};
 
-export const allGameCategories = [
-  'action',
-  'adventure',
-  'shooter',
-  'platformer',
-  'rpg',
-  'horror',
-  'strategy',
-  'puzzle',
-  'story-rich',
-  'survival',
-  'racing',
-  'building',
-  'simulation',
-  'sport',
-  'multiplayer',
-  'leaderboard',
-  'educational',
-];
+const capitalize = (str: string) => {
+  return str ? str[0].toUpperCase() + str.substr(1) : '';
+};
 
 export const getCategoryName = (category: string, i18n: I18nType) => {
   switch (category) {
@@ -141,7 +130,7 @@ export const getCategoryName = (category: string, i18n: I18nType) => {
     case 'educational':
       return i18n._(t`Educational`);
     default:
-      return category;
+      return capitalize(category);
   }
 };
 
@@ -422,5 +411,11 @@ export const getGameSlugs = (
         },
       })
     )
+    .then(response => response.data);
+};
+
+export const getGameCategories = (): Promise<GameCategory[]> => {
+  return axios
+    .get(`${GDevelopGameApi.baseUrl}/game-category`)
     .then(response => response.data);
 };


### PR DESCRIPTION
Made the decision that the translations will be kept in the IDE.
We will probably not add that many user-defined categories, and admin-only categories can stay untranslated and just capitalized (Jam 1, ...)

<img width="427" alt="Capture d’écran 2022-10-07 à 18 20 59" src="https://user-images.githubusercontent.com/4895034/194601364-673a375d-ec7f-45f8-bbe7-c336fe4efe0e.png">
<img width="1005" alt="Capture d’écran 2022-10-07 à 18 21 15" src="https://user-images.githubusercontent.com/4895034/194601368-937ef53d-c810-4d7d-8836-5918598dc1fb.png">
<img width="984" alt="image" src="https://user-images.githubusercontent.com/4895034/194601417-b0c51b27-9e44-4068-a93a-d2fabfd648fb.png">

