### PR TITLE
Fix the default image name suggested to Piskel when the animation name is empty

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -154,8 +154,10 @@ const checkDirectionPointsAndCollisionsMasks = (direction: gdDirection) => {
   };
 };
 
-const removeExtensionFromFileName = fileName =>
-  fileName.substring(0, fileName.lastIndexOf('.'));
+const removeExtensionFromFileName = fileName => {
+  const dotIndex = fileName.lastIndexOf('.');
+  return dotIndex < 0 ? fileName : fileName.substring(0, dotIndex);
+};
 
 type Props = {|
   direction: gdDirection,

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -154,6 +154,9 @@ const checkDirectionPointsAndCollisionsMasks = (direction: gdDirection) => {
   };
 };
 
+const removeExtensionFromFileName = fileName =>
+  fileName.substring(0, fileName.lastIndexOf('.'));
+
 type Props = {|
   direction: gdDirection,
   project: gdProject,
@@ -266,7 +269,10 @@ const SpritesList = ({
                 direction.getTimeBetweenFrames() > 0
                   ? 1 / direction.getTimeBetweenFrames()
                   : 1,
-              name: animationName || resourceNames[0] || objectName,
+              name:
+                animationName ||
+                removeExtensionFromFileName(resourceNames[0]) ||
+                objectName,
               isLooping: direction.isLooping(),
               existingMetadata: direction.getMetadata(),
             },


### PR DESCRIPTION
* The resource name was given with the extension which resulted to a file names with twice the extension.