### PR TITLE
Tabs no longer disappear when scrolling in the extension editor

### DIFF
--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
@@ -18,102 +18,84 @@ type Props = {|
   onRenameSharedProperty: (oldName: string, newName: string) => void,
 |};
 
-type State = {|
-  currentTab: TabName,
-|};
+export default function EventsBasedBehaviorEditorDialog({
+  onApply,
+  eventsBasedBehavior,
+  eventsFunctionsExtension,
+  project,
+  onRenameProperty,
+  onRenameSharedProperty,
+}: Props) {
+  const [currentTab, setCurrentTab] = React.useState<TabName>('configuration');
 
-export default class EventsBasedBehaviorEditorDialog extends React.Component<
-  Props,
-  State
-> {
-  state = {
-    currentTab: 'configuration',
-  };
-
-  _changeTab = (newTab: TabName) => {
-    this.setState({
-      currentTab: newTab,
-    });
-  };
-
-  render() {
-    const {
-      onApply,
-      eventsBasedBehavior,
-      eventsFunctionsExtension,
-      project,
-    } = this.props;
-    const { currentTab } = this.state;
-
-    return (
-      <Dialog
-        title={<Trans>Edit {eventsBasedBehavior.getName()}</Trans>}
-        secondaryActions={[
-          <HelpButton
-            key="help"
-            helpPagePath="/behaviors/events-based-behaviors"
-          />,
-        ]}
-        actions={[
-          <DialogPrimaryButton
-            label={<Trans>Apply</Trans>}
-            primary
-            onClick={onApply}
-            key={'Apply'}
-          />,
-        ]}
-        open
-        onRequestClose={onApply}
-        onApply={onApply}
-        fullHeight
-        flexBody
-        fixedContent={
-          <Tabs
-            value={currentTab}
-            onChange={this._changeTab}
-            options={[
-              {
-                value: 'configuration',
-                label: <Trans>Configuration</Trans>,
-              },
-              {
-                value: 'behavior-properties',
-                label: <Trans>Behavior properties</Trans>,
-              },
-              {
-                value: 'scene-properties',
-                label: <Trans>Scene properties</Trans>,
-              },
-            ]}
-          />
-        }
-      >
-        {currentTab === 'configuration' && (
-          <EventsBasedBehaviorEditor
-            project={project}
-            eventsFunctionsExtension={eventsFunctionsExtension}
-            eventsBasedBehavior={eventsBasedBehavior}
-          />
-        )}
-        {currentTab === 'behavior-properties' && (
-          <EventsBasedBehaviorPropertiesEditor
-            allowRequiredBehavior
-            project={project}
-            properties={eventsBasedBehavior.getPropertyDescriptors()}
-            onPropertiesUpdated={() => {}}
-            onRenameProperty={this.props.onRenameProperty}
-            behaviorObjectType={eventsBasedBehavior.getObjectType()}
-          />
-        )}
-        {currentTab === 'scene-properties' && (
-          <EventsBasedBehaviorPropertiesEditor
-            project={project}
-            properties={eventsBasedBehavior.getSharedPropertyDescriptors()}
-            onPropertiesUpdated={() => {}}
-            onRenameProperty={this.props.onRenameSharedProperty}
-          />
-        )}
-      </Dialog>
-    );
-  }
+  return (
+    <Dialog
+      title={<Trans>Edit {eventsBasedBehavior.getName()}</Trans>}
+      secondaryActions={[
+        <HelpButton
+          key="help"
+          helpPagePath="/behaviors/events-based-behaviors"
+        />,
+      ]}
+      actions={[
+        <DialogPrimaryButton
+          label={<Trans>Apply</Trans>}
+          primary
+          onClick={onApply}
+          key={'Apply'}
+        />,
+      ]}
+      open
+      onRequestClose={onApply}
+      onApply={onApply}
+      fullHeight
+      flexBody
+      fixedContent={
+        <Tabs
+          value={currentTab}
+          onChange={setCurrentTab}
+          options={[
+            {
+              value: 'configuration',
+              label: <Trans>Configuration</Trans>,
+            },
+            {
+              value: 'behavior-properties',
+              label: <Trans>Behavior properties</Trans>,
+            },
+            {
+              value: 'scene-properties',
+              label: <Trans>Scene properties</Trans>,
+            },
+          ]}
+        />
+      }
+    >
+      {currentTab === 'configuration' && (
+        <EventsBasedBehaviorEditor
+          project={project}
+          eventsFunctionsExtension={eventsFunctionsExtension}
+          eventsBasedBehavior={eventsBasedBehavior}
+        />
+      )}
+      {currentTab === 'behavior-properties' && (
+        <EventsBasedBehaviorPropertiesEditor
+          allowRequiredBehavior
+          project={project}
+          properties={eventsBasedBehavior.getPropertyDescriptors()}
+          onPropertiesUpdated={() => {}}
+          onRenameProperty={onRenameProperty}
+          behaviorObjectType={eventsBasedBehavior.getObjectType()}
+        />
+      )}
+      {currentTab === 'scene-properties' && (
+        <EventsBasedBehaviorPropertiesEditor
+          project={project}
+          properties={eventsBasedBehavior.getSharedPropertyDescriptors()}
+          onPropertiesUpdated={() => {}}
+          onRenameProperty={onRenameSharedProperty}
+        />
+      )}
+    </Dialog>
+  );
 }

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
@@ -4,6 +4,10 @@ import * as React from 'react';
 import Dialog, { DialogPrimaryButton } from '../UI/Dialog';
 import EventsBasedBehaviorEditor from './index';
 import HelpButton from '../UI/HelpButton';
+import { Tabs } from '../UI/Tabs';
+import EventsBasedBehaviorPropertiesEditor from './EventsBasedBehaviorPropertiesEditor';
+
+type TabName = 'configuration' | 'behavior-properties' | 'scene-properties';
 
 type Props = {|
   onApply: () => void,
@@ -14,10 +18,24 @@ type Props = {|
   onRenameSharedProperty: (oldName: string, newName: string) => void,
 |};
 
+type State = {|
+  currentTab: TabName,
+|};
+
 export default class EventsBasedBehaviorEditorDialog extends React.Component<
   Props,
-  {||}
+  State
 > {
+  state = {
+    currentTab: 'configuration',
+  };
+
+  _changeTab = (newTab: TabName) => {
+    this.setState({
+      currentTab: newTab,
+    });
+  };
+
   render() {
     const {
       onApply,
@@ -25,6 +43,7 @@ export default class EventsBasedBehaviorEditorDialog extends React.Component<
       eventsFunctionsExtension,
       project,
     } = this.props;
+    const { currentTab } = this.state;
 
     return (
       <Dialog
@@ -46,22 +65,54 @@ export default class EventsBasedBehaviorEditorDialog extends React.Component<
         open
         onRequestClose={onApply}
         onApply={onApply}
+        fullHeight
+        flexBody
+        fixedContent={
+          <Tabs
+            value={currentTab}
+            onChange={this._changeTab}
+            options={[
+              {
+                value: 'configuration',
+                label: <Trans>Configuration</Trans>,
+              },
+              {
+                value: 'behavior-properties',
+                label: <Trans>Behavior properties</Trans>,
+              },
+              {
+                value: 'scene-properties',
+                label: <Trans>Scene properties</Trans>,
+              },
+            ]}
+          />
+        }
       >
-        <EventsBasedBehaviorEditor
-          project={project}
-          eventsFunctionsExtension={eventsFunctionsExtension}
-          eventsBasedBehavior={eventsBasedBehavior}
-          onTabChanged={
-            () =>
-              this.forceUpdate() /*Force update to ensure dialog is properly positioned*/
-          }
-          onPropertiesUpdated={
-            () =>
-              this.forceUpdate() /*Force update to ensure dialog is properly positioned*/
-          }
-          onRenameProperty={this.props.onRenameProperty}
-          onRenameSharedProperty={this.props.onRenameSharedProperty}
-        />
+        {currentTab === 'configuration' && (
+          <EventsBasedBehaviorEditor
+            project={project}
+            eventsFunctionsExtension={eventsFunctionsExtension}
+            eventsBasedBehavior={eventsBasedBehavior}
+          />
+        )}
+        {currentTab === 'behavior-properties' && (
+          <EventsBasedBehaviorPropertiesEditor
+            allowRequiredBehavior
+            project={project}
+            properties={eventsBasedBehavior.getPropertyDescriptors()}
+            onPropertiesUpdated={() => {}}
+            onRenameProperty={this.props.onRenameProperty}
+            behaviorObjectType={eventsBasedBehavior.getObjectType()}
+          />
+        )}
+        {currentTab === 'shared-properties' && (
+          <EventsBasedBehaviorPropertiesEditor
+            project={project}
+            properties={eventsBasedBehavior.getSharedPropertyDescriptors()}
+            onPropertiesUpdated={() => {}}
+            onRenameProperty={this.props.onRenameSharedProperty}
+          />
+        )}
       </Dialog>
     );
   }

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
@@ -105,7 +105,7 @@ export default class EventsBasedBehaviorEditorDialog extends React.Component<
             behaviorObjectType={eventsBasedBehavior.getObjectType()}
           />
         )}
-        {currentTab === 'shared-properties' && (
+        {currentTab === 'scene-properties' && (
           <EventsBasedBehaviorPropertiesEditor
             project={project}
             properties={eventsBasedBehavior.getSharedPropertyDescriptors()}

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.js
@@ -83,7 +83,6 @@ export default function EventsBasedBehaviorEditorDialog({
           allowRequiredBehavior
           project={project}
           properties={eventsBasedBehavior.getPropertyDescriptors()}
-          onPropertiesUpdated={() => {}}
           onRenameProperty={onRenameProperty}
           behaviorObjectType={eventsBasedBehavior.getObjectType()}
         />
@@ -92,7 +91,6 @@ export default function EventsBasedBehaviorEditorDialog({
         <EventsBasedBehaviorPropertiesEditor
           project={project}
           properties={eventsBasedBehavior.getSharedPropertyDescriptors()}
-          onPropertiesUpdated={() => {}}
           onRenameProperty={onRenameSharedProperty}
         />
       )}

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -97,7 +97,7 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
     const property = properties.insertNew(newName, properties.getCount());
     property.setType('Number');
     this.forceUpdate();
-    this.props.onPropertiesUpdated();
+    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
   };
 
   _removeProperty = (name: string) => {
@@ -105,7 +105,7 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
 
     properties.remove(name);
     this.forceUpdate();
-    this.props.onPropertiesUpdated();
+    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
   };
 
   _moveProperty = (oldIndex: number, newIndex: number) => {
@@ -113,7 +113,7 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
 
     properties.move(oldIndex, newIndex);
     this.forceUpdate();
-    this.props.onPropertiesUpdated();
+    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
   };
 
   _setChoiceExtraInfo = (property: gdNamedPropertyDescriptor) => {
@@ -172,7 +172,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
 
                           property.setName(newName);
                           this.forceUpdate();
-                          this.props.onPropertiesUpdated();
+                          this.props.onPropertiesUpdated &&
+                            this.props.onPropertiesUpdated();
                         }}
                         fullWidth
                       />
@@ -190,7 +191,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                         onCheck={(e, checked) => {
                           property.setHidden(!checked);
                           this.forceUpdate();
-                          this.props.onPropertiesUpdated();
+                          this.props.onPropertiesUpdated &&
+                            this.props.onPropertiesUpdated();
                         }}
                         checkedIcon={<Visibility />}
                         uncheckedIcon={<VisibilityOff />}
@@ -238,7 +240,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                               property.setHidden(false);
                             }
                             this.forceUpdate();
-                            this.props.onPropertiesUpdated();
+                            this.props.onPropertiesUpdated &&
+                              this.props.onPropertiesUpdated();
                           }}
                           fullWidth
                         >
@@ -281,7 +284,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                             onChange={newValue => {
                               property.setValue(newValue);
                               this.forceUpdate();
-                              this.props.onPropertiesUpdated();
+                              this.props.onPropertiesUpdated &&
+                                this.props.onPropertiesUpdated();
                             }}
                             fullWidth
                           />
@@ -295,7 +299,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                             onChange={(e, i, value) => {
                               property.setValue(value);
                               this.forceUpdate();
-                              this.props.onPropertiesUpdated();
+                              this.props.onPropertiesUpdated &&
+                                this.props.onPropertiesUpdated();
                             }}
                             fullWidth
                           >
@@ -328,7 +333,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                                   extraInfo.set(0, newValue);
                                 }
                                 this.forceUpdate();
-                                this.props.onPropertiesUpdated();
+                                this.props.onPropertiesUpdated &&
+                                  this.props.onPropertiesUpdated();
                               }}
                               disabled={false}
                             />
