### PR TITLE
LocalFolderPicker: prop "required"

### DIFF
--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -401,6 +401,7 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
             value={values.newProjectsDefaultFolder}
             onChange={setNewProjectsDefaultFolder}
             type="default-workspace"
+            required
           />
         </ColumnStackLayout>
       )}

--- a/newIDE/app/src/UI/LocalFolderPicker/index.js
+++ b/newIDE/app/src/UI/LocalFolderPicker/index.js
@@ -32,6 +32,7 @@ type Props = {|
   onChange: string => void,
   defaultPath?: string,
   fullWidth?: boolean,
+  required?: boolean,
 |};
 
 type TitleAndMessage = {|
@@ -45,11 +46,14 @@ const LocalFolderPicker = ({
   onChange,
   defaultPath,
   fullWidth,
+  required,
 }: Props) => {
   // Use an internal state to avoid validating the value when the user
   // is typing in the text field. This allows typing a "/" without the
   // formatting kicking in.
   const [textValue, setTextValue] = React.useState(value);
+  const [errorText, setErrorText] = React.useState(null);
+
   const onChooseFolder = async ({ title, message }: TitleAndMessage) => {
     if (!dialog || !electron) return;
 
@@ -61,6 +65,8 @@ const LocalFolderPicker = ({
       defaultPath: defaultPath,
     });
 
+    setErrorText(null);
+
     if (!filePaths || !filePaths.length) return;
 
     const filePath = filePaths[0];
@@ -68,7 +74,12 @@ const LocalFolderPicker = ({
     setTextValue(filePath);
   };
 
-  const onBlur = () => {
+  const onBlur = (i18n: I18nType) => {
+    setErrorText(null);
+    if (textValue === '' && required) {
+      setErrorText(i18n._(t`This field is required`));
+      return;
+    }
     onChange(textValue);
   };
 
@@ -109,7 +120,8 @@ const LocalFolderPicker = ({
               hintText={titleAndMessage.title}
               value={textValue}
               onChange={(event, value) => setTextValue(value)}
-              onBlur={onBlur}
+              onBlur={() => onBlur(i18n)}
+              errorText={errorText}
             />
             <FlatButton
               label={<Trans>Choose folder</Trans>}


### PR DESCRIPTION
When required=true, an error is displayed below the input

Closing the PreferencesDialog will not save the value in the preferences storage if the value is empty.

![image](https://user-images.githubusercontent.com/21989259/209398898-af7c3a3e-fc57-4d76-9e6d-32721a372ba2.png)
