### PR TITLE
Fix: parameter default value changes were not saved.

### DIFF
--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.cpp
@@ -15,9 +15,12 @@ ParameterMetadata::ParameterMetadata() : codeOnly(false) {}
 void ParameterMetadata::SerializeTo(SerializerElement& element) const {
   valueTypeMetadata.SerializeTo(element);
   element.SetAttribute("description", description);
-  element.SetAttribute("longDescription", longDescription);
-  element.SetAttribute("codeOnly", codeOnly);
-  element.SetAttribute("defaultValue", defaultValue);
+  if (!longDescription.empty()) {
+    element.SetAttribute("longDescription", longDescription);
+  }
+  if (codeOnly) {
+   element.SetAttribute("codeOnly", codeOnly);
+  }
   element.SetAttribute("name", name);
 }
 
@@ -26,7 +29,6 @@ void ParameterMetadata::UnserializeFrom(const SerializerElement& element) {
   description = element.GetStringAttribute("description");
   longDescription = element.GetStringAttribute("longDescription");
   codeOnly = element.GetBoolAttribute("codeOnly");
-  defaultValue = element.GetStringAttribute("defaultValue");
   name = element.GetStringAttribute("name");
 }
 

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
@@ -144,13 +144,15 @@ class GD_CORE_API ParameterMetadata {
   /**
    * \brief Get the default value for the parameter.
    */
-  const gd::String &GetDefaultValue() const { return defaultValue; }
+  const gd::String &GetDefaultValue() const {
+    return valueTypeMetadata.GetDefaultValue();
+  }
 
   /**
    * \brief Set the default value, if the parameter is optional.
    */
   ParameterMetadata &SetDefaultValue(const gd::String &defaultValue_) {
-    defaultValue = defaultValue_;
+    valueTypeMetadata.SetDefaultValue(defaultValue_);
     return *this;
   }
 
@@ -236,8 +238,6 @@ class GD_CORE_API ParameterMetadata {
  private:
   gd::ValueTypeMetadata valueTypeMetadata; ///< Parameter type
   gd::String longDescription;  ///< Long description shown in the editor.
-  gd::String defaultValue;     ///< Used as a default value in editor or if an
-                               ///< optional parameter is empty.
   gd::String name;             ///< The name of the parameter to be used in code
                                ///< generation. Optional.
 };

--- a/Core/GDCore/Project/EventsFunction.cpp
+++ b/Core/GDCore/Project/EventsFunction.cpp
@@ -59,11 +59,19 @@ const std::vector<gd::ParameterMetadata>& EventsFunction::GetParametersForEvents
 void EventsFunction::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("name", name);
   element.SetAttribute("fullName", fullName);
-  element.SetAttribute("description", description);
+  if (!description.empty()) {
+    element.SetAttribute("description", description);
+  }
   element.SetAttribute("sentence", sentence);
-  element.SetAttribute("group", group);
-  element.SetAttribute("getterName", getterName);
-  element.SetBoolAttribute("private", isPrivate);
+  if (!group.empty()) {
+    element.SetAttribute("group", group);
+  }
+  if (!getterName.empty()) {
+    element.SetAttribute("getterName", getterName);
+  }
+  if (isPrivate) {
+    element.SetBoolAttribute("private", isPrivate);
+  }
   events.SerializeTo(element.AddChild("events"));
 
   gd::String functionTypeStr = "Action";


### PR DESCRIPTION
This is a regression introduced with:
- https://github.com/4ian/GDevelop/pull/3909

It also avoid to serialize some optional attributes when they are empty to make extensions with a lot of properties a bit lighter.