### PR TITLE
[Platformer] Fix horizontal speed losses when characters land or jump from a slop

### DIFF
--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -261,8 +261,6 @@ namespace gdjs {
         this._lastDirectionIsLeft = this._leftKey;
       }
 
-      const oldState = this._state;
-
       //0.2) Track changes in object size
       this._state.beforeUpdatingObstacles(timeDelta);
       this._onFloor._oldHeight = object.getHeight();
@@ -276,6 +274,7 @@ namespace gdjs {
       this._updateOverlappedJumpThru();
 
       //1) X axis:
+      const beforeMovingXState = this._state;
       this._state.checkTransitionBeforeX();
       this._state.beforeMovingX();
 
@@ -290,6 +289,7 @@ namespace gdjs {
       const mayCollideWall = object.getX() !== oldX + this._requestedDeltaX;
 
       //2) Y axis:
+      const beforeMovingYState = this._state;
       this._state.checkTransitionBeforeY(timeDelta);
       this._state.beforeMovingY(timeDelta, oldX);
 
@@ -298,6 +298,7 @@ namespace gdjs {
 
       //3) Update the current floor data for the next tick:
       //TODO what about a moving platforms, remove this condition to do the same as for grabbing?
+      const beforeLastTransitionYState = this._state;
       if (this._state !== this._onLadder) {
         this._checkTransitionOnFloorOrFalling();
       }
@@ -313,7 +314,9 @@ namespace gdjs {
       // and already stop if necessary.
       if (
         mayCollideWall &&
-        this._state == oldState &&
+        this._state === beforeMovingXState &&
+        this._state === beforeMovingYState &&
+        this._state === beforeLastTransitionYState &&
         this._state !== this._onFloor
       ) {
         this._currentSpeed = 0;

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -297,26 +297,25 @@ namespace gdjs {
       this._moveY();
 
       //3) Update the current floor data for the next tick:
-      //TODO what about a moving platforms, remove this condition to do the same as for grabbing?
       const beforeLastTransitionYState = this._state;
+      //TODO what about a moving platforms, remove this condition to do the same as for grabbing?
       if (this._state !== this._onLadder) {
         this._checkTransitionOnFloorOrFalling();
       }
 
-      // When the character is against a wall and the player hold left or
-      // right, the speed shouldn't stack because starting at full speed when
-      // jumping over the wall would look strange.
-      //
-      // When the state has change, the collision is probably a landing or a
-      // collision from the floor when stating to jump. The speed must not be
-      // lost in these cases.
-      // When the character is on the floor, it will try to walk on the obstacles
-      // and already stop if necessary.
       if (
+        // When the character is against a wall and the player hold left or
+        // right, the speed shouldn't stack because starting at full speed when
+        // jumping over the wall would look strange.
         mayCollideWall &&
+        // Whereas, when the state has change, the collision is probably a
+        // landing or a collision from the floor when stating to jump. The
+        // speed must not be lost in these cases.
         this._state === beforeMovingXState &&
         this._state === beforeMovingYState &&
         this._state === beforeLastTransitionYState &&
+        // When the character is on the floor, it will try to walk on the
+        // obstacles and already stop if necessary.
         this._state !== this._onFloor
       ) {
         this._currentSpeed = 0;

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -1785,4 +1785,168 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       expect(behavior.isOnFloor()).to.be(true);
     });
   });
+
+  describe('(jump from slopes)', function () {
+    /** @type {gdjs.RuntimeScene} */
+    let runtimeScene;
+    /** @type {gdjs.RuntimeObject} */
+    let object;
+    /** @type {gdjs.PlatformerObjectRuntimeBehavior} */
+    let behavior;
+
+    beforeEach(function () {
+      runtimeScene = makePlatformerTestRuntimeScene();
+
+      // Put a platformer object on a platform
+      object = new gdjs.TestRuntimeObject(runtimeScene, {
+        name: 'obj1',
+        type: '',
+        behaviors: [
+          {
+            type: 'PlatformBehavior::PlatformerObjectBehavior',
+            name: 'auto1',
+            gravity: 900,
+            maxFallingSpeed: 1500,
+            acceleration: 500,
+            deceleration: 1500,
+            maxSpeed: 500,
+            jumpSpeed: 500,
+            canGrabPlatforms: true,
+            ignoreDefaultControls: true,
+            slopeMaxAngle: 60,
+            jumpSustainTime: 0.2,
+            useLegacyTrajectory: false,
+          },
+        ],
+        effects: [],
+      });
+      behavior = object.getBehavior('auto1');
+      object.setCustomWidthAndHeight(10, 20);
+      runtimeScene.addObject(object);
+      // The object is in the slope.
+      object.setPosition(0, 70);
+
+      const platform = addUpSlopePlatformObject(runtimeScene);
+      platform.setPosition(0, 0);
+    });
+
+    it('keep its speed on X when jumping while moving up on a slope', function () {
+      // The object stays on the platform.
+      for (let i = 0; i < 5; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      expect(object.getY()).to.within(70, 70 + 1);
+      expect(behavior.isFalling()).to.be(false);
+      expect(behavior.isFallingWithoutJumping()).to.be(false);
+      expect(behavior.isMoving()).to.be(false);
+
+      // Walk and gain speed.
+      for (let i = 0; i < 5; ++i) {
+        behavior.simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      const walkingSpeed = behavior.getCurrentSpeed();
+
+      // Jump and keep the speed.
+      behavior.simulateJumpKey();
+      behavior.simulateRightKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(behavior.isJumping()).to.be(true);
+      expect(behavior.getCurrentSpeed()).to.be.greaterThan(walkingSpeed);
+      for (let i = 0; i < 5; ++i) {
+        const oldY = object.getY();
+        behavior.simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(behavior.isJumping()).to.be(true);
+        expect(behavior.isFalling()).to.be(false);
+        expect(behavior.getCurrentSpeed()).to.be.greaterThan(walkingSpeed);
+      }
+    });
+  });
+
+  describe('(jump to slopes)', function () {
+    /** @type {gdjs.RuntimeScene} */
+    let runtimeScene;
+    /** @type {gdjs.RuntimeObject} */
+    let object;
+    /** @type {gdjs.PlatformerObjectRuntimeBehavior} */
+    let behavior;
+
+    beforeEach(function () {
+      runtimeScene = makePlatformerTestRuntimeScene();
+
+      // Put a platformer object on a platform
+      object = new gdjs.TestRuntimeObject(runtimeScene, {
+        name: 'obj1',
+        type: '',
+        behaviors: [
+          {
+            type: 'PlatformBehavior::PlatformerObjectBehavior',
+            name: 'auto1',
+            gravity: 900,
+            maxFallingSpeed: 1500,
+            acceleration: 500,
+            deceleration: 1500,
+            maxSpeed: 500,
+            jumpSpeed: 200,
+            canGrabPlatforms: true,
+            ignoreDefaultControls: true,
+            slopeMaxAngle: 60,
+            jumpSustainTime: 0.2,
+            useLegacyTrajectory: false,
+          },
+        ],
+        effects: [],
+      });
+      behavior = object.getBehavior('auto1');
+      object.setCustomWidthAndHeight(10, 20);
+      runtimeScene.addObject(object);
+      // The object is in the slope.
+      object.setPosition(10, -20);
+
+      addPlatformObject(runtimeScene);
+      const platform = addUpSlopePlatformObject(runtimeScene);
+      platform.setPosition(60, -100);
+    });
+
+    it('keep its speed on X when landing on a slope', function () {
+      // The object stays on the platform.
+      for (let i = 0; i < 5; ++i) {
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      expect(object.getY()).to.within(-20, -20 + 1);
+      expect(behavior.isFalling()).to.be(false);
+      expect(behavior.isFallingWithoutJumping()).to.be(false);
+      expect(behavior.isMoving()).to.be(false);
+
+      // Walk and gain speed.
+      for (let i = 0; i < 20; ++i) {
+        behavior.simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+      }
+      const walkingSpeed = behavior.getCurrentSpeed();
+
+      // Jump and keep the speed.
+      behavior.simulateJumpKey();
+      behavior.simulateRightKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(behavior.isJumping()).to.be(true);
+      expect(behavior.getCurrentSpeed()).to.be.greaterThan(100);
+      for (let i = 0; i < 6; ++i) {
+        const oldY = object.getY();
+        behavior.simulateRightKey();
+        runtimeScene.renderAndStep(1000 / 60);
+        expect(behavior.isJumping()).to.be(true);
+        expect(behavior.getCurrentSpeed()).to.be.greaterThan(100);
+        console.log(object.getX() + ' ' + object.getY());
+      }
+
+      // Land on the slope and keep the speed.
+      behavior.simulateRightKey();
+      runtimeScene.renderAndStep(1000 / 60);
+      expect(behavior.isOnFloor()).to.be(true);
+      expect(behavior.getCurrentSpeed()).to.be.greaterThan(100);
+      console.log(object.getX() + ' ' + object.getY());
+    });
+  });
 });

--- a/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
+++ b/Extensions/PlatformBehavior/tests/JumpAndFallingPlatformer.spec.js
@@ -1938,7 +1938,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
         runtimeScene.renderAndStep(1000 / 60);
         expect(behavior.isJumping()).to.be(true);
         expect(behavior.getCurrentSpeed()).to.be.greaterThan(100);
-        console.log(object.getX() + ' ' + object.getY());
       }
 
       // Land on the slope and keep the speed.
@@ -1946,7 +1945,6 @@ describe('gdjs.PlatformerObjectRuntimeBehavior', function () {
       runtimeScene.renderAndStep(1000 / 60);
       expect(behavior.isOnFloor()).to.be(true);
       expect(behavior.getCurrentSpeed()).to.be.greaterThan(100);
-      console.log(object.getX() + ' ' + object.getY());
     });
   });
 });


### PR DESCRIPTION
It can still happens when characters are not jumping fast enough and the `requestedDeltaX` would move it into the slope. But in this case the character barely take off from the floor and do very small jump which doesn't look good anyway. Stopping the character in this situation is almost a feature as it makes the jumps look bigger.

It should fix the issue for Mario-like platformers.

Fast-paced platformers like Sonic will likely jump perpendicularly to the slope which would probably solve the issue as it would reduce how much the character move on X.