### PR TITLE
Add autocompletion for choices and color property private instructions

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -711,6 +711,12 @@ const convertPropertyTypeToValueType = (propertyType: string): string => {
   }
 };
 
+const getStringifiedExtraInfo = (property: gdPropertyDescriptor) => {
+  return property.getType() === 'Choice'
+    ? JSON.stringify(property.getExtraInfo().toJSArray())
+    : '';
+};
+
 /**
  * Declare the instructions (actions/conditions) and expressions for the
  * properties of the given events based behavior.
@@ -779,7 +785,7 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
     )
       .useStandardParameters(
         convertPropertyTypeToValueType(propertyType),
-        JSON.stringify(property.getExtraInfo().toJSArray())
+        getStringifiedExtraInfo(property)
       )
       .setFunctionName(
         gd.BehaviorCodeGenerator.getBehaviorPropertySetterName(propertyName)
@@ -840,7 +846,7 @@ export const declareObjectPropertiesInstructionAndExpressions = (
     )
       .useStandardParameters(
         convertPropertyTypeToValueType(propertyType),
-        JSON.stringify(property.getExtraInfo().toJSArray())
+        getStringifiedExtraInfo(property)
       )
       .setFunctionName(
         gd.BehaviorCodeGenerator.getBehaviorPropertySetterName(propertyName)

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/MetadataDeclarationHelpers.js
@@ -692,7 +692,24 @@ export const declareObjectInstructionOrExpressionMetadata = (
 
 type gdInstructionOrExpressionMetadata =
   | gdInstructionMetadata
-  | gdExpressionMetadata;
+  | gdExpressionMetadata
+  | gdMultipleInstructionMetadata;
+
+const convertPropertyTypeToValueType = (propertyType: string): string => {
+  switch (propertyType) {
+    case 'Number':
+      return 'number';
+    case 'Boolean':
+      return 'boolean';
+    case 'Color':
+      return 'color';
+    case 'Choice':
+      return 'stringWithSelector';
+    case 'String':
+    default:
+      return 'string';
+  }
+};
 
 /**
  * Declare the instructions (actions/conditions) and expressions for the
@@ -739,176 +756,37 @@ export const declareBehaviorPropertiesInstructionAndExpressions = (
 
   mapVector(eventsBasedBehavior.getPropertyDescriptors(), property => {
     const propertyType = property.getType();
+    if (propertyType === 'Behavior') {
+      // Required behaviors don't need accessors and mutators.
+      return;
+    }
+
     const propertyName = property.getName();
-    const getterName = gd.BehaviorCodeGenerator.getBehaviorPropertyGetterName(
-      propertyName
-    );
-    const setterName = gd.BehaviorCodeGenerator.getBehaviorPropertySetterName(
-      propertyName
-    );
     const propertyLabel = i18n._(
       t`${property.getLabel() || propertyName} property`
     );
 
-    if (propertyType === 'String' || propertyType === 'Choice') {
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addStrExpression(
-          gd.EventsBasedBehavior.getPropertyExpressionName(propertyName),
-          propertyLabel,
-          propertyLabel,
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension)
-        )
+    addObjectAndBehaviorParameters(
+      behaviorMetadata.addExpressionAndConditionAndAction(
+        convertPropertyTypeToValueType(propertyType),
+        gd.EventsBasedBehavior.getPropertyExpressionName(propertyName),
+        propertyLabel,
+        i18n._(t`the value of ${propertyLabel}`),
+        i18n._(t`the value of ${propertyLabel}`),
+        eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
+        getExtensionIconUrl(extension)
       )
-        .getCodeExtraInformation()
-        .setFunctionName(getterName);
-
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedCondition(
-          gd.EventsBasedBehavior.getPropertyConditionName(propertyName),
-          propertyLabel,
-          i18n._(t`Compare the content of ${propertyLabel}`),
-          i18n._(t`the property ${propertyName}`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
+    )
+      .useStandardParameters(
+        convertPropertyTypeToValueType(propertyType),
+        JSON.stringify(property.getExtraInfo().toJSArray())
       )
-        .useStandardRelationalOperatorParameters('string')
-        .getCodeExtraInformation()
-        .setFunctionName(getterName);
-
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedAction(
-          gd.EventsBasedBehavior.getPropertyActionName(propertyName),
-          propertyLabel,
-          i18n._(t`Change the content of ${propertyLabel}`),
-          i18n._(t`the property ${propertyName}`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
+      .setFunctionName(
+        gd.BehaviorCodeGenerator.getBehaviorPropertySetterName(propertyName)
       )
-        .useStandardOperatorParameters('string')
-        .getCodeExtraInformation()
-        .setFunctionName(setterName)
-        .setManipulatedType('string')
-        .setGetter(getterName);
-    } else if (propertyType === 'Number') {
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addExpression(
-          gd.EventsBasedBehavior.getPropertyExpressionName(propertyName),
-          propertyLabel,
-          propertyLabel,
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .getCodeExtraInformation()
-        .setFunctionName(getterName);
-
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedCondition(
-          gd.EventsBasedBehavior.getPropertyConditionName(propertyName),
-          propertyLabel,
-          i18n._(t`Compare the value of ${propertyLabel}`),
-          i18n._(t`the property ${propertyName}`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .useStandardRelationalOperatorParameters('number')
-        .getCodeExtraInformation()
-        .setFunctionName(getterName);
-
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedAction(
-          gd.EventsBasedBehavior.getPropertyActionName(propertyName),
-          propertyLabel,
-          i18n._(t`Change the value of ${propertyLabel}`),
-          i18n._(t`the property ${propertyName}`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .useStandardOperatorParameters('number')
-        .getCodeExtraInformation()
-        .setFunctionName(setterName)
-        .setGetter(getterName);
-    } else if (propertyType === 'Boolean') {
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedCondition(
-          gd.EventsBasedBehavior.getPropertyConditionName(propertyName),
-          propertyLabel,
-          i18n._(t`Check the value of ${propertyLabel}`),
-          i18n._(t`Property ${propertyName} of _PARAM0_ is true`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .getCodeExtraInformation()
-        .setFunctionName(getterName);
-
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedAction(
-          gd.EventsBasedBehavior.getPropertyActionName(propertyName),
-          propertyLabel,
-          i18n._(t`Update the value of ${propertyLabel}`),
-          i18n._(t`Set property ${propertyName} of _PARAM0_ to _PARAM2_`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .addParameter('yesorno', i18n._(t`New value to set`), '', false)
-        .getCodeExtraInformation()
-        .setFunctionName(setterName);
-    } else if (propertyType === 'Color') {
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedCondition(
-          gd.EventsBasedBehavior.getPropertyConditionName(propertyName),
-          propertyLabel,
-          i18n._(t`Check the color of ${propertyLabel}`),
-          i18n._(t`Color ${propertyName}`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .useStandardRelationalOperatorParameters('string')
-        .getCodeExtraInformation()
-        .setFunctionName(getterName);
-
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addScopedAction(
-          gd.EventsBasedBehavior.getPropertyActionName(propertyName),
-          propertyLabel,
-          i18n._(t`Update the color of ${propertyLabel}`),
-          i18n._(t`Change color ${propertyName} of _PARAM0_ to _PARAM2_`),
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .addParameter('color', i18n._(t`New color to set`), '', false)
-        .getCodeExtraInformation()
-        .setFunctionName(setterName);
-
-      addObjectAndBehaviorParameters(
-        behaviorMetadata.addStrExpression(
-          gd.EventsBasedBehavior.getPropertyExpressionName(propertyName),
-          propertyLabel,
-          propertyLabel,
-          eventsBasedBehavior.getFullName() || eventsBasedBehavior.getName(),
-          getExtensionIconUrl(extension)
-        )
-      )
-        .getCodeExtraInformation()
-        .setFunctionName(getterName);
-    }
+      .setGetter(
+        gd.BehaviorCodeGenerator.getBehaviorPropertyGetterName(propertyName)
+      );
   });
 };
 
@@ -941,6 +819,36 @@ export const declareObjectPropertiesInstructionAndExpressions = (
 
     return instructionOrExpression;
   };
+
+  mapVector(eventsBasedObject.getPropertyDescriptors(), property => {
+    const propertyType = property.getType();
+    const propertyName = property.getName();
+    const propertyLabel = i18n._(
+      t`${property.getLabel() || propertyName} property`
+    );
+
+    addObjectParameter(
+      objectMetadata.addExpressionAndConditionAndAction(
+        convertPropertyTypeToValueType(propertyType),
+        gd.EventsBasedObject.getPropertyExpressionName(propertyName),
+        propertyLabel,
+        i18n._(t`the value of ${propertyLabel}`),
+        i18n._(t`the value of ${propertyLabel}`),
+        eventsBasedObject.getFullName() || eventsBasedObject.getName(),
+        getExtensionIconUrl(extension)
+      )
+    )
+      .useStandardParameters(
+        convertPropertyTypeToValueType(propertyType),
+        JSON.stringify(property.getExtraInfo().toJSArray())
+      )
+      .setFunctionName(
+        gd.BehaviorCodeGenerator.getBehaviorPropertySetterName(propertyName)
+      )
+      .setGetter(
+        gd.BehaviorCodeGenerator.getBehaviorPropertyGetterName(propertyName)
+      );
+  });
 
   mapVector(eventsBasedObject.getPropertyDescriptors(), property => {
     const propertyType = property.getType();


### PR DESCRIPTION
It uses addExpressionAndConditionAndAction to declare properties instructions. It will be easier to add new property types.

Manually tested for every property type for behavior and object with this project
- https://www.dropbox.com/s/rs5aa0w5d4ts4s2/ExpressionAndConditionTest.zip?dl=1

![image](https://user-images.githubusercontent.com/2611977/199754435-8c389cb8-3548-43c1-855c-2f2704bb10e8.png)
