### PR TITLE
On Resize an instance, if Alt key is pressed, we don't snap to Grid

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -138,7 +138,8 @@ export default class InstancesResizer {
     deltaX: number,
     deltaY: number,
     grabbingLocation: ResizeGrabbingLocation,
-    proportional: boolean
+    proportional: boolean,
+    noGridSnap: boolean
   ) {
     this.totalDeltaX += deltaX;
     this.totalDeltaY += deltaY;
@@ -166,7 +167,8 @@ export default class InstancesResizer {
     grabbingPosition[1] = initialGrabbingY + this.totalDeltaY;
     if (
       this.instancesEditorSettings.snap &&
-      this.instancesEditorSettings.grid
+      this.instancesEditorSettings.grid &&
+      !noGridSnap
     ) {
       roundPositionForResizing(
         grabbingPosition,

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -781,7 +781,8 @@ export default class InstancesEditor extends Component<Props> {
       sceneDeltaX,
       sceneDeltaY,
       grabbingLocation,
-      proportional
+      proportional,
+      this.keyboardShortcuts.shouldNotSnapToGrid()
     );
   };
 


### PR DESCRIPTION
At present, we have these options in the Scene Editor with the Grid visible:

1. _Move an instance_: the instance snaps to the Grid.
1. _Alt + Move_: the instance doesn't snap.
1. _Scale an instance_: the instance snaps to the Grid.

I added the __Alt + Scale__ option, so you can scale freely an instance without snapping.  
I followed the same logic as it is in the _Alt + Move_ code.

I attach a video with the 3 current options and the new one (visible in the second 00:17).

https://user-images.githubusercontent.com/21989259/213515338-560ae3e0-2dc5-4509-9d16-04bd801d6c1d.mp4

