### PR TITLE
When selecting multiple instances, dynamically show instances that will be (un)selected

### DIFF
--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -378,6 +378,7 @@ export default class InstancesEditor extends Component<Props> {
       instances: props.initialInstances,
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       toSceneCoordinates: this.viewPosition.toSceneCoordinates,
+      onInstancesTemporarySelected: this.temporarySelectInstances,
     });
     this.selectedInstances = new SelectedInstances({
       instancesSelection: this.props.instancesSelection,
@@ -626,12 +627,14 @@ export default class InstancesEditor extends Component<Props> {
 
       this.scrollBy(-sceneDeltaX, -sceneDeltaY);
     } else {
-      const temporarySelectedInstances = this.selectionRectangle.updateSelectionRectangle(
-        x,
-        y
-      );
+      this.selectionRectangle.updateSelectionRectangle(x, y);
+    }
+  };
+
+  temporarySelectInstances = (instances: Array<gdInitialInstance>) => {
+    if (this.selectionRectangle.hasStartedSelectionRectangle()) {
       this.instancesTemporarySelection.selectInstances({
-        instances: temporarySelectedInstances,
+        instances,
         multiSelect: false,
         layersVisibility: this._getLayersVisibility(),
       });


### PR DESCRIPTION
This PR makes it possible to see which instance will be selected with the selection rectangle.

Selected instances that are included in the selection rectangle will be unselected. Currently, they are show with 2 rectangle with their own opacity so it's a bit darker but I don't know if one can easily see it.

A quick solution could be to use a different color for the dynamical selection but it could feel weird.

https://user-images.githubusercontent.com/32449369/209108395-e651ad00-0af3-4fdd-8916-a6bba50420d7.mov

