### PR TITLE
Use composedPath method to get path to click target

### DIFF
--- a/newIDE/app/src/EventsSheet/InlinePopover.js
+++ b/newIDE/app/src/EventsSheet/InlinePopover.js
@@ -59,7 +59,7 @@ export default function InlinePopover(props: Props) {
         // the AlertProvider seem to trigger this click away listener
         // even if they are displayed above the InlinePopover element.
         // To avoid this, we need to check the click is not made on a dialog.
-        if (doesPathContainDialog(event.path)) {
+        if (doesPathContainDialog(event.composedPath())) {
           return;
         }
         // For a popover, clicking/touching away means validating,

--- a/newIDE/app/src/UI/MaterialUISpecificUtil.js
+++ b/newIDE/app/src/UI/MaterialUISpecificUtil.js
@@ -57,9 +57,9 @@ export const doesPathContainDialog = (path: Array<Element>): boolean => {
     return isElementADialog(path[path.length - 5], { isVisible: true });
   } catch (error) {
     console.error(
-      `An error occurred when determining if path ${path.join(
-        ' > '
-      )} leads to a dialog`,
+      `An error occurred when determining if path ${
+        path && path.join ? path.join(' > ') : '[not serializable]'
+      } leads to a dialog`,
       error
     );
     return false;


### PR DESCRIPTION
Fixes #4828 
Fixed the error throwing as well.

That was expected https://chromestatus.com/feature/5726124632965120 but I had not seen this deprecation.