### PR TITLE
Add conditions to compare function parameter values.

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -670,6 +670,18 @@ gd::String EventsCodeGenerator::GenerateActionsListCode(
   return outputCode;
 }
 
+const gd::String EventsCodeGenerator::GenerateRelationalOperatorCodes(const gd::String &operatorString) {
+    if (operatorString == "=") {
+        return "==";
+    }
+    if (operatorString != "<" && operatorString != ">" &&
+        operatorString != "<=" && operatorString != ">=" && operatorString != "!=") {
+      cout << "Warning: Bad relational operator: Set to == by default." << endl;
+      return "==";
+    }
+    return operatorString;
+}
+
 gd::String EventsCodeGenerator::GenerateParameterCodes(
     const gd::Expression& parameter,
     const gd::ParameterMetadata& metadata,
@@ -694,14 +706,7 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(
     argOutput =
         GenerateObject(parameter.GetPlainString(), metadata.GetType(), context);
   } else if (metadata.GetType() == "relationalOperator") {
-    auto parameterString = parameter.GetPlainString();
-    argOutput += parameterString == "=" ? "==" : parameterString;
-    if (argOutput != "==" && argOutput != "<" && argOutput != ">" &&
-        argOutput != "<=" && argOutput != ">=" && argOutput != "!=") {
-      cout << "Warning: Bad relational operator: Set to == by default." << endl;
-      argOutput = "==";
-    }
-
+    argOutput += GenerateRelationalOperatorCodes(parameter.GetPlainString());
     argOutput = "\"" + argOutput + "\"";
   } else if (metadata.GetType() == "operator") {
     argOutput += parameter.GetPlainString();

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.h
@@ -481,6 +481,9 @@ class GD_CORE_API EventsCodeGenerator {
    */
   size_t GenerateSingleUsageUniqueIdForEventsList();
 
+  virtual const gd::String GenerateRelationalOperatorCodes(
+      const gd::String& operatorString);
+
  protected:
   /**
    * \brief Generate the code for a single parameter.

--- a/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
@@ -81,7 +81,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
       .AddExpression(
           "GetArgumentAsNumber",
           _("Get function parameter value"),
-          _("Get function parameter (also called \"argument\") value"),
+          _("Get function parameter (also called \"argument\") value."),
           "",
           "res/function16.png")
       .AddParameter("functionParameterName", "Parameter name");
@@ -90,10 +90,34 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
       .AddStrExpression(
           "GetArgumentAsString",
           _("Get function parameter text"),
-          _("Get function parameter (also called \"argument\") text "),
+          _("Get function parameter (also called \"argument\") text."),
           "",
           "res/function16.png")
       .AddParameter("functionParameterName", "Parameter name");
+
+  extension
+      .AddCondition(
+          "CompareArgumentAsNumber",
+          _("Compare function parameter value"),
+          _("Compare function parameter (also called \"argument\") value."),
+          _("Parameter _PARAM0_"),
+          "",
+          "res/function32.png",
+          "res/function16.png")
+      .AddParameter("functionParameterName", "Parameter name")
+      .UseStandardRelationalOperatorParameters("number");
+
+  extension
+      .AddCondition(
+          "CompareArgumentAsString",
+          _("Compare function parameter text"),
+          _("Compare function parameter (also called \"argument\") text."),
+          _("Parameter _PARAM0_"),
+          "",
+          "res/function32.png",
+          "res/function16.png")
+      .AddParameter("functionParameterName", "Parameter name")
+      .UseStandardRelationalOperatorParameters("string");
 }
 
 }  // namespace gd

--- a/GDJS/GDJS/Extensions/Builtin/AdvancedExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/AdvancedExtension.cpp
@@ -121,6 +121,62 @@ AdvancedExtension::AdvancedExtension() {
                "eventsFunctionContext.getArgument(" +
                parameterNameCode + ") : \"\")";
       });
+
+  GetAllConditions()["CompareArgumentAsNumber"]
+      .GetCodeExtraInformation()
+      .SetCustomCodeGenerator([](gd::Instruction &instruction,
+                                 gd::EventsCodeGenerator &codeGenerator,
+                                 gd::EventsCodeGenerationContext &context) {
+        gd::String parameterNameCode =
+            gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                codeGenerator, context, "string",
+                instruction.GetParameter(0).GetPlainString());
+
+        gd::String operatorCode = codeGenerator.GenerateRelationalOperatorCodes(
+            instruction.GetParameter(1).GetPlainString());
+
+        gd::String operandCode =
+            gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                codeGenerator, context, "number",
+                instruction.GetParameter(2).GetPlainString());
+
+        gd::String resultingBoolean =
+            codeGenerator.GenerateBooleanFullName("conditionTrue", context) +
+            ".val";
+
+        return resultingBoolean + " = ((typeof eventsFunctionContext !== 'undefined' ? "
+               "Number(eventsFunctionContext.getArgument(" +
+               parameterNameCode + ")) || 0 : 0) " + operatorCode + " " +
+               operandCode + ");\n";
+      });
+
+  GetAllConditions()["CompareArgumentAsString"]
+      .GetCodeExtraInformation()
+      .SetCustomCodeGenerator([](gd::Instruction &instruction,
+                                 gd::EventsCodeGenerator &codeGenerator,
+                                 gd::EventsCodeGenerationContext &context) {
+        gd::String parameterNameCode =
+            gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                codeGenerator, context, "string",
+                instruction.GetParameter(0).GetPlainString());
+
+        gd::String operatorCode = codeGenerator.GenerateRelationalOperatorCodes(
+            instruction.GetParameter(1).GetPlainString());
+
+        gd::String operandCode =
+            gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                codeGenerator, context, "string",
+                instruction.GetParameter(2).GetPlainString());
+
+        gd::String resultingBoolean =
+            codeGenerator.GenerateBooleanFullName("conditionTrue", context) +
+            ".val";
+
+        return resultingBoolean + " = ((typeof eventsFunctionContext !== 'undefined' ? "
+               "\"\" + eventsFunctionContext.getArgument(" +
+               parameterNameCode + ") : \"\") " + operatorCode + " " +
+               operandCode + ");\n";
+      });
 }
 
-}  // namespace gdjs
+} // namespace gdjs

--- a/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -55,40 +55,24 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
                 codeGenerator,
                 context,
                 "number",
-                instruction.GetParameters()[0].GetPlainString());
+                instruction.GetParameter(0).GetPlainString());
+
+        gd::String operatorCode = codeGenerator.GenerateRelationalOperatorCodes(
+            instruction.GetParameter(1).GetPlainString());
 
         gd::String value2Code =
             gd::ExpressionCodeGenerator::GenerateExpressionCode(
                 codeGenerator,
                 context,
                 "number",
-                instruction.GetParameters()[2].GetPlainString());
+                instruction.GetParameter(2).GetPlainString());
 
         gd::String resultingBoolean =
             codeGenerator.GenerateBooleanFullName("conditionTrue", context) +
             ".val";
 
-        if (instruction.GetParameters()[1].GetPlainString() == "=" ||
-            instruction.GetParameters()[1].GetPlainString().empty())
-          return resultingBoolean + " = (" + value1Code + " == " + value2Code +
-                 ");\n";
-        else if (instruction.GetParameters()[1].GetPlainString() == ">")
-          return resultingBoolean + " = (" + value1Code + " > " + value2Code +
-                 ");\n";
-        else if (instruction.GetParameters()[1].GetPlainString() == "<")
-          return resultingBoolean + " = (" + value1Code + " < " + value2Code +
-                 ");\n";
-        else if (instruction.GetParameters()[1].GetPlainString() == "<=")
-          return resultingBoolean + " = (" + value1Code + " <= " + value2Code +
-                 ");\n";
-        else if (instruction.GetParameters()[1].GetPlainString() == ">=")
-          return resultingBoolean + " = (" + value1Code + " >= " + value2Code +
-                 ");\n";
-        else if (instruction.GetParameters()[1].GetPlainString() == "!=")
-          return resultingBoolean + " = (" + value1Code + " != " + value2Code +
-                 ");\n";
-
-        return gd::String("");
+        return resultingBoolean + " = (" + value1Code + " " + operatorCode +
+               " " + value2Code + ");\n";
       });
   GetAllConditions()["BuiltinCommonInstructions::CompareNumbers"]
       .codeExtraInformation = GetAllConditions()["Egal"].codeExtraInformation;
@@ -102,27 +86,24 @@ CommonInstructionsExtension::CommonInstructionsExtension() {
                 codeGenerator,
                 context,
                 "string",
-                instruction.GetParameters()[0].GetPlainString());
+                instruction.GetParameter(0).GetPlainString());
+
+        gd::String operatorCode = codeGenerator.GenerateRelationalOperatorCodes(
+            instruction.GetParameter(1).GetPlainString());
 
         gd::String value2Code =
             gd::ExpressionCodeGenerator::GenerateExpressionCode(
                 codeGenerator,
                 context,
                 "string",
-                instruction.GetParameters()[2].GetPlainString());
+                instruction.GetParameter(2).GetPlainString());
 
         gd::String resultingBoolean =
             codeGenerator.GenerateBooleanFullName("conditionTrue", context) +
             ".val";
 
-        if (instruction.GetParameters()[1].GetPlainString() == "=")
-          return resultingBoolean + " = (" + value1Code + " == " + value2Code +
-                 ");\n";
-        else if (instruction.GetParameters()[1].GetPlainString() == "!=")
-          return resultingBoolean + " = (" + value1Code + " != " + value2Code +
-                 ");\n";
-
-        return gd::String("");
+        return resultingBoolean + " = (" + value1Code + " " + operatorCode +
+               " " + value2Code + ");\n";
       });
   GetAllConditions()["BuiltinCommonInstructions::CompareStrings"]
       .codeExtraInformation =


### PR DESCRIPTION
Fixes https://github.com/4ian/GDevelop/issues/4465
- https://github.com/4ian/GDevelop/issues/4465

It should be more intuitive and it reduces the number of inputs a bit.

I wonder if we should also generate one condition for each parameters like we do for properties, but I'm not sure if it would be easy to implement nor very useful.

## String

![image](https://user-images.githubusercontent.com/2611977/200022089-3d18cb9a-b139-41ac-bf93-cd21050aceae.png)

````JS
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.condition0IsTrue_0.val = false;
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.condition1IsTrue_0.val = false;
{
{gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.conditionTrue_1 = gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.condition0IsTrue_0;
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.conditionTrue_1.val = ((typeof eventsFunctionContext !== 'undefined' ? "" + eventsFunctionContext.getArgument("Value") : "") == "Blue");
}
}if ( gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.condition0IsTrue_0.val ) {
{
{gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.conditionTrue_1 = gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.condition1IsTrue_0;
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.conditionTrue_1.val = ((typeof eventsFunctionContext !== 'undefined' ? "" + eventsFunctionContext.getArgument("Value") : "") == "Blue");
}
}}
if (gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetColorContext.condition1IsTrue_0.val) {
{gdjs.evtTools.debuggerTools.log("It's blue!", "", "");
}}
````

## Number

![image](https://user-images.githubusercontent.com/2611977/200022202-4b1b0efd-992f-42f2-88ec-47a3ae57c356.png)

````JS
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.condition0IsTrue_0.val = false;
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.condition1IsTrue_0.val = false;
{
{gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.conditionTrue_1 = gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.condition0IsTrue_0;
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.conditionTrue_1.val = ((typeof eventsFunctionContext !== 'undefined' ? Number(eventsFunctionContext.getArgument("Value")) || 0 : 0) < 50);
}
}if ( gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.condition0IsTrue_0.val ) {
{
{gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.conditionTrue_1 = gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.condition1IsTrue_0;
gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.conditionTrue_1.val = ((typeof eventsFunctionContext !== 'undefined' ? Number(eventsFunctionContext.getArgument("Value")) || 0 : 0) < 45);
}
}}
if (gdjs.evtsExt__NewExtension__MyBehavior2.MyBehavior2.prototype.SetDimensionContext.condition1IsTrue_0.val) {
{gdjs.evtTools.debuggerTools.log("It's low", "", "");
}}
````