### PR TITLE
Improve preview of dragged items

### DIFF
--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
@@ -143,7 +143,7 @@ export function ExampleDialog({
           {hasIcon ? (
             <ExampleThumbnailOrIcon exampleShortHeader={exampleShortHeader} />
           ) : null}
-          <Column>
+          <Column noMargin>
             {
               <Line>
                 <div style={{ flexWrap: 'wrap' }}>
@@ -173,9 +173,11 @@ export function ExampleDialog({
         </ResponsiveLineStackLayout>
 
         {example && example.description && (
-          <Column>
+          <Column noMargin>
             <Divider />
-            <MarkdownText source={example.description} isStandaloneText />
+            <Text size="body" displayInlineAsSpan>
+              <MarkdownText source={example.description} />
+            </Text>
           </Column>
         )}
         {!example && error && (

--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
@@ -173,10 +173,10 @@ export function ExampleDialog({
         </ResponsiveLineStackLayout>
 
         {example && example.description && (
-          <>
+          <Column>
             <Divider />
             <MarkdownText source={example.description} isStandaloneText />
-          </>
+          </Column>
         )}
         {!example && error && (
           <PlaceholderError onRetry={loadExample}>

--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleListItem.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleListItem.js
@@ -108,39 +108,45 @@ export const ExampleListItem = ({
     <div style={styles.container} ref={containerRef}>
       <ResponsiveLineStackLayout noMargin expand>
         <ButtonBase style={styles.button} onClick={onChoose} focusRipple>
-          {!!exampleShortHeader.previewImageUrls.length && (
-            <ExampleThumbnailOrIcon exampleShortHeader={exampleShortHeader} />
-          )}
-          <Column expand>
-            <Text noMargin>{renderExampleField('name')} </Text>
-            {
-              <Line>
-                <div style={{ flexWrap: 'wrap' }}>
-                  {exampleShortHeader.difficultyLevel && (
-                    <ExampleDifficultyChip
-                      difficultyLevel={exampleShortHeader.difficultyLevel}
-                    />
-                  )}
-                  {exampleShortHeader.codeSizeLevel && (
-                    <ExampleSizeChip
-                      codeSizeLevel={exampleShortHeader.codeSizeLevel}
-                    />
-                  )}
-                  {exampleShortHeader.authors &&
-                    exampleShortHeader.authors.map(author => (
-                      <UserPublicProfileChip user={author} key={author.id} />
-                    ))}
-                </div>
-              </Line>
-            }
-            <Text
-              noMargin
-              size="body2"
-              displayInlineAsSpan // Important to avoid the text to use a "p" which causes crashes with automatic translation tools with the hightlighted text.
-            >
-              {renderExampleField('shortDescription')}
-            </Text>
-          </Column>
+          <ResponsiveLineStackLayout noMargin expand>
+            {!!exampleShortHeader.previewImageUrls.length && (
+              <Column>
+                <ExampleThumbnailOrIcon
+                  exampleShortHeader={exampleShortHeader}
+                />
+              </Column>
+            )}
+            <Column expand>
+              <Text noMargin>{renderExampleField('name')} </Text>
+              {
+                <Line>
+                  <div style={{ flexWrap: 'wrap' }}>
+                    {exampleShortHeader.difficultyLevel && (
+                      <ExampleDifficultyChip
+                        difficultyLevel={exampleShortHeader.difficultyLevel}
+                      />
+                    )}
+                    {exampleShortHeader.codeSizeLevel && (
+                      <ExampleSizeChip
+                        codeSizeLevel={exampleShortHeader.codeSizeLevel}
+                      />
+                    )}
+                    {exampleShortHeader.authors &&
+                      exampleShortHeader.authors.map(author => (
+                        <UserPublicProfileChip user={author} key={author.id} />
+                      ))}
+                  </div>
+                </Line>
+              }
+              <Text
+                noMargin
+                size="body2"
+                displayInlineAsSpan // Important to avoid the text to use a "p" which causes crashes with automatic translation tools with the hightlighted text.
+              >
+                {renderExampleField('shortDescription')}
+              </Text>
+            </Column>
+          </ResponsiveLineStackLayout>
         </ButtonBase>
         <Column noMargin justifyContent="flex-end">
           <Line noMargin justifyContent="flex-end">

--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleListItem.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleListItem.js
@@ -110,13 +110,13 @@ export const ExampleListItem = ({
         <ButtonBase style={styles.button} onClick={onChoose} focusRipple>
           <ResponsiveLineStackLayout noMargin expand>
             {!!exampleShortHeader.previewImageUrls.length && (
-              <Column>
+              <Column noMargin>
                 <ExampleThumbnailOrIcon
                   exampleShortHeader={exampleShortHeader}
                 />
               </Column>
             )}
-            <Column expand>
+            <Column expand noMargin>
               <Text noMargin>{renderExampleField('name')} </Text>
               {
                 <Line>

--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleThumbnailOrIcon.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleThumbnailOrIcon.js
@@ -17,8 +17,7 @@ const styles = {
   },
 };
 
-const ICON_HEIGHT = 120;
-const SMALL_WINDOW_ICON_HEIGHT = 50;
+const ICON_DESKTOP_HEIGHT = 120;
 
 type Props = {|
   exampleShortHeader: ExampleShortHeader,
@@ -28,13 +27,13 @@ export const ExampleThumbnailOrIcon = ({ exampleShortHeader }: Props) => {
   const windowWidth = useResponsiveWindowWidth();
   const iconUrl = exampleShortHeader.previewImageUrls[0];
   const aspectRatio = iconUrl.endsWith('square-icon.png') ? '1 / 1' : '16 / 9';
-  const height =
-    windowWidth === 'small' ? SMALL_WINDOW_ICON_HEIGHT : ICON_HEIGHT;
+  const height = windowWidth === 'small' ? undefined : ICON_DESKTOP_HEIGHT;
+  const width = windowWidth === 'small' ? '100%' : undefined;
 
   return (
     <div style={styles.iconBackground}>
       <CorsAwareImage
-        style={{ ...styles.icon, height, aspectRatio }}
+        style={{ ...styles.icon, height, width, aspectRatio }}
         src={iconUrl}
         alt={exampleShortHeader.name}
       />

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -42,6 +42,7 @@ import {
 } from '../Utils/ZoomUtils';
 const gd: libGDevelop = global.gd;
 
+export const instancesEditorId = 'instances-editor-canvas';
 const styles = {
   canvasArea: { flex: 1, position: 'absolute', overflow: 'hidden' },
   dropCursor: { cursor: 'copy' },
@@ -1078,6 +1079,7 @@ export default class InstancesEditor extends Component<Props> {
             <div
               ref={canvasArea => (this.canvasArea = canvasArea)}
               style={styles.canvasArea}
+              id={instancesEditorId}
             />
           );
         }}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3329,7 +3329,7 @@ const MainFrame = (props: Props) => {
           endTutorial={() => endTutorial(true)}
         />
       )}
-      {currentProject && <CustomDragLayer />}
+      <CustomDragLayer />
     </div>
   );
 };

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -174,6 +174,7 @@ import {
   isMiniTutorial,
   allInAppTutorialIds,
 } from '../Utils/GDevelopServices/InAppTutorial';
+import CustomDragLayer from '../UI/DragAndDrop/CustomDragLayer';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -3328,6 +3329,7 @@ const MainFrame = (props: Props) => {
           endTutorial={() => endTutorial(true)}
         />
       )}
+      {currentProject && <CustomDragLayer />}
     </div>
   );
 };

--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -295,6 +295,12 @@ export default class GroupsListContainer extends React.Component<Props, State> {
     return false;
   };
 
+  _selectGroup = (groupWithContext: ?GroupWithContext) => {
+    this.setState({
+      selectedGroupWithContext: groupWithContext,
+    });
+  };
+
   _moveSelectionTo = (targetGroupWithContext: GroupWithContext) => {
     const { selectedGroupWithContext } = this.state;
     if (!selectedGroupWithContext) return;
@@ -455,12 +461,12 @@ export default class GroupsListContainer extends React.Component<Props, State> {
                     onEditItem={groupWithContext =>
                       this.props.onEditGroup(groupWithContext.group)
                     }
-                    selectedItems={[]}
-                    onItemSelected={groupWithContext => {
-                      this.setState({
-                        selectedGroupWithContext: groupWithContext,
-                      });
-                    }}
+                    selectedItems={
+                      this.state.selectedGroupWithContext
+                        ? [this.state.selectedGroupWithContext]
+                        : []
+                    }
+                    onItemSelected={this._selectGroup}
                     renamedItem={renamedGroupWithContext}
                     onRename={this._onRename}
                     buildMenuTemplate={this._renderGroupMenuTemplate(i18n)}

--- a/newIDE/app/src/UI/DragAndDrop/CustomDragLayer.js
+++ b/newIDE/app/src/UI/DragAndDrop/CustomDragLayer.js
@@ -1,0 +1,149 @@
+// @flow
+import * as React from 'react';
+import { DragLayer } from 'react-dnd';
+import { Identifier } from 'dnd-core';
+import Text from '../Text';
+
+const layerStyles = {
+  position: 'fixed',
+  pointerEvents: 'none',
+  zIndex: 100,
+  left: 0,
+  top: 0,
+  width: '100%',
+  height: '100%',
+};
+
+const THUMBNAIL_SIZE = 32;
+
+function getItemStyles({
+  initialOffset,
+  clientOffset,
+  previewPosition,
+}: {
+  initialOffset: ?{ x: number, y: number },
+  clientOffset: ?{ x: number, y: number },
+  previewPosition: 'center' | 'aboveRight',
+}) {
+  if (!initialOffset || !clientOffset) {
+    return {
+      display: 'none',
+    };
+  }
+
+  const { x, y } = clientOffset;
+
+  const previewX = previewPosition === 'center' ? x - THUMBNAIL_SIZE / 2 : x;
+  const previewY =
+    previewPosition === 'center'
+      ? y - THUMBNAIL_SIZE / 2
+      : previewPosition === 'aboveRight'
+      ? y - THUMBNAIL_SIZE
+      : y;
+
+  const transform = `translate(${previewX}px, ${previewY}px)`;
+
+  return {
+    transform,
+    WebkitTransform: transform,
+  };
+}
+
+// This interface is supposed to be available in react-dnd, but flow complains.
+type XYCoord = {|
+  x: number,
+  y: number,
+|};
+
+export type DraggedItem = {|
+  name: string,
+  thumbnail?: string,
+|};
+
+type InternalCustomDragLayerProps = {|
+  item?: DraggedItem,
+  itemType?: Identifier | null,
+  initialOffset?: XYCoord | null,
+  currentOffset?: XYCoord | null,
+  clientOffset?: XYCoord | null,
+  isDragging?: boolean,
+|};
+
+const CustomDragLayer = ({
+  item,
+  itemType,
+  isDragging,
+  initialOffset,
+  currentOffset,
+  clientOffset,
+}: InternalCustomDragLayerProps) => {
+  const itemThumbnail = React.useMemo(
+    () => {
+      if (!item) return null;
+      return item.thumbnail;
+    },
+    [item]
+  );
+
+  const itemName = React.useMemo(
+    () => {
+      if (!item) return null;
+      return item.name;
+    },
+    [item]
+  );
+
+  function renderItem() {
+    return itemThumbnail ? (
+      <img
+        alt={itemName}
+        src={itemThumbnail}
+        style={{
+          maxWidth: THUMBNAIL_SIZE,
+          maxHeight: THUMBNAIL_SIZE,
+        }}
+      />
+    ) : (
+      <Text>{itemName}</Text>
+    );
+  }
+
+  if (!isDragging) {
+    return null;
+  }
+
+  return (
+    <div style={layerStyles}>
+      <div
+        style={getItemStyles({
+          initialOffset,
+          clientOffset,
+          previewPosition: !itemThumbnail ? 'aboveRight' : 'center',
+        })}
+      >
+        {renderItem()}
+      </div>
+    </div>
+  );
+};
+
+const collect = (monitor: any): InternalCustomDragLayerProps => ({
+  // This contains the item that is returned by the method `beginDrag` of the DragSourceAndDropTarget component.
+  item: monitor.getItem(),
+  // This contains the type of the item being dragged, defined when calling the function `makeDragSourceAndDropTarget`.
+  itemType: monitor.getItemType(),
+  // This is the initial offset of the drag source.
+  initialOffset: monitor.getInitialSourceClientOffset(),
+  // This is the current offset of the drag source (the whole wrapper element, not just the mouse position)
+  currentOffset: monitor.getSourceClientOffset(),
+  // This is the current offset of the mouse.
+  clientOffset: monitor.getClientOffset(),
+  isDragging: monitor.isDragging(),
+});
+
+// $FlowFixMe - Forcing the type of the component, unsure how to make the DragLayer happy.
+const ExternalCustomDragLayer: ({||}) => React.Node = DragLayer(collect)(
+  CustomDragLayer
+);
+
+export default ExternalCustomDragLayer;

--- a/newIDE/app/src/UI/DragAndDrop/CustomDragLayer.js
+++ b/newIDE/app/src/UI/DragAndDrop/CustomDragLayer.js
@@ -16,6 +16,7 @@ const layerStyles = {
 };
 
 const THUMBNAIL_SIZE = 48;
+const TEXT_SHIFT = 16;
 
 const getItemStyles = ({
   clientOffset,
@@ -32,13 +33,10 @@ const getItemStyles = ({
 
   const { x, y } = clientOffset;
 
-  const previewX = previewPosition === 'center' ? x - THUMBNAIL_SIZE / 2 : x;
+  const previewX =
+    previewPosition === 'center' ? x - THUMBNAIL_SIZE / 2 : x + TEXT_SHIFT;
   const previewY =
-    previewPosition === 'center'
-      ? y - THUMBNAIL_SIZE / 2
-      : previewPosition === 'aboveRight'
-      ? y - THUMBNAIL_SIZE
-      : y;
+    previewPosition === 'center' ? y - THUMBNAIL_SIZE / 2 : y - TEXT_SHIFT;
 
   const transform = `translate(${previewX}px, ${previewY}px)`;
 
@@ -67,6 +65,27 @@ type InternalCustomDragLayerProps = {|
   isDragging?: boolean,
 |};
 
+const shouldHidePreviewBecauseDraggingOnSceneEditorCanvas = ({
+  x,
+  y,
+}: XYCoord) => {
+  const activeCanvas = document.querySelector(
+    `#scene-editor[data-active=true] #${instancesEditorId}`
+  );
+  if (activeCanvas) {
+    const canvasRect = activeCanvas.getBoundingClientRect();
+    if (
+      x >= canvasRect.left &&
+      x <= canvasRect.right &&
+      y >= canvasRect.top &&
+      y <= canvasRect.bottom
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const CustomDragLayer = ({
   item,
   itemType,
@@ -79,20 +98,8 @@ const CustomDragLayer = ({
     () => {
       if (!item || !clientOffset) return null;
 
-      const { x, y } = clientOffset;
-      const activeCanvas = document.querySelector(
-        `#scene-editor[data-active=true] #${instancesEditorId}`
-      );
-      if (activeCanvas) {
-        const canvasRect = activeCanvas.getBoundingClientRect();
-        if (
-          x >= canvasRect.left &&
-          x <= canvasRect.right &&
-          y >= canvasRect.top &&
-          y <= canvasRect.bottom
-        ) {
-          return null;
-        }
+      if (shouldHidePreviewBecauseDraggingOnSceneEditorCanvas(clientOffset)) {
+        return null;
       }
 
       return item.thumbnail ? (

--- a/newIDE/app/src/UI/DragAndDrop/DragSourceAndDropTarget.js
+++ b/newIDE/app/src/UI/DragAndDrop/DragSourceAndDropTarget.js
@@ -9,16 +9,18 @@ import {
   type DropTargetMonitor,
   type DropTargetConnector,
   type ConnectDropTarget,
+  type ConnectDragPreview,
 } from 'react-dnd';
 
 type Props<DraggedItemType> = {|
-  children: ({
+  children: ({|
     connectDragSource: ConnectDragSource,
     connectDropTarget: ConnectDropTarget,
+    connectDragPreview: ConnectDragPreview,
     isOver: boolean,
     isOverLazy: boolean,
     canDrop: boolean,
-  }) => ?React.Node,
+  |}) => ?React.Node,
   beginDrag: () => DraggedItemType,
   canDrag?: (item: DraggedItemType) => boolean,
   canDrop: (item: DraggedItemType) => boolean,
@@ -28,6 +30,8 @@ type Props<DraggedItemType> = {|
 
 type DragSourceProps = {|
   connectDragSource: ConnectDragSource,
+  connectDragPreview: ConnectDragPreview,
+  isDragging: boolean,
 |};
 
 type DropTargetProps = {|
@@ -67,6 +71,8 @@ export const makeDragSourceAndDropTarget = <DraggedItemType>(
   ): DragSourceProps {
     return {
       connectDragSource: connect.dragSource(),
+      connectDragPreview: connect.dragPreview(),
+      isDragging: monitor.isDragging(),
     };
   }
 
@@ -105,6 +111,8 @@ export const makeDragSourceAndDropTarget = <DraggedItemType>(
         children,
         connectDragSource,
         connectDropTarget,
+        connectDragPreview,
+        isDragging,
         isOver,
         isOverLazy,
         canDrop,
@@ -112,6 +120,8 @@ export const makeDragSourceAndDropTarget = <DraggedItemType>(
         return children({
           connectDragSource,
           connectDropTarget,
+          connectDragPreview,
+          isDragging,
           isOver,
           isOverLazy,
           canDrop,

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/ItemRow.js
@@ -42,7 +42,6 @@ type Props<Item> = {|
   onEdit?: ?(Item) => void,
   hideMenuButton: boolean,
   scaleUpItemIconWhenSelected?: boolean,
-  connectIconDragSource?: ?(React.Element<any>) => ?React.Node,
 |};
 
 function ItemRow<Item>({
@@ -62,7 +61,6 @@ function ItemRow<Item>({
   onEdit,
   hideMenuButton,
   scaleUpItemIconWhenSelected,
-  connectIconDragSource,
 }: Props<Item>) {
   const textFieldRef = React.useRef<?TextFieldInterface>(null);
   const shouldDiscardChanges = React.useRef<boolean>(false);
@@ -161,11 +159,7 @@ function ItemRow<Item>({
     <ListItem
       style={{ ...itemStyle }}
       primaryText={label}
-      leftIcon={
-        connectIconDragSource && leftIcon
-          ? connectIconDragSource(<div>{leftIcon}</div>)
-          : leftIcon
-      }
+      leftIcon={leftIcon}
       displayMenuButton={!hideMenuButton}
       rightIconColor={
         selected

--- a/newIDE/app/src/UI/SortableVirtualizedItemList/index.js
+++ b/newIDE/app/src/UI/SortableVirtualizedItemList/index.js
@@ -60,12 +60,7 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
     }
   }
 
-  _renderItemRow(
-    item: Item,
-    index: number,
-    windowWidth: WidthType,
-    connectIconDragSource?: ?(React.Element<any>) => ?React.Node
-  ) {
+  _renderItemRow(item: Item, index: number, windowWidth: WidthType) {
     const {
       selectedItems,
       getItemThumbnail,
@@ -83,6 +78,9 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
     const nameBeingEdited = renamedItem === item;
     const itemName = getItemName(item);
 
+    const selected =
+      selectedItems.findIndex(item => getItemName(item) === itemName) !== -1;
+
     return (
       <ItemRow
         item={item}
@@ -98,14 +96,13 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
         getThumbnail={
           getItemThumbnail ? () => getItemThumbnail(item) : undefined
         }
-        selected={selectedItems.indexOf(item) !== -1}
+        selected={selected}
         onItemSelected={this.props.onItemSelected}
         errorStatus={erroredItems ? erroredItems[itemName] || '' : ''}
         buildMenuTemplate={() => this.props.buildMenuTemplate(item, index)}
         onEdit={onEditItem}
         hideMenuButton={windowWidth === 'small'}
         scaleUpItemIconWhenSelected={scaleUpItemIconWhenSelected}
-        connectIconDragSource={connectIconDragSource || null}
       />
     );
   }
@@ -169,12 +166,30 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
 
                   const item = fullList[index];
                   const nameBeingEdited = renamedItem === item;
-                  const isSelected = selectedItems.indexOf(item) !== -1;
+                  const isSelected =
+                    selectedItems.findIndex(
+                      selectedItem =>
+                        getItemName(selectedItem) === getItemName(item)
+                    ) !== -1;
+                  // If on a touch screen, we only allow dragging if the item is selected.
+                  const canDrag =
+                    !nameBeingEdited && (screenType !== 'touch' || isSelected);
 
                   return (
                     <div style={style} key={key}>
                       <DragSourceAndDropTarget
                         beginDrag={() => {
+                          // This is a hack for touch screens. We need to prevent the react-dnd list from scrolling
+                          // at the same time as the drag is happening.
+                          // react-dnd does not work well with react-virtualized.
+                          // Find the React-Virtualized list and prevent it from scrolling whilst dragging
+                          // by setting the overflow to 'hidden' and then back to 'auto' when the drag is finished.
+                          if (screenType === 'touch') {
+                            if (this._list) {
+                              this._list.props.style.overflow = 'hidden';
+                            }
+                          }
+
                           // Ensure we reselect the item even if it's already selected.
                           // This prevents a bug where the connected preview is not
                           // updated when the item is already selected.
@@ -194,7 +209,7 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
                           // $FlowFixMe
                           return draggedItem;
                         }}
-                        canDrag={() => !nameBeingEdited}
+                        canDrag={() => canDrag}
                         canDrop={() =>
                           canMoveSelectionToItem
                             ? canMoveSelectionToItem(item)
@@ -202,6 +217,14 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
                         }
                         drop={() => {
                           onMoveSelectionToItem(item);
+                        }}
+                        endDrag={() => {
+                          // Re-enable scrolling on touch screens.
+                          if (screenType !== 'touch') return;
+                          if (this._list) {
+                            this._list.props.style.overflow = 'auto';
+                            this.forceUpdate();
+                          }
                         }}
                       >
                         {({
@@ -211,40 +234,22 @@ export default class SortableVirtualizedItemList<Item> extends React.Component<
                           isOver,
                           canDrop,
                         }) => {
-                          // If on a touch screen, setting the whole item to be
-                          // draggable would prevent scroll. Set the icon only to be
-                          // draggable if the item is not selected. When selected,
-                          // set the whole item to be draggable.
-                          const canDragOnlyIcon =
-                            screenType === 'touch' && !isSelected;
-
                           // Connect the drag preview with an empty image to override the default
                           // drag preview.
-                          connectDragPreview(emptyImage, {
-                            captureDraggingState: true,
-                          });
+                          connectDragPreview(emptyImage);
 
                           // Add an extra div because connectDropTarget/connectDragSource can
                           // only be used on native elements
                           const dropTarget = connectDropTarget(
                             <div>
                               {isOver && <DropIndicator canDrop={canDrop} />}
-                              {this._renderItemRow(
-                                item,
-                                index,
-                                windowWidth,
-                                // Only mark the icon as draggable if needed
-                                // (touchscreens).
-                                canDragOnlyIcon ? connectDragSource : null
-                              )}
+                              {this._renderItemRow(item, index, windowWidth)}
                             </div>
                           );
 
                           if (!dropTarget) return null;
 
-                          return canDragOnlyIcon
-                            ? dropTarget
-                            : connectDragSource(dropTarget);
+                          return connectDragSource(dropTarget);
                         }}
                       </DragSourceAndDropTarget>
                     </div>


### PR DESCRIPTION
Few things:

- created custom drag layer positioning previews of items on top of the screen (positioned absolutely)
- hide default previews with empty pixel and connectDragPreview()
- Change drag behavior on mobile, so that only selected rows can be dragged. This prevents weird behaviors where the preview appears for no reason + the long click is triggered when dragging a non selected icon. + I feel this is more intuitive on mobile (You select. You drag)
- Also improve example thumbnails on mobile to be more visible.


https://user-images.githubusercontent.com/4895034/224965607-70f51746-2a4c-464b-a6c1-da2bf25fb154.mov

https://user-images.githubusercontent.com/4895034/224965955-cebce4b2-17fd-4278-9b54-226dba5f410f.mov

![Capture d’écran 2023-03-14 à 10 39 22](https://user-images.githubusercontent.com/4895034/224965697-89cbafe6-d32d-4e5d-9d1e-7e4c55795766.png)
![Capture d’écran 2023-03-14 à 10 39 29](https://user-images.githubusercontent.com/4895034/224965700-8ba4c979-fb60-4726-981f-97c9a31a4b1a.png)
![Capture d’écran 2023-03-14 à 10 39 34](https://user-images.githubusercontent.com/4895034/224965703-beb77db2-e743-4669-b687-68997d7cfbfb.png)
![Capture d’écran 2023-03-14 à 10 40 25](https://user-images.githubusercontent.com/4895034/224965707-3c702256-b6b8-4f9a-a055-a3fb2c9b5cf1.png)
