### PR TITLE
Open the file chooser when adding a sprite or choosing a resource with less clicks for Cloud projects

### DIFF
--- a/newIDE/app/src/ResourcesList/BrowserResourceSources.js
+++ b/newIDE/app/src/ResourcesList/BrowserResourceSources.js
@@ -180,23 +180,6 @@ export const UrlChooser = ({
 };
 
 const browserResourceSources: Array<ResourceSource> = [
-  // Have the "asset store" source before the "file(s) from your device" source,
-  // for cloud projects, so that the asset store is opened by default when clicking
-  // on a button without opening a menu showing all sources.
-  ...allResourceKindsAndMetadata.map(({ kind, createNewResource }) => ({
-    name: `resource-store-${kind}`,
-    displayName: t`Choose from asset store`,
-    displayTab: 'standalone',
-    kind,
-    renderComponent: (props: ResourceSourceComponentProps) => (
-      <ResourceStoreChooser
-        createNewResource={createNewResource}
-        onChooseResources={props.onChooseResources}
-        options={props.options}
-        key={`resource-store-${kind}`}
-      />
-    ),
-  })),
   ...allResourceKindsAndMetadata.map(({ kind, createNewResource }) => ({
     name: `upload-${kind}`,
     displayName: t`File(s) from your device`,
@@ -210,6 +193,21 @@ const browserResourceSources: Array<ResourceSource> = [
         fileMetadata={props.fileMetadata}
         getStorageProvider={props.getStorageProvider}
         key={`url-chooser-${kind}`}
+        automaticallyOpenInput={!!props.automaticallyOpenIfPossible}
+      />
+    ),
+  })),
+  ...allResourceKindsAndMetadata.map(({ kind, createNewResource }) => ({
+    name: `resource-store-${kind}`,
+    displayName: t`Choose from asset store`,
+    displayTab: 'standalone',
+    kind,
+    renderComponent: (props: ResourceSourceComponentProps) => (
+      <ResourceStoreChooser
+        createNewResource={createNewResource}
+        onChooseResources={props.onChooseResources}
+        options={props.options}
+        key={`resource-store-${kind}`}
       />
     ),
   })),

--- a/newIDE/app/src/ResourcesList/LocalResourceSources.js
+++ b/newIDE/app/src/ResourcesList/LocalResourceSources.js
@@ -211,23 +211,6 @@ const localResourceSources: Array<ResourceSource> = [
       };
     }
   ),
-  // Have the "asset store" source before the "file(s) from your device" source,
-  // for cloud projects, so that the asset store is opened by default when clicking
-  // on a button without opening a menu showing all sources.
-  ...allResourceKindsAndMetadata.map(({ kind, createNewResource }) => ({
-    name: `resource-store-${kind}`,
-    displayName: t`Choose from asset store`,
-    displayTab: 'standalone',
-    kind,
-    renderComponent: (props: ResourceSourceComponentProps) => (
-      <ResourceStoreChooser
-        createNewResource={createNewResource}
-        onChooseResources={props.onChooseResources}
-        options={props.options}
-        key={`resource-store-${kind}`}
-      />
-    ),
-  })),
   ...allResourceKindsAndMetadata.map(({ kind, createNewResource }) => ({
     name: `upload-${kind}`,
     displayName: t`File(s) from your device`,
@@ -242,6 +225,21 @@ const localResourceSources: Array<ResourceSource> = [
         fileMetadata={props.fileMetadata}
         getStorageProvider={props.getStorageProvider}
         key={`url-chooser-${kind}`}
+        automaticallyOpenInput={!!props.automaticallyOpenIfPossible}
+      />
+    ),
+  })),
+  ...allResourceKindsAndMetadata.map(({ kind, createNewResource }) => ({
+    name: `resource-store-${kind}`,
+    displayName: t`Choose from asset store`,
+    displayTab: 'standalone',
+    kind,
+    renderComponent: (props: ResourceSourceComponentProps) => (
+      <ResourceStoreChooser
+        createNewResource={createNewResource}
+        onChooseResources={props.onChooseResources}
+        options={props.options}
+        key={`resource-store-${kind}`}
       />
     ),
   })),

