### PR TITLE
Modernize scene properties to look the same as behavior properties

### DIFF
--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -649,6 +649,9 @@ export default class ProjectManager extends React.Component<Props, State> {
       eventsFunctionsExtensionsError,
       onReloadEventsFunctionsExtensions,
       onInstallExtension,
+      resourceSources,
+      onChooseResource,
+      resourceExternalEditors,
     } = this.props;
     const {
       renamedItemKind,
@@ -1137,6 +1140,9 @@ export default class ProjectManager extends React.Component<Props, State> {
                   );
                   this._onOpenLayoutProperties(null);
                 }}
+                resourceSources={resourceSources}
+                resourceExternalEditors={resourceExternalEditors}
+                onChooseResource={onChooseResource}
               />
             )}
             {!!this.state.editedVariablesLayout && (

--- a/newIDE/app/src/SceneEditor/BehaviorSharedPropertiesEditor.js
+++ b/newIDE/app/src/SceneEditor/BehaviorSharedPropertiesEditor.js
@@ -1,0 +1,53 @@
+// @flow
+import { Trans } from '@lingui/macro';
+
+import * as React from 'react';
+import PropertiesEditor from '../PropertiesEditor';
+import propertiesMapToSchema from '../PropertiesEditor/PropertiesMapToSchema';
+import EmptyMessage from '../UI/EmptyMessage';
+import { Column } from '../UI/Grid';
+import {
+  type ResourceSource,
+  type ChooseResourceFunction,
+} from '../ResourcesList/ResourceSource';
+import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
+
+type Props = {|
+  behaviorSharedData: gdBehaviorsSharedData,
+  project: gdProject,
+  resourceSources: Array<ResourceSource>,
+  onChooseResource: ChooseResourceFunction,
+  resourceExternalEditors: Array<ResourceExternalEditor>,
+|};
+
+export default class BehaviorSharedPropertiesEditor extends React.Component<Props> {
+  render() {
+    const { behaviorSharedData } = this.props;
+
+    const propertiesSchema = propertiesMapToSchema(
+      behaviorSharedData.getProperties(),
+      behavior => behavior.getProperties(),
+      (behavior, name, value) => {
+        behavior.updateProperty(name, value);
+      }
+    );
+
+    return (
+      <Column expand>
+        {propertiesSchema.length ? (
+          <PropertiesEditor
+            schema={propertiesSchema}
+            instances={[behaviorSharedData]}
+          />
+        ) : (
+          <EmptyMessage>
+            <Trans>
+              There is nothing to configure for this behavior. You can still use
+              events to interact with the object and this behavior.
+            </Trans>
+          </EmptyMessage>
+        )}
+      </Column>
+    );
+  }
+}

--- a/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
+++ b/newIDE/app/src/SceneEditor/ScenePropertiesDialog.js
@@ -7,7 +7,7 @@ import RaisedButton from '../UI/RaisedButton';
 import Dialog, { DialogPrimaryButton } from '../UI/Dialog';
 import ColorField from '../UI/ColorField';
 import EmptyMessage from '../UI/EmptyMessage';
-import PropertiesEditor from '../PropertiesEditor';
+import BehaviorSharedPropertiesEditor from './BehaviorSharedPropertiesEditor';
 import propertiesMapToSchema from '../PropertiesEditor/PropertiesMapToSchema';
 import some from 'lodash/some';
 import Checkbox from '../UI/Checkbox';
@@ -18,6 +18,19 @@ import {
   rgbStringAndAlphaToRGBColor,
   type RGBColor,
 } from '../Utils/ColorTransformer';
+import HelpIcon from '../UI/HelpIcon';
+import { Column, Line } from '../UI/Grid';
+import DismissableTutorialMessage from '../Hints/DismissableTutorialMessage';
+import { Accordion, AccordionHeader, AccordionBody } from '../UI/Accordion';
+import { IconContainer } from '../UI/IconContainer';
+import { getBehaviorTutorialIds } from '../Utils/GDevelopServices/Tutorial';
+import ScrollView from '../UI/ScrollView';
+import {
+  type ResourceSource,
+  type ChooseResourceFunction,
+} from '../ResourcesList/ResourceSource';
+import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
+
 const gd: libGDevelop = global.gd;
 
 type Props = {|
@@ -28,6 +41,9 @@ type Props = {|
   onClose: () => void,
   onOpenMoreSettings?: ?() => void,
   onEditVariables: () => void,
+  resourceSources: Array<ResourceSource>,
+  onChooseResource: ChooseResourceFunction,
+  resourceExternalEditors: Array<ResourceExternalEditor>,
 |};
 
 type State = {|
@@ -102,16 +118,8 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
       .toJSArray();
 
     const propertiesEditors = allBehaviorSharedDataNames
-      .map(name => {
-        const behaviorSharedData = layout.getBehaviorSharedData(name);
-
-        // TODO Check if this extra check is needed.
-        const behaviorMetadata = gd.MetadataProvider.getBehaviorMetadata(
-          gd.JsPlatform.get(),
-          behaviorSharedData.getTypeName()
-        );
-        if (gd.MetadataProvider.isBadBehaviorMetadata(behaviorMetadata))
-          return null;
+      .map(behaviorName => {
+        const behaviorSharedData = layout.getBehaviorSharedData(behaviorName);
 
         if (isNullPtr(gd, behaviorSharedData)) return null;
 
@@ -123,14 +131,85 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
             behaviorSharedData.updateProperty(name, value);
           }
         );
+        const behaviorTypeName = behaviorSharedData.getTypeName();
+
+        const behaviorMetadata = gd.MetadataProvider.getBehaviorMetadata(
+          gd.JsPlatform.get(),
+          behaviorTypeName
+        );
+        const tutorialIds = getBehaviorTutorialIds(behaviorTypeName);
+        // TODO Make this a functional component to use PreferencesContext
+        const enabledTutorialIds = [];
+        const iconUrl = behaviorMetadata.getIconFilename();
 
         return (
           !!propertiesSchema.length && (
-            <PropertiesEditor
-              key={name}
-              schema={propertiesSchema}
-              instances={[behaviorSharedData]}
-            />
+            <Accordion
+              key={behaviorName}
+              defaultExpanded
+              id={`behavior-parameters-${behaviorName}`}
+            >
+              <AccordionHeader
+                actions={[
+                  <HelpIcon
+                    key="help"
+                    size="small"
+                    helpPagePath={behaviorMetadata.getHelpPath()}
+                  />,
+                ]}
+              >
+                {iconUrl ? (
+                  <IconContainer
+                    src={iconUrl}
+                    alt={behaviorMetadata.getFullName()}
+                    size={20}
+                  />
+                ) : null}
+                <Column expand>
+                  <TextField
+                    value={behaviorName}
+                    margin="none"
+                    fullWidth
+                    disabled
+                    onChange={(e, text) => {}}
+                    id={`behavior-${behaviorName}-name-text-field`}
+                  />
+                </Column>
+              </AccordionHeader>
+              <AccordionBody>
+                <Column
+                  expand
+                  noMargin
+                  // Avoid Physics2 behavior overflow on small screens
+                  noOverflowParent
+                >
+                  {enabledTutorialIds.length ? (
+                    <Line>
+                      <ColumnStackLayout expand>
+                        {tutorialIds.map(tutorialId => (
+                          <DismissableTutorialMessage
+                            key={tutorialId}
+                            tutorialId={tutorialId}
+                          />
+                        ))}
+                      </ColumnStackLayout>
+                    </Line>
+                  ) : null}
+                  <Line>
+                    <BehaviorSharedPropertiesEditor
+                      key={behaviorName}
+                      behaviorSharedData={behaviorSharedData}
+                      project={this.props.project}
+                      resourceSources={this.props.resourceSources}
+                      onChooseResource={this.props.onChooseResource}
+                      resourceExternalEditors={
+                        this.props.resourceExternalEditors
+                      }
+                    />
+                  </Line>
+                </Column>
+              </AccordionBody>
+            </Accordion>
           )
         );
       })
@@ -156,55 +235,57 @@ export default class ScenePropertiesDialog extends Component<Props, State> {
         open={this.props.open}
         maxWidth="sm"
       >
-        <ColumnStackLayout expand noMargin>
-          <TextField
-            floatingLabelText={<Trans>Window title</Trans>}
-            fullWidth
-            type="text"
-            value={this.state.windowTitle}
-            onChange={(e, value) => this.setState({ windowTitle: value })}
-          />
-          <Checkbox
-            checked={this.state.shouldStopSoundsOnStartup}
-            label={<Trans>Stop music and sounds on startup</Trans>}
-            onCheck={(e, check) =>
-              this.setState({
-                shouldStopSoundsOnStartup: check,
-              })
-            }
-          />
-          <ColorField
-            floatingLabelText={<Trans>Scene background color</Trans>}
-            fullWidth
-            disableAlpha
-            color={rgbColorToRGBString(this.state.backgroundColor)}
-            onChange={color =>
-              this.setState({
-                backgroundColor: rgbStringAndAlphaToRGBColor(color),
-              })
-            }
-          />
-          {!some(propertiesEditors) && (
-            <EmptyMessage>
-              <Trans>
-                Any additional properties will appear here if you add behaviors
-                to objects, like Physics behavior.
-              </Trans>
-            </EmptyMessage>
-          )}
-          {propertiesEditors}
-          {this.props.onOpenMoreSettings && (
-            <RaisedButton
-              label={<Trans>Open advanced settings</Trans>}
+        <ScrollView>
+          <ColumnStackLayout expand noMargin>
+            <TextField
+              floatingLabelText={<Trans>Window title</Trans>}
               fullWidth
-              onClick={() => {
-                if (this.props.onOpenMoreSettings)
-                  this.props.onOpenMoreSettings();
-                this.props.onClose();
-              }}
+              type="text"
+              value={this.state.windowTitle}
+              onChange={(e, value) => this.setState({ windowTitle: value })}
             />
-          )}
-        </ColumnStackLayout>
+            <Checkbox
+              checked={this.state.shouldStopSoundsOnStartup}
+              label={<Trans>Stop music and sounds on startup</Trans>}
+              onCheck={(e, check) =>
+                this.setState({
+                  shouldStopSoundsOnStartup: check,
+                })
+              }
+            />
+            <ColorField
+              floatingLabelText={<Trans>Scene background color</Trans>}
+              fullWidth
+              disableAlpha
+              color={rgbColorToRGBString(this.state.backgroundColor)}
+              onChange={color =>
+                this.setState({
+                  backgroundColor: rgbStringAndAlphaToRGBColor(color),
+                })
+              }
+            />
+            {!some(propertiesEditors) && (
+              <EmptyMessage>
+                <Trans>
+                  Any additional properties will appear here if you add
+                  behaviors to objects, like Physics behavior.
+                </Trans>
+              </EmptyMessage>
+            )}
+            {propertiesEditors}
+            {this.props.onOpenMoreSettings && (
+              <RaisedButton
+                label={<Trans>Open advanced settings</Trans>}
+                fullWidth
+                onClick={() => {
+                  if (this.props.onOpenMoreSettings)
+                    this.props.onOpenMoreSettings();
+                  this.props.onClose();
+                }}
+              />
+            )}
+          </ColumnStackLayout>
+        </ScrollView>
       </Dialog>
     );
   }

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1789,6 +1789,9 @@ export default class SceneEditor extends React.Component<Props, State> {
             onApply={() => this.openSceneProperties(false)}
             onEditVariables={() => this.editLayoutVariables(true)}
             onOpenMoreSettings={this.props.onOpenMoreSettings}
+            resourceSources={resourceSources}
+            resourceExternalEditors={resourceExternalEditors}
+            onChooseResource={onChooseResource}
           />
         )}
         {!!this.state.layoutVariablesDialogOpen && (

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectExporterDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectExporterDialog.stories.js
@@ -7,7 +7,6 @@ import { action } from '@storybook/addon-actions';
 import { testProject } from '../../GDevelopJsInitializerDecorator';
 
 import muiDecorator from '../../ThemeDecorator';
-import paperDecorator from '../../PaperDecorator';
 import ObjectExporterDialog from '../../../ObjectEditor/ObjectExporterDialog';
 import EventsFunctionsExtensionsContext from '../../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
 import LocalEventsFunctionsExtensionWriter from '../../../EventsFunctionsExtensionsLoader/Storage/LocalEventsFunctionsExtensionWriter';
@@ -16,7 +15,7 @@ import LocalEventsFunctionsExtensionOpener from '../../../EventsFunctionsExtensi
 export default {
   title: 'LayoutEditor/ObjectExporterDialog',
   component: ObjectExporterDialog,
-  decorators: [muiDecorator, paperDecorator],
+  decorators: [muiDecorator],
 };
 
 const fakeEventsFunctionsExtensionsContext = {

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ScenePropertiesDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ScenePropertiesDialog.stories.js
@@ -1,0 +1,45 @@
+// @flow
+
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+
+// Keep first as it creates the `global.gd` object:
+import { testProject } from '../../GDevelopJsInitializerDecorator';
+
+import muiDecorator from '../../ThemeDecorator';
+import ScenePropertiesDialog from '../../../SceneEditor/ScenePropertiesDialog';
+
+export default {
+  title: 'LayoutEditor/ScenePropertiesDialog',
+  component: ScenePropertiesDialog,
+  decorators: [muiDecorator],
+};
+
+export const Default = () => (
+  <ScenePropertiesDialog
+    open
+    project={testProject.project}
+    layout={testProject.testLayout}
+    onClose={() => action('Close the dialog')}
+    onApply={() => action('Apply changes')}
+    onEditVariables={() => action('Edit variables')}
+    resourceSources={[]}
+    resourceExternalEditors={[]}
+    onChooseResource={() => action('Choose a resource')}
+  />
+);
+
+export const MoreSettings = () => (
+  <ScenePropertiesDialog
+    open
+    project={testProject.project}
+    layout={testProject.testLayout}
+    onClose={() => action('Close the dialog')}
+    onApply={() => action('Apply changes')}
+    onEditVariables={() => action('Edit variables')}
+    onOpenMoreSettings={() => action('Open more settings')}
+    resourceSources={[]}
+    resourceExternalEditors={[]}
+    onChooseResource={() => action('Choose a resource')}
+  />
+);


### PR DESCRIPTION
The story is not really useful because Physics 2 can't be used but we will be able to show shared data of event-based behaviors in the future.
http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/shared-property-editor/latest/index.html?path=/story/layouteditor-scenepropertiesdialog--default

It uses the PropertiesEditor to give the same level of features as the behavior property editor.

![image](https://user-images.githubusercontent.com/2611977/198349285-c12a0ec1-ed9c-4bc2-a47f-5c1f11ace3b2.png)
