### PR TITLE
Use same design for open from dialog as for save to dialog

### DIFF
--- a/newIDE/app/src/ProjectsStorage/OpenFromStorageProviderDialog.js
+++ b/newIDE/app/src/ProjectsStorage/OpenFromStorageProviderDialog.js
@@ -10,6 +10,7 @@ import optionalRequire from '../Utils/OptionalRequire';
 import BackgroundText from '../UI/BackgroundText';
 import { Column, Line } from '../UI/Grid';
 import StorageProviderListItem from './StorageProviderListItem';
+import AlertMessage from '../UI/AlertMessage';
 const electron = optionalRequire('electron');
 
 type Props = {|
@@ -23,6 +24,9 @@ const OpenFromStorageProviderDialog = ({
   storageProviders,
   onChooseProvider,
 }: Props) => {
+  const isCloudStorageProviderEnabled = storageProviders.some(
+    provider => provider.internalName === 'Cloud'
+  );
   return (
     <I18n>
       {({ i18n }) => (
@@ -40,6 +44,14 @@ const OpenFromStorageProviderDialog = ({
           open
           maxWidth="sm"
         >
+          {isCloudStorageProviderEnabled && (
+            <AlertMessage kind="info">
+              <Trans>
+                You can find your cloud projects in the Build section of the
+                homepage.
+              </Trans>
+            </AlertMessage>
+          )}
           <List useGap>
             {storageProviders
               .filter(storageProvider => !storageProvider.hiddenInOpenDialog)

--- a/newIDE/app/src/ProjectsStorage/OpenFromStorageProviderDialog.js
+++ b/newIDE/app/src/ProjectsStorage/OpenFromStorageProviderDialog.js
@@ -5,10 +5,11 @@ import * as React from 'react';
 import Dialog from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
 import { type StorageProvider } from '.';
-import { List, ListItem } from '../UI/List';
+import { List } from '../UI/List';
 import optionalRequire from '../Utils/OptionalRequire';
 import BackgroundText from '../UI/BackgroundText';
 import { Column, Line } from '../UI/Grid';
+import StorageProviderListItem from './StorageProviderListItem';
 const electron = optionalRequire('electron');
 
 type Props = {|
@@ -39,20 +40,14 @@ const OpenFromStorageProviderDialog = ({
           open
           maxWidth="sm"
         >
-          <List>
+          <List useGap>
             {storageProviders
               .filter(storageProvider => !storageProvider.hiddenInOpenDialog)
               .map(storageProvider => (
-                <ListItem
+                <StorageProviderListItem
                   key={storageProvider.internalName}
-                  disabled={!!storageProvider.disabled}
-                  primaryText={i18n._(storageProvider.name)}
-                  leftIcon={
-                    storageProvider.renderIcon
-                      ? storageProvider.renderIcon({})
-                      : undefined
-                  }
-                  onClick={() => onChooseProvider(storageProvider)}
+                  onChooseProvider={onChooseProvider}
+                  storageProvider={storageProvider}
                 />
               ))}
           </List>

--- a/newIDE/app/src/ProjectsStorage/StorageProviderListItem.js
+++ b/newIDE/app/src/ProjectsStorage/StorageProviderListItem.js
@@ -25,7 +25,7 @@ const useListItemStyles = makeStyles(theme => {
   return {
     root: {
       border: `1px solid ${theme.palette.divider}`,
-      borderRadius: '5px',
+      borderRadius: 8,
     },
   };
 });


### PR DESCRIPTION
- Use the same design for opening as for saving
- Display message in opening dialog regarding cloud projects
  - Web
  
  <img width="607" alt="image" src="https://user-images.githubusercontent.com/32449369/207000497-6f799a45-1192-4f1a-8f27-66966bf16882.png">

  - Desktop
  
  <img width="607" alt="image" src="https://user-images.githubusercontent.com/32449369/207000400-8bda7dd8-c4fa-45f8-9d90-d9806634a31a.png">
