### PR TITLE
Allow event extensions to declare variable parameters.

### DIFF
--- a/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
@@ -33,7 +33,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           "res/function32.png",
           "res/function32.png")
       .SetHelpPath("/events/functions/return")
-      .AddParameter("expression", "The number to be returned")
+      .AddParameter("expression", _("The number to be returned"))
       .SetRelevantForFunctionEventsOnly()
       .MarkAsAdvanced();
 
@@ -48,7 +48,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           "res/function32.png",
           "res/function32.png")
       .SetHelpPath("/events/functions/return")
-      .AddParameter("string", "The text to be returned")
+      .AddParameter("string", _("The text to be returned"))
       .SetRelevantForFunctionEventsOnly()
       .MarkAsAdvanced();
 
@@ -62,7 +62,37 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                  "res/function32.png",
                  "res/function32.png")
       .SetHelpPath("/events/functions/return")
-      .AddParameter("trueorfalse", "Should the condition be true or false?")
+      .AddParameter("trueorfalse", _("Should the condition be true or false?"))
+      .SetRelevantForFunctionEventsOnly()
+      .MarkAsAdvanced();
+
+  extension
+      .AddAction("CopyArgumentToVariable",
+                 _("Copy function parameter to variable"),
+                 _("Copy a function parameter (also called \"argument\") to a variable. "
+                 "The parameter type must be a variable."),
+                 _("Copy the parameter _PARAM0_ into the variable _PARAM1_"),
+                 "",
+                 "res/function32.png",
+                 "res/function32.png")
+      .SetHelpPath("/events/functions/return")
+      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("scenevar", _("Scene variable"))
+      .SetRelevantForFunctionEventsOnly()
+      .MarkAsAdvanced();
+
+  extension
+      .AddAction("CopyVariableToArgument",
+                 _("Copy variable to function parameter"),
+                 _("Copy a variable to function parameter (also called \"argument\"). "
+                 "The parameter type must be a variable."),
+                 _("Copy the variable _PARAM1_ into the parameter _PARAM0_"),
+                 "",
+                 "res/function32.png",
+                 "res/function32.png")
+      .SetHelpPath("/events/functions/return")
+      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("scenevar", _("Scene variable"))
       .SetRelevantForFunctionEventsOnly()
       .MarkAsAdvanced();
 
@@ -77,7 +107,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                     "",
                     "res/function32.png",
                     "res/function32.png")
-      .AddParameter("functionParameterName", "Parameter name")
+      .AddParameter("functionParameterName", _("Parameter name"))
       .SetRelevantForFunctionEventsOnly()
       .MarkAsAdvanced();
 
@@ -88,7 +118,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           _("Get function parameter (also called \"argument\") value."),
           "",
           "res/function16.png")
-      .AddParameter("functionParameterName", "Parameter name")
+      .AddParameter("functionParameterName", _("Parameter name"))
       .SetRelevantForFunctionEventsOnly();
 
   extension
@@ -98,7 +128,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           _("Get function parameter (also called \"argument\") text."),
           "",
           "res/function16.png")
-      .AddParameter("functionParameterName", "Parameter name")
+      .AddParameter("functionParameterName", _("Parameter name"))
       .SetRelevantForFunctionEventsOnly();
 
   extension
@@ -110,7 +140,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           "",
           "res/function32.png",
           "res/function16.png")
-      .AddParameter("functionParameterName", "Parameter name")
+      .AddParameter("functionParameterName", _("Parameter name"))
       .UseStandardRelationalOperatorParameters(
           "number", gd::ParameterOptions::MakeNewOptions())
       .SetRelevantForFunctionEventsOnly();
@@ -124,7 +154,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           "",
           "res/function32.png",
           "res/function16.png")
-      .AddParameter("functionParameterName", "Parameter name")
+      .AddParameter("functionParameterName", _("Parameter name"))
       .UseStandardRelationalOperatorParameters(
           "string", gd::ParameterOptions::MakeNewOptions())
       .SetRelevantForFunctionEventsOnly();

--- a/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
@@ -76,7 +76,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                  "res/function32.png",
                  "res/function32.png")
       .SetHelpPath("/events/functions/return")
-      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("functionParameterName", _("Parameter name"), "variable")
       .AddParameter("scenevar", _("Scene variable"))
       .SetRelevantForFunctionEventsOnly()
       .MarkAsAdvanced();
@@ -91,7 +91,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                  "res/function32.png",
                  "res/function32.png")
       .SetHelpPath("/events/functions/return")
