### PR TITLE
Fix the color property definition editor layout.

### DIFF
--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -346,6 +346,19 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                                 disabled={false}
                               />
                             )}
+                            {property.getType() === 'Color' && (
+                              <ColorField
+                                floatingLabelText={<Trans>Default value</Trans>}
+                                disableAlpha
+                                fullWidth
+                                color={property.getValue()}
+                                onChange={color => {
+                                  property.setValue(color);
+                                  this.forceUpdate();
+                                  this.props.onPropertiesUpdated();
+                                }}
+                              />
+                            )}
                             {property.getType() === 'Choice' && (
                               <SelectField
                                 floatingLabelText={<Trans>Default value</Trans>}
@@ -373,19 +386,6 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                             <StringArrayEditor
                               extraInfo={getExtraInfoArray(property)}
                               setExtraInfo={this._setChoiceExtraInfo(property)}
-                            />
-                          )}
-                          {property.getType() === 'Color' && (
-                            <ColorField
-                              floatingLabelText={<Trans>Color</Trans>}
-                              disableAlpha
-                              fullWidth
-                              color={property.getValue()}
-                              onChange={color => {
-                                property.setValue(color);
-                                this.forceUpdate();
-                                this.props.onPropertiesUpdated();
-                              }}
                             />
                           )}
                           <ResponsiveLineStackLayout noMargin>


### PR DESCRIPTION
It avoids to have the default value on another line.

![image](https://user-images.githubusercontent.com/2611977/200303105-a815290e-b2a4-4980-ac15-9da100b8e46f.png)
