### PR TITLE
Use a constant zoom speed, regardless of zoom factor

### DIFF
--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -182,7 +182,7 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.onwheel = (event: any) => {
       const zoomFactor = this.getZoomFactor();
       if (this.keyboardShortcuts.shouldZoom()) {
-        this.zoomOnCursorBy(-event.deltaY / 5000);
+        this.zoomOnCursorBy((-event.deltaY / 2000) * this.getZoomFactor());
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
         const deltaX = event.deltaY / (5 * zoomFactor);
         this.scrollBy(-deltaX, 0);

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -182,7 +182,7 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.onwheel = (event: any) => {
       const zoomFactor = this.getZoomFactor();
       if (this.keyboardShortcuts.shouldZoom()) {
-        this.zoomOnCursorBy((-event.deltaY / 2000) * this.getZoomFactor());
+        this.zoomOnCursorBy(1 - event.deltaY / 100);
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
         const deltaX = event.deltaY / (5 * zoomFactor);
         this.scrollBy(-deltaX, 0);
@@ -516,7 +516,7 @@ export default class InstancesEditor extends Component<Props> {
   }
 
   zoomBy(value: number) {
-    this.setZoomFactor(this.getZoomFactor() + value);
+    this.setZoomFactor(this.getZoomFactor() * value);
   }
 
   /**
@@ -524,7 +524,7 @@ export default class InstancesEditor extends Component<Props> {
    */
   zoomOnCursorBy(value: number) {
     const beforeZoomCursorPosition = this.getLastCursorSceneCoordinates();
-    this.setZoomFactor(this.getZoomFactor() + value);
+    this.setZoomFactor(this.getZoomFactor() * value);
     const afterZoomCursorPosition = this.getLastCursorSceneCoordinates();
     // Compensate for the cursor change in position
     this.scrollBy(

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -36,7 +36,10 @@ import {
 } from './InstancesEditorSettings';
 import Rectangle from '../Utils/Rectangle';
 import { isNoDialogOpened } from '../UI/MaterialUISpecificUtil';
-import { getContinuousZoomFactor } from '../Utils/ZoomUtils';
+import {
+  clampInstancesEditorZoom,
+  getContinuousZoomFactor,
+} from '../Utils/ZoomUtils';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -541,7 +544,7 @@ export default class InstancesEditor extends Component<Props> {
   setZoomFactor = (zoomFactor: number) => {
     this.props.onChangeInstancesEditorSettings({
       ...this.props.instancesEditorSettings,
-      zoomFactor: Math.max(Math.min(zoomFactor, 100), 0.01),
+      zoomFactor: clampInstancesEditorZoom(zoomFactor),
     });
   };
 

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -36,6 +36,7 @@ import {
 } from './InstancesEditorSettings';
 import Rectangle from '../Utils/Rectangle';
 import { isNoDialogOpened } from '../UI/MaterialUISpecificUtil';
+import { getContinuousZoomFactor } from '../Utils/ZoomUtils';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -182,7 +183,7 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.onwheel = (event: any) => {
       const zoomFactor = this.getZoomFactor();
       if (this.keyboardShortcuts.shouldZoom()) {
-        this.zoomOnCursorBy(1 - event.deltaY / 100);
+        this.zoomOnCursorBy(getContinuousZoomFactor(-event.deltaY));
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
         const deltaX = event.deltaY / (5 * zoomFactor);
         this.scrollBy(-deltaX, 0);
@@ -540,7 +541,7 @@ export default class InstancesEditor extends Component<Props> {
   setZoomFactor = (zoomFactor: number) => {
     this.props.onChangeInstancesEditorSettings({
       ...this.props.instancesEditorSettings,
-      zoomFactor: Math.max(Math.min(zoomFactor, 10), 0.01),
+      zoomFactor: Math.max(Math.min(zoomFactor, 100), 0.01),
     });
   };
 

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -38,7 +38,7 @@ import Rectangle from '../Utils/Rectangle';
 import { isNoDialogOpened } from '../UI/MaterialUISpecificUtil';
 import {
   clampInstancesEditorZoom,
-  getContinuousZoomFactor,
+  getWheelStepZoomFactor,
 } from '../Utils/ZoomUtils';
 const gd: libGDevelop = global.gd;
 
@@ -186,7 +186,7 @@ export default class InstancesEditor extends Component<Props> {
     this.pixiRenderer.view.onwheel = (event: any) => {
       const zoomFactor = this.getZoomFactor();
       if (this.keyboardShortcuts.shouldZoom()) {
-        this.zoomOnCursorBy(getContinuousZoomFactor(-event.deltaY));
+        this.zoomOnCursorBy(getWheelStepZoomFactor(-event.deltaY));
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
         const deltaX = event.deltaY / (5 * zoomFactor);
         this.scrollBy(-deltaX, 0);

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
@@ -2,7 +2,7 @@
 import { Trans } from '@lingui/macro';
 
 import React from 'react';
-import { Column, Line } from '../../../UI/Grid';
+import { Column } from '../../../UI/Grid';
 import { LineStackLayout, ResponsiveLineStackLayout } from '../../../UI/Layout';
 import ImagePreview from '../../../ResourcesList/ResourcePreview/ImagePreview';
 import Replay from '@material-ui/icons/Replay';
@@ -21,6 +21,7 @@ const styles = {
     position: 'relative',
     display: 'flex',
     flex: 1,
+    height: 'calc(100% - 80px)', // 80px are allocated to the space the play pause button line can take once the responsive line stack layout is collapsed
   },
   loaderContainer: {
     position: 'absolute',
@@ -238,98 +239,109 @@ const AnimationPreview = ({
 
   return (
     <Column expand noOverflowParent noMargin>
-      <Line noMargin expand>
-        <div style={styles.imageContainer}>
-          <ImagePreview
-            resourceName={resourceName}
-            imageResourceSource={getImageResourceSource(resourceName)}
-            isImageResourceSmooth={isImageResourceSmooth(resourceName)}
-            initialZoom={initialZoom}
-            project={project}
-            hideCheckeredBackground={hideCheckeredBackground}
-            hideControls={hideControls}
-            fixedHeight={fixedHeight}
-            fixedWidth={fixedWidth}
-            onImageLoaded={onImageLoaded}
-            isImagePrivate={isAssetPrivate}
-            hideLoader // Handled by the animation preview, important to let the browser cache the image.
-          />
-          {!hideAnimationLoader && isStillLoadingResources && (
-            <div style={styles.loaderContainer}>
-              <PlaceholderLoader />
-            </div>
-          )}
-        </div>
-      </Line>
+      <div style={styles.imageContainer}>
+        <ImagePreview
+          resourceName={resourceName}
+          imageResourceSource={getImageResourceSource(resourceName)}
+          isImageResourceSmooth={isImageResourceSmooth(resourceName)}
+          initialZoom={initialZoom}
+          project={project}
+          hideCheckeredBackground={hideCheckeredBackground}
+          hideControls={hideControls}
+          fixedHeight={fixedHeight}
+          fixedWidth={fixedWidth}
+          onImageLoaded={onImageLoaded}
+          isImagePrivate={isAssetPrivate}
+          hideLoader // Handled by the animation preview, important to let the browser cache the image.
+        />
+        {!hideAnimationLoader && isStillLoadingResources && (
+          <div style={styles.loaderContainer}>
+            <PlaceholderLoader />
+          </div>
+        )}
+      </div>
       {!hideControls && (
-        <ResponsiveLineStackLayout alignItems="center">
-          <LineStackLayout alignItems="center" justifyContent="center" noMargin>
-            <Text>
-              <Trans>FPS:</Trans>
-            </Text>
-            <TextField
-              margin="none"
-              value={fps}
-              onChange={(e, text) => {
-                const fps = parseFloat(text);
-                if (fps > 0) {
-                  setFps(fps);
-                  const newTimeBetweenFrames = parseFloat((1 / fps).toFixed(4));
-                  timeBetweenFramesRef.current = newTimeBetweenFrames;
-                  if (onChangeTimeBetweenFrames) {
-                    onChangeTimeBetweenFrames(newTimeBetweenFrames);
+        // Column used to not have the expand behavior when responsive line stack layout is a column
+        <Column noMargin>
+          <ResponsiveLineStackLayout alignItems="center">
+            <LineStackLayout
+              alignItems="center"
+              justifyContent="center"
+              noMargin
+            >
+              <Text>
+                <Trans>FPS:</Trans>
+              </Text>
+              <TextField
+                margin="none"
+                value={fps}
+                onChange={(e, text) => {
+                  const fps = parseFloat(text);
+                  if (fps > 0) {
+                    setFps(fps);
+                    const newTimeBetweenFrames = parseFloat(
+                      (1 / fps).toFixed(4)
+                    );
+                    timeBetweenFramesRef.current = newTimeBetweenFrames;
+                    if (onChangeTimeBetweenFrames) {
+                      onChangeTimeBetweenFrames(newTimeBetweenFrames);
+                    }
+                    replay();
                   }
-                  replay();
-                }
-              }}
-              id="direction-time-between-frames"
-              type="number"
-              step={1}
-              min={1}
-              max={100}
-              style={styles.timeField}
-              autoFocus={true}
-            />
-            <Timer style={styles.timeIcon} />
-            <TextField
-              margin="none"
-              value={timeBetweenFramesRef.current}
-              onChange={(e, text) => {
-                const time = parseFloat(text);
-                if (time > 0) {
-                  setFps(Math.round(1 / time));
-                  timeBetweenFramesRef.current = time;
-                  if (onChangeTimeBetweenFrames) {
-                    onChangeTimeBetweenFrames(time);
+                }}
+                id="direction-time-between-frames"
+                type="number"
+                step={1}
+                min={1}
+                max={100}
+                style={styles.timeField}
+                autoFocus={true}
+              />
+              <Timer style={styles.timeIcon} />
+              <TextField
+                margin="none"
+                value={timeBetweenFramesRef.current}
+                onChange={(e, text) => {
+                  const time = parseFloat(text);
+                  if (time > 0) {
+                    setFps(Math.round(1 / time));
+                    timeBetweenFramesRef.current = time;
+                    if (onChangeTimeBetweenFrames) {
+                      onChangeTimeBetweenFrames(time);
+                    }
+                    replay();
                   }
-                  replay();
-                }
-              }}
-              id="direction-time-between-frames"
-              type="number"
-              step={0.005}
-              precision={2}
-              min={0.01}
-              max={5}
-              style={styles.timeField}
-            />
-          </LineStackLayout>
-          <LineStackLayout alignItems="center" justifyContent="center" noMargin>
-            <FlatButton
-              leftIcon={<Replay />}
-              label={<Trans>Replay</Trans>}
-              onClick={replay}
-            />
-            <FlatButton
-              leftIcon={!!pausedRef.current ? <PlayArrow /> : <Pause />}
-              label={!!pausedRef.current ? 'Play' : 'Pause'}
-              onClick={() => {
-                pausedRef.current = !pausedRef.current;
-                forceUdpate();
-              }}
-            />
-          </LineStackLayout>
-        </ResponsiveLineStackLayout>
+                }}
+                id="direction-time-between-frames"
+                type="number"
+                step={0.005}
+                precision={2}
+                min={0.01}
+                max={5}
+                style={styles.timeField}
+              />
+            </LineStackLayout>
+            <LineStackLayout
+              alignItems="center"
+              justifyContent="center"
+              noMargin
+            >
+              <FlatButton
+                leftIcon={<Replay />}
+                label={<Trans>Replay</Trans>}
+                onClick={replay}
+              />
+              <FlatButton
+                leftIcon={!!pausedRef.current ? <PlayArrow /> : <Pause />}
+                label={!!pausedRef.current ? 'Play' : 'Pause'}
+                onClick={() => {
+                  pausedRef.current = !pausedRef.current;
+                  forceUdpate();
+                }}
+              />
+            </LineStackLayout>
+          </ResponsiveLineStackLayout>
+        </Column>
       )}
     </Column>
   );

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
@@ -21,6 +21,7 @@ const styles = {
     position: 'relative',
     display: 'flex',
     flex: 1,
+    width: '100%', // Needed for ImagePreview to be able to scroll horizontally
     height: 'calc(100% - 80px)', // 80px are allocated to the space the play pause button line can take once the responsive line stack layout is collapsed
   },
   loaderContainer: {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
@@ -14,6 +14,7 @@ import FlatButton from '../../../UI/FlatButton';
 import Text from '../../../UI/Text';
 import useForceUpdate from '../../../Utils/UseForceUpdate';
 import PlaceholderLoader from '../../../UI/PlaceholderLoader';
+import { useResponsiveWindowWidth } from '../../../UI/Reponsive/ResponsiveWindowMeasurer';
 
 const styles = {
   // This container is important to have the loader positioned on top of the image.
@@ -74,6 +75,7 @@ const AnimationPreview = ({
   hideAnimationLoader,
 }: Props) => {
   const forceUdpate = useForceUpdate();
+  const windowWidth = useResponsiveWindowWidth();
 
   // Use state for elements that don't need to be read from inside the animation callback.
   const [fps, setFps] = React.useState<number>(
@@ -296,7 +298,7 @@ const AnimationPreview = ({
                 min={1}
                 max={100}
                 style={styles.timeField}
-                autoFocus={true}
+                autoFocus={windowWidth !== 'small'} // Do not autofocus textfield if on mobile
               />
               <Timer style={styles.timeIcon} />
               <TextField

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationPreview.js
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro';
 
 import React from 'react';
 import { Column, Line } from '../../../UI/Grid';
-import { LineStackLayout } from '../../../UI/Layout';
+import { LineStackLayout, ResponsiveLineStackLayout } from '../../../UI/Layout';
 import ImagePreview from '../../../ResourcesList/ResourcePreview/ImagePreview';
 import Replay from '@material-ui/icons/Replay';
 import PlayArrow from '@material-ui/icons/PlayArrow';
@@ -262,70 +262,74 @@ const AnimationPreview = ({
         </div>
       </Line>
       {!hideControls && (
-        <LineStackLayout noMargin alignItems="center">
-          <Text>
-            <Trans>FPS:</Trans>
-          </Text>
-          <TextField
-            margin="none"
-            value={fps}
-            onChange={(e, text) => {
-              const fps = parseFloat(text);
-              if (fps > 0) {
-                setFps(fps);
-                const newTimeBetweenFrames = parseFloat((1 / fps).toFixed(4));
-                timeBetweenFramesRef.current = newTimeBetweenFrames;
-                if (onChangeTimeBetweenFrames) {
-                  onChangeTimeBetweenFrames(newTimeBetweenFrames);
+        <ResponsiveLineStackLayout alignItems="center">
+          <LineStackLayout alignItems="center" justifyContent="center" noMargin>
+            <Text>
+              <Trans>FPS:</Trans>
+            </Text>
+            <TextField
+              margin="none"
+              value={fps}
+              onChange={(e, text) => {
+                const fps = parseFloat(text);
+                if (fps > 0) {
+                  setFps(fps);
+                  const newTimeBetweenFrames = parseFloat((1 / fps).toFixed(4));
+                  timeBetweenFramesRef.current = newTimeBetweenFrames;
+                  if (onChangeTimeBetweenFrames) {
+                    onChangeTimeBetweenFrames(newTimeBetweenFrames);
+                  }
+                  replay();
                 }
-                replay();
-              }
-            }}
-            id="direction-time-between-frames"
-            type="number"
-            step={1}
-            min={1}
-            max={100}
-            style={styles.timeField}
-            autoFocus={true}
-          />
-          <Timer style={styles.timeIcon} />
-          <TextField
-            margin="none"
-            value={timeBetweenFramesRef.current}
-            onChange={(e, text) => {
-              const time = parseFloat(text);
-              if (time > 0) {
-                setFps(Math.round(1 / time));
-                timeBetweenFramesRef.current = time;
-                if (onChangeTimeBetweenFrames) {
-                  onChangeTimeBetweenFrames(time);
+              }}
+              id="direction-time-between-frames"
+              type="number"
+              step={1}
+              min={1}
+              max={100}
+              style={styles.timeField}
+              autoFocus={true}
+            />
+            <Timer style={styles.timeIcon} />
+            <TextField
+              margin="none"
+              value={timeBetweenFramesRef.current}
+              onChange={(e, text) => {
+                const time = parseFloat(text);
+                if (time > 0) {
+                  setFps(Math.round(1 / time));
+                  timeBetweenFramesRef.current = time;
+                  if (onChangeTimeBetweenFrames) {
+                    onChangeTimeBetweenFrames(time);
+                  }
+                  replay();
                 }
-                replay();
-              }
-            }}
-            id="direction-time-between-frames"
-            type="number"
-            step={0.005}
-            precision={2}
-            min={0.01}
-            max={5}
-            style={styles.timeField}
-          />
-          <FlatButton
-            leftIcon={<Replay />}
-            label={<Trans>Replay</Trans>}
-            onClick={replay}
-          />
-          <FlatButton
-            leftIcon={!!pausedRef.current ? <PlayArrow /> : <Pause />}
-            label={!!pausedRef.current ? 'Play' : 'Pause'}
-            onClick={() => {
-              pausedRef.current = !pausedRef.current;
-              forceUdpate();
-            }}
-          />
-        </LineStackLayout>
+              }}
+              id="direction-time-between-frames"
+              type="number"
+              step={0.005}
+              precision={2}
+              min={0.01}
+              max={5}
+              style={styles.timeField}
+            />
+          </LineStackLayout>
+          <LineStackLayout alignItems="center" justifyContent="center" noMargin>
+            <FlatButton
+              leftIcon={<Replay />}
+              label={<Trans>Replay</Trans>}
+              onClick={replay}
+            />
+            <FlatButton
+              leftIcon={!!pausedRef.current ? <PlayArrow /> : <Pause />}
+              label={!!pausedRef.current ? 'Play' : 'Pause'}
+              onClick={() => {
+                pausedRef.current = !pausedRef.current;
+                forceUdpate();
+              }}
+            />
+          </LineStackLayout>
+        </ResponsiveLineStackLayout>
       )}
     </Column>
   );

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -150,6 +150,14 @@ const ImagePreview = ({
     [imageHeight, imageWidth, containerHeight, containerWidth]
   );
 
+  // Reset ref to adapt zoom when image changes
+  React.useEffect(
+    () => {
+      hasImageLoadedRef.current = false;
+    },
+    [imageResourceSource]
+  );
+
   React.useEffect(
     () => {
       if (hasImageLoadedRef.current) return;

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -19,7 +19,10 @@ import { shouldZoom } from '../../UI/KeyboardShortcuts/InteractionKeys';
 import Slider from '../../UI/Slider';
 import AuthorizedAssetImage from '../../AssetStore/PrivateAssets/AuthorizedAssetImage';
 import {
+  clampImagePreviewZoom,
   getContinuousZoomFactor,
+  imagePreviewMaxZoom,
+  imagePreviewMinZoom,
   zoomInFactor,
   zoomOutFactor,
 } from '../../Utils/ZoomUtils';
@@ -27,11 +30,6 @@ const gd: libGDevelop = global.gd;
 
 const MARGIN = 50;
 const SPRITE_MARGIN_RATIO = 1.3;
-const MAX_ZOOM_FACTOR = 10;
-const MIN_ZOOM_FACTOR = 0.1;
-
-const getBoundedZoomFactor = (zoom: number): number =>
-  Math.min(MAX_ZOOM_FACTOR, Math.max(MIN_ZOOM_FACTOR, zoom));
 
 const styles = {
   previewImagePixelated: {
@@ -138,7 +136,7 @@ const ImagePreview = ({
       if (!imageWidth || !imageHeight || !containerHeight || !containerWidth) {
         return;
       }
-      const zoomFactor = getBoundedZoomFactor(
+      const zoomFactor = clampImagePreviewZoom(
         Math.min(
           containerWidth / (imageWidth * SPRITE_MARGIN_RATIO),
           containerHeight / (imageHeight * SPRITE_MARGIN_RATIO)
@@ -169,7 +167,7 @@ const ImagePreview = ({
   };
 
   const zoomTo = (imageZoomFactor: number) => {
-    setImageZoomFactor(getBoundedZoomFactor(imageZoomFactor));
+    setImageZoomFactor(clampImagePreviewZoom(imageZoomFactor));
   };
 
   const theme = React.useContext(GDevelopThemeContext);
@@ -254,8 +252,8 @@ const ImagePreview = ({
                 </IconButton>
                 <div style={styles.sliderContainer}>
                   <Slider
-                    min={Math.log10(MIN_ZOOM_FACTOR)}
-                    max={Math.log10(MAX_ZOOM_FACTOR)}
+                    min={Math.log10(imagePreviewMinZoom)}
+                    max={Math.log10(imagePreviewMaxZoom)}
                     step={0.05}
                     value={Math.log10(imageZoomFactor)}
                     onChange={value => {

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -55,7 +55,7 @@ const styles = {
     touchAction: 'none',
   },
   spriteThumbnailImage: {
-    position: 'relative',
+    position: 'absolute',
     pointerEvents: 'none',
   },
   sliderContainer: {

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -158,8 +158,8 @@ const ImagePreview = ({
     if (onImageLoaded) onImageLoaded();
   };
 
-  const zoomBy = (imageZoomFactorDelta: number) => {
-    zoomTo(imageZoomFactor + imageZoomFactorDelta);
+  const zoomBy = (imageZoomFactorMultiplier: number) => {
+    zoomTo(imageZoomFactor * imageZoomFactorMultiplier);
   };
 
   const zoomTo = (imageZoomFactor: number) => {
@@ -247,7 +247,7 @@ const ImagePreview = ({
             {!hideControls && (
               <MiniToolbar noPadding>
                 <IconButton
-                  onClick={() => zoomBy(-0.2)}
+                  onClick={() => zoomBy(0.9)}
                   tooltip={t`Zoom out (you can also use Ctrl + Mouse wheel)`}
                 >
                   <ZoomOut />
@@ -264,7 +264,7 @@ const ImagePreview = ({
                   />
                 </div>
                 <IconButton
-                  onClick={() => zoomBy(+0.2)}
+                  onClick={() => zoomBy(1.1)}
                   tooltip={t`Zoom in (you can also use Ctrl + Mouse wheel)`}
                 >
                   <ZoomIn />
@@ -297,8 +297,7 @@ const ImagePreview = ({
                 onWheel={event => {
                   const { deltaY } = event;
                   if (!hideControls && shouldZoom(event)) {
-                    zoomBy(-deltaY / 500);
-                    event.preventDefault();
+                    zoomBy(1 - deltaY / 100);
                     event.stopPropagation();
                   } else {
                     // Let the usual, native vertical or horizontal scrolling happen.

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -4,7 +4,6 @@ import { Trans } from '@lingui/macro';
 import IconButton from '../../UI/IconButton';
 import Measure from 'react-measure';
 import * as React from 'react';
-import { Column } from '../../UI/Grid';
 import MiniToolbar from '../../UI/MiniToolbar';
 import ZoomIn from '@material-ui/icons/ZoomIn';
 import ZoomOut from '@material-ui/icons/ZoomOut';
@@ -41,8 +40,15 @@ const styles = {
     height: '100%',
     overflow: 'hidden',
   },
-  imagePreviewContainer: {
+  container: {
     display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    flex: 1,
+    minHeight: 0,
+    width: '100%', // Needed for the div containing the image to scroll horizontally when image overflowing due to scroll.
+  },
+  imagePreviewContainer: {
     position: 'relative',
     width: '100%',
     height: '100%',
@@ -57,7 +63,6 @@ const styles = {
   spriteThumbnailImage: {
     position: 'relative',
     pointerEvents: 'none',
-    maxWidth: '100%', // to enable scroll when overflowing on x
   },
   sliderContainer: {
     maxWidth: 150,
@@ -264,7 +269,7 @@ const ImagePreview = ({
     >
       {({ measureRef }) => {
         return (
-          <Column expand noMargin useFullHeight>
+          <div style={styles.container}>
             {!hideControls && (
               <MiniToolbar noPadding>
                 <IconButton
@@ -367,7 +372,7 @@ const ImagePreview = ({
                 )}
               </div>
             </div>
-          </Column>
+          </div>
         );
       }}
     </Measure>

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -19,7 +19,7 @@ import Slider from '../../UI/Slider';
 import AuthorizedAssetImage from '../../AssetStore/PrivateAssets/AuthorizedAssetImage';
 import {
   clampImagePreviewZoom,
-  getContinuousZoomFactor,
+  getWheelStepZoomFactor,
   imagePreviewMaxZoom,
   imagePreviewMinZoom,
   zoomInFactor,
@@ -325,7 +325,7 @@ const ImagePreview = ({
                 onWheel={event => {
                   const { deltaY } = event;
                   if (!hideControls && shouldZoom(event)) {
-                    zoomBy(getContinuousZoomFactor(-deltaY));
+                    zoomBy(getWheelStepZoomFactor(-deltaY));
                     event.stopPropagation();
                   } else {
                     // Let the usual, native vertical or horizontal scrolling happen.

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -131,7 +131,7 @@ const ImagePreview = ({
     setErrored(true);
   };
 
-  React.useEffect(
+  const adaptZoomFactorToImage = React.useCallback(
     () => {
       if (!imageWidth || !imageHeight || !containerHeight || !containerWidth) {
         return;
@@ -144,7 +144,14 @@ const ImagePreview = ({
       );
       setImageZoomFactor(zoomFactor);
     },
-    [containerHeight, containerWidth, imageHeight, imageWidth]
+    [imageHeight, imageWidth, containerHeight, containerWidth]
+  );
+
+  React.useEffect(
+    () => {
+      adaptZoomFactorToImage();
+    },
+    [adaptZoomFactorToImage]
   );
 
   const handleImageLoaded = (e: any) => {
@@ -268,8 +275,8 @@ const ImagePreview = ({
                   <ZoomIn />
                 </IconButton>
                 <IconButton
-                  onClick={() => zoomTo(1)}
-                  tooltip={t`Restore original size`}
+                  onClick={adaptZoomFactorToImage}
+                  tooltip={t`Fit content to window`}
                 >
                   <ZoomOutMap />
                 </IconButton>

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -55,8 +55,9 @@ const styles = {
     touchAction: 'none',
   },
   spriteThumbnailImage: {
-    position: 'absolute',
+    position: 'relative',
     pointerEvents: 'none',
+    maxWidth: '100%', // to enable scroll when overflowing on x
   },
   sliderContainer: {
     maxWidth: 150,

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -127,6 +127,7 @@ const ImagePreview = ({
   const [imageZoomFactor, setImageZoomFactor] = React.useState<number>(
     initialZoom || 1
   );
+  const hasImageLoadedRef = React.useRef<boolean>(false);
 
   const handleImageError = () => {
     setErrored(true);
@@ -144,12 +145,14 @@ const ImagePreview = ({
         )
       );
       setImageZoomFactor(zoomFactor);
+      hasImageLoadedRef.current = true;
     },
     [imageHeight, imageWidth, containerHeight, containerWidth]
   );
 
   React.useEffect(
     () => {
+      if (hasImageLoadedRef.current) return;
       adaptZoomFactorToImage();
     },
     [adaptZoomFactorToImage]

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -18,6 +18,11 @@ import { getPixelatedImageRendering } from '../../Utils/CssHelpers';
 import { shouldZoom } from '../../UI/KeyboardShortcuts/InteractionKeys';
 import Slider from '../../UI/Slider';
 import AuthorizedAssetImage from '../../AssetStore/PrivateAssets/AuthorizedAssetImage';
+import {
+  getContinuousZoomFactor,
+  zoomInFactor,
+  zoomOutFactor,
+} from '../../Utils/ZoomUtils';
 const gd: libGDevelop = global.gd;
 
 const MARGIN = 50;
@@ -247,7 +252,7 @@ const ImagePreview = ({
             {!hideControls && (
               <MiniToolbar noPadding>
                 <IconButton
-                  onClick={() => zoomBy(0.9)}
+                  onClick={() => zoomBy(zoomOutFactor)}
                   tooltip={t`Zoom out (you can also use Ctrl + Mouse wheel)`}
                 >
                   <ZoomOut />
@@ -264,7 +269,7 @@ const ImagePreview = ({
                   />
                 </div>
                 <IconButton
-                  onClick={() => zoomBy(1.1)}
+                  onClick={() => zoomBy(zoomInFactor)}
                   tooltip={t`Zoom in (you can also use Ctrl + Mouse wheel)`}
                 >
                   <ZoomIn />
@@ -297,7 +302,7 @@ const ImagePreview = ({
                 onWheel={event => {
                   const { deltaY } = event;
                   if (!hideControls && shouldZoom(event)) {
-                    zoomBy(1 - deltaY / 100);
+                    zoomBy(getContinuousZoomFactor(-deltaY));
                     event.stopPropagation();
                   } else {
                     // Let the usual, native vertical or horizontal scrolling happen.

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -25,6 +25,7 @@ import {
   imagePreviewMinZoom,
   zoomInFactor,
   zoomOutFactor,
+  zoomStepBasePower,
 } from '../../Utils/ZoomUtils';
 const gd: libGDevelop = global.gd;
 
@@ -259,12 +260,12 @@ const ImagePreview = ({
                 </IconButton>
                 <div style={styles.sliderContainer}>
                   <Slider
-                    min={Math.log10(imagePreviewMinZoom)}
-                    max={Math.log10(imagePreviewMaxZoom)}
-                    step={0.05}
-                    value={Math.log10(imageZoomFactor)}
+                    min={Math.log2(imagePreviewMinZoom)}
+                    max={Math.log2(imagePreviewMaxZoom)}
+                    step={zoomStepBasePower * 4}
+                    value={Math.log2(imageZoomFactor)}
                     onChange={value => {
-                      zoomTo(Math.pow(10, value));
+                      zoomTo(Math.pow(2, value));
                     }}
                   />
                 </div>

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -120,33 +120,34 @@ const ImagePreview = ({
   onImageLoaded,
   hideLoader,
 }: Props) => {
-  const [errored, setErrored] = React.useState(false);
-  const [imageWidth, setImageWidth] = React.useState(null);
-  const [imageHeight, setImageHeight] = React.useState(null);
-  const [imageZoomFactor, setImageZoomFactor] = React.useState(
+  const [errored, setErrored] = React.useState<boolean>(false);
+  const [imageWidth, setImageWidth] = React.useState<?number>(null);
+  const [imageHeight, setImageHeight] = React.useState<?number>(null);
+  const [containerWidth, setContainerWidth] = React.useState<?number>(null);
+  const [containerHeight, setContainerHeight] = React.useState<?number>(null);
+  const [imageZoomFactor, setImageZoomFactor] = React.useState<number>(
     initialZoom || 1
-  );
-  const [isResizeObserverReady, setIsResizeObserverReady] = React.useState(
-    false
   );
 
   const handleImageError = () => {
     setErrored(true);
   };
 
-  const adaptZoomToImage = (
-    containerHeight: number,
-    containerWidth: number
-  ) => {
-    if (!imageWidth || !imageHeight) return;
-    const zoomFactor = getBoundedZoomFactor(
-      Math.min(
-        containerWidth / (imageWidth * SPRITE_MARGIN_RATIO),
-        containerHeight / (imageHeight * SPRITE_MARGIN_RATIO)
-      )
-    );
-    setImageZoomFactor(zoomFactor);
-  };
+  React.useEffect(
+    () => {
+      if (!imageWidth || !imageHeight || !containerHeight || !containerWidth) {
+        return;
+      }
+      const zoomFactor = getBoundedZoomFactor(
+        Math.min(
+          containerWidth / (imageWidth * SPRITE_MARGIN_RATIO),
+          containerHeight / (imageHeight * SPRITE_MARGIN_RATIO)
+        )
+      );
+      setImageZoomFactor(zoomFactor);
+    },
+    [containerHeight, containerWidth, imageHeight, imageWidth]
+  );
 
   const handleImageLoaded = (e: any) => {
     const imgElement = e.target;
@@ -174,79 +175,73 @@ const ImagePreview = ({
   const theme = React.useContext(GDevelopThemeContext);
   const frameBorderColor = theme.imagePreview.frameBorderColor || '#aaa';
 
+  const containerLoaded = !!containerWidth && !!containerHeight;
+  const imageLoaded = !!imageWidth && !!imageHeight && !errored;
+
+  // Centre-align the image and overlays
+  const imagePositionTop = Math.max(
+    0,
+    (containerHeight || 0) / 2 -
+      ((imageHeight || 0) * imageZoomFactor) / 2 -
+      MARGIN
+  );
+  const imagePositionLeft = Math.max(
+    0,
+    (containerWidth || 0) / 2 -
+      ((imageWidth || 0) * imageZoomFactor) / 2 -
+      MARGIN
+  );
+
+  // We display the elements only when the image is loaded and
+  // the zoom is applied to avoid a shift in the image.
+  // We use "visibility": "hidden" instead of "display": "none"
+  // so that the image takes the space of the container whilst being hidden.
+  // TODO: handle a proper loader.
+  const visibility = containerLoaded ? undefined : 'hidden';
+  const width = imageWidth ? imageWidth * imageZoomFactor : undefined;
+  const height = imageHeight ? imageHeight * imageZoomFactor : undefined;
+
+  const imageStyle = {
+    ...styles.spriteThumbnailImage,
+    // Apply margin only once the container is loaded, to avoid a shift in the image
+    margin: containerLoaded ? MARGIN : 0,
+    top: imagePositionTop,
+    left: imagePositionLeft,
+    width,
+    height,
+    visibility,
+    ...(!isImageResourceSmooth ? styles.previewImagePixelated : undefined),
+  };
+
+  const frameStyle = {
+    position: 'absolute',
+    top: imagePositionTop + MARGIN,
+    left: imagePositionLeft + MARGIN,
+    width,
+    height,
+    visibility,
+    border: `1px solid ${frameBorderColor}`,
+    boxSizing: 'border-box',
+  };
+
+  const overlayStyle = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    visibility,
+  };
+
   return (
-    <Measure bounds>
-      {({ contentRect, measureRef }) => {
-        const containerWidth = contentRect.bounds.width;
-        const containerHeight = contentRect.bounds.height;
-        const containerLoaded = !!containerWidth && !!containerHeight;
-        const imageLoaded = !!imageWidth && !!imageHeight && !errored;
-
-        // Once the container is loaded, adapt the zoom to the image size.
-        if (!isResizeObserverReady && containerLoaded) {
-          if (!initialZoom) {
-            adaptZoomToImage(containerHeight, containerWidth);
-          }
-          setIsResizeObserverReady(true);
-        }
-
-        // Centre-align the image and overlays
-        const imagePositionTop = Math.max(
-          0,
-          (containerHeight || 0) / 2 -
-            ((imageHeight || 0) * imageZoomFactor) / 2 -
-            MARGIN
-        );
-        const imagePositionLeft = Math.max(
-          0,
-          (containerWidth || 0) / 2 -
-            ((imageWidth || 0) * imageZoomFactor) / 2 -
-            MARGIN
-        );
-
-        // We display the elements only when the image is loaded and
-        // the zoom is applied to avoid a shift in the image.
-        // We use "visibility": "hidden" instead of "display": "none"
-        // so that the image takes the space of the container whilst being hidden.
-        // TODO: handle a proper loader.
-        const visibility = containerLoaded ? undefined : 'hidden';
-        const width = imageWidth ? imageWidth * imageZoomFactor : undefined;
-        const height = imageHeight ? imageHeight * imageZoomFactor : undefined;
-
-        const imageStyle = {
-          ...styles.spriteThumbnailImage,
-          // Apply margin only once the container is loaded, to avoid a shift in the image
-          margin: containerLoaded ? MARGIN : 0,
-          top: imagePositionTop,
-          left: imagePositionLeft,
-          width,
-          height,
-          visibility,
-          ...(!isImageResourceSmooth
-            ? styles.previewImagePixelated
-            : undefined),
-        };
-
-        const frameStyle = {
-          position: 'absolute',
-          top: imagePositionTop + MARGIN,
-          left: imagePositionLeft + MARGIN,
-          width,
-          height,
-          visibility,
-          border: `1px solid ${frameBorderColor}`,
-          boxSizing: 'border-box',
-        };
-
-        const overlayStyle = {
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          visibility,
-        };
-
+    <Measure
+      bounds
+      onResize={contentRect => {
+        setContainerWidth(contentRect.bounds.width);
+        setContainerHeight(contentRect.bounds.height);
+      }}
+    >
+      {({ measureRef }) => {
         return (
           <Column expand noMargin useFullHeight>
             {!hideControls && (

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -982,17 +982,11 @@ export default class SceneEditor extends React.Component<Props, State> {
   };
 
   zoomIn = () => {
-    const { editor } = this;
-    if (editor) {
-      editor.zoomBy(zoomInFactor);
-    }
+    if (this.editor) this.editor.zoomBy(zoomInFactor);
   };
 
   zoomOut = () => {
-    const { editor } = this;
-    if (editor) {
-      editor.zoomBy(zoomOutFactor);
-    }
+    if (this.editor) this.editor.zoomBy(zoomOutFactor);
   };
 
   _onContextMenu = (

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -981,11 +981,17 @@ export default class SceneEditor extends React.Component<Props, State> {
   };
 
   zoomIn = () => {
-    if (this.editor) this.editor.zoomBy(0.1);
+    const { editor } = this;
+    if (editor) {
+      editor.zoomBy(0.1 * editor.getZoomFactor());
+    }
   };
 
   zoomOut = () => {
-    if (this.editor) this.editor.zoomBy(-0.1);
+    const { editor } = this;
+    if (editor) {
+      editor.zoomBy(-0.1 * editor.getZoomFactor());
+    }
   };
 
   _onContextMenu = (

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -72,6 +72,7 @@ import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewB
 import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
 import { MOVEMENT_BIG_DELTA } from '../UI/KeyboardShortcuts';
 import { getInstancesInLayoutForObject } from '../Utils/Layout';
+import { zoomInFactor, zoomOutFactor } from '../Utils/ZoomUtils';
 
 const gd: libGDevelop = global.gd;
 
@@ -983,14 +984,14 @@ export default class SceneEditor extends React.Component<Props, State> {
   zoomIn = () => {
     const { editor } = this;
     if (editor) {
-      editor.zoomBy(1.1);
+      editor.zoomBy(zoomInFactor);
     }
   };
 
   zoomOut = () => {
     const { editor } = this;
     if (editor) {
-      editor.zoomBy(0.9);
+      editor.zoomBy(zoomOutFactor);
     }
   };
 

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -983,14 +983,14 @@ export default class SceneEditor extends React.Component<Props, State> {
   zoomIn = () => {
     const { editor } = this;
     if (editor) {
-      editor.zoomBy(0.1 * editor.getZoomFactor());
+      editor.zoomBy(1.1);
     }
   };
 
   zoomOut = () => {
     const { editor } = this;
     if (editor) {
-      editor.zoomBy(-0.1 * editor.getZoomFactor());
+      editor.zoomBy(0.9);
     }
   };
 

--- a/newIDE/app/src/Utils/ZoomUtils.js
+++ b/newIDE/app/src/Utils/ZoomUtils.js
@@ -1,0 +1,13 @@
+// @flow
+
+const stepZoomFactor = Math.pow(2, 1 / 8);
+export const zoomInFactor = stepZoomFactor;
+export const zoomOutFactor = Math.pow(stepZoomFactor, -1);
+const continuousZoomFactor = Math.sqrt(stepZoomFactor);
+
+// TODO: Use absolute value of signal that should represent either:
+// - Mouse sensitivity
+// - MacOS scroll acceleration
+// Signal is usually WheelEvent.deltaY
+export const getContinuousZoomFactor = (signal: number): number =>
+  Math.pow(continuousZoomFactor, Math.sign(signal));

--- a/newIDE/app/src/Utils/ZoomUtils.js
+++ b/newIDE/app/src/Utils/ZoomUtils.js
@@ -5,14 +5,14 @@ export const zoomStepBasePower = 1 / 16;
 const stepZoomFactor = Math.pow(2, 2 * zoomStepBasePower);
 export const zoomInFactor = stepZoomFactor;
 export const zoomOutFactor = Math.pow(stepZoomFactor, -1);
-const continuousZoomFactor = Math.pow(2, zoomStepBasePower);
+const wheelStepZoomFactor = Math.pow(2, zoomStepBasePower);
 
 // TODO: Use absolute value of signal that should represent either:
 // - Mouse sensitivity
 // - MacOS scroll acceleration
 // Signal is usually WheelEvent.deltaY
-export const getContinuousZoomFactor = (signal: number): number =>
-  Math.pow(continuousZoomFactor, Math.sign(signal));
+export const getWheelStepZoomFactor = (signal: number): number =>
+  Math.pow(wheelStepZoomFactor, Math.sign(signal));
 
 const instancesEditorMaxZoom = 128;
 const instancesEditorMinZoom = 1 / 128;

--- a/newIDE/app/src/Utils/ZoomUtils.js
+++ b/newIDE/app/src/Utils/ZoomUtils.js
@@ -1,11 +1,11 @@
 // @flow
 
-const basePower = 1 / 16;
+export const zoomStepBasePower = 1 / 16;
 
-const stepZoomFactor = Math.pow(2, 2 * basePower);
+const stepZoomFactor = Math.pow(2, 2 * zoomStepBasePower);
 export const zoomInFactor = stepZoomFactor;
 export const zoomOutFactor = Math.pow(stepZoomFactor, -1);
-const continuousZoomFactor = Math.pow(2, basePower);
+const continuousZoomFactor = Math.pow(2, zoomStepBasePower);
 
 // TODO: Use absolute value of signal that should represent either:
 // - Mouse sensitivity

--- a/newIDE/app/src/Utils/ZoomUtils.js
+++ b/newIDE/app/src/Utils/ZoomUtils.js
@@ -13,3 +13,15 @@ const continuousZoomFactor = Math.pow(2, basePower);
 // Signal is usually WheelEvent.deltaY
 export const getContinuousZoomFactor = (signal: number): number =>
   Math.pow(continuousZoomFactor, Math.sign(signal));
+
+const instancesEditorMaxZoom = 128;
+const instancesEditorMinZoom = 1 / 128;
+
+export const clampInstancesEditorZoom = (zoom: number): number =>
+  Math.max(Math.min(zoom, instancesEditorMaxZoom), instancesEditorMinZoom);
+
+export const imagePreviewMaxZoom = 16;
+export const imagePreviewMinZoom = 1 / 16;
+
+export const clampImagePreviewZoom = (zoom: number): number =>
+  Math.max(Math.min(zoom, imagePreviewMaxZoom), imagePreviewMinZoom);

--- a/newIDE/app/src/Utils/ZoomUtils.js
+++ b/newIDE/app/src/Utils/ZoomUtils.js
@@ -1,9 +1,11 @@
 // @flow
 
-const stepZoomFactor = Math.pow(2, 1 / 8);
+const basePower = 1 / 16;
+
+const stepZoomFactor = Math.pow(2, 2 * basePower);
 export const zoomInFactor = stepZoomFactor;
 export const zoomOutFactor = Math.pow(stepZoomFactor, -1);
-const continuousZoomFactor = Math.sqrt(stepZoomFactor);
+const continuousZoomFactor = Math.pow(2, basePower);
 
 // TODO: Use absolute value of signal that should represent either:
 // - Mouse sensitivity

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourcePreview.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourcePreview.stories.js
@@ -5,6 +5,7 @@ import muiDecorator from '../../ThemeDecorator';
 import { testProject } from '../../GDevelopJsInitializerDecorator';
 import ResourcesLoader from '../../../ResourcesLoader';
 import ResourcePreview from '../../../ResourcesList/ResourcePreview';
+import FixedHeightFlexContainer from '../../FixedHeightFlexContainer';
 
 export default {
   title: 'ResourcesList/ResourcePreview',
@@ -13,25 +14,31 @@ export default {
 };
 
 export const Image = () => (
-  <ResourcePreview
-    project={testProject.project}
-    resourceName="icon128.png"
-    resourcesLoader={ResourcesLoader}
-  />
+  <FixedHeightFlexContainer height={300}>
+    <ResourcePreview
+      project={testProject.project}
+      resourceName="icon128.png"
+      resourcesLoader={ResourcesLoader}
+    />
+  </FixedHeightFlexContainer>
 );
 
 export const NotExisting = () => (
-  <ResourcePreview
-    project={testProject.project}
-    resourceName="resource-that-does-not-exists-in-the-project"
-    resourcesLoader={ResourcesLoader}
-  />
+  <FixedHeightFlexContainer height={300}>
+    <ResourcePreview
+      project={testProject.project}
+      resourceName="resource-that-does-not-exists-in-the-project"
+      resourcesLoader={ResourcesLoader}
+    />
+  </FixedHeightFlexContainer>
 );
 
 export const Audio = () => (
-  <ResourcePreview
-    project={testProject.project}
-    resourceName="fake-audio1.mp3"
-    resourcesLoader={ResourcesLoader}
-  />
+  <FixedHeightFlexContainer height={300}>
+    <ResourcePreview
+      project={testProject.project}
+      resourceName="fake-audio1.mp3"
+      resourcesLoader={ResourcesLoader}
+    />
+  </FixedHeightFlexContainer>
 );


### PR DESCRIPTION
Use multiplier factors when setting zoom
Also:
- Fix image preview for animation preview overflowing the dialog
  before: 
  <img width="975" alt="image" src="https://user-images.githubusercontent.com/32449369/207850974-bde280c6-df0e-4e32-b174-080ae7c0b21f.png">
  after:
  <img width="942" alt="image" src="https://user-images.githubusercontent.com/32449369/207864349-0c17e6f7-7db4-4ef7-a902-1a09c91a2ca2.png">

