### PR TITLE
Allow drag and drop or copy and paste of properties in the extension editor

### DIFF
--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2627,6 +2627,7 @@ interface NamedPropertyDescriptorsList {
     void Remove([Const] DOMString name);
     void Move(unsigned long oldIndex, unsigned long newIndex);
     unsigned long GetCount();
+    unsigned long GetPosition([Const, Ref] NamedPropertyDescriptor item);
 
     unsigned long size();
     [Ref] NamedPropertyDescriptor at(unsigned long index);

--- a/GDevelop.js/types/gdnamedpropertydescriptorslist.js
+++ b/GDevelop.js/types/gdnamedpropertydescriptorslist.js
@@ -9,6 +9,7 @@ declare class gdNamedPropertyDescriptorsList {
   remove(name: string): void;
   move(oldIndex: number, newIndex: number): void;
   getCount(): number;
+  getPosition(item: gdNamedPropertyDescriptor): number;
   size(): number;
   at(index: number): gdNamedPropertyDescriptor;
   delete(): void;

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -64,13 +64,13 @@ const styles = {
   },
 };
 
-export const useEffectOverridingAlertDialog = () => {
+export const usePropertyOverridingAlertDialog = () => {
   const { showConfirmation } = useAlertDialog();
-  return async (existingEffectNames: Array<string>): Promise<boolean> => {
+  return async (existingPropertyNames: Array<string>): Promise<boolean> => {
     return await showConfirmation({
-      title: t`Existing effects`,
-      message: t`These effects are already exists:${'\n\n - ' +
-        existingEffectNames.join('\n\n - ') +
+      title: t`Existing properties`,
+      message: t`These properties already exist:${'\n\n - ' +
+        existingPropertyNames.join('\n\n - ') +
         '\n\n'}Do you want to replace them?`,
       confirmButtonLabel: t`Replace`,
       dismissButtonLabel: t`Omit`,
@@ -164,7 +164,7 @@ export default function EventsBasedBehaviorPropertiesEditor(props: Props) {
 
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
 
-  const showPropertyOverridingConfirmation = useEffectOverridingAlertDialog();
+  const showPropertyOverridingConfirmation = usePropertyOverridingAlertDialog();
 
   const forceUpdate = useForceUpdate();
 
@@ -196,7 +196,7 @@ export default function EventsBasedBehaviorPropertiesEditor(props: Props) {
       Clipboard.set(PROPERTIES_CLIPBOARD_KIND, [
         {
           name: property.getName(),
-          serializedEffect: serializeToJSObject(property),
+          serializedProperty: serializeToJSObject(property),
         },
       ]);
       forceUpdate();
@@ -205,7 +205,7 @@ export default function EventsBasedBehaviorPropertiesEditor(props: Props) {
   );
 
   const pasteProperties = React.useCallback(
-    async effectInsertionIndex => {
+    async propertyInsertionIndex => {
       const clipboardContent = Clipboard.get(PROPERTIES_CLIPBOARD_KIND);
       const propertyContents = SafeExtractor.extractArray(clipboardContent);
       if (!propertyContents) return;
@@ -218,11 +218,14 @@ export default function EventsBasedBehaviorPropertiesEditor(props: Props) {
         name: string,
         serializedProperty: string,
       }> = [];
-      propertyContents.forEach(effectContent => {
-        const name = SafeExtractor.extractStringProperty(effectContent, 'name');
+      propertyContents.forEach(propertyContent => {
+        const name = SafeExtractor.extractStringProperty(
+          propertyContent,
+          'name'
+        );
         const serializedProperty = SafeExtractor.extractObjectProperty(
-          effectContent,
-          'serializedEffect'
+          propertyContent,
+          'serializedProperty'
         );
         if (!name || !serializedProperty) {
           return;
@@ -236,7 +239,7 @@ export default function EventsBasedBehaviorPropertiesEditor(props: Props) {
       });
 
       let firstAddedPropertyName: string | null = null;
-      let index = effectInsertionIndex;
+      let index = propertyInsertionIndex;
       newNamedProperties.forEach(({ name, serializedProperty }) => {
         const property = properties.insertNew(name, index);
         index++;

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -4,16 +4,15 @@ import { t } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 import * as React from 'react';
-import { Column, Line } from '../UI/Grid';
+import { Column, Line, Spacer } from '../UI/Grid';
+import { LineStackLayout } from '../UI/Layout';
 import SelectField from '../UI/SelectField';
 import SelectOption from '../UI/SelectOption';
 import { mapFor, mapVector } from '../Utils/MapFor';
 import RaisedButton from '../UI/RaisedButton';
 import IconButton from '../UI/IconButton';
-import EmptyMessage from '../UI/EmptyMessage';
 import ElementWithMenu from '../UI/Menu/ElementWithMenu';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
-import MiniToolbar from '../UI/MiniToolbar';
 import { showWarningBox } from '../UI/Messages/MessageBox';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import InlineCheckbox from '../UI/InlineCheckbox';
@@ -22,14 +21,62 @@ import StringArrayEditor from '../StringArrayEditor';
 import ColorField from '../UI/ColorField';
 import BehaviorTypeSelector from '../BehaviorTypeSelector';
 import SemiControlledAutoComplete from '../UI/SemiControlledAutoComplete';
-import ScrollView from '../UI/ScrollView';
+import ScrollView, { type ScrollViewInterface } from '../UI/ScrollView';
 import ThreeDotsMenu from '../UI/CustomSvgIcons/ThreeDotsMenu';
 import { getMeasurementUnitShortLabel } from '../PropertiesEditor/PropertiesMapToSchema';
 import Visibility from '../UI/CustomSvgIcons/Visibility';
 import VisibilityOff from '../UI/CustomSvgIcons/VisibilityOff';
 import Add from '../UI/CustomSvgIcons/Add';
+import { DragHandleIcon } from '../UI/DragHandle';
+import GDevelopThemeContext from '../UI/Theme/GDevelopThemeContext';
+import DropIndicator from '../UI/SortableVirtualizedItemList/DropIndicator';
+import { makeDragSourceAndDropTarget } from '../UI/DragAndDrop/DragSourceAndDropTarget';
+import useForceUpdate from '../Utils/UseForceUpdate';
+import Clipboard, { SafeExtractor } from '../Utils/Clipboard';
+import {
+  serializeToJSObject,
+  unserializeFromJSObject,
+} from '../Utils/Serializer';
+import PasteIcon from '../UI/CustomSvgIcons/Clipboard';
+import FlatButton from '../UI/FlatButton';
+import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
+import { EmptyPlaceholder } from '../UI/EmptyPlaceholder';
+import useAlertDialog from '../UI/Alert/useAlertDialog';
 
 const gd: libGDevelop = global.gd;
+
+const PROPERTIES_CLIPBOARD_KIND = 'Properties';
+
+const DragSourceAndDropTarget = makeDragSourceAndDropTarget(
+  'behavior-properties-list'
+);
+
+const styles = {
+  rowContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginTop: 5,
+  },
+  rowContent: {
+    display: 'flex',
+    flex: 1,
+    alignItems: 'center',
+  },
+};
+
+export const useEffectOverridingAlertDialog = () => {
+  const { showConfirmation } = useAlertDialog();
+  return async (existingEffectNames: Array<string>): Promise<boolean> => {
+    return await showConfirmation({
+      title: t`Existing effects`,
+      message: t`These effects are already exists:${'\n\n - ' +
+        existingEffectNames.join('\n\n - ') +
+        '\n\n'}Do you want to replace them?`,
+      confirmButtonLabel: t`Replace`,
+      dismissButtonLabel: t`Omit`,
+    });
+  };
+};
 
 type Props = {|
   project: gdProject,
@@ -89,420 +136,746 @@ const getExtraInfoArray = (property: gdNamedPropertyDescriptor) => {
   return extraInfoVector.toJSArray();
 };
 
-export default class EventsBasedBehaviorPropertiesEditor extends React.Component<
-  Props,
-  {||}
-> {
-  _addProperty = () => {
-    const { properties } = this.props;
+export default function EventsBasedBehaviorPropertiesEditor(props: Props) {
+  const { properties, onPropertiesUpdated } = props;
+  const scrollView = React.useRef<?ScrollViewInterface>(null);
+  const [
+    justAddedPropertyName,
+    setJustAddedPropertyName,
+  ] = React.useState<?string>(null);
+  const justAddedPropertyElement = React.useRef<?any>(null);
 
-    const newName = newNameGenerator('Property', name => properties.has(name));
-    const property = properties.insertNew(newName, properties.getCount());
-    property.setType('Number');
-    this.forceUpdate();
-    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
-  };
+  React.useEffect(
+    () => {
+      if (
+        scrollView.current &&
+        justAddedPropertyElement.current &&
+        justAddedPropertyName
+      ) {
+        scrollView.current.scrollTo(justAddedPropertyElement.current);
+        setJustAddedPropertyName(null);
+        justAddedPropertyElement.current = null;
+      }
+    },
+    [justAddedPropertyName]
+  );
 
-  _removeProperty = (name: string) => {
-    const { properties } = this.props;
+  const draggedProperty = React.useRef<?gdNamedPropertyDescriptor>(null);
 
-    properties.remove(name);
-    this.forceUpdate();
-    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
-  };
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
 
-  _moveProperty = (oldIndex: number, newIndex: number) => {
-    const { properties } = this.props;
+  const showPropertyOverridingConfirmation = useEffectOverridingAlertDialog();
 
-    properties.move(oldIndex, newIndex);
-    this.forceUpdate();
-    this.props.onPropertiesUpdated && this.props.onPropertiesUpdated();
-  };
+  const forceUpdate = useForceUpdate();
 
-  _setChoiceExtraInfo = (property: gdNamedPropertyDescriptor) => {
-    return (newExtraInfo: Array<string>) => {
-      const defaultValueIndex = getExtraInfoArray(property).indexOf(
-        property.getValue()
+  const addProperty = React.useCallback(
+    () => {
+      const newName = newNameGenerator('Property', name =>
+        properties.has(name)
       );
-      const vectorString = new gd.VectorString();
-      newExtraInfo.forEach(item => vectorString.push_back(item));
-      property.setExtraInfo(vectorString);
-      vectorString.delete();
-      property.setValue(newExtraInfo[defaultValueIndex] || '');
-      this.forceUpdate();
-    };
-  };
+      const property = properties.insertNew(newName, properties.getCount());
+      property.setType('Number');
+      forceUpdate();
+      onPropertiesUpdated && onPropertiesUpdated();
+      setJustAddedPropertyName(newName);
+    },
+    [forceUpdate, onPropertiesUpdated, properties]
+  );
 
-  _getPropertyGroupNames = (): Array<string> => {
-    const { properties } = this.props;
+  const _removeProperty = React.useCallback(
+    (name: string) => {
+      properties.remove(name);
+      forceUpdate();
+      onPropertiesUpdated && onPropertiesUpdated();
+    },
+    [forceUpdate, onPropertiesUpdated, properties]
+  );
 
-    const groupNames = new Set<string>();
-    for (let i = 0; i < properties.size(); i++) {
-      const property = properties.at(i);
-      const group = property.getGroup() || '';
-      groupNames.add(group);
-    }
-    return [...groupNames].sort((a, b) => a.localeCompare(b));
-  };
+  const copyProperty = React.useCallback(
+    (property: gdNamedPropertyDescriptor) => {
+      Clipboard.set(PROPERTIES_CLIPBOARD_KIND, [
+        {
+          name: property.getName(),
+          serializedEffect: serializeToJSObject(property),
+        },
+      ]);
+      forceUpdate();
+    },
+    [forceUpdate]
+  );
 
-  render() {
-    const { properties } = this.props;
+  const pasteProperties = React.useCallback(
+    async effectInsertionIndex => {
+      const clipboardContent = Clipboard.get(PROPERTIES_CLIPBOARD_KIND);
+      const propertyContents = SafeExtractor.extractArray(clipboardContent);
+      if (!propertyContents) return;
 
-    return (
-      <I18n>
-        {({ i18n }) => (
-          <ScrollView>
-            {mapVector(
-              properties,
-              (property: gdNamedPropertyDescriptor, i: number) => (
-                <React.Fragment key={i}>
-                  <MiniToolbar noPadding>
-                    <Column expand noMargin>
-                      <SemiControlledTextField
-                        margin="none"
-                        commitOnBlur
-                        translatableHintText={t`Enter the property name`}
-                        value={property.getName()}
-                        onChange={newName => {
-                          if (newName === property.getName()) return;
-                          if (!validatePropertyName(i18n, properties, newName))
-                            return;
+      const newNamedProperties: Array<{
+        name: string,
+        serializedProperty: string,
+      }> = [];
+      const existingNamedProperties: Array<{
+        name: string,
+        serializedProperty: string,
+      }> = [];
+      propertyContents.forEach(effectContent => {
+        const name = SafeExtractor.extractStringProperty(effectContent, 'name');
+        const serializedProperty = SafeExtractor.extractObjectProperty(
+          effectContent,
+          'serializedEffect'
+        );
+        if (!name || !serializedProperty) {
+          return;
+        }
 
-                          this.props.onRenameProperty(
-                            property.getName(),
-                            newName
-                          );
+        if (properties.has(name)) {
+          existingNamedProperties.push({ name, serializedProperty });
+        } else {
+          newNamedProperties.push({ name, serializedProperty });
+        }
+      });
 
-                          property.setName(newName);
-                          this.forceUpdate();
-                          this.props.onPropertiesUpdated &&
-                            this.props.onPropertiesUpdated();
-                        }}
-                        fullWidth
-                      />
-                    </Column>
-                    <Column>
-                      <InlineCheckbox
-                        label={
-                          property.isHidden() ? (
-                            <Trans>Hidden</Trans>
-                          ) : (
-                            <Trans>Visible in editor</Trans>
-                          )
-                        }
-                        checked={!property.isHidden()}
-                        onCheck={(e, checked) => {
-                          property.setHidden(!checked);
-                          this.forceUpdate();
-                          this.props.onPropertiesUpdated &&
-                            this.props.onPropertiesUpdated();
-                        }}
-                        checkedIcon={<Visibility />}
-                        uncheckedIcon={<VisibilityOff />}
-                        disabled={
-                          property.getType() === 'Behavior' &&
-                          // Allow to make it visible just in case.
-                          !property.isHidden()
-                        }
-                      />
-                    </Column>
-                    <ElementWithMenu
-                      element={
-                        <IconButton>
-                          <ThreeDotsMenu />
-                        </IconButton>
-                      }
-                      buildMenuTemplate={(i18n: I18nType) => [
-                        {
-                          label: i18n._(t`Delete`),
-                          click: () => this._removeProperty(property.getName()),
-                        },
-                        { type: 'separator' },
-                        {
-                          label: i18n._(t`Move up`),
-                          click: () => this._moveProperty(i, i - 1),
-                          enabled: i - 1 >= 0,
-                        },
-                        {
-                          label: i18n._(t`Move down`),
-                          click: () => this._moveProperty(i, i + 1),
-                          enabled: i + 1 < properties.getCount(),
-                        },
-                        {
-                          label: i18n._(t`Generate expression and action`),
-                          click: () =>
-                            gd.PropertyFunctionGenerator.generateBehaviorGetterAndSetter(
-                              this.props.project,
-                              this.props.extension,
-                              this.props.eventsBasedBehavior,
-                              property,
-                              !!this.props.isSceneProperties
-                            ),
-                          enabled: gd.PropertyFunctionGenerator.canGenerateGetterAndSetter(
-                            this.props.eventsBasedBehavior,
-                            property
-                          ),
-                        },
-                      ]}
-                    />
-                  </MiniToolbar>
-                  <Line>
-                    <ColumnStackLayout expand noMargin>
-                      <ResponsiveLineStackLayout noMargin>
-                        <SelectField
-                          floatingLabelText={<Trans>Type</Trans>}
-                          value={property.getType()}
-                          onChange={(e, i, value: string) => {
-                            property.setType(value);
-                            if (value === 'Behavior') {
-                              property.setHidden(false);
-                            }
-                            this.forceUpdate();
-                            this.props.onPropertiesUpdated &&
-                              this.props.onPropertiesUpdated();
-                          }}
-                          fullWidth
-                        >
-                          <SelectOption value="Number" label={t`Number`} />
-                          <SelectOption value="String" label={t`String`} />
-                          <SelectOption
-                            value="Boolean"
-                            label={t`Boolean (checkbox)`}
-                          />
-                          <SelectOption
-                            value="Choice"
-                            label={t`String from a list of options (text)`}
-                          />
-                          <SelectOption value="Color" label={t`Color (text)`} />
-                          {!this.props.isSceneProperties && (
-                            <SelectOption
-                              value="Behavior"
-                              label={t`Required behavior`}
-                            />
-                          )}
-                        </SelectField>
-                        {property.getType() === 'Number' && (
-                          <SelectField
-                            floatingLabelText={<Trans>Measurement unit</Trans>}
-                            value={property.getMeasurementUnit().getName()}
-                            onChange={(e, i, value: string) => {
-                              property.setMeasurementUnit(
-                                gd.MeasurementUnit.getDefaultMeasurementUnitByName(
-                                  value
-                                )
-                              );
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated &&
-                                this.props.onPropertiesUpdated();
+      let firstAddedPropertyName: string | null = null;
+      let index = effectInsertionIndex;
+      newNamedProperties.forEach(({ name, serializedProperty }) => {
+        const property = properties.insertNew(name, index);
+        index++;
+        unserializeFromJSObject(property, serializedProperty);
+        if (!firstAddedPropertyName) {
+          firstAddedPropertyName = name;
+        }
+      });
+
+      let shouldOverrideProperties = false;
+      if (existingNamedProperties.length > 0) {
+        shouldOverrideProperties = await showPropertyOverridingConfirmation(
+          existingNamedProperties.map(namedProperty => namedProperty.name)
+        );
+
+        if (shouldOverrideProperties) {
+          existingNamedProperties.forEach(({ name, serializedProperty }) => {
+            if (properties.has(name)) {
+              const property = properties.get(name);
+              unserializeFromJSObject(property, serializedProperty);
+            }
+          });
+        }
+      }
+
+      forceUpdate();
+      if (firstAddedPropertyName) {
+        setJustAddedPropertyName(firstAddedPropertyName);
+      } else if (existingNamedProperties.length === 1) {
+        setJustAddedPropertyName(existingNamedProperties[0].name);
+      }
+      if (firstAddedPropertyName || shouldOverrideProperties) {
+        if (onPropertiesUpdated) onPropertiesUpdated();
+      }
+    },
+    [
+      forceUpdate,
+      properties,
+      showPropertyOverridingConfirmation,
+      onPropertiesUpdated,
+    ]
+  );
+
+  const pastePropertiesAtTheEnd = React.useCallback(
+    async () => {
+      await pasteProperties(properties.getCount());
+    },
+    [properties, pasteProperties]
+  );
+
+  const pastePropertiesBefore = React.useCallback(
+    async (property: gdNamedPropertyDescriptor) => {
+      await pasteProperties(properties.getPosition(property));
+    },
+    [properties, pasteProperties]
+  );
+
+  const moveProperty = React.useCallback(
+    (oldIndex: number, newIndex: number) => {
+      properties.move(oldIndex, newIndex);
+      forceUpdate();
+      onPropertiesUpdated && onPropertiesUpdated();
+    },
+    [forceUpdate, onPropertiesUpdated, properties]
+  );
+
+  const movePropertyBefore = React.useCallback(
+    (targetProperty: gdNamedPropertyDescriptor) => {
+      const { current } = draggedProperty;
+      if (!current) return;
+
+      const draggedIndex = properties.getPosition(current);
+      const targetIndex = properties.getPosition(targetProperty);
+
+      properties.move(
+        draggedIndex,
+        targetIndex > draggedIndex ? targetIndex - 1 : targetIndex
+      );
+      forceUpdate();
+      onPropertiesUpdated && onPropertiesUpdated();
+    },
+    [properties, forceUpdate, onPropertiesUpdated]
+  );
+
+  const _setChoiceExtraInfo = React.useCallback(
+    (property: gdNamedPropertyDescriptor) => {
+      return (newExtraInfo: Array<string>) => {
+        const defaultValueIndex = getExtraInfoArray(property).indexOf(
+          property.getValue()
+        );
+        const vectorString = new gd.VectorString();
+        newExtraInfo.forEach(item => vectorString.push_back(item));
+        property.setExtraInfo(vectorString);
+        vectorString.delete();
+        property.setValue(newExtraInfo[defaultValueIndex] || '');
+        forceUpdate();
+      };
+    },
+    [forceUpdate]
+  );
+
+  const _getPropertyGroupNames = React.useCallback(
+    (): Array<string> => {
+      const groupNames = new Set<string>();
+      for (let i = 0; i < properties.size(); i++) {
+        const property = properties.at(i);
+        const group = property.getGroup() || '';
+        groupNames.add(group);
+      }
+      return [...groupNames].sort((a, b) => a.localeCompare(b));
+    },
+    [properties]
+  );
+
+  const isClipboardContainingProperties = Clipboard.has(
+    PROPERTIES_CLIPBOARD_KIND
+  );
+
+  const windowWidth = useResponsiveWindowWidth();
+  const isSmall = windowWidth === 'small';
+
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <Column noMargin expand useFullHeight>
+          {properties.getCount() > 0 ? (
+            <React.Fragment>
+              <ScrollView ref={scrollView}>
+                <Line>
+                  <Column noMargin expand>
+                    {mapVector(
+                      properties,
+                      (property: gdNamedPropertyDescriptor, i: number) => {
+                        const propertyRef =
+                          justAddedPropertyName === property.getName()
+                            ? justAddedPropertyElement
+                            : null;
+
+                        return (
+                          <DragSourceAndDropTarget
+                            key={property.ptr}
+                            beginDrag={() => {
+                              draggedProperty.current = property;
+                              return {};
                             }}
-                            fullWidth
+                            canDrag={() => true}
+                            canDrop={() => true}
+                            drop={() => {
+                              movePropertyBefore(property);
+                            }}
                           >
-                            {mapFor(
-                              0,
-                              gd.MeasurementUnit.getDefaultMeasurementUnitsCount(),
-                              i => {
-                                const measurementUnit = gd.MeasurementUnit.getDefaultMeasurementUnitAtIndex(
-                                  i
-                                );
-                                const unitShortLabel = getMeasurementUnitShortLabel(
-                                  measurementUnit
-                                );
-                                const label =
-                                  measurementUnit.getLabel() +
-                                  (unitShortLabel.length > 0
-                                    ? ' — ' + unitShortLabel
-                                    : '');
-                                return (
-                                  <SelectOption
-                                    value={measurementUnit.getName()}
-                                    label={label}
-                                  />
-                                );
-                              }
-                            )}
-                          </SelectField>
-                        )}
-                        {(property.getType() === 'String' ||
-                          property.getType() === 'Number') && (
-                          <SemiControlledTextField
-                            commitOnBlur
-                            floatingLabelText={<Trans>Default value</Trans>}
-                            hintText={
-                              property.getType() === 'Number' ? '123' : 'ABC'
-                            }
-                            value={property.getValue()}
-                            onChange={newValue => {
-                              property.setValue(newValue);
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated &&
-                                this.props.onPropertiesUpdated();
-                            }}
-                            fullWidth
-                          />
-                        )}
-                        {property.getType() === 'Boolean' && (
-                          <SelectField
-                            floatingLabelText={<Trans>Default value</Trans>}
-                            value={
-                              property.getValue() === 'true' ? 'true' : 'false'
-                            }
-                            onChange={(e, i, value) => {
-                              property.setValue(value);
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated &&
-                                this.props.onPropertiesUpdated();
-                            }}
-                            fullWidth
-                          >
-                            <SelectOption
-                              value="true"
-                              label={t`True (checked)`}
-                            />
-                            <SelectOption
-                              value="false"
-                              label={t`False (not checked)`}
-                            />
-                          </SelectField>
-                        )}
-                        {property.getType() === 'Behavior' && (
-                          <BehaviorTypeSelector
-                            project={this.props.project}
-                            objectType={this.props.behaviorObjectType || ''}
-                            value={
-                              property.getExtraInfo().size() === 0
-                                ? ''
-                                : property.getExtraInfo().at(0)
-                            }
-                            onChange={(newValue: string) => {
-                              // Change the type of the required behavior.
-                              const extraInfo = property.getExtraInfo();
-                              if (extraInfo.size() === 0) {
-                                extraInfo.push_back(newValue);
-                              } else {
-                                extraInfo.set(0, newValue);
-                              }
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated &&
-                                this.props.onPropertiesUpdated();
-                            }}
-                            disabled={false}
-                          />
-                        )}
-                        {property.getType() === 'Color' && (
-                          <ColorField
-                            floatingLabelText={<Trans>Default value</Trans>}
-                            disableAlpha
-                            fullWidth
-                            color={property.getValue()}
-                            onChange={color => {
-                              property.setValue(color);
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated &&
-                                this.props.onPropertiesUpdated();
-                            }}
-                          />
-                        )}
-                        {property.getType() === 'Choice' && (
-                          <SelectField
-                            floatingLabelText={<Trans>Default value</Trans>}
-                            value={property.getValue()}
-                            onChange={(e, i, value) => {
-                              property.setValue(value);
-                              this.forceUpdate();
-                              this.props.onPropertiesUpdated &&
-                                this.props.onPropertiesUpdated();
-                            }}
-                            fullWidth
-                          >
-                            {getExtraInfoArray(property).map(
-                              (choice, index) => (
-                                <SelectOption
-                                  key={index}
-                                  value={choice}
-                                  label={choice}
-                                />
+                            {({
+                              connectDragSource,
+                              connectDropTarget,
+                              isOver,
+                              canDrop,
+                            }) =>
+                              connectDropTarget(
+                                <div
+                                  key={property.ptr}
+                                  style={styles.rowContainer}
+                                >
+                                  {isOver && (
+                                    <DropIndicator canDrop={canDrop} />
+                                  )}
+                                  <div
+                                    ref={propertyRef}
+                                    style={{
+                                      ...styles.rowContent,
+                                      backgroundColor:
+                                        gdevelopTheme.list.itemsBackgroundColor,
+                                    }}
+                                  >
+                                    {connectDragSource(
+                                      <span>
+                                        <Spacer />
+                                        <DragHandleIcon />
+                                        <Spacer />
+                                      </span>
+                                    )}
+                                    <ResponsiveLineStackLayout expand>
+                                      <Line noMargin expand alignItems="center">
+                                        <SemiControlledTextField
+                                          margin="none"
+                                          commitOnBlur
+                                          translatableHintText={t`Enter the property name`}
+                                          value={property.getName()}
+                                          onChange={newName => {
+                                            if (newName === property.getName())
+                                              return;
+                                            if (
+                                              !validatePropertyName(
+                                                i18n,
+                                                properties,
+                                                newName
+                                              )
+                                            )
+                                              return;
+
+                                            props.onRenameProperty(
+                                              property.getName(),
+                                              newName
+                                            );
+
+                                            property.setName(newName);
+                                            forceUpdate();
+                                            props.onPropertiesUpdated &&
+                                              props.onPropertiesUpdated();
+                                          }}
+                                          fullWidth
+                                        />
+                                      </Line>
+                                      <Line
+                                        noMargin
+                                        alignItems="center"
+                                        justifyContent="flex-end"
+                                      >
+                                        <InlineCheckbox
+                                          label={
+                                            property.isHidden() ? (
+                                              <Trans>Hidden</Trans>
+                                            ) : (
+                                              <Trans>Visible in editor</Trans>
+                                            )
+                                          }
+                                          checked={!property.isHidden()}
+                                          onCheck={(e, checked) => {
+                                            property.setHidden(!checked);
+                                            forceUpdate();
+                                            props.onPropertiesUpdated &&
+                                              props.onPropertiesUpdated();
+                                          }}
+                                          checkedIcon={<Visibility />}
+                                          uncheckedIcon={<VisibilityOff />}
+                                          disabled={
+                                            property.getType() === 'Behavior' &&
+                                            // Allow to make it visible just in case.
+                                            !property.isHidden()
+                                          }
+                                        />
+                                      </Line>
+                                    </ResponsiveLineStackLayout>
+                                    <ElementWithMenu
+                                      element={
+                                        <IconButton>
+                                          <ThreeDotsMenu />
+                                        </IconButton>
+                                      }
+                                      buildMenuTemplate={(i18n: I18nType) => [
+                                        {
+                                          label: i18n._(t`Delete`),
+                                          click: () =>
+                                            _removeProperty(property.getName()),
+                                        },
+                                        {
+                                          label: i18n._(t`Copy`),
+                                          click: () => copyProperty(property),
+                                        },
+                                        {
+                                          label: i18n._(t`Paste`),
+                                          click: () =>
+                                            pastePropertiesBefore(property),
+                                          enabled: isClipboardContainingProperties,
+                                        },
+                                        { type: 'separator' },
+                                        {
+                                          label: i18n._(t`Move up`),
+                                          click: () => moveProperty(i, i - 1),
+                                          enabled: i - 1 >= 0,
+                                        },
+                                        {
+                                          label: i18n._(t`Move down`),
+                                          click: () => moveProperty(i, i + 1),
+                                          enabled:
+                                            i + 1 < properties.getCount(),
+                                        },
+                                        {
+                                          label: i18n._(
+                                            t`Generate expression and action`
+                                          ),
+                                          click: () =>
+                                            gd.PropertyFunctionGenerator.generateBehaviorGetterAndSetter(
+                                              props.project,
+                                              props.extension,
+                                              props.eventsBasedBehavior,
+                                              property,
+                                              !!props.isSceneProperties
+                                            ),
+                                          enabled: gd.PropertyFunctionGenerator.canGenerateGetterAndSetter(
+                                            props.eventsBasedBehavior,
+                                            property
+                                          ),
+                                        },
+                                      ]}
+                                    />
+                                    <Spacer />
+                                  </div>
+                                  <Line expand>
+                                    <ColumnStackLayout expand>
+                                      <ResponsiveLineStackLayout noMargin>
+                                        <SelectField
+                                          floatingLabelText={
+                                            <Trans>Type</Trans>
+                                          }
+                                          value={property.getType()}
+                                          onChange={(e, i, value: string) => {
+                                            property.setType(value);
+                                            if (value === 'Behavior') {
+                                              property.setHidden(false);
+                                            }
+                                            forceUpdate();
+                                            props.onPropertiesUpdated &&
+                                              props.onPropertiesUpdated();
+                                          }}
+                                          fullWidth
+                                        >
+                                          <SelectOption
+                                            key="property-type-number"
+                                            value="Number"
+                                            label={t`Number`}
+                                          />
+                                          <SelectOption
+                                            key="property-type-string"
+                                            value="String"
+                                            label={t`String`}
+                                          />
+                                          <SelectOption
+                                            key="property-type-boolean"
+                                            value="Boolean"
+                                            label={t`Boolean (checkbox)`}
+                                          />
+                                          <SelectOption
+                                            key="property-type-choice"
+                                            value="Choice"
+                                            label={t`String from a list of options (text)`}
+                                          />
+                                          <SelectOption
+                                            key="property-type-color"
+                                            value="Color"
+                                            label={t`Color (text)`}
+                                          />
+                                          {!props.isSceneProperties && (
+                                            <SelectOption
+                                              key="property-type-behavior"
+                                              value="Behavior"
+                                              label={t`Required behavior`}
+                                            />
+                                          )}
+                                        </SelectField>
+                                        {property.getType() === 'Number' && (
+                                          <SelectField
+                                            floatingLabelText={
+                                              <Trans>Measurement unit</Trans>
+                                            }
+                                            value={property
+                                              .getMeasurementUnit()
+                                              .getName()}
+                                            onChange={(e, i, value: string) => {
+                                              property.setMeasurementUnit(
+                                                gd.MeasurementUnit.getDefaultMeasurementUnitByName(
+                                                  value
+                                                )
+                                              );
+                                              forceUpdate();
+                                              props.onPropertiesUpdated &&
+                                                props.onPropertiesUpdated();
+                                            }}
+                                            fullWidth
+                                          >
+                                            {mapFor(
+                                              0,
+                                              gd.MeasurementUnit.getDefaultMeasurementUnitsCount(),
+                                              i => {
+                                                const measurementUnit = gd.MeasurementUnit.getDefaultMeasurementUnitAtIndex(
+                                                  i
+                                                );
+                                                const unitShortLabel = getMeasurementUnitShortLabel(
+                                                  measurementUnit
+                                                );
+                                                const label =
+                                                  measurementUnit.getLabel() +
+                                                  (unitShortLabel.length > 0
+                                                    ? ' — ' + unitShortLabel
+                                                    : '');
+                                                return (
+                                                  <SelectOption
+                                                    key={
+                                                      'measurement-unit-' +
+                                                      measurementUnit.getName()
+                                                    }
+                                                    value={measurementUnit.getName()}
+                                                    label={label}
+                                                  />
+                                                );
+                                              }
+                                            )}
+                                          </SelectField>
+                                        )}
+                                        {(property.getType() === 'String' ||
+                                          property.getType() === 'Number') && (
+                                          <SemiControlledTextField
+                                            commitOnBlur
+                                            floatingLabelText={
+                                              <Trans>Default value</Trans>
+                                            }
+                                            hintText={
+                                              property.getType() === 'Number'
+                                                ? '123'
+                                                : 'ABC'
+                                            }
+                                            value={property.getValue()}
+                                            onChange={newValue => {
+                                              property.setValue(newValue);
+                                              forceUpdate();
+                                              props.onPropertiesUpdated &&
+                                                props.onPropertiesUpdated();
+                                            }}
+                                            fullWidth
+                                          />
+                                        )}
+                                        {property.getType() === 'Boolean' && (
+                                          <SelectField
+                                            floatingLabelText={
+                                              <Trans>Default value</Trans>
+                                            }
+                                            value={
+                                              property.getValue() === 'true'
+                                                ? 'true'
+                                                : 'false'
+                                            }
+                                            onChange={(e, i, value) => {
+                                              property.setValue(value);
+                                              forceUpdate();
+                                              props.onPropertiesUpdated &&
+                                                props.onPropertiesUpdated();
+                                            }}
+                                            fullWidth
+                                          >
+                                            <SelectOption
+                                              key="boolean-true"
+                                              value="true"
+                                              label={t`True (checked)`}
+                                            />
+                                            <SelectOption
+                                              key="boolean-false"
+                                              value="false"
+                                              label={t`False (not checked)`}
+                                            />
+                                          </SelectField>
+                                        )}
+                                        {property.getType() === 'Behavior' && (
+                                          <BehaviorTypeSelector
+                                            project={props.project}
+                                            objectType={
+                                              props.behaviorObjectType || ''
+                                            }
+                                            value={
+                                              property.getExtraInfo().size() ===
+                                              0
+                                                ? ''
+                                                : property.getExtraInfo().at(0)
+                                            }
+                                            onChange={(newValue: string) => {
+                                              // Change the type of the required behavior.
+                                              const extraInfo = property.getExtraInfo();
+                                              if (extraInfo.size() === 0) {
+                                                extraInfo.push_back(newValue);
+                                              } else {
+                                                extraInfo.set(0, newValue);
+                                              }
+                                              forceUpdate();
+                                              props.onPropertiesUpdated &&
+                                                props.onPropertiesUpdated();
+                                            }}
+                                            disabled={false}
+                                          />
+                                        )}
+                                        {property.getType() === 'Color' && (
+                                          <ColorField
+                                            floatingLabelText={
+                                              <Trans>Default value</Trans>
+                                            }
+                                            disableAlpha
+                                            fullWidth
+                                            color={property.getValue()}
+                                            onChange={color => {
+                                              property.setValue(color);
+                                              forceUpdate();
+                                              props.onPropertiesUpdated &&
+                                                props.onPropertiesUpdated();
+                                            }}
+                                          />
+                                        )}
+                                        {property.getType() === 'Choice' && (
+                                          <SelectField
+                                            floatingLabelText={
+                                              <Trans>Default value</Trans>
+                                            }
+                                            value={property.getValue()}
+                                            onChange={(e, i, value) => {
+                                              property.setValue(value);
+                                              forceUpdate();
+                                              props.onPropertiesUpdated &&
+                                                props.onPropertiesUpdated();
+                                            }}
+                                            fullWidth
+                                          >
+                                            {getExtraInfoArray(property).map(
+                                              (choice, index) => (
+                                                <SelectOption
+                                                  key={index}
+                                                  value={choice}
+                                                  label={choice}
+                                                />
+                                              )
+                                            )}
+                                          </SelectField>
+                                        )}
+                                      </ResponsiveLineStackLayout>
+                                      {property.getType() === 'Choice' && (
+                                        <StringArrayEditor
+                                          extraInfo={getExtraInfoArray(
+                                            property
+                                          )}
+                                          setExtraInfo={_setChoiceExtraInfo(
+                                            property
+                                          )}
+                                        />
+                                      )}
+                                      <ResponsiveLineStackLayout noMargin>
+                                        <SemiControlledTextField
+                                          commitOnBlur
+                                          floatingLabelText={
+                                            <Trans>Short label</Trans>
+                                          }
+                                          translatableHintText={t`Make the purpose of the property easy to understand`}
+                                          floatingLabelFixed
+                                          value={property.getLabel()}
+                                          onChange={text => {
+                                            property.setLabel(text);
+                                            forceUpdate();
+                                          }}
+                                          fullWidth
+                                        />
+                                        <SemiControlledAutoComplete
+                                          floatingLabelText={
+                                            <Trans>Group name</Trans>
+                                          }
+                                          hintText={t`Leave it empty to use the default group`}
+                                          fullWidth
+                                          value={property.getGroup()}
+                                          onChange={text => {
+                                            property.setGroup(text);
+                                            forceUpdate();
+                                            props.onPropertiesUpdated &&
+                                              props.onPropertiesUpdated();
+                                          }}
+                                          dataSource={_getPropertyGroupNames().map(
+                                            name => ({
+                                              text: name,
+                                              value: name,
+                                            })
+                                          )}
+                                          openOnFocus={true}
+                                        />
+                                      </ResponsiveLineStackLayout>
+                                      <SemiControlledTextField
+                                        commitOnBlur
+                                        floatingLabelText={
+                                          <Trans>Description</Trans>
+                                        }
+                                        translatableHintText={t`Optionally, explain the purpose of the property in more details`}
+                                        floatingLabelFixed
+                                        value={property.getDescription()}
+                                        onChange={text => {
+                                          property.setDescription(text);
+                                          forceUpdate();
+                                        }}
+                                        fullWidth
+                                      />
+                                    </ColumnStackLayout>
+                                  </Line>
+                                </div>
                               )
-                            )}
-                          </SelectField>
-                        )}
-                      </ResponsiveLineStackLayout>
-                      {property.getType() === 'Choice' && (
-                        <StringArrayEditor
-                          extraInfo={getExtraInfoArray(property)}
-                          setExtraInfo={this._setChoiceExtraInfo(property)}
-                        />
-                      )}
-                      <ResponsiveLineStackLayout noMargin>
-                        <SemiControlledTextField
-                          commitOnBlur
-                          floatingLabelText={<Trans>Short label</Trans>}
-                          translatableHintText={t`Make the purpose of the property easy to understand`}
-                          floatingLabelFixed
-                          value={property.getLabel()}
-                          onChange={text => {
-                            property.setLabel(text);
-                            this.forceUpdate();
-                          }}
-                          fullWidth
-                        />
-                        <SemiControlledAutoComplete
-                          floatingLabelText={<Trans>Group name</Trans>}
-                          hintText={t`Leave it empty to use the default group`}
-                          fullWidth
-                          value={property.getGroup()}
-                          onChange={text => {
-                            property.setGroup(text);
-                            this.forceUpdate();
-                            this.props.onPropertiesUpdated &&
-                              this.props.onPropertiesUpdated();
-                          }}
-                          dataSource={this._getPropertyGroupNames().map(
-                            name => ({
-                              text: name,
-                              value: name,
-                            })
-                          )}
-                          openOnFocus={true}
-                        />
-                      </ResponsiveLineStackLayout>
-                      <SemiControlledTextField
-                        commitOnBlur
-                        floatingLabelText={<Trans>Description</Trans>}
-                        translatableHintText={t`Optionally, explain the purpose of the property in more details`}
-                        floatingLabelFixed
-                        value={property.getDescription()}
-                        onChange={text => {
-                          property.setDescription(text);
-                          this.forceUpdate();
-                        }}
-                        fullWidth
-                      />
-                    </ColumnStackLayout>
-                  </Line>
-                </React.Fragment>
-              )
-            )}
-            {properties.getCount() === 0 ? (
-              <EmptyMessage>
-                <Trans>
-                  No properties for this behavior. Add one to store data inside
-                  this behavior (for example: health, ammo, speed, etc...)
-                </Trans>
-              </EmptyMessage>
-            ) : null}
-            <Column>
-              <Line justifyContent="flex-end" expand>
-                <RaisedButton
-                  primary
-                  label={<Trans>Add a property</Trans>}
-                  onClick={this._addProperty}
-                  icon={<Add />}
-                />
-              </Line>
+                            }
+                          </DragSourceAndDropTarget>
+                        );
+                      }
+                    )}
+                  </Column>
+                </Line>
+              </ScrollView>
+              <Column>
+                <Line noMargin>
+                  <LineStackLayout expand>
+                    <FlatButton
+                      key={'paste-properties'}
+                      leftIcon={<PasteIcon />}
+                      label={isSmall ? '' : <Trans>Paste</Trans>}
+                      onClick={() => {
+                        pastePropertiesAtTheEnd();
+                      }}
+                      disabled={!isClipboardContainingProperties}
+                    />
+                  </LineStackLayout>
+                  <LineStackLayout justifyContent="flex-end" expand>
+                    <RaisedButton
+                      primary
+                      label={<Trans>Add a property</Trans>}
+                      onClick={addProperty}
+                      icon={<Add />}
+                    />
+                  </LineStackLayout>
+                </Line>
+              </Column>
+            </React.Fragment>
+          ) : (
+            <Column noMargin expand justifyContent="center">
+              <EmptyPlaceholder
+                title={<Trans>Add your first property</Trans>}
+                description={
+                  <Trans>Properties store data inside behaviors.</Trans>
+                }
+                actionLabel={<Trans>Add a property</Trans>}
+                helpPagePath={'/behaviors/events-based-behaviors'}
+                helpPageAnchor={'add-and-use-properties-in-a-behavior'}
+                onAction={addProperty}
+                secondaryActionIcon={<PasteIcon />}
+                secondaryActionLabel={
+                  isClipboardContainingProperties ? <Trans>Paste</Trans> : null
+                }
+                onSecondaryAction={() => {
+                  pastePropertiesAtTheEnd();
+                }}
+              />
             </Column>
-          </ScrollView>
-        )}
-      </I18n>
-    );
-  }
+          )}
+        </Column>
+      )}
+    </I18n>
+  );
 }

--- a/newIDE/app/src/UI/EmptyPlaceholder.js
+++ b/newIDE/app/src/UI/EmptyPlaceholder.js
@@ -3,8 +3,10 @@ import * as React from 'react';
 import { Trans } from '@lingui/macro';
 import Container from '@material-ui/core/Container';
 import { ColumnStackLayout } from './Layout';
+import { LineStackLayout } from '../UI/Layout';
 import RaisedButton from '../UI/RaisedButton';
-import { Column, LargeSpacer } from './Grid';
+import FlatButton from '../UI/FlatButton';
+import { Column, Line, LargeSpacer } from './Grid';
 import HelpButton from '../UI/HelpButton';
 import Text from '../UI/Text';
 import TutorialButton from './TutorialButton';
@@ -14,13 +16,16 @@ import Add from './CustomSvgIcons/Add';
 type Props = {|
   title: React.Node,
   description: React.Node,
-  actionLabel: React.Node,
   helpPagePath?: string,
   tutorialId?: string,
-  actionButtonId?: string,
-  onAction: () => void,
   isLoading?: boolean,
+  actionButtonId?: string,
+  actionLabel: React.Node,
   actionIcon?: React.Node,
+  onAction: () => void,
+  secondaryActionLabel?: React.Node,
+  secondaryActionIcon?: React.Node,
+  onSecondaryAction?: () => void,
 |};
 
 const DefaultHelpButton = ({ helpPagePath }: { helpPagePath?: string }) => (
@@ -48,22 +53,33 @@ export const EmptyPlaceholder = (props: Props) => (
         </Text>
         <LargeSpacer />
         <ColumnStackLayout alignItems="center" noMargin>
-          <RaisedButton
-            label={props.actionLabel}
-            primary
-            onClick={props.onAction}
-            disabled={!!props.isLoading}
-            icon={
-              props.isLoading ? (
-                <CircularProgress size={24} />
-              ) : props.actionIcon ? (
-                props.actionIcon
-              ) : (
-                <Add />
-              )
-            }
-            id={props.actionButtonId}
-          />
+          <LineStackLayout noMargin>
+            {props.secondaryActionLabel && props.onSecondaryAction && (
+              <FlatButton
+                label={props.secondaryActionLabel}
+                primary
+                onClick={props.onSecondaryAction}
+                disabled={!!props.isLoading}
+                leftIcon={props.secondaryActionIcon}
+              />
+            )}
+            <RaisedButton
+              label={props.actionLabel}
+              primary
+              onClick={props.onAction}
+              disabled={!!props.isLoading}
+              icon={
+                props.isLoading ? (
+                  <CircularProgress size={24} />
+                ) : props.actionIcon ? (
+                  props.actionIcon
+                ) : (
+                  <Add />
+                )
+              }
+              id={props.actionButtonId}
+            />
+          </LineStackLayout>
           {props.tutorialId ? (
             <TutorialButton
               tutorialId={props.tutorialId}

--- a/newIDE/app/src/UI/EmptyPlaceholder.js
+++ b/newIDE/app/src/UI/EmptyPlaceholder.js
@@ -17,6 +17,7 @@ type Props = {|
   title: React.Node,
   description: React.Node,
   helpPagePath?: string,
+  helpPageAnchor?: string,
   tutorialId?: string,
   isLoading?: boolean,
   actionButtonId?: string,
@@ -28,8 +29,18 @@ type Props = {|
   onSecondaryAction?: () => void,
 |};
 
-const DefaultHelpButton = ({ helpPagePath }: { helpPagePath?: string }) => (
-  <HelpButton label={<Trans>Read the doc</Trans>} helpPagePath={helpPagePath} />
+const DefaultHelpButton = ({
+  helpPagePath,
+  helpPageAnchor,
+}: {
+  helpPagePath?: string,
+  helpPageAnchor?: string,
+}) => (
+  <HelpButton
+    label={<Trans>Read the doc</Trans>}
+    helpPagePath={helpPagePath}
+    anchor={helpPageAnchor}
+  />
 );
 
 /**
@@ -85,11 +96,17 @@ export const EmptyPlaceholder = (props: Props) => (
               tutorialId={props.tutorialId}
               label={<Trans>Watch tutorial</Trans>}
               renderIfNotFound={
-                <DefaultHelpButton helpPagePath={props.helpPagePath} />
+                <DefaultHelpButton
+                  helpPagePath={props.helpPagePath}
+                  helpPageAnchor={props.helpPageAnchor}
+                />
               }
             />
           ) : (
-            <DefaultHelpButton helpPagePath={props.helpPagePath} />
+            <DefaultHelpButton
+              helpPagePath={props.helpPagePath}
+              helpPageAnchor={props.helpPageAnchor}
+            />
           )}
         </ColumnStackLayout>
       </Column>

--- a/newIDE/app/src/stories/componentStories/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog.stories.js
@@ -8,6 +8,7 @@ import { testProject } from '../../GDevelopJsInitializerDecorator';
 
 import muiDecorator from '../../ThemeDecorator';
 import EventsBasedBehaviorEditorDialog from '../../../EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog';
+import DragAndDropContextProvider from '../../../UI/DragAndDrop/DragAndDropContextProvider';
 
 export default {
   title: 'EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog',
@@ -16,23 +17,27 @@ export default {
 };
 
 export const Default = () => (
-  <EventsBasedBehaviorEditorDialog
-    project={testProject.project}
-    eventsFunctionsExtension={testProject.testEventsFunctionsExtension}
-    eventsBasedBehavior={testProject.testEventsBasedBehavior}
-    onApply={action('apply')}
-    onRenameProperty={action('property rename')}
-    onRenameSharedProperty={action('shared property rename')}
-  />
+  <DragAndDropContextProvider>
+    <EventsBasedBehaviorEditorDialog
+      project={testProject.project}
+      eventsFunctionsExtension={testProject.testEventsFunctionsExtension}
+      eventsBasedBehavior={testProject.testEventsBasedBehavior}
+      onApply={action('apply')}
+      onRenameProperty={action('property rename')}
+      onRenameSharedProperty={action('shared property rename')}
+    />
+  </DragAndDropContextProvider>
 );
 
 export const WithoutFunction = () => (
-  <EventsBasedBehaviorEditorDialog
-    project={testProject.project}
-    eventsFunctionsExtension={testProject.testEventsFunctionsExtension}
-    eventsBasedBehavior={testProject.testEmptyEventsBasedBehavior}
-    onApply={action('apply')}
-    onRenameProperty={action('property rename')}
-    onRenameSharedProperty={action('shared property rename')}
-  />
+  <DragAndDropContextProvider>
+    <EventsBasedBehaviorEditorDialog
+      project={testProject.project}
+      eventsFunctionsExtension={testProject.testEventsFunctionsExtension}
+      eventsBasedBehavior={testProject.testEmptyEventsBasedBehavior}
+      onApply={action('apply')}
+      onRenameProperty={action('property rename')}
+      onRenameSharedProperty={action('shared property rename')}
+    />
+  </DragAndDropContextProvider>
 );


### PR DESCRIPTION
https://gdevelop-storybook.s3.amazonaws.com/property-editor-refresh/latest/index.html?path=/story/eventsbasedbehavioreditor-eventsbasedbehavioreditordialog--default

### Changes
- It reports the new features that was added to the effect editor.
- drag and drop
- copy and paste
- placeholder view for empty list
- Title and content indentation
- "Add" button always visible
- Fix the "visibility" checkbox layout for small screens

### Wins
- Users no longer have to write easing function choice properties by hand (or edit the project with a text editor)
- Beginners have access to the "property" section of the doc directly
- Users can move visible properties on the top more easily