### PR TITLE
Fix animation ended condition

### DIFF
--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -325,6 +325,19 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                    "res/conditions/animation.png")
 
       .AddParameter("object", _("Object"), "Sprite")
+      .MarkAsSimple()
+      .SetHidden();
+
+  obj.AddCondition("AnimationEnded2",
+                   _("Animation finished"),
+                   _("Check if the animation being played by the Sprite object "
+                     "is finished."),
+                   _("The animation of _PARAM0_ is finished"),
+                   _("Animations and images"),
+                   "res/conditions/animation24.png",
+                   "res/conditions/animation.png")
+
+      .AddParameter("object", _("Object"), "Sprite")
       .MarkAsSimple();
 
   obj.AddCondition("ScaleWidth",

--- a/GDJS/GDJS/Extensions/Builtin/SpriteExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/SpriteExtension.cpp
@@ -46,6 +46,7 @@ SpriteExtension::SpriteExtension() {
   spriteConditions["Direction"].SetFunctionName("getDirectionOrAngle");
   spriteConditions["Sprite"].SetFunctionName("getAnimationFrame");
   spriteConditions["AnimationEnded"].SetFunctionName("hasAnimationEnded");
+  spriteConditions["AnimationEnded2"].SetFunctionName("hasAnimationEnded2");
   spriteActions["PauseAnimation"].SetFunctionName("pauseAnimation");
   spriteActions["PlayAnimation"].SetFunctionName("playAnimation");
   spriteConditions["AnimStopped"].SetFunctionName("animationPaused");

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -473,7 +473,7 @@ namespace gdjs {
 
       //*Optimization*: Animation is finished, don't change the current frame
       //and compute nothing more.
-      if (!direction.loop && this._currentFrame >= direction.frames.length) {
+      if (!direction.loop && this._currentFrame >= direction.frames.length - 1) {
       } else {
         const elapsedTime = this.getElapsedTime() / 1000;
         this._frameElapsedTime += this._animationPaused

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.spec.js
@@ -18,7 +18,7 @@ describe('EnumerateInstructions', () => {
         expect.objectContaining({
           displayedName: 'Animation finished',
           fullGroupName: 'General/Sprite/Animations and images',
-          type: 'AnimationEnded',
+          type: 'AnimationEnded2',
         }),
         expect.objectContaining({
           displayedName: 'Trigger once while true',
@@ -105,11 +105,11 @@ describe('EnumerateInstructions', () => {
     expect(triggerOnce).not.toBeUndefined();
     expect(getObjectParameterIndex(triggerOnce.metadata)).toBe(-1);
 
-    const spriteAnimatedEnded = conditions.filter(
-      ({ type }) => type === 'AnimationEnded'
+    const spriteAnimationEnded = conditions.filter(
+      ({ type }) => type === 'AnimationEnded2'
     )[0];
-    expect(spriteAnimatedEnded).not.toBeUndefined();
-    expect(getObjectParameterIndex(spriteAnimatedEnded.metadata)).toBe(0);
+    expect(spriteAnimationEnded).not.toBeUndefined();
+    expect(getObjectParameterIndex(spriteAnimationEnded.metadata)).toBe(0);
   });
 
   it('can enumerate instructions for an object (Sprite)', () => {
@@ -129,7 +129,7 @@ describe('EnumerateInstructions', () => {
       expect.arrayContaining([
         expect.objectContaining({
           displayedName: 'Animation finished',
-          type: 'AnimationEnded',
+          type: 'AnimationEnded2',
         }),
         expect.objectContaining({
           displayedName: 'The cursor/touch is on an object',


### PR DESCRIPTION
It was reported by @HelperWesley that the "Animation Finished" condition fires when an animation enters its last frame, not when the last frame has been displayed long enough for the animation to be considered finished.

This PR fixes this:
- Hide current condition to prevent regression
- Create identical condition that behaves correctly

## Example

With this event sheet:

<img width="976" alt="image" src="https://user-images.githubusercontent.com/32449369/198298691-066ae0e9-4500-4d86-8826-b96a6801dc13.png">

Here is what happens:

https://user-images.githubusercontent.com/32449369/198299256-8cc6be6e-2d15-43c6-8212-c1864758b145.mov
