### PR TITLE
Use skeleton rather than loader on homepage build section

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -12,7 +12,7 @@ import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import Text from '../../../../UI/Text';
 import TextButton from '../../../../UI/TextButton';
 import RaisedButton from '../../../../UI/RaisedButton';
-import { Line, Column, Spacer } from '../../../../UI/Grid';
+import { Line, Column, Spacer, marginsSize } from '../../../../UI/Grid';
 import { useResponsiveWindowWidth } from '../../../../UI/Reponsive/ResponsiveWindowMeasurer';
 import {
   LineStackLayout,
@@ -49,6 +49,7 @@ import Add from '../../../../UI/CustomSvgIcons/Add';
 import ImageTileRow from '../../../../UI/ImageTileRow';
 import { prepareExamples } from '../../../../AssetStore/ExampleStore';
 import Window from '../../../../Utils/Window';
+import Skeleton from '@material-ui/lab/Skeleton';
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
 
@@ -60,6 +61,7 @@ const styles = {
     borderRadius: 8,
     overflowWrap: 'anywhere', // Ensure everything is wrapped on small devices.
   },
+  projectSkeleton: { borderRadius: 6 },
 };
 
 const getTemplatesGridSizeFromWidth = (width: WidthType) => {
@@ -72,6 +74,18 @@ const getTemplatesGridSizeFromWidth = (width: WidthType) => {
     default:
       return 6;
   }
+};
+
+const getProjectLineHeight = (width: WidthType) => {
+  let lineHeight;
+  switch (width) {
+    case 'small':
+      lineHeight = 52;
+      break;
+    default:
+      lineHeight = 36;
+  }
+  return lineHeight - 2 * marginsSize;
 };
 
 type Props = {|
@@ -286,6 +300,7 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
     };
 
     const isWindowWidthMediumOrLarger = windowWidth !== 'small';
