### PR TITLE
Shortcut for duplicate instance(s)

### DIFF
--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -54,6 +54,7 @@ export type InstancesEditorShortcutsCallbacks = {|
   onCopy: () => void,
   onCut: () => void,
   onPaste: () => void,
+  onDuplicate: () => void,
   onUndo: () => void,
   onRedo: () => void,
   onZoomOut: () => void,

--- a/newIDE/app/src/KeyboardShortcuts/ReservedShortcuts.js
+++ b/newIDE/app/src/KeyboardShortcuts/ReservedShortcuts.js
@@ -7,6 +7,7 @@ const reservedShortcuts = [
   'CmdOrCtrl+KeyX', // Cut
   'CmdOrCtrl+KeyC', // Copy
   'CmdOrCtrl+KeyV', // Paste
+  'CmdOrCtrl+KeyD', // Duplicate
   'CmdOrCtrl+Shift+KeyV', // Paste with style
   'CmdOrCtrl+KeyA', // Select all
   'Delete', // Delete

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1206,7 +1206,9 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.deleteSelection();
   };
 
-  duplicateSelection = ({ useLastCursorPosition }: CopyCutPasteOptions = {}) => {
+  duplicateSelection = ({
+    useLastCursorPosition,
+  }: CopyCutPasteOptions = {}) => {
     const { editor } = this;
     if (!editor) return;
     const serializedSelection = this.instancesSelection

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1120,6 +1120,7 @@ export default class SceneEditor extends React.Component<Props, State> {
           click: () => {
             this.duplicateSelection();
           },
+          accelerator: 'CmdOrCtrl+D',
         },
         { type: 'separator' },
         {
@@ -1205,7 +1206,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.deleteSelection();
   };
 
-  duplicateSelection = () => {
+  duplicateSelection = ({ useLastCursorPosition }: CopyCutPasteOptions = {}) => {
     const { editor } = this;
     if (!editor) return;
     const serializedSelection = this.instancesSelection
@@ -1459,6 +1460,8 @@ export default class SceneEditor extends React.Component<Props, State> {
               onCopy: () => this.copySelection({ useLastCursorPosition: true }),
               onCut: () => this.cutSelection({ useLastCursorPosition: true }),
               onPaste: () => this.paste({ useLastCursorPosition: true }),
+              onDuplicate: () =>
+                this.duplicateSelection({ useLastCursorPosition: true }),
               onDelete: this.deleteSelection,
               onUndo: this.undo,
               onRedo: this.redo,

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -15,6 +15,7 @@ const SPACE_KEY = 32;
 const NUMPAD_ADD = 107;
 const NUMPAD_SUBTRACT = 109;
 const C_KEY = 67;
+const D_KEY = 68;
 const F_KEY = 70;
 const V_KEY = 86;
 const X_KEY = 88;
@@ -36,6 +37,7 @@ type ShortcutCallbacks = {|
   onCopy?: () => void,
   onCut?: () => void,
   onPaste?: () => void,
+  onDuplicate?: () => void,
   onUndo?: () => void,
   onRedo?: () => void,
   onSearch?: () => void,
@@ -178,6 +180,7 @@ export default class KeyboardShortcuts {
       onCopy,
       onCut,
       onPaste,
+      onDuplicate,
       onUndo,
       onRedo,
       onSearch,
@@ -219,6 +222,10 @@ export default class KeyboardShortcuts {
     if (onPaste && this._isControlOrCmdPressed() && evt.which === V_KEY) {
       evt.preventDefault();
       onPaste();
+    }
+    if (onDuplicate && this._isControlOrCmdPressed() && evt.which === D_KEY) {
+      evt.preventDefault();
+      onDuplicate();
     }
     if (
       (onUndo || onRedo) &&

--- a/newIDE/app/src/stories/componentStories/FullSizeInstancesEditorWithScrollbars.stories.js
+++ b/newIDE/app/src/stories/componentStories/FullSizeInstancesEditorWithScrollbars.stories.js
@@ -55,6 +55,7 @@ export const Default = () => (
           onCopy: () => {},
           onCut: () => {},
           onPaste: () => {},
+          onDuplicate: () => {},
           onDelete: () => {},
           onUndo: () => {},
           onRedo: () => {},


### PR DESCRIPTION
I added a shortcut for Duplicating instance(s) `Ctrl + D`.
This shortcut is used in many programs, and I think some times is more intuitive.

![image](https://user-images.githubusercontent.com/21989259/221035215-e19e5493-fc18-4440-8f2a-a1959fa3098b.png)
