### PR TITLE
Allow to set the text alignment for text objects by property.

### DIFF
--- a/Extensions/TextObject/TextObject.cpp
+++ b/Extensions/TextObject/TextObject.cpp
@@ -29,7 +29,8 @@ TextObject::TextObject()
       underlined(false),
       colorR(0),
       colorG(0),
-      colorB(0)
+      colorB(0),
+      textAlignment("left")
 {
 }
 
@@ -39,6 +40,7 @@ void TextObject::DoUnserializeFrom(gd::Project& project,
                                    const gd::SerializerElement& element) {
   SetString(element.GetChild("string", 0, "String").GetValue().GetString());
   SetFontName(element.GetChild("font", 0, "Font").GetValue().GetString());
+  SetTextAlignment(element.GetChild("textAlignment").GetValue().GetString());
   SetCharacterSize(element.GetChild("characterSize", 0, "CharacterSize")
                        .GetValue()
                        .GetInt());
@@ -56,6 +58,7 @@ void TextObject::DoUnserializeFrom(gd::Project& project,
 void TextObject::DoSerializeTo(gd::SerializerElement& element) const {
   element.AddChild("string").SetValue(GetString());
   element.AddChild("font").SetValue(GetFontName());
+  element.AddChild("textAlignment").SetValue(GetTextAlignment());
   element.AddChild("characterSize").SetValue(GetCharacterSize());
   element.AddChild("color")
       .SetAttribute("r", (int)GetColorR())

--- a/Extensions/TextObject/TextObject.h
+++ b/Extensions/TextObject/TextObject.h
@@ -53,6 +53,9 @@ class GD_EXTENSION_API TextObject : public gd::ObjectConfiguration {
    */
   void SetFontName(const gd::String& resourceName) { fontName = resourceName; };
 
+  inline const gd::String& GetTextAlignment() const { return textAlignment; };
+  void SetTextAlignment(const gd::String& textAlignment_) { textAlignment = textAlignment_; };
+
   bool IsBold() const { return bold; };
   void SetBold(bool enable) { bold = enable; };
   bool IsItalic() const { return italic; };
@@ -87,6 +90,7 @@ class GD_EXTENSION_API TextObject : public gd::ObjectConfiguration {
   unsigned int colorR;
   unsigned int colorG;
   unsigned int colorB;
+  gd::String textAlignment;
 };
 
 #endif  // TEXTOBJECT_H

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -101,30 +101,19 @@ namespace gdjs {
             : this._object._textAlign === 'center'
             ? 0.5
             : 0;
-        const alignmentY = 0;
 
         const width = this._object.getWrappingWidth();
-        const height = this._text.height;
-        console.log('custom width: ' + width);
-        console.log('x: ' + this._object.x);
-        console.log('alignmentX: ' + alignmentX);
 
         // A vector from the custom size center to the renderer center.
         const centerToCenterX = (width - this._text.width) * (alignmentX - 0.5);
-        const centerToCenterY =
-          (height - this._text.height) * (alignmentY - 0.5);
 
         this._text.position.x = this._object.x + width / 2;
-        this._text.position.y = this._object.y + height / 2;
         this._text.anchor.x = 0.5 - centerToCenterX / this._text.width;
-        this._text.anchor.y = 0.5 - centerToCenterY / this._text.height;
       } else {
-        console.log('default width');
         this._text.position.x = this._object.x + this._text.width / 2;
-        this._text.position.y = this._object.y + this._text.height / 2;
         this._text.anchor.x = 0.5;
-        this._text.anchor.y = 0.5;
       }
+      this._text.position.y = this._object.y + this._text.height / 2;
     }
 
     updateAngle(): void {

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -94,8 +94,37 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      this._text.position.x = this._object.x + this._text.width / 2;
-      this._text.position.y = this._object.y + this._text.height / 2;
+      if (this._object.isWrapping()) {
+        const alignmentX =
+          this._object._textAlign === 'right'
+            ? 1
+            : this._object._textAlign === 'center'
+            ? 0.5
+            : 0;
+        const alignmentY = 0;
+
+        const width = this._object.getWrappingWidth();
+        const height = this._text.height;
+        console.log('custom width: ' + width);
+        console.log('x: ' + this._object.x);
+        console.log('alignmentX: ' + alignmentX);
+
+        // A vector from the custom size center to the renderer center.
+        const centerToCenterX = (width - this._text.width) * (alignmentX - 0.5);
+        const centerToCenterY =
+          (height - this._text.height) * (alignmentY - 0.5);
+
+        this._text.position.x = this._object.x + width / 2;
+        this._text.position.y = this._object.y + height / 2;
+        this._text.anchor.x = 0.5 - centerToCenterX / this._text.width;
+        this._text.anchor.y = 0.5 - centerToCenterY / this._text.height;
+      } else {
+        console.log('default width');
+        this._text.position.x = this._object.x + this._text.width / 2;
+        this._text.position.y = this._object.y + this._text.height / 2;
+        this._text.anchor.x = 0.5;
+        this._text.anchor.y = 0.5;
+      }
     }
 
     updateAngle(): void {

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -26,6 +26,7 @@ namespace gdjs {
     };
     /** The text of the object */
     string: string;
+    textAlignment: string;
   };
 
   export type TextObjectData = ObjectData & TextObjectDataType;
@@ -82,6 +83,7 @@ namespace gdjs {
         textObjectData.color.b,
       ];
       this._str = textObjectData.string;
+      this._textAlign = textObjectData.textAlignment;
       this._renderer = new gdjs.TextRuntimeObjectRenderer(
         this,
         instanceContainer
@@ -126,6 +128,9 @@ namespace gdjs {
       }
       if (oldObjectData.underlined !== newObjectData.underlined) {
         return false;
+      }
+      if (oldObjectData.textAlignment !== newObjectData.textAlignment) {
+        this.setTextAlignment(newObjectData.textAlignment);
       }
       return true;
     }
@@ -288,7 +293,7 @@ namespace gdjs {
      * Get width of the text.
      */
     getWidth(): float {
-      return this._renderer.getWidth();
+      return this._wrapping ? this._wrappingWidth : this._renderer.getWidth();
     }
 
     /**

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2871,6 +2871,8 @@ interface TextObject {
     unsigned long GetColorR();
     unsigned long GetColorG();
     unsigned long GetColorB();
+    void SetTextAlignment([Const] DOMString textAlignment);
+    [Const, Ref] DOMString GetTextAlignment();
 };
 TextObject implements ObjectConfiguration;
 

--- a/GDevelop.js/__tests__/Serializer.js
+++ b/GDevelop.js/__tests__/Serializer.js
@@ -65,7 +65,7 @@ describe('libGD.js object serialization', function() {
       obj.delete();
 
       expect(jsonObject).toBe(
-        '{"bold":false,"italic":false,"smoothed":true,"underlined":false,"string":"Text of the object, with 官话 characters","font":"","characterSize":20.0,"color":{"b":0,"g":0,"r":0}}'
+        '{"bold":false,"italic":false,"smoothed":true,"underlined":false,"string":"Text of the object, with 官话 characters","font":"","textAlignment":"left","characterSize":20.0,"color":{"b":0,"g":0,"r":0}}'
       );
     });
   });

--- a/GDevelop.js/types/gdtextobject.js
+++ b/GDevelop.js/types/gdtextobject.js
@@ -17,6 +17,8 @@ declare class gdTextObject extends gdObjectConfiguration {
   getColorR(): number;
   getColorG(): number;
   getColorB(): number;
+  setTextAlignment(textAlignment: string): void;
+  getTextAlignment(): string;
   delete(): void;
   ptr: number;
 };

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -7,12 +7,17 @@ import Checkbox from '../../UI/Checkbox';
 import { Line, Column } from '../../UI/Grid';
 import ColorPicker from '../../UI/ColorField/ColorPicker';
 import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';
+import Text from '../../UI/Text';
 import ResourceSelector from '../../ResourcesList/ResourceSelector';
 import ResourcesLoader from '../../ResourcesLoader';
 import { type EditorProps } from './EditorProps.flow';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+import LeftTextAlignment from '../../UI/CustomSvgIcons/LeftTextAlignment';
+import CenterTextAlignment from '../../UI/CustomSvgIcons/CenterTextAlignment';
+import RightTextAlignment from '../../UI/CustomSvgIcons/RightTextAlignment';
 
 const gd = global.gd;
 
@@ -103,57 +108,63 @@ export default class TextEditor extends React.Component<EditorProps, void> {
             style={styles.checkbox}
           />
           <ButtonGroup>
-            <Button
-              variant={textAlignment === 'left' ? 'contained' : 'outlined'}
-              color={textAlignment === 'left' ? 'secondary' : 'default'}
-              onClick={() => {
-                textObjectConfiguration.setTextAlignment('left');
-                this.forceUpdate();
-              }}
-            >
-              <Trans>Left</Trans>
-            </Button>
-            <Button
-              variant={textAlignment === 'center' ? 'contained' : 'outlined'}
-              color={textAlignment === 'center' ? 'secondary' : 'default'}
-              onClick={() => {
-                textObjectConfiguration.setTextAlignment('center');
-                this.forceUpdate();
-              }}
-            >
-              <Trans>Center</Trans>
-            </Button>
-            <Button
-              variant={textAlignment === 'right' ? 'contained' : 'outlined'}
-              color={textAlignment === 'right' ? 'secondary' : 'default'}
-              onClick={() => {
-                textObjectConfiguration.setTextAlignment('right');
-                this.forceUpdate();
-              }}
-            >
-              <Trans>Right</Trans>
-            </Button>
+            <Tooltip title={<Trans>Align text on the left</Trans>}>
+              <Button
+                variant={textAlignment === 'left' ? 'contained' : 'outlined'}
+                color={textAlignment === 'left' ? 'secondary' : 'default'}
+                onClick={() => {
+                  textObjectConfiguration.setTextAlignment('left');
+                  this.forceUpdate();
+                }}
+              >
+                <LeftTextAlignment />
+              </Button>
+            </Tooltip>
+            <Tooltip title={<Trans>Align text on the center</Trans>}>
+              <Button
+                variant={textAlignment === 'center' ? 'contained' : 'outlined'}
+                color={textAlignment === 'center' ? 'secondary' : 'default'}
+                onClick={() => {
+                  textObjectConfiguration.setTextAlignment('center');
+                  this.forceUpdate();
+                }}
+              >
+                <CenterTextAlignment />
+              </Button>
+            </Tooltip>
+            <Tooltip title={<Trans>Align text on the right</Trans>}>
+              <Button
+                variant={textAlignment === 'right' ? 'contained' : 'outlined'}
+                color={textAlignment === 'right' ? 'secondary' : 'default'}
+                onClick={() => {
+                  textObjectConfiguration.setTextAlignment('right');
+                  this.forceUpdate();
+                }}
+              >
+                <RightTextAlignment />
+              </Button>
+            </Tooltip>
           </ButtonGroup>
-          <MiniToolbarText>
-            <Trans>Font:</Trans>
-          </MiniToolbarText>
-          <ResourceSelector
-            margin="none"
-            project={project}
-            resourceManagementProps={resourceManagementProps}
-            resourcesLoader={ResourcesLoader}
-            resourceKind="font"
-            fullWidth
-            canBeReset
-            initialResourceName={textObjectConfiguration.getFontName()}
-            onChange={resourceName => {
-              textObjectConfiguration.setFontName(resourceName);
-              this.forceUpdate();
-            }}
-            hintText={<Trans>Choose a font</Trans>}
-            style={styles.resourcesSelector}
-          />
         </MiniToolbar>
+        <Line>
+          <Column expand>
+            <ResourceSelector
+              project={project}
+              resourceManagementProps={resourceManagementProps}
+              resourcesLoader={ResourcesLoader}
+              resourceKind="font"
+              fullWidth
+              canBeReset
+              initialResourceName={textObjectConfiguration.getFontName()}
+              onChange={resourceName => {
+                textObjectConfiguration.setFontName(resourceName);
+                this.forceUpdate();
+              }}
+              floatingLabelText={<Trans>Choose a font</Trans>}
+              hintText={<Trans>Choose a font</Trans>}
+            />
+          </Column>
+        </Line>
         <Line noMargin>
           <Column expand>
             <Line>

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -110,7 +110,6 @@ export default class TextEditor extends React.Component<EditorProps, void> {
                 textObjectConfiguration.setTextAlignment('left');
                 this.forceUpdate();
               }}
-              ref={this._trueButton}
             >
               <Trans>Left</Trans>
             </Button>

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -11,6 +11,9 @@ import ResourceSelector from '../../ResourcesList/ResourceSelector';
 import ResourcesLoader from '../../ResourcesLoader';
 import { type EditorProps } from './EditorProps.flow';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import Button from '@material-ui/core/Button';
+
 const gd = global.gd;
 
 const toolbarItemStyle = {
@@ -37,6 +40,8 @@ export default class TextEditor extends React.Component<EditorProps, void> {
     const textObjectConfiguration = gd.asTextObjectConfiguration(
       objectConfiguration
     );
+
+    const textAlignment = textObjectConfiguration.getTextAlignment();
 
     return (
       <Column noMargin>
@@ -97,6 +102,39 @@ export default class TextEditor extends React.Component<EditorProps, void> {
             }}
             style={styles.checkbox}
           />
+          <ButtonGroup>
+            <Button
+              variant={textAlignment === 'left' ? 'contained' : 'outlined'}
+              color={textAlignment === 'left' ? 'secondary' : 'default'}
+              onClick={() => {
+                textObjectConfiguration.setTextAlignment('left');
+                this.forceUpdate();
+              }}
+              ref={this._trueButton}
+            >
+              <Trans>Left</Trans>
+            </Button>
+            <Button
+              variant={textAlignment === 'center' ? 'contained' : 'outlined'}
+              color={textAlignment === 'center' ? 'secondary' : 'default'}
+              onClick={() => {
+                textObjectConfiguration.setTextAlignment('center');
+                this.forceUpdate();
+              }}
+            >
+              <Trans>Center</Trans>
+            </Button>
+            <Button
+              variant={textAlignment === 'right' ? 'contained' : 'outlined'}
+              color={textAlignment === 'right' ? 'secondary' : 'default'}
+              onClick={() => {
+                textObjectConfiguration.setTextAlignment('right');
+                this.forceUpdate();
+              }}
+            >
+              <Trans>Right</Trans>
+            </Button>
+          </ButtonGroup>
           <MiniToolbarText>
             <Trans>Font:</Trans>
           </MiniToolbarText>

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -20,6 +20,7 @@ export default class RenderedTextInstance extends RenderedInstance {
   _colorR: number = 0;
   _colorG: number = 0;
   _colorB: number = 0;
+  _textAlignment: string = 'left';
 
   constructor(
     project: gdProject,
@@ -76,6 +77,7 @@ export default class RenderedTextInstance extends RenderedInstance {
       textObjectConfiguration.isItalic() !== this._isItalic ||
       textObjectConfiguration.isBold() !== this._isBold ||
       textObjectConfiguration.getCharacterSize() !== this._characterSize ||
+      textObjectConfiguration.getTextAlignment() !== this._textAlignment ||
       this._instance.hasCustomSize() !== this._wrapping ||
       (this._instance.getCustomWidth() !== this._wrappingWidth &&
         this._wrapping)
@@ -83,6 +85,7 @@ export default class RenderedTextInstance extends RenderedInstance {
       this._isItalic = textObjectConfiguration.isItalic();
       this._isBold = textObjectConfiguration.isBold();
       this._characterSize = textObjectConfiguration.getCharacterSize();
+      this._textAlignment = textObjectConfiguration.getTextAlignment();
       this._wrapping = this._instance.hasCustomSize();
       this._wrappingWidth = this._instance.getCustomWidth();
       this._styleFontDirty = true;
@@ -118,6 +121,7 @@ export default class RenderedTextInstance extends RenderedInstance {
       this._pixiObject.style.wordWrapWidth =
         this._wrappingWidth <= 1 ? 1 : this._wrappingWidth;
       this._pixiObject.style.breakWords = true;
+      this._pixiObject.style.align = this._textAlignment;
 
       // Manually ask the PIXI object to re-render as we changed a style property
       // see http://www.html5gamedevs.com/topic/16924-change-text-style-post-render/
@@ -141,10 +145,38 @@ export default class RenderedTextInstance extends RenderedInstance {
       this._pixiObject.dirty = true;
     }
 
-    this._pixiObject.position.x =
-      this._instance.getX() + this._pixiObject.width / 2;
-    this._pixiObject.position.y =
-      this._instance.getY() + this._pixiObject.height / 2;
+    if (this._instance.hasCustomSize()) {
+      const alignmentX =
+        this._textAlignment === 'right'
+          ? 1
+          : this._textAlignment === 'center'
+          ? 0.5
+          : 0;
+      const alignmentY = 0;
+
+      const width = this._instance.getCustomWidth();
+      const height = this._instance.getCustomHeight();
+
+      // A vector from the custom size center to the renderer center.
+      const centerToCenterX =
+        (width - this._pixiObject.width) * (alignmentX - 0.5);
+      const centerToCenterY =
+        (height - this._pixiObject.height) * (alignmentY - 0.5);
+
+      this._pixiObject.position.x = this._instance.getX() + width / 2;
+      this._pixiObject.position.y = this._instance.getY() + height / 2;
+      this._pixiObject.anchor.x =
+        0.5 - centerToCenterX / this._pixiObject.width;
+      this._pixiObject.anchor.y =
+        0.5 - centerToCenterY / this._pixiObject.height;
+    } else {
+      this._pixiObject.position.x =
+        this._instance.getX() + this._pixiObject.width / 2;
+      this._pixiObject.position.y =
+        this._instance.getY() + this._pixiObject.height / 2;
+      this._pixiObject.anchor.x = 0.5;
+      this._pixiObject.anchor.y = 0.5;
+    }
     this._pixiObject.rotation = RenderedInstance.toRad(
       this._instance.getAngle()
     );

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -152,31 +152,23 @@ export default class RenderedTextInstance extends RenderedInstance {
           : this._textAlignment === 'center'
           ? 0.5
           : 0;
-      const alignmentY = 0;
 
       const width = this._instance.getCustomWidth();
-      const height = this._instance.getCustomHeight();
 
       // A vector from the custom size center to the renderer center.
       const centerToCenterX =
         (width - this._pixiObject.width) * (alignmentX - 0.5);
-      const centerToCenterY =
-        (height - this._pixiObject.height) * (alignmentY - 0.5);
 
       this._pixiObject.position.x = this._instance.getX() + width / 2;
-      this._pixiObject.position.y = this._instance.getY() + height / 2;
       this._pixiObject.anchor.x =
         0.5 - centerToCenterX / this._pixiObject.width;
-      this._pixiObject.anchor.y =
-        0.5 - centerToCenterY / this._pixiObject.height;
     } else {
       this._pixiObject.position.x =
         this._instance.getX() + this._pixiObject.width / 2;
-      this._pixiObject.position.y =
-        this._instance.getY() + this._pixiObject.height / 2;
       this._pixiObject.anchor.x = 0.5;
-      this._pixiObject.anchor.y = 0.5;
     }
+    this._pixiObject.position.y =
+      this._instance.getY() + this._pixiObject.height / 2;
     this._pixiObject.rotation = RenderedInstance.toRad(
       this._instance.getAngle()
     );

--- a/newIDE/app/src/UI/CustomSvgIcons/CenterTextAlignment.js
+++ b/newIDE/app/src/UI/CustomSvgIcons/CenterTextAlignment.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export default React.memo(props => (
+  <SvgIcon {...props} width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M5.5 6.66667C5.5 6.39052 5.72386 6.16667 6 6.16667H11.3333C11.6095 6.16667 11.8333 6.39052 11.8333 6.66667C11.8333 6.94281 11.6095 7.16667 11.3333 7.16667H6C5.72386 7.16667 5.5 6.94281 5.5 6.66667Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 4C3.5 3.72386 3.72386 3.5 4 3.5H13.3333C13.6095 3.5 13.8333 3.72386 13.8333 4C13.8333 4.27614 13.6095 4.5 13.3333 4.5H4C3.72386 4.5 3.5 4.27614 3.5 4Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 9.33333C3.5 9.05719 3.72386 8.83333 4 8.83333H13.3333C13.6095 8.83333 13.8333 9.05719 13.8333 9.33333C13.8333 9.60948 13.6095 9.83333 13.3333 9.83333H4C3.72386 9.83333 3.5 9.60948 3.5 9.33333Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M5.5 12C5.5 11.7239 5.72386 11.5 6 11.5H11.3333C11.6095 11.5 11.8333 11.7239 11.8333 12C11.8333 12.2761 11.6095 12.5 11.3333 12.5H6C5.72386 12.5 5.5 12.2761 5.5 12Z"
+      fill="currentColor"
+    />
+  </SvgIcon>
+));

--- a/newIDE/app/src/UI/CustomSvgIcons/LeftTextAlignment.js
+++ b/newIDE/app/src/UI/CustomSvgIcons/LeftTextAlignment.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export default React.memo(props => (
+  <SvgIcon {...props} width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 6.66667C3.5 6.39052 3.72386 6.16667 4 6.16667H11.3333C11.6095 6.16667 11.8333 6.39052 11.8333 6.66667C11.8333 6.94281 11.6095 7.16667 11.3333 7.16667H4C3.72386 7.16667 3.5 6.94281 3.5 6.66667Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 4C3.5 3.72386 3.72386 3.5 4 3.5H13.3333C13.6095 3.5 13.8333 3.72386 13.8333 4C13.8333 4.27614 13.6095 4.5 13.3333 4.5H4C3.72386 4.5 3.5 4.27614 3.5 4Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 9.33333C3.5 9.05719 3.72386 8.83333 4 8.83333H13.3333C13.6095 8.83333 13.8333 9.05719 13.8333 9.33333C13.8333 9.60948 13.6095 9.83333 13.3333 9.83333H4C3.72386 9.83333 3.5 9.60948 3.5 9.33333Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 12C3.5 11.7239 3.72386 11.5 4 11.5H11.3333C11.6095 11.5 11.8333 11.7239 11.8333 12C11.8333 12.2761 11.6095 12.5 11.3333 12.5H4C3.72386 12.5 3.5 12.2761 3.5 12Z"
+      fill="currentColor"
+    />
+  </SvgIcon>
+));

--- a/newIDE/app/src/UI/CustomSvgIcons/RightTextAlignment.js
+++ b/newIDE/app/src/UI/CustomSvgIcons/RightTextAlignment.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export default React.memo(props => (
+  <SvgIcon {...props} width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M5.5 6.66667C5.5 6.39052 5.72386 6.16667 6 6.16667H13.3333C13.6095 6.16667 13.8333 6.39052 13.8333 6.66667C13.8333 6.94281 13.6095 7.16667 13.3333 7.16667H6C5.72386 7.16667 5.5 6.94281 5.5 6.66667Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 4C3.5 3.72386 3.72386 3.5 4 3.5H13.3333C13.6095 3.5 13.8333 3.72386 13.8333 4C13.8333 4.27614 13.6095 4.5 13.3333 4.5H4C3.72386 4.5 3.5 4.27614 3.5 4Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M3.5 9.33333C3.5 9.05719 3.72386 8.83333 4 8.83333H13.3333C13.6095 8.83333 13.8333 9.05719 13.8333 9.33333C13.8333 9.60948 13.6095 9.83333 13.3333 9.83333H4C3.72386 9.83333 3.5 9.60948 3.5 9.33333Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M5.5 12C5.5 11.7239 5.72386 11.5 6 11.5H13.3333C13.6095 11.5 13.8333 11.7239 13.8333 12C13.8333 12.2761 13.6095 12.5 13.3333 12.5H6C5.72386 12.5 5.5 12.2761 5.5 12Z"
+      fill="currentColor"
+    />
+  </SvgIcon>
+));


### PR DESCRIPTION
The text aligns on the custom size box (for x axis only).

![image](https://user-images.githubusercontent.com/2611977/206533481-96d52e2c-86b6-42a4-8b51-61abff7ed219.png)

The center of rotation is
- the center of the custom width (wrapping width)
- still the center of the actual text height

I kept the vertical center as it was because at runtime the height is dynamically updated according to the text to display. There is no actual custom height.

https://user-images.githubusercontent.com/2611977/206686337-77fe2316-649b-4392-b689-15fb7763a0fb.mp4

This means that a text with lines smaller than the wrapping will no revolve around the rendered text. It allows a consistent behavior when the whole wrapping width is never used because words are not break.

https://user-images.githubusercontent.com/2611977/206686349-e8730b13-66a1-4bca-b7bb-acd2c7f2d5aa.mp4

https://user-images.githubusercontent.com/2611977/206686362-65771bf6-123b-4315-ad29-75dc461db4f6.mp4

When the wrapping is enabled, it's no longer possible to know the actual size of the rendered text. It was useful to fix the text alignment, but, as it's now correctly handled by the objet, it's no longer useful.

The object editor:

![image](https://user-images.githubusercontent.com/2611977/207038437-fc7032ca-4e87-4caa-8fe1-fe539b207fca.png)
