### PR TITLE
Optimize z-order change

### DIFF
--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -35,6 +35,7 @@ namespace gdjs {
       pixiRenderer: PIXI.Renderer | null
     ) {
       this._pixiContainer = new PIXI.Container();
+      this._pixiContainer.sortableChildren = true;
       this._layer = layer;
       this._runtimeSceneRenderer = runtimeInstanceContainerRenderer;
       this._pixiRenderer = pixiRenderer;
@@ -133,33 +134,24 @@ namespace gdjs {
      * Add a child to the pixi container associated to the layer.
      * All objects which are on this layer must be children of this container.
      *
-     * @param child The child (PIXI object) to be added.
+     * @param pixiChild The child (PIXI object) to be added.
      * @param zOrder The z order of the associated object.
      */
-    addRendererObject(child, zOrder: integer): void {
-      child.zOrder = zOrder;
-
-      //Extend the pixi object with a z order.
-      for (let i = 0, len = this._pixiContainer.children.length; i < len; ++i) {
-        // @ts-ignore - we added a "zOrder" property.
-        if (this._pixiContainer.children[i].zOrder >= zOrder) {
-          //TODO : Dichotomic search
-          this._pixiContainer.addChildAt(child, i);
-          return;
-        }
-      }
+    addRendererObject(pixiChild, zOrder: integer): void {
+      const child = pixiChild as PIXI.DisplayObject;
+      child.zIndex = zOrder;
       this._pixiContainer.addChild(child);
     }
 
     /**
      * Change the z order of a child associated to an object.
      *
-     * @param child The child (PIXI object) to be modified.
+     * @param pixiChild The child (PIXI object) to be modified.
      * @param newZOrder The z order of the associated object.
      */
-    changeRendererObjectZOrder(child, newZOrder: integer): void {
-      this._pixiContainer.removeChild(child);
-      this.addRendererObject(child, newZOrder);
+    changeRendererObjectZOrder(pixiChild, newZOrder: integer): void {
+      const child = pixiChild as PIXI.DisplayObject;
+      child.zIndex = newZOrder;
     }
 
     /**

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -26,6 +26,11 @@ namespace gdjs {
     _clearColor: Array<integer>;
 
     /**
+     * Pixi doesn't sort children with zIndex == 0.
+     */
+    private static readonly zeroZOrder = Math.pow(2, -24);
+
+    /**
      * @param layer The layer
      * @param runtimeInstanceContainerRenderer The scene renderer
      */
@@ -137,9 +142,9 @@ namespace gdjs {
      * @param pixiChild The child (PIXI object) to be added.
      * @param zOrder The z order of the associated object.
      */
-    addRendererObject(pixiChild, zOrder: integer): void {
+    addRendererObject(pixiChild, zOrder: float): void {
       const child = pixiChild as PIXI.DisplayObject;
-      child.zIndex = zOrder;
+      child.zIndex = zOrder || LayerPixiRenderer.zeroZOrder;
       this._pixiContainer.addChild(child);
     }
 
@@ -149,7 +154,7 @@ namespace gdjs {
      * @param pixiChild The child (PIXI object) to be modified.
      * @param newZOrder The z order of the associated object.
      */
-    changeRendererObjectZOrder(pixiChild, newZOrder: integer): void {
+    changeRendererObjectZOrder(pixiChild, newZOrder: float): void {
       const child = pixiChild as PIXI.DisplayObject;
       child.zIndex = newZOrder;
     }


### PR DESCRIPTION
Pixi allows to sort the object before the rendering which is probably O(n log(n)).

To keep the objects in order, we had to remove and insert an element in the array which takes O(n) for one z-order change and thus O(n²) when every object z-order changes.

When few objects are created or change of z-order in one frame, the engine will be less efficient than before, but it should not show much.
Whereas, when a lot of objects are created at the same frame (at the start of a scene for instance) or when a lot of y-ordered object are moving, the engine should be more efficient.