### PR TITLE
Fix TextInput having extra margins on iOS

### DIFF
--- a/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
@@ -58,6 +58,7 @@ namespace gdjs {
       this._input.style.outline = 'none';
       this._input.style.pointerEvents = 'auto'; // Element can be clicked/touched.
       this._input.style.display = 'none'; // Hide while object is being set up.
+      this._input.style.boxSizing = 'border-box'; // Important for iOS, because border is added to width/height.
 
       this._input.addEventListener('input', () => {
         if (!this._input) return;


### PR DESCRIPTION
Tested on iOS Safari/Desktop Safari/Chrome/Firefox

![Capture d’écran 2023-05-09 à 10 25 48](https://user-images.githubusercontent.com/4895034/237039499-2e6ac38e-a58b-428d-968d-0b67bbd12d3e.png)
