### PR TITLE
Move the filter button and panel in the assets store

### DIFF
--- a/newIDE/app/src/AssetStore/AssetCard.js
+++ b/newIDE/app/src/AssetStore/AssetCard.js
@@ -36,6 +36,7 @@ const styles = {
   cardContainer: {
     overflow: 'hidden',
     position: 'relative',
+    borderRadius: 8,
   },
   titleContainer: {
     position: 'absolute',

--- a/newIDE/app/src/AssetStore/AssetDetails.js
+++ b/newIDE/app/src/AssetStore/AssetDetails.js
@@ -543,6 +543,7 @@ export const AssetDetails = React.forwardRef<Props, AssetDetailsInterface>(
                   onRetry={fetchAssetsAndFilters}
                   error={filterError}
                   searchItems={truncatedSearchResults}
+                  spacing={8}
                   renderSearchItem={(assetShortHeader, size) => (
                     <AssetCard
                       size={size}

--- a/newIDE/app/src/AssetStore/NewObjectFromScratch.js
+++ b/newIDE/app/src/AssetStore/NewObjectFromScratch.js
@@ -109,6 +109,7 @@ export const CustomObjectPackResults = ({
           onRetry={fetchAssetsAndFilters}
           error={error}
           searchItems={selectedAssetPackSearchResults}
+          spacing={8}
           renderSearchItem={(assetShortHeader, size) => (
             <AssetCard
               size={size}

--- a/newIDE/app/src/AssetStore/ResourceStore/index.js
+++ b/newIDE/app/src/AssetStore/ResourceStore/index.js
@@ -88,6 +88,7 @@ export const ResourceStore = ({ onChoose, resourceKind }: Props) => {
         </Column>
         <BoxSearchResults
           baseSize={128}
+          spacing={8}
           onRetry={fetchResourcesAndFilters}
           error={error}
           searchItems={searchResultsForResourceKind}

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -4,7 +4,6 @@ import { t, Trans } from '@lingui/macro';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import Tune from '@material-ui/icons/Tune';
 import SearchBar from '../UI/SearchBar';
-import DoubleChevronArrowLeft from '../UI/CustomSvgIcons/DoubleChevronArrowLeft';
 import { Column, Line, Spacer } from '../UI/Grid';
 import ScrollView from '../UI/ScrollView';
 import Window from '../Utils/Window';
@@ -148,6 +147,15 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       [navigationState]
     );
 
+    const canShowFiltersPanel =
+      !openedAssetShortHeader && // Don't show filters on asset page.
+      !openedPrivateAssetPackListingData && // Don't show filters on private asset pack information page.
+      !(
+        openedAssetPack &&
+        openedAssetPack.content &&
+        // Don't show filters if opened asset pack contains audio only.
+        isAssetPackAudioOnly(openedAssetPack)
+      );
     const assetsHome = React.useRef<?AssetsHomeInterface>(null);
     const boxSearchResults = React.useRef<?BoxSearchResultsInterface>(null);
     const assetDetails = React.useRef<?AssetDetailsInterface>(null);
@@ -471,6 +479,14 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                       id="asset-store-search-bar"
                     />
                   </Column>
+                  <IconButton
+                    onClick={() => setIsFiltersPanelOpen(!isFiltersPanelOpen)}
+                    disabled={!canShowFiltersPanel}
+                    selected={canShowFiltersPanel && isFiltersPanelOpen}
+                    size="small"
+                  >
+                    <Tune />
+                  </IconButton>
                 </LineStackLayout>
                 <Spacer />
                 <Column noMargin>
@@ -538,71 +554,6 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                     'hidden' /* Somehow required on Chrome/Firefox to avoid children growing (but not on Safari) */
                   }
                 >
-                  {!openedAssetShortHeader && // Don't show filters on asset page.
-                  !openedPrivateAssetPackListingData && // Don't show filters on private asset pack information page.
-                    !(
-                      openedAssetPack &&
-                      openedAssetPack.content &&
-                      // Don't show filters if opened asset pack contains audio only.
-                      isAssetPackAudioOnly(openedAssetPack)
-                    ) && (
-                      <Column noMargin>
-                        <ScrollView>
-                          <Paper
-                            style={{
-                              width: !isFiltersPanelOpen
-                                ? 50
-                                : windowWidth === 'small'
-                                ? 205
-                                : 250,
-                            }}
-                            background="medium"
-                          >
-                            {!isFiltersPanelOpen ? (
-                              <Line justifyContent="center">
-                                <IconButton
-                                  onClick={() => setIsFiltersPanelOpen(true)}
-                                >
-                                  <Tune />
-                                </IconButton>
-                              </Line>
-                            ) : (
-                              <>
-                                <Line
-                                  justifyContent="space-between"
-                                  alignItems="center"
-                                >
-                                  <Column noMargin>
-                                    <Line alignItems="center">
-                                      <Tune />
-                                      <Subheader>
-                                        <Trans>Object filters</Trans>
-                                      </Subheader>
-                                    </Line>
-                                  </Column>
-                                  <IconButton
-                                    onClick={() => setIsFiltersPanelOpen(false)}
-                                  >
-                                    <DoubleChevronArrowLeft />
-                                  </IconButton>
-                                </Line>
-                                <Line
-                                  justifyContent="space-between"
-                                  alignItems="center"
-                                >
-                                  <AssetStoreFilterPanel
-                                    assetFiltersState={assetFiltersState}
-                                    onChoiceChange={() => {
-                                      navigationState.openSearchResultPage();
-                                    }}
-                                  />
-                                </Line>
-                              </>
-                            )}
-                          </Paper>
-                        </ScrollView>
-                      </Column>
-                    )}
                   {isOnHomePage ? (
                     error ? (
                       <PlaceholderError onRetry={fetchAssetsAndFilters}>
@@ -636,6 +587,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                       onRetry={fetchAssetsAndFilters}
                       error={error}
                       searchItems={searchResults}
+                      spacing={8}
                       renderSearchItem={(assetShortHeader, size) => (
                         <AssetCard
                           size={size}
@@ -707,6 +659,43 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                       }
                       onSuccessfulPurchase={onPurchaseSuccessful}
                     />
+                  )}
+                  {isFiltersPanelOpen && canShowFiltersPanel && (
+                    <Paper
+                      style={{
+                        display: 'flex',
+                        width: !isFiltersPanelOpen
+                          ? 50
+                          : windowWidth === 'small'
+                          ? 205
+                          : 250,
+                      }}
+                      background="medium"
+                    >
+                      <ScrollView>
+                        <Column>
+                          <Column noMargin>
+                            <Line alignItems="center">
+                              <Tune />
+                              <Subheader>
+                                <Trans>Object filters</Trans>
+                              </Subheader>
+                            </Line>
+                          </Column>
+                          <Line
+                            justifyContent="space-between"
+                            alignItems="center"
+                          >
+                            <AssetStoreFilterPanel
+                              assetFiltersState={assetFiltersState}
+                              onChoiceChange={() => {
+                                navigationState.openSearchResultPage();
+                              }}
+                            />
+                          </Line>
+                        </Column>
+                      </ScrollView>
+                    </Paper>
                   )}
                 </Line>
               </Column>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -49,9 +49,9 @@ import AlertMessage from '../UI/AlertMessage';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import PrivateAssetPackPurchaseDialog from './PrivateAssets/PrivateAssetPackPurchaseDialog';
 import { LineStackLayout } from '../UI/Layout';
-import Paper from '../UI/Paper';
 import { isHomePage, isSearchResultPage } from './AssetStoreNavigator';
 import RaisedButton from '../UI/RaisedButton';
+import { ResponsivePaperOrDrawer } from '../UI/ResponsivePaperOrDrawer';
 import PrivateAssetsAuthorizationContext from './PrivateAssets/PrivateAssetsAuthorizationContext';
 import Music from '../UI/CustomSvgIcons/Music';
 
@@ -660,17 +660,10 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                       onSuccessfulPurchase={onPurchaseSuccessful}
                     />
                   )}
-                  {isFiltersPanelOpen && canShowFiltersPanel && (
-                    <Paper
-                      style={{
-                        display: 'flex',
-                        width: !isFiltersPanelOpen
-                          ? 50
-                          : windowWidth === 'small'
-                          ? 205
-                          : 250,
-                      }}
-                      background="medium"
+                  {canShowFiltersPanel && (
+                    <ResponsivePaperOrDrawer
+                      onClose={() => setIsFiltersPanelOpen(false)}
+                      open={isFiltersPanelOpen}
                     >
                       <ScrollView>
                         <Column>
@@ -695,7 +688,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                           </Line>
                         </Column>
                       </ScrollView>
-                    </Paper>
+                    </ResponsivePaperOrDrawer>
                   )}
                 </Line>
               </Column>

--- a/newIDE/app/src/UI/ResponsivePaperOrDrawer.js
+++ b/newIDE/app/src/UI/ResponsivePaperOrDrawer.js
@@ -1,0 +1,58 @@
+// @flow
+import * as React from 'react';
+import Paper from './Paper';
+import { useResponsiveWindowWidth } from './Reponsive/ResponsiveWindowMeasurer';
+import Drawer from '@material-ui/core/Drawer';
+
+const styles = {
+  paper: {
+    display: 'flex',
+    width: 250,
+  },
+  drawerPaper: {
+    display: 'flex',
+  },
+};
+
+const drawerPaperProps = {
+  style: styles.drawerPaper,
+};
+
+const drawerModalProps = {
+  keepMounted: true,
+};
+
+/**
+ * Display a Paper element, for medium/large screens, or a Drawer on small screens.
+ */
+export const ResponsivePaperOrDrawer = ({
+  open,
+  onClose,
+  children,
+}: {|
+  open: boolean,
+  onClose: () => void,
+  children: React.Node,
+|}) => {
+  const windowWidth = useResponsiveWindowWidth();
+  if (windowWidth !== 'small') {
+    if (!open) return null;
+    return (
+      <Paper style={styles.paper} background="medium">
+        {children}
+      </Paper>
+    );
+  }
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={drawerPaperProps}
+      ModalProps={drawerModalProps}
+    >
+      {children}
+    </Drawer>
+  );
+};

--- a/newIDE/app/src/UI/Search/BoxSearchResults.js
+++ b/newIDE/app/src/UI/Search/BoxSearchResults.js
@@ -10,6 +10,7 @@ import EmptyMessage from '../EmptyMessage';
 type Props<SearchItem> = {|
   searchItems: ?Array<SearchItem>,
   renderSearchItem: (item: SearchItem, size: number) => React.Node,
+  spacing: number,
   error: ?Error,
   onRetry: () => void,
   baseSize: number,
@@ -38,6 +39,7 @@ export const BoxSearchResults = React.forwardRef<
     {
       searchItems,
       renderSearchItem,
+      spacing,
       error,
       onRetry,
       baseSize,
@@ -125,9 +127,18 @@ export const BoxSearchResults = React.forwardRef<
                     : null;
 
                 return (
-                  <div key={key} style={style}>
+                  <div
+                    key={key}
+                    style={{
+                      ...style,
+                      left: style.left + spacing / 2,
+                      top: style.top + spacing / 2,
+                      width: style.width - spacing,
+                      height: style.height - spacing,
+                    }}
+                  >
                     {searchItem
-                      ? renderSearchItem(searchItem, columnWidth)
+                      ? renderSearchItem(searchItem, columnWidth - spacing)
                       : null}
                   </div>
                 );


### PR DESCRIPTION
* Move the button next to the search bar, and the panel to the right.
  * This allows the button to not take valuable space on a small screen where the width is limited.
* Also add some spacing and rounded borders to the assets.

<img width="931" alt="image" src="https://user-images.githubusercontent.com/1280130/221976818-a50542d9-677f-439e-9ab6-f29f907d6bec.png">
<img width="437" alt="image" src="https://user-images.githubusercontent.com/1280130/221976903-a3a96dc5-16d8-4d0d-b56b-c62b793f4155.png">
<img width="608" alt="image" src="https://user-images.githubusercontent.com/1280130/221989911-f01c3acd-566e-4203-a0f5-3a1b01843ce4.png">
