### PR TITLE
Add word wrap in the code editors to avoid horizontal scrolling

### DIFF
--- a/newIDE/app/src/CodeEditor/index.js
+++ b/newIDE/app/src/CodeEditor/index.js
@@ -158,6 +158,13 @@ export class CodeEditor extends React.Component<Props, State> {
               options={{
                 ...monacoEditorOptions,
                 fontSize: preferences.eventsSheetZoomLevel,
+
+                // Wrap the code at either the viewport width
+                // (so no need to scroll horizontally
+                // on small code editors) or at 80 columns max
+                // (as a good practice).
+                wordWrap: 'bounded',
+                wordWrapColumn: 80,
               }}
             />
           )}


### PR DESCRIPTION
* Also fix some text overflowing out of the screen for some languages.

Fix #4412