### PR TITLE
Display seller asset packs

### DIFF
--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -117,7 +117,7 @@ const PublicAssetPackTile = ({
   );
 };
 
-const PrivateAssetPackTile = ({
+export const PrivateAssetPackTile = ({
   assetPackListingData,
   onSelect,
   style,

--- a/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackInformationPage.js
+++ b/newIDE/app/src/AssetStore/PrivateAssets/PrivateAssetPackInformationPage.js
@@ -58,12 +58,14 @@ type Props = {|
   privateAssetPackListingData: PrivateAssetPackListingData,
   onOpenPurchaseDialog: () => void,
   isPurchaseDialogOpen: boolean,
+  onAssetPackOpen: PrivateAssetPackListingData => void,
 |};
 
 const PrivateAssetPackInformationPage = ({
   privateAssetPackListingData,
   onOpenPurchaseDialog,
   isPurchaseDialogOpen,
+  onAssetPackOpen,
 }: Props) => {
   const { id, name, sellerId, prices } = privateAssetPackListingData;
   const [assetPack, setAssetPack] = React.useState<?PrivateAssetPack>(null);
@@ -285,6 +287,10 @@ const PrivateAssetPackInformationPage = ({
             <PublicProfileDialog
               userId={sellerId}
               onClose={() => setOpenSellerPublicProfileDialog(false)}
+              onAssetPackOpen={assetPackListingData => {
+                onAssetPackOpen(assetPackListingData);
+                setOpenSellerPublicProfileDialog(false);
+              }}
             />
           )}
         </>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -222,6 +222,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
           assetPackId: null,
           assetPackName: assetPack.name,
           assetPackKind: 'public',
+          source: 'store-home',
         });
 
         if (assetPack.externalWebLink) {
@@ -267,6 +268,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
           assetPackId: assetPackListingData.id,
           assetPackTag: null,
           assetPackKind: 'private',
+          source: 'store-home',
         });
         saveScrollPosition();
         navigationState.openPackPage(receivedAssetPack);
@@ -601,6 +603,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                       isPurchaseDialogOpen={
                         !!purchasingPrivateAssetPackListingData
                       }
+                      onAssetPackOpen={selectPrivateAssetPack}
                     />
                   ) : null}
                   {!!purchasingPrivateAssetPackListingData && (

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -211,7 +211,7 @@ const ProfileDetails = ({
             <UserAchievements
               badges={badges}
               displayUnclaimedAchievements={!!isAuthenticatedUserProfile}
-              displayNotifications={!!isAuthenticatedUserProfile}
+              displayNotifications
             />
           )}
         </ColumnStackLayout>

--- a/newIDE/app/src/Profile/ProfileDetails.js
+++ b/newIDE/app/src/Profile/ProfileDetails.js
@@ -19,10 +19,15 @@ import PlaceholderError from '../UI/PlaceholderError';
 import RaisedButton from '../UI/RaisedButton';
 import UserAchievements from './Achievement/UserAchievements';
 import { type Badge } from '../Utils/GDevelopServices/Badge';
+import { type PrivateAssetPackListingData } from '../Utils/GDevelopServices/Shop';
 import Window from '../Utils/Window';
 import { GDevelopGamesPlatform } from '../Utils/GDevelopServices/ApiConfigs';
 import FlatButton from '../UI/FlatButton';
 import Coffee from '../UI/CustomSvgIcons/Coffee';
+import { GridList } from '@material-ui/core';
+import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
+import { PrivateAssetPackTile } from '../AssetStore/AssetsHome';
+import { sendAssetPackOpened } from '../Utils/Analytics/EventSender';
 
 type DisplayedProfile = {
   id: string,
@@ -40,6 +45,8 @@ type Props = {|
   onChangeEmail?: () => void,
   onEditProfile?: () => void,
   badges: ?Array<Badge>,
+  assetPacksListingData?: ?Array<PrivateAssetPackListingData>,
+  onAssetPackOpen?: (assetPack: PrivateAssetPackListingData) => void,
 |};
 
 const ProfileDetails = ({
@@ -50,9 +57,16 @@ const ProfileDetails = ({
   onChangeEmail,
   onEditProfile,
   badges,
+  assetPacksListingData,
+  onAssetPackOpen,
 }: Props) => {
   const donateLink = profile ? profile.donateLink : null;
-  return profile ? (
+  const windowWidth = useResponsiveWindowWidth();
+
+  return !!profile &&
+    // ensure asset packs or badges are loaded to avoid a layout shift.
+    ((isAuthenticatedUserProfile && !!badges) ||
+      (!isAuthenticatedUserProfile && !!assetPacksListingData)) ? (
     <I18n>
       {({ i18n }) => (
         <ColumnStackLayout noMargin>
@@ -156,11 +170,50 @@ const ProfileDetails = ({
               />
             </ResponsiveLineStackLayout>
           )}
-          <UserAchievements
-            badges={badges}
-            displayUnclaimedAchievements={!!isAuthenticatedUserProfile}
-            displayNotifications={!!isAuthenticatedUserProfile}
-          />
+          {!isAuthenticatedUserProfile &&
+            onAssetPackOpen &&
+            assetPacksListingData &&
+            assetPacksListingData.length > 0 && (
+              <ColumnStackLayout expand noMargin>
+                <Line noMargin>
+                  <Text size="block-title">
+                    <Trans>Asset packs</Trans>
+                  </Text>
+                </Line>
+                <Line expand noMargin justifyContent="center">
+                  <GridList
+                    cols={windowWidth === 'small' ? 1 : 3}
+                    cellHeight="auto"
+                    spacing={2}
+                  >
+                    {assetPacksListingData.map(assetPackListingData => (
+                      <PrivateAssetPackTile
+                        assetPackListingData={assetPackListingData}
+                        onSelect={() => {
+                          sendAssetPackOpened({
+                            assetPackName: assetPackListingData.name,
+                            assetPackId: assetPackListingData.id,
+                            assetPackTag: null,
+                            assetPackKind: 'private',
+                            source: 'author-profile',
+                          });
+                          onAssetPackOpen(assetPackListingData);
+                        }}
+                        owned={false}
+                        key={assetPackListingData.id}
+                      />
+                    ))}
+                  </GridList>
+                </Line>
+              </ColumnStackLayout>
+            )}
+          {isAuthenticatedUserProfile && (
+            <UserAchievements
+              badges={badges}
+              displayUnclaimedAchievements={!!isAuthenticatedUserProfile}
+              displayNotifications={!!isAuthenticatedUserProfile}
+            />
+          )}
         </ColumnStackLayout>
       )}
     </I18n>

--- a/newIDE/app/src/Utils/Analytics/EventSender.js
+++ b/newIDE/app/src/Utils/Analytics/EventSender.js
@@ -300,6 +300,7 @@ export const sendAssetPackOpened = (options: {|
   assetPackTag: string | null,
   assetPackId: string | null,
   assetPackKind: 'public' | 'private' | 'unknown',
+  source: 'store-home' | 'author-profile',
 |}) => {
   recordEvent('asset_pack_opened', options);
 };

--- a/newIDE/app/src/Utils/GDevelopServices/Shop.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Shop.js
@@ -43,6 +43,21 @@ export const listListedPrivateAssetPacks = async (): Promise<
   return response.data;
 };
 
+export const listSellerProducts = async ({
+  sellerId,
+  productType,
+}: {|
+  sellerId: string,
+  productType: 'asset-pack',
+|}): Promise<Array<PrivateAssetPackListingData>> => {
+  const response = await client.get(`/user/${sellerId}/product`, {
+    params: {
+      productType,
+    },
+  });
+  return response.data;
+};
+
 export const listUserPurchases = async (
   getAuthorizationHeader: () => Promise<string>,
   {

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/PrivateAssetPackInformationPage.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/PrivateAssetPackInformationPage.stories.js
@@ -99,6 +99,7 @@ export const Default = () => {
       privateAssetPackListingData={privateAssetPackListingData}
       isPurchaseDialogOpen={false}
       onOpenPurchaseDialog={() => action('open purchase dialog')()}
+      onAssetPackOpen={() => action('open asset pack')()}
     />
   );
 };
@@ -136,6 +137,7 @@ export const WithPurchaseDialogOpen = () => {
       privateAssetPackListingData={privateAssetPackListingData}
       isPurchaseDialogOpen
       onOpenPurchaseDialog={() => action('open purchase dialog')()}
+      onAssetPackOpen={() => action('open asset pack')()}
     />
   );
 };
@@ -175,6 +177,7 @@ export const Loading = () => {
       privateAssetPackListingData={privateAssetPackListingData}
       isPurchaseDialogOpen={false}
       onOpenPurchaseDialog={() => action('open purchase dialog')()}
+      onAssetPackOpen={() => action('open asset pack')()}
     />
   );
 };
@@ -213,6 +216,7 @@ export const With404 = () => {
       privateAssetPackListingData={privateAssetPackListingData}
       isPurchaseDialogOpen={false}
       onOpenPurchaseDialog={() => action('open purchase dialog')()}
+      onAssetPackOpen={() => action('open asset pack')()}
     />
   );
 };
@@ -251,6 +255,7 @@ export const WithUnknownError = () => {
       privateAssetPackListingData={privateAssetPackListingData}
       isPurchaseDialogOpen={false}
       onOpenPurchaseDialog={() => action('open purchase dialog')()}
+      onAssetPackOpen={() => action('open asset pack')()}
     />
   );
 };

--- a/newIDE/app/src/stories/componentStories/PublicProfileDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/PublicProfileDialog.stories.js
@@ -8,7 +8,10 @@ import paperDecorator from '../PaperDecorator';
 import PublicProfileDialog from '../../Profile/PublicProfileDialog';
 import { indieUserProfile } from '../../fixtures/GDevelopServicesTestData';
 import { type Profile } from '../../Utils/GDevelopServices/Authentication';
-import { GDevelopUserApi } from '../../Utils/GDevelopServices/ApiConfigs';
+import {
+  GDevelopShopApi,
+  GDevelopUserApi,
+} from '../../Utils/GDevelopServices/ApiConfigs';
 
 const indieUserWithoutUsernameNorDescriptionProfile: Profile = {
   ...indieUserProfile,
@@ -23,34 +26,48 @@ export default {
   decorators: [paperDecorator, muiDecorator],
 };
 
-const badges = [
-  {
-    achievementId: 'trivial_first-event',
-    seen: true,
-    unlockedAt: '2020-10-05T11:28:24.864Z',
-    userId: 'userId',
-  },
-  {
-    achievementId: 'trivial_first-behavior',
-    seen: false,
-    unlockedAt: '2021-11-15T11:28:24.864Z',
-    userId: 'userId',
-  },
-];
+const userId = 'user-id';
+
+const packs = new Array(5).fill(0).map((_, i) => ({
+  id: `644db285-6ed7-4ba6-abf4-06ea825f441${i}`,
+  sellerId: userId,
+  createdAt: '2022-12-14T10:11:49.305Z',
+  updatedAt: '2022-12-14T10:11:49.305Z',
+  name: 'Blue Girl Platformer Pack',
+  description: '28 assets',
+  sellerStripeAccountId: 'acct_14EN2o46T03ISJOc',
+  productType: 'ASSET_PACK',
+  listing: 'ASSET_PACK',
+  thumbnailUrls: [
+    'https://resources.gdevelop-app.com/private-assets/Blue Girl Platformer Pack/thumbnail.png',
+  ],
+  stripeProductId: 'prod_MypbkdW56ntnME',
+  prices: [
+    {
+      name: 'default',
+      value: 399,
+      stripePriceId: 'price_1MErwH46T03ISJOcghK9hyKB',
+    },
+  ],
+}));
 
 const apiDataFullUser = {
   mockData: [
     {
-      url: `${GDevelopUserApi.baseUrl}/user-public-profile/user-id`,
+      url: `${GDevelopUserApi.baseUrl}/user-public-profile/${userId}`,
       method: 'GET',
       status: 200,
       response: indieUserProfile,
+      delay: 500,
     },
     {
-      url: `${GDevelopUserApi.baseUrl}/user/user-id/badge`,
+      url: `${
+        GDevelopShopApi.baseUrl
+      }/user/${userId}/product?productType=asset-pack`,
       method: 'GET',
       status: 200,
-      response: badges,
+      response: packs,
+      delay: 1000,
     },
   ],
 };
@@ -58,28 +75,40 @@ const apiDataFullUser = {
 const apiDataEmptyUser = {
   mockData: [
     {
-      url: `${GDevelopUserApi.baseUrl}/user-public-profile/user-id`,
+      url: `${GDevelopUserApi.baseUrl}/user-public-profile/${userId}`,
       method: 'GET',
       status: 200,
       response: indieUserWithoutUsernameNorDescriptionProfile,
+      delay: 1000,
     },
     {
-      url: `${GDevelopUserApi.baseUrl}/user/user-id/badge`,
+      url: `${
+        GDevelopShopApi.baseUrl
+      }/user/${userId}/product?productType=asset-pack`,
       method: 'GET',
       status: 200,
       response: [],
+      delay: 1000,
     },
   ],
 };
 
 export const FullProfile = () => (
-  <PublicProfileDialog userId="user-id" onClose={() => {}} />
+  <PublicProfileDialog
+    userId={userId}
+    onClose={() => {}}
+    onAssetPackOpen={() => {}}
+  />
 );
 FullProfile.decorators = [withMock];
 FullProfile.parameters = apiDataFullUser;
 
 export const EmptyProfile = () => (
-  <PublicProfileDialog userId="user-id" onClose={() => {}} />
+  <PublicProfileDialog
+    userId={userId}
+    onClose={() => {}}
+    onAssetPackOpen={() => {}}
+  />
 );
 EmptyProfile.decorators = [withMock];
 EmptyProfile.parameters = apiDataEmptyUser;

--- a/newIDE/app/src/stories/componentStories/PublicProfileDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/PublicProfileDialog.stories.js
@@ -28,7 +28,7 @@ export default {
 
 const userId = 'user-id';
 
-const packs = new Array(5).fill(0).map((_, i) => ({
+const assetPacks = new Array(5).fill(0).map((_, i) => ({
   id: `644db285-6ed7-4ba6-abf4-06ea825f441${i}`,
   sellerId: userId,
   createdAt: '2022-12-14T10:11:49.305Z',
@@ -66,7 +66,7 @@ const apiDataFullUser = {
       }/user/${userId}/product?productType=asset-pack`,
       method: 'GET',
       status: 200,
-      response: packs,
+      response: assetPacks,
       delay: 1000,
     },
   ],


### PR DESCRIPTION
Simple strategy of displaying the asset packs an author sells.
Then redirecting to the store's page of that pack (which either opens the purchase page or the assets page, depending on if the user owns that pack or not)


https://user-images.githubusercontent.com/4895034/209566925-aa704e04-bf80-4d3b-b39b-ace178605cea.mov

