### PR TITLE
Support mouse forward, back buttons

### DIFF
--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -210,19 +210,31 @@ namespace gdjs {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonPressed(0);
+            .isMouseButtonPressed(gdjs.InputManager.MOUSE_LEFT_BUTTON);
         }
         if (button === 'Right') {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonPressed(1);
+            .isMouseButtonPressed(gdjs.InputManager.MOUSE_RIGHT_BUTTON);
         }
         if (button === 'Middle') {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonPressed(2);
+            .isMouseButtonPressed(gdjs.InputManager.MOUSE_MIDDLE_BUTTON);
+        }
+        if (button === 'Back') {
+          return instanceContainer
+            .getGame()
+            .getInputManager()
+            .isMouseButtonPressed(gdjs.InputManager.MOUSE_BACK_BUTTON);
+        }
+        if (button === 'Forward') {
+          return instanceContainer
+            .getGame()
+            .getInputManager()
+            .isMouseButtonPressed(gdjs.InputManager.MOUSE_FORWARD_BUTTON);
         }
         return false;
       };
@@ -235,19 +247,31 @@ namespace gdjs {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonReleased(0);
+            .isMouseButtonReleased(gdjs.InputManager.MOUSE_LEFT_BUTTON);
         }
         if (button === 'Right') {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonReleased(1);
+            .isMouseButtonReleased(gdjs.InputManager.MOUSE_RIGHT_BUTTON);
         }
         if (button === 'Middle') {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonReleased(2);
+            .isMouseButtonReleased(gdjs.InputManager.MOUSE_MIDDLE_BUTTON);
+        }
+        if (button === 'Back') {
+          return instanceContainer
+            .getGame()
+            .getInputManager()
+            .isMouseButtonReleased(gdjs.InputManager.MOUSE_BACK_BUTTON);
+        }
+        if (button === 'Forward') {
+          return instanceContainer
+            .getGame()
+            .getInputManager()
+            .isMouseButtonReleased(gdjs.InputManager.MOUSE_FORWARD_BUTTON);
         }
         return false;
       };

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -141,6 +141,18 @@ namespace gdjs {
       }
 
       /**
+       * A hashmap associates each name of a mouse button with its respective code.
+       * @memberof gdjs.evtTools
+       */
+      export const mouseButtonsNameToCode = {
+        Left: gdjs.InputManager.MOUSE_LEFT_BUTTON,
+        Right: gdjs.InputManager.MOUSE_RIGHT_BUTTON,
+        Middle: gdjs.InputManager.MOUSE_MIDDLE_BUTTON,
+        Back: gdjs.InputManager.MOUSE_BACK_BUTTON,
+        Forward: gdjs.InputManager.MOUSE_FORWARD_BUTTON,
+      };
+
+      /**
        * Return true if the specified key is pressed
        *
        */
@@ -206,35 +218,11 @@ namespace gdjs {
         instanceContainer: gdjs.RuntimeInstanceContainer,
         button: string
       ) {
-        if (button === 'Left') {
+        if (gdjs.evtTools.input.mouseButtonsNameToCode.hasOwnProperty(button)) {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonPressed(gdjs.InputManager.MOUSE_LEFT_BUTTON);
-        }
-        if (button === 'Right') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonPressed(gdjs.InputManager.MOUSE_RIGHT_BUTTON);
-        }
-        if (button === 'Middle') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonPressed(gdjs.InputManager.MOUSE_MIDDLE_BUTTON);
-        }
-        if (button === 'Back') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonPressed(gdjs.InputManager.MOUSE_BACK_BUTTON);
-        }
-        if (button === 'Forward') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonPressed(gdjs.InputManager.MOUSE_FORWARD_BUTTON);
+            .isMouseButtonPressed(gdjs.evtTools.input.mouseButtonsNameToCode[button]);
         }
         return false;
       };
