### PR TITLE
Fix force update generating crashes

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -214,7 +214,6 @@ const InstancePropertiesEditor = ({
       );
       return {
         object,
-        instance,
         instanceSchema: is3DInstance
           ? reorganizeSchemaFor3DInstance(
               schema,

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -40,261 +40,244 @@ type Props = {|
 
 export type InstancePropertiesEditorInterface = {| forceUpdate: () => void |};
 
-const InstancePropertiesEditor = React.forwardRef<
-  Props,
-  InstancePropertiesEditorInterface
->(
-  (
-    {
-      instances,
-      i18n,
-      project,
-      layout,
-      unsavedChanges,
-      historyHandler,
-      onEditObjectByName,
-      onGetInstanceSize,
-      editInstanceVariables,
-      onInstancesModified,
-    },
-    ref
-  ) => {
-    const forceUpdate = useForceUpdate();
-    React.useImperativeHandle(ref, () => ({
-      forceUpdate,
-    }));
-
-    const schema: Schema = React.useMemo(
-      () => [
-        {
-          name: i18n._(t`Object`),
-          getValue: (instance: gdInitialInstance) => instance.getObjectName(),
-          nonFieldType: 'sectionTitle',
-          defaultValue: i18n._(t`Different objects`),
-        },
-        {
-          label: i18n._(t`Edit object`),
-          disabled: 'onValuesDifferent',
-          nonFieldType: 'button',
-          getValue: (instance: gdInitialInstance) => instance.getObjectName(),
-          onClick: (instance: gdInitialInstance) =>
-            onEditObjectByName(instance.getObjectName()),
-        },
-        {
-          name: i18n._(t`Instance`),
-          nonFieldType: 'sectionTitle',
-        },
-        {
-          name: 'Position',
-          type: 'row',
-          children: [
-            {
-              name: 'X',
-              getLabel: () => i18n._(t`X`),
-              valueType: 'number',
-              getValue: (instance: gdInitialInstance) => instance.getX(),
-              setValue: (instance: gdInitialInstance, newValue: number) =>
-                instance.setX(newValue),
-            },
-            {
-              name: 'Y',
-              getLabel: () => i18n._(t`Y`),
-              valueType: 'number',
-              getValue: (instance: gdInitialInstance) => instance.getY(),
-              setValue: (instance: gdInitialInstance, newValue: number) =>
-                instance.setY(newValue),
-            },
-          ],
-        },
-        {
-          name: 'Angles',
-          type: 'row',
-          children: [
-            {
-              name: 'Angle',
-              getLabel: () => i18n._(t`Angle`),
-              valueType: 'number',
-              getValue: (instance: gdInitialInstance) => instance.getAngle(),
-              setValue: (instance: gdInitialInstance, newValue: number) =>
-                instance.setAngle(newValue),
-            },
-          ],
-        },
-        {
-          name: 'Lock instance position angle',
-          getLabel: () => i18n._(t`Lock position/angle in the editor`),
-          valueType: 'boolean',
-          getValue: (instance: gdInitialInstance) => instance.isLocked(),
-          setValue: (instance: gdInitialInstance, newValue: boolean) => {
-            instance.setLocked(newValue);
-            if (!newValue) {
-              instance.setSealed(newValue);
-            }
+const InstancePropertiesEditor = ({
+  instances,
+  i18n,
+  project,
+  layout,
+  unsavedChanges,
+  historyHandler,
+  onEditObjectByName,
+  onGetInstanceSize,
+  editInstanceVariables,
+  onInstancesModified,
+}: Props) => {
+  const schema: Schema = React.useMemo(
+    () => [
+      {
+        name: i18n._(t`Object`),
+        getValue: (instance: gdInitialInstance) => instance.getObjectName(),
+        nonFieldType: 'sectionTitle',
+        defaultValue: i18n._(t`Different objects`),
+      },
+      {
+        label: i18n._(t`Edit object`),
+        disabled: 'onValuesDifferent',
+        nonFieldType: 'button',
+        getValue: (instance: gdInitialInstance) => instance.getObjectName(),
+        onClick: (instance: gdInitialInstance) =>
+          onEditObjectByName(instance.getObjectName()),
+      },
+      {
+        name: i18n._(t`Instance`),
+        nonFieldType: 'sectionTitle',
+      },
+      {
+        name: 'Position',
+        type: 'row',
+        children: [
+          {
+            name: 'X',
+            getLabel: () => i18n._(t`X`),
+            valueType: 'number',
+            getValue: (instance: gdInitialInstance) => instance.getX(),
+            setValue: (instance: gdInitialInstance, newValue: number) =>
+              instance.setX(newValue),
           },
-        },
-        {
-          name: 'Prevent instance selection',
-          getLabel: () => i18n._(t`Prevent selection in the editor`),
-          valueType: 'boolean',
-          disabled: (instances: gdInitialInstance[]) => {
-            return instances.some(instance => !instance.isLocked());
+          {
+            name: 'Y',
+            getLabel: () => i18n._(t`Y`),
+            valueType: 'number',
+            getValue: (instance: gdInitialInstance) => instance.getY(),
+            setValue: (instance: gdInitialInstance, newValue: number) =>
+              instance.setY(newValue),
           },
-          getValue: (instance: gdInitialInstance) => instance.isSealed(),
-          setValue: (instance: gdInitialInstance, newValue: boolean) =>
-            instance.setSealed(newValue),
-        },
-        {
-          name: 'Z Order',
-          getLabel: () => i18n._(t`Z Order`),
-          valueType: 'number',
-          getValue: (instance: gdInitialInstance) => instance.getZOrder(),
-          setValue: (instance: gdInitialInstance, newValue: number) =>
-            instance.setZOrder(newValue),
-        },
-        {
-          name: 'Layer',
-          getLabel: () => i18n._(t`Layer`),
-          valueType: 'string',
-          getChoices: () => enumerateLayers(layout),
-          getValue: (instance: gdInitialInstance) => instance.getLayer(),
-          setValue: (instance: gdInitialInstance, newValue: string) =>
-            instance.setLayer(newValue),
-        },
-        {
-          name: 'Custom size',
-          getLabel: () => i18n._(t`Custom size`),
-          valueType: 'boolean',
-          getValue: (instance: gdInitialInstance) => instance.hasCustomSize(),
-          setValue: (instance: gdInitialInstance, newValue: boolean) => {
-            if (newValue) {
-              const [width, height] = onGetInstanceSize(instance);
-              instance.setCustomWidth(width);
-              instance.setCustomHeight(height);
-            }
-            instance.setHasCustomSize(newValue);
+        ],
+      },
+      {
+        name: 'Angles',
+        type: 'row',
+        children: [
+          {
+            name: 'Angle',
+            getLabel: () => i18n._(t`Angle`),
+            valueType: 'number',
+            getValue: (instance: gdInitialInstance) => instance.getAngle(),
+            setValue: (instance: gdInitialInstance, newValue: number) =>
+              instance.setAngle(newValue),
           },
+        ],
+      },
+      {
+        name: 'Lock instance position angle',
+        getLabel: () => i18n._(t`Lock position/angle in the editor`),
+        valueType: 'boolean',
+        getValue: (instance: gdInitialInstance) => instance.isLocked(),
+        setValue: (instance: gdInitialInstance, newValue: boolean) => {
+          instance.setLocked(newValue);
+          if (!newValue) {
+            instance.setSealed(newValue);
+          }
         },
-        {
-          name: 'custom-size-row',
-          type: 'row',
-          children: [
-            {
-              name: 'Width',
-              getLabel: () => i18n._(t`Width`),
-              valueType: 'number',
-              getValue: (instance: gdInitialInstance) =>
-                instance.getCustomWidth(),
-              setValue: (instance: gdInitialInstance, newValue: number) => {
-                instance.setHasCustomSize(true);
-                instance.setCustomWidth(Math.max(newValue, 0));
-              },
-            },
-            {
-              name: 'Height',
-              getLabel: () => i18n._(t`Height`),
-              valueType: 'number',
-              getValue: (instance: gdInitialInstance) =>
-                instance.getCustomHeight(),
-              setValue: (instance: gdInitialInstance, newValue: number) => {
-                instance.setHasCustomSize(true);
-                instance.setCustomHeight(Math.max(newValue, 0));
-              },
-            },
-          ],
+      },
+      {
+        name: 'Prevent instance selection',
+        getLabel: () => i18n._(t`Prevent selection in the editor`),
+        valueType: 'boolean',
+        disabled: (instances: gdInitialInstance[]) => {
+          return instances.some(instance => !instance.isLocked());
         },
-      ],
-      [i18n, layout, onEditObjectByName, onGetInstanceSize]
-    );
+        getValue: (instance: gdInitialInstance) => instance.isSealed(),
+        setValue: (instance: gdInitialInstance, newValue: boolean) =>
+          instance.setSealed(newValue),
+      },
+      {
+        name: 'Z Order',
+        getLabel: () => i18n._(t`Z Order`),
+        valueType: 'number',
+        getValue: (instance: gdInitialInstance) => instance.getZOrder(),
+        setValue: (instance: gdInitialInstance, newValue: number) =>
+          instance.setZOrder(newValue),
+      },
+      {
+        name: 'Layer',
+        getLabel: () => i18n._(t`Layer`),
+        valueType: 'string',
+        getChoices: () => enumerateLayers(layout),
+        getValue: (instance: gdInitialInstance) => instance.getLayer(),
+        setValue: (instance: gdInitialInstance, newValue: string) =>
+          instance.setLayer(newValue),
+      },
+      {
+        name: 'Custom size',
+        getLabel: () => i18n._(t`Custom size`),
+        valueType: 'boolean',
+        getValue: (instance: gdInitialInstance) => instance.hasCustomSize(),
+        setValue: (instance: gdInitialInstance, newValue: boolean) => {
+          if (newValue) {
+            const [width, height] = onGetInstanceSize(instance);
+            instance.setCustomWidth(width);
+            instance.setCustomHeight(height);
+          }
+          instance.setHasCustomSize(newValue);
+        },
+      },
+      {
+        name: 'custom-size-row',
+        type: 'row',
+        children: [
+          {
+            name: 'Width',
+            getLabel: () => i18n._(t`Width`),
+            valueType: 'number',
+            getValue: (instance: gdInitialInstance) =>
+              instance.getCustomWidth(),
+            setValue: (instance: gdInitialInstance, newValue: number) => {
+              instance.setHasCustomSize(true);
+              instance.setCustomWidth(Math.max(newValue, 0));
+            },
+          },
+          {
+            name: 'Height',
+            getLabel: () => i18n._(t`Height`),
+            valueType: 'number',
+            getValue: (instance: gdInitialInstance) =>
+              instance.getCustomHeight(),
+            setValue: (instance: gdInitialInstance, newValue: number) => {
+              instance.setHasCustomSize(true);
+              instance.setCustomHeight(Math.max(newValue, 0));
+            },
+          },
+        ],
+      },
+    ],
+    [i18n, layout, onEditObjectByName, onGetInstanceSize]
+  );
 
-    const instance = instances[0];
-    const associatedObjectName = instance.getObjectName();
-    const object = getObjectByName(project, layout, associatedObjectName);
-    // TODO: multiple instances support
-    const properties = instance.getCustomProperties(project, layout);
-    // TODO: Reorganize fields if any of the selected instances is 3D.
-    const is3DInstance = properties.has('z');
-    const instanceSchemaForCustomProperties = propertiesMapToSchema(
-      properties,
-      (instance: gdInitialInstance) =>
-        instance.getCustomProperties(project, layout),
-      (instance: gdInitialInstance, name, value) =>
-        instance.updateCustomProperty(name, value, project, layout)
-    );
-    let instanceSchema = React.useMemo(
-      () =>
-        is3DInstance
-          ? reorganizeSchemaFor3DInstance(
-              schema,
-              instanceSchemaForCustomProperties
-            )
-          : schema.concat(instanceSchemaForCustomProperties),
-      [is3DInstance, instanceSchemaForCustomProperties, schema]
-    );
+  const instance = instances[0];
+  const associatedObjectName = instance.getObjectName();
+  const object = getObjectByName(project, layout, associatedObjectName);
+  // TODO: multiple instances support
+  const properties = instance.getCustomProperties(project, layout);
+  // TODO: Reorganize fields if any of the selected instances is 3D.
+  const is3DInstance = properties.has('z');
+  const instanceSchemaForCustomProperties = propertiesMapToSchema(
+    properties,
+    (instance: gdInitialInstance) =>
+      instance.getCustomProperties(project, layout),
+    (instance: gdInitialInstance, name, value) =>
+      instance.updateCustomProperty(name, value, project, layout)
+  );
+  let instanceSchema = React.useMemo(
+    () =>
+      is3DInstance
+        ? reorganizeSchemaFor3DInstance(
+            schema,
+            instanceSchemaForCustomProperties
+          )
+        : schema.concat(instanceSchemaForCustomProperties),
+    [is3DInstance, instanceSchemaForCustomProperties, schema]
+  );
 
-    return (
-      <ScrollView
-        autoHideScrollbar
-        key={instances
-          .map((instance: gdInitialInstance) => '' + instance.ptr)
-          .join(';')}
-      >
-        <Column expand noMargin id="instance-properties-editor">
-          <Column>
-            <PropertiesEditor
-              unsavedChanges={unsavedChanges}
-              schema={instanceSchema}
-              instances={instances}
-              onInstancesModified={onInstancesModified}
-            />
-            <Line alignItems="center" justifyContent="space-between">
-              <Text>
-                <Trans>Instance Variables</Trans>
-              </Text>
-              <IconButton
-                size="small"
-                onClick={() => {
-                  editInstanceVariables(instance);
-                }}
-              >
-                <ShareExternal />
-              </IconButton>
-            </Line>
-          </Column>
-          {object ? (
-            <VariablesList
-              commitChangesOnBlur={false}
-              inheritedVariablesContainer={object.getVariables()}
-              variablesContainer={instance.getVariables()}
+  return (
+    <ScrollView
+      autoHideScrollbar
+      key={instances
+        .map((instance: gdInitialInstance) => '' + instance.ptr)
+        .join(';')}
+    >
+      <Column expand noMargin id="instance-properties-editor">
+        <Column>
+          <PropertiesEditor
+            unsavedChanges={unsavedChanges}
+            schema={instanceSchema}
+            instances={instances}
+            onInstancesModified={onInstancesModified}
+          />
+          <Line alignItems="center" justifyContent="space-between">
+            <Text>
+              <Trans>Instance Variables</Trans>
+            </Text>
+            <IconButton
               size="small"
-              onComputeAllVariableNames={() =>
-                object
-                  ? EventsRootVariablesFinder.findAllObjectVariables(
-                      project.getCurrentPlatform(),
-                      project,
-                      layout,
-                      object
-                    )
-                  : []
-              }
-              historyHandler={historyHandler}
-            />
-          ) : null}
+              onClick={() => {
+                editInstanceVariables(instance);
+              }}
+            >
+              <ShareExternal />
+            </IconButton>
+          </Line>
         </Column>
-      </ScrollView>
-    );
-  }
-);
+        {object ? (
+          <VariablesList
+            commitChangesOnBlur={false}
+            inheritedVariablesContainer={object.getVariables()}
+            variablesContainer={instance.getVariables()}
+            size="small"
+            onComputeAllVariableNames={() =>
+              object
+                ? EventsRootVariablesFinder.findAllObjectVariables(
+                    project.getCurrentPlatform(),
+                    project,
+                    layout,
+                    object
+                  )
+                : []
+            }
+            historyHandler={historyHandler}
+          />
+        ) : null}
+      </Column>
+    </ScrollView>
+  );
+};
 
 const InstancePropertiesEditorContainer = React.forwardRef<
   Props,
   InstancePropertiesEditorInterface
 >((props, ref) => {
   const editorRef = React.useRef<?InstancePropertiesEditorInterface>(null);
-  const forceUpdate = React.useCallback(() => {
-    if (editorRef.current) {
-      editorRef.current.forceUpdate();
-    }
-  }, []);
+  const forceUpdate = useForceUpdate();
   React.useImperativeHandle(ref, () => ({
     forceUpdate,
   }));

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -195,29 +195,38 @@ const InstancePropertiesEditor = ({
   );
 
   const instance = instances[0];
-  const associatedObjectName = instance.getObjectName();
-  const object = getObjectByName(project, layout, associatedObjectName);
-  // TODO: multiple instances support
-  const properties = instance.getCustomProperties(project, layout);
-  // TODO: Reorganize fields if any of the selected instances is 3D.
-  const is3DInstance = properties.has('z');
-  const instanceSchemaForCustomProperties = propertiesMapToSchema(
-    properties,
-    (instance: gdInitialInstance) =>
-      instance.getCustomProperties(project, layout),
-    (instance: gdInitialInstance, name, value) =>
-      instance.updateCustomProperty(name, value, project, layout)
+
+  const { object, instanceSchema } = React.useMemo(
+    () => {
+      if (!instance) return {};
+      const associatedObjectName = instance.getObjectName();
+      const object = getObjectByName(project, layout, associatedObjectName);
+      // TODO: multiple instances support
+      const properties = instance.getCustomProperties(project, layout);
+      // TODO: Reorganize fields if any of the selected instances is 3D.
+      const is3DInstance = properties.has('z');
+      const instanceSchemaForCustomProperties = propertiesMapToSchema(
+        properties,
+        (instance: gdInitialInstance) =>
+          instance.getCustomProperties(project, layout),
+        (instance: gdInitialInstance, name, value) =>
+          instance.updateCustomProperty(name, value, project, layout)
+      );
+      return {
+        object,
+        instance,
+        instanceSchema: is3DInstance
+          ? reorganizeSchemaFor3DInstance(
+              schema,
+              instanceSchemaForCustomProperties
+            )
+          : schema.concat(instanceSchemaForCustomProperties),
+      };
+    },
+    [project, layout, instance, schema]
   );
-  let instanceSchema = React.useMemo(
-    () =>
-      is3DInstance
-        ? reorganizeSchemaFor3DInstance(
-            schema,
-            instanceSchemaForCustomProperties
-          )
-        : schema.concat(instanceSchemaForCustomProperties),
-    [is3DInstance, instanceSchemaForCustomProperties, schema]
-  );
+
+  if (!object || !instance || !instanceSchema) return null;
 
   return (
     <ScrollView


### PR DESCRIPTION
It looks like the forceUpdate on the instance properties editor was executed before the container had the time to say: "There is no instance selected, I won't render the editor".
So when the editor was updated, it was crashing on:
```js
const instance = instances[0]
const associatedObjectName = instance.getObjectName();
```
since instance was undefined. 