### PR TITLE
Clean project name from special characters for electron builds

### DIFF
--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -76,12 +76,14 @@ static gd::String CleanProjectName(gd::String projectName) {
       "\\/:*?\"<>|";  // See
                       // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
 
-  for (size_t i = 0; i < partiallyCleanedProjectName.size();
-       ++i)  // Delete all characters that are not allowed
-  {
+  for (size_t i = 0; i < partiallyCleanedProjectName.size();) {
+    // Delete all characters that are not allowed in a filename
     if (forbiddenFileNameCharacters.find(partiallyCleanedProjectName[i]) !=
-        gd::String::npos)
+        gd::String::npos) {
       partiallyCleanedProjectName.erase(i, 1);
+    } else {
+      i++;
+    }
   }
 
   if (partiallyCleanedProjectName.empty())

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -69,6 +69,23 @@ static void InsertUnique(std::vector<gd::String> &container, gd::String str) {
     container.push_back(str);
 }
 
+static gd::String CleanProjectName(gd::String projectName) {
+  gd::String partiallyCleanedProjectName = projectName;
+
+  static const gd::String allowedCharacters =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ ";
+
+  for (size_t i = 0; i < partiallyCleanedProjectName.size();
+       ++i)  // Delete all characters that are not allowed
+  {
+    if (allowedCharacters.find(partiallyCleanedProjectName[i]) ==
+        gd::String::npos)
+      partiallyCleanedProjectName.erase(i, 1);
+  }
+
+  return partiallyCleanedProjectName;
+}
+
 ExporterHelper::ExporterHelper(gd::AbstractFileSystem &fileSystem,
                                gd::String gdjsRoot_,
                                gd::String codeOutputDir_)
@@ -101,8 +118,9 @@ bool ExporterHelper::ExportProjectForPixiPreview(
   } else {
     // Most of the time, we skip the logo and minimum duration so that
     // the preview start as soon as possible.
-    exportedProject.GetLoadingScreen().ShowGDevelopLogoDuringLoadingScreen(false).SetMinDuration(
-        0);
+    exportedProject.GetLoadingScreen()
+        .ShowGDevelopLogoDuringLoadingScreen(false)
+        .SetMinDuration(0);
     exportedProject.GetWatermark().ShowGDevelopWatermark(false);
   }
 
@@ -308,16 +326,22 @@ bool ExporterHelper::ExportCordovaFiles(const gd::Project &project,
     }
 
     // Splashscreen icon for Android 12+.
-    gd::String splashScreenIconFilename = getIconFilename("android", "windowSplashScreenAnimatedIcon");
+    gd::String splashScreenIconFilename =
+        getIconFilename("android", "windowSplashScreenAnimatedIcon");
     if (!splashScreenIconFilename.empty())
-      output += "<preference name=\"AndroidWindowSplashScreenAnimatedIcon\" value=\""
-        + splashScreenIconFilename + "\" />\n";
+      output +=
+          "<preference name=\"AndroidWindowSplashScreenAnimatedIcon\" "
+          "value=\"" +
+          splashScreenIconFilename + "\" />\n";
 
     // Splashscreen "branding" image for Android 12+.
-    gd::String splashScreenBrandingImageFilename = getIconFilename("android", "windowSplashScreenBrandingImage");
+    gd::String splashScreenBrandingImageFilename =
+        getIconFilename("android", "windowSplashScreenBrandingImage");
     if (!splashScreenBrandingImageFilename.empty())
-      output += "<preference name=\"AndroidWindowSplashScreenBrandingImage\" value=\""
-        + splashScreenBrandingImageFilename + "\" />\n";
+      output +=
+          "<preference name=\"AndroidWindowSplashScreenBrandingImage\" "
+          "value=\"" +
+          splashScreenBrandingImageFilename + "\" />\n";
 
     return output;
   };
@@ -458,11 +482,15 @@ bool ExporterHelper::ExportElectronFiles(const gd::Project &project,
                                 ->GetMangledSceneName(project.GetName())
                                 .LowerCase()
                                 .FindAndReplace(" ", "-")));
