### PR TITLE
Improve user experience with users autocomplete

### DIFF
--- a/newIDE/app/src/UI/SemiControlledAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledAutoComplete.js
@@ -84,6 +84,7 @@ export const autocompleteStyles = {
     padding: 0,
     margin: 0,
   },
+  listbox: { padding: 0, margin: 0 },
   listItemText: {
     margin: '1px 0',
   },
@@ -93,10 +94,7 @@ const useStyles = makeStyles({
   option: {
     cursor: 'default',
   },
-  listbox: {
-    padding: 0,
-    margin: 0,
-  },
+  listbox: autocompleteStyles.listbox,
   input: {
     width: 'auto',
     flexGrow: 1,

--- a/newIDE/app/src/UI/SemiControlledMultiAutoComplete.js
+++ b/newIDE/app/src/UI/SemiControlledMultiAutoComplete.js
@@ -28,6 +28,13 @@ const renderItem = (option: AutocompleteOption, state: Object): React.Node => (
   </ListItem>
 );
 
+const styles = {
+  listbox: {
+    maxHeight: 250,
+    overflowY: 'scroll',
+  },
+};
+
 export type AutocompleteOption = {|
   text: string, // The text displayed
   value: string, // The internal value selected
@@ -63,8 +70,25 @@ type Props = {|
   disableAutoTranslate?: boolean,
 |};
 
-export default function SemiControlledMultiAutoComplete(props: Props) {
+export type SemiControlledMultiAutoCompleteInterface = {|
+  focusInput: () => void,
+|};
+
+const SemiControlledMultiAutoComplete = React.forwardRef<
+  Props,
+  SemiControlledMultiAutoCompleteInterface
+>((props, ref) => {
   const chipStyles = useChipStyles();
+  const inputRef = React.useRef<?TextField>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    focusInput: () => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    },
+  }));
+
   return (
     <I18n>
       {({ i18n }) => (
@@ -89,6 +113,10 @@ export default function SemiControlledMultiAutoComplete(props: Props) {
           loading={props.loading}
           ListboxProps={{
             className: props.disableAutoTranslate ? 'notranslate' : '',
+            style: {
+              ...autocompleteStyles.listbox,
+              ...styles.listbox,
+            },
           }}
           renderInput={params => (
             <TextField
@@ -102,6 +130,7 @@ export default function SemiControlledMultiAutoComplete(props: Props) {
               helperText={props.error || props.helperText}
               variant="filled"
               error={!!props.error}
+              inputRef={inputRef}
               disabled={props.disabled || props.loading}
             />
           )}
@@ -125,4 +154,6 @@ export default function SemiControlledMultiAutoComplete(props: Props) {
       )}
     </I18n>
   );
-}
+});
+
+export default SemiControlledMultiAutoComplete;

--- a/newIDE/app/src/Utils/UsersAutocomplete.js
+++ b/newIDE/app/src/Utils/UsersAutocomplete.js
@@ -3,7 +3,9 @@ import * as React from 'react';
 import { useState } from 'react';
 import { t } from '@lingui/macro';
 import { useDebounce } from './UseDebounce';
-import SemiControlledMultiAutoComplete from '../UI/SemiControlledMultiAutoComplete';
+import SemiControlledMultiAutoComplete, {
+  type SemiControlledMultiAutoCompleteInterface,
+} from '../UI/SemiControlledMultiAutoComplete';
 import {
   searchCreatorPublicProfilesByUsername,
   type UserPublicProfile,
@@ -41,6 +43,9 @@ export const UsersAutocomplete = ({
     setCompletionUserPublicProfiles,
   ] = React.useState<Array<UserPublicProfile>>([]);
   const [error, setError] = React.useState(null);
+  const autocompleteRef = React.useRef<?SemiControlledMultiAutoCompleteInterface>(
+    null
+  );
 
   // Recalculate if the userInput has changed.
   const searchUserPublicProfiles = useDebounce(async () => {
@@ -60,6 +65,7 @@ export const UsersAutocomplete = ({
       console.error('Could not load the users: ', err);
     } finally {
       setLoading(false);
+      focusInput();
     }
   }, 500);
 
@@ -108,6 +114,10 @@ export const UsersAutocomplete = ({
     [userIds]
   );
 
+  const focusInput = React.useCallback(() => {
+    if (autocompleteRef.current) autocompleteRef.current.focusInput();
+  }, []);
+
   // Do only once.
   React.useEffect(
     () => {
@@ -139,6 +149,7 @@ export const UsersAutocomplete = ({
       onInputChange={(event, value) => {
         setUserInput(value);
       }}
+      ref={autocompleteRef}
       dataSource={completionUserPublicProfiles
         .map((userPublicProfile: UserPublicProfile) => {
           if (userPublicProfile.username && userPublicProfile.id) {


### PR DESCRIPTION
Fixes #5400 

- Make it so the popper does not take the whole height
- After a username query has been done, refocus the input so that one can use Escape as a way to close the popper