### PR TITLE
Fix extension function missing code files when exporting a project

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
@@ -158,17 +158,13 @@ const getExtensionIncludeFiles = (
   return mapFor(0, eventsFunctionsExtension.getEventsFunctionsCount(), i => {
     const eventsFunction = eventsFunctionsExtension.getEventsFunctionAt(i);
 
-    if (isExtensionLifecycleEventsFunction(eventsFunction.getName())) {
-      const codeNamespace = getFreeFunctionCodeNamespace(
-        eventsFunction,
-        codeNamespacePrefix
-      );
-      const functionName = codeNamespace + '.func'; // TODO
+    const codeNamespace = getFreeFunctionCodeNamespace(
+      eventsFunction,
+      codeNamespacePrefix
+    );
+    const functionName = codeNamespace + '.func'; // TODO
 
-      return options.eventsFunctionCodeWriter.getIncludeFileFor(functionName);
-    }
-
-    return null;
+    return options.eventsFunctionCodeWriter.getIncludeFileFor(functionName);
   }).filter(Boolean);
 };
 


### PR DESCRIPTION
It always includes every function of an extension when the extension is used.