@@ -243,35 +231,11 @@ namespace gdjs {
         instanceContainer: gdjs.RuntimeInstanceContainer,
         button: string
       ) {
-        if (button === 'Left') {
+        if (gdjs.evtTools.input.mouseButtonsNameToCode.hasOwnProperty(button)) {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonReleased(gdjs.InputManager.MOUSE_LEFT_BUTTON);
-        }
-        if (button === 'Right') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonReleased(gdjs.InputManager.MOUSE_RIGHT_BUTTON);
-        }
-        if (button === 'Middle') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonReleased(gdjs.InputManager.MOUSE_MIDDLE_BUTTON);
-        }
-        if (button === 'Back') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonReleased(gdjs.InputManager.MOUSE_BACK_BUTTON);
-        }
-        if (button === 'Forward') {
-          return instanceContainer
-            .getGame()
-            .getInputManager()
-            .isMouseButtonReleased(gdjs.InputManager.MOUSE_FORWARD_BUTTON);
+            .isMouseButtonReleased(gdjs.evtTools.input.mouseButtonsNameToCode[button]);
         }
         return false;
       };

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -222,7 +222,9 @@ namespace gdjs {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonPressed(gdjs.evtTools.input.mouseButtonsNameToCode[button]);
+            .isMouseButtonPressed(
+              gdjs.evtTools.input.mouseButtonsNameToCode[button]
+            );
         }
         return false;
       };
@@ -235,7 +237,9 @@ namespace gdjs {
           return instanceContainer
             .getGame()
             .getInputManager()
-            .isMouseButtonReleased(gdjs.evtTools.input.mouseButtonsNameToCode[button]);
+            .isMouseButtonReleased(
+              gdjs.evtTools.input.mouseButtonsNameToCode[button]
+            );
         }
         return false;
       };

