### PR TITLE
Fix offset between image and container for small images

### DIFF
--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -416,6 +416,7 @@ const ImagePreview = ({
     width: imageWidth,
     height: imageHeight,
     transformOrigin: '0 0',
+    display: 'flex',
   };
 
   const imageStyle = {


### PR DESCRIPTION
Fixes a bug that introduces an offset between container and image in image preview component, only on small images

Before:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/32449369/222743978-c05d78d3-bf73-4665-9448-1896f8b883f3.png">

After:
<img width="221" alt="image" src="https://user-images.githubusercontent.com/32449369/222744026-e295eb81-02cd-4503-9a03-bc0d4386abd4.png">
