### PR TITLE
Improve build card name editing

### DIFF
--- a/newIDE/app/src/Export/Builds/BuildCard.js
+++ b/newIDE/app/src/Export/Builds/BuildCard.js
@@ -144,7 +144,7 @@ export const BuildCard = ({
   const [showCopiedInfoBar, setShowCopiedInfoBar] = React.useState(false);
 
   const [isEditingName, setIsEditingName] = React.useState(false);
-  const [name, setName] = React.useState(build.name || buildName);
+  const [name, setName] = React.useState(buildName);
 
   const onCopyUuid = () => {
     navigator.clipboard.writeText(build.id);
@@ -297,7 +297,7 @@ export const BuildCard = ({
                         if (shouldCloseOrCancel(event)) {
                           event.stopPropagation();
                           setIsEditingName(false);
-                          setName(build.name || buildName);
+                          setName(buildName);
                         }
                       }}
                       maxLength={BUILD_NAME_MAX_LENGTH}


### PR DESCRIPTION
- Cancel name editing with Escape
- Use the computed build name as a first value in the text field