### PR TITLE
Improve new scrollbars on scene editor canvas

### DIFF
--- a/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
+++ b/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
@@ -84,34 +84,45 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
     hideScrollbarsAfterDelay();
   }, 500);
 
+  const showScrollbarsThrottled = throttle(
+    () => {
+      if (!showScrollbars.current) {
+        showScrollbars.current = true;
+        forceUpdate();
+      }
+      if (timeoutHidingScrollbarsId.current) {
+        clearTimeout(timeoutHidingScrollbarsId.current);
+        timeoutHidingScrollbarsId.current = null;
+      }
+    },
+    1000,
+    { leading: true, trailing: false }
+  );
+
   const onMouseMoveOverInstanceEditor = React.useCallback(
     (event: MouseEvent) => {
       if (!editorRef.current) {
         return;
       }
-      let shouldDisplayScrollBars = false;
 
-      shouldDisplayScrollBars = !canvasRectangle.containsPoint(
+      const shouldDisplayScrollBars = !canvasRectangle.containsPoint(
         event.clientX,
         event.clientY
       );
 
       if (shouldDisplayScrollBars) {
-        if (!showScrollbars.current) {
-          showScrollbars.current = true;
-          forceUpdate();
-        }
-        if (timeoutHidingScrollbarsId.current) {
-          clearTimeout(timeoutHidingScrollbarsId.current);
-          timeoutHidingScrollbarsId.current = null;
-        }
+        showScrollbarsThrottled();
       } else {
         if (!isDragging.current) {
-          hideScrollbarsAfterDelay();
+          hideScrollbarsAfterDelayDebounced();
         }
       }
     },
-    [canvasRectangle, forceUpdate, hideScrollbarsAfterDelay]
+    [
+      canvasRectangle,
+      hideScrollbarsAfterDelayDebounced,
+      showScrollbarsThrottled,
+    ]
   );
 
   // When the mouse is moving after dragging the thumb:

--- a/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
+++ b/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
@@ -12,53 +12,15 @@ import { useDebounce } from '../Utils/UseDebounce';
 import Rectangle from '../Utils/Rectangle';
 
 const SCROLLBAR_DETECTION_WIDTH = 50;
-const SCROLLBAR_TRACK_WIDTH = 16;
+// Those scrollbar dimensions should be the same as in the CSS file Scrollbar.css
 const SCROLLBAR_THUMB_WIDTH = 8;
 const SCROLLBAR_SIZE = 200;
-const VERTICAL_SCROLLBAR_PADDING = 1;
-const HORIZONTAL_SCROLLBAR_PADDING = 3;
 
 const THROTTLE_TIME = 1000 / 60; // 60 FPS
 
 const styles = {
   container: {
     overflow: 'hidden',
-  },
-  xScrollbarTrack: {
-    position: 'absolute',
-    left: 0,
-    right: SCROLLBAR_TRACK_WIDTH - VERTICAL_SCROLLBAR_PADDING,
-    bottom: 0,
-    paddingBottom: HORIZONTAL_SCROLLBAR_PADDING,
-  },
-  xThumb: {
-    position: 'relative',
-    width: SCROLLBAR_SIZE,
-    height: SCROLLBAR_THUMB_WIDTH,
-    backgroundColor: '#8d8d8dcc', // Theme-invariant color
-    border: '1px solid transparent',
-    boxSizing: 'border-box',
-    backgroundClip: 'content-box',
-    borderRadius: 4,
-    pointerEvents: 'all',
-  },
-  yScrollbarTrack: {
-    position: 'absolute',
-    top: 0,
-    bottom: SCROLLBAR_TRACK_WIDTH - HORIZONTAL_SCROLLBAR_PADDING,
-    right: 0,
-    paddingRight: VERTICAL_SCROLLBAR_PADDING,
-  },
-  yThumb: {
-    position: 'relative',
-    height: SCROLLBAR_SIZE,
-    width: SCROLLBAR_THUMB_WIDTH,
-    backgroundColor: '#8d8d8dcc', // Theme-invariant color
-    border: '1px solid transparent',
-    boxSizing: 'border-box',
-    backgroundClip: 'content-box',
-    borderRadius: 4,
-    pointerEvents: 'all',
   },
 };
 
@@ -350,7 +312,7 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
 
   // Ensure the X Scrollbar doesn't go out of bounds.
   const minXScrollbarLeftPosition = '0%';
-  const maxXScrollbarLeftPosition = `calc(100% - ${SCROLLBAR_SIZE}px - ${SCROLLBAR_TRACK_WIDTH}px)`;
+  const maxXScrollbarLeftPosition = `calc(100% - ${SCROLLBAR_SIZE}px - ${SCROLLBAR_THUMB_WIDTH}px)`;
   const expectedXScrollbarLeftPosition = `calc(${((xValue.current -
     xMin.current) /
     (xMax.current - xMin.current)) *
@@ -360,7 +322,7 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
 
   // Ensure the Y Scrollbar doesn't go out of bounds.
   const minYScrollbarTopPosition = '0%';
-  const maxYScrollbarTopPosition = `calc(100% - ${SCROLLBAR_SIZE}px - ${SCROLLBAR_TRACK_WIDTH}px)`;
+  const maxYScrollbarTopPosition = `calc(100% - ${SCROLLBAR_SIZE}px - ${SCROLLBAR_THUMB_WIDTH}px)`;
   const expectedYScrollbarTopPosition = `calc(${((yValue.current -
     yMin.current) /
     (yMax.current - yMin.current)) *
@@ -393,17 +355,17 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
           {screenType !== 'touch' && (
             <div
               style={{
-                ...styles.yScrollbarTrack,
                 // Keep it in the DOM, so we can register the mouse down event.
                 visibility: showScrollbars.current ? 'visible' : 'hidden',
               }}
+              className="canvas-vertical-scrollbar-track"
               ref={yScrollbarTrack}
             >
               <div
                 style={{
-                  ...styles.yThumb,
                   top: yScrollbarTopPosition,
                 }}
+                className="canvas-scrollbar-thumb canvas-vertical-scrollbar-thumb"
                 ref={yScrollbarThumb}
               />
             </div>
@@ -411,17 +373,17 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
           {screenType !== 'touch' && (
             <div
               style={{
-                ...styles.xScrollbarTrack,
                 // Keep it in the DOM, so we can register the mouse down event.
                 visibility: showScrollbars.current ? 'visible' : 'hidden',
               }}
+              className="canvas-horizontal-scrollbar-track"
               ref={xScrollbarTrack}
             >
               <div
                 style={{
-                  ...styles.xThumb,
                   marginLeft: xScrollbarLeftPosition,
                 }}
+                className="canvas-scrollbar-thumb canvas-horizontal-scrollbar-thumb"
                 ref={xScrollbarThumb}
               />
             </div>

--- a/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
+++ b/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
@@ -40,18 +40,18 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
   const yScrollbarTrack = React.useRef<?HTMLDivElement>(null);
   const yScrollbarThumb = React.useRef<?HTMLDivElement>(null);
 
-  const showScrollbars = React.useRef(false);
+  const showScrollbars = React.useRef<boolean>(false);
   const timeoutHidingScrollbarsId = React.useRef<?TimeoutID>(null);
-  const isDragging = React.useRef(false);
+  const isDragging = React.useRef<boolean>(false);
 
-  const xValue = React.useRef(0);
-  const yValue = React.useRef(0);
-  const xMin = React.useRef(-5000);
-  const xMax = React.useRef(5000);
-  const yMin = React.useRef(-5000);
-  const yMax = React.useRef(5000);
-  const canvasWidth = React.useRef(0);
-  const canvasHeight = React.useRef(0);
+  const xValue = React.useRef<number>(0);
+  const yValue = React.useRef<number>(0);
+  const xMin = React.useRef<number>(-5000);
+  const xMax = React.useRef<number>(5000);
+  const yMin = React.useRef<number>(-5000);
+  const yMax = React.useRef<number>(5000);
+  const canvasWidth = React.useRef<number>(0);
+  const canvasHeight = React.useRef<number>(0);
 
   const forceUpdate = useForceUpdate();
 
@@ -117,9 +117,12 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
       );
 
       if (shouldDisplayScrollBars) {
-        showScrollbarsThrottled();
+        if (timeoutHidingScrollbarsId.current) {
+          clearTimeout(timeoutHidingScrollbarsId.current);
+        }
+        if (!showScrollbars.current) showScrollbarsThrottled();
       } else {
-        if (!isDragging.current) {
+        if (!isDragging.current && showScrollbars.current) {
           hideScrollbarsAfterDelayThrottled();
         }
       }
@@ -324,6 +327,15 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
     [setAndAdjust]
   );
 
+  const onMouseEnterThumb = (event: MouseEvent) => {
+    if (timeoutHidingScrollbarsId.current) {
+      clearTimeout(timeoutHidingScrollbarsId.current);
+    }
+  };
+  const onMouseLeaveThumb = (event: MouseEvent) => {
+    if (!isDragging.current) hideScrollbarsAfterDelay();
+  };
+
   // Ensure the X Scrollbar doesn't go out of bounds.
   const minXScrollbarLeftPosition = '0%';
   const maxXScrollbarLeftPosition = `calc(100% - ${SCROLLBAR_SIZE}px - ${SCROLLBAR_THUMB_WIDTH}px)`;
@@ -398,9 +410,8 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
                 }}
                 className="canvas-scrollbar-thumb canvas-vertical-scrollbar-thumb"
                 ref={yScrollbarThumb}
-                onMouseLeave={(event: MouseEvent) => {
-                  if (!isDragging.current) hideScrollbarsAfterDelay();
-                }}
+                onMouseEnter={onMouseEnterThumb}
+                onMouseLeave={onMouseLeaveThumb}
               />
             </div>
           )}
@@ -419,9 +430,8 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
                 }}
                 className="canvas-scrollbar-thumb canvas-horizontal-scrollbar-thumb"
                 ref={xScrollbarThumb}
