### PR TITLE
Improve ResourceSelector with file selection button and when there is only 1 external action

### DIFF
--- a/newIDE/app/src/AssetStore/NewObjectDialog.js
+++ b/newIDE/app/src/AssetStore/NewObjectDialog.js
@@ -21,7 +21,6 @@ import {
   type ChooseResourceFunction,
 } from '../ResourcesList/ResourceSource';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
-import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import {
   sendAssetAddedToProject,
   sendNewObjectCreated,
@@ -79,7 +78,6 @@ type Props = {|
   resourceSources: Array<ResourceSource>,
   onChooseResource: ChooseResourceFunction,
   onFetchNewlyAddedResources: OnFetchNewlyAddedResourcesFunction,
-  resourceExternalEditors: Array<ResourceExternalEditor>,
   onClose: () => void,
   onCreateNewObject: (type: string) => void,
   onObjectAddedFromAsset: gdObject => void,
@@ -94,7 +92,6 @@ export default function NewObjectDialog({
   resourceSources,
   onChooseResource,
   onFetchNewlyAddedResources,
-  resourceExternalEditors,
   onClose,
   onCreateNewObject,
   onObjectAddedFromAsset,

--- a/newIDE/app/src/LayersList/index.js
+++ b/newIDE/app/src/LayersList/index.js
@@ -7,11 +7,6 @@ import LayerRow, { styles } from './LayerRow';
 import BackgroundColorRow from './BackgroundColorRow';
 import { Column, Line } from '../UI/Grid';
 import Add from '@material-ui/icons/Add';
-import {
-  type ResourceSource,
-  type ChooseResourceFunction,
-} from '../ResourcesList/ResourceSource';
-import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEditor.flow';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 import ScrollView from '../UI/ScrollView';
 import { FullSizeMeasurer } from '../UI/FullSizeMeasurer';
@@ -165,9 +160,6 @@ const LayersListBody = (props: LayersListBodyProps) => {
 
 type Props = {|
   project: gdProject,
-  resourceSources: Array<ResourceSource>,
-  onChooseResource: ChooseResourceFunction,
-  resourceExternalEditors: Array<ResourceExternalEditor>,
   layersContainer: gdLayout,
   onEditLayerEffects: (layer: ?gdLayer) => void,
   onEditLayer: (layer: ?gdLayer) => void,

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/DirectionTools.js
@@ -2,6 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React, { Component } from 'react';
+import { I18n } from '@lingui/react';
 import Timer from '@material-ui/icons/Timer';
 import TextButton from '../../../UI/TextButton';
 import Checkbox from '../../../UI/Checkbox';
@@ -112,84 +113,94 @@ export default class DirectionTools extends Component<Props, State> {
       ({ kind }) => kind === 'image'
     );
 
+    const hasSprites = direction.getSpritesCount();
+
     return (
-      <div style={styles.container}>
-        <ResponsiveWindowMeasurer>
-          {windowWidth =>
-            windowWidth !== 'small' &&
-            !!imageResourceExternalEditors.length && (
-              <TextButton
-                label={imageResourceExternalEditors[0].displayName}
-                icon={<Brush />}
-                onClick={() => onEditWith(imageResourceExternalEditors[0])}
-              />
-            )
-          }
-        </ResponsiveWindowMeasurer>
-        <TextButton
-          label={<Trans>Preview</Trans>}
-          icon={<PlayArrow />}
-          onClick={() => this.openPreview(true)}
-        />
-        <Timer style={styles.timeIcon} />
-        <TextField
-          value={this.state.timeBetweenFrames}
-          onChange={(e, text) =>
-            this.setState({ timeBetweenFrames: parseFloat(text) || 0 })
-          }
-          onBlur={() => this.saveTimeBetweenFrames()}
-          id="direction-time-between-frames"
-          margin="none"
-          style={styles.timeField}
-          type="number"
-          step={0.005}
-          precision={2}
-          min={0.01}
-          max={5}
-        />
-        <span style={styles.spacer} />
-        <Checkbox
-          checked={direction.isLooping()}
-          label={<Trans>Loop</Trans>}
-          onCheck={(e, check) => this.setLooping(check)}
-        />
-        {this.state.previewOpen && (
-          <Dialog
-            actions={[
-              <DialogPrimaryButton
-                label={<Trans>Ok</Trans>}
-                primary
-                onClick={() => this.openPreview(false)}
-                key="ok"
-              />,
-            ]}
-            noMargin
-            onRequestClose={() => this.openPreview(false)}
-            onApply={() => this.openPreview(false)}
-            open={this.state.previewOpen}
-            fullHeight
-            flexBody
-          >
-            <AnimationPreview
-              animationName={this.props.animationName}
-              resourceNames={direction.getSpriteNames().toJSArray()}
-              getImageResourceSource={(name: string) =>
-                resourcesLoader.getResourceFullUrl(project, name, {})
+      <I18n>
+        {({ i18n }) => (
+          <div style={styles.container}>
+            <ResponsiveWindowMeasurer>
+              {windowWidth =>
+                windowWidth !== 'small' &&
+                !!imageResourceExternalEditors.length && (
+                  <TextButton
+                    label={i18n._(
+                      hasSprites
+                        ? imageResourceExternalEditors[0].editDisplayName
+                        : imageResourceExternalEditors[0].createDisplayName
+                    )}
+                    icon={<Brush />}
+                    onClick={() => onEditWith(imageResourceExternalEditors[0])}
+                  />
+                )
               }
-              isImageResourceSmooth={(name: string) =>
-                isProjectImageResourceSmooth(project, name)
-              }
-              project={project}
-              timeBetweenFrames={this.state.timeBetweenFrames}
-              onChangeTimeBetweenFrames={text =>
-                this.setState({ timeBetweenFrames: text })
-              }
-              isLooping={direction.isLooping()}
-              hideAnimationLoader // No need to show a loader in the Direction Tools.
+            </ResponsiveWindowMeasurer>
+            <TextButton
+              label={<Trans>Preview</Trans>}
+              icon={<PlayArrow />}
+              onClick={() => this.openPreview(true)}
             />
-          </Dialog>
+            <Timer style={styles.timeIcon} />
+            <TextField
+              value={this.state.timeBetweenFrames}
+              onChange={(e, text) =>
+                this.setState({ timeBetweenFrames: parseFloat(text) || 0 })
+              }
+              onBlur={() => this.saveTimeBetweenFrames()}
+              id="direction-time-between-frames"
+              margin="none"
+              style={styles.timeField}
+              type="number"
+              step={0.005}
+              precision={2}
+              min={0.01}
+              max={5}
+            />
+            <span style={styles.spacer} />
+            <Checkbox
+              checked={direction.isLooping()}
+              label={<Trans>Loop</Trans>}
+              onCheck={(e, check) => this.setLooping(check)}
+            />
+            {this.state.previewOpen && (
+              <Dialog
+                actions={[
+                  <DialogPrimaryButton
+                    label={<Trans>Ok</Trans>}
+                    primary
+                    onClick={() => this.openPreview(false)}
+                    key="ok"
+                  />,
+                ]}
+                noMargin
+                onRequestClose={() => this.openPreview(false)}
+                onApply={() => this.openPreview(false)}
+                open={this.state.previewOpen}
+                fullHeight
+                flexBody
+              >
+                <AnimationPreview
+                  animationName={this.props.animationName}
+                  resourceNames={direction.getSpriteNames().toJSArray()}
+                  getImageResourceSource={(name: string) =>
+                    resourcesLoader.getResourceFullUrl(project, name, {})
+                  }
+                  isImageResourceSmooth={(name: string) =>
+                    isProjectImageResourceSmooth(project, name)
+                  }
+                  project={project}
+                  timeBetweenFrames={this.state.timeBetweenFrames}
+                  onChangeTimeBetweenFrames={text =>
+                    this.setState({ timeBetweenFrames: text })
+                  }
+                  isLooping={direction.isLooping()}
+                  hideAnimationLoader // No need to show a loader in the Direction Tools.
+                />
+              </Dialog>
+            )}
+          </div>
         )}
-      </div>
+      </I18n>
     );
   }
 }

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -824,7 +824,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
                 objectsContainer={objectsContainer}
                 resourceSources={resourceSources}
                 onChooseResource={onChooseResource}
-                resourceExternalEditors={resourceExternalEditors}
                 onFetchNewlyAddedResources={onFetchNewlyAddedResources}
                 canInstallPrivateAsset={canInstallPrivateAsset}
                 i18n={i18n}

--- a/newIDE/app/src/ResourcesList/BrowserResourceExternalEditors.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceExternalEditors.js
@@ -11,7 +11,8 @@ import { t } from '@lingui/macro';
 const editors: Array<ResourceExternalEditor> = [
   {
     name: 'piskel-app',
-    displayName: t`Create/Edit with Piskel`,
+    createDisplayName: t`Create with Piskel`,
+    editDisplayName: t`Edit with Piskel`,
     kind: 'image',
     edit: () => {
       sendExternalEditorOpened('piskel');
@@ -22,7 +23,8 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'jfxr-app',
-    displayName: t`Create/Edit with Jfxr`,
+    createDisplayName: t`Create with Jfxr`,
+    editDisplayName: t`Edit with Jfxr`,
     kind: 'audio',
     edit: () => {
       sendExternalEditorOpened('jfxr');
@@ -33,7 +35,8 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'yarn-app',
-    displayName: t`Create/Edit with Yarn`,
+    createDisplayName: t`Create with Yarn`,
+    editDisplayName: t`Edit with Yarn`,
     kind: 'json',
     edit: () => {
       sendExternalEditorOpened('yarn');

--- a/newIDE/app/src/ResourcesList/BrowserResourceExternalEditors.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceExternalEditors.js
@@ -2,6 +2,7 @@
 import Window from '../Utils/Window';
 import { type ResourceExternalEditor } from './ResourceExternalEditor.flow';
 import { sendExternalEditorOpened } from '../Utils/Analytics/EventSender';
+import { t } from '@lingui/macro';
 
 /**
  * This is the list of editors that can be used to edit resources
@@ -10,7 +11,7 @@ import { sendExternalEditorOpened } from '../Utils/Analytics/EventSender';
 const editors: Array<ResourceExternalEditor> = [
   {
     name: 'piskel-app',
-    displayName: 'Edit with Piskel',
+    displayName: t`Create/Edit with Piskel`,
     kind: 'image',
     edit: () => {
       sendExternalEditorOpened('piskel');
@@ -21,7 +22,7 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'jfxr-app',
-    displayName: 'Edit with Jfxr',
+    displayName: t`Create/Edit with Jfxr`,
     kind: 'audio',
     edit: () => {
       sendExternalEditorOpened('jfxr');
@@ -32,7 +33,7 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'yarn-app',
-    displayName: 'Edit with Yarn',
+    displayName: t`Create/Edit with Yarn`,
     kind: 'json',
     edit: () => {
       sendExternalEditorOpened('yarn');

--- a/newIDE/app/src/ResourcesList/LocalResourceExternalEditors.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceExternalEditors.js
@@ -4,6 +4,7 @@ import { openJfxr } from './LocalJfxrBridge';
 import { openYarn } from './LocalYarnBridge';
 import { type ResourceExternalEditor } from './ResourceExternalEditor.flow';
 import { sendExternalEditorOpened } from '../Utils/Analytics/EventSender';
+import { t } from '@lingui/macro';
 
 /**
  * This is the list of editors that can be used to edit resources
@@ -12,7 +13,7 @@ import { sendExternalEditorOpened } from '../Utils/Analytics/EventSender';
 const editors: Array<ResourceExternalEditor> = [
   {
     name: 'piskel-app',
-    displayName: 'Edit with Piskel',
+    displayName: t`Create/Edit with Piskel`,
     kind: 'image',
     edit: options => {
       sendExternalEditorOpened('piskel');
@@ -21,7 +22,7 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'Jfxr',
-    displayName: 'Create/Edit a Sound effect with Jfxr (*.wav)',
+    displayName: t`Create/Edit with Jfxr`,
     kind: 'audio',
     edit: options => {
       sendExternalEditorOpened('jfxr');
@@ -30,7 +31,7 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'Yarn',
-    displayName: 'Create/Edit a Dialogue Tree with Yarn (*.json)',
+    displayName: t`Create/Edit with Yarn`,
     kind: 'json',
     edit: options => {
       sendExternalEditorOpened('yarn');

--- a/newIDE/app/src/ResourcesList/LocalResourceExternalEditors.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceExternalEditors.js
@@ -13,7 +13,8 @@ import { t } from '@lingui/macro';
 const editors: Array<ResourceExternalEditor> = [
   {
     name: 'piskel-app',
-    displayName: t`Create/Edit with Piskel`,
+    createDisplayName: t`Create with Piskel`,
+    editDisplayName: t`Edit with Piskel`,
     kind: 'image',
     edit: options => {
       sendExternalEditorOpened('piskel');
@@ -22,7 +23,8 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'Jfxr',
-    displayName: t`Create/Edit with Jfxr`,
+    createDisplayName: t`Create with Jfxr`,
+    editDisplayName: t`Edit with Jfxr`,
     kind: 'audio',
     edit: options => {
       sendExternalEditorOpened('jfxr');
@@ -31,7 +33,8 @@ const editors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'Yarn',
-    displayName: t`Create/Edit with Yarn`,
+    createDisplayName: t`Create with Yarn`,
+    editDisplayName: t`Edit with Yarn`,
     kind: 'json',
     edit: options => {
       sendExternalEditorOpened('yarn');

--- a/newIDE/app/src/ResourcesList/ResourceExternalEditor.flow.js
+++ b/newIDE/app/src/ResourcesList/ResourceExternalEditor.flow.js
@@ -30,7 +30,8 @@ export type ExternalEditorOpenOptions = {|
 
 export type ResourceExternalEditor = {|
   name: string,
-  displayName: MessageDescriptor,
+  createDisplayName: MessageDescriptor,
+  editDisplayName: MessageDescriptor,
   kind: ResourceKind,
   edit: ExternalEditorOpenOptions => void,
 |};

--- a/newIDE/app/src/ResourcesList/ResourceExternalEditor.flow.js
+++ b/newIDE/app/src/ResourcesList/ResourceExternalEditor.flow.js
@@ -1,6 +1,7 @@
 // @flow
 import { type ResourceKind } from './ResourceSource';
 import ResourcesLoader from '../ResourcesLoader';
+import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 
 /**
  * These are the options passed to an external editor to edit one or more resources.
@@ -27,9 +28,9 @@ export type ExternalEditorOpenOptions = {|
   },
 |};
 
-export type ResourceExternalEditor = {
+export type ResourceExternalEditor = {|
   name: string,
-  displayName: string,
+  displayName: MessageDescriptor,
   kind: ResourceKind,
   edit: ExternalEditorOpenOptions => void,
-};
+|};

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -19,8 +19,17 @@ import ResourcesLoader from '../ResourcesLoader';
 import { applyResourceDefaults } from './ResourceUtils';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 import RaisedButtonWithMenu from '../UI/RaisedButtonWithMenu';
-import { TextFieldWithButtonLayout } from '../UI/Layout';
+import { LineStackLayout, ResponsiveLineStackLayout } from '../UI/Layout';
 import IconButton from '../UI/IconButton';
+import RaisedButton from '../UI/RaisedButton';
+import FlatButton from '../UI/FlatButton';
+import { type I18n as I18nType } from '@lingui/core';
+import { I18n } from '@lingui/react';
+import { Column } from '../UI/Grid';
+
+const styles = {
+  textFieldStyle: { display: 'flex', flex: 1 },
+};
 
 type Props = {|
   project: gdProject,
@@ -267,62 +276,75 @@ export default class ResourceSelector extends React.Component<Props, State> {
       externalEditor => externalEditor.kind === this.props.resourceKind
     );
     return (
-      <TextFieldWithButtonLayout
-        noFloatingLabelText={!this.props.floatingLabelText}
-        margin={this.props.margin}
-        renderTextField={() => (
-          <SemiControlledAutoComplete
-            style={this.props.style}
-            floatingLabelText={this.props.floatingLabelText}
-            helperMarkdownText={this.props.helperMarkdownText}
-            hintText={this.props.hintText}
-            openOnFocus
-            dataSource={this.autoCompleteData || []}
-            value={this.state.resourceName}
-            onChange={this._onChangeResourceName}
-            errorText={errorText}
-            fullWidth={this.props.fullWidth}
-            margin={this.props.margin}
-            onRequestClose={this.props.onRequestClose}
-            onApply={this.props.onApply}
-            ref={autoComplete => (this._autoComplete = autoComplete)}
-          />
-        )}
-        renderButton={style => (
-          <React.Fragment>
-            {this.props.canBeReset && (
-              <IconButton
-                size="small"
-                onClick={() => {
-                  this._onResetResourceName();
-                }}
-              >
-                <BackspaceIcon />
-              </IconButton>
+      <I18n>
+        {({ i18n }) => (
+          <ResponsiveLineStackLayout noMargin expand alignItems="center">
+            <Column expand noMargin>
+              <LineStackLayout expand noMargin>
+                <SemiControlledAutoComplete
+                  style={this.props.style}
+                  textFieldStyle={styles.textFieldStyle}
+                  floatingLabelText={this.props.floatingLabelText}
+                  helperMarkdownText={this.props.helperMarkdownText}
+                  hintText={this.props.hintText}
+                  openOnFocus
+                  dataSource={this.autoCompleteData || []}
+                  value={this.state.resourceName}
+                  onChange={this._onChangeResourceName}
+                  errorText={errorText}
+                  fullWidth={this.props.fullWidth}
+                  margin={this.props.margin}
+                  onRequestClose={this.props.onRequestClose}
+                  onApply={this.props.onApply}
+                  ref={autoComplete => (this._autoComplete = autoComplete)}
+                />
+                {this.props.canBeReset && (
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      this._onResetResourceName();
+                    }}
+                  >
+                    <BackspaceIcon />
+                  </IconButton>
+                )}
+              </LineStackLayout>
+            </Column>
+            <RaisedButton
+              label={<Trans>Choose a file</Trans>}
+              onClick={() => {
+                this._autoComplete && this._autoComplete.focus();
+              }}
+              primary
+            />
+            {externalEditors.length === 1 && (
+              <FlatButton
+                leftIcon={<Brush />}
+                label={i18n._(externalEditors[0].displayName)}
+                onClick={() => this._editWith(externalEditors[0])}
+              />
             )}
-            {!!externalEditors.length ? (
+            {externalEditors.length > 1 ? (
               <RaisedButtonWithMenu
-                style={style}
                 icon={<Brush />}
                 label={
                   this.state.resourceName ? (
-                    <Trans>Edit</Trans>
+                    <Trans>Edit with...</Trans>
                   ) : (
-                    <Trans>Create</Trans>
+                    <Trans>Create with...</Trans>
                   )
                 }
-                primary
-                buildMenuTemplate={() =>
+                buildMenuTemplate={(i18n: I18nType) =>
                   externalEditors.map(externalEditor => ({
-                    label: externalEditor.displayName,
+                    label: i18n._(externalEditor.displayName),
                     click: () => this._editWith(externalEditor),
                   }))
                 }
               />
             ) : null}
-          </React.Fragment>
+          </ResponsiveLineStackLayout>
         )}
-      />
+      </I18n>
     );
   }
 }

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -18,7 +18,7 @@ import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEd
 import ResourcesLoader from '../ResourcesLoader';
 import { applyResourceDefaults } from './ResourceUtils';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
-import RaisedButtonWithMenu from '../UI/RaisedButtonWithMenu';
+import RaisedButtonWithSplitMenu from '../UI/RaisedButtonWithSplitMenu';
 import { LineStackLayout, ResponsiveLineStackLayout } from '../UI/Layout';
 import IconButton from '../UI/IconButton';
 import RaisedButton from '../UI/RaisedButton';
@@ -329,15 +329,14 @@ export default class ResourceSelector extends React.Component<Props, State> {
               />
             )}
             {externalEditors.length > 1 ? (
-              <RaisedButtonWithMenu
+              <RaisedButtonWithSplitMenu
                 icon={<Brush fontSize="small" />}
-                label={
-                  this.state.resourceName ? (
-                    <Trans>Edit with...</Trans>
-                  ) : (
-                    <Trans>Create with...</Trans>
-                  )
-                }
+                label={i18n._(
+                  this.state.resourceName
+                    ? externalEditors[0].editDisplayName
+                    : externalEditors[0].createDisplayName
+                )}
+                onClick={() => this._editWith(externalEditors[0])}
                 buildMenuTemplate={(i18n: I18nType) =>
                   externalEditors.map(externalEditor => ({
                     label: i18n._(

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -319,14 +319,18 @@ export default class ResourceSelector extends React.Component<Props, State> {
             />
             {externalEditors.length === 1 && (
               <FlatButton
-                leftIcon={<Brush />}
-                label={i18n._(externalEditors[0].displayName)}
+                leftIcon={<Brush fontSize="small" />}
+                label={i18n._(
+                  this.state.resourceName
+                    ? externalEditors[0].editDisplayName
+                    : externalEditors[0].createDisplayName
+                )}
                 onClick={() => this._editWith(externalEditors[0])}
               />
             )}
             {externalEditors.length > 1 ? (
               <RaisedButtonWithMenu
-                icon={<Brush />}
+                icon={<Brush fontSize="small" />}
                 label={
                   this.state.resourceName ? (
                     <Trans>Edit with...</Trans>
@@ -336,7 +340,11 @@ export default class ResourceSelector extends React.Component<Props, State> {
                 }
                 buildMenuTemplate={(i18n: I18nType) =>
                   externalEditors.map(externalEditor => ({
-                    label: i18n._(externalEditor.displayName),
+                    label: i18n._(
+                      this.state.resourceName
+                        ? externalEditor.editDisplayName
+                        : externalEditor.createDisplayName
+                    ),
                     click: () => this._editWith(externalEditor),
                   }))
                 }

--- a/newIDE/app/src/ResourcesList/ResourceSelectorWithThumbnail.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelectorWithThumbnail.js
@@ -10,6 +10,7 @@ import {
 import ResourceThumbnail from './ResourceThumbnail';
 import { type ResourceExternalEditor } from './ResourceExternalEditor.flow';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
+import { LineStackLayout } from '../UI/Layout';
 
 type Props = {|
   project: gdProject,
@@ -24,12 +25,6 @@ type Props = {|
   helperMarkdownText?: ?string,
 |};
 
-const styles = {
-  container: { flex: 1, display: 'flex', alignItems: 'flex-end' },
-  selectorContainer: { flex: 1 },
-  resourceThumbnail: { marginLeft: 10, marginBottom: 4 },
-};
-
 const ResourceSelectorWithThumbnail = ({
   project,
   resourceSources,
@@ -43,30 +38,27 @@ const ResourceSelectorWithThumbnail = ({
   helperMarkdownText,
 }: Props) => {
   return (
-    <div style={styles.container}>
-      <div style={styles.selectorContainer}>
-        <ResourceSelector
-          project={project}
-          resourceSources={resourceSources}
-          onChooseResource={onChooseResource}
-          resourceExternalEditors={resourceExternalEditors}
-          resourcesLoader={ResourcesLoader}
-          resourceKind={resourceKind}
-          fullWidth
-          initialResourceName={resourceName}
-          onChange={onChange}
-          floatingLabelText={floatingLabelText}
-          hintText={hintText}
-          helperMarkdownText={helperMarkdownText}
-        />
-      </div>
+    <LineStackLayout noMargin expand alignItems="flex-end">
+      <ResourceSelector
+        project={project}
+        resourceSources={resourceSources}
+        onChooseResource={onChooseResource}
+        resourceExternalEditors={resourceExternalEditors}
+        resourcesLoader={ResourcesLoader}
+        resourceKind={resourceKind}
+        fullWidth
+        initialResourceName={resourceName}
+        onChange={onChange}
+        floatingLabelText={floatingLabelText}
+        hintText={hintText}
+        helperMarkdownText={helperMarkdownText}
+      />
       <ResourceThumbnail
         resourceName={resourceName}
         resourcesLoader={ResourcesLoader}
         project={project}
-        style={styles.resourceThumbnail}
       />
-    </div>
+    </LineStackLayout>
   );
 };
 

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1361,9 +1361,6 @@ export default class SceneEditor extends React.Component<Props, State> {
         renderEditor: () => (
           <LayersList
             project={project}
-            resourceSources={resourceSources}
-            resourceExternalEditors={resourceExternalEditors}
-            onChooseResource={onChooseResource}
             onEditLayerEffects={this.editLayerEffects}
             onEditLayer={this.editLayer}
             onRemoveLayer={this._onRemoveLayer}

--- a/newIDE/app/src/stories/FakeResourceExternalEditors.js
+++ b/newIDE/app/src/stories/FakeResourceExternalEditors.js
@@ -7,7 +7,8 @@ import { type ResourceExternalEditor } from '../ResourcesList/ResourceExternalEd
 const fakeResourceExternalEditors: Array<ResourceExternalEditor> = [
   {
     name: 'fake-image-editor',
-    displayName: 'Edit with Super Image Editor',
+    createDisplayName: 'Create with Super Image Editor',
+    editDisplayName: 'Edit with Super Image Editor',
     kind: 'image',
     edit: options => {
       console.log('Open the image editor with these options:', options);
@@ -15,7 +16,8 @@ const fakeResourceExternalEditors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'fake-audio-editor',
-    displayName: 'Create/Edit a Sound effect with Super Audio Editor',
+    createDisplayName: 'Create a Sound effect with Super Audio Editor',
+    editDisplayName: 'Edit the Sound effect with Super Audio Editor',
     kind: 'audio',
     edit: options => {
       console.log('Open the audio editor with these options:', options);
@@ -23,7 +25,8 @@ const fakeResourceExternalEditors: Array<ResourceExternalEditor> = [
   },
   {
     name: 'fake-json-editor',
-    displayName: 'Create/Edit a Dialogue Tree with Super JSON Dialogue Editor',
+    createDisplayName: 'Create a Dialogue Tree with Super JSON Dialogue Editor',
+    editDisplayName: 'Edit the Dialogue Tree with Super JSON Dialogue Editor',
     kind: 'json',
     edit: options => {
       console.log('Open the json editor with these options:', options);

--- a/newIDE/app/src/stories/componentStories/AssetStore/NewObjectDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/NewObjectDialog.stories.js
@@ -8,7 +8,6 @@ import paperDecorator from '../../PaperDecorator';
 import NewObjectDialog from '../../../AssetStore/NewObjectDialog';
 import { AssetStoreStateProvider } from '../../../AssetStore/AssetStoreContext';
 import { testProject } from '../../GDevelopJsInitializerDecorator';
-import fakeResourceExternalEditors from '../../FakeResourceExternalEditors';
 
 export default {
   title: 'AssetStore/NewObjectDialog',
@@ -27,7 +26,6 @@ export const Default = () => (
           onCreateNewObject={action('onCreateNewObject')}
           onObjectAddedFromAsset={action('onObjectAddedFromAsset')}
           objectsContainer={testProject.testLayout}
-          resourceExternalEditors={fakeResourceExternalEditors}
           onChooseResource={() => {
             action('onChooseResource');
             return Promise.reject();

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/LayersList.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/LayersList.stories.js
@@ -6,7 +6,6 @@ import { action } from '@storybook/addon-actions';
 // Keep first as it creates the `global.gd` object:
 import { testProject } from '../../GDevelopJsInitializerDecorator';
 
-import fakeResourceExternalEditors from '../../FakeResourceExternalEditors';
 import fakeHotReloadPreviewButtonProps from '../../FakeHotReloadPreviewButtonProps';
 import muiDecorator from '../../ThemeDecorator';
 import paperDecorator from '../../PaperDecorator';
@@ -21,12 +20,6 @@ export default {
 export const Default = () => (
   <LayersList
     project={testProject.project}
-    resourceExternalEditors={fakeResourceExternalEditors}
-    onChooseResource={() => {
-      action('onChooseResource');
-      return Promise.reject();
-    }}
-    resourceSources={[]}
     onEditLayerEffects={action('onEditLayerEffects')}
     onEditLayer={action('onEditLayer')}
     onRemoveLayer={(layerName, cb) => {
@@ -45,12 +38,6 @@ export const SmallWidthAndHeight = () => (
   <div style={{ width: 250, height: 200 }}>
     <LayersList
       project={testProject.project}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      onChooseResource={() => {
-        action('onChooseResource');
-        return Promise.reject();
-      }}
-      resourceSources={[]}
       onEditLayerEffects={action('onEditLayerEffects')}
       onEditLayer={action('onEditLayer')}
       onRemoveLayer={(layerName, cb) => {

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ImageThumbnail.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ImageThumbnail.stories.js
@@ -1,0 +1,30 @@
+// @flow
+import * as React from 'react';
+import paperDecorator from '../../PaperDecorator';
+import muiDecorator from '../../ThemeDecorator';
+import { testProject } from '../../GDevelopJsInitializerDecorator';
+import ImageThumbnail from '../../../ResourcesList/ResourceThumbnail/ImageThumbnail';
+import ResourcesLoader from '../../../ResourcesLoader';
+
+export default {
+  title: 'ResourcesList/ImageThumbnail',
+  component: ImageThumbnail,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <ImageThumbnail
+    project={testProject.project}
+    resourceName="res/icon128.png"
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const Selectable = () => (
+  <ImageThumbnail
+    selectable
+    project={testProject.project}
+    resourceName="res/icon128.png"
+    resourcesLoader={ResourcesLoader}
+  />
+);

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourcePreview.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourcePreview.stories.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react';
+import paperDecorator from '../../PaperDecorator';
+import muiDecorator from '../../ThemeDecorator';
+import { testProject } from '../../GDevelopJsInitializerDecorator';
+import ResourcesLoader from '../../../ResourcesLoader';
+import ResourcePreview from '../../../ResourcesList/ResourcePreview';
+
+export default {
+  title: 'ResourcesList/ResourcePreview',
+  component: ResourcePreview,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Image = () => (
+  <ResourcePreview
+    project={testProject.project}
+    resourceName="icon128.png"
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const NotExisting = () => (
+  <ResourcePreview
+    project={testProject.project}
+    resourceName="resource-that-does-not-exists-in-the-project"
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const Audio = () => (
+  <ResourcePreview
+    project={testProject.project}
+    resourceName="fake-audio1.mp3"
+    resourcesLoader={ResourcesLoader}
+  />
+);

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
@@ -15,7 +15,20 @@ export default {
   decorators: [paperDecorator, muiDecorator],
 };
 
-export const Image = () => (
+export const ImageNotSelected = () => (
+  <ResourceSelector
+    resourceKind="image"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    initialResourceName=""
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const ImageSelected = () => (
   <ResourceSelector
     resourceKind="image"
     project={testProject.project}
@@ -23,6 +36,30 @@ export const Image = () => (
     onChooseResource={() => Promise.reject('Unimplemented')}
     resourceExternalEditors={fakeResourceExternalEditors}
     initialResourceName="icon128.png"
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const ImageWithMultipleExternalEditors = () => (
+  <ResourceSelector
+    resourceKind="image"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={[
+      ...fakeResourceExternalEditors,
+      {
+        name: 'fake-image-editor-2',
+        createDisplayName: 'Create with Super Image Editor 2',
+        editDisplayName: 'Edit with Super Image Editor 2',
+        kind: 'image',
+        edit: options => {
+          console.log('Open the image editor with these options:', options);
+        },
+      },
+    ]}
+    initialResourceName=""
     onChange={action('on change')}
     resourcesLoader={ResourcesLoader}
   />

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
@@ -1,0 +1,110 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+import paperDecorator from '../../PaperDecorator';
+import muiDecorator from '../../ThemeDecorator';
+import { testProject } from '../../GDevelopJsInitializerDecorator';
+import ResourceSelector from '../../../ResourcesList/ResourceSelector';
+import fakeResourceExternalEditors from '../../FakeResourceExternalEditors';
+import ResourcesLoader from '../../../ResourcesLoader';
+import ResourceSelectorWithThumbnail from '../../../ResourcesList/ResourceSelectorWithThumbnail';
+
+export default {
+  title: 'ResourcesList/ResourceSelector',
+  component: ResourceSelector,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Image = () => (
+  <ResourceSelector
+    resourceKind="image"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    initialResourceName="icon128.png"
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const NotExisting = () => (
+  <ResourceSelector
+    resourceKind="image"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={action('onChooseResource')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    initialResourceName="resource-that-does-not-exists-in-the-project"
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const ImageNoMargin = () => (
+  <ResourceSelector
+    margin="none"
+    resourceKind="image"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    initialResourceName="icon128.png"
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const ImageWithThumbnail = () => (
+  <ResourceSelectorWithThumbnail
+    resourceKind="image"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    resourceName="icon128.png"
+    onChange={action('on change')}
+  />
+);
+
+export const Audio = () => (
+  <ResourceSelector
+    resourceKind="audio"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    initialResourceName="fake-audio1.mp3"
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const FontWithResetButton = () => (
+  <ResourceSelector
+    canBeReset
+    resourceKind="font"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    initialResourceName="font.otf"
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);
+
+export const FontNoMarginWithResetButton = () => (
+  <ResourceSelector
+    canBeReset
+    margin="none"
+    resourceKind="font"
+    project={testProject.project}
+    resourceSources={[]}
+    onChooseResource={() => Promise.reject('Unimplemented')}
+    resourceExternalEditors={fakeResourceExternalEditors}
+    initialResourceName="font.otf"
+    onChange={action('on change')}
+    resourcesLoader={ResourcesLoader}
+  />
+);

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourcesList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourcesList.stories.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+import paperDecorator from '../../PaperDecorator';
+import muiDecorator from '../../ThemeDecorator';
+import { testProject } from '../../GDevelopJsInitializerDecorator';
+import ResourcesList from '../../../ResourcesList';
+import ValueStateHolder from '../../ValueStateHolder';
+import DragAndDropContextProvider from '../../../UI/DragAndDrop/DragAndDropContextProvider';
+
+export default {
+  title: 'ResourcesList/ResourcesList',
+  component: ResourcesList,
+  decorators: [paperDecorator, muiDecorator],
+};
+
+export const Default = () => (
+  <DragAndDropContextProvider>
+    <div style={{ height: 200 }}>
+      <ValueStateHolder
+        initialValue={null}
+        render={(value, onChange) => (
+          <ResourcesList
+            onSelectResource={onChange}
+            selectedResource={value}
+            onDeleteResource={action('onDeleteResource')}
+            onRenameResource={action('onRenameResource')}
+            project={testProject.project}
+            onRemoveUnusedResources={action('onRemoveUnusedResources')}
+            onRemoveAllResourcesWithInvalidPath={action(
+              'onRemoveAllResourcesWithInvalidPath'
+            )}
+          />
+        )}
+      />
+    </div>
+  </DragAndDropContextProvider>
+);

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -21,9 +21,6 @@ import HelpFinder from '../HelpFinder';
 import LocalFolderPicker from '../UI/LocalFolderPicker';
 import LocalFilePicker from '../UI/LocalFilePicker';
 import LocalNetworkPreviewDialog from '../Export/LocalExporters/LocalPreviewLauncher/LocalNetworkPreviewDialog';
-import ImageThumbnail from '../ResourcesList/ResourceThumbnail/ImageThumbnail';
-import ResourceSelector from '../ResourcesList/ResourceSelector';
-import ResourceSelectorWithThumbnail from '../ResourcesList/ResourceSelectorWithThumbnail';
 import ExternalEventsAutoComplete from '../EventsSheet/EventsTree/Renderers/LinkEvent/ExternalEventsAutoComplete';
 import LayerField from '../EventsSheet/ParameterFields/LayerField';
 import MouseField from '../EventsSheet/ParameterFields/MouseField';
@@ -44,15 +41,12 @@ import paperDecorator from './PaperDecorator';
 import ValueStateHolder from './ValueStateHolder';
 import RefGetter from './RefGetter';
 import DragAndDropContextProvider from '../UI/DragAndDrop/DragAndDropContextProvider';
-import ResourcesLoader from '../ResourcesLoader';
 import InstructionSelector from '../EventsSheet/InstructionEditor/InstructionOrExpressionSelector/InstructionSelector';
 import ParameterRenderingService from '../EventsSheet/ParameterRenderingService';
 import { ErrorFallbackComponent } from '../UI/ErrorBoundary';
 import CreateProfile from '../Profile/CreateProfile';
 import AuthenticatedUserProfileDetails from '../Profile/AuthenticatedUserProfileDetails';
 import CurrentUsageDisplayer from '../Profile/CurrentUsageDisplayer';
-import ResourcePreview from '../ResourcesList/ResourcePreview';
-import ResourcesList from '../ResourcesList';
 import {
   subscriptionForIndieUser,
   limitsForIndieUser,
@@ -2581,26 +2575,6 @@ storiesOf('NewInstructionEditorMenu', module)
       </PopoverButton>
     </Column>
   ));
-
-storiesOf('ImageThumbnail', module)
-  .addDecorator(paperDecorator)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <ImageThumbnail
-      project={testProject.project}
-      resourceName="res/icon128.png"
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('selectable', () => (
-    <ImageThumbnail
-      selectable
-      project={testProject.project}
-      resourceName="res/icon128.png"
-      resourcesLoader={ResourcesLoader}
-    />
-  ));
-
 storiesOf('ObjectSelector', module)
   .addDecorator(paperDecorator)
   .addDecorator(muiDecorator)
@@ -2941,143 +2915,6 @@ storiesOf('SubscriptionCheckDialog', module)
         mode="mandatory"
       />
     </RefGetter>
-  ));
-
-storiesOf('ResourcePreview', module)
-  .addDecorator(muiDecorator)
-  .add('not existing/missing resource', () => (
-    <ResourcePreview
-      project={testProject.project}
-      resourceName="resource-that-does-not-exists-in-the-project"
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('image resource', () => (
-    <ResourcePreview
-      project={testProject.project}
-      resourceName="icon128.png"
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('audio resource', () => (
-    <ResourcePreview
-      project={testProject.project}
-      resourceName="fake-audio1.mp3"
-      resourcesLoader={ResourcesLoader}
-    />
-  ));
-
-storiesOf('ResourceSelector (and ResourceSelectorWithThumbnail)', module)
-  .addDecorator(muiDecorator)
-  .add('image resource (not existing/missing resource)', () => (
-    <ResourceSelector
-      resourceKind="image"
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      initialResourceName="resource-that-does-not-exists-in-the-project"
-      onChange={action('on change')}
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('image resource', () => (
-    <ResourceSelector
-      resourceKind="image"
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      initialResourceName="icon128.png"
-      onChange={action('on change')}
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('image resource, no margin', () => (
-    <ResourceSelector
-      margin="none"
-      resourceKind="image"
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      initialResourceName="icon128.png"
-      onChange={action('on change')}
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('image resource, with thumbnail', () => (
-    <ResourceSelectorWithThumbnail
-      resourceKind="image"
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      resourceName="icon128.png"
-      onChange={action('on change')}
-    />
-  ))
-  .add('audio resource', () => (
-    <ResourceSelector
-      resourceKind="audio"
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      initialResourceName="fake-audio1.mp3"
-      onChange={action('on change')}
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('font resource, with reset button', () => (
-    <ResourceSelector
-      canBeReset
-      resourceKind="font"
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      initialResourceName="font.otf"
-      onChange={action('on change')}
-      resourcesLoader={ResourcesLoader}
-    />
-  ))
-  .add('font resource, no margin, with reset button', () => (
-    <ResourceSelector
-      canBeReset
-      margin="none"
-      resourceKind="font"
-      project={testProject.project}
-      resourceSources={[]}
-      onChooseResource={() => Promise.reject('Unimplemented')}
-      resourceExternalEditors={fakeResourceExternalEditors}
-      initialResourceName="font.otf"
-      onChange={action('on change')}
-      resourcesLoader={ResourcesLoader}
-    />
-  ));
-
-storiesOf('ResourcesList', module)
-  .addDecorator(muiDecorator)
-  .add('default', () => (
-    <DragAndDropContextProvider>
-      <div style={{ height: 200 }}>
-        <ValueStateHolder
-          initialValue={null}
-          render={(value, onChange) => (
-            <ResourcesList
-              onSelectResource={onChange}
-              selectedResource={value}
-              onDeleteResource={() => {}}
-              onRenameResource={() => {}}
-              project={testProject.project}
-              onRemoveUnusedResources={() => {}}
-              onRemoveAllResourcesWithInvalidPath={() => {}}
-            />
-          )}
-        />
-      </div>
-    </DragAndDropContextProvider>
   ));
 
 storiesOf('ProjectManager', module)


### PR DESCRIPTION
Before:
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/4895034/200604025-6c6c0e05-b2bf-48aa-8256-06fed4271953.png">

After:
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/4895034/200778880-c22ebcfb-9e1e-4433-9f04-5610bcbc0f39.png">
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/4895034/200778956-0b990338-5b58-4bbd-94e4-a2870ce81357.png">



Also translate the external resources action names.
Stories extracted on storybook.

I went for a simple "focus on Autocomplete" when clicking on "choose a local file" because it was the easiest. We could trigger the first option of the autocomplete (opening the local file browser) but it's slightly harder to do.

<img width="421" alt="image" src="https://user-images.githubusercontent.com/4895034/200779265-cc4a850f-01d1-45e4-bbcc-1d6f66c66fd0.png">
