### PR TITLE
Fix the drag and drop of the extension editor.

### DIFF
--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -184,7 +184,7 @@ export default class EventsBasedBehaviorsList extends React.Component<
     );
     eventsBasedBehaviorsList.move(
       originIndex,
-      // When moving the item down, it not must be counted.
+      // When moving the item down, it must not be counted.
       destinationIndex + (destinationIndex <= originIndex ? 0 : -1)
     );
 

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -176,9 +176,16 @@ export default class EventsBasedBehaviorsList extends React.Component<
     } = this.props;
     if (!selectedEventsBasedBehavior) return;
 
+    const originIndex = eventsBasedBehaviorsList.getPosition(
+      selectedEventsBasedBehavior
+    );
+    const destinationIndex = eventsBasedBehaviorsList.getPosition(
+      destinationEventsBasedBehavior
+    );
     eventsBasedBehaviorsList.move(
-      eventsBasedBehaviorsList.getPosition(selectedEventsBasedBehavior),
-      eventsBasedBehaviorsList.getPosition(destinationEventsBasedBehavior)
+      originIndex,
+      // When moving the item down, it not must be counted.
+      destinationIndex + (destinationIndex <= originIndex ? 0 : -1)
     );
 
     this.forceUpdateList();

--- a/newIDE/app/src/EventsBasedObjectsList/index.js
+++ b/newIDE/app/src/EventsBasedObjectsList/index.js
@@ -143,9 +143,16 @@ export default class EventsBasedObjectsList extends React.Component<
     const { eventsBasedObjectsList, selectedEventsBasedObject } = this.props;
     if (!selectedEventsBasedObject) return;
 
+    const originIndex = eventsBasedObjectsList.getPosition(
+      selectedEventsBasedObject
+    );
+    const destinationIndex = eventsBasedObjectsList.getPosition(
+      destinationEventsBasedObject
+    );
     eventsBasedObjectsList.move(
-      eventsBasedObjectsList.getPosition(selectedEventsBasedObject),
-      eventsBasedObjectsList.getPosition(destinationEventsBasedObject)
+      originIndex,
+      // When moving the item down, it not must be counted.
+      destinationIndex + (destinationIndex <= originIndex ? 0 : -1)
     );
 
     this.forceUpdateList();

--- a/newIDE/app/src/EventsBasedObjectsList/index.js
+++ b/newIDE/app/src/EventsBasedObjectsList/index.js
@@ -151,7 +151,7 @@ export default class EventsBasedObjectsList extends React.Component<
     );
     eventsBasedObjectsList.move(
       originIndex,
-      // When moving the item down, it not must be counted.
+      // When moving the item down, it must not be counted.
       destinationIndex + (destinationIndex <= originIndex ? 0 : -1)
     );
 

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -219,7 +219,7 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
     );
     eventsFunctionsContainer.moveEventsFunction(
       originIndex,
-      // When moving the item down, it not must be counted.
+      // When moving the item down, it must not be counted.
       destinationIndex + (destinationIndex <= originIndex ? 0 : -1)
     );
 

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -211,13 +211,16 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
     const { eventsFunctionsContainer, selectedEventsFunction } = this.props;
     if (!selectedEventsFunction) return;
 
+    const originIndex = eventsFunctionsContainer.getEventsFunctionPosition(
+      selectedEventsFunction
+    );
+    const destinationIndex = eventsFunctionsContainer.getEventsFunctionPosition(
+      destinationEventsFunction
+    );
     eventsFunctionsContainer.moveEventsFunction(
-      eventsFunctionsContainer.getEventsFunctionPosition(
-        selectedEventsFunction
-      ),
-      eventsFunctionsContainer.getEventsFunctionPosition(
-        destinationEventsFunction
-      )
+      originIndex,
+      // When moving the item down, it not must be counted.
+      destinationIndex + (destinationIndex <= originIndex ? 0 : -1)
     );
 
     this.forceUpdateList();


### PR DESCRIPTION
* Items were not drop at the right position when they were moved down.

http://gdevelop-storybook.s3-website-us-east-1.amazonaws.com/fix-function-drag-and-drop/latest/index.html?path=/story/eventsfunctionsextensioneditor-index--default