### PR TITLE
Fix resource store display for extension icon

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/OptionsEditorDialog/ExtensionOptionsEditor.js
@@ -325,6 +325,8 @@ export const ExtensionOptionsEditor = ({
                   }}
                 />,
               ]}
+              flexColumnBody
+              fullHeight
               open
               onRequestClose={() => {
                 setResourceStoreOpen(false);


### PR DESCRIPTION
Fixes https://forum.gdevelop.io/t/two-sliders-when-selecting-an-extension-icon/45001