### PR TITLE
Fix clearing storage provider on project close, causing problems.

### DIFF
--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -63,7 +63,6 @@ export const create = (authentication: Authentication) => {
             storageProviders,
             initialFileMetadataToOpen,
             getStorageProvider,
-            resetStorageProvider,
           }) => (
             <MainFrame
               i18n={i18n}
@@ -101,7 +100,6 @@ export const create = (authentication: Authentication) => {
               onCreateBlank={onCreateBlank}
               getStorageProviderOperations={getStorageProviderOperations}
               getStorageProvider={getStorageProvider}
-              resetStorageProvider={resetStorageProvider}
               resourceSources={browserResourceSources}
               resourceExternalEditors={browserResourceExternalEditors}
               extensionsLoader={makeExtensionsLoader({

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -65,7 +65,6 @@ export const create = (authentication: Authentication) => {
             storageProviders,
             initialFileMetadataToOpen,
             getStorageProvider,
-            resetStorageProvider,
           }) => (
             <MainFrame
               i18n={i18n}
@@ -105,7 +104,6 @@ export const create = (authentication: Authentication) => {
               resourceFetcher={LocalResourceFetcher}
               getStorageProviderOperations={getStorageProviderOperations}
               getStorageProvider={getStorageProvider}
-              resetStorageProvider={resetStorageProvider}
               resourceSources={localResourceSources}
               resourceExternalEditors={localResourceExternalEditors}
               extensionsLoader={makeExtensionsLoader({

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -2281,69 +2281,62 @@ const MainFrame = (props: Props) => {
         currentProject.setTemplateSlug(selectedExampleShortHeader.slug);
       if (source.projectName) currentProject.setName(source.projectName);
 
-      const destinationFileMetadata = destination
-        ? destination.fileMetadata
-        : null;
-      if (destination && destinationFileMetadata) {
-        // If there is a destination, save the project where asked to.
-        const destinationStorageProviderOperations = getStorageProviderOperations(
-          destination.storageProvider
-        );
+      console.log(destination.storageProvider);
+      const destinationStorageProviderOperations = getStorageProviderOperations(
+        destination.storageProvider
+      );
 
-        const { onSaveProjectAs } = destinationStorageProviderOperations;
+      const { onSaveProjectAs } = destinationStorageProviderOperations;
 
-        if (onSaveProjectAs) {
-          try {
-            const { wasSaved } = await onSaveProjectAs(
-              currentProject,
-              destination.fileMetadata,
-              {
-                onStartSaving: () => {
-                  console.log('Start saving as the new project...');
-                },
-                onMoveResources: async () => {
-                  if (
-                    !sourceStorageProvider ||
-                    !sourceStorageProviderOperations ||
-                    !source.fileMetadata
-                  ) {
-                    console.log(
-                      'No storage provider set or no previous FileMetadata (probably creating a blank project) - skipping resources copy.'
-                    );
-                    return;
-                  }
+      if (onSaveProjectAs) {
+        try {
+          const { wasSaved } = await onSaveProjectAs(
+            currentProject,
+            destination.fileMetadata,
+            {
+              onStartSaving: () => {
+                console.log('Start saving as the new project...');
+              },
+              onMoveResources: async () => {
+                if (
+                  !sourceStorageProvider ||
+                  !sourceStorageProviderOperations ||
+                  !source.fileMetadata ||
+                  !destination.fileMetadata
+                ) {
+                  console.log(
+                    'No storage provider set or no previous/destination FileMetadata (probably creating a blank project) - skipping resources copy.'
+                  );
+                  return;
+                }
 
-                  await ensureResourcesAreMoved({
-                    project: currentProject,
-                    newFileMetadata: destinationFileMetadata,
-                    newStorageProvider: destination.storageProvider,
-                    newStorageProviderOperations: destinationStorageProviderOperations,
-                    oldFileMetadata: source.fileMetadata,
-                    oldStorageProvider: sourceStorageProvider,
-                    oldStorageProviderOperations: sourceStorageProviderOperations,
-                    authenticatedUser,
-                  });
-                },
-              }
-            );
-
-            if (wasSaved) {
-              setState(state => ({
-                ...state,
-                currentFileMetadata: destination.fileMetadata,
-              }));
-              if (unsavedChanges) unsavedChanges.sealUnsavedChanges();
-              if (destination.storageProvider.internalName === 'LocalFile') {
-                preferences.setHasProjectOpened(true);
-              }
+                await ensureResourcesAreMoved({
+                  project: currentProject,
+                  newFileMetadata: destination.fileMetadata,
+                  newStorageProvider: destination.storageProvider,
+                  newStorageProviderOperations: destinationStorageProviderOperations,
+                  oldFileMetadata: source.fileMetadata,
+                  oldStorageProvider: sourceStorageProvider,
+                  oldStorageProviderOperations: sourceStorageProviderOperations,
+                  authenticatedUser,
+                });
+              },
             }
-          } catch (rawError) {
-            // Do not prevent creating the project.
-            console.error(
-              "Couldn't save the project after creation.",
-              rawError
-            );
+          );
+
+          if (wasSaved) {
+            setState(state => ({
+              ...state,
+              currentFileMetadata: destination.fileMetadata,
+            }));
+            if (unsavedChanges) unsavedChanges.sealUnsavedChanges();
+            if (destination.storageProvider.internalName === 'LocalFile') {
+              preferences.setHasProjectOpened(true);
+            }
           }
+        } catch (rawError) {
+          // Do not prevent creating the project.
+          console.error("Couldn't save the project after creation.", rawError);
         }
       }
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -679,7 +679,6 @@ const MainFrame = (props: Props) => {
             currentProject
           );
           currentProject.delete();
-          resetStorageProvider();
         }
 
         return {
@@ -695,7 +694,6 @@ const MainFrame = (props: Props) => {
       eventsFunctionsExtensionsState,
       setHasProjectOpened,
       setState,
-      resetStorageProvider,
     ]
   );
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -246,7 +246,6 @@ export type Props = {
     storageProvider?: ?StorageProvider
   ) => StorageProviderOperations,
   getStorageProvider: () => StorageProvider,
-  resetStorageProvider: () => void,
   resourceSources: Array<ResourceSource>,
   resourceExternalEditors: Array<ResourceExternalEditor>,
   requestUpdate?: () => void,
@@ -412,7 +411,6 @@ const MainFrame = (props: Props) => {
     resourceFetcher,
     getStorageProviderOperations,
     getStorageProvider,
-    resetStorageProvider,
     initialDialog,
     initialFileMetadataToOpen,
     introDialog,
@@ -2283,10 +2281,10 @@ const MainFrame = (props: Props) => {
         currentProject.setTemplateSlug(selectedExampleShortHeader.slug);
       if (source.projectName) currentProject.setName(source.projectName);
 
-      if (!destination) {
-        // If there is no destination, ensure the storageProvider is reset.
-        resetStorageProvider();
-      } else {
+      const destinationFileMetadata = destination
+        ? destination.fileMetadata
+        : null;
+      if (destination && destinationFileMetadata) {
         // If there is a destination, save the project where asked to.
         const destinationStorageProviderOperations = getStorageProviderOperations(
           destination.storageProvider
@@ -2317,7 +2315,7 @@ const MainFrame = (props: Props) => {
 
                   await ensureResourcesAreMoved({
                     project: currentProject,
-                    newFileMetadata: destination.fileMetadata,
+                    newFileMetadata: destinationFileMetadata,
                     newStorageProvider: destination.storageProvider,
                     newStorageProviderOperations: destinationStorageProviderOperations,
                     oldFileMetadata: source.fileMetadata,

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -2281,7 +2281,6 @@ const MainFrame = (props: Props) => {
         currentProject.setTemplateSlug(selectedExampleShortHeader.slug);
       if (source.projectName) currentProject.setName(source.projectName);
 
-      console.log(destination.storageProvider);
       const destinationStorageProviderOperations = getStorageProviderOperations(
         destination.storageProvider
       );

--- a/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
+++ b/newIDE/app/src/ProjectCreation/CreateProjectDialog.js
@@ -32,9 +32,9 @@ export type CreateProjectSetup = {|
     storageProvider: ?StorageProvider,
     fileMetadata: ?FileMetadata,
   |},
-  destination: ?{|
+  destination: {|
     storageProvider: StorageProvider,
-    fileMetadata: FileMetadata,
+    fileMetadata: ?FileMetadata,
   |},
 |};
 

--- a/newIDE/app/src/ProjectCreation/services/BrowserCreation.js
+++ b/newIDE/app/src/ProjectCreation/services/BrowserCreation.js
@@ -9,6 +9,7 @@ import {
   type OnCreateBlankFunction,
   type OnCreateFromExampleShortHeaderFunction,
 } from '../CreateProjectDialog';
+import { emptyStorageProvider } from '../../ProjectsStorage/ProjectStorageProviders';
 
 const gd: libGDevelop = global.gd;
 
@@ -28,7 +29,10 @@ export const onCreateBlank: OnCreateBlankFunction = async ({
       storageProvider: null,
       fileMetadata: null,
     },
-    destination: null,
+    destination: {
+      storageProvider: emptyStorageProvider,
+      fileMetadata: null,
+    },
   };
 };
 
@@ -54,7 +58,10 @@ export const onCreateFromExampleShortHeader: OnCreateFromExampleShortHeaderFunct
           fileIdentifier: example.projectFileUrl,
         },
       },
-      destination: null,
+      destination: {
+        storageProvider: emptyStorageProvider,
+        fileMetadata: null,
+      },
     };
   } catch (error) {
     showErrorBox({

--- a/newIDE/app/src/ProjectsStorage/ProjectStorageProviders.js
+++ b/newIDE/app/src/ProjectsStorage/ProjectStorageProviders.js
@@ -41,7 +41,6 @@ type Props = {|
     ) => StorageProviderOperations,
     initialFileMetadataToOpen: ?FileMetadata,
     getStorageProvider: () => StorageProvider,
-    resetStorageProvider: () => void,
   }) => React.Node,
 |};
 
@@ -104,15 +103,6 @@ const ProjectStorageProviders = (props: Props) => {
 
   const closeDialog = () => {
     setRenderDialog(null);
-  };
-
-  const resetStorageProvider = () => {
-    currentStorageProvider.current = emptyStorageProvider;
-    storageProviderOperations.current = emptyStorageProvider.createOperations({
-      setDialog,
-      closeDialog,
-      authenticatedUser,
-    });
   };
 
   const getStorageProviderOperations = (
@@ -186,7 +176,6 @@ const ProjectStorageProviders = (props: Props) => {
         initialFileMetadataToOpen:
           defaultConfiguration.initialFileMetadataToOpen,
         getStorageProvider,
-        resetStorageProvider,
       })}
       {renderDialog && renderDialog()}
     </React.Fragment>

--- a/newIDE/app/src/ProjectsStorage/ProjectStorageProviders.js
+++ b/newIDE/app/src/ProjectsStorage/ProjectStorageProviders.js
@@ -16,18 +16,7 @@ import { type AppArguments } from '../Utils/Window';
 export const emptyStorageProvider: StorageProvider = {
   internalName: 'Empty',
   name: 'No storage',
-  createOperations: () => ({
-    onOpenWithPicker: () => Promise.reject('No storage provider set up'),
-    onOpen: () => Promise.reject('No storage provider set up'),
-    hasAutoSave: () => Promise.resolve(false),
-    onSaveProject: (project: gdProject) =>
-      Promise.reject('No storage provider set up'),
-    onChooseSaveProjectAsLocation: (project: gdProject) =>
-      Promise.reject('No storage provider set up'),
-    onSaveProjectAs: (project: gdProject) =>
-      Promise.reject('No storage provider set up'),
-    onAutoSaveProject: (project: gdProject) => Promise.resolve(),
-  }),
+  createOperations: () => ({}),
 };
 
 type Props = {|


### PR DESCRIPTION
closeProject is called inside project loading functions, which means we cannot clear the storage provider here, but instead leave the responsability of the createProject / loadProject functions to clear/set the storageProvider