### PR TITLE
Display some properties in one row

### DIFF
--- a/Extensions/PathfindingBehavior/PathfindingBehavior.cpp
+++ b/Extensions/PathfindingBehavior/PathfindingBehavior.cpp
@@ -32,67 +32,79 @@ std::map<gd::String, gd::PropertyDescriptor> PathfindingBehavior::GetProperties(
     const gd::SerializerElement &behaviorContent) const {
   std::map<gd::String, gd::PropertyDescriptor> properties;
 
-  properties[_("Allows diagonals")]
+  properties["AllowDiagonals"]
+      .SetLabel(_("Allows diagonals"))
       .SetValue(behaviorContent.GetBoolAttribute("allowDiagonals") ? "true"
                                                                    : "false")
       .SetGroup(_("Path smoothing"))
       .SetType("Boolean");
-  properties[_("Acceleration")]
+  properties["Acceleration"]
+      .SetLabel(_("Acceleration"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelAcceleration()).SetValue(
       gd::String::From(behaviorContent.GetDoubleAttribute("acceleration")));
-  properties[_("Max. speed")]
+  properties["MaxSpeed"]
+      .SetLabel(_("Max. speed"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelSpeed()).SetValue(
       gd::String::From(behaviorContent.GetDoubleAttribute("maxSpeed")));
-  properties[_("Rotation speed")]
+  properties["AngularMaxSpeed"]
+      .SetLabel(_("Rotation speed"))
       .SetGroup(_("Rotation"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetAngularSpeed())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("angularMaxSpeed")));
-  properties[_("Rotate object")]
+  properties["RotateObject"]
+      .SetLabel(_("Rotate object"))
       .SetGroup(_("Rotation"))
       .SetValue(behaviorContent.GetBoolAttribute("rotateObject") ? "true"
                                                                  : "false")
       .SetType("Boolean");
-  properties[_("Angle offset")]
+  properties["AngleOffset"]
+      .SetLabel(_("Angle offset"))
       .SetGroup(_("Rotation"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetDegreeAngle())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("angleOffset")));
-  properties[_("Virtual cell width")]
+  properties["CellWidth"]
+      .SetLabel(_("Virtual cell width"))
       .SetGroup(_("Virtual Grid"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("cellWidth", 0)));
-  properties[_("Virtual cell height")]
+  properties["CellHeight"]
+      .SetLabel(_("Virtual cell height"))
       .SetGroup(_("Virtual Grid"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("cellHeight", 0)));
-  properties[_("Virtual grid X offset")]
+  properties["GridOffsetX"]
+      .SetLabel(_("Virtual grid X offset"))
       .SetGroup(_("Virtual Grid"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("gridOffsetX", 0)));
-  properties[_("Virtual grid Y offset")]
+  properties["GridOffsetY"]
+      .SetLabel(_("Virtual grid Y offset"))
       .SetGroup(_("Virtual Grid"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("gridOffsetY", 0)));
-  properties[_("Extra border size")]
+  properties["ExtraBorder"]
+      .SetDescription(_("Extra border size"))
       .SetGroup(_("Collision"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("extraBorder")));
-  properties[_("Smoothing max cell gap")]
+  properties["SmoothingMaxCellGap"]
+      .SetLabel(_("Smoothing max cell gap"))
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("smoothingMaxCellGap")))
       .SetGroup(_("Path smoothing"))
@@ -105,38 +117,38 @@ std::map<gd::String, gd::PropertyDescriptor> PathfindingBehavior::GetProperties(
 bool PathfindingBehavior::UpdateProperty(gd::SerializerElement& behaviorContent,
                                          const gd::String& name,
                                          const gd::String& value) {
-  if (name == _("Allows diagonals")) {
+  if (name == "AllowDiagonals") {
     behaviorContent.SetAttribute("allowDiagonals", (value != "0"));
     return true;
   }
-  if (name == _("Rotate object")) {
+  if (name == "RotateObject") {
     behaviorContent.SetAttribute("rotateObject", (value != "0"));
     return true;
   }
-  if (name == _("Extra border size")) {
+  if (name == "ExtraBorder") {
     behaviorContent.SetAttribute("extraBorder", value.To<float>());
     return true;
   }
 
   if (value.To<float>() < 0) return false;
 
-  if (name == _("Acceleration"))
+  if (name == "Acceleration")
     behaviorContent.SetAttribute("acceleration", value.To<float>());
-  else if (name == _("Max. speed"))
+  else if (name == "MaxSpeed")
     behaviorContent.SetAttribute("maxSpeed", value.To<float>());
-  else if (name == _("Rotation speed"))
+  else if (name == "AngularMaxSpeed")
     behaviorContent.SetAttribute("angularMaxSpeed", value.To<float>());
-  else if (name == _("Angle offset"))
+  else if (name == "AngleOffset")
     behaviorContent.SetAttribute("angleOffset", value.To<float>());
-  else if (name == _("Virtual cell width"))
+  else if (name == "CellWidth")
     behaviorContent.SetAttribute("cellWidth", value.To<float>());
-  else if (name == _("Virtual cell height"))
+  else if (name == "CellHeight")
     behaviorContent.SetAttribute("cellHeight", value.To<float>());
-  else if (name == _("Virtual grid X offset"))
+  else if (name == "GridOffsetX")
     behaviorContent.SetAttribute("gridOffsetX", value.To<float>());
-  else if (name == _("Virtual grid Y offset"))
+  else if (name == "GridOffsetY")
     behaviorContent.SetAttribute("gridOffsetY", value.To<float>());
-  else if (name == _("Smoothing max cell gap"))
+  else if (name == "SmoothingMaxCellGap")
     behaviorContent.SetAttribute("smoothingMaxCellGap", value.To<float>());
   else
     return false;

--- a/Extensions/PathfindingBehavior/PathfindingObstacleBehavior.cpp
+++ b/Extensions/PathfindingBehavior/PathfindingObstacleBehavior.cpp
@@ -20,12 +20,14 @@ std::map<gd::String, gd::PropertyDescriptor>
 PathfindingObstacleBehavior::GetProperties(
     const gd::SerializerElement& behaviorContent) const {
   std::map<gd::String, gd::PropertyDescriptor> properties;
-  properties[_("Impassable obstacle")]
+  properties["Impassable"]
+      .SetLabel(_("Impassable obstacle"))
       .SetValue(behaviorContent.GetBoolAttribute("impassable") ? "true"
                                                                : "false")
       .SetType("Boolean");
-  properties[_("Cost (if not impassable)")].SetValue(
-      gd::String::From(behaviorContent.GetDoubleAttribute("cost")));
+  properties["Cost"]
+      .SetLabel(_("Cost (if not impassable)"))
+      .SetValue(gd::String::From(behaviorContent.GetDoubleAttribute("cost")));
 
   return properties;
 }
@@ -34,14 +36,14 @@ bool PathfindingObstacleBehavior::UpdateProperty(
     gd::SerializerElement& behaviorContent,
     const gd::String& name,
     const gd::String& value) {
-  if (name == _("Impassable obstacle")) {
+  if (name == "Impassable") {
     behaviorContent.SetAttribute("impassable", (value != "0"));
     return true;
   }
 
   if (value.To<float>() < 0) return false;
 
-  if (name == _("Cost (if not impassable)"))
+  if (name == "Cost")
     behaviorContent.SetAttribute("cost", value.To<float>());
   else
     return false;

--- a/Extensions/PlatformBehavior/PlatformBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformBehavior.cpp
@@ -36,18 +36,24 @@ std::map<gd::String, gd::PropertyDescriptor> PlatformBehavior::GetProperties(
   else if (platformType == "Jumpthru")
     platformTypeStr = _("Jumpthru platform");
 
-  properties[_("Type")]
+  properties["PlatformType"]
+      .SetLabel(_("Type"))
       .SetValue(platformTypeStr)
       .SetType("Choice")
       .AddExtraInfo(_("Platform"))
       .AddExtraInfo(_("Jumpthru platform"))
       .AddExtraInfo(_("Ladder"));
-  properties[_("Ledges can be grabbed")].SetGroup(_("Ledge"))
+  properties["CanBeGrabbed"]
+      .SetLabel(_("Ledges can be grabbed"))
+      .SetGroup(_("Ledge"))
       .SetValue(behaviorContent.GetBoolAttribute("canBeGrabbed", true)
                     ? "true"
                     : "false")
       .SetType("Boolean");
-  properties[_("Grab offset on Y axis")].SetGroup(_("Ledge")).SetValue(
+  properties["YGrabOffset"]
+      .SetLabel(_("Grab offset on Y axis"))
+      .SetGroup(_("Ledge"))
+      .SetValue(
       gd::String::From(behaviorContent.GetDoubleAttribute("yGrabOffset")));
 
   return properties;
@@ -56,16 +62,16 @@ std::map<gd::String, gd::PropertyDescriptor> PlatformBehavior::GetProperties(
 bool PlatformBehavior::UpdateProperty(gd::SerializerElement& behaviorContent,
                                       const gd::String& name,
                                       const gd::String& value) {
-  if (name == _("Ledges can be grabbed"))
+  if (name == "CanBeGrabbed")
     behaviorContent.SetAttribute("canBeGrabbed", (value == "1"));
-  else if (name == _("Type")) {
+  else if (name == "PlatformType") {
     if (value == _("Jumpthru platform"))
       behaviorContent.SetAttribute("platformType", "Jumpthru");
     else if (value == _("Ladder"))
       behaviorContent.SetAttribute("platformType", "Ladder");
     else
       behaviorContent.SetAttribute("platformType", "NormalPlatform");
-  } else if (name == _("Grab offset on Y axis"))
+  } else if (name == "YGrabOffset")
     behaviorContent.SetAttribute("yGrabOffset", value.To<double>());
   else
     return false;

--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -45,96 +45,109 @@ PlatformerObjectBehavior::GetProperties(
     const gd::SerializerElement& behaviorContent) const {
   std::map<gd::String, gd::PropertyDescriptor> properties;
 
-  properties[_("Gravity")]
+  properties["Gravity"]
+      .SetLabel(_("Gravity"))
       .SetGroup(_("Jump"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelAcceleration())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("gravity")));
-  properties[_("Jump speed")]
+  properties["JumpSpeed"]
+      .SetLabel(_("Jump speed"))
       .SetGroup(_("Jump"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelSpeed())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("jumpSpeed")));
-  properties["jumpSustainTime"]
+  properties["JumpSustainTime"]
+      .SetLabel(_("Jump sustain time"))
       .SetGroup(_("Jump"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetSecond())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("jumpSustainTime", 0)))
-      .SetLabel(_("Jump sustain time"))
       .SetDescription(
           _("Maximum time (in seconds) during which the jump strength is "
             "sustained if the jump key is held - allowing variable height "
             "jumps."));
-  properties[_("Max. falling speed")]
+  properties["MaxFallingSpeed"]
+      .SetLabel(_("Max. falling speed"))
       .SetGroup(_("Jump"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelSpeed())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("maxFallingSpeed")));
-  properties[_("Ladder climbing speed")]
+  properties["LadderClimbingSpeed"]
+      .SetLabel(_("Ladder climbing speed"))
       .SetGroup(_("Ladder"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelSpeed())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("ladderClimbingSpeed", 150)));
-  properties[_("Acceleration")]
+  properties["Acceleration"]
+      .SetLabel(_("Acceleration"))
       .SetGroup(_("Walk"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelAcceleration())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("acceleration")));
-  properties[_("Deceleration")]
+  properties["Deceleration"]
+      .SetLabel(_("Deceleration"))
       .SetGroup(_("Walk"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelAcceleration())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("deceleration")));
-  properties[_("Max. speed")]
+  properties["MaxSpeed"]
+      .SetLabel(_("Max. speed"))
       .SetGroup(_("Walk"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelSpeed())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("maxSpeed")));
-  properties[_("Default controls")]
+  properties["IgnoreDefaultControls"]
+      .SetLabel(_("Default controls"))
       .SetValue(behaviorContent.GetBoolAttribute("ignoreDefaultControls")
                     ? "false"
                     : "true")
       .SetType("Boolean");
-  properties[_("Slope max. angle")]
+  properties["SlopeMaxAngle"]
+      .SetLabel(_("Slope max. angle"))
       .SetGroup(_("Walk"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetDegreeAngle())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("slopeMaxAngle")));
-  properties[_("Can grab platform ledges")]
+  properties["CanGrabPlatforms"]
+      .SetLabel(_("Can grab platform ledges"))
       .SetGroup(_("Ledge"))
       .SetValue(behaviorContent.GetBoolAttribute("canGrabPlatforms", false)
                     ? "true"
                     : "false")
       .SetType("Boolean");
-  properties[_("Automatically grab platform ledges without having to move "
-               "horizontally")]
+  properties["CanGrabWithoutMoving"]
+      .SetLabel(_("Automatically grab platform ledges without having to move "
+                  "horizontally"))
       .SetGroup(_("Ledge"))
       .SetValue(behaviorContent.GetBoolAttribute("canGrabWithoutMoving", false)
                     ? "true"
                     : "false")
       .SetType("Boolean");
-  properties[_("Grab offset on Y axis")]
+  properties["YGrabOffset"]
+      .SetLabel(_("Grab offset on Y axis"))
       .SetGroup(_("Ledge"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("yGrabOffset")));
-  properties[_("Grab tolerance on X axis")]
+  properties["XGrabTolerance"]
+      .SetLabel(_("Grab tolerance on X axis"))
       .SetGroup(_("Ledge"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("xGrabTolerance", 10)));
-  properties["useLegacyTrajectory"]
+  properties["UseLegacyTrajectory"]
       .SetLabel(_("Use frame rate dependent trajectories (deprecated, it's "
                   "recommended to leave this unchecked)"))
       .SetGroup(_("Deprecated options (advanced)"))
@@ -142,7 +155,8 @@ PlatformerObjectBehavior::GetProperties(
                     ? "true"
                     : "false")
       .SetType("Boolean");
-  properties[_("Can go down from jumpthru platforms")]
+  properties["CanGoDownFromJumpthru"]
+      .SetLabel(_("Can go down from jumpthru platforms"))
       .SetGroup(_("Walk"))
       .SetValue(behaviorContent.GetBoolAttribute("canGoDownFromJumpthru", false)
                     ? "true"
@@ -155,44 +169,43 @@ bool PlatformerObjectBehavior::UpdateProperty(
     gd::SerializerElement& behaviorContent,
     const gd::String& name,
     const gd::String& value) {
-  if (name == _("Default controls"))
+  if (name == "IgnoreDefaultControls")
     behaviorContent.SetAttribute("ignoreDefaultControls", (value == "0"));
-  else if (name == _("Can grab platform ledges"))
+  else if (name == "CanGrabPlatforms")
     behaviorContent.SetAttribute("canGrabPlatforms", (value == "1"));
-  else if (name == _("Automatically grab platform ledges without having to "
-                     "move horizontally"))
+  else if (name == "CanGrabWithoutMoving")
     behaviorContent.SetAttribute("canGrabWithoutMoving", (value == "1"));
-  else if (name == "useLegacyTrajectory")
+  else if (name == "UseLegacyTrajectory")
     behaviorContent.SetAttribute("useLegacyTrajectory", (value == "1"));
-  else if (name == _("Can go down from jumpthru platforms"))
+  else if (name == "CanGoDownFromJumpthru")
     behaviorContent.SetAttribute("canGoDownFromJumpthru", (value == "1"));
-  else if (name == _("Grab offset on Y axis"))
+  else if (name == "YGrabOffset")
     behaviorContent.SetAttribute("yGrabOffset", value.To<double>());
   else {
     if (value.To<double>() < 0) return false;
 
-    if (name == _("Gravity"))
+    if (name == "Gravity")
       behaviorContent.SetAttribute("gravity", value.To<double>());
-    else if (name == _("Max. falling speed"))
+    else if (name == "MaxFallingSpeed")
       behaviorContent.SetAttribute("maxFallingSpeed", value.To<double>());
-    else if (name == _("Ladder climbing speed"))
+    else if (name == "LadderClimbingSpeed")
       behaviorContent.SetAttribute("ladderClimbingSpeed", value.To<double>());
-    else if (name == _("Acceleration"))
+    else if (name == "Acceleration")
       behaviorContent.SetAttribute("acceleration", value.To<double>());
-    else if (name == _("Deceleration"))
+    else if (name == "Deceleration")
       behaviorContent.SetAttribute("deceleration", value.To<double>());
-    else if (name == _("Max. speed"))
+    else if (name == "MaxSpeed")
       behaviorContent.SetAttribute("maxSpeed", value.To<double>());
-    else if (name == _("Jump speed"))
+    else if (name == "JumpSpeed")
       behaviorContent.SetAttribute("jumpSpeed", value.To<double>());
-    else if (name == "jumpSustainTime")
+    else if (name == "JumpSustainTime")
       behaviorContent.SetAttribute("jumpSustainTime", value.To<double>());
-    else if (name == _("Slope max. angle")) {
+    else if (name == "SlopeMaxAngle") {
       double newMaxAngle = value.To<double>();
       if (newMaxAngle < 0 || newMaxAngle >= 90) return false;
 
       behaviorContent.SetAttribute("slopeMaxAngle", newMaxAngle);
-    } else if (name == _("Grab tolerance on X axis"))
+    } else if (name == "XGrabTolerance")
       behaviorContent.SetAttribute("xGrabTolerance", value.To<double>());
     else
       return false;

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -46,47 +46,55 @@ TopDownMovementBehavior::GetProperties(
     const gd::SerializerElement& behaviorContent) const {
   std::map<gd::String, gd::PropertyDescriptor> properties;
 
-  properties[_("Allows diagonals")]
+  properties["AllowDiagonals"]
+      .SetLabel(_("Allows diagonals"))
       .SetGroup(_("Movement"))
       .SetValue(behaviorContent.GetBoolAttribute("allowDiagonals") ? "true"
                                                                    : "false")
       .SetType("Boolean");
-  properties[_("Acceleration")]
+  properties["Acceleration"]
+      .SetLabel(_("Acceleration"))
       .SetGroup(_("Movement"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelAcceleration())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("acceleration")));
-  properties[_("Deceleration")]
+  properties["Deceleration"]
+      .SetLabel(_("Deceleration"))
       .SetGroup(_("Movement"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelAcceleration())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("deceleration")));
-  properties[_("Max. speed")]
+  properties["MaxSpeed"]
+      .SetLabel(_("Max. speed"))
       .SetGroup(_("Movement"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetPixelSpeed())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("maxSpeed")));
-  properties[_("Rotation speed")]
+  properties["AngularMaxSpeed"]
+      .SetLabel(_("Rotation speed"))
       .SetGroup(_("Rotation"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetAngularSpeed())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("angularMaxSpeed")));
-  properties[_("Rotate object")]
+  properties["rotateObject"]
+      .SetLabel(_("Rotate object"))
       .SetGroup(_("Rotation"))
       .SetValue(behaviorContent.GetBoolAttribute("rotateObject") ? "true"
                                                                  : "false")
       .SetType("Boolean");
-  properties[_("Angle offset")]
+  properties["AngleOffset"]
+      .SetLabel(_("Angle offset"))
       .SetGroup(_("Rotation"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetDegreeAngle())
       .SetValue(
           gd::String::From(behaviorContent.GetDoubleAttribute("angleOffset")));
-  properties[_("Default controls")]
+  properties["IgnoreDefaultControls"]
+      .SetLabel(_("Default controls"))
       .SetValue(behaviorContent.GetBoolAttribute("ignoreDefaultControls")
                     ? "false"
                     : "true")
@@ -102,7 +110,8 @@ TopDownMovementBehavior::GetProperties(
     viewpointStr = _("True Isometry (30°)");
   else if (viewpoint == "CustomIsometry")
     viewpointStr = _("Custom Isometry");
-  properties[_("Viewpoint")]
+  properties["Viewpoint"]
+      .SetLabel(_("Viewpoint"))
       .SetGroup(_("Viewpoint"))
       .SetValue(viewpointStr)
       .SetType("Choice")
@@ -110,7 +119,8 @@ TopDownMovementBehavior::GetProperties(
       .AddExtraInfo(_("Isometry 2:1 (26.565°)"))
       .AddExtraInfo(_("True Isometry (30°)"))
       .AddExtraInfo(_("Custom Isometry"));
-  properties[_("Custom isometry angle")]
+  properties["CustomIsometryAngle"]
+      .SetLabel(_("Custom isometry angle"))
       .SetGroup(_("Viewpoint"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetDegreeAngle())
@@ -118,7 +128,8 @@ TopDownMovementBehavior::GetProperties(
           behaviorContent.GetDoubleAttribute("customIsometryAngle")))
       .SetDescription(_("If you choose \"Custom Isometry\", this allows to "
                         "specify the angle of your isometry projection."));
-  properties[_("Movement angle offset")]
+  properties["MovementAngleOffset"]
+      .SetLabel(_("Movement angle offset"))
       .SetGroup(_("Viewpoint"))
       .SetType("Number")
       .SetMeasurementUnit(gd::MeasurementUnit::GetDegreeAngle())
@@ -135,19 +146,19 @@ bool TopDownMovementBehavior::UpdateProperty(
     gd::SerializerElement& behaviorContent,
     const gd::String& name,
     const gd::String& value) {
-  if (name == _("Default controls")) {
+  if (name == "ignoreDefaultControls") {
     behaviorContent.SetAttribute("ignoreDefaultControls", (value == "0"));
     return true;
   }
-  if (name == _("Allows diagonals")) {
+  if (name == "AllowDiagonals") {
     behaviorContent.SetAttribute("allowDiagonals", (value != "0"));
     return true;
   }
-  if (name == _("Rotate object")) {
+  if (name == "RotateObject") {
     behaviorContent.SetAttribute("rotateObject", (value != "0"));
     return true;
   }
-  if (name == _("Viewpoint")) {
+  if (name == "Viewpoint") {
     // Fix the offset angle when switching between top-down and isometry
     const gd::String& oldValue =
         behaviorContent.GetStringAttribute("viewpoint", "TopDown", "");
@@ -173,23 +184,23 @@ bool TopDownMovementBehavior::UpdateProperty(
       behaviorContent.SetAttribute("viewpoint", "TopDown");
     return true;
   }
-  if (name == _("Movement angle offset")) {
+  if (name == "MovementAngleOffset") {
     behaviorContent.SetAttribute("movementAngleOffset", value.To<float>());
   }
 
   if (value.To<float>() < 0) return false;
 
-  if (name == _("Acceleration"))
+  if (name == "Acceleration")
     behaviorContent.SetAttribute("acceleration", value.To<float>());
-  else if (name == _("Deceleration"))
+  else if (name == "Deceleration")
     behaviorContent.SetAttribute("deceleration", value.To<float>());
-  else if (name == _("Max. speed"))
+  else if (name == "MaxSpeed")
     behaviorContent.SetAttribute("maxSpeed", value.To<float>());
-  else if (name == _("Rotation speed"))
+  else if (name == "RotationSpeed")
     behaviorContent.SetAttribute("angularMaxSpeed", value.To<float>());
-  else if (name == _("Angle offset"))
+  else if (name == "AngleOffset")
     behaviorContent.SetAttribute("angleOffset", value.To<float>());
-  else if (name == _("Custom isometry angle")) {
+  else if (name == "CustomIsometryAngle") {
     if (value.To<float>() < 1 || value.To<float>() > 44) return false;
     behaviorContent.SetAttribute("customIsometryAngle", value.To<float>());
   } else

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -80,7 +80,7 @@ TopDownMovementBehavior::GetProperties(
       .SetMeasurementUnit(gd::MeasurementUnit::GetAngularSpeed())
       .SetValue(gd::String::From(
           behaviorContent.GetDoubleAttribute("angularMaxSpeed")));
-  properties["rotateObject"]
+  properties["RotateObject"]
       .SetLabel(_("Rotate object"))
       .SetGroup(_("Rotation"))
       .SetValue(behaviorContent.GetBoolAttribute("rotateObject") ? "true"
@@ -146,7 +146,7 @@ bool TopDownMovementBehavior::UpdateProperty(
     gd::SerializerElement& behaviorContent,
     const gd::String& name,
     const gd::String& value) {
-  if (name == "ignoreDefaultControls") {
+  if (name == "IgnoreDefaultControls") {
     behaviorContent.SetAttribute("ignoreDefaultControls", (value == "0"));
     return true;
   }

--- a/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
+++ b/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
@@ -283,28 +283,29 @@ const propertiesMapToSchema = (
         const firstProperty = properties.get(firstName);
         const secondProperty = properties.get(secondName);
         if (firstProperty.getGroup() === secondProperty.getGroup()) {
-          field = {
-            name: firstName + '-' + secondName,
-            type: 'row',
-            children: [
-              createField(
-                firstName,
-                firstProperty,
-                getProperties,
-                onUpdateProperty,
-                object
-              ),
-              createField(
-                secondName,
-                secondProperty,
-                getProperties,
-                onUpdateProperty,
-                object
-              ),
-            ],
-          };
-          alreadyHandledProperties.add(firstName);
-          alreadyHandledProperties.add(secondName);
+          const firstField = createField(
+            firstName,
+            firstProperty,
+            getProperties,
+            onUpdateProperty,
+            object
+          );
+          const secondField = createField(
+            secondName,
+            secondProperty,
+            getProperties,
+            onUpdateProperty,
+            object
+          );
+          if (firstField && secondField) {
+            field = {
+              name: firstName + '-' + secondName,
+              type: 'row',
+              children: [firstField, secondField],
+            };
+            alreadyHandledProperties.add(firstName);
+            alreadyHandledProperties.add(secondName);
+          }
         }
       }
     }

--- a/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
+++ b/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
@@ -216,7 +216,7 @@ const propertyKeywordCouples: Array<[string, string]> = [
   ['Left', 'Right'],
   ['Up', 'Down'],
   ['Min', 'Max'],
-  ['Low', 'Heigh'],
+  ['Low', 'High'],
   ['Color', 'Opacity'],
   ['Horizontal', 'Vertical'],
   ['Acceleration', 'Deceleration'],

--- a/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
+++ b/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
@@ -6,6 +6,223 @@ import { type Field } from '.';
 import MeasurementUnitDocumentation from './MeasurementUnitDocumentation';
 import * as React from 'react';
 
+const createField = (
+  name: string,
+  property: gdPropertyDescriptor,
+  getProperties: (instance: Instance) => any,
+  onUpdateProperty: (
+    instance: Instance,
+    propertyName: string,
+    newValue: string
+  ) => void,
+  object: ?gdObject
+): ?Field => {
+  const propertyDescription = property.getDescription();
+  const getLabel = (instance: Instance) => {
+    const propertyName = getProperties(instance)
+      .get(name)
+      .getLabel();
+    if (propertyName) return propertyName;
+    return (
+      name.charAt(0).toUpperCase() +
+      name
+        .slice(1)
+        .split(/(?=[A-Z])/)
+        .join(' ')
+    );
+  };
+  const getDescription = () => propertyDescription;
+  const getEndAdornment = (instance: Instance) => {
+    const property = getProperties(instance).get(name);
+    const measurementUnit = property.getMeasurementUnit();
+    return {
+      label: getMeasurementUnitShortLabel(measurementUnit),
+      tooltipContent: (
+        <MeasurementUnitDocumentation
+          label={measurementUnit.getLabel()}
+          description={measurementUnit.getDescription()}
+          elementsWithWords={measurementUnit.getElementsWithWords()}
+        />
+      ),
+    };
+  };
+
+  const valueType = property.getType().toLowerCase();
+  if (valueType === 'number') {
+    return {
+      name,
+      valueType,
+      getValue: (instance: Instance): number => {
+        return (
+          parseFloat(
+            getProperties(instance)
+              .get(name)
+              .getValue()
+          ) || 0
+        ); // Consider a missing value as 0 to avoid propagating NaN.
+      },
+      setValue: (instance: Instance, newValue: number) => {
+        onUpdateProperty(instance, name, '' + newValue);
+      },
+      getLabel,
+      getDescription,
+      getEndAdornment,
+    };
+  } else if (valueType === 'string' || valueType === '') {
+    return {
+      name,
+      valueType: 'string',
+      getValue: (instance: Instance): string => {
+        return getProperties(instance)
+          .get(name)
+          .getValue();
+      },
+      setValue: (instance: Instance, newValue: string) => {
+        onUpdateProperty(instance, name, newValue);
+      },
+      getLabel,
+      getDescription,
+    };
+  } else if (valueType === 'boolean') {
+    return {
+      name,
+      valueType,
+      getValue: (instance: Instance): boolean => {
+        return (
+          getProperties(instance)
+            .get(name)
+            .getValue() === 'true'
+        );
+      },
+      setValue: (instance: Instance, newValue: boolean) => {
+        onUpdateProperty(instance, name, newValue ? '1' : '0');
+      },
+      getLabel,
+      getDescription,
+    };
+  } else if (valueType === 'choice') {
+    // Choice is a "string" (with a selector for the user in the UI)
+    const choices = property
+      .getExtraInfo()
+      .toJSArray()
+      .map(value => ({ value, label: value }));
+    return {
+      name,
+      valueType: 'string',
+      getChoices: () => choices,
+      getValue: (instance: Instance): string => {
+        return getProperties(instance)
+          .get(name)
+          .getValue();
+      },
+      setValue: (instance: Instance, newValue: string) => {
+        onUpdateProperty(instance, name, newValue);
+      },
+      getLabel,
+      getDescription,
+    };
+  } else if (valueType === 'behavior') {
+    const behaviorType =
+      property.getExtraInfo().size() > 0 ? property.getExtraInfo().at(0) : '';
+    return {
+      name,
+      valueType: 'string',
+      getChoices: () => {
+        return !object || behaviorType === ''
+          ? []
+          : object
+              .getAllBehaviorNames()
+              .toJSArray()
+              .map(name =>
+                object.getBehavior(name).getTypeName() === behaviorType
+                  ? name
+                  : null
+              )
+              .filter(Boolean)
+              .map(value => ({ value, label: value }));
+      },
+      getValue: (instance: Instance): string => {
+        return getProperties(instance)
+          .get(name)
+          .getValue();
+      },
+      setValue: (instance: Instance, newValue: string) => {
+        onUpdateProperty(instance, name, newValue);
+      },
+      getLabel,
+      getDescription,
+    };
+  } else if (valueType === 'resource') {
+    // Resource is a "string" (with a selector in the UI)
+    // $FlowFixMe - assume the passed resource kind is always valid.
+    const kind: ResourceKind = property.getExtraInfo().toJSArray()[0] || '';
+    return {
+      name,
+      valueType: 'resource',
+      resourceKind: kind,
+      getValue: (instance: Instance): string => {
+        return getProperties(instance)
+          .get(name)
+          .getValue();
+      },
+      setValue: (instance: Instance, newValue: string) => {
+        onUpdateProperty(instance, name, newValue);
+      },
+      getLabel,
+      getDescription,
+    };
+  } else if (valueType === 'color') {
+    return {
+      name,
+      valueType: 'color',
+      getValue: (instance: Instance): string => {
+        return getProperties(instance)
+          .get(name)
+          .getValue();
+      },
+      setValue: (instance: Instance, newValue: string) => {
+        onUpdateProperty(instance, name, newValue);
+      },
+      getLabel,
+      getDescription,
+    };
+  } else if (valueType === 'textarea') {
+    return {
+      name,
+      valueType: 'textarea',
+      getValue: (instance: Instance): string => {
+        return getProperties(instance)
+          .get(name)
+          .getValue();
+      },
+      setValue: (instance: Instance, newValue: string) => {
+        onUpdateProperty(instance, name, newValue);
+      },
+      getLabel,
+      getDescription,
+    };
+  } else {
+    console.error(
+      `A property with type=${valueType} could not be mapped to a field. Ensure that this type is correct and understood by the IDE.`
+    );
+    return null;
+  }
+};
+
+const propertyKeywordCouples: Array<[string, string]> = [
+  ['X', 'Y'],
+  ['Width', 'Height'],
+  ['Top', 'Bottom'],
+  ['Left', 'Right'],
+  ['Up', 'Down'],
+  ['Min', 'Max'],
+  ['Low', 'Heigh'],
+  ['Color', 'Opacity'],
+  ['Horizontal', 'Vertical'],
+  ['Acceleration', 'Deceleration'],
+  ['Duration', 'Easing'],
+];
+
 /**
  * Transform a MapStringPropertyDescriptor to a schema that can be used in PropertiesEditor.
  *
@@ -26,9 +243,12 @@ const propertiesMapToSchema = (
   const propertyNames = properties.keys();
   // Aggregate field by groups to be able to build field groups with a title.
   const fieldsByGroups = new Map<string, Array<Field>>();
+  const alreadyHandledProperties = new Set<string>();
   mapFor(0, propertyNames.size(), i => {
     const name = propertyNames.at(i);
     const property = properties.get(name);
+    if (property.isHidden()) return null;
+    if (alreadyHandledProperties.has(name)) return null;
 
     const groupName = property.getGroup() || '';
     let fields = fieldsByGroups.get(groupName);
@@ -37,205 +257,68 @@ const propertiesMapToSchema = (
       fieldsByGroups.set(groupName, fields);
     }
 
-    const propertyDescription = property.getDescription();
-    const valueType = property.getType().toLowerCase();
-    const getLabel = (instance: Instance) => {
-      const propertyName = getProperties(instance)
-        .get(name)
-        .getLabel();
-      if (propertyName) return propertyName;
-      return (
-        name.charAt(0).toUpperCase() +
-        name
-          .slice(1)
-          .split(/(?=[A-Z])/)
-          .join(' ')
-      );
-    };
-    const getDescription = () => propertyDescription;
-    const getEndAdornment = (instance: Instance) => {
-      const property = getProperties(instance).get(name);
-      const measurementUnit = property.getMeasurementUnit();
-      return {
-        label: getMeasurementUnitShortLabel(measurementUnit),
-        tooltipContent: (
-          <MeasurementUnitDocumentation
-            label={measurementUnit.getLabel()}
-            description={measurementUnit.getDescription()}
-            elementsWithWords={measurementUnit.getElementsWithWords()}
-          />
-        ),
-      };
-    };
+    // Search a property couple that can be put in a row.
+    let field: ?Field = null;
+    for (const propertyKeywords of propertyKeywordCouples) {
+      const firstKeyword = propertyKeywords[0];
+      const secondKeyword = propertyKeywords[1];
 
-    if (property.isHidden()) return null;
+      let firstName: ?string = null;
+      let secondName: ?string = null;
+      if (name.includes(firstKeyword)) {
+        const otherPropertyName = name.replace(firstKeyword, secondKeyword);
+        if (properties.has(otherPropertyName)) {
+          firstName = name;
+          secondName = otherPropertyName;
+        }
+      } else if (name.includes(secondKeyword)) {
+        const otherPropertyName = name.replace(secondKeyword, firstKeyword);
+        if (properties.has(otherPropertyName)) {
+          firstName = otherPropertyName;
+          secondName = name;
+        }
+      }
 
-    if (valueType === 'number') {
-      fields.push({
+      if (firstName && secondName) {
+        const firstProperty = properties.get(firstName);
+        const secondProperty = properties.get(secondName);
+        if (firstProperty.getGroup() === secondProperty.getGroup()) {
+          field = {
+            name: firstName + '-' + secondName,
+            type: 'row',
+            children: [
+              createField(
+                firstName,
+                firstProperty,
+                getProperties,
+                onUpdateProperty,
+                object
+              ),
+              createField(
+                secondName,
+                secondProperty,
+                getProperties,
+                onUpdateProperty,
+                object
+              ),
+            ],
+          };
+          alreadyHandledProperties.add(firstName);
+          alreadyHandledProperties.add(secondName);
+        }
+      }
+    }
+    if (!field) {
+      field = createField(
         name,
-        valueType,
-        getValue: (instance: Instance): number => {
-          return (
-            parseFloat(
-              getProperties(instance)
-                .get(name)
-                .getValue()
-            ) || 0
-          ); // Consider a missing value as 0 to avoid propagating NaN.
-        },
-        setValue: (instance: Instance, newValue: number) => {
-          onUpdateProperty(instance, name, '' + newValue);
-        },
-        getLabel,
-        getDescription,
-        getEndAdornment,
-      });
-      return null;
-    } else if (valueType === 'string' || valueType === '') {
-      fields.push({
-        name,
-        valueType: 'string',
-        getValue: (instance: Instance): string => {
-          return getProperties(instance)
-            .get(name)
-            .getValue();
-        },
-        setValue: (instance: Instance, newValue: string) => {
-          onUpdateProperty(instance, name, newValue);
-        },
-        getLabel,
-        getDescription,
-      });
-      return null;
-    } else if (valueType === 'boolean') {
-      fields.push({
-        name,
-        valueType,
-        getValue: (instance: Instance): boolean => {
-          return (
-            getProperties(instance)
-              .get(name)
-              .getValue() === 'true'
-          );
-        },
-        setValue: (instance: Instance, newValue: boolean) => {
-          onUpdateProperty(instance, name, newValue ? '1' : '0');
-        },
-        getLabel,
-        getDescription,
-      });
-      return null;
-    } else if (valueType === 'choice') {
-      // Choice is a "string" (with a selector for the user in the UI)
-      const choices = property
-        .getExtraInfo()
-        .toJSArray()
-        .map(value => ({ value, label: value }));
-      fields.push({
-        name,
-        valueType: 'string',
-        getChoices: () => choices,
-        getValue: (instance: Instance): string => {
-          return getProperties(instance)
-            .get(name)
-            .getValue();
-        },
-        setValue: (instance: Instance, newValue: string) => {
-          onUpdateProperty(instance, name, newValue);
-        },
-        getLabel,
-        getDescription,
-      });
-      return null;
-    } else if (valueType === 'behavior') {
-      const behaviorType =
-        property.getExtraInfo().size() > 0 ? property.getExtraInfo().at(0) : '';
-      fields.push({
-        name,
-        valueType: 'string',
-        getChoices: () => {
-          return !object || behaviorType === ''
-            ? []
-            : object
-                .getAllBehaviorNames()
-                .toJSArray()
-                .map(name =>
-                  object.getBehavior(name).getTypeName() === behaviorType
-                    ? name
-                    : null
-                )
-                .filter(Boolean)
-                .map(value => ({ value, label: value }));
-        },
-        getValue: (instance: Instance): string => {
-          return getProperties(instance)
-            .get(name)
-            .getValue();
-        },
-        setValue: (instance: Instance, newValue: string) => {
-          onUpdateProperty(instance, name, newValue);
-        },
-        getLabel,
-        getDescription,
-      });
-      return null;
-    } else if (valueType === 'resource') {
-      // Resource is a "string" (with a selector in the UI)
-      // $FlowFixMe - assume the passed resource kind is always valid.
-      const kind: ResourceKind = property.getExtraInfo().toJSArray()[0] || '';
-      fields.push({
-        name,
-        valueType: 'resource',
-        resourceKind: kind,
-        getValue: (instance: Instance): string => {
-          return getProperties(instance)
-            .get(name)
-            .getValue();
-        },
-        setValue: (instance: Instance, newValue: string) => {
-          onUpdateProperty(instance, name, newValue);
-        },
-        getLabel,
-        getDescription,
-      });
-      return null;
-    } else if (valueType === 'color') {
-      fields.push({
-        name,
-        valueType: 'color',
-        getValue: (instance: Instance): string => {
-          return getProperties(instance)
-            .get(name)
-            .getValue();
-        },
-        setValue: (instance: Instance, newValue: string) => {
-          onUpdateProperty(instance, name, newValue);
-        },
-        getLabel,
-        getDescription,
-      });
-      return null;
-    } else if (valueType === 'textarea') {
-      fields.push({
-        name,
-        valueType: 'textarea',
-        getValue: (instance: Instance): string => {
-          return getProperties(instance)
-            .get(name)
-            .getValue();
-        },
-        setValue: (instance: Instance, newValue: string) => {
-          onUpdateProperty(instance, name, newValue);
-        },
-        getLabel,
-        getDescription,
-      });
-      return null;
-    } else {
-      console.error(
-        `A property with type=${valueType} could not be mapped to a field. Ensure that this type is correct and understood by the IDE.`
+        property,
+        getProperties,
+        onUpdateProperty,
+        object
       );
-      return null;
+    }
+    if (field) {
+      fields.push(field);
     }
   });
   if (fieldsByGroups.size === 0) {

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -29,7 +29,7 @@ import RaisedButton from '../UI/RaisedButton';
 import UnsavedChangesContext, {
   type UnsavedChanges,
 } from '../MainFrame/UnsavedChangesContext';
-import { Line, Spacer } from '../UI/Grid';
+import { Column, Line, Spacer } from '../UI/Grid';
 import Text from '../UI/Text';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import RaisedButtonWithSplitMenu from '../UI/RaisedButtonWithSplitMenu';
@@ -333,21 +333,23 @@ const PropertiesEditor = ({
       } else if (field.valueType === 'color') {
         const { setValue } = field;
         return (
-          <ColorField
-            key={field.name}
-            id={field.name}
-            floatingLabelText={getFieldLabel(instances, field)}
-            helperMarkdownText={getFieldDescription(field)}
-            disableAlpha
-            style={styles.field}
-            color={getFieldValue(instances, field)}
-            onChange={color => {
-              const rgbString =
-                color.length === 0 ? '' : rgbOrHexToRGBString(color);
-              instances.forEach(i => setValue(i, rgbString));
-              _onInstancesModified(instances);
-            }}
-          />
+          <Column expand noMargin>
+            <ColorField
+              key={field.name}
+              id={field.name}
+              floatingLabelText={getFieldLabel(instances, field)}
+              helperMarkdownText={getFieldDescription(field)}
+              disableAlpha
+              fullWidth
+              color={getFieldValue(instances, field)}
+              onChange={color => {
+                const rgbString =
+                  color.length === 0 ? '' : rgbOrHexToRGBString(color);
+                instances.forEach(i => setValue(i, rgbString));
+                _onInstancesModified(instances);
+              }}
+            />
+          </Column>
         );
       } else if (field.valueType === 'textarea') {
         const { setValue } = field;

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -339,7 +339,7 @@ const PropertiesEditor = ({
             floatingLabelText={getFieldLabel(instances, field)}
             helperMarkdownText={getFieldDescription(field)}
             disableAlpha
-            fullWidth
+            style={styles.field}
             color={getFieldValue(instances, field)}
             onChange={color => {
               const rgbString =

--- a/newIDE/app/src/UI/ColorField/index.js
+++ b/newIDE/app/src/UI/ColorField/index.js
@@ -29,7 +29,6 @@ type Props = {|
   onChange: (string, ?number) => void,
   color: string,
   alpha?: number,
-  style?: Object,
 |};
 
 type State = {|
@@ -72,14 +71,10 @@ export default class ColorField extends React.Component<Props, State> {
   render() {
     return (
       <div
-        style={
-          this.props.style
-            ? { ...styles.container, ...this.props.style }
-            : {
-                ...styles.container,
-                width: this.props.fullWidth ? '100%' : undefined,
-              }
-        }
+        style={{
+          ...styles.container,
+          width: this.props.fullWidth ? '100%' : undefined,
+        }}
       >
         <TextField
           id={this.props.id}

--- a/newIDE/app/src/UI/ColorField/index.js
+++ b/newIDE/app/src/UI/ColorField/index.js
@@ -29,6 +29,7 @@ type Props = {|
   onChange: (string, ?number) => void,
   color: string,
   alpha?: number,
+  style?: Object,
 |};
 
 type State = {|
@@ -71,10 +72,14 @@ export default class ColorField extends React.Component<Props, State> {
   render() {
     return (
       <div
-        style={{
-          ...styles.container,
-          width: this.props.fullWidth ? '100%' : undefined,
-        }}
+        style={
+          this.props.style
+            ? { ...styles.container, ...this.props.style }
+            : {
+                ...styles.container,
+                width: this.props.fullWidth ? '100%' : undefined,
+              }
+        }
       >
         <TextField
           id={this.props.id}


### PR DESCRIPTION
It also avoid empty property groups to show (if all their properties are private). This could allow extension creators to organize their private properties.

![image](https://user-images.githubusercontent.com/2611977/205122974-93a0ea1a-8040-4f22-9555-41f42bd1583f.png)
