### PR TITLE
Scroll editor tabs when a new tab is activated or opened

### DIFF
--- a/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
@@ -9,6 +9,7 @@ import {
   type EditorTab,
   getEditors,
   getCurrentTabIndex,
+  getCurrentTab,
 } from './EditorTabsHandler';
 import {
   ClosableTabs,
@@ -31,6 +32,9 @@ type DraggableEditorTabsProps = {|
   onDropTab: (fromIndex: number, toHoveredIndex: number) => void,
 |};
 
+const getTabId = (editorTab: EditorTab) =>
+  `tab-${editorTab.key.replace(/\s/g, '-')}`;
+
 export function DraggableEditorTabs({
   hideLabels,
   editorTabs,
@@ -43,6 +47,19 @@ export function DraggableEditorTabs({
 }: DraggableEditorTabsProps) {
   let draggedTabIndex: ?number = null;
 
+  const currentTab = getCurrentTab(editorTabs);
+
+  React.useEffect(
+    () => {
+      if (!currentTab) return;
+      const tabElement = document.getElementById(getTabId(currentTab));
+      if (tabElement) {
+        tabElement.scrollIntoView();
+      }
+    },
+    [currentTab]
+  );
+
   return (
     <ClosableTabs hideLabels={hideLabels}>
       {getEditors(editorTabs).map((editorTab, id) => {
@@ -53,7 +70,7 @@ export function DraggableEditorTabs({
             label={editorTab.label}
             icon={editorTab.icon}
             key={editorTab.key}
-            id={`tab-${editorTab.key.replace(/\s/g, '-')}`}
+            id={getTabId(editorTab)}
             data={editorTab.tabOptions ? editorTab.tabOptions.data : undefined}
             active={isCurrentTab}
             onClick={() => onClickTab(id)}

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -180,6 +180,7 @@ export function ClosableTab({
   return (
     <React.Fragment>
       <span
+        id={id}
         style={{
           flexShrink: 0, // Tabs are never resized to fit in flex container
           position: 'relative',


### PR DESCRIPTION
I didn't do it with ref to avoid drilling forward refs but it's doable.