### PR TITLE
Fix not keeping a white line for some extension descriptions

### DIFF
--- a/newIDE/app/scripts/lib/PythonMarkdownHelper.js
+++ b/newIDE/app/scripts/lib/PythonMarkdownHelper.js
@@ -1,5 +1,5 @@
 const convertCommonMarkdownToPythonMarkdown = content => {
-  return content.replace(/((\n[-*].*)+)/gm, '\n$1');
+  return content.replace(/((\n[ \t]{0,2}[-*].*)+)/gm, '\n$1');
 };
 
 module.exports = { convertCommonMarkdownToPythonMarkdown };


### PR DESCRIPTION
### Problematic format
``` md
Content:
  - ~~~
  - ~~~
```

``` md
Content:
  * ~~~
  * ~~~
```
<https://wiki.gdevelop.io/gdevelop5/extensions/extended-math/> (Expressions: ~~~)
<https://wiki.gdevelop.io/gdevelop5/extensions/marching-squares/> (It can be helpful for: ~~~)
<https://wiki.gdevelop.io/gdevelop5/extensions/newgrounds-api/>(Actions: ~~~, Actions: ~~~)
<https://wiki.gdevelop.io/gdevelop5/extensions/sprite-sheet/> (How to use - 4)
<https://wiki.gdevelop.io/gdevelop5/extensions/voice-recognition/>(Can be used for: ~~~)
<https://wiki.gdevelop.io/gdevelop5/extensions/web-socket-client/> (Features: ~~~)