### PR TITLE
Display additional menu items only if not mac

### DIFF
--- a/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
+++ b/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
@@ -4,7 +4,7 @@ import { type CommandName } from '../CommandPalette/CommandsList';
 export type ShortcutMap = { [CommandName]: string };
 
 const defaultShortcuts: ShortcutMap = {
-  QUIT_APP: 'CmdOrCtrl+Shift+KeyQ',
+  QUIT_APP: 'CmdOrCtrl+KeyQ', // It's important to keep this shortcut, as this default cannot be overriden on Mac.
   OPEN_PROJECT_MANAGER: 'CmdOrCtrl+Alt+KeyE',
   LAUNCH_NEW_PREVIEW: 'F4',
   LAUNCH_DEBUG_PREVIEW: 'F6',
@@ -15,7 +15,7 @@ const defaultShortcuts: ShortcutMap = {
   OPEN_PROJECT: 'CmdOrCtrl+KeyO',
   SAVE_PROJECT: 'CmdOrCtrl+KeyS',
   SAVE_PROJECT_AS: 'CmdOrCtrl+Shift+KeyS',
-  CLOSE_PROJECT: 'CmdOrCtrl+KeyQ',
+  CLOSE_PROJECT: 'CmdOrCtrl+KeyW',
   EXPORT_GAME: 'CmdOrCtrl+Shift+KeyE',
   OPEN_RECENT_PROJECT: '',
   OPEN_COMMAND_PALETTE: 'CmdOrCtrl+KeyP',

--- a/newIDE/app/src/MainFrame/MainMenu.js
+++ b/newIDE/app/src/MainFrame/MainMenu.js
@@ -165,7 +165,7 @@ export const buildMainMenuDeclarativeTemplate = ({
         onClickSendEvent: 'main-menu-close',
         enabled: !!project,
       },
-      ...(!isMacLike() || !isApplicationTopLevelMenu
+      ...(!isMacLike() && !isApplicationTopLevelMenu
         ? [
             { type: 'separator' },
             {


### PR DESCRIPTION
Fix #4708 

Still 1 thing to fix.
I don't understand how the topmenu shortcurt for "Close Project" does not appear, whilst it appears in the app menu.

Before:
topmenu
![image](https://user-images.githubusercontent.com/4895034/208381140-17d9a812-8fd6-4be2-9d80-0f4eeb2ba4bd.png)
appmenu
![image](https://user-images.githubusercontent.com/4895034/208381065-dd7bb99e-cf6e-46f2-9520-8ec9dfaba061.png)

After:
topmenu
<img width="349" alt="image" src="https://user-images.githubusercontent.com/4895034/208381188-b6e70edd-84d4-4afa-8785-def0bad9f9ca.png">
filemenu
<img width="416" alt="image" src="https://user-images.githubusercontent.com/4895034/208381109-fe35289f-57d7-42a2-9ecb-01057b6277ad.png">