-      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("functionParameterName", _("Parameter name"), "variable")
       .AddParameter("scenevar", _("Scene variable"))
       .SetRelevantForFunctionEventsOnly()
       .MarkAsAdvanced();
@@ -107,7 +107,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                     "",
                     "res/function32.png",
                     "res/function32.png")
-      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .SetRelevantForFunctionEventsOnly()
       .MarkAsAdvanced();
 
@@ -118,7 +118,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           _("Get function parameter (also called \"argument\") value."),
           "",
           "res/function16.png")
-      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .SetRelevantForFunctionEventsOnly();
 
   extension
@@ -128,7 +128,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           _("Get function parameter (also called \"argument\") text."),
           "",
           "res/function16.png")
-      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .SetRelevantForFunctionEventsOnly();
 
   extension
@@ -140,7 +140,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           "",
           "res/function32.png",
           "res/function16.png")
-      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .UseStandardRelationalOperatorParameters(
           "number", gd::ParameterOptions::MakeNewOptions())
       .SetRelevantForFunctionEventsOnly();
@@ -154,7 +154,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
           "",
           "res/function32.png",
           "res/function16.png")
-      .AddParameter("functionParameterName", _("Parameter name"))
+      .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .UseStandardRelationalOperatorParameters(
           "string", gd::ParameterOptions::MakeNewOptions())
       .SetRelevantForFunctionEventsOnly();

