### PR TITLE
Handle new format for public asset resources

### DIFF
--- a/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudResourceFetcher.js
@@ -12,23 +12,10 @@ import {
 import { type FileMetadata } from '../index';
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
 import {
-  extractFilenameAndExtensionFromProductAuthorizedUrl,
+  extractFilenameWithExtensionFromProductAuthorizedUrl,
   isProductAuthorizedResourceUrl,
 } from '../../Utils/GDevelopServices/Shop';
-
-const isURL = (filename: string) => {
-  return (
-    filename.startsWith('http://') ||
-    filename.startsWith('https://') ||
-    filename.startsWith('ftp://') ||
-    filename.startsWith('blob:') ||
-    filename.startsWith('data:')
-  );
-};
-
-const isBlobURL = (filename: string) => {
-  return filename.startsWith('blob:');
-};
+import { isBlobURL, isURL } from '../../ResourcesList/ResourceUtils';
 
 export const moveUrlResourcesToCloudFilesIfPrivate = async ({
   project,
@@ -70,16 +57,13 @@ export const moveUrlResourcesToCloudFilesIfPrivate = async ({
 
           if (isURL(resourceFile)) {
             if (isProductAuthorizedResourceUrl(resourceFile)) {
-              const {
-                extension,
-                filenameWithoutExtension,
-              } = extractFilenameAndExtensionFromProductAuthorizedUrl(
+              const filenameWithExtension = extractFilenameWithExtensionFromProductAuthorizedUrl(
                 resourceFile
               );
               return {
                 resource,
                 url: resourceFile,
-                filename: filenameWithoutExtension + extension,
+                filename: filenameWithExtension,
               };
             } else if (isBlobURL(resourceFile)) {
               result.erroredResources.push({

--- a/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudResourceFetcher.js
@@ -11,7 +11,10 @@ import {
 } from '../../Utils/BlobDownloader';
 import { type FileMetadata } from '../index';
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
-import { extractFilenameAndExtensionFromProductAuthorizedUrl } from '../../Utils/GDevelopServices/Shop';
+import {
+  extractFilenameAndExtensionFromProductAuthorizedUrl,
+  isProductAuthorizedResourceUrl,
+} from '../../Utils/GDevelopServices/Shop';
 
 const isURL = (filename: string) => {
   return (
@@ -20,13 +23,6 @@ const isURL = (filename: string) => {
     filename.startsWith('ftp://') ||
     filename.startsWith('blob:') ||
     filename.startsWith('data:')
-  );
-};
-
-const isPrivateAssetUrl = (filename: string) => {
-  return (
-    filename.startsWith('https://private-assets-dev.gdevelop.io') ||
-    filename.startsWith('https://private-assets.gdevelop.io')
   );
 };
 
@@ -73,7 +69,7 @@ export const moveUrlResourcesToCloudFilesIfPrivate = async ({
           const resourceFile = resource.getFile();
 
           if (isURL(resourceFile)) {
-            if (isPrivateAssetUrl(resourceFile)) {
+            if (isProductAuthorizedResourceUrl(resourceFile)) {
               const {
                 extension,
                 filenameWithoutExtension,

--- a/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudResourceMover.js
+++ b/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudResourceMover.js
@@ -16,20 +16,7 @@ import {
   downloadUrlsToBlobs,
   type ItemResult,
 } from '../../Utils/BlobDownloader';
-
-const isURL = (filename: string) => {
-  return (
-    filename.startsWith('http://') ||
-    filename.startsWith('https://') ||
-    filename.startsWith('ftp://') ||
-    filename.startsWith('blob:') ||
-    filename.startsWith('data:')
-  );
-};
-
-const isBlobURL = (filename: string) => {
-  return filename.startsWith('blob:');
-};
+import { isBlobURL, isURL } from '../../ResourcesList/ResourceUtils';
 
 export const moveAllCloudProjectResourcesToCloudProject = async ({
   project,

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourceMover.spec.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourceMover.spec.js
@@ -9,23 +9,39 @@ jest.mock('../../Utils/OptionalRequire');
 
 const mockFn = (fn: Function): JestMockFn<any, any> => fn;
 
+const classicUrl = 'https://www.example.com/file-to-download.png';
+const productAuthorizedUrl =
+  'https://private-assets.gdevelop.io/a2adcae7-ceba-4c0d-ad0f-411bf83692ea/resources/Misc/stars_levels (3).png?token=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnZGV2ZWxvcC1zaG9wLWFwaSIsImF1ZCI6IjNwejJvWEZHSmVTaTVyVjROQ0pkclU4MjVUVDIiLCJleHAiOjE2NjY5NjM5NDY1OTUsInN1YiI6WyJhMmFkY2FlNy1jZWJhLTRjMGQtYWQwZi00MTFiZjgzNjkyZWEiLCJjM2ZmZjUyZS1lMTZjLTQxMTYtYTYzNS03ZjUzOGRmN2Y1YWEiXX0%3D.WY0V%2B2ypgT0PEWPUKVPSaiazKNfl4ib%2Bf89CpgcdxGo';
+const publicResourceUrl =
+  'https://asset-resources.gdevelop.io/public-resources/16x16 Dungeon Tileset/Armor/0a130324cd2501a97027b518b41231896a81e25034fd3a7baaca9581d079f8b6_Imp_Run_2.png';
+const localFileUrl = 'some-local-file.png';
+
 const makeTestProjectWithResourcesToDownload = () => {
   const { project } = makeTestProject(gd);
 
   // Add a resource that uses a URL, which will be download
-  // by the LocalResourceMover (whatever the origin).
+  // by the LocalResourceMover.
   {
     const newResource = new gd.ImageResource();
     newResource.setName('MyResourceToDownload');
-    newResource.setFile('http://example/file-to-download.png');
+    newResource.setFile(classicUrl);
     project.getResourcesManager().addResource(newResource);
     newResource.delete();
   }
   // Resource with an authorized URL
   {
     const newResource = new gd.ImageResource();
-    newResource.setName('MyResourceToDownload');
-    newResource.setFile('http://example/file-to-download.png?token=123');
+    newResource.setName('MyAuthorizedResourceToDownload');
+    newResource.setFile(productAuthorizedUrl);
+    project.getResourcesManager().addResource(newResource);
+    newResource.delete();
+  }
+
+  // Resource with a public asset URL
+  {
+    const newResource = new gd.ImageResource();
+    newResource.setName('MyPublicResourceToDownload');
+    newResource.setFile(publicResourceUrl);
     project.getResourcesManager().addResource(newResource);
     newResource.delete();
   }
@@ -35,7 +51,7 @@ const makeTestProjectWithResourcesToDownload = () => {
   {
     const newResource = new gd.ImageResource();
     newResource.setName('MyAlreadyLocalResource');
-    newResource.setFile('some-local-file.png');
+    newResource.setFile(localFileUrl);
     project.getResourcesManager().addResource(newResource);
     newResource.delete();
   }
@@ -60,15 +76,9 @@ describe('LocalResourceMover', () => {
     const project = makeTestProjectWithResourcesToDownload();
 
     // Mock a proper download
-    mockFn(optionalRequire.mockFsExtra.ensureDir).mockImplementation(
-      async () => {}
-    );
-    mockFn(optionalRequire.mockFsExtra.existsSync).mockImplementation(
-      () => false
-    );
-    mockFn(optionalRequire.mockElectron.ipcRenderer.invoke).mockImplementation(
-      () => Promise.resolve()
-    );
+    mockFn(optionalRequire.mockFsExtra.ensureDir).mockResolvedValue({});
+    mockFn(optionalRequire.mockFsExtra.existsSync).mockReturnValue(false);
+    mockFn(optionalRequire.mockElectron.ipcRenderer.invoke).mockResolvedValue();
 
     const options = makeMoveAllProjectResourcesOptions(project);
     const fetchedResources = await moveUrlResourcesToLocalFiles(options);
@@ -78,8 +88,22 @@ describe('LocalResourceMover', () => {
       optionalRequire.mockElectron.ipcRenderer.invoke
     ).toHaveBeenCalledWith(
       'local-file-download',
-      'http://example/file-to-download.png',
+      classicUrl,
       path.join('assets', 'file-to-download.png')
+    );
+    expect(
+      optionalRequire.mockElectron.ipcRenderer.invoke
+    ).toHaveBeenCalledWith(
+      'local-file-download',
+      productAuthorizedUrl,
+      path.join('assets', 'stars_levels (3).png')
+    );
+    expect(
+      optionalRequire.mockElectron.ipcRenderer.invoke
+    ).toHaveBeenCalledWith(
+      'local-file-download',
+      publicResourceUrl,
+      path.join('assets', 'Imp_Run_2.png')
     );
     expect(fetchedResources.erroredResources).toEqual([]);
   });
@@ -87,33 +111,48 @@ describe('LocalResourceMover', () => {
   it('reports errors in case of download failure', async () => {
     const project = makeTestProjectWithResourcesToDownload();
 
-    // Mock a failed download
-    mockFn(optionalRequire.mockFsExtra.ensureDir).mockImplementation(
-      async () => {}
-    );
-    mockFn(optionalRequire.mockFsExtra.existsSync).mockImplementation(
-      () => false
-    );
-    mockFn(optionalRequire.mockElectron.ipcRenderer.invoke).mockImplementation(
-      () => Promise.reject(new Error('Fake download failure'))
+    mockFn(optionalRequire.mockFsExtra.ensureDir).mockResolvedValue({});
+    mockFn(optionalRequire.mockFsExtra.existsSync).mockReturnValue(false);
+    // Mock failed download twice for first file
+    mockFn(optionalRequire.mockElectron.ipcRenderer.invoke).mockRejectedValue(
+      new Error('Fake download failure')
     );
 
     const options = makeMoveAllProjectResourcesOptions(project);
     const fetchedResources = await moveUrlResourcesToLocalFiles(options);
 
-    // Verify that download was done and reported as failed, even after 2 tries.
+    // Verify that download was done and reported as failed, even after 2 tries for each file.
     expect(
       optionalRequire.mockElectron.ipcRenderer.invoke
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(6);
     expect(
       optionalRequire.mockElectron.ipcRenderer.invoke
     ).toHaveBeenCalledWith(
       'local-file-download',
-      'http://example/file-to-download.png',
+      classicUrl,
       path.join('assets', 'file-to-download.png')
+    );
+    expect(
+      optionalRequire.mockElectron.ipcRenderer.invoke
+    ).toHaveBeenCalledWith(
+      'local-file-download',
+      productAuthorizedUrl,
+      path.join('assets', 'stars_levels (3).png')
+    );
+    expect(
+      optionalRequire.mockElectron.ipcRenderer.invoke
+    ).toHaveBeenCalledWith(
+      'local-file-download',
+      publicResourceUrl,
+      path.join('assets', 'Imp_Run_2.png')
     );
     expect(fetchedResources.erroredResources).toEqual([
       { resourceName: 'MyResourceToDownload', error: expect.any(Error) },
+      {
+        resourceName: 'MyAuthorizedResourceToDownload',
+        error: expect.any(Error),
+      },
+      { resourceName: 'MyPublicResourceToDownload', error: expect.any(Error) },
     ]);
   });
 
@@ -121,16 +160,10 @@ describe('LocalResourceMover', () => {
     const project = makeTestProjectWithResourcesToDownload();
 
     // Mock a failed download once, then successful
-    mockFn(optionalRequire.mockFsExtra.ensureDir).mockImplementation(
-      async () => {}
-    );
-    mockFn(optionalRequire.mockFsExtra.existsSync).mockImplementation(
-      () => false
-    );
+    mockFn(optionalRequire.mockFsExtra.ensureDir).mockResolvedValue({});
+    mockFn(optionalRequire.mockFsExtra.existsSync).mockReturnValue(false);
     mockFn(optionalRequire.mockElectron.ipcRenderer.invoke)
-      .mockImplementationOnce(() =>
-        Promise.reject(new Error('Fake download failure'))
-      )
+      .mockRejectedValueOnce(new Error('Fake download failure'))
       .mockImplementationOnce(() => Promise.resolve());
 
     const options = makeMoveAllProjectResourcesOptions(project);
@@ -139,22 +172,27 @@ describe('LocalResourceMover', () => {
     // Verify that download was done.
     expect(
       optionalRequire.mockElectron.ipcRenderer.invoke
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(4);
     expect(
       optionalRequire.mockElectron.ipcRenderer.invoke
-    ).toHaveBeenNthCalledWith(
-      1,
+    ).toHaveBeenCalledWith(
       'local-file-download',
-      'http://example/file-to-download.png',
+      classicUrl,
       path.join('assets', 'file-to-download.png')
     );
     expect(
       optionalRequire.mockElectron.ipcRenderer.invoke
-    ).toHaveBeenNthCalledWith(
-      2,
+    ).toHaveBeenCalledWith(
       'local-file-download',
-      'http://example/file-to-download.png',
-      path.join('assets', 'file-to-download.png')
+      productAuthorizedUrl,
+      path.join('assets', 'stars_levels (3).png')
+    );
+    expect(
+      optionalRequire.mockElectron.ipcRenderer.invoke
+    ).toHaveBeenCalledWith(
+      'local-file-download',
+      publicResourceUrl,
+      path.join('assets', 'Imp_Run_2.png')
     );
     expect(fetchedResources.erroredResources).toEqual([]);
   });

--- a/newIDE/app/src/ProjectsStorage/ResourceMover/BrowserResourceMover.js
+++ b/newIDE/app/src/ProjectsStorage/ResourceMover/BrowserResourceMover.js
@@ -11,20 +11,8 @@ import UrlStorageProvider from '../UrlStorageProvider';
 import DownloadFileStorageProvider from '../DownloadFileStorageProvider';
 import { checkIfIsGDevelopCloudBucketUrl } from '../../Utils/CrossOrigin';
 import { moveAllCloudProjectResourcesToCloudProject } from '../CloudStorageProvider/CloudResourceMover';
+import { isBlobURL, isURL } from '../../ResourcesList/ResourceUtils';
 
-const isURL = (filename: string) => {
-  return (
-    filename.startsWith('http://') ||
-    filename.startsWith('https://') ||
-    filename.startsWith('ftp://') ||
-    filename.startsWith('blob:') ||
-    filename.startsWith('data:')
-  );
-};
-
-const isBlobURL = (filename: string) => {
-  return filename.startsWith('blob:');
-};
 const ensureNoCloudProjectResources = async ({
   project,
 }: MoveAllProjectResourcesOptions): Promise<MoveAllProjectResourcesResult> => {

--- a/newIDE/app/src/ProjectsStorage/UrlStorageProvider/UrlResourceFetcher.js
+++ b/newIDE/app/src/ProjectsStorage/UrlStorageProvider/UrlResourceFetcher.js
@@ -1,25 +1,8 @@
 // @flow
 import PromisePool from '@supercharge/promise-pool';
 import axios from 'axios';
+import { isFetchableUrl, isURL } from '../../ResourcesList/ResourceUtils';
 import { type FileMetadata } from '../index';
-
-const isURL = (filename: string) => {
-  return (
-    filename.startsWith('http://') ||
-    filename.startsWith('https://') ||
-    filename.startsWith('ftp://') ||
-    filename.startsWith('blob:') ||
-    filename.startsWith('data:')
-  );
-};
-
-const isFetchableUrl = (url: string) => {
-  return (
-    url.startsWith('http://') ||
-    url.startsWith('https://') ||
-    url.startsWith('ftp://')
-  );
-};
 
 type Options = {
   project: gdProject,

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -152,3 +152,25 @@ export const renameResourcesInProject = (
   project.exposeResources(resourcesRenamer);
   resourcesRenamer.delete();
 };
+
+export const isFetchableUrl = (url: string) => {
+  return (
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('ftp://')
+  );
+};
+
+export const isURL = (filename: string) => {
+  return (
+    filename.startsWith('http://') ||
+    filename.startsWith('https://') ||
+    filename.startsWith('ftp://') ||
+    filename.startsWith('blob:') ||
+    filename.startsWith('data:')
+  );
+};
+
+export const isBlobURL = (filename: string) => {
+  return filename.startsWith('blob:');
+};

--- a/newIDE/app/src/ResourcesList/ResourceUtils.spec.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.spec.js
@@ -1,6 +1,5 @@
 // @flow
 import { renameResourcesInProject } from './ResourceUtils';
-import { makeTestProject } from '../fixtures/TestProject';
 const gd: libGDevelop = global.gd;
 
 const addNewAnimationWithImageToSpriteObject = (

--- a/newIDE/app/src/Utils/GDevelopServices/ApiConfigs.js
+++ b/newIDE/app/src/Utils/GDevelopServices/ApiConfigs.js
@@ -106,3 +106,8 @@ export const GDevelopPrivateAssetsStorage = {
     ? 'https://private-assets-dev.gdevelop.io'
     : 'https://private-assets.gdevelop.io',
 };
+
+export const GDevelopPublicAssetResourcesStorageBaseUrl =
+  'https://asset-resources.gdevelop.io';
+export const GDevelopPublicAssetResourcesStorageStagingBaseUrl =
+  'https://asset-resources.gdevelop.io/staging';

--- a/newIDE/app/src/Utils/GDevelopServices/Asset.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Asset.js
@@ -343,19 +343,15 @@ const resourceFilenameRegex = new RegExp(
     GDevelopPublicAssetResourcesStorageBaseUrl
   )}|${escapeStringForRegExp(
     GDevelopPublicAssetResourcesStorageStagingBaseUrl
-  )})\\/public-resources\\/(.*)\\/([a-z0-9]{64})_(.*)(\\..*)`
+  )})\\/public-resources\\/(.*)\\/([a-z0-9]{64})_(.*)`
 );
-export const extractFilenameAndExtensionFromPublicAssetResourceUrl = (
+export const extractFilenameWithExtensionFromPublicAssetResourceUrl = (
   url: string
-): {
-  filenameWithoutExtension: string,
-  extension: string,
-} => {
+): string => {
   const matches = resourceFilenameRegex.exec(url);
   if (!matches) {
     throw new Error('The URL is not a valid public asset resource URL: ' + url);
   }
-  const filenameWithoutExtension = matches[4];
-  const extension = matches[5];
-  return { filenameWithoutExtension, extension };
+  const filenameWithExtension = matches[4];
+  return filenameWithExtension;
 };

--- a/newIDE/app/src/Utils/GDevelopServices/Asset.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Asset.js
@@ -1,9 +1,17 @@
 // @flow
 import axios from 'axios';
-import { GDevelopAssetApi, GDevelopPrivateAssetsStorage } from './ApiConfigs';
+import {
+  GDevelopAssetApi,
+  GDevelopPrivateAssetsStorage,
+  GDevelopPublicAssetResourcesStorageBaseUrl,
+  GDevelopPublicAssetResourcesStorageStagingBaseUrl,
+} from './ApiConfigs';
 import semverSatisfies from 'semver/functions/satisfies';
 import { type Filters } from './Filters';
-import { createProductAuthorizedUrl } from './Shop';
+import {
+  createProductAuthorizedUrl,
+  isProductAuthorizedResourceUrl,
+} from './Shop';
 
 export type SerializedParameterMetadata = {|
   codeOnly: boolean,
@@ -290,11 +298,7 @@ export const isPrivateAsset = (
   assetOrAssetShortHeader: AssetShortHeader | Asset
 ): boolean => {
   const imageUrl = assetOrAssetShortHeader.previewImageUrls[0];
-  return (
-    !!imageUrl &&
-    (imageUrl.startsWith('https://private-assets.gdevelop.io') ||
-      imageUrl.startsWith('https://private-assets-dev.gdevelop.io'))
-  );
+  return !!imageUrl && isProductAuthorizedResourceUrl(imageUrl);
 };
 
 export const listReceivedAssetShortHeaders = async (
@@ -327,4 +331,31 @@ export const listReceivedAssetPacks = async (
     params: { userId },
   });
   return response.data;
+};
+
+export const isPublicAssetResourceUrl = (url: string) =>
+  url.startsWith(GDevelopPublicAssetResourcesStorageBaseUrl) ||
+  url.startsWith(GDevelopPublicAssetResourcesStorageStagingBaseUrl);
+const escapeStringForRegExp = string =>
+  string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+const resourceFilenameRegex = new RegExp(
+  `(${escapeStringForRegExp(
+    GDevelopPublicAssetResourcesStorageBaseUrl
+  )}|${escapeStringForRegExp(
+    GDevelopPublicAssetResourcesStorageStagingBaseUrl
+  )})\\/public-resources\\/(.*)\\/([a-z0-9]{64})_(.*)(\\..*)`
+);
+export const extractFilenameAndExtensionFromPublicAssetResourceUrl = (
+  url: string
+): {
+  filenameWithoutExtension: string,
+  extension: string,
+} => {
+  const matches = resourceFilenameRegex.exec(url);
+  if (!matches) {
+    throw new Error('The URL is not a valid public asset resource URL: ' + url);
+  }
+  const filenameWithoutExtension = matches[4];
+  const extension = matches[5];
+  return { filenameWithoutExtension, extension };
 };

--- a/newIDE/app/src/Utils/GDevelopServices/Shop.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Shop.js
@@ -102,19 +102,12 @@ export const isProductAuthorizedResourceUrl = (url: string): boolean =>
   url.startsWith('https://private-assets.gdevelop.io/') ||
   url.startsWith('https://private-assets-dev.gdevelop.io/');
 
-export const extractFilenameAndExtensionFromProductAuthorizedUrl = (
+export const extractFilenameWithExtensionFromProductAuthorizedUrl = (
   url: string
-): {
-  filenameWithoutExtension: string,
-  extension: string,
-} => {
+): string => {
   const urlWithoutQueryParams = url.split('?')[0];
-  const extension = path.extname(urlWithoutQueryParams);
-  const filenameWithoutExtension = path.basename(
-    urlWithoutQueryParams,
-    extension
-  );
-  return { filenameWithoutExtension, extension };
+  const filenameWithExtension = path.basename(urlWithoutQueryParams);
+  return filenameWithExtension;
 };
 
 export const getStripeCheckoutUrl = async (

--- a/newIDE/app/src/Utils/GDevelopServices/Shop.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Shop.js
@@ -98,6 +98,10 @@ export const createProductAuthorizedUrl = (
     : `${url}?token=${encodeURIComponent(token)}`;
 };
 
+export const isProductAuthorizedResourceUrl = (url: string): boolean =>
+  url.startsWith('https://private-assets.gdevelop.io/') ||
+  url.startsWith('https://private-assets-dev.gdevelop.io/');
+
 export const extractFilenameAndExtensionFromProductAuthorizedUrl = (
   url: string
 ): {

--- a/newIDE/app/src/Utils/GDevelopServices/Shop.spec.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Shop.spec.js
@@ -1,27 +1,21 @@
 // @flow
-import { extractFilenameAndExtensionFromProductAuthorizedUrl } from './Shop';
+import { extractFilenameWithExtensionFromProductAuthorizedUrl } from './Shop';
 
 describe('Shop service', () => {
   describe('extractFilenameAndExtensionFromProductAuthorizedUrl', () => {
     it('works if file has an extension', () => {
       expect(
-        extractFilenameAndExtensionFromProductAuthorizedUrl(
+        extractFilenameWithExtensionFromProductAuthorizedUrl(
           'https://private-assets.gdevelop.io/a9fe5bce-de39-4147-a669-93fc5cd69632/file-to-download.png?token=1234567890'
         )
-      ).toStrictEqual({
-        filenameWithoutExtension: 'file-to-download',
-        extension: '.png',
-      });
+      ).toStrictEqual('file-to-download.png');
     });
     it('works if file has no extension', () => {
       expect(
-        extractFilenameAndExtensionFromProductAuthorizedUrl(
+        extractFilenameWithExtensionFromProductAuthorizedUrl(
           'https://private-assets.gdevelop.io/a9fe5bce-de39-4147-a669-93fc5cd69632/file-to-download?token=1234567890'
         )
-      ).toStrictEqual({
-        filenameWithoutExtension: 'file-to-download',
-        extension: '',
-      });
+      ).toStrictEqual('file-to-download');
     });
   });
 });


### PR DESCRIPTION
The main goal is to allow easy modification of existing public assets, without impacting projects that may be using them.

The strategy picked is to add a unique id to the files, corresponding the sha of the file (thus, when it changes, the file changes without affecting the existing one)

This PR is to handle those new file formats.