### PR TITLE
Changed text on the button to "Create package for Android"

### DIFF
--- a/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/BrowserExporters/BrowserOnlineCordovaExport.js
@@ -77,7 +77,7 @@ export const browserOnlineCordovaExportPipeline: ExportPipeline<
 
   renderHeader: props => <SetupExportHeader {...props} />,
 
-  renderLaunchButtonLabel: () => <Trans>Packaging for Android</Trans>,
+  renderLaunchButtonLabel: () => <Trans>Create package for Android</Trans>,
 
   prepareExporter: (
     context: ExportPipelineContext<ExportState>

--- a/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalOnlineCordovaExport.js
@@ -74,7 +74,7 @@ export const localOnlineCordovaExportPipeline: ExportPipeline<
 
   renderHeader: props => <SetupExportHeader {...props} />,
 
-  renderLaunchButtonLabel: () => <Trans>Packaging for Android</Trans>,
+  renderLaunchButtonLabel: () => <Trans>Create package for Android</Trans>,
 
   prepareExporter: (
     context: ExportPipelineContext<ExportState>


### PR DESCRIPTION
This button label is ambiguous, it sounds like it might open another window to set the properties of Android packages.
Instead, this button immediately starts creating the package.