--- a/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadata.h
@@ -209,10 +209,10 @@ class GD_CORE_API ParameterMetadata {
    * \brief Return the expression type from the parameter type.
    * Declinations of "number" and "string" types (like "forceMultiplier" or
    * "sceneName") are replaced by "number" and "string".
-   * \deprecated Use gd::ValueTypeMetadata instead.
+   * \deprecated Use gd::ValueTypeMetadata or gd::GetExpressionPrimitiveValueType instead.
    */
   static const gd::String &GetExpressionValueType(const gd::String &parameterType) {
-    return gd::ValueTypeMetadata::GetPrimitiveValueType(parameterType);
+    return gd::ValueTypeMetadata::GetExpressionPrimitiveValueType(parameterType);
   }
 
   /** \name Serialization

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
@@ -35,6 +35,8 @@ void ValueTypeMetadata::UnserializeFrom(const SerializerElement& element) {
 
 const gd::String ValueTypeMetadata::numberType = "number";
 const gd::String ValueTypeMetadata::stringType = "string";
+const gd::String ValueTypeMetadata::variableType = "variable";
+const gd::String ValueTypeMetadata::booleanType = "boolean";
 
 const gd::String &ValueTypeMetadata::GetPrimitiveValueType(const gd::String &parameterType) {
   if (parameterType == "number" || gd::ValueTypeMetadata::IsTypeExpression("number", parameterType)) {
@@ -42,6 +44,12 @@ const gd::String &ValueTypeMetadata::GetPrimitiveValueType(const gd::String &par
   }
   if (parameterType == "string" || gd::ValueTypeMetadata::IsTypeExpression("string", parameterType)) {
     return ValueTypeMetadata::stringType;
+  }
+  if (parameterType == "variable" || gd::ValueTypeMetadata::IsTypeExpression("variable", parameterType)) {
+    return ValueTypeMetadata::variableType;
+  }
+  if (parameterType == "boolean" || gd::ValueTypeMetadata::IsTypeExpression("boolean", parameterType)) {
+    return ValueTypeMetadata::variableType;
   }
   return parameterType;
 }

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
@@ -59,7 +59,7 @@ ValueTypeMetadata::GetPrimitiveValueType(const gd::String &parameterType) {
   }
   if (parameterType == "boolean" || parameterType == "yesorno" ||
       parameterType == "trueorfalse") {
-    return ValueTypeMetadata::variableType;
+    return ValueTypeMetadata::booleanType;
   }
   return GetExpressionPrimitiveValueType(parameterType);
 }

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
@@ -38,20 +38,30 @@ const gd::String ValueTypeMetadata::stringType = "string";
 const gd::String ValueTypeMetadata::variableType = "variable";
 const gd::String ValueTypeMetadata::booleanType = "boolean";
 
-const gd::String &ValueTypeMetadata::GetPrimitiveValueType(const gd::String &parameterType) {
-  if (parameterType == "number" || gd::ValueTypeMetadata::IsTypeExpression("number", parameterType)) {
+const gd::String &ValueTypeMetadata::GetExpressionPrimitiveValueType(
+    const gd::String &parameterType) {
+  if (parameterType == "number" ||
+      gd::ValueTypeMetadata::IsTypeExpression("number", parameterType)) {
     return ValueTypeMetadata::numberType;
   }
-  if (parameterType == "string" || gd::ValueTypeMetadata::IsTypeExpression("string", parameterType)) {
+  if (parameterType == "string" ||
+      gd::ValueTypeMetadata::IsTypeExpression("string", parameterType)) {
     return ValueTypeMetadata::stringType;
   }
-  if (parameterType == "variable" || gd::ValueTypeMetadata::IsTypeExpression("variable", parameterType)) {
-    return ValueTypeMetadata::variableType;
-  }
-  if (parameterType == "boolean" || gd::ValueTypeMetadata::IsTypeExpression("boolean", parameterType)) {
-    return ValueTypeMetadata::variableType;
-  }
   return parameterType;
+}
+
+const gd::String &
+ValueTypeMetadata::GetPrimitiveValueType(const gd::String &parameterType) {
+  if (parameterType == "variable" ||
+      gd::ValueTypeMetadata::IsTypeExpression("variable", parameterType)) {
+    return ValueTypeMetadata::variableType;
+  }
+  if (parameterType == "boolean" || parameterType == "yesorno" ||
+      parameterType == "trueorfalse") {
+    return ValueTypeMetadata::variableType;
+  }
+  return GetExpressionPrimitiveValueType(parameterType);
 }
 
 const gd::String ValueTypeMetadata::numberValueType = "number";

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.cpp
@@ -61,6 +61,11 @@ ValueTypeMetadata::GetPrimitiveValueType(const gd::String &parameterType) {
       parameterType == "trueorfalse") {
     return ValueTypeMetadata::booleanType;
   }
+  // These 2 types are not strings from the code generator point of view,
+  // but it is for event-based extensions.
+  if (parameterType == "key" || parameterType == "mouse") {
+    return ValueTypeMetadata::stringType;
+  }
   return GetExpressionPrimitiveValueType(parameterType);
 }
 

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
@@ -187,6 +187,8 @@ class GD_CORE_API ValueTypeMetadata {
              parameterType == "jsonResource" ||
              parameterType == "tilemapResource" ||
              parameterType == "tilesetResource";
+    } else if (type == "boolean") {
+      return parameterType == "yesorno" || parameterType == "trueorfalse";
     }
     return false;
   }
@@ -199,6 +201,8 @@ class GD_CORE_API ValueTypeMetadata {
   static const gd::String &GetPrimitiveValueType(const gd::String &parameterType);
   static const gd::String numberType;
   static const gd::String stringType;
+  static const gd::String variableType;
+  static const gd::String booleanType;
 
   /**
    * \brief Return the ValueTypeMetadata name for a property type.

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
@@ -174,7 +174,9 @@ class GD_CORE_API ValueTypeMetadata {
              parameterType == "functionParameterName" ||
              parameterType == "externalLayoutName" ||
              parameterType == "leaderboardId" ||
-             parameterType == "identifier";
+             parameterType == "identifier" ||
+             parameterType == "key" ||
+             parameterType == "mouse";
     } else if (type == "variable") {
       return parameterType == "objectvar" || parameterType == "globalvar" ||
              parameterType == "scenevar";

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
@@ -174,9 +174,7 @@ class GD_CORE_API ValueTypeMetadata {
              parameterType == "functionParameterName" ||
              parameterType == "externalLayoutName" ||
              parameterType == "leaderboardId" ||
-             parameterType == "identifier" ||
-             parameterType == "key" ||
-             parameterType == "mouse";
+             parameterType == "identifier";
     } else if (type == "variable") {
       return parameterType == "objectvar" || parameterType == "globalvar" ||
              parameterType == "scenevar";

--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
@@ -187,8 +187,6 @@ class GD_CORE_API ValueTypeMetadata {
              parameterType == "jsonResource" ||
              parameterType == "tilemapResource" ||
              parameterType == "tilesetResource";
-    } else if (type == "boolean") {
-      return parameterType == "yesorno" || parameterType == "trueorfalse";
     }
     return false;
   }
@@ -197,6 +195,17 @@ class GD_CORE_API ValueTypeMetadata {
    * \brief Return the expression type from the parameter type.
    * Declinations of "number" and "string" types (like "forceMultiplier" or
    * "sceneName") are replaced by "number" and "string".
+   * 
+   * \note It only maps string and number types.
+   */
+  static const gd::String &GetExpressionPrimitiveValueType(const gd::String &parameterType);
+
+  /**
+   * \brief Return the primitive type from the parameter type.
+   * Declinations of "number" and "string" types (like "forceMultiplier" or
+   * "sceneName") are replaced by "number" and "string".
+   * 
+   * \note It also maps variable and boolean types.
    */
   static const gd::String &GetPrimitiveValueType(const gd::String &parameterType);
   static const gd::String numberType;

--- a/GDJS/GDJS/Extensions/Builtin/AdvancedExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/AdvancedExtension.cpp
@@ -66,6 +66,44 @@ AdvancedExtension::AdvancedExtension() {
                booleanCode + "; }";
       });
 
