### PR TITLE
Fix autofocus of searchbar on tablets in landscape

### DIFF
--- a/newIDE/app/src/AssetStore/ExtensionStore/index.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/index.js
@@ -126,6 +126,7 @@ export const ExtensionStore = ({
                     tagsHandler={tagsHandler}
                     tags={filters && filters.allTags}
                     placeholder={t`Search extensions`}
+                    autoFocus="desktop"
                   />
                 </Column>
               </ResponsiveLineStackLayout>

--- a/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
+++ b/newIDE/app/src/BehaviorsEditor/NewBehaviorDialog.js
@@ -275,6 +275,7 @@ export default function NewBehaviorDialog({
                     onChange={setSearchText}
                     ref={searchBar}
                     placeholder={t`Search installed behaviors`}
+                    autoFocus="desktop"
                   />
                 </Column>
               </Line>

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -113,6 +113,7 @@ const SortableList = SortableContainer(
               // If there is only one sprite, don't make it draggable.
               <ImageThumbnail
                 selectable
+                key={sprite.ptr}
                 selected={!!selectedSprites[sprite.ptr]}
                 onSelect={selected => onSelectSprite(sprite, selected)}
                 onContextMenu={(x, y) => onOpenSpriteContextMenu(x, y, sprite)}

--- a/newIDE/app/src/UI/Reponsive/ScreenTypeMeasurer.js
+++ b/newIDE/app/src/UI/Reponsive/ScreenTypeMeasurer.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { useResponsiveWindowWidth } from './ResponsiveWindowMeasurer';
 
 export type ScreenType = 'normal' | 'touch';
 
@@ -12,6 +11,21 @@ if (typeof window !== 'undefined') {
       console.info('Touch detected, considering the screen as touch enabled.');
       userHasTouchedScreen = true;
       window.removeEventListener('touchstart', onFirstTouch, false);
+    },
+    false
+  );
+}
+
+let userHasMovedMouse = false;
+if (typeof window !== 'undefined') {
+  window.addEventListener(
+    'mousemove',
+    function onFirstMouseMove() {
+      console.info(
+        'Mouse move detected, considering the device is a desktop/laptop computer.'
+      );
+      userHasMovedMouse = true;
+      window.removeEventListener('mousemove', onFirstMouseMove, false);
     },
     false
   );
@@ -41,8 +55,8 @@ export const useScreenType = (): ScreenType => {
 
 export const useShouldAutofocusInput = (): boolean => {
   const isTouchscreen = useScreenType() === 'touch';
-  const windowWidth = useResponsiveWindowWidth();
-  return (
-    windowWidth === 'large' || (windowWidth === 'medium' && !isTouchscreen)
-  );
+  // Whatever size the screen is, if a touch event has been detected, no autofocus should
+  // be triggered (that would annoyingly open the keyboard) unless a mouse move has been
+  // detected (in that case, the device should be a touch-enabled desktop/laptop computer).
+  return !(isTouchscreen && !userHasMovedMouse);
 };

--- a/newIDE/app/src/UI/Reponsive/ScreenTypeMeasurer.js
+++ b/newIDE/app/src/UI/Reponsive/ScreenTypeMeasurer.js
@@ -4,6 +4,8 @@ import * as React from 'react';
 export type ScreenType = 'normal' | 'touch';
 
 let userHasTouchedScreen = false;
+let userHasMovedMouse = false;
+
 if (typeof window !== 'undefined') {
   window.addEventListener(
     'touchstart',
@@ -14,10 +16,7 @@ if (typeof window !== 'undefined') {
     },
     false
   );
-}
 
-let userHasMovedMouse = false;
-if (typeof window !== 'undefined') {
   window.addEventListener(
     'mousemove',
     function onFirstMouseMove() {


### PR DESCRIPTION
The criteria to know if the different search bars should be autofocused were relying on the screen size but it's not reliable when using a tablet in landscape mode.

The decision critera now relies on the different event the app receives (touchstart & mousemove)