### PR TITLE
Set credentials options on THREE GLTF Loader depending on resource url

### DIFF
--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -82,9 +82,13 @@ namespace gdjs {
       let loaded = 0;
       for (let i = 0; i < model3DResources.length; ++i) {
         const resource = model3DResources[i];
+        const url = this._resourcesLoader.getFullUrl(resource.file);
 
+        this._loader.withCredentials = this._resourcesLoader.checkIfCredentialsRequired(
+          url
+        );
         this._loader.load(
-          resource.file,
+          url,
           (gltf) => {
             gltf.scene.rotation.order = 'ZYX';
             this._loadedThreeModels.set(resource.name, gltf.scene);

--- a/newIDE/app/src/ObjectsRendering/PixiResourcesLoader.js
+++ b/newIDE/app/src/ObjectsRendering/PixiResourcesLoader.js
@@ -257,6 +257,7 @@ export default class PixiResourcesLoader {
     });
 
     const loader = new GLTFLoader();
+    loader.withCredentials = checkIfCredentialsRequired(url);
     // TODO Cache promises that are not yet resolved to void `load` being
     // called more than once for the same resource.
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
To fix https://forum.gdevelop.io/t/custom-3d-objects-showing-a-white-box/47407

Glb models are not loading in both editors and previews for cloud projects in the browser (and maybe mobile apps)