### PR TITLE
Correctly deactivate cloud projects on desktop app in prod

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/MaxProjectCountAlertMessage.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/MaxProjectCountAlertMessage.js
@@ -9,6 +9,8 @@ import { Line, Column } from '../../../../UI/Grid';
 import { type Limits } from '../../../../Utils/GDevelopServices/Usage';
 import { type AuthenticatedUser } from '../../../../Profile/AuthenticatedUserContext';
 import Window from '../../../../Utils/Window';
+import optionalRequire from '../../../../Utils/OptionalRequire';
+const electron = optionalRequire('electron');
 
 type Props = {|
   onUpgrade: () => void,
@@ -17,7 +19,7 @@ type Props = {|
 
 // Search "activate cloud projects" in the codebase for everything to
 // remove once cloud projects are activated for the desktop app.
-const supportsCloudProjects = Window.isDev();
+const supportsCloudProjects = !electron || Window.isDev();
 
 export const checkIfHasTooManyCloudProjects = (
   authenticatedUser: AuthenticatedUser

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -152,7 +152,7 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
 
     // Search "activate cloud projects" in the codebase for everything to
     // remove once cloud projects are activated for the desktop app.
-    const supportsCloudProjects = Window.isDev();
+    const supportsCloudProjects = !electron || Window.isDev();
 
     const iconClasses = useStylesForListItemIcon();
 


### PR DESCRIPTION
Feature flag misses a check on presence of electron in files that are used by both the Browser and the Local apps