### PR TITLE
Fix Objects Panel button tooltip.

### DIFF
--- a/newIDE/app/src/SceneEditor/Toolbar.js
+++ b/newIDE/app/src/SceneEditor/Toolbar.js
@@ -82,7 +82,7 @@ const Toolbar = (props: Props) => {
           onClick={props.toggleObjectsList}
           selected={props.isObjectsListShown}
           tooltip={
-            props.isObjectGroupsListShown
+            props.isObjectsListShown
               ? t`Close Objects Panel`
               : t`Open Objects Panel`
           }


### PR DESCRIPTION
The tooltip for the Object Panel button always "Open Objects Panel", even when it's already open.

![image](https://user-images.githubusercontent.com/2385329/229699703-010cfd29-71fc-406f-be51-2380a7b609ff.png)

![image](https://user-images.githubusercontent.com/2385329/229699749-d0cfc70e-f90a-45a1-bcce-0456ba0468be.png)

Turns out it's because it's linked to the status of the Object Groups Panel button instead (so it only says "Close Objects Panel" when the Object Groups panel is open (even if the Objects Panel is closed).

![image](https://user-images.githubusercontent.com/2385329/229699812-03f39bc5-4ae6-4c56-8f54-cd9e8e6999f9.png)
