### PR TITLE
Close preview window with cmd w

### DIFF
--- a/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/Export/LocalExporters/LocalPreviewLauncher/index.js
@@ -80,6 +80,11 @@ export default class LocalPreviewLauncher extends React.Component<
     });
   };
 
+  closePreview = (windowId: number) => {
+    if (!ipcRenderer) return;
+    ipcRenderer.invoke('preview-close', { windowId });
+  };
+
   _openPreviewWindow = (
     project: gdProject,
     gamePath: string,

--- a/newIDE/app/src/Export/PreviewLauncher.flow.js
+++ b/newIDE/app/src/Export/PreviewLauncher.flow.js
@@ -72,6 +72,7 @@ export type PreviewLauncherInterface = {
   launchPreview: (previewOptions: PreviewOptions) => Promise<any>,
   canDoNetworkPreview: () => boolean,
   canDoHotReload: () => boolean,
+  +closePreview?: (windowId: number) => void,
   +getPreviewDebuggerServer: () => ?PreviewDebuggerServer,
 };
 

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -65,8 +65,12 @@ export const create = (authentication: Authentication) => {
           }) => (
             <MainFrame
               i18n={i18n}
-              renderMainMenu={(props, callbacks) => (
-                <ElectronMainMenu props={props} callbacks={callbacks} />
+              renderMainMenu={(props, callbacks, extraCallbacks) => (
+                <ElectronMainMenu
+                  props={props}
+                  callbacks={callbacks}
+                  extraCallbacks={extraCallbacks}
+                />
               )}
               renderPreviewLauncher={(props, ref) => (
                 <LocalPreviewLauncher {...props} ref={ref} />

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -85,9 +85,11 @@ const ElectronMainMenu = ({
     isFocusedOnMainWindow,
     setIsFocusedOnMainWindow,
   ] = React.useState<boolean>(true);
-  const [focusedWindowId, setFocusedWindowId] = React.useState<?number>(null);
+  const [focusedWindowId, setFocusedWindowId] = React.useState<number>(
+    remote.getCurrentWindow().id
+  );
   const closePreviewWindow =
-    !isFocusedOnMainWindow && onClosePreview && focusedWindowId
+    !isFocusedOnMainWindow && onClosePreview
       ? () => onClosePreview(focusedWindowId)
       : null;
   const {

--- a/newIDE/app/src/MainFrame/MainMenu.js
+++ b/newIDE/app/src/MainFrame/MainMenu.js
@@ -45,6 +45,10 @@ export type MainMenuCallbacks = {|
   setElectronUpdateStatus: ElectronUpdateStatus => void,
 |};
 
+export type MainMenuExtraCallbacks = {|
+  onClosePreview?: ?(windowId: number) => void,
+|};
+
 export type MainMenuEvent =
   | 'main-menu-open'
   | 'main-menu-open-recent'

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -204,6 +204,7 @@ export type PreferencesValues = {|
   inAppTutorialsProgress: InAppTutorialProgressDatabase,
   newProjectsDefaultFolder: string,
   newProjectsDefaultStorageProviderName: string,
+  useShortcutToClosePreviewWindow: boolean,
 |};
 
 /**
@@ -278,6 +279,7 @@ export type Preferences = {|
     userId: ?string,
   |}) => ?InAppTutorialUserProgress,
   setNewProjectsDefaultFolder: (newProjectsDefaultFolder: string) => void,
+  setUseShortcutToClosePreviewWindow: (enabled: boolean) => void,
 |};
 
 export const initialPreferences = {
@@ -320,6 +322,7 @@ export const initialPreferences = {
     inAppTutorialsProgress: {},
     newProjectsDefaultFolder: app ? findDefaultFolder(app) : '',
     newProjectsDefaultStorageProviderName: 'Cloud',
+    useShortcutToClosePreviewWindow: true,
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -373,6 +376,7 @@ export const initialPreferences = {
   getTutorialProgress: () => {},
   setNewProjectsDefaultFolder: () => {},
   setNewProjectsDefaultStorageProviderName: () => {},
+  setUseShortcutToClosePreviewWindow: () => {}
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -376,7 +376,7 @@ export const initialPreferences = {
   getTutorialProgress: () => {},
   setNewProjectsDefaultFolder: () => {},
   setNewProjectsDefaultStorageProviderName: () => {},
-  setUseShortcutToClosePreviewWindow: () => {}
+  setUseShortcutToClosePreviewWindow: () => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -23,6 +23,9 @@ import ShortcutsList from '../../KeyboardShortcuts/ShortcutsList';
 import LanguageSelector from './LanguageSelector';
 import Link from '../../UI/Link';
 import { useResponsiveWindowWidth } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
+import { adaptAcceleratorString } from '../../UI/AcceleratorString';
+import { getElectronAccelerator } from '../../KeyboardShortcuts';
+import defaultShortcuts from '../../KeyboardShortcuts/DefaultShortcuts';
 const electron = optionalRequire('electron');
 
 type Props = {|
@@ -62,6 +65,7 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
     setShowCommunityExtensions,
     setShowEventBasedObjectsEditor,
     setNewProjectsDefaultFolder,
+    setUseShortcutToClosePreviewWindow,
   } = React.useContext(PreferencesContext);
 
   return (
@@ -361,6 +365,25 @@ const PreferencesDialog = ({ i18n, onClose }: Props) => {
                   label={
                     <Trans>
                       Always display the preview window on top of the editor
+                    </Trans>
+                  }
+                />
+                <Toggle
+                  onToggle={(e, check) =>
+                    setUseShortcutToClosePreviewWindow(check)
+                  }
+                  toggled={values.useShortcutToClosePreviewWindow}
+                  labelPosition="right"
+                  label={
+                    <Trans>
+                      Enable "Close project" shortcut (
+                      {adaptAcceleratorString(
+                        getElectronAccelerator(
+                          values.userShortcutMap['CLOSE_PROJECT'] ||
+                            defaultShortcuts['CLOSE_PROJECT']
+                        )
+                      )}
+                      ) to close preview window
                     </Trans>
                   }
                 />

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -154,6 +154,9 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     setNewProjectsDefaultStorageProviderName: this._setNewProjectsDefaultStorageProviderName.bind(
       this
     ),
+    setUseShortcutToClosePreviewWindow: this._setUseShortcutToClosePreviewWindow.bind(
+      this
+    ),
   };
 
   componentDidMount() {
@@ -378,6 +381,20 @@ export default class PreferencesProvider extends React.Component<Props, State> {
         values: {
           ...state.values,
           eventsSheetCancelInlineParameter,
+        },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _setUseShortcutToClosePreviewWindow(
+    useShortcutToClosePreviewWindow: boolean
+  ) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          useShortcutToClosePreviewWindow,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -108,6 +108,7 @@ import UnsavedChangesContext from './UnsavedChangesContext';
 import {
   type BuildMainMenuProps,
   type MainMenuCallbacks,
+  type MainMenuExtraCallbacks,
   buildMainMenuDeclarativeTemplate,
   adaptFromDeclarativeTemplate,
 } from './MainMenu';
@@ -264,7 +265,11 @@ type LaunchPreviewOptions = {
 };
 
 export type Props = {|
-  renderMainMenu?: (BuildMainMenuProps, MainMenuCallbacks) => React.Node,
+  renderMainMenu?: (
+    BuildMainMenuProps,
+    MainMenuCallbacks,
+    MainMenuExtraCallbacks
+  ) => React.Node,
   renderPreviewLauncher?: (
     props: PreviewLauncherProps,
     ref: (previewLauncher: ?PreviewLauncherInterface) => void
@@ -2944,7 +2949,13 @@ const MainFrame = (props: Props) => {
       {!!renderMainMenu &&
         renderMainMenu(
           { ...buildMainMenuProps, isApplicationTopLevelMenu: true },
-          mainMenuCallbacks
+          mainMenuCallbacks,
+          {
+            onClosePreview:
+              _previewLauncher.current && _previewLauncher.current.closePreview
+                ? _previewLauncher.current.closePreview
+                : null,
+          }
         )}
       <ProjectTitlebar
         projectName={currentProject ? currentProject.getName() : null}

--- a/newIDE/electron-app/app/PreviewWindow.js
+++ b/newIDE/electron-app/app/PreviewWindow.js
@@ -50,6 +50,8 @@ const openPreviewWindow = ({
 
   previewWindow.loadURL(previewGameIndexHtmlPath);
 
+  previewWindows.push(previewWindow);
+
   previewWindow.on('closed', event => {
     previewWindows = previewWindows.filter(
       otherPreviewBrowserWindow => otherPreviewBrowserWindow !== previewWindow
@@ -58,6 +60,12 @@ const openPreviewWindow = ({
   });
 };
 
+const closePreviewWindow = windowId => {
+  const previewWindow = previewWindows.find(window => window.id === windowId);
+  if (previewWindow) previewWindow.close();
+};
+
 module.exports = {
   openPreviewWindow,
+  closePreviewWindow,
 };

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -26,7 +26,7 @@ const {
   downloadLocalFile,
   saveLocalFileFromArrayBuffer,
 } = require('./LocalFileDownloader');
-const { openPreviewWindow } = require('./PreviewWindow');
+const { openPreviewWindow, closePreviewWindow } = require('./PreviewWindow');
 const {
   setupLocalGDJSDevelopmentWatcher,
   closeLocalGDJSDevelopmentWatcher,
@@ -180,6 +180,9 @@ app.on('ready', function() {
       alwaysOnTop: options.alwaysOnTop,
       hideMenuBar: options.hideMenuBar,
     });
+  });
+  ipcMain.handle('preview-close', async (event, options) => {
+    return closePreviewWindow(options.windowId);
   });
 
   // Piskel image editor


### PR DESCRIPTION
Follow up of #5088 that did not implement the feature and only prevented to use electron shortcuts when a preview window is focused