### PR TITLE
Fix scroll setting after back navigation

### DIFF
--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -112,8 +112,8 @@ export const AssetStoreContext = React.createContext<AssetStoreState>({
   },
   navigationState: {
     getCurrentPage: () => assetStoreHomePageState,
-    backToPreviousPage: () => {},
-    openHome: () => {},
+    backToPreviousPage: () => assetStoreHomePageState,
+    openHome: () => assetStoreHomePageState,
     clearHistory: () => {},
     openSearchResultPage: () => {},
     openTagPage: tag => {},

--- a/newIDE/app/src/AssetStore/AssetStoreNavigator.js
+++ b/newIDE/app/src/AssetStore/AssetStoreNavigator.js
@@ -20,8 +20,8 @@ export type AssetStorePageState = {|
 
 export type NavigationState = {|
   getCurrentPage: () => AssetStorePageState,
-  backToPreviousPage: () => void,
-  openHome: () => void,
+  backToPreviousPage: () => AssetStorePageState,
+  openHome: () => AssetStorePageState,
   clearHistory: () => void,
   openSearchResultPage: () => void,
   openTagPage: string => void,
@@ -91,13 +91,21 @@ export const useNavigation = (): NavigationState => {
       getCurrentPage: () => previousPages[previousPages.length - 1],
       backToPreviousPage: () => {
         if (previousPages.length > 1) {
+          const newPreviousPages = previousPages.slice(
+            0,
+            previousPages.length - 1
+          );
+          const newCurrentPage = newPreviousPages[newPreviousPages.length - 1];
           setHistory({
             previousPages: previousPages.slice(0, previousPages.length - 1),
           });
+          return newCurrentPage;
         }
+        return previousPages[0];
       },
       openHome: () => {
         setHistory({ previousPages: [assetStoreHomePageState] });
+        return assetStoreHomePageState;
       },
       clearHistory: () => {
         setHistory(previousHistory => {

--- a/newIDE/app/src/AssetStore/AssetStoreNavigator.js
+++ b/newIDE/app/src/AssetStore/AssetStoreNavigator.js
@@ -97,7 +97,7 @@ export const useNavigation = (): NavigationState => {
           );
           const newCurrentPage = newPreviousPages[newPreviousPages.length - 1];
           setHistory({
-            previousPages: previousPages.slice(0, previousPages.length - 1),
+            previousPages: newPreviousPages,
           });
           return newCurrentPage;
         }

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -104,17 +104,16 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       assetFiltersState,
       assetPackRandomOrdering,
     } = React.useContext(AssetStoreContext);
+    const currentPage = navigationState.getCurrentPage();
     const {
       openedAssetPack,
       openedAssetShortHeader,
       openedAssetCategory,
       openedPrivateAssetPackListingData,
       filtersState,
-    } = navigationState.getCurrentPage();
-    const isOnHomePage = isHomePage(navigationState.getCurrentPage());
-    const isOnSearchResultPage = isSearchResultPage(
-      navigationState.getCurrentPage()
-    );
+    } = currentPage;
+    const isOnHomePage = isHomePage(currentPage);
+    const isOnSearchResultPage = isSearchResultPage(currentPage);
     const searchBar = React.useRef<?SearchBarInterface>(null);
     const shouldAutofocusSearchbar = useShouldAutofocusInput();
 
@@ -152,14 +151,10 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
     const isAssetDetailLoading = React.useRef<boolean>(
       openedAssetShortHeader != null
     );
-    const setScrollUpdateIsNeeded = React.useCallback(
-      () => {
-        hasAppliedSavedScrollPosition.current = false;
-        isAssetDetailLoading.current =
-          navigationState.getCurrentPage().openedAssetShortHeader != null;
-      },
-      [navigationState]
-    );
+    const setScrollUpdateIsNeeded = React.useCallback(page => {
+      hasAppliedSavedScrollPosition.current = false;
+      isAssetDetailLoading.current = page.openedAssetShortHeader !== null;
+    }, []);
 
     const canShowFiltersPanel =
       !openedAssetShortHeader && // Don't show filters on asset page.
@@ -184,9 +179,9 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         if (!scrollView) {
           return;
         }
-        navigationState.getCurrentPage().scrollPosition = scrollView.getScrollPosition();
+        currentPage.scrollPosition = scrollView.getScrollPosition();
       },
-      [getScrollView, navigationState]
+      [getScrollView, currentPage]
     );
     // This is also called when the asset detail page has loaded.
     const applyBackScrollPosition = React.useCallback(
@@ -198,7 +193,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         if (!scrollView) {
           return;
         }
-        const scrollPosition = navigationState.getCurrentPage().scrollPosition;
+        const scrollPosition = currentPage.scrollPosition;
         if (scrollPosition) scrollView.scrollToPosition(scrollPosition);
         // If no saved scroll position, force scroll to 0 in case the displayed component
         // is the same as the previous page so the scroll is naturally kept between pages
@@ -206,7 +201,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         else scrollView.scrollToPosition(0);
         hasAppliedSavedScrollPosition.current = true;
       },
-      [getScrollView, navigationState]
+      [getScrollView, currentPage]
     );
 
     React.useImperativeHandle(ref, () => ({
@@ -342,7 +337,6 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       () => {
         if (!purchasingPrivateAssetPackListingData) return;
         // Ensure the user is not already on the pack page, to trigger the effect only once.
-        const currentPage = navigationState.getCurrentPage();
         const isOnPrivatePackPage =
           currentPage.openedAssetPack &&
           currentPage.openedAssetPack.id &&
@@ -365,6 +359,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         receivedAssetPacks,
         purchasingPrivateAssetPackListingData,
         navigationState,
+        currentPage,
         saveScrollPosition,
         setSearchText,
         openFiltersPanelIfAppropriate,
@@ -483,8 +478,8 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
             tooltip={t`Back to discover`}
             onClick={() => {
               setSearchText('');
-              navigationState.openHome();
-              setScrollUpdateIsNeeded();
+              const page = navigationState.openHome();
+              setScrollUpdateIsNeeded(page);
               clearAllFilters(assetFiltersState);
               setIsFiltersPanelOpen(false);
             }}
@@ -538,8 +533,8 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                     label={<Trans>Back</Trans>}
                     primary={false}
                     onClick={() => {
-                      navigationState.backToPreviousPage();
-                      setScrollUpdateIsNeeded();
+                      const page = navigationState.backToPreviousPage();
+                      setScrollUpdateIsNeeded(page);
                     }}
                   />
                 </Column>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -49,7 +49,11 @@ import AlertMessage from '../UI/AlertMessage';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import PrivateAssetPackPurchaseDialog from './PrivateAssets/PrivateAssetPackPurchaseDialog';
 import { LineStackLayout } from '../UI/Layout';
-import { isHomePage, isSearchResultPage } from './AssetStoreNavigator';
+import {
+  isHomePage,
+  isSearchResultPage,
+  type AssetStorePageState,
+} from './AssetStoreNavigator';
 import RaisedButton from '../UI/RaisedButton';
 import { ResponsivePaperOrDrawer } from '../UI/ResponsivePaperOrDrawer';
 import PrivateAssetsAuthorizationContext from './PrivateAssets/PrivateAssetsAuthorizationContext';
@@ -151,10 +155,13 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
     const isAssetDetailLoading = React.useRef<boolean>(
       openedAssetShortHeader != null
     );
-    const setScrollUpdateIsNeeded = React.useCallback(page => {
-      hasAppliedSavedScrollPosition.current = false;
-      isAssetDetailLoading.current = page.openedAssetShortHeader !== null;
-    }, []);
+    const setScrollUpdateIsNeeded = React.useCallback(
+      (page: AssetStorePageState) => {
+        hasAppliedSavedScrollPosition.current = false;
+        isAssetDetailLoading.current = page.openedAssetShortHeader !== null;
+      },
+      []
+    );
 
     const canShowFiltersPanel =
       !openedAssetShortHeader && // Don't show filters on asset page.

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -208,15 +208,6 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       onClose: saveScrollPosition,
     }));
 
-    React.useLayoutEffect(
-      () => {
-        if (!isAssetDetailLoading.current) {
-          applyBackScrollPosition();
-        }
-      },
-      [applyBackScrollPosition]
-    );
-
     const onOpenDetails = React.useCallback(
       (assetShortHeader: AssetShortHeader) => {
         const assetPackName = openedAssetPack ? openedAssetPack.name : null;
@@ -438,14 +429,22 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
 
     React.useLayoutEffect(
       () => {
-        if (isOnHomePage) {
-          clearAllFilters(assetFiltersState);
-          setIsFiltersPanelOpen(false);
-        }
+        // When going back to the homepage from a page where the asset filters
+        // were open, we must first close the panel and then apply the scroll position.
+        const applyEffect = async () => {
+          if (isOnHomePage) {
+            clearAllFilters(assetFiltersState);
+            await setIsFiltersPanelOpen(false);
+          }
+          if (!isAssetDetailLoading.current) {
+            applyBackScrollPosition();
+          }
+        };
+        applyEffect();
       },
       // assetFiltersState is not stable, so don't list it.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [isOnHomePage]
+      [isOnHomePage, applyBackScrollPosition]
     );
 
     const privateAssetPackFromSameCreator: ?Array<PrivateAssetPackListingData> = React.useMemo(

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -293,6 +293,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
           });
 
           setSearchText('');
+          saveScrollPosition();
           navigationState.openPrivateAssetPackInformationPage(
             assetPackListingData
           );


### PR DESCRIPTION
- Going back from asset page to research page was using a not-yet-up-to-date current page and was not applying scroll
- Going back to asset home was setting scroll position before the filters panel was closed and the closing of the panel changed the scroll position