### PR TITLE
Fix grammar; change 'let' to 'leave'.

### DIFF
--- a/Extensions/AnchorBehavior/AnchorBehavior.cpp
+++ b/Extensions/AnchorBehavior/AnchorBehavior.cpp
@@ -105,9 +105,9 @@ std::map<gd::String, gd::PropertyDescriptor> AnchorBehavior::GetProperties(
 
   properties[("useLegacyBottomAndRightAnchors")]
       .SetLabel(_(
-          "Stretch object when anchoring right or bottom ledge (deprecated, "
-          "it's recommended to let this unchecked and anchor both sides if you "
-          "want Sprite to stretch instead.)"))
+          "Stretch object when anchoring right or bottom edge (deprecated, "
+          "it's recommended to leave this unchecked and anchor both sides if "
+          "you want Sprite to stretch instead.)"))
       .SetGroup(_("Deprecated options (advanced)"))
       .SetValue(behaviorContent.GetBoolAttribute(
                     "useLegacyBottomAndRightAnchors", true)

--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -99,7 +99,7 @@ PlatformerObjectBehavior::GetProperties(
           behaviorContent.GetDoubleAttribute("xGrabTolerance", 10)));
   properties["useLegacyTrajectory"]
       .SetLabel(_("Use frame rate dependent trajectories (deprecated, it's "
-                  "recommended to let this unchecked)"))
+                  "recommended to leave this unchecked)"))
       .SetGroup(_("Deprecated options (advanced)"))
       .SetValue(behaviorContent.GetBoolAttribute("useLegacyTrajectory", true)
                     ? "true"


### PR DESCRIPTION
"it's recommended to let this unchecked" isn't proper grammar. Should be "it's recommended to **leave** this unchecked" instead.