### PR TITLE
Prevent in app tutorial tooltip from overflowing

### DIFF
--- a/newIDE/app/src/InAppTutorial/InAppTutorialTooltipDisplayer.js
+++ b/newIDE/app/src/InAppTutorial/InAppTutorialTooltipDisplayer.js
@@ -325,6 +325,10 @@ const InAppTutorialTooltipDisplayer = ({
               enabled: true,
               offset: '0,10',
             },
+            preventOverflow: {
+              enabled: true,
+              boundariesElement: document.querySelector('.main-frame'),
+            },
           },
         }}
         style={{


### PR DESCRIPTION
## Before

<img width="572" alt="image" src="https://user-images.githubusercontent.com/32449369/222135806-4133f4b8-0203-467a-996d-36e3bfbba0d7.png">

## After

<img width="495" alt="image" src="https://user-images.githubusercontent.com/32449369/222135744-ff726917-dbde-456c-9aba-b02a63a2dd29.png">
