### PR TITLE
Add an action to focus the text input object

### DIFF
--- a/Extensions/TextInput/JsExtension.js
+++ b/Extensions/TextInput/JsExtension.js
@@ -561,6 +561,20 @@ module.exports = {
       .getCodeExtraInformation()
       .setFunctionName('isFocused');
 
+      object
+        .addScopedAction(
+          'Focus',
+          _('Focus'),
+          _('Focus the object to enable the inputs from keyboard automatically.'),
+          _('Focus on _PARAM0_'),
+          _(''),
+          'res/conditions/surObjet24.png',
+          'res/conditions/surObjet.png'
+        )
+        .addParameter('object', _('Text input'), 'TextInputObject', false)
+        .getCodeExtraInformation()
+        .setFunctionName('focus');
+
     return extension;
   },
   /**

--- a/Extensions/TextInput/JsExtension.js
+++ b/Extensions/TextInput/JsExtension.js
@@ -561,19 +561,19 @@ module.exports = {
       .getCodeExtraInformation()
       .setFunctionName('isFocused');
 
-      object
-        .addScopedAction(
-          'Focus',
-          _('Focus'),
-          _('Focus the object to enable the inputs from keyboard automatically.'),
-          _('Focus on _PARAM0_'),
-          _(''),
-          'res/conditions/surObjet24.png',
-          'res/conditions/surObjet.png'
-        )
-        .addParameter('object', _('Text input'), 'TextInputObject', false)
-        .getCodeExtraInformation()
-        .setFunctionName('focus');
+    object
+      .addScopedAction(
+        'Focus',
+        _('Focus'),
+        _('Focus the input so that text can be entered (like if it was touched/clicked).'),
+        _('Focus _PARAM0_'),
+        _(''),
+        'res/conditions/surObjet24.png',
+        'res/conditions/surObjet.png'
+      )
+      .addParameter('object', _('Text input'), 'TextInputObject', false)
+      .getCodeExtraInformation()
+      .setFunctionName('focus');
 
     return extension;
   },

--- a/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
@@ -277,7 +277,7 @@ namespace gdjs {
     }
     updateDisabled() {
       if (!this._input) return;
-      
+
       this._input.disabled = this._object.isDisabled();
     }
     updateReadOnly() {
@@ -285,14 +285,14 @@ namespace gdjs {
 
       this._input.readOnly = this._object.isReadOnly();
     }
-    
+
     isFocused() {
       return this._input === document.activeElement;
     }
-    
+
     focus() {
       if (!this._input) return;
-      
+
       this._input.focus();
     }
   }

--- a/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
@@ -277,7 +277,7 @@ namespace gdjs {
     }
     updateDisabled() {
       if (!this._input) return;
-
+      
       this._input.disabled = this._object.isDisabled();
     }
     updateReadOnly() {
@@ -285,9 +285,15 @@ namespace gdjs {
 
       this._input.readOnly = this._object.isReadOnly();
     }
-
+    
     isFocused() {
       return this._input === document.activeElement;
+    }
+    
+    focus() {
+      if (!this._input) return;
+      
+      this._input.focus();
     }
   }
 

--- a/Extensions/TextInput/textinputruntimeobject.ts
+++ b/Extensions/TextInput/textinputruntimeobject.ts
@@ -430,8 +430,8 @@ namespace gdjs {
       return this._renderer.isFocused();
     }
 
-    focus(): boolean {
-      return this._renderer.isFocused();
+    focus(): void {
+      this._renderer.focus();
     }
   }
   gdjs.registerObject(

--- a/Extensions/TextInput/textinputruntimeobject.ts
+++ b/Extensions/TextInput/textinputruntimeobject.ts
@@ -429,6 +429,10 @@ namespace gdjs {
     isFocused(): boolean {
       return this._renderer.isFocused();
     }
+
+    focus(): boolean {
+      return this._renderer.isFocused();
+    }
   }
   gdjs.registerObject(
     'TextInput::TextInputObject',


### PR DESCRIPTION
This allow creators to open the keyboard without people have to click on the object.
This action could help on [this project](https://forum.gdevelop.io/t/please-return-the-text-entry/46517?u=bouh).

I added the action in the code, compiled, but I don't see it in the application. I may have forgotten something?