### PR TITLE
Includes the free functions of every extension that is actually used

### DIFF
--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -54,8 +54,8 @@ bool Exporter::ExportWholePixiProject(
 
   auto usedExtensions = gd::UsedExtensionsFinder::ScanProject(project);
 
-  auto exportProject = [this, &exportedProject, &exportOptions, &helper](
-                           gd::String exportDir) {
+  auto exportProject = [this, &exportedProject, &exportOptions, &helper,
+                        &usedExtensions](gd::String exportDir) {
     bool exportForCordova = exportOptions["exportForCordova"];
     bool exportForFacebookInstantGames =
         exportOptions["exportForFacebookInstantGames"];
@@ -89,6 +89,7 @@ bool Exporter::ExportWholePixiProject(
         includesFiles);
 
     // Export files for object and behaviors
+    helper.ExportFreeFunctionIncludes(exportedProject, includesFiles, usedExtensions);
     helper.ExportObjectAndBehaviorsIncludes(exportedProject, includesFiles);
     helper.ExportObjectAndBehaviorsRequiredFiles(exportedProject, resourcesFiles);
 

--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -88,7 +88,7 @@ bool Exporter::ExportWholePixiProject(
         exportedProject.GetLoadingScreen().GetGDevelopLogoStyle(),
         includesFiles);
 
-    // Export files for object and behaviors
+    // Export files for free function, object and behaviors
     helper.ExportFreeFunctionIncludes(exportedProject, includesFiles, usedExtensions);
     helper.ExportObjectAndBehaviorsIncludes(exportedProject, includesFiles);
     helper.ExportObjectAndBehaviorsRequiredFiles(exportedProject, resourcesFiles);

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -117,7 +117,8 @@ bool ExporterHelper::ExportProjectForPixiPreview(
                  includesFiles);
 
   // Export files for free function, object and behaviors
-  ExportFreeFunctionIncludes(exportedProject, includesFiles);
+  auto usedExtensions = gd::UsedExtensionsFinder::ScanProject(exportedProject);
+  ExportFreeFunctionIncludes(exportedProject, includesFiles, usedExtensions);
   ExportObjectAndBehaviorsIncludes(immutableProject, includesFiles);
   ExportObjectAndBehaviorsRequiredFiles(immutableProject, resourcesFiles);
 
@@ -800,21 +801,21 @@ bool ExporterHelper::ExportIncludesAndLibs(
 }
 
 void ExporterHelper::ExportFreeFunctionIncludes(
-    gd::Project &project, std::vector<gd::String> &includesFiles) {
+    gd::Project &project, std::vector<gd::String> &includesFiles,
+    std::set<gd::String> &usedExtensions) {
   auto addIncludeFiles = [&](const std::vector<gd::String> &newIncludeFiles) {
     for (const auto &includeFile : newIncludeFiles) {
       InsertUnique(includesFiles, includeFile);
     }
   };
 
-  auto usedExtensions = gd::UsedExtensionsFinder::ScanProject(project);
   for (auto &&usedExtension : usedExtensions) {
     if (project.HasEventsFunctionsExtensionNamed(usedExtension)) {
       auto &extension = project.GetEventsFunctionsExtension(usedExtension);
 
-      for (size_t functionIdex = 0;
-           functionIdex < extension.GetEventsFunctionsCount(); functionIdex++) {
-        auto &function = extension.GetEventsFunction(functionIdex);
+      for (size_t functionIndex = 0;
+           functionIndex < extension.GetEventsFunctionsCount(); functionIndex++) {
+        auto &function = extension.GetEventsFunction(functionIndex);
 
         gd::String fullType = gd::PlatformExtension::GetEventsFunctionFullType(
             usedExtension, function.GetName());

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -251,7 +251,8 @@ class ExporterHelper {
    * \brief Add the include files for all free functions from used extensions.
    */
   void ExportFreeFunctionIncludes(gd::Project &project,
-                                        std::vector<gd::String> &includesFiles);
+                                  std::vector<gd::String> &includesFiles,
+                                  std::set<gd::String> &usedExtensions);
   /**
    * \brief Add the include files for all the objects of the project
    * and their behaviors.

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -248,6 +248,11 @@ class ExporterHelper {
                             std::vector<gd::String> &includesFiles);
 
   /**
+   * \brief Add the include files for all free functions from used extensions.
+   */
+  void ExportFreeFunctionIncludes(gd::Project &project,
+                                        std::vector<gd::String> &includesFiles);
+  /**
    * \brief Add the include files for all the objects of the project
    * and their behaviors.
    */

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
@@ -43,7 +43,6 @@ type Options = {|
 
 type CodeGenerationContext = {|
   codeNamespacePrefix: string,
-  extensionIncludeFiles: Array<string>,
 |};
 
 const mangleName = (name: string) => {
@@ -146,29 +145,6 @@ const loadProjectEventsFunctionsExtension = (
 };
 
 /**
- * Get the list of mandatory include files when using the
- * extension.
- */
-const getExtensionIncludeFiles = (
-  project: gdProject,
-  eventsFunctionsExtension: gdEventsFunctionsExtension,
-  options: Options,
-  codeNamespacePrefix: string
-): Array<string> => {
-  return mapFor(0, eventsFunctionsExtension.getEventsFunctionsCount(), i => {
-    const eventsFunction = eventsFunctionsExtension.getEventsFunctionAt(i);
-
-    const codeNamespace = getFreeFunctionCodeNamespace(
-      eventsFunction,
-      codeNamespacePrefix
-    );
-    const functionName = codeNamespace + '.func'; // TODO
-
-    return options.eventsFunctionCodeWriter.getIncludeFileFor(functionName);
-  }).filter(Boolean);
-};
-
-/**
  * Generate the code for the events based extension
  */
 const generateEventsFunctionExtension = (
@@ -182,15 +158,8 @@ const generateEventsFunctionExtension = (
   const codeNamespacePrefix =
     'gdjs.evtsExt__' + mangleName(eventsFunctionsExtension.getName());
 
-  const extensionIncludeFiles = getExtensionIncludeFiles(
-    project,
-    eventsFunctionsExtension,
-    options,
-    codeNamespacePrefix
-  );
   const codeGenerationContext = {
     codeNamespacePrefix,
-    extensionIncludeFiles,
   };
 
   return Promise.all(
@@ -298,11 +267,6 @@ const generateFreeFunction = (
     .setIncludeFile(functionFile)
     .setFunctionName(functionName);
 
-  // Always include the extension include files when using a free function.
-  codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
-    instructionOrExpression.addIncludeFile(includeFile);
-  });
-
   if (!options.skipCodeGeneration) {
     const includeFiles = new gd.SetString();
     const eventsFunctionsExtensionCodeGenerator = new gd.EventsFunctionsExtensionCodeGenerator(
@@ -373,11 +337,6 @@ function generateBehavior(
   );
 
   behaviorMetadata.setIncludeFile(includeFile);
-
-  // Always include the extension include files when using a behavior.
-  codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
-    behaviorMetadata.addIncludeFile(includeFile);
-  });
 
   return Promise.resolve().then(() => {
     const behaviorMethodMangledNames = new gd.MapStringString();
@@ -494,11 +453,6 @@ function generateObject(
   );
 
   objectMetadata.setIncludeFile(includeFile);
-
-  // Always include the extension include files when using an object.
-  codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
-    objectMetadata.addIncludeFile(includeFile);
-  });
 
   return Promise.resolve().then(() => {
     const objectMethodMangledNames = new gd.MapStringString();


### PR DESCRIPTION
Event-based free functions only need to declare the include for their own file because the exporter look for used extension and  includes every of their free functions.