### PR TITLE
Fix asset store preview

### DIFF
--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -65,6 +65,9 @@ const styles = {
     maxHeight: '100%',
     verticalAlign: 'middle',
     pointerEvents: 'none',
+    // Compromise between having a preview of the asset slightly more zoomed
+    // compared to the search results and a not too zoomed image for small
+    // smooth assets that could give a sense of bad quality.
     flex: 0.6,
   },
   arrowContainer: {

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -293,7 +293,7 @@ export const AssetDetails = React.forwardRef<Props, AssetDetailsInterface>(
                     </Text>
                     {!!assetAuthors &&
                       assetAuthors.map(author => (
-                        <Text size="body">
+                        <Text size="body" key={author.name}>
                           <Link
                             key={author.name}
                             href={author.website}
@@ -310,7 +310,7 @@ export const AssetDetails = React.forwardRef<Props, AssetDetailsInterface>(
                         const username =
                           userPublicProfile.username || 'GDevelop user';
                         return (
-                          <Text size="body">
+                          <Text size="body" key={userPublicProfile.id}>
                             <Link
                               key={userPublicProfile.id}
                               href="#"

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -40,6 +40,7 @@ import {
   getUserPublicProfilesByIds,
   type UserPublicProfile,
 } from '../Utils/GDevelopServices/User';
+import { getPixelatedImageRendering } from '../Utils/CssHelpers';
 
 const FIXED_HEIGHT = 250;
 const FIXED_WIDTH = 300;
@@ -64,6 +65,7 @@ const styles = {
     maxHeight: '100%',
     verticalAlign: 'middle',
     pointerEvents: 'none',
+    flex: 0.6,
   },
   arrowContainer: {
     padding: 6,
@@ -152,6 +154,15 @@ export const AssetDetails = React.forwardRef<Props, AssetDetailsInterface>(
         scrollViewElement.scrollToPosition(y);
       },
     }));
+
+    const getImagePreviewStyle = (assetShortHeader: Asset) => {
+      return {
+        ...styles.previewImage,
+        imageRendering: isPixelArt(assetShortHeader)
+          ? getPixelatedImageRendering()
+          : undefined,
+      };
+    };
 
     const loadAsset = React.useCallback(
       () => {
@@ -391,13 +402,13 @@ export const AssetDetails = React.forwardRef<Props, AssetDetailsInterface>(
                     <div style={styles.previewBackground}>
                       {isAssetPrivate ? (
                         <AuthorizedAssetImage
-                          style={styles.previewImage}
+                          style={getImagePreviewStyle(asset)}
                           url={asset.previewImageUrls[0]}
                           alt={asset.name}
                         />
                       ) : (
                         <CorsAwareImage
-                          style={styles.previewImage}
+                          style={getImagePreviewStyle(asset)}
                           src={asset.previewImageUrls[0]}
                           alt={asset.name}
                         />

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -21,7 +21,7 @@ const styles = {
     padding: 8,
     overflowY: 'scroll',
     overflowX: 'hidden',
-    flex: 2,
+    flex: 1,
   },
 };
 

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -167,10 +167,14 @@ const ImagePreview = ({
   // the zoom factor to the image.
   React.useEffect(
     () => {
-      if (hasZoomBeenAdaptedToImageRef.current) return;
+      if (hasZoomBeenAdaptedToImageRef.current || initialZoom) {
+        // Do not adapt zoom to image if a zoom as been provided in the props
+        // or if the zoom has already been adapted.
+        return;
+      }
       hasZoomBeenAdaptedToImageRef.current = adaptZoomFactorToImage();
     },
-    [adaptZoomFactorToImage]
+    [adaptZoomFactorToImage, initialZoom]
   );
 
   const handleImageLoaded = (e: any) => {

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -29,7 +29,7 @@ import {
 const gd: libGDevelop = global.gd;
 
 const MARGIN = 50;
-const SPRITE_MARGIN_RATIO = 1.3;
+const SPRITE_MARGIN_RATIO = 1.5;
 
 const styles = {
   previewImagePixelated: {


### PR DESCRIPTION
Fix image preview displaying scrollbars in the asset store
Also adds zoom on tiled sprites in the asset store

Before:

<img width="433" alt="image" src="https://user-images.githubusercontent.com/32449369/209146188-26256d7c-25ce-45fa-a1f0-3e3a91de0417.png">


After:

<img width="471" alt="image" src="https://user-images.githubusercontent.com/32449369/209145676-855bcf92-be96-4659-b1dd-66685f78f3e1.png">
