### PR TITLE
Force the expression mode for parameter fields within an extension

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
@@ -109,7 +109,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
+          isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
@@ -40,7 +40,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
 
     // If the current value is not in the list of layouts, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
-      !!props.value && !isCurrentValueInLayoutsList
+      (!!props.value && !isCurrentValueInLayoutsList) ||
+        props.scope.eventsFunctionsExtension
     );
 
     const switchFieldType = () => {
@@ -108,7 +109,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          isExpressionField ? (
+          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
@@ -62,7 +62,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
 
     // If the current value is not in the list of animation names, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
-      !!props.value && !isCurrentValueInEffectNamesList
+      (!!props.value && !isCurrentValueInEffectNamesList) ||
+        props.scope.eventsFunctionsExtension
     );
 
     const switchFieldType = () => {
@@ -132,7 +133,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          isExpressionField ? (
+          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
@@ -84,7 +84,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
 
     // If the current value is not in the list of animation names, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
-      !!props.value && !isCurrentValueInEffectParameterNamesList
+      (!!props.value && !isCurrentValueInEffectParameterNamesList) ||
+        props.scope.eventsFunctionsExtension
     );
 
     const switchFieldType = () => {
@@ -158,7 +159,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          isExpressionField ? (
+          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
@@ -45,7 +45,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
 
     // If the current value is not in the list of layers, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
-      !!props.value && !isCurrentValueInLayersList
+      (!!props.value && !isCurrentValueInLayersList) ||
+        props.scope.eventsFunctionsExtension
     );
 
     const switchFieldType = () => {
@@ -119,7 +120,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          isExpressionField ? (
+          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -89,7 +89,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
 
     // If the current value is not in the list of animation names, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
-      !!props.value && !isCurrentValueInAnimationNamesList
+      (!!props.value && !isCurrentValueInAnimationNamesList) ||
+        props.scope.eventsFunctionsExtension
     );
 
     const switchFieldType = () => {
@@ -159,7 +160,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          isExpressionField ? (
+          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
@@ -39,7 +39,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
 
     // If the current value is not in the list of layouts, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
-      !!props.value && !isCurrentValueInLayoutsList
+      (!!props.value && !isCurrentValueInLayoutsList) ||
+        props.scope.eventsFunctionsExtension
     );
 
     const switchFieldType = () => {
@@ -107,7 +108,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          isExpressionField ? (
+          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
@@ -108,7 +108,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
+          isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}


### PR DESCRIPTION
Changes
- All fields but leaderboard ones are expression by default
- Fields that can't have autocompletion in extension context no longer have a button to switch mode.

In extension, actual objects are only known at runtime. For instance, their animation names or layout layer names are only known at runtime.