### PR TITLE
Round dragged points and collision masks vertices of sprites

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -217,6 +217,8 @@ const CollisionMasksPreview = (props: Props) => {
           onPolygonsUpdated();
           onClickVertice(null);
         } else {
+          draggedVertex.vertex.set_x(Math.round(draggedVertex.vertex.get_x()));
+          draggedVertex.vertex.set_y(Math.round(draggedVertex.vertex.get_y()));
           onPolygonsUpdated();
           onClickVertice(draggedVertex.vertex.ptr);
         }

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -4,6 +4,7 @@ import { mapVector } from '../../../../Utils/MapFor';
 import useForceUpdate from '../../../../Utils/UseForceUpdate';
 import { dataObjectToProps } from '../../../../Utils/HTMLDataset';
 import {
+  roundVertexToHalfPixel,
   findNearestEdgePoint,
   getMagnetizedVertexForDeletion,
   type NewVertexHintPoint,
@@ -217,8 +218,7 @@ const CollisionMasksPreview = (props: Props) => {
           onPolygonsUpdated();
           onClickVertice(null);
         } else {
-          draggedVertex.vertex.set_x(Math.round(draggedVertex.vertex.get_x()));
-          draggedVertex.vertex.set_y(Math.round(draggedVertex.vertex.get_y()));
+          roundVertexToHalfPixel(draggedVertex.vertex);
           onPolygonsUpdated();
           onClickVertice(draggedVertex.vertex.ptr);
         }

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/PolygonHelper.js
@@ -3,6 +3,11 @@ import { mapFor, mapVector } from '../../../../Utils/MapFor';
 
 const gd = global.gd;
 
+export const roundVertexToHalfPixel = (vertex: gdVector2f) => {
+  vertex.set_x(Math.round(vertex.get_x() * 2) / 2);
+  vertex.set_y(Math.round(vertex.get_y() * 2) / 2);
+};
+
 export const addVertexOnLongestEdge = (vertices: gdVectorVector2f) => {
   const verticesSize = vertices.size();
   if (verticesSize > 0) {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
@@ -103,6 +103,8 @@ const PointsPreview = (props: Props) => {
     () => {
       const draggingWasDone = !!state.draggedPoint;
       if (draggingWasDone) {
+        state.draggedPoint.setX(Math.round(state.draggedPoint.getX()));
+        state.draggedPoint.setY(Math.round(state.draggedPoint.getY()));
         onPointsUpdated();
         // Select point at the end of the drag
         if (state.draggedPointKind && state.draggedPoint) {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
@@ -101,8 +101,7 @@ const PointsPreview = (props: Props) => {
 
   const onEndDragPoint = React.useCallback(
     () => {
-      const draggingWasDone = !!state.draggedPoint;
-      if (draggingWasDone) {
+      if (state.draggedPoint) {
         state.draggedPoint.setX(Math.round(state.draggedPoint.getX()));
         state.draggedPoint.setY(Math.round(state.draggedPoint.getY()));
         onPointsUpdated();

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/PointsPreview.js
@@ -29,6 +29,11 @@ const getPointName = (kind: PointKind, point: gdPoint): string =>
     ? 'Center'
     : point.getName();
 
+const roundPointToHalfPixel = (point: gdPoint) => {
+  point.setX(Math.round(point.getX() * 2) / 2);
+  point.setY(Math.round(point.getY() * 2) / 2);
+};
+
 type Props = {|
   pointsContainer: gdSprite, // Could potentially be generalized to other things than Sprite in the future.
   imageWidth: number,
@@ -102,8 +107,7 @@ const PointsPreview = (props: Props) => {
   const onEndDragPoint = React.useCallback(
     () => {
       if (state.draggedPoint) {
-        state.draggedPoint.setX(Math.round(state.draggedPoint.getX()));
-        state.draggedPoint.setY(Math.round(state.draggedPoint.getY()));
+        roundPointToHalfPixel(state.draggedPoint);
         onPointsUpdated();
         // Select point at the end of the drag
         if (state.draggedPointKind && state.draggedPoint) {


### PR DESCRIPTION
I wonder if we should allow half pixels. Half pixels can be useful to put vertices at the center of a pixel or at the center of an object that has odd dimensions.

https://gdevelop-storybook.s3.amazonaws.com/round-collision-mask/latest/index.html?path=/story/objecteditor-spriteeditor--collision-masks