### PR TITLE
Translate event-based extension categories

### DIFF
--- a/newIDE/app/src/AssetStore/NewObjectDialog.js
+++ b/newIDE/app/src/AssetStore/NewObjectDialog.js
@@ -1,5 +1,7 @@
 // @flow
 import { t, Trans } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+import { type I18n as I18nType } from '@lingui/core';
 import * as React from 'react';
 import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
@@ -38,6 +40,7 @@ import Window from '../Utils/Window';
 import PrivateAssetsAuthorizationContext from './PrivateAssets/PrivateAssetsAuthorizationContext';
 import { isPrivateAsset } from '../Utils/GDevelopServices/Asset';
 import useAlertDialog from '../UI/Alert/useAlertDialog';
+import { translateExtensionCategory } from '../Utils/Extension/ExtensionCategories';
 const isDev = Window.isDev();
 
 const ObjectListItem = ({
@@ -82,6 +85,7 @@ type Props = {|
   onCreateNewObject: (type: string) => void,
   onObjectAddedFromAsset: gdObject => void,
   canInstallPrivateAsset: () => boolean,
+  i18n: I18nType,
 |};
 
 export default function NewObjectDialog({
@@ -96,6 +100,7 @@ export default function NewObjectDialog({
   onCreateNewObject,
   onObjectAddedFromAsset,
   canInstallPrivateAsset,
+  i18n,
 }: Props) {
   const {
     setNewObjectDialogDefaultTab,
@@ -113,7 +118,10 @@ export default function NewObjectDialog({
     () => {
       const objectsByCategory = {};
       allObjectMetadata.forEach(objectMetadata => {
-        const category = objectMetadata.categoryFullName;
+        const category = translateExtensionCategory(
+          objectMetadata.categoryFullName,
+          i18n
+        );
         objectsByCategory[category] = [
           ...(objectsByCategory[category] || []),
           objectMetadata,
@@ -121,7 +129,7 @@ export default function NewObjectDialog({
       });
       return objectsByCategory;
     },
-    [allObjectMetadata]
+    [allObjectMetadata, i18n]
   );
 
   React.useEffect(() => setNewObjectDialogDefaultTab(currentTab), [

--- a/newIDE/app/src/AssetStore/NewObjectDialog.js
+++ b/newIDE/app/src/AssetStore/NewObjectDialog.js
@@ -1,6 +1,5 @@
 // @flow
 import { t, Trans } from '@lingui/macro';
-import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 import * as React from 'react';
 import Dialog from '../UI/Dialog';

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
@@ -202,54 +202,67 @@ export const ExtensionOptionsEditor = ({
               eventsFunctionsExtension.setCategory(category);
               forceUpdate();
             }}
+            // TODO Sort by translated value.
             dataSource={[
               {
                 text: '',
                 value: 'General',
+                translatableValue: 'General',
               },
               {
                 text: 'Ads',
                 value: 'Ads',
+                translatableValue: 'Ads',
               },
               {
                 text: 'Visual effect',
                 value: 'Visual effect',
+                translatableValue: 'Visual effect',
               },
               {
                 text: 'Audio',
                 value: 'Audio',
+                translatableValue: 'Audio',
               },
               {
                 text: 'Advanced',
                 value: 'Advanced',
+                translatableValue: 'Advanced',
               },
               {
                 text: 'Camera',
                 value: 'Camera',
+                translatableValue: 'Camera',
               },
               {
                 text: 'Input',
                 value: 'Input',
+                translatableValue: 'Input',
               },
               {
                 text: 'Game mechanic',
                 value: 'Game mechanic',
+                translatableValue: 'Game mechanic',
               },
               {
                 text: 'Movement',
                 value: 'Movement',
+                translatableValue: 'Movement',
               },
               {
                 text: 'Network',
                 value: 'Network',
+                translatableValue: 'Network',
               },
               {
                 text: 'Third-party',
                 value: 'Third-party',
+                translatableValue: 'Third-party',
               },
               {
                 text: 'User interface',
                 value: 'User interface',
+                translatableValue: 'User interface',
               },
             ]}
           />

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -94,11 +94,12 @@ export const declareObjectMetadata = (
       eventsBasedObject.getDescription(),
       getExtensionIconUrl(extension)
     )
-    // TODO Set untranslated categories and make the UI translated them.
-    // TODO Update every built-in extension accordingly.
-    // The category metadata should not be translated as it's an identifier.
-    // The translation should be done by the UI when categories are shown.
-    .setCategoryFullName(i18n._('User interface'));
+    // TODO Change the metadata model to only set a category on the extension.
+    // If an extension has behavior or object across several categories,
+    // we can assume it's not scoped correctly.
+    // Note: We shouldn't rely on gdPlatformExtension but this line will
+    // be removed soon.
+    .setCategoryFullName(extension.getCategory());
 
   // TODO EBO Use full type to identify object to avoid collision.
   // Objects are identified by their name alone.

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -87,12 +87,18 @@ export const declareObjectMetadata = (
   extension: gdPlatformExtension,
   eventsBasedObject: gdEventsBasedObject
 ): gdObjectMetadata => {
-  const objectMetadata = extension.addEventsBasedObject(
-    eventsBasedObject.getName(),
-    eventsBasedObject.getFullName() || eventsBasedObject.getName(),
-    eventsBasedObject.getDescription(),
-    getExtensionIconUrl(extension)
-  );
+  const objectMetadata = extension
+    .addEventsBasedObject(
+      eventsBasedObject.getName(),
+      eventsBasedObject.getFullName() || eventsBasedObject.getName(),
+      eventsBasedObject.getDescription(),
+      getExtensionIconUrl(extension)
+    )
+    // TODO Set untranslated categories and make the UI translated them.
+    // TODO Update every built-in extension accordingly.
+    // The category metadata should not be translated as it's an identifier.
+    // The translation should be done by the UI when categories are shown.
+    .setCategoryFullName(i18n._('User interface'));
 
   // TODO EBO Use full type to identify object to avoid collision.
   // Objects are identified by their name alone.
@@ -1053,7 +1059,7 @@ export const declareObjectPropertiesInstructionAndExpressions = (
           gd.EventsBasedObject.getPropertyActionName(propertyName),
           propertyLabel,
           i18n._(t`Update the value of ${propertyLabel}`),
-          i18n._(t`Set property ${propertyName} of _PARAM0_ to _PARAM2_`),
+          i18n._(t`Set property ${propertyName} of _PARAM0_ to _PARAM1_`),
           eventsBasedObject.getFullName() || eventsBasedObject.getName(),
           getExtensionIconUrl(extension),
           getExtensionIconUrl(extension)
@@ -1083,7 +1089,7 @@ export const declareObjectPropertiesInstructionAndExpressions = (
           gd.EventsBasedObject.getPropertyActionName(propertyName),
           propertyLabel,
           i18n._(t`Update the color of ${propertyLabel}`),
-          i18n._(t`Change color ${propertyName} of _PARAM0_ to _PARAM2_`),
+          i18n._(t`Change color ${propertyName} of _PARAM0_ to _PARAM1_`),
           eventsBasedObject.getFullName() || eventsBasedObject.getName(),
           getExtensionIconUrl(extension),
           getExtensionIconUrl(extension)

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -15,8 +15,8 @@ import {
 } from '../../InstructionOrExpression/CreateTree';
 import {
   enumerateAllInstructions,
-  enumerateFreeInstructions,
   deduplicateInstructionsList,
+  enumerateFreeInstructionsWithTranslatedCategories,
 } from '../../InstructionOrExpression/EnumerateInstructions';
 import {
   type EnumeratedInstructionMetadata,
@@ -96,6 +96,7 @@ type Props = {|
   onSearchStartOrReset?: () => void,
   style?: Object,
   onClickMore?: () => void,
+  i18n: I18nType,
 |};
 
 const iconSize = 24;
@@ -120,7 +121,10 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
 
   // Free instructions, to be displayed in a tab next to the objects.
   freeInstructionsInfo: Array<EnumeratedInstructionMetadata> = filterEnumeratedInstructionOrExpressionMetadataByScope(
-    enumerateFreeInstructions(this.props.isCondition),
+    enumerateFreeInstructionsWithTranslatedCategories(
+      this.props.isCondition,
+      this.props.i18n
+    ),
     this.props.scope
   );
   freeInstructionsInfoTree: InstructionOrExpressionTreeNode = createTree(
@@ -136,9 +140,12 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
   groupSearchApi = null;
   tagSearchApi = null;
 
-  reEnumerateInstructions = () => {
+  reEnumerateInstructions = (i18n: I18nType) => {
     this.freeInstructionsInfo = filterEnumeratedInstructionOrExpressionMetadataByScope(
-      enumerateFreeInstructions(this.props.isCondition),
+      enumerateFreeInstructionsWithTranslatedCategories(
+        this.props.isCondition,
+        i18n
+      ),
       this.props.scope
     );
     this.freeInstructionsInfoTree = createTree(this.freeInstructionsInfo);

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -1,5 +1,7 @@
 // @flow
 import { Trans } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
 import Dialog, { DialogPrimaryButton } from '../../UI/Dialog';
@@ -194,10 +196,10 @@ export default function NewInstructionEditorDialog({
     chooseObject(chosenObject.getName());
   };
 
-  const onExtensionInstalled = () => {
+  const onExtensionInstalled = (i18n: I18nType) => {
     setNewExtensionDialogOpen(false);
     freeInstructionComponentRef.current &&
-      freeInstructionComponentRef.current.reEnumerateInstructions();
+      freeInstructionComponentRef.current.reEnumerateInstructions(i18n);
   };
 
   // Focus the parameters when showing them
@@ -225,31 +227,38 @@ export default function NewInstructionEditorDialog({
     : undefined;
 
   const renderInstructionOrObjectSelector = () => (
-    <InstructionOrObjectSelector
-      key="instruction-or-object-selector"
-      style={styles.fullHeightSelector}
-      project={project}
-      scope={scope}
-      ref={freeInstructionComponentRef}
-      currentTab={currentInstructionOrObjectSelectorTab}
-      onChangeTab={setCurrentInstructionOrObjectSelectorTab}
-      globalObjectsContainer={globalObjectsContainer}
-      objectsContainer={objectsContainer}
-      isCondition={isCondition}
-      chosenInstructionType={!chosenObjectName ? instructionType : undefined}
-      onChooseInstruction={(instructionType: string) => {
-        chooseInstruction(instructionType);
-        setStep('parameters');
-      }}
-      chosenObjectName={chosenObjectName}
-      onChooseObject={(chosenObjectName: string) => {
-        chooseObject(chosenObjectName);
-        setStep('object-instructions');
-      }}
-      focusOnMount={!instructionType}
-      onSearchStartOrReset={forceUpdate}
-      onClickMore={() => setNewExtensionDialogOpen(true)}
-    />
+    <I18n>
+      {({ i18n }) => (
+        <InstructionOrObjectSelector
+          key="instruction-or-object-selector"
+          style={styles.fullHeightSelector}
+          project={project}
+          scope={scope}
+          ref={freeInstructionComponentRef}
+          currentTab={currentInstructionOrObjectSelectorTab}
+          onChangeTab={setCurrentInstructionOrObjectSelectorTab}
+          globalObjectsContainer={globalObjectsContainer}
+          objectsContainer={objectsContainer}
+          isCondition={isCondition}
+          chosenInstructionType={
+            !chosenObjectName ? instructionType : undefined
+          }
+          onChooseInstruction={(instructionType: string) => {
+            chooseInstruction(instructionType);
+            setStep('parameters');
+          }}
+          chosenObjectName={chosenObjectName}
+          onChooseObject={(chosenObjectName: string) => {
+            chooseObject(chosenObjectName);
+            setStep('object-instructions');
+          }}
+          focusOnMount={!instructionType}
+          onSearchStartOrReset={forceUpdate}
+          onClickMore={() => setNewExtensionDialogOpen(true)}
+          i18n={i18n}
+        />
+      )}
+    </I18n>
   );
 
   const renderParameters = () => (
@@ -399,12 +408,16 @@ export default function NewInstructionEditorDialog({
         />
       )}
       {newExtensionDialogOpen && (
-        <ExtensionsSearchDialog
-          project={project}
-          onClose={() => setNewExtensionDialogOpen(false)}
-          onInstallExtension={() => {}}
-          onExtensionInstalled={onExtensionInstalled}
-        />
+        <I18n>
+          {({ i18n }) => (
+            <ExtensionsSearchDialog
+              project={project}
+              onClose={() => setNewExtensionDialogOpen(false)}
+              onInstallExtension={() => {}}
+              onExtensionInstalled={() => onExtensionInstalled(i18n)}
+            />
+          )}
+        </I18n>
       )}
     </>
   );

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorMenu.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorMenu.js
@@ -1,5 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
+import { I18n } from '@lingui/react';
 import Popover from '@material-ui/core/Popover';
 import * as React from 'react';
 import {
@@ -138,31 +139,38 @@ export default function NewInstructionEditorMenu({
   };
 
   const renderInstructionOrObjectSelector = () => (
-    <InstructionOrObjectSelector
-      key="instruction-or-object-selector"
-      style={styles.fullHeightSelector}
-      project={project}
-      scope={scope}
-      currentTab={currentInstructionOrObjectSelectorTab}
-      onChangeTab={setCurrentInstructionOrObjectSelectorTab}
-      globalObjectsContainer={globalObjectsContainer}
-      objectsContainer={objectsContainer}
-      isCondition={isCondition}
-      chosenInstructionType={!chosenObjectName ? instructionType : undefined}
-      onChooseInstruction={(instructionType: string) => {
-        const { instruction, chosenObjectName } = chooseInstruction(
-          instructionType
-        );
-        submitInstruction({ instruction, chosenObjectName });
-      }}
-      chosenObjectName={chosenObjectName}
-      onChooseObject={chosenObjectName => {
-        chooseObject(chosenObjectName);
-        setStep('object-instructions');
-      }}
-      focusOnMount={!instructionType}
-      onSearchStartOrReset={forceUpdate}
-    />
+    <I18n>
+      {({ i18n }) => (
+        <InstructionOrObjectSelector
+          key="instruction-or-object-selector"
+          style={styles.fullHeightSelector}
+          project={project}
+          scope={scope}
+          currentTab={currentInstructionOrObjectSelectorTab}
+          onChangeTab={setCurrentInstructionOrObjectSelectorTab}
+          globalObjectsContainer={globalObjectsContainer}
+          objectsContainer={objectsContainer}
+          isCondition={isCondition}
+          chosenInstructionType={
+            !chosenObjectName ? instructionType : undefined
+          }
+          onChooseInstruction={(instructionType: string) => {
+            const { instruction, chosenObjectName } = chooseInstruction(
+              instructionType
+            );
+            submitInstruction({ instruction, chosenObjectName });
+          }}
+          chosenObjectName={chosenObjectName}
+          onChooseObject={chosenObjectName => {
+            chooseObject(chosenObjectName);
+            setStep('object-instructions');
+          }}
+          focusOnMount={!instructionType}
+          onSearchStartOrReset={forceUpdate}
+          i18n={i18n}
+        />
+      )}
+    </I18n>
   );
 
   const renderObjectInstructionSelector = () =>

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
@@ -1,8 +1,10 @@
 // @flow
+import { type I18n as I18nType } from '@lingui/core';
 import {
   type EnumeratedInstructionMetadata,
   type InstructionOrExpressionScope,
 } from './EnumeratedInstructionOrExpressionMetadata';
+import { translateExtensionCategory } from '../Utils/Extension/ExtensionCategories.js';
 
 const gd: libGDevelop = global.gd;
 
@@ -68,6 +70,17 @@ const freeInstructionsToRemove = {
 
 export const getExtensionPrefix = (extension: gdPlatformExtension): string => {
   return extension.getCategory() + GROUP_DELIMITER + extension.getFullName();
+};
+
+const getExtensionTranslatedPrefix = (
+  extension: gdPlatformExtension,
+  i18n: I18nType
+): string => {
+  return (
+    translateExtensionCategory(extension.getCategory(), i18n) +
+    GROUP_DELIMITER +
+    extension.getFullName()
+  );
 };
 
 /**
@@ -459,6 +472,30 @@ export const enumerateObjectAndBehaviorsInstructions = (
  */
 export const enumerateFreeInstructions = (
   isCondition: boolean
+): Array<EnumeratedInstructionMetadata> => {
+  return doEnumerateFreeInstructions(isCondition, getExtensionPrefix);
+};
+
+/**
+ * Enumerate all the instructions that are not directly tied
+ * to an object.
+ */
+export const enumerateFreeInstructionsWithTranslatedCategories = (
+  isCondition: boolean,
+  i18n: I18nType
+): Array<EnumeratedInstructionMetadata> => {
+  return doEnumerateFreeInstructions(isCondition, extension =>
+    getExtensionTranslatedPrefix(extension, i18n)
+  );
+};
+
+/**
+ * Enumerate all the instructions that are not directly tied
+ * to an object.
+ */
+const doEnumerateFreeInstructions = (
+  isCondition: boolean,
+  getExtensionPrefix: (extension: gdPlatformExtension) => string
 ): Array<EnumeratedInstructionMetadata> => {
   let allFreeInstructions = [];
 

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -813,19 +813,24 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
           placeholder={t`Search objects`}
         />
         {newObjectDialogOpen && (
-          <NewObjectDialog
-            onClose={() => setNewObjectDialogOpen(false)}
-            onCreateNewObject={addObject}
-            onObjectAddedFromAsset={onObjectAddedFromAsset}
-            project={project}
-            layout={layout}
-            objectsContainer={objectsContainer}
-            resourceSources={resourceSources}
-            onChooseResource={onChooseResource}
-            resourceExternalEditors={resourceExternalEditors}
-            onFetchNewlyAddedResources={onFetchNewlyAddedResources}
-            canInstallPrivateAsset={canInstallPrivateAsset}
-          />
+          <I18n>
+            {({ i18n }) => (
+              <NewObjectDialog
+                onClose={() => setNewObjectDialogOpen(false)}
+                onCreateNewObject={addObject}
+                onObjectAddedFromAsset={onObjectAddedFromAsset}
+                project={project}
+                layout={layout}
+                objectsContainer={objectsContainer}
+                resourceSources={resourceSources}
+                onChooseResource={onChooseResource}
+                resourceExternalEditors={resourceExternalEditors}
+                onFetchNewlyAddedResources={onFetchNewlyAddedResources}
+                canInstallPrivateAsset={canInstallPrivateAsset}
+                i18n={i18n}
+              />
+            )}
+          </I18n>
         )}
         {tagEditedObject && (
           <EditTagsDialog

--- a/newIDE/app/src/Utils/Extension/ExtensionCategories.js
+++ b/newIDE/app/src/Utils/Extension/ExtensionCategories.js
@@ -1,0 +1,37 @@
+import { t } from '@lingui/macro';
+import { type I18n as I18nType } from '@lingui/core';
+
+export const translateExtensionCategory = (
+  category: string,
+  i18n: I18nType
+) => {
+  if (!i18n) {
+    return category;
+  }
+  switch (category) {
+    case 'Ads':
+      return i18n._(t`Ads`);
+    case 'Visual effect':
+      return i18n._(t`Visual effect`);
+    case 'Audio':
+      return i18n._(t`Audio`);
+    case 'Advanced':
+      return i18n._(t`Advanced`);
+    case 'Camera':
+      return i18n._(t`Camera`);
+    case 'Input':
+      return i18n._(t`Input`);
+    case 'Game mechanic':
+      return i18n._(t`Game mechanic`);
+    case 'Movement':
+      return i18n._(t`Movement`);
+    case 'Network':
+      return i18n._(t`Network`);
+    case 'Third-party':
+      return i18n._(t`Third-party`);
+    case 'User interface':
+      return i18n._(t`User interface`);
+    default:
+      return category;
+  }
+};

--- a/newIDE/app/src/stories/componentStories/AssetStore/NewObjectDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/NewObjectDialog.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { I18n } from '@lingui/react';
 import { action } from '@storybook/addon-actions';
 
 import muiDecorator from '../../ThemeDecorator';
@@ -17,21 +18,26 @@ export default {
 
 export const Default = () => (
   <AssetStoreStateProvider>
-    <NewObjectDialog
-      project={testProject.project}
-      layout={testProject.testLayout}
-      onClose={action('onClose')}
-      onCreateNewObject={action('onCreateNewObject')}
-      onObjectAddedFromAsset={action('onObjectAddedFromAsset')}
-      objectsContainer={testProject.testLayout}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      onChooseResource={() => {
-        action('onChooseResource');
-        return Promise.reject();
-      }}
-      resourceSources={[]}
-      onFetchNewlyAddedResources={action('onFetchNewlyAddedResources')}
-      canInstallPrivateAsset={() => false}
-    />
+    <I18n>
+      {({ i18n }) => (
+        <NewObjectDialog
+          project={testProject.project}
+          layout={testProject.testLayout}
+          onClose={action('onClose')}
+          onCreateNewObject={action('onCreateNewObject')}
+          onObjectAddedFromAsset={action('onObjectAddedFromAsset')}
+          objectsContainer={testProject.testLayout}
+          resourceExternalEditors={fakeResourceExternalEditors}
+          onChooseResource={() => {
+            action('onChooseResource');
+            return Promise.reject();
+          }}
+          resourceSources={[]}
+          onFetchNewlyAddedResources={action('onFetchNewlyAddedResources')}
+          canInstallPrivateAsset={() => false}
+          i18n={i18n}
+        />
+      )}
+    </I18n>
   </AssetStoreStateProvider>
 );

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -2359,24 +2359,29 @@ storiesOf('InstructionOrObjectSelector', module)
     <ValueStateHolder
       initialValue={'free-instructions'}
       render={(value, onChange) => (
-        <FixedHeightFlexContainer height={400}>
-          <InstructionOrObjectSelector
-            style={{ flex: 1, display: 'flex', flexDirection: 'column' }} // TODO
-            project={testProject.project}
-            scope={{ layout: testProject.testLayout }}
-            currentTab={value}
-            onChangeTab={onChange}
-            globalObjectsContainer={testProject.project}
-            objectsContainer={testProject.testLayout}
-            isCondition
-            chosenInstructionType={'KeyPressed'}
-            onChooseInstruction={action('instruction chosen')}
-            chosenObjectName={null}
-            onChooseObject={action('choose object')}
-            focusOnMount
-            onClickMore={action('See new behaviors')}
-          />
-        </FixedHeightFlexContainer>
+        <I18n>
+          {({ i18n }) => (
+            <FixedHeightFlexContainer height={400}>
+              <InstructionOrObjectSelector
+                style={{ flex: 1, display: 'flex', flexDirection: 'column' }} // TODO
+                project={testProject.project}
+                scope={{ layout: testProject.testLayout }}
+                currentTab={value}
+                onChangeTab={onChange}
+                globalObjectsContainer={testProject.project}
+                objectsContainer={testProject.testLayout}
+                isCondition
+                chosenInstructionType={'KeyPressed'}
+                onChooseInstruction={action('instruction chosen')}
+                chosenObjectName={null}
+                onChooseObject={action('choose object')}
+                focusOnMount
+                onClickMore={action('See new behaviors')}
+                i18n={i18n}
+              />
+            </FixedHeightFlexContainer>
+          )}
+        </I18n>
       )}
     />
   ))
@@ -2384,24 +2389,29 @@ storiesOf('InstructionOrObjectSelector', module)
     <ValueStateHolder
       initialValue={'objects'}
       render={(value, onChange) => (
-        <FixedHeightFlexContainer height={400}>
-          <InstructionOrObjectSelector
-            style={{ flex: 1, display: 'flex', flexDirection: 'column' }} // TODO
-            project={testProject.project}
-            scope={{ layout: testProject.testLayout }}
-            currentTab={value}
-            onChangeTab={onChange}
-            globalObjectsContainer={testProject.project}
-            objectsContainer={testProject.testLayout}
-            isCondition
-            chosenInstructionType={''}
-            onChooseInstruction={action('instruction chosen')}
-            chosenObjectName={'MySpriteObject'}
-            onChooseObject={action('choose object')}
-            focusOnMount
-            onClickMore={action('See new behaviors')}
-          />
-        </FixedHeightFlexContainer>
+        <I18n>
+          {({ i18n }) => (
+            <FixedHeightFlexContainer height={400}>
+              <InstructionOrObjectSelector
+                style={{ flex: 1, display: 'flex', flexDirection: 'column' }} // TODO
+                project={testProject.project}
+                scope={{ layout: testProject.testLayout }}
+                currentTab={value}
+                onChangeTab={onChange}
+                globalObjectsContainer={testProject.project}
+                objectsContainer={testProject.testLayout}
+                isCondition
+                chosenInstructionType={''}
+                onChooseInstruction={action('instruction chosen')}
+                chosenObjectName={'MySpriteObject'}
+                onChooseObject={action('choose object')}
+                focusOnMount
+                onClickMore={action('See new behaviors')}
+                i18n={i18n}
+              />
+            </FixedHeightFlexContainer>
+          )}
+        </I18n>
       )}
     />
   ));


### PR DESCRIPTION
It fixes:
- EBO categories are now translated
- Expression and instruction categories are now translated.
- It also fix a parameter index in boolean and color property instruction sentences for EBO.

## Expressions
![image](https://user-images.githubusercontent.com/2611977/199050204-c74f508e-82f3-47fb-8a43-8f2b4d8a2128.png)

## Instructions
![image](https://user-images.githubusercontent.com/2611977/199050382-888690ca-f9e2-41e6-be0e-3635bd9a6e5c.png)

![image](https://user-images.githubusercontent.com/2611977/199050441-2f286475-3848-44c1-aa4c-c5a218021506.png)

## Object types
![image](https://user-images.githubusercontent.com/2611977/199050515-bcaa0c95-0c9d-4354-8d81-07da3e5ee91e.png)

## Extension properties
![image](https://user-images.githubusercontent.com/2611977/199050690-cdc14221-687d-4b2a-84c6-0af6e2bd9f10.png)
