### PR TITLE
Slightly improve animation preview zoom to the image fit the canvas

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
@@ -16,6 +16,10 @@ import useForceUpdate from '../../../Utils/UseForceUpdate';
 import PlaceholderLoader from '../../../UI/PlaceholderLoader';
 
 const styles = {
+  // This container is important to have the loader positioned on top of the image.
+  imageContainer: {
+    position: 'relative',
+  },
   loaderContainer: {
     position: 'absolute',
     left: 'calc(50% - 30px)',
@@ -233,25 +237,27 @@ const AnimationPreview = ({
   return (
     <Column expand noOverflowParent noMargin>
       <Line noMargin expand>
-        <ImagePreview
-          resourceName={resourceName}
-          imageResourceSource={getImageResourceSource(resourceName)}
-          isImageResourceSmooth={isImageResourceSmooth(resourceName)}
-          initialZoom={initialZoom}
-          project={project}
-          hideCheckeredBackground={hideCheckeredBackground}
-          hideControls={hideControls}
-          fixedHeight={fixedHeight}
-          fixedWidth={fixedWidth}
-          onImageLoaded={onImageLoaded}
-          isImagePrivate={isAssetPrivate}
-          hideLoader // Handled by the animation preview, important to let the browser cache the image.
-        />
-        {!hideAnimationLoader && isStillLoadingResources && (
-          <div style={styles.loaderContainer}>
-            <PlaceholderLoader />
-          </div>
-        )}
+        <div style={styles.imageContainer}>
+          <ImagePreview
+            resourceName={resourceName}
+            imageResourceSource={getImageResourceSource(resourceName)}
+            isImageResourceSmooth={isImageResourceSmooth(resourceName)}
+            initialZoom={initialZoom}
+            project={project}
+            hideCheckeredBackground={hideCheckeredBackground}
+            hideControls={hideControls}
+            fixedHeight={fixedHeight}
+            fixedWidth={fixedWidth}
+            onImageLoaded={onImageLoaded}
+            isImagePrivate={isAssetPrivate}
+            hideLoader // Handled by the animation preview, important to let the browser cache the image.
+          />
+          {!hideAnimationLoader && isStillLoadingResources && (
+            <div style={styles.loaderContainer}>
+              <PlaceholderLoader />
+            </div>
+          )}
+        </div>
       </Line>
       {!hideControls && (
         <LineStackLayout noMargin alignItems="center">

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -21,6 +21,7 @@ import AuthorizedAssetImage from '../../AssetStore/PrivateAssets/AuthorizedAsset
 const gd: libGDevelop = global.gd;
 
 const MARGIN = 50;
+const SPRITE_MARGIN_RATIO = 1.3;
 const MAX_ZOOM_FACTOR = 10;
 const MIN_ZOOM_FACTOR = 0.1;
 
@@ -132,15 +133,13 @@ const ImagePreview = ({
     containerHeight: number,
     containerWidth: number
   ) => {
-    const zoomFactor =
-      !imageHeight || !imageWidth
-        ? 1
-        : getBoundedZoomFactor(
-            Math.min(
-              containerWidth / (imageWidth + 2 * MARGIN),
-              containerHeight / (imageHeight + 2 * MARGIN)
-            )
-          );
+    if (!imageWidth || !imageHeight) return;
+    const zoomFactor = getBoundedZoomFactor(
+      Math.min(
+        containerWidth / (imageWidth * SPRITE_MARGIN_RATIO),
+        containerHeight / (imageHeight * SPRITE_MARGIN_RATIO)
+      )
+    );
     setImageZoomFactor(zoomFactor);
   };
 


### PR DESCRIPTION
This improves the positioning of objects based on the asset size, avoiding zooming too much or not enough.
**This is helpful especially on tiny assets.**

Before:
<img width="1348" alt="Capture d’écran 2022-11-09 à 13 47 43" src="https://user-images.githubusercontent.com/4895034/200834679-02c7e119-40c2-4c6c-bd07-6533ecb7e189.png">
<img width="1369" alt="Capture d’écran 2022-11-09 à 13 47 53" src="https://user-images.githubusercontent.com/4895034/200834684-074905f0-fa5e-4ebb-9c96-b99ad04596c5.png">
<img width="1375" alt="Capture d’écran 2022-11-09 à 13 48 04" src="https://user-images.githubusercontent.com/4895034/200834687-99c64170-5c92-49f8-9d17-863868f4e9e3.png">

After:
<img width="1333" alt="Capture d’écran 2022-11-09 à 13 40 40" src="https://user-images.githubusercontent.com/4895034/200834831-39121c53-1f25-4d3c-abbc-9f21214d7e50.png">
<img width="1331" alt="Capture d’écran 2022-11-09 à 13 50 11" src="https://user-images.githubusercontent.com/4895034/200834837-b6d9ce5b-f396-46bc-969c-536aeef35e7b.png">
<img width="1332" alt="Capture d’écran 2022-11-09 à 13 41 06" src="https://user-images.githubusercontent.com/4895034/200834843-2276a2a9-3252-4ad2-b81a-41134b98fdd9.png">
