### PR TITLE
Refactor to make some ParameterMetadata attributes private

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -43,7 +43,7 @@ gd::String EventsCodeGenerator::GenerateRelationalOperatorCall(
   std::size_t relationalOperatorIndex = instrInfos.parameters.size();
   for (std::size_t i = startFromArgument; i < instrInfos.parameters.size();
        ++i) {
-    if (instrInfos.parameters[i].type == "relationalOperator")
+    if (instrInfos.parameters[i].GetType() == "relationalOperator")
       relationalOperatorIndex = i;
   }
   // Ensure that there is at least one parameter after the relational operator
@@ -95,7 +95,7 @@ gd::String EventsCodeGenerator::GenerateOperatorCall(
   std::size_t operatorIndex = instrInfos.parameters.size();
   for (std::size_t i = startFromArgument; i < instrInfos.parameters.size();
        ++i) {
-    if (instrInfos.parameters[i].type == "operator") operatorIndex = i;
+    if (instrInfos.parameters[i].GetType() == "operator") operatorIndex = i;
   }
 
   // Ensure that there is at least one parameter after the operator
@@ -164,7 +164,7 @@ gd::String EventsCodeGenerator::GenerateCompoundOperatorCall(
   std::size_t operatorIndex = instrInfos.parameters.size();
   for (std::size_t i = startFromArgument; i < instrInfos.parameters.size();
        ++i) {
-    if (instrInfos.parameters[i].type == "operator") operatorIndex = i;
+    if (instrInfos.parameters[i].GetType() == "operator") operatorIndex = i;
   }
 
   // Ensure that there is at least one parameter after the operator
@@ -215,7 +215,7 @@ gd::String EventsCodeGenerator::GenerateMutatorCall(
   std::size_t operatorIndex = instrInfos.parameters.size();
   for (std::size_t i = startFromArgument; i < instrInfos.parameters.size();
        ++i) {
-    if (instrInfos.parameters[i].type == "operator") operatorIndex = i;
+    if (instrInfos.parameters[i].GetType() == "operator") operatorIndex = i;
   }
 
   // Ensure that there is at least one parameter after the operator
@@ -293,7 +293,7 @@ gd::String EventsCodeGenerator::GenerateConditionCode(
 
   // Verify that there are no mismatchs between object type in parameters.
   for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
-    if (ParameterMetadata::IsObject(instrInfos.parameters[pNb].type)) {
+    if (ParameterMetadata::IsObject(instrInfos.parameters[pNb].GetType())) {
       gd::String objectInParameter =
           condition.GetParameter(pNb).GetPlainString();
 
@@ -303,11 +303,11 @@ gd::String EventsCodeGenerator::GenerateConditionCode(
           !GetGlobalObjectsAndGroups().GetObjectGroups().Has(
               objectInParameter)) {
         return "/* Unknown object - skipped. */";
-      } else if (!instrInfos.parameters[pNb].supplementaryInformation.empty() &&
+      } else if (!instrInfos.parameters[pNb].GetExtraInfo().empty() &&
                  gd::GetTypeOfObject(GetGlobalObjectsAndGroups(),
                                      GetObjectsAndGroups(),
                                      objectInParameter) !=
-                     instrInfos.parameters[pNb].supplementaryInformation) {
+                     instrInfos.parameters[pNb].GetExtraInfo()) {
         return "/* Mismatched object type - skipped. */";
       }
     }
@@ -485,7 +485,7 @@ gd::String EventsCodeGenerator::GenerateActionCode(
 
   // Verify that there are no mismatchs between object type in parameters.
   for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
-    if (ParameterMetadata::IsObject(instrInfos.parameters[pNb].type)) {
+    if (ParameterMetadata::IsObject(instrInfos.parameters[pNb].GetType())) {
       gd::String objectInParameter = action.GetParameter(pNb).GetPlainString();
       if (!GetObjectsAndGroups().HasObjectNamed(objectInParameter) &&
           !GetGlobalObjectsAndGroups().HasObjectNamed(objectInParameter) &&
@@ -493,11 +493,11 @@ gd::String EventsCodeGenerator::GenerateActionCode(
           !GetGlobalObjectsAndGroups().GetObjectGroups().Has(
               objectInParameter)) {
         return "/* Unknown object - skipped. */";
-      } else if (!instrInfos.parameters[pNb].supplementaryInformation.empty() &&
+      } else if (!instrInfos.parameters[pNb].GetExtraInfo().empty() &&
                  gd::GetTypeOfObject(GetGlobalObjectsAndGroups(),
                                      GetObjectsAndGroups(),
                                      objectInParameter) !=
-                     instrInfos.parameters[pNb].supplementaryInformation) {
+                     instrInfos.parameters[pNb].GetExtraInfo()) {
         return "/* Mismatched object type - skipped. */";
       }
     }
@@ -679,21 +679,21 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
         supplementaryParametersTypes) {
   gd::String argOutput;
 
-  if (ParameterMetadata::IsExpression("number", metadata.type)) {
+  if (ParameterMetadata::IsExpression("number", metadata.GetType())) {
     argOutput = gd::ExpressionCodeGenerator::GenerateExpressionCode(
         *this, context, "number", parameter, lastObjectName);
-  } else if (ParameterMetadata::IsExpression("string", metadata.type)) {
+  } else if (ParameterMetadata::IsExpression("string", metadata.GetType())) {
     argOutput = gd::ExpressionCodeGenerator::GenerateExpressionCode(
         *this, context, "string", parameter, lastObjectName);
-  } else if (ParameterMetadata::IsExpression("variable", metadata.type)) {
+  } else if (ParameterMetadata::IsExpression("variable", metadata.GetType())) {
     argOutput = gd::ExpressionCodeGenerator::GenerateExpressionCode(
-        *this, context, metadata.type, parameter, lastObjectName);
-  } else if (ParameterMetadata::IsObject(metadata.type)) {
+        *this, context, metadata.GetType(), parameter, lastObjectName);
+  } else if (ParameterMetadata::IsObject(metadata.GetType())) {
     // It would be possible to run a gd::ExpressionCodeGenerator if later
     // objects can have nested objects, or function returning objects.
     argOutput =
-        GenerateObject(parameter.GetPlainString(), metadata.type, context);
-  } else if (metadata.type == "relationalOperator") {
+        GenerateObject(parameter.GetPlainString(), metadata.GetType(), context);
+  } else if (metadata.GetType() == "relationalOperator") {
     auto parameterString = parameter.GetPlainString();
     argOutput += parameterString == "=" ? "==" : parameterString;
     if (argOutput != "==" && argOutput != "<" && argOutput != ">" &&
@@ -703,7 +703,7 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
     }
 
     argOutput = "\"" + argOutput + "\"";
-  } else if (metadata.type == "operator") {
+  } else if (metadata.GetType() == "operator") {
     argOutput += parameter.GetPlainString();
     if (argOutput != "=" && argOutput != "+" && argOutput != "-" &&
         argOutput != "/" && argOutput != "*") {
@@ -712,28 +712,28 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
     }
 
     argOutput = "\"" + argOutput + "\"";
-  } else if (ParameterMetadata::IsBehavior(metadata.type)) {
+  } else if (ParameterMetadata::IsBehavior(metadata.GetType())) {
     argOutput = GenerateGetBehaviorNameCode(parameter.GetPlainString());
-  } else if (metadata.type == "key") {
+  } else if (metadata.GetType() == "key") {
     argOutput = "\"" + ConvertToString(parameter.GetPlainString()) + "\"";
-  } else if (metadata.type == "audioResource" ||
-             metadata.type == "bitmapFontResource" ||
-             metadata.type == "fontResource" ||
-             metadata.type == "imageResource" ||
-             metadata.type == "jsonResource" ||
-             metadata.type == "videoResource" ||
+  } else if (metadata.GetType() == "audioResource" ||
+             metadata.GetType() == "bitmapFontResource" ||
+             metadata.GetType() == "fontResource" ||
+             metadata.GetType() == "imageResource" ||
+             metadata.GetType() == "jsonResource" ||
+             metadata.GetType() == "videoResource" ||
              // Deprecated, old parameter names:
-             metadata.type == "password" || metadata.type == "musicfile" ||
-             metadata.type == "soundfile" || metadata.type == "police") {
+             metadata.GetType() == "password" || metadata.GetType() == "musicfile" ||
+             metadata.GetType() == "soundfile" || metadata.GetType() == "police") {
     argOutput = "\"" + ConvertToString(parameter.GetPlainString()) + "\"";
-  } else if (metadata.type == "mouse") {
+  } else if (metadata.GetType() == "mouse") {
     argOutput = "\"" + ConvertToString(parameter.GetPlainString()) + "\"";
-  } else if (metadata.type == "yesorno") {
+  } else if (metadata.GetType() == "yesorno") {
     auto parameterString = parameter.GetPlainString();
     argOutput += (parameterString == "yes" || parameterString == "oui")
                      ? GenerateTrue()
                      : GenerateFalse();
-  } else if (metadata.type == "trueorfalse") {
+  } else if (metadata.GetType() == "trueorfalse") {
     auto parameterString = parameter.GetPlainString();
     // This is duplicated in AdvancedExtension.cpp for GDJS
     argOutput += (parameterString == "True" || parameterString == "Vrai")
@@ -741,21 +741,21 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
                      : GenerateFalse();
   }
   // Code only parameter type
-  else if (metadata.type == "inlineCode") {
-    argOutput += metadata.supplementaryInformation;
+  else if (metadata.GetType() == "inlineCode") {
+    argOutput += metadata.GetExtraInfo();
   } else {
     // Try supplementary types if provided
     if (supplementaryParametersTypes) {
       for (std::size_t i = 0; i < supplementaryParametersTypes->size(); ++i) {
-        if ((*supplementaryParametersTypes)[i].first == metadata.type)
+        if ((*supplementaryParametersTypes)[i].first == metadata.GetType())
           argOutput += (*supplementaryParametersTypes)[i].second;
       }
     }
 
     // Type unknown
     if (argOutput.empty()) {
-      if (!metadata.type.empty())
-        cout << "Warning: Unknown type of parameter \"" << metadata.type
+      if (!metadata.GetType().empty())
+        cout << "Warning: Unknown type of parameter \"" << metadata.GetType()
              << "\"." << std::endl;
       argOutput += "\"" + ConvertToString(parameter.GetPlainString()) + "\"";
     }
@@ -1030,7 +1030,7 @@ gd::String EventsCodeGenerator::GenerateFreeCondition(
   for (std::size_t i = 0; i < instrInfos.parameters.size();
        ++i)  // Some conditions already have a "conditionInverted" parameter
   {
-    if (instrInfos.parameters[i].type == "conditionInverted")
+    if (instrInfos.parameters[i].GetType() == "conditionInverted")
       conditionAlreadyTakeCareOfInversion = true;
   }
   if (!conditionAlreadyTakeCareOfInversion && conditionInverted)
@@ -1051,7 +1051,7 @@ gd::String EventsCodeGenerator::GenerateObjectCondition(
   // Prepare call
   // Add a static_cast if necessary
   gd::String objectFunctionCallNamePart =
-      (!instrInfos.parameters[0].supplementaryInformation.empty())
+      (!instrInfos.parameters[0].GetExtraInfo().empty())
           ? "static_cast<" + objInfo.className + "*>(" +
                 GetObjectListName(objectName, context) + "[i])->" +
                 instrInfos.codeExtraInformation.functionCallName

--- a/Core/GDCore/Events/Serialization.cpp
+++ b/Core/GDCore/Events/Serialization.cpp
@@ -184,8 +184,8 @@ void EventsListSerialization::UpdateInstructionsFromGD2x(
     for (std::size_t j = 0;
          j < parameters.size() && j < metadata.parameters.size();
          ++j) {
-      if (metadata.parameters[j].type == "relationalOperator" ||
-          metadata.parameters[j].type == "operator") {
+      if (metadata.parameters[j].GetType() == "relationalOperator" ||
+          metadata.parameters[j].GetType() == "operator") {
         if (j == parameters.size() - 1) {
           std::cout << "ERROR: No more parameters after a [relational]operator "
                        "when trying to update an instruction from GD2.x";

--- a/Core/GDCore/Extensions/Metadata/ExpressionMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ExpressionMetadata.cpp
@@ -37,11 +37,11 @@ gd::ExpressionMetadata& ExpressionMetadata::AddParameter(
     const gd::String& supplementaryInformation,
     bool parameterIsOptional) {
   gd::ParameterMetadata info;
-  info.type = type;
+  info.SetType(type);
   info.description = description;
   info.codeOnly = false;
-  info.optional = parameterIsOptional;
-  info.supplementaryInformation =
+  info.SetOptional(parameterIsOptional);
+  info.SetExtraInfo(
       // For objects/behavior, the supplementary information
       // parameter is an object/behavior type...
       (gd::ParameterMetadata::IsObject(type) ||
@@ -52,7 +52,7 @@ gd::ExpressionMetadata& ExpressionMetadata::AddParameter(
                        supplementaryInformation  //... so prefix it with the extension
                                            // namespace.
              )
-          : supplementaryInformation;  // Otherwise don't change anything
+          : supplementaryInformation);  // Otherwise don't change anything
 
   // TODO: Assert against supplementaryInformation === "emsc" (when running with
   // Emscripten), and warn about a missing argument when calling addParameter.
@@ -64,9 +64,9 @@ gd::ExpressionMetadata& ExpressionMetadata::AddParameter(
 gd::ExpressionMetadata& ExpressionMetadata::AddCodeOnlyParameter(
     const gd::String& type, const gd::String& supplementaryInformation) {
   gd::ParameterMetadata info;
-  info.type = type;
+  info.SetType(type);
   info.codeOnly = true;
-  info.supplementaryInformation = supplementaryInformation;
+  info.SetExtraInfo(supplementaryInformation);
 
   parameters.push_back(info);
   return *this;

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
@@ -55,11 +55,11 @@ InstructionMetadata& InstructionMetadata::AddParameter(
     const gd::String& supplementaryInformation,
     bool parameterIsOptional) {
   ParameterMetadata info;
-  info.type = type;
+  info.SetType(type);
   info.description = description;
   info.codeOnly = false;
-  info.optional = parameterIsOptional;
-  info.supplementaryInformation =
+  info.SetOptional(parameterIsOptional);
+  info.SetExtraInfo(
       // For objects/behavior, the supplementary information
       // parameter is an object/behavior type...
       (gd::ParameterMetadata::IsObject(type) ||
@@ -71,7 +71,7 @@ InstructionMetadata& InstructionMetadata::AddParameter(
                                                  // extension
                                                  // namespace.
              )
-          : supplementaryInformation;  // Otherwise don't change anything
+          : supplementaryInformation);  // Otherwise don't change anything
 
   // TODO: Assert against supplementaryInformation === "emsc" (when running with
   // Emscripten), and warn about a missing argument when calling addParameter.
@@ -83,9 +83,9 @@ InstructionMetadata& InstructionMetadata::AddParameter(
 InstructionMetadata& InstructionMetadata::AddCodeOnlyParameter(
     const gd::String& type, const gd::String& supplementaryInformation) {
   ParameterMetadata info;
-  info.type = type;
+  info.SetType(type);
   info.codeOnly = true;
-  info.supplementaryInformation = supplementaryInformation;
+  info.SetExtraInfo(supplementaryInformation);
 
   parameters.push_back(info);
   return *this;

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
@@ -233,14 +233,14 @@ class GD_CORE_API ParameterMetadata {
 
   // TODO: Deprecated public fields. Any direct usage should be moved to
   // getter/setter.
-  gd::String type;                      ///< Parameter type
-  gd::String supplementaryInformation;  ///< Used if needed
-  bool optional;                        ///< True if the parameter is optional
 
   gd::String description;  ///< Description shown in editor
   bool codeOnly;  ///< True if parameter is relative to code generation only,
                   ///< i.e. must not be shown in editor
  private:
+  gd::String type;                      ///< Parameter type
+  gd::String supplementaryInformation;  ///< Used if needed
+  bool optional;                        ///< True if the parameter is optional
   gd::String longDescription;  ///< Long description shown in the editor.
   gd::String defaultValue;     ///< Used as a default value in editor or if an
                                ///< optional parameter is empty.

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadataTools.cpp
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadataTools.cpp
@@ -85,7 +85,7 @@ void ParameterMetadataTools::IterateOverParametersWithIndex(
     const gd::Expression& parameterValue =
         pNb < parameters.size() ? parameters[pNb].GetPlainString() : "";
     const gd::Expression& parameterValueOrDefault =
-        parameterValue.GetPlainString().empty() && parameterMetadata.optional
+        parameterValue.GetPlainString().empty() && parameterMetadata.IsOptional()
             ? Expression(parameterMetadata.GetDefaultValue())
             : parameterValue;
 

--- a/Core/GDCore/IDE/Events/EventsBehaviorRenamer.cpp
+++ b/Core/GDCore/IDE/Events/EventsBehaviorRenamer.cpp
@@ -120,7 +120,7 @@ bool EventsBehaviorRenamer::DoVisitInstruction(gd::Instruction& instruction,
           const gd::Expression& parameterValue,
           size_t parameterIndex,
           const gd::String& lastObjectName) {
-        const gd::String& type = parameterMetadata.type;
+        const gd::String& type = parameterMetadata.GetType();
 
         if (gd::ParameterMetadata::IsBehavior(type)) {
           if (lastObjectName == objectName) {

--- a/Core/GDCore/IDE/Events/EventsIdentifiersFinder.cpp
+++ b/Core/GDCore/IDE/Events/EventsIdentifiersFinder.cpp
@@ -149,8 +149,8 @@ class GD_CORE_API IdentifierFinderEventWorker
                               platform, instruction.GetType());
       for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
         // The parameter has the searched type...
-      if (instrInfos.parameters[pNb].type == "identifier"
-       && instrInfos.parameters[pNb].supplementaryInformation == identifierType) {
+      if (instrInfos.parameters[pNb].GetType() == "identifier"
+       && instrInfos.parameters[pNb].GetExtraInfo() == identifierType) {
           //...remember the value of the parameter.
           if (objectName.empty() || lastObjectParameter == objectName) {
             results.insert(instruction.GetParameter(pNb).GetPlainString());
@@ -158,9 +158,9 @@ class GD_CORE_API IdentifierFinderEventWorker
         }
         // Search in expressions
         else if (ParameterMetadata::IsExpression(
-                    "number", instrInfos.parameters[pNb].type) ||
+                    "number", instrInfos.parameters[pNb].GetType()) ||
                 ParameterMetadata::IsExpression(
-                    "string", instrInfos.parameters[pNb].type)) {
+                    "string", instrInfos.parameters[pNb].GetType())) {
           auto node = instruction.GetParameter(pNb).GetRootNode();
 
           IdentifierFinderExpressionNodeWorker searcher(
@@ -174,7 +174,7 @@ class GD_CORE_API IdentifierFinderEventWorker
         }
         // Remember the value of the last "object" parameter.
         else if (gd::ParameterMetadata::IsObject(
-                    instrInfos.parameters[pNb].type)) {
+                    instrInfos.parameters[pNb].GetType())) {
           lastObjectParameter =
               instruction.GetParameter(pNb).GetPlainString();
         }

--- a/Core/GDCore/IDE/Events/EventsLeaderboardsLister.cpp
+++ b/Core/GDCore/IDE/Events/EventsLeaderboardsLister.cpp
@@ -30,7 +30,7 @@ bool EventsLeaderboardsLister::DoVisitInstruction(gd::Instruction& instruction,
   for (int i = 0; i < instruction.GetParametersCount() &&
                   i < instrInfo.GetParametersCount();
        ++i)
-    if (instrInfo.GetParameter(i).type == "leaderboardId") {
+    if (instrInfo.GetParameter(i).GetType() == "leaderboardId") {
       leaderboardIds.insert(instruction.GetParameter(i).GetPlainString());
     }
   return false;

--- a/Core/GDCore/IDE/Events/EventsLeaderboardsRenamer.cpp
+++ b/Core/GDCore/IDE/Events/EventsLeaderboardsRenamer.cpp
@@ -32,7 +32,7 @@ bool EventsLeaderboardsRenamer::DoVisitInstruction(gd::Instruction& instruction,
        ++i) {
     const gd::ParameterMetadata parameter = instrInfo.GetParameter(i);
 
-    if (parameter.type == "leaderboardId") {
+    if (parameter.GetType() == "leaderboardId") {
       const gd::String leaderboardId =
           instruction.GetParameter(i).GetPlainString();
 

--- a/Core/GDCore/IDE/Events/EventsRefactorer.cpp
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.cpp
@@ -237,12 +237,12 @@ bool EventsRefactorer::RenameObjectInActions(const gd::Platform& platform,
         MetadataProvider::GetActionMetadata(platform, actions[aId].GetType());
     for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
       // Replace object's name in parameters
-      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].type) &&
+      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].GetType()) &&
           actions[aId].GetParameter(pNb).GetPlainString() == oldName)
         actions[aId].SetParameter(pNb, gd::Expression(newName));
       // Replace object's name in expressions
       else if (ParameterMetadata::IsExpression(
-                   "number", instrInfos.parameters[pNb].type)) {
+                   "number", instrInfos.parameters[pNb].GetType())) {
         auto node = actions[aId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectRenamer::Rename(platform, project, layout, "number", *node, oldName, newName)) {
@@ -252,7 +252,7 @@ bool EventsRefactorer::RenameObjectInActions(const gd::Platform& platform,
       }
       // Replace object's name in text expressions
       else if (ParameterMetadata::IsExpression(
-                   "string", instrInfos.parameters[pNb].type)) {
+                   "string", instrInfos.parameters[pNb].GetType())) {
         auto node = actions[aId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectRenamer::Rename(platform, project, layout, "string", *node, oldName, newName)) {
@@ -291,12 +291,12 @@ bool EventsRefactorer::RenameObjectInConditions(
                                                conditions[cId].GetType());
     for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
       // Replace object's name in parameters
-      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].type) &&
+      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].GetType()) &&
           conditions[cId].GetParameter(pNb).GetPlainString() == oldName)
         conditions[cId].SetParameter(pNb, gd::Expression(newName));
       // Replace object's name in expressions
       else if (ParameterMetadata::IsExpression(
-                   "number", instrInfos.parameters[pNb].type)) {
+                   "number", instrInfos.parameters[pNb].GetType())) {
         auto node = conditions[cId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectRenamer::Rename(platform, project, layout, "number", *node, oldName, newName)) {
@@ -306,7 +306,7 @@ bool EventsRefactorer::RenameObjectInConditions(
       }
       // Replace object's name in text expressions
       else if (ParameterMetadata::IsExpression(
-                   "string", instrInfos.parameters[pNb].type)) {
+                   "string", instrInfos.parameters[pNb].GetType())) {
         auto node = conditions[cId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectRenamer::Rename(platform, project, layout, "string", *node, oldName, newName)) {
@@ -425,14 +425,14 @@ bool EventsRefactorer::RemoveObjectInActions(const gd::Platform& platform,
         MetadataProvider::GetActionMetadata(platform, actions[aId].GetType());
     for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
       // Find object's name in parameters
-      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].type) &&
+      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].GetType()) &&
           actions[aId].GetParameter(pNb).GetPlainString() == name) {
         deleteMe = true;
         break;
       }
       // Find object's name in expressions
       else if (ParameterMetadata::IsExpression(
-                   "number", instrInfos.parameters[pNb].type)) {
+                   "number", instrInfos.parameters[pNb].GetType())) {
         auto node = actions[aId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectFinder::CheckIfHasObject(platform, globalObjectsContainer, objectsContainer, "number", *node, name)) {
@@ -442,7 +442,7 @@ bool EventsRefactorer::RemoveObjectInActions(const gd::Platform& platform,
       }
       // Find object's name in text expressions
       else if (ParameterMetadata::IsExpression(
-                   "string", instrInfos.parameters[pNb].type)) {
+                   "string", instrInfos.parameters[pNb].GetType())) {
         auto node = actions[aId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectFinder::CheckIfHasObject(platform, globalObjectsContainer, objectsContainer, "string", *node, name)) {
@@ -485,14 +485,14 @@ bool EventsRefactorer::RemoveObjectInConditions(
                                                conditions[cId].GetType());
     for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
       // Find object's name in parameters
-      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].type) &&
+      if (gd::ParameterMetadata::IsObject(instrInfos.parameters[pNb].GetType()) &&
           conditions[cId].GetParameter(pNb).GetPlainString() == name) {
         deleteMe = true;
         break;
       }
       // Find object's name in expressions
       else if (ParameterMetadata::IsExpression(
-                   "number", instrInfos.parameters[pNb].type)) {
+                   "number", instrInfos.parameters[pNb].GetType())) {
         auto node = conditions[cId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectFinder::CheckIfHasObject(platform, globalObjectsContainer, objectsContainer, "number", *node, name)) {
@@ -502,7 +502,7 @@ bool EventsRefactorer::RemoveObjectInConditions(
       }
       // Find object's name in text expressions
       else if (ParameterMetadata::IsExpression(
-                   "string", instrInfos.parameters[pNb].type)) {
+                   "string", instrInfos.parameters[pNb].GetType())) {
         auto node = conditions[cId].GetParameter(pNb).GetRootNode();
 
         if (ExpressionObjectFinder::CheckIfHasObject(platform, globalObjectsContainer, objectsContainer, "string", *node, name)) {

--- a/Core/GDCore/IDE/Events/EventsVariablesFinder.cpp
+++ b/Core/GDCore/IDE/Events/EventsVariablesFinder.cpp
@@ -148,16 +148,16 @@ class GD_CORE_API VariableFinderEventWorker
                               platform, instruction.GetType());
       for (std::size_t pNb = 0; pNb < instrInfos.parameters.size(); ++pNb) {
         // The parameter has the searched type...
-        if (instrInfos.parameters[pNb].type == parameterType) {
+        if (instrInfos.parameters[pNb].GetType() == parameterType) {
           //...remember the value of the parameter.
           if (objectName.empty() || lastObjectParameter == objectName)
             results.insert(instruction.GetParameter(pNb).GetPlainString());
         }
         // Search in expressions
         else if (ParameterMetadata::IsExpression(
-                    "number", instrInfos.parameters[pNb].type) ||
+                    "number", instrInfos.parameters[pNb].GetType()) ||
                 ParameterMetadata::IsExpression(
-                    "string", instrInfos.parameters[pNb].type)) {
+                    "string", instrInfos.parameters[pNb].GetType())) {
           auto node = instruction.GetParameter(pNb).GetRootNode();
 
           VariableFinderExpressionNodeWorker searcher(
@@ -171,7 +171,7 @@ class GD_CORE_API VariableFinderEventWorker
         }
         // Remember the value of the last "object" parameter.
         else if (gd::ParameterMetadata::IsObject(
-                    instrInfos.parameters[pNb].type)) {
+                    instrInfos.parameters[pNb].GetType())) {
           lastObjectParameter =
               instruction.GetParameter(pNb).GetPlainString();
         }

--- a/Core/GDCore/IDE/Events/ExpressionValidator.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.cpp
@@ -36,7 +36,7 @@ size_t GetMinimumParametersNumber(
     size_t initialParameterIndex) {
   size_t nb = 0;
   for (std::size_t i = initialParameterIndex; i < parameters.size(); ++i) {
-    if (!parameters[i].optional && !parameters[i].codeOnly) nb++;
+    if (!parameters[i].IsOptional() && !parameters[i].codeOnly) nb++;
   }
 
   return nb;

--- a/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionsParameterMover.cpp
@@ -150,7 +150,7 @@ bool ExpressionsParameterMover::DoVisitInstruction(gd::Instruction& instruction,
   for (std::size_t pNb = 0; pNb < metadata.parameters.size() &&
                             pNb < instruction.GetParametersCount();
        ++pNb) {
-    const gd::String& type = metadata.parameters[pNb].type;
+    const gd::String& type = metadata.parameters[pNb].GetType();
     const gd::Expression& expression = instruction.GetParameter(pNb);
 
     auto node = expression.GetRootNode();

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -683,7 +683,7 @@ gd::String EventsCodeGenerator::GenerateFreeCondition(
   for (std::size_t i = 0; i < instrInfos.parameters.size();
        ++i)  // Some conditions already have a "conditionInverted" parameter
   {
-    if (instrInfos.parameters[i].type == "conditionInverted")
+    if (instrInfos.parameters[i].GetType() == "conditionInverted")
       conditionAlreadyTakeCareOfInversion = true;
   }
   if (!conditionAlreadyTakeCareOfInversion && conditionInverted)
@@ -1100,17 +1100,17 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
   gd::String argOutput;
 
   // Code only parameter type
-  if (metadata.type == "currentScene") {
+  if (metadata.GetType() == "currentScene") {
     argOutput = "runtimeScene";
   }
   // Code only parameter type
-  else if (metadata.type == "objectsContext") {
+  else if (metadata.GetType() == "objectsContext") {
     argOutput =
         "(typeof eventsFunctionContext !== 'undefined' ? eventsFunctionContext "
         ": runtimeScene)";
   }
   // Code only parameter type
-  else if (metadata.type == "eventsFunctionContext") {
+  else if (metadata.GetType() == "eventsFunctionContext") {
     argOutput =
         "(typeof eventsFunctionContext !== 'undefined' ? eventsFunctionContext "
         ": undefined)";


### PR DESCRIPTION
Refactor to make some ParameterMetadata attributes private (type, supplementaryInformation and optional).

It will allow to extract a class for type metadata and keep ParameterMetadata interface the same to avoid to refactor in a PR that add features (like an expression type or unit definition)