### PR TITLE
Allow private event-based behaviors.

### DIFF
--- a/Core/GDCore/Extensions/Metadata/BehaviorMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/BehaviorMetadata.h
@@ -236,7 +236,6 @@ class GD_CORE_API BehaviorMetadata {
   }
 
   const gd::String& GetName() const;
-#if defined(GD_IDE_ONLY)
   const gd::String& GetFullName() const { return fullname; }
   const gd::String& GetDefaultName() const { return defaultName; }
   const gd::String& GetDescription() const { return description; }
@@ -257,7 +256,21 @@ class GD_CORE_API BehaviorMetadata {
    * \note An empty string means the base object, so any object.
    */
   const gd::String& GetObjectType() const { return objectType; }
-#endif
+
+  /**
+   * Check if the behavior is private - it can't be used outside of its
+   * extension.
+   */
+  bool IsPrivate() const { return isPrivate; }
+
+  /**
+   * Set that the behavior is private - it can't be used outside of its
+   * extension.
+   */
+  BehaviorMetadata &SetPrivate() {
+    isPrivate = true;
+    return *this;
+  }
 
   /**
    * \brief Return the associated gd::Behavior, handling behavior contents.
@@ -315,6 +328,7 @@ class GD_CORE_API BehaviorMetadata {
   gd::String group;
   gd::String iconFilename;
   gd::String objectType;
+  bool isPrivate = false;
 
   // TODO: Nitpicking: convert these to std::unique_ptr to clarify ownership.
   std::shared_ptr<gd::Behavior> instance;

--- a/Core/GDCore/Project/EventsBasedBehavior.cpp
+++ b/Core/GDCore/Project/EventsBasedBehavior.cpp
@@ -18,12 +18,16 @@ EventsBasedBehavior::EventsBasedBehavior()
 void EventsBasedBehavior::SerializeTo(SerializerElement& element) const {
   AbstractEventsBasedEntity::SerializeTo(element);
   element.SetAttribute("objectType", objectType);
+  if (isPrivate) {
+    element.SetBoolAttribute("private", isPrivate);
+  }
 }
 
 void EventsBasedBehavior::UnserializeFrom(gd::Project& project,
                                           const SerializerElement& element) {
   AbstractEventsBasedEntity::UnserializeFrom(project, element);
   objectType = element.GetStringAttribute("objectType");
+  isPrivate = element.GetBoolAttribute("private");
 }
 
 }  // namespace gd

--- a/Core/GDCore/Project/EventsBasedBehavior.h
+++ b/Core/GDCore/Project/EventsBasedBehavior.h
@@ -73,6 +73,21 @@ class GD_CORE_API EventsBasedBehavior: public AbstractEventsBasedEntity {
     return *this;
   }
 
+  /**
+   * \brief Check if the behavior is private - it can't be used outside of its
+   * extension.
+   */
+  bool IsPrivate() { return isPrivate; }
+
+  /**
+   * \brief Set that the behavior is private - it can't be used outside of its
+   * extension.
+   */
+  EventsBasedBehavior& SetPrivate(bool _isPrivate) {
+    isPrivate = _isPrivate;
+    return *this;
+  }
+
   void SerializeTo(SerializerElement& element) const override;
 
   void UnserializeFrom(gd::Project& project,
@@ -80,6 +95,7 @@ class GD_CORE_API EventsBasedBehavior: public AbstractEventsBasedEntity {
 
  private:
   gd::String objectType;
+  bool isPrivate = false;
 };
 
 }  // namespace gd

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1579,6 +1579,9 @@ interface BehaviorMetadata {
 
     [Ref] BehaviorMetadata SetObjectType([Const] DOMString objectType);
     [Const, Ref] DOMString GetObjectType();
+    
+    boolean IsPrivate();
+    [Ref] BehaviorMetadata SetPrivate();
 
     [Ref] Behavior Get();
     BehaviorsSharedData GetSharedDataInstance();
@@ -2352,6 +2355,8 @@ interface EventsBasedBehavior {
     [Const, Ref] DOMString GetFullName();
     [Ref] EventsBasedBehavior SetObjectType([Const] DOMString fullName);
     [Const, Ref] DOMString GetObjectType();
+    [Ref] EventsBasedBehavior SetPrivate(boolean isPrivate);
+    boolean IsPrivate();
 
     [Ref] EventsFunctionsContainer GetEventsFunctions();
     [Ref] NamedPropertyDescriptorsList GetPropertyDescriptors();

--- a/GDevelop.js/types/gdbehaviormetadata.js
+++ b/GDevelop.js/types/gdbehaviormetadata.js
@@ -28,6 +28,8 @@ declare class gdBehaviorMetadata {
   addRequiredFile(resourceFile: string): gdBehaviorMetadata;
   setObjectType(objectType: string): gdBehaviorMetadata;
   getObjectType(): string;
+  isPrivate(): boolean;
+  setPrivate(): gdBehaviorMetadata;
   get(): gdBehavior;
   getSharedDataInstance(): gdBehaviorsSharedData;
   delete(): void;

--- a/GDevelop.js/types/gdeventsbasedbehavior.js
+++ b/GDevelop.js/types/gdeventsbasedbehavior.js
@@ -9,6 +9,8 @@ declare class gdEventsBasedBehavior {
   getFullName(): string;
   setObjectType(fullName: string): gdEventsBasedBehavior;
   getObjectType(): string;
+  setPrivate(isPrivate: boolean): gdEventsBasedBehavior;
+  isPrivate(): boolean;
   getEventsFunctions(): gdEventsFunctionsContainer;
   getPropertyDescriptors(): gdNamedPropertyDescriptorsList;
   serializeTo(element: gdSerializerElement): void;

--- a/newIDE/app/src/BehaviorTypeSelector/index.js
+++ b/newIDE/app/src/BehaviorTypeSelector/index.js
@@ -14,6 +14,7 @@ type Props = {|
   value: string,
   onChange: string => void,
   disabled?: boolean,
+  eventsFunctionsExtension?: gdEventsFunctionsExtension,
 |};
 type State = {|
   behaviorMetadata: Array<EnumeratedBehaviorMetadata>,
@@ -26,7 +27,8 @@ export default class BehaviorTypeSelector extends React.Component<
   state = {
     behaviorMetadata: enumerateBehaviorsMetadata(
       this.props.project.getCurrentPlatform(),
-      this.props.project
+      this.props.project,
+      this.props.eventsFunctionsExtension
     ),
   };
 

--- a/newIDE/app/src/BehaviorsEditor/EnumerateBehaviorsMetadata.js
+++ b/newIDE/app/src/BehaviorsEditor/EnumerateBehaviorsMetadata.js
@@ -31,23 +31,22 @@ export const enumerateBehaviorsMetadata = (
           behaviorType,
           behaviorMetadata: extension.getBehaviorMetadata(behaviorType),
         }))
-        .map(({ behaviorType, behaviorMetadata }) =>
-          !behaviorMetadata.isPrivate() ||
-          (eventsFunctionsExtension &&
-            extension.getName() === eventsFunctionsExtension.getName())
-            ? {
-                extension,
-                behaviorMetadata,
-                type: behaviorType,
-                defaultName: behaviorMetadata.getDefaultName(),
-                fullName: behaviorMetadata.getFullName(),
-                description: behaviorMetadata.getDescription(),
-                iconFilename: behaviorMetadata.getIconFilename(),
-                objectType: behaviorMetadata.getObjectType(),
-              }
-            : null
+        .filter(
+          ({ behaviorMetadata }) =>
+            !behaviorMetadata.isPrivate() ||
+            (eventsFunctionsExtension &&
+              extension.getName() === eventsFunctionsExtension.getName())
         )
-        .filter(Boolean);
+        .map(({ behaviorType, behaviorMetadata }) => ({
+          extension,
+          behaviorMetadata,
+          type: behaviorType,
+          defaultName: behaviorMetadata.getDefaultName(),
+          fullName: behaviorMetadata.getFullName(),
+          description: behaviorMetadata.getDescription(),
+          iconFilename: behaviorMetadata.getIconFilename(),
+          objectType: behaviorMetadata.getObjectType(),
+        }));
     })
   );
 };

--- a/newIDE/app/src/BehaviorsEditor/EnumerateBehaviorsMetadata.js
+++ b/newIDE/app/src/BehaviorsEditor/EnumerateBehaviorsMetadata.js
@@ -15,7 +15,8 @@ export type EnumeratedBehaviorMetadata = {|
 
 export const enumerateBehaviorsMetadata = (
   platform: gdPlatform,
-  project: gdProject
+  project: gdProject,
+  eventsFunctionsExtension?: gdEventsFunctionsExtension
 ): Array<EnumeratedBehaviorMetadata> => {
   const extensionsList = platform.getAllPlatformExtensions();
 
@@ -30,16 +31,23 @@ export const enumerateBehaviorsMetadata = (
           behaviorType,
           behaviorMetadata: extension.getBehaviorMetadata(behaviorType),
         }))
-        .map(({ behaviorType, behaviorMetadata }) => ({
-          extension,
-          behaviorMetadata,
-          type: behaviorType,
-          defaultName: behaviorMetadata.getDefaultName(),
-          fullName: behaviorMetadata.getFullName(),
-          description: behaviorMetadata.getDescription(),
-          iconFilename: behaviorMetadata.getIconFilename(),
-          objectType: behaviorMetadata.getObjectType(),
-        }));
+        .map(({ behaviorType, behaviorMetadata }) =>
+          !behaviorMetadata.isPrivate() ||
+          (eventsFunctionsExtension &&
+            extension.getName() === eventsFunctionsExtension.getName())
+            ? {
+                extension,
+                behaviorMetadata,
+                type: behaviorType,
+                defaultName: behaviorMetadata.getDefaultName(),
+                fullName: behaviorMetadata.getFullName(),
+                description: behaviorMetadata.getDescription(),
+                iconFilename: behaviorMetadata.getIconFilename(),
+                objectType: behaviorMetadata.getObjectType(),
+              }
+            : null
+        )
+        .filter(Boolean);
     })
   );
 };

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -82,6 +82,7 @@ const BehaviorListItem = ({
 
 type Props = {|
   project: gdProject,
+  eventsFunctionsExtension?: gdEventsFunctionsExtension,
   objectType: string,
   objectBehaviorsTypes: Array<string>,
   open: boolean,
@@ -91,6 +92,7 @@ type Props = {|
 
 export default function NewBehaviorDialog({
   project,
+  eventsFunctionsExtension,
   open,
   onClose,
   onChoose,
@@ -119,13 +121,17 @@ export default function NewBehaviorDialog({
   );
 
   const platform = project.getCurrentPlatform();
-  const behaviorMetadata: Array<EnumeratedBehaviorMetadata> = React.useMemo(
+  const behaviorsMetadata: Array<EnumeratedBehaviorMetadata> = React.useMemo(
     () => {
       return project && platform
-        ? enumerateBehaviorsMetadata(platform, project)
+        ? enumerateBehaviorsMetadata(
+            platform,
+            project,
+            eventsFunctionsExtension
+          )
         : [];
     },
-    [project, platform, extensionInstallTime] // eslint-disable-line react-hooks/exhaustive-deps
+    [project, platform, eventsFunctionsExtension, extensionInstallTime] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const shouldAutofocusSearchbar = useShouldAutofocusSearchbar();
@@ -144,7 +150,7 @@ export default function NewBehaviorDialog({
   const deprecatedBehaviorsInformation = getDeprecatedBehaviorsInformation();
 
   const filteredBehaviorMetadata = filterEnumeratedBehaviorMetadata(
-    behaviorMetadata,
+    behaviorsMetadata,
     searchText
   );
   const behaviors = filteredBehaviorMetadata.filter(

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -38,6 +38,7 @@ const gd: libGDevelop = global.gd;
 
 type Props = {|
   project: gdProject,
+  eventsFunctionsExtension?: gdEventsFunctionsExtension,
   object: gdObject,
   onUpdateBehaviorsSharedData: () => void,
   onSizeUpdated?: ?() => void,
@@ -51,7 +52,7 @@ const BehaviorsEditor = (props: Props) => {
     false
   );
 
-  const { object, project } = props;
+  const { object, project, eventsFunctionsExtension } = props;
   const allBehaviorNames = object.getAllBehaviorNames().toJSArray();
   const forceUpdate = useForceUpdate();
 
@@ -300,6 +301,7 @@ const BehaviorsEditor = (props: Props) => {
           onClose={() => setNewBehaviorDialogOpen(false)}
           onChoose={addBehavior}
           project={project}
+          eventsFunctionsExtension={eventsFunctionsExtension}
         />
       )}
     </Column>

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -27,16 +27,24 @@ import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 
 const EVENTS_BASED_BEHAVIOR_CLIPBOARD_KIND = 'Events Based Behavior';
 
+const styles = {
+  listContainer: {
+    flex: 1,
+  },
+  tooltip: { marginRight: 5, verticalAlign: 'bottom' },
+};
+
 const renderEventsBehaviorLabel = (
   eventsBasedBehavior: gdEventsBasedBehavior
 ) =>
   eventsBasedBehavior.isPrivate() ? (
     <>
-      <Tooltip title="This function won't be visible in the events editor">
-        <VisibilityOffIcon
-          fontSize="small"
-          style={{ marginRight: 5, verticalAlign: 'bottom' }}
-        />
+      <Tooltip
+        title={
+          <Trans>This behavior won't be visible in the events editor.</Trans>
+        }
+      >
+        <VisibilityOffIcon fontSize="small" style={styles.tooltip} />
       </Tooltip>
       <span title={eventsBasedBehavior.getName()}>
         {eventsBasedBehavior.getName()}
@@ -45,12 +53,6 @@ const renderEventsBehaviorLabel = (
   ) : (
     eventsBasedBehavior.getName()
   );
-
-const styles = {
-  listContainer: {
-    flex: 1,
-  },
-};
 
 type State = {|
   renamedEventsBasedBehavior: ?gdEventsBasedBehavior,

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -22,8 +22,29 @@ import {
   unserializeFromJSObject,
 } from '../Utils/Serializer';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
+import Tooltip from '@material-ui/core/Tooltip';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 
 const EVENTS_BASED_BEHAVIOR_CLIPBOARD_KIND = 'Events Based Behavior';
+
+const renderEventsBehaviorLabel = (
+  eventsBasedBehavior: gdEventsBasedBehavior
+) =>
+  eventsBasedBehavior.isPrivate() ? (
+    <>
+      <Tooltip title="This function won't be visible in the events editor">
+        <VisibilityOffIcon
+          fontSize="small"
+          style={{ marginRight: 5, verticalAlign: 'bottom' }}
+        />
+      </Tooltip>
+      <span title={eventsBasedBehavior.getName()}>
+        {eventsBasedBehavior.getName()}
+      </span>
+    </>
+  ) : (
+    eventsBasedBehavior.getName()
+  );
 
 const styles = {
   listContainer: {
@@ -161,6 +182,11 @@ export default class EventsBasedBehaviorsList extends React.Component<
     this.forceUpdateList();
   };
 
+  _togglePrivate = (eventsBasedBehavior: gdEventsBasedBehavior) => {
+    eventsBasedBehavior.setPrivate(!eventsBasedBehavior.isPrivate());
+    this.forceUpdate();
+  };
+
   forceUpdateList = () => {
     this._onEventsBasedBehaviorModified();
     if (this.sortableList) this.sortableList.forceUpdateGrid();
@@ -241,6 +267,12 @@ export default class EventsBasedBehaviorsList extends React.Component<
           }),
       },
       {
+        label: eventsBasedBehavior.isPrivate()
+          ? i18n._(t`Make public`)
+          : i18n._(t`Make private`),
+        click: () => this._togglePrivate(eventsBasedBehavior),
+      },
+      {
         type: 'separator',
       },
       {
@@ -315,6 +347,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
                     height={height}
                     onAddNewItem={this._addNewEventsBasedBehavior}
                     addNewItemLabel={<Trans>Add a new behavior</Trans>}
+                    renderItemLabel={renderEventsBehaviorLabel}
                     getItemName={getEventsBasedBehaviorName}
                     selectedItems={
                       selectedEventsBasedBehavior

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -192,7 +192,7 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
   };
 
   render() {
-    const { eventsBasedObject, project } = this.props;
+    const { eventsBasedObject, project, eventsFunctionsExtension } = this.props;
 
     // TODO EBO When adding an object, filter the object types to excludes
     // object that depend (transitively) on this object to avoid cycles.
@@ -260,6 +260,7 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 object={this.state.editedObjectWithContext.object}
                 initialTab={this.state.editedObjectInitialTab}
                 project={project}
+                eventsFunctionsExtension={eventsFunctionsExtension}
                 resourceSources={[]}
                 resourceExternalEditors={[]}
                 onChooseResource={() => Promise.resolve([])}

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -67,7 +67,7 @@ export const declareBehaviorMetadata = (
   extension: gdPlatformExtension,
   eventsBasedBehavior: gdEventsBasedBehavior
 ): gdBehaviorMetadata => {
-  return extension
+  const behaviorMetadata = extension
     .addEventsBasedBehavior(
       eventsBasedBehavior.getName(),
       eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
@@ -76,6 +76,10 @@ export const declareBehaviorMetadata = (
       getExtensionIconUrl(extension)
     )
     .setObjectType(eventsBasedBehavior.getObjectType());
+
+  if (eventsBasedBehavior.isPrivate()) behaviorMetadata.setPrivate();
+
+  return behaviorMetadata;
 };
 
 /**

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -31,6 +31,7 @@ const styles = {
   listContainer: {
     flex: 1,
   },
+  tooltip: { marginRight: 5, verticalAlign: 'bottom' },
 };
 
 export type EventsFunctionCreationParameters = {|
@@ -41,11 +42,12 @@ export type EventsFunctionCreationParameters = {|
 const renderEventsFunctionLabel = (eventsFunction: gdEventsFunction) =>
   eventsFunction.isPrivate() ? (
     <>
-      <Tooltip title="This function won't be visible in the events editor">
-        <VisibilityOffIcon
-          fontSize="small"
-          style={{ marginRight: 5, verticalAlign: 'bottom' }}
-        />
+      <Tooltip
+        title={
+          <Trans>This function won't be visible in the events editor.</Trans>
+        }
+      >
+        <VisibilityOffIcon fontSize="small" style={styles.tooltip} />
       </Tooltip>
       <span title={eventsFunction.getName()}>{eventsFunction.getName()}</span>
     </>

--- a/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/NewInstructionEditorDialog.js
@@ -391,6 +391,7 @@ export default function NewInstructionEditorDialog({
       {newBehaviorDialogOpen && chosenObject && (
         <NewBehaviorDialog
           project={project}
+          eventsFunctionsExtension={scope.eventsFunctionsExtension}
           open={newBehaviorDialogOpen}
           objectType={chosenObject.getType()}
           objectBehaviorsTypes={listObjectBehaviorsTypes(chosenObject)}

--- a/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js
@@ -57,38 +57,35 @@ export const filterEnumeratedInstructionOrExpressionMetadataByScope = <
   scope: EventsScope
 ): Array<T> => {
   return list.filter(enumeratedInstructionOrExpressionMetadata => {
-    if (!enumeratedInstructionOrExpressionMetadata.isPrivate) return true;
-
-    // The instruction or expression is marked as "private":
-    // we now compare its scope (where it was declared) and the current scope
-    // (where we are) to see if we should filter it or not.
-
     const {
       behaviorMetadata,
       extension,
     } = enumeratedInstructionOrExpressionMetadata.scope;
     const { eventsBasedBehavior, eventsFunctionsExtension } = scope;
 
-    // Show private behavior functions when editing the behavior
-    if (
-      behaviorMetadata &&
-      eventsBasedBehavior &&
-      eventsFunctionsExtension &&
-      getBehaviorFullType(
-        eventsFunctionsExtension.getName(),
-        eventsBasedBehavior.getName()
-      ) === behaviorMetadata.getName()
-    )
-      return true;
+    return (
+      (!enumeratedInstructionOrExpressionMetadata.isPrivate &&
+        (!behaviorMetadata || !behaviorMetadata.isPrivate())) ||
+      // The instruction or expression is marked as "private":
+      // we now compare its scope (where it was declared) and the current scope
+      // (where we are) to see if we should filter it or not.
 
-    // Show private non-behavior functions when editing the extension
-    if (
-      !behaviorMetadata &&
-      eventsFunctionsExtension &&
-      eventsFunctionsExtension.getName() === extension.getName()
-    )
-      return true;
-
-    return false;
+      // Show public functions of a private behavior when editing the extension.
+      (!enumeratedInstructionOrExpressionMetadata.isPrivate &&
+        eventsFunctionsExtension &&
+        eventsFunctionsExtension.getName() === extension.getName()) ||
+      // Show private behavior functions when editing the behavior
+      (behaviorMetadata &&
+        eventsBasedBehavior &&
+        eventsFunctionsExtension &&
+        getBehaviorFullType(
+          eventsFunctionsExtension.getName(),
+          eventsBasedBehavior.getName()
+        ) === behaviorMetadata.getName()) ||
+      // Show private non-behavior functions when editing the extension
+      (!behaviorMetadata &&
+        eventsFunctionsExtension &&
+        eventsFunctionsExtension.getName() === extension.getName())
+    );
   });
 };

--- a/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.js
@@ -70,10 +70,6 @@ export const filterEnumeratedInstructionOrExpressionMetadataByScope = <
       // we now compare its scope (where it was declared) and the current scope
       // (where we are) to see if we should filter it or not.
 
-      // Show public functions of a private behavior when editing the extension.
-      (!enumeratedInstructionOrExpressionMetadata.isPrivate &&
-        eventsFunctionsExtension &&
-        eventsFunctionsExtension.getName() === extension.getName()) ||
       // Show private behavior functions when editing the behavior
       (behaviorMetadata &&
         eventsBasedBehavior &&
@@ -82,10 +78,13 @@ export const filterEnumeratedInstructionOrExpressionMetadataByScope = <
           eventsFunctionsExtension.getName(),
           eventsBasedBehavior.getName()
         ) === behaviorMetadata.getName()) ||
-      // Show private non-behavior functions when editing the extension
-      (!behaviorMetadata &&
-        eventsFunctionsExtension &&
-        eventsFunctionsExtension.getName() === extension.getName())
+      // When editing the extension...
+      (eventsFunctionsExtension &&
+        eventsFunctionsExtension.getName() === extension.getName() &&
+        // ...show public functions of a private behavior
+        (!enumeratedInstructionOrExpressionMetadata.isPrivate ||
+          // ...show private non-behavior functions
+          !behaviorMetadata))
     );
   });
 };

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -56,6 +56,9 @@ type Props = {|
   onUpdateBehaviorsSharedData: () => void,
   initialTab: ?ObjectEditorTab,
 
+  // Passed down to the behaviors editor:
+  eventsFunctionsExtension?: gdEventsFunctionsExtension,
+
   // Preview:
   hotReloadPreviewButtonProps: HotReloadPreviewButtonProps,
 |};
@@ -224,6 +227,7 @@ const InnerDialog = (props: InnerDialogProps) => {
         <BehaviorsEditor
           object={props.object}
           project={props.project}
+          eventsFunctionsExtension={props.eventsFunctionsExtension}
           resourceSources={props.resourceSources}
           onChooseResource={props.onChooseResource}
           resourceExternalEditors={props.resourceExternalEditors}


### PR DESCRIPTION
This will reduce EBO maintenance cost. For instance, every button object kinds will use the same FSM as a behavior internally and when we improve the FSM, we'll only have to copy-paste the new behavior version.

I wanted to add some tests but it would need to declare an event-based behavior and generate its metadata. It seems a lot to cover a few lines. I'm not sure if it's worth the effort and I guess the person who implemented private functions though the same thing.

Manual tests can be done with this project:
- https://www.dropbox.com/s/amqaqeizwgsap0c/PrivateBehavior.zip?dl=0