### PR TITLE
Add a button to jump to behavior events

### DIFF
--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -485,6 +485,8 @@ interface Project {
     [Ref] EventsFunctionsExtension InsertEventsFunctionsExtension([Const, Ref] EventsFunctionsExtension eventsFunctionsExtension, unsigned long position);
     void RemoveEventsFunctionsExtension([Const] DOMString name);
 
+    boolean HasEventsBasedBehavior([Const] DOMString type);
+    [Ref] EventsBasedBehavior GetEventsBasedBehavior([Const] DOMString type);
     boolean HasEventsBasedObject([Const] DOMString type);
     [Ref] EventsBasedObject GetEventsBasedObject([Const] DOMString type);
 

--- a/GDevelop.js/types/gdproject.js
+++ b/GDevelop.js/types/gdproject.js
@@ -91,6 +91,8 @@ declare class gdProject extends gdObjectsContainer {
   insertNewEventsFunctionsExtension(name: string, position: number): gdEventsFunctionsExtension;
   insertEventsFunctionsExtension(eventsFunctionsExtension: gdEventsFunctionsExtension, position: number): gdEventsFunctionsExtension;
   removeEventsFunctionsExtension(name: string): void;
+  hasEventsBasedBehavior(type: string): boolean;
+  getEventsBasedBehavior(type: string): gdEventsBasedBehavior;
   hasEventsBasedObject(type: string): boolean;
   getEventsBasedObject(type: string): gdEventsBasedObject;
   getVariables(): gdVariablesContainer;

--- a/newIDE/app/src/BehaviorsEditor/Editors/BehaviorEditorProps.flow.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/BehaviorEditorProps.flow.js
@@ -9,5 +9,5 @@ export type BehaviorEditorProps = {|
   project: gdProject,
   object: gdObject,
   resourceManagementProps: ResourceManagementProps,
-  onBehaviorsUpdated: () => void,
+  onBehaviorUpdated: () => void,
 |};

--- a/newIDE/app/src/BehaviorsEditor/Editors/BehaviorEditorProps.flow.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/BehaviorEditorProps.flow.js
@@ -9,4 +9,5 @@ export type BehaviorEditorProps = {|
   project: gdProject,
   object: gdObject,
   resourceManagementProps: ResourceManagementProps,
+  onBehaviorsUpdated: () => void,
 |};

--- a/newIDE/app/src/BehaviorsEditor/Editors/BehaviorPropertiesEditor.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/BehaviorPropertiesEditor.js
@@ -12,7 +12,7 @@ type Props = BehaviorEditorProps;
 
 export default class BehaviorPropertiesEditor extends React.Component<Props> {
   render() {
-    const { behavior, object } = this.props;
+    const { behavior, object, onBehaviorsUpdated } = this.props;
 
     const propertiesSchema = propertiesMapToSchema(
       behavior.getProperties(),
@@ -26,7 +26,11 @@ export default class BehaviorPropertiesEditor extends React.Component<Props> {
     return (
       <Column expand>
         {propertiesSchema.length ? (
-          <PropertiesEditor schema={propertiesSchema} instances={[behavior]} />
+          <PropertiesEditor
+            schema={propertiesSchema}
+            instances={[behavior]}
+            onInstancesModified={onBehaviorsUpdated}
+          />
         ) : (
           <EmptyMessage>
             <Trans>

--- a/newIDE/app/src/BehaviorsEditor/Editors/BehaviorPropertiesEditor.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/BehaviorPropertiesEditor.js
@@ -12,7 +12,7 @@ type Props = BehaviorEditorProps;
 
 export default class BehaviorPropertiesEditor extends React.Component<Props> {
   render() {
-    const { behavior, object, onBehaviorsUpdated } = this.props;
+    const { behavior, object, onBehaviorUpdated } = this.props;
 
     const propertiesSchema = propertiesMapToSchema(
       behavior.getProperties(),
@@ -29,7 +29,7 @@ export default class BehaviorPropertiesEditor extends React.Component<Props> {
           <PropertiesEditor
             schema={propertiesSchema}
             instances={[behavior]}
-            onInstancesModified={onBehaviorsUpdated}
+            onInstancesModified={onBehaviorUpdated}
           />
         ) : (
           <EmptyMessage>

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -100,7 +100,7 @@ const BitGroupEditor = (props: {|
 const Physics2Editor = (props: Props) => {
   const { current: resourcesLoader } = React.useRef(ResourcesLoader);
   const [image, setImage] = React.useState('');
-  const { behavior, onBehaviorsUpdated } = props;
+  const { behavior, onBehaviorUpdated } = props;
   const forceUpdate = useForceUpdate();
 
   const isBitEnabled = (bitsValue: number, pos: number) => {
@@ -111,6 +111,12 @@ const Physics2Editor = (props: Props) => {
     if (enable) bitsValue |= 1 << pos;
     else bitsValue &= ~(1 << pos);
     return bitsValue;
+  };
+
+  const updateBehaviorProperty = (property, value) => {
+    behavior.updateProperty(property, value);
+    forceUpdate();
+    onBehaviorUpdated();
   };
 
   const properties = behavior.getProperties();
@@ -132,11 +138,9 @@ const Physics2Editor = (props: Props) => {
           fullWidth
           floatingLabelText={properties.get('bodyType').getLabel()}
           value={properties.get('bodyType').getValue()}
-          onChange={(e, i, newValue: string) => {
-            behavior.updateProperty('bodyType', newValue);
-            onBehaviorsUpdated();
-            forceUpdate();
-          }}
+          onChange={(e, i, newValue: string) =>
+            updateBehaviorProperty('bodyType', newValue)
+          }
         >
           {[
             <SelectOption
@@ -161,29 +165,23 @@ const Physics2Editor = (props: Props) => {
         <Checkbox
           label={properties.get('bullet').getLabel()}
           checked={properties.get('bullet').getValue() === 'true'}
-          onCheck={(e, checked) => {
-            behavior.updateProperty('bullet', checked ? '1' : '0');
-            onBehaviorsUpdated();
-            forceUpdate();
-          }}
+          onCheck={(e, checked) =>
+            updateBehaviorProperty('bullet', checked ? '1' : '0')
+          }
         />
         <Checkbox
           label={properties.get('fixedRotation').getLabel()}
           checked={properties.get('fixedRotation').getValue() === 'true'}
-          onCheck={(e, checked) => {
-            behavior.updateProperty('fixedRotation', checked ? '1' : '0');
-            onBehaviorsUpdated();
-            forceUpdate();
-          }}
+          onCheck={(e, checked) =>
+            updateBehaviorProperty('fixedRotation', checked ? '1' : '0')
+          }
         />
         <Checkbox
           label={properties.get('canSleep').getLabel()}
           checked={properties.get('canSleep').getValue() === 'true'}
-          onCheck={(e, checked) => {
-            behavior.updateProperty('canSleep', checked ? '1' : '0');
-            onBehaviorsUpdated();
-            forceUpdate();
-          }}
+          onCheck={(e, checked) =>
+            updateBehaviorProperty('canSleep', checked ? '1' : '0')
+          }
         />
       </ResponsiveLineStackLayout>
       <Line>
@@ -206,11 +204,9 @@ const Physics2Editor = (props: Props) => {
           fullWidth
           floatingLabelText={properties.get('shape').getLabel()}
           value={properties.get('shape').getValue()}
-          onChange={(e, i, newValue: string) => {
-            behavior.updateProperty('shape', newValue);
-            onBehaviorsUpdated();
-            forceUpdate();
-          }}
+          onChange={(e, i, newValue: string) =>
+            updateBehaviorProperty('shape', newValue)
+          }
         >
           <SelectOption key={'box'} value={'Box'} primaryText={t`Box`} />
           <SelectOption
@@ -240,11 +236,9 @@ const Physics2Editor = (props: Props) => {
                 : 'Width'
             }
             min={0}
-            onChange={newValue => {
-              behavior.updateProperty('shapeDimensionA', newValue);
-              onBehaviorsUpdated();
-              forceUpdate();
-            }}
+            onChange={newValue =>
+              updateBehaviorProperty('shapeDimensionA', newValue)
+            }
             type="number"
             endAdornment={
               <UnitAdornment property={properties.get('shapeDimensionA')} />
@@ -258,11 +252,9 @@ const Physics2Editor = (props: Props) => {
             key={'shapeDimensionB'}
             floatingLabelText={shape === 'Edge' ? 'Angle' : 'Height'}
             min={shape === 'Edge' ? undefined : 0}
-            onChange={newValue => {
-              behavior.updateProperty('shapeDimensionB', newValue);
-              onBehaviorsUpdated();
-              forceUpdate();
-            }}
+            onChange={newValue =>
+              updateBehaviorProperty('shapeDimensionB', newValue)
+            }
             type="number"
             endAdornment={
               <UnitAdornment property={properties.get('shapeDimensionB')} />
@@ -274,11 +266,9 @@ const Physics2Editor = (props: Props) => {
             fullWidth
             floatingLabelText={properties.get('polygonOrigin').getLabel()}
             value={properties.get('polygonOrigin').getValue()}
-            onChange={(e, i, newValue: string) => {
-              behavior.updateProperty('polygonOrigin', newValue);
-              onBehaviorsUpdated();
-              forceUpdate();
-            }}
+            onChange={(e, i, newValue: string) =>
+              updateBehaviorProperty('polygonOrigin', newValue)
+            }
           >
             {[
               <SelectOption
@@ -303,21 +293,17 @@ const Physics2Editor = (props: Props) => {
           properties={properties}
           propertyName={'shapeOffsetX'}
           step={1}
-          onUpdate={newValue => {
-            behavior.updateProperty('shapeOffsetX', newValue);
-            onBehaviorsUpdated();
-            forceUpdate();
-          }}
+          onUpdate={newValue =>
+            updateBehaviorProperty('shapeOffsetX', newValue)
+          }
         />
         <NumericProperty
           properties={properties}
           propertyName={'shapeOffsetY'}
           step={1}
-          onUpdate={newValue => {
-            behavior.updateProperty('shapeOffsetY', newValue);
-            onBehaviorsUpdated();
-            forceUpdate();
-          }}
+          onUpdate={newValue =>
+            updateBehaviorProperty('shapeOffsetY', newValue)
+          }
         />
       </ResponsiveLineStackLayout>
       <Line>
@@ -335,7 +321,7 @@ const Physics2Editor = (props: Props) => {
           fullWidth
           onChange={resourceName => {
             setImage(resourceName);
-            onBehaviorsUpdated();
+            onBehaviorUpdated();
             forceUpdate();
           }}
         />
@@ -408,7 +394,7 @@ const Physics2Editor = (props: Props) => {
                         JSON.stringify(vertices)
                       );
                       forceUpdate();
-                      onBehaviorsUpdated();
+                      onBehaviorUpdated();
                     }}
                   />
                 );
@@ -424,31 +410,23 @@ const Physics2Editor = (props: Props) => {
             onChangeVertexX={(newValue, index) => {
               let vertices = JSON.parse(properties.get('vertices').getValue());
               vertices[index].x = newValue;
-              behavior.updateProperty('vertices', JSON.stringify(vertices));
-              forceUpdate();
-              onBehaviorsUpdated();
+              updateBehaviorProperty('vertices', JSON.stringify(vertices));
             }}
             onChangeVertexY={(newValue, index) => {
               let vertices = JSON.parse(properties.get('vertices').getValue());
               vertices[index].y = newValue;
-              behavior.updateProperty('vertices', JSON.stringify(vertices));
-              forceUpdate();
-              onBehaviorsUpdated();
+              updateBehaviorProperty('vertices', JSON.stringify(vertices));
             }}
             onAdd={() => {
               let vertices = JSON.parse(properties.get('vertices').getValue());
               if (vertices.length >= 8) return;
               vertices.push({ x: 0, y: 0 });
-              behavior.updateProperty('vertices', JSON.stringify(vertices));
-              forceUpdate();
-              onBehaviorsUpdated();
+              updateBehaviorProperty('vertices', JSON.stringify(vertices));
             }}
             onRemove={index => {
               let vertices = JSON.parse(properties.get('vertices').getValue());
               vertices.splice(index, 1);
-              behavior.updateProperty('vertices', JSON.stringify(vertices));
-              forceUpdate();
-              onBehaviorsUpdated();
+              updateBehaviorProperty('vertices', JSON.stringify(vertices));
             }}
           />
         </Line>
@@ -459,24 +437,20 @@ const Physics2Editor = (props: Props) => {
           properties={properties}
           propertyName={'density'}
           step={0.1}
-          onUpdate={newValue => {
-            behavior.updateProperty(
+          onUpdate={newValue =>
+            updateBehaviorProperty(
               'density',
               parseFloat(newValue) > 0 ? newValue : '0'
-            );
-            forceUpdate();
-            onBehaviorsUpdated();
-          }}
+            )
+          }
         />
         <NumericProperty
           properties={properties}
           propertyName={'gravityScale'}
           step={0.1}
-          onUpdate={newValue => {
-            behavior.updateProperty('gravityScale', newValue);
-            forceUpdate();
-            onBehaviorsUpdated();
-          }}
+          onUpdate={newValue =>
+            updateBehaviorProperty('gravityScale', newValue)
+          }
         />
       </ResponsiveLineStackLayout>
       <ResponsiveLineStackLayout>
@@ -484,27 +458,23 @@ const Physics2Editor = (props: Props) => {
           properties={properties}
           propertyName={'friction'}
           step={0.1}
-          onUpdate={newValue => {
-            behavior.updateProperty(
+          onUpdate={newValue =>
+            updateBehaviorProperty(
               'friction',
               parseFloat(newValue) > 0 ? newValue : '0'
-            );
-            forceUpdate();
-            onBehaviorsUpdated();
-          }}
+            )
+          }
         />
         <NumericProperty
           properties={properties}
           propertyName={'restitution'}
           step={0.1}
-          onUpdate={newValue => {
-            behavior.updateProperty(
+          onUpdate={newValue =>
+            updateBehaviorProperty(
               'restitution',
               parseFloat(newValue) > 0 ? newValue : '0'
-            );
-            forceUpdate();
-            onBehaviorsUpdated();
-          }}
+            )
+          }
         />
       </ResponsiveLineStackLayout>
       <ResponsiveLineStackLayout>
@@ -512,22 +482,18 @@ const Physics2Editor = (props: Props) => {
           properties={properties}
           propertyName={'linearDamping'}
           step={0.05}
-          onUpdate={newValue => {
-            behavior.updateProperty('linearDamping', newValue);
-            forceUpdate();
-            onBehaviorsUpdated();
-          }}
+          onUpdate={newValue =>
+            updateBehaviorProperty('linearDamping', newValue)
+          }
         />
         <NumericProperty
           id="physics2-parameter-angular-damping"
           properties={properties}
           propertyName={'angularDamping'}
           step={0.05}
-          onUpdate={newValue => {
-            behavior.updateProperty('angularDamping', newValue);
-            forceUpdate();
-            onBehaviorsUpdated();
-          }}
+          onUpdate={newValue =>
+            updateBehaviorProperty('angularDamping', newValue)
+          }
         />
       </ResponsiveLineStackLayout>
       <Line>
@@ -538,9 +504,7 @@ const Physics2Editor = (props: Props) => {
           bits={bits.map((_, idx) => isBitEnabled(layersValues, idx))}
           onChange={(index, value) => {
             const newValue = enableBit(layersValues, index, value);
-            behavior.updateProperty('layers', newValue.toString(10));
-            forceUpdate();
-            onBehaviorsUpdated();
+            updateBehaviorProperty('layers', newValue.toString(10));
           }}
         />
       </Line>
@@ -552,9 +516,7 @@ const Physics2Editor = (props: Props) => {
           bits={bits.map((_, idx) => isBitEnabled(masksValues, idx))}
           onChange={(index, value) => {
             const newValue = enableBit(masksValues, index, value);
-            behavior.updateProperty('masks', newValue.toString(10));
-            forceUpdate();
-            onBehaviorsUpdated();
+            updateBehaviorProperty('masks', newValue.toString(10));
           }}
         />
       </Line>

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -97,27 +97,30 @@ const BitGroupEditor = (props: {|
   );
 };
 
+const isBitEnabled = (bitsValue: number, pos: number) => {
+  return !!(bitsValue & (1 << pos));
+};
+
+const enableBit = (bitsValue: number, pos: number, enable: boolean) => {
+  if (enable) bitsValue |= 1 << pos;
+  else bitsValue &= ~(1 << pos);
+  return bitsValue;
+};
+
 const Physics2Editor = (props: Props) => {
   const { current: resourcesLoader } = React.useRef(ResourcesLoader);
   const [image, setImage] = React.useState('');
   const { behavior, onBehaviorUpdated } = props;
   const forceUpdate = useForceUpdate();
 
-  const isBitEnabled = (bitsValue: number, pos: number) => {
-    return !!(bitsValue & (1 << pos));
-  };
-
-  const enableBit = (bitsValue: number, pos: number, enable: boolean) => {
-    if (enable) bitsValue |= 1 << pos;
-    else bitsValue &= ~(1 << pos);
-    return bitsValue;
-  };
-
-  const updateBehaviorProperty = (property, value) => {
-    behavior.updateProperty(property, value);
-    forceUpdate();
-    onBehaviorUpdated();
-  };
+  const updateBehaviorProperty = React.useCallback(
+    (property, value) => {
+      behavior.updateProperty(property, value);
+      forceUpdate();
+      onBehaviorUpdated();
+    },
+    [behavior, forceUpdate, onBehaviorUpdated]
+  );
 
   const properties = behavior.getProperties();
   const bits = Array(16).fill(null);

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -100,7 +100,7 @@ const BitGroupEditor = (props: {|
 const Physics2Editor = (props: Props) => {
   const { current: resourcesLoader } = React.useRef(ResourcesLoader);
   const [image, setImage] = React.useState('');
-  const { behavior } = props;
+  const { behavior, onBehaviorsUpdated } = props;
   const forceUpdate = useForceUpdate();
 
   const isBitEnabled = (bitsValue: number, pos: number) => {
@@ -134,6 +134,7 @@ const Physics2Editor = (props: Props) => {
           value={properties.get('bodyType').getValue()}
           onChange={(e, i, newValue: string) => {
             behavior.updateProperty('bodyType', newValue);
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         >
@@ -162,6 +163,7 @@ const Physics2Editor = (props: Props) => {
           checked={properties.get('bullet').getValue() === 'true'}
           onCheck={(e, checked) => {
             behavior.updateProperty('bullet', checked ? '1' : '0');
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         />
@@ -170,6 +172,7 @@ const Physics2Editor = (props: Props) => {
           checked={properties.get('fixedRotation').getValue() === 'true'}
           onCheck={(e, checked) => {
             behavior.updateProperty('fixedRotation', checked ? '1' : '0');
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         />
@@ -178,6 +181,7 @@ const Physics2Editor = (props: Props) => {
           checked={properties.get('canSleep').getValue() === 'true'}
           onCheck={(e, checked) => {
             behavior.updateProperty('canSleep', checked ? '1' : '0');
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         />
@@ -204,6 +208,7 @@ const Physics2Editor = (props: Props) => {
           value={properties.get('shape').getValue()}
           onChange={(e, i, newValue: string) => {
             behavior.updateProperty('shape', newValue);
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         >
@@ -237,6 +242,7 @@ const Physics2Editor = (props: Props) => {
             min={0}
             onChange={newValue => {
               behavior.updateProperty('shapeDimensionA', newValue);
+              onBehaviorsUpdated();
               forceUpdate();
             }}
             type="number"
@@ -254,6 +260,7 @@ const Physics2Editor = (props: Props) => {
             min={shape === 'Edge' ? undefined : 0}
             onChange={newValue => {
               behavior.updateProperty('shapeDimensionB', newValue);
+              onBehaviorsUpdated();
               forceUpdate();
             }}
             type="number"
@@ -269,6 +276,7 @@ const Physics2Editor = (props: Props) => {
             value={properties.get('polygonOrigin').getValue()}
             onChange={(e, i, newValue: string) => {
               behavior.updateProperty('polygonOrigin', newValue);
+              onBehaviorsUpdated();
               forceUpdate();
             }}
           >
@@ -297,6 +305,7 @@ const Physics2Editor = (props: Props) => {
           step={1}
           onUpdate={newValue => {
             behavior.updateProperty('shapeOffsetX', newValue);
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         />
@@ -306,6 +315,7 @@ const Physics2Editor = (props: Props) => {
           step={1}
           onUpdate={newValue => {
             behavior.updateProperty('shapeOffsetY', newValue);
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         />
@@ -325,6 +335,7 @@ const Physics2Editor = (props: Props) => {
           fullWidth
           onChange={resourceName => {
             setImage(resourceName);
+            onBehaviorsUpdated();
             forceUpdate();
           }}
         />
@@ -397,6 +408,7 @@ const Physics2Editor = (props: Props) => {
                         JSON.stringify(vertices)
                       );
                       forceUpdate();
+                      onBehaviorsUpdated();
                     }}
                   />
                 );
@@ -414,12 +426,14 @@ const Physics2Editor = (props: Props) => {
               vertices[index].x = newValue;
               behavior.updateProperty('vertices', JSON.stringify(vertices));
               forceUpdate();
+              onBehaviorsUpdated();
             }}
             onChangeVertexY={(newValue, index) => {
               let vertices = JSON.parse(properties.get('vertices').getValue());
               vertices[index].y = newValue;
               behavior.updateProperty('vertices', JSON.stringify(vertices));
               forceUpdate();
+              onBehaviorsUpdated();
             }}
             onAdd={() => {
               let vertices = JSON.parse(properties.get('vertices').getValue());
@@ -427,12 +441,14 @@ const Physics2Editor = (props: Props) => {
               vertices.push({ x: 0, y: 0 });
               behavior.updateProperty('vertices', JSON.stringify(vertices));
               forceUpdate();
+              onBehaviorsUpdated();
             }}
             onRemove={index => {
               let vertices = JSON.parse(properties.get('vertices').getValue());
               vertices.splice(index, 1);
               behavior.updateProperty('vertices', JSON.stringify(vertices));
               forceUpdate();
+              onBehaviorsUpdated();
             }}
           />
         </Line>
@@ -449,6 +465,7 @@ const Physics2Editor = (props: Props) => {
               parseFloat(newValue) > 0 ? newValue : '0'
             );
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
         <NumericProperty
@@ -458,6 +475,7 @@ const Physics2Editor = (props: Props) => {
           onUpdate={newValue => {
             behavior.updateProperty('gravityScale', newValue);
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
       </ResponsiveLineStackLayout>
@@ -472,6 +490,7 @@ const Physics2Editor = (props: Props) => {
               parseFloat(newValue) > 0 ? newValue : '0'
             );
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
         <NumericProperty
@@ -484,6 +503,7 @@ const Physics2Editor = (props: Props) => {
               parseFloat(newValue) > 0 ? newValue : '0'
             );
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
       </ResponsiveLineStackLayout>
@@ -495,6 +515,7 @@ const Physics2Editor = (props: Props) => {
           onUpdate={newValue => {
             behavior.updateProperty('linearDamping', newValue);
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
         <NumericProperty
@@ -505,6 +526,7 @@ const Physics2Editor = (props: Props) => {
           onUpdate={newValue => {
             behavior.updateProperty('angularDamping', newValue);
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
       </ResponsiveLineStackLayout>
@@ -518,6 +540,7 @@ const Physics2Editor = (props: Props) => {
             const newValue = enableBit(layersValues, index, value);
             behavior.updateProperty('layers', newValue.toString(10));
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
       </Line>
@@ -531,6 +554,7 @@ const Physics2Editor = (props: Props) => {
             const newValue = enableBit(masksValues, index, value);
             behavior.updateProperty('masks', newValue.toString(10));
             forceUpdate();
+            onBehaviorsUpdated();
           }}
         />
       </Line>

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -1,6 +1,7 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import { t } from '@lingui/macro';
+import { type I18n as I18nType } from '@lingui/core';
 import * as React from 'react';
 import TextField from '../UI/TextField';
 import Add from '@material-ui/icons/Add';
@@ -29,8 +30,8 @@ import {
   listObjectBehaviorsTypes,
 } from '../Utils/Behavior';
 import { sendBehaviorAdded } from '../Utils/Analytics/EventSender';
-import OpenInNew from '@material-ui/icons/OpenInNew';
-import AccordionActions from '@material-ui/core/AccordionActions';
+import ElementWithMenu from '../UI/Menu/ElementWithMenu';
+import ThreeDotsMenu from '../UI/CustomSvgIcons/ThreeDotsMenu';
 
 const gd: libGDevelop = global.gd;
 
@@ -229,28 +230,28 @@ const BehaviorsEditor = (props: Props) => {
                         size="small"
                         helpPagePath={behaviorMetadata.getHelpPath()}
                       />,
-                      project.hasEventsBasedBehavior(behaviorTypeName) ? (
-                        <IconButton
-                          key="open-extension"
-                          size="small"
-                          tooltip={t`Open extension events`}
-                          onClick={() => {
-                            openExtension(behaviorTypeName);
-                          }}
-                        >
-                          <OpenInNew />
-                        </IconButton>
-                      ) : null,
-                      <IconButton
-                        key="delete"
-                        size="small"
-                        onClick={ev => {
-                          ev.stopPropagation();
-                          onRemoveBehavior(behaviorName);
-                        }}
-                      >
-                        <Delete />
-                      </IconButton>,
+                      <ElementWithMenu
+                        element={
+                          <IconButton size="small">
+                            <ThreeDotsMenu />
+                          </IconButton>
+                        }
+                        buildMenuTemplate={(i18n: I18nType) => [
+                          {
+                            label: i18n._(t`Delete`),
+                            click: () => onRemoveBehavior(behaviorName),
+                          },
+                          ...(project.hasEventsBasedBehavior(behaviorTypeName)
+                            ? [
+                                { type: 'separator' },
+                                {
+                                  label: i18n._(t`Edit this behavior`),
+                                  click: () => openExtension(behaviorTypeName),
+                                },
+                              ]
+                            : []),
+                        ]}
+                      />,
                     ]}
                   >
                     {iconUrl ? (

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -30,6 +30,7 @@ import {
 } from '../Utils/Behavior';
 import { sendBehaviorAdded } from '../Utils/Analytics/EventSender';
 import OpenInNew from '@material-ui/icons/OpenInNew';
+import AccordionActions from '@material-ui/core/AccordionActions';
 
 const gd: libGDevelop = global.gd;
 
@@ -230,6 +231,8 @@ const BehaviorsEditor = (props: Props) => {
                       />,
                       project.hasEventsBasedBehavior(behaviorTypeName) ? (
                         <IconButton
+                          key="open-extension"
+                          size="small"
                           tooltip={t`Open extension events`}
                           onClick={() => {
                             openExtension(behaviorTypeName);

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -29,6 +29,7 @@ import {
   listObjectBehaviorsTypes,
 } from '../Utils/Behavior';
 import { sendBehaviorAdded } from '../Utils/Analytics/EventSender';
+import OpenInNew from '@material-ui/icons/OpenInNew';
 
 const gd: libGDevelop = global.gd;
 
@@ -39,7 +40,11 @@ type Props = {|
   onUpdateBehaviorsSharedData: () => void,
   onSizeUpdated?: ?() => void,
   resourceManagementProps: ResourceManagementProps,
-  onBehaviorsUpdated?: () => void,
+  onBehaviorsUpdated: () => void,
+  openBehaviorEvents: (
+    extensionName: string,
+    behaviorName: string
+  ) => Promise<void>,
 |};
 
 const BehaviorsEditor = (props: Props) => {
@@ -109,6 +114,23 @@ const BehaviorsEditor = (props: Props) => {
       if (props.onSizeUpdated) props.onSizeUpdated();
     }
     if (props.onBehaviorsUpdated) props.onBehaviorsUpdated();
+  };
+
+  const openExtension = (behaviorType: string) => {
+    const elements = behaviorType.split('::');
+    if (elements.length !== 2) {
+      return;
+    }
+    const extensionName = elements[0];
+    const behaviorName = elements[1];
+
+    if (
+      !extensionName ||
+      !props.project.hasEventsFunctionsExtensionNamed(extensionName)
+    ) {
+      return;
+    }
+    props.openBehaviorEvents(extensionName, behaviorName);
   };
 
   return (
@@ -206,6 +228,16 @@ const BehaviorsEditor = (props: Props) => {
                         size="small"
                         helpPagePath={behaviorMetadata.getHelpPath()}
                       />,
+                      project.hasEventsBasedBehavior(behaviorTypeName) ? (
+                        <IconButton
+                          tooltip={t`Open extension events`}
+                          onClick={() => {
+                            openExtension(behaviorTypeName);
+                          }}
+                        >
+                          <OpenInNew />
+                        </IconButton>
+                      ) : null,
                       <IconButton
                         key="delete"
                         size="small"
@@ -266,6 +298,7 @@ const BehaviorsEditor = (props: Props) => {
                           resourceManagementProps={
                             props.resourceManagementProps
                           }
+                          onBehaviorsUpdated={props.onBehaviorsUpdated}
                         />
                       </Line>
                     </Column>

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -298,7 +298,7 @@ const BehaviorsEditor = (props: Props) => {
                           resourceManagementProps={
                             props.resourceManagementProps
                           }
-                          onBehaviorsUpdated={props.onBehaviorsUpdated}
+                          onBehaviorUpdated={props.onBehaviorsUpdated}
                         />
                       </Line>
                     </Column>

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -337,6 +337,8 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 onUpdateBehaviorsSharedData={() =>
                   this.updateBehaviorsSharedData()
                 }
+                // TODO EBO Go to the behavior extension tab.
+                openBehaviorEvents={() => {}}
               />
             )}
           </React.Fragment>

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -146,6 +146,10 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
         this.props.initiallyFocusedFunctionName,
         this.props.initiallyFocusedBehaviorName
       );
+    } else if (this.props.initiallyFocusedBehaviorName) {
+      this.selectEventsBasedBehaviorByName(
+        this.props.initiallyFocusedBehaviorName
+      );
     }
   }
 
@@ -469,6 +473,16 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     }
 
     cb(true);
+  };
+
+  selectEventsBasedBehaviorByName = (behaviorName: string) => {
+    const { eventsFunctionsExtension } = this.props;
+    const eventsBasedBehaviorsList = eventsFunctionsExtension.getEventsBasedBehaviors();
+    if (eventsBasedBehaviorsList.has(behaviorName)) {
+      this._selectEventsBasedBehavior(
+        eventsBasedBehaviorsList.get(behaviorName)
+      );
+    }
   };
 
   _selectEventsBasedBehavior = (

--- a/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
@@ -87,6 +87,9 @@ export type RenderEditorContainerProps = {|
 
   // Project creation
   onOpenNewProjectSetupDialog: (?ExampleShortHeader) => void,
+
+  // Object editing
+  openBehaviorEvents: (extensionName: string, behaviorName: string) => void,
 |};
 
 export type RenderEditorContainerPropsWithRef = {|

--- a/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
@@ -114,6 +114,10 @@ export class EventsFunctionsExtensionEditorContainer extends React.Component<Ren
       this.editor.selectEventsFunctionByName(eventsFunctionName, behaviorName);
   }
 
+  selectEventsBasedBehaviorByName(behaviorName: string) {
+    if (this.editor) this.editor.selectEventsBasedBehaviorByName(behaviorName);
+  }
+
   render() {
     const { project, projectItemName } = this.props;
     const eventsFunctionsExtension = this.getEventsFunctionsExtension();

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
@@ -187,6 +187,7 @@ export class ExternalLayoutEditorContainer extends React.Component<
             onOpenMoreSettings={this.openExternalPropertiesDialog}
             isActive={isActive}
             canInstallPrivateAsset={this.props.canInstallPrivateAsset}
+            openBehaviorEvents={this.props.openBehaviorEvents}
           />
         )}
         {!layout && (

--- a/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
@@ -102,6 +102,7 @@ export class SceneEditorContainer extends React.Component<RenderEditorContainerP
         onOpenEvents={this.props.onOpenEvents}
         isActive={isActive}
         hotReloadPreviewButtonProps={this.props.hotReloadPreviewButtonProps}
+        openBehaviorEvents={this.props.openBehaviorEvents}
       />
     );
   }

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1528,7 +1528,7 @@ const MainFrame = (props: Props) => {
   const openEventsFunctionsExtension = React.useCallback(
     (
       name: string,
-      initiallyFocusedFunctionName?: string,
+      initiallyFocusedFunctionName?: ?string,
       initiallyFocusedBehaviorName?: ?string
     ) => {
       setState(state => ({
@@ -1647,6 +1647,39 @@ const MainFrame = (props: Props) => {
           functionName.name,
           functionName.behaviorName
         );
+      }
+    } else {
+      // It's not an events functions extension, we should not be here.
+      console.warn(
+        `Extension with name=${extensionName} can not be opened (no editor for this)`
+      );
+    }
+  };
+
+  const openBehaviorEvents = (extensionName: string, behaviorName: string) => {
+    const { currentProject, editorTabs } = state;
+    if (!currentProject) return;
+
+    if (currentProject.hasEventsFunctionsExtensionNamed(extensionName)) {
+      // It's an events functions extension, open the editor for it.
+      const eventsFunctionsExtension = currentProject.getEventsFunctionsExtension(
+        extensionName
+      );
+
+      const foundTab = getEventsFunctionsExtensionEditor(
+        editorTabs,
+        eventsFunctionsExtension
+      );
+      if (foundTab) {
+        // Open the given function and focus the tab
+        foundTab.editor.selectEventsBasedBehaviorByName(behaviorName);
+        setState(state => ({
+          ...state,
+          editorTabs: changeCurrentTab(editorTabs, foundTab.tabIndex),
+        }));
+      } else {
+        // Open a new editor for the extension and the given function
+        openEventsFunctionsExtension(extensionName, null, behaviorName);
       }
     } else {
       // It's not an events functions extension, we should not be here.
@@ -2934,6 +2967,7 @@ const MainFrame = (props: Props) => {
 
                       cb(true);
                     },
+                    openBehaviorEvents: openBehaviorEvents,
                   })}
                 </ErrorBoundary>
               </CommandsContextScopedProvider>

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -123,9 +123,10 @@ const InnerDialog = (props: InnerDialogProps) => {
     async (extensionName, behaviorName) => {
       if (hasUnsavedChanges()) {
         const answer = await showConfirmation({
-          title: t`Abort changes and open events`,
+          title: t`Discard changes and open events`,
           message: t`You've made some changes here. Are you sure you want to discard them and open the behavior events?`,
-          confirmButtonLabel: t`Abort changes`,
+          confirmButtonLabel: t`Yes, discard my changes`,
+          dismissButtonLabel: t`Stay there`,
         });
         if (!answer) return;
       }

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -1,7 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
 import { t } from '@lingui/macro';
-import { I18n } from '@lingui/react';
 import * as React from 'react';
 import FlatButton from '../UI/FlatButton';
 import ObjectsEditorService from './ObjectsEditorService';
@@ -69,6 +68,7 @@ type InnerDialogProps = {|
 |};
 
 const InnerDialog = (props: InnerDialogProps) => {
+  const { openBehaviorEvents } = props;
   const [currentTab, setCurrentTab] = React.useState<ObjectEditorTab>(
     props.initialTab || 'properties'
   );
@@ -130,9 +130,9 @@ const InnerDialog = (props: InnerDialogProps) => {
         if (!answer) return;
       }
       onCancelChanges();
-      props.openBehaviorEvents(extensionName, behaviorName);
+      openBehaviorEvents(extensionName, behaviorName);
     },
-    [hasUnsavedChanges, onCancelChanges, props, showConfirmation]
+    [hasUnsavedChanges, onCancelChanges, openBehaviorEvents, showConfirmation]
   );
 
   return (
@@ -232,7 +232,7 @@ const InnerDialog = (props: InnerDialogProps) => {
             project={props.project}
             resourceManagementProps={props.resourceManagementProps}
             onSizeUpdated={
-              forceUpdate /*Force update to ensure dialog is properly positionned*/
+              forceUpdate /*Force update to ensure dialog is properly positioned*/
             }
             objectName={props.objectName}
             onObjectUpdated={notifyOfChange}
@@ -240,22 +240,18 @@ const InnerDialog = (props: InnerDialogProps) => {
         </Column>
       ) : null}
       {currentTab === 'behaviors' && (
-        <I18n>
-          {({ i18n }) => (
-            <BehaviorsEditor
-              object={props.object}
-              project={props.project}
-              eventsFunctionsExtension={props.eventsFunctionsExtension}
-              resourceManagementProps={props.resourceManagementProps}
-              onSizeUpdated={
-                forceUpdate /*Force update to ensure dialog is properly positionned*/
-              }
-              onUpdateBehaviorsSharedData={props.onUpdateBehaviorsSharedData}
-              onBehaviorsUpdated={notifyOfChange}
-              openBehaviorEvents={askConfirmationAndOpenBehaviorEvents}
-            />
-          )}
-        </I18n>
+        <BehaviorsEditor
+          object={props.object}
+          project={props.project}
+          eventsFunctionsExtension={props.eventsFunctionsExtension}
+          resourceManagementProps={props.resourceManagementProps}
+          onSizeUpdated={
+            forceUpdate /*Force update to ensure dialog is properly positioned*/
+          }
+          onUpdateBehaviorsSharedData={props.onUpdateBehaviorsSharedData}
+          onBehaviorsUpdated={notifyOfChange}
+          openBehaviorEvents={askConfirmationAndOpenBehaviorEvents}
+        />
       )}
       {currentTab === 'variables' && (
         <Column expand noMargin>
@@ -291,7 +287,7 @@ const InnerDialog = (props: InnerDialogProps) => {
           resourceManagementProps={props.resourceManagementProps}
           effectsContainer={props.object.getEffects()}
           onEffectsUpdated={() => {
-            forceUpdate(); /*Force update to ensure dialog is properly positionned*/
+            forceUpdate(); /*Force update to ensure dialog is properly positioned*/
             notifyOfChange();
           }}
         />

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -117,6 +117,7 @@ type Props = {|
   isActive: boolean,
   unsavedChanges?: ?UnsavedChanges,
   canInstallPrivateAsset: () => boolean,
+  openBehaviorEvents: (extensionName: string, behaviorName: string) => void,
 
   // Preview:
   hotReloadPreviewButtonProps: HotReloadPreviewButtonProps,
@@ -1660,6 +1661,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                   onUpdateBehaviorsSharedData={() =>
                     this.updateBehaviorsSharedData()
                   }
+                  openBehaviorEvents={this.props.openBehaviorEvents}
                 />
               )}
             </React.Fragment>

--- a/newIDE/app/src/UI/Accordion.js
+++ b/newIDE/app/src/UI/Accordion.js
@@ -14,6 +14,19 @@ const styles = {
     // Remove body padding
     padding: 0,
   },
+  accordionSummaryWithExpandOnLeft: {
+    flexDirection: 'row-reverse',
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
+  accordionSummaryContent: {
+    flexGrow: 1,
+    display: 'flex',
+    alignItems: 'center',
+    // Avoids the summary content to overlap the expand icon that was put on the left
+    marginLeft: 16,
+  },
+  actionsContainer: { flexGrow: 0, flexShrink: 0, alignSelf: 'center' },
 };
 
 type AccordionHeadProps = {|
@@ -24,7 +37,7 @@ type AccordionHeadProps = {|
 
 /**
  * The header of an accordion section.
- * Based on Material-UI AccordionSummary.
+ * Based on Material-UI AccordionSummary (but we could almost remove it).
  */
 export const AccordionHeader = (props: AccordionHeadProps) => {
   return (
@@ -32,11 +45,7 @@ export const AccordionHeader = (props: AccordionHeadProps) => {
       <Line noMargin expand alignItems="center">
         <Column noMargin expand>
           <MUIAccordionSummary
-            style={{
-              flexDirection: 'row-reverse',
-              paddingLeft: 0,
-              paddingRight: 0,
-            }}
+            style={styles.accordionSummaryWithExpandOnLeft}
             expandIcon={
               props.expandIcon || (
                 <IconButton size="small">
@@ -45,22 +54,11 @@ export const AccordionHeader = (props: AccordionHeadProps) => {
               )
             }
           >
-            <div
-              style={{
-                flexGrow: 1,
-                display: 'flex',
-                alignItems: 'center',
-                marginLeft: 16,
-              }}
-            >
-              {props.children}
-            </div>
+            <div style={styles.accordionSummaryContent}>{props.children}</div>
           </MUIAccordionSummary>
         </Column>
         {props.actions && (
-          <div style={{ flexGrow: 0, flexShrink: 0, alignSelf: 'center' }}>
-            {props.actions}
-          </div>
+          <div style={styles.actionsContainer}>{props.actions}</div>
         )}
       </Line>
     </Column>

--- a/newIDE/app/src/UI/Accordion.js
+++ b/newIDE/app/src/UI/Accordion.js
@@ -7,6 +7,7 @@ import MUIAccordionActions from '@material-ui/core/AccordionActions';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import IconButton from './IconButton';
 import GDevelopThemeContext from './Theme/ThemeContext';
+import { Column, Line } from '../UI/Grid';
 
 const styles = {
   bodyRoot: {
@@ -27,24 +28,42 @@ type AccordionHeadProps = {|
  */
 export const AccordionHeader = (props: AccordionHeadProps) => {
   return (
-    <MUIAccordionSummary
-      expandIcon={
-        props.expandIcon || (
-          <IconButton size="small">
-            <ExpandMoreIcon />
-          </IconButton>
-        )
-      }
-    >
-      <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
-        {props.children}
-      </div>
-      {props.actions && (
-        <div style={{ flexGrow: 0, flexShrink: 0, alignSelf: 'center' }}>
-          {props.actions}
-        </div>
-      )}
-    </MUIAccordionSummary>
+    <Column expand>
+      <Line noMargin expand alignItems="center">
+        <Column noMargin expand>
+          <MUIAccordionSummary
+            style={{
+              flexDirection: 'row-reverse',
+              paddingLeft: 0,
+              paddingRight: 0,
+            }}
+            expandIcon={
+              props.expandIcon || (
+                <IconButton size="small">
+                  <ExpandMoreIcon />
+                </IconButton>
+              )
+            }
+          >
+            <div
+              style={{
+                flexGrow: 1,
+                display: 'flex',
+                alignItems: 'center',
+                marginLeft: 16,
+              }}
+            >
+              {props.children}
+            </div>
+          </MUIAccordionSummary>
+        </Column>
+        {props.actions && (
+          <div style={{ flexGrow: 0, flexShrink: 0, alignSelf: 'center' }}>
+            {props.actions}
+          </div>
+        )}
+      </Line>
+    </Column>
   );
 };
 

--- a/newIDE/app/src/Utils/SerializableObjectCancelableEditor.js
+++ b/newIDE/app/src/Utils/SerializableObjectCancelableEditor.js
@@ -55,6 +55,10 @@ export const useSerializableObjectCancelableEditor = ({
     numberOfChangesRef.current++;
   }, []);
 
+  const hasUnsavedChanges = React.useCallback(() => {
+    return numberOfChangesRef.current > 0;
+  }, []);
+
   const onCancelChanges = React.useCallback(
     async () => {
       // Use the value that was serialized to cancel the changes
@@ -105,5 +109,5 @@ export const useSerializableObjectCancelableEditor = ({
     ]
   );
 
-  return { onCancelChanges, notifyOfChange };
+  return { onCancelChanges, notifyOfChange, hasUnsavedChanges };
 };

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/BehaviorsEditor.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/BehaviorsEditor.stories.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import { action } from '@storybook/addon-actions';
 
 // Keep first as it creates the `global.gd` object:
 import { testProject } from '../../GDevelopJsInitializerDecorator';
@@ -32,6 +33,8 @@ export const Default = () => (
         resourceExternalEditors: fakeResourceExternalEditors,
       }}
       onUpdateBehaviorsSharedData={() => {}}
+      openBehaviorEvents={() => action('Open behavior events')}
+      onBehaviorsUpdated={() => {}}
     />
   </SerializedObjectDisplay>
 );
@@ -50,6 +53,8 @@ export const WithoutAnyBehaviors = () => (
         resourceExternalEditors: fakeResourceExternalEditors,
       }}
       onUpdateBehaviorsSharedData={() => {}}
+      openBehaviorEvents={() => action('Open behavior events')}
+      onBehaviorsUpdated={() => {}}
     />
   </SerializedObjectDisplay>
 );

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/ObjectEditorDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/ObjectEditorDialog.stories.js
@@ -41,6 +41,7 @@ export const CustomObject = () => (
       launchProjectDataOnlyPreview: () => action('Hot-reload'),
       launchProjectWithLoadingScreenPreview: () => action('Reload'),
     }}
+    openBehaviorEvents={() => action('Open behavior events')}
   />
 );
 
@@ -68,5 +69,6 @@ export const StandardObject = () => (
       launchProjectDataOnlyPreview: () => action('Hot-reload'),
       launchProjectWithLoadingScreenPreview: () => action('Reload'),
     }}
+    openBehaviorEvents={() => action('Open behavior events')}
   />
 );


### PR DESCRIPTION
It also fixes the unsaved change watching of the object editor to detect behavior properties changes.

![image](https://user-images.githubusercontent.com/2611977/216024996-c119e06a-fbe0-4d6b-abb2-8784058b3f7a.png)
