### PR TITLE
Fix extensions refresh after closing a project to create a new one

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -2512,7 +2512,6 @@ const MainFrame = (props: Props) => {
   const createProject = React.useCallback(
     async (i18n: I18n, newProjectSetup: NewProjectSetup) => {
       setIsProjectOpening(true);
-      setIsProjectClosedSoAvoidReloadingExtensions(false);
 
       // 4 cases when creating a project:
       // - From an example
@@ -2682,6 +2681,8 @@ const MainFrame = (props: Props) => {
           currentProject: currentProject,
           editorTabs: editorTabs,
         });
+
+        setIsProjectClosedSoAvoidReloadingExtensions(false);
       } catch (rawError) {
         const { getWriteErrorMessage } = getStorageProviderOperations();
         const errorMessage = getWriteErrorMessage


### PR DESCRIPTION
When creating a new project, the flag was reset before the old project was closed which lead to extensions stopping to refresh until the project was reopened.