### PR TITLE
Focus comment or group event after adding it

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/MissingParameterValue.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/MissingParameterValue.js
@@ -6,7 +6,10 @@ import { instructionMissingParameter } from './ClassNames';
  * Displayed when a parameter is missing (i.e: empty and not optional)
  */
 const MissingParameterValue = () => (
-  <span className={instructionMissingParameter} />
+  <span className={instructionMissingParameter}>
+    {/* If span is empty, the browser renders the span with an unwanted vertical offset. */}
+    &nbsp;
+  </span>
 );
 
 export default MissingParameterValue;

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -32,7 +32,7 @@ const styles = {
     overflow: 'hidden',
     minHeight: '2.1em',
   },
-  commentTextField: commentTextStyle,
+  commentTextField: { ...commentTextStyle, fontSize: 'inherit' },
   commentSpan: {
     ...commentTextStyle,
     boxSizing: 'border-box',
@@ -155,7 +155,6 @@ export default class CommentEvent extends React.Component<
               color: `#${textColor}`,
               padding: 0,
               lineHeight: 1.5,
-              fontSize: '1em',
             }}
             underlineFocusStyle={{
               borderColor: `#${textColor}`,

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -35,12 +35,10 @@ const styles = {
   commentTextField: { ...commentTextStyle, fontSize: 'inherit' },
   commentSpan: {
     ...commentTextStyle,
-    boxSizing: 'border-box',
     alignItems: 'center',
     height: '100%',
     whiteSpace: 'pre-wrap',
     lineHeight: 1.5,
-    border: 1,
   },
 };
 

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -157,9 +157,6 @@ export default class CommentEvent extends React.Component<
               padding: 0,
               lineHeight: 1.5,
             }}
-            underlineFocusStyle={{
-              borderColor: `#${textColor}`,
-            }}
             fullWidth
             id="comment-title"
             onKeyDown={event => {

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -169,6 +169,7 @@ export default class CommentEvent extends React.Component<
                 this.endEditing();
               }
             }}
