### PR TITLE
Fix the creation of a new frame with the image editor

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -154,7 +154,7 @@ const checkDirectionPointsAndCollisionsMasks = (direction: gdDirection) => {
   };
 };
 
-const removeExtensionFromFileName = fileName => {
+const removeExtensionFromFileName = (fileName: string) => {
   const dotIndex = fileName.lastIndexOf('.');
   return dotIndex < 0 ? fileName : fileName.substring(0, dotIndex);
 };
@@ -273,7 +273,8 @@ const SpritesList = ({
                   : 1,
               name:
                 animationName ||
-                removeExtensionFromFileName(resourceNames[0]) ||
+                (resourceNames[0] &&
+                  removeExtensionFromFileName(resourceNames[0])) ||
                 objectName,
               isLooping: direction.isLooping(),
               existingMetadata: direction.getMetadata(),


### PR DESCRIPTION
 when the animation doesn't have a name

* Don't show in changelogs

It's a regression that is not released.