### PR TITLE
Allow opening Game from dashboard + first version of router + various fixes

### DIFF
--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -64,10 +64,6 @@ export const create = (authentication: Authentication) => {
               renderPreviewLauncher={(props, ref) => (
                 <BrowserS3PreviewLauncher {...props} ref={ref} />
               )}
-              initialDialog={appArguments['initial-dialog']}
-              initialGameId={appArguments['game-id']}
-              initialGamesDashboardTab={appArguments['games-dashboard-tab']}
-              initialAssetPackUserFriendlySlug={appArguments['asset-pack']}
               renderExportDialog={props => (
                 <ExportDialog
                   project={props.project}

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -455,7 +455,11 @@ export default class ExportLauncher extends Component<Props, State> {
           })}
         {doneFooterOpen && (
           <Line justifyContent="center">
-            <GameRegistration project={project} hideIfSubscribed hideLoader />
+            <GameRegistration
+              project={project}
+              hideLoader
+              suggestGameStatsEmail
+            />
           </Line>
         )}
       </Column>

--- a/newIDE/app/src/GameDashboard/GameCard.js
+++ b/newIDE/app/src/GameDashboard/GameCard.js
@@ -185,6 +185,7 @@ export const GameCard = ({
         <>
           <Card
             key={game.id}
+            background={isCurrentGame ? 'dark' : 'medium'}
             cardCornerAction={
               <ElementWithMenu
                 element={
@@ -249,6 +250,7 @@ export const GameCard = ({
                 <GameThumbnail
                   gameName={game.gameName}
                   thumbnailUrl={game.thumbnailUrl}
+                  background={isCurrentGame ? 'medium' : 'light'}
                 />
               </Column>
               <Spacer />

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -45,6 +45,7 @@ import LeaderboardAdmin from './LeaderboardAdmin';
 import { GameAnalyticsPanel } from './GameAnalyticsPanel';
 import GameFeedback from './Feedbacks/GameFeedback';
 import { GameMonetization } from './Monetization/GameMonetization';
+import RouterContext from '../MainFrame/RouterContext';
 
 export type GameDetailsTab =
   | 'details'
@@ -84,7 +85,6 @@ export const gameDetailsTabs: TabOptions<GameDetailsTab> = [
 type Props = {|
   game: Game,
   project: ?gdProject,
-  initialTab: GameDetailsTab,
   onClose: () => void,
   onGameUpdated: (updatedGame: Game) => void,
   onGameDeleted: () => void,
@@ -93,17 +93,15 @@ type Props = {|
 export const GameDetailsDialog = ({
   game,
   project,
-  initialTab,
   onClose,
   onGameUpdated,
   onGameDeleted,
 }: Props) => {
+  const { appArguments, removeArguments } = React.useContext(RouterContext);
   const { getAuthorizationHeader, profile } = React.useContext(
     AuthenticatedUserContext
   );
-  const [currentTab, setCurrentTab] = React.useState<GameDetailsTab>(
-    initialTab
-  );
+  const [currentTab, setCurrentTab] = React.useState<GameDetailsTab>('details');
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [
     gameUnregisterErrorText,
@@ -118,6 +116,23 @@ export const GameDetailsDialog = ({
     isPublicGamePropertiesDialogOpen,
     setIsPublicGamePropertiesDialogOpen,
   ] = React.useState(false);
+
+  // If a game dashboard tab is specified, switch to it.
+  React.useEffect(
+    () => {
+      if (appArguments['games-dashboard-tab']) {
+        // Ensure that the tab is valid.
+        const gameDetailsTab = gameDetailsTabs.find(
+          gameDetailsTab =>
+            gameDetailsTab.value === appArguments['games-dashboard-tab']
+        );
+        if (gameDetailsTab) setCurrentTab(gameDetailsTab.value);
+        // Cleanup once open, to ensure it is not opened again.
+        removeArguments(['games-dashboard-tab']);
+      }
+    },
+    [appArguments, removeArguments]
+  );
 
   const loadPublicGame = React.useCallback(
     async () => {

--- a/newIDE/app/src/GameDashboard/GameDetailsDialog.js
+++ b/newIDE/app/src/GameDashboard/GameDetailsDialog.js
@@ -97,7 +97,9 @@ export const GameDetailsDialog = ({
   onGameUpdated,
   onGameDeleted,
 }: Props) => {
-  const { appArguments, removeArguments } = React.useContext(RouterContext);
+  const { routeArguments, removeRouteArguments } = React.useContext(
+    RouterContext
+  );
   const { getAuthorizationHeader, profile } = React.useContext(
     AuthenticatedUserContext
   );
@@ -120,18 +122,18 @@ export const GameDetailsDialog = ({
   // If a game dashboard tab is specified, switch to it.
   React.useEffect(
     () => {
-      if (appArguments['games-dashboard-tab']) {
+      if (routeArguments['games-dashboard-tab']) {
         // Ensure that the tab is valid.
         const gameDetailsTab = gameDetailsTabs.find(
           gameDetailsTab =>
-            gameDetailsTab.value === appArguments['games-dashboard-tab']
+            gameDetailsTab.value === routeArguments['games-dashboard-tab']
         );
         if (gameDetailsTab) setCurrentTab(gameDetailsTab.value);
         // Cleanup once open, to ensure it is not opened again.
-        removeArguments(['games-dashboard-tab']);
+        removeRouteArguments(['games-dashboard-tab']);
       }
     },
-    [appArguments, removeArguments]
+    [routeArguments, removeRouteArguments]
   );
 
   const loadPublicGame = React.useCallback(

--- a/newIDE/app/src/GameDashboard/GameRegistration.js
+++ b/newIDE/app/src/GameDashboard/GameRegistration.js
@@ -4,8 +4,6 @@ import * as React from 'react';
 import CreateProfile from '../Profile/CreateProfile';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import AlertMessage from '../UI/AlertMessage';
-import { Line } from '../UI/Grid';
-import { ColumnStackLayout } from '../UI/Layout';
 import { showErrorBox } from '../UI/Messages/MessageBox';
 import PlaceholderError from '../UI/PlaceholderError';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
@@ -15,28 +13,22 @@ import {
   getGame,
   registerGame,
 } from '../Utils/GDevelopServices/Game';
-import { type Profile } from '../Utils/GDevelopServices/Authentication';
-import TimelineIcon from '@material-ui/icons/Timeline';
-import { GameDetailsDialog } from './GameDetailsDialog';
 
-type Props = {|
+export type GameRegistrationProps = {|
   project: ?gdProject,
-  hideIfRegistered?: boolean,
-  hideIfSubscribed?: boolean,
+  suggestGameStatsEmail?: boolean,
   hideLoader?: boolean,
   onGameRegistered?: () => void | Promise<void>,
 |};
 
-type DetailsTab = 'details' | 'analytics';
 type UnavailableReason = 'unauthorized' | 'not-existing' | null;
 
 export const GameRegistration = ({
   project,
-  hideIfRegistered,
-  hideIfSubscribed,
+  suggestGameStatsEmail,
   hideLoader,
   onGameRegistered,
-}: Props) => {
+}: GameRegistrationProps) => {
   const {
     authenticated,
     onLogin,
@@ -58,10 +50,6 @@ export const GameRegistration = ({
     acceptGameStatsEmailInProgress,
     setAcceptGameStatsEmailInProgress,
   ] = React.useState(false);
-  const [detailsOpened, setDetailsOpened] = React.useState(false);
-  const [detailsInitialTab, setDetailsInitialTab] = React.useState<DetailsTab>(
-    'details'
-  );
 
   const loadGame = React.useCallback(
     async () => {
@@ -159,80 +147,6 @@ export const GameRegistration = ({
     [loadGame, game]
   );
 
-  return (
-    <GameRegistrationWidget
-      authenticated={authenticated}
-      profile={profile}
-      onLogin={onLogin}
-      onCreateAccount={onCreateAccount}
-      project={project}
-      game={game}
-      setGame={setGame}
-      loadGame={loadGame}
-      onRegisterGame={onRegisterGame}
-      registrationInProgress={registrationInProgress}
-      hideIfRegistered={hideIfRegistered}
-      hideIfSubscribed={hideIfSubscribed}
-      unavailableReason={unavailableReason}
-      acceptGameStatsEmailInProgress={acceptGameStatsEmailInProgress}
-      onAcceptGameStatsEmail={_onAcceptGameStatsEmail}
-      detailsInitialTab={detailsInitialTab}
-      setDetailsInitialTab={setDetailsInitialTab}
-      detailsOpened={detailsOpened}
-      setDetailsOpened={setDetailsOpened}
-      error={error}
-      hideLoader={hideLoader}
-    />
-  );
-};
-
-export type GameRegistrationWidgetProps = {|
-  authenticated: boolean,
-  profile?: ?Profile,
-  onLogin: () => void,
-  onCreateAccount: () => void,
-  project?: ?gdProject,
-  game: ?Game,
-  setGame: Game => void,
-  loadGame: () => Promise<void>,
-  onRegisterGame: () => Promise<void>,
-  registrationInProgress: boolean,
-  hideIfRegistered?: boolean,
-  hideIfSubscribed?: boolean,
-  unavailableReason: ?UnavailableReason,
-  acceptGameStatsEmailInProgress: boolean,
-  onAcceptGameStatsEmail: () => Promise<void>,
-  detailsInitialTab: DetailsTab,
-  setDetailsInitialTab: (string: DetailsTab) => void,
-  detailsOpened: boolean,
-  setDetailsOpened: boolean => void,
-  error: ?Error,
-  hideLoader?: boolean,
-|};
-
-export const GameRegistrationWidget = ({
-  authenticated,
-  profile,
-  onLogin,
-  onCreateAccount,
-  project,
-  game,
-  setGame,
-  loadGame,
-  onRegisterGame,
-  registrationInProgress,
-  hideIfRegistered,
-  hideIfSubscribed,
-  unavailableReason,
-  acceptGameStatsEmailInProgress,
-  onAcceptGameStatsEmail,
-  detailsInitialTab,
-  setDetailsInitialTab,
-  detailsOpened,
-  setDetailsOpened,
-  error,
-  hideLoader,
-}: GameRegistrationWidgetProps) => {
   if (!project) {
     return null;
   }
@@ -257,9 +171,8 @@ export const GameRegistrationWidget = ({
         )}
       >
         <Trans>
-          This project is not registered online. Register it now to get access
-          to metrics collected anonymously, like the number of daily players and
-          retention of the players after a few days.
+          The project currently opened is not registered online. Register it now
+          to get access to leaderboards, player accounts, analytics and more!
         </Trans>
       </AlertMessage>
     );
@@ -269,9 +182,9 @@ export const GameRegistrationWidget = ({
     return (
       <AlertMessage kind="error">
         <Trans>
-          This project is registered online but you don't have access to it. Ask
-          the original owner of the game to share it with you to get access to
-          the game metrics.
+          The project currently opened is registered online but you don't have
+          access to it. Ask the original owner of the game to share it with you
+          to be able to manage it.
         </Trans>
       </AlertMessage>
     );
@@ -290,58 +203,27 @@ export const GameRegistrationWidget = ({
     );
   }
 
-  if (game) {
-    if (hideIfRegistered) return null;
-    if (!profile.getGameStatsEmail) {
-      return (
-        <AlertMessage
-          kind="info"
-          renderRightButton={() => (
-            <RaisedButton
-              label={<Trans>Get game stats</Trans>}
-              disabled={acceptGameStatsEmailInProgress}
-              primary
-              onClick={onAcceptGameStatsEmail}
-            />
-          )}
-        >
-          <Trans>Get stats about your game every week!</Trans>
-        </AlertMessage>
-      );
-    }
-    if (hideIfSubscribed) return null;
+  if (!game && !hideLoader) {
+    return <PlaceholderLoader />;
+  }
+
+  if (game && suggestGameStatsEmail && !profile.getGameStatsEmail) {
     return (
-      <ColumnStackLayout noMargin>
-        <Line justifyContent="center">
+      <AlertMessage
+        kind="info"
+        renderRightButton={() => (
           <RaisedButton
-            icon={<TimelineIcon />}
-            label={<Trans>Analytics</Trans>}
-            onClick={() => {
-              setDetailsInitialTab('analytics');
-              setDetailsOpened(true);
-            }}
-          />
-        </Line>
-        {detailsOpened && (
-          <GameDetailsDialog
-            game={game}
-            project={project}
-            initialTab={detailsInitialTab}
-            onClose={() => {
-              setDetailsOpened(false);
-            }}
-            onGameUpdated={updatedGame => {
-              setGame(updatedGame);
-            }}
-            onGameDeleted={() => {
-              setDetailsOpened(false);
-              loadGame();
-            }}
+            label={<Trans>Get game stats</Trans>}
+            disabled={acceptGameStatsEmailInProgress}
+            primary
+            onClick={_onAcceptGameStatsEmail}
           />
         )}
-      </ColumnStackLayout>
+      >
+        <Trans>Get stats about your game every week!</Trans>
+      </AlertMessage>
     );
   }
 
-  return hideLoader ? null : <PlaceholderLoader />;
+  return null; // Hide the component if the game is registered.
 };

--- a/newIDE/app/src/GameDashboard/GameThumbnail.js
+++ b/newIDE/app/src/GameDashboard/GameThumbnail.js
@@ -19,9 +19,14 @@ const styles = {
 type Props = {|
   thumbnailUrl?: string,
   gameName: string,
+  background?: 'light' | 'medium' | 'dark',
 |};
 
-export const GameThumbnail = ({ thumbnailUrl, gameName }: Props) =>
+export const GameThumbnail = ({
+  thumbnailUrl,
+  gameName,
+  background = 'light',
+}: Props) =>
   thumbnailUrl ? (
     <img
       src={thumbnailUrl}
@@ -40,7 +45,7 @@ export const GameThumbnail = ({ thumbnailUrl, gameName }: Props) =>
         whiteSpace: 'normal',
         display: 'flex',
       }}
-      background="light"
+      background={background}
     >
       <EmptyMessage>
         <Trans>No thumbnail set</Trans>

--- a/newIDE/app/src/GameDashboard/GamesList.js
+++ b/newIDE/app/src/GameDashboard/GamesList.js
@@ -22,9 +22,11 @@ type Props = {|
 |};
 
 export const GamesList = ({ project }: Props) => {
-  const { appArguments, removeArguments, addArguments } = React.useContext(
-    RouterContext
-  );
+  const {
+    routeArguments,
+    addRouteArguments,
+    removeRouteArguments,
+  } = React.useContext(RouterContext);
   const [error, setError] = React.useState<?Error>(null);
   const [games, setGames] = React.useState<?Array<Game>>(null);
   const {
@@ -97,10 +99,10 @@ export const GamesList = ({ project }: Props) => {
     () => {
       const loadInitialGame = async () => {
         // When games are loaded and we have an initial game id, try to open it.
-        const initialGameId = appArguments['game-id'];
+        const initialGameId = routeArguments['game-id'];
         if (games && initialGameId) {
           const game = games.find(game => game.id === initialGameId);
-          removeArguments(['game-id']);
+          removeRouteArguments(['game-id']);
           if (game) {
             setOpenedGame(game);
           } else {
@@ -131,8 +133,8 @@ export const GamesList = ({ project }: Props) => {
     },
     [
       games,
-      appArguments,
-      removeArguments,
+      routeArguments,
+      removeRouteArguments,
       onRegisterGame,
       showConfirmation,
       showAlert,
@@ -191,7 +193,7 @@ export const GamesList = ({ project }: Props) => {
           isCurrentGame={!!projectUuid && game.id === projectUuid}
           game={game}
           onOpenGameManager={(tab: GameDetailsTab) => {
-            addArguments({ 'games-dashboard-tab': tab });
+            addRouteArguments({ 'games-dashboard-tab': tab });
             setOpenedGame(game);
           }}
           onUpdateGame={loadGames}

--- a/newIDE/app/src/GameDashboard/GamesList.js
+++ b/newIDE/app/src/GameDashboard/GamesList.js
@@ -1,40 +1,41 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import PlaceholderError from '../UI/PlaceholderError';
-import { type Game, getGames } from '../Utils/GDevelopServices/Game';
+import {
+  type Game,
+  getGames,
+  registerGame,
+} from '../Utils/GDevelopServices/Game';
 import { GameCard } from './GameCard';
 import { ColumnStackLayout } from '../UI/Layout';
 import { GameRegistration } from './GameRegistration';
 import { GameDetailsDialog, type GameDetailsTab } from './GameDetailsDialog';
+import useAlertDialog from '../UI/Alert/useAlertDialog';
+import RouterContext from '../MainFrame/RouterContext';
+import { extractGDevelopApiErrorStatusAndCode } from '../Utils/GDevelopServices/Errors';
 
 type Props = {|
   project: ?gdProject,
-  initialGameId: ?string,
-  initialTab: ?GameDetailsTab,
-  onGameDetailsDialogClose: () => void,
 |};
 
-export const GamesList = ({
-  project,
-  initialGameId,
-  initialTab,
-  onGameDetailsDialogClose,
-}: Props) => {
+export const GamesList = ({ project }: Props) => {
+  const { appArguments, removeArguments, addArguments } = React.useContext(
+    RouterContext
+  );
   const [error, setError] = React.useState<?Error>(null);
   const [games, setGames] = React.useState<?Array<Game>>(null);
   const {
     authenticated,
     firebaseUser,
     getAuthorizationHeader,
+    profile,
   } = React.useContext(AuthenticatedUserContext);
   const [openedGame, setOpenedGame] = React.useState<?Game>(null);
-  const [
-    openedGameInitialTab,
-    setOpenedGameInitialTab,
-  ] = React.useState<GameDetailsTab>(initialTab || 'details');
+  const { showAlert, showConfirmation } = useAlertDialog();
+  const [isGameRegistering, setIsGameRegistering] = React.useState(false);
 
   const loadGames = React.useCallback(
     async () => {
@@ -44,19 +45,99 @@ export const GamesList = ({
         setError(null);
         const games = await getGames(getAuthorizationHeader, firebaseUser.uid);
         setGames(games);
-        // If a game id was passed, open it.
-        if (initialGameId) {
-          const game = games.find(game => game.id === initialGameId);
-          if (game) {
-            setOpenedGame(game);
-          }
-        }
       } catch (error) {
         console.error('Error while loading user games.', error);
         setError(error);
       }
     },
-    [authenticated, firebaseUser, getAuthorizationHeader, initialGameId]
+    [authenticated, firebaseUser, getAuthorizationHeader]
+  );
+
+  const onRegisterGame = React.useCallback(
+    async () => {
+      if (!profile || !project) return;
+
+      const { id } = profile;
+      try {
+        setIsGameRegistering(true);
+        await registerGame(getAuthorizationHeader, id, {
+          gameId: project.getProjectUuid(),
+          authorName: project.getAuthor() || 'Unspecified publisher',
+          gameName: project.getName() || 'Untitled game',
+          templateSlug: project.getTemplateSlug(),
+        });
+        await loadGames();
+      } catch (error) {
+        console.error('Unable to register the game.', error);
+        const extractedStatusAndCode = extractGDevelopApiErrorStatusAndCode(
+          error
+        );
+        if (extractedStatusAndCode && extractedStatusAndCode.status === 403) {
+          await showAlert({
+            title: t`Game already registered`,
+            message: t`The project currently opened is registered online but you don't have
+          access to it. Ask the original owner of the game to share it with you
+          to be able to manage it.`,
+          });
+        } else {
+          await showAlert({
+            title: t`Unable to register the game`,
+            message: t`An error happened while registering the game. Verify your internet connection
+          or retry later.`,
+          });
+        }
+      } finally {
+        setIsGameRegistering(false);
+      }
+    },
+    [getAuthorizationHeader, profile, project, showAlert, loadGames]
+  );
+
+  React.useEffect(
+    () => {
+      const loadInitialGame = async () => {
+        // When games are loaded and we have an initial game id, try to open it.
+        const initialGameId = appArguments['game-id'];
+        if (games && initialGameId) {
+          const game = games.find(game => game.id === initialGameId);
+          removeArguments(['game-id']);
+          if (game) {
+            setOpenedGame(game);
+          } else {
+            // If the game is not in the list, then either
+            // - allow to register it, if it's the current project.
+            // - suggest to open the file before continuing, if it's not the current project.
+            if (project && project.getProjectUuid() === initialGameId) {
+              const answer = await showConfirmation({
+                title: t`Game not found`,
+                message: t`This project is not registered online. Register it now
+              to get access to leaderboards, player accounts, analytics and more!`,
+                confirmButtonLabel: t`Register`,
+              });
+              if (!answer) return;
+
+              await onRegisterGame();
+            } else {
+              await showAlert({
+                title: t`Game not found`,
+                message: t`The game you're trying to open is not registered online. Open the project
+              file, then register it before continuing.`,
+              });
+            }
+          }
+        }
+      };
+      loadInitialGame();
+    },
+    [
+      games,
+      appArguments,
+      removeArguments,
+      onRegisterGame,
+      showConfirmation,
+      showAlert,
+      project,
+    ]
   );
 
   React.useEffect(
@@ -97,19 +178,20 @@ export const GamesList = ({
 
   return (
     <ColumnStackLayout noMargin>
-      <GameRegistration
-        project={project}
-        hideIfRegistered
-        hideLoader
-        onGameRegistered={loadGames}
-      />
+      {!isGameRegistering && (
+        <GameRegistration
+          project={project}
+          hideLoader
+          onGameRegistered={loadGames}
+        />
+      )}
       {displayedGames.map(game => (
         <GameCard
           key={game.id}
           isCurrentGame={!!projectUuid && game.id === projectUuid}
           game={game}
           onOpenGameManager={(tab: GameDetailsTab) => {
-            setOpenedGameInitialTab(tab);
+            addArguments({ 'games-dashboard-tab': tab });
             setOpenedGame(game);
           }}
           onUpdateGame={loadGames}
@@ -121,10 +203,8 @@ export const GamesList = ({
           project={
             !!projectUuid && openedGame.id === projectUuid ? project : null
           }
-          initialTab={openedGameInitialTab}
           onClose={() => {
             setOpenedGame(null);
-            onGameDetailsDialogClose();
           }}
           onGameUpdated={updatedGame => {
             setGames(

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -517,7 +517,6 @@ export const LeaderboardAdmin = ({
       <CenteredError>
         <GameRegistration
           project={project}
-          hideIfRegistered
           onGameRegistered={() => {
             setDisplayGameRegistration(false);
             onListLeaderboards();

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -53,6 +53,10 @@ import BackgroundText from '../../../../UI/BackgroundText';
 import Paper from '../../../../UI/Paper';
 import PlaceholderError from '../../../../UI/PlaceholderError';
 import AlertMessage from '../../../../UI/AlertMessage';
+import { ListItemSecondaryAction } from '@material-ui/core';
+import IconButton from '../../../../UI/IconButton';
+import ThreeDotsMenu from '../../../../UI/CustomSvgIcons/ThreeDotsMenu';
+import RouterContext from '../../../RouterContext';
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
 
@@ -146,6 +150,7 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
     },
     ref
   ) => {
+    const { addArguments } = React.useContext(RouterContext);
     const { getRecentProjectFiles, removeRecentProjectFile } = React.useContext(
       PreferencesContext
     );
@@ -187,6 +192,7 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
                 fileIdentifier: cloudProject.id,
                 lastModifiedDate: Date.parse(cloudProject.lastModifiedAt),
                 name: cloudProject.name,
+                gameId: cloudProject.gameId,
               },
             };
             return file;
@@ -268,7 +274,6 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
       ];
       if (file.storageProviderName === 'Cloud') {
         actions = actions.concat([
-          { type: 'separator' },
           {
             label: i18n._(t`Delete`),
             click: () => onDeleteCloudProject(i18n, file),
@@ -280,7 +285,6 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
             label: i18n._(t`Show in local folder`),
             click: () => locateProjectFile(file),
           },
-          { type: 'separator' },
           {
             label: i18n._(t`Remove from list`),
             click: () => onRemoveFromRecentFiles(file),
@@ -288,13 +292,28 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
         ]);
       } else {
         actions = actions.concat([
-          { type: 'separator' },
           {
             label: i18n._(t`Remove from list`),
             click: () => onRemoveFromRecentFiles(file),
           },
         ]);
       }
+
+      const gameId = file.fileMetadata.gameId;
+      if (gameId) {
+        actions = actions.concat([
+          { type: 'separator' },
+          {
+            label: i18n._(t`Manage game`),
+            click: () =>
+              addArguments({
+                'initial-dialog': 'games-dashboard',
+                'game-id': gameId,
+              }),
+          },
+        ]);
+      }
+
       return actions;
     };
 
@@ -522,6 +541,20 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
                                         </Text>
                                       )}
                                     </Column>
+                                    <ListItemSecondaryAction>
+                                      <IconButton
+                                        size="small"
+                                        edge="end"
+                                        aria-label="menu"
+                                        onClick={event => {
+                                          // prevent triggering the click on the list item.
+                                          event.stopPropagation();
+                                          openContextMenu(event, file);
+                                        }}
+                                      >
+                                        <ThreeDotsMenu />
+                                      </IconButton>
+                                    </ListItemSecondaryAction>
                                   </LineStackLayout>
                                 ) : (
                                   <Column expand>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -150,7 +150,7 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
     },
     ref
   ) => {
-    const { addArguments } = React.useContext(RouterContext);
+    const { navigateToRoute } = React.useContext(RouterContext);
     const { getRecentProjectFiles, removeRecentProjectFile } = React.useContext(
       PreferencesContext
     );
@@ -306,8 +306,7 @@ const BuildSection = React.forwardRef<Props, BuildSectionInterface>(
           {
             label: i18n._(t`Manage game`),
             click: () =>
-              addArguments({
-                'initial-dialog': 'games-dashboard',
+              navigateToRoute('games-dashboard', {
                 'game-id': gameId,
               }),
           },

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -53,7 +53,7 @@ import BackgroundText from '../../../../UI/BackgroundText';
 import Paper from '../../../../UI/Paper';
 import PlaceholderError from '../../../../UI/PlaceholderError';
 import AlertMessage from '../../../../UI/AlertMessage';
-import { ListItemSecondaryAction } from '@material-ui/core';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import IconButton from '../../../../UI/IconButton';
 import ThreeDotsMenu from '../../../../UI/CustomSvgIcons/ThreeDotsMenu';
 import RouterContext from '../../../RouterContext';

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageMenu.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageMenu.js
@@ -51,23 +51,6 @@ export type HomeTab =
   | 'community'
   | 'shop';
 
-export const getInitialHomeTab = (
-  initialTab: ?string,
-  showGetStartedSection: boolean
-): HomeTab => {
-  if (
-    initialTab === 'get-started' ||
-    initialTab === 'build' ||
-    initialTab === 'learn' ||
-    initialTab === 'play' ||
-    initialTab === 'community' ||
-    initialTab === 'shop'
-  )
-    return initialTab;
-
-  return showGetStartedSection ? 'get-started' : 'build';
-};
-
 const tabs: {
   label: React.Node,
   tab: HomeTab,

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -16,13 +16,15 @@ import StoreSection from './StoreSection';
 import { TutorialContext } from '../../../Tutorial/TutorialContext';
 import { ExampleStoreContext } from '../../../AssetStore/ExampleStore/ExampleStoreContext';
 import { HomePageHeader } from './HomePageHeader';
-import { getInitialHomeTab, HomePageMenu, type HomeTab } from './HomePageMenu';
+import { HomePageMenu, type HomeTab } from './HomePageMenu';
 import PreferencesContext from '../../Preferences/PreferencesContext';
 import AuthenticatedUserContext from '../../../Profile/AuthenticatedUserContext';
 import { type ExampleShortHeader } from '../../../Utils/GDevelopServices/Example';
 import { AnnouncementsFeed } from '../../../AnnouncementsFeed';
 import { AnnouncementsFeedContext } from '../../../AnnouncementsFeed/AnnouncementsFeedContext';
 import { type ResourceManagementProps } from '../../../ResourcesList/ResourceSource';
+import RouterContext from '../../RouterContext';
+import { AssetStoreContext } from '../../../AssetStore/AssetStoreContext';
 
 type Props = {|
   project: ?gdProject,
@@ -167,8 +169,26 @@ export const HomePage = React.memo<Props>(
         forceUpdateEditor,
       }));
 
-      const [activeTab, setActiveTab] = React.useState<HomeTab>(() =>
-        getInitialHomeTab(initialTab, showGetStartedSection)
+      const { appArguments, removeArguments } = React.useContext(RouterContext);
+      const { setInitialPackUserFriendlySlug } = React.useContext(
+        AssetStoreContext
+      );
+
+      // Open the asset store and a pack if asked to do so.
+      React.useEffect(
+        () => {
+          if (appArguments['initial-dialog'] === 'asset-store') {
+            setActiveTab('shop');
+            setInitialPackUserFriendlySlug(appArguments['asset-pack']);
+            // Remove the arguments so that the asset store is not opened again.
+            removeArguments(['initial-dialog', 'asset-pack']);
+          }
+        },
+        [appArguments, removeArguments, setInitialPackUserFriendlySlug]
+      );
+
+      const [activeTab, setActiveTab] = React.useState<HomeTab>(
+        showGetStartedSection ? 'get-started' : 'build'
       );
 
       return (

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -169,7 +169,9 @@ export const HomePage = React.memo<Props>(
         forceUpdateEditor,
       }));
 
-      const { appArguments, removeArguments } = React.useContext(RouterContext);
+      const { routeArguments, removeRouteArguments } = React.useContext(
+        RouterContext
+      );
       const { setInitialPackUserFriendlySlug } = React.useContext(
         AssetStoreContext
       );
@@ -177,14 +179,14 @@ export const HomePage = React.memo<Props>(
       // Open the asset store and a pack if asked to do so.
       React.useEffect(
         () => {
-          if (appArguments['initial-dialog'] === 'asset-store') {
+          if (routeArguments['initial-dialog'] === 'asset-store') {
             setActiveTab('shop');
-            setInitialPackUserFriendlySlug(appArguments['asset-pack']);
+            setInitialPackUserFriendlySlug(routeArguments['asset-pack']);
             // Remove the arguments so that the asset store is not opened again.
-            removeArguments(['initial-dialog', 'asset-pack']);
+            removeRouteArguments(['initial-dialog', 'asset-pack']);
           }
         },
-        [appArguments, removeArguments, setInitialPackUserFriendlySlug]
+        [routeArguments, removeRouteArguments, setInitialPackUserFriendlySlug]
       );
 
       const [activeTab, setActiveTab] = React.useState<HomeTab>(

--- a/newIDE/app/src/MainFrame/Providers.js
+++ b/newIDE/app/src/MainFrame/Providers.js
@@ -36,6 +36,7 @@ import { AnnouncementsFeedStateProvider } from '../AnnouncementsFeed/Announcemen
 import PrivateAssetsAuthorizationProvider from '../AssetStore/PrivateAssets/PrivateAssetsAuthorizationProvider';
 import InAppTutorialProvider from '../InAppTutorial/InAppTutorialProvider';
 import { SubscriptionSuggestionProvider } from '../Profile/Subscription/SubscriptionSuggestionContext';
+import { RouterContextProvider } from './RouterContext';
 
 // Add the rtl plugin to the JSS instance to support RTL languages in material-ui components.
 const jss = create({
@@ -57,19 +58,18 @@ type Props = {|
  * Wrap the children with Drag and Drop, Material UI theme and i18n React providers,
  * so that these modules can be used in the children.
  */
-export default class Providers extends React.Component<Props, {||}> {
-  render() {
-    const {
-      disableCheckForUpdates,
-      authentication,
-      children,
-      makeEventsFunctionCodeWriter,
-      eventsFunctionsExtensionWriter,
-      eventsFunctionsExtensionOpener,
-    } = this.props;
-    return (
-      <DragAndDropContextProvider>
-        <UnsavedChangesContextProvider>
+const Providers = ({
+  disableCheckForUpdates,
+  authentication,
+  children,
+  makeEventsFunctionCodeWriter,
+  eventsFunctionsExtensionWriter,
+  eventsFunctionsExtensionOpener,
+}: Props) => {
+  return (
+    <DragAndDropContextProvider>
+      <UnsavedChangesContextProvider>
+        <RouterContextProvider>
           <PreferencesProvider disableCheckForUpdates={disableCheckForUpdates}>
             <PreferencesContext.Consumer>
               {({ values }) => {
@@ -136,8 +136,10 @@ export default class Providers extends React.Component<Props, {||}> {
               }}
             </PreferencesContext.Consumer>
           </PreferencesProvider>
-        </UnsavedChangesContextProvider>
-      </DragAndDropContextProvider>
-    );
-  }
-}
+        </RouterContextProvider>
+      </UnsavedChangesContextProvider>
+    </DragAndDropContextProvider>
+  );
+};
+
+export default Providers;

--- a/newIDE/app/src/MainFrame/RouterContext.js
+++ b/newIDE/app/src/MainFrame/RouterContext.js
@@ -30,9 +30,8 @@ export const RouterContextProvider = ({ children }: Props) => {
   );
 
   const removeArguments = React.useCallback((argumentsToRemove: string[]) => {
-    const argumentStrings = argumentsToRemove.map(argument => argument);
     // Remove them from the window. (only for web)
-    Window.removeArguments(argumentStrings);
+    Window.removeArguments(argumentsToRemove);
     // Update the state accordingly, based on the previous state.
     setCleanedArguments(oldArguments => {
       const newArguments = { ...oldArguments };

--- a/newIDE/app/src/MainFrame/RouterContext.js
+++ b/newIDE/app/src/MainFrame/RouterContext.js
@@ -3,15 +3,17 @@ import * as React from 'react';
 import Window, { type AppArguments } from '../Utils/Window';
 
 export type Router = {|
-  appArguments: AppArguments,
-  removeArguments: (string[]) => void,
-  addArguments: AppArguments => void,
+  routeArguments: AppArguments,
+  removeRouteArguments: (string[]) => void,
+  addRouteArguments: AppArguments => void,
+  navigateToRoute: (route: string, additionalArgument?: AppArguments) => void,
 |};
 
 const initialState: Router = {
-  appArguments: {},
-  removeArguments: () => {},
-  addArguments: () => {},
+  routeArguments: {},
+  removeRouteArguments: () => {},
+  addRouteArguments: () => {},
+  navigateToRoute: () => {},
 };
 
 const RouterContext = React.createContext<Router>(initialState);
@@ -29,18 +31,21 @@ export const RouterContextProvider = ({ children }: Props) => {
     initialWindowArguments
   );
 
-  const removeArguments = React.useCallback((argumentsToRemove: string[]) => {
-    // Remove them from the window. (only for web)
-    Window.removeArguments(argumentsToRemove);
-    // Update the state accordingly, based on the previous state.
-    setCleanedArguments(oldArguments => {
-      const newArguments = { ...oldArguments };
-      argumentsToRemove.forEach(argument => {
-        delete newArguments[argument];
+  const removeRouteArguments = React.useCallback(
+    (argumentsToRemove: string[]) => {
+      // Remove them from the window. (only for web)
+      Window.removeArguments(argumentsToRemove);
+      // Update the state accordingly, based on the previous state.
+      setCleanedArguments(oldArguments => {
+        const newArguments = { ...oldArguments };
+        argumentsToRemove.forEach(argument => {
+          delete newArguments[argument];
+        });
+        return newArguments;
       });
-      return newArguments;
-    });
-  }, []);
+    },
+    []
+  );
 
   const addArguments = React.useCallback((argumentsToAdd: AppArguments) => {
     // Add them to the window. (only for web)
@@ -52,12 +57,21 @@ export const RouterContextProvider = ({ children }: Props) => {
     }));
   }, []);
 
+  const navigateToRoute = React.useCallback(
+    (route: string, additionalArguments?: AppArguments) => {
+      // add the new route, assumed to be a dialog, and possible additional arguments to the router.
+      addArguments({ ...additionalArguments, 'initial-dialog': route });
+    },
+    [addArguments]
+  );
+
   return (
     <RouterContext.Provider
       value={{
-        appArguments: cleanedArguments,
-        removeArguments,
-        addArguments,
+        routeArguments: cleanedArguments,
+        addRouteArguments: addArguments,
+        removeRouteArguments,
+        navigateToRoute,
       }}
     >
       {children}

--- a/newIDE/app/src/MainFrame/RouterContext.js
+++ b/newIDE/app/src/MainFrame/RouterContext.js
@@ -1,0 +1,67 @@
+// @flow
+import * as React from 'react';
+import Window, { type AppArguments } from '../Utils/Window';
+
+export type Router = {|
+  appArguments: AppArguments,
+  removeArguments: (string[]) => void,
+  addArguments: AppArguments => void,
+|};
+
+const initialState: Router = {
+  appArguments: {},
+  removeArguments: () => {},
+  addArguments: () => {},
+};
+
+const RouterContext = React.createContext<Router>(initialState);
+
+export default RouterContext;
+
+type Props = {|
+  children?: React.Node,
+|};
+
+export const RouterContextProvider = ({ children }: Props) => {
+  const initialWindowArguments = Window.getArguments();
+  // Put value in the state, so we can control when the DOM re-renders.
+  const [cleanedArguments, setCleanedArguments] = React.useState(
+    initialWindowArguments
+  );
+
+  const removeArguments = React.useCallback((argumentsToRemove: string[]) => {
+    const argumentStrings = argumentsToRemove.map(argument => argument);
+    // Remove them from the window. (only for web)
+    Window.removeArguments(argumentStrings);
+    // Update the state accordingly, based on the previous state.
+    setCleanedArguments(oldArguments => {
+      const newArguments = { ...oldArguments };
+      argumentsToRemove.forEach(argument => {
+        delete newArguments[argument];
+      });
+      return newArguments;
+    });
+  }, []);
+
+  const addArguments = React.useCallback((argumentsToAdd: AppArguments) => {
+    // Add them to the window. (only for web)
+    Window.addArguments(argumentsToAdd);
+    // Update the state accordingly, based on the previous state.
+    setCleanedArguments(oldArguments => ({
+      ...oldArguments,
+      ...argumentsToAdd,
+    }));
+  }, []);
+
+  return (
+    <RouterContext.Provider
+      value={{
+        appArguments: cleanedArguments,
+        removeArguments,
+        addArguments,
+      }}
+    >
+      {children}
+    </RouterContext.Provider>
+  );
+};

--- a/newIDE/app/src/MainFrame/RouterContext.js
+++ b/newIDE/app/src/MainFrame/RouterContext.js
@@ -27,7 +27,7 @@ type Props = {|
 export const RouterContextProvider = ({ children }: Props) => {
   const initialWindowArguments = Window.getArguments();
   // Put value in the state, so we can control when the DOM re-renders.
-  const [cleanedArguments, setCleanedArguments] = React.useState(
+  const [routeArguments, setRouteArguments] = React.useState(
     initialWindowArguments
   );
 
@@ -36,7 +36,7 @@ export const RouterContextProvider = ({ children }: Props) => {
       // Remove them from the window. (only for web)
       Window.removeArguments(argumentsToRemove);
       // Update the state accordingly, based on the previous state.
-      setCleanedArguments(oldArguments => {
+      setRouteArguments(oldArguments => {
         const newArguments = { ...oldArguments };
         argumentsToRemove.forEach(argument => {
           delete newArguments[argument];
@@ -47,29 +47,32 @@ export const RouterContextProvider = ({ children }: Props) => {
     []
   );
 
-  const addArguments = React.useCallback((argumentsToAdd: AppArguments) => {
-    // Add them to the window. (only for web)
-    Window.addArguments(argumentsToAdd);
-    // Update the state accordingly, based on the previous state.
-    setCleanedArguments(oldArguments => ({
-      ...oldArguments,
-      ...argumentsToAdd,
-    }));
-  }, []);
+  const addRouteArguments = React.useCallback(
+    (argumentsToAdd: AppArguments) => {
+      // Add them to the window. (only for web)
+      Window.addArguments(argumentsToAdd);
+      // Update the state accordingly, based on the previous state.
+      setRouteArguments(oldArguments => ({
+        ...oldArguments,
+        ...argumentsToAdd,
+      }));
+    },
+    []
+  );
 
   const navigateToRoute = React.useCallback(
     (route: string, additionalArguments?: AppArguments) => {
       // add the new route, assumed to be a dialog, and possible additional arguments to the router.
-      addArguments({ ...additionalArguments, 'initial-dialog': route });
+      addRouteArguments({ ...additionalArguments, 'initial-dialog': route });
     },
-    [addArguments]
+    [addRouteArguments]
   );
 
   return (
     <RouterContext.Provider
       value={{
-        routeArguments: cleanedArguments,
-        addRouteArguments: addArguments,
+        routeArguments,
+        addRouteArguments,
         removeRouteArguments,
         navigateToRoute,
       }}

--- a/newIDE/app/src/MainFrame/RouterContext.js
+++ b/newIDE/app/src/MainFrame/RouterContext.js
@@ -1,12 +1,20 @@
 // @flow
 import * as React from 'react';
-import Window, { type AppArguments } from '../Utils/Window';
+import Window from '../Utils/Window';
+
+type Route = 'onboarding' | 'subscription' | 'games-dashboard' | 'asset-store';
+type RouteKey =
+  | 'initial-dialog'
+  | 'game-id'
+  | 'games-dashboard-tab'
+  | 'asset-pack';
+type RouteArguments = { [RouteKey]: string };
 
 export type Router = {|
-  routeArguments: AppArguments,
-  removeRouteArguments: (string[]) => void,
-  addRouteArguments: AppArguments => void,
-  navigateToRoute: (route: string, additionalArgument?: AppArguments) => void,
+  routeArguments: RouteArguments,
+  removeRouteArguments: (RouteKey[]) => void,
+  addRouteArguments: RouteArguments => void,
+  navigateToRoute: (route: Route, additionalArgument?: RouteArguments) => void,
 |};
 
 const initialState: Router = {
@@ -25,15 +33,16 @@ type Props = {|
 |};
 
 export const RouterContextProvider = ({ children }: Props) => {
-  const initialWindowArguments = Window.getArguments();
   // Put value in the state, so we can control when the DOM re-renders.
-  const [routeArguments, setRouteArguments] = React.useState(
-    initialWindowArguments
+  const [routeArguments, setRouteArguments] = React.useState<RouteArguments>(
+    // $FlowFixMe - Assume that the arguments are always valid.
+    Window.getArguments()
   );
 
   const removeRouteArguments = React.useCallback(
-    (argumentsToRemove: string[]) => {
+    (argumentsToRemove: RouteKey[]) => {
       // Remove them from the window. (only for web)
+      // $FlowFixMe - Assume that the arguments are always valid.
       Window.removeArguments(argumentsToRemove);
       // Update the state accordingly, based on the previous state.
       setRouteArguments(oldArguments => {
@@ -48,8 +57,9 @@ export const RouterContextProvider = ({ children }: Props) => {
   );
 
   const addRouteArguments = React.useCallback(
-    (argumentsToAdd: AppArguments) => {
+    (argumentsToAdd: RouteArguments) => {
       // Add them to the window. (only for web)
+      // $FlowFixMe - Assume that the arguments are always valid.
       Window.addArguments(argumentsToAdd);
       // Update the state accordingly, based on the previous state.
       setRouteArguments(oldArguments => ({
@@ -61,7 +71,7 @@ export const RouterContextProvider = ({ children }: Props) => {
   );
 
   const navigateToRoute = React.useCallback(
-    (route: string, additionalArguments?: AppArguments) => {
+    (route: Route, additionalArguments?: RouteArguments) => {
       // add the new route, assumed to be a dialog, and possible additional arguments to the router.
       addRouteArguments({ ...additionalArguments, 'initial-dialog': route });
     },

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -538,7 +538,7 @@ const MainFrame = (props: Props) => {
     },
     openProfileDialog,
   });
-  const { addArguments } = React.useContext(RouterContext);
+  const { navigateToRoute } = React.useContext(RouterContext);
 
   const _closeSnackMessage = React.useCallback(
     () => {
@@ -2652,8 +2652,7 @@ const MainFrame = (props: Props) => {
       ? commandPaletteRef.current.open
       : () => {},
     onOpenProfile: () => openProfileDialog(true),
-    onOpenGamesDashboard: () =>
-      addArguments({ 'initial-dialog': 'games-dashboard' }),
+    onOpenGamesDashboard: () => navigateToRoute('games-dashboard'),
   });
 
   const resourceManagementProps: ResourceManagementProps = React.useMemo(
@@ -2700,9 +2699,7 @@ const MainFrame = (props: Props) => {
     onOpenPreferences: () => openPreferencesDialog(true),
     onOpenLanguage: () => openLanguageDialog(true),
     onOpenProfile: () => openProfileDialog(true),
-    onOpenGamesDashboard: () => {
-      addArguments({ 'initial-dialog': 'games-dashboard' });
-    },
+    onOpenGamesDashboard: () => navigateToRoute('games-dashboard'),
     setElectronUpdateStatus: setElectronUpdateStatus,
   };
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -164,6 +164,7 @@ import useInAppTutorialOrchestrator from '../InAppTutorial/useInAppTutorialOrche
 import { FLING_GAME_IN_APP_TUTORIAL_ID } from '../InAppTutorial/InAppTutorialProvider';
 import TabsTitlebar from './TabsTitlebar';
 import { registerGame } from '../Utils/GDevelopServices/Game';
+import RouterContext from './RouterContext';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -251,11 +252,6 @@ type LaunchPreviewOptions = {
 };
 
 export type Props = {|
-  initialDialog?: string,
-  initialGameId?: string,
-  initialGamesDashboardTab?: string,
-  initialAssetPackUserFriendlySlug?: string,
-  introDialog?: React.Element<*>,
   renderMainMenu?: (BuildMainMenuProps, MainMenuCallbacks) => React.Node,
   renderPreviewLauncher?: (
     props: PreviewLauncherProps,
@@ -319,7 +315,6 @@ const MainFrame = (props: Props) => {
   const [projectManagerOpen, openProjectManager] = React.useState<boolean>(
     false
   );
-  const [introDialogOpen, openIntroDialog] = React.useState<boolean>(false);
   const [languageDialogOpen, openLanguageDialog] = React.useState<boolean>(
     false
   );
@@ -442,12 +437,7 @@ const MainFrame = (props: Props) => {
     resourceFetcher,
     getStorageProviderOperations,
     getStorageProvider,
-    initialDialog,
-    initialGameId,
-    initialGamesDashboardTab,
-    initialAssetPackUserFriendlySlug,
     initialFileMetadataToOpen,
-    introDialog,
     i18n,
     renderGDJSDevelopmentWatcher,
     renderMainMenu,
@@ -531,9 +521,6 @@ const MainFrame = (props: Props) => {
               openFromFileMetadataWithStorageProvider(
                 fileMetadataAndStorageProviderName
               );
-          } else {
-            // Open the intro dialog if not opening any project.
-            if (introDialog) openIntroDialog(true);
           }
         })
         .catch(() => {
@@ -545,27 +532,13 @@ const MainFrame = (props: Props) => {
     []
   );
 
-  const {
-    openProfileDialogWithTab,
-    profileDialogInitialTab,
-    gamesDashboardInitialGameId,
-    setGamesDashboardInitialGameId,
-    gamesDashboardInitialTab,
-    setGamesDashboardInitialTab,
-  } = useOpenInitialDialog({
-    parameters: {
-      initialDialog,
-      initialGameId,
-      initialGamesDashboardTab,
-      initialAssetPackUserFriendlySlug,
+  useOpenInitialDialog({
+    openOnboardingDialog: () => {
+      selectInAppTutorial(FLING_GAME_IN_APP_TUTORIAL_ID);
     },
-    actions: {
-      openOnboardingDialog: () => {
-        selectInAppTutorial(FLING_GAME_IN_APP_TUTORIAL_ID);
-      },
-      openProfileDialog,
-    },
+    openProfileDialog,
   });
+  const { addArguments } = React.useContext(RouterContext);
 
   const _closeSnackMessage = React.useCallback(
     () => {
@@ -743,9 +716,12 @@ const MainFrame = (props: Props) => {
         // (like locally or on Google Drive).
         if (onSaveProject) {
           preferences.insertRecentProjectFile({
-            fileMetadata: fileMetadata.name
-              ? fileMetadata
-              : { ...fileMetadata, name: project.getName() },
+            fileMetadata: {
+              ...fileMetadata,
+              name: project.getName(),
+              gameId: project.getProjectUuid(),
+              lastModifiedDate: Date.now(),
+            },
             storageProviderName: storageProvider.internalName,
           });
         }
@@ -1588,13 +1564,12 @@ const MainFrame = (props: Props) => {
           key: 'start page',
           extraEditorProps: {
             storageProviders: props.storageProviders,
-            initialTab: initialDialog === 'asset-store' ? 'shop' : null,
           },
           closable: false,
         }),
       }));
     },
-    [setState, i18n, initialDialog, props.storageProviders]
+    [setState, i18n, props.storageProviders]
   );
 
   const _openDebugger = React.useCallback(
@@ -1955,7 +1930,6 @@ const MainFrame = (props: Props) => {
       // At the end of the promise below, currentProject and storageProvider
       // may have changed (if the user opened another project). So we read and
       // store their values in variables now.
-      const projectName = currentProject.getName();
       const storageProviderInternalName = newStorageProvider.internalName;
 
       try {
@@ -2006,11 +1980,8 @@ const MainFrame = (props: Props) => {
 
         // Save was done on a new file/location, so save it in the
         // recent projects and in the state.
-        const enrichedFileMetadata = fileMetadata.name
-          ? fileMetadata
-          : { ...fileMetadata, name: projectName };
         const fileMetadataAndStorageProviderName = {
-          fileMetadata: enrichedFileMetadata,
+          fileMetadata,
           storageProviderName: storageProviderInternalName,
         };
         preferences.insertRecentProjectFile(fileMetadataAndStorageProviderName);
@@ -2041,7 +2012,7 @@ const MainFrame = (props: Props) => {
           // can happen if another project was loaded in the meantime.
           setState(state => ({
             ...state,
-            currentFileMetadata: enrichedFileMetadata,
+            currentFileMetadata: fileMetadata,
           }));
         }
       } catch (rawError) {
@@ -2133,7 +2104,6 @@ const MainFrame = (props: Props) => {
         // At the end of the promise below, currentProject and storageProvider
         // may have changed (if the user opened another project). So we read and
         // store their values in variables now.
-        const projectName = currentProject.getName();
         const storageProviderInternalName = getStorageProvider().internalName;
 
         const { wasSaved, fileMetadata } = await onSaveProject(
@@ -2145,12 +2115,9 @@ const MainFrame = (props: Props) => {
           console.info(
             `Project saved in ${performance.now() - saveStartTime}ms.`
           );
-          const enrichedFileMetadata = fileMetadata.name
-            ? fileMetadata
-            : { ...fileMetadata, name: projectName };
 
           const fileMetadataAndStorageProviderName = {
-            fileMetadata: enrichedFileMetadata,
+            fileMetadata: fileMetadata,
             storageProviderName: storageProviderInternalName,
           };
           preferences.insertRecentProjectFile(
@@ -2175,7 +2142,7 @@ const MainFrame = (props: Props) => {
             // can happen if another project was loaded in the meantime.
             setState(state => ({
               ...state,
-              currentFileMetadata: enrichedFileMetadata,
+              currentFileMetadata: fileMetadata,
             }));
           }
 
@@ -2684,14 +2651,9 @@ const MainFrame = (props: Props) => {
     onOpenCommandPalette: commandPaletteRef.current
       ? commandPaletteRef.current.open
       : () => {},
-    onOpenProfile: React.useCallback(
-      () => openProfileDialogWithTab('profile'),
-      [openProfileDialogWithTab]
-    ),
-    onOpenGamesDashboard: React.useCallback(
-      () => openProfileDialogWithTab('games-dashboard'),
-      [openProfileDialogWithTab]
-    ),
+    onOpenProfile: () => openProfileDialog(true),
+    onOpenGamesDashboard: () =>
+      addArguments({ 'initial-dialog': 'games-dashboard' }),
   });
 
   const resourceManagementProps: ResourceManagementProps = React.useMemo(
@@ -2737,8 +2699,10 @@ const MainFrame = (props: Props) => {
     onOpenAbout: () => openAboutDialog(true),
     onOpenPreferences: () => openPreferencesDialog(true),
     onOpenLanguage: () => openLanguageDialog(true),
-    onOpenProfile: () => openProfileDialogWithTab('profile'),
-    onOpenGamesDashboard: () => openProfileDialogWithTab('games-dashboard'),
+    onOpenProfile: () => openProfileDialog(true),
+    onOpenGamesDashboard: () => {
+      addArguments({ 'initial-dialog': 'games-dashboard' });
+    },
     setElectronUpdateStatus: setElectronUpdateStatus,
   };
 
@@ -2925,7 +2889,7 @@ const MainFrame = (props: Props) => {
                     onCloseProject: () => askToCloseProject(),
                     onCreateProject: exampleShortHeader =>
                       openCreateProjectDialog(true, exampleShortHeader),
-                    onOpenProfile: () => openProfileDialogWithTab('profile'),
+                    onOpenProfile: () => openProfileDialog(true),
                     onOpenHelpFinder: () => openHelpFinderDialog(true),
                     onOpenLanguageDialog: () => openLanguageDialog(true),
                     onOpenPreferences: () => openPreferencesDialog(true),
@@ -3002,12 +2966,6 @@ const MainFrame = (props: Props) => {
           }}
         />
       )}
-      {!!introDialog &&
-        introDialogOpen &&
-        React.cloneElement(introDialog, {
-          open: true,
-          onClose: () => openIntroDialog(false),
-        })}
       {!!currentProject && platformSpecificAssetsDialogOpen && (
         <PlatformSpecificAssetsDialog
           project={currentProject}
@@ -3051,17 +3009,9 @@ const MainFrame = (props: Props) => {
       {profileDialogOpen && (
         <ProfileDialog
           currentProject={currentProject}
-          initialTab={profileDialogInitialTab}
           open
           onClose={() => {
             openProfileDialog(false);
-          }}
-          gamesDashboardInitialGameId={gamesDashboardInitialGameId}
-          gamesDashboardInitialTab={gamesDashboardInitialTab}
-          onGameDetailsDialogClose={() => {
-            // On dialog close, reset any initial props.
-            setGamesDashboardInitialGameId(null);
-            setGamesDashboardInitialTab('details');
           }}
         />
       )}

--- a/newIDE/app/src/Profile/ProfileDialog.js
+++ b/newIDE/app/src/Profile/ProfileDialog.js
@@ -17,7 +17,7 @@ import Window from '../Utils/Window';
 import { showErrorBox } from '../UI/Messages/MessageBox';
 import CreateProfile from './CreateProfile';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
-import { type GameDetailsTab } from '../GameDashboard/GameDetailsDialog';
+import RouterContext from '../MainFrame/RouterContext';
 
 export type ProfileTab = 'profile' | 'games-dashboard';
 
@@ -25,24 +25,23 @@ type Props = {|
   currentProject: ?gdProject,
   open: boolean,
   onClose: () => void,
-  initialTab: ProfileTab,
-  gamesDashboardInitialGameId: ?string,
-  gamesDashboardInitialTab: ?GameDetailsTab,
-  onGameDetailsDialogClose: () => void,
 |};
 
-const ProfileDialog = ({
-  currentProject,
-  open,
-  onClose,
-  initialTab,
-  gamesDashboardInitialGameId,
-  gamesDashboardInitialTab,
-  onGameDetailsDialogClose,
-}: Props) => {
-  const [currentTab, setCurrentTab] = React.useState<ProfileTab>(initialTab);
+const ProfileDialog = ({ currentProject, open, onClose }: Props) => {
+  const { appArguments, removeArguments } = React.useContext(RouterContext);
+  const [currentTab, setCurrentTab] = React.useState<ProfileTab>('profile');
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const isUserLoading = authenticatedUser.loginState !== 'done';
+
+  React.useEffect(
+    () => {
+      if (appArguments['initial-dialog'] === 'games-dashboard') {
+        setCurrentTab('games-dashboard');
+        removeArguments(['initial-dialog']);
+      }
+    },
+    [appArguments, removeArguments]
+  );
 
   const [
     isManageSubscriptionLoading,
@@ -169,12 +168,7 @@ const ProfileDialog = ({
             </Line>
           )}
           {currentTab === 'games-dashboard' && (
-            <GamesList
-              project={currentProject}
-              initialGameId={gamesDashboardInitialGameId}
-              initialTab={gamesDashboardInitialTab}
-              onGameDetailsDialogClose={onGameDetailsDialogClose}
-            />
+            <GamesList project={currentProject} />
           )}
         </>
       ) : (

--- a/newIDE/app/src/Profile/ProfileDialog.js
+++ b/newIDE/app/src/Profile/ProfileDialog.js
@@ -28,19 +28,21 @@ type Props = {|
 |};
 
 const ProfileDialog = ({ currentProject, open, onClose }: Props) => {
-  const { appArguments, removeArguments } = React.useContext(RouterContext);
+  const { routeArguments, removeRouteArguments } = React.useContext(
+    RouterContext
+  );
   const [currentTab, setCurrentTab] = React.useState<ProfileTab>('profile');
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const isUserLoading = authenticatedUser.loginState !== 'done';
 
   React.useEffect(
     () => {
-      if (appArguments['initial-dialog'] === 'games-dashboard') {
+      if (routeArguments['initial-dialog'] === 'games-dashboard') {
         setCurrentTab('games-dashboard');
-        removeArguments(['initial-dialog']);
+        removeRouteArguments(['initial-dialog']);
       }
     },
-    [appArguments, removeArguments]
+    [routeArguments, removeRouteArguments]
   );
 
   const [

--- a/newIDE/app/src/Profile/Subscription/SubscriptionDialog.js
+++ b/newIDE/app/src/Profile/Subscription/SubscriptionDialog.js
@@ -343,39 +343,40 @@ export default function SubscriptionDialog({
                 </EmptyMessage>
               </Line>
             </Column>
-            {!authenticatedUser.authenticated && (
-              <Dialog
-                open
-                title={<Trans>Create a GDevelop account to continue</Trans>}
-                maxWidth="sm"
-                cannotBeDismissed
-                secondaryActions={[
-                  <FlatButton
-                    key="later"
-                    label={<Trans>Maybe later</Trans>}
-                    onClick={onClose}
-                  />,
-                ]}
-                actions={[
-                  <FlatButton
-                    key="login"
-                    label={<Trans>Login</Trans>}
-                    onClick={authenticatedUser.onLogin}
-                  />,
-                  <DialogPrimaryButton
-                    key="create-account"
-                    label={<Trans>Create my account</Trans>}
-                    primary
-                    onClick={authenticatedUser.onCreateAccount}
-                  />,
-                ]}
-              >
-                <Text>
-                  It's free and you'll get access to online services: cloud
-                  projects, leaderboards, player feedbacks, cloud builds...
-                </Text>
-              </Dialog>
-            )}
+            {!authenticatedUser.authenticated &&
+              authenticatedUser.loginState !== 'loggingIn' && (
+                <Dialog
+                  open
+                  title={<Trans>Create a GDevelop account to continue</Trans>}
+                  maxWidth="sm"
+                  cannotBeDismissed
+                  secondaryActions={[
+                    <FlatButton
+                      key="later"
+                      label={<Trans>Maybe later</Trans>}
+                      onClick={onClose}
+                    />,
+                  ]}
+                  actions={[
+                    <FlatButton
+                      key="login"
+                      label={<Trans>Login</Trans>}
+                      onClick={authenticatedUser.onLogin}
+                    />,
+                    <DialogPrimaryButton
+                      key="create-account"
+                      label={<Trans>Create my account</Trans>}
+                      primary
+                      onClick={authenticatedUser.onCreateAccount}
+                    />,
+                  ]}
+                >
+                  <Text>
+                    It's free and you'll get access to online services: cloud
+                    projects, leaderboards, player feedbacks, cloud builds...
+                  </Text>
+                </Dialog>
+              )}
             {subscriptionPendingDialogOpen && (
               <SubscriptionPendingDialog
                 authenticatedUser={authenticatedUser}

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -24,7 +24,6 @@ import RaisedButton from '../UI/RaisedButton';
 import Window from '../Utils/Window';
 import { I18n } from '@lingui/react';
 import AlertMessage from '../UI/AlertMessage';
-import { GameRegistration } from '../GameDashboard/GameRegistration';
 import { Tabs } from '../UI/Tabs';
 import { LoadingScreenEditor } from './LoadingScreenEditor';
 import { type ResourceManagementProps } from '../ResourcesList/ResourceSource';
@@ -429,10 +428,6 @@ function ProjectPropertiesDialog(props: Props) {
                     />
                   </React.Fragment>
                 ) : null}
-                <Text size="block-title">
-                  <Trans>Analytics</Trans>
-                </Text>
-                <GameRegistration project={project} />
                 <Text size="block-title">
                   <Trans>Resolution and rendering</Trans>
                 </Text>

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -130,8 +130,11 @@ export const onSaveProject = (
       'Project file is empty, "Save as" should have been called?'
     );
   }
+  // Ensure we always pick the latest name and gameId.
   const newFileMetadata = {
     ...fileMetadata,
+    name: project.getName(),
+    gameId: project.getProjectUuid(),
     lastModifiedDate: now,
   };
 
@@ -192,7 +195,13 @@ export const onSaveProjectAs = async (
     throw new Error('A file path was not chosen before saving as.');
 
   options.onStartSaving();
-  const newFileMetadata = { fileIdentifier: filePath };
+  // Ensure we always pick the latest name and gameId.
+  const newFileMetadata = {
+    fileIdentifier: filePath,
+    name: project.getName(),
+    gameId: project.getProjectUuid(),
+    lastModifiedDate: Date.now(),
+  };
 
   // Move (copy or download, etc...) the resources first.
   await options.onMoveResources({ newFileMetadata });

--- a/newIDE/app/src/ProjectsStorage/index.js
+++ b/newIDE/app/src/ProjectsStorage/index.js
@@ -13,6 +13,7 @@ export type FileMetadata = {|
   fileIdentifier: string,
   lastModifiedDate?: number,
   name?: string,
+  gameId?: string,
 |};
 
 /**
@@ -30,6 +31,10 @@ export type SaveAsLocation = {|
    * (for example, a local file path is stored only in `fileIdentifier`).
    */
   name?: string,
+  /**
+   * The id of the game. Might be null if unused
+   */
+  gameId?: string,
 
   // New fields can be added if a storage provider needs other things to identify
   // a new location where to save a project to.
@@ -97,7 +102,7 @@ export type StorageProviderOperations = {|
   onChangeProjectProperty?: (
     project: gdProject,
     fileMetadata: FileMetadata,
-    properties: { name: string } // In order to synchronize project and cloud project names.
+    properties: {| name?: string, gameId?: string |} // In order to synchronize project and cloud project names.
   ) => Promise<boolean>,
 
   // Project auto saving:

--- a/newIDE/app/src/ProjectsStorage/index.js
+++ b/newIDE/app/src/ProjectsStorage/index.js
@@ -32,7 +32,7 @@ export type SaveAsLocation = {|
    */
   name?: string,
   /**
-   * The id of the game. Might be null if unused
+   * The id of the game. Might be null if no game is published.
    */
   gameId?: string,
 

--- a/newIDE/app/src/Utils/GDevelopServices/Project.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Project.js
@@ -40,6 +40,7 @@ export type UploadedProjectResourceFiles = Array<{|
 type CloudProject = {|
   id: string,
   name: string,
+  gameId?: string,
   createdAt: string,
   currentVersion?: string,
   deletedAt?: string,
@@ -109,7 +110,7 @@ export const clearCloudProjectCredentials = async (): Promise<void> => {
 
 export const createCloudProject = async (
   authenticatedUser: AuthenticatedUser,
-  cloudProjectCreationPayload: { name: string }
+  cloudProjectCreationPayload: {| name: string, gameId?: string |}
 ): Promise<?CloudProject> => {
   const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
   if (!firebaseUser) return null;
@@ -251,13 +252,16 @@ export const getCloudProject = async (
 export const updateCloudProject = async (
   authenticatedUser: AuthenticatedUser,
   cloudProjectId: string,
-  attributes: { name: string }
+  attributes: {| name?: string, gameId?: string |}
 ): Promise<?CloudProject> => {
   const { getAuthorizationHeader, firebaseUser } = authenticatedUser;
   if (!firebaseUser) return;
 
   const cleanedAttributes = {
-    name: attributes.name.slice(0, CLOUD_PROJECT_NAME_MAX_LENGTH),
+    name: attributes.name
+      ? attributes.name.slice(0, CLOUD_PROJECT_NAME_MAX_LENGTH)
+      : undefined,
+    gameId: attributes.gameId,
   };
 
   const { uid: userId } = firebaseUser;

--- a/newIDE/app/src/Utils/UseOpenInitialDialog.js
+++ b/newIDE/app/src/Utils/UseOpenInitialDialog.js
@@ -1,121 +1,52 @@
 // @flow
 import * as React from 'react';
-import { AssetStoreContext } from '../AssetStore/AssetStoreContext';
-import {
-  type GameDetailsTab,
-  gameDetailsTabs,
-} from '../GameDashboard/GameDetailsDialog';
-import { type ProfileTab } from '../Profile/ProfileDialog';
+import RouterContext from '../MainFrame/RouterContext';
 import { SubscriptionSuggestionContext } from '../Profile/Subscription/SubscriptionSuggestionContext';
-import Window from './Window';
 
 type Props = {|
-  parameters: {|
-    initialDialog?: string,
-    initialGameId?: string,
-    initialGamesDashboardTab?: string,
-    initialAssetPackUserFriendlySlug?: string,
-  |},
-  actions: {|
-    openOnboardingDialog: boolean => void,
-    openProfileDialog: boolean => void,
-  |},
+  openOnboardingDialog: boolean => void,
+  openProfileDialog: boolean => void,
 |};
 
 /**
  * Helper for Mainframe to open a dialog when the component is mounted.
  * This corresponds to when a user opens the app on web, with a parameter in the URL.
  */
-export const useOpenInitialDialog = ({ parameters, actions }: Props) => {
-  // Put the initial info in a ref, so that we con change its value
-  // and not rely on what stays in the parameters + prevent re-rendering.
-  const initialDialogRef = React.useRef<?string>(parameters.initialDialog);
-  const [
-    profileDialogInitialTab,
-    setProfileDialogInitialTab,
-  ] = React.useState<ProfileTab>('profile');
-  const [
-    gamesDashboardInitialGameId,
-    setGamesDashboardInitialGameId,
-  ] = React.useState<?string>(null);
-  const [
-    gamesDashboardInitialTab,
-    setGamesDashboardInitialTab,
-  ] = React.useState<GameDetailsTab>('details');
+export const useOpenInitialDialog = ({
+  openOnboardingDialog,
+  openProfileDialog,
+}: Props) => {
+  const { appArguments, removeArguments } = React.useContext(RouterContext);
   const { openSubscriptionDialog } = React.useContext(
     SubscriptionSuggestionContext
   );
 
-  const { setInitialPackUserFriendlySlug } = React.useContext(
-    AssetStoreContext
-  );
-
-  const openProfileDialogWithTab = (profileDialogInitialTab: ProfileTab) => {
-    setProfileDialogInitialTab(profileDialogInitialTab);
-    actions.openProfileDialog(true);
-  };
-
-  const openGameDashboard = React.useCallback(
-    ({ gameId, tab }: {| gameId?: ?string, tab?: ?string |}) => {
-      setProfileDialogInitialTab('games-dashboard');
-      if (gameId) setGamesDashboardInitialGameId(gameId);
-      if (tab) {
-        // Ensure that the tab is valid.
-        const gameDetailsTab = gameDetailsTabs.find(
-          gameDetailsTab => gameDetailsTab.value === tab
-        );
-        if (gameDetailsTab) setGamesDashboardInitialTab(gameDetailsTab.value);
-      }
-      actions.openProfileDialog(true);
-    },
-    [actions]
-  );
-
-  const cleanupAfterDialogOpened = () => {
-    Window.removeArguments(); // Remove the arguments from the URL for cleanup.
-    initialDialogRef.current = null; // Reset the initial dialog, to avoid opening it again.
-  };
-
   React.useEffect(
     () => {
-      switch (initialDialogRef.current) {
+      switch (appArguments['initial-dialog']) {
         case 'subscription':
           openSubscriptionDialog({ reason: 'Landing dialog at opening' });
-          cleanupAfterDialogOpened();
+          removeArguments(['initial-dialog']);
           break;
         case 'onboarding':
-          actions.openOnboardingDialog(true);
-          cleanupAfterDialogOpened();
+          openOnboardingDialog(true);
+          removeArguments(['initial-dialog']);
           break;
         case 'games-dashboard':
-          openGameDashboard({
-            gameId: parameters.initialGameId,
-            tab: parameters.initialGamesDashboardTab,
-          });
-          cleanupAfterDialogOpened();
-          break;
-        case 'asset-store':
-          if (parameters.initialAssetPackUserFriendlySlug)
-            setInitialPackUserFriendlySlug(
-              parameters.initialAssetPackUserFriendlySlug
-            );
-          cleanupAfterDialogOpened();
+          openProfileDialog(true);
+          // As the games dashboard is not a dialog in itself, we don't remove the argument
+          // and let the ProfileDialog do it once the tab is opened.
           break;
         default:
           break;
       }
     },
-    // Disable the warning as we want to do this only once.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [
+      appArguments,
+      openOnboardingDialog,
+      openProfileDialog,
+      removeArguments,
+      openSubscriptionDialog,
+    ]
   );
-
-  return {
-    profileDialogInitialTab,
-    openProfileDialogWithTab,
-    gamesDashboardInitialGameId,
-    setGamesDashboardInitialGameId,
-    gamesDashboardInitialTab,
-    setGamesDashboardInitialTab,
-  };
 };

--- a/newIDE/app/src/Utils/UseOpenInitialDialog.js
+++ b/newIDE/app/src/Utils/UseOpenInitialDialog.js
@@ -16,21 +16,23 @@ export const useOpenInitialDialog = ({
   openOnboardingDialog,
   openProfileDialog,
 }: Props) => {
-  const { appArguments, removeArguments } = React.useContext(RouterContext);
+  const { routeArguments, removeRouteArguments } = React.useContext(
+    RouterContext
+  );
   const { openSubscriptionDialog } = React.useContext(
     SubscriptionSuggestionContext
   );
 
   React.useEffect(
     () => {
-      switch (appArguments['initial-dialog']) {
+      switch (routeArguments['initial-dialog']) {
         case 'subscription':
           openSubscriptionDialog({ reason: 'Landing dialog at opening' });
-          removeArguments(['initial-dialog']);
+          removeRouteArguments(['initial-dialog']);
           break;
         case 'onboarding':
           openOnboardingDialog(true);
-          removeArguments(['initial-dialog']);
+          removeRouteArguments(['initial-dialog']);
           break;
         case 'games-dashboard':
           openProfileDialog(true);
@@ -42,10 +44,10 @@ export const useOpenInitialDialog = ({
       }
     },
     [
-      appArguments,
+      routeArguments,
       openOnboardingDialog,
       openProfileDialog,
-      removeArguments,
+      removeRouteArguments,
       openSubscriptionDialog,
     ]
   );

--- a/newIDE/app/src/Utils/Window.js
+++ b/newIDE/app/src/Utils/Window.js
@@ -204,13 +204,27 @@ export default class Window {
   }
 
   /**
-   * On web, removes any query params from the URL.
+   * On web, removes a list of query params from the URL.
    */
-  static removeArguments() {
+  static removeArguments(argumentNames: string[]) {
+    // On Electron, we don't have a way to modify global args.
     if (remote) return;
 
     const url = new URL(window.location.href);
-    url.search = '';
+    for (const argumentName of argumentNames) {
+      url.searchParams.delete(argumentName);
+    }
+    window.history.replaceState({}, document.title, url.toString());
+  }
+
+  static addArguments(argumentNamesAndValues: { [key: string]: string }) {
+    // On Electron, we don't have a way to modify global args.
+    if (remote) return;
+
+    const url = new URL(window.location.href);
+    for (const argumentName in argumentNamesAndValues) {
+      url.searchParams.set(argumentName, argumentNamesAndValues[argumentName]);
+    }
     window.history.replaceState({}, document.title, url.toString());
   }
 

--- a/newIDE/app/src/stories/componentStories/GameDashboard/GamesList.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameDashboard/GamesList.stories.js
@@ -35,12 +35,7 @@ export const WithoutAProjectOpened = () => {
 
   return (
     <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
-      <GamesList
-        project={null}
-        initialGameId={null}
-        initialTab={null}
-        onGameDetailsDialogClose={() => {}}
-      />
+      <GamesList project={null} />
     </AuthenticatedUserContext.Provider>
   );
 };
@@ -58,12 +53,7 @@ export const WithoutAProjectOpenedLongLoading = () => {
 
   return (
     <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
-      <GamesList
-        project={null}
-        initialGameId={null}
-        initialTab={null}
-        onGameDetailsDialogClose={() => {}}
-      />
+      <GamesList project={null} />
     </AuthenticatedUserContext.Provider>
   );
 };
@@ -80,12 +70,7 @@ export const WithAnError = () => {
     });
   return (
     <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
-      <GamesList
-        project={null}
-        initialGameId={null}
-        initialTab={null}
-        onGameDetailsDialogClose={() => {}}
-      />
+      <GamesList project={null} />
     </AuthenticatedUserContext.Provider>
   );
 };

--- a/newIDE/app/src/stories/componentStories/GameRegistration.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameRegistration.stories.js
@@ -1,108 +1,177 @@
 // @flow
 import * as React from 'react';
-import { action } from '@storybook/addon-actions';
 
 import muiDecorator from '../ThemeDecorator';
 import paperDecorator from '../PaperDecorator';
 
-import {
-  GameRegistrationWidget,
-  type GameRegistrationWidgetProps,
-} from '../../GameDashboard/GameRegistration';
+import { GameRegistration } from '../../GameDashboard/GameRegistration';
 import GDevelopJsInitializerDecorator, {
   testProject,
 } from '../GDevelopJsInitializerDecorator';
 import {
-  indieUserProfile,
-  game1,
+  fakeIndieAuthenticatedUser,
+  fakeNotAuthenticatedAuthenticatedUser,
 } from '../../fixtures/GDevelopServicesTestData';
-import { type Profile } from '../../Utils/GDevelopServices/Authentication';
-
-const indieUserProfileWithGameStatsEmail: Profile = {
-  ...indieUserProfile,
-  getGameStatsEmail: true,
-};
+import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
+import withMock from 'storybook-addon-mock';
+import { GDevelopGameApi } from '../../Utils/GDevelopServices/ApiConfigs';
 
 export default {
-  title: 'GameDashboard/GameRegistrationWidget',
-  component: GameRegistrationWidget,
+  title: 'GameDashboard/GameRegistration',
+  component: GameRegistration,
   decorators: [paperDecorator, muiDecorator, GDevelopJsInitializerDecorator],
 };
 
-const defaultProps: GameRegistrationWidgetProps = {
-  authenticated: true,
-  profile: indieUserProfile,
-  onLogin: action('onLogin'),
-  onCreateAccount: action('onCreateAccount'),
-  project: testProject.project,
-  game: game1,
-  setGame: action('setGame'),
-  loadGame: action('loadGame'),
-  onRegisterGame: action('onRegisterGame'),
-  registrationInProgress: false,
-  hideIfRegistered: false,
-  unavailableReason: null,
-  acceptGameStatsEmailInProgress: false,
-  onAcceptGameStatsEmail: action('onAcceptGameStatsEmail'),
-  detailsInitialTab: 'details',
-  setDetailsInitialTab: action('setDetailsInitialTab'),
-  detailsOpened: false,
-  setDetailsOpened: action('setDetailsOpened'),
-  error: null,
-  hideLoader: false,
+export const NoProjectLoaded = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <GameRegistration project={null} onGameRegistered={() => {}} />
+  </AuthenticatedUserContext.Provider>
+);
+
+export const NotLoggedIn = () => (
+  <AuthenticatedUserContext.Provider
+    value={fakeNotAuthenticatedAuthenticatedUser}
+  >
+    <GameRegistration
+      project={testProject.project}
+      onGameRegistered={() => {}}
+    />
+  </AuthenticatedUserContext.Provider>
+);
+
+export const NotAuthorized = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <GameRegistration
+      project={testProject.project}
+      onGameRegistered={() => {}}
+    />
+  </AuthenticatedUserContext.Provider>
+);
+NotAuthorized.decorators = [withMock];
+NotAuthorized.parameters = {
+  mockData: [
+    {
+      url: `${GDevelopGameApi.baseUrl}/game/?userId=indie-user`,
+      method: 'GET',
+      status: 403,
+      response: {},
+      delay: 500,
+    },
+  ],
 };
 
-export const NoProjectLoaded = () => (
-  <GameRegistrationWidget {...defaultProps} project={null} />
+export const GameNotExisting = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <GameRegistration
+      project={testProject.project}
+      onGameRegistered={() => {}}
+    />
+  </AuthenticatedUserContext.Provider>
 );
-export const Loading = () => (
-  <GameRegistrationWidget {...defaultProps} game={null} />
+GameNotExisting.decorators = [withMock];
+GameNotExisting.parameters = {
+  mockData: [
+    {
+      url: `${GDevelopGameApi.baseUrl}/game/?userId=indie-user`,
+      method: 'GET',
+      status: 404,
+      response: {},
+      delay: 500,
+    },
+  ],
+};
+
+export const ErrorLoadingGame = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <GameRegistration
+      project={testProject.project}
+      onGameRegistered={() => {}}
+    />
+  </AuthenticatedUserContext.Provider>
 );
-export const LoadingButHidingLoader = () => (
-  <GameRegistrationWidget {...defaultProps} game={null} hideLoader />
+ErrorLoadingGame.decorators = [withMock];
+ErrorLoadingGame.parameters = {
+  mockData: [
+    {
+      url: `${GDevelopGameApi.baseUrl}/game/?userId=indie-user`,
+      method: 'GET',
+      status: 500,
+      response: {},
+      delay: 500,
+    },
+  ],
+};
+
+export const RegisteredWithGameStatsEmail = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <GameRegistration
+      project={testProject.project}
+      onGameRegistered={() => {}}
+      suggestGameStatsEmail
+    />
+  </AuthenticatedUserContext.Provider>
 );
-export const NotLoggedIn = () => (
-  <GameRegistrationWidget
-    {...defaultProps}
-    authenticated={false}
-    profile={null}
-  />
+RegisteredWithGameStatsEmail.decorators = [withMock];
+RegisteredWithGameStatsEmail.parameters = {
+  mockData: [
+    {
+      url: `${GDevelopGameApi.baseUrl}/game/?userId=indie-user`,
+      method: 'GET',
+      status: 200,
+      response: {
+        id: 'game-id',
+        name: 'My game',
+      },
+      delay: 500,
+    },
+  ],
+};
+
+export const RegisteredWithLoader = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <GameRegistration
+      project={testProject.project}
+      onGameRegistered={() => {}}
+    />
+  </AuthenticatedUserContext.Provider>
 );
-export const GameNotRegistered = () => (
-  <GameRegistrationWidget {...defaultProps} unavailableReason="not-existing" />
+RegisteredWithLoader.decorators = [withMock];
+RegisteredWithLoader.parameters = {
+  mockData: [
+    {
+      url: `${GDevelopGameApi.baseUrl}/game/?userId=indie-user`,
+      method: 'GET',
+      status: 200,
+      response: {
+        id: 'game-id',
+        name: 'My game',
+      },
+      delay: 500,
+    },
+  ],
+};
+
+export const RegisteredWithoutLoader = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <GameRegistration
+      project={testProject.project}
+      onGameRegistered={() => {}}
+      hideLoader
+    />
+  </AuthenticatedUserContext.Provider>
 );
-export const NotAuthorized = () => (
-  <GameRegistrationWidget {...defaultProps} unavailableReason="unauthorized" />
-);
-export const Errored = () => (
-  <GameRegistrationWidget
-    {...defaultProps}
-    error={new Error('there was an error')}
-  />
-);
-export const LoadedButHidingIfRegistered = () => (
-  <GameRegistrationWidget {...defaultProps} hideIfRegistered />
-);
-export const EmailNotAccepted = () => (
-  <GameRegistrationWidget {...defaultProps} profile={indieUserProfile} />
-);
-export const EmailAccepted = () => (
-  <GameRegistrationWidget
-    {...defaultProps}
-    profile={indieUserProfileWithGameStatsEmail}
-  />
-);
-export const EmailAcceptedButHidingIfSubscribed = () => (
-  <GameRegistrationWidget
-    {...defaultProps}
-    profile={indieUserProfileWithGameStatsEmail}
-    hideIfSubscribed
-  />
-);
-export const DetailsOpened = () => (
-  <GameRegistrationWidget
-    {...defaultProps}
-    profile={indieUserProfileWithGameStatsEmail}
-    detailsOpened
-  />
-);
+RegisteredWithoutLoader.decorators = [withMock];
+RegisteredWithoutLoader.parameters = {
+  mockData: [
+    {
+      url: `${GDevelopGameApi.baseUrl}/game/?userId=indie-user`,
+      method: 'GET',
+      status: 200,
+      response: {
+        id: 'game-id',
+        name: 'My game',
+      },
+      delay: 500,
+    },
+  ],
+};


### PR DESCRIPTION
Starting from #4721 I've started a first version of a "router".
The idea is to be able to open a dialog from anywhere in the app, directly from this context, using the URL params on the web.
Also useful for opening a dialog directly when launching the app (already the case)

It's not perfect and I can see multiple improvements:

- changing the names of the parameters (initial-dialog => dialog)
- do the same for all dialogs that can be opened from the mainframe
- ideally, the parameters would stay in the URL and not be removed right away, but it feels that it's more work to do it properly for the moment
- create helpers with clear names, rather than always using `addArguments`

But I feel that it's a step forward compared to what we had (the code feels simpler to modify/understand).

I've also made various fixes:

- Simplify GameRegistration's logic and remove it from the Project Properties (didn't really make sense here)
- Improve wordings for registering
- Fix showing a "create account" alert when opening the subscription dialog for a split second
- improve background of current game card to be more visible