### PR TITLE
Add possibility to use markdown for asset descriptions

### DIFF
--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -35,6 +35,7 @@ import { BoxSearchResults } from '../UI/Search/BoxSearchResults';
 import Link from '../UI/Link';
 import PrivateAssetsAuthorizationContext from './PrivateAssets/PrivateAssetsAuthorizationContext';
 import AuthorizedAssetImage from './PrivateAssets/AuthorizedAssetImage';
+import { MarkdownText } from '../UI/MarkdownText';
 
 const FIXED_HEIGHT = 250;
 const FIXED_WIDTH = 300;
@@ -410,7 +411,9 @@ export const AssetDetails = ({
                     </Trans>
                   )}
                 </Text>
-                <Text size="body">{asset.description}</Text>
+                <Text size="body" displayInlineAsSpan>
+                  <MarkdownText source={asset.description} />
+                </Text>
               </React.Fragment>
             ) : error ? (
               <PlaceholderError onRetry={loadAsset}>

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -412,7 +412,7 @@ export const AssetDetails = ({
                   )}
                 </Text>
                 <Text size="body" displayInlineAsSpan>
-                  <MarkdownText source={asset.description} />
+                  <MarkdownText source={asset.description} allowParagraphs />
                 </Text>
               </React.Fragment>
             ) : error ? (

--- a/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackInformationDialog.js
+++ b/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackInformationDialog.js
@@ -13,11 +13,7 @@ import PriceTag, { formatPrice } from '../../UI/PriceTag';
 import FlatButton from '../../UI/FlatButton';
 import AlertMessage from '../../UI/AlertMessage';
 import PlaceholderLoader from '../../UI/PlaceholderLoader';
-import {
-  ColumnStackLayout,
-  ResponsiveLineStackLayout,
-  LineStackLayout,
-} from '../../UI/Layout';
+import { ResponsiveLineStackLayout, LineStackLayout } from '../../UI/Layout';
 import { Column, Line } from '../../UI/Grid';
 import {
   getUserPublicProfile,
@@ -32,6 +28,7 @@ import ResponsiveImagesGallery from '../../UI/ResponsiveImagesGallery';
 import { useResponsiveWindowWidth } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
 import RaisedButton from '../../UI/RaisedButton';
 import { sendAssetPackBuyClicked } from '../../Utils/Analytics/EventSender';
+import { MarkdownText } from '../../UI/MarkdownText';
 
 const sortedContentType = [
   'sprite',
@@ -208,7 +205,7 @@ const PrivateAssetPackDialog = ({
                       variant="outlined"
                       style={{ padding: windowWidth === 'small' ? 20 : 30 }}
                     >
-                      <ColumnStackLayout noMargin useLargeSpacer>
+                      <Column noMargin>
                         <Line
                           noMargin
                           expand
@@ -218,7 +215,9 @@ const PrivateAssetPackDialog = ({
                           <PriceTag value={prices[0].value} />
                           {getBuyButton(i18n)}
                         </Line>
-                        <Text noMargin>{assetPack.longDescription}</Text>
+                        <Text size="body2" displayInlineAsSpan>
+                          <MarkdownText source={assetPack.longDescription} />
+                        </Text>
                         <ResponsiveLineStackLayout noMargin noColumnMargin>
                           <Column noMargin expand>
                             <Text size="sub-title">
@@ -277,7 +276,7 @@ const PrivateAssetPackDialog = ({
                             </LineStackLayout>
                           </Column>
                         </ResponsiveLineStackLayout>
-                      </ColumnStackLayout>
+                      </Column>
                     </Paper>
                   </Column>
                 </ResponsiveLineStackLayout>

--- a/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackInformationDialog.js
+++ b/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackInformationDialog.js
@@ -216,7 +216,10 @@ const PrivateAssetPackDialog = ({
                           {getBuyButton(i18n)}
                         </Line>
                         <Text size="body2" displayInlineAsSpan>
-                          <MarkdownText source={assetPack.longDescription} />
+                          <MarkdownText
+                            source={assetPack.longDescription}
+                            allowParagraphs
+                          />
                         </Text>
                         <ResponsiveLineStackLayout noMargin noColumnMargin>
                           <Column noMargin expand>

--- a/newIDE/app/src/UI/MarkdownText.js
+++ b/newIDE/app/src/UI/MarkdownText.js
@@ -61,6 +61,7 @@ export const MarkdownText = (props: Props) => {
             'standalone-text-container': props.isStandaloneText,
           })}
           components={markdownCustomComponents}
+          linkTarget="_blank"
         >
           {props.translatableSource
             ? i18n._(props.translatableSource)

--- a/newIDE/app/src/UI/MarkdownText.js
+++ b/newIDE/app/src/UI/MarkdownText.js
@@ -61,7 +61,6 @@ export const MarkdownText = (props: Props) => {
             'standalone-text-container': props.isStandaloneText,
           })}
           components={markdownCustomComponents}
-          linkTarget="_blank"
         >
           {props.translatableSource
             ? i18n._(props.translatableSource)


### PR DESCRIPTION
In order to credit creators in asset and asset pack descriptions:

<img width="899" alt="image" src="https://user-images.githubusercontent.com/32449369/199954696-f0c47627-c367-4a32-a4b8-be7ce104873f.png">

<img width="470" alt="image" src="https://user-images.githubusercontent.com/32449369/199954824-82ab3b53-f3ac-4afb-b5ba-9d3421c1ed4f.png">
