### PR TITLE
Use instance default size as default custom size

### DIFF
--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -1896,12 +1896,8 @@ module.exports = {
       }
 
       updatePIXISprite() {
-        const width = this._instance.hasCustomSize()
-          ? this._instance.getCustomWidth()
-          : this.getDefaultWidth();
-        const height = this._instance.hasCustomSize()
-          ? this._instance.getCustomHeight()
-          : this.getDefaultHeight();
+        const width = this.getWidth();
+        const height = this.getHeight();
 
         this._pixiTexturedObject.anchor.x =
           this._centerX / this._pixiTexturedObject.texture.frame.width;
@@ -1923,12 +1919,8 @@ module.exports = {
       }
 
       updateFallbackObject() {
-        const width = this._instance.hasCustomSize()
-          ? this._instance.getCustomWidth()
-          : this.getDefaultWidth();
-        const height = this._instance.hasCustomSize()
-          ? this._instance.getCustomHeight()
-          : this.getDefaultHeight();
+        const width = this.getWidth();
+        const height = this.getHeight();
 
         this._pixiFallbackObject.clear();
         this._pixiFallbackObject.beginFill(0x0033ff);
@@ -1968,11 +1960,7 @@ module.exports = {
 
       getCenterX() {
         if (this._renderFallbackObject) {
-          if (this._instance.hasCustomSize()) {
-            return this._instance.getCustomWidth() / 2;
-          } else {
-            return this.getDefaultWidth() / 2;
-          }
+          return this.getWidth() / 2;
         } else {
           return this._centerX * this._pixiTexturedObject.scale.x;
         }
@@ -1980,11 +1968,7 @@ module.exports = {
 
       getCenterY() {
         if (this._renderFallbackObject) {
-          if (this._instance.hasCustomSize()) {
-            return this._instance.getCustomHeight() / 2;
-          } else {
-            return this.getDefaultHeight() / 2;
-          }
+          return this.getHeight() / 2;
         } else {
           return this._centerY * this._pixiTexturedObject.scale.y;
         }
@@ -2081,12 +2065,8 @@ module.exports = {
       }
 
       updateThreeObject() {
-        const width = this._instance.hasCustomSize()
-          ? this._instance.getCustomWidth()
-          : this.getDefaultWidth();
-        const height = this._instance.hasCustomSize()
-          ? this._instance.getCustomHeight()
-          : this.getDefaultHeight();
+        const width = this.getWidth();
+        const height = this.getHeight();
         let depth;
         if (this._instance.hasCustomSize()) {
           const instancePropertyDepth =
@@ -2334,12 +2314,8 @@ module.exports = {
       }
 
       updatePixiObject() {
-        const width = this._instance.hasCustomSize()
-          ? this._instance.getCustomWidth()
-          : this.getDefaultWidth();
-        const height = this._instance.hasCustomSize()
-          ? this._instance.getCustomHeight()
-          : this.getDefaultHeight();
+        const width = this.getWidth();
+        const height = this.getHeight();
 
         this._pixiObject.clear();
         this._pixiObject.beginFill(0x999999, 0.2);
@@ -2366,22 +2342,6 @@ module.exports = {
 
       getDefaultHeight() {
         return this._defaultHeight;
-      }
-
-      getCenterX() {
-        if (this._instance.hasCustomSize()) {
-          return this._instance.getCustomWidth() / 2;
-        } else {
-          return this.getDefaultWidth() / 2;
-        }
-      }
-
-      getCenterY() {
-        if (this._instance.hasCustomSize()) {
-          return this._instance.getCustomHeight() / 2;
-        } else {
-          return this.getDefaultHeight() / 2;
-        }
       }
     }
 
@@ -2425,12 +2385,8 @@ module.exports = {
       }
 
       update() {
-        const width = this._instance.hasCustomSize()
-          ? this._instance.getCustomWidth()
-          : this._defaultWidth;
-        const height = this._instance.hasCustomSize()
-          ? this._instance.getCustomHeight()
-          : this._defaultHeight;
+        const width = this.getWidth();
+        const height = this.getHeight();
 
         this._pixiObject.clear();
         this._pixiObject.beginFill(0x0033ff);
@@ -2598,12 +2554,8 @@ module.exports = {
       }
 
       updateThreeObject() {
-        const width = this._instance.hasCustomSize()
-          ? this._instance.getCustomWidth()
-          : this.getDefaultWidth();
-        const height = this._instance.hasCustomSize()
-          ? this._instance.getCustomHeight()
-          : this.getDefaultHeight();
+        const width = this.getWidth();
+        const height = this.getHeight();
         let depth;
         if (this._instance.hasCustomSize()) {
           const instancePropertyDepth =
@@ -2639,12 +2591,8 @@ module.exports = {
       }
 
       updatePixiObject() {
-        const width = this._instance.hasCustomSize()
-          ? this._instance.getCustomWidth()
-          : this.getDefaultWidth();
-        const height = this._instance.hasCustomSize()
-          ? this._instance.getCustomHeight()
-          : this.getDefaultHeight();
+        const width = this.getWidth();
+        const height = this.getHeight();
 
         this._pixiObject.clear();
         this._pixiObject.beginFill(0x999999, 0.2);

--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -606,7 +606,7 @@ module.exports = {
       );
 
       if (this._instance.hasCustomSize() && this._pixiObject) {
-        const customWidth = this._instance.getCustomWidth();
+        const customWidth = this.getCustomWidth();
         if (
           this._pixiObject &&
           this._pixiObject._style.wordWrapWidth !== customWidth

--- a/Extensions/BitmapText/JsExtension.js
+++ b/Extensions/BitmapText/JsExtension.js
@@ -711,7 +711,7 @@ module.exports = {
       const wordWrap = properties.get('wordWrap').getValue() === 'true';
       if (wordWrap && this._instance.hasCustomSize()) {
         this._pixiObject.maxWidth =
-          this._instance.getCustomWidth() / this._pixiObject.scale.x;
+          this.getCustomWidth() / this._pixiObject.scale.x;
         this._pixiObject.dirty = true;
       } else {
         this._pixiObject.maxWidth = 0;

--- a/Extensions/ExampleJsExtension/JsExtension.js
+++ b/Extensions/ExampleJsExtension/JsExtension.js
@@ -563,8 +563,8 @@ module.exports = {
       this._pixiObject.rotation = RenderedInstance.toRad(
         this._instance.getAngle()
       );
-      // Custom size can be read in getCustomWidth() and
-      // getCustomHeight()
+      // Custom size can be read in this.getCustomWidth() and
+      // this.getCustomHeight()
     };
 
     /**

--- a/Extensions/ExampleJsExtension/JsExtension.js
+++ b/Extensions/ExampleJsExtension/JsExtension.js
@@ -563,8 +563,8 @@ module.exports = {
       this._pixiObject.rotation = RenderedInstance.toRad(
         this._instance.getAngle()
       );
-      // Custom size can be read in instance.getCustomWidth() and
-      // instance.getCustomHeight()
+      // Custom size can be read in getCustomWidth() and
+      // getCustomHeight()
     };
 
     /**

--- a/Extensions/TextInput/JsExtension.js
+++ b/Extensions/TextInput/JsExtension.js
@@ -714,8 +714,8 @@ module.exports = {
         let width = DEFAULT_WIDTH;
         let height = DEFAULT_HEIGHT;
         if (instance.hasCustomSize()) {
-          width = getCustomWidth();
-          height = getCustomHeight();
+          width = this.getCustomWidth();
+          height = this.getCustomHeight();
         }
 
         this._pixiObject.pivot.x = width / 2;

--- a/Extensions/TextInput/JsExtension.js
+++ b/Extensions/TextInput/JsExtension.js
@@ -714,8 +714,8 @@ module.exports = {
         let width = DEFAULT_WIDTH;
         let height = DEFAULT_HEIGHT;
         if (instance.hasCustomSize()) {
-          width = instance.getCustomWidth();
-          height = instance.getCustomHeight();
+          width = getCustomWidth();
+          height = getCustomHeight();
         }
 
         this._pixiObject.pivot.x = width / 2;

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -1347,7 +1347,7 @@ module.exports = {
      */
     RenderedTileMapInstance.prototype.update = function () {
       if (this._instance.hasCustomSize()) {
-        this._pixiObject.scale.x = this._instance.getCustomWidth() / this.width;
+        this._pixiObject.scale.x = this.getCustomWidth() / this.width;
         this._pixiObject.scale.y =
           this._instance.getCustomHeight() / this.height;
       } else {
@@ -1599,7 +1599,7 @@ module.exports = {
      */
     RenderedCollisionMaskInstance.prototype.update = function () {
       if (this._instance.hasCustomSize()) {
-        this._pixiObject.scale.x = this._instance.getCustomWidth() / this.width;
+        this._pixiObject.scale.x = this.getCustomWidth() / this.width;
         this._pixiObject.scale.y =
           this._instance.getCustomHeight() / this.height;
       } else {

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -1349,7 +1349,7 @@ module.exports = {
       if (this._instance.hasCustomSize()) {
         this._pixiObject.scale.x = this.getCustomWidth() / this.width;
         this._pixiObject.scale.y =
-          this._instance.getCustomHeight() / this.height;
+          this.getCustomHeight() / this.height;
       } else {
         this._pixiObject.scale.x = 1;
         this._pixiObject.scale.y = 1;
@@ -1601,7 +1601,7 @@ module.exports = {
       if (this._instance.hasCustomSize()) {
         this._pixiObject.scale.x = this.getCustomWidth() / this.width;
         this._pixiObject.scale.y =
-          this._instance.getCustomHeight() / this.height;
+          this.getCustomHeight() / this.height;
       } else {
         this._pixiObject.scale.x = 1;
         this._pixiObject.scale.y = 1;

--- a/Extensions/Video/JsExtension.js
+++ b/Extensions/Video/JsExtension.js
@@ -664,8 +664,8 @@ module.exports = {
       );
 
       if (this._instance.hasCustomSize()) {
-        this._pixiObject.width = this._instance.getCustomWidth();
-        this._pixiObject.height = this._instance.getCustomHeight();
+        this._pixiObject.width = this.getCustomWidth();
+        this._pixiObject.height = this.getCustomHeight();
       }
     };
 

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -154,11 +154,6 @@ const InstancePropertiesEditor = ({
         valueType: 'boolean',
         getValue: (instance: gdInitialInstance) => instance.hasCustomSize(),
         setValue: (instance: gdInitialInstance, newValue: boolean) => {
-          if (newValue) {
-            const [width, height] = onGetInstanceSize(instance);
-            instance.setCustomWidth(width);
-            instance.setCustomHeight(height);
-          }
           instance.setHasCustomSize(newValue);
         },
       },
@@ -170,8 +165,12 @@ const InstancePropertiesEditor = ({
             name: 'Width',
             getLabel: () => i18n._(t`Width`),
             valueType: 'number',
-            getValue: (instance: gdInitialInstance) =>
-              instance.getCustomWidth(),
+            getValue: (instance: gdInitialInstance) => {
+              console.log(onGetInstanceSize(instance)[0]);
+              return (
+                instance.getCustomWidth() || onGetInstanceSize(instance)[0]
+              );
+            },
             setValue: (instance: gdInitialInstance, newValue: number) => {
               instance.setHasCustomSize(true);
               instance.setCustomWidth(Math.max(newValue, 0));
@@ -182,7 +181,7 @@ const InstancePropertiesEditor = ({
             getLabel: () => i18n._(t`Height`),
             valueType: 'number',
             getValue: (instance: gdInitialInstance) =>
-              instance.getCustomHeight(),
+              instance.getCustomHeight() || onGetInstanceSize(instance)[1],
             setValue: (instance: gdInitialInstance, newValue: number) => {
               instance.setHasCustomSize(true);
               instance.setCustomHeight(Math.max(newValue, 0));

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -165,12 +165,8 @@ const InstancePropertiesEditor = ({
             name: 'Width',
             getLabel: () => i18n._(t`Width`),
             valueType: 'number',
-            getValue: (instance: gdInitialInstance) => {
-              console.log(onGetInstanceSize(instance)[0]);
-              return (
-                instance.getCustomWidth() || onGetInstanceSize(instance)[0]
-              );
-            },
+            getValue: (instance: gdInitialInstance) => 
+                instance.getCustomWidth() || onGetInstanceSize(instance)[0],
             setValue: (instance: gdInitialInstance, newValue: number) => {
               instance.setHasCustomSize(true);
               instance.setCustomWidth(Math.max(newValue, 0));

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -165,8 +165,8 @@ const InstancePropertiesEditor = ({
             name: 'Width',
             getLabel: () => i18n._(t`Width`),
             valueType: 'number',
-            getValue: (instance: gdInitialInstance) => 
-                instance.getCustomWidth() || onGetInstanceSize(instance)[0],
+            getValue: (instance: gdInitialInstance) =>
+              instance.getCustomWidth() || onGetInstanceSize(instance)[0],
             setValue: (instance: gdInitialInstance, newValue: number) => {
               instance.setHasCustomSize(true);
               instance.setCustomWidth(Math.max(newValue, 0));

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -221,7 +221,16 @@ export default class LayerRenderer {
 
   getUnrotatedInstanceSize = (instance: gdInitialInstance) => {
     if (instance.hasCustomSize())
-      return [instance.getCustomWidth(), instance.getCustomHeight()];
+      return [
+        instance.getCustomWidth() ||
+          (this.renderedInstances[instance.ptr]
+            ? this.renderedInstances[instance.ptr].getDefaultWidth()
+            : 0),
+        instance.getCustomHeight() ||
+          (this.renderedInstances[instance.ptr]
+            ? this.renderedInstances[instance.ptr].getDefaultHeight()
+            : 0),
+      ];
 
     return this.renderedInstances[instance.ptr]
       ? [

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -220,22 +220,19 @@ export default class LayerRenderer {
   };
 
   getUnrotatedInstanceSize = (instance: gdInitialInstance) => {
+    const renderedInstance = this.renderedInstances[instance.ptr];
     if (instance.hasCustomSize())
       return [
         instance.getCustomWidth() ||
-          (this.renderedInstances[instance.ptr]
-            ? this.renderedInstances[instance.ptr].getDefaultWidth()
-            : 0),
+          (renderedInstance ? renderedInstance.getDefaultWidth() : 0),
         instance.getCustomHeight() ||
-          (this.renderedInstances[instance.ptr]
-            ? this.renderedInstances[instance.ptr].getDefaultHeight()
-            : 0),
+          (renderedInstance ? renderedInstance.getDefaultHeight() : 0),
       ];
 
-    return this.renderedInstances[instance.ptr]
+    return renderedInstance
       ? [
-          this.renderedInstances[instance.ptr].getDefaultWidth(),
-          this.renderedInstances[instance.ptr].getDefaultHeight(),
+          renderedInstance.getDefaultWidth(),
+          renderedInstance.getDefaultHeight(),
         ]
       : [0, 0];
   };

--- a/newIDE/app/src/ObjectsRendering/Renderers/Rendered3DInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/Rendered3DInstance.js
@@ -87,17 +87,31 @@ export default class Rendered3DInstance {
   }
 
   getCenterX() {
-    if (this._instance.hasCustomSize())
-      return this._instance.getCustomWidth() / 2;
-
-    return this.getDefaultWidth() / 2;
+    return this.getWidth() / 2;
   }
 
   getCenterY() {
-    if (this._instance.hasCustomSize())
-      return this._instance.getCustomHeight() / 2;
+    return this.getHeight() / 2;
+  }
 
-    return this.getDefaultHeight() / 2;
+  getCustomWidth(): number {
+    return this._instance.getCustomWidth() || this.getDefaultWidth();
+  }
+
+  getCustomHeight(): number {
+    return this._instance.getCustomHeight() || this.getDefaultHeight();
+  }
+
+  getWidth(): number {
+    return this._instance.hasCustomSize()
+      ? this.getCustomWidth()
+      : this.getDefaultWidth();
+  }
+
+  getHeight(): number {
+    return this._instance.hasCustomSize()
+      ? this.getCustomHeight()
+      : this.getDefaultHeight();
   }
 
   /**

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -235,18 +235,6 @@ export default class RenderedCustomObjectInstance extends Rendered3DInstance
     }
   }
 
-  getWidth() {
-    return this._instance.hasCustomSize()
-      ? this._instance.getCustomWidth()
-      : this.getDefaultWidth();
-  }
-
-  getHeight() {
-    return this._instance.hasCustomSize()
-      ? this._instance.getCustomHeight()
-      : this.getDefaultHeight();
-  }
-
   getDefaultWidth() {
     return this.childrenRenderedInstances.length > 0
       ? this.childrenRenderedInstances[0].getDefaultWidth()

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
@@ -75,17 +75,31 @@ export default class RenderedInstance {
   }
 
   getCenterX() {
-    if (this._instance.hasCustomSize())
-      return this._instance.getCustomWidth() / 2;
-
-    return this.getDefaultWidth() / 2;
+    return this.getWidth() / 2;
   }
 
   getCenterY() {
-    if (this._instance.hasCustomSize())
-      return this._instance.getCustomHeight() / 2;
+    return this.getHeight() / 2;
+  }
 
-    return this.getDefaultHeight() / 2;
+  getCustomWidth(): number {
+    return this._instance.getCustomWidth() || this.getDefaultWidth();
+  }
+
+  getCustomHeight(): number {
+    return this._instance.getCustomHeight() || this.getDefaultHeight();
+  }
+
+  getWidth(): number {
+    return this._instance.hasCustomSize()
+      ? this.getCustomWidth()
+      : this.getDefaultWidth();
+  }
+
+  getHeight(): number {
+    return this._instance.hasCustomSize()
+      ? this._instance.getCustomHeight()
+      : this.getDefaultHeight();
   }
 
   /**

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
@@ -98,7 +98,7 @@ export default class RenderedInstance {
 
   getHeight(): number {
     return this._instance.hasCustomSize()
-      ? this._instance.getCustomHeight()
+      ? this.getCustomHeight()
       : this.getDefaultHeight();
   }
 

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
@@ -66,8 +66,8 @@ export default class RenderedPanelSpriteInstance extends RenderedInstance {
     const oldWidth = this._width;
     const oldHeight = this._height;
     if (this._instance.hasCustomSize()) {
-      this._width = this._instance.getCustomWidth();
-      this._height = this._instance.getCustomHeight();
+      this._width = this.getCustomWidth();
+      this._height = this.getCustomHeight();
     } else {
       var tiledSprite = gd.asPanelSpriteConfiguration(
         this._associatedObjectConfiguration

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
@@ -89,10 +89,9 @@ export default class RenderedSpriteInstance extends RenderedInstance {
       : RenderedInstance.toRad(this._instance.getAngle());
     if (this._instance.hasCustomSize()) {
       this._pixiObject.scale.x =
-        this._instance.getCustomWidth() / this._pixiObject.texture.frame.width;
+        this.getCustomWidth() / this._pixiObject.texture.frame.width;
       this._pixiObject.scale.y =
-        this._instance.getCustomHeight() /
-        this._pixiObject.texture.frame.height;
+        this.getCustomHeight() / this._pixiObject.texture.frame.height;
     } else {
       this._pixiObject.scale.x = 1;
       this._pixiObject.scale.y = 1;

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -79,15 +79,14 @@ export default class RenderedTextInstance extends RenderedInstance {
       textObjectConfiguration.getCharacterSize() !== this._characterSize ||
       textObjectConfiguration.getTextAlignment() !== this._textAlignment ||
       this._instance.hasCustomSize() !== this._wrapping ||
-      (this._instance.getCustomWidth() !== this._wrappingWidth &&
-        this._wrapping)
+      (this.getCustomWidth() !== this._wrappingWidth && this._wrapping)
     ) {
       this._isItalic = textObjectConfiguration.isItalic();
       this._isBold = textObjectConfiguration.isBold();
       this._characterSize = textObjectConfiguration.getCharacterSize();
       this._textAlignment = textObjectConfiguration.getTextAlignment();
       this._wrapping = this._instance.hasCustomSize();
-      this._wrappingWidth = this._instance.getCustomWidth();
+      this._wrappingWidth = this.getCustomWidth();
       this._styleFontDirty = true;
     }
 
@@ -153,7 +152,7 @@ export default class RenderedTextInstance extends RenderedInstance {
           ? 0.5
           : 0;
 
-      const width = this._instance.getCustomWidth();
+      const width = this.getCustomWidth();
 
       // A vector from the custom size center to the renderer center.
       const centerToCenterX =

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTiledSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTiledSpriteInstance.js
@@ -65,8 +65,8 @@ export default class RenderedTiledSpriteInstance extends RenderedInstance {
       this._associatedObjectConfiguration
     );
     if (this._instance.hasCustomSize()) {
-      this._pixiObject.width = this._instance.getCustomWidth();
-      this._pixiObject.height = this._instance.getCustomHeight();
+      this._pixiObject.width = this.getCustomWidth();
+      this._pixiObject.height = this.getCustomHeight();
     } else {
       this._pixiObject.width = tiledSprite.getWidth();
       this._pixiObject.height = tiledSprite.getHeight();

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedUnknownInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedUnknownInstance.js
@@ -39,12 +39,8 @@ export default class RenderedUnknownInstance extends RenderedInstance {
   }
 
   update() {
-    const width = this._instance.hasCustomSize()
-      ? this._instance.getCustomWidth()
-      : 32;
-    const height = this._instance.hasCustomSize()
-      ? this._instance.getCustomHeight()
-      : 32;
+    const width = this.getWidth();
+    const height = this.getHeight();
 
     this._pixiObject.clear();
     this._pixiObject.beginFill(0x0033ff);


### PR DESCRIPTION
Better encapsulate the size calculus.

* Add `getCustomWidth` and  `getCustomHeight` on rendered instance to default on the default dimension when `0`.
* Add `getWidth` and  `getHeight` that choose between default and custom dimensions instead of leaving it to the subclasses.