### PR TITLE
Improve Instance decimals chaos

### DIFF
--- a/Core/GDCore/Project/InitialInstance.h
+++ b/Core/GDCore/Project/InitialInstance.h
@@ -7,13 +7,14 @@
 #ifndef GDCORE_INITIALINSTANCE_H
 #define GDCORE_INITIALINSTANCE_H
 #include <map>
+
 #include "GDCore/Project/VariablesContainer.h"
 #include "GDCore/String.h"
 namespace gd {
 class PropertyDescriptor;
 class Project;
 class Layout;
-}
+}  // namespace gd
 
 namespace gd {
 
@@ -127,7 +128,8 @@ class GD_CORE_API InitialInstance {
   void SetCustomHeight(double height_) { height = height_; }
 
   /**
-   * \brief Return true if the instance is locked and cannot be moved in the IDE.
+   * \brief Return true if the instance is locked and cannot be moved in the
+   * IDE.
    */
   bool IsLocked() const { return locked; };
 
@@ -240,7 +242,7 @@ class GD_CORE_API InitialInstance {
    * \brief Set the value of a string property stored in the instance.
    */
   void SetRawStringProperty(const gd::String& name, const gd::String& value);
-///@}
+  ///@}
 
   /** \name Saving and loading
    * Members functions related to serialization.
@@ -272,18 +274,19 @@ class GD_CORE_API InitialInstance {
       stringProperties;  ///< More data which can be used by the object
 
   gd::String objectName;  ///< Object name
-  double x;                ///< Object initial X position
-  double y;                ///< Object initial Y position
-  double angle;            ///< Object initial angle
+  double x;               ///< Object initial X position
+  double y;               ///< Object initial Y position
+  double angle;           ///< Object initial angle
   int zOrder;             ///< Object initial Z order
   gd::String layer;       ///< Object initial layer
   bool personalizedSize;  ///< True if object has a custom size
-  double width;            ///< Object custom width
-  double height;           ///< Object custom height
+  double width;           ///< Object custom width
+  double height;          ///< Object custom height
   gd::VariablesContainer initialVariables;  ///< Instance specific variables
   bool locked;                              ///< True if the instance is locked
   bool sealed;                              ///< True if the instance is sealed
-  mutable gd::String persistentUuid; ///< A persistent random version 4 UUID, useful for hot reloading.
+  mutable gd::String persistentUuid;  ///< A persistent random version 4 UUID,
+                                      ///< useful for hot reloading.
 
   static gd::String*
       badStringProperyValue;  ///< Empty string returned by GetRawStringProperty

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -978,12 +978,12 @@ interface InitialInstance {
     void SetObjectName([Const] DOMString name);
     [Const, Ref] DOMString GetObjectName();
 
-    float GetX();
-    void SetX(float x);
-    float GetY();
-    void SetY(float y);
-    float GetAngle();
-    void SetAngle(float angle);
+    double GetX();
+    void SetX(double x);
+    double GetY();
+    void SetY(double y);
+    double GetAngle();
+    void SetAngle(double angle);
     boolean IsLocked();
     void SetLocked(boolean lock);
     boolean IsSealed();
@@ -996,18 +996,18 @@ interface InitialInstance {
     void SetHasCustomSize(boolean enable);
     boolean HasCustomSize();
 
-    void SetCustomWidth(float width);
-    float GetCustomWidth();
-    void SetCustomHeight(float height);
-    float GetCustomHeight();
+    void SetCustomWidth(double width);
+    double GetCustomWidth();
+    void SetCustomHeight(double height);
+    double GetCustomHeight();
 
     [Ref] InitialInstance ResetPersistentUuid();
 
     void UpdateCustomProperty([Const] DOMString name, [Const] DOMString value, [Ref] Project project, [Ref] Layout layout);
     [Value] MapStringPropertyDescriptor GetCustomProperties([Ref] Project project, [Ref] Layout layout);
-    float GetRawDoubleProperty([Const] DOMString name);
+    double GetRawDoubleProperty([Const] DOMString name);
     [Const, Ref] DOMString GetRawStringProperty([Const] DOMString name);
-    void SetRawDoubleProperty([Const] DOMString name, float value);
+    void SetRawDoubleProperty([Const] DOMString name, double value);
     void SetRawStringProperty([Const] DOMString name, [Const] DOMString value);
 
     [Ref] VariablesContainer GetVariables();
@@ -1062,7 +1062,7 @@ interface SerializerValue {
     boolean GetBool();
     [Const, Value] DOMString GetString();
     long GetInt();
-    float GetDouble();
+    double GetDouble();
 
     [Const, Value] DOMString GetRawString();
 
@@ -2788,9 +2788,9 @@ interface Direction {
     void RemoveAllSprites();
     boolean IsLooping();
     void SetLoop(boolean enable);
-    float GetTimeBetweenFrames();
+    double GetTimeBetweenFrames();
     [Const, Ref] VectorString GetSpriteNames();
-    void SetTimeBetweenFrames(float time);
+    void SetTimeBetweenFrames(double time);
     void SwapSprites(unsigned long first, unsigned long second);
     void MoveSprite(unsigned long oldIndex, unsigned long newIndex);
 

--- a/newIDE/app/src/InstancesEditor/HighlightedInstance.js
+++ b/newIDE/app/src/InstancesEditor/HighlightedInstance.js
@@ -81,13 +81,14 @@ export default class InstancesSelection {
       highlightedInstance.getObjectName() +
       '\n' +
       'X: ' +
-      parseInt(highlightedInstance.getX()) +
+      Math.round(highlightedInstance.getX() * 100) / 100 + // An instance position can have a lot of decimals, so round to 2 decimals.
       '  Y: ' +
-      parseInt(highlightedInstance.getY()) +
+      Math.round(highlightedInstance.getY() * 100) / 100 + // An instance position can have a lot of decimals, so round to 2 decimals.
       '\n' +
       'Layer: ' +
-      highlightedInstance.getLayer() +
-      '  Z: ' +
+      (highlightedInstance.getLayer() || 'Base layer') +
+      '\n' +
+      'Z: ' +
       highlightedInstance.getZOrder() +
       '\n';
     this.tooltipText.text = tooltipInfo;

--- a/newIDE/app/src/InstancesEditor/InstancesMover.js
+++ b/newIDE/app/src/InstancesEditor/InstancesMover.js
@@ -139,7 +139,10 @@ export default class InstancesMover {
           y: selectedInstance.getY(),
         };
       }
-      selectedInstance.setX(
+      // We round the position to the nearest pixel when an instance is moved in the editor.
+      // This is to avoid having a lot of decimals in the position of instances.
+      // It does not prevent the user from having decimals, when editing the position manually.
+      const newX = Math.round(
         initialPosition.x +
           this._getMoveDeltaX(
             roundedTotalDeltaX,
@@ -147,7 +150,7 @@ export default class InstancesMover {
             followAxis
           )
       );
-      selectedInstance.setY(
+      const newY = Math.round(
         initialPosition.y +
           this._getMoveDeltaY(
             roundedTotalDeltaX,
@@ -155,6 +158,8 @@ export default class InstancesMover {
             followAxis
           )
       );
+      selectedInstance.setX(newX);
+      selectedInstance.setY(newY);
     }
   }
 

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -293,14 +293,17 @@ export default class InstancesResizer {
       // is stable by instance rotation. This allows to use the same formula
       // for both 90° or 270°.
       const angle = ((selectedInstance.getAngle() % 360) + 360) % 360;
+      let newX = initialInstanceOriginPosition.x;
+      let newY = initialInstanceOriginPosition.y;
+      let newWidth = initialWidth;
+      let newHeight = initialHeight;
       if (
         !proportional &&
         !hasRotatedInstance &&
         (angle === 90 || angle === 270)
       ) {
-        selectedInstance.setCustomWidth(scaleY * initialWidth);
-        selectedInstance.setCustomHeight(scaleX * initialHeight);
-        selectedInstance.setHasCustomSize(true);
+        newWidth = scaleY * initialWidth;
+        newHeight = scaleX * initialHeight;
 
         // These 4 variables are the positions and vector after the scaling.
         // It's easier to scale the instance center
@@ -322,20 +325,27 @@ export default class InstancesResizer {
           scaleX *
           (initialInstanceOriginPosition.y -
             initialUnrotatedInstanceAABB.centerY());
-        selectedInstance.setX(centerX + centerToOriginX);
-        selectedInstance.setY(centerY + centerToOriginY);
+        newX = centerX + centerToOriginX;
+        newY = centerY + centerToOriginY;
       } else {
-        selectedInstance.setCustomWidth(scaleX * initialWidth);
-        selectedInstance.setCustomHeight(scaleY * initialHeight);
-        selectedInstance.setHasCustomSize(true);
-
-        selectedInstance.setX(
-          (initialInstanceOriginPosition.x - fixedPointX) * scaleX + fixedPointX
-        );
-        selectedInstance.setY(
-          (initialInstanceOriginPosition.y - fixedPointY) * scaleY + fixedPointY
-        );
+        newWidth = scaleX * initialWidth;
+        newHeight = scaleY * initialHeight;
+        newX =
+          (initialInstanceOriginPosition.x - fixedPointX) * scaleX +
+          fixedPointX;
+        newY =
+          (initialInstanceOriginPosition.y - fixedPointY) * scaleY +
+          fixedPointY;
       }
+
+      // After resizing, we round the new positions and dimensions to the nearest pixel.
+      // This is to avoid having a lot of decimals appearing, and it does not
+      // prevent the user from modifying them manually in the inline fields.
+      selectedInstance.setX(Math.round(newX));
+      selectedInstance.setY(Math.round(newY));
+      selectedInstance.setCustomWidth(Math.round(newWidth));
+      selectedInstance.setCustomHeight(Math.round(newHeight));
+      selectedInstance.setHasCustomSize(true);
     }
   }
 

--- a/newIDE/app/src/InstancesEditor/InstancesRotator.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRotator.js
@@ -110,25 +110,32 @@ export default class InstancesRotator {
       );
 
       const degreeAngle = this._getNewAngle(proportional, initialAngle);
-      selectedInstance.setAngle(((degreeAngle % 360) + 360) % 360);
+      // We round the angle to the nearest degree when an instance is rotated in the editor.
+      // This is to avoid having a lot of decimals in the angle of instances.
+      // It does not prevent the user from having decimals, when editing the angle manually.
+      const newAngle = Math.round(((degreeAngle % 360) + 360) % 360);
+      selectedInstance.setAngle(newAngle);
 
       const rotationAngle = ((degreeAngle - initialAngle) * Math.PI) / 180;
       const cosa = Math.cos(-rotationAngle);
       const sina = Math.sin(-rotationAngle);
       const deltaX = initialAABB.centerX() - this._fixedPoint[0];
       const deltaY = initialAABB.centerY() - this._fixedPoint[1];
-      selectedInstance.setX(
+      // We also round the position to the nearest pixel after rotation.
+      const newX = Math.round(
         this._fixedPoint[0] +
           (initialInstanceOriginPosition.x - initialAABB.centerX()) +
           cosa * deltaX +
           sina * deltaY
       );
-      selectedInstance.setY(
+      const newY = Math.round(
         this._fixedPoint[1] +
           (initialInstanceOriginPosition.y - initialAABB.centerY()) -
           sina * deltaX +
           cosa * deltaY
       );
+      selectedInstance.setX(newX);
+      selectedInstance.setY(newY);
     }
   }
 

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -171,7 +171,13 @@ const styles = {
   },
 };
 
-const getDisabled = (instances: Instances, field: ValueField): boolean => {
+const getDisabled = ({
+  instances,
+  field,
+}: {|
+  instances: Instances,
+  field: ValueField,
+|}): boolean => {
   return typeof field.disabled === 'boolean'
     ? field.disabled
     : typeof field.disabled === 'function'
@@ -185,11 +191,15 @@ const getDisabled = (instances: Instances, field: ValueField): boolean => {
  * If there is no instances, returns the default value.
  * If the field does not have a `getValue` method, returns `null`.
  */
-const getFieldValue = (
+const getFieldValue = ({
+  instances,
+  field,
+  defaultValue,
+}: {|
   instances: Instances,
   field: ValueField | ActionButton | SectionTitle,
-  defaultValue?: any
-): any => {
+  defaultValue?: any,
+|}): any => {
   if (!instances[0]) {
     console.log(
       'getFieldValue was called with an empty list of instances (or containing undefined). This is a bug that should be fixed'
@@ -211,7 +221,13 @@ const getFieldValue = (
   return value;
 };
 
-const getFieldLabel = (instances: Instances, field: ValueField): any => {
+const getFieldLabel = ({
+  instances,
+  field,
+}: {|
+  instances: Instances,
+  field: ValueField,
+|}): any => {
   if (!instances[0]) {
     console.log(
       'PropertiesEditor._getFieldLabel was called with an empty list of instances (or containing undefined). This is a bug that should be fixed'
@@ -282,10 +298,10 @@ const PropertiesEditor = ({
           <InlineCheckbox
             label={
               !description ? (
-                getFieldLabel(instances, field)
+                getFieldLabel({ instances, field })
               ) : (
                 <React.Fragment>
-                  <Line noMargin>{getFieldLabel(instances, field)}</Line>
+                  <Line noMargin>{getFieldLabel({ instances, field })}</Line>
                   <FormHelperText style={{ display: 'inline' }}>
                     <MarkdownText source={description} />
                   </FormHelperText>
@@ -293,12 +309,12 @@ const PropertiesEditor = ({
               )
             }
             key={field.name}
-            checked={getFieldValue(instances, field)}
+            checked={getFieldValue({ instances, field })}
             onCheck={(event, newValue) => {
               instances.forEach(i => setValue(i, !!newValue));
               _onInstancesModified(instances);
             }}
-            disabled={getDisabled(instances, field)}
+            disabled={getDisabled({ instances, field })}
           />
         );
       } else if (field.valueType === 'number') {
@@ -306,19 +322,23 @@ const PropertiesEditor = ({
         const endAdornment = getEndAdornment && getEndAdornment(instances[0]);
         return (
           <SemiControlledTextField
-            value={getFieldValue(instances, field)}
+            value={getFieldValue({ instances, field })}
             key={field.name}
             id={field.name}
-            floatingLabelText={getFieldLabel(instances, field)}
+            floatingLabelText={getFieldLabel({ instances, field })}
             floatingLabelFixed
             helperMarkdownText={getFieldDescription(field)}
             onChange={newValue => {
-              instances.forEach(i => setValue(i, parseFloat(newValue) || 0));
+              const newNumberValue = parseFloat(newValue);
+              // If the value is not a number, the user is probably still typing, adding a dot or a comma.
+              // So don't update the value, it will be reverted if they leave the field.
+              if (isNaN(newNumberValue)) return;
+              instances.forEach(i => setValue(i, newNumberValue));
               _onInstancesModified(instances);
             }}
             type="number"
             style={styles.field}
-            disabled={getDisabled(instances, field)}
+            disabled={getDisabled({ instances, field })}
             endAdornment={
               endAdornment && (
                 <Tooltip title={endAdornment.tooltipContent}>
@@ -337,11 +357,11 @@ const PropertiesEditor = ({
             <ColorField
               key={field.name}
               id={field.name}
-              floatingLabelText={getFieldLabel(instances, field)}
+              floatingLabelText={getFieldLabel({ instances, field })}
               helperMarkdownText={getFieldDescription(field)}
               disableAlpha
               fullWidth
-              color={getFieldValue(instances, field)}
+              color={getFieldValue({ instances, field })}
               onChange={color => {
                 const rgbString =
                   color.length === 0 ? '' : rgbOrHexToRGBString(color);
@@ -361,8 +381,8 @@ const PropertiesEditor = ({
               instances.forEach(i => setValue(i, text || ''));
               _onInstancesModified(instances);
             }}
-            value={getFieldValue(instances, field)}
-            floatingLabelText={getFieldLabel(instances, field)}
+            value={getFieldValue({ instances, field })}
+            floatingLabelText={getFieldLabel({ instances, field })}
             floatingLabelFixed
             helperMarkdownText={getFieldDescription(field)}
             multiline
@@ -380,9 +400,13 @@ const PropertiesEditor = ({
             key={field.name}
             renderTextField={() => (
               <SemiControlledTextField
-                value={getFieldValue(instances, field, '(Multiple values)')}
+                value={getFieldValue({
+                  instances,
+                  field,
+                  defaultValue: '(Multiple values)',
+                })}
                 id={field.name}
-                floatingLabelText={getFieldLabel(instances, field)}
+                floatingLabelText={getFieldLabel({ instances, field })}
                 floatingLabelFixed
                 helperMarkdownText={getFieldDescription(field)}
                 onChange={newValue => {
@@ -390,7 +414,7 @@ const PropertiesEditor = ({
                   _onInstancesModified(instances);
                 }}
                 style={styles.field}
-                disabled={getDisabled(instances, field)}
+                disabled={getDisabled({ instances, field })}
               />
             )}
             renderButton={style =>
@@ -441,9 +465,9 @@ const PropertiesEditor = ({
         const { setValue } = field;
         return (
           <SelectField
-            value={getFieldValue(instances, field)}
+            value={getFieldValue({ instances, field })}
             key={field.name}
-            floatingLabelText={getFieldLabel(instances, field)}
+            floatingLabelText={getFieldLabel({ instances, field })}
             helperMarkdownText={getFieldDescription(field)}
             onChange={(event, index, newValue: string) => {
               instances.forEach(i => setValue(i, parseFloat(newValue) || 0));
@@ -459,16 +483,20 @@ const PropertiesEditor = ({
         const { setValue } = field;
         return (
           <SelectField
-            value={getFieldValue(instances, field, '(Multiple values)')}
+            value={getFieldValue({
+              instances,
+              field,
+              defaultValue: '(Multiple values)',
+            })}
             key={field.name}
-            floatingLabelText={getFieldLabel(instances, field)}
+            floatingLabelText={getFieldLabel({ instances, field })}
             helperMarkdownText={getFieldDescription(field)}
             onChange={(event, index, newValue: string) => {
               instances.forEach(i => setValue(i, newValue || ''));
               _onInstancesModified(instances);
             }}
             style={styles.field}
-            disabled={getDisabled(instances, field)}
+            disabled={getDisabled({ instances, field })}
           >
             {children}
           </SelectField>
@@ -484,8 +512,11 @@ const PropertiesEditor = ({
       if (field.disabled === 'onValuesDifferent') {
         const DIFFERENT_VALUES = 'DIFFERENT_VALUES';
         disabled =
-          getFieldValue(instances, field, DIFFERENT_VALUES) ===
-          DIFFERENT_VALUES;
+          getFieldValue({
+            instances,
+            field,
+            defaultValue: DIFFERENT_VALUES,
+          }) === DIFFERENT_VALUES;
       }
       return (
         <RaisedButton
@@ -521,16 +552,16 @@ const PropertiesEditor = ({
         resourcesLoader={ResourcesLoader}
         resourceKind={field.resourceKind}
         fullWidth
-        initialResourceName={getFieldValue(
+        initialResourceName={getFieldValue({
           instances,
           field,
-          '(Multiple values)' //TODO
-        )}
+          defaultValue: '(Multiple values)', //TODO
+        })}
         onChange={newValue => {
           instances.forEach(i => setValue(i, newValue));
           _onInstancesModified(instances);
         }}
-        floatingLabelText={getFieldLabel(instances, field)}
+        floatingLabelText={getFieldLabel({ instances, field })}
         helperMarkdownText={getFieldDescription(field)}
       />
     );
@@ -554,11 +585,11 @@ const PropertiesEditor = ({
       let additionalText = null;
 
       if (getValue) {
-        let selectedInstancesValue = getFieldValue(
+        let selectedInstancesValue = getFieldValue({
           instances,
           field,
-          field.defaultValue || 'Multiple Values'
-        );
+          defaultValue: field.defaultValue || 'Multiple Values',
+        });
         if (!!selectedInstancesValue) additionalText = selectedInstancesValue;
       }
 


### PR DESCRIPTION
Updated logic:

- If a "resize", "drag" or "rotate" is done in the instance editor, then we round the "size", "position" and "angle" to the nearest integer.
   - The assumption is that a user using the instance editor will not be looking for sub pixel precision
   - And if they do, they can still edit the instance properties with as many digits as they want

- The tooltip now displays up to 2 digits on the coordinates of the instances

- The number fields do not update the instance with "0" when a user is still typing (ex: "19," does not update the field)

- The instance number fields (width/height/x/y/angle) can now correctly accept precise float numbers, avoiding excessive and inaccurate digits

Before:


https://user-images.githubusercontent.com/4895034/207826496-089000a1-fe33-4b1d-8cb0-a9caa5b81cd4.mov


https://user-images.githubusercontent.com/4895034/207826511-0a02cd5d-f4df-4631-b18a-b58c4d965581.mov


After:


https://user-images.githubusercontent.com/4895034/207826567-6c2b237b-579c-40ad-ba48-d7936ce3b8d7.mov


https://user-images.githubusercontent.com/4895034/207826574-d421886f-b507-45da-9fea-0b314f244c2c.mov

