### PR TITLE
Make popovers more visible + a few UI improvements

### DIFF
--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -45,6 +45,8 @@ import { ResponsiveLineStackLayout } from '../UI/Layout';
 import Text from '../UI/Text';
 import GDevelopThemeContext from '../UI/Theme/ThemeContext';
 
+const DragSourceAndDropTarget = makeDragSourceAndDropTarget('effects-list');
+
 const styles = {
   rowContainer: {
     display: 'flex',
@@ -93,10 +95,6 @@ export default function EffectsList(props: Props) {
   const setShowEffectParameterNames = preferences.setShowEffectParameterNames;
   const [nameErrors, setNameErrors] = React.useState<{ [number]: React.Node }>(
     {}
-  );
-  const DragSourceAndDropTarget = React.useMemo(
-    () => makeDragSourceAndDropTarget('effects-list'),
-    []
   );
 
   const allEffectMetadata = React.useMemo(

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
@@ -14,7 +14,7 @@ import { type ParameterRenderingServiceType } from '../ParameterFieldCommons';
 import { type EnumeratedInstructionOrExpressionMetadata } from '../../../InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata';
 import { Column, Line, Spacer } from '../../../UI/Grid';
 import ObjectsRenderingService from '../../../ObjectsRendering/ObjectsRenderingService';
-import { useTheme } from '@material-ui/styles';
+import GDevelopThemeContext from '../../../UI/Theme/ThemeContext';
 
 const defaultTextStyle = {
   // Break words if they are too long to fit on a single line.
@@ -274,8 +274,7 @@ export default function ExpressionAutocompletionsDisplayer({
   onScroll,
   parameterRenderingService,
 }: Props) {
-  const muiTheme = useTheme();
-
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const scrollView = React.useRef((null: ?ScrollViewInterface));
   const selectedAutocompletionElement = React.useRef(
     (null: ?React$Component<any, any>)
@@ -311,7 +310,7 @@ export default function ExpressionAutocompletionsDisplayer({
             square
             style={{
               ...styles.container,
-              backgroundColor: muiTheme.palette.background.alternate,
+              backgroundColor: gdevelopTheme.palette.alternateCanvasColor,
             }}
           >
             <ScrollView ref={scrollView} onScroll={onScroll}>
@@ -380,7 +379,7 @@ export default function ExpressionAutocompletionsDisplayer({
                 square
                 style={{
                   ...styles.container,
-                  backgroundColor: muiTheme.palette.background.alternate,
+                  backgroundColor: gdevelopTheme.palette.alternateCanvasColor,
                 }}
               >
                 <ScrollView autoHideScrollbar>

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
@@ -14,6 +14,7 @@ import { type ParameterRenderingServiceType } from '../ParameterFieldCommons';
 import { type EnumeratedInstructionOrExpressionMetadata } from '../../../InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata';
 import { Column, Line, Spacer } from '../../../UI/Grid';
 import ObjectsRenderingService from '../../../ObjectsRendering/ObjectsRenderingService';
+import { useTheme } from '@material-ui/styles';
 
 const defaultTextStyle = {
   // Break words if they are too long to fit on a single line.
@@ -273,6 +274,8 @@ export default function ExpressionAutocompletionsDisplayer({
   onScroll,
   parameterRenderingService,
 }: Props) {
+  const muiTheme = useTheme();
+
   const scrollView = React.useRef((null: ?ScrollViewInterface));
   const selectedAutocompletionElement = React.useRef(
     (null: ?React$Component<any, any>)
@@ -303,7 +306,14 @@ export default function ExpressionAutocompletionsDisplayer({
             false
           }
         >
-          <Paper variant="outlined" square style={styles.container}>
+          <Paper
+            variant="outlined"
+            square
+            style={{
+              ...styles.container,
+              backgroundColor: muiTheme.palette.background.alternate,
+            }}
+          >
             <ScrollView ref={scrollView} onScroll={onScroll}>
               {expressionAutocompletions.map(
                 (expressionAutocompletion, index) => {
@@ -365,7 +375,14 @@ export default function ExpressionAutocompletionsDisplayer({
             expressionAutocompletions[selectedCompletionIndex].kind ===
               'Expression' &&
             !expressionAutocompletions[selectedCompletionIndex].isExact && (
-              <Paper variant="outlined" square style={styles.container}>
+              <Paper
+                variant="outlined"
+                square
+                style={{
+                  ...styles.container,
+                  backgroundColor: muiTheme.palette.background.alternate,
+                }}
+              >
                 <ScrollView autoHideScrollbar>
                   <Column>
                     <Line noMargin expand alignItems="center">

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { Trans, t } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
-import { useTheme } from '@material-ui/styles';
 
 import Avatar from '@material-ui/core/Avatar';
 import Divider from '@material-ui/core/Divider';
@@ -68,6 +67,7 @@ import LeaderboardSortOptionsDialog from './LeaderboardSortOptionsDialog';
 import { type LeaderboardSortOption } from '../../Utils/GDevelopServices/Play';
 import { formatScore } from '../../Leaderboard/LeaderboardScoreFormatter';
 import Toggle from '../../UI/Toggle';
+import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
 
 type Props = {|
   onLoading: boolean => void,
@@ -184,7 +184,7 @@ export const LeaderboardAdmin = ({
   leaderboardIdToSelectAtOpening,
 }: Props) => {
   const isOnline = useOnlineStatus();
-  const muiTheme = useTheme();
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const windowWidth = useResponsiveWindowWidth();
   const [isEditingAppearance, setIsEditingAppearance] = React.useState<boolean>(
     false
@@ -845,7 +845,7 @@ export const LeaderboardAdmin = ({
                 elevation={5}
                 style={{
                   ...styles.leaderboardConfigurationPaper,
-                  backgroundColor: muiTheme.palette.background.alternate,
+                  backgroundColor: gdevelopTheme.palette.alternateCanvasColor,
                 }}
               >
                 <Column>

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Trans, t } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
+import { useTheme } from '@material-ui/styles';
 
 import Avatar from '@material-ui/core/Avatar';
 import Divider from '@material-ui/core/Divider';
@@ -183,6 +184,7 @@ export const LeaderboardAdmin = ({
   leaderboardIdToSelectAtOpening,
 }: Props) => {
   const isOnline = useOnlineStatus();
+  const muiTheme = useTheme();
   const windowWidth = useResponsiveWindowWidth();
   const [isEditingAppearance, setIsEditingAppearance] = React.useState<boolean>(
     false
@@ -839,7 +841,13 @@ export const LeaderboardAdmin = ({
         <>
           <ResponsiveLineStackLayout noMargin expand noColumnMargin>
             <div style={styles.leftColumn}>
-              <Paper elevation={5} style={styles.leaderboardConfigurationPaper}>
+              <Paper
+                elevation={5}
+                style={{
+                  ...styles.leaderboardConfigurationPaper,
+                  backgroundColor: muiTheme.palette.background.alternate,
+                }}
+              >
                 <Column>
                   <Line>
                     {currentLeaderboard && leaderboards ? (

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -68,6 +68,7 @@ const LayerRow = ({
     () => makeDragSourceAndDropTarget('layers-list'),
     []
   );
+  const isBaseLayer = !layerName;
   return (
     <I18n>
       {({ i18n }) => (
@@ -103,7 +104,9 @@ const LayerRow = ({
                   <TreeTableCell expand>
                     <TextField
                       margin="none"
-                      defaultValue={layerName || i18n._(t`Base layer`)}
+                      defaultValue={
+                        isBaseLayer ? i18n._(t`Base layer`) : layerName
+                      }
                       id={layerName}
                       errorText={
                         nameError ? (
@@ -112,7 +115,7 @@ const LayerRow = ({
                           undefined
                         )
                       }
-                      disabled={!layerName}
+                      disabled={isBaseLayer}
                       onBlur={onBlur}
                       fullWidth
                     />
@@ -145,7 +148,7 @@ const LayerRow = ({
                           { type: 'separator' },
                           {
                             label: i18n._(t`Delete`),
-                            enabled: !!layerName,
+                            enabled: !isBaseLayer,
                             click: onRemove,
                           },
                         ]}
@@ -192,7 +195,7 @@ const LayerRow = ({
                         <IconButton
                           size="small"
                           onClick={onRemove}
-                          disabled={!layerName}
+                          disabled={isBaseLayer}
                           tooltip={t`Delete the layer`}
                         >
                           <Delete />

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -20,6 +20,8 @@ import Badge from '../UI/Badge';
 import { makeDragSourceAndDropTarget } from '../UI/DragAndDrop/DragSourceAndDropTarget';
 import GDevelopThemeContext from '../UI/Theme/ThemeContext';
 
+const DragSourceAndDropTarget = makeDragSourceAndDropTarget('layers-list');
+
 export const styles = {
   dropIndicator: {
     outline: '1px solid white',
@@ -56,10 +58,7 @@ const LayerRow = ({
   onEdit,
 }: Props) => {
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
-  const DragSourceAndDropTarget = React.useMemo(
-    () => makeDragSourceAndDropTarget('layers-list'),
-    []
-  );
+
   const layerName = layer.getName();
   const isLightingLayer = layer.isLightingLayer();
 

--- a/newIDE/app/src/LayersList/LayerRow.js
+++ b/newIDE/app/src/LayersList/LayerRow.js
@@ -10,7 +10,7 @@ import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import FlareIcon from '@material-ui/icons/Flare';
 import IconButton from '../UI/IconButton';
 import Delete from '@material-ui/icons/Delete';
-import TextField from '../UI/TextField';
+import SemiControlledTextField from '../UI/SemiControlledTextField';
 import DragHandle from '../UI/DragHandle';
 import ElementWithMenu from '../UI/Menu/ElementWithMenu';
 import MoreVert from '@material-ui/icons/MoreVert';
@@ -28,18 +28,12 @@ export const styles = {
 
 type Props = {|
   layer: gdLayer,
-  layerName: string,
-  nameError: boolean,
-  onBlur: ({
-    currentTarget: {
-      value: string,
-    },
-  }) => void,
+  nameError: React.Node,
+  onBlur: string => void,
   onRemove: () => void,
   onBeginDrag: () => void,
   onDrop: () => void,
   isVisible: boolean,
-  isLightingLayer: boolean,
   onChangeVisibility: boolean => void,
   effectsCount: number,
   onEditEffects: () => void,
@@ -49,7 +43,6 @@ type Props = {|
 
 const LayerRow = ({
   layer,
-  layerName,
   nameError,
   onBlur,
   onRemove,
@@ -60,7 +53,6 @@ const LayerRow = ({
   onBeginDrag,
   onDrop,
   width,
-  isLightingLayer,
   onEdit,
 }: Props) => {
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
@@ -68,7 +60,11 @@ const LayerRow = ({
     () => makeDragSourceAndDropTarget('layers-list'),
     []
   );
+  const layerName = layer.getName();
+  const isLightingLayer = layer.isLightingLayer();
+
   const isBaseLayer = !layerName;
+
   return (
     <I18n>
       {({ i18n }) => (
@@ -102,21 +98,14 @@ const LayerRow = ({
                     )}
                   </TreeTableCell>
                   <TreeTableCell expand>
-                    <TextField
+                    <SemiControlledTextField
                       margin="none"
-                      defaultValue={
-                        isBaseLayer ? i18n._(t`Base layer`) : layerName
-                      }
+                      value={isBaseLayer ? i18n._(t`Base layer`) : layerName}
                       id={layerName}
-                      errorText={
-                        nameError ? (
-                          <Trans>This name is already taken</Trans>
-                        ) : (
-                          undefined
-                        )
-                      }
+                      errorText={nameError}
                       disabled={isBaseLayer}
-                      onBlur={onBlur}
+                      onChange={onBlur}
+                      commitOnBlur
                       fullWidth
                     />
                   </TreeTableCell>

--- a/newIDE/app/src/LayersList/index.js
+++ b/newIDE/app/src/LayersList/index.js
@@ -22,6 +22,8 @@ import useForceUpdate from '../Utils/UseForceUpdate';
 import { makeDropTarget } from '../UI/DragAndDrop/DropTarget';
 import GDevelopThemeContext from '../UI/Theme/ThemeContext';
 
+const DropTarget = makeDropTarget('layers-list');
+
 type LayersListBodyProps = {|
   layersContainer: gdLayout,
   unsavedChanges?: ?UnsavedChanges,
@@ -72,8 +74,6 @@ const LayersListBody = (props: LayersListBodyProps) => {
     }
     draggedLayerIndexRef.current = null;
   };
-
-  const DropTarget = React.useMemo(() => makeDropTarget('layers-list'), []);
 
   const layersCount = layersContainer.getLayersCount();
   const containerLayersList = mapReverseFor(0, layersCount, i => {

--- a/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
@@ -16,6 +16,10 @@ import {
   type ClosableTabProps,
 } from '../../UI/ClosableTabs';
 
+const DragSourceAndDropTarget = makeDragSourceAndDropTarget<EditorTab>(
+  'draggable-closable-tab'
+);
+
 type DraggableEditorTabsProps = {|
   hideLabels?: boolean,
   editorTabs: EditorTabsState,
@@ -96,10 +100,6 @@ export function DraggableClosableTab({
   onBeginDrag,
   onDrop,
 }: DraggableClosableTabProps) {
-  const DragSourceAndDropTarget = makeDragSourceAndDropTarget<EditorTab>(
-    'draggable-closable-tab'
-  );
-
   return (
     <ScreenTypeMeasurer>
       {screenType => (

--- a/newIDE/app/src/ObjectGroupEditor/index.js
+++ b/newIDE/app/src/ObjectGroupEditor/index.js
@@ -1,12 +1,15 @@
 // @flow
+import * as React from 'react';
 import { t } from '@lingui/macro';
 
-import * as React from 'react';
 import { List, ListItem } from '../UI/List';
 import ObjectSelector from '../ObjectsList/ObjectSelector';
 import EmptyMessage from '../UI/EmptyMessage';
 import { Column } from '../UI/Grid';
 import { Paper } from '@material-ui/core';
+import ListIcon from '../UI/ListIcon';
+import ObjectsRenderingService from '../ObjectsRendering/ObjectsRenderingService';
+import getObjectByName from '../Utils/GetObjectByName';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -78,12 +81,28 @@ const ObjectGroupEditor = ({
             .getAllObjectsNames()
             .toJSArray()
             .map(objectName => {
+              let object = getObjectByName(
+                globalObjectsContainer,
+                objectsContainer,
+                objectName
+              );
+              const icon =
+                project && object ? (
+                  <ListIcon
+                    iconSize={24}
+                    src={ObjectsRenderingService.getThumbnail(
+                      project,
+                      object.getConfiguration()
+                    )}
+                  />
+                ) : null;
               return (
                 <ListItem
                   key={objectName}
                   primaryText={objectName}
                   displayRemoveButton
                   onRemove={() => removeObject(objectName)}
+                  leftIcon={icon}
                 />
               );
             })}

--- a/newIDE/app/src/Profile/Achievement/AchievementList.js
+++ b/newIDE/app/src/Profile/Achievement/AchievementList.js
@@ -96,6 +96,7 @@ const AchievementList = ({
                   >
                     <Text
                       noMargin
+                      size="sub-title"
                       style={
                         achievementWithBadgeData.unlockedAt
                           ? styles.unlockedAchievement

--- a/newIDE/app/src/UI/SelectOption.js
+++ b/newIDE/app/src/UI/SelectOption.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { I18n } from '@lingui/react';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
-import { useTheme } from '@material-ui/core/styles';
+import GDevelopThemeContext from './Theme/ThemeContext';
 
 // We support a subset of the props supported by Material-UI v0.x MenuItem
 // They should be self descriptive - refer to Material UI docs otherwise.
@@ -17,7 +17,7 @@ type Props = {|
  * A native select option to be used with `SelectField`.
  */
 const SelectOption = (props: Props) => {
-  const muiTheme = useTheme();
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
 
   return (
     <I18n>
@@ -26,8 +26,8 @@ const SelectOption = (props: Props) => {
           value={props.value}
           disabled={props.disabled}
           style={{
-            color: muiTheme.palette.text.primary,
-            backgroundColor: muiTheme.palette.background.paper,
+            color: gdevelopTheme.text.color.primary,
+            backgroundColor: gdevelopTheme.palette.canvasColor,
           }}
         >
           {props.primaryTextIsUserDefined

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -259,6 +259,11 @@ export function getMuiOverrides(
         backgroundColor: alternateCanvasBackgroundColor,
       },
     },
+    MuiAutocomplete: {
+      paper: {
+        backgroundColor: alternateCanvasBackgroundColor,
+      },
+    },
   };
 }
 

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -348,7 +348,8 @@ export function createGdevelopTheme({
       palette: {
         type: paletteType,
         canvasColor: styles['ThemeSurfaceCanvasBackgroundColor'],
-        alternateCanvasColor: styles['ThemeSurfaceAlternateCanvasBackgroundColor'],
+        alternateCanvasColor:
+          styles['ThemeSurfaceAlternateCanvasBackgroundColor'],
         primary: styles['ThemePrimaryColor'],
         secondary: styles['ThemeSecondaryColor'],
       },
@@ -362,6 +363,10 @@ export function createGdevelopTheme({
         separatorColor: styles['ThemeToolbarSeparatorColor'],
       },
       text: {
+        color: {
+          primary: styles['ThemeTextDefaultColor'],
+          secondary: styles['ThemeTextSecondaryColor'],
+        },
         highlighted: {
           backgroundColor: styles['ThemeTextHighlightedBackgroundColor'],
         },

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -348,6 +348,7 @@ export function createGdevelopTheme({
       palette: {
         type: paletteType,
         canvasColor: styles['ThemeSurfaceCanvasBackgroundColor'],
+        alternateCanvasColor: styles['ThemeSurfaceAlternateCanvasBackgroundColor'],
         primary: styles['ThemePrimaryColor'],
         secondary: styles['ThemeSecondaryColor'],
       },

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -75,6 +75,8 @@ import { normalizeString } from '../Utils/Search';
 import { I18n } from '@lingui/react';
 const gd: libGDevelop = global.gd;
 
+const DragSourceAndDropTarget = makeDragSourceAndDropTarget('variable-editor');
+
 const stopEventPropagation = (event: SyntheticPointerEvent<HTMLInputElement>) =>
   event.stopPropagation();
 const preventEventDefaultEffect = (
@@ -184,11 +186,6 @@ const VariablesList = ({ onComputeAllVariableNames, ...props }: Props) => {
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const draggedNodeId = React.useRef<?string>(null);
   const forceUpdate = useForceUpdate();
-
-  const DragSourceAndDropTarget = React.useMemo(
-    () => makeDragSourceAndDropTarget('variable-editor'),
-    []
-  );
 
   const triggerSearch = React.useCallback(
     () => {

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -300,12 +300,14 @@ const VariablesList = ({ onComputeAllVariableNames, ...props }: Props) => {
     props.historyHandler
       ? props.historyHandler.undo()
       : setHistory(undo(history, props.variablesContainer));
+    setSelectedNodes([]);
   };
 
   const _redo = () => {
     props.historyHandler
       ? props.historyHandler.redo()
       : setHistory(redo(history, props.variablesContainer));
+    setSelectedNodes([]);
   };
   const _canUndo = (): boolean =>
     props.historyHandler ? props.historyHandler.canUndo() : canUndo(history);


### PR DESCRIPTION
The idea is to make the popovers and poppers more discernable from the underlying background color.

So far:

## Autocomplete dropdown

### Before


<img width="967" alt="image" src="https://user-images.githubusercontent.com/32449369/197831616-28610e85-6932-43b2-89aa-63b1cfa932be.png">

### After

<img width="975" alt="image" src="https://user-images.githubusercontent.com/32449369/197831293-eece3f8e-f0ed-4cf4-9da6-d6546344ed79.png">

## Expression Autocompletion Displayer

### Before

#### 2 panels

<img width="999" alt="image" src="https://user-images.githubusercontent.com/32449369/197831975-01f3b643-8a01-4de4-ab49-33b128a3212a.png">

#### 1 panel

<img width="978" alt="image" src="https://user-images.githubusercontent.com/32449369/197956084-7d1b0d12-257d-489b-a084-755acb353a7c.png">

### After

#### 2 panels

<img width="956" alt="image" src="https://user-images.githubusercontent.com/32449369/197831422-723633a1-a1a2-477a-bdf7-aa102baf399a.png">

#### 1 panel

<img width="973" alt="image" src="https://user-images.githubusercontent.com/32449369/197956319-6f65fecc-cda4-430b-80e6-685012c6ccce.png">

## Leaderboard admin

### Before

<img width="960" alt="image" src="https://user-images.githubusercontent.com/32449369/197959922-6fff9840-737a-483d-923b-ae7e636470f3.png">

### After

<img width="960" alt="image" src="https://user-images.githubusercontent.com/32449369/197959860-09b23677-041c-4a0a-924d-27d40174e791.png">

# Also

- Use same DragNDrop library for layers list as for objects and objects groups.
- Improve user experience when renaming layers
- Add object icon in objects group object list:

<img width="874" alt="image" src="https://user-images.githubusercontent.com/32449369/197964567-5ce2b710-8a7c-43ac-8e9b-3daf87948f9e.png">

