### PR TITLE
Change default workspace location in Preferences

### DIFF
--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -7,7 +7,11 @@ import { type FileMetadataAndStorageProviderName } from '../../ProjectsStorage';
 import { type ShortcutMap } from '../../KeyboardShortcuts/DefaultShortcuts';
 import { type CommandName } from '../../CommandPalette/CommandsList';
 import optionalRequire from '../../Utils/OptionalRequire';
+import { findDefaultFolder } from '../../ProjectsStorage/LocalFileStorageProvider/LocalPathFinder';
+
 const electron = optionalRequire('electron');
+const remote = optionalRequire('@electron/remote');
+const app = remote ? remote.app : null;
 
 export type AlertMessageIdentifier =
   | 'default-additional-work'
@@ -221,6 +225,7 @@ export type PreferencesValues = {|
   showGetStartedSection: boolean,
   showEventBasedObjectsEditor: boolean,
   inAppTutorialsProgress: InAppTutorialProgressDatabase,
+  newProjectsDefaultFolder: string,
 |};
 
 /**
@@ -293,6 +298,7 @@ export type Preferences = {|
     tutorialId: string,
     userId: ?string,
   |}) => ?InAppTutorialUserProgress,
+  setNewProjectsDefaultFolder: (newProjectsDefaultFolder: string) => void,
 |};
 
 export const initialPreferences = {
@@ -333,6 +339,7 @@ export const initialPreferences = {
     showGetStartedSection: true,
     showEventBasedObjectsEditor: false,
     inAppTutorialsProgress: {},
+    newProjectsDefaultFolder: app ? findDefaultFolder(app) : '',
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -384,6 +391,7 @@ export const initialPreferences = {
   getShowEventBasedObjectsEditor: () => false,
   saveTutorialProgress: () => {},
   getTutorialProgress: () => {},
+  setNewProjectsDefaultFolder: () => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -5,6 +5,7 @@ import { type I18n } from '@lingui/core';
 import React from 'react';
 import SelectField from '../../UI/SelectField';
 import FlatButton from '../../UI/FlatButton';
+import LocalFolderPicker from '../../UI/LocalFolderPicker';
 import SelectOption from '../../UI/SelectOption';
 import Toggle from '../../UI/Toggle';
 import Dialog from '../../UI/Dialog';
@@ -60,6 +61,7 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
     setEventsSheetCancelInlineParameter,
     setShowCommunityExtensions,
     setShowEventBasedObjectsEditor,
+    setNewProjectsDefaultFolder,
   } = React.useContext(PreferencesContext);
 
   return (
@@ -83,6 +85,9 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
           options={[
             { value: 'preferences', label: <Trans>Preferences</Trans> },
             { value: 'shortcuts', label: <Trans>Keyboard Shortcuts</Trans> },
+            ...(electron
+              ? [{ value: 'folders', label: <Trans>Folders</Trans> }]
+              : []),
           ]}
           // Enforce scroll on small screen, because the tabs have long names.
           variant={windowWidth === 'small' ? 'scrollable' : undefined}
@@ -388,6 +393,16 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
             />
           </Column>
         </Line>
+      )}
+      {electron && currentTab === 'folders' && (
+        <ColumnStackLayout noMargin>
+          <LocalFolderPicker
+            fullWidth
+            value={values.newProjectsDefaultFolder}
+            onChange={setNewProjectsDefaultFolder}
+            type="default-workspace"
+          />
+        </ColumnStackLayout>
       )}
     </Dialog>
   );

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -150,6 +150,7 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     ),
     saveTutorialProgress: this._saveTutorialProgress.bind(this),
     getTutorialProgress: this._getTutorialProgress.bind(this),
+    setNewProjectsDefaultFolder: this._setNewProjectsDefaultFolder.bind(this),
   };
 
   componentDidMount() {
@@ -750,6 +751,18 @@ export default class PreferencesProvider extends React.Component<Props, State> {
         values: {
           ...state.values,
           isAlwaysOnTopInPreview: enabled,
+        },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _setNewProjectsDefaultFolder(newProjectsDefaultFolder: string) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          newProjectsDefaultFolder,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/ProjectCreation/NewProjectSetupDialog.js
+++ b/newIDE/app/src/ProjectCreation/NewProjectSetupDialog.js
@@ -12,6 +12,7 @@ import { type NewProjectSetup } from './CreateProjectDialog';
 import IconButton from '../UI/IconButton';
 import { ColumnStackLayout } from '../UI/Layout';
 import { emptyStorageProvider } from '../ProjectsStorage/ProjectStorageProviders';
+import { findEmptyPathInWorkspaceFolder } from '../ProjectsStorage/LocalFileStorageProvider/LocalPathFinder';
 import SelectField from '../UI/SelectField';
 import SelectOption from '../UI/SelectOption';
 import CreateProfile from '../Profile/CreateProfile';
@@ -24,7 +25,11 @@ import {
 } from '../MainFrame/EditorContainers/HomePage/BuildSection/MaxProjectCountAlertMessage';
 import { SubscriptionSuggestionContext } from '../Profile/Subscription/SubscriptionSuggestionContext';
 import optionalRequire from '../Utils/OptionalRequire';
+import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
+
 const electron = optionalRequire('electron');
+const remote = optionalRequire('@electron/remote');
+const app = remote ? remote.app : null;
 
 type Props = {|
   isOpening?: boolean,
@@ -48,6 +53,7 @@ const NewProjectSetupDialog = ({
   storageProviders,
   authenticatedUser,
 }: Props): React.Node => {
+  const { values } = React.useContext(PreferencesContext);
   const { openSubscriptionDialog } = React.useContext(
     SubscriptionSuggestionContext
   );
@@ -57,6 +63,9 @@ const NewProjectSetupDialog = ({
   const [projectName, setProjectName] = React.useState<string>(() =>
     generateProjectName(sourceExampleName)
   );
+  const newProjectsDefaultFolder = app
+    ? findEmptyPathInWorkspaceFolder(app, values.newProjectsDefaultFolder || '')
+    : '';
   const [saveAsLocation, setSaveAsLocation] = React.useState<?SaveAsLocation>(
     null
   );
@@ -228,6 +237,7 @@ const NewProjectSetupDialog = ({
             projectName,
             saveAsLocation,
             setSaveAsLocation,
+            newProjectsDefaultFolder,
           })}
         {limits && hasTooManyCloudProjects ? (
           <MaxProjectCountAlertMessage

--- a/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudProjectWriter.js
@@ -231,6 +231,7 @@ export const onRenderNewProjectSaveAsLocationChooser = ({
   projectName: string,
   saveAsLocation: ?SaveAsLocation,
   setSaveAsLocation: (?SaveAsLocation) => void,
+  newProjectsDefaultFolder?: string,
 |}) => {
   if (!saveAsLocation || saveAsLocation.name !== projectName) {
     setSaveAsLocation({

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalPathFinder.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalPathFinder.js
@@ -19,7 +19,10 @@ const findEmptyPath = (basePath: string) => {
   return path.join(basePath, folderName);
 };
 
-export const findEmptyPathInDefaultFolder = (electronApp: any): string => {
+/**
+ * Returns the default workspace folder from the Documents folder or the Home folder
+ */
+export const findDefaultFolder = (electronApp: any): string => {
   let documentsPath = '';
   try {
     documentsPath = electronApp.getPath('documents');
@@ -27,5 +30,17 @@ export const findEmptyPathInDefaultFolder = (electronApp: any): string => {
     // A user may not have the Documents folder defined on Windows.
     documentsPath = electronApp.getPath('home');
   }
-  return findEmptyPath(path.join(documentsPath, 'GDevelop projects'));
+  return path.join(documentsPath, 'GDevelop projects');
+};
+
+/**
+ * Returns the current workspace with a generated project name
+ */
+export const findEmptyPathInWorkspaceFolder = (
+  electronApp: any,
+  defaultFolder: string | null
+): string => {
+  const folder =
+    defaultFolder === null ? findDefaultFolder(electronApp) : defaultFolder;
+  return findEmptyPath(folder);
 };

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -11,13 +11,11 @@ import {
 } from '../../Utils/ObjectSplitter';
 import type { MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 import LocalFolderPicker from '../../UI/LocalFolderPicker';
-import { findEmptyPathInDefaultFolder } from './LocalPathFinder';
 
 const fs = optionalRequire('fs-extra');
 const path = optionalRequire('path');
 const remote = optionalRequire('@electron/remote');
 const dialog = remote ? remote.dialog : null;
-const app = remote ? remote.app : null;
 
 const checkFileContent = (filePath: string, expectedContent: string) => {
   const time = performance.now();
@@ -229,14 +227,16 @@ export const getWriteErrorMessage = (error: Error): MessageDescriptor =>
 export const onRenderNewProjectSaveAsLocationChooser = ({
   saveAsLocation,
   setSaveAsLocation,
+  newProjectsDefaultFolder,
 }: {
   saveAsLocation: ?SaveAsLocation,
   setSaveAsLocation: (?SaveAsLocation) => void,
+  newProjectsDefaultFolder?: string,
 }) => {
   const outputPath = saveAsLocation
     ? path.dirname(saveAsLocation.fileIdentifier)
-    : app
-    ? findEmptyPathInDefaultFolder(app)
+    : newProjectsDefaultFolder
+    ? newProjectsDefaultFolder
     : '';
   if (!saveAsLocation) {
     setSaveAsLocation({

--- a/newIDE/app/src/ProjectsStorage/index.js
+++ b/newIDE/app/src/ProjectsStorage/index.js
@@ -128,6 +128,7 @@ export type StorageProvider = {|
     projectName: string,
     saveAsLocation: ?SaveAsLocation,
     setSaveAsLocation: (?SaveAsLocation) => void,
+    newProjectsDefaultFolder?: string,
   |}) => React.Node,
   createOperations: ({
     /** Open a dialog (a render function) */

--- a/newIDE/app/src/UI/LocalFolderPicker/index.js
+++ b/newIDE/app/src/UI/LocalFolderPicker/index.js
@@ -27,7 +27,7 @@ const styles = {
 };
 
 type Props = {|
-  type: 'export' | 'create-game',
+  type: 'export' | 'create-game' | 'default-workspace',
   value: string,
   onChange: string => void,
   defaultPath?: string,
@@ -63,6 +63,12 @@ export default class LocalFolderPicker extends PureComponent<Props, {||}> {
       return {
         title: i18n._(t`Choose an export folder`),
         message: i18n._(t`Choose where to export the game`),
+      };
+    }
+    if (type === 'default-workspace') {
+      return {
+        title: i18n._(t`Choose a workspace folder`),
+        message: i18n._(t`Choose where to create your projects`),
       };
     }
     return {


### PR DESCRIPTION
- In the "_Preferences_" Dialog there is now a new third tab called "**Folders**".
- In this tab you can choose the **default workspace folder where to save new projects**.
- The first time you enter this tab is filled with the user's Home folder.
- This tab is only visible when using the desktop version.
- The "_New Project_" Dialog will show the folder you saved in the Preferences Dialog.

![image](https://user-images.githubusercontent.com/21989259/203866880-de77abad-567a-4ca6-9c1b-a02a2f7a004a.png)

![image](https://user-images.githubusercontent.com/21989259/203866971-e88c5324-46d1-42c0-816a-f992c606036f.png)
