### PR TITLE
Fix a crash when an event-based object tries to access scene variables

### DIFF
--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -1246,7 +1246,7 @@ gd::String EventsCodeGenerator::GenerateGetVariable(
   gd::String output;
   const gd::VariablesContainer* variables = NULL;
   if (scope == LAYOUT_VARIABLE) {
-    output = "runtimeScene.getVariables()";
+    output = "runtimeScene.getScene().getVariables()";
 
     if (HasProjectAndLayout()) {
       variables = &GetLayout().GetVariables();

--- a/GDevelop.js/TestUtils/GDJSMocks.js
+++ b/GDevelop.js/TestUtils/GDJSMocks.js
@@ -418,6 +418,10 @@ class RuntimeScene {
   getInitialSharedDataForBehavior(name) {
     return null;
   }
+
+  getScene() {
+    return this;
+  }
 }
 
 /**


### PR DESCRIPTION
EBO should avoid to use scene variables, but it's useful for the multi-touch joystick to expose "static" gamepads indexed by player id through free functions so they can be used by a mapper behavior.

There is probably issues with trigger once:
- when called from the scene, it uses the scene trigger once list
- when called from an EBO, it uses the scene trigger once list
This will be tricky to solve and trigger once must not be used in free functions according to good practices so I guess it can be left as it is for now.