### PR TITLE
Events Instructions Paste text "or paste actions" - Add margin to the left

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
@@ -20,6 +20,9 @@ const styles = {
   addButton: {
     cursor: 'pointer',
   },
+  pasteButtonContainer: {
+    marginLeft: '4px',
+  },
 };
 
 type Props = {
@@ -232,7 +235,7 @@ export default function InstructionsList({
                 {addButtonLabel || addButtonDefaultLabel}
               </button>
               {canPaste && (
-                <span>
+                <span style={styles.pasteButtonContainer}>
                   <button
                     style={styles.addButton}
                     className="add-link"


### PR DESCRIPTION
Hi,
In the Events sheet, I added a left margin before the parenthesis because I think is prettier with a space between both texts.

`"Add action(or paste actions)" -> "Add action (or paste actions)"`

Here it is a screenshot explaining it:

![image](https://user-images.githubusercontent.com/21989259/210186389-38266c06-5de8-4e1d-8232-eba02c0213e4.png)