--- a/newIDE/app/src/ResourcesList/NewResourceDialog.js
+++ b/newIDE/app/src/ResourcesList/NewResourceDialog.js
@@ -64,6 +64,7 @@ export const NewResourceDialog = ({
   );
   const isInitialSourceHeadless =
     initialSource && initialSource.selectResourcesHeadless;
+
   const [currentTab, setCurrentTab] = React.useState(() => {
     if (!initialSource) return 'import';
 
@@ -74,7 +75,15 @@ export const NewResourceDialog = ({
 
     return 'import';
   });
+  const [hasChangedTabs, setHasChangedTabs] = React.useState(false);
   const [isShowingAdvanced, setIsShowingAdvanced] = React.useState(false);
+
+  React.useEffect(
+    () => {
+      return () => setHasChangedTabs(true);
+    },
+    [currentTab]
+  );
 
   React.useEffect(
     () => {
@@ -179,6 +188,12 @@ export const NewResourceDialog = ({
                   getLastUsedPath: preferences.getLastUsedPath,
                   setLastUsedPath: preferences.setLastUsedPath,
                   onChooseResources,
+
+                  // Ask the component to try to automatically open the dialog to import file(s),
+                  // but only if tabs were not changed, meaning the user navigated out of it already.
+                  // In other words, only do this at the dialog opening.
+                  automaticallyOpenIfPossible:
+                    initialSource === source && !hasChangedTabs,
                 })}
               </React.Fragment>
             ))}

--- a/newIDE/app/src/ResourcesList/ResourceSource.js
+++ b/newIDE/app/src/ResourcesList/ResourceSource.js
@@ -99,6 +99,7 @@ export type ChooseResourceProps = {|
     path: string
   ) => void,
   options: ChooseResourceOptions,
+  automaticallyOpenIfPossible?: boolean,
 |};
 
 export type ResourceSourceComponentProps = {|

--- a/newIDE/app/src/stories/componentStories/ResourcesList/FileToCloudProjectResourceUploader.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/FileToCloudProjectResourceUploader.stories.js
@@ -36,6 +36,25 @@ export const Default = () => (
       }}
       fileMetadata={{ fileIdentifier: 'fake-identifier' }}
       getStorageProvider={() => CloudStorageProvider}
+      automaticallyOpenInput={false}
+    />
+  </AuthenticatedUserContext.Provider>
+);
+
+export const AutomaticallyOpenInput = () => (
+  <AuthenticatedUserContext.Provider value={fakeIndieAuthenticatedUser}>
+    <FileToCloudProjectResourceUploader
+      project={testProject.project}
+      createNewResource={() => new gd.ImageResource()}
+      onChooseResources={action('onChooseResources')}
+      options={{
+        initialSourceName: 'unused',
+        multiSelection: true,
+        resourceKind: 'image',
+      }}
+      fileMetadata={{ fileIdentifier: 'fake-identifier' }}
+      getStorageProvider={() => CloudStorageProvider}
+      automaticallyOpenInput
     />
   </AuthenticatedUserContext.Provider>
 );
@@ -53,6 +72,7 @@ export const SingleFile = () => (
       }}
       fileMetadata={{ fileIdentifier: 'fake-identifier' }}
       getStorageProvider={() => CloudStorageProvider}
+      automaticallyOpenInput={false}
     />
   </AuthenticatedUserContext.Provider>
 );
@@ -70,6 +90,7 @@ export const IncompatibleStorageProvider = () => (
       }}
       fileMetadata={{ fileIdentifier: 'fake-identifier' }}
       getStorageProvider={() => UrlStorageProvider}
+      automaticallyOpenInput={false}
     />
   </AuthenticatedUserContext.Provider>
 );
@@ -89,6 +110,7 @@ export const NotAuthenticatedUser = () => (
       }}
       fileMetadata={{ fileIdentifier: 'fake-identifier' }}
       getStorageProvider={() => UrlStorageProvider}
+      automaticallyOpenInput={false}
     />
   </AuthenticatedUserContext.Provider>
 );


### PR DESCRIPTION
Tested on Chrome, Firefox, Safari iOS, Chrome Android.