### PR TITLE
Highlight opened editors icons in the toolbar of the scene editor

### DIFF
--- a/newIDE/app/src/CommandPalette/CommandsList.js
+++ b/newIDE/app/src/CommandPalette/CommandsList.js
@@ -207,23 +207,23 @@ const commandsList: { [CommandName]: CommandMetadata } = {
   // Scene editor toolbar commands
   OPEN_OBJECTS_PANEL: {
     area: 'SCENE',
-    displayText: t`Open Objects Panel`,
+    displayText: t`Toggle Objects Panel`,
   },
   OPEN_OBJECT_GROUPS_PANEL: {
     area: 'SCENE',
-    displayText: t`Open Object Groups Panel`,
+    displayText: t`Toggle Object Groups Panel`,
   },
   OPEN_PROPERTIES_PANEL: {
     area: 'SCENE',
-    displayText: t`Open Properties Panel`,
+    displayText: t`Toggle Properties Panel`,
   },
   TOGGLE_INSTANCES_PANEL: {
     area: 'SCENE',
-    displayText: t`Open Instances List Panel`,
+    displayText: t`Toggle Instances List Panel`,
   },
   TOGGLE_LAYERS_PANEL: {
     area: 'SCENE',
-    displayText: t`Open Layers Panel`,
+    displayText: t`Toggle Layers Panel`,
   },
   SCENE_EDITOR_UNDO: {
     area: 'SCENE',

--- a/newIDE/app/src/Debugger/DebuggerContent.js
+++ b/newIDE/app/src/Debugger/DebuggerContent.js
@@ -40,6 +40,7 @@ type Props = {|
   profilerOutput: ?ProfilerOutput,
   profilingInProgress: boolean,
   logsManager: LogsManager,
+  onOpenedEditorsChanged: () => void,
 |};
 
 type State = {|
@@ -78,12 +79,26 @@ export default class DebuggerContent extends React.Component<Props, State> {
 
   _editors: ?EditorMosaic = null;
 
-  openProfiler = () => {
-    if (this._editors) this._editors.openEditor('profiler', 'end', 75, 'row');
+  isProfilerShown = () => {
+    return (
+      !!this._editors &&
+      this._editors.getOpenedEditorNames().includes('profiler')
+    );
   };
 
-  openConsole = () => {
-    if (this._editors) this._editors.openEditor('console', 'start', 40, 'row');
+  isConsoleShown = () => {
+    return (
+      !!this._editors &&
+      this._editors.getOpenedEditorNames().includes('console')
+    );
+  };
+
+  toggleProfiler = () => {
+    if (this._editors) this._editors.toggleEditor('profiler', 'end', 75, 'row');
+  };
+
+  toggleConsole = () => {
+    if (this._editors) this._editors.toggleEditor('console', 'end', 75, 'row');
   };
 
   render() {
@@ -97,6 +112,7 @@ export default class DebuggerContent extends React.Component<Props, State> {
       profilerOutput,
       profilingInProgress,
       logsManager,
+      onOpenedEditorsChanged,
     } = this.props;
     const {
       selectedInspector,
@@ -241,6 +257,7 @@ export default class DebuggerContent extends React.Component<Props, State> {
             onPersistNodes={node =>
               setDefaultEditorMosaicNode('debugger', node)
             }
+            onOpenedEditorsChanged={onOpenedEditorsChanged}
           />
         )}
       </PreferencesContext.Consumer>

--- a/newIDE/app/src/Debugger/Toolbar.js
+++ b/newIDE/app/src/Debugger/Toolbar.js
@@ -15,9 +15,11 @@ type Props = {|
   canPlay: boolean,
   onPause: () => void,
   canPause: boolean,
-  onOpenProfiler: () => void,
+  isProfilerShown: boolean,
+  onToggleProfiler: () => void,
   canOpenProfiler: boolean,
-  onOpenConsole: () => void,
+  isConsoleShown: boolean,
+  onToggleConsole: () => void,
   canOpenConsole: boolean,
 |};
 
@@ -28,10 +30,12 @@ export class Toolbar extends React.PureComponent<Props> {
       onPause,
       canPlay,
       canPause,
-      onOpenProfiler,
+      onToggleProfiler,
       canOpenProfiler,
-      onOpenConsole,
+      onToggleConsole,
       canOpenConsole,
+      isProfilerShown,
+      isConsoleShown,
     } = this.props;
 
     return (
@@ -39,8 +43,9 @@ export class Toolbar extends React.PureComponent<Props> {
         <IconButton
           size="small"
           color="default"
-          onClick={onOpenProfiler}
+          onClick={onToggleProfiler}
           disabled={!canOpenProfiler}
+          selected={isProfilerShown}
           tooltip={t`Open the performance profiler`}
         >
           <ProfilerIcon />
@@ -48,8 +53,9 @@ export class Toolbar extends React.PureComponent<Props> {
         <IconButton
           size="small"
           color="default"
-          onClick={onOpenConsole}
+          onClick={onToggleConsole}
           disabled={!canOpenConsole}
+          selected={isConsoleShown}
           tooltip={t`Open the console`}
         >
           <ConsoleIcon />

--- a/newIDE/app/src/Debugger/index.js
+++ b/newIDE/app/src/Debugger/index.js
@@ -78,8 +78,12 @@ export default class Debugger extends React.Component<Props, State> {
   _debuggerContents: { [DebuggerId]: ?DebuggerContent } = {};
   _debuggerLogs: Map<number, LogsManager> = new Map();
 
-  updateToolbar() {
+  updateToolbar = () => {
     const { selectedId, gameIsPaused } = this.state;
+
+    const selectedDebuggerContents = this._debuggerContents[
+      this.state.selectedId
+    ];
 
     this.props.setToolbar(
       <Toolbar
@@ -88,18 +92,26 @@ export default class Debugger extends React.Component<Props, State> {
         canPlay={this._hasSelectedDebugger() && gameIsPaused[selectedId]}
         canPause={this._hasSelectedDebugger() && !gameIsPaused[selectedId]}
         canOpenProfiler={this._hasSelectedDebugger()}
-        onOpenProfiler={() => {
+        isProfilerShown={
+          !!selectedDebuggerContents &&
+          selectedDebuggerContents.isProfilerShown()
+        }
+        onToggleProfiler={() => {
           if (this._debuggerContents[this.state.selectedId])
-            this._debuggerContents[this.state.selectedId].openProfiler();
+            this._debuggerContents[this.state.selectedId].toggleProfiler();
         }}
         canOpenConsole={this._hasSelectedDebugger()}
-        onOpenConsole={() => {
+        isConsoleShown={
+          !!selectedDebuggerContents &&
+          selectedDebuggerContents.isConsoleShown()
+        }
+        onToggleConsole={() => {
           if (this._debuggerContents[this.state.selectedId])
-            this._debuggerContents[this.state.selectedId].openConsole();
+            this._debuggerContents[this.state.selectedId].toggleConsole();
         }}
       />
     );
-  }
+  };
 
   componentDidMount() {
     this._registerServerCallbacks();
@@ -389,6 +401,7 @@ export default class Debugger extends React.Component<Props, State> {
                 profilerOutput={profilerOutputs[selectedId]}
                 profilingInProgress={profilingInProgress[selectedId]}
                 logsManager={this._getLogsManager(selectedId)}
+                onOpenedEditorsChanged={this.updateToolbar}
               />
             )}
             {!this._hasSelectedDebugger() && (

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -32,10 +32,6 @@ export type AlertMessageIdentifier =
   | 'lighting-layer-usage'
   | 'resource-properties-panel-explanation'
   | 'instance-drag-n-drop-explanation'
-  | 'objects-panel-explanation'
-  | 'instance-properties-panel-explanation'
-  | 'layers-panel-explanation'
-  | 'instances-panel-explanation'
   | 'physics2-shape-collisions'
   | 'edit-instruction-explanation'
   | 'lifecycle-events-function-included-only-if-extension-used'
@@ -137,22 +133,6 @@ export const allAlertMessages: Array<{
   {
     key: 'instance-drag-n-drop-explanation',
     label: <Trans>Using instance drag'n'drop</Trans>,
-  },
-  {
-    key: 'objects-panel-explanation',
-    label: <Trans>Using the objects panel</Trans>,
-  },
-  {
-    key: 'instance-properties-panel-explanation',
-    label: <Trans>Using the instance properties panel</Trans>,
-  },
-  {
-    key: 'layers-panel-explanation',
-    label: <Trans>Using the layers panel</Trans>,
-  },
-  {
-    key: 'instances-panel-explanation',
-    label: <Trans>Using the instances panel</Trans>,
   },
   {
     key: 'physics2-shape-collisions',

--- a/newIDE/app/src/ResourcesEditor/Toolbar.js
+++ b/newIDE/app/src/ResourcesEditor/Toolbar.js
@@ -12,14 +12,15 @@ type Props = {|
   onOpenProjectFolder: () => void,
   onDeleteSelection: () => void,
   canDelete: boolean,
-  onOpenProperties: () => void,
+  onToggleProperties: () => void,
+  isPropertiesShown: boolean,
 |};
 
 type State = {||};
 
 export class Toolbar extends PureComponent<Props, State> {
   render() {
-    const { canDelete } = this.props;
+    const { canDelete, isPropertiesShown } = this.props;
 
     return (
       <ToolbarGroup lastChild>
@@ -35,8 +36,9 @@ export class Toolbar extends PureComponent<Props, State> {
         <IconButton
           size="small"
           color="default"
-          onClick={this.props.onOpenProperties}
+          onClick={this.props.onToggleProperties}
           tooltip={t`Open the properties panel`}
+          selected={isPropertiesShown}
         >
           <PropertiesPanelIcon />
         </IconButton>

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -33,7 +33,6 @@ const styles = {
 };
 
 type State = {|
-  showPropertiesInfoBar: boolean,
   selectedResource: ?gdResource,
 |};
 
@@ -66,7 +65,6 @@ export default class ResourcesEditor extends React.Component<Props, State> {
   _resourcesList: ?ResourcesList = null;
   resourcesLoader = ResourcesLoader;
   state = {
-    showPropertiesInfoBar: false,
     selectedResource: null,
   };
 
@@ -74,18 +72,23 @@ export default class ResourcesEditor extends React.Component<Props, State> {
     if (this._resourcesList) this._resourcesList.forceUpdate();
   }
 
-  updateToolbar() {
+  updateToolbar = () => {
+    const openedEditorNames = this.editorMosaic
+      ? this.editorMosaic.getOpenedEditorNames()
+      : [];
+
     this.props.setToolbar(
       <Toolbar
         onOpenProjectFolder={this.openProjectFolder}
-        onOpenProperties={this.openProperties}
+        onToggleProperties={this.toggleProperties}
+        isPropertiesShown={openedEditorNames.includes('properties')}
         canDelete={!!this.state.selectedResource}
         onDeleteSelection={() =>
           this.deleteResource(this.state.selectedResource)
         }
       />
     );
-  }
+  };
 
   deleteResource = (resource: ?gdResource) => {
     const { project, onDeleteResource } = this.props;
@@ -183,13 +186,9 @@ export default class ResourcesEditor extends React.Component<Props, State> {
     if (shell) shell.openPath(path.dirname(project.getProjectFile()));
   };
 
-  openProperties = () => {
+  toggleProperties = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('properties', 'start', 66, 'column')) {
-      this.setState({
-        showPropertiesInfoBar: true,
-      });
-    }
+    this.editorMosaic.toggleEditor('properties', 'start', 66, 'column');
   };
 
   _onResourceSelected = (selectedResource: ?gdResource) => {
@@ -261,22 +260,13 @@ export default class ResourcesEditor extends React.Component<Props, State> {
                 getDefaultEditorMosaicNode('resources-editor') ||
                 initialMosaicEditorNodes
               }
+              onOpenedEditorsChanged={this.updateToolbar}
               onPersistNodes={node =>
                 setDefaultEditorMosaicNode('resources-editor', node)
               }
             />
           )}
         </PreferencesContext.Consumer>
-        <DismissableInfoBar
-          message={
-            <Trans>
-              Properties panel is already opened. After selecting a resource,
-              inspect and change its properties from this panel.
-            </Trans>
-          }
-          show={!!this.state.showPropertiesInfoBar}
-          identifier="resource-properties-panel-explanation"
-        />
       </div>
     );
   }

--- a/newIDE/app/src/SceneEditor/Toolbar.js
+++ b/newIDE/app/src/SceneEditor/Toolbar.js
@@ -22,11 +22,11 @@ import ZoomInIcon from '../UI/CustomSvgIcons/ZoomIn';
 import EditSceneIcon from '../UI/CustomSvgIcons/EditScene';
 
 type Props = {|
-  openObjectsList: () => void,
+  toggleObjectsList: () => void,
   isObjectsListShown: boolean,
-  openObjectGroupsList: () => void,
+  toggleObjectGroupsList: () => void,
   isObjectGroupsListShown: boolean,
-  openProperties: () => void,
+  toggleProperties: () => void,
   isPropertiesShown: boolean,
   undo: () => void,
   canUndo: boolean,
@@ -34,9 +34,9 @@ type Props = {|
   canRedo: boolean,
   deleteSelection: () => void,
   instancesSelection: InstancesSelection,
-  openInstancesList: () => void,
+  toggleInstancesList: () => void,
   isInstancesListShown: boolean,
-  openLayersList: () => void,
+  toggleLayersList: () => void,
   isLayersListShown: boolean,
   isWindowMaskShown: () => boolean,
   toggleWindowMask: () => void,
@@ -55,11 +55,11 @@ const Toolbar = (props: Props) => {
   return (
     <>
       <ToolbarCommands
-        openObjectsList={props.openObjectsList}
-        openObjectGroupsList={props.openObjectGroupsList}
-        openPropertiesPanel={props.openProperties}
-        openInstancesList={props.openInstancesList}
-        openLayersList={props.openLayersList}
+        toggleObjectsList={props.toggleObjectsList}
+        toggleObjectGroupsList={props.toggleObjectGroupsList}
+        togglePropertiesPanel={props.toggleProperties}
+        toggleInstancesList={props.toggleInstancesList}
+        toggleLayersList={props.toggleLayersList}
         undo={props.undo}
         canUndo={props.canUndo}
         redo={props.redo}
@@ -79,7 +79,7 @@ const Toolbar = (props: Props) => {
           size="small"
           color="default"
           id="toolbar-open-objects-panel-button"
-          onClick={props.openObjectsList}
+          onClick={props.toggleObjectsList}
           selected={props.isObjectsListShown}
           tooltip={t`Open Objects Panel`}
         >
@@ -89,7 +89,7 @@ const Toolbar = (props: Props) => {
           size="small"
           color="default"
           id="toolbar-open-object-groups-panel-button"
-          onClick={props.openObjectGroupsList}
+          onClick={props.toggleObjectGroupsList}
           selected={props.isObjectGroupsListShown}
           tooltip={t`Open Object Groups Panel`}
         >
@@ -99,7 +99,7 @@ const Toolbar = (props: Props) => {
           size="small"
           color="default"
           id="toolbar-open-properties-panel-button"
-          onClick={props.openProperties}
+          onClick={props.toggleProperties}
           selected={props.isPropertiesShown}
           tooltip={t`Open Properties Panel`}
         >
@@ -109,7 +109,7 @@ const Toolbar = (props: Props) => {
           size="small"
           color="default"
           id="toolbar-open-instances-list-panel-button"
-          onClick={props.openInstancesList}
+          onClick={props.toggleInstancesList}
           selected={props.isInstancesListShown}
           tooltip={t`Open Instances List Panel`}
         >
@@ -119,7 +119,7 @@ const Toolbar = (props: Props) => {
           size="small"
           color="default"
           id="toolbar-open-layers-panel-button"
-          onClick={props.openLayersList}
+          onClick={props.toggleLayersList}
           selected={props.isLayersListShown}
           tooltip={t`Open Layers Panel`}
         >

--- a/newIDE/app/src/SceneEditor/Toolbar.js
+++ b/newIDE/app/src/SceneEditor/Toolbar.js
@@ -23,16 +23,21 @@ import EditSceneIcon from '../UI/CustomSvgIcons/EditScene';
 
 type Props = {|
   openObjectsList: () => void,
+  isObjectsListShown: boolean,
   openObjectGroupsList: () => void,
+  isObjectGroupsListShown: boolean,
   openProperties: () => void,
+  isPropertiesShown: boolean,
   undo: () => void,
   canUndo: boolean,
   redo: () => void,
   canRedo: boolean,
   deleteSelection: () => void,
   instancesSelection: InstancesSelection,
-  toggleInstancesList: () => void,
-  toggleLayersList: () => void,
+  openInstancesList: () => void,
+  isInstancesListShown: boolean,
+  openLayersList: () => void,
+  isLayersListShown: boolean,
   isWindowMaskShown: () => boolean,
   toggleWindowMask: () => void,
   isGridShown: () => boolean,
@@ -53,8 +58,8 @@ const Toolbar = (props: Props) => {
         openObjectsList={props.openObjectsList}
         openObjectGroupsList={props.openObjectGroupsList}
         openPropertiesPanel={props.openProperties}
-        toggleInstancesList={props.toggleInstancesList}
-        toggleLayersList={props.toggleLayersList}
+        openInstancesList={props.openInstancesList}
+        openLayersList={props.openLayersList}
         undo={props.undo}
         canUndo={props.canUndo}
         redo={props.redo}
@@ -75,6 +80,7 @@ const Toolbar = (props: Props) => {
           color="default"
           id="toolbar-open-objects-panel-button"
           onClick={props.openObjectsList}
+          selected={props.isObjectsListShown}
           tooltip={t`Open Objects Panel`}
         >
           <ObjectIcon />
@@ -84,6 +90,7 @@ const Toolbar = (props: Props) => {
           color="default"
           id="toolbar-open-object-groups-panel-button"
           onClick={props.openObjectGroupsList}
+          selected={props.isObjectGroupsListShown}
           tooltip={t`Open Object Groups Panel`}
         >
           <ObjectGroupIcon />
@@ -93,6 +100,7 @@ const Toolbar = (props: Props) => {
           color="default"
           id="toolbar-open-properties-panel-button"
           onClick={props.openProperties}
+          selected={props.isPropertiesShown}
           tooltip={t`Open Properties Panel`}
         >
           <PropertiesPanelIcon />
@@ -101,7 +109,8 @@ const Toolbar = (props: Props) => {
           size="small"
           color="default"
           id="toolbar-open-instances-list-panel-button"
-          onClick={props.toggleInstancesList}
+          onClick={props.openInstancesList}
+          selected={props.isInstancesListShown}
           tooltip={t`Open Instances List Panel`}
         >
           <InstancesListIcon />
@@ -110,7 +119,8 @@ const Toolbar = (props: Props) => {
           size="small"
           color="default"
           id="toolbar-open-layers-panel-button"
-          onClick={props.toggleLayersList}
+          onClick={props.openLayersList}
+          selected={props.isLayersListShown}
           tooltip={t`Open Layers Panel`}
         >
           <LayersIcon />

--- a/newIDE/app/src/SceneEditor/ToolbarCommands.js
+++ b/newIDE/app/src/SceneEditor/ToolbarCommands.js
@@ -5,8 +5,8 @@ type Props = {|
   openObjectsList: () => void,
   openObjectGroupsList: () => void,
   openPropertiesPanel: () => void,
-  toggleInstancesList: () => void,
-  toggleLayersList: () => void,
+  openInstancesList: () => void,
+  openLayersList: () => void,
   undo: () => void,
   canUndo: boolean,
   redo: () => void,
@@ -34,11 +34,11 @@ const ToolbarCommands = (props: Props) => {
   });
 
   useCommand('TOGGLE_INSTANCES_PANEL', true, {
-    handler: props.toggleInstancesList,
+    handler: props.openInstancesList,
   });
 
   useCommand('TOGGLE_LAYERS_PANEL', true, {
-    handler: props.toggleLayersList,
+    handler: props.openLayersList,
   });
 
   useCommand('SCENE_EDITOR_UNDO', props.canUndo, {

--- a/newIDE/app/src/SceneEditor/ToolbarCommands.js
+++ b/newIDE/app/src/SceneEditor/ToolbarCommands.js
@@ -2,11 +2,11 @@
 import { useCommand } from '../CommandPalette/CommandHooks';
 
 type Props = {|
-  openObjectsList: () => void,
-  openObjectGroupsList: () => void,
-  openPropertiesPanel: () => void,
-  openInstancesList: () => void,
-  openLayersList: () => void,
+  toggleObjectsList: () => void,
+  toggleObjectGroupsList: () => void,
+  togglePropertiesPanel: () => void,
+  toggleInstancesList: () => void,
+  toggleLayersList: () => void,
   undo: () => void,
   canUndo: boolean,
   redo: () => void,
@@ -22,23 +22,23 @@ type Props = {|
 
 const ToolbarCommands = (props: Props) => {
   useCommand('OPEN_OBJECTS_PANEL', true, {
-    handler: props.openObjectsList,
+    handler: props.toggleObjectsList,
   });
 
   useCommand('OPEN_OBJECT_GROUPS_PANEL', true, {
-    handler: props.openObjectGroupsList,
+    handler: props.toggleObjectGroupsList,
   });
 
   useCommand('OPEN_PROPERTIES_PANEL', true, {
-    handler: props.openPropertiesPanel,
+    handler: props.togglePropertiesPanel,
   });
 
   useCommand('TOGGLE_INSTANCES_PANEL', true, {
-    handler: props.openInstancesList,
+    handler: props.toggleInstancesList,
   });
 
   useCommand('TOGGLE_LAYERS_PANEL', true, {
-    handler: props.openLayersList,
+    handler: props.toggleLayersList,
   });
 
   useCommand('SCENE_EDITOR_UNDO', props.canUndo, {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -233,18 +233,18 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.props.setToolbar(
       <Toolbar
         instancesSelection={this.instancesSelection}
-        openObjectsList={this.openObjectsList}
+        toggleObjectsList={this.toggleObjectsList}
         isObjectsListShown={openedEditorNames.includes('objects-list')}
-        openObjectGroupsList={this.openObjectGroupsList}
+        toggleObjectGroupsList={this.toggleObjectGroupsList}
         isObjectGroupsListShown={openedEditorNames.includes(
           'object-groups-list'
         )}
-        openProperties={this.openProperties}
+        toggleProperties={this.toggleProperties}
         isPropertiesShown={openedEditorNames.includes('properties')}
         deleteSelection={this.deleteSelection}
-        openInstancesList={this.openInstancesList}
+        toggleInstancesList={this.toggleInstancesList}
         isInstancesListShown={openedEditorNames.includes('instances-list')}
-        openLayersList={this.openLayersList}
+        toggleLayersList={this.toggleLayersList}
         isLayersListShown={openedEditorNames.includes('layers-list')}
         toggleWindowMask={this.toggleWindowMask}
         isWindowMaskShown={() =>
@@ -281,29 +281,29 @@ export default class SceneEditor extends React.Component<Props, State> {
     }
   }
 
-  openObjectsList = () => {
+  toggleObjectsList = () => {
     if (!this.editorMosaic) return;
-    this.editorMosaic.openEditor('objects-list', 'end', 75, 'column');
+    this.editorMosaic.toggleEditor('objects-list', 'end', 75, 'column');
   };
 
-  openProperties = () => {
+  toggleProperties = () => {
     if (!this.editorMosaic) return;
-    this.editorMosaic.openEditor('properties', 'start', 25, 'column');
+    this.editorMosaic.toggleEditor('properties', 'start', 25, 'column');
   };
 
-  openObjectGroupsList = () => {
+  toggleObjectGroupsList = () => {
     if (!this.editorMosaic) return;
-    this.editorMosaic.openEditor('object-groups-list', 'end', 75, 'column');
+    this.editorMosaic.toggleEditor('object-groups-list', 'end', 75, 'column');
   };
 
-  openInstancesList = () => {
+  toggleInstancesList = () => {
     if (!this.editorMosaic) return;
-    this.editorMosaic.openEditor('instances-list', 'end', 75, 'row');
+    this.editorMosaic.toggleEditor('instances-list', 'end', 75, 'row');
   };
 
-  openLayersList = () => {
+  toggleLayersList = () => {
     if (!this.editorMosaic) return;
-    this.editorMosaic.openEditor('layers-list', 'end', 75, 'row');
+    this.editorMosaic.toggleEditor('layers-list', 'end', 75, 'row');
   };
 
   toggleWindowMask = () => {
@@ -488,7 +488,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     });
 
     if (this._objectsList) this._objectsList.openNewObjectDialog();
-    else this.openObjectsList();
+    else this.toggleObjectsList();
   };
 
   _onAddInstanceUnderCursor = () => {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -146,11 +146,7 @@ type State = {|
   instancesEditorSettings: Object,
   history: HistoryState,
 
-  showObjectsListInfoBar: boolean,
   layoutVariablesDialogOpen: boolean,
-  showPropertiesInfoBar: boolean,
-  showLayersInfoBar: boolean,
-  showInstancesInfoBar: boolean,
   showAdditionalWorkInfoBar: boolean,
   additionalWorkInfoBar: InfoBarDetails,
 
@@ -204,11 +200,7 @@ export default class SceneEditor extends React.Component<Props, State> {
         historyMaxSize: 50,
       }),
 
-      showObjectsListInfoBar: false,
       layoutVariablesDialogOpen: false,
-      showPropertiesInfoBar: false,
-      showLayersInfoBar: false,
-      showInstancesInfoBar: false,
 
       showAdditionalWorkInfoBar: false,
       additionalWorkInfoBar: {
@@ -234,22 +226,32 @@ export default class SceneEditor extends React.Component<Props, State> {
     return this.state.instancesEditorSettings;
   }
 
-  updateToolbar() {
+  updateToolbar = () => {
+    const openedEditorNames = this.editorMosaic
+      ? this.editorMosaic.getOpenedEditorNames()
+      : [];
     this.props.setToolbar(
       <Toolbar
         instancesSelection={this.instancesSelection}
         openObjectsList={this.openObjectsList}
+        isObjectsListShown={openedEditorNames.includes('objects-list')}
         openObjectGroupsList={this.openObjectGroupsList}
+        isObjectGroupsListShown={openedEditorNames.includes(
+          'object-groups-list'
+        )}
         openProperties={this.openProperties}
+        isPropertiesShown={openedEditorNames.includes('properties')}
         deleteSelection={this.deleteSelection}
-        toggleInstancesList={this.toggleInstancesList}
-        toggleLayersList={this.toggleLayersList}
+        openInstancesList={this.openInstancesList}
+        isInstancesListShown={openedEditorNames.includes('instances-list')}
+        openLayersList={this.openLayersList}
+        isLayersListShown={openedEditorNames.includes('layers-list')}
         toggleWindowMask={this.toggleWindowMask}
-        toggleGrid={this.toggleGrid}
-        isGridShown={() => !!this.state.instancesEditorSettings.grid}
         isWindowMaskShown={() =>
           !!this.state.instancesEditorSettings.windowMask
         }
+        toggleGrid={this.toggleGrid}
+        isGridShown={() => !!this.state.instancesEditorSettings.grid}
         openSetupGrid={this.openSetupGrid}
         setZoomFactor={this.setZoomFactor}
         getContextMenuZoomItems={this.getContextMenuZoomItems}
@@ -263,7 +265,7 @@ export default class SceneEditor extends React.Component<Props, State> {
         onRenameObject={this._startRenamingSelectedObject}
       />
     );
-  }
+  };
 
   // To be updated, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops.
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
@@ -281,20 +283,12 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   openObjectsList = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('objects-list', 'end', 75, 'column')) {
-      this.setState({
-        showObjectsListInfoBar: true,
-      });
-    }
+    this.editorMosaic.openEditor('objects-list', 'end', 75, 'column');
   };
 
   openProperties = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('properties', 'start', 25, 'column')) {
-      this.setState({
-        showPropertiesInfoBar: true,
-      });
-    }
+    this.editorMosaic.openEditor('properties', 'start', 25, 'column');
   };
 
   openObjectGroupsList = () => {
@@ -302,22 +296,14 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.editorMosaic.openEditor('object-groups-list', 'end', 75, 'column');
   };
 
-  toggleInstancesList = () => {
+  openInstancesList = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('instances-list', 'end', 75, 'row')) {
-      this.setState({
-        showInstancesInfoBar: true,
-      });
-    }
+    this.editorMosaic.openEditor('instances-list', 'end', 75, 'row');
   };
 
-  toggleLayersList = () => {
+  openLayersList = () => {
     if (!this.editorMosaic) return;
-    if (!this.editorMosaic.openEditor('layers-list', 'end', 75, 'row')) {
-      this.setState({
-        showLayersInfoBar: true,
-      });
-    }
+    this.editorMosaic.openEditor('layers-list', 'end', 75, 'row');
   };
 
   toggleWindowMask = () => {
@@ -1601,6 +1587,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                       : getDefaultEditorMosaicNode('scene-editor') ||
                         initialMosaicEditorNodes
                   }
+                  onOpenedEditorsChanged={this.updateToolbar}
                   onPersistNodes={node =>
                     setDefaultEditorMosaicNode(
                       windowWidth === 'small'
@@ -1708,45 +1695,6 @@ export default class SceneEditor extends React.Component<Props, State> {
             </Trans>
           }
           show={!!this.state.selectedObjectsWithContext.length}
-        />
-        <DismissableInfoBar
-          identifier="objects-panel-explanation"
-          message={
-            <Trans>
-              Objects panel is already opened: use it to add and edit objects.
-            </Trans>
-          }
-          show={!!this.state.showObjectsListInfoBar}
-        />
-        <DismissableInfoBar
-          identifier="instance-properties-panel-explanation"
-          message={
-            <Trans>
-              Properties panel is already opened. After selecting an instance on
-              the scene, inspect and change its properties from this panel.
-            </Trans>
-          }
-          show={!!this.state.showPropertiesInfoBar}
-        />
-        <DismissableInfoBar
-          identifier="layers-panel-explanation"
-          message={
-            <Trans>
-              Layers panel is already opened. You can add new layers and apply
-              effects on them from this panel.
-            </Trans>
-          }
-          show={!!this.state.showLayersInfoBar}
-        />
-        <DismissableInfoBar
-          identifier="instances-panel-explanation"
-          message={
-            <Trans>
-              Instances panel is already opened. You can search instances in the
-              scene and click one to move the view to it.
-            </Trans>
-          }
-          show={!!this.state.showInstancesInfoBar}
         />
         {this.state.setupGridOpen && (
           <SetupGridDialog

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -218,14 +218,7 @@ export default class EditorMosaic extends React.Component<Props, State> {
     const openedEditorNames = getLeaves(this.state.mosaicNode);
     if (openedEditorNames.indexOf(editorName) !== -1) {
       // The editor is already opened: close it.
-      this.setState(
-        {
-          mosaicNode: removeNode(this.state.mosaicNode, editorName),
-        },
-        () => {
-          this._onOpenedEditorsChanged();
-        }
-      );
+      this._onChanged(removeNode(this.state.mosaicNode, editorName));
 
       return false;
     }
@@ -256,17 +249,8 @@ export default class EditorMosaic extends React.Component<Props, State> {
         editorName => editors[editorName].type === 'secondary'
       );
       if (secondaryEditorName) {
-        this.setState(
-          {
-            mosaicNode: replaceNode(
-              this.state.mosaicNode,
-              secondaryEditorName,
-              editorName
-            ),
-          },
-          () => {
-            this._onOpenedEditorsChanged();
-          }
+        this._onChanged(
+          replaceNode(this.state.mosaicNode, secondaryEditorName, editorName)
         );
 
         return true;
@@ -274,19 +258,14 @@ export default class EditorMosaic extends React.Component<Props, State> {
     }
 
     // Open a new editor at the indicated position.
-    this.setState(
-      {
-        mosaicNode: addNode(
-          this.state.mosaicNode,
-          editorName,
-          position,
-          splitPercentage,
-          direction
-        ),
-      },
-      () => {
-        this._onOpenedEditorsChanged();
-      }
+    this._onChanged(
+      addNode(
+        this.state.mosaicNode,
+        editorName,
+        position,
+        splitPercentage,
+        direction
+      )
     );
 
     return true;
@@ -300,7 +279,7 @@ export default class EditorMosaic extends React.Component<Props, State> {
     this.setState({ mosaicNode });
   };
 
-  _onChanged = (mosaicNode: EditorMosaicNode) => {
+  _onChanged = (mosaicNode: ?EditorMosaicNode) => {
     this.setState({ mosaicNode }, () => {
       this._onOpenedEditorsChanged();
     });

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -127,6 +127,36 @@ const replaceNode = (
   }
 };
 
+// Remove the specified node (editor).
+const removeNode = (
+  currentNode: ?EditorMosaicNode,
+  oldNode: ?EditorMosaicNode
+): ?EditorMosaicNode => {
+  if (!currentNode) {
+    return currentNode;
+  } else if (typeof currentNode === 'string') {
+    if (currentNode === oldNode) return null;
+
+    return currentNode;
+  } else {
+    if (currentNode === oldNode) return null;
+
+    const first = removeNode(currentNode.first, oldNode);
+    const second = removeNode(currentNode.second, oldNode);
+
+    if (first && second) {
+      return {
+        ...currentNode,
+        first,
+        second,
+      };
+    } else {
+      if (!first) return second;
+      else return first;
+    }
+  }
+};
+
 const defaultToolbarControls = [<CloseButton key="close" />];
 
 const renderMosaicWindowPreview = props => (
@@ -176,6 +206,33 @@ export default class EditorMosaic extends React.Component<Props, State> {
     mosaicNode: this.props.initialNodes,
   };
 
+  toggleEditor = (
+    editorName: string,
+    position: 'start' | 'end',
+    splitPercentage: number,
+    direction: 'row' | 'column'
+  ) => {
+    const editor = this.props.editors[editorName];
+    if (!editor) return false;
+
+    const openedEditorNames = getLeaves(this.state.mosaicNode);
+    if (openedEditorNames.indexOf(editorName) !== -1) {
+      // The editor is already opened: close it.
+      this.setState(
+        {
+          mosaicNode: removeNode(this.state.mosaicNode, editorName),
+        },
+        () => {
+          this._onOpenedEditorsChanged();
+        }
+      );
+
+      return false;
+    }
+
+    return this.openEditor(editorName, position, splitPercentage, direction);
+  };
+
   openEditor = (
     editorName: string,
     position: 'start' | 'end',
@@ -189,6 +246,7 @@ export default class EditorMosaic extends React.Component<Props, State> {
 
     const openedEditorNames = getLeaves(this.state.mosaicNode);
     if (openedEditorNames.indexOf(editorName) !== -1) {
+      // Editor is already opened.
       return false;
     }
 

--- a/newIDE/app/src/UI/HelpIcon/__snapshots__/HelpIcon.spec.js.snap
+++ b/newIDE/app/src/UI/HelpIcon/__snapshots__/HelpIcon.spec.js.snap
@@ -4,7 +4,7 @@ exports[`HelpIcon renders nothing if the helpPagePath is empty 1`] = `null`;
 
 exports[`HelpIcon renders the icon linking to a help page 1`] = `
 <button
-  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary"
+  className="MuiButtonBase-root MuiIconButton-root makeStyles-root-1 makeStyles-root-3 MuiIconButton-colorSecondary"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
@@ -22,7 +22,7 @@ exports[`HelpIcon renders the icon linking to a help page 1`] = `
   type="button"
 >
   <span
-    className="MuiIconButton-label"
+    className="MuiIconButton-label makeStyles-label-2 makeStyles-label-4"
   >
     <svg
       aria-hidden={true}

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -6,6 +6,8 @@ import { I18n } from '@lingui/react';
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 import { adaptAcceleratorString } from '../UI/AcceleratorString';
 import { tooltipEnterDelay } from './Tooltip';
+import GDevelopThemeContext from './Theme/GDevelopThemeContext';
+import { makeStyles } from '@material-ui/core/styles';
 
 type IconProps =
   | {|
@@ -29,6 +31,7 @@ type Props = {|
   target?: string,
   onContextMenu?: () => void,
   disabled?: boolean,
+  selected?: boolean,
   edge?: 'start' | 'end' | false,
   id?: string,
 
@@ -57,46 +60,67 @@ type Props = {|
   color?: 'default',
 |};
 
+const useStyles = makeStyles({
+  root: (props) => props.color ? {
+    color: props.color,
+  } : undefined,
+  label: (props) => props.backgroundColor ? {
+    backgroundColor: props.backgroundColor,
+    borderRadius: 4,
+  } : undefined,
+});
+
 /**
  * A button showing just an icon, based on Material-UI icon button.
  * Supports displaying a tooltip.
  */
-export default class IconButton extends React.Component<Props, {||}> {
-  render() {
-    const {
-      tooltip,
-      acceleratorString,
-      color,
-      style,
-      ...otherProps
-    } = this.props;
-    const iconButton = (
-      <MUIIconButton
-        {...otherProps}
-        style={style}
-        color={color || 'secondary'}
-      />
-    );
 
-    return tooltip && !this.props.disabled ? (
-      <I18n>
-        {({ i18n }) => (
-          <Tooltip
-            title={
-              i18n._(tooltip) +
-              (acceleratorString
-                ? ' ' + adaptAcceleratorString(acceleratorString)
-                : '')
-            }
-            placement="bottom"
-            enterDelay={tooltipEnterDelay}
-          >
-            {iconButton}
-          </Tooltip>
-        )}
-      </I18n>
-    ) : (
-      iconButton
-    );
-  }
-}
+const IconButton = React.forwardRef<Props, {||}>((props: Props, ref) => {
+  const {
+    selected,
+    tooltip,
+    acceleratorString,
+    color,
+    style,
+    ...otherProps
+  } = props;
+
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
+  const classes = useStyles({
+    color: selected ? gdevelopTheme.toolbar.backgroundColor : undefined,
+    backgroundColor: selected ? gdevelopTheme.iconButton.selectedBackgroundColor : undefined,
+  })
+
+  const iconButton = (
+    <MUIIconButton
+      {...otherProps}
+      classes={classes}
+      style={style}
+      color={selected ? 'inherit' : color || 'secondary'}
+      ref={ref}
+    />
+  );
+
+  return tooltip && !props.disabled ? (
+    <I18n>
+      {({ i18n }) => (
+        <Tooltip
+          title={
+            i18n._(tooltip) +
+            (acceleratorString
+              ? ' ' + adaptAcceleratorString(acceleratorString)
+              : '')
+          }
+          placement="bottom"
+          enterDelay={tooltipEnterDelay}
+        >
+          {iconButton}
+        </Tooltip>
+      )}
+    </I18n>
+  ) : (
+    iconButton
+  );
+});
+
+export default IconButton;

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -61,13 +61,19 @@ type Props = {|
 |};
 
 const useStyles = makeStyles({
-  root: (props) => props.color ? {
-    color: props.color,
-  } : undefined,
-  label: (props) => props.backgroundColor ? {
-    backgroundColor: props.backgroundColor,
-    borderRadius: 4,
-  } : undefined,
+  root: props =>
+    props.color
+      ? {
+          color: props.color,
+        }
+      : undefined,
+  label: props =>
+    props.backgroundColor
+      ? {
+          backgroundColor: props.backgroundColor,
+          borderRadius: 4,
+        }
+      : undefined,
 });
 
 /**
@@ -88,8 +94,10 @@ const IconButton = React.forwardRef<Props, {||}>((props: Props, ref) => {
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const classes = useStyles({
     color: selected ? gdevelopTheme.toolbar.backgroundColor : undefined,
-    backgroundColor: selected ? gdevelopTheme.iconButton.selectedBackgroundColor : undefined,
-  })
+    backgroundColor: selected
+      ? gdevelopTheme.iconButton.selectedBackgroundColor
+      : undefined,
+  });
 
   const iconButton = (
     <MUIIconButton

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -93,7 +93,8 @@ const IconButton = React.forwardRef<Props, {||}>((props: Props, ref) => {
 
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const classes = useStyles({
-    color: selected ? gdevelopTheme.toolbar.backgroundColor : undefined,
+    // Override Material-UI colors only when the button is selected.
+    color: selected ? gdevelopTheme.iconButton.selectedColor : undefined,
     backgroundColor: selected
       ? gdevelopTheme.iconButton.selectedBackgroundColor
       : undefined,

--- a/newIDE/app/src/UI/Theme/BlueDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/BlueDarkTheme/theme.json
@@ -65,6 +65,10 @@
     },
     "icon-button": {
       "selected": {
+        "color": {
+          "value": "#25252E",
+          "comment": "Palette/Grey/90"
+        },
         "background-color": {
           "value": "#6BAFFF",
           "comment": "Palette/Blue/40"

--- a/newIDE/app/src/UI/Theme/BlueDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/BlueDarkTheme/theme.json
@@ -63,6 +63,14 @@
         }
       }
     },
+    "icon-button": {
+      "selected": {
+        "background-color": {
+          "value": "#6BAFFF",
+          "comment": "Palette/Blue/40"
+        }
+      }
+    },
     "link": {
       "color": {
         "value": "#008DFF"

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -589,6 +589,9 @@ export function createGdevelopTheme({
       emptyMessage: {
         shadowColor: styles['ThemeMessageEmptyShadowColor'],
       },
+      iconButton: {
+        selectedBackgroundColor: styles['ThemeIconButtonSelectedBackgroundColor'],
+      },
       ...getRootClassNames(rootClassNameIdentifier),
       logo: {
         src: 'res/GD-logo-big.png',

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -590,7 +590,8 @@ export function createGdevelopTheme({
         shadowColor: styles['ThemeMessageEmptyShadowColor'],
       },
       iconButton: {
-        selectedBackgroundColor: styles['ThemeIconButtonSelectedBackgroundColor'],
+        selectedBackgroundColor:
+          styles['ThemeIconButtonSelectedBackgroundColor'],
       },
       ...getRootClassNames(rootClassNameIdentifier),
       logo: {

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -592,6 +592,8 @@ export function createGdevelopTheme({
       iconButton: {
         selectedBackgroundColor:
           styles['ThemeIconButtonSelectedBackgroundColor'],
+        selectedColor:
+          styles['ThemeIconButtonSelectedColor'],
       },
       ...getRootClassNames(rootClassNameIdentifier),
       logo: {

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -592,8 +592,7 @@ export function createGdevelopTheme({
       iconButton: {
         selectedBackgroundColor:
           styles['ThemeIconButtonSelectedBackgroundColor'],
-        selectedColor:
-          styles['ThemeIconButtonSelectedColor'],
+        selectedColor: styles['ThemeIconButtonSelectedColor'],
       },
       ...getRootClassNames(rootClassNameIdentifier),
       logo: {

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -170,9 +170,13 @@
     },
     "icon-button": {
       "selected": {
+        "color": {
+          "value": "#1D1D26",
+          "comment": "Palette/Grey/100"
+        },
         "background-color": {
-          "value": "#DDD1FF",
-          "comment:": "Palette/Purple/10"
+          "value": "#C9B6FC",
+          "comment:": "Palette/Purple/20"
         }
       }
     },

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -168,6 +168,14 @@
         }
       }
     },
+    "icon-button": {
+      "selected": {
+        "background-color": {
+          "value": "#DDD1FF",
+          "comment:": "Palette/Purple/10"
+        }
+      }
+    },
     "link": {
       "color": {
         "value": "#DDD1FF",

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -153,6 +153,14 @@
         }
       }
     },
+    "icon-button": {
+      "selected": {
+        "background-color": {
+          "value": "#7046EC",
+          "comment:": "Palette/Purple/40"
+        }
+      }
+    },
     "link": {
       "color": {
         "value": "#7046EC",

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -155,9 +155,13 @@
     },
     "icon-button": {
       "selected": {
+        "color": {
+          "value": "#1D1D26",
+          "comment": "Palette/Grey/100"
+        },
         "background-color": {
-          "value": "#7046EC",
-          "comment:": "Palette/Purple/40"
+          "value": "#DDD1FF",
+          "comment:": "Palette/Purple/10"
         }
       }
     },

--- a/newIDE/app/src/UI/Theme/NordTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/NordTheme/theme.json
@@ -61,6 +61,9 @@
     },
     "icon-button": {
       "selected": {
+        "color": {
+          "value": "#3B4252"
+        },
         "background-color": {
           "value": "#88C0D0"
         }

--- a/newIDE/app/src/UI/Theme/NordTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/NordTheme/theme.json
@@ -59,6 +59,13 @@
         }
       }
     },
+    "icon-button": {
+      "selected": {
+        "background-color": {
+          "value": "#88C0D0"
+        }
+      }
+    },
     "link": {
       "color": {
         "value": "#7EA1CC"

--- a/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
@@ -73,6 +73,10 @@
     },
     "icon-button": {
       "selected": {
+        "color": {
+          "value": "#25252E",
+          "comment": "Palette/Grey/90"
+        },
         "background-color": {
           "value": "#56B6C2"
         }

--- a/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
@@ -71,6 +71,13 @@
         }
       }
     },
+    "icon-button": {
+      "selected": {
+        "background-color": {
+          "value": "#56B6C2"
+        }
+      }
+    },
     "link": {
       "color": {
         "value": "#81CFFF"

--- a/newIDE/app/src/UI/Theme/RosePineTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/RosePineTheme/theme.json
@@ -60,6 +60,9 @@
       }
     },
     "icon-button": {
+      "color": {
+        "value": "#1f1d2e"
+      },
       "selected": {
         "background-color": {
           "value": "#ebbcba"

--- a/newIDE/app/src/UI/Theme/RosePineTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/RosePineTheme/theme.json
@@ -59,6 +59,13 @@
         }
       }
     },
+    "icon-button": {
+      "selected": {
+        "background-color": {
+          "value": "#ebbcba"
+        }
+      }
+    },
     "link": {
       "color": {
         "value": "#E4C7FF"

--- a/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
@@ -61,6 +61,9 @@
       }
     },
     "icon-button": {
+      "color": {
+        "value": "#002B36"
+      },
       "selected": {
         "background-color": {
           "value": "#2799b9"

--- a/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
@@ -60,6 +60,13 @@
         }
       }
     },
+    "icon-button": {
+      "selected": {
+        "background-color": {
+          "value": "#2799b9"
+        }
+      }
+    },
     "link": {
       "color": {
         "value": "#249AC6"

--- a/newIDE/app/src/stories/EditorMosaicPlayground.js
+++ b/newIDE/app/src/stories/EditorMosaicPlayground.js
@@ -31,7 +31,7 @@ export default ({ renderButtons, renderEditorMosaic }: Props) => {
     direction: 'column' | 'row'
   ) => {
     if (editorRef.current)
-      editorRef.current.openEditor(
+      editorRef.current.toggleEditor(
         editorName,
         position,
         slipPercentage,

--- a/newIDE/app/src/stories/componentStories/MainFrameToolbar.stories.js
+++ b/newIDE/app/src/stories/componentStories/MainFrameToolbar.stories.js
@@ -31,6 +31,9 @@ const fakeEditorToolbar = (
     <IconButton size="small" tooltip={'Test tooltip'} color="default">
       <DebugIcon />
     </IconButton>
+    <IconButton size="small" tooltip={'Test tooltip'} color="default" selected>
+      <DebugIcon />
+    </IconButton>
     <IconButton size="small" tooltip={'Test tooltip'} disabled color="default">
       <DebugIcon />
     </IconButton>

--- a/newIDE/app/src/stories/componentStories/UI/Buttons.stories.js
+++ b/newIDE/app/src/stories/componentStories/UI/Buttons.stories.js
@@ -213,20 +213,28 @@ export const Default = () => (
           <IconButton>
             <Brush />
           </IconButton>
-          <IconButton>
-            <Brush fontSize="small" />
+          <IconButton selected>
+            <Brush />
           </IconButton>
           <IconButton>
             <Delete />
           </IconButton>
           <IconButton>
-            <Delete fontSize="small" />
-          </IconButton>
-          <IconButton>
             <AddCircle />
           </IconButton>
-          <IconButton>
-            <AddCircle fontSize="small" />
+        </Line>
+        <Line>
+          <IconButton size="small">
+            <Brush />
+          </IconButton>
+          <IconButton size="small" selected>
+            <Brush />
+          </IconButton>
+          <IconButton size="small">
+            <Delete />
+          </IconButton>
+          <IconButton size="small">
+            <AddCircle />
           </IconButton>
         </Line>
       </Column>
@@ -237,19 +245,27 @@ export const Default = () => (
             <Home />
           </IconButton>
           <IconButton>
-            <Home fontSize="small" />
-          </IconButton>
-          <IconButton>
             <Cut />
-          </IconButton>
-          <IconButton>
-            <Cut fontSize="small" />
           </IconButton>
           <IconButton>
             <Crown />
           </IconButton>
-          <IconButton>
-            <Crown fontSize="small" />
+          <IconButton selected>
+            <Crown />
+          </IconButton>
+        </Line>
+        <Line>
+          <IconButton size="small">
+            <Home />
+          </IconButton>
+          <IconButton size="small">
+            <Cut />
+          </IconButton>
+          <IconButton size="small">
+            <Crown />
+          </IconButton>
+          <IconButton size="small" selected>
+            <Crown />
           </IconButton>
         </Line>
       </Column>

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -2073,6 +2073,7 @@ storiesOf('DebuggerContent', module)
           profilerOutput={profilerOutputsTestData}
           profilingInProgress={false}
           logsManager={consoleTestData}
+          onOpenedEditorsChanged={() => {}}
         />
       </FixedHeightFlexContainer>
     </DragAndDropContextProvider>
@@ -2092,6 +2093,7 @@ storiesOf('DebuggerContent', module)
           profilerOutput={profilerOutputsTestData}
           profilingInProgress={true}
           logsManager={consoleTestData}
+          onOpenedEditorsChanged={() => {}}
         />
       </FixedHeightFlexContainer>
     </DragAndDropContextProvider>


### PR DESCRIPTION

<img width="814" alt="image" src="https://user-images.githubusercontent.com/1280130/221567324-dd9773c1-bd34-43c2-a4a4-b3cd871f609d.png">


<img width="810" alt="image" src="https://user-images.githubusercontent.com/1280130/221567234-819ef4b2-70b2-44a6-91d4-1bfd0221d86e.png">
<img width="808" alt="image" src="https://user-images.githubusercontent.com/1280130/221567462-42a9309e-cef1-43ad-abe7-b0051080ad0f.png">
<img width="814" alt="image" src="https://user-images.githubusercontent.com/1280130/221567546-13fe3914-8c7d-4775-8f40-4c70d20adb59.png">


Also:
- Also remove the useless tooltips explaining that the editor is opened - the highlighting does this job.
- Allow buttons to toggle the editors
- And this also in the debugger and resources editor.

Stories:
- https://gdevelop-storybook.s3.amazonaws.com/feature/selected-toolbar-icons/latest/index.html?path=/story/ui-building-blocks-buttons--default
- https://gdevelop-storybook.s3.amazonaws.com/feature/selected-toolbar-icons/latest/index.html?path=/story/mainframetoolbar--project-open-with-fake-buttons