### PR TITLE
Fix cleaning the resource URL when added from the resource store

### DIFF
--- a/newIDE/app/src/ResourcesList/BrowserResourceSources.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceSources.js
@@ -17,6 +17,10 @@ import { useDebounce } from '../Utils/UseDebounce';
 import axios from 'axios';
 import AlertMessage from '../UI/AlertMessage';
 import { FileToCloudProjectResourceUploader } from './FileToCloudProjectResourceUploader';
+import {
+  extractFilenameWithExtensionFromPublicAssetResourceUrl,
+  isPublicAssetResourceUrl,
+} from '../Utils/GDevelopServices/Asset';
 
 type ResourceStoreChooserProps = {
   options: ChooseResourceOptions,
@@ -35,7 +39,12 @@ const ResourceStoreChooser = ({
         const chosenResourceUrl = resource.url;
         const newResource = createNewResource();
         newResource.setFile(chosenResourceUrl);
-        newResource.setName(path.basename(chosenResourceUrl));
+        const resourceCleanedName = isPublicAssetResourceUrl(chosenResourceUrl)
+          ? extractFilenameWithExtensionFromPublicAssetResourceUrl(
+              chosenResourceUrl
+            )
+          : path.basename(chosenResourceUrl);
+        newResource.setName(resourceCleanedName);
         newResource.setOrigin('gdevelop-asset-store', chosenResourceUrl);
 
         onChooseResources([newResource]);


### PR DESCRIPTION
Forgot to clean resource names when added directly from the resource store

Bfore:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/4895034/203388468-30e7b366-72da-4d4d-913d-170f765b88b1.png">

After:

<img width="1509" alt="image" src="https://user-images.githubusercontent.com/4895034/203388279-a6403e52-4376-4255-b813-a21352f79dcf.png">
