### PR TITLE
Update extension field hints to fit the good practices.

### DIFF
--- a/newIDE/app/src/EventsBasedBehaviorEditor/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/index.js
@@ -1,6 +1,8 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import { t } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
 import TextField from '../UI/TextField';
@@ -59,115 +61,120 @@ export default class EventsBasedBehaviorEditor extends React.Component<
     const { eventsBasedBehavior, project } = this.props;
 
     return (
-      <React.Fragment>
-        <Tabs value={currentTab} onChange={this._changeTab}>
-          <Tab label={<Trans>Configuration</Trans>} value="configuration" />
-          <Tab label={<Trans>Properties</Trans>} value="properties" />
-        </Tabs>
-        <Line>
-          {currentTab === 'configuration' && (
-            <ColumnStackLayout expand>
-              <DismissableAlertMessage
-                identifier="events-based-behavior-explanation"
-                kind="info"
-              >
-                <Trans>
-                  This is the configuration of your behavior. Make sure to
-                  choose a proper internal name as it's hard to change it later.
-                  Enter a description explaining what the behavior is doing to
-                  the object.
-                </Trans>
-              </DismissableAlertMessage>
-              <TextField
-                floatingLabelText={<Trans>Internal Name</Trans>}
-                value={eventsBasedBehavior.getName()}
-                disabled
-                fullWidth
-              />
-              <SemiControlledTextField
-                commitOnBlur
-                floatingLabelText={<Trans>Name displayed in editor</Trans>}
-                value={eventsBasedBehavior.getFullName()}
-                onChange={text => {
-                  eventsBasedBehavior.setFullName(text);
-                  this.forceUpdate();
-                }}
-                fullWidth
-              />
-              <SemiControlledTextField
-                commitOnBlur
-                floatingLabelText={<Trans>Description</Trans>}
-                floatingLabelFixed
-                translatableHintText={t`The description of the behavior should explain what the behavior is doing to the object, and, briefly, how to use it.`}
-                value={eventsBasedBehavior.getDescription()}
-                onChange={text => {
-                  eventsBasedBehavior.setDescription(text);
-                  this.forceUpdate();
-                }}
-                multiline
-                fullWidth
-                rows={3}
-              />
-              <ObjectTypeSelector
-                floatingLabelText={
-                  <Trans>Object on which this behavior can be used</Trans>
-                }
-                project={project}
-                value={eventsBasedBehavior.getObjectType()}
-                onChange={(objectType: string) => {
-                  eventsBasedBehavior.setObjectType(objectType);
-                  this.forceUpdate();
-                }}
-                allowedObjectTypes={
-                  this._allObjectTypes.length === 0
-                    ? undefined /* Allow anything as the behavior is not used */
-                    : this._allObjectTypes.length === 1
-                    ? [
-                        '',
-                        this._allObjectTypes[0],
-                      ] /* Allow only the type of the objects using the behavior */
-                    : [
-                        '',
-                      ] /* More than one type of object are using the behavior. Only "any object" can be used on this behavior */
-                }
-              />
-              {this._allObjectTypes.length > 1 && (
-                <AlertMessage kind="info">
-                  <Trans>
-                    This behavior is being used by multiple types of objects.
-                    Thus, you can't restrict its usage to any particular object
-                    type. All the object types using this behavior are listed
-                    here:
-                    {this._allObjectTypes.join(', ')}
-                  </Trans>
-                </AlertMessage>
+      <I18n>
+        {({ i18n }: { i18n: I18nType }) => (
+          <React.Fragment>
+            <Tabs value={currentTab} onChange={this._changeTab}>
+              <Tab label={<Trans>Configuration</Trans>} value="configuration" />
+              <Tab label={<Trans>Properties</Trans>} value="properties" />
+            </Tabs>
+            <Line>
+              {currentTab === 'configuration' && (
+                <ColumnStackLayout expand>
+                  <DismissableAlertMessage
+                    identifier="events-based-behavior-explanation"
+                    kind="info"
+                  >
+                    <Trans>
+                      This is the configuration of your behavior. Make sure to
+                      choose a proper internal name as it's hard to change it
+                      later. Enter a description explaining what the behavior is
+                      doing to the object.
+                    </Trans>
+                  </DismissableAlertMessage>
+                  <TextField
+                    floatingLabelText={<Trans>Internal Name</Trans>}
+                    value={eventsBasedBehavior.getName()}
+                    disabled
+                    fullWidth
+                  />
+                  <SemiControlledTextField
+                    commitOnBlur
+                    floatingLabelText={<Trans>Name displayed in editor</Trans>}
+                    value={eventsBasedBehavior.getFullName()}
+                    onChange={text => {
+                      eventsBasedBehavior.setFullName(text);
+                      this.forceUpdate();
+                    }}
+                    fullWidth
+                  />
+                  <SemiControlledTextField
+                    commitOnBlur
+                    floatingLabelText={<Trans>Description</Trans>}
+                    helperMarkdownText={i18n._(
+                      t`Explain what the behavior is doing to the object. Start with a verb when possible.`
+                    )}
+                    value={eventsBasedBehavior.getDescription()}
+                    onChange={text => {
+                      eventsBasedBehavior.setDescription(text);
+                      this.forceUpdate();
+                    }}
+                    multiline
+                    fullWidth
+                    rows={3}
+                  />
+                  <ObjectTypeSelector
+                    floatingLabelText={
+                      <Trans>Object on which this behavior can be used</Trans>
+                    }
+                    project={project}
+                    value={eventsBasedBehavior.getObjectType()}
+                    onChange={(objectType: string) => {
+                      eventsBasedBehavior.setObjectType(objectType);
+                      this.forceUpdate();
+                    }}
+                    allowedObjectTypes={
+                      this._allObjectTypes.length === 0
+                        ? undefined /* Allow anything as the behavior is not used */
+                        : this._allObjectTypes.length === 1
+                        ? [
+                            '',
+                            this._allObjectTypes[0],
+                          ] /* Allow only the type of the objects using the behavior */
+                        : [
+                            '',
+                          ] /* More than one type of object are using the behavior. Only "any object" can be used on this behavior */
+                    }
+                  />
+                  {this._allObjectTypes.length > 1 && (
+                    <AlertMessage kind="info">
+                      <Trans>
+                        This behavior is being used by multiple types of
+                        objects. Thus, you can't restrict its usage to any
+                        particular object type. All the object types using this
+                        behavior are listed here:
+                        {this._allObjectTypes.join(', ')}
+                      </Trans>
+                    </AlertMessage>
+                  )}
+                  {eventsBasedBehavior
+                    .getEventsFunctions()
+                    .getEventsFunctionsCount() === 0 && (
+                    <DismissableAlertMessage
+                      identifier="empty-events-based-behavior-explanation"
+                      kind="info"
+                    >
+                      <Trans>
+                        Once you're done, close this dialog and start adding
+                        some functions to the behavior. Then, test the behavior
+                        by adding it to an object in a scene.
+                      </Trans>
+                    </DismissableAlertMessage>
+                  )}
+                </ColumnStackLayout>
               )}
-              {eventsBasedBehavior
-                .getEventsFunctions()
-                .getEventsFunctionsCount() === 0 && (
-                <DismissableAlertMessage
-                  identifier="empty-events-based-behavior-explanation"
-                  kind="info"
-                >
-                  <Trans>
-                    Once you're done, close this dialog and start adding some
-                    functions to the behavior. Then, test the behavior by adding
-                    it to an object in a scene.
-                  </Trans>
-                </DismissableAlertMessage>
+              {currentTab === 'properties' && (
+                <EventsBasedBehaviorPropertiesEditor
+                  project={project}
+                  eventsBasedBehavior={eventsBasedBehavior}
+                  onPropertiesUpdated={this.props.onPropertiesUpdated}
+                  onRenameProperty={this.props.onRenameProperty}
+                />
               )}
-            </ColumnStackLayout>
-          )}
-          {currentTab === 'properties' && (
-            <EventsBasedBehaviorPropertiesEditor
-              project={project}
-              eventsBasedBehavior={eventsBasedBehavior}
-              onPropertiesUpdated={this.props.onPropertiesUpdated}
-              onRenameProperty={this.props.onRenameProperty}
-            />
-          )}
-        </Line>
-      </React.Fragment>
+            </Line>
+          </React.Fragment>
+        )}
+      </I18n>
     );
   }
 }

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -82,9 +82,9 @@ const getSentenceErrorText = (
 
 const getFullNameHintText = (type: any): MessageDescriptor => {
   if (type === gd.EventsFunction.Condition) {
-    return t`Example: Is flashing?`;
+    return t`Example: Is flashing`;
   } else if (type === gd.EventsFunction.Expression) {
-    return t`Example: Life remaining`;
+    return t`Example: Remaining life`;
   } else if (type === gd.EventsFunction.StringExpression) {
     return t`Example: Equipped shield name`;
   }
@@ -96,9 +96,9 @@ const getDescriptionHintText = (type: any): MessageDescriptor => {
   if (type === gd.EventsFunction.Condition) {
     return t`Example: Check if the object is flashing.`;
   } else if (type === gd.EventsFunction.Expression) {
-    return t`Example: Life remaining for the player.`;
+    return t`Example: Return the number of remaining lives for the player.`;
   } else if (type === gd.EventsFunction.StringExpression) {
-    return t`Example: Name of the shield equipped by the player.`;
+    return t`Example: Return the name of the shield equipped by the player.`;
   }
 
   return t`Example: Make the object flash for 5 seconds.`;

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
@@ -181,6 +181,9 @@ export const ExtensionOptionsEditor = ({
             fullWidth
             rows={5}
             rowsMax={15}
+            helperMarkdownText={i18n._(
+              t`Explain and give some examples of what can be achieved with this extension.`
+            )}
           />
           <TextField
             floatingLabelText={<Trans>Version</Trans>}


### PR DESCRIPTION
### New tips

http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/extension-description/latest/index.html?path=/story/eventsfunctionsextensioneditor-optionseditordialog--default

http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/extension-description/latest/index.html?path=/story/eventsbasedbehavioreditor-eventsbasedbehavioreditordialog--events-based-behavior-without-functions

http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/extension-description/latest/index.html?path=/story/eventsfunctionconfigurationeditor--default-for-a-free-function-i-e-no-behavior

### Old tips

I used `helperMarkdownText` instead of `translatableHintText` to be consistent but it was easier to read the old way.

http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/master/latest/index.html?path=/story/eventsbasedbehavioreditor-eventsbasedbehavioreditordialog--events-based-behavior-without-functions