+    const skeletonLineHeight = getProjectLineHeight(windowWidth);
 
     return (
       <I18n>
@@ -374,45 +389,48 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
                     </ResponsiveLineStackLayout>
                   </Column>
                 </LineStackLayout>
-                {authenticatedUser.loginState === 'loggingIn' ? (
-                  <Column
-                    useFullHeight
-                    expand
-                    noMargin
-                    justifyContent="flex-start"
-                    alignItems="center"
-                  >
-                    <CircularProgress />
-                    <Text>
-                      <Trans>Loading projects...</Trans>
-                    </Text>
-                  </Column>
-                ) : (
-                  projectFiles &&
-                  projectFiles.length > 0 && (
-                    <Line>
-                      <Column noMargin expand>
-                        {isWindowWidthMediumOrLarger && (
-                          <LineStackLayout justifyContent="space-between">
-                            <Column expand>
-                              <Text color="secondary">
-                                <Trans>File name</Trans>
-                              </Text>
-                            </Column>
-                            <Column expand>
-                              <Text color="secondary">
-                                <Trans>Location</Trans>
-                              </Text>
-                            </Column>
-                            <Column expand>
-                              <Text color="secondary">
-                                <Trans>Last edited</Trans>
-                              </Text>
-                            </Column>
-                          </LineStackLayout>
-                        )}
-                        <List>
-                          {projectFiles.map(file => {
+                <Line>
+                  <Column noMargin expand>
+                    {isWindowWidthMediumOrLarger && (
+                      <LineStackLayout justifyContent="space-between">
+                        <Column expand>
+                          <Text color="secondary">
+                            <Trans>File name</Trans>
+                          </Text>
+                        </Column>
+                        <Column expand>
+                          <Text color="secondary">
+                            <Trans>Location</Trans>
+                          </Text>
+                        </Column>
+                        <Column expand>
+                          <Text color="secondary">
+                            <Trans>Last edited</Trans>
+                          </Text>
+                        </Column>
+                      </LineStackLayout>
+                    )}
+                    <List>
+                      {authenticatedUser.loginState === 'loggingIn'
+                        ? new Array(5).fill(0).map((_, index) => (
+                            <ListItem
+                              style={styles.listItem}
+                              key={`skeleton-${index}`}
+                            >
+                              <Line expand>
+                                <Column expand>
+                                  <Skeleton
+                                    variant="rect"
+                                    height={skeletonLineHeight}
+                                    style={styles.projectSkeleton}
+                                  />
+                                </Column>
+                              </Line>
+                            </ListItem>
+                          ))
+                        : projectFiles &&
+                          projectFiles.length > 0 &&
+                          projectFiles.map(file => {
                             const storageProvider = getStorageProviderByInternalName(
                               storageProviders,
                               file.storageProviderName
@@ -542,11 +560,9 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
                               </ListItem>
                             );
                           })}
-                        </List>
-                      </Column>
-                    </Line>
-                  )
-                )}
+                    </List>
+                  </Column>
+                </Line>
               </SectionRow>
             </SectionContainer>
             <ContextMenu

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -45,7 +45,6 @@ import { ExampleStoreContext } from '../../../../AssetStore/ExampleStore/Example
 import { SubscriptionSuggestionContext } from '../../../../Profile/Subscription/SubscriptionSuggestionContext';
 import { type ExampleShortHeader } from '../../../../Utils/GDevelopServices/Example';
 import { type WidthType } from '../../../../UI/Reponsive/ResponsiveWindowMeasurer';
-import PlaceholderLoader from '../../../../UI/PlaceholderLoader';
 import Add from '../../../../UI/CustomSvgIcons/Add';
 import ImageTileRow from '../../../../UI/ImageTileRow';
 import { prepareExamples } from '../../../../AssetStore/ExampleStore';
@@ -312,21 +311,22 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
               }
             >
               <SectionRow>
-                {!allExamples ? (
-                  <PlaceholderLoader />
-                ) : (
-                  <ImageTileRow
-                    items={prepareExamples(allExamples).map(example => ({
-                      onClick: () => onSelectExample(example),
-                      imageUrl: example.previewImageUrls[0],
-                    }))}
-                    title={<Trans>Recommended templates</Trans>}
-                    onShowAll={onShowAllExamples}
-                    showAllIcon={<Add fontSize="small" />}
-                    getColumnsFromWidth={getTemplatesGridSizeFromWidth}
-                    getLimitFromWidth={getTemplatesGridSizeFromWidth}
-                  />
-                )}
+                <ImageTileRow
+                  isLoading={!allExamples}
+                  items={
+                    allExamples
+                      ? prepareExamples(allExamples).map(example => ({
+                          onClick: () => onSelectExample(example),
+                          imageUrl: example.previewImageUrls[0],
+                        }))
+                      : []
+                  }
+                  title={<Trans>Recommended templates</Trans>}
+                  onShowAll={onShowAllExamples}
+                  showAllIcon={<Add fontSize="small" />}
+                  getColumnsFromWidth={getTemplatesGridSizeFromWidth}
+                  getLimitFromWidth={getTemplatesGridSizeFromWidth}
+                />
               </SectionRow>
               <SectionRow>
                 <LineStackLayout

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -77,14 +77,8 @@ const getTemplatesGridSizeFromWidth = (width: WidthType) => {
 };
 
 const getProjectLineHeight = (width: WidthType) => {
-  let lineHeight;
-  switch (width) {
-    case 'small':
-      lineHeight = 52;
-      break;
-    default:
-      lineHeight = 36;
-  }
+  const lineHeight = width === 'small' ? 52 : 36;
+
   return lineHeight - 2 * marginsSize;
 };
 

--- a/newIDE/app/src/UI/Carousel.js
+++ b/newIDE/app/src/UI/Carousel.js
@@ -2,11 +2,11 @@
 import * as React from 'react';
 import { makeStyles, createStyles } from '@material-ui/styles';
 import GridList from '@material-ui/core/GridList';
-import { GridListTile } from '@material-ui/core';
+import GridListTile from '@material-ui/core/GridListTile';
 import ArrowBackIos from '@material-ui/icons/ArrowBackIos';
 import ArrowForwardIos from '@material-ui/icons/ArrowForwardIos';
 import ListOutlined from '@material-ui/icons/ListOutlined';
-import { Skeleton } from '@material-ui/lab';
+import Skeleton from '@material-ui/lab/Skeleton';
 
 import Window from '../Utils/Window';
 import Text from './Text';

--- a/newIDE/app/src/UI/ImageTileGrid.js
+++ b/newIDE/app/src/UI/ImageTileGrid.js
@@ -139,7 +139,6 @@ const ImageTileGrid = ({
                     <div style={styles.skeletonContainer}>
                       <Skeleton
                         variant="rect"
-                        key={index}
                         width="100%"
                         height="100%"
                         style={styles.skeleton}

--- a/newIDE/app/src/UI/ImageTileGrid.js
+++ b/newIDE/app/src/UI/ImageTileGrid.js
@@ -11,7 +11,8 @@ import {
 } from './Reponsive/ResponsiveWindowMeasurer';
 import { CorsAwareImage } from './CorsAwareImage';
 import Text from './Text';
-import { Typography } from '@material-ui/core';
+import Skeleton from '@material-ui/lab/Skeleton';
+import Typography from '@material-ui/core/Typography';
 import { shortenString } from '../Utils/StringHelpers';
 
 const MAX_TILE_SIZE = 300;
@@ -58,6 +59,12 @@ const styles = {
     // the 16:9 ratio.
     aspectRatio: '16 / 9',
   },
+  skeletonTile: { padding: 8, height: 'auto' },
+  skeletonContainer: {
+    padding: 4,
+    aspectRatio: '16 / 9',
+  },
+  skeleton: { borderRadius: 8 },
 };
 
 // Styles to give the impression of pressing an element.
@@ -95,12 +102,14 @@ export type ImageTileComponent = {|
 
 type ImageTileGridProps = {|
   items: Array<ImageTileComponent>,
+  isLoading?: boolean,
   getColumnsFromWidth: (width: WidthType) => number,
   getLimitFromWidth?: (width: WidthType) => number,
 |};
 
 const ImageTileGrid = ({
   items,
+  isLoading,
   getColumnsFromWidth,
   getLimitFromWidth,
 }: ImageTileGridProps) => {
@@ -116,44 +125,61 @@ const ImageTileGrid = ({
         <GridList
           cols={getColumnsFromWidth(windowWidth)}
           style={{
+            flex: 1,
             maxWidth: (MAX_TILE_SIZE + 2 * SPACING) * MAX_COLUMNS, // Avoid tiles taking too much space on large screens.
           }}
           cellHeight="auto"
           spacing={SPACING * 2}
         >
-          {itemsToDisplay.map((item, index) => (
-            <GridListTile key={index} classes={tileClasses}>
-              <ButtonBase
-                style={styles.buttonStyle}
-                onClick={item.onClick}
-                tabIndex={0}
-                focusRipple
-              >
-                <Column noMargin>
-                  <div style={styles.imageContainer}>
-                    <CorsAwareImage
-                      style={styles.thumbnailImageWithDescription}
-                      src={item.imageUrl}
-                      alt={`thumbnail ${index}`}
-                    />
-                    {item.overlayText && (
-                      <ImageOverlay content={item.overlayText} />
-                    )}
-                  </div>
-                  {item.title && (
-                    <div style={styles.titleContainer}>
-                      <Text size="sub-title">{item.title}</Text>
+          {isLoading
+            ? new Array(getColumnsFromWidth(windowWidth))
+                .fill(0)
+                .map((_, index) => (
+                  <GridListTile key={index} style={styles.skeletonTile}>
+                    <div style={styles.skeletonContainer}>
+                      <Skeleton
+                        variant="rect"
+                        key={index}
+                        width="100%"
+                        height="100%"
+                        style={styles.skeleton}
+                      />
                     </div>
-                  )}
-                  {item.description && (
-                    <Text size="body" color="secondary">
-                      {shortenString(item.description, 120)}
-                    </Text>
-                  )}
-                </Column>
-              </ButtonBase>
-            </GridListTile>
-          ))}
+                  </GridListTile>
+                ))
+            : itemsToDisplay.map((item, index) => (
+                <GridListTile key={index} classes={tileClasses}>
+                  <ButtonBase
+                    style={styles.buttonStyle}
+                    onClick={item.onClick}
+                    tabIndex={0}
+                    focusRipple
+                  >
+                    <Column noMargin>
+                      <div style={styles.imageContainer}>
+                        <CorsAwareImage
+                          style={styles.thumbnailImageWithDescription}
+                          src={item.imageUrl}
+                          alt={`thumbnail ${index}`}
+                        />
+                        {item.overlayText && (
+                          <ImageOverlay content={item.overlayText} />
+                        )}
+                      </div>
+                      {item.title && (
+                        <div style={styles.titleContainer}>
+                          <Text size="sub-title">{item.title}</Text>
+                        </div>
+                      )}
+                      {item.description && (
+                        <Text size="body" color="secondary">
+                          {shortenString(item.description, 120)}
+                        </Text>
+                      )}
+                    </Column>
+                  </ButtonBase>
+                </GridListTile>
+              ))}
         </GridList>
       </Line>
     </div>

--- a/newIDE/app/src/UI/ImageTileRow.js
+++ b/newIDE/app/src/UI/ImageTileRow.js
@@ -10,6 +10,7 @@ import { type WidthType } from './Reponsive/ResponsiveWindowMeasurer';
 
 type ImageTileRowProps = {|
   title: React.Node,
+  isLoading?: boolean,
   description?: React.Node,
   items: Array<ImageTileComponent>,
   onShowAll: () => void,
@@ -21,6 +22,7 @@ type ImageTileRowProps = {|
 const ImageTileRow = ({
   title,
   description,
+  isLoading,
   items,
   onShowAll,
   showAllIcon,
@@ -53,6 +55,7 @@ const ImageTileRow = ({
       )}
       <ImageTileGrid
         items={items}
+        isLoading={isLoading}
         getLimitFromWidth={getLimitFromWidth}
         getColumnsFromWidth={getColumnsFromWidth}
       />

--- a/newIDE/app/src/stories/componentStories/HomePage.stories.js
+++ b/newIDE/app/src/stories/componentStories/HomePage.stories.js
@@ -20,6 +20,7 @@ import AuthenticatedUserContext, {
 import CloudStorageProvider from '../../ProjectsStorage/CloudStorageProvider';
 import {
   fakeIndieAuthenticatedUser,
+  fakeAuthenticatedButLoadingAuthenticatedUser,
   indieUserProfile,
 } from '../../fixtures/GDevelopServicesTestData';
 import { GDevelopAssetApi } from '../../Utils/GDevelopServices/ApiConfigs';
@@ -110,6 +111,13 @@ export default {
   decorators: [muiDecorator, GDevelopJsInitializerDecorator],
 };
 
+export const BuildSectionLoading = () => (
+  <WrappedHomePage
+    project={null}
+    recentProjectFiles={getRecentProjectFiles(5)}
+    user={fakeAuthenticatedButLoadingAuthenticatedUser}
+  />
+);
 export const NoProjectOpened = () => (
   <WrappedHomePage
     project={null}

--- a/newIDE/app/src/stories/componentStories/UI/ImageTile/ImageTileRow.stories.js
+++ b/newIDE/app/src/stories/componentStories/UI/ImageTile/ImageTileRow.stories.js
@@ -42,6 +42,18 @@ export const Default = () => (
   />
 );
 
+export const Loading = () => (
+  <ImageTileRow
+    items={itemsWithJustImage}
+    isLoading
+    title="Recommended templates"
+    onShowAll={() => {}}
+    showAllIcon={<Add fontSize="small" />}
+    getColumnsFromWidth={getColumnsFromWidth}
+    getLimitFromWidth={getColumnsFromWidth}
+  />
+);
+
 export const WithDescription = () => (
   <ImageTileRow
     items={itemsWithJustImage}


### PR DESCRIPTION
Fixes #4584 

There's still a layout shift but it's minor. I couldn't get rid of it.

New loading view:

https://user-images.githubusercontent.com/32449369/204866394-7ebdb4d5-de42-4280-b319-4a9a2163acf2.mov

https://user-images.githubusercontent.com/32449369/204866423-4068f3c1-4991-48f3-ac0f-b2b2e839724c.mov


