### PR TITLE
Fix textfield

### DIFF
--- a/newIDE/app/src/ProjectManager/ProjectManagerItems.js
+++ b/newIDE/app/src/ProjectManager/ProjectManagerItems.js
@@ -188,7 +188,7 @@ export const Item = ({
             onBeginDrag();
             return {};
           }}
-          canDrag={() => true}
+          canDrag={() => !editingName}
           canDrop={() => true}
           drop={onDrop}
         >

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
@@ -59,31 +59,31 @@ function ItemRow<Item>({
   scaleUpItemIconWhenSelected,
   connectIconDragSource,
 }: Props<Item>) {
-  const [textField, setTextField] = React.useState<?TextFieldInterface>(null);
+  const textFieldRef = React.useRef<?TextFieldInterface>(null);
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
 
   React.useEffect(
     () => {
       if (editingName) {
         const timeoutId = setTimeout(() => {
-          if (textField) textField.focus();
+          if (textFieldRef.current) textFieldRef.current.focus();
         }, 100);
         return () => clearTimeout(timeoutId);
       }
     },
-    [editingName, textField]
+    [editingName]
   );
 
   const label = editingName ? (
     <TextField
       id="rename-item-field"
       margin="none"
-      ref={textField => setTextField(textField)}
+      ref={textFieldRef}
       defaultValue={itemName}
       onBlur={e => onRename(e.currentTarget.value)}
       onKeyPress={event => {
         if (shouldValidate(event)) {
-          if (textField) textField.blur();
+          if (textFieldRef.current) textFieldRef.current.blur();
         }
       }}
       fullWidth


### PR DESCRIPTION
- Resolves https://forum.gdevelop.io/t/cannot-select-the-names-while-renaming-the-itens-in-the-project-manager-with-version-5-1-154/43952/2
- Resolves a bug introduced with #4754 
- Allows to cancel a change with Escape key when renaming an item in either:
  - the project manager items
  - any sortable virtualized item list (objects list, object groups list, etc.)