### PR TITLE
Update layers list when scene editor becomes active again

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
@@ -81,7 +81,12 @@ export class ExternalLayoutEditorContainer extends React.Component<
   }
 
   forceUpdateEditor() {
-    // No updates to be done.
+    const { editor } = this;
+    if (editor) {
+      editor.forceUpdateObjectsList();
+      editor.forceUpdateObjectGroupsList();
+      editor.forceUpdateLayersList();
+    }
   }
 
   getExternalLayout(): ?gdExternalLayout {

--- a/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
@@ -49,6 +49,7 @@ export class SceneEditorContainer extends React.Component<RenderEditorContainerP
     if (editor) {
       editor.forceUpdateObjectsList();
       editor.forceUpdateObjectGroupsList();
+      editor.forceUpdateLayersList();
     }
   }
 

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1304,6 +1304,10 @@ export default class SceneEditor extends React.Component<Props, State> {
   };
 
   forceUpdateLayersList = () => {
+    // The selected layer could have been deleted when editing a linked external layout.
+    if (!this.props.layout.hasLayerNamed(this.state.selectedLayer)) {
+      this.setState({ selectedLayer: BASE_LAYER_NAME });
+    }
     if (this._layersList) this._layersList.forceUpdate();
   };
 


### PR DESCRIPTION
Update selected layer when editor becomes active again.
Useful if one deletes a layer from an external layout and comes back to the layout (that had this now-deleted layer selected)