+            underlineShow={false}
           />
         ) : (
           <span

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -112,17 +112,17 @@ export default class CommentEvent extends React.Component<
   render() {
     const commentEvent = gd.asCommentEvent(this.props.event);
 
-    const backgroundColor = rgbToHex(
+    const backgroundColor = `#${rgbToHex(
       commentEvent.getBackgroundColorRed(),
       commentEvent.getBackgroundColorGreen(),
       commentEvent.getBackgroundColorBlue()
-    );
+    )}`;
 
-    const textColor = rgbToHex(
+    const textColor = `#${rgbToHex(
       commentEvent.getTextColorRed(),
       commentEvent.getTextColorGreen(),
       commentEvent.getTextColorBlue()
-    );
+    )}`;
 
     return (
       <div
@@ -132,7 +132,7 @@ export default class CommentEvent extends React.Component<
         })}
         style={{
           ...styles.container,
-          backgroundColor: `#${backgroundColor}`,
+          backgroundColor,
         }}
         onClick={this.edit}
         onKeyUp={event => {
@@ -153,7 +153,7 @@ export default class CommentEvent extends React.Component<
             onChange={this.onChange}
             style={styles.commentTextField}
             inputStyle={{
-              color: `#${textColor}`,
+              color: textColor,
               padding: 0,
               lineHeight: 1.5,
             }}
@@ -175,7 +175,7 @@ export default class CommentEvent extends React.Component<
             })}
             style={{
               ...styles.commentSpan,
-              color: `#${textColor}`,
+              color: textColor,
             }}
             dangerouslySetInnerHTML={{
               __html: this._getCommentHTML(),

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -132,7 +132,7 @@ export default class CommentEvent extends React.Component<
           backgroundColor: `#${backgroundColor}`,
         }}
         onClick={this.edit}
-        onKeyPress={event => {
+        onKeyUp={event => {
           if (shouldActivate(event)) {
             this.edit();
           }

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -62,6 +62,7 @@ export default class CommentEvent extends React.Component<
   _textField: ?TextFieldInterface;
 
   edit = () => {
+    if (this.state.editing) return;
     const commentEvent = gd.asCommentEvent(this.props.event);
     this.setState(
       {
@@ -135,6 +136,7 @@ export default class CommentEvent extends React.Component<
           ...styles.container,
           backgroundColor: `#${backgroundColor}`,
         }}
+        onClick={this.edit}
         onKeyUp={event => {
           if (!this.state.editing && shouldActivate(event)) {
             this.edit();
@@ -182,7 +184,6 @@ export default class CommentEvent extends React.Component<
             dangerouslySetInnerHTML={{
               __html: this._getCommentHTML(),
             }}
-            onClick={this.edit}
             {...dataObjectToProps({ editableText: 'true' })}
           />
         )}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -69,12 +69,14 @@ export default class CommentEvent extends React.Component<
         editingPreviousValue: commentEvent.getComment(),
       },
       () => {
-        if (this._textField) this._textField.focus();
+        if (this._textField) {
+          this._textField.focus({ caretPosition: 'end' });
+        }
       }
     );
   };
 
-  onEvent = (e: any, text: string) => {
+  onChange = (e: any, text: string) => {
     const commentEvent = gd.asCommentEvent(this.props.event);
     commentEvent.setComment(text);
 
@@ -133,9 +135,8 @@ export default class CommentEvent extends React.Component<
           ...styles.container,
           backgroundColor: `#${backgroundColor}`,
         }}
-        onClick={this.edit}
         onKeyUp={event => {
-          if (shouldActivate(event)) {
+          if (!this.state.editing && shouldActivate(event)) {
             this.edit();
           }
         }}
@@ -149,7 +150,7 @@ export default class CommentEvent extends React.Component<
             value={commentEvent.getComment()}
             translatableHintText={t`<Enter comment>`}
             onBlur={this.endEditing}
-            onChange={this.onEvent}
+            onChange={this.onChange}
             style={styles.commentTextField}
             inputStyle={{
               color: `#${textColor}`,
@@ -181,6 +182,7 @@ export default class CommentEvent extends React.Component<
             dangerouslySetInnerHTML={{
               __html: this._getCommentHTML(),
             }}
+            onClick={this.edit}
             {...dataObjectToProps({ editableText: 'true' })}
           />
         )}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -15,6 +15,7 @@ import { type EventRendererProps } from './EventRenderer';
 import {
   shouldActivate,
   shouldCloseOrCancel,
+  shouldSubmit,
 } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 import { dataObjectToProps } from '../../../Utils/HTMLDataset';
 const gd: libGDevelop = global.gd;
@@ -161,8 +162,8 @@ export default class CommentEvent extends React.Component<
             }}
             fullWidth
             id="comment-title"
-            onKeyUp={event => {
-              if (shouldCloseOrCancel(event)) {
+            onKeyDown={event => {
+              if (shouldCloseOrCancel(event) || shouldSubmit(event)) {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -16,6 +16,7 @@ import {
   shouldActivate,
   shouldCloseOrCancel,
 } from '../../../UI/KeyboardShortcuts/InteractionKeys';
+import { dataObjectToProps } from '../../../Utils/HTMLDataset';
 const gd: libGDevelop = global.gd;
 
 const commentTextStyle = {
@@ -180,6 +181,7 @@ export default class CommentEvent extends React.Component<
             dangerouslySetInnerHTML={{
               __html: this._getCommentHTML(),
             }}
+            {...dataObjectToProps({ editableText: 'true' })}
           />
         )}
       </div>

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -127,6 +127,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
                 this.endEditing();
               }
             }}
+            underlineShow={false}
           />
         ) : (
           <span

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -17,6 +17,7 @@ import {
   shouldValidate,
 } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 import { Trans } from '@lingui/macro';
+import { dataObjectToProps } from '../../../Utils/HTMLDataset';
 const gd: libGDevelop = global.gd;
 
 const styles = {
@@ -131,6 +132,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
               [disabledText]: this.props.disabled,
             })}
             style={{ ...styles.title, color: textColor }}
+            {...dataObjectToProps({ editableText: 'true' })}
           >
             {groupEvent.getName() ? (
               groupEvent.getName()

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -14,6 +14,7 @@ import { type EventRendererProps } from './EventRenderer';
 import {
   shouldActivate,
   shouldCloseOrCancel,
+  shouldSubmit,
   shouldValidate,
 } from '../../../UI/KeyboardShortcuts/InteractionKeys';
 import { Trans } from '@lingui/macro';
@@ -119,8 +120,8 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
                 this.endEditing();
               }
             }}
-            onKeyPress={event => {
-              if (shouldValidate(event)) {
+            onKeyDown={event => {
+              if (shouldValidate(event) || shouldSubmit(event)) {
                 this.endEditing();
               }
             }}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -43,6 +43,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
   _textField: ?TextFieldInterface = null;
 
   edit = () => {
+    if (this.state.editing) return;
     const groupEvent = gd.asGroupEvent(this.props.event);
     if (!this.state.editingPreviousValue) {
       this.setState({ editingPreviousValue: groupEvent.getName() });

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -97,6 +97,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
       >
         {this.state.editing ? (
           <TextField
+            margin="none"
             ref={textField => (this._textField = textField)}
             value={groupEvent.getName()}
             translatableHintText={t`<Enter group name>`}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -86,7 +86,7 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
           backgroundColor: `rgb(${r}, ${g}, ${b})`,
         }}
         onClick={this.edit}
-        onKeyPress={event => {
+        onKeyUp={event => {
           if (shouldActivate(event)) {
             this.edit();
           }

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/GroupEvent.js
@@ -112,9 +112,6 @@ export default class GroupEvent extends React.Component<EventRendererProps, *> {
               color: textColor,
               WebkitTextFillColor: textColor,
             }}
-            underlineFocusStyle={{
-              borderColor: textColor,
-            }}
             fullWidth
             id="group-title"
             onKeyUp={event => {

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -48,6 +48,7 @@ import { makeDropTarget } from '../../UI/DragAndDrop/DropTarget';
 import { AutoScroll, DropContainer } from './DropContainer';
 import { isDescendant, type MoveFunctionArguments } from './helpers';
 import GDevelopThemeContext from '../../UI/Theme/ThemeContext';
+import { dataObjectToProps } from '../../Utils/HTMLDataset';
 const gd: libGDevelop = global.gd;
 
 const eventsSheetEventsDnDType = 'events-sheet-events-dnd-type';
@@ -304,6 +305,7 @@ export type SortableTreeNode = {
   depth: number,
   disabled: boolean,
   indexInList: number,
+  rowIndex: number,
   nodePath: Array<number>,
   // Key is event pointer or an identification string.
   key: number | string,
@@ -486,6 +488,7 @@ export default class ThemableEventsTree extends Component<
           event,
           eventsList,
           indexInList: i,
+          rowIndex: flatData.length - 1,
           expanded: !event.isFolded(),
           disabled,
           depth,
@@ -720,6 +723,7 @@ export default class ThemableEventsTree extends Component<
                 opacity: isDragged ? 0.5 : 1,
                 ...getEventContainerStyle(this.props.windowWidth),
               }}
+              {...dataObjectToProps({ rowIndex: node.rowIndex.toString() })}
             >
               <EventContainer
                 project={this.props.project}

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -858,6 +858,8 @@ export default class ThemableEventsTree extends Component<
           ...styles.container,
           fontSize: `${zoomLevel}px`,
           '--icon-size': `${Math.round(zoomLevel * 1.14)}px`,
+          '--instruction-missing-parameter-min-height': `${Math.round(zoomLevel * 1.1)}px`,
+          '--instruction-missing-parameter-min-width': `${Math.round(zoomLevel * 3)}px`,
         }}
       >
         {/* Disable for touchscreen because the dragged DOM node gets deleted, the */}

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -858,8 +858,12 @@ export default class ThemableEventsTree extends Component<
           ...styles.container,
           fontSize: `${zoomLevel}px`,
           '--icon-size': `${Math.round(zoomLevel * 1.14)}px`,
-          '--instruction-missing-parameter-min-height': `${Math.round(zoomLevel * 1.1)}px`,
-          '--instruction-missing-parameter-min-width': `${Math.round(zoomLevel * 3)}px`,
+          '--instruction-missing-parameter-min-height': `${Math.round(
+            zoomLevel * 1.1
+          )}px`,
+          '--instruction-missing-parameter-min-width': `${Math.round(
+            zoomLevel * 3
+          )}px`,
         }}
       >
         {/* Disable for touchscreen because the dragged DOM node gets deleted, the */}

--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -89,6 +89,14 @@
 }
 
 /**
+ * Remove default style of multiline textfield (for comment events) to remove
+ * the height change occurring when starting to edit the comment.
+ */
+.gd-events-sheet .rst__rowTitle .MuiInput-multiline {
+    padding-bottom: 0;
+}
+
+/**
  * Expand/collapse buttons
  */
 .gd-events-sheet .rst__collapseButton, .rst__expandButton {

--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -92,7 +92,8 @@
  * Remove default style of multiline textfield (for comment events) to remove
  * the height change occurring when starting to edit the comment.
  */
-.gd-events-sheet .rst__rowTitle .MuiInput-multiline {
+.gd-events-sheet .rst__rowTitle .MuiInput-multiline,
+.gd-events-sheet .rst__rowTitle .MuiInputBase-input {
     padding-bottom: 0;
 }
 
@@ -164,7 +165,7 @@
  */
 .gd-events-sheet .selectable {
     box-sizing: border-box;
-    border: 1px transparent solid;
+    border: 1px solid transparent;
 }
 
 /**
@@ -172,7 +173,7 @@
  */
 .gd-events-sheet .large-selectable {
     box-sizing: border-box;
-    border: 1px transparent solid;
+    border: 1px solid transparent;
 }
 
 /**

--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -80,6 +80,10 @@
     font-weight: normal;
 }
 
+.gd-events-sheet .rst__rowTitle .MuiInputBase-root {
+    font-family: unset;
+}
+
 /**
  * Expand/collapse buttons
  */

--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -80,6 +80,10 @@
     font-weight: normal;
 }
 
+/**
+ * Unset font family of Material UI textfields (for comment and group events)
+ * so that they get the same font family as the rest of the event sheet.
+ */
 .gd-events-sheet .rst__rowTitle .MuiInputBase-root {
     font-family: unset;
 }

--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -98,6 +98,16 @@
 }
 
 /**
+ * Add transparent border around Material UI textfields (for comment and group events)
+ * to avoid a slight shift due to the border added by the class "selectable" applied
+ * to those events.
+ */
+.gd-events-sheet .rst__rowTitle .MuiInputBase-root{
+    box-sizing: border-box;
+    border: 1px solid transparent;
+}
+
+/**
  * Expand/collapse buttons
  */
 .gd-events-sheet .rst__collapseButton, .rst__expandButton {

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -423,6 +423,10 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     const hasEventsSelected = hasEventSelected(this.state.selection);
     let insertTopOfSelection = false;
 
+    // This is not a real hook.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const screenType = useScreenType();
+
     let insertions: Array<EventInsertionContext> = [];
     if (context) {
       insertions = [context];
@@ -473,6 +477,17 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
             }
           }
         );
+        if (
+          screenType !== 'touch' &&
+          (type === 'BuiltinCommonInstructions::Comment' ||
+            type === 'BuiltinCommonInstructions::Group')
+        ) {
+          const rowIndex = currentTree.getEventRow(newEvents[0]);
+          const clickableElement = document.querySelector(
+            `[data-row-index="${rowIndex}"] [data-editable-text="true"]`
+          );
+          if (clickableElement) clickableElement.click();
+        }
       });
     }
 

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -112,7 +112,6 @@ type Props = {|
     lineHeight?: 1.4 | 1.5,
     padding?: 0,
   |},
-  underlineFocusStyle?: {| borderColor: string |}, // TODO
   underlineShow?: boolean,
 |};
 

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -168,7 +168,7 @@ export const computeTextFieldStyleProps = (props: {
 };
 
 export type TextFieldInterface = {|
-  focus: () => void,
+  focus: (?{ caretPosition: 'end' }) => void,
   blur: () => void,
   getInputNode: () => ?HTMLInputElement,
   getFieldWidth: () => ?number,
@@ -181,9 +181,17 @@ const TextField = React.forwardRef<Props, TextFieldInterface>((props, ref) => {
   const inputRef = React.useRef<?HTMLInputElement>(null);
   const muiTextFieldRef = React.useRef<?MUITextField>(null);
 
-  const focus = () => {
-    if (inputRef.current) {
-      inputRef.current.focus();
+  const focus = (options: ?{ caretPosition: 'end' }) => {
+    const { current: input } = inputRef;
+    if (input) {
+      input.focus();
+
+      if (options && options.caretPosition === 'end' && props.value) {
+        input.setSelectionRange(
+          props.value.toString().length,
+          props.value.toString().length
+        );
+      }
     }
   };
 

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -94,7 +94,7 @@ type Props = {|
   margin?: 'none' | 'dense',
   fullWidth?: boolean,
   style?: {|
-    fontSize?: 14 | 18 | '1.3em',
+    fontSize?: 14 | 18 | '1.3em' | 'inherit', // 'inherit' should only be used on an event sheet where font size is adapted to zoom
     fontStyle?: 'normal' | 'italic',
     width?: number | '30%' | '70%' | '100%',
     flex?: 1,

--- a/newIDE/app/src/UI/TextField.js
+++ b/newIDE/app/src/UI/TextField.js
@@ -94,7 +94,7 @@ type Props = {|
   margin?: 'none' | 'dense',
   fullWidth?: boolean,
   style?: {|
-    fontSize?: 14 | 18 | '1.3em' | 'inherit', // 'inherit' should only be used on an event sheet where font size is adapted to zoom
+    fontSize?: 14 | 18 | '1.3em' | 'inherit', // 'inherit' should only be used on an event sheet where font size is adapted to zoom.
     fontStyle?: 'normal' | 'italic',
     width?: number | '30%' | '70%' | '100%',
     flex?: 1,

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -87,6 +87,10 @@ export function getMuiOverrides({
         padding: 0,
         paddingBottom: 3,
       },
+      multiline: {
+        padding: 0,
+        paddingBottom: 3,
+      },
       underline: {
         '&:before': {
           borderBottom: `1px solid ${inputBorderBottomColor}`,

--- a/newIDE/app/src/UI/Theme/Global/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/Global/EventsSheet.css
@@ -162,8 +162,8 @@
   display: inline-flex;
   background-color: var(--event-sheet-instruction-parameter-error-background-color);
   border-bottom: 1px dashed  var(--event-sheet-instruction-parameter-error-color);
-  min-width: 25px;
-  min-height: 14px;
+  min-width: var(--instruction-missing-parameter-min-width);
+  min-height: var(--instruction-missing-parameter-min-height);
 }
 
 /**

--- a/newIDE/app/src/UI/Theme/Global/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/Global/EventsSheet.css
@@ -161,7 +161,7 @@
 .gd-events-sheet .instruction-parameter .instruction-missing-parameter {
   display: inline-flex;
   background-color: var(--event-sheet-instruction-parameter-error-background-color);
-  border-bottom: 1px dashed  var(--event-sheet-instruction-parameter-error-color);
+  border-bottom: 1px dashed var(--event-sheet-instruction-parameter-error-color);
   min-width: var(--instruction-missing-parameter-min-width);
   min-height: var(--instruction-missing-parameter-min-height);
 }


### PR DESCRIPTION
Different things:

- Fix bug that added a new line when one typed Enter key to edit a comment event
- Focus comment or group event after adding it (so that one doesn't have to click on it after adding it)
- Keep the same style when editing a group or comment event
- Submit modifications of group or comment event with Ctrl/Cmd + Enter

Before:
<img width="310" alt="image" src="https://user-images.githubusercontent.com/32449369/213515143-a1143239-4984-47ff-b910-b2a2f1d1b026.png">

After:
<img width="284" alt="image" src="https://user-images.githubusercontent.com/32449369/213515172-9db55f01-9932-4746-a9ef-5e59a9f2447c.png">
