### PR TITLE
Fix color encoding of glb models

### DIFF
--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -89,7 +89,7 @@ namespace gdjs {
         );
         this._loader.load(
           url,
-          (gltf: globalThis.THREE_ADDONS.GLTF) => {
+          (gltf: THREE_ADDONS.GLTF) => {
             // Iterate over loaded texture as a fix for https://forum.gdevelop.io/t/dark-textures-on-3d-models/47575.
             // TODO (3D): Investigate if it's a legitimate thing to do or if the loaded glb file should be
             // adapted so that loader uses the "correct" encoding.

--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -89,7 +89,19 @@ namespace gdjs {
         );
         this._loader.load(
           url,
-          (gltf) => {
+          (gltf: globalThis.THREE_ADDONS.GLTF) => {
+            // Iterate over loaded texture as a fix for https://forum.gdevelop.io/t/dark-textures-on-3d-models/47575.
+            // TODO (3D): Investigate if it's a legitimate thing to do or if the loaded glb file should be
+            // adapted so that loader uses the "correct" encoding.
+            gltf.scene.traverse((object) => {
+              if ((object as THREE.Mesh).isMesh) {
+                // @ts-ignore - The typing is not accurate here.
+                const texture = (object as THREE.Mesh).material.map;
+                if (texture && texture.isTexture) {
+                  texture.encoding = THREE.LinearEncoding;
+                }
+              }
+            });
             gltf.scene.rotation.order = 'ZYX';
             this._loadedThreeModels.set(resource.name, gltf.scene);
 

--- a/GDJS/Runtime/types/global-three-addons.d.ts
+++ b/GDJS/Runtime/types/global-three-addons.d.ts
@@ -1,7 +1,7 @@
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+import { GLTFLoader, GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 
 declare global {
   namespace THREE_ADDONS {
-    export { GLTFLoader };
+    export { GLTFLoader, GLTF };
   }
 }

--- a/newIDE/app/src/ObjectsRendering/PixiResourcesLoader.js
+++ b/newIDE/app/src/ObjectsRendering/PixiResourcesLoader.js
@@ -293,6 +293,8 @@ export default class PixiResourcesLoader {
         if (mesh.material.map) {
           //@ts-ignore
           basicMaterial.map = mesh.material.map;
+          //@ts-ignore - Fix for https://forum.gdevelop.io/t/dark-textures-on-3d-models/47575.
+          basicMaterial.map.encoding = THREE.LinearEncoding;
         }
         mesh.material = basicMaterial;
       }


### PR DESCRIPTION
To fix https://forum.gdevelop.io/t/dark-textures-on-3d-models/47575

From left to right:
Sprite, cube, model
<img width="1004" alt="image" src="https://github.com/4ian/GDevelop/assets/32449369/ae36a868-bc1b-4171-8c9b-8df3cac9789d">
