### PR TITLE
New Expression: Inventory Maximum, to get the maximum set for an item

### DIFF
--- a/Extensions/Inventory/Extension.cpp
+++ b/Extensions/Inventory/Extension.cpp
@@ -202,4 +202,15 @@ void DeclareInventoryExtension(gd::PlatformExtension& extension) {
       .AddParameter("string", _("Inventory name"))
       .AddParameter("string", _("Item name"))
       .SetFunctionName("InventoryTools::Count");
+
+  extension
+	  .AddExpression("Maximum",
+		  _("Item maximum"),
+		  _("Get the maximum of an item in the inventory, or 0 if it unlimited"),
+		  "",
+		  "CppPlatform/Extensions/Inventoryicon.png")
+	  .AddCodeOnlyParameter("currentScene", "")
+	  .AddParameter("string", _("Inventory name"))
+	  .AddParameter("string", _("Item name"))
+	  .SetFunctionName("InventoryTools::Maximum");
 }

--- a/Extensions/Inventory/Extension.cpp
+++ b/Extensions/Inventory/Extension.cpp
@@ -206,7 +206,7 @@ void DeclareInventoryExtension(gd::PlatformExtension& extension) {
   extension
 	  .AddExpression("Maximum",
 		  _("Item maximum"),
-		  _("Get the maximum of an item in the inventory, or 0 if it unlimited"),
+		  _("Get the maximum of an item in the inventory, or 0 if it is unlimited"),
 		  "",
 		  "CppPlatform/Extensions/Inventoryicon.png")
 	  .AddCodeOnlyParameter("currentScene", "")

--- a/Extensions/Inventory/JsExtension.cpp
+++ b/Extensions/Inventory/JsExtension.cpp
@@ -88,6 +88,11 @@ class InventoryJsExtension : public gd::PlatformExtension {
         .SetIncludeFile("Extensions/Inventory/inventory.js")
         .AddIncludeFile("Extensions/Inventory/inventorytools.js")
         .SetFunctionName("gdjs.evtTools.inventory.count");
+	GetAllExpressions()["Inventory::Maximum"]
+		.codeExtraInformation
+		.SetIncludeFile("Extensions/Inventory/inventory.js")
+		.AddIncludeFile("Extensions/Inventory/inventorytools.js")
+		.SetFunctionName("gdjs.evtTools.inventory.maximum");
 
     StripUnimplementedInstructionsAndExpressions();
     GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();

--- a/Extensions/Inventory/inventory.ts
+++ b/Extensions/Inventory/inventory.ts
@@ -23,7 +23,7 @@ namespace gdjs {
       return this._items[itemName].count;
     }
 
-	maximum(itemName) {
+    maximum(itemName) {
       if (!this._items.hasOwnProperty(itemName)) {
         return 0;
       }
@@ -87,7 +87,7 @@ namespace gdjs {
       if (!this._items.hasOwnProperty(itemName)) {
         this._makeItemEntry(itemName);
       }
-	  this._items[itemName].maxCount = 0;
+      this._items[itemName].maxCount = 0;
       this._items[itemName].unlimited = enable;
     }
 

--- a/Extensions/Inventory/inventory.ts
+++ b/Extensions/Inventory/inventory.ts
@@ -23,6 +23,13 @@ namespace gdjs {
       return this._items[itemName].count;
     }
 
+	maximum(itemName) {
+      if (!this._items.hasOwnProperty(itemName)) {
+        return 0;
+      }
+      return this._items[itemName].maxCount;
+    }
+
     add(itemName) {
       if (!this._items.hasOwnProperty(itemName)) {
         this._makeItemEntry(itemName);
@@ -80,6 +87,7 @@ namespace gdjs {
       if (!this._items.hasOwnProperty(itemName)) {
         this._makeItemEntry(itemName);
       }
+	  this._items[itemName].maxCount = 0;
       this._items[itemName].unlimited = enable;
     }
 

--- a/Extensions/Inventory/inventorytools.ts
+++ b/Extensions/Inventory/inventorytools.ts
@@ -49,7 +49,7 @@ namespace gdjs {
         );
       };
 
-	  export const maximum = function (
+      export const maximum = function (
         instanceContainer: gdjs.RuntimeInstanceContainer,
         inventoryName: string,
         name: string

--- a/Extensions/Inventory/inventorytools.ts
+++ b/Extensions/Inventory/inventorytools.ts
@@ -49,6 +49,16 @@ namespace gdjs {
         );
       };
 
+	  export const maximum = function (
+        instanceContainer: gdjs.RuntimeInstanceContainer,
+        inventoryName: string,
+        name: string
+      ) {
+        return InventoryManager.get(instanceContainer, inventoryName).maximum(
+          name
+        );
+      };
+
       export const has = function (
         instanceContainer: gdjs.RuntimeInstanceContainer,
         inventoryName: string,


### PR DESCRIPTION
New expression for the inventory, the Maximum was missing.
Two cases: 

- The item has a maximum: it returns the value set
- The item is unlimited: it returns 0
- When you set an item as "unlimited" the maxCount change to become 0, unchanged previously