+  // It's important to clean the project name from special characters,
+  // otherwise Windows executable may be corrupted when electron builds it.
+  gd::String jsonCleanedName = gd::Serializer::ToJSON(
+      gd::SerializerElement(CleanProjectName(project.GetName())));
 
   {
     gd::String str =
         fs.ReadFile(gdjsRoot + "/Runtime/Electron/package.json")
-            .FindAndReplace("\"GDJS_GAME_NAME\"", jsonName)
+            .FindAndReplace("\"GDJS_GAME_NAME\"", jsonCleanedName)
             .FindAndReplace("\"GDJS_GAME_PACKAGE_NAME\"", jsonPackageName)
             .FindAndReplace("\"GDJS_GAME_AUTHOR\"", jsonAuthor)
             .FindAndReplace("\"GDJS_GAME_VERSION\"", jsonVersion)
@@ -651,10 +679,8 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
     InsertUnique(includesFiles, "pixi-renderers/pixi-bitmapfont-manager.js");
     InsertUnique(includesFiles,
                  "pixi-renderers/spriteruntimeobject-pixi-renderer.js");
-    InsertUnique(includesFiles,
-                 "pixi-renderers/CustomObjectPixiRenderer.js");
-    InsertUnique(includesFiles,
-                 "pixi-renderers/DebuggerPixiRenderer.js");
+    InsertUnique(includesFiles, "pixi-renderers/CustomObjectPixiRenderer.js");
+    InsertUnique(includesFiles, "pixi-renderers/DebuggerPixiRenderer.js");
     InsertUnique(includesFiles,
                  "pixi-renderers/loadingscreen-pixi-renderer.js");
     InsertUnique(includesFiles, "pixi-renderers/pixi-effects-manager.js");

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -72,16 +72,20 @@ static void InsertUnique(std::vector<gd::String> &container, gd::String str) {
 static gd::String CleanProjectName(gd::String projectName) {
   gd::String partiallyCleanedProjectName = projectName;
 
-  static const gd::String allowedCharacters =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ ";
+  static const gd::String forbiddenFileNameCharacters =
+      "\\/:*?\"<>|";  // See
+                      // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
 
   for (size_t i = 0; i < partiallyCleanedProjectName.size();
        ++i)  // Delete all characters that are not allowed
   {
-    if (allowedCharacters.find(partiallyCleanedProjectName[i]) ==
+    if (forbiddenFileNameCharacters.find(partiallyCleanedProjectName[i]) !=
         gd::String::npos)
       partiallyCleanedProjectName.erase(i, 1);
   }
+
+  if (partiallyCleanedProjectName.empty())
+    partiallyCleanedProjectName = "Project";
 
   return partiallyCleanedProjectName;
 }

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -152,8 +152,8 @@ struct PreviewExportOptions {
   }
 
   /**
-   * Set the token to use by the game engine when requiring any resource stored on
-   * GDevelop Cloud buckets. Note that this is only useful during previews.
+   * Set the token to use by the game engine when requiring any resource stored
+   * on GDevelop Cloud buckets. Note that this is only useful during previews.
    */
   PreviewExportOptions &SetGDevelopResourceToken(
       const gd::String &gdevelopResourceToken_) {

--- a/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
+++ b/newIDE/app/src/Export/ExportDialog/ExportLauncher.js
@@ -263,7 +263,7 @@ export default class ExportLauncher extends Component<Props, State> {
                 t`A game with this ID already exists and you are not the owner.`
               ),
               i18n._(
-                t`A test link will be created but the game will not be registered.`
+                t`A link or file will be created but the game will not be registered.`
               ),
             ].join('\n\n'),
             rawError: registerError,
@@ -279,7 +279,7 @@ export default class ExportLauncher extends Component<Props, State> {
                 t`You have reached the maximum number of games you can register! You can unregister games in your Games Dashboard.`
               ),
               i18n._(
-                t`A test link will be created but the game will not be registered.`
+                t`A link or file will be created but the game will not be registered.`
               ),
             ].join('\n\n'),
             rawError: registerError,


### PR DESCRIPTION
This avoids unexpected .exe being corrupted and not launching

Tested on a windows with the full build flow

Name is still the "Mangled" version, not sure if we should keep it like that or not.

![Capture d’écran 2023-04-24 à 13 28 21](https://user-images.githubusercontent.com/4895034/233984754-70ecb85a-bd40-4158-9289-7528c912e3d7.png)
![Capture d’écran 2023-04-24 à 13 28 08](https://user-images.githubusercontent.com/4895034/233984760-174459ff-db60-40a3-8c89-a1b1f1320e3e.png)
