### PR TITLE
3D editor improvement

### DIFF
--- a/newIDE/app/src/InstancesEditor/HighlightedInstance.js
+++ b/newIDE/app/src/InstancesEditor/HighlightedInstance.js
@@ -7,7 +7,9 @@ import Rectangle from '../Utils/Rectangle';
 export default class HighlightedInstance {
   instanceMeasurer: InstanceMeasurer;
   toCanvasCoordinates: (x: number, y: number) => [number, number];
+  isInstanceOf3DObject: gdInitialInstance => boolean;
   highlightedInstance: gdInitialInstance | null;
+  isHighlightedInstanceOf3DObject: boolean;
   highlightRectangle: PIXI.Container;
   tooltipBackground: PIXI.Container;
   tooltipText: PIXI.Container;
@@ -15,14 +17,18 @@ export default class HighlightedInstance {
   constructor({
     instanceMeasurer,
     toCanvasCoordinates,
+    isInstanceOf3DObject,
   }: {
     instanceMeasurer: InstanceMeasurer,
     toCanvasCoordinates: (x: number, y: number) => [number, number],
+    isInstanceOf3DObject: gdInitialInstance => boolean,
   }) {
     this.instanceMeasurer = instanceMeasurer;
     this.toCanvasCoordinates = toCanvasCoordinates;
+    this.isInstanceOf3DObject = isInstanceOf3DObject;
 
     this.highlightedInstance = null;
+    this.isHighlightedInstanceOf3DObject = false;
     this.highlightRectangle = new PIXI.Graphics();
     this.highlightRectangle.hitArea = new PIXI.Rectangle(0, 0, 0, 0);
 
@@ -37,6 +43,9 @@ export default class HighlightedInstance {
   }
 
   setInstance(instance: gdInitialInstance | null) {
+    this.isHighlightedInstanceOf3DObject = instance
+      ? this.isInstanceOf3DObject(instance)
+      : false;
     this.highlightedInstance = instance;
   }
 
@@ -84,13 +93,19 @@ export default class HighlightedInstance {
       Math.round(highlightedInstance.getX() * 100) / 100 + // An instance position can have a lot of decimals, so round to 2 decimals.
       '  Y: ' +
       Math.round(highlightedInstance.getY() * 100) / 100 + // An instance position can have a lot of decimals, so round to 2 decimals.
+      (this.isHighlightedInstanceOf3DObject
+        ? '  Z: ' +
+          // An instance position can have a lot of decimals, so round to 2 decimals.
+          Math.round(highlightedInstance.getZ() * 100) / 100
+        : '') +
       '\n' +
       'Layer: ' +
       (highlightedInstance.getLayer() || 'Base layer') +
-      '\n' +
-      'Z: ' +
-      highlightedInstance.getZOrder() +
+      (this.isHighlightedInstanceOf3DObject
+        ? ''
+        : '\nZ order: ' + highlightedInstance.getZOrder()) +
       '\n';
+
     this.tooltipText.text = tooltipInfo;
 
     this.tooltipText.x = Math.round(

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -197,6 +197,18 @@ const makeSchema = ({
       valueType: 'boolean',
       getValue: (instance: gdInitialInstance) => instance.hasCustomSize(),
       setValue: (instance: gdInitialInstance, newValue: boolean) => {
+        if (
+          instance.getCustomHeight() === 0 &&
+          instance.getCustomWidth() === 0 &&
+          instance.getCustomDepth() === 0
+        ) {
+          // The instance custom dimensions have never been set before.
+          // To avoid setting setting all the dimensions to 0 when enabling
+          // the instance custom size flag, the current instance dimensions are used.
+          instance.setCustomWidth(getInstanceWidth(instance));
+          instance.setCustomHeight(getInstanceHeight(instance));
+          instance.setCustomDepth(getInstanceDepth(instance));
+        }
         instance.setHasCustomSize(newValue);
         instance.setHasCustomDepth(newValue);
         forceUpdate();

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -71,6 +71,7 @@ export type InstancesEditorPropsWithoutSizeAndScroll = {|
   selectedLayer: string,
   initialInstances: gdInitialInstancesContainer,
   instancesEditorSettings: InstancesEditorSettings,
+  isInstanceOf3DObject: gdInitialInstance => boolean,
   onInstancesEditorSettingsMutated: (
     instancesEditorSettings: InstancesEditorSettings
   ) => void,
@@ -430,6 +431,7 @@ export default class InstancesEditor extends Component<Props> {
     this.highlightedInstance = new HighlightedInstance({
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       toCanvasCoordinates: this.viewPosition.toCanvasCoordinates,
+      isInstanceOf3DObject: this.props.isInstanceOf3DObject,
     });
     this.instancesResizer = new InstancesResizer({
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedInstance.js
@@ -83,11 +83,11 @@ export default class RenderedInstance {
   }
 
   getCustomWidth(): number {
-    return this._instance.getCustomWidth() || this.getDefaultWidth();
+    return this._instance.getCustomWidth();
   }
 
   getCustomHeight(): number {
-    return this._instance.getCustomHeight() || this.getDefaultHeight();
+    return this._instance.getCustomHeight();
   }
 
   getWidth(): number {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1153,6 +1153,13 @@ export default class SceneEditor extends React.Component<Props, State> {
       });
   };
 
+  isInstanceOf3DObject = (instance: gdInitialInstance) => {
+    const { project, layout } = this.props;
+
+    const object = getObjectByName(project, layout, instance.getObjectName());
+    return !!object && object.is3DObject();
+  };
+
   buildContextMenu = (i18n: I18nType, layout: gdLayout, options: any) => {
     let contextMenuItems = [];
     if (
@@ -1590,6 +1597,7 @@ export default class SceneEditor extends React.Component<Props, State> {
             onInstancesRotated={this._onInstancesRotated}
             selectedObjectNames={selectedObjectNames}
             onContextMenu={this._onContextMenu}
+            isInstanceOf3DObject={this.isInstanceOf3DObject}
             instancesEditorShortcutsCallbacks={{
               onCopy: () => this.copySelection({ useLastCursorPosition: true }),
               onCut: () => this.cutSelection({ useLastCursorPosition: true }),

--- a/newIDE/app/src/stories/componentStories/FullSizeInstancesEditorWithScrollbars.stories.js
+++ b/newIDE/app/src/stories/componentStories/FullSizeInstancesEditorWithScrollbars.stories.js
@@ -43,6 +43,7 @@ export const Default = () => (
         initialInstances={testProject.testLayout.getInitialInstances()}
         instancesEditorSettings={instancesEditorSettings}
         onInstancesEditorSettingsMutated={() => {}}
+        isInstanceOf3DObject={() => false}
         instancesSelection={instancesSelection}
         onInstancesAdded={() => {}}
         onInstancesSelected={() => {}}


### PR DESCRIPTION
- Display Z coordinated for instances of 3D objects while keeping the z order for the instances of 2D objects:
|<img width="148" alt="image" src="https://github.com/4ian/GDevelop/assets/32449369/2fd0b114-6e44-4f23-90b2-49f39f0b432e">|<img width="163" alt="image" src="https://github.com/4ian/GDevelop/assets/32449369/e3757611-ba5f-42ce-92a3-50c5b3213fc0">|

- Also:
  - When activating the checkbox "Custom size", the editor would set the dimensions to 0. With this PR, it reads the instance size to automatically set those dimensions as custom dimensions to the instance.
  - I also changed the RenderedInstance.getCustomHeight/Width methods so that the default value is not used as a fallback anymore. With this previous behavior, it was not possible to have a sprite instance with width = 0 correctly rendered in the editor