### PR TITLE
Fix a regression on extension loading

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -800,6 +800,8 @@ const MainFrame = (props: Props) => {
           storageProviderOperations,
           authenticatedUser,
         }));
+
+        setIsProjectClosedSoAvoidReloadingExtensions(false);
       }
 
       return state;


### PR DESCRIPTION
I forgot to reset the flag when a project is opened in the previous PR.