### PR TITLE
Fix direction actions on Sprites after an animation change with custom origin.

### DIFF
--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -944,6 +944,9 @@ namespace gdjs {
      * @return the X position, on the scene, of the origin of the texture of the object.
      */
     getDrawableX(): float {
+      if (this._animationFrameDirty) {
+        this._updateAnimationFrame();
+      }
       if (this._animationFrame === null) {
         return this.x;
       }
@@ -966,6 +969,9 @@ namespace gdjs {
      * @return the Y position, on the scene, of the origin of the texture of the object.
      */
     getDrawableY(): float {
+      if (this._animationFrameDirty) {
+        this._updateAnimationFrame();
+      }
       if (this._animationFrame === null) {
         return this.y;
       }


### PR DESCRIPTION
* Impacted actions are "Turn toward a position" and "Add a force toward a position".

### Demo
[ForceBug.zip](https://github.com/4ian/GDevelop/files/10480632/ForceBug.zip)