@@ -342,7 +348,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                             onChange={color => {
                               property.setValue(color);
                               this.forceUpdate();
-                              this.props.onPropertiesUpdated();
+                              this.props.onPropertiesUpdated &&
+                                this.props.onPropertiesUpdated();
                             }}
                           />
                         )}
@@ -353,7 +360,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                             onChange={(e, i, value) => {
                               property.setValue(value);
                               this.forceUpdate();
-                              this.props.onPropertiesUpdated();
+                              this.props.onPropertiesUpdated &&
+                                this.props.onPropertiesUpdated();
                             }}
                             fullWidth
                           >
@@ -396,7 +404,8 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
                           onChange={text => {
                             property.setGroup(text);
                             this.forceUpdate();
-                            this.props.onPropertiesUpdated();
+                            this.props.onPropertiesUpdated &&
+                              this.props.onPropertiesUpdated();
                           }}
                           dataSource={this._getPropertyGroupNames().map(
                             name => ({

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -34,7 +34,7 @@ type Props = {|
   project: gdProject,
   properties: gdNamedPropertyDescriptorsList,
   allowRequiredBehavior?: boolean,
-  onPropertiesUpdated: () => void,
+  onPropertiesUpdated?: () => void,
   onRenameProperty: (oldName: string, newName: string) => void,
   behaviorObjectType?: string,
 |};

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -26,6 +26,7 @@ import StringArrayEditor from '../StringArrayEditor';
 import ColorField from '../UI/ColorField';
 import BehaviorTypeSelector from '../BehaviorTypeSelector';
 import SemiControlledAutoComplete from '../UI/SemiControlledAutoComplete';
+import ScrollView from '../UI/ScrollView';
 
 const gd: libGDevelop = global.gd;
 
@@ -37,12 +38,6 @@ type Props = {|
   onRenameProperty: (oldName: string, newName: string) => void,
   behaviorObjectType?: string,
 |};
-
-const styles = {
-  propertiesContainer: {
-    flex: 1,
-  },
-};
 
 const validatePropertyName = (
   i18n: I18nType,
@@ -153,313 +148,301 @@ export default class EventsBasedBehaviorPropertiesEditor extends React.Component
     return (
       <I18n>
         {({ i18n }) => (
-          <Column noMargin expand>
-            <Line noMargin>
-              <div style={styles.propertiesContainer}>
-                {mapVector(
-                  properties,
-                  (property: gdNamedPropertyDescriptor, i: number) => (
-                    <React.Fragment key={i}>
-                      <MiniToolbar noPadding>
-                        <Column expand noMargin>
-                          <SemiControlledTextField
-                            margin="none"
-                            commitOnBlur
-                            translatableHintText={t`Enter the property name`}
-                            value={property.getName()}
-                            onChange={newName => {
-                              if (newName === property.getName()) return;
-                              if (
-                                !validatePropertyName(i18n, properties, newName)
-                              )
-                                return;
+          <ScrollView>
+            {mapVector(
+              properties,
+              (property: gdNamedPropertyDescriptor, i: number) => (
+                <React.Fragment key={i}>
+                  <MiniToolbar noPadding>
+                    <Column expand noMargin>
+                      <SemiControlledTextField
+                        margin="none"
+                        commitOnBlur
+                        translatableHintText={t`Enter the property name`}
+                        value={property.getName()}
+                        onChange={newName => {
+                          if (newName === property.getName()) return;
+                          if (!validatePropertyName(i18n, properties, newName))
+                            return;
 
-                              this.props.onRenameProperty(
-                                property.getName(),
-                                newName
-                              );
+                          this.props.onRenameProperty(
+                            property.getName(),
+                            newName
+                          );
 
-                              property.setName(newName);
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated();
-                            }}
-                            fullWidth
-                          />
-                        </Column>
-                        <Column>
-                          <InlineCheckbox
-                            label={
-                              property.isHidden() ? (
-                                <Trans>Hidden</Trans>
-                              ) : (
-                                <Trans>Visible in editor</Trans>
-                              )
+                          property.setName(newName);
+                          this.forceUpdate();
+                          this.props.onPropertiesUpdated();
+                        }}
+                        fullWidth
+                      />
+                    </Column>
+                    <Column>
+                      <InlineCheckbox
+                        label={
+                          property.isHidden() ? (
+                            <Trans>Hidden</Trans>
+                          ) : (
+                            <Trans>Visible in editor</Trans>
+                          )
+                        }
+                        checked={!property.isHidden()}
+                        onCheck={(e, checked) => {
+                          property.setHidden(!checked);
+                          this.forceUpdate();
+                          this.props.onPropertiesUpdated();
+                        }}
+                        checkedIcon={<Visibility />}
+                        uncheckedIcon={<VisibilityOff />}
+                        disabled={
+                          property.getType() === 'Behavior' &&
+                          // Allow to make it visible just in case.
+                          !property.isHidden()
+                        }
+                      />
+                    </Column>
+                    <ElementWithMenu
+                      element={
+                        <IconButton>
+                          <MoreVert />
+                        </IconButton>
+                      }
+                      buildMenuTemplate={(i18n: I18nType) => [
+                        {
+                          label: i18n._(t`Delete`),
+                          click: () => this._removeProperty(property.getName()),
+                        },
+                        { type: 'separator' },
+                        {
+                          label: i18n._(t`Move up`),
+                          click: () => this._moveProperty(i, i - 1),
+                          enabled: i - 1 >= 0,
+                        },
+                        {
+                          label: i18n._(t`Move down`),
+                          click: () => this._moveProperty(i, i + 1),
+                          enabled: i + 1 < properties.getCount(),
+                        },
+                      ]}
+                    />
+                  </MiniToolbar>
+                  <Line>
+                    <ColumnStackLayout expand noMargin>
+                      <ResponsiveLineStackLayout noMargin>
+                        <SelectField
+                          floatingLabelText={<Trans>Type</Trans>}
+                          value={property.getType()}
+                          onChange={(e, i, value: string) => {
+                            property.setType(value);
+                            if (value === 'Behavior') {
+                              property.setHidden(false);
                             }
-                            checked={!property.isHidden()}
-                            onCheck={(e, checked) => {
-                              property.setHidden(!checked);
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated();
-                            }}
-                            checkedIcon={<Visibility />}
-                            uncheckedIcon={<VisibilityOff />}
-                            disabled={
-                              property.getType() === 'Behavior' &&
-                              // Allow to make it visible just in case.
-                              !property.isHidden()
-                            }
+                            this.forceUpdate();
+                            this.props.onPropertiesUpdated();
+                          }}
+                          fullWidth
+                        >
+                          <SelectOption
+                            value="Number"
+                            primaryText={t`Number`}
                           />
-                        </Column>
-                        <ElementWithMenu
-                          element={
-                            <IconButton>
-                              <MoreVert />
-                            </IconButton>
-                          }
-                          buildMenuTemplate={(i18n: I18nType) => [
-                            {
-                              label: i18n._(t`Delete`),
-                              click: () =>
-                                this._removeProperty(property.getName()),
-                            },
-                            { type: 'separator' },
-                            {
-                              label: i18n._(t`Move up`),
-                              click: () => this._moveProperty(i, i - 1),
-                              enabled: i - 1 >= 0,
-                            },
-                            {
-                              label: i18n._(t`Move down`),
-                              click: () => this._moveProperty(i, i + 1),
-                              enabled: i + 1 < properties.getCount(),
-                            },
-                          ]}
-                        />
-                      </MiniToolbar>
-                      <Line>
-                        <ColumnStackLayout expand noMargin>
-                          <ResponsiveLineStackLayout noMargin>
-                            <SelectField
-                              floatingLabelText={<Trans>Type</Trans>}
-                              value={property.getType()}
-                              onChange={(e, i, value: string) => {
-                                property.setType(value);
-                                if (value === 'Behavior') {
-                                  property.setHidden(false);
-                                }
-                                this.forceUpdate();
-                                this.props.onPropertiesUpdated();
-                              }}
-                              fullWidth
-                            >
-                              <SelectOption
-                                value="Number"
-                                primaryText={t`Number`}
-                              />
-                              <SelectOption
-                                value="String"
-                                primaryText={t`String`}
-                              />
-                              <SelectOption
-                                value="Boolean"
-                                primaryText={t`Boolean (checkbox)`}
-                              />
-                              <SelectOption
-                                value="Choice"
-                                primaryText={t`String from a list of options (text)`}
-                              />
-                              <SelectOption
-                                value="Color"
-                                primaryText={t`Color (text)`}
-                              />
-                              {this.props.allowRequiredBehavior && (
-                                <SelectOption
-                                  value="Behavior"
-                                  primaryText={t`Required behavior`}
-                                />
-                              )}
-                            </SelectField>
-                            {(property.getType() === 'String' ||
-                              property.getType() === 'Number') && (
-                              <SemiControlledTextField
-                                commitOnBlur
-                                floatingLabelText={<Trans>Default value</Trans>}
-                                hintText={
-                                  property.getType() === 'Number'
-                                    ? '123'
-                                    : 'ABC'
-                                }
-                                value={property.getValue()}
-                                onChange={newValue => {
-                                  property.setValue(newValue);
-                                  this.forceUpdate();
-                                  this.props.onPropertiesUpdated();
-                                }}
-                                fullWidth
-                              />
-                            )}
-                            {property.getType() === 'Boolean' && (
-                              <SelectField
-                                floatingLabelText={<Trans>Default value</Trans>}
-                                value={
-                                  property.getValue() === 'true'
-                                    ? 'true'
-                                    : 'false'
-                                }
-                                onChange={(e, i, value) => {
-                                  property.setValue(value);
-                                  this.forceUpdate();
-                                  this.props.onPropertiesUpdated();
-                                }}
-                                fullWidth
-                              >
-                                <SelectOption
-                                  value="true"
-                                  primaryText={t`True (checked)`}
-                                />
-                                <SelectOption
-                                  value="false"
-                                  primaryText={t`False (not checked)`}
-                                />
-                              </SelectField>
-                            )}
-                            {property.getType() === 'Behavior' &&
-                              this.props.behaviorObjectType && (
-                                <BehaviorTypeSelector
-                                  project={this.props.project}
-                                  objectType={this.props.behaviorObjectType}
-                                  value={
-                                    property.getExtraInfo().size() === 0
-                                      ? ''
-                                      : property.getExtraInfo().at(0)
-                                  }
-                                  onChange={(newValue: string) => {
-                                    // Change the type of the required behavior.
-                                    const extraInfo = property.getExtraInfo();
-                                    if (extraInfo.size() === 0) {
-                                      extraInfo.push_back(newValue);
-                                    } else {
-                                      extraInfo.set(0, newValue);
-                                    }
-                                    this.forceUpdate();
-                                    this.props.onPropertiesUpdated();
-                                  }}
-                                  disabled={false}
-                                />
-                              )}
-                            {property.getType() === 'Color' && (
-                              <ColorField
-                                floatingLabelText={<Trans>Default value</Trans>}
-                                disableAlpha
-                                fullWidth
-                                color={property.getValue()}
-                                onChange={color => {
-                                  property.setValue(color);
-                                  this.forceUpdate();
-                                  this.props.onPropertiesUpdated();
-                                }}
-                              />
-                            )}
-                            {property.getType() === 'Choice' && (
-                              <SelectField
-                                floatingLabelText={<Trans>Default value</Trans>}
-                                value={property.getValue()}
-                                onChange={(e, i, value) => {
-                                  property.setValue(value);
-                                  this.forceUpdate();
-                                  this.props.onPropertiesUpdated();
-                                }}
-                                fullWidth
-                              >
-                                {getExtraInfoArray(property).map(
-                                  (choice, index) => (
-                                    <SelectOption
-                                      key={index}
-                                      value={choice}
-                                      primaryText={choice}
-                                    />
-                                  )
-                                )}
-                              </SelectField>
-                            )}
-                          </ResponsiveLineStackLayout>
-                          {property.getType() === 'Choice' && (
-                            <StringArrayEditor
-                              extraInfo={getExtraInfoArray(property)}
-                              setExtraInfo={this._setChoiceExtraInfo(property)}
+                          <SelectOption
+                            value="String"
+                            primaryText={t`String`}
+                          />
+                          <SelectOption
+                            value="Boolean"
+                            primaryText={t`Boolean (checkbox)`}
+                          />
+                          <SelectOption
+                            value="Choice"
+                            primaryText={t`String from a list of options (text)`}
+                          />
+                          <SelectOption
+                            value="Color"
+                            primaryText={t`Color (text)`}
+                          />
+                          {this.props.allowRequiredBehavior && (
+                            <SelectOption
+                              value="Behavior"
+                              primaryText={t`Required behavior`}
                             />
                           )}
-                          <ResponsiveLineStackLayout noMargin>
-                            <SemiControlledTextField
-                              commitOnBlur
-                              floatingLabelText={<Trans>Short label</Trans>}
-                              translatableHintText={t`Make the purpose of the property easy to understand`}
-                              floatingLabelFixed
-                              value={property.getLabel()}
-                              onChange={text => {
-                                property.setLabel(text);
-                                this.forceUpdate();
-                              }}
-                              fullWidth
-                            />
-                            <SemiControlledAutoComplete
-                              floatingLabelText={<Trans>Group name</Trans>}
-                              hintText={t`Leave it empty to use the default group`}
-                              fullWidth
-                              value={property.getGroup()}
-                              onChange={text => {
-                                property.setGroup(text);
-                                this.forceUpdate();
-                                this.props.onPropertiesUpdated();
-                              }}
-                              dataSource={this._getPropertyGroupNames().map(
-                                name => ({
-                                  text: name,
-                                  value: name,
-                                })
-                              )}
-                              openOnFocus={true}
-                            />
-                          </ResponsiveLineStackLayout>
+                        </SelectField>
+                        {(property.getType() === 'String' ||
+                          property.getType() === 'Number') && (
                           <SemiControlledTextField
                             commitOnBlur
-                            floatingLabelText={<Trans>Description</Trans>}
-                            translatableHintText={t`Optionally, explain the purpose of the property in more details`}
-                            floatingLabelFixed
-                            value={property.getDescription()}
-                            onChange={text => {
-                              property.setDescription(text);
+                            floatingLabelText={<Trans>Default value</Trans>}
+                            hintText={
+                              property.getType() === 'Number' ? '123' : 'ABC'
+                            }
+                            value={property.getValue()}
+                            onChange={newValue => {
+                              property.setValue(newValue);
                               this.forceUpdate();
+                              this.props.onPropertiesUpdated();
                             }}
                             fullWidth
                           />
-                        </ColumnStackLayout>
-                      </Line>
-                    </React.Fragment>
-                  )
-                )}
-                {properties.getCount() === 0 ? (
-                  <EmptyMessage>
-                    <Trans>
-                      No properties for this behavior. Add one to store data
-                      inside this behavior (for example: health, ammo, speed,
-                      etc...)
-                    </Trans>
-                  </EmptyMessage>
-                ) : null}
-                <Column>
-                  <Line justifyContent="flex-end" expand>
-                    <RaisedButton
-                      primary
-                      label={<Trans>Add a property</Trans>}
-                      onClick={this._addProperty}
-                      icon={<Add />}
-                    />
+                        )}
+                        {property.getType() === 'Boolean' && (
+                          <SelectField
+                            floatingLabelText={<Trans>Default value</Trans>}
+                            value={
+                              property.getValue() === 'true' ? 'true' : 'false'
+                            }
+                            onChange={(e, i, value) => {
+                              property.setValue(value);
+                              this.forceUpdate();
+                              this.props.onPropertiesUpdated();
+                            }}
+                            fullWidth
+                          >
+                            <SelectOption
+                              value="true"
+                              primaryText={t`True (checked)`}
+                            />
+                            <SelectOption
+                              value="false"
+                              primaryText={t`False (not checked)`}
+                            />
+                          </SelectField>
+                        )}
+                        {property.getType() === 'Behavior' &&
+                          this.props.behaviorObjectType && (
+                            <BehaviorTypeSelector
+                              project={this.props.project}
+                              objectType={this.props.behaviorObjectType}
+                              value={
+                                property.getExtraInfo().size() === 0
+                                  ? ''
+                                  : property.getExtraInfo().at(0)
+                              }
+                              onChange={(newValue: string) => {
+                                // Change the type of the required behavior.
+                                const extraInfo = property.getExtraInfo();
+                                if (extraInfo.size() === 0) {
+                                  extraInfo.push_back(newValue);
+                                } else {
+                                  extraInfo.set(0, newValue);
+                                }
+                                this.forceUpdate();
+                                this.props.onPropertiesUpdated();
+                              }}
+                              disabled={false}
+                            />
+                          )}
+                        {property.getType() === 'Color' && (
+                          <ColorField
+                            floatingLabelText={<Trans>Default value</Trans>}
+                            disableAlpha
+                            fullWidth
+                            color={property.getValue()}
+                            onChange={color => {
+                              property.setValue(color);
+                              this.forceUpdate();
+                              this.props.onPropertiesUpdated();
+                            }}
+                          />
+                        )}
+                        {property.getType() === 'Choice' && (
+                          <SelectField
+                            floatingLabelText={<Trans>Default value</Trans>}
+                            value={property.getValue()}
+                            onChange={(e, i, value) => {
+                              property.setValue(value);
+                              this.forceUpdate();
+                              this.props.onPropertiesUpdated();
+                            }}
+                            fullWidth
+                          >
+                            {getExtraInfoArray(property).map(
+                              (choice, index) => (
+                                <SelectOption
+                                  key={index}
+                                  value={choice}
+                                  primaryText={choice}
+                                />
+                              )
+                            )}
+                          </SelectField>
+                        )}
+                      </ResponsiveLineStackLayout>
+                      {property.getType() === 'Choice' && (
+                        <StringArrayEditor
+                          extraInfo={getExtraInfoArray(property)}
+                          setExtraInfo={this._setChoiceExtraInfo(property)}
+                        />
+                      )}
+                      <ResponsiveLineStackLayout noMargin>
+                        <SemiControlledTextField
+                          commitOnBlur
+                          floatingLabelText={<Trans>Short label</Trans>}
+                          translatableHintText={t`Make the purpose of the property easy to understand`}
+                          floatingLabelFixed
+                          value={property.getLabel()}
+                          onChange={text => {
+                            property.setLabel(text);
+                            this.forceUpdate();
+                          }}
+                          fullWidth
+                        />
+                        <SemiControlledAutoComplete
+                          floatingLabelText={<Trans>Group name</Trans>}
+                          hintText={t`Leave it empty to use the default group`}
+                          fullWidth
+                          value={property.getGroup()}
+                          onChange={text => {
+                            property.setGroup(text);
+                            this.forceUpdate();
+                            this.props.onPropertiesUpdated();
+                          }}
+                          dataSource={this._getPropertyGroupNames().map(
+                            name => ({
+                              text: name,
+                              value: name,
+                            })
+                          )}
+                          openOnFocus={true}
+                        />
+                      </ResponsiveLineStackLayout>
+                      <SemiControlledTextField
+                        commitOnBlur
+                        floatingLabelText={<Trans>Description</Trans>}
+                        translatableHintText={t`Optionally, explain the purpose of the property in more details`}
+                        floatingLabelFixed
+                        value={property.getDescription()}
+                        onChange={text => {
+                          property.setDescription(text);
+                          this.forceUpdate();
+                        }}
+                        fullWidth
+                      />
+                    </ColumnStackLayout>
                   </Line>
-                </Column>
-              </div>
-            </Line>
-          </Column>
+                </React.Fragment>
+              )
+            )}
+            {properties.getCount() === 0 ? (
+              <EmptyMessage>
+                <Trans>
+                  No properties for this behavior. Add one to store data inside
+                  this behavior (for example: health, ammo, speed, etc...)
+                </Trans>
+              </EmptyMessage>
+            ) : null}
+            <Column>
+              <Line justifyContent="flex-end" expand>
+                <RaisedButton
+                  primary
+                  label={<Trans>Add a property</Trans>}
+                  onClick={this._addProperty}
+                  icon={<Add />}
+                />
+              </Line>
+            </Column>
+          </ScrollView>
         )}
       </I18n>
     );

--- a/newIDE/app/src/EventsBasedBehaviorEditor/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/index.js
@@ -11,6 +11,8 @@ import ObjectTypeSelector from '../ObjectTypeSelector';
 import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import AlertMessage from '../UI/AlertMessage';
 import { ColumnStackLayout } from '../UI/Layout';
+import useForceUpdate from '../Utils/UseForceUpdate';
+
 const gd: libGDevelop = global.gd;
 
 type Props = {|
@@ -19,118 +21,120 @@ type Props = {|
   eventsBasedBehavior: gdEventsBasedBehavior,
 |};
 
-export default class EventsBasedBehaviorEditor extends React.Component<
-  Props,
-  {||}
-> {
+export default function EventsBasedBehaviorEditor({
+  project,
+  eventsFunctionsExtension,
+  eventsBasedBehavior,
+}: Props) {
+  const forceUpdate = useForceUpdate();
+
   // An array containing all the object types that are using the behavior
-  _allObjectTypes: Array<string> = gd.WholeProjectRefactorer.getAllObjectTypesUsingEventsBasedBehavior(
-    this.props.project,
-    this.props.eventsFunctionsExtension,
-    this.props.eventsBasedBehavior
-  )
-    .toNewVectorString()
-    .toJSArray();
+  const allObjectTypes: Array<string> = React.useMemo(
+    () =>
+      gd.WholeProjectRefactorer.getAllObjectTypesUsingEventsBasedBehavior(
+        project,
+        eventsFunctionsExtension,
+        eventsBasedBehavior
+      )
+        .toNewVectorString()
+        .toJSArray(),
+    [project, eventsFunctionsExtension, eventsBasedBehavior]
+  );
 
-  render() {
-    const { eventsBasedBehavior, project } = this.props;
-
-    return (
-      <I18n>
-        {({ i18n }: { i18n: I18nType }) => (
-          <ColumnStackLayout expand noMargin>
+  return (
+    <I18n>
+      {({ i18n }: { i18n: I18nType }) => (
+        <ColumnStackLayout expand noMargin>
+          <DismissableAlertMessage
+            identifier="events-based-behavior-explanation"
+            kind="info"
+          >
+            <Trans>
+              This is the configuration of your behavior. Make sure to choose a
+              proper internal name as it's hard to change it later. Enter a
+              description explaining what the behavior is doing to the object.
+            </Trans>
+          </DismissableAlertMessage>
+          <TextField
+            floatingLabelText={<Trans>Internal Name</Trans>}
+            value={eventsBasedBehavior.getName()}
+            disabled
+            fullWidth
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Name displayed in editor</Trans>}
+            value={eventsBasedBehavior.getFullName()}
+            onChange={text => {
+              eventsBasedBehavior.setFullName(text);
+              forceUpdate();
+            }}
+            fullWidth
+          />
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Description</Trans>}
+            helperMarkdownText={i18n._(
+              t`Explain what the behavior is doing to the object. Start with a verb when possible.`
+            )}
+            value={eventsBasedBehavior.getDescription()}
+            onChange={text => {
+              eventsBasedBehavior.setDescription(text);
+              forceUpdate();
+            }}
+            multiline
+            fullWidth
+            rows={3}
+          />
+          <ObjectTypeSelector
+            floatingLabelText={
+              <Trans>Object on which this behavior can be used</Trans>
+            }
+            project={project}
+            value={eventsBasedBehavior.getObjectType()}
+            onChange={(objectType: string) => {
+              eventsBasedBehavior.setObjectType(objectType);
+              forceUpdate();
+            }}
+            allowedObjectTypes={
+              allObjectTypes.length === 0
+                ? undefined /* Allow anything as the behavior is not used */
+                : allObjectTypes.length === 1
+                ? [
+                    '',
+                    allObjectTypes[0],
+                  ] /* Allow only the type of the objects using the behavior */
+                : [
+                    '',
+                  ] /* More than one type of object are using the behavior. Only "any object" can be used on this behavior */
+            }
+          />
+          {allObjectTypes.length > 1 && (
+            <AlertMessage kind="info">
+              <Trans>
+                This behavior is being used by multiple types of objects. Thus,
+                you can't restrict its usage to any particular object type. All
+                the object types using this behavior are listed here:
+                {allObjectTypes.join(', ')}
+              </Trans>
+            </AlertMessage>
+          )}
+          {eventsBasedBehavior
+            .getEventsFunctions()
+            .getEventsFunctionsCount() === 0 && (
             <DismissableAlertMessage
-              identifier="events-based-behavior-explanation"
+              identifier="empty-events-based-behavior-explanation"
               kind="info"
             >
               <Trans>
-                This is the configuration of your behavior. Make sure to choose
-                a proper internal name as it's hard to change it later. Enter a
-                description explaining what the behavior is doing to the object.
+                Once you're done, close this dialog and start adding some
+                functions to the behavior. Then, test the behavior by adding it
+                to an object in a scene.
               </Trans>
             </DismissableAlertMessage>
-            <TextField
-              floatingLabelText={<Trans>Internal Name</Trans>}
-              value={eventsBasedBehavior.getName()}
-              disabled
-              fullWidth
-            />
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={<Trans>Name displayed in editor</Trans>}
-              value={eventsBasedBehavior.getFullName()}
-              onChange={text => {
-                eventsBasedBehavior.setFullName(text);
-                this.forceUpdate();
-              }}
-              fullWidth
-            />
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={<Trans>Description</Trans>}
-              helperMarkdownText={i18n._(
-                t`Explain what the behavior is doing to the object. Start with a verb when possible.`
-              )}
-              value={eventsBasedBehavior.getDescription()}
-              onChange={text => {
-                eventsBasedBehavior.setDescription(text);
-                this.forceUpdate();
-              }}
-              multiline
-              fullWidth
-              rows={3}
-            />
-            <ObjectTypeSelector
-              floatingLabelText={
-                <Trans>Object on which this behavior can be used</Trans>
-              }
-              project={project}
-              value={eventsBasedBehavior.getObjectType()}
-              onChange={(objectType: string) => {
-                eventsBasedBehavior.setObjectType(objectType);
-                this.forceUpdate();
-              }}
-              allowedObjectTypes={
-                this._allObjectTypes.length === 0
-                  ? undefined /* Allow anything as the behavior is not used */
-                  : this._allObjectTypes.length === 1
-                  ? [
-                      '',
-                      this._allObjectTypes[0],
-                    ] /* Allow only the type of the objects using the behavior */
-                  : [
-                      '',
-                    ] /* More than one type of object are using the behavior. Only "any object" can be used on this behavior */
-              }
-            />
-            {this._allObjectTypes.length > 1 && (
-              <AlertMessage kind="info">
-                <Trans>
-                  This behavior is being used by multiple types of objects.
-                  Thus, you can't restrict its usage to any particular object
-                  type. All the object types using this behavior are listed
-                  here:
-                  {this._allObjectTypes.join(', ')}
-                </Trans>
-              </AlertMessage>
-            )}
-            {eventsBasedBehavior
-              .getEventsFunctions()
-              .getEventsFunctionsCount() === 0 && (
-              <DismissableAlertMessage
-                identifier="empty-events-based-behavior-explanation"
-                kind="info"
-              >
-                <Trans>
-                  Once you're done, close this dialog and start adding some
-                  functions to the behavior. Then, test the behavior by adding
-                  it to an object in a scene.
-                </Trans>
-              </DismissableAlertMessage>
-            )}
-          </ColumnStackLayout>
-        )}
-      </I18n>
-    );
-  }
+          )}
+        </ColumnStackLayout>
+      )}
+    </I18n>
+  );
 }

--- a/newIDE/app/src/EventsBasedBehaviorEditor/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/index.js
@@ -8,38 +8,21 @@ import * as React from 'react';
 import TextField from '../UI/TextField';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import ObjectTypeSelector from '../ObjectTypeSelector';
-import { Tabs } from '../UI/Tabs';
 import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import AlertMessage from '../UI/AlertMessage';
-import EventsBasedBehaviorPropertiesEditor from './EventsBasedBehaviorPropertiesEditor';
 import { ColumnStackLayout } from '../UI/Layout';
-import { Line } from '../UI/Grid';
 const gd: libGDevelop = global.gd;
-
-type TabName = 'configuration' | 'behavior-properties' | 'scene-properties';
 
 type Props = {|
   project: gdProject,
   eventsFunctionsExtension: gdEventsFunctionsExtension,
   eventsBasedBehavior: gdEventsBasedBehavior,
-  onPropertiesUpdated: () => void,
-  onRenameProperty: (oldName: string, newName: string) => void,
-  onRenameSharedProperty: (oldName: string, newName: string) => void,
-  onTabChanged: () => void,
-|};
-
-type State = {|
-  currentTab: TabName,
 |};
 
 export default class EventsBasedBehaviorEditor extends React.Component<
   Props,
-  State
+  {||}
 > {
-  state = {
-    currentTab: 'configuration',
-  };
-
   // An array containing all the object types that are using the behavior
   _allObjectTypes: Array<string> = gd.WholeProjectRefactorer.getAllObjectTypesUsingEventsBasedBehavior(
     this.props.project,
@@ -49,155 +32,103 @@ export default class EventsBasedBehaviorEditor extends React.Component<
     .toNewVectorString()
     .toJSArray();
 
-  _changeTab = (newTab: TabName) =>
-    this.setState(
-      {
-        currentTab: newTab,
-      },
-      () => this.props.onTabChanged()
-    );
-
   render() {
-    const { currentTab } = this.state;
     const { eventsBasedBehavior, project } = this.props;
 
     return (
       <I18n>
         {({ i18n }: { i18n: I18nType }) => (
-          <React.Fragment>
-            <Tabs
-              value={currentTab}
-              onChange={this._changeTab}
-              options={[
-                {
-                  value: 'configuration',
-                  label: <Trans>Configuration</Trans>,
-                },
-                {
-                  value: 'behavior-properties',
-                  label: <Trans>Behavior properties</Trans>,
-                },
-                {
-                  value: 'scene-properties',
-                  label: <Trans>Scene properties</Trans>,
-                },
-              ]}
+          <ColumnStackLayout expand noMargin>
+            <DismissableAlertMessage
+              identifier="events-based-behavior-explanation"
+              kind="info"
+            >
+              <Trans>
+                This is the configuration of your behavior. Make sure to choose
+                a proper internal name as it's hard to change it later. Enter a
+                description explaining what the behavior is doing to the object.
+              </Trans>
+            </DismissableAlertMessage>
+            <TextField
+              floatingLabelText={<Trans>Internal Name</Trans>}
+              value={eventsBasedBehavior.getName()}
+              disabled
+              fullWidth
             />
-            <Line>
-              {currentTab === 'configuration' && (
-                <ColumnStackLayout expand noMargin>
-                  <DismissableAlertMessage
-                    identifier="events-based-behavior-explanation"
-                    kind="info"
-                  >
-                    <Trans>
-                      This is the configuration of your behavior. Make sure to
-                      choose a proper internal name as it's hard to change it
-                      later. Enter a description explaining what the behavior is
-                      doing to the object.
-                    </Trans>
-                  </DismissableAlertMessage>
-                  <TextField
-                    floatingLabelText={<Trans>Internal Name</Trans>}
-                    value={eventsBasedBehavior.getName()}
-                    disabled
-                    fullWidth
-                  />
-                  <SemiControlledTextField
-                    commitOnBlur
-                    floatingLabelText={<Trans>Name displayed in editor</Trans>}
-                    value={eventsBasedBehavior.getFullName()}
-                    onChange={text => {
-                      eventsBasedBehavior.setFullName(text);
-                      this.forceUpdate();
-                    }}
-                    fullWidth
-                  />
-                  <SemiControlledTextField
-                    commitOnBlur
-                    floatingLabelText={<Trans>Description</Trans>}
-                    helperMarkdownText={i18n._(
-                      t`Explain what the behavior is doing to the object. Start with a verb when possible.`
-                    )}
-                    value={eventsBasedBehavior.getDescription()}
-                    onChange={text => {
-                      eventsBasedBehavior.setDescription(text);
-                      this.forceUpdate();
-                    }}
-                    multiline
-                    fullWidth
-                    rows={3}
-                  />
-                  <ObjectTypeSelector
-                    floatingLabelText={
-                      <Trans>Object on which this behavior can be used</Trans>
-                    }
-                    project={project}
-                    value={eventsBasedBehavior.getObjectType()}
-                    onChange={(objectType: string) => {
-                      eventsBasedBehavior.setObjectType(objectType);
-                      this.forceUpdate();
-                    }}
-                    allowedObjectTypes={
-                      this._allObjectTypes.length === 0
-                        ? undefined /* Allow anything as the behavior is not used */
-                        : this._allObjectTypes.length === 1
-                        ? [
-                            '',
-                            this._allObjectTypes[0],
-                          ] /* Allow only the type of the objects using the behavior */
-                        : [
-                            '',
-                          ] /* More than one type of object are using the behavior. Only "any object" can be used on this behavior */
-                    }
-                  />
-                  {this._allObjectTypes.length > 1 && (
-                    <AlertMessage kind="info">
-                      <Trans>
-                        This behavior is being used by multiple types of
-                        objects. Thus, you can't restrict its usage to any
-                        particular object type. All the object types using this
-                        behavior are listed here:
-                        {this._allObjectTypes.join(', ')}
-                      </Trans>
-                    </AlertMessage>
-                  )}
-                  {eventsBasedBehavior
-                    .getEventsFunctions()
-                    .getEventsFunctionsCount() === 0 && (
-                    <DismissableAlertMessage
-                      identifier="empty-events-based-behavior-explanation"
-                      kind="info"
-                    >
-                      <Trans>
-                        Once you're done, close this dialog and start adding
-                        some functions to the behavior. Then, test the behavior
-                        by adding it to an object in a scene.
-                      </Trans>
-                    </DismissableAlertMessage>
-                  )}
-                </ColumnStackLayout>
+            <SemiControlledTextField
+              commitOnBlur
+              floatingLabelText={<Trans>Name displayed in editor</Trans>}
+              value={eventsBasedBehavior.getFullName()}
+              onChange={text => {
+                eventsBasedBehavior.setFullName(text);
+                this.forceUpdate();
+              }}
+              fullWidth
+            />
+            <SemiControlledTextField
+              commitOnBlur
+              floatingLabelText={<Trans>Description</Trans>}
+              helperMarkdownText={i18n._(
+                t`Explain what the behavior is doing to the object. Start with a verb when possible.`
               )}
-              {currentTab === 'behavior-properties' && (
-                <EventsBasedBehaviorPropertiesEditor
-                  allowRequiredBehavior
-                  project={project}
-                  properties={eventsBasedBehavior.getPropertyDescriptors()}
-                  onPropertiesUpdated={this.props.onPropertiesUpdated}
-                  onRenameProperty={this.props.onRenameProperty}
-                  behaviorObjectType={eventsBasedBehavior.getObjectType()}
-                />
-              )}
-              {currentTab === 'shared-properties' && (
-                <EventsBasedBehaviorPropertiesEditor
-                  project={project}
-                  properties={eventsBasedBehavior.getSharedPropertyDescriptors()}
-                  onPropertiesUpdated={this.props.onPropertiesUpdated}
-                  onRenameProperty={this.props.onRenameSharedProperty}
-                />
-              )}
-            </Line>
-          </React.Fragment>
+              value={eventsBasedBehavior.getDescription()}
+              onChange={text => {
+                eventsBasedBehavior.setDescription(text);
+                this.forceUpdate();
+              }}
+              multiline
+              fullWidth
+              rows={3}
+            />
+            <ObjectTypeSelector
+              floatingLabelText={
+                <Trans>Object on which this behavior can be used</Trans>
+              }
+              project={project}
+              value={eventsBasedBehavior.getObjectType()}
+              onChange={(objectType: string) => {
+                eventsBasedBehavior.setObjectType(objectType);
+                this.forceUpdate();
+              }}
+              allowedObjectTypes={
+                this._allObjectTypes.length === 0
+                  ? undefined /* Allow anything as the behavior is not used */
+                  : this._allObjectTypes.length === 1
+                  ? [
+                      '',
+                      this._allObjectTypes[0],
+                    ] /* Allow only the type of the objects using the behavior */
+                  : [
+                      '',
+                    ] /* More than one type of object are using the behavior. Only "any object" can be used on this behavior */
+              }
+            />
+            {this._allObjectTypes.length > 1 && (
+              <AlertMessage kind="info">
+                <Trans>
+                  This behavior is being used by multiple types of objects.
+                  Thus, you can't restrict its usage to any particular object
+                  type. All the object types using this behavior are listed
+                  here:
+                  {this._allObjectTypes.join(', ')}
+                </Trans>
+              </AlertMessage>
+            )}
+            {eventsBasedBehavior
+              .getEventsFunctions()
+              .getEventsFunctionsCount() === 0 && (
+              <DismissableAlertMessage
+                identifier="empty-events-based-behavior-explanation"
+                kind="info"
+              >
+                <Trans>
+                  Once you're done, close this dialog and start adding some
+                  functions to the behavior. Then, test the behavior by adding
+                  it to an object in a scene.
+                </Trans>
+              </DismissableAlertMessage>
+            )}
+          </ColumnStackLayout>
         )}
       </I18n>
     );

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectEditorDialog.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectEditorDialog.js
@@ -21,99 +21,77 @@ type Props = {|
   onRenameProperty: (oldName: string, newName: string) => void,
 |};
 
-type State = {|
-  currentTab: TabName,
-|};
+export default function EventsBasedObjectEditorDialog({
+  onApply,
+  project,
+  onFetchNewlyAddedResources,
+  globalObjectsContainer,
+  eventsFunctionsExtension,
+  eventsBasedObject,
+  onRenameProperty,
+}: Props) {
+  const [currentTab, setCurrentTab] = React.useState<TabName>('configuration');
 
-export default class EventsBasedObjectEditorDialog extends React.Component<
-  Props,
-  State
-> {
-  state = {
-    currentTab: 'configuration',
-  };
-
-  _changeTab = (newTab: TabName) => {
-    this.setState({
-      currentTab: newTab,
-    });
-  };
-
-  render() {
-    const {
-      onApply,
-      eventsBasedObject,
-      eventsFunctionsExtension,
-      project,
-      globalObjectsContainer,
-    } = this.props;
-
-    const { currentTab } = this.state;
-
-    return (
-      <Dialog
-        title={<Trans>Edit {eventsBasedObject.getName()}</Trans>}
-        secondaryActions={[
-          <HelpButton
-            key="help"
-            helpPagePath="/objects/events-based-objects"
-          />,
-        ]}
-        actions={[
-          <DialogPrimaryButton
-            label={<Trans>Apply</Trans>}
-            primary
-            onClick={onApply}
-            key={'Apply'}
-          />,
-        ]}
-        open
-        onRequestClose={onApply}
-        onApply={onApply}
-        fullHeight
-        flexBody
-        fixedContent={
-          <Tabs
-            value={currentTab}
-            onChange={this._changeTab}
-            options={[
-              {
-                value: 'configuration',
-                label: <Trans>Configuration</Trans>,
-              },
-              {
-                value: 'properties',
-                label: <Trans>Properties</Trans>,
-              },
-              {
-                value: 'children',
-                label: <Trans>Children</Trans>,
-              },
-            ]}
-          />
-        }
-      >
-        {currentTab === 'configuration' && (
-          <EventsBasedObjectEditor eventsBasedObject={eventsBasedObject} />
-        )}
-        {currentTab === 'properties' && (
-          <EventsBasedObjectPropertiesEditor
-            project={project}
-            eventsBasedObject={eventsBasedObject}
-            onPropertiesUpdated={() => {}}
-            onRenameProperty={this.props.onRenameProperty}
-          />
-        )}
-        {currentTab === 'children' && (
-          <EventBasedObjectChildrenEditor
-            project={project}
-            onFetchNewlyAddedResources={this.props.onFetchNewlyAddedResources}
-            globalObjectsContainer={globalObjectsContainer}
-            eventsFunctionsExtension={eventsFunctionsExtension}
-            eventsBasedObject={eventsBasedObject}
-          />
-        )}
-      </Dialog>
-    );
-  }
+  return (
+    <Dialog
+      title={<Trans>Edit {eventsBasedObject.getName()}</Trans>}
+      secondaryActions={[
+        <HelpButton key="help" helpPagePath="/objects/events-based-objects" />,
+      ]}
+      actions={[
+        <DialogPrimaryButton
+          label={<Trans>Apply</Trans>}
+          primary
+          onClick={onApply}
+          key={'Apply'}
+        />,
+      ]}
+      open
+      onRequestClose={onApply}
+      onApply={onApply}
+      fullHeight
+      flexBody
+      fixedContent={
+        <Tabs
+          value={currentTab}
+          onChange={setCurrentTab}
+          options={[
+            {
+              value: 'configuration',
+              label: <Trans>Configuration</Trans>,
+            },
+            {
+              value: 'properties',
+              label: <Trans>Properties</Trans>,
+            },
+            {
+              value: 'children',
+              label: <Trans>Children</Trans>,
+            },
+          ]}
+        />
+      }
+    >
+      {currentTab === 'configuration' && (
+        <EventsBasedObjectEditor eventsBasedObject={eventsBasedObject} />
+      )}
+      {currentTab === 'properties' && (
+        <EventsBasedObjectPropertiesEditor
+          project={project}
+          eventsBasedObject={eventsBasedObject}
+          onPropertiesUpdated={() => {}}
+          onRenameProperty={onRenameProperty}
+        />
+      )}
+      {currentTab === 'children' && (
+        <EventBasedObjectChildrenEditor
+          project={project}
+          onFetchNewlyAddedResources={onFetchNewlyAddedResources}
+          globalObjectsContainer={globalObjectsContainer}
+          eventsFunctionsExtension={eventsFunctionsExtension}
+          eventsBasedObject={eventsBasedObject}
+        />
+      )}
+    </Dialog>
+  );
 }

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectEditorDialog.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectEditorDialog.js
@@ -5,6 +5,11 @@ import Dialog, { DialogPrimaryButton } from '../UI/Dialog';
 import EventsBasedObjectEditor from './index';
 import HelpButton from '../UI/HelpButton';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
+import { Tabs } from '../UI/Tabs';
+import EventsBasedObjectPropertiesEditor from './EventsBasedObjectPropertiesEditor';
+import EventBasedObjectChildrenEditor from './EventBasedObjectChildrenEditor';
+
+type TabName = 'configuration' | 'properties' | 'children';
 
 type Props = {|
   onApply: () => void,
@@ -16,10 +21,24 @@ type Props = {|
   onRenameProperty: (oldName: string, newName: string) => void,
 |};
 
+type State = {|
+  currentTab: TabName,
+|};
+
 export default class EventsBasedObjectEditorDialog extends React.Component<
   Props,
-  {||}
+  State
 > {
+  state = {
+    currentTab: 'configuration',
+  };
+
+  _changeTab = (newTab: TabName) => {
+    this.setState({
+      currentTab: newTab,
+    });
+  };
+
   render() {
     const {
       onApply,
@@ -29,11 +48,11 @@ export default class EventsBasedObjectEditorDialog extends React.Component<
       globalObjectsContainer,
     } = this.props;
 
+    const { currentTab } = this.state;
+
     return (
       <Dialog
         title={<Trans>Edit {eventsBasedObject.getName()}</Trans>}
-        fullHeight
-        flexColumnBody
         secondaryActions={[
           <HelpButton
             key="help"
@@ -51,23 +70,49 @@ export default class EventsBasedObjectEditorDialog extends React.Component<
         open
         onRequestClose={onApply}
         onApply={onApply}
+        fullHeight
+        flexBody
+        fixedContent={
+          <Tabs
+            value={currentTab}
+            onChange={this._changeTab}
+            options={[
+              {
+                value: 'configuration',
+                label: <Trans>Configuration</Trans>,
+              },
+              {
+                value: 'properties',
+                label: <Trans>Properties</Trans>,
+              },
+              {
+                value: 'children',
+                label: <Trans>Children</Trans>,
+              },
+            ]}
+          />
+        }
       >
-        <EventsBasedObjectEditor
-          project={project}
-          onFetchNewlyAddedResources={this.props.onFetchNewlyAddedResources}
-          globalObjectsContainer={globalObjectsContainer}
-          eventsFunctionsExtension={eventsFunctionsExtension}
-          eventsBasedObject={eventsBasedObject}
-          onTabChanged={
-            () =>
-              this.forceUpdate() /*Force update to ensure dialog is properly positioned*/
-          }
-          onPropertiesUpdated={
-            () =>
-              this.forceUpdate() /*Force update to ensure dialog is properly positioned*/
-          }
-          onRenameProperty={this.props.onRenameProperty}
-        />
+        {currentTab === 'configuration' && (
+          <EventsBasedObjectEditor eventsBasedObject={eventsBasedObject} />
+        )}
+        {currentTab === 'properties' && (
+          <EventsBasedObjectPropertiesEditor
+            project={project}
+            eventsBasedObject={eventsBasedObject}
+            onPropertiesUpdated={() => {}}
+            onRenameProperty={this.props.onRenameProperty}
+          />
+        )}
+        {currentTab === 'children' && (
+          <EventBasedObjectChildrenEditor
+            project={project}
+            onFetchNewlyAddedResources={this.props.onFetchNewlyAddedResources}
+            globalObjectsContainer={globalObjectsContainer}
+            eventsFunctionsExtension={eventsFunctionsExtension}
+            eventsBasedObject={eventsBasedObject}
+          />
+        )}
       </Dialog>
     );
   }

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectEditorDialog.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectEditorDialog.js
@@ -79,7 +79,6 @@ export default function EventsBasedObjectEditorDialog({
         <EventsBasedObjectPropertiesEditor
           project={project}
           eventsBasedObject={eventsBasedObject}
-          onPropertiesUpdated={() => {}}
           onRenameProperty={onRenameProperty}
         />
       )}

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -280,7 +280,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                                 onChange={newValue => {
                                   property.setValue(newValue);
                                   this.forceUpdate();
-                                  this.props.onPropertiesUpdated();
+                                  this.props.onPropertiesUpdated &&
+                                    this.props.onPropertiesUpdated();
                                 }}
                                 fullWidth
                               />
@@ -296,7 +297,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                                 onChange={(e, i, value) => {
                                   property.setValue(value);
                                   this.forceUpdate();
-                                  this.props.onPropertiesUpdated();
+                                  this.props.onPropertiesUpdated &&
+                                    this.props.onPropertiesUpdated();
                                 }}
                                 fullWidth
                               >
@@ -317,7 +319,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                                 onChange={(e, i, value) => {
                                   property.setValue(value);
                                   this.forceUpdate();
-                                  this.props.onPropertiesUpdated();
+                                  this.props.onPropertiesUpdated &&
+                                    this.props.onPropertiesUpdated();
                                 }}
                                 fullWidth
                               >
@@ -348,7 +351,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                               onChange={color => {
                                 property.setValue(color);
                                 this.forceUpdate();
-                                this.props.onPropertiesUpdated();
+                                this.props.onPropertiesUpdated &&
+                                  this.props.onPropertiesUpdated();
                               }}
                             />
                           )}
@@ -375,7 +379,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                               onChange={text => {
                                 property.setGroup(text);
                                 this.forceUpdate();
-                                this.props.onPropertiesUpdated();
+                                this.props.onPropertiesUpdated &&
+                                  this.props.onPropertiesUpdated();
                               }}
                               dataSource={this._getPropertyGroupNames().map(
                                 name => ({

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -31,7 +31,7 @@ const gd: libGDevelop = global.gd;
 type Props = {|
   project: gdProject,
   eventsBasedObject: gdEventsBasedObject,
-  onPropertiesUpdated: () => void,
+  onPropertiesUpdated?: () => void,
   onRenameProperty: (oldName: string, newName: string) => void,
 |};
 

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -100,7 +100,7 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
     const property = properties.insertNew(newName, properties.getCount());
     property.setType('Number');
     this.forceUpdate();
-    this.props.onPropertiesUpdated();
+    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
   };
 
   _removeProperty = (name: string) => {
@@ -109,7 +109,7 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
 
     properties.remove(name);
     this.forceUpdate();
-    this.props.onPropertiesUpdated();
+    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
   };
 
   _moveProperty = (oldIndex: number, newIndex: number) => {
@@ -118,7 +118,7 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
 
     properties.move(oldIndex, newIndex);
     this.forceUpdate();
-    this.props.onPropertiesUpdated();
+    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
   };
 
   _setChoiceExtraInfo = (property: gdNamedPropertyDescriptor) => {
@@ -184,7 +184,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
 
                               property.setName(newName);
                               this.forceUpdate();
-                              this.props.onPropertiesUpdated();
+                              this.props.onPropertiesUpdated &&
+                                this.props.onPropertiesUpdated();
                             }}
                             fullWidth
                           />
@@ -201,7 +202,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                           onCheck={(e, checked) => {
                             property.setHidden(!checked);
                             this.forceUpdate();
-                            this.props.onPropertiesUpdated();
+                            this.props.onPropertiesUpdated &&
+                              this.props.onPropertiesUpdated();
                           }}
                           checkedIcon={<Visibility />}
                           uncheckedIcon={<VisibilityOff />}
@@ -241,7 +243,8 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                               onChange={(e, i, value: string) => {
                                 property.setType(value);
                                 this.forceUpdate();
-                                this.props.onPropertiesUpdated();
+                                this.props.onPropertiesUpdated &&
+                                  this.props.onPropertiesUpdated();
                               }}
                               fullWidth
                             >

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -10,6 +10,7 @@ import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import AlertMessage from '../UI/AlertMessage';
 import { ColumnStackLayout } from '../UI/Layout';
 import { showWarningBox } from '../UI/Messages/MessageBox';
+import useForceUpdate from '../Utils/UseForceUpdate';
 
 const gd: libGDevelop = global.gd;
 
@@ -17,104 +18,95 @@ type Props = {|
   eventsBasedObject: gdEventsBasedObject,
 |};
 
-export default class EventsBasedObjectEditor extends React.Component<
-  Props,
-  {||}
-> {
-  render() {
-    const { eventsBasedObject } = this.props;
+export default function EventsBasedObjectEditor({ eventsBasedObject }: Props) {
+  const forceUpdate = useForceUpdate();
 
-    return (
-      <ColumnStackLayout expand noMargin>
-        <AlertMessage kind="warning">
-          <Trans>
-            The custom object editor is at a very early stage. A lot of features
-            are missing or broken. Extensions written with it may no longer work
-            in future GDevelop releases.
-          </Trans>
-        </AlertMessage>
+  return (
+    <ColumnStackLayout expand noMargin>
+      <AlertMessage kind="warning">
+        <Trans>
+          The custom object editor is at a very early stage. A lot of features
+          are missing or broken. Extensions written with it may no longer work
+          in future GDevelop releases.
+        </Trans>
+      </AlertMessage>
+      <DismissableAlertMessage
+        identifier="events-based-object-explanation"
+        kind="info"
+      >
+        <Trans>
+          This is the configuration of your object. Make sure to choose a proper
+          internal name as it's hard to change it later. Enter a description
+          explaining how the object works.
+        </Trans>
+      </DismissableAlertMessage>
+      <TextField
+        floatingLabelText={<Trans>Internal Name</Trans>}
+        value={eventsBasedObject.getName()}
+        disabled
+        fullWidth
+      />
+      <SemiControlledTextField
+        commitOnBlur
+        floatingLabelText={<Trans>Name displayed in editor</Trans>}
+        value={eventsBasedObject.getFullName()}
+        onChange={text => {
+          eventsBasedObject.setFullName(text);
+          forceUpdate();
+        }}
+        fullWidth
+      />
+      <SemiControlledTextField
+        commitOnBlur
+        floatingLabelText={<Trans>Description</Trans>}
+        floatingLabelFixed
+        translatableHintText={t`The description of the object should explain what the object is doing, and, briefly, how to use it.`}
+        value={eventsBasedObject.getDescription()}
+        onChange={text => {
+          eventsBasedObject.setDescription(text);
+          forceUpdate();
+        }}
+        multiline
+        fullWidth
+        rows={3}
+      />
+      <I18n>
+        {({ i18n }) => (
+          <SemiControlledTextField
+            commitOnBlur
+            floatingLabelText={<Trans>Default name for created objects</Trans>}
+            value={
+              eventsBasedObject.getDefaultName() || eventsBasedObject.getName()
+            }
+            onChange={text => {
+              if (gd.Project.validateName(text)) {
+                eventsBasedObject.setDefaultName(text);
+                forceUpdate();
+              } else {
+                showWarningBox(
+                  i18n._(
+                    t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
+                  ),
+                  { delayToNextTick: true }
+                );
+              }
+            }}
+            fullWidth
+          />
+        )}
+      </I18n>
+      {eventsBasedObject.getEventsFunctions().getEventsFunctionsCount() ===
+        0 && (
         <DismissableAlertMessage
-          identifier="events-based-object-explanation"
+          identifier="empty-events-based-object-explanation"
           kind="info"
         >
           <Trans>
-            This is the configuration of your object. Make sure to choose a
-            proper internal name as it's hard to change it later. Enter a
-            description explaining how the object works.
+            Once you're done, close this dialog and start adding some functions
+            to the object. Then, test the object by adding to a scene.
           </Trans>
         </DismissableAlertMessage>
-        <TextField
-          floatingLabelText={<Trans>Internal Name</Trans>}
-          value={eventsBasedObject.getName()}
-          disabled
-          fullWidth
-        />
-        <SemiControlledTextField
-          commitOnBlur
-          floatingLabelText={<Trans>Name displayed in editor</Trans>}
-          value={eventsBasedObject.getFullName()}
-          onChange={text => {
-            eventsBasedObject.setFullName(text);
-            this.forceUpdate();
-          }}
-          fullWidth
-        />
-        <SemiControlledTextField
-          commitOnBlur
-          floatingLabelText={<Trans>Description</Trans>}
-          floatingLabelFixed
-          translatableHintText={t`The description of the object should explain what the object is doing, and, briefly, how to use it.`}
-          value={eventsBasedObject.getDescription()}
-          onChange={text => {
-            eventsBasedObject.setDescription(text);
-            this.forceUpdate();
-          }}
-          multiline
-          fullWidth
-          rows={3}
-        />
-        <I18n>
-          {({ i18n }) => (
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Default name for created objects</Trans>
-              }
-              value={
-                eventsBasedObject.getDefaultName() ||
-                eventsBasedObject.getName()
-              }
-              onChange={text => {
-                if (gd.Project.validateName(text)) {
-                  eventsBasedObject.setDefaultName(text);
-                  this.forceUpdate();
-                } else {
-                  showWarningBox(
-                    i18n._(
-                      t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-                    ),
-                    { delayToNextTick: true }
-                  );
-                }
-              }}
-              fullWidth
-            />
-          )}
-        </I18n>
-        {eventsBasedObject.getEventsFunctions().getEventsFunctionsCount() ===
-          0 && (
-          <DismissableAlertMessage
-            identifier="empty-events-based-object-explanation"
-            kind="info"
-          >
-            <Trans>
-              Once you're done, close this dialog and start adding some
-              functions to the object. Then, test the object by adding to a
-              scene.
-            </Trans>
-          </DismissableAlertMessage>
-        )}
-      </ColumnStackLayout>
-    );
-  }
+      )}
+    </ColumnStackLayout>
+  );
 }

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -6,193 +6,115 @@ import { I18n } from '@lingui/react';
 import * as React from 'react';
 import TextField from '../UI/TextField';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
-import { Tabs } from '../UI/Tabs';
 import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import AlertMessage from '../UI/AlertMessage';
-import EventsBasedObjectPropertiesEditor from './EventsBasedObjectPropertiesEditor';
-import EventBasedObjectChildrenEditor from './EventBasedObjectChildrenEditor';
 import { ColumnStackLayout } from '../UI/Layout';
-import { Line } from '../UI/Grid';
-import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 
 const gd: libGDevelop = global.gd;
 
-type TabName = 'configuration' | 'properties' | 'children';
-
 type Props = {|
-  project: gdProject,
-  onFetchNewlyAddedResources: OnFetchNewlyAddedResourcesFunction,
-  globalObjectsContainer: gdObjectsContainer,
-  eventsFunctionsExtension: gdEventsFunctionsExtension,
   eventsBasedObject: gdEventsBasedObject,
-  onPropertiesUpdated: () => void,
-  onRenameProperty: (oldName: string, newName: string) => void,
-  onTabChanged: () => void,
-|};
-
-type State = {|
-  currentTab: TabName,
 |};
 
 export default class EventsBasedObjectEditor extends React.Component<
   Props,
-  State
+  {||}
 > {
-  state = {
-    currentTab: 'configuration',
-  };
-
-  _changeTab = (newTab: TabName) =>
-    this.setState(
-      {
-        currentTab: newTab,
-      },
-      () => this.props.onTabChanged()
-    );
-
   render() {
-    const { currentTab } = this.state;
-    const {
-      eventsBasedObject,
-      project,
-      globalObjectsContainer,
-      eventsFunctionsExtension,
-    } = this.props;
+    const { eventsBasedObject } = this.props;
 
     return (
-      <React.Fragment>
-        <Tabs
-          value={currentTab}
-          onChange={this._changeTab}
-          options={[
-            {
-              value: 'configuration',
-              label: <Trans>Configuration</Trans>,
-            },
-            {
-              value: 'properties',
-              label: <Trans>Properties</Trans>,
-            },
-            {
-              value: 'children',
-              label: <Trans>Children</Trans>,
-            },
-          ]}
+      <ColumnStackLayout expand noMargin>
+        <AlertMessage kind="warning">
+          <Trans>
+            The custom object editor is at a very early stage. A lot of features
+            are missing or broken. Extensions written with it may no longer work
+            in future GDevelop releases.
+          </Trans>
+        </AlertMessage>
+        <DismissableAlertMessage
+          identifier="events-based-object-explanation"
+          kind="info"
+        >
+          <Trans>
+            This is the configuration of your object. Make sure to choose a
+            proper internal name as it's hard to change it later. Enter a
+            description explaining how the object works.
+          </Trans>
+        </DismissableAlertMessage>
+        <TextField
+          floatingLabelText={<Trans>Internal Name</Trans>}
+          value={eventsBasedObject.getName()}
+          disabled
+          fullWidth
         />
-        <Line expand useFullHeight>
-          {currentTab === 'configuration' && (
-            <ColumnStackLayout expand noMargin>
-              <AlertMessage kind="warning">
-                <Trans>
-                  The custom object editor is at a very early stage. A lot of
-                  features are missing or broken. Extensions written with it may
-                  no longer work in future GDevelop releases.
-                </Trans>
-              </AlertMessage>
-              <DismissableAlertMessage
-                identifier="events-based-object-explanation"
-                kind="info"
-              >
-                <Trans>
-                  This is the configuration of your object. Make sure to choose
-                  a proper internal name as it's hard to change it later. Enter
-                  a description explaining how the object works.
-                </Trans>
-              </DismissableAlertMessage>
-              <TextField
-                floatingLabelText={<Trans>Internal Name</Trans>}
-                value={eventsBasedObject.getName()}
-                disabled
-                fullWidth
-              />
-              <SemiControlledTextField
-                commitOnBlur
-                floatingLabelText={<Trans>Name displayed in editor</Trans>}
-                value={eventsBasedObject.getFullName()}
-                onChange={text => {
-                  eventsBasedObject.setFullName(text);
+        <SemiControlledTextField
+          commitOnBlur
+          floatingLabelText={<Trans>Name displayed in editor</Trans>}
+          value={eventsBasedObject.getFullName()}
+          onChange={text => {
+            eventsBasedObject.setFullName(text);
+            this.forceUpdate();
+          }}
+          fullWidth
+        />
+        <SemiControlledTextField
+          commitOnBlur
+          floatingLabelText={<Trans>Description</Trans>}
+          floatingLabelFixed
+          translatableHintText={t`The description of the object should explain what the object is doing, and, briefly, how to use it.`}
+          value={eventsBasedObject.getDescription()}
+          onChange={text => {
+            eventsBasedObject.setDescription(text);
+            this.forceUpdate();
+          }}
+          multiline
+          fullWidth
+          rows={3}
+        />
+        <I18n>
+          {({ i18n }) => (
+            <SemiControlledTextField
+              commitOnBlur
+              floatingLabelText={
+                <Trans>Default name for created objects</Trans>
+              }
+              value={
+                eventsBasedObject.getDefaultName() ||
+                eventsBasedObject.getName()
+              }
+              onChange={text => {
+                if (gd.Project.validateName(text)) {
+                  eventsBasedObject.setDefaultName(text);
                   this.forceUpdate();
-                }}
-                fullWidth
-              />
-              <SemiControlledTextField
-                commitOnBlur
-                floatingLabelText={<Trans>Description</Trans>}
-                floatingLabelFixed
-                translatableHintText={t`The description of the object should explain what the object is doing, and, briefly, how to use it.`}
-                value={eventsBasedObject.getDescription()}
-                onChange={text => {
-                  eventsBasedObject.setDescription(text);
-                  this.forceUpdate();
-                }}
-                multiline
-                fullWidth
-                rows={3}
-              />
-              <I18n>
-                {({ i18n }) => (
-                  <SemiControlledTextField
-                    commitOnBlur
-                    floatingLabelText={
-                      <Trans>Default name for created objects</Trans>
-                    }
-                    value={
-                      eventsBasedObject.getDefaultName() ||
-                      eventsBasedObject.getName()
-                    }
-                    onChange={text => {
-                      if (gd.Project.validateName(text)) {
-                        eventsBasedObject.setDefaultName(text);
-                        this.forceUpdate();
-                      } else {
-                        showWarningBox(
-                          i18n._(
-                            t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-                          ),
-                          { delayToNextTick: true }
-                        );
-                      }
-                    }}
-                    fullWidth
-                  />
-                )}
-              </I18n>
-              {eventsBasedObject
-                .getEventsFunctions()
-                .getEventsFunctionsCount() === 0 && (
-                <DismissableAlertMessage
-                  identifier="empty-events-based-object-explanation"
-                  kind="info"
-                >
-                  <Trans>
-                    Once you're done, close this dialog and start adding some
-                    functions to the object. Then, test the object by adding to
-                    a scene.
-                  </Trans>
-                </DismissableAlertMessage>
-              )}
-            </ColumnStackLayout>
-          )}
-          {currentTab === 'properties' && (
-            <EventsBasedObjectPropertiesEditor
-              project={project}
-              eventsBasedObject={eventsBasedObject}
-              onPropertiesUpdated={this.props.onPropertiesUpdated}
-              onRenameProperty={this.props.onRenameProperty}
+                } else {
+                  showWarningBox(
+                    i18n._(
+                      t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
+                    ),
+                    { delayToNextTick: true }
+                  );
+                }
+              }}
+              fullWidth
             />
           )}
-          {currentTab === 'children' && (
-            <EventBasedObjectChildrenEditor
-              project={project}
-              onFetchNewlyAddedResources={this.props.onFetchNewlyAddedResources}
-              globalObjectsContainer={globalObjectsContainer}
-              eventsFunctionsExtension={eventsFunctionsExtension}
-              eventsBasedObject={eventsBasedObject}
-            />
-          )}
-        </Line>
-      </React.Fragment>
+        </I18n>
+        {eventsBasedObject.getEventsFunctions().getEventsFunctionsCount() ===
+          0 && (
+          <DismissableAlertMessage
+            identifier="empty-events-based-object-explanation"
+            kind="info"
+          >
+            <Trans>
+              Once you're done, close this dialog and start adding some
+              functions to the object. Then, test the object by adding to a
+              scene.
+            </Trans>
+          </DismissableAlertMessage>
+        )}
+      </ColumnStackLayout>
     );
   }
 }

--- a/newIDE/app/src/stories/componentStories/EventsBasedBehaviorEditor/EventsBasedBehaviorEditor.stories.js
+++ b/newIDE/app/src/stories/componentStories/EventsBasedBehaviorEditor/EventsBasedBehaviorEditor.stories.js
@@ -21,10 +21,6 @@ export const Default = () => (
     project={testProject.project}
     eventsFunctionsExtension={testProject.testEventsFunctionsExtension}
     eventsBasedBehavior={testProject.testEventsBasedBehavior}
-    onPropertiesUpdated={action('properties updated')}
-    onTabChanged={action('tab changed')}
-    onRenameProperty={action('property rename')}
-    onRenameSharedProperty={action('shared property rename')}
   />
 );
 
@@ -33,9 +29,5 @@ export const WithoutFunction = () => (
     project={testProject.project}
     eventsFunctionsExtension={testProject.testEventsFunctionsExtension}
     eventsBasedBehavior={testProject.testEmptyEventsBasedBehavior}
-    onPropertiesUpdated={action('properties updated')}
-    onTabChanged={action('tab changed')}
-    onRenameProperty={action('property rename')}
-    onRenameSharedProperty={action('shared property rename')}
   />
 );

--- a/newIDE/app/src/stories/componentStories/EventsBasedObjectEditor/EventsBasedObjectEditor.stories.js
+++ b/newIDE/app/src/stories/componentStories/EventsBasedObjectEditor/EventsBasedObjectEditor.stories.js
@@ -18,13 +18,6 @@ export default {
 
 export const Default = () => (
   <EventsBasedObjectEditor
-    project={testProject.project}
-    globalObjectsContainer={testProject.emptyObjectsContainer}
-    eventsFunctionsExtension={testProject.testEventsFunctionsExtension}
     eventsBasedObject={testProject.testEventsBasedObject}
-    onPropertiesUpdated={action('properties updated')}
-    onTabChanged={action('tab changed')}
-    onRenameProperty={action('property rename')}
-    onFetchNewlyAddedResources={async () => {}}
   />
 );


### PR DESCRIPTION
http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/fix-behavior-scroll/latest/index.html?path=/story/eventsbasedbehavioreditor-eventsbasedbehavioreditordialog--default

It also fixes a typo I made that was forbidding the shared property editor to be displayed.

Maybe the component should be renamed because it only contains one tab now.