### PR TITLE
Fix the authors list on extension wiki pages

### DIFF
--- a/newIDE/app/scripts/extract-extensions-document.js
+++ b/newIDE/app/scripts/extract-extensions-document.js
@@ -80,8 +80,7 @@ const getAllExtensionHeaders = async () => {
           }).`
         );
       }
-
-      return extensionHeader;
+      return { ...extensionHeader, ...extensionShortHeader};
     })
   );
 


### PR DESCRIPTION
The service probably does some changes on the short headers `authors` attribute.