+  GetAllActions()["CopyArgumentToVariable"]
+      .GetCodeExtraInformation()
+      .SetCustomCodeGenerator([](gd::Instruction &instruction,
+                                 gd::EventsCodeGenerator &codeGenerator,
+                                 gd::EventsCodeGenerationContext &context) {
+        // This is duplicated from EventsCodeGenerator::GenerateParameterCodes
+        gd::String parameter = instruction.GetParameter(0).GetPlainString();
+        gd::String variable =
+            gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                codeGenerator, context, "scenevar", instruction.GetParameter(1),
+                "");
+
+        return "if (typeof eventsFunctionContext !== 'undefined') {\n"
+               "gdjs.Variable.copy(eventsFunctionContext.getArgument(" +
+               parameter + "), " + variable +
+               ", false);\n"
+               "}\n";
+      });
+
+  GetAllActions()["CopyArgumentFromVariable"]
+      .GetCodeExtraInformation()
+      .SetCustomCodeGenerator([](gd::Instruction &instruction,
+                                 gd::EventsCodeGenerator &codeGenerator,
+                                 gd::EventsCodeGenerationContext &context) {
+        // This is duplicated from EventsCodeGenerator::GenerateParameterCodes
+        gd::String parameter = instruction.GetParameter(0).GetPlainString();
+        gd::String variable =
+            gd::ExpressionCodeGenerator::GenerateExpressionCode(
+                codeGenerator, context, "scenevar", instruction.GetParameter(1),
+                "");
+
+        return "if (typeof eventsFunctionContext !== 'undefined') {\n"
+               "gdjs.Variable.copy(" +
+               variable + ", eventsFunctionContext.getArgument(" + parameter +
+               "), false);\n"
+               "}\n";
+      });
+
   GetAllConditions()["GetArgumentAsBoolean"]
       .GetCodeExtraInformation()
       .SetCustomCodeGenerator([](gd::Instruction& instruction,

--- a/GDJS/GDJS/Extensions/Builtin/AdvancedExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/AdvancedExtension.cpp
@@ -85,7 +85,7 @@ AdvancedExtension::AdvancedExtension() {
                "}\n";
       });
 
-  GetAllActions()["CopyArgumentFromVariable"]
+  GetAllActions()["CopyVariableToArgument"]
       .GetCodeExtraInformation()
       .SetCustomCodeGenerator([](gd::Instruction &instruction,
                                  gd::EventsCodeGenerator &codeGenerator,

--- a/GDevelop.js/TestUtils/GDJSMocks.js
+++ b/GDevelop.js/TestUtils/GDJSMocks.js
@@ -127,6 +127,10 @@ class Variable {
     this.setNumber(value);
   }
 
+  /**
+   * @param {string} childName 
+   * @returns {Variable}
+   */
   getChild(childName) {
     if (
       this._children[childName] === undefined ||
@@ -153,6 +157,51 @@ class Variable {
   getType() {
     return this.isPrimitive() ? 'number' : 'structure';
   }
+
+  clearChildren() {
+    this._children = {};
+    this._childrenArray = [];
+  }
+
+  clone() {
+    return Variable.copy(this, new Variable());
+  }
+
+  addChild(childName, childVariable) {
+    // Make sure this is a structure
+    this.castTo('structure');
+    this._children[childName] = childVariable;
+    return this;
+  }
+
+  /**
+   * 
+   * @param {Variable} source 
+   * @param {Variable} target 
+   * @param {?boolean} merge 
+   * @returns {Variable}
+   */
+  static copy(
+    source,
+    target,
+    merge
+  ) {
+    if (!merge) target.clearChildren();
+    target.castTo(source.getType());
+    if (source.isPrimitive()) {
+      target.setValue(source.getValue());
+    } else if (source.getType() === 'structure') {
+      const children = source.getAllChildren();
+      for (const p in children) {
+        if (children.hasOwnProperty(p))
+          target.addChild(p, children[p].clone());
+      }
+    } else if (source.getType() === 'array') {
+      for (const p of source.getAllChildrenArray())
+        target.pushVariableCopy(p);
+    }
+    return target;
+  }
 }
 
 class VariablesContainer {
@@ -160,6 +209,10 @@ class VariablesContainer {
     this._variables = new Hashtable();
   }
 
+  /**
+   * @param {string} name 
+   * @returns {Variable}
+   */
   get(name) {
     let variable = this._variables.get(name);
     if (!variable) {
@@ -610,6 +663,7 @@ function makeMinimalGDJSMock() {
       TaskGroup,
       CustomRuntimeObject,
       ManuallyResolvableTask,
+      Variable,
     },
     mocks: {
       runRuntimeScenePreEventsCallbacks: () => {

--- a/GDevelop.js/__tests__/GDJSAdvancedExtensionCodeGenerationIntegrationTests.js
+++ b/GDevelop.js/__tests__/GDJSAdvancedExtensionCodeGenerationIntegrationTests.js
@@ -46,12 +46,12 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
 
   it('can generate a number parameter condition that is true', function () {
     const runtimeScene = generateAndRunVariableAffectationWithConditions(
-      { ParameterName: 'number' },
+      { MyParameter: 'number' },
       [123],
       [
         {
           type: { value: 'CompareArgumentAsNumber' },
-          parameters: ['"ParameterName"', '=', '123'],
+          parameters: ['"MyParameter"', '=', '123'],
         },
       ]
     );
@@ -64,12 +64,12 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
 
   it('can generate a number parameter condition that is false', function () {
     const runtimeScene = generateAndRunVariableAffectationWithConditions(
-      { ParameterName: 'number' },
+      { MyParameter: 'number' },
       [123],
       [
         {
           type: { value: 'BuiltinAdvanced::CompareArgumentAsNumber' },
-          parameters: ['ParameterName', '=', '456'],
+          parameters: ['MyParameter', '=', '456'],
         },
       ]
     );
@@ -79,12 +79,12 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
 
   it('can generate a string parameter condition that is true', function () {
     const runtimeScene = generateAndRunVariableAffectationWithConditions(
-      { ParameterName: 'number' },
+      { MyParameter: 'number' },
       ['123'],
       [
         {
           type: { value: 'CompareArgumentAsString' },
-          parameters: ['"ParameterName"', '=', '"123"'],
+          parameters: ['"MyParameter"', '=', '"123"'],
         },
       ]
     );
@@ -97,12 +97,12 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
 
   it('can generate a string parameter condition that is false', function () {
     const runtimeScene = generateAndRunVariableAffectationWithConditions(
-      { ParameterName: 'number' },
+      { MyParameter: 'number' },
       ['123'],
       [
         {
           type: { value: 'BuiltinAdvanced::CompareArgumentAsString' },
-          parameters: ['ParameterName', '=', '"456"'],
+          parameters: ['MyParameter', '=', '"456"'],
         },
       ]
     );
@@ -118,7 +118,7 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
         actions: [
           {
             type: { value: 'CopyArgumentToVariable' },
-            parameters: ['"ParameterName"', '__MyExtensionVariable'],
+            parameters: ['"MyParameter"', '__MyExtensionVariable'],
           },
         ],
         events: [],
@@ -128,7 +128,7 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
     const runCompiledEvents = generateCompiledEventsFromSerializedEvents(
       gd,
       serializerElement,
-      { parameterTypes: { ParameterName: 'scenevar' }, logCode: false }
+      { parameterTypes: { MyParameter: 'scenevar' }, logCode: false }
     );
 
     const { gdjs, runtimeScene } = makeMinimalGDJSMock();
@@ -159,7 +159,7 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
           },
           {
             type: { value: 'CopyVariableToArgument' },
-            parameters: ['"ParameterName"', '__MyExtensionVariable'],
+            parameters: ['"MyParameter"', '__MyExtensionVariable'],
           },
         ],
         events: [],
@@ -169,7 +169,7 @@ describe('libGD.js - GDJS Code Generation integration tests', function () {
     const runCompiledEvents = generateCompiledEventsFromSerializedEvents(
       gd,
       serializerElement,
-      { parameterTypes: { ParameterName: 'scenevar' }, logCode: true }
+      { parameterTypes: { MyParameter: 'scenevar' }, logCode: true }
     );
 
     const { gdjs, runtimeScene } = makeMinimalGDJSMock();

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ValueTypeEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ValueTypeEditor.js
@@ -113,6 +113,7 @@ export default function ValueTypeEditor({
                   label={t`Object animation (text)`}
                 />
                 <SelectOption value="identifier" label={t`Identifier (text)`} />
+                <SelectOption value="scenevar" label={t`Scene variable`} />
               </SelectField>
             )}
             {valueTypeMetadata.isObject() && (

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -277,6 +277,8 @@ const Instruction = (props: Props) => {
                   );
                 }
               } else {
+                // This can happen if function-dedicated instructions are
+                // copied to scene events.
                 expressionIsValid = false;
               }
             }

--- a/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
@@ -15,6 +15,7 @@ import { makeDropTarget } from '../../UI/DragAndDrop/DropTarget';
 import { type ScreenType } from '../../UI/Reponsive/ScreenTypeMeasurer';
 import { type WidthType } from '../../UI/Reponsive/ResponsiveWindowMeasurer';
 import { useLongTouch } from '../../Utils/UseLongTouch';
+import { type EventsScope } from '../../InstructionOrExpression/EventsScope.flow';
 
 const styles = {
   addButton: {
@@ -53,6 +54,7 @@ type Props = {|
   screenType: ScreenType,
   windowWidth: WidthType,
 
+  scope: EventsScope,
   resourcesManager: gdResourcesManager,
   globalObjectsContainer: gdObjectsContainer,
   objectsContainer: gdObjectsContainer,
@@ -85,6 +87,7 @@ export default function InstructionsList({
   renderObjectThumbnail,
   screenType,
   windowWidth,
+  scope,
   resourcesManager,
   globalObjectsContainer,
   objectsContainer,
@@ -158,6 +161,7 @@ export default function InstructionsList({
         renderObjectThumbnail={renderObjectThumbnail}
         screenType={screenType}
         windowWidth={windowWidth}
+        scope={scope}
         resourcesManager={resourcesManager}
         globalObjectsContainer={globalObjectsContainer}
         objectsContainer={objectsContainer}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachChildVariableEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachChildVariableEvent.js
@@ -300,6 +300,7 @@ export default class ForEachChildVariableEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}
@@ -332,6 +333,7 @@ export default class ForEachChildVariableEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachEvent.js
@@ -157,6 +157,7 @@ export default class ForEachEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}
@@ -189,6 +190,7 @@ export default class ForEachEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/RepeatEvent.js
@@ -157,6 +157,7 @@ export default class RepeatEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}
@@ -189,6 +190,7 @@ export default class RepeatEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/StandardEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/StandardEvent.js
@@ -53,6 +53,7 @@ export default class StandardEvent extends React.Component<
             renderObjectThumbnail={this.props.renderObjectThumbnail}
             screenType={this.props.screenType}
             windowWidth={this.props.windowWidth}
+            scope={this.props.scope}
             resourcesManager={this.props.project.getResourcesManager()}
             globalObjectsContainer={this.props.globalObjectsContainer}
             objectsContainer={this.props.objectsContainer}
@@ -83,6 +84,7 @@ export default class StandardEvent extends React.Component<
             renderObjectThumbnail={this.props.renderObjectThumbnail}
             screenType={this.props.screenType}
             windowWidth={this.props.windowWidth}
+            scope={this.props.scope}
             resourcesManager={this.props.project.getResourcesManager()}
             globalObjectsContainer={this.props.globalObjectsContainer}
             objectsContainer={this.props.objectsContainer}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
@@ -71,6 +71,7 @@ export default class ForEachEvent extends React.Component<
           renderObjectThumbnail={this.props.renderObjectThumbnail}
           screenType={this.props.screenType}
           windowWidth={this.props.windowWidth}
+          scope={this.props.scope}
           resourcesManager={this.props.project.getResourcesManager()}
           globalObjectsContainer={this.props.globalObjectsContainer}
           objectsContainer={this.props.objectsContainer}
@@ -108,6 +109,7 @@ export default class ForEachEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/WhileEvent.js
@@ -142,6 +142,7 @@ export default class ForEachEvent extends React.Component<
               renderObjectThumbnail={this.props.renderObjectThumbnail}
               screenType={this.props.screenType}
               windowWidth={this.props.windowWidth}
+              scope={this.props.scope}
               resourcesManager={this.props.project.getResourcesManager()}
               globalObjectsContainer={this.props.globalObjectsContainer}
               objectsContainer={this.props.objectsContainer}

--- a/newIDE/app/src/EventsSheet/ParameterFields/EnumerateFunctionParameters.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/EnumerateFunctionParameters.js
@@ -4,15 +4,22 @@ const gd: libGDevelop = global.gd;
 
 export const enumerateParametersUsableInExpressions = (
   eventsFunctionsContainer: gdEventsFunctionsContainer,
-  eventsFunction: gdEventsFunction
+  eventsFunction: gdEventsFunction,
+  allowedParameterTypes: string[]
 ): Array<gdParameterMetadata> => {
   return mapVector(
     eventsFunction.getParametersForEvents(eventsFunctionsContainer),
     parameterMetadata =>
-      parameterMetadata.isCodeOnly() ||
-      gd.ParameterMetadata.isObject(parameterMetadata.getType()) ||
-      gd.ParameterMetadata.isBehavior(parameterMetadata.getType())
-        ? null
-        : parameterMetadata
+      !parameterMetadata.isCodeOnly() &&
+      !gd.ParameterMetadata.isObject(parameterMetadata.getType()) &&
+      !gd.ParameterMetadata.isBehavior(parameterMetadata.getType()) &&
+      (allowedParameterTypes.length === 0 ||
+        allowedParameterTypes.includes(
+          gd.ValueTypeMetadata.getPrimitiveValueType(
+            parameterMetadata.getType()
+          )
+        ))
+        ? parameterMetadata
+        : null
   ).filter(Boolean);
 };

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -9,6 +9,8 @@ import {
 import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
 import { enumerateParametersUsableInExpressions } from './EnumerateFunctionParameters';
 
+const gd: libGDevelop = global.gd;
+
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function FunctionParameterNameField(props: ParameterFieldProps, ref) {
     const field = React.useRef<?GenericExpressionField>(null);
@@ -18,6 +20,13 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
     React.useImperativeHandle(ref, () => ({
       focus,
     }));
+
+    const { parameterMetadata } = props;
+    const allowedParameterTypes =
+      parameterMetadata && parameterMetadata.getExtraInfo()
+        ? parameterMetadata.getExtraInfo().split(',')
+        : [];
+    console.log(allowedParameterTypes);
 
     const eventsBasedEntity =
       props.scope.eventsBasedBehavior || props.scope.eventsBasedObject;
@@ -29,10 +38,20 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         ? enumerateParametersUsableInExpressions(
             functionsContainer,
             props.scope.eventsFunction
-          ).map(parameterMetadata => ({
-            kind: 'Text',
-            completion: `"${parameterMetadata.getName()}"`,
-          }))
+          )
+            .filter(
+              parameterMetadata =>
+                allowedParameterTypes.length === 0 ||
+                allowedParameterTypes.includes(
+                  gd.ValueTypeMetadata.getPrimitiveValueType(
+                    parameterMetadata.getType()
+                  )
+                )
+            )
+            .map(parameterMetadata => ({
+              kind: 'Text',
+              completion: `"${parameterMetadata.getName()}"`,
+            }))
         : [];
 
     return (

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -26,7 +26,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       parameterMetadata && parameterMetadata.getExtraInfo()
         ? parameterMetadata.getExtraInfo().split(',')
         : [];
-    console.log(allowedParameterTypes);
 
     const eventsBasedEntity =
       props.scope.eventsBasedBehavior || props.scope.eventsBasedObject;
@@ -37,22 +36,15 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       props.scope.eventsFunction && functionsContainer
         ? enumerateParametersUsableInExpressions(
             functionsContainer,
-            props.scope.eventsFunction
-          )
-            .filter(
-              parameterMetadata =>
-                allowedParameterTypes.length === 0 ||
-                allowedParameterTypes.includes(
-                  gd.ValueTypeMetadata.getPrimitiveValueType(
-                    parameterMetadata.getType()
-                  )
-                )
-            )
-            .map(parameterMetadata => ({
-              kind: 'Text',
-              completion: `"${parameterMetadata.getName()}"`,
-            }))
+            props.scope.eventsFunction,
+            allowedParameterTypes
+          ).map(parameterMetadata => ({
+            kind: 'Text',
+            completion: `"${parameterMetadata.getName()}"`,
+          }))
         : [];
+
+    const errorText = props.value;
 
     return (
       <GenericExpressionField

--- a/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/FunctionParameterNameField.js
@@ -1,19 +1,18 @@
 // @flow
 import React from 'react';
-import GenericExpressionField from './GenericExpressionField';
+import { t } from '@lingui/macro';
 import {
   type ParameterFieldProps,
   type ParameterFieldInterface,
   type FieldFocusFunction,
 } from './ParameterFieldCommons';
-import { type ExpressionAutocompletion } from '../../ExpressionAutocompletion';
 import { enumerateParametersUsableInExpressions } from './EnumerateFunctionParameters';
-
-const gd: libGDevelop = global.gd;
+import SelectField, { type SelectFieldInterface } from '../../UI/SelectField';
+import SelectOption from '../../UI/SelectOption';
 
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function FunctionParameterNameField(props: ParameterFieldProps, ref) {
-    const field = React.useRef<?GenericExpressionField>(null);
+    const field = React.useRef<?SelectFieldInterface>(null);
     const focus: FieldFocusFunction = options => {
       if (field.current) field.current.focus(options);
     };
@@ -32,31 +31,57 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
     const functionsContainer = eventsBasedEntity
       ? eventsBasedEntity.getEventsFunctions()
       : props.scope.eventsFunctionsExtension;
-    const parameterNames: Array<ExpressionAutocompletion> =
+    const parameters: Array<gdParameterMetadata> =
       props.scope.eventsFunction && functionsContainer
         ? enumerateParametersUsableInExpressions(
             functionsContainer,
             props.scope.eventsFunction,
             allowedParameterTypes
-          ).map(parameterMetadata => ({
-            kind: 'Text',
-            completion: `"${parameterMetadata.getName()}"`,
-          }))
+          )
         : [];
 
-    const errorText = props.value;
+    const selectOptions = parameters.map(parameter => {
+      const parameterName = parameter.getName();
+      return (
+        <SelectOption
+          key={parameterName}
+          value={`"${parameterName}"`}
+          label={parameterName}
+          shouldNotTranslate={true}
+        />
+      );
+    });
+
+    const onChangeSelectValue = (event, value) => {
+      props.onChange(event.target.value);
+    };
+
+    const fieldLabel = props.parameterMetadata
+      ? props.parameterMetadata.getDescription()
+      : undefined;
 
     return (
-      <GenericExpressionField
-        expressionType="string"
-        onGetAdditionalAutocompletions={expression =>
-          parameterNames.filter(
-            ({ completion }) => completion.indexOf(expression) === 0
-          )
-        }
+      <SelectField
         ref={field}
-        {...props}
-      />
+        id={
+          props.parameterIndex !== undefined
+            ? `parameter-${props.parameterIndex}-function-parameter-field`
+            : undefined
+        }
+        value={props.value}
+        onChange={onChangeSelectValue}
+        margin={props.isInline ? 'none' : 'dense'}
+        fullWidth
+        floatingLabelText={fieldLabel}
+        translatableHintText={t`Choose a parameter`}
+        helperMarkdownText={
+          (props.parameterMetadata &&
+            props.parameterMetadata.getLongDescription()) ||
+          null
+        }
+      >
+        {selectOptions}
+      </SelectField>
     );
   }
 );

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -45,6 +45,7 @@ export const VariableNameQuickAnalyzeResults = {
   WRONG_EXPRESSION: 3,
 };
 
+// TODO As parsed node tree are cached, this may no longer be needed.
 export const quicklyAnalyzeVariableName = (
   name: string
 ): VariableNameQuickAnalyzeResult => {

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -362,10 +362,16 @@ const getAutocompletionsForText = function(
     const functionsContainer = eventsBasedEntity
       ? eventsBasedEntity.getEventsFunctions()
       : scope.eventsFunctionsExtension;
-    if (scope.eventsFunction && functionsContainer) {
+    const eventsFunction = scope.eventsFunction;
+    if (eventsFunction && functionsContainer) {
+      const allowedParameterTypes = completionDescription
+        .getParameterMetadata()
+        .getExtraInfo()
+        .split(',');
       autocompletionTexts = enumerateParametersUsableInExpressions(
         functionsContainer,
-        scope.eventsFunction
+        eventsFunction,
+        allowedParameterTypes
       ).map(parameterMetadata => `"${parameterMetadata.getName()}"`);
     }
   }


### PR DESCRIPTION
## Changes
- `supplementaryInformation` is used to constraint the type of `FunctionParameterName` parameters.
- The editor checks that parameters in `FunctionParameterName` parameters exist and have right type "scenevar" or value and show an error otherwise.
- The autocompletion gives either parameters with the type "scenevar" or value ("string", "number" and "boolean").
- Use a `SelectField` instead of an expression field as the code generator only handle literal strings for it anyway.

![image](https://user-images.githubusercontent.com/2611977/230739113-129a96c4-b2ee-46d0-bd44-8b4f9f8cd096.png)
