### PR TITLE
Allow leaderboard color customisation

### DIFF
--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/GetSubscriptionCard.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/GetSubscriptionCard.js
@@ -46,7 +46,7 @@ const GetSubscriptionCard = () => {
             href="#"
             onClick={() => {
               openSubscriptionDialog({
-                reason: 'Leaderboard count per game limit reached',
+                reason: 'Leaderboard customization',
               });
             }}
           >

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/GetSubscriptionCard.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/GetSubscriptionCard.js
@@ -3,11 +3,12 @@ import * as React from 'react';
 import { Trans } from '@lingui/macro';
 
 import Text from '../../UI/Text';
-import { Column } from '../../UI/Grid';
+import { Column, Line } from '../../UI/Grid';
 import { LineStackLayout } from '../../UI/Layout';
 import Link from '../../UI/Link';
 import { SubscriptionSuggestionContext } from '../../Profile/Subscription/SubscriptionSuggestionContext';
 import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
+import Window from '../../Utils/Window';
 
 const styles = {
   subscriptionContainer: {
@@ -35,12 +36,28 @@ const GetSubscriptionCard = () => {
   return (
     <div style={subscriptionContainerStyle}>
       <img src="res/diamond.svg" style={styles.diamondIcon} alt="diamond" />
-      <LineStackLayout noMargin alignItems="center">
-        <Text>
-          <Trans>
-            Get a silver or gold subscription to unlock color customization.
-          </Trans>
-        </Text>
+      <LineStackLayout alignItems="center">
+        <Column noMargin>
+          <Text>
+            <Trans>
+              Get a silver or gold subscription to unlock color customization.
+            </Trans>
+          </Text>
+          <Line noMargin>
+            <Link
+              href="https://liluo.io/playground/test-leaderboard"
+              onClick={() =>
+                Window.openExternalURL(
+                  'https://liluo.io/playground/test-leaderboard'
+                )
+              }
+            >
+              <Text noMargin color="inherit">
+                <Trans>Test it out!</Trans>
+              </Text>
+            </Link>
+          </Line>
+        </Column>
         <Column>
           <Link
             href="#"

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/GetSubscriptionCard.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/GetSubscriptionCard.js
@@ -1,0 +1,63 @@
+// @flow
+import * as React from 'react';
+import { Trans } from '@lingui/macro';
+
+import Text from '../../UI/Text';
+import { Column } from '../../UI/Grid';
+import { LineStackLayout } from '../../UI/Layout';
+import Link from '../../UI/Link';
+import { SubscriptionSuggestionContext } from '../../Profile/Subscription/SubscriptionSuggestionContext';
+import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
+
+const styles = {
+  subscriptionContainer: {
+    display: 'flex',
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  diamondIcon: {
+    width: 50,
+    height: 50,
+  },
+};
+
+const GetSubscriptionCard = () => {
+  const { openSubscriptionDialog } = React.useContext(
+    SubscriptionSuggestionContext
+  );
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
+
+  const subscriptionContainerStyle = {
+    ...styles.subscriptionContainer,
+    border: `1px solid ${gdevelopTheme.palette.primary}`,
+  };
+
+  return (
+    <div style={subscriptionContainerStyle}>
+      <img src="res/diamond.svg" style={styles.diamondIcon} alt="diamond" />
+      <LineStackLayout noMargin alignItems="center">
+        <Text>
+          <Trans>
+            Get a silver or gold subscription to unlock color customization.
+          </Trans>
+        </Text>
+        <Column>
+          <Link
+            href="#"
+            onClick={() => {
+              openSubscriptionDialog({
+                reason: 'Leaderboard count per game limit reached',
+              });
+            }}
+          >
+            <Text noMargin color="inherit">
+              <Trans>Upgrade</Trans>
+            </Text>
+          </Link>
+        </Column>
+      </LineStackLayout>
+    </div>
+  );
+};
+
+export default GetSubscriptionCard;

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
@@ -96,7 +96,7 @@ function LeaderboardAppearanceDialog({
   const canCustomizeTheme =
     !!limits &&
     !!limits.capabilities.leaderboards &&
-    !!limits.capabilities.leaderboards.canCustomizeTheme;
+    limits.capabilities.leaderboards.themeCustomizationCapabilities !== 'NONE';
   const [scoreTitleError, setScoreTitleError] = React.useState<?string>(null);
   const [
     defaultDisplayedEntriesNumber,

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
@@ -27,6 +27,7 @@ import HelpButton from '../../UI/HelpButton';
 import ColorField from '../../UI/ColorField';
 import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
 import GetSubscriptionCard from './GetSubscriptionCard';
+import LeaderboardPlaygroundCard from './LeaderboardPlaygroundCard';
 
 const unitToAbbreviation = {
   hour: 'HH',
@@ -287,22 +288,6 @@ function LeaderboardAppearanceDialog({
                 disabled={!canCustomizeTheme}
               />
             </ResponsiveLineStackLayout>
-            {!canCustomizeTheme && <GetSubscriptionCard />}
-            <Spacer />
-            <Text size="sub-title" noMargin>
-              <Trans>Score column settings</Trans>
-            </Text>
-            <TextField
-              fullWidth
-              floatingLabelText={<Trans>Column title</Trans>}
-              maxLength={20}
-              errorText={scoreTitleError}
-              value={scoreTitle}
-              onChange={(e, newTitle) => {
-                if (!!scoreTitleError && !!newTitle) setScoreTitleError(null);
-                setScoreTitle(newTitle);
-              }}
-            />
             <ResponsiveLineStackLayout noMargin>
               <ColorField
                 floatingLabelText={<Trans>Highlight background color</Trans>}
@@ -321,7 +306,26 @@ function LeaderboardAppearanceDialog({
                 disabled={!canCustomizeTheme}
               />
             </ResponsiveLineStackLayout>
-            {!canCustomizeTheme && <GetSubscriptionCard />}
+            {canCustomizeTheme ? (
+              <LeaderboardPlaygroundCard />
+            ) : (
+              <GetSubscriptionCard />
+            )}
+            <Spacer />
+            <Text size="sub-title" noMargin>
+              <Trans>Score column settings</Trans>
+            </Text>
+            <TextField
+              fullWidth
+              floatingLabelText={<Trans>Column title</Trans>}
+              maxLength={20}
+              errorText={scoreTitleError}
+              value={scoreTitle}
+              onChange={(e, newTitle) => {
+                if (!!scoreTitleError && !!newTitle) setScoreTitleError(null);
+                setScoreTitle(newTitle);
+              }}
+            />
             <SelectField
               fullWidth
               value={scoreType}

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
@@ -323,8 +323,11 @@ function LeaderboardAppearanceDialog({
                 disabled={!canUserCustomizeTheme || isLoading}
               />
             </ResponsiveLineStackLayout>
-            <LeaderboardPlaygroundCard />
-            {!canUserCustomizeTheme && <GetSubscriptionCard />}
+            {!canUserCustomizeTheme ? (
+              <GetSubscriptionCard />
+            ) : (
+              <LeaderboardPlaygroundCard />
+            )}
             <Spacer />
             <Text size="sub-title" noMargin>
               <Trans>Score column settings</Trans>

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
@@ -96,7 +96,10 @@ function LeaderboardAppearanceDialog({
   const canCustomizeTheme =
     !!limits &&
     !!limits.capabilities.leaderboards &&
-    limits.capabilities.leaderboards.themeCustomizationCapabilities !== 'NONE';
+    (limits.capabilities.leaderboards.themeCustomizationCapabilities ===
+      'BASIC' ||
+      limits.capabilities.leaderboards.themeCustomizationCapabilities ===
+        'FULL');
   const [scoreTitleError, setScoreTitleError] = React.useState<?string>(null);
   const [
     defaultDisplayedEntriesNumber,

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog.js
@@ -6,7 +6,7 @@ import { type I18n as I18nType } from '@lingui/core';
 
 import Dialog, { DialogPrimaryButton } from '../../UI/Dialog';
 import FlatButton from '../../UI/FlatButton';
-import { ResponsiveLineStackLayout } from '../../UI/Layout';
+import { ColumnStackLayout, ResponsiveLineStackLayout } from '../../UI/Layout';
 import SelectField from '../../UI/SelectField';
 import SelectOption from '../../UI/SelectOption';
 import Text from '../../UI/Text';
@@ -16,7 +16,7 @@ import {
   type LeaderboardCustomizationSettings,
   type LeaderboardScoreFormattingTimeUnit,
 } from '../../Utils/GDevelopServices/Play';
-import { Column, Line, Spacer } from '../../UI/Grid';
+import { Spacer } from '../../UI/Grid';
 import {
   formatScore,
   orderedTimeUnits,
@@ -24,6 +24,9 @@ import {
 } from '../../Leaderboard/LeaderboardScoreFormatter';
 import AlertMessage from '../../UI/AlertMessage';
 import HelpButton from '../../UI/HelpButton';
+import ColorField from '../../UI/ColorField';
+import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
+import GetSubscriptionCard from './GetSubscriptionCard';
 
 const unitToAbbreviation = {
   hour: 'HH',
@@ -89,6 +92,11 @@ function LeaderboardAppearanceDialog({
   leaderboardCustomizationSettings,
 }: Props) {
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const { limits } = React.useContext(AuthenticatedUserContext);
+  const canCustomizeTheme =
+    !!limits &&
+    !!limits.capabilities.leaderboards &&
+    !!limits.capabilities.leaderboards.canCustomizeTheme;
   const [scoreTitleError, setScoreTitleError] = React.useState<?string>(null);
   const [
     defaultDisplayedEntriesNumber,
@@ -97,6 +105,15 @@ function LeaderboardAppearanceDialog({
     (leaderboardCustomizationSettings &&
       leaderboardCustomizationSettings.defaultDisplayedEntriesNumber) ||
       20
+  );
+  const [backgroundColor, setBackgroundColor] = React.useState<string>('');
+  const [textColor, setTextColor] = React.useState<string>('');
+  const [
+    highlightBackgroundColor,
+    setHighlightBackgroundColor,
+  ] = React.useState<string>('');
+  const [highlightTextColor, setHighlightTextColor] = React.useState<string>(
+    ''
   );
   const [
     defaultDisplayedEntriesNumberError,
@@ -220,10 +237,10 @@ function LeaderboardAppearanceDialog({
             onSaveSettings(i18n);
           }}
         >
-          <Text size="block-title">
-            <Trans>Table settings</Trans>
-          </Text>
-          <Line>
+          <ColumnStackLayout noMargin>
+            <Text size="sub-title" noMargin>
+              <Trans>Table settings</Trans>
+            </Text>
             <TextField
               fullWidth
               type="number"
@@ -249,11 +266,29 @@ function LeaderboardAppearanceDialog({
                 );
               }}
             />
-          </Line>
-          <Text size="block-title">
-            <Trans>Score column settings</Trans>
-          </Text>
-          <Line>
+            <ResponsiveLineStackLayout noMargin>
+              <ColorField
+                floatingLabelText={<Trans>Background color</Trans>}
+                disableAlpha
+                fullWidth
+                color={backgroundColor}
+                onChange={setBackgroundColor}
+                disabled={!canCustomizeTheme}
+              />
+              <ColorField
+                floatingLabelText={<Trans>Text color</Trans>}
+                disableAlpha
+                fullWidth
+                color={textColor}
+                onChange={setTextColor}
+                disabled={!canCustomizeTheme}
+              />
+            </ResponsiveLineStackLayout>
+            {!canCustomizeTheme && <GetSubscriptionCard />}
+            <Spacer />
+            <Text size="sub-title" noMargin>
+              <Trans>Score column settings</Trans>
+            </Text>
             <TextField
               fullWidth
               floatingLabelText={<Trans>Column title</Trans>}
@@ -265,178 +300,168 @@ function LeaderboardAppearanceDialog({
                 setScoreTitle(newTitle);
               }}
             />
-          </Line>
-          <Column noMargin>
-            <Line>
-              <SelectField
+            <ResponsiveLineStackLayout noMargin>
+              <ColorField
+                floatingLabelText={<Trans>Highlight background color</Trans>}
+                disableAlpha
                 fullWidth
-                value={scoreType}
-                floatingLabelText={<Trans>Score display</Trans>}
-                onChange={(e, i, newValue) =>
-                  // $FlowIgnore
-                  setScoreType(newValue)
-                }
-              >
-                <SelectOption
-                  key={'custom'}
-                  value={'custom'}
-                  primaryText={t`Custom display`}
-                />
-                <SelectOption
-                  key={'time'}
-                  value={'time'}
-                  primaryText={t`Display as time`}
-                />
-              </SelectField>
-            </Line>
-            <Column>
-              <Line noMargin>
-                <Text size="body2">
-                  <Trans>Settings</Trans>
-                </Text>
-              </Line>
-              {scoreType === 'custom' ? (
-                <>
-                  <ResponsiveLineStackLayout noColumnMargin>
-                    <Column expand noMargin>
-                      <TextField
-                        fullWidth
-                        floatingLabelFixed
-                        floatingLabelText={<Trans>Prefix</Trans>}
-                        maxLength={10}
-                        value={prefix}
-                        translatableHintText={t`Ex: $`}
-                        onChange={(e, newValue) => {
-                          setPrefix(newValue);
-                        }}
-                      />
-                    </Column>
-                    <Column expand noMargin>
-                      <TextField
-                        fullWidth
-                        floatingLabelFixed
-                        floatingLabelText={<Trans>Suffix</Trans>}
-                        maxLength={10}
-                        value={suffix}
-                        translatableHintText={t`Ex: coins`}
-                        onChange={(e, newValue) => {
-                          setSuffix(newValue);
-                        }}
-                      />
-                    </Column>
-                  </ResponsiveLineStackLayout>
-                  <Spacer />
-                  <ResponsiveLineStackLayout noColumnMargin noMargin>
-                    <Column expand noMargin>
-                      <TextField
-                        fullWidth
-                        type="number"
-                        floatingLabelText={
-                          <Trans>Round to X decimal point</Trans>
-                        }
-                        errorText={precisionError}
-                        value={isNaN(precision) ? '' : precision}
-                        min={precisionMinValue}
-                        max={precisionMaxValue}
-                        onChange={(e, newValue) => {
-                          if (!!precisionError && !!newValue) {
-                            setPrecisionError(null);
-                          }
-                          setPrecision(
-                            Math.max(
-                              precisionMinValue,
-                              Math.min(precisionMaxValue, parseFloat(newValue))
-                            )
-                          );
-                        }}
-                      />
-                    </Column>
-                    <Column expand noMargin />
-                  </ResponsiveLineStackLayout>
-                </>
-              ) : (
-                <>
-                  <Line noMargin>
-                    <SelectField
-                      fullWidth
-                      value={timeUnits}
-                      floatingLabelText={<Trans>Time format</Trans>}
-                      onChange={(e, i, newValue) =>
-                        // $FlowIgnore
-                        setTimeUnits(newValue)
-                      }
-                    >
-                      {Object.keys(unitSelectOptions).map(option => (
-                        <SelectOption
-                          key={option}
-                          value={option}
-                          primaryText={option}
-                        />
-                      ))}
-                    </SelectField>
-                  </Line>
-                  <Line>
-                    <AlertMessage kind="info">
-                      <Trans>
-                        To use this formatting, you must send a score expressed
-                        in seconds
-                      </Trans>
-                    </AlertMessage>
-                  </Line>
-                </>
-              )}
-              <Spacer />
-              <Line noMargin>
-                <Text size="body2">
-                  <Trans>Preview</Trans>
-                </Text>
-              </Line>
-              <ResponsiveLineStackLayout noColumnMargin>
+                color={highlightBackgroundColor}
+                onChange={setHighlightBackgroundColor}
+                disabled={!canCustomizeTheme}
+              />
+              <ColorField
+                floatingLabelText={<Trans>Highlight text color</Trans>}
+                disableAlpha
+                fullWidth
+                color={highlightTextColor}
+                onChange={setHighlightTextColor}
+                disabled={!canCustomizeTheme}
+              />
+            </ResponsiveLineStackLayout>
+            {!canCustomizeTheme && <GetSubscriptionCard />}
+            <SelectField
+              fullWidth
+              value={scoreType}
+              floatingLabelText={<Trans>Score display</Trans>}
+              onChange={(e, i, newValue) =>
+                // $FlowIgnore
+                setScoreType(newValue)
+              }
+            >
+              <SelectOption
+                key={'custom'}
+                value={'custom'}
+                primaryText={t`Custom display`}
+              />
+              <SelectOption
+                key={'time'}
+                value={'time'}
+                primaryText={t`Display as time`}
+              />
+            </SelectField>
+            <Spacer />
+            <Text size="sub-title" noMargin>
+              <Trans>Settings</Trans>
+            </Text>
+            {scoreType === 'custom' ? (
+              <ColumnStackLayout noMargin>
+                <ResponsiveLineStackLayout noMargin>
+                  <TextField
+                    fullWidth
+                    floatingLabelFixed
+                    floatingLabelText={<Trans>Prefix</Trans>}
+                    maxLength={10}
+                    value={prefix}
+                    translatableHintText={t`Ex: $`}
+                    onChange={(e, newValue) => {
+                      setPrefix(newValue);
+                    }}
+                  />
+                  <TextField
+                    fullWidth
+                    floatingLabelFixed
+                    floatingLabelText={<Trans>Suffix</Trans>}
+                    maxLength={10}
+                    value={suffix}
+                    translatableHintText={t`Ex: coins`}
+                    onChange={(e, newValue) => {
+                      setSuffix(newValue);
+                    }}
+                  />
+                </ResponsiveLineStackLayout>
                 <TextField
                   fullWidth
-                  floatingLabelText={
-                    scoreType === 'custom' ? (
-                      <Trans>Test value</Trans>
-                    ) : (
-                      <Trans>Test value (in second)</Trans>
-                    )
-                  }
-                  max={scorePreviewMaxValue}
-                  min={0}
                   type="number"
-                  value={isNaN(scorePreview) ? '' : scorePreview}
-                  onChange={(e, value) =>
-                    setScorePreview(
+                  floatingLabelText={<Trans>Round to X decimal point</Trans>}
+                  errorText={precisionError}
+                  value={isNaN(precision) ? '' : precision}
+                  min={precisionMinValue}
+                  max={precisionMaxValue}
+                  onChange={(e, newValue) => {
+                    if (!!precisionError && !!newValue) {
+                      setPrecisionError(null);
+                    }
+                    setPrecision(
                       Math.max(
-                        0,
-                        Math.min(scorePreviewMaxValue, parseFloat(value))
+                        precisionMinValue,
+                        Math.min(precisionMaxValue, parseFloat(newValue))
                       )
-                    )
-                  }
+                    );
+                  }}
                 />
-
-                <TextField
-                  disabled
+              </ColumnStackLayout>
+            ) : (
+              <ColumnStackLayout noMargin>
+                <SelectField
                   fullWidth
-                  floatingLabelText={<Trans>Displayed score</Trans>}
-                  value={formatScore(
-                    scorePreview || 0,
-                    scoreType === 'time'
-                      ? {
-                          type: scoreType,
-                          ...unitSelectOptions[timeUnits],
-                        }
-                      : {
-                          type: scoreType,
-                          prefix,
-                          suffix,
-                          precision: precision || 0,
-                        }
-                  )}
-                />
-              </ResponsiveLineStackLayout>
-            </Column>
-          </Column>
+                  value={timeUnits}
+                  floatingLabelText={<Trans>Time format</Trans>}
+                  onChange={(e, i, newValue) => setTimeUnits(newValue)}
+                >
+                  {Object.keys(unitSelectOptions).map(option => (
+                    <SelectOption
+                      key={option}
+                      value={option}
+                      primaryText={option}
+                    />
+                  ))}
+                </SelectField>
+                <AlertMessage kind="info">
+                  <Trans>
+                    To use this formatting, you must send a score expressed in
+                    seconds
+                  </Trans>
+                </AlertMessage>
+              </ColumnStackLayout>
+            )}
+            <Spacer />
+            <Text size="sub-title" noMargin>
+              <Trans>Preview</Trans>
+            </Text>
+            <ResponsiveLineStackLayout noMargin>
+              <TextField
+                fullWidth
+                floatingLabelText={
+                  scoreType === 'custom' ? (
+                    <Trans>Test value</Trans>
+                  ) : (
+                    <Trans>Test value (in second)</Trans>
+                  )
+                }
+                max={scorePreviewMaxValue}
+                min={0}
+                type="number"
+                value={isNaN(scorePreview) ? '' : scorePreview}
+                onChange={(e, value) =>
+                  setScorePreview(
+                    Math.max(
+                      0,
+                      Math.min(scorePreviewMaxValue, parseFloat(value))
+                    )
+                  )
+                }
+              />
+              <TextField
+                disabled
+                fullWidth
+                floatingLabelText={<Trans>Displayed score</Trans>}
+                value={formatScore(
+                  scorePreview || 0,
+                  scoreType === 'time'
+                    ? {
+                        type: scoreType,
+                        ...unitSelectOptions[timeUnits],
+                      }
+                    : {
+                        type: scoreType,
+                        prefix,
+                        suffix,
+                        precision: precision || 0,
+                      }
+                )}
+              />
+            </ResponsiveLineStackLayout>
+          </ColumnStackLayout>
         </Dialog>
       )}
     </I18n>

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardPlaygroundCard.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardPlaygroundCard.js
@@ -10,7 +10,12 @@ import Window from '../../Utils/Window';
 
 const LeaderboardPlaygroundCard = () => {
   return (
-    <LineStackLayout expand noMargin alignItems="center">
+    <LineStackLayout
+      expand
+      noMargin
+      alignItems="center"
+      justifyContent="space-around"
+    >
       <Column>
         <Text>
           <Trans>

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardPlaygroundCard.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardPlaygroundCard.js
@@ -1,0 +1,39 @@
+// @flow
+import * as React from 'react';
+import { Trans } from '@lingui/macro';
+
+import Text from '../../UI/Text';
+import { Column } from '../../UI/Grid';
+import { LineStackLayout } from '../../UI/Layout';
+import Link from '../../UI/Link';
+import Window from '../../Utils/Window';
+
+const LeaderboardPlaygroundCard = () => {
+  return (
+    <LineStackLayout expand noMargin alignItems="center">
+      <Column>
+        <Text>
+          <Trans>
+            Experiment with the leaderboard colors using the playground
+          </Trans>
+        </Text>
+      </Column>
+      <Column>
+        <Link
+          href="https://liluo.io/playground/test-leaderboard"
+          onClick={() =>
+            Window.openExternalURL(
+              'https://liluo.io/playground/test-leaderboard'
+            )
+          }
+        >
+          <Text noMargin color="inherit">
+            <Trans>Playground</Trans>
+          </Text>
+        </Link>
+      </Column>
+    </LineStackLayout>
+  );
+};
+
+export default LeaderboardPlaygroundCard;

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -277,7 +277,7 @@ export const LeaderboardAdmin = ({
   const onListLeaderboards = React.useCallback(
     () => {
       const fetchAndHandleError = async () => {
-        setIsLoading(true);
+        setIsRequestPending(true); // We only set the local loading state here to avoid blocking the dialog buttons on first load.
         setApiError(null);
         try {
           await listLeaderboards();
@@ -297,12 +297,12 @@ export const LeaderboardAdmin = ({
             ),
           });
         } finally {
-          setIsLoading(false);
+          setIsRequestPending(false);
         }
       };
       fetchAndHandleError();
     },
-    [setIsLoading, listLeaderboards]
+    [listLeaderboards]
   );
 
   const onFetchLeaderboardEntries = async () => {

--- a/newIDE/app/src/UI/ColorField/ColorPicker.js
+++ b/newIDE/app/src/UI/ColorField/ColorPicker.js
@@ -19,10 +19,7 @@ type Props = {|
   onChange?: ColorChangeHandler,
   onChangeComplete?: ColorChangeHandler,
   disableAlpha?: boolean,
-|};
-
-type State = {|
-  displayColorPicker: boolean,
+  disabled?: boolean,
 |};
 
 const styles = {
@@ -41,6 +38,10 @@ const styles = {
     display: 'inline-block',
     cursor: 'pointer',
   },
+  disabled: {
+    opacity: 0.2,
+    cursor: 'default',
+  },
   popover: {
     // Ensure the popover is above everything (modal, dialog, snackbar, tooltips, etc).
     // There will be only one ColorPicker opened at a time, so it's fair to put the
@@ -49,67 +50,73 @@ const styles = {
   },
 };
 
-class ColorPicker extends React.Component<Props, State> {
-  _swatch = React.createRef<HTMLDivElement>();
-  state = {
-    displayColorPicker: false,
+const ColorPicker = ({
+  color,
+  style,
+  onChange,
+  onChangeComplete,
+  disableAlpha,
+  disabled,
+}: Props) => {
+  const swatchRef = React.useRef<?HTMLDivElement>(null);
+  const [displayColorPicker, setDisplayColorPicker] = React.useState(false);
+
+  const handleClick = () => {
+    if (disabled) return;
+    setDisplayColorPicker(!displayColorPicker);
   };
 
-  open = () => {
-    this.setState({ displayColorPicker: true });
+  const handleClose = () => {
+    setDisplayColorPicker(false);
   };
 
-  handleClick = () => {
-    this.setState({ displayColorPicker: !this.state.displayColorPicker });
-  };
+  const displayedColor = color
+    ? color
+    : {
+        r: 200,
+        g: 200,
+        b: 200,
+        a: 1,
+      };
 
-  handleClose = () => {
-    this.setState({ displayColorPicker: false });
-  };
-
-  render() {
-    const { style, color, ...otherProps } = this.props;
-
-    const displayedColor = color
-      ? color
-      : {
-          r: 200,
-          g: 200,
-          b: 200,
-          a: 1,
-        };
-
-    return (
-      <div style={style}>
+  return (
+    <div style={style}>
+      <div
+        style={{
+          ...styles.swatch,
+          ...(disabled ? styles.disabled : {}),
+        }}
+        onClick={handleClick}
+        ref={swatchRef}
+      >
         <div
-          style={styles.swatch}
-          onClick={this.handleClick}
-          ref={this._swatch}
+          style={{
+            ...styles.color,
+            background: `rgba(${displayedColor.r}, ${displayedColor.g}, ${
+              displayedColor.b
+            }, ${displayedColor.a || 1})`,
+          }}
         >
-          <div
-            style={{
-              ...styles.color,
-              background: `rgba(${displayedColor.r}, ${displayedColor.g}, ${
-                displayedColor.b
-              }, ${displayedColor.a || 1})`,
-            }}
-          >
-            {color ? null : '?'}
-          </div>
+          {color ? null : '?'}
         </div>
-        {this.state.displayColorPicker && this._swatch.current ? (
-          <Popover
-            open
-            onClose={this.handleClose}
-            anchorEl={this._swatch.current}
-            style={styles.popover}
-          >
-            <SketchPicker color={displayedColor} {...otherProps} />
-          </Popover>
-        ) : null}
       </div>
-    );
-  }
-}
+      {displayColorPicker && swatchRef.current ? (
+        <Popover
+          open
+          onClose={handleClose}
+          anchorEl={swatchRef.current}
+          style={styles.popover}
+        >
+          <SketchPicker
+            color={displayedColor}
+            onChange={onChange}
+            onChangeComplete={onChangeComplete}
+            disableAlpha={disableAlpha}
+          />
+        </Popover>
+      ) : null}
+    </div>
+  );
+};
 
 export default ColorPicker;

--- a/newIDE/app/src/UI/ColorField/index.js
+++ b/newIDE/app/src/UI/ColorField/index.js
@@ -29,97 +29,99 @@ type Props = {|
   onChange: (string, ?number) => void,
   color: string,
   alpha?: number,
+  disabled?: boolean,
 |};
 
-type State = {|
-  color: string,
-  alpha: number,
-|};
+const ColorField = ({
+  fullWidth,
+  disableAlpha,
+  id,
+  floatingLabelText,
+  helperMarkdownText,
+  onChange,
+  color,
+  alpha,
+  disabled,
+}: Props) => {
+  const [colorValue, setColorValue] = React.useState<string>(color);
+  // alpha can be equal to 0, so we have to check if it is not undefined
+  const [alphaValue, setAlphaValue] = React.useState<number>(
+    !disableAlpha && alpha !== undefined ? alpha : 1
+  );
+  const textFieldRef = React.useRef<?TextField>(null);
 
-export default class ColorField extends React.Component<Props, State> {
-  state = {
-    color: this.props.color,
-    // alpha can be equal to 0, so we have to check if it is not undefined
-    alpha:
-      !this.props.disableAlpha && this.props.alpha !== undefined
-        ? this.props.alpha
-        : 1,
+  const handleChange = (newColor: string, newAlpha: number) => {
+    setColorValue(newColor);
+    setAlphaValue(newAlpha);
   };
 
-  _textField: ?TextField = null;
-
-  _handleChange = (color: string, alpha: number) => {
-    this.setState({ color, alpha });
-  };
-
-  _handleBlur = () => {
+  const handleBlur = () => {
     // change alpha value to be within allowed limits (0-1)
-    let alpha = parseFloat(this.state.alpha);
-    if (alpha < 0) alpha = 0;
-    if (alpha > 1) alpha = 1;
-    this.setState({ alpha });
-    this.props.onChange(this.state.color, alpha);
+    let newAlpha = parseFloat(alpha);
+    if (newAlpha < 0) newAlpha = 0;
+    if (newAlpha > 1) newAlpha = 1;
+    setAlphaValue(newAlpha);
+    onChange(color, newAlpha);
   };
 
-  _handlePickerChange = (color: ColorResult) => {
+  const handlePickerChange = (color: ColorResult) => {
     const rgbString = rgbColorToRGBString(color.rgb);
-    const alpha = this.props.disableAlpha ? 1 : color.rgb.a;
-    this.setState({ color: rgbString, alpha });
-    this.props.onChange(rgbString, alpha);
+    const newAlpha = disableAlpha ? 1 : color.rgb.a;
+    setColorValue(rgbString);
+    if (newAlpha) setAlphaValue(newAlpha);
+    onChange(rgbString, newAlpha);
   };
 
-  render() {
-    return (
-      <div
-        style={{
-          ...styles.container,
-          width: this.props.fullWidth ? '100%' : undefined,
-        }}
-      >
+  return (
+    <div
+      style={{
+        ...styles.container,
+        width: fullWidth ? '100%' : undefined,
+      }}
+    >
+      <TextField
+        id={id}
+        fullWidth={disableAlpha}
+        style={!disableAlpha ? { width: '70%' } : undefined}
+        floatingLabelText={floatingLabelText}
+        floatingLabelFixed
+        helperMarkdownText={helperMarkdownText}
+        type="text"
+        translatableHintText={t`R;G;B, like 100;200;180`}
+        value={colorValue}
+        onChange={event => handleChange(event.target.value, alphaValue)}
+        onBlur={handleBlur}
+        ref={textFieldRef}
+        disabled={disabled}
+      />
+      {!disableAlpha && (
         <TextField
-          id={this.props.id}
-          fullWidth={this.props.disableAlpha}
-          style={!this.props.disableAlpha ? { width: '70%' } : undefined}
-          floatingLabelText={this.props.floatingLabelText}
+          id={`${id || ''}-alpha`}
+          floatingLabelText="Alpha"
           floatingLabelFixed
-          helperMarkdownText={this.props.helperMarkdownText}
-          type="text"
-          translatableHintText={t`Text in the format R;G;B, like 100;200;180`}
-          value={this.state.color}
-          onChange={event =>
-            this._handleChange(event.target.value, this.state.alpha)
+          style={{ width: '30%' }}
+          translatableHintText={t`Number between 0 and 1`}
+          value={alphaValue.toString()}
+          onChange={(event, newAlphaValue) =>
+            handleChange(colorValue, parseFloat(newAlphaValue))
           }
-          onBlur={this._handleBlur}
-          ref={textField => (this._textField = textField)}
+          onBlur={handleBlur}
+          ref={textFieldRef}
+          type="number"
+          step={0.1}
+          disabled={disabled}
         />
-        {!this.props.disableAlpha && (
-          <TextField
-            id={`${this.props.id || ''}-alpha`}
-            floatingLabelText="Alpha"
-            floatingLabelFixed
-            style={{ width: '30%' }}
-            translatableHintText={t`Number between 0 and 1`}
-            value={this.state.alpha.toString()}
-            onChange={(event, value) =>
-              this._handleChange(this.state.color, parseFloat(value))
-            }
-            onBlur={this._handleBlur}
-            ref={textField => (this._textField = textField)}
-            type="number"
-            step={0.1}
-          />
-        )}
-        <div style={styles.picker}>
-          <ColorPicker
-            disableAlpha={this.props.disableAlpha}
-            onChangeComplete={this._handlePickerChange}
-            color={rgbStringAndAlphaToRGBColor(
-              this.state.color,
-              this.state.alpha
-            )}
-          />
-        </div>
+      )}
+      <div style={styles.picker}>
+        <ColorPicker
+          disableAlpha={disableAlpha}
+          onChangeComplete={handlePickerChange}
+          color={rgbStringAndAlphaToRGBColor(colorValue, alphaValue)}
+          disabled={disabled}
+        />
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+export default ColorField;

--- a/newIDE/app/src/UI/ColorField/index.js
+++ b/newIDE/app/src/UI/ColorField/index.js
@@ -84,10 +84,10 @@ const ColorField = ({
         fullWidth={disableAlpha}
         style={!disableAlpha ? { width: '70%' } : undefined}
         floatingLabelText={floatingLabelText}
-        floatingLabelFixed
+        floatingLabelFixed={!disabled}
         helperMarkdownText={helperMarkdownText}
         type="text"
-        translatableHintText={t`R;G;B, like 100;200;180`}
+        translatableHintText={disabled ? null : t`R;G;B, like 100;200;180`}
         value={colorValue}
         onChange={event => handleChange(event.target.value, alphaValue)}
         onBlur={handleBlur}

--- a/newIDE/app/src/Utils/Analytics/EventSender.js
+++ b/newIDE/app/src/Utils/Analytics/EventSender.js
@@ -377,7 +377,8 @@ export type SubscriptionDialogDisplayReason =
   | 'Leaderboard count per game limit reached'
   | 'Cloud Project limit reached'
   | 'Consult profile'
-  | 'Build limit reached';
+  | 'Build limit reached'
+  | 'Leaderboard customization';
 
 export const sendSubscriptionDialogShown = (metadata: {|
   reason: SubscriptionDialogDisplayReason,

--- a/newIDE/app/src/Utils/ColorTransformer.js
+++ b/newIDE/app/src/Utils/ColorTransformer.js
@@ -38,6 +38,15 @@ export const rgbStringToHexNumber = (rgbString: string) => {
 };
 
 /**
+ * Convert a RGB string ("rr;gg;bb") to a Hex string (#000000).
+ */
+export const rgbStringToHexString = (rgbString: string) => {
+  const rgbColor = rgbStringAndAlphaToRGBColor(rgbString);
+  if (!rgbColor) return '#000000';
+  return rgbColorToHex(rgbColor.r, rgbColor.g, rgbColor.b);
+};
+
+/**
  * Convert a RGB string ("rrr;ggg;bbb") or a Hex string ("#112244") to a Hex number.
  */
 export const rgbOrHexToHexNumber = (value: string): number => {

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -34,10 +34,18 @@ export type LeaderboardScoreFormatting =
   | LeaderboardScoreFormattingCustom
   | LeaderboardScoreFormattingTime;
 
+export interface LeaderboardTheme {
+  backgroundColor: string;
+  textColor: string;
+  highlightBackgroundColor: string;
+  highlightTextColor: string;
+}
+
 export type LeaderboardCustomizationSettings = {|
   defaultDisplayedEntriesNumber?: number,
   scoreTitle: string,
   scoreFormatting: LeaderboardScoreFormatting,
+  theme?: LeaderboardTheme,
 |};
 
 export type Leaderboard = {|

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { GDevelopPlayApi } from './ApiConfigs';
 
 import { type AuthenticatedUser } from '../../Profile/AuthenticatedUserContext';
+import { rgbOrHexToRGBString } from '../ColorTransformer';
 
 export type LeaderboardSortOption = 'ASC' | 'DESC';
 export type LeaderboardVisibilityOption = 'HIDDEN' | 'PUBLIC';
@@ -409,4 +410,55 @@ export const updateComment = async (
       )
     )
     .then(response => response.data);
+};
+
+export const canUserCustomizeLeaderboardTheme = (
+  authenticatedUser: AuthenticatedUser
+): boolean => {
+  const { limits } = authenticatedUser;
+  return (
+    !!limits &&
+    !!limits.capabilities.leaderboards &&
+    (limits.capabilities.leaderboards.themeCustomizationCapabilities ===
+      'BASIC' ||
+      limits.capabilities.leaderboards.themeCustomizationCapabilities ===
+        'FULL')
+  );
+};
+
+export const getRGBLeaderboardTheme = (
+  leaderboardCustomizationSettings: ?LeaderboardCustomizationSettings
+): LeaderboardTheme => {
+  const defaultBackgroundColor = '#d0d1ff';
+  const defaultTextColor = '#000000';
+  const defaultHighlightBackgroundColor = '#5763dd';
+  const defaultHighlightTextColor = '#ffffff';
+
+  const hexLeaderboardTheme =
+    leaderboardCustomizationSettings && leaderboardCustomizationSettings.theme
+      ? {
+          backgroundColor:
+            leaderboardCustomizationSettings.theme.backgroundColor,
+          textColor: leaderboardCustomizationSettings.theme.textColor,
+          highlightBackgroundColor:
+            leaderboardCustomizationSettings.theme.highlightBackgroundColor,
+          highlightTextColor:
+            leaderboardCustomizationSettings.theme.highlightTextColor,
+        }
+      : {
+          backgroundColor: defaultBackgroundColor,
+          textColor: defaultTextColor,
+          highlightBackgroundColor: defaultHighlightBackgroundColor,
+          highlightTextColor: defaultHighlightTextColor,
+        };
+  return {
+    backgroundColor: rgbOrHexToRGBString(hexLeaderboardTheme.backgroundColor),
+    textColor: rgbOrHexToRGBString(hexLeaderboardTheme.textColor),
+    highlightBackgroundColor: rgbOrHexToRGBString(
+      hexLeaderboardTheme.highlightBackgroundColor
+    ),
+    highlightTextColor: rgbOrHexToRGBString(
+      hexLeaderboardTheme.highlightTextColor
+    ),
+  };
 };

--- a/newIDE/app/src/Utils/GDevelopServices/Usage.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Usage.js
@@ -55,6 +55,7 @@ export type Capabilities = {
   leaderboards?: {
     maximumCountPerGame: number,
     canMaximumCountPerGameBeIncreased: boolean,
+    canCustomizeTheme: boolean,
   },
 };
 

--- a/newIDE/app/src/Utils/GDevelopServices/Usage.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Usage.js
@@ -55,7 +55,7 @@ export type Capabilities = {
   leaderboards?: {
     maximumCountPerGame: number,
     canMaximumCountPerGameBeIncreased: boolean,
-    canCustomizeTheme: boolean,
+    themeCustomizationCapabilities: 'NONE' | 'BASIC' | 'FULL',
   },
 };
 

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData/index.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData/index.js
@@ -167,6 +167,35 @@ export const noSubscription: Subscription = {
   userId: 'no-subscription-user',
 };
 
+export const limitsForNoSubscriptionUser: Limits = {
+  capabilities: {
+    analytics: {
+      sessions: true,
+      players: false,
+      retention: false,
+      sessionsTimeStats: false,
+      platforms: false,
+    },
+    cloudProjects: {
+      maximumCount: 10,
+      canMaximumCountBeIncreased: true,
+    },
+    leaderboards: {
+      maximumCountPerGame: 3,
+      canMaximumCountPerGameBeIncreased: true,
+      canCustomizeTheme: false,
+    },
+  },
+  limits: {
+    'cordova-build': {
+      current: 0,
+      max: 2,
+      limitReached: false,
+    },
+  },
+  message: undefined,
+};
+
 export const limitsForIndieUser: Limits = {
   capabilities: {
     analytics: {
@@ -183,6 +212,7 @@ export const limitsForIndieUser: Limits = {
     leaderboards: {
       maximumCountPerGame: -1,
       canMaximumCountPerGameBeIncreased: false,
+      canCustomizeTheme: true,
     },
   },
   limits: {
@@ -211,6 +241,7 @@ export const limitsForProUser: Limits = {
     leaderboards: {
       maximumCountPerGame: -1,
       canMaximumCountPerGameBeIncreased: false,
+      canCustomizeTheme: true,
     },
   },
   limits: {
@@ -239,6 +270,7 @@ export const limitsReached: Limits = {
     leaderboards: {
       maximumCountPerGame: 3,
       canMaximumCountPerGameBeIncreased: true,
+      canCustomizeTheme: false,
     },
   },
   limits: {
@@ -301,7 +333,7 @@ export const fakeNoSubscriptionAuthenticatedUser: AuthenticatedUser = {
   firebaseUser: indieFirebaseUser,
   subscription: noSubscription,
   usages: usagesForIndieUser,
-  limits: limitsForIndieUser,
+  limits: limitsForNoSubscriptionUser,
   receivedAssetPacks: [],
   receivedAssetShortHeaders: [],
   onLogout: async () => {},
@@ -383,7 +415,7 @@ export const fakeAuthenticatedAndEmailVerifiedUser: AuthenticatedUser = {
   firebaseUser: indieVerifiedFirebaseUser,
   subscription: noSubscription,
   usages: usagesForIndieUser,
-  limits: limitsForIndieUser,
+  limits: limitsForNoSubscriptionUser,
   receivedAssetPacks: [],
   receivedAssetShortHeaders: [],
   onLogout: async () => {},
@@ -472,7 +504,7 @@ export const fakeAuthenticatedUserWithBadges: AuthenticatedUser = {
   firebaseUser: indieVerifiedFirebaseUser,
   subscription: noSubscription,
   usages: usagesForIndieUser,
-  limits: limitsForIndieUser,
+  limits: limitsForNoSubscriptionUser,
   receivedAssetPacks: [],
   receivedAssetShortHeaders: [],
   onLogout: async () => {},

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData/index.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData/index.js
@@ -183,7 +183,7 @@ export const limitsForNoSubscriptionUser: Limits = {
     leaderboards: {
       maximumCountPerGame: 3,
       canMaximumCountPerGameBeIncreased: true,
-      canCustomizeTheme: false,
+      themeCustomizationCapabilities: 'NONE',
     },
   },
   limits: {
@@ -212,7 +212,7 @@ export const limitsForIndieUser: Limits = {
     leaderboards: {
       maximumCountPerGame: -1,
       canMaximumCountPerGameBeIncreased: false,
-      canCustomizeTheme: true,
+      themeCustomizationCapabilities: 'BASIC',
     },
   },
   limits: {
@@ -241,7 +241,7 @@ export const limitsForProUser: Limits = {
     leaderboards: {
       maximumCountPerGame: -1,
       canMaximumCountPerGameBeIncreased: false,
-      canCustomizeTheme: true,
+      themeCustomizationCapabilities: 'FULL',
     },
   },
   limits: {
@@ -270,7 +270,7 @@ export const limitsReached: Limits = {
     leaderboards: {
       maximumCountPerGame: 3,
       canMaximumCountPerGameBeIncreased: true,
-      canCustomizeTheme: false,
+      themeCustomizationCapabilities: 'BASIC',
     },
   },
   limits: {

--- a/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardAppearanceDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardAppearanceDialog.stories.js
@@ -5,6 +5,11 @@ import { action } from '@storybook/addon-actions';
 import muiDecorator from '../../ThemeDecorator';
 import paperDecorator from '../../PaperDecorator';
 import LeaderboardAppearanceDialog from '../../../GameDashboard/LeaderboardAdmin/LeaderboardAppearanceDialog';
+import AuthenticatedUserContext from '../../../Profile/AuthenticatedUserContext';
+import {
+  fakeIndieAuthenticatedUser,
+  fakeNoSubscriptionAuthenticatedUser,
+} from '../../../fixtures/GDevelopServicesTestData';
 
 export default {
   title: 'Leaderboard/LeaderboardAppearanceDialog',
@@ -12,19 +17,42 @@ export default {
   decorators: [paperDecorator, muiDecorator],
 };
 
-export const Default = () => (
-  <LeaderboardAppearanceDialog
-    open
-    onClose={() => action('onClose')()}
-    onSave={() => action('onSave')()}
-    leaderboardCustomizationSettings={{
-      scoreTitle: 'Coins collected',
-      scoreFormatting: {
-        type: 'custom',
-        prefix: '',
-        suffix: ' coins',
-        precision: 0,
-      },
-    }}
-  />
+export const WithoutSubscription = () => (
+  <AuthenticatedUserContext.Provider
+    value={fakeNoSubscriptionAuthenticatedUser}
+  >
+    <LeaderboardAppearanceDialog
+      open
+      onClose={() => action('onClose')()}
+      onSave={() => action('onSave')()}
+      leaderboardCustomizationSettings={{
+        scoreTitle: 'Coins collected',
+        scoreFormatting: {
+          type: 'custom',
+          prefix: '',
+          suffix: ' coins',
+          precision: 0,
+        },
+      }}
+    />
+  </AuthenticatedUserContext.Provider>
+);
+
+export const WithSubscription = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <LeaderboardAppearanceDialog
+      open
+      onClose={() => action('onClose')()}
+      onSave={() => action('onSave')()}
+      leaderboardCustomizationSettings={{
+        scoreTitle: 'Coins collected',
+        scoreFormatting: {
+          type: 'custom',
+          prefix: '',
+          suffix: ' coins',
+          precision: 0,
+        },
+      }}
+    />
+  </AuthenticatedUserContext.Provider>
 );


### PR DESCRIPTION
Allow customizing 4 colors for the leaderboard of a game, to improve the embedded experience of a leaderboard in-game.
For subscribed users only.

https://gdevelop-storybook.s3.amazonaws.com/allow-leaderboard-color-customisation/latest/index.html?path=/story/leaderboard-leaderboardappearancedialog--without-subscription

![image](https://user-images.githubusercontent.com/4895034/205602063-e4d6e932-2a92-4304-9399-fad1b1687bc1.png)
![image](https://user-images.githubusercontent.com/4895034/205602194-117b5a3f-f4d3-41d7-858e-ba499084f449.png)

