### PR TITLE
Add autocompletions for some fields that can contain object groups

### DIFF
--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -274,9 +274,9 @@ interface ObjectGroup {
 
     [Const, Ref] DOMString GetName();
     void SetName([Const] DOMString name);
-    void AddObject([Const] DOMString obj);
-    void RemoveObject([Const] DOMString obj);
-    boolean Find([Const] DOMString obj);
+    void AddObject([Const] DOMString objectName);
+    void RemoveObject([Const] DOMString objectName);
+    boolean Find([Const] DOMString objectName);
 
     [Const, Ref] VectorString GetAllObjectsNames();
 

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import intersection from 'lodash/intersection';
 import GenericExpressionField from './GenericExpressionField';
 import {
   type ParameterFieldProps,
@@ -9,6 +10,8 @@ import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
 import getObjectByName from '../../Utils/GetObjectByName';
 import { getLastObjectParameterValue } from './ParameterMetadataTools';
 import { enumerateEffectNames } from '../../EffectsList/EnumerateEffects';
+import getObjectGroupByName from '../../Utils/GetObjectGroupByName';
+import { mapVector } from '../../Utils/MapFor';
 
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function ObjectEffectNameField(props: ParameterFieldProps, ref) {
@@ -30,28 +33,51 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
     } = props;
 
     const getEffectNames = (): Array<ExpressionAutocompletion> => {
-      const objectName = getLastObjectParameterValue({
+      const objectOrGroupName = getLastObjectParameterValue({
         instructionMetadata,
         instruction,
         expressionMetadata,
         expression,
         parameterIndex,
       });
-      if (!objectName || !project) {
+      if (!objectOrGroupName || !project) {
         return [];
       }
 
-      const object = getObjectByName(project, scope.layout, objectName);
-      if (!object) {
-        return [];
+      const object = getObjectByName(project, scope.layout, objectOrGroupName);
+      if (object) {
+        return enumerateEffectNames(object.getEffects())
+          .sort()
+          .map(effectName => ({
+            kind: 'Text',
+            completion: `"${effectName}"`,
+          }));
+      }
+      const group = getObjectGroupByName(
+        project,
+        scope.layout,
+        objectOrGroupName
+      );
+      if (group) {
+        const effectsNamesByObject: string[][] = mapVector(
+          group.getAllObjectsNames(),
+          objectName => {
+            const object = getObjectByName(project, scope.layout, objectName);
+            if (!object) {
+              return null;
+            }
+            return enumerateEffectNames(object.getEffects());
+          }
+        ).filter(Boolean);
+        return intersection(...effectsNamesByObject)
+          .sort()
+          .map(effectName => ({
+            kind: 'Text',
+            completion: `"${effectName}"`,
+          }));
       }
 
-      return enumerateEffectNames(object.getEffects())
-        .sort()
-        .map(effectName => ({
-          kind: 'Text',
-          completion: `"${effectName}"`,
-        }));
+      return [];
     };
 
     return (

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import uniq from 'lodash/uniq';
 import GenericExpressionField from './GenericExpressionField';
 import {
   type ParameterFieldProps,
@@ -12,6 +13,8 @@ import {
   getPreviousParameterValue,
   tryExtractStringLiteralContent,
 } from './ParameterMetadataTools';
+import getObjectGroupByName from '../../Utils/GetObjectGroupByName';
+import { mapVector } from '../../Utils/MapFor';
 
 const gd: libGDevelop = global.gd;
 
@@ -35,7 +38,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         parameterIndex,
       } = props;
 
-      const objectName = getLastObjectParameterValue({
+      const objectOrGroupName = getLastObjectParameterValue({
         instructionMetadata,
         instruction,
         expressionMetadata,
@@ -49,17 +52,56 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           parameterIndex,
         })
       );
-      if (!objectName || !project || !effectName) {
+      if (!objectOrGroupName || !project || !effectName) {
         return [];
       }
 
-      const object = getObjectByName(project, scope.layout, objectName);
-      if (!object || !object.getEffects().hasEffectNamed(effectName)) {
-        return [];
+      let effectType: string | null = null;
+      const object = getObjectByName(project, scope.layout, objectOrGroupName);
+      if (object && object.getEffects().hasEffectNamed(effectName)) {
+        effectType = object
+          .getEffects()
+          .getEffect(effectName)
+          .getEffectType();
       }
-      const effect = object.getEffects().getEffect(effectName);
 
-      const effectType = effect.getEffectType();
+      if (!effectType) {
+        const group = getObjectGroupByName(
+          project,
+          scope.layout,
+          objectOrGroupName
+        );
+        if (group) {
+          // If the instruction targets a group, we check that the effect behind
+          // the effect name on every object of the group is of the same type.
+          const effectTypes: Array<string | null> = mapVector(
+            group.getAllObjectsNames(),
+            objectName => {
+              const object = getObjectByName(project, scope.layout, objectName);
+              if (!object) {
+                // If object not found, we consider this as an error.
+                return null;
+              }
+              if (!object.getEffects().hasEffectNamed(effectName)) {
+                return null;
+              }
+              return object
+                .getEffects()
+                .getEffect(effectName)
+                .getEffectType();
+            }
+          );
+          if (
+            effectTypes.every(type => !!type) &&
+            uniq(effectTypes).length === 1
+          ) {
+            effectType = effectTypes[0];
+          }
+        }
+      }
+
+      if (!effectType) return [];
+
       const effectMetadata = gd.MetadataProvider.getEffectMetadata(
         project.getCurrentPlatform(),
         effectType

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectPointNameField.js
@@ -1,11 +1,14 @@
 // @flow
 import React, { Component } from 'react';
+import intersection from 'lodash/intersection';
 import GenericExpressionField from './GenericExpressionField';
 import { type ParameterFieldProps } from './ParameterFieldCommons';
 import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
 import getObjectByName from '../../Utils/GetObjectByName';
 import { getLastObjectParameterValue } from './ParameterMetadataTools';
 import { getAllPointNames } from '../../ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper';
+import getObjectGroupByName from '../../Utils/GetObjectGroupByName';
+import { mapVector } from '../../Utils/MapFor';
 
 const gd: libGDevelop = global.gd;
 
@@ -30,23 +33,19 @@ export default class ObjectPointNameField extends Component<
       parameterIndex,
     } = this.props;
 
-    const objectName = getLastObjectParameterValue({
+    const objectOrGroupName = getLastObjectParameterValue({
       instructionMetadata,
       instruction,
       expressionMetadata,
       expression,
       parameterIndex,
     });
-    if (!objectName || !project) {
+    if (!objectOrGroupName || !project) {
       return [];
     }
 
-    const object = getObjectByName(project, scope.layout, objectName);
-    if (!object) {
-      return [];
-    }
-
-    if (object.getType() === 'Sprite') {
+    const object = getObjectByName(project, scope.layout, objectOrGroupName);
+    if (object && object.getType() === 'Sprite') {
       const spriteConfiguration = gd.asSpriteConfiguration(
         object.getConfiguration()
       );
@@ -56,6 +55,46 @@ export default class ObjectPointNameField extends Component<
           spriteObjectName.length > 0 ? spriteObjectName : null
         )
         .filter(Boolean)
+        .sort()
+        .map(pointName => ({
+          kind: 'Text',
+          completion: `"${pointName}"`,
+        }));
+    }
+
+    const group = getObjectGroupByName(
+      project,
+      scope.layout,
+      objectOrGroupName
+    );
+    if (group) {
+      // If the instruction targets a group, we check that every object of the
+      // group is a sprite and get the points that they all have in common.
+      const pointsNamesByObject = mapVector(
+        group.getAllObjectsNames(),
+        objectName => {
+          const object = getObjectByName(project, scope.layout, objectName);
+          if (!object || object.getType() !== 'Sprite') {
+            return null;
+          }
+          const spriteConfiguration = gd.asSpriteConfiguration(
+            object.getConfiguration()
+          );
+
+          return getAllPointNames(spriteConfiguration)
+            .map(spriteObjectName =>
+              spriteObjectName.length > 0 ? spriteObjectName : null
+            )
+            .filter(Boolean);
+        }
+      );
+
+      if (pointsNamesByObject.some(pointsNames => !pointsNames)) return [];
+
+      // Flow fears that pointsNamesByObject contains null values but this
+      // possibility should be handled above.
+      // $FlowExpectedError[incompatible-call]
+      return intersection<string>(...pointsNamesByObject)
         .sort()
         .map(pointName => ({
           kind: 'Text',

--- a/newIDE/app/src/Utils/GetObjectGroupByName.js
+++ b/newIDE/app/src/Utils/GetObjectGroupByName.js
@@ -2,10 +2,13 @@
 
 export default function getObjectGroupByName(
   globalObjectsContainer: gdObjectsContainer,
-  objectsContainer: gdObjectsContainer,
+  objectsContainer?: ?gdObjectsContainer,
   objectGroupName: string
 ): ?gdObjectGroup {
-  if (objectsContainer.getObjectGroups().has(objectGroupName)) {
+  if (
+    objectsContainer &&
+    objectsContainer.getObjectGroups().has(objectGroupName)
+  ) {
     return objectsContainer.getObjectGroups().get(objectGroupName);
   } else if (globalObjectsContainer.getObjectGroups().has(objectGroupName)) {
     return globalObjectsContainer.getObjectGroups().get(objectGroupName);


### PR DESCRIPTION
Fixes #4771

This PR adds autocompletions for 3 fields:
- Effect names: Suggests effects names that all objects in the group have
- Effect parameter names: if all the objects in the group have an effect with the given name and those effects are of the same type, suggests the parameters of the effect
- Point name: if all the objects in the group are sprites, suggests points names that all objects in the group have