### PR TITLE
Include tags in the search for extensions and examples

### DIFF
--- a/newIDE/app/src/UI/Search/UseSearchStructuredItem.js
+++ b/newIDE/app/src/UI/Search/UseSearchStructuredItem.js
@@ -205,6 +205,7 @@ export const useSearchStructuredItem = <
             { name: 'name', weight: 2 },
             { name: 'fullName', weight: 5 },
             { name: 'shortDescription', weight: 1 },
+            { name: 'tags', weight: 4 },
           ],
           minMatchCharLength: 2,
           threshold: 0.35,


### PR DESCRIPTION
Here, the last result is only from a tag.
I guess, visually, it would be too heavy to display tags for each extension.

![image](https://user-images.githubusercontent.com/2611977/201683872-c9489510-73f2-4726-ae02-21d33b286a15.png)
