### PR TITLE
In the scene editor, paste cut instances at highest z order

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -1,5 +1,6 @@
 // @flow
 import { roundPosition } from '../Utils/GridHelpers';
+import { unserializeFromJSObject } from '../Utils/Serializer';
 import { type InstancesEditorSettings } from './InstancesEditorSettings';
 const gd: libGDevelop = global.gd;
 
@@ -50,6 +51,25 @@ export default class InstancesAdder {
   setInstancesEditorSettings(instancesEditorSettings: InstancesEditorSettings) {
     this._instancesEditorSettings = instancesEditorSettings;
   }
+
+  addSerializedInstances = (
+    position: [number, number],
+    copyReferential: [number, number],
+    serializedInstances: Array<Object>
+  ): Array<gdInitialInstance> => {
+    const newInstances = serializedInstances.map(serializedInstance => {
+      const instance = new gd.InitialInstance();
+      unserializeFromJSObject(instance, serializedInstance);
+      instance.setX(instance.getX() - copyReferential[0] + position[0]);
+      instance.setY(instance.getY() - copyReferential[1] + position[1]);
+      const newInstance = this._instances
+        .insertInitialInstance(instance)
+        .resetPersistentUuid();
+      instance.delete();
+      return newInstance;
+    });
+    return newInstances;
+  };
 
   /**
    * Immediately create new instance at the specified position

--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -52,12 +52,23 @@ export default class InstancesAdder {
     this._instancesEditorSettings = instancesEditorSettings;
   }
 
-  addSerializedInstances = (
+  addSerializedInstances = ({
+    position,
+    copyReferential,
+    serializedInstances,
+    preventSnapToGrid = false,
+    addInstancesInTheForeground = false,
+  }: {|
     position: [number, number],
     copyReferential: [number, number],
     serializedInstances: Array<Object>,
-    preventSnapToGrid?: boolean = false
-  ): Array<gdInitialInstance> => {
+    preventSnapToGrid?: boolean,
+    addInstancesInTheForeground?: boolean,
+  |}): Array<gdInitialInstance> => {
+    this._zOrderFinder.reset();
+    this._instances.iterateOverInstances(this._zOrderFinder);
+    const zOrder = this._zOrderFinder.getHighestZOrder() + 1;
+
     const newInstances = serializedInstances.map(serializedInstance => {
       const instance = new gd.InitialInstance();
       unserializeFromJSObject(instance, serializedInstance);
@@ -70,6 +81,7 @@ export default class InstancesAdder {
         : roundPositionsToGrid(desiredPosition, this._instancesEditorSettings);
       instance.setX(newPos[0]);
       instance.setY(newPos[1]);
+      if (addInstancesInTheForeground) instance.setZOrder(zOrder);
       const newInstance = this._instances
         .insertInitialInstance(instance)
         .resetPersistentUuid();

--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -55,13 +55,21 @@ export default class InstancesAdder {
   addSerializedInstances = (
     position: [number, number],
     copyReferential: [number, number],
-    serializedInstances: Array<Object>
+    serializedInstances: Array<Object>,
+    preventSnapToGrid?: boolean = false
   ): Array<gdInitialInstance> => {
     const newInstances = serializedInstances.map(serializedInstance => {
       const instance = new gd.InitialInstance();
       unserializeFromJSObject(instance, serializedInstance);
-      instance.setX(instance.getX() - copyReferential[0] + position[0]);
-      instance.setY(instance.getY() - copyReferential[1] + position[1]);
+      const desiredPosition = [
+        instance.getX() - copyReferential[0] + position[0],
+        instance.getY() - copyReferential[1] + position[1],
+      ];
+      const newPos = preventSnapToGrid
+        ? desiredPosition
+        : roundPositionsToGrid(desiredPosition, this._instancesEditorSettings);
+      instance.setX(newPos[0]);
+      instance.setY(newPos[1]);
       const newInstance = this._instances
         .insertInitialInstance(instance)
         .resetPersistentUuid();

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -552,18 +552,14 @@ export default class InstancesEditor extends Component<Props> {
    * Immediately add serialized instances at the given
    * position (in scene coordinates).
    */
-  addSerializedInstances = (
+  addSerializedInstances = (options: {|
     position: [number, number],
     copyReferential: [number, number],
     serializedInstances: Array<Object>,
-    preventSnapToGrid: boolean = false,
-  ): Array<gdInitialInstance> => {
-    return this._instancesAdder.addSerializedInstances(
-      position,
-      copyReferential,
-      serializedInstances,
-      preventSnapToGrid
-    );
+    preventSnapToGrid?: boolean,
+    addInstancesInTheForeground?: boolean,
+  |}): Array<gdInitialInstance> => {
+    return this._instancesAdder.addSerializedInstances(options);
   };
 
   /**

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -555,12 +555,14 @@ export default class InstancesEditor extends Component<Props> {
   addSerializedInstances = (
     position: [number, number],
     copyReferential: [number, number],
-    serializedInstances: Array<Object>
+    serializedInstances: Array<Object>,
+    preventSnapToGrid: boolean = false,
   ): Array<gdInitialInstance> => {
     return this._instancesAdder.addSerializedInstances(
       position,
       copyReferential,
-      serializedInstances
+      serializedInstances,
+      preventSnapToGrid
     );
   };
 

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -549,12 +549,28 @@ export default class InstancesEditor extends Component<Props> {
   };
 
   /**
-   * Immediately add instances for the specified objects at the given
+   * Immediately add serialized instances at the given
    * position (in scene coordinates).
    */
+  addSerializedInstances = (
+    position: [number, number],
+    copyReferential: [number, number],
+    serializedInstances: Array<Object>
+  ): Array<gdInitialInstance> => {
+    return this._instancesAdder.addSerializedInstances(
+      position,
+      copyReferential,
+      serializedInstances
+    );
+  };
+
+  /**
+   * Immediately add instances for the specified objects at the given
+   * position (in scene coordinates) given their names.
+   */
   addInstances = (
-    pos /*: [number, number] */,
-    objectNames /*: Array<string> */
+    pos: [number, number],
+    objectNames: Array<string>
   ): Array<gdInitialInstance> => {
     return this._instancesAdder.addInstances(pos, objectNames);
   };

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -154,10 +154,10 @@ type State = {|
   selectedObjectTags: SelectedTags,
 |};
 
-type CopyCutPasteOptions = {
+type CopyCutPasteOptions = {|
   useLastCursorPosition?: boolean,
   pasteInTheForeground?: boolean,
-};
+|};
 
 export default class SceneEditor extends React.Component<Props, State> {
   static defaultProps = {
@@ -1147,8 +1147,8 @@ export default class SceneEditor extends React.Component<Props, State> {
     }
   };
 
-  cutSelection = (options: CopyCutPasteOptions = {}) => {
-    this.copySelection({ ...options, pasteInTheForeground: true });
+  cutSelection = ({ useLastCursorPosition }: CopyCutPasteOptions = {}) => {
+    this.copySelection({ useLastCursorPosition, pasteInTheForeground: true });
     this.deleteSelection();
   };
 

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1155,7 +1155,8 @@ export default class SceneEditor extends React.Component<Props, State> {
     const newInstances = editor.addSerializedInstances(
       [0, 0],
       [-2 * MOVEMENT_BIG_DELTA, -2 * MOVEMENT_BIG_DELTA],
-      serializedSelection
+      serializedSelection,
+      /* preventSnapToGrid */ true
     );
     this._onInstancesAdded(newInstances);
     this.instancesSelection.clearSelection();


### PR DESCRIPTION
Multiple things in this PR:
- When pasting cut instances, put them at the highest z order
  - The relative z order of the cut instances is respected
- When pasting instances, snap them to the grid if activated
  - Duplicating instances is not concerned, new instances are still added slightly off
- Almost related: Duplicating objects in the objects list do not appear in the clipboard anymore