### PR TITLE
Fix the tile map scale action

### DIFF
--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -514,7 +514,8 @@ const defineTileMap = function (
     )
     .markAsAdvanced()
     .getCodeExtraInformation()
-    .setFunctionName('setScale');
+    .setFunctionName('setScale')
+    .setGetter('getScale');
 
   object
     .addExpressionAndConditionAndAction(
@@ -905,7 +906,8 @@ const defineCollisionMask = function (
     )
     .markAsAdvanced()
     .getCodeExtraInformation()
-    .setFunctionName('setScale');
+    .setFunctionName('setScale')
+    .setGetter('getScale');
 
   object
     .addExpressionAndConditionAndAction(

--- a/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
+++ b/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
@@ -491,6 +491,17 @@ namespace gdjs {
     }
 
     /**
+     * Get the scale of the object (or the geometric mean of the X and Y scale in case they are different).
+     *
+     * @return the scale of the object (or the geometric mean of the X and Y scale in case they are different).
+     */
+    getScale(): number {
+      const scaleX = this.getScaleX();
+      const scaleY = this.getScaleY();
+      return scaleX === scaleY ? scaleX : Math.sqrt(scaleX * scaleY);
+    }
+
+    /**
      * Change the scale on X and Y axis of the object.
      *
      * @param scale The new scale (must be greater than 0).

--- a/Extensions/TileMap/tilemapruntimeobject.ts
+++ b/Extensions/TileMap/tilemapruntimeobject.ts
@@ -259,6 +259,17 @@ namespace gdjs {
     }
 
     /**
+     * Get the scale of the object (or the geometric mean of the X and Y scale in case they are different).
+     *
+     * @return the scale of the object (or the geometric mean of the X and Y scale in case they are different).
+     */
+    getScale(): number {
+      const scaleX = this.getScaleX();
+      const scaleY = this.getScaleY();
+      return scaleX === scaleY ? scaleX : Math.sqrt(scaleX * scaleY);
+    }
+
+    /**
      * Change the scale on X and Y axis of the object.
      *
      * @param scale The new scale (must be greater than 0).


### PR DESCRIPTION
* Operators +=, -=, *= and /= were making previews crash.