-                onMouseLeave={(event: MouseEvent) => {
-                  if (!isDragging.current) hideScrollbarsAfterDelay();
-                }}
+                onMouseEnter={onMouseEnterThumb}
+                onMouseLeave={onMouseLeaveThumb}
               />
             </div>
           )}

--- a/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
+++ b/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
@@ -189,12 +189,10 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
   );
 
   // When the user releases the thumb, we need to stop listening to mouse move and up events.
-  // In the case the user releases outside of the detection zone, we need to hide the scrollbars.
   const makeMouseUpXThumbHandler = React.useCallback(
     mouseMoveHandler =>
       function mouseUpHandler(e: MouseEvent) {
         isDragging.current = false;
-        // If the user releases the mouse outside of the detection zone, we want to hide the scrollbars.
         if (
           e.target !== xScrollbarTrack.current &&
           e.target !== xScrollbarThumb.current
@@ -210,7 +208,6 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
     mouseMoveHandler =>
       function mouseUpHandler(e: MouseEvent) {
         isDragging.current = false;
-        // If the user releases the mouse outside of the detection zone, we want to hide the scrollbars.
         if (
           e.target !== yScrollbarTrack.current &&
           e.target !== yScrollbarThumb.current

--- a/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
+++ b/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
@@ -15,7 +15,8 @@ const SCROLLBAR_DETECTION_WIDTH = 50;
 const SCROLLBAR_TRACK_WIDTH = 16;
 const SCROLLBAR_THUMB_WIDTH = 8;
 const SCROLLBAR_SIZE = 200;
-const SCROLLBAR_MARGIN = (SCROLLBAR_TRACK_WIDTH - SCROLLBAR_THUMB_WIDTH) / 2;
+const VERTICAL_SCROLLBAR_PADDING = 1;
+const HORIZONTAL_SCROLLBAR_PADDING = 3;
 
 const THROTTLE_TIME = 1000 / 60; // 60 FPS
 
@@ -26,38 +27,36 @@ const styles = {
   xScrollbarTrack: {
     position: 'absolute',
     left: 0,
-    right: SCROLLBAR_TRACK_WIDTH - SCROLLBAR_MARGIN,
+    right: SCROLLBAR_TRACK_WIDTH - VERTICAL_SCROLLBAR_PADDING,
     bottom: 0,
-    display: 'inline-block',
-    height: SCROLLBAR_TRACK_WIDTH,
+    paddingBottom: HORIZONTAL_SCROLLBAR_PADDING,
   },
   xThumb: {
     position: 'relative',
     width: SCROLLBAR_SIZE,
-    marginTop: SCROLLBAR_MARGIN,
     height: SCROLLBAR_THUMB_WIDTH,
-    backgroundColor: '#1D1D26',
-    outline: '2px solid #FAFAFA',
-    opacity: 0.3,
+    backgroundColor: '#8d8d8dcc', // Theme-invariant color
+    border: '1px solid transparent',
+    boxSizing: 'border-box',
+    backgroundClip: 'content-box',
     borderRadius: 4,
     pointerEvents: 'all',
   },
   yScrollbarTrack: {
     position: 'absolute',
     top: 0,
-    bottom: SCROLLBAR_TRACK_WIDTH - SCROLLBAR_MARGIN,
+    bottom: SCROLLBAR_TRACK_WIDTH - HORIZONTAL_SCROLLBAR_PADDING,
     right: 0,
-    display: 'inline-block',
-    width: SCROLLBAR_TRACK_WIDTH,
+    paddingRight: VERTICAL_SCROLLBAR_PADDING,
   },
   yThumb: {
     position: 'relative',
     height: SCROLLBAR_SIZE,
-    marginLeft: SCROLLBAR_MARGIN,
     width: SCROLLBAR_THUMB_WIDTH,
-    backgroundColor: '#1D1D26',
-    outline: '1px solid #FAFAFA',
-    opacity: 0.3,
+    backgroundColor: '#8d8d8dcc', // Theme-invariant color
+    border: '1px solid transparent',
+    boxSizing: 'border-box',
+    backgroundClip: 'content-box',
     borderRadius: 4,
     pointerEvents: 'all',
   },

--- a/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
+++ b/newIDE/app/src/InstancesEditor/FullSizeInstancesEditorWithScrollbars.js
@@ -99,6 +99,12 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
     { leading: true, trailing: false }
   );
 
+  const hideScrollbarsAfterDelayThrottled = throttle(
+    hideScrollbarsAfterDelay,
+    1000,
+    { leading: true, trailing: false }
+  );
+
   const onMouseMoveOverInstanceEditor = React.useCallback(
     (event: MouseEvent) => {
       if (!editorRef.current) {
@@ -114,13 +120,13 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
         showScrollbarsThrottled();
       } else {
         if (!isDragging.current) {
-          hideScrollbarsAfterDelayDebounced();
+          hideScrollbarsAfterDelayThrottled();
         }
       }
     },
     [
       canvasRectangle,
-      hideScrollbarsAfterDelayDebounced,
+      hideScrollbarsAfterDelayThrottled,
       showScrollbarsThrottled,
     ]
   );
@@ -360,6 +366,23 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
               height={height}
               screenType={screenType}
               onMouseMove={onMouseMoveOverInstanceEditor}
+              onMouseLeave={(event: MouseEvent) => {
+                const { relatedTarget } = event;
+                if (!isDragging.current && relatedTarget) {
+                  if (
+                    // Flow says className is not present in ElementTarget but this piece
+                    // of code cannot break.
+                    // $FlowFixMe
+                    relatedTarget.className &&
+                    typeof relatedTarget.className === 'string' &&
+                    // Hide only if the mouse is not leaving to go on one of the scrollbars' thumb.
+                    // $FlowFixMe
+                    !relatedTarget.className.includes('canvas-scrollbar-thumb')
+                  ) {
+                    hideScrollbarsAfterDelay();
+                  }
+                }
+              }}
               {...otherProps}
             />
           )}
@@ -378,6 +401,9 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
                 }}
                 className="canvas-scrollbar-thumb canvas-vertical-scrollbar-thumb"
                 ref={yScrollbarThumb}
+                onMouseLeave={(event: MouseEvent) => {
+                  if (!isDragging.current) hideScrollbarsAfterDelay();
+                }}
               />
             </div>
           )}
