### PR TITLE
Add an special object parameter to handle object creation in extension

### DIFF
--- a/GDJS/tests/tests/objecttools.js
+++ b/GDJS/tests/tests/objecttools.js
@@ -105,7 +105,7 @@ describe('gdjs.evtTools.object', function () {
     // This instance is not picked.
     runtimeScene.createObject('MyObjectA');
 
-    // 1 of 3 instances are picked.
+    // 1 of 2 instances are picked.
     const pickedObjectList = Hashtable.newFrom({
       MyObjectA: [objectA1],
     });
@@ -121,6 +121,34 @@ describe('gdjs.evtTools.object', function () {
     // The created instance has been added to the picked instances.
     expect(getInstancesIds(pickedObjectList.get('MyObjectA'))).to.eql(
       getInstancesIds([objectA1, newObjectA])
+    );
+  });
+
+  it('can create and pick an instance when no instance was picked', function () {
+    const runtimeGame = gdjs.getPixiRuntimeGame();
+    const runtimeScene = new gdjs.TestRuntimeScene(runtimeGame);
+
+    runtimeScene.registerEmptyObjectWithName('MyObjectA');
+    // These instances are not picked.
+    runtimeScene.createObject('MyObjectA');
+    runtimeScene.createObject('MyObjectA');
+
+    // 0 of 2 instances are picked.
+    const pickedObjectList = Hashtable.newFrom({
+      MyObjectA: [],
+    });
+
+    const newObjectA = gdjs.evtTools.object.createObjectOnScene(
+      runtimeScene,
+      pickedObjectList,
+      0,
+      0,
+      ''
+    );
+
+    // The created instance has been added to the picked instances.
+    expect(getInstancesIds(pickedObjectList.get('MyObjectA'))).to.eql(
+      getInstancesIds([newObjectA])
     );
   });
 

--- a/GDevelop.js/__tests__/GDJSBaseObjectExtensionCodeGenerationIntegrationTests.js
+++ b/GDevelop.js/__tests__/GDJSBaseObjectExtensionCodeGenerationIntegrationTests.js
@@ -31,7 +31,7 @@ describe('libGD.js - GDJS Code Generation integration tests', () => {
       ]);
 
       return generateCompiledEventsFromSerializedEvents(gd, serializerElement, {
-        parameterTypes: { MyObject: 'object' },
+        parameterTypes: { MyObject: 'objectList' },
         logCode: false,
       });
     };
@@ -76,6 +76,29 @@ describe('libGD.js - GDJS Code Generation integration tests', () => {
 
       // The created instance has been added to the picked instances.
       expect(myObjectLists.get('MyObject').length).toBe(3);
+    });
+
+    it('can create and pick an instance when no instance was picked', function () {
+      const runCompiledEvents = generateFunctionWithCreateAction(gd);
+      const { gdjs, runtimeScene } = makeMinimalGDJSMock();
+
+      const objectName = 'MyObject';
+      const myObjectLists = new gdjs.Hashtable();
+      // These objects are not added to the list.
+      runtimeScene.createObject(objectName);
+      runtimeScene.createObject(objectName);
+      runtimeScene.createObject(objectName);
+      // The list can be empty when the object parameter is a
+      // objectListOrEmptyIfJustDeclared.
+      myObjectLists.put(objectName, []);
+
+      // 2 of 5 instances are picked.
+      expect(myObjectLists.get('MyObject').length).toBe(0);
+
+      runCompiledEvents(gdjs, runtimeScene, [myObjectLists]);
+
+      // The created instance has been added to the picked instances.
+      expect(myObjectLists.get('MyObject').length).toBe(1);
     });
 
     it('can create an instance and keep all instances picked of a group', function () {

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ValueTypeEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ValueTypeEditor.js
@@ -114,6 +114,12 @@ export default function ValueTypeEditor({
                 />
                 <SelectOption value="identifier" label={t`Identifier (text)`} />
                 <SelectOption value="scenevar" label={t`Scene variable`} />
+                {!isExpressionType && (
+                  <SelectOption
+                    value="objectListOrEmptyIfJustDeclared"
+                    label={t`Created objects`}
+                  />
+                )}
               </SelectField>
             )}
             {valueTypeMetadata.isObject() && (


### PR DESCRIPTION
* It allow extension users to apply actions on created objects.

Project with a modified version of the "fire bullet" extension
- [CreatedObjectParameterTest.zip](https://github.com/4ian/GDevelop/files/11248257/CreatedObjectParameterTest.zip)
