### PR TITLE
GlobalVariableString() is returning '0' when a String variable is empty

### DIFF
--- a/GDJS/Runtime/variable.ts
+++ b/GDJS/Runtime/variable.ts
@@ -47,7 +47,7 @@ namespace gdjs {
           // Protect against NaN.
           if (this._value !== this._value) this._value = 0;
         } else if (this._type === 'string') {
-          this._str = '' + varData.value || '0';
+          this._str = '' + varData.value;
         } else if (this._type === 'boolean') {
           this._bool = !!varData.value;
         } else if (this._type === 'structure') {


### PR DESCRIPTION
Hi all,

I think I found a bug when using `GlobalVariableString(variableName)` function.

![image](https://user-images.githubusercontent.com/21989259/213696920-f4a59294-1c6e-4d6e-8918-65ee103da791.png)

![image](https://user-images.githubusercontent.com/21989259/213696973-7261bc3d-3f69-4ac0-a2a9-02e2e4cd30a1.png)


When the value of the String Variable is empty, the Preview renders a '0'.

This is because this line in `Runtime/variable.ts`:

```
} else if (this._type === 'string') {
  this._str = '' + varData.value || '0';
}
```

If `varData.value` is empty, then this results as '0':

```
this._str = '' + '' || '0'  -->
this._str = '0'
```

![image](https://user-images.githubusercontent.com/21989259/213697586-9a4cfa0e-552c-4634-9b56-101e5aea921d.png)

In the same `Runtime/variable.ts`, you can see that the method `setString(newValue: string): void` doesn't use these `|| '0'` at the end, so I think it should be equals both the constructor and the setString().

```
setString(newValue: string): void {
  this._type = 'string';
  this._str = '' + newValue;
}
```

I attach 2 videos Before and After the fix.

Please, check if I have missed something important.
Thanks in advance!

**Before the fix**

https://user-images.githubusercontent.com/21989259/213698045-604a55ad-7d68-42b3-8d52-d3ee80bf6c79.mp4

**After the fix**

https://user-images.githubusercontent.com/21989259/213698074-ddf61a8e-7d83-4dcb-924f-c99a06235d83.mp4

