### PR TITLE
Add Enter as a key to validate changes to a parameter in an event sheet

### DIFF
--- a/newIDE/app/src/EventsSheet/InlinePopover.js
+++ b/newIDE/app/src/EventsSheet/InlinePopover.js
@@ -9,6 +9,7 @@ import {
   shouldFocusNextField,
   shouldFocusPreviousField,
   shouldSubmit,
+  shouldValidate,
 } from '../UI/KeyboardShortcuts/InteractionKeys';
 
 const styles = {
@@ -92,6 +93,13 @@ export default function InlinePopover(props: Props) {
           if (shouldCloseOrCancel(event)) {
             props.onRequestClose();
           } else if (shouldSubmit(event)) {
+            props.onApply();
+          } else if (shouldValidate(event)) {
+            // Stop propagation to avoid immediately re-opening the inline popover (as the key down
+            // would be detected by the parameter of the instruction).
+            event.stopPropagation();
+            event.preventDefault();
+
             props.onApply();
           }
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsHandler.js
@@ -136,6 +136,10 @@ export const handleAutocompletionsKeyDown = (
       // the user should be able to freely move to the next line.
       if (autocompletion.isExact) return state;
       onInsertAutocompletion(autocompletion);
+
+      // Stop propagation to avoid closing the modal the
+      // field is contained in.
+      event.stopPropagation();
     }
 
     // Avoid entering a new line or tabbing to the next field.

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -40,6 +40,7 @@ import { ResponsiveWindowMeasurer } from '../../../UI/Reponsive/ResponsiveWindow
 import {
   shouldCloseOrCancel,
   shouldSubmit,
+  shouldValidate,
 } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 import Paper from '../../../UI/Paper';
 const gd: libGDevelop = global.gd;
@@ -582,7 +583,11 @@ export default class ExpressionField extends React.Component<Props, State> {
                     // Apply the changes now as otherwise the onBlur handler
                     // has a risk not to be called (as the component will be
                     // unmounted).
-                    if (shouldCloseOrCancel(event) || shouldSubmit(event)) {
+                    if (
+                      shouldCloseOrCancel(event) ||
+                      shouldSubmit(event) ||
+                      shouldValidate(event)
+                    ) {
                       const value = event.currentTarget.value;
                       if (this.props.onChange) this.props.onChange(value);
                     }

--- a/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/InteractionKeys.js
@@ -16,7 +16,7 @@ export const shouldCloseOrCancel = (event: SupportedEvent) => {
  * Check if the user asked to validate what is being edited.
  */
 export const shouldValidate = (event: SupportedEvent) => {
-  return event.key === 'Enter';
+  return event.key === 'Enter' && !event.shiftKey;
 };
 
 /**


### PR DESCRIPTION
* Shift+Enter can be used to enter new lines in expressions when editing a parameter inline

Fix #4619