### PR TITLE
Simplify assets loading to prevent unnecessary calls

### DIFF
--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -218,11 +218,11 @@ export const AssetsHome = React.forwardRef<Props, AssetsHomeInterface>(
       },
     }));
 
-    const starterPacksTiles = starterPacks.map(assetPack => (
+    const starterPacksTiles = starterPacks.map((assetPack, index) => (
       <PublicAssetPackTile
         assetPack={assetPack}
         onSelect={() => onPublicAssetPackSelection(assetPack)}
-        key={assetPack.tag}
+        key={`${assetPack.tag}-${index}`}
       />
     ));
 

--- a/newIDE/app/src/AssetStore/NewObjectDialog.js
+++ b/newIDE/app/src/AssetStore/NewObjectDialog.js
@@ -134,7 +134,6 @@ export default function NewObjectDialog({
   const {
     searchResults,
     navigationState,
-    fetchAssetsAndFilters,
     environment,
     setEnvironment,
   } = React.useContext(AssetStoreContext);
@@ -242,18 +241,6 @@ export default function NewObjectDialog({
       showAlert,
       resourceManagementProps,
     ]
-  );
-
-  // Load assets and filters when the dialog is opened or when the environment changes.
-  React.useEffect(
-    () => {
-      // The variable environment is always defined, this check is a hack
-      // to ensure we call fetchAssetsAndFilters every time the value changes.
-      if (environment) {
-        fetchAssetsAndFilters();
-      }
-    },
-    [fetchAssetsAndFilters, environment]
   );
 
   const mainAction =

--- a/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackPurchaseDialog.js
+++ b/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackPurchaseDialog.js
@@ -17,7 +17,6 @@ import CircularProgress from '../../UI/CircularProgress';
 import BackgroundText from '../../UI/BackgroundText';
 import { showErrorBox } from '../../UI/Messages/MessageBox';
 import Mark from '../../UI/CustomSvgIcons/Mark';
-import { AssetStoreContext } from '../AssetStoreContext';
 import FlatButton from '../../UI/FlatButton';
 import { LineStackLayout } from '../../UI/Layout';
 
@@ -39,9 +38,6 @@ const PrivateAssetPackPurchaseDialog = ({
     onCreateAccount,
     receivedAssetPacks,
   } = React.useContext(AuthenticatedUserContext);
-  const { loadedReceivedAssetPackInStore } = React.useContext(
-    AssetStoreContext
-  );
   const [isPurchasing, setIsPurchasing] = React.useState(false);
   const [
     isCheckingPurchasesAfterLogin,
@@ -137,8 +133,8 @@ const PrivateAssetPackPurchaseDialog = ({
   // - they just bought it, we display the success message.
   React.useEffect(
     () => {
-      if (loadedReceivedAssetPackInStore) {
-        const receivedAssetPack = loadedReceivedAssetPackInStore.find(
+      if (receivedAssetPacks) {
+        const receivedAssetPack = receivedAssetPacks.find(
           pack => pack.id === privateAssetPackListingData.id
         );
         if (receivedAssetPack) {
@@ -152,7 +148,7 @@ const PrivateAssetPackPurchaseDialog = ({
       }
     },
     [
-      loadedReceivedAssetPackInStore,
+      receivedAssetPacks,
       privateAssetPackListingData,
       isPurchasing,
       onClose,

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -87,7 +87,6 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
     const {
       publicAssetPacks,
       privateAssetPacks,
-      loadedReceivedAssetPackInStore,
       searchResults,
       error,
       fetchAssetsAndFilters,
@@ -117,7 +116,9 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       purchasingPrivateAssetPackListingData,
       setPurchasingPrivateAssetPackListingData,
     ] = React.useState<?PrivateAssetPackListingData>(null);
-    const { onPurchaseSuccessful } = React.useContext(AuthenticatedUserContext);
+    const { onPurchaseSuccessful, receivedAssetPacks } = React.useContext(
+      AuthenticatedUserContext
+    );
 
     // The saved scroll position must not be reset by a scroll event until it
     // has been applied.
@@ -240,10 +241,8 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
     // otherwise we open the dialog to buy it.
     const selectPrivateAssetPack = React.useCallback(
       (assetPackListingData: PrivateAssetPackListingData) => {
-        const receivedAssetPack = loadedReceivedAssetPackInStore
-          ? loadedReceivedAssetPackInStore.find(
-              pack => pack.id === assetPackListingData.id
-            )
+        const receivedAssetPack = receivedAssetPacks
+          ? receivedAssetPacks.find(pack => pack.id === assetPackListingData.id)
           : null;
 
         if (!receivedAssetPack) {
@@ -269,7 +268,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         navigationState.openPackPage(receivedAssetPack);
         setIsFiltersPanelOpen(true);
       },
-      [loadedReceivedAssetPackInStore, saveScrollPosition, navigationState]
+      [receivedAssetPacks, saveScrollPosition, navigationState]
     );
 
     // If the user has received the pack they are currently viewing,
@@ -284,8 +283,8 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
           currentPage.openedAssetPack.id &&
           currentPage.openedAssetPack.id ===
             purchasingPrivateAssetPackListingData.id;
-        if (loadedReceivedAssetPackInStore && !isOnPrivatePackPage) {
-          const receivedAssetPack = loadedReceivedAssetPackInStore.find(
+        if (receivedAssetPacks && !isOnPrivatePackPage) {
+          const receivedAssetPack = receivedAssetPacks.find(
             pack => pack.id === purchasingPrivateAssetPackListingData.id
           );
           if (receivedAssetPack) {
@@ -298,7 +297,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         }
       },
       [
-        loadedReceivedAssetPackInStore,
+        receivedAssetPacks,
         purchasingPrivateAssetPackListingData,
         navigationState,
         saveScrollPosition,
@@ -311,8 +310,8 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
     const selectTag = React.useCallback(
       (tag: string) => {
         const privateAssetPack =
-          loadedReceivedAssetPackInStore &&
-          loadedReceivedAssetPackInStore.find(pack => pack.tag === tag);
+          receivedAssetPacks &&
+          receivedAssetPacks.find(pack => pack.tag === tag);
         const publicAssetPack =
           publicAssetPacks &&
           publicAssetPacks.starterPacks.find(pack => pack.tag === tag);
@@ -328,7 +327,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         setIsFiltersPanelOpen(true);
       },
       [
-        loadedReceivedAssetPackInStore,
+        receivedAssetPacks,
         publicAssetPacks,
         saveScrollPosition,
         assetFiltersState,


### PR DESCRIPTION
in a few words:

- split "asset fetching" and "creating the assetById structure" into 2 different effects.
  - this allows fetching the assets only once. (or again, when the environment changes)
  - whilst the second effect listens to both private & public assets, to update the structure.
- removed the timeout as it was almost never triggered (if the user is connected, everything is fetched directly)
- removed the concept of "loaded assets in store" as now that the public assets are not loaded again when a purchase is made, the lag between "asset pack is available in authenticationContext" and "asset pack is visible on the asset store" is only the indexing of the search items, which is almost instant.
- fixed a duplicated key for "ads" items