### PR TITLE
Fix tutorial tooltip being translated and causing a crash

### DIFF
--- a/newIDE/app/src/InAppTutorial/InAppTutorialTooltipDisplayer.js
+++ b/newIDE/app/src/InAppTutorial/InAppTutorialTooltipDisplayer.js
@@ -138,13 +138,13 @@ const TooltipBody = ({
   return (
     <>
       {tooltip.title && (
-        <Typography style={styles.title} variant="subtitle">
+        <Typography style={styles.title} variant="subtitle" translate="no">
           <MarkdownText source={tooltip.title} allowParagraphs />
         </Typography>
       )}
       {tooltip.title && tooltip.description && <span style={styles.divider} />}
       {tooltip.description && (
-        <Typography style={styles.description}>
+        <Typography style={styles.description} translate="no">
           <MarkdownText source={tooltip.description} allowParagraphs />
         </Typography>
       )}
@@ -205,7 +205,10 @@ const TooltipHeader = ({
       noMargin
       justifyContent={tooltipContent ? undefined : 'space-between'}
     >
-      <Typography style={{ ...styles.headerText, color: progressColor }}>
+      <Typography
+        style={{ ...styles.headerText, color: progressColor }}
+        translate="no"
+      >
         {progress}%
       </Typography>
       <LineStackLayout noMargin alignItems="center" overflow="hidden">
@@ -222,7 +225,7 @@ const TooltipHeader = ({
               }}
             >
               <Cross />
-              <Typography style={styles.headerText}>
+              <Typography style={styles.headerText} translate="no">
                 <Trans>Quit tutorial</Trans>
               </Typography>
             </div>

--- a/newIDE/app/src/InAppTutorial/InAppTutorialTooltipDisplayer.js
+++ b/newIDE/app/src/InAppTutorial/InAppTutorialTooltipDisplayer.js
@@ -232,6 +232,7 @@ const TooltipHeader = ({
           <Typography
             variant="body2"
             style={{ ...styles.headerContentPreview, ...textEllipsisStyle }}
+            translate="no"
           >
             {tooltipContent}
           </Typography>


### PR DESCRIPTION
Fix #4975, #4986, #4982, #4928

![image](https://user-images.githubusercontent.com/4895034/220387362-e25a01a5-953a-41fd-a9f9-4b7b3d1736a7.png)

This seems to be the culprit. (I haven't reproduced the problem, but the stacktraces point to this)
Automatic translation + the fact that another DOM element (strong) is inserted seem to conflict.