--- a/GDJS/Runtime/inputmanager.ts
+++ b/GDJS/Runtime/inputmanager.ts
@@ -14,6 +14,8 @@ namespace gdjs {
     static MOUSE_LEFT_BUTTON: integer = 0;
     static MOUSE_RIGHT_BUTTON: integer = 1;
     static MOUSE_MIDDLE_BUTTON: integer = 2;
+    static MOUSE_BACK_BUTTON: integer = 3;
+    static MOUSE_FORWARD_BUTTON: integer = 4;
     static MOUSE_TOUCH_ID: integer = 1;
 
     /**

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -569,7 +569,7 @@ namespace gdjs {
       };
 
       // Mouse:
-      
+
       // Converts HTML mouse button to InputManager mouse button.
       // This function is used to align HTML button values with GDevelop 3 C++ SFML Mouse button enum values,
       // notably the middle and right buttons.

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -569,17 +569,26 @@ namespace gdjs {
       };
 
       // Mouse:
+      
+      // Converts HTML mouse button to InputManager mouse button.
+      // This function is used to align HTML button values with GDevelop 3 C++ SFML Mouse button enum values,
+      // notably the middle and right buttons.
+      function convertHtmlMouseButtonToInputManagerMouseButton(button: number) {
+        switch (button) {
+          case 1: // Middle button
+            return gdjs.InputManager.MOUSE_MIDDLE_BUTTON;
+          case 2: // Right button
+            return gdjs.InputManager.MOUSE_RIGHT_BUTTON;
+        }
+        return button;
+      }
       canvas.onmousemove = function (e) {
         const pos = getEventPosition(e);
         manager.onMouseMove(pos[0], pos[1]);
       };
       canvas.onmousedown = function (e) {
         manager.onMouseButtonPressed(
-          e.button === 2
-            ? gdjs.InputManager.MOUSE_RIGHT_BUTTON
-            : e.button === 1
-            ? gdjs.InputManager.MOUSE_MIDDLE_BUTTON
-            : e.button
+          convertHtmlMouseButtonToInputManagerMouseButton(e.button)
         );
         if (window.focus !== undefined) {
           window.focus();
@@ -588,11 +597,7 @@ namespace gdjs {
       };
       canvas.onmouseup = function (e) {
         manager.onMouseButtonReleased(
-          e.button === 2
-            ? gdjs.InputManager.MOUSE_RIGHT_BUTTON
-            : e.button === 1
-            ? gdjs.InputManager.MOUSE_MIDDLE_BUTTON
-            : e.button
+          convertHtmlMouseButtonToInputManagerMouseButton(e.button)
         );
         return false;
       };

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -579,7 +579,7 @@ namespace gdjs {
             ? gdjs.InputManager.MOUSE_RIGHT_BUTTON
             : e.button === 1
             ? gdjs.InputManager.MOUSE_MIDDLE_BUTTON
-            : gdjs.InputManager.MOUSE_LEFT_BUTTON
+            : e.button
         );
         if (window.focus !== undefined) {
           window.focus();
@@ -592,7 +592,7 @@ namespace gdjs {
             ? gdjs.InputManager.MOUSE_RIGHT_BUTTON
             : e.button === 1
             ? gdjs.InputManager.MOUSE_MIDDLE_BUTTON
-            : gdjs.InputManager.MOUSE_LEFT_BUTTON
+            : e.button
         );
         return false;
       };
@@ -603,42 +603,21 @@ namespace gdjs {
         manager.onMouseEnter();
         // There is no mouse event when the cursor is outside of the canvas.
         // We catchup what happened.
-        {
-          const leftIsPressed = (e.buttons & 1) !== 0;
-          const leftWasPressed = manager.isMouseButtonPressed(
-            gdjs.InputManager.MOUSE_LEFT_BUTTON
-          );
-          if (leftIsPressed && !leftWasPressed) {
-            manager.onMouseButtonPressed(gdjs.InputManager.MOUSE_LEFT_BUTTON);
-          }
-          if (!leftIsPressed && leftWasPressed) {
-            manager.onMouseButtonReleased(gdjs.InputManager.MOUSE_LEFT_BUTTON);
-          }
-        }
-        {
-          const rightIsPressed = (e.buttons & 2) !== 0;
-          const rightWasPressed = manager.isMouseButtonPressed(
-            gdjs.InputManager.MOUSE_RIGHT_BUTTON
-          );
-          if (rightIsPressed && !rightWasPressed) {
-            manager.onMouseButtonPressed(gdjs.InputManager.MOUSE_RIGHT_BUTTON);
-          }
-          if (!rightIsPressed && rightWasPressed) {
-            manager.onMouseButtonReleased(gdjs.InputManager.MOUSE_RIGHT_BUTTON);
-          }
-        }
-        {
-          const middleIsPressed = (e.buttons & 4) !== 0;
-          const middleWasPressed = manager.isMouseButtonPressed(
-            gdjs.InputManager.MOUSE_MIDDLE_BUTTON
-          );
-          if (middleIsPressed && !middleWasPressed) {
-            manager.onMouseButtonPressed(gdjs.InputManager.MOUSE_MIDDLE_BUTTON);
-          }
-          if (!middleIsPressed && middleWasPressed) {
-            manager.onMouseButtonReleased(
-              gdjs.InputManager.MOUSE_MIDDLE_BUTTON
-            );
+        const buttons = [
+          gdjs.InputManager.MOUSE_LEFT_BUTTON,
+          gdjs.InputManager.MOUSE_RIGHT_BUTTON,
+          gdjs.InputManager.MOUSE_MIDDLE_BUTTON,
+          gdjs.InputManager.MOUSE_BACK_BUTTON,
+          gdjs.InputManager.MOUSE_FORWARD_BUTTON,
+        ];
+        for (let i = 0, len = buttons.length; i < len; ++i) {
+          const button = buttons[i];
+          const buttonIsPressed = (e.buttons & (1 << i)) !== 0;
+          const buttonWasPressed = manager.isMouseButtonPressed(button);
+          if (buttonIsPressed && !buttonWasPressed) {
+            manager.onMouseButtonPressed(button);
+          } else if (!buttonIsPressed && buttonWasPressed) {
+            manager.onMouseButtonReleased(button);
           }
         }
       };

--- a/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/MouseField.js
@@ -44,6 +44,14 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           value="Middle"
           label={t`Middle (Auxiliary button, usually the wheel button)`}
         />
+        <SelectOption
+          value="Back"
+          label={t`Back (Additional button, typically the Browser Back button)`}
+        />
+        <SelectOption
+          value="Forward"
+          label={t`Forward (Additional button, typically the Browser Forward button)`}
+        />
       </SelectField>
     );
   }


### PR DESCRIPTION
I submitted a pull request to add support for extra mouse buttons (back and forward). Let me know what you think!

Initially, my goal was to prevent the sprite buttons from being pressed by the additional mouse buttons. However, although these buttons are not widely used, it seemed like a good idea to allow users to utilize the additional buttons in the game as well.