### PR TITLE
Change current file metadata name after renaming a project

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -2184,6 +2184,10 @@ const MainFrame = (props: Props) => {
       if (wasSaved && unsavedChanges) unsavedChanges.sealUnsavedChanges();
       updateWindowTitle();
     }
+    await setState(state => ({
+      ...state,
+      currentFileMetadata: { ...currentFileMetadata, name: newName },
+    }));
   };
 
   const onSaveProjectProperties = async (options: {


### PR DESCRIPTION
Before this PR:
- User renames project
- User saves project
- Still former name in recent project files

After this PR, the name displayed in the recent project files is updated after the save has finished