### PR TITLE
Add missing particle emitter actions conditions and expressions

### DIFF
--- a/Extensions/ParticleSystem/ExtensionSubDeclaration2.cpp
+++ b/Extensions/ParticleSystem/ExtensionSubDeclaration2.cpp
@@ -7,6 +7,7 @@ This project is released under the MIT License.
 
 #include "GDCore/Extensions/PlatformExtension.h"
 #include "GDCore/Tools/Localization.h"
+#include "GDCore/Extensions/Metadata/MultipleInstructionMetadata.h"
 
 #include "Extension.h"
 #include "ParticleEmitterObject.h"
@@ -258,5 +259,60 @@ void ExtensionSubDeclaration2(gd::ObjectMetadata& obj) {
                    "CppPlatform/Extensions/particleSystemicon24.png",
                    "CppPlatform/Extensions/particleSystemicon16.png")
       .AddParameter("object", _("Object"), "ParticleEmitter");
+
+  obj.AddExpressionAndConditionAndAction(
+          "number",
+          "ParticleRotationMinSpeed",
+          _("Particle rotation min speed"),
+          _("the minimum rotation speed of the particles"),
+          _("the particles minimum rotation speed"),
+          _("Common"),
+          "CppPlatform/Extensions/particleSystemicon24.png")
+      .AddParameter("object", _("Object"), "ParticleEmitter")
+      .UseStandardParameters("number")
+      .MarkAsAdvanced()
+      .SetFunctionName("setParticleRotationMinSpeed")
+      .SetGetter("getParticleRotationMinSpeed");
+
+  obj.AddExpressionAndConditionAndAction(
+          "number",
+          "ParticleRotationMaxSpeed",
+          _("Particle rotation max speed"),
+          _("the maximum rotation speed of the particles"),
+          _("the particles maximum rotation speed"),
+          _("Common"),
+          "CppPlatform/Extensions/particleSystemicon24.png")
+      .AddParameter("object", _("Object"), "ParticleEmitter")
+      .UseStandardParameters("number")
+      .MarkAsAdvanced()
+      .SetFunctionName("setParticleRotationMaxSpeed")
+      .SetGetter("getParticleRotationMaxSpeed");
+
+  obj.AddExpressionAndConditionAndAction(
+          "number",
+          "MaxParticlesCount",
+          _("Number of displayed particles"),
+          _("the maximum number of displayed particles"),
+          _("the maximum number of displayed particles"),
+          _("Common"),
+          "CppPlatform/Extensions/particleSystemicon24.png")
+      .AddParameter("object", _("Object"), "ParticleEmitter")
+      .UseStandardParameters("number")
+      .SetFunctionName("setMaxParticlesCount")
+      .SetGetter("getMaxParticlesCount");
+
+  obj.AddExpressionAndConditionAndAction(
+          "boolean",
+          "AdditiveRendering",
+          _("Activate particles additive rendering"),
+          _("the particles additive rendering is activated"),
+          _("displaying particles with additive rendering activated"),
+          _("Common"),
+          "CppPlatform/Extensions/particleSystemicon24.png")
+      .AddParameter("object", _("Object"), "ParticleEmitter")
+      .UseStandardParameters("boolean")
+      .MarkAsAdvanced()
+      .SetFunctionName("setAdditiveRendering")
+      .SetGetter("getAdditiveRendering");
 
 }

--- a/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
+++ b/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
@@ -164,6 +164,9 @@ namespace gdjs {
       // @ts-ignore
       config.blendMode = objectData.additive ? 'ADD' : 'NORMAL';
       this.renderer = new PIXI.Container();
+      // The embedded particle emitter is supposed to be the last minor version
+      // of the version 4 of the particle emitter object
+      // See source https://github.com/pixijs/particle-emitter/blob/v4.3.1/src/Emitter.ts
       // @ts-ignore
       this.emitter = new PIXI.particles.Emitter(this.renderer, texture, config);
       this.start();

--- a/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
+++ b/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
@@ -246,6 +246,21 @@ namespace gdjs {
       }
     }
 
+    setParticleRotationSpeed(min: float, max: float): void {
+      this.emitter.minRotationSpeed = min;
+      this.emitter.maxRotationSpeed = max;
+    }
+
+    setMaxParticlesCount(count: float): void {
+      this.emitter.maxParticles = count;
+    }
+
+    setAdditiveRendering(enabled: boolean): void {
+      this.emitter.particleBlendMode = enabled
+        ? PIXI.BLEND_MODES.ADD
+        : PIXI.BLEND_MODES.NORMAL;
+    }
+
     setAlpha(alpha1: number, alpha2: number): void {
       this.emitter.startAlpha.value = alpha1 / 255.0;
       if (this.emitter.startAlpha.next) {

--- a/Extensions/ParticleSystem/particleemitterobject.ts
+++ b/Extensions/ParticleSystem/particleemitterobject.ts
@@ -90,6 +90,10 @@ namespace gdjs {
     flow: number;
     tank: number;
     destroyWhenNoParticles: boolean;
+    particleRotationMinSpeed: number;
+    particleRotationMaxSpeed: number;
+    maxParticlesCount: number;
+    additiveRendering: boolean;
     _posDirty: boolean = true;
     _angleDirty: boolean = true;
     _forceDirty: boolean = true;
@@ -101,6 +105,9 @@ namespace gdjs {
     _alphaDirty: boolean = true;
     _flowDirty: boolean = true;
     _tankDirty: boolean = true;
+    _particleRotationSpeedDirty: boolean = true;
+    _maxParticlesCountDirty: boolean = true;
+    _additiveRenderingDirty: boolean = true;
     // Don't mark texture as dirty if not using one.
     _textureDirty: boolean;
 
@@ -147,6 +154,10 @@ namespace gdjs {
       this.flow = particleObjectData.flow;
       this.tank = particleObjectData.tank;
       this.destroyWhenNoParticles = particleObjectData.destroyWhenNoParticles;
+      this.particleRotationMinSpeed = particleObjectData.particleAngle1;
+      this.particleRotationMaxSpeed = particleObjectData.particleAngle2;
+      this.maxParticlesCount = particleObjectData.maxParticleNb;
+      this.additiveRendering = particleObjectData.additive;
       this._textureDirty = this.texture !== '';
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
@@ -190,6 +201,18 @@ namespace gdjs {
       }
       if (oldObjectData.emitterForceMin !== newObjectData.emitterForceMin) {
         this.setEmitterForceMin(newObjectData.emitterForceMin);
+      }
+      if (oldObjectData.particleAngle1 !== newObjectData.particleAngle1) {
+        this.setParticleRotationMinSpeed(newObjectData.particleAngle1);
+      }
+      if (oldObjectData.particleAngle2 !== newObjectData.particleAngle2) {
+        this.setParticleRotationMaxSpeed(newObjectData.particleAngle2);
+      }
+      if (oldObjectData.maxParticleNb !== newObjectData.maxParticleNb) {
+        this.setMaxParticlesCount(newObjectData.maxParticleNb);
+      }
+      if (oldObjectData.additive !== newObjectData.additive) {
+        this.setAdditiveRendering(newObjectData.additive);
       }
       if (oldObjectData.emitterForceMax !== newObjectData.emitterForceMax) {
         this.setEmitterForceMax(newObjectData.emitterForceMax);
@@ -303,6 +326,18 @@ namespace gdjs {
       if (this._posDirty) {
         this._renderer.setPosition(this.getX(), this.getY());
       }
+      if (this._particleRotationSpeedDirty) {
+        this._renderer.setParticleRotationSpeed(
+          this.particleRotationMinSpeed,
+          this.particleRotationMaxSpeed
+        );
+      }
+      if (this._maxParticlesCountDirty) {
+        this._renderer.setMaxParticlesCount(this.maxParticlesCount);
+      }
+      if (this._additiveRenderingDirty) {
+        this._renderer.setAdditiveRendering(this.additiveRendering);
+      }
       if (this._angleDirty) {
         const angle = this.getAngle();
         this._renderer.setAngle(
@@ -347,6 +382,7 @@ namespace gdjs {
       this._posDirty = this._angleDirty = this._forceDirty = this._zoneRadiusDirty = false;
       this._lifeTimeDirty = this._gravityDirty = this._colorDirty = this._sizeDirty = false;
       this._alphaDirty = this._flowDirty = this._textureDirty = this._tankDirty = false;
+      this._additiveRenderingDirty = this._maxParticlesCountDirty = this._particleRotationSpeedDirty = false;
       this._renderer.update(this.getElapsedTime() / 1000.0);
       if (
         this._renderer.hasStarted() &&
@@ -388,6 +424,50 @@ namespace gdjs {
         this._forceDirty = true;
         this.forceMax = force;
       }
+    }
+
+    setParticleRotationMinSpeed(speed: number): void {
+      if (this.particleRotationMinSpeed !== speed) {
+        this._particleRotationSpeedDirty = true;
+        this.particleRotationMinSpeed = speed;
+      }
+    }
+
+    getParticleRotationMinSpeed(): number {
+      return this.particleRotationMinSpeed;
+    }
+
+    setParticleRotationMaxSpeed(speed: number): void {
+      if (this.particleRotationMaxSpeed !== speed) {
+        this._particleRotationSpeedDirty = true;
+        this.particleRotationMaxSpeed = speed;
+      }
+    }
+
+    getParticleRotationMaxSpeed(): number {
+      return this.particleRotationMaxSpeed;
+    }
+
+    setMaxParticlesCount(count: number): void {
+      if (this.maxParticlesCount !== count) {
+        this._maxParticlesCountDirty = true;
+        this.maxParticlesCount = count;
+      }
+    }
+
+    getMaxParticlesCount(): number {
+      return this.maxParticlesCount;
+    }
+
+    setAdditiveRendering(enabled: boolean) {
+      if (this.additiveRendering !== enabled) {
+        this._additiveRenderingDirty = true;
+        this.additiveRendering = enabled;
+      }
+    }
+
+    getAdditiveRendering(): boolean {
+      return this.additiveRendering;
     }
 
     /**

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -162,7 +162,7 @@ export const declareObjectMetadata = (
     .useStandardParameters('number')
     .markAsAdvanced()
     .setFunctionName('setScaleX')
-    .setGetter('getScaleY');
+    .setGetter('getScaleX');
 
   objectMetadata
     .addExpressionAndConditionAndAction(


### PR DESCRIPTION
- Add actions, conditions and expressions for:
  - max particle count displayed
  - particle rotation min and max speed
  - additive rendering
<img width="520" alt="image" src="https://user-images.githubusercontent.com/32449369/197149723-c3f17f67-273f-41f2-8e63-76d18b3f0bae.png">
<img width="715" alt="image" src="https://user-images.githubusercontent.com/32449369/197149794-e78827c1-8e24-473b-95de-af10ef50f1d2.png">

- There's also a collateral fix