### PR TITLE
When renaming or removing an object, only refactor associated external events

### DIFF
--- a/Core/GDCore/IDE/WholeProjectRefactorer.cpp
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.cpp
@@ -1382,25 +1382,12 @@ void WholeProjectRefactorer::ObjectOrGroupRemovedInLayout(
 
   // Remove object in external events
   if (removeEventsAndGroups) {
-    DependenciesAnalyzer analyzer(project, layout);
-    if (analyzer.Analyze()) {
-      for (auto& externalEventsName :
-           analyzer.GetExternalEventsDependencies()) {
-        auto& externalEvents = project.GetExternalEvents(externalEventsName);
-        gd::EventsRefactorer::RemoveObjectInEvents(project.GetCurrentPlatform(),
-                                                   project,
-                                                   layout,
-                                                   externalEvents.GetEvents(),
-                                                   objectName);
-      }
-      for (auto& layoutName : analyzer.GetScenesDependencies()) {
-        auto& layout = project.GetLayout(layoutName);
-        gd::EventsRefactorer::RemoveObjectInEvents(project.GetCurrentPlatform(),
-                                                   project,
-                                                   layout,
-                                                   layout.GetEvents(),
-                                                   objectName);
-      }
+    for (auto &externalEventsName :
+         GetAssociatedExternalEvents(project, layout.GetName())) {
+      auto &externalEvents = project.GetExternalEvents(externalEventsName);
+      gd::EventsRefactorer::RemoveObjectInEvents(
+          project.GetCurrentPlatform(), project, layout,
+          externalEvents.GetEvents(), objectName);
     }
   }
 
@@ -1439,26 +1426,12 @@ void WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
   }
 
   // Rename object in external events
-  DependenciesAnalyzer analyzer(project, layout);
-  if (analyzer.Analyze()) {
-    for (auto& externalEventsName : analyzer.GetExternalEventsDependencies()) {
-      auto& externalEvents = project.GetExternalEvents(externalEventsName);
-      gd::EventsRefactorer::RenameObjectInEvents(project.GetCurrentPlatform(),
-                                                 project,
-                                                 layout,
-                                                 externalEvents.GetEvents(),
-                                                 oldName,
-                                                 newName);
-    }
-    for (auto& layoutName : analyzer.GetScenesDependencies()) {
-      auto& layout = project.GetLayout(layoutName);
-      gd::EventsRefactorer::RenameObjectInEvents(project.GetCurrentPlatform(),
-                                                 project,
-                                                 layout,
-                                                 layout.GetEvents(),
-                                                 oldName,
-                                                 newName);
-    }
+  for (auto &externalEventsName :
+       GetAssociatedExternalEvents(project, layout.GetName())) {
+    auto &externalEvents = project.GetExternalEvents(externalEventsName);
+    gd::EventsRefactorer::RenameObjectInEvents(
+        project.GetCurrentPlatform(), project, layout,
+        externalEvents.GetEvents(), oldName, newName);
   }
 
   // Rename object in external layouts

--- a/Core/GDCore/IDE/WholeProjectRefactorer.h
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.h
@@ -325,7 +325,7 @@ class GD_CORE_API WholeProjectRefactorer {
    * \brief Refactor the project after an object is renamed in a layout
    *
    * This will update the layout, all external layouts associated with it
-   * and all external events used by the layout.
+   * and all external events associated with it.
    */
   static void ObjectOrGroupRenamedInLayout(gd::Project& project,
                                            gd::Layout& layout,
@@ -337,7 +337,7 @@ class GD_CORE_API WholeProjectRefactorer {
    * \brief Refactor the project after an object is removed in a layout
    *
    * This will update the layout, all external layouts associated with it
-   * and all external events used by the layout.
+   * and all external events associated with it.
    */
   static void ObjectOrGroupRemovedInLayout(gd::Project& project,
                                            gd::Layout& layout,

--- a/Core/tests/WholeProjectRefactorer.cpp
+++ b/Core/tests/WholeProjectRefactorer.cpp
@@ -314,7 +314,7 @@ const void SetupEvents(gd::EventsList &eventList) {
     if (eventList.GetEventsCount() != FreeFunctionWithGroup) {
       throw std::logic_error("Invalid events setup: " + std::to_string(eventList.GetEventsCount()));
     }
-    // Create an event referring to objects
+    // Create an event referring to a group.
     {
       gd::StandardEvent event;
       gd::Instruction action;
@@ -329,7 +329,7 @@ const void SetupEvents(gd::EventsList &eventList) {
     if (eventList.GetEventsCount() != FreeFunctionWithObjectExpressionOnGroup) {
       throw std::logic_error("Invalid events setup: " + std::to_string(eventList.GetEventsCount()));
     }
-    // Create an event referring to objects in an expression
+    // Create an event referring to a group in an expression.
     {
       gd::StandardEvent event;
       gd::Instruction action;
@@ -1472,15 +1472,15 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
 
       auto &layout = project.GetLayout("Scene");
 
-      // Trigger the refactoring after removing an object
+      // Trigger the refactoring after removing a group
       gd::WholeProjectRefactorer::ObjectOrGroupRemovedInLayout(
           project, layout, "GroupWithMyBehavior", /* isObjectGroup=*/false);
 
       for (auto *eventsList : GetLayerScopeEventsLists(project)) {
-        // Check actions with the object in parameters have been removed.
+        // Check actions with the group in parameters have been removed.
         REQUIRE(IsActionsEmpty(eventsList->GetEvent(FreeFunctionWithGroup)));
 
-        // Check actions with the object in expressions have been removed.
+        // Check actions with the group in expressions have been removed.
         REQUIRE(IsActionsEmpty(
             eventsList->GetEvent(FreeFunctionWithObjectExpressionOnGroup)));
       }
@@ -1496,17 +1496,17 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
 
       auto &layout = project.GetLayout("Scene");
 
-      // Trigger the refactoring after the renaming of an object
+      // Trigger the refactoring after the renaming of a group
       gd::WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
           project, layout, "GroupWithMyBehavior", "RenamedGroupWithMyBehavior",
           /* isObjectGroup=*/false);
 
       for (auto *eventsList : GetLayerScopeEventsLists(project)) {
-        // Check object name has been renamed in action parameters.
+        // Check group name has been renamed in action parameters.
         REQUIRE(GetEventFirstActionFirstParameterString(eventsList->GetEvent(
                     FreeFunctionWithGroup)) == "RenamedGroupWithMyBehavior");
 
-        // Check object name has been renamed in expressions.
+        // Check group name has been renamed in expressions.
         REQUIRE(GetEventFirstActionFirstParameterString(eventsList->GetEvent(
                     FreeFunctionWithObjectExpressionOnGroup)) ==
                 "RenamedGroupWithMyBehavior.GetObjectNumber()");

--- a/Core/tests/WholeProjectRefactorer.cpp
+++ b/Core/tests/WholeProjectRefactorer.cpp
@@ -57,7 +57,7 @@ GetEventFirstActionFirstParameterString(const gd::BaseEvent &event) {
 }
 
 bool
-IsActionsEmpty(const gd::BaseEvent &event) {
+AreActionsEmpty(const gd::BaseEvent &event) {
   auto &actions = EnsureStandardEvent(event).GetActions();
   return actions.IsEmpty();
 }
@@ -115,7 +115,7 @@ enum TestEvent {
   ObjectActionWithOperator,
 };
 
-const std::vector<const gd::EventsList *> GetLayerScopeEventsLists(gd::Project &project) {
+const std::vector<const gd::EventsList *> GetEventsListsAssociatedToScene(gd::Project &project) {
   std::vector<const gd::EventsList *> eventLists;
   auto &scene = project.GetLayout("Scene").GetEvents();
   auto &externalEvents =
@@ -125,7 +125,7 @@ const std::vector<const gd::EventsList *> GetLayerScopeEventsLists(gd::Project &
   return eventLists;
 }
 
-const std::vector<const gd::EventsList *> GetLayerOutOfScopeEventsLists(gd::Project &project) {
+const std::vector<const gd::EventsList *> GetEventsListsNotAssociatedToScene(gd::Project &project) {
   std::vector<const gd::EventsList *> eventLists;
   auto &eventsExtension = project.GetEventsFunctionsExtension("MyEventsExtension");
   auto &objectFunctionEvents =
@@ -152,10 +152,10 @@ const std::vector<const gd::EventsList *> GetLayerOutOfScopeEventsLists(gd::Proj
 const std::vector<const gd::EventsList *> GetEventsLists(gd::Project &project) {
   std::vector<const gd::EventsList *> eventLists;
 
-  for (auto *eventsList : GetLayerScopeEventsLists(project)) {
+  for (auto *eventsList : GetEventsListsAssociatedToScene(project)) {
     eventLists.push_back(eventsList);
   }
-  for (auto *eventsList : GetLayerOutOfScopeEventsLists(project)) {
+  for (auto *eventsList : GetEventsListsNotAssociatedToScene(project)) {
     eventLists.push_back(eventsList);
   }
   return eventLists;
@@ -1307,13 +1307,13 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
       gd::WholeProjectRefactorer::ObjectOrGroupRemovedInLayout(
           project, layout, "ObjectWithMyBehavior", /* isObjectGroup=*/false);
 
-      for (auto *eventsList : GetLayerScopeEventsLists(project)) {
+      for (auto *eventsList : GetEventsListsAssociatedToScene(project)) {
       // Check actions with the object in parameters have been removed.
       REQUIRE(
-          IsActionsEmpty(eventsList->GetEvent(FreeFunctionWithObjects)));
+          AreActionsEmpty(eventsList->GetEvent(FreeFunctionWithObjects)));
 
       // Check actions with the object in expressions have been removed.
-      REQUIRE(IsActionsEmpty(
+      REQUIRE(AreActionsEmpty(
           eventsList->GetEvent(FreeFunctionWithObjectExpression)));
       }
     }
@@ -1450,7 +1450,7 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
           "RenamedObjectWithMyBehavior",
           /* isObjectGroup=*/false);
 
-      for (auto *eventsList : GetLayerScopeEventsLists(project)) {
+      for (auto *eventsList : GetEventsListsAssociatedToScene(project)) {
         // Check object name has been renamed in action parameters.
         REQUIRE(GetEventFirstActionFirstParameterString(eventsList->GetEvent(
                     FreeFunctionWithObjects)) == "RenamedObjectWithMyBehavior");
@@ -1474,14 +1474,14 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
 
       // Trigger the refactoring after removing a group
       gd::WholeProjectRefactorer::ObjectOrGroupRemovedInLayout(
-          project, layout, "GroupWithMyBehavior", /* isObjectGroup=*/false);
+          project, layout, "GroupWithMyBehavior", /* isObjectGroup=*/true);
 
-      for (auto *eventsList : GetLayerScopeEventsLists(project)) {
+      for (auto *eventsList : GetEventsListsAssociatedToScene(project)) {
         // Check actions with the group in parameters have been removed.
-        REQUIRE(IsActionsEmpty(eventsList->GetEvent(FreeFunctionWithGroup)));
+        REQUIRE(AreActionsEmpty(eventsList->GetEvent(FreeFunctionWithGroup)));
 
         // Check actions with the group in expressions have been removed.
-        REQUIRE(IsActionsEmpty(
+        REQUIRE(AreActionsEmpty(
             eventsList->GetEvent(FreeFunctionWithObjectExpressionOnGroup)));
       }
     }
@@ -1499,9 +1499,9 @@ TEST_CASE("WholeProjectRefactorer", "[common]") {
       // Trigger the refactoring after the renaming of a group
       gd::WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
           project, layout, "GroupWithMyBehavior", "RenamedGroupWithMyBehavior",
-          /* isObjectGroup=*/false);
+          /* isObjectGroup=*/true);
 
-      for (auto *eventsList : GetLayerScopeEventsLists(project)) {
+      for (auto *eventsList : GetEventsListsAssociatedToScene(project)) {
         // Check group name has been renamed in action parameters.
         REQUIRE(GetEventFirstActionFirstParameterString(eventsList->GetEvent(
                     FreeFunctionWithGroup)) == "RenamedGroupWithMyBehavior");


### PR DESCRIPTION
It also add some tests on external events or groups.