### PR TITLE
Start over from the suffix number when generating a new name

### DIFF
--- a/newIDE/app/src/Utils/NewNameGenerator.js
+++ b/newIDE/app/src/Utils/NewNameGenerator.js
@@ -4,15 +4,31 @@ const newNameGenerator = (
   name /*:string */,
   exists /*:(string) => boolean */,
   prefix /*: string */ = ''
-) => {
+): string => {
   if (!exists(name)) return name;
+  if (prefix && !exists(prefix + name)) return prefix + name;
 
-  let potentialName = prefix + name;
-  for (let i = 2; exists(potentialName); ++i) {
-    potentialName = prefix + name + i;
+  const [radix, numberSuffix] = splitNameAndNumberSuffix(prefix + name);
+  const startingNumberSuffix = numberSuffix === null ? 2 : numberSuffix + 1;
+  let potentialName = radix + startingNumberSuffix;
+  for (let i = startingNumberSuffix + 1; exists(potentialName); ++i) {
+    potentialName = radix + i;
   }
-
   return potentialName;
+};
+
+export const splitNameAndNumberSuffix = (
+  text: string
+): [string, number | null] => {
+  for (let i = 0; i < text.length; i++) {
+    const suffix = text.slice(i, text.length);
+    if (suffix.startsWith('0')) continue;
+    const numberSuffix = Number(suffix);
+    if (numberSuffix === Math.floor(numberSuffix)) {
+      return [text.slice(0, i), numberSuffix];
+    }
+  }
+  return [text, null];
 };
 
 export default newNameGenerator;

--- a/newIDE/app/src/Utils/NewNameGenerator.js
+++ b/newIDE/app/src/Utils/NewNameGenerator.js
@@ -23,6 +23,8 @@ export const splitNameAndNumberSuffix = (
   for (let i = 0; i < text.length; i++) {
     const suffix = text.slice(i, text.length);
     if (suffix.startsWith('0')) continue;
+
+    // parseInt cannot be used since parseInt('3D4') returns 3.
     const numberSuffix = Number(suffix);
     if (numberSuffix === Math.floor(numberSuffix)) {
       return [text.slice(0, i), numberSuffix];

--- a/newIDE/app/src/Utils/NewNameGenerator.spec.js
+++ b/newIDE/app/src/Utils/NewNameGenerator.spec.js
@@ -1,0 +1,104 @@
+// @flow
+
+import newNameGenerator, { splitNameAndNumberSuffix } from './NewNameGenerator';
+
+describe('NewNameGenerator', () => {
+  describe('newNameGenerator', () => {
+    describe('with prefix', () => {
+      it('should return the name with the given prefix if it is already used', () => {
+        expect(
+          newNameGenerator('Object', text => text === 'Object', 'CopyOf')
+        ).toEqual('CopyOfObject');
+      });
+      it('should return the name with the given prefix if the name contains a number suffix', () => {
+        expect(
+          newNameGenerator('Object2', text => text === 'Object2', 'CopyOf')
+        ).toEqual('CopyOfObject2');
+      });
+      it('should return the prefix and the name with a 3 as a suffix if the 2 suffix is already used', () => {
+        expect(
+          newNameGenerator(
+            'Object',
+            text =>
+              text === 'Object' ||
+              text === 'CopyOfObject' ||
+              text === 'CopyOfObject2',
+            'CopyOf'
+          )
+        ).toEqual('CopyOfObject3');
+      });
+    });
+    describe('without prefix', () => {
+      it("should return the name if it isn't already used", () => {
+        expect(newNameGenerator('Object', () => false)).toEqual('Object');
+      });
+      it('should return the name with a 2 as a suffix if it is already used', () => {
+        expect(newNameGenerator('Object', text => text === 'Object')).toEqual(
+          'Object2'
+        );
+      });
+      it('should return the name with a 3 as a suffix if the name and the name with a 2 as a suffix is already used', () => {
+        expect(
+          newNameGenerator(
+            'Object',
+            text => text === 'Object' || text === 'Object2'
+          )
+        ).toEqual('Object3');
+      });
+
+      it('should return the radix with a 3 as a suffix if the name contains a number suffix', () => {
+        expect(
+          newNameGenerator(
+            'Object2',
+            text => text === 'Object' || text === 'Object2'
+          )
+        ).toEqual('Object3');
+      });
+    });
+  });
+
+  describe('splitNameAndNumberSuffix', () => {
+    it('should return the whole text if no number suffix', () => {
+      expect(splitNameAndNumberSuffix('NewObject')).toEqual([
+        'NewObject',
+        null,
+      ]);
+    });
+    it('should return an empty string if the input is an empty string', () => {
+      expect(splitNameAndNumberSuffix('')).toEqual(['', null]);
+    });
+    it('should return an empty string and a number if the whole text is a number', () => {
+      expect(splitNameAndNumberSuffix('5602')).toEqual(['', 5602]);
+    });
+    it('should return 0 as a string and a number if the whole text is a number and starts with 0', () => {
+      expect(splitNameAndNumberSuffix('05602')).toEqual(['0', 5602]);
+    });
+    it('should return 000 as a string and a number if the whole text is a number and starts with 000', () => {
+      expect(splitNameAndNumberSuffix('00014')).toEqual(['000', 14]);
+    });
+    it("should return the text and the number suffix when there's a number in the name", () => {
+      expect(splitNameAndNumberSuffix('NewCube3D4')).toEqual(['NewCube3D', 4]);
+    });
+    it("should return the text and the number suffix when there's a float in the name", () => {
+      expect(splitNameAndNumberSuffix('Player5.10')).toEqual(['Player5.', 10]);
+    });
+    it("should return the text and the number suffix when there's a float in the name with decimals starting with 0", () => {
+      expect(splitNameAndNumberSuffix('Player8.041')).toEqual([
+        'Player8.0',
+        41,
+      ]);
+    });
+    it('should return the text and the number suffix for a regular latin name with a suffix', () => {
+      expect(splitNameAndNumberSuffix('Enemy5')).toEqual(['Enemy', 5]);
+    });
+    it('should return the text and the number suffix for a regular cyrillic name with a suffix', () => {
+      expect(splitNameAndNumberSuffix('Ябвгд40')).toEqual(['Ябвгд', 40]);
+    });
+    it('should return the text and the number suffix for a regular chinese name with a suffix', () => {
+      expect(splitNameAndNumberSuffix('隧道1')).toEqual(['隧道', 1]);
+    });
+    it('should return the text and the number suffix for a regular chinese name without a suffix', () => {
+      expect(splitNameAndNumberSuffix('隧道')).toEqual(['隧道', null]);
+    });
+  });
+});


### PR DESCRIPTION
When duplicating something, we generate a new name with a number suffix. This PR make sure we start over the with the last number suffix value instead of appending a new number to the already present number.

Before this PR:
* Duplicate Object => Object2
* Duplicate Object => Object3
* Duplicate Object2 => Object22

After this PR:
* Duplicate Object => Object2
* Duplicate Object => Object3
* Duplicate Object2 => Object4