### PR TITLE
Improve initial dialog logic to avoid opening tab on subsequent profile openings.

### DIFF
--- a/newIDE/app/src/GameDashboard/GamesList.js
+++ b/newIDE/app/src/GameDashboard/GamesList.js
@@ -14,9 +14,15 @@ type Props = {|
   project: ?gdProject,
   initialGameId: ?string,
   initialTab: ?GameDetailsTab,
+  onGameDetailsDialogClose: () => void,
 |};
 
-export const GamesList = ({ project, initialGameId, initialTab }: Props) => {
+export const GamesList = ({
+  project,
+  initialGameId,
+  initialTab,
+  onGameDetailsDialogClose,
+}: Props) => {
   const [error, setError] = React.useState<?Error>(null);
   const [games, setGames] = React.useState<?Array<Game>>(null);
   const {
@@ -118,6 +124,7 @@ export const GamesList = ({ project, initialGameId, initialTab }: Props) => {
           initialTab={openedGameInitialTab}
           onClose={() => {
             setOpenedGame(null);
+            onGameDetailsDialogClose();
           }}
           onGameUpdated={updatedGame => {
             setGames(

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -512,7 +512,9 @@ const MainFrame = (props: Props) => {
     openProfileDialogWithTab,
     profileDialogInitialTab,
     gamesDashboardInitialGameId,
+    setGamesDashboardInitialGameId,
     gamesDashboardInitialTab,
+    setGamesDashboardInitialTab,
   } = useOpenInitialDialog({
     parameters: {
       initialDialog,
@@ -2803,9 +2805,16 @@ const MainFrame = (props: Props) => {
           currentProject={currentProject}
           initialTab={profileDialogInitialTab}
           open
-          onClose={() => openProfileDialog(false)}
+          onClose={() => {
+            openProfileDialog(false);
+          }}
           gamesDashboardInitialGameId={gamesDashboardInitialGameId}
           gamesDashboardInitialTab={gamesDashboardInitialTab}
+          onGameDetailsDialogClose={() => {
+            // On dialog close, reset any initial props.
+            setGamesDashboardInitialGameId(null);
+            setGamesDashboardInitialTab('details');
+          }}
         />
       )}
       {newProjectSetupDialogOpen && (

--- a/newIDE/app/src/Profile/ProfileDialog.js
+++ b/newIDE/app/src/Profile/ProfileDialog.js
@@ -28,6 +28,7 @@ type Props = {|
   initialTab: ProfileTab,
   gamesDashboardInitialGameId: ?string,
   gamesDashboardInitialTab: ?GameDetailsTab,
+  onGameDetailsDialogClose: () => void,
 |};
 
 const ProfileDialog = ({
@@ -37,6 +38,7 @@ const ProfileDialog = ({
   initialTab,
   gamesDashboardInitialGameId,
   gamesDashboardInitialTab,
+  onGameDetailsDialogClose,
 }: Props) => {
   const [currentTab, setCurrentTab] = React.useState<ProfileTab>(initialTab);
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
@@ -171,6 +173,7 @@ const ProfileDialog = ({
               project={currentProject}
               initialGameId={gamesDashboardInitialGameId}
               initialTab={gamesDashboardInitialTab}
+              onGameDetailsDialogClose={onGameDetailsDialogClose}
             />
           )}
         </>

--- a/newIDE/app/src/Utils/UseOpenInitialDialog.js
+++ b/newIDE/app/src/Utils/UseOpenInitialDialog.js
@@ -28,10 +28,6 @@ export const useOpenInitialDialog = ({ parameters, actions }: Props) => {
   // Put the initial info in a ref, so that we con change its value
   // and not rely on what stays in the parameters + prevent re-rendering.
   const initialDialogRef = React.useRef<?string>(parameters.initialDialog);
-  const initialGameIdRef = React.useRef<?string>(parameters.initialGameId);
-  const initialGamesDashboardTabRef = React.useRef<?string>(
-    parameters.initialGamesDashboardTab
-  );
   const [
     profileDialogInitialTab,
     setProfileDialogInitialTab,
@@ -69,30 +65,28 @@ export const useOpenInitialDialog = ({ parameters, actions }: Props) => {
     [actions]
   );
 
+  const cleanupAfterDialogOpened = () => {
+    Window.removeArguments(); // Remove the arguments from the URL for cleanup.
+    initialDialogRef.current = null; // Reset the initial dialog, to avoid opening it again.
+  };
+
   React.useEffect(
     () => {
       switch (initialDialogRef.current) {
         case 'subscription':
           openSubscriptionDialog({ reason: 'Landing dialog at opening' });
-          Window.removeArguments(); // Remove the arguments from the URL for cleanup.
-          initialDialogRef.current = null; // Reset the initial dialog, to avoid opening it again.
+          cleanupAfterDialogOpened();
           break;
         case 'onboarding':
           actions.openOnboardingDialog(true);
-          Window.removeArguments(); // Remove the arguments from the URL for cleanup.
-          initialDialogRef.current = null; // Reset the initial dialog, to avoid opening it again.
+          cleanupAfterDialogOpened();
           break;
         case 'games-dashboard':
           openGameDashboard({
-            gameId: initialGameIdRef.current,
-            tab: initialGamesDashboardTabRef.current,
+            gameId: parameters.initialGameId,
+            tab: parameters.initialGamesDashboardTab,
           });
-          // Ensure any arguments are removed from the URL to prevent
-          // triggering a reopen of the game on the next dashboard opening.
-          Window.removeArguments(); // Remove the arguments from the URL for cleanup.
-          initialDialogRef.current = null; // Reset the initial dialog and parameters, to avoid opening it again.
-          initialGameIdRef.current = null;
-          initialGamesDashboardTabRef.current = null;
+          cleanupAfterDialogOpened();
           break;
         default:
           break;
@@ -105,6 +99,8 @@ export const useOpenInitialDialog = ({ parameters, actions }: Props) => {
     profileDialogInitialTab,
     openProfileDialogWithTab,
     gamesDashboardInitialGameId,
+    setGamesDashboardInitialGameId,
     gamesDashboardInitialTab,
+    setGamesDashboardInitialTab,
   };
 };


### PR DESCRIPTION
Fix edge case, where after opening a link to a game tab, all subsequent profile openings redirect to the game dashboard. (because state is not updated)