### PR TITLE
Fix outline style when drawing a path with the shape painter

### DIFF
--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -239,6 +239,7 @@ namespace gdjs {
     }
 
     beginFillPath() {
+      this.updateOutline();
       this._graphics.beginFill(
         this._object._fillColor,
         this._object._fillOpacity / 255


### PR DESCRIPTION
`updateOutline` was called before each shape drawing but the paths.

It could maybe be called in the constructor instead of each draw methods though.