### PR TITLE
Fix extension renaming

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsProvider.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsProvider.js
@@ -118,7 +118,7 @@ export default class EventsFunctionsExtensionsProvider extends React.Component<
         });
         showErrorBox({
           message: i18n._(
-            t`An error has occured during functions generation. If GDevelop is installed, verify that nothing is preventing GDevelop from writing on disk. If you're running GDevelop online, verify your internet connection and refresh functions from the Project Manager.`
+            t`An error has occurred during functions generation. If GDevelop is installed, verify that nothing is preventing GDevelop from writing on disk. If you're running GDevelop online, verify your internet connection and refresh functions from the Project Manager.`
           ),
           rawError: eventsFunctionsExtensionsError,
           errorId: 'events-functions-extensions-load-error',

--- a/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
@@ -111,6 +111,13 @@ export class EventsFunctionsExtensionEditorContainer extends React.Component<Ren
     return project.getEventsFunctionsExtension(projectItemName);
   }
 
+  getEventsFunctionsExtensionName(): ?string {
+    const { project, projectItemName } = this.props;
+    if (!project || !projectItemName) return null;
+
+    return projectItemName;
+  }
+
   selectEventsFunctionByName(
     eventsFunctionName: string,
     behaviorName: ?string

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -270,14 +270,15 @@ export const closeExternalEventsTabs = (
 
 export const closeEventsFunctionsExtensionTabs = (
   state: EditorTabsState,
-  eventsFunctionsExtension: gdEventsFunctionsExtension
+  eventsFunctionsExtensionName: string
 ) => {
   return closeTabsExceptIf(state, editorTab => {
     const editor = editorTab.editorRef;
     if (editor instanceof EventsFunctionsExtensionEditorContainer) {
       return (
-        !editor.getEventsFunctionsExtension() ||
-        editor.getEventsFunctionsExtension() !== eventsFunctionsExtension
+        !editor.getEventsFunctionsExtensionName() ||
+        editor.getEventsFunctionsExtensionName() !==
+          eventsFunctionsExtensionName
       );
     }
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -979,15 +979,11 @@ const MainFrame = (props: Props) => {
         eventsFunctionsExtensionName
       )
     ) {
-      const eventsFunctionsExtension = currentProject.getEventsFunctionsExtension(
-        eventsFunctionsExtensionName
-      );
-
       setState(state => ({
         ...state,
         editorTabs: closeEventsFunctionsExtensionTabs(
           state.editorTabs,
-          eventsFunctionsExtension
+          eventsFunctionsExtensionName
         ),
       }));
     }
@@ -1073,16 +1069,16 @@ const MainFrame = (props: Props) => {
     );
     if (!answer) return;
 
+    const extensionName = eventsFunctionsExtension.getName();
     setState(state => ({
       ...state,
       editorTabs: closeEventsFunctionsExtensionTabs(
         state.editorTabs,
-        eventsFunctionsExtension
+        extensionName
       ),
     })).then(state => {
       // Unload the Platform extension that was generated from the events
       // functions extension.
-      const extensionName = eventsFunctionsExtension.getName();
       eventsFunctionsExtensionsState.unloadProjectEventsFunctionsExtension(
         currentProject,
         extensionName
@@ -1248,26 +1244,25 @@ const MainFrame = (props: Props) => {
     const eventsFunctionsExtension = currentProject.getEventsFunctionsExtension(
       oldName
     );
+
+    // Refactor the project to update the instructions (and later expressions)
+    // of this extension:
+    gd.WholeProjectRefactorer.renameEventsFunctionsExtension(
+      currentProject,
+      eventsFunctionsExtension,
+      oldName,
+      newName
+    );
+    eventsFunctionsExtension.setName(newName);
+    eventsFunctionsExtensionsState.unloadProjectEventsFunctionsExtension(
+      currentProject,
+      oldName
+    );
+
     setState(state => ({
       ...state,
-      editorTabs: closeEventsFunctionsExtensionTabs(
-        state.editorTabs,
-        eventsFunctionsExtension
-      ),
+      editorTabs: closeEventsFunctionsExtensionTabs(state.editorTabs, oldName),
     })).then(state => {
-      // Refactor the project to update the instructions (and later expressions)
-      // of this extension:
-      gd.WholeProjectRefactorer.renameEventsFunctionsExtension(
-        currentProject,
-        eventsFunctionsExtension,
-        oldName,
-        newName
-      );
-      eventsFunctionsExtension.setName(newName);
-      eventsFunctionsExtensionsState.unloadProjectEventsFunctionsExtension(
-        currentProject,
-        oldName
-      );
       eventsFunctionsExtensionsState.reloadProjectEventsFunctionsExtensions(
         currentProject
       );


### PR DESCRIPTION
* Behaviors of the extension with the old name no longer stay in the list.

### Reproduction steps
* Open an extension in a tab
* Rename this extension
* Change the full name of the behavior (optional)
* Open the “add new behavior panel”

The behavior from the extension that no longer exist is also in the list.

### Solution
* Rename the extension before closing the tab to be sure that the generation triggered by tab change uses the new name.

I'll do other an PR to update extension metadata (without code generation) when a function signature change to avoid the "Unsupported instruction" issues and a 2nd PR to maybe reduce the code generation to only what is necessary (it can mess the order in the UI so the UI must do sort).