### PR TITLE
Add a grab tool to the collision mask and points editors

### DIFF
--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/ShapePreview.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/ShapePreview.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import useForceUpdate from '../../../Utils/UseForceUpdate';
 import { type Vertex } from './PolygonEditor';
 
 type Props = {|
@@ -11,12 +10,14 @@ type Props = {|
   offsetY: number,
   polygonOrigin: string,
   vertices: Array<Vertex>,
-  width: number,
-  height: number,
-  frameOffsetTop: number,
-  frameOffsetLeft: number,
-  zoomFactor: number,
+  imageWidth: number,
+  imageHeight: number,
+  imageOffsetTop: number,
+  imageOffsetLeft: number,
+  imageZoomFactor: number,
   onMoveVertex: (index: number, newX: number, newY: number) => void,
+  forcedCursor: string | null,
+  deactivateControls?: boolean,
 |};
 
 type State = {|
@@ -25,13 +26,22 @@ type State = {|
 |};
 
 const ShapePreview = (props: Props) => {
+  const { forcedCursor, deactivateControls } = props;
+
   const svgRef = React.useRef<React.ElementRef<'svg'> | null>(null);
   const [state, setState] = React.useState<State>({
     draggedVertex: null,
     draggedIndex: -1,
   });
 
-  const forceUpdate = useForceUpdate();
+  if (deactivateControls) {
+    if (state.draggedVertex) {
+      setState({
+        draggedVertex: null,
+        draggedIndex: -1,
+      });
+    }
+  }
 
   const onVertexDown = (vertex: Vertex, index: number) => {
     if (state.draggedVertex) return;
@@ -51,8 +61,8 @@ const ShapePreview = (props: Props) => {
   };
 
   const onMouseMove = (event: any) => {
-    const { polygonOrigin, width, height, zoomFactor } = props;
-    const { draggedVertex } = state;
+    const { polygonOrigin, imageWidth, imageHeight, imageZoomFactor } = props;
+    const { draggedVertex, draggedIndex } = state;
     if (!draggedVertex) return;
 
     // $FlowExpectedError Flow doesn't have SVG typings yet (@facebook/flow#4551)
@@ -66,15 +76,20 @@ const ShapePreview = (props: Props) => {
     const { frameX, frameY } = confinePointToFrame(pointOnSvg.x, pointOnSvg.y);
 
     draggedVertex.x =
-      frameX / zoomFactor -
+      frameX / imageZoomFactor -
       props.offsetX -
-      (polygonOrigin === 'Center' ? width / 2 : 0);
+      (polygonOrigin === 'Center' ? imageWidth / 2 : 0);
     draggedVertex.y =
-      frameY / zoomFactor -
+      frameY / imageZoomFactor -
       props.offsetY -
-      (polygonOrigin === 'Center' ? height / 2 : 0);
+      (polygonOrigin === 'Center' ? imageHeight / 2 : 0);
 
-    forceUpdate();
+    props.onMoveVertex(
+      draggedIndex,
+      Math.round(draggedVertex ? draggedVertex.x : 0),
+      Math.round(draggedVertex ? draggedVertex.y : 0)
+    );
+    setState({ draggedVertex, draggedIndex });
   };
 
   /**
@@ -82,8 +97,8 @@ const ShapePreview = (props: Props) => {
    * are confined inside the sprite frame.
    */
   const confinePointToFrame = (freeX: number, freeY: number) => {
-    const maxX = props.width * props.zoomFactor;
-    const maxY = props.height * props.zoomFactor;
+    const maxX = props.imageWidth * props.imageZoomFactor;
+    const maxY = props.imageHeight * props.imageZoomFactor;
 
     const frameX = Math.min(maxX, Math.max(freeX, 0));
     const frameY = Math.min(maxY, Math.max(freeY, 0));
@@ -94,44 +109,53 @@ const ShapePreview = (props: Props) => {
     const {
       dimensionA,
       dimensionB,
-      width,
-      height,
+      imageWidth,
+      imageHeight,
       offsetX,
       offsetY,
-      zoomFactor,
+      imageZoomFactor,
     } = props;
-    const fixedWidth = dimensionA > 0 ? dimensionA : width > 0 ? width : 1;
-    const fixedHeight = dimensionB > 0 ? dimensionB : height > 0 ? height : 1;
+    const fixedWidth =
+      dimensionA > 0 ? dimensionA : imageWidth > 0 ? imageWidth : 1;
+    const fixedHeight =
+      dimensionB > 0 ? dimensionB : imageHeight > 0 ? imageHeight : 1;
 
     return (
       <rect
         key={'boxShape'}
         fill="rgba(255,0,0,0.75)"
         strokeWidth={1}
-        x={(offsetX + width / 2 - fixedWidth / 2) * zoomFactor}
-        y={(offsetY + height / 2 - fixedHeight / 2) * zoomFactor}
-        width={fixedWidth * zoomFactor}
-        height={fixedHeight * zoomFactor}
+        x={(offsetX + imageWidth / 2 - fixedWidth / 2) * imageZoomFactor}
+        y={(offsetY + imageHeight / 2 - fixedHeight / 2) * imageZoomFactor}
+        width={fixedWidth * imageZoomFactor}
+        height={fixedHeight * imageZoomFactor}
       />
     );
   };
 
   const renderCircle = () => {
-    const { dimensionA, width, height, offsetX, offsetY, zoomFactor } = props;
+    const {
+      dimensionA,
+      imageWidth,
+      imageHeight,
+      offsetX,
+      offsetY,
+      imageZoomFactor,
+    } = props;
 
     return (
       <circle
         key={'circleShape'}
         fill="rgba(255,0,0,0.75)"
         strokeWidth={1}
-        cx={(offsetX + width / 2) * zoomFactor}
-        cy={(offsetY + height / 2) * zoomFactor}
+        cx={(offsetX + imageWidth / 2) * imageZoomFactor}
+        cy={(offsetY + imageHeight / 2) * imageZoomFactor}
         r={
           (dimensionA > 0
             ? dimensionA
-            : width + height > 0
-            ? (width + height) / 4
-            : 1) * zoomFactor
+            : imageWidth + imageHeight > 0
+            ? (imageWidth + imageHeight) / 4
+            : 1) * imageZoomFactor
         }
       />
     );
@@ -141,15 +165,15 @@ const ShapePreview = (props: Props) => {
     const {
       dimensionA,
       dimensionB,
-      width,
-      height,
+      imageWidth,
+      imageHeight,
       offsetX,
       offsetY,
-      zoomFactor,
+      imageZoomFactor,
     } = props;
 
     const halfLength =
-      (dimensionA > 0 ? dimensionA : width > 0 ? width : 1) / 2;
+      (dimensionA > 0 ? dimensionA : imageWidth > 0 ? imageWidth : 1) / 2;
     const cos = Math.cos((dimensionB * Math.PI) / 180);
     const sin = Math.sin((dimensionB * Math.PI) / 180);
 
@@ -158,29 +182,44 @@ const ShapePreview = (props: Props) => {
         key={'edgeShape'}
         stroke="rgba(255,0,0,0.75)"
         strokeWidth={2}
-        x1={(offsetX + width / 2 - halfLength * cos) * zoomFactor}
-        y1={(offsetY + height / 2 - halfLength * sin) * zoomFactor}
-        x2={(offsetX + width / 2 + halfLength * cos) * zoomFactor}
-        y2={(offsetY + height / 2 + halfLength * sin) * zoomFactor}
+        x1={(offsetX + imageWidth / 2 - halfLength * cos) * imageZoomFactor}
+        y1={(offsetY + imageHeight / 2 - halfLength * sin) * imageZoomFactor}
+        x2={(offsetX + imageWidth / 2 + halfLength * cos) * imageZoomFactor}
+        y2={(offsetY + imageHeight / 2 + halfLength * sin) * imageZoomFactor}
       />
     );
   };
+
+  const forcedCursorStyle = forcedCursor
+    ? {
+        cursor: forcedCursor,
+      }
+    : {};
 
   const renderPolygon = () => {
     const {
       vertices,
       polygonOrigin,
-      width,
-      height,
+      imageWidth,
+      imageHeight,
       offsetX,
       offsetY,
-      zoomFactor,
+      imageZoomFactor,
     } = props;
+
+    const pointStyle = {
+      cursor: 'move',
+      ...forcedCursorStyle,
+    };
+    const polygonStyle = {
+      ...forcedCursorStyle,
+    };
 
     return (
       <React.Fragment>
         <polygon
           key={'polygonShape'}
+          style={polygonStyle}
           fill="rgba(255,0,0,0.75)"
           strokeWidth={1}
           fillRule="evenodd"
@@ -189,11 +228,11 @@ const ShapePreview = (props: Props) => {
               vertex =>
                 `${(vertex.x +
                   offsetX +
-                  (polygonOrigin === 'Center' ? width / 2 : 0)) *
-                  zoomFactor},${(vertex.y +
+                  (polygonOrigin === 'Center' ? imageWidth / 2 : 0)) *
+                  imageZoomFactor},${(vertex.y +
                   offsetY +
-                  (polygonOrigin === 'Center' ? height / 2 : 0)) *
-                  zoomFactor}`
+                  (polygonOrigin === 'Center' ? imageHeight / 2 : 0)) *
+                  imageZoomFactor}`
             )
             .join(' ')}
         />
@@ -203,18 +242,18 @@ const ShapePreview = (props: Props) => {
             key={`vertex-${index}`}
             fill="rgba(150,0,0,0.75)"
             strokeWidth={1}
-            style={{ cursor: 'move' }}
+            style={pointStyle}
             cx={
               (vertex.x +
                 offsetX +
-                (polygonOrigin === 'Center' ? width / 2 : 0)) *
-              zoomFactor
+                (polygonOrigin === 'Center' ? imageWidth / 2 : 0)) *
+              imageZoomFactor
             }
             cy={
               (vertex.y +
                 offsetY +
-                (polygonOrigin === 'Center' ? height / 2 : 0)) *
-              zoomFactor
+                (polygonOrigin === 'Center' ? imageHeight / 2 : 0)) *
+              imageZoomFactor
             }
             r={5}
           />
@@ -227,22 +266,24 @@ const ShapePreview = (props: Props) => {
     position: 'relative',
     width: '100%',
     height: '100%',
+    ...forcedCursorStyle,
   };
 
   const frameStyle = {
     position: 'absolute',
-    top: props.frameOffsetTop || 0,
-    left: props.frameOffsetLeft || 0,
-    width: props.width * props.zoomFactor,
-    height: props.height * props.zoomFactor,
+    top: props.imageOffsetTop || 0,
+    left: props.imageOffsetLeft || 0,
+    width: props.imageWidth * props.imageZoomFactor,
+    height: props.imageHeight * props.imageZoomFactor,
     overflow: 'visible',
+    ...forcedCursorStyle,
   };
 
   return (
     <div
       style={containerStyle}
-      onPointerMove={onMouseMove}
-      onPointerUp={onMouseUp}
+      onPointerMove={deactivateControls ? null : onMouseMove}
+      onPointerUp={deactivateControls ? null : onMouseUp}
     >
       <svg style={frameStyle} ref={svgRef}>
         {props.shape === 'Box' && renderBox()}

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/ShapePreview.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/ShapePreview.js
@@ -105,6 +105,16 @@ const ShapePreview = (props: Props) => {
     return { frameX, frameY };
   };
 
+  const forcedCursorStyle = forcedCursor
+    ? {
+        cursor: forcedCursor,
+      }
+    : {};
+
+  const boxStyle = {
+    ...forcedCursorStyle,
+  };
+
   const renderBox = () => {
     const {
       dimensionA,
@@ -123,6 +133,7 @@ const ShapePreview = (props: Props) => {
     return (
       <rect
         key={'boxShape'}
+        style={boxStyle}
         fill="rgba(255,0,0,0.75)"
         strokeWidth={1}
         x={(offsetX + imageWidth / 2 - fixedWidth / 2) * imageZoomFactor}
@@ -131,6 +142,10 @@ const ShapePreview = (props: Props) => {
         height={fixedHeight * imageZoomFactor}
       />
     );
+  };
+
+  const circleStyle = {
+    ...forcedCursorStyle,
   };
 
   const renderCircle = () => {
@@ -146,6 +161,7 @@ const ShapePreview = (props: Props) => {
     return (
       <circle
         key={'circleShape'}
+        style={circleStyle}
         fill="rgba(255,0,0,0.75)"
         strokeWidth={1}
         cx={(offsetX + imageWidth / 2) * imageZoomFactor}
@@ -159,6 +175,10 @@ const ShapePreview = (props: Props) => {
         }
       />
     );
+  };
+
+  const edgeStyle = {
+    ...forcedCursorStyle,
   };
 
   const renderEdge = () => {
@@ -180,6 +200,7 @@ const ShapePreview = (props: Props) => {
     return (
       <line
         key={'edgeShape'}
+        style={edgeStyle}
         stroke="rgba(255,0,0,0.75)"
         strokeWidth={2}
         x1={(offsetX + imageWidth / 2 - halfLength * cos) * imageZoomFactor}
@@ -189,12 +210,6 @@ const ShapePreview = (props: Props) => {
       />
     );
   };
-
-  const forcedCursorStyle = forcedCursor
-    ? {
-        cursor: forcedCursor,
-      }
-    : {};
 
   const renderPolygon = () => {
     const {

--- a/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/Editors/Physics2Editor/index.js
@@ -354,6 +354,7 @@ const Physics2Editor = (props: Props) => {
 
                 return (
                   <ShapePreview
+                    {...overlayProps}
                     shape={properties.get('shape').getValue()}
                     dimensionA={parseFloat(
                       properties.get('shapeDimensionA').getValue()
@@ -369,11 +370,6 @@ const Physics2Editor = (props: Props) => {
                     )}
                     polygonOrigin={properties.get('polygonOrigin').getValue()}
                     vertices={JSON.parse(properties.get('vertices').getValue())}
-                    width={overlayProps.imageWidth}
-                    height={overlayProps.imageHeight}
-                    frameOffsetTop={overlayProps.offsetTop}
-                    frameOffsetLeft={overlayProps.offsetLeft}
-                    zoomFactor={overlayProps.imageZoomFactor}
                     onMoveVertex={(index, newX, newY) => {
                       let vertices = JSON.parse(
                         properties.get('vertices').getValue()

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -12,12 +12,6 @@ import {
 
 const gd = global.gd;
 
-const styles = {
-  vertexCircle: {
-    cursor: 'move',
-  },
-};
-
 type SelectedVertex = {|
   vertex: gdVector2f,
   polygonIndex: number,
@@ -29,13 +23,15 @@ type Props = {|
   isDefaultBoundingBox: boolean,
   imageWidth: number,
   imageHeight: number,
-  offsetTop: number,
-  offsetLeft: number,
+  imageOffsetTop: number,
+  imageOffsetLeft: number,
   highlightedVerticePtr: ?number,
   selectedVerticePtr: ?number,
   onClickVertice: (ptr: ?number) => void,
   imageZoomFactor: number,
   onPolygonsUpdated: () => void,
+  forcedCursor: string | null,
+  deactivateControls?: boolean,
 |};
 
 const CollisionMasksPreview = (props: Props) => {
@@ -54,12 +50,23 @@ const CollisionMasksPreview = (props: Props) => {
     imageZoomFactor,
     imageHeight,
     imageWidth,
-    offsetTop,
-    offsetLeft,
+    imageOffsetTop,
+    imageOffsetLeft,
     isDefaultBoundingBox,
     onPolygonsUpdated,
     onClickVertice,
+    forcedCursor,
+    deactivateControls,
   } = props;
+
+  if (deactivateControls) {
+    if (draggedVertex) {
+      setDraggedVertex(null);
+    }
+    if (newVertexHintPoint) {
+      setNewVertexHintPoint(null);
+    }
+  }
 
   const forceUpdate = useForceUpdate();
 
@@ -285,6 +292,20 @@ const CollisionMasksPreview = (props: Props) => {
     );
   };
 
+  const forcedCursorStyle = forcedCursor
+    ? {
+        cursor: forcedCursor,
+      }
+    : {};
+
+  const vertexCircleStyle = {
+    cursor: 'move',
+    ...forcedCursorStyle,
+  };
+  const polygonStyle = {
+    ...forcedCursorStyle,
+  };
+
   const renderPolygons = () => {
     return (
       <React.Fragment>
@@ -303,6 +324,7 @@ const CollisionMasksPreview = (props: Props) => {
                   `${vertex.get_x() * imageZoomFactor},${vertex.get_y() *
                     imageZoomFactor}`
               ).join(' ')}
+              style={polygonStyle}
             />
           );
         })}
@@ -310,8 +332,10 @@ const CollisionMasksPreview = (props: Props) => {
           const vertices = polygon.getVertices();
           return mapVector(vertices, (vertex, vertexIndex) => (
             <circle
-              onPointerDown={() =>
-                onStartDragVertex(vertex, polygonIndex, vertexIndex)
+              onPointerDown={
+                deactivateControls
+                  ? null
+                  : () => onStartDragVertex(vertex, polygonIndex, vertexIndex)
               }
               {...dataObjectToProps({ draggable: 'true' })}
               key={`polygon-${polygonIndex}-vertex-${vertexIndex}`}
@@ -329,13 +353,15 @@ const CollisionMasksPreview = (props: Props) => {
               cx={vertex.get_x() * imageZoomFactor}
               cy={vertex.get_y() * imageZoomFactor}
               r={7}
-              style={styles.vertexCircle}
+              style={vertexCircleStyle}
             />
           ));
         })}
         {newVertexHintPoint && (
           <circle
-            onPointerDown={() => addVertex(newVertexHintPoint)}
+            onPointerDown={
+              deactivateControls ? null : () => addVertex(newVertexHintPoint)
+            }
             key={`new-vertex`}
             fill={'rgba(0,0,0,0.75)'}
             stroke={'white'}
@@ -343,7 +369,7 @@ const CollisionMasksPreview = (props: Props) => {
             cx={newVertexHintPoint.x * imageZoomFactor}
             cy={newVertexHintPoint.y * imageZoomFactor}
             r={5}
-            style={styles.vertexCircle}
+            style={vertexCircleStyle}
           />
         )}
       </React.Fragment>
@@ -354,23 +380,25 @@ const CollisionMasksPreview = (props: Props) => {
     position: 'relative',
     width: '100%',
     height: '100%',
+    ...forcedCursorStyle,
   };
 
   const svgStyle = {
     position: 'absolute',
-    top: offsetTop || 0,
-    left: offsetLeft || 0,
+    top: imageOffsetTop || 0,
+    left: imageOffsetLeft || 0,
     width: imageWidth * imageZoomFactor,
     height: imageHeight * imageZoomFactor,
     overflow: 'visible',
+    ...forcedCursorStyle,
   };
 
   return (
     <div
       style={containerStyle}
-      onPointerMove={onPointerMove}
-      onPointerUp={onEndDragVertex}
-      onPointerDown={onPointerDown}
+      onPointerMove={deactivateControls ? null : onPointerMove}
+      onPointerUp={deactivateControls ? null : onEndDragVertex}
+      onPointerDown={deactivateControls ? null : onPointerDown}
     >
       <svg style={svgStyle} ref={svgRef}>
         {isDefaultBoundingBox && renderBoundingBox()}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMasksPreview.js
@@ -278,20 +278,6 @@ const CollisionMasksPreview = (props: Props) => {
     ]
   );
 
-  const renderBoundingBox = () => {
-    return (
-      <polygon
-        fill="rgba(255,133,105,0.2)"
-        stroke="rgba(255,133,105,0.5)"
-        strokeWidth={1}
-        fillRule="evenodd"
-        points={`0,0 ${imageWidth * imageZoomFactor},0 ${imageWidth *
-          imageZoomFactor},${imageHeight * imageZoomFactor} 0,${imageHeight *
-          imageZoomFactor}`}
-      />
-    );
-  };
-
   const forcedCursorStyle = forcedCursor
     ? {
         cursor: forcedCursor,
@@ -304,6 +290,21 @@ const CollisionMasksPreview = (props: Props) => {
   };
   const polygonStyle = {
     ...forcedCursorStyle,
+  };
+
+  const renderBoundingBox = () => {
+    return (
+      <polygon
+        style={forcedCursorStyle}
+        fill="rgba(255,133,105,0.2)"
+        stroke="rgba(255,133,105,0.5)"
+        strokeWidth={1}
+        fillRule="evenodd"
+        points={`0,0 ${imageWidth * imageZoomFactor},0 ${imageWidth *
+          imageZoomFactor},${imageHeight * imageZoomFactor} 0,${imageHeight *
+          imageZoomFactor}`}
+      />
+    );
   };
 
   const renderPolygons = () => {

--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -454,17 +454,18 @@ const ImagePreview = ({
     }
   }, []);
   const onPointerMove = React.useCallback((event: PointerEvent) => {
-    if (keyboardShortcuts.current.shouldMoveView()) {
-      if (previousPointerCoordinates.current) {
-        const [previousX, previousY] = previousPointerCoordinates.current;
-        const newPosition = [event.clientX, event.clientY];
-        previousPointerCoordinates.current = newPosition;
-        setZoomState(zoomState => ({
-          ...zoomState,
-          xOffset: zoomState.xOffset + (newPosition[0] - previousX),
-          yOffset: zoomState.yOffset + (newPosition[1] - previousY),
-        }));
-      }
+    if (
+      keyboardShortcuts.current.shouldMoveView() &&
+      previousPointerCoordinates.current
+    ) {
+      const [previousX, previousY] = previousPointerCoordinates.current;
+      const newPosition = [event.clientX, event.clientY];
+      previousPointerCoordinates.current = newPosition;
+      setZoomState(zoomState => ({
+        ...zoomState,
+        xOffset: zoomState.xOffset + (newPosition[0] - previousX),
+        yOffset: zoomState.yOffset + (newPosition[1] - previousY),
+      }));
     }
   }, []);
   const onPointerUp = React.useCallback((event: PointerEvent) => {

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -159,7 +159,7 @@ export default class KeyboardShortcuts {
 
   _updateSpecialKeysStatus = (evt: KeyboardEvent, isDown: boolean) => {
     if (evt.which === SPACE_KEY) {
-      // Prevent scrolling in Physics2 property editor.
+      // Prevent scrolling in the rest of the UI when the grab tool is used.
       evt.preventDefault();
       evt.stopPropagation();
 


### PR DESCRIPTION
It adds the grab tool (with space key) to:
* Collision mask
  https://gdevelop-storybook.s3.amazonaws.com/grab-tool/latest/index.html?path=/story/objecteditor-spriteeditor--collision-masks
* Points
  https://gdevelop-storybook.s3.amazonaws.com/grab-tool/latest/index.html?path=/story/objecteditor-spriteeditor--points
* Resource
  https://gdevelop-storybook.s3.amazonaws.com/grab-tool/latest/index.html?path=/story/resourceslist-resourcepreview--image
* Physics2 (no story)

It also fixes the Physics2 polygon editor that wasn't refresh when dragging a vertex.