### PR TITLE
Panel sprite objects now respect the resource smoothing option

### DIFF
--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
@@ -33,27 +33,24 @@ namespace gdjs {
       const StretchedSprite = !tiled ? PIXI.Sprite : PIXI.TilingSprite;
       this._spritesContainer = new PIXI.Container();
       this._wrapperContainer = new PIXI.Container();
-      // @ts-ignore
-      this._centerSprite = new StretchedSprite(new PIXI.Texture(texture));
+      this._centerSprite = new StretchedSprite(
+        new PIXI.Texture(texture.baseTexture)
+      );
       this._borderSprites = [
-        // @ts-ignore
-        new StretchedSprite(new PIXI.Texture(texture)),
-        //Right
+        // Right
+        new StretchedSprite(new PIXI.Texture(texture.baseTexture)),
+        // Top-Right
         new PIXI.Sprite(texture),
-        //Top-Right
-        // @ts-ignore
-        new StretchedSprite(new PIXI.Texture(texture)),
-        //Top
+        // Top
+        new StretchedSprite(new PIXI.Texture(texture.baseTexture)),
+        // Top-Left
         new PIXI.Sprite(texture),
-        //Top-Left
-        // @ts-ignore
-        new StretchedSprite(new PIXI.Texture(texture)),
-        //Left
+        // Left
+        new StretchedSprite(new PIXI.Texture(texture.baseTexture)),
+        // Bottom-Left
         new PIXI.Sprite(texture),
-        //Bottom-Left
-        // @ts-ignore
-        new StretchedSprite(new PIXI.Texture(texture)),
-        //Bottom
+        // Bottom
+        new StretchedSprite(new PIXI.Texture(texture.baseTexture)),
         new PIXI.Sprite(texture),
       ];
 
@@ -77,11 +74,19 @@ namespace gdjs {
 
     ensureUpToDate() {
       if (this._spritesContainer.visible && this._wasRendered) {
-        // Cache the rendered sprites as a bitmap to speed up rendering when
-        // lots of panel sprites are on the scene.
-        // Sadly, because of this, we need a wrapper container to workaround
-        // a PixiJS issue with alpha (see updateOpacity).
-        this._spritesContainer.cacheAsBitmap = true;
+        // PIXI uses PIXI.SCALE_MODES.LINEAR for the cached image:
+        // this._spritesContainer._cacheData.sprite._texture.baseTexture.scaleMode
+        // There seems to be no way to configure this so the optimization is disabled.
+        if (
+          this._centerSprite.texture.baseTexture.scaleMode !==
+          PIXI.SCALE_MODES.NEAREST
+        ) {
+          // Cache the rendered sprites as a bitmap to speed up rendering when
+          // lots of panel sprites are on the scene.
+          // Sadly, because of this, we need a wrapper container to workaround
+          // a PixiJS issue with alpha (see updateOpacity).
+          this._spritesContainer.cacheAsBitmap = true;
+        }
       }
       this._wasRendered = true;
     }
@@ -193,14 +198,10 @@ namespace gdjs {
       instanceContainer: gdjs.RuntimeInstanceContainer
     ): void {
       const obj = this._object;
-      // @ts-ignore
       const texture = instanceContainer
         .getGame()
         .getImageManager()
-        .getPIXITexture(textureName) as PIXI.BaseTexture<
-        PIXI.Resource,
-        PIXI.IAutoDetectOptions
-      >;
+        .getPIXITexture(textureName).baseTexture;
       this._textureWidth = texture.width;
       this._textureHeight = texture.height;
 

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -66,13 +66,13 @@ namespace gdjs {
       return this._tiledSprite.height;
     }
 
-    setWidth(width): void {
+    setWidth(width: float): void {
       this._tiledSprite.width = width;
       this._tiledSprite.pivot.x = width / 2;
       this.updatePosition();
     }
 
-    setHeight(height): void {
+    setHeight(height: float): void {
       this._tiledSprite.height = height;
       this._tiledSprite.pivot.y = height / 2;
       this.updatePosition();
@@ -94,7 +94,7 @@ namespace gdjs {
         -this._object._yOffset % this._tiledSprite.texture.height;
     }
 
-    setColor(rgbColor): void {
+    setColor(rgbColor: string): void {
       const colors = rgbColor.split(';');
       if (colors.length < 3) {
         return;


### PR DESCRIPTION
Fixes https://github.com/4ian/GDevelop/issues/4523
- https://github.com/4ian/GDevelop/issues/4523

### Solution
It deactivates the `cacheAsBitmap` optimization when the image smoothing is deactivated on the image used by the 9-patch.

### Issue
The isssue is that cacheAsBitmap uses the scale mode PIXI.SCALE_MODES.LINEAR for the sprite in cache (this._spritesContainer._cacheData.sprite._texture.baseTexture.scaleMode).
https://github.com/pixijs/pixijs/blob/main/packages/mixin-cache-as-bitmap/src/index.ts

Ideally, we would need a `cacheAsBitmapScaleMode` property in Pixi.

### Efficiency
There will be 9 times more draw calls, but it's not really an issue as it takes very little CPU time. What really impacts efficiency is actually the tilling. It's very heavy on the GPU. It seems that Pixi uses the WebGL `repeat` texture wrap. So, I guess the only way to improve efficiency was `cacheAsBitmap` (can `cacheAsBitmap` creates giant texture which could be an issue too?).

I don't think it's a big deal as TiledSpriteObject have the exact same efficiency issue and no one complained about it. The editor also render without `cacheAsBitmap` and it's fine as long as there less than 100 big areas to tile.