@@ -396,6 +422,9 @@ const FullSizeInstancesEditorWithScrollbars = (props: Props) => {
                 }}
                 className="canvas-scrollbar-thumb canvas-horizontal-scrollbar-thumb"
                 ref={xScrollbarThumb}
+                onMouseLeave={(event: MouseEvent) => {
+                  if (!isDragging.current) hideScrollbarsAfterDelay();
+                }}
               />
             </div>
           )}

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -181,16 +181,13 @@ export default class InstancesEditor extends Component<Props> {
         this.zoomOnCursorBy(-event.deltaY / 5000);
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
         const deltaX = event.deltaY / (5 * zoomFactor);
-        this.viewPosition.scrollBy(-deltaX, 0);
+        this.scrollBy(-deltaX, 0);
       } else {
         const deltaX = event.deltaX / (5 * zoomFactor);
         const deltaY = event.deltaY / (5 * zoomFactor);
-        this.viewPosition.scrollBy(deltaX, deltaY);
+        this.scrollBy(deltaX, deltaY);
       }
 
-      if (this.props.onViewPositionChanged) {
-        this.props.onViewPositionChanged(this.viewPosition);
-      }
       event.preventDefault();
     };
     this.pixiRenderer.view.setAttribute('tabIndex', -1);
@@ -526,13 +523,10 @@ export default class InstancesEditor extends Component<Props> {
     this.setZoomFactor(this.getZoomFactor() + value);
     const afterZoomCursorPosition = this.getLastCursorSceneCoordinates();
     // Compensate for the cursor change in position
-    this.viewPosition.scrollBy(
+    this.scrollBy(
       beforeZoomCursorPosition[0] - afterZoomCursorPosition[0],
       beforeZoomCursorPosition[1] - afterZoomCursorPosition[1]
     );
-    if (this.props.onViewPositionChanged) {
-      this.props.onViewPositionChanged(this.viewPosition);
-    }
   }
 
   getZoomFactor = () => {
@@ -590,11 +584,7 @@ export default class InstancesEditor extends Component<Props> {
       const sceneDeltaX = deltaX / this.getZoomFactor();
       const sceneDeltaY = deltaY / this.getZoomFactor();
 
-      this.viewPosition.scrollBy(-sceneDeltaX, -sceneDeltaY);
-
-      if (this.props.onViewPositionChanged) {
-        this.props.onViewPositionChanged(this.viewPosition);
-      }
+      this.scrollBy(-sceneDeltaX, -sceneDeltaY);
     } else {
       this.selectionRectangle.updateSelectionRectangle(x, y);
     }
@@ -724,11 +714,7 @@ export default class InstancesEditor extends Component<Props> {
     // to move the view, move it, then unpress it and continue to move the instance.
     // This means that while we're in "_onMoveInstance", we must handle view moving.
     if (this.keyboardShortcuts.shouldMoveView()) {
-      this.viewPosition.scrollBy(-sceneDeltaX, -sceneDeltaY);
-
-      if (this.props.onViewPositionChanged) {
-        this.props.onViewPositionChanged(this.viewPosition);
-      }
+      this.scrollBy(-sceneDeltaX, -sceneDeltaY);
       return;
     }
 
@@ -819,6 +805,14 @@ export default class InstancesEditor extends Component<Props> {
     });
     this.props.onInstancesMoved(unlockedSelectedInstances);
   };
+
+  scrollBy(x: number, y: number) {
+    this.viewPosition.scrollBy(x, y);
+
+    if (this.props.onViewPositionChanged) {
+      this.props.onViewPositionChanged(this.viewPosition);
+    }
+  }
 
   scrollTo(x: number, y: number) {
     this.viewPosition.scrollTo(x, y);

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -85,6 +85,7 @@ type Props = {|
   width: number,
   height: number,
   onViewPositionChanged: ViewPosition => void,
+  onMouseMove: MouseEvent => void,
   screenType: ScreenType,
 |};
 
@@ -207,6 +208,9 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.addEventListener(
       'mouseup',
       this.keyboardShortcuts.onMouseUp
+    );
+    this.pixiRenderer.view.addEventListener('mousemove', event =>
+      this.props.onMouseMove(event)
     );
 
     this.pixiContainer = new PIXI.Container();
@@ -814,6 +818,11 @@ export default class InstancesEditor extends Component<Props> {
 
   scrollTo(x: number, y: number) {
     this.viewPosition.scrollTo(x, y);
+  }
+
+  getBoundingClientRect() {
+    if (!this.canvasArea) return { left: 0, top: 0, right: 0, bottom: 0 };
+    return this.canvasArea.getBoundingClientRect();
   }
 
   zoomToFitContent() {

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -857,6 +857,9 @@ export default class InstancesEditor extends Component<Props> {
       const idealZoom = this.viewPosition.fitToRectangle(contentAABB);
       this.setZoomFactor(idealZoom);
     }
+    if (this.props.onViewPositionChanged) {
+      this.props.onViewPositionChanged(this.viewPosition);
+    }
   }
 
   zoomToInitialPosition() {
@@ -864,6 +867,9 @@ export default class InstancesEditor extends Component<Props> {
     const y = this.props.project.getGameResolutionHeight() / 2;
     this.viewPosition.scrollTo(x, y);
     this.setZoomFactor(1);
+    if (this.props.onViewPositionChanged) {
+      this.props.onViewPositionChanged(this.viewPosition);
+    }
   }
 
   zoomToFitSelection(instances: Array<gdInitialInstance>) {
@@ -883,6 +889,9 @@ export default class InstancesEditor extends Component<Props> {
       selectedInstancesRectangle
     );
     this.setZoomFactor(idealZoom);
+    if (this.props.onViewPositionChanged) {
+      this.props.onViewPositionChanged(this.viewPosition);
+    }
   }
 
   centerViewOnLastInstance(instances: Array<gdInitialInstance>) {

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -86,6 +86,7 @@ type Props = {|
   height: number,
   onViewPositionChanged: ViewPosition => void,
   onMouseMove: MouseEvent => void,
+  onMouseLeave: MouseEvent => void,
   screenType: ScreenType,
 |};
 
@@ -212,6 +213,9 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.addEventListener('mousemove', event =>
       this.props.onMouseMove(event)
     );
+    this.pixiRenderer.view.addEventListener('mouseout', event => {
+      this.props.onMouseLeave(event);
+    });
 
     this.pixiContainer = new PIXI.Container();
 

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -822,6 +822,20 @@ export default class InstancesEditor extends Component<Props> {
 
   scrollTo(x: number, y: number) {
     this.viewPosition.scrollTo(x, y);
+    if (this.props.onViewPositionChanged) {
+      this.props.onViewPositionChanged(this.viewPosition);
+    }
+  }
+
+  fitViewToRectangle(
+    rectangle: Rectangle,
+    { adaptZoom }: { adaptZoom: boolean }
+  ) {
+    const idealZoom = this.viewPosition.fitToRectangle(rectangle);
+    if (adaptZoom) this.setZoomFactor(idealZoom);
+    if (this.props.onViewPositionChanged) {
+      this.props.onViewPositionChanged(this.viewPosition);
+    }
   }
 
   getBoundingClientRect() {
@@ -857,23 +871,14 @@ export default class InstancesEditor extends Component<Props> {
     // $FlowFixMe - JSFunctor is incompatible with Functor
     initialInstances.iterateOverInstances(getInstanceRectangle);
     getInstanceRectangle.delete();
-    if (contentAABB) {
-      const idealZoom = this.viewPosition.fitToRectangle(contentAABB);
-      this.setZoomFactor(idealZoom);
-    }
-    if (this.props.onViewPositionChanged) {
-      this.props.onViewPositionChanged(this.viewPosition);
-    }
+    if (contentAABB) this.fitViewToRectangle(contentAABB, { adaptZoom: true });
   }
 
   zoomToInitialPosition() {
     const x = this.props.project.getGameResolutionWidth() / 2;
     const y = this.props.project.getGameResolutionHeight() / 2;
-    this.viewPosition.scrollTo(x, y);
     this.setZoomFactor(1);
-    if (this.props.onViewPositionChanged) {
-      this.props.onViewPositionChanged(this.viewPosition);
-    }
+    this.scrollTo(x, y);
   }
 
   zoomToFitSelection(instances: Array<gdInitialInstance>) {
@@ -889,13 +894,7 @@ export default class InstancesEditor extends Component<Props> {
         instanceMeasurer.getInstanceAABB(instance, new Rectangle())
       );
     });
-    const idealZoom = this.viewPosition.fitToRectangle(
-      selectedInstancesRectangle
-    );
-    this.setZoomFactor(idealZoom);
-    if (this.props.onViewPositionChanged) {
-      this.props.onViewPositionChanged(this.viewPosition);
-    }
+    this.fitViewToRectangle(selectedInstancesRectangle, { adaptZoom: true });
   }
 
   centerViewOnLastInstance(instances: Array<gdInitialInstance>) {
@@ -906,10 +905,7 @@ export default class InstancesEditor extends Component<Props> {
       instances[instances.length - 1],
       new Rectangle()
     );
-    this.viewPosition.fitToRectangle(lastInstanceRectangle);
-    if (this.props.onViewPositionChanged) {
-      this.props.onViewPositionChanged(this.viewPosition);
-    }
+    this.fitViewToRectangle(lastInstanceRectangle, { adaptZoom: false });
   }
 
   getLastContextMenuSceneCoordinates = () => {

--- a/newIDE/app/src/UI/EditorMosaic/style.css
+++ b/newIDE/app/src/UI/EditorMosaic/style.css
@@ -23,7 +23,7 @@
 
 /* Make the horizontal split to have the same thickness as the vertical */
 .mosaic-gd-theme .mosaic-split.-column {
-  margin-top: -2px;
+  margin-top: -3px;
   height: 4px;
 }
 

--- a/newIDE/app/src/UI/Theme/Global/Mosaic.css
+++ b/newIDE/app/src/UI/Theme/Global/Mosaic.css
@@ -43,9 +43,10 @@
 
 .mosaic-gd-theme .mosaic-split.-column:hover .mosaic-split-line {
   background-color: var(--mosaic-toolbar-border-color-hover);
-  transform: scaleY(2);
+  transform: scaleY(2.5);
   box-shadow: none !important;
   cursor: ns-resize;
+  z-index: 5;
 }
 
 /* Separator draggable background (vertical split) */
@@ -60,7 +61,8 @@
 
 .mosaic-gd-theme .mosaic-split.-row:hover .mosaic-split-line {
   background-color: var(--mosaic-toolbar-border-color-hover);
-  transform: scaleX(2);
+  transform: scaleX(2.5);
   box-shadow: none !important;
   cursor: ew-resize;
+  z-index: 5;
 }

--- a/newIDE/app/src/UI/Theme/Global/Scrollbar.css
+++ b/newIDE/app/src/UI/Theme/Global/Scrollbar.css
@@ -83,6 +83,7 @@ body {
   );
   bottom: 0px;
   padding-bottom: var(--canvas-horizontal-scrollbar-padding);
+  pointer-events: none;
 }
 .canvas-horizontal-scrollbar-thumb {
   width: var(--canvas-scrollbar-length);
@@ -96,6 +97,7 @@ body {
   );
   right: 0px;
   padding-right: var(--canvas-vertical-scrollbar-padding);
+  pointer-events: none;
 }
 .canvas-vertical-scrollbar-thumb {
   height: var(--canvas-scrollbar-length);

--- a/newIDE/app/src/UI/Theme/Global/Scrollbar.css
+++ b/newIDE/app/src/UI/Theme/Global/Scrollbar.css
@@ -71,7 +71,8 @@ body {
   border-radius: var(--canvas-scrollbar-border-radius);
   pointer-events: all;
 }
-.canvas-scrollbar-thumb:hover {
+.canvas-scrollbar-thumb:hover,
+.canvas-scrollbar-thumb:active {
   background-color: #8d8d8d;
 }
 

--- a/newIDE/app/src/UI/Theme/Global/Scrollbar.css
+++ b/newIDE/app/src/UI/Theme/Global/Scrollbar.css
@@ -1,54 +1,103 @@
 /* The default scrollbar for the app */
 ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track,
 ::-webkit-scrollbar-thumb {
-    border: 1px solid transparent;
-    background-clip: padding-box;
-    border-radius: 4px;
+  border: 1px solid transparent;
+  background-clip: padding-box;
+  border-radius: 4px;
 }
 
 ::-webkit-scrollbar-track {
-    background-color: rgba(0, 0, 0, 0.07);
+  background-color: rgba(0, 0, 0, 0.07);
 }
 
 ::-webkit-scrollbar-thumb {
-    background-color: #8d8d8dcc;
+  background-color: #8d8d8dcc;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background-color: #8d8d8d;
+  background-color: #8d8d8d;
 }
 
 /** The scrollbar for tabs or toolbars: either invisible or very thing */
 .almost-invisible-scrollbar {
-    /** For browsers not supporting -webkit-scrollbar, hide it because even the `thin` option is too large. */
-    scrollbar-width: none;
+  /** For browsers not supporting -webkit-scrollbar, hide it because even the `thin` option is too large. */
+  scrollbar-width: none;
 }
 
 .almost-invisible-scrollbar::-webkit-scrollbar {
-    width: 4px;
-    height: 4px;
+  width: 4px;
+  height: 4px;
 }
 
 .almost-invisible-scrollbar::-webkit-scrollbar-track,
 .almost-invisible-scrollbar::-webkit-scrollbar-thumb {
-    border: 1px solid transparent;
-    background-clip: padding-box;
-    border-radius: 4px;
+  border: 1px solid transparent;
+  background-clip: padding-box;
+  border-radius: 4px;
 }
 
 .almost-invisible-scrollbar::-webkit-scrollbar-track {
-    background-color: rgba(0, 0, 0, 0.07);
+  background-color: rgba(0, 0, 0, 0.07);
 }
 
 .almost-invisible-scrollbar::-webkit-scrollbar-thumb {
-    background-color: #8d8d8dcc;
+  background-color: #8d8d8dcc;
 }
 
 .almost-invisible-scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: #8d8d8d;
+  background-color: #8d8d8d;
+}
+
+/* Manually handled scrollbar for canvas */
+body {
+  --canvas-scrollbar-border-radius: 4px;
+  --canvas-scrollbar-width: 8px;
+  --canvas-scrollbar-length: 200px;
+  --canvas-horizontal-scrollbar-padding: 3px;
+  --canvas-vertical-scrollbar-padding: 1px;
+}
+
+.canvas-scrollbar-thumb {
+  position: relative;
+  background-color: #8d8d8dcc;
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border-radius: var(--canvas-scrollbar-border-radius);
+  pointer-events: all;
+}
+.canvas-scrollbar-thumb:hover {
+  background-color: #8d8d8d;
+}
+
+.canvas-horizontal-scrollbar-track {
+  position: absolute;
+  left: 0px;
+  right: calc(
+    var(--canvas-scrollbar-width) - var(--canvas-vertical-scrollbar-padding)
+  );
+  bottom: 0px;
+  padding-bottom: var(--canvas-horizontal-scrollbar-padding);
+}
+.canvas-horizontal-scrollbar-thumb {
+  width: var(--canvas-scrollbar-length);
+  height: var(--canvas-scrollbar-width);
+}
+.canvas-vertical-scrollbar-track {
+  position: absolute;
+  top: 0px;
+  bottom: calc(
+    var(--canvas-scrollbar-width) - var(--canvas-horizontal-scrollbar-padding)
+  );
+  right: 0px;
+  padding-right: var(--canvas-vertical-scrollbar-padding);
+}
+.canvas-vertical-scrollbar-thumb {
+  height: var(--canvas-scrollbar-length);
+  width: var(--canvas-scrollbar-width);
 }

--- a/newIDE/app/src/Utils/Rectangle.js
+++ b/newIDE/app/src/Utils/Rectangle.js
@@ -91,6 +91,10 @@ export default class Rectangle {
     }
   }
 
+  containsPoint(x: number, y: number): boolean {
+    return this.left <= x && this.right > x && this.bottom > y && this.top <= y;
+  }
+
   toString() {
     return (
       '[' +


### PR DESCRIPTION
- Make it possible to click and scroll through the "scrollbar detection zones"
- Make mosaic horizontal resize handle easier to grab
- Use same style as for other scrollbars around the editor (+ hover and active states)

Tested on Chrome and Safari

Storybook to test: http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/fix-scroll/latest/index.html?path=/story/editor-fullsizeinstanceseditorwithscrollbars--default