### PR TITLE
Enable serialization of JS code events and extension descriptions as arrays of strings

### DIFF
--- a/Core/GDCore/Serialization/SerializerElement.cpp
+++ b/Core/GDCore/Serialization/SerializerElement.cpp
@@ -290,8 +290,8 @@ void SerializerElement::Init(const gd::SerializerElement& other) {
 }
 
 // TODO Remove shouldAlwayUseSetString in a release that follows the 150.
-void SerializerElement::SetMultilineStringValue(const gd::String& value, bool shouldAlwayUseSetString) {
-  if (shouldAlwayUseSetString || value.find('\n') == gd::String::npos) {
+void SerializerElement::SetMultilineStringValue(const gd::String& value) {
+  if (value.find('\n') == gd::String::npos) {
     SetStringValue(value);
     return;
   }

--- a/Core/GDCore/Serialization/SerializerElement.cpp
+++ b/Core/GDCore/Serialization/SerializerElement.cpp
@@ -289,7 +289,6 @@ void SerializerElement::Init(const gd::SerializerElement& other) {
   deprecatedArrayOf = other.deprecatedArrayOf;
 }
 
-// TODO Remove shouldAlwayUseSetString in a release that follows the 150.
 void SerializerElement::SetMultilineStringValue(const gd::String& value) {
   if (value.find('\n') == gd::String::npos) {
     SetStringValue(value);

--- a/Core/GDCore/Serialization/SerializerElement.h
+++ b/Core/GDCore/Serialization/SerializerElement.h
@@ -183,7 +183,7 @@ class GD_CORE_API SerializerElement {
    * \brief Save the value either as a string or as an array of strings if it
    * has line breaks.
    */
-  void SetMultilineStringValue(const gd::String &value, bool shouldAlwayUseSetString = true);
+  void SetMultilineStringValue(const gd::String &value);
 
   /**
    * \brief Read the value, either represented as a string or as an array of strings,

--- a/Core/tests/Serializer.cpp
+++ b/Core/tests/Serializer.cpp
@@ -85,7 +85,7 @@ TEST_CASE("SerializerElement", "[common]") {
     SerializerElement element;
 
     // A single line is saved as a string.
-    element.SetMultilineStringValue("test", false);
+    element.SetMultilineStringValue("test");
     REQUIRE(element.GetMultilineStringValue() == "test");
     REQUIRE(element.GetStringValue() == "test");
 
@@ -94,12 +94,12 @@ TEST_CASE("SerializerElement", "[common]") {
     REQUIRE(element.GetMultilineStringValue() == "test of\nsomething\nsaved as a string");
 
     // A multi lines string is saved as an array.
-    element.SetMultilineStringValue("test\nwith\nmultiple lines.", false);
+    element.SetMultilineStringValue("test\nwith\nmultiple lines.");
     REQUIRE(element.ConsideredAsArray() == true);
     REQUIRE(element.GetChildrenCount() == 3);
     REQUIRE(element.GetMultilineStringValue() == "test\nwith\nmultiple lines.");
 
-    element.SetMultilineStringValue("test\n\nwith\n\nmultiple lines.\n", false);
+    element.SetMultilineStringValue("test\n\nwith\n\nmultiple lines.\n");
     REQUIRE(element.ConsideredAsArray() == true);
     REQUIRE(element.GetChildrenCount() == 6);
     REQUIRE(element.GetMultilineStringValue() == "test\n\nwith\n\nmultiple lines.\n");


### PR DESCRIPTION
… to make collaboration/reviews easier

Only show in developer changelog

It follows:
- https://github.com/4ian/GDevelop/pull/4468

Some changes on the extensions scripts:
- https://github.com/GDevelopApp/GDevelop-extensions/pull/679
- https://github.com/GDevelopApp/GDevelop-extensions/pull/680
- https://github.com/GDevelopApp/GDevelop-extensions/pull/681

Tested on:
- https://github.com/GDevelopApp/GDevelop-extensions/pull/669
