### PR TITLE
feat: enable `.ldtk` files

### DIFF
--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -79,9 +79,9 @@ const defineTileMap = function (
         .setType('resource')
         .addExtraInfo('tilemap')
         .addExtraInfo('json')
-        .setLabel(_('Tilemap Tiled JSON or LDtk file'))
+        .setLabel(_('Tilemap file (Tiled or LDtk)'))
         .setDescription(
-          _('This is the JSON/LDtk file that was saved or exported from Tiled/LDtk.')
+          _('This is the file that was saved or exported from Tiled/LDtk.')
         )
         .setGroup(_('LDtk and Tiled: Tilemap'))
     );
@@ -214,32 +214,32 @@ const defineTileMap = function (
   object
     .addCondition(
       'TilemapJsonFile',
-      _('Tilemap JSON/LDtk file'),
-      _('Check the Tilemap JSON/LDtk file being used.'),
-      _('The Tilemap JSON/LDtk file of _PARAM0_ is _PARAM1_'),
+      _('Tilemap file (Tiled or LDtk)'),
+      _('Check the tilemap file (Tiled or LDtk) being used.'),
+      _('The tilemap file of _PARAM0_ is _PARAM1_'),
       '',
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
     .addParameter('object', _('Tile map'), 'TileMap', false)
-    .addParameter('tilemapResource', _('Tilemap JSON/LDtk file'), '', false)
+    .addParameter('tilemapResource', _('Tilemap file (Tiled or LDtk)'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('isTilemapJsonFile');
 
   object
     .addAction(
       'SetTilemapJsonFile',
-      _('Tilemap JSON/LDtk file'),
+      _('Tilemap file (Tiled or LDtk)'),
       _(
-        'Set the JSON/LDtk file containing the Tilemap data to display. This is usually the JSON/LDtk file from Tiled/LDtk.'
+        'Set the Tiled or LDtk file containing the Tilemap data to display. This is usually the main file exported from Tiled/LDtk.'
       ),
-      _('Set the Tilemap JSON/LDtk file of _PARAM0_ to _PARAM1_'),
+      _('Set the tilemape file of _PARAM0_ to _PARAM1_'),
       '',
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
     .addParameter('object', _('Tile map'), 'TileMap', false)
-    .addParameter('tilemapResource', _('Tilemap JSON/LDtk file'), '', false)
+    .addParameter('tilemapResource', _('Tilemap file (Tiled or LDtk)'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('setTilemapJsonFile');
 
@@ -651,7 +651,7 @@ const defineCollisionMask = function (
         .addExtraInfo('json')
         .setLabel(_('Tilemap JSON file'))
         .setDescription(
-          _('This is the JSON file that was saved or exported from Tiled.')
+          _('This is the JSON file that was saved or exported from Tiled. LDtk is not supported yet for collisions.')
         )
     );
     objectProperties.set(

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -78,6 +78,7 @@ const defineTileMap = function (
       new gd.PropertyDescriptor(objectContent.tilemapJsonFile)
         .setType('resource')
         .addExtraInfo('tilemap')
+        .addExtraInfo('json')
         .setLabel(_('Tilemap Tiled JSON or LDtk file'))
         .setDescription(
           _('This is the JSON/LDtk file that was saved or exported from Tiled/LDtk.')

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -77,10 +77,10 @@ const defineTileMap = function (
       'tilemapJsonFile',
       new gd.PropertyDescriptor(objectContent.tilemapJsonFile)
         .setType('resource')
-        .addExtraInfo('json')
+        .addExtraInfo('tilemap')
         .setLabel(_('Tilemap Tiled JSON or LDtk file'))
         .setDescription(
-          _('This is the JSON file that was saved or exported from Tiled/LDtk.')
+          _('This is the JSON/LDtk file that was saved or exported from Tiled/LDtk.')
         )
         .setGroup(_('LDtk and Tiled: Tilemap'))
     );
@@ -213,32 +213,32 @@ const defineTileMap = function (
   object
     .addCondition(
       'TilemapJsonFile',
-      _('Tilemap JSON file'),
-      _('Check the Tilemap JSON file being used.'),
-      _('The Tilemap JSON file of _PARAM0_ is _PARAM1_'),
+      _('Tilemap JSON/LDtk file'),
+      _('Check the Tilemap JSON/LDtk file being used.'),
+      _('The Tilemap JSON/LDtk file of _PARAM0_ is _PARAM1_'),
       '',
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
     .addParameter('object', _('Tile map'), 'TileMap', false)
-    .addParameter('tilemapResource', _('Tilemap JSON file'), '', false)
+    .addParameter('tilemapResource', _('Tilemap JSON/LDtk file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('isTilemapJsonFile');
 
   object
     .addAction(
       'SetTilemapJsonFile',
-      _('Tilemap JSON file'),
+      _('Tilemap JSON/LDtk file'),
       _(
-        'Set the JSON file containing the Tilemap data to display. This is usually the JSON file from Tiled/LDtk.'
+        'Set the JSON/LDtk file containing the Tilemap data to display. This is usually the JSON/LDtk file from Tiled/LDtk.'
       ),
-      _('Set the Tilemap JSON file of _PARAM0_ to _PARAM1_'),
+      _('Set the Tilemap JSON/LDtk file of _PARAM0_ to _PARAM1_'),
       '',
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
     )
     .addParameter('object', _('Tile map'), 'TileMap', false)
-    .addParameter('tilemapResource', _('Tilemap JSON file'), '', false)
+    .addParameter('tilemapResource', _('Tilemap JSON/LDtk file'), '', false)
     .getCodeExtraInformation()
     .setFunctionName('setTilemapJsonFile');
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/TilemapResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/TilemapResourceField.js
@@ -31,6 +31,7 @@ export default class TilemapResourceField extends Component<
         resourceManagementProps={this.props.resourceManagementProps}
         resourcesLoader={ResourcesLoader}
         resourceKind="tilemap"
+        fallbackResourceKind="json"
         fullWidth
         initialResourceName={this.props.value}
         onChange={this.props.onChange}

--- a/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
+++ b/newIDE/app/src/PropertiesEditor/PropertiesMapToSchema.js
@@ -154,12 +154,16 @@ const createField = (
     };
   } else if (valueType === 'resource') {
     // Resource is a "string" (with a selector in the UI)
+    const extraInfos = property.getExtraInfo().toJSArray();
     // $FlowFixMe - assume the passed resource kind is always valid.
-    const kind: ResourceKind = property.getExtraInfo().toJSArray()[0] || '';
+    const kind: ResourceKind = extraInfos[0] || '';
+    // $FlowFixMe - assume the passed resource kind is always valid.
+    const fallbackKind: ResourceKind = extraInfos[1] || '';
     return {
       name,
       valueType: 'resource',
       resourceKind: kind,
+      fallbackResourceKind: fallbackKind,
       getValue: (instance: Instance): string => {
         return getProperties(instance)
           .get(name)

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -96,6 +96,7 @@ export type PrimitiveValueField =
 type ResourceField = {|
   valueType: 'resource',
   resourceKind: ResourceKind,
+  fallbackResourceKind?: ResourceKind,
   getValue: Instance => string,
   setValue: (instance: Instance, newValue: string) => void,
   ...ValueFieldCommonProperties,
@@ -551,6 +552,7 @@ const PropertiesEditor = ({
         resourceManagementProps={resourceManagementProps}
         resourcesLoader={ResourcesLoader}
         resourceKind={field.resourceKind}
+        fallbackResourceKind={field.fallbackResourceKind}
         fullWidth
         initialResourceName={getFieldValue({
           instances,

--- a/newIDE/app/src/ResourcesList/ResourceSelector.js
+++ b/newIDE/app/src/ResourcesList/ResourceSelector.js
@@ -36,6 +36,7 @@ type Props = {|
   resourceManagementProps: ResourceManagementProps,
   resourcesLoader: typeof ResourcesLoader,
   resourceKind: ResourceKind,
+  fallbackResourceKind?: ResourceKind,
   fullWidth?: boolean,
   canBeReset?: boolean,
   initialResourceName: string,
@@ -115,12 +116,25 @@ export default class ResourceSelector extends React.Component<Props, State> {
   _loadFrom(resourcesManager: gdResourcesManager) {
     this.allResourcesNames = resourcesManager.getAllResourceNames().toJSArray();
     if (this.props.resourceKind) {
-      this.allResourcesNames = this.allResourcesNames.filter(resourceName => {
+      const mainResourcesNames = this.allResourcesNames.filter(resourceName => {
         return (
           resourcesManager.getResource(resourceName).getKind() ===
           this.props.resourceKind
         );
       });
+
+      if (this.props.fallbackResourceKind) {
+        mainResourcesNames.push(
+          ...this.allResourcesNames.filter(resourceName => {
+            return (
+              resourcesManager.getResource(resourceName).getKind() ===
+              this.props.fallbackResourceKind
+            );
+          })
+        );
+      }
+
+      this.allResourcesNames = mainResourcesNames;
     }
     const resourceSourceItems = this._getResourceSourceItems();
     const resourceItems = this.allResourcesNames.map(resourceName => ({

--- a/newIDE/app/src/ResourcesList/ResourceSource.js
+++ b/newIDE/app/src/ResourcesList/ResourceSource.js
@@ -54,7 +54,7 @@ export const allResourceKindsAndMetadata = [
   {
     kind: 'tilemap',
     displayName: t`Tile Map`,
-    fileExtensions: ['json', 'ldtk'],
+    fileExtensions: ['json', 'ldtk', 'tmj'],
     createNewResource: () => new gd.TilemapResource(),
   },
   {


### PR DESCRIPTION
This PR enables the support for `.ldtk` files.

But there is an issue with existing tilemaps.
When editing them, the existing resources are of type `json` instead of `tilemap` and so they can't be reused.
I think we should detect this case and convert them as tilemap resources.

This is a follow up of #4575.