### PR TITLE
Add a condition to check if at least one touch is pressed.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/MouseExtension.cpp
@@ -300,6 +300,17 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsMouseExtension(
 
   extension
       .AddCondition(
+          "IsAnyTouchPressed",
+          _("Any touch pressed"),
+          _("Check if any touch is pressed."),
+          _("At least one touch is pressed"),
+          _("Multitouch"),
+          "res/conditions/touch24.png",
+          "res/conditions/touch.png")
+      .AddCodeOnlyParameter("currentScene", "");
+
+  extension
+      .AddCondition(
           "PopStartedTouch",
           _("A new touch has started"),
           _("Check if a touch has started. The touch identifier can be "

--- a/GDJS/GDJS/Extensions/Builtin/MouseExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/MouseExtension.cpp
@@ -39,6 +39,8 @@ MouseExtension::MouseExtension() {
       "gdjs.evtTools.input.showCursor");
   GetAllActions()["TouchSimulateMouse"].SetFunctionName(
       "gdjs.evtTools.input.touchSimulateMouse");
+  GetAllConditions()["IsAnyTouchPressed"].SetFunctionName(
+      "gdjs.evtTools.input.isAnyTouchPressed");
 
   GetAllConditions()["IsMouseWheelScrollingUp"].SetFunctionName(
       "gdjs.evtTools.input.isScrollingUp");

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -486,6 +486,12 @@ namespace gdjs {
           .getInputManager()
           .touchSimulateMouse(enable);
       };
+
+      export const isAnyTouchPressed = function (
+        instanceContainer: gdjs.RuntimeInstanceContainer
+      ) {
+        instanceContainer.getGame().getInputManager()._touches.firstKey() !== null;
+      };
     }
   }
 }

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -490,7 +490,8 @@ namespace gdjs {
       export const isAnyTouchPressed = function (
         instanceContainer: gdjs.RuntimeInstanceContainer
       ) {
-        instanceContainer.getGame().getInputManager()._touches.firstKey() !== null;
+        instanceContainer.getGame().getInputManager()._touches.firstKey() !==
+          null;
       };
     }
   }


### PR DESCRIPTION
This is useful for extensions because they can't disable mouse emulation and could have the same event twice.
It avoids each behavior to remember if a touch is pressed when this touch may not concern their owner (when another button is pressed for instance).