### PR TITLE
Objects List - Filter objects by type

### DIFF
--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -240,6 +240,9 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 selectedObjectTags={[]}
                 onChangeSelectedObjectTags={selectedObjectTags => {}}
                 getAllObjectTags={() => []}
+                selectedObjectTypes={[]}
+                onChangeSelectedObjectTypes={selectedObjectTypes => {}}
+                getAllObjectTypes={() => []}
                 ref={
                   // $FlowFixMe Make this component functional.
                   objectsList => (this._objectsList = objectsList)

--- a/newIDE/app/src/ObjectsList/EnumerateObjects.js
+++ b/newIDE/app/src/ObjectsList/EnumerateObjects.js
@@ -128,6 +128,13 @@ export type ObjectFilteringOptions = {|
   hideExactMatches?: boolean,
 |};
 
+export type ObjectFilteringOptionsEnhaced = {|
+  searchText: string,
+  selectedTags: SelectedTags,
+  hideExactMatches?: boolean,
+  selectedObjectTypes: SelectedObjectTypes,
+|};
+
 export const filterObjectByTags = (
   objectWithContext: ObjectWithContext,
   selectedTags: SelectedTags
@@ -147,8 +154,15 @@ export const filterObjectByTypes = (
 ): boolean => {
   if (!selectedObjectTypes.length) return true;
 
-  const typeOfObject = gd.getTypeOfObject(project, objectsContainer, objectWithContext.object.getName(), false);
-  const objectMetadata = allObjectMetadata.filter(e => e.name === typeOfObject)[0];
+  const typeOfObject = gd.getTypeOfObject(
+    project,
+    objectsContainer,
+    objectWithContext.object.getName(),
+    false
+  );
+  const objectMetadata = allObjectMetadata.filter(
+    e => e.name === typeOfObject
+  )[0];
   return selectedObjectTypes.includes(objectMetadata.fullName);
 };
 
@@ -172,12 +186,19 @@ export const filterObjectsList = (
 };
 
 export const filterObjectsListEnhaced = (
-  project: gdObjectsContainer,
+  project: gdProject,
+  globalObjectsContainer: gdObjectsContainer,
   objectsContainer: gdObjectsContainer,
   list: ObjectWithContextList,
-  { searchText, selectedTags, selectedObjectTypes, hideExactMatches }: ObjectFilteringOptions
+  {
+    searchText,
+    selectedTags,
+    selectedObjectTypes,
+    hideExactMatches,
+  }: ObjectFilteringOptionsEnhaced
 ): ObjectWithContextList => {
-  if (!searchText && !selectedTags.length && !selectedObjectTypes.length) return list;
+  if (!searchText && !selectedTags.length && !selectedObjectTypes.length)
+    return list;
 
   const allObjectMetadata = enumerateObjectTypes(project);
 
@@ -186,10 +207,13 @@ export const filterObjectsListEnhaced = (
       filterObjectByTags(objectWithContext, selectedTags)
     )
     .filter(objectWithContext =>
-      filterObjectByTypes(objectWithContext, selectedObjectTypes, 
-        project,
+      filterObjectByTypes(
+        objectWithContext,
+        selectedObjectTypes,
+        globalObjectsContainer,
         objectsContainer,
-        allObjectMetadata)
+        allObjectMetadata
+      )
     )
     .filter((objectWithContext: ObjectWithContext) => {
       const objectName = objectWithContext.object.getName();

--- a/newIDE/app/src/ObjectsList/EnumerateObjects.js
+++ b/newIDE/app/src/ObjectsList/EnumerateObjects.js
@@ -2,6 +2,8 @@
 import { mapFor } from '../Utils/MapFor';
 import flatten from 'lodash/flatten';
 import { type SelectedTags, hasStringAllTags } from '../Utils/TagsHelper';
+import { type SelectedObjectTypes, hasStringAllObjectTypes } from '../Utils/ObjectTypesHelper';
+
 const gd: libGDevelop = global.gd;
 
 export type EnumeratedObjectMetadata = {|
@@ -136,6 +138,18 @@ export const filterObjectByTags = (
   return hasStringAllTags(objectTags, selectedTags);
 };
 
+export const filterObjectByTypes = (
+  objectWithContext: ObjectWithContext,
+  selectedObjectTypes: SelectedObjectTypes,
+  project: gdObjectsContainer,
+  objectsContainer: gdObjectsContainer,
+): boolean => {
+  if (!selectedObjectTypes.length) return true;
+
+  const objectType = gd.getTypeOfObject(project, objectsContainer, objectWithContext.object.getName(), false);
+  return hasStringAllObjectTypes(objectType, selectedObjectTypes);
+};
+
 export const filterObjectsList = (
   list: ObjectWithContextList,
   { searchText, selectedTags, hideExactMatches }: ObjectFilteringOptions
@@ -145,6 +159,32 @@ export const filterObjectsList = (
   return list
     .filter(objectWithContext =>
       filterObjectByTags(objectWithContext, selectedTags)
+    )
+    .filter((objectWithContext: ObjectWithContext) => {
+      const objectName = objectWithContext.object.getName();
+
+      if (hideExactMatches && searchText === objectName) return undefined;
+
+      return objectName.toLowerCase().indexOf(searchText.toLowerCase()) !== -1;
+    });
+};
+
+export const filterObjectsListEnhaced = (
+  project: gdObjectsContainer,
+  objectsContainer: gdObjectsContainer,
+  list: ObjectWithContextList,
+  { searchText, selectedTags, selectedObjectTypes, hideExactMatches }: ObjectFilteringOptions
+): ObjectWithContextList => {
+  if (!searchText && !selectedTags.length && !selectedObjectTypes.length) return list;
+
+  return list
+    .filter(objectWithContext =>
+      filterObjectByTags(objectWithContext, selectedTags)
+    )
+    .filter(objectWithContext =>
+      filterObjectByTypes(objectWithContext, selectedObjectTypes, 
+        project,
+        objectsContainer)
     )
     .filter((objectWithContext: ObjectWithContext) => {
       const objectName = objectWithContext.object.getName();

--- a/newIDE/app/src/ObjectsList/EnumerateObjects.js
+++ b/newIDE/app/src/ObjectsList/EnumerateObjects.js
@@ -2,7 +2,7 @@
 import { mapFor } from '../Utils/MapFor';
 import flatten from 'lodash/flatten';
 import { type SelectedTags, hasStringAllTags } from '../Utils/TagsHelper';
-import { type SelectedObjectTypes, hasStringAllObjectTypes } from '../Utils/ObjectTypesHelper';
+import { type SelectedObjectTypes } from '../Utils/ObjectTypesHelper';
 
 const gd: libGDevelop = global.gd;
 
@@ -143,11 +143,13 @@ export const filterObjectByTypes = (
   selectedObjectTypes: SelectedObjectTypes,
   project: gdObjectsContainer,
   objectsContainer: gdObjectsContainer,
+  allObjectMetadata: Array<EnumeratedObjectMetadata>
 ): boolean => {
   if (!selectedObjectTypes.length) return true;
 
-  const objectType = gd.getTypeOfObject(project, objectsContainer, objectWithContext.object.getName(), false);
-  return hasStringAllObjectTypes(objectType, selectedObjectTypes);
+  const typeOfObject = gd.getTypeOfObject(project, objectsContainer, objectWithContext.object.getName(), false);
+  const objectMetadata = allObjectMetadata.filter(e => e.name === typeOfObject)[0];
+  return selectedObjectTypes.includes(objectMetadata.fullName);
 };
 
 export const filterObjectsList = (
@@ -177,6 +179,8 @@ export const filterObjectsListEnhaced = (
 ): ObjectWithContextList => {
   if (!searchText && !selectedTags.length && !selectedObjectTypes.length) return list;
 
+  const allObjectMetadata = enumerateObjectTypes(project);
+
   return list
     .filter(objectWithContext =>
       filterObjectByTags(objectWithContext, selectedTags)
@@ -184,7 +188,8 @@ export const filterObjectsListEnhaced = (
     .filter(objectWithContext =>
       filterObjectByTypes(objectWithContext, selectedObjectTypes, 
         project,
-        objectsContainer)
+        objectsContainer,
+        allObjectMetadata)
     )
     .filter((objectWithContext: ObjectWithContext) => {
       const objectName = objectWithContext.object.getName();

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -20,7 +20,7 @@ import {
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import {
   enumerateObjects,
-  filterObjectsList,
+  filterObjectsListEnhaced,
   isSameObjectWithContext,
 } from './EnumerateObjects';
 import { type ObjectEditorTab } from '../ObjectEditor/ObjectEditorDialog';
@@ -35,6 +35,13 @@ import {
   buildTagsMenuTemplate,
   getTagsFromString,
 } from '../Utils/TagsHelper';
+import {
+  type ObjectTypes,
+  type SelectedObjectTypes,
+  getStringFromObjectTypes,
+  buildObjectTypesMenuTemplate,
+  getObjectTypesFromString,
+} from '../Utils/ObjectTypesHelper';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewButton';
 import { useScreenType } from '../UI/Reponsive/ScreenTypeMeasurer';
@@ -118,6 +125,10 @@ type Props = {|
   getAllObjectTags: () => Tags,
   onChangeSelectedObjectTags: SelectedTags => void,
 
+  selectedObjectTypes: SelectedObjectTypes,
+  getAllObjectTypes: () => ObjectTypes,
+  onChangeSelectedObjectTypes: SelectedObjectTypes => void,
+
   onEditObject: (object: gdObject, initialTab: ?ObjectEditorTab) => void,
   onExportObject: (object: gdObject) => void,
   onObjectCreated: gdObject => void,
@@ -150,6 +161,10 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
       selectedObjectTags,
       getAllObjectTags,
       onChangeSelectedObjectTags,
+
+      selectedObjectTypes,
+      getAllObjectTypes,
+      onChangeSelectedObjectTypes,
 
       onEditObject,
       onExportObject,
@@ -418,11 +433,14 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
     );
 
     const lists = enumerateObjects(project, objectsContainer);
-    const displayedObjectWithContextsList = filterObjectsList(
+    const displayedObjectWithContextsList = filterObjectsListEnhaced(
+      project,
+      objectsContainer,
       lists.allObjectsList,
       {
         searchText,
         selectedTags: selectedObjectTags,
+        selectedObjectTypes,
       }
     );
     const selectedObjects = displayedObjectWithContextsList.filter(

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -434,6 +434,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
     const lists = enumerateObjects(project, objectsContainer);
     const displayedObjectWithContextsList = filterObjectsListEnhaced(
       project,
+      project,
       objectsContainer,
       lists.allObjectsList,
       {

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -27,6 +27,7 @@ import { type ObjectEditorTab } from '../ObjectEditor/ObjectEditorDialog';
 import type { ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import { CLIPBOARD_KIND } from './ClipboardKind';
 import TagChips from '../UI/TagChips';
+import ObjectTypeChips from '../UI/ObjectTypeChips';
 import EditTagsDialog from '../UI/EditTagsDialog';
 import {
   type Tags,
@@ -38,9 +39,7 @@ import {
 import {
   type ObjectTypes,
   type SelectedObjectTypes,
-  getStringFromObjectTypes,
   buildObjectTypesMenuTemplate,
-  getObjectTypesFromString,
 } from '../Utils/ObjectTypesHelper';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewButton';
@@ -773,6 +772,10 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         <TagChips
           tags={selectedObjectTags}
           onChange={onChangeSelectedObjectTags}
+        />
+        <ObjectTypeChips
+          objectTypes={selectedObjectTypes}
+          onChange={onChangeSelectedObjectTypes}
         />
         <div style={styles.listContainer} id="objects-list">
           <AutoSizer>

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1306,8 +1306,15 @@ export default class SceneEditor extends React.Component<Props, State> {
 
     const typesSet: Set<string> = new Set();
     enumerateObjects(project, layout).allObjectsList.forEach(({ object }) => {
-      const typeOfObject = gd.getTypeOfObject(project, layout, object.getName(), false);
-      const objectMetadata = allObjectMetadata.filter(e => e.name === typeOfObject)[0];
+      const typeOfObject = gd.getTypeOfObject(
+        project,
+        layout,
+        object.getName(),
+        false
+      );
+      const objectMetadata = allObjectMetadata.filter(
+        e => e.name === typeOfObject
+      )[0];
       typesSet.add(objectMetadata.fullName);
     });
 
@@ -1512,7 +1519,6 @@ export default class SceneEditor extends React.Component<Props, State> {
                   })
                 }
                 getAllObjectTags={this._getAllObjectTags}
-
                 selectedObjectTypes={this.state.selectedObjectTypes}
                 onChangeSelectedObjectTypes={selectedObjectTypes =>
                   this.setState({
@@ -1520,7 +1526,6 @@ export default class SceneEditor extends React.Component<Props, State> {
                   })
                 }
                 getAllObjectTypes={this._getAllObjectTypes}
-
                 ref={
                   // $FlowFixMe Make this component functional.
                   objectsList => (this._objectsList = objectsList)

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -54,6 +54,7 @@ import {
   type ObjectWithContext,
   type GroupWithContext,
   enumerateObjects,
+  enumerateObjectTypes,
 } from '../ObjectsList/EnumerateObjects';
 import CloseButton from '../UI/EditorMosaic/CloseButton';
 import ObjectTypesButton from '../UI/EditorMosaic/ObjectTypesButton';
@@ -66,7 +67,6 @@ import {
 import {
   type SelectedObjectTypes,
   buildObjectTypesMenuTemplate,
-  getObjectTypesFromString,
 } from '../Utils/ObjectTypesHelper';
 import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
@@ -78,6 +78,7 @@ import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewB
 import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
 import { MOVEMENT_BIG_DELTA } from '../UI/KeyboardShortcuts';
 import { getInstancesInLayoutForObject } from '../Utils/Layout';
+import { translateExtensionCategory } from '../Utils/Extension/ExtensionCategories';
 
 const gd: libGDevelop = global.gd;
 
@@ -1301,9 +1302,13 @@ export default class SceneEditor extends React.Component<Props, State> {
   _getAllObjectTypes = (): Array<string> => {
     const { project, layout } = this.props;
 
+    const allObjectMetadata = enumerateObjectTypes(project);
+
     const typesSet: Set<string> = new Set();
     enumerateObjects(project, layout).allObjectsList.forEach(({ object }) => {
-      typesSet.add(gd.getTypeOfObject(project, layout, object.getName(), false));
+      const typeOfObject = gd.getTypeOfObject(project, layout, object.getName(), false);
+      const objectMetadata = allObjectMetadata.filter(e => e.name === typeOfObject)[0];
+      typesSet.add(objectMetadata.fullName);
     });
 
     return Array.from(typesSet);
@@ -1457,6 +1462,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 buildMenuTemplate={(i18n: I18nType) =>
                   this._buildObjectTagsMenuTemplate(i18n)
                 }
+                tooltip={t`Filter by tag`}
               />
             )}
           </I18n>,
@@ -1466,6 +1472,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 buildMenuTemplate={(i18n: I18nType) =>
                   this._buildObjectTypesMenuTemplate(i18n)
                 }
+                tooltip={t`Filter by type`}
               />
             )}
           </I18n>,

--- a/newIDE/app/src/UI/EditorMosaic/ObjectTypesButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/ObjectTypesButton.js
@@ -20,13 +20,14 @@ const styles = {
 
 type Props = {|
   buildMenuTemplate: (i18n: I18nType) => Array<MenuItemTemplate>,
+  tooltip?: MessageDescriptor,
 |};
 
 export default function ObjectTypesButton(props: Props) {
   return (
     <ElementWithMenu
       element={
-        <IconButton style={styles.container}>
+        <IconButton style={styles.container} tooltip={props.tooltip}>
           <FilterList htmlColor="inherit" style={styles.icon} />
         </IconButton>
       }

--- a/newIDE/app/src/UI/EditorMosaic/ObjectTypesButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/ObjectTypesButton.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from 'react';
+import { type I18n as I18nType } from '@lingui/core';
+import IconButton from '../IconButton';
+import FilterList from '@material-ui/icons/FilterList';
+import ElementWithMenu from '../Menu/ElementWithMenu';
+import { type MenuItemTemplate } from '../Menu/Menu.flow';
+
+const styles = {
+  container: {
+    padding: 0,
+    width: 32,
+    height: 32,
+  },
+  icon: {
+    width: 16,
+    height: 16,
+  },
+};
+
+type Props = {|
+  buildMenuTemplate: (i18n: I18nType) => Array<MenuItemTemplate>,
+|};
+
+export default function ObjectTypesButton(props: Props) {
+  return (
+    <ElementWithMenu
+      element={
+        <IconButton style={styles.container}>
+          <FilterList htmlColor="inherit" style={styles.icon} />
+        </IconButton>
+      }
+      buildMenuTemplate={props.buildMenuTemplate}
+    />
+  );
+}

--- a/newIDE/app/src/UI/EditorMosaic/ObjectTypesButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/ObjectTypesButton.js
@@ -5,6 +5,7 @@ import IconButton from '../IconButton';
 import FilterList from '@material-ui/icons/FilterList';
 import ElementWithMenu from '../Menu/ElementWithMenu';
 import { type MenuItemTemplate } from '../Menu/Menu.flow';
+import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 
 const styles = {
   container: {

--- a/newIDE/app/src/UI/EditorMosaic/TagsButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/TagsButton.js
@@ -5,6 +5,7 @@ import IconButton from '../IconButton';
 import FilterList from '@material-ui/icons/FilterList';
 import ElementWithMenu from '../Menu/ElementWithMenu';
 import { type MenuItemTemplate } from '../Menu/Menu.flow';
+import { type MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 
 const styles = {
   container: {

--- a/newIDE/app/src/UI/EditorMosaic/TagsButton.js
+++ b/newIDE/app/src/UI/EditorMosaic/TagsButton.js
@@ -20,13 +20,14 @@ const styles = {
 
 type Props = {|
   buildMenuTemplate: (i18n: I18nType) => Array<MenuItemTemplate>,
+  tooltip?: MessageDescriptor,
 |};
 
 export default function TagsButton(props: Props) {
   return (
     <ElementWithMenu
       element={
-        <IconButton style={styles.container}>
+        <IconButton style={styles.container} tooltip={props.tooltip}>
           <FilterList htmlColor="inherit" style={styles.icon} />
         </IconButton>
       }

--- a/newIDE/app/src/UI/ObjectTypeChips.js
+++ b/newIDE/app/src/UI/ObjectTypeChips.js
@@ -23,7 +23,9 @@ type Props = {|
 |};
 
 const ObjectTypeChips = ({ objectTypes, onChange, onRemove }: Props) => {
-  const [focusedObjectType, setFocusedObjectType] = React.useState<?string>(null);
+  const [focusedObjectType, setFocusedObjectType] = React.useState<?string>(
+    null
+  );
   const objectTypesRefs = React.useRef([]);
 
   const getChipStyle = React.useCallback(
@@ -68,7 +70,9 @@ const ObjectTypeChips = ({ objectTypes, onChange, onRemove }: Props) => {
             style={getChipStyle(objectType)}
             onBlur={() => setFocusedObjectType(null)}
             onFocus={() => setFocusedObjectType(objectType)}
-            onDelete={onChange || onRemove ? handleDeleteObjectType(objectType) : null}
+            onDelete={
+              onChange || onRemove ? handleDeleteObjectType(objectType) : null
+            }
             label={objectType}
             ref={newRef}
           />

--- a/newIDE/app/src/UI/ObjectTypeChips.js
+++ b/newIDE/app/src/UI/ObjectTypeChips.js
@@ -1,0 +1,81 @@
+// @flow
+import React from 'react';
+import Chip from '../UI/Chip';
+import { type ObjectTypes, removeObjectType } from '../Utils/ObjectTypesHelper';
+
+const styles = {
+  chipContainer: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    overflowX: 'auto',
+    marginTop: 4,
+  },
+  chip: {
+    marginRight: 4,
+    marginBottom: 4,
+  },
+};
+
+type Props = {|
+  objectTypes: ObjectTypes,
+  onChange?: ObjectTypes => void,
+  onRemove?: string => void,
+|};
+
+const ObjectTypeChips = ({ objectTypes, onChange, onRemove }: Props) => {
+  const [focusedObjectType, setFocusedObjectType] = React.useState<?string>(null);
+  const objectTypesRefs = React.useRef([]);
+
+  const getChipStyle = React.useCallback(
+    (objectType: string) => {
+      const isFocused = !!focusedObjectType && focusedObjectType === objectType;
+      return {
+        ...styles.chip,
+        filter: isFocused ? 'brightness(1.2)' : undefined,
+      };
+    },
+    [focusedObjectType]
+  );
+
+  const handleDeleteObjectType = (objectType: string) => event => {
+    const deletedObjectTypeIndex = objectTypes.indexOf(objectType);
+    objectTypesRefs.current.splice(deletedObjectTypeIndex, 1);
+    if (event.nativeEvent instanceof KeyboardEvent) {
+      const newIndexToFocus = Math.min(
+        objectTypesRefs.current.length - 1,
+        deletedObjectTypeIndex
+      );
+      const newObjectTypeToFocus = objectTypesRefs.current[newIndexToFocus];
+      if (newObjectTypeToFocus && newObjectTypeToFocus.current) {
+        newObjectTypeToFocus.current.focus();
+      }
+    }
+    if (onChange) onChange(removeObjectType(objectTypes, objectType));
+    else if (onRemove) onRemove(objectType);
+  };
+
+  if (!objectTypes.length) return null;
+
+  return (
+    <div style={styles.chipContainer}>
+      {objectTypes.map((objectType, index) => {
+        const newRef = React.createRef();
+        objectTypesRefs.current[index] = newRef;
+        return (
+          <Chip
+            key={objectType}
+            size="small"
+            style={getChipStyle(objectType)}
+            onBlur={() => setFocusedObjectType(null)}
+            onFocus={() => setFocusedObjectType(objectType)}
+            onDelete={onChange || onRemove ? handleDeleteObjectType(objectType) : null}
+            label={objectType}
+            ref={newRef}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ObjectTypeChips;

--- a/newIDE/app/src/Utils/ObjectTypesHelper.js
+++ b/newIDE/app/src/Utils/ObjectTypesHelper.js
@@ -5,11 +5,19 @@
 export type ObjectTypes = Array<string>;
 export type SelectedObjectTypes = ObjectTypes;
 
-export const removeObjectType = (objectTypes: ObjectTypes, objectType: string): ObjectTypes => {
-  return objectTypes.filter(selectedObjectType => selectedObjectType !== objectType);
+export const removeObjectType = (
+  objectTypes: ObjectTypes,
+  objectType: string
+): ObjectTypes => {
+  return objectTypes.filter(
+    selectedObjectType => selectedObjectType !== objectType
+  );
 };
 
-export const addObjectTypes = (objectTypes: ObjectTypes, newObjectTypes: ObjectTypes): ObjectTypes => {
+export const addObjectTypes = (
+  objectTypes: ObjectTypes,
+  newObjectTypes: ObjectTypes
+): ObjectTypes => {
   return Array.from(new Set([...objectTypes, ...newObjectTypes]));
 };
 

--- a/newIDE/app/src/Utils/ObjectTypesHelper.js
+++ b/newIDE/app/src/Utils/ObjectTypesHelper.js
@@ -1,0 +1,85 @@
+// @flow
+
+// Helpers to manipulate objectTypes. See also EditObjectTypesDialog.js
+
+export type ObjectTypes = Array<string>;
+export type SelectedObjectTypes = ObjectTypes;
+
+export const removeObjectType = (objectTypes: ObjectTypes, objectType: string): ObjectTypes => {
+  return objectTypes.filter(selectedObjectType => selectedObjectType !== objectType);
+};
+
+export const addObjectTypes = (objectTypes: ObjectTypes, newObjectTypes: ObjectTypes): ObjectTypes => {
+  return Array.from(new Set([...objectTypes, ...newObjectTypes]));
+};
+
+export type BuildObjectTypesMenuTemplateOptions = {|
+  noObjectTypeLabel: string,
+  getAllObjectTypes: () => Array<string>,
+  selectedObjectTypes: SelectedObjectTypes,
+  onChange: SelectedObjectTypes => void,
+  onEditObjectTypes?: () => void,
+  editObjectTypesLabel?: string,
+|};
+
+export const buildObjectTypesMenuTemplate = ({
+  noObjectTypeLabel,
+  getAllObjectTypes,
+  selectedObjectTypes,
+  onChange,
+  onEditObjectTypes,
+  editObjectTypesLabel,
+}: BuildObjectTypesMenuTemplateOptions): Array<any> => {
+  const allObjectTypes = getAllObjectTypes();
+  const footerMenuItems =
+    onEditObjectTypes && editObjectTypesLabel
+      ? [
+          {
+            type: 'separator',
+          },
+          {
+            label: editObjectTypesLabel,
+            click: onEditObjectTypes,
+          },
+        ]
+      : [];
+
+  if (!allObjectTypes.length) {
+    return [
+      {
+        label: noObjectTypeLabel,
+        enabled: false,
+      },
+      ...footerMenuItems,
+    ];
+  }
+
+  return allObjectTypes
+    .map(objectType => ({
+      type: 'checkbox',
+      label: objectType,
+      checked: selectedObjectTypes.includes(objectType),
+      click: () => {
+        if (selectedObjectTypes.includes(objectType)) {
+          onChange(removeObjectType(selectedObjectTypes, objectType));
+        } else {
+          onChange(addObjectTypes(selectedObjectTypes, [objectType]));
+        }
+      },
+    }))
+    .concat(footerMenuItems);
+};
+
+export const getObjectTypesFromString = (objectTypesString: string): ObjectTypes => {
+  if (objectTypesString.trim() === '') return [];
+
+  return objectTypesString.split(',').map(objectType => objectType.trim());
+};
+
+export const getStringFromObjectTypes = (objectTypes: ObjectTypes): string => {
+  return objectTypes.join(', ');
+};
+
+export const hasStringAllObjectTypes = (objectTypeStr: string, objectTypes: ObjectTypes) => {
+  return objectTypes.includes(objectTypeStr);
+};

--- a/newIDE/app/src/Utils/ObjectTypesHelper.js
+++ b/newIDE/app/src/Utils/ObjectTypesHelper.js
@@ -69,17 +69,3 @@ export const buildObjectTypesMenuTemplate = ({
     }))
     .concat(footerMenuItems);
 };
-
-export const getObjectTypesFromString = (objectTypesString: string): ObjectTypes => {
-  if (objectTypesString.trim() === '') return [];
-
-  return objectTypesString.split(',').map(objectType => objectType.trim());
-};
-
-export const getStringFromObjectTypes = (objectTypes: ObjectTypes): string => {
-  return objectTypes.join(', ');
-};
-
-export const hasStringAllObjectTypes = (objectTypeStr: string, objectTypes: ObjectTypes) => {
-  return objectTypes.includes(objectTypeStr);
-};

--- a/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
+++ b/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
@@ -279,6 +279,9 @@ export const WithObjectsList = () => (
                   selectedObjectTags={[]}
                   onChangeSelectedObjectTags={() => {}}
                   getAllObjectTags={() => []}
+                  selectedObjectTypes={[]}
+                  onChangeSelectedObjectTypes={() => {}}
+                  getAllObjectTypes={() => []}
                   canRenameObject={() => true}
                   onDeleteObject={(objectWithContext, cb) => cb(true)}
                   onRenameObject={(objectWithContext, newName, cb) => cb(true)}

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
@@ -45,6 +45,9 @@ export const Default = () => (
           selectedObjectTags={[]}
           onChangeSelectedObjectTags={selectedObjectTags => {}}
           getAllObjectTags={() => []}
+          selectedObjectTypes={[]}
+          onChangeSelectedObjectTypes={selectedObjectTypes => {}}
+          getAllObjectTypes={() => []}
           canRenameObject={() => true}
           onDeleteObject={(objectWithContext, cb) => cb(true)}
           onRenameObject={(objectWithContext, newName, cb) => cb(true)}
@@ -86,6 +89,9 @@ export const WithTags = () => (
             'Looooooooooong Tag 3',
             'Unselected Tag 4',
           ]}
+          selectedObjectTypes={[]}
+          onChangeSelectedObjectTypes={selectedObjectTypes => {}}
+          getAllObjectTypes={() => []}
           canRenameObject={() => true}
           onDeleteObject={(objectWithContext, cb) => cb(true)}
           onRenameObject={(objectWithContext, newName, cb) => cb(true)}


### PR DESCRIPTION
I added a new filter by type icon in the Objects List. Example video:

https://user-images.githubusercontent.com/21989259/206910083-812c71f4-cc86-4c0b-b879-37997bc89f24.mp4

#### Briefing

- New icon "Filter by type" next to the "Filter by tag" option
  - I began copying the same files and code from the Tags functionality.
- Added tooltips in both icons.
- Both filters work together.
- Types Chips working when selecting a filter.

#### Details

- I got some problems when recovering the "type" of the object, but I think now is right. If you see anything wrong ask me.
- I had to use "gdProject" and "gdObjectsContainer" in some cases, so I didn't want to use it in `EnumerateObjects.filterObjectsList`, because this function is used in more places. Then, I created a new `filterObjectsListEnhaced` that is only used in the Objects List.