### PR TITLE
Fix sprite images selection when opening up the options menu

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -200,7 +200,7 @@ const SpritesList = ({
   const spriteContextMenu = React.useRef<?ContextMenuInterface>(null);
   const forceUpdate = useForceUpdate();
 
-  const updateIndexesAfterMoveUp = React.useCallback(
+  const updateSelectionIndexesAfterMoveUp = React.useCallback(
     (oldIndex: number, newIndex: number, wasMovedItemSelected: boolean) => {
       for (let i = oldIndex; i <= newIndex; ++i) {
         const spriteAtIndex = direction.getSprite(i);
@@ -213,7 +213,6 @@ const SpritesList = ({
           const previousSelectionStatus = !!selectedSprites.current[
             direction.getSprite(previousSpriteIndex).ptr
           ];
-          console.log('previousSelectionStatus', previousSelectionStatus);
           selectedSprites.current[spriteAtIndex.ptr] = previousSelectionStatus;
         }
       }
@@ -221,7 +220,7 @@ const SpritesList = ({
     [direction]
   );
 
-  const updateIndexesAfterMoveDown = React.useCallback(
+  const updateSelectionIndexesAfterMoveDown = React.useCallback(
     (oldIndex: number, newIndex: number, wasMovedItemSelected: boolean) => {
       for (let i = oldIndex; i >= newIndex; --i) {
         const spriteAtIndex = direction.getSprite(i);
@@ -254,9 +253,17 @@ const SpritesList = ({
       // When moving a sprite, the pointers are all shifted, so we need to
       // update the selectedSprites map for the user not to lose their selection.
       if (oldIndex < newIndex) {
-        updateIndexesAfterMoveUp(oldIndex, newIndex, wasMovedItemSelected);
+        updateSelectionIndexesAfterMoveUp(
+          oldIndex,
+          newIndex,
+          wasMovedItemSelected
+        );
       } else {
-        updateIndexesAfterMoveDown(oldIndex, newIndex, wasMovedItemSelected);
+        updateSelectionIndexesAfterMoveDown(
+          oldIndex,
+          newIndex,
+          wasMovedItemSelected
+        );
       }
 
       forceUpdate();
@@ -266,8 +273,8 @@ const SpritesList = ({
       direction,
       forceUpdate,
       onSpriteUpdated,
-      updateIndexesAfterMoveDown,
-      updateIndexesAfterMoveUp,
+      updateSelectionIndexesAfterMoveDown,
+      updateSelectionIndexesAfterMoveUp,
     ]
   );
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -48,7 +48,7 @@ const styles = {
     flex: 1,
   },
   thumbnailExtraStyle: {
-    marginLeft: 10,
+    marginLeft: 5,
   },
   spriteThumbnailImage: {
     maxWidth: SPRITE_SIZE,

--- a/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
+++ b/newIDE/app/src/ResourcesList/ResourceThumbnail/ImageThumbnail.js
@@ -65,13 +65,15 @@ const ImageThumbnail = (props: Props) => {
     )
   );
 
-  const { selectedBorderColor } = theme.imageThumbnail;
   const normalBorderColor = theme.imagePreview.borderColor;
-  const borderColor = props.selected ? selectedBorderColor : normalBorderColor;
+  const borderColor = props.selected
+    ? theme.palette.secondary
+    : normalBorderColor;
 
   const containerStyle = {
     ...styles.spriteThumbnail,
-    border: `1px solid ${borderColor}`,
+    border: `2px solid ${borderColor}`,
+    borderRadius: 4,
     ...props.style,
   };
 

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -546,9 +546,6 @@ export function createGdevelopTheme({
         selectedBorderColor: styles['ThemeClosableTabsSelectedBorderColor'],
         ...closeableTabSizeOverrides,
       },
-      imageThumbnail: {
-        selectedBorderColor: styles['ThemeSelectionBackgroundColor'],
-      },
       imagePreview: {
         backgroundFilter: styles['ThemeImagePreviewBackgroundFilter'],
         borderColor: styles['ThemeImagePreviewBorderColor'],


### PR DESCRIPTION
Fixes a bug where right clicking on an image and deleting it would not delete that particular image. (race condition, moved to references instead)
Also fix a bug where moving an element up and down the list would not keep the selection.

BEFORE:


https://github.com/4ian/GDevelop/assets/4895034/8cd01eb0-7631-4142-a1a0-ab6bc3494abc


AFTER:

https://github.com/4ian/GDevelop/assets/4895034/defdc50c-75ec-49fc-b984-a1ba9a1877ae

