### PR TITLE
Remove jimp, use Canvas for image manipulation

### DIFF
--- a/newIDE/app/.storybook/main.js
+++ b/newIDE/app/.storybook/main.js
@@ -9,10 +9,4 @@ module.exports = {
     },
     'storybook-addon-mock/register',
   ],
-  // This fix the error "Can't resolve 'fs'" because of the package "jimp".
-  // See https://github.com/storybookjs/storybook/issues/16833#issuecomment-1060655174
-  webpackFinal: config => {
-    config.node = { fs: 'empty' };
-    return config;
-  },
 };

--- a/newIDE/app/package-lock.json
+++ b/newIDE/app/package-lock.json
@@ -27,7 +27,6 @@
         "firebase": "9.0.0-beta.2",
         "fontfaceobserver": "2.0.13",
         "fuse.js": "^6.5.3",
-        "jimp": "0.22.8",
         "js-worker-search": "^1.4.1",
         "jss-rtl": "^0.3.0",
         "lodash": "4.17.4",
@@ -5061,484 +5060,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/@jimp/bmp": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.8.tgz",
-      "integrity": "sha512-JEMKgM1AEvvWfn9ZCHn62nK+QCE3Pb/ZhPdL3NF0ZgKNww6pqOmo6KqXzqY18JLB7c0epuTp4GPDPDhOh/ou1g==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8",
-        "bmp-js": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/core": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.22.8.tgz",
-      "integrity": "sha512-vkN28aFikzQieA6bGxN+qe20pseCAemCyUI0YmRkJIArlb6OujtAwWAKyokv2lylV56bq8EQGIz+Y30OXUnRqg==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8",
-        "any-base": "^1.1.0",
-        "buffer": "^5.2.0",
-        "exif-parser": "^0.1.12",
-        "file-type": "^16.5.4",
-        "isomorphic-fetch": "^3.0.0",
-        "mkdirp": "^2.1.3",
-        "pixelmatch": "^4.0.2",
-        "tinycolor2": "^1.6.0"
-      }
-    },
-    "node_modules/@jimp/core/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/@jimp/core/node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/@jimp/core/node_modules/mkdirp": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jimp/core/node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jimp/core/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/@jimp/core/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/@jimp/core/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/@jimp/custom": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.8.tgz",
-      "integrity": "sha512-u6lP9x/HNeGHB0Oojv4c2mhuDvn7G0ikzYbK4IKLsH4HzHxt62faMjBzQMcFhKJhR6UiiKE/jiHrhGvBT/fMkw==",
-      "dependencies": {
-        "@jimp/core": "^0.22.8"
-      }
-    },
-    "node_modules/@jimp/gif": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.22.8.tgz",
-      "integrity": "sha512-I0l6koS67IPU40RPxCJTD1NvePEd8vUIHTejx1ly0jrjGnumbqdarAlBUkDrKfPPc+Fnqp84hBbSN1w5hNPT6w==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8",
-        "gifwrap": "^0.9.2",
-        "omggif": "^1.0.9"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/jpeg": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.8.tgz",
-      "integrity": "sha512-hLXrQ7/0QiUhAVAF10dfGCSq3hvyqjKltlpu/87b3wqMDKe9KdvhX1AJHiUUrAbJv1fAcnOmQGTyXGuySa1D6A==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8",
-        "jpeg-js": "^0.4.4"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-blit": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.8.tgz",
-      "integrity": "sha512-rQ19txVCKIwo74HtgFodFt4//0ATPCJK+f24riqzb+nx+1JaOo1xRvpJqg4moirHwKR2fhwdDxmY7KX20kCeYA==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-blur": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.8.tgz",
-      "integrity": "sha512-GWbNK3YW6k2EKiGJdpAFEr0jezPBtiVxj2wG/lCPuWJz7KmzSSN99hQjIy73xQxoBCRdALfJlkhe3leFNRueSQ==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-circle": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.8.tgz",
-      "integrity": "sha512-qPCw8XFW8opT89ciFDuvs+eB3EB1mZIJWVajD2qAlprHiE7YGr34TkM7N5MNr3qZ1pJgkYdW6+HbBrJwBaonqw==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-color": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.8.tgz",
-      "integrity": "sha512-ogkbg6rpDVH/mMLgAQKg17z3oZE0VN7ZWxNoH12fUHchqKz1I57zpa65fxZe2I8T5Xz97HR3x+7V7oI8qQGdSA==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8",
-        "tinycolor2": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-contain": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.8.tgz",
-      "integrity": "sha512-oiaPLdJt9Dk+XEEhM/OU3lFemM51mA9NgMCAdburSCjDzKacJYBGFSHjTOhXzcxOie/ZDpOYN/UzFGKy8Dgl9A==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blit": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5",
-        "@jimp/plugin-scale": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-cover": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.8.tgz",
-      "integrity": "sha512-mO68w1m/LhfuHU8LKHY05a4/hhWnY4t+T+8JCw9t+5yfzA4+LofBZZKtFtWgwf/QGe1y3X2rtUU/avAzDUKyyA==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-crop": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5",
-        "@jimp/plugin-scale": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-crop": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.8.tgz",
-      "integrity": "sha512-ns4oH0h0gezYsbuH8RThcMLY5uTLk/vnqOVjWCehMHEzxi0DHMWCmpcb6bC//vJ+XFNhtVGn1ALN7+ROmPrj+A==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-displace": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.8.tgz",
-      "integrity": "sha512-Cj8nHYgsdFynOIx3dbbiVwRuZn3xO+RVfwkTRy0JBye+K2AU8SQJS+hSFNMQFTZt5djivh6kh0TzvR/6LkOd1w==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-dither": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.8.tgz",
-      "integrity": "sha512-oE0Us/6bEgrgEg56plU3jSBzvB9iGhweKUHmxYMWnQbFCHP4mNCtPAs8+Fmq6c+m98ZgBgRcrJTnC7lphHkGyw==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-fisheye": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.8.tgz",
-      "integrity": "sha512-bWvYY/nfMcKclWEaRyAir+YsT6C5St823HUQAsewZowTrJmme+w4U2a6InsryTHUL01BBcV5BLH0aDHuV3StvA==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-flip": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.8.tgz",
-      "integrity": "sha512-0NFTNzjsdmOQkaIkNjZqO3/yU4SQb9nnWQXsLS1fFo+9QrIL5v8vVkXpk/rhiND6PyTj2mMTNjOa76GuZcC+iQ==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-rotate": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-gaussian": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.8.tgz",
-      "integrity": "sha512-E/f14aLzCS50QAM7K+InI9V61KVy/Zx52vy7Jjfo1h7qKhQHss3PYaydaH0N6qlXRNeXgh+4/32P9JfieLMcdw==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-invert": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.8.tgz",
-      "integrity": "sha512-UauP39FF2cwbA5VU+Tz9VlNa9rtULPSHZb0Huwcjqjm9/G/xVN69VJ8+RKiFC4zM1/kYAUp/6IRwPa6qdKJpSw==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-mask": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.8.tgz",
-      "integrity": "sha512-bhg5+3i8x1CmYj6cjvPBQZLwZEI3iK3gJWF25ZHF+12d3cqDuJngtr8oRQOQLlAgvKmrj9FXIiEPDczUI9cnWQ==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-normalize": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.8.tgz",
-      "integrity": "sha512-Yg5nreAR1JYuSObu3ExlgaLxVeW6VvjVL5qFwiPFxSNlG8JIwL1Ir3K3ChSnnvymyZvJMHb6YKTYNfXKw5Da6g==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-print": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.8.tgz",
-      "integrity": "sha512-86O5ejCDi543IYl0TykSmNWErzAjEYhiAxNQb2F7rFRT38WJYNVsvJ6QhxhDQHKxSmF5iwmqbk0jYk5Wp2Z1kw==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8",
-        "load-bmfont": "^1.4.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blit": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-resize": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.8.tgz",
-      "integrity": "sha512-kg8ArQRPqv/iU3DWNXCa8kcVIhoq64Ze0aGCAeFLKlAq/59f5pzAci6m6vV4L/uOVdYmUa9/kYwIFY6RWKpfzQ==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-rotate": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.8.tgz",
-      "integrity": "sha512-9a+VPZWMN/Cks76wf8LjM5RVA3ntP9+NAdsS1SZhhXel7U3Re/dWMouIEbo3QTt6K+igRo4txUCdZiw4ZucvkQ==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blit": ">=0.3.5",
-        "@jimp/plugin-crop": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-scale": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.8.tgz",
-      "integrity": "sha512-dQS4pG6DX6endu8zUpvBBOEtGC+ljDDDNw0scSXY71TxyQdNo5Ro0apfsppjmuAr8rNotRkfyxbITKkXQDRUDQ==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-shadow": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.8.tgz",
-      "integrity": "sha512-HyAhr7OblTQh+BoKHQg4qbS9MweNlH77yfpBqUEyDtfyjI5r06+5chf1ZdLRIPEWv/BdCfdI/g81Wv69muCMwA==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blur": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-threshold": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.8.tgz",
-      "integrity": "sha512-ZmkfH0PtjvF1UcKsjw0H7V6r+LC0yKzEfg76Jhs2nIqIgsxsSOVfHwS7z0/1IWnyXxSw36m+NjCAotNHRILGmA==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-color": ">=0.8.0",
-        "@jimp/plugin-resize": ">=0.8.0"
-      }
-    },
-    "node_modules/@jimp/plugins": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.8.tgz",
-      "integrity": "sha512-ieI2+kCpmIfjwVlT7B67ULCzxMizfj7LspJh9HnIZCDXQB9GBOZ9KImLYc75Krae0dP/3FR7FglLiSI7fkOHbw==",
-      "dependencies": {
-        "@jimp/plugin-blit": "^0.22.8",
-        "@jimp/plugin-blur": "^0.22.8",
-        "@jimp/plugin-circle": "^0.22.8",
-        "@jimp/plugin-color": "^0.22.8",
-        "@jimp/plugin-contain": "^0.22.8",
-        "@jimp/plugin-cover": "^0.22.8",
-        "@jimp/plugin-crop": "^0.22.8",
-        "@jimp/plugin-displace": "^0.22.8",
-        "@jimp/plugin-dither": "^0.22.8",
-        "@jimp/plugin-fisheye": "^0.22.8",
-        "@jimp/plugin-flip": "^0.22.8",
-        "@jimp/plugin-gaussian": "^0.22.8",
-        "@jimp/plugin-invert": "^0.22.8",
-        "@jimp/plugin-mask": "^0.22.8",
-        "@jimp/plugin-normalize": "^0.22.8",
-        "@jimp/plugin-print": "^0.22.8",
-        "@jimp/plugin-resize": "^0.22.8",
-        "@jimp/plugin-rotate": "^0.22.8",
-        "@jimp/plugin-scale": "^0.22.8",
-        "@jimp/plugin-shadow": "^0.22.8",
-        "@jimp/plugin-threshold": "^0.22.8",
-        "timm": "^1.6.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/png": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.22.8.tgz",
-      "integrity": "sha512-XOj11kcCr8zKg24QSwlRfH9k4hbV6rkMGUVxMS3puRzzB0FBSQy42NBYEfYf2XlY2QJSAByPl4AYerOtKb805w==",
-      "dependencies": {
-        "@jimp/utils": "^0.22.8",
-        "pngjs": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/tiff": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.8.tgz",
-      "integrity": "sha512-K0hYUVW5MLgwq3jiHVHa6LvP05J1rXOlRCC+5dMTUnAXVwi45+MKsqA/8lzzwhHYJ65CNhZwy6D3+ZNzM9SIBQ==",
-      "dependencies": {
-        "utif2": "^4.0.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/types": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.22.8.tgz",
-      "integrity": "sha512-9+xc+mzuYwu0i+6dsnhXiUgfcS+Ktqn5q2jczoKyyBT0cOKgsk+57EIeFLgpTfVGRKRR0y/UIdHByeCzGguF3A==",
-      "dependencies": {
-        "@jimp/bmp": "^0.22.8",
-        "@jimp/gif": "^0.22.8",
-        "@jimp/jpeg": "^0.22.8",
-        "@jimp/png": "^0.22.8",
-        "@jimp/tiff": "^0.22.8",
-        "timm": "^1.6.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/utils": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.22.8.tgz",
-      "integrity": "sha512-AaqjfqDeLzSFzrbGRKHMXg/ntiWKvoG9tpVgWzgOx5/gPWj/IyGfztojLTTvY8HqZCr25z8z91u2lAQD2v46Jw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.3"
-      }
-    },
-    "node_modules/@jimp/utils/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
@@ -16575,11 +16096,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -17974,11 +17490,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/any-base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
-    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -19160,7 +18671,8 @@
     "node_modules/base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -19276,11 +18788,6 @@
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
       "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
-    },
-    "node_modules/bmp-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "node_modules/bn.js": {
       "version": "5.1.3",
@@ -19668,14 +19175,6 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/buffer-from": {
@@ -24544,11 +24043,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/exif-parser": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
-    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -25165,22 +24659,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
       "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
       "dev": true
-    },
-    "node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -26423,15 +25901,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/gifwrap": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
-      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
-      "dependencies": {
-        "image-q": "^4.0.0",
-        "omggif": "^1.0.10"
-      }
-    },
     "node_modules/github-slugger": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
@@ -27542,6 +27011,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -27571,19 +27041,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/image-q": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
-      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
-      "dependencies": {
-        "@types/node": "16.9.1"
-      }
-    },
-    "node_modules/image-q/node_modules/@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
     },
     "node_modules/immediate": {
       "version": "3.0.6",
@@ -28322,7 +27779,8 @@
     "node_modules/is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "dev": true
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -32149,27 +31607,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jimp": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.22.8.tgz",
-      "integrity": "sha512-pBbrooJMX7795sDcxx1XpwNZC8B/ITyDV+JK2/1qNbQl/1UWqWeh5Dq7qQpMZl5jLdcFDv5IVTM+OhpafSqSFA==",
-      "dependencies": {
-        "@jimp/custom": "^0.22.8",
-        "@jimp/plugins": "^0.22.8",
-        "@jimp/types": "^0.22.8",
-        "regenerator-runtime": "^0.13.3"
-      }
-    },
-    "node_modules/jimp/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-    },
-    "node_modules/jpeg-js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
-    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -32647,21 +32084,6 @@
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
       "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
       "dev": true
-    },
-    "node_modules/load-bmfont": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-      "dependencies": {
-        "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.4",
-        "phin": "^2.9.1",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
-      }
     },
     "node_modules/load-json-file": {
       "version": "5.3.0",
@@ -34366,6 +33788,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -35290,11 +34713,6 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "node_modules/omggif": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -35754,25 +35172,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/parse-bmfont-ascii": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
-    },
-    "node_modules/parse-bmfont-binary": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
-    },
-    "node_modules/parse-bmfont-xml": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-      "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-      "dependencies": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
-      }
-    },
     "node_modules/parse-entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
@@ -35790,11 +35189,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parse-json": {
       "version": "4.0.0",
@@ -36084,27 +35478,10 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "node_modules/phin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -36160,25 +35537,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-      "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
-      "dependencies": {
-        "pngjs": "^3.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
-    "node_modules/pixelmatch/node_modules/pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/pixi-simple-gesture": {
@@ -36428,14 +35786,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "engines": {
-        "node": ">=12.13.0"
       }
     },
     "node_modules/pnp-webpack-plugin": {
@@ -40422,34 +39772,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -42054,7 +41376,8 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -43516,22 +42839,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/style-dictionary": {
       "version": "2.10.2",
       "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-2.10.2.tgz",
@@ -44344,11 +43651,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/timm": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
-      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
-    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -44469,22 +43771,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tough-cookie": {
@@ -45405,14 +44691,6 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/utif2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
-      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
-      "dependencies": {
-        "pako": "^1.0.11"
       }
     },
     "node_modules/util": {
@@ -47134,47 +46412,11 @@
         "default-browser-id": "^1.0.4"
       }
     },
-    "node_modules/xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "dependencies": {
-        "global": "~4.4.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
-    },
-    "node_modules/xml-parse-from-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -47194,6 +46436,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -51296,354 +50539,6 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
-      }
-    },
-    "@jimp/bmp": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.8.tgz",
-      "integrity": "sha512-JEMKgM1AEvvWfn9ZCHn62nK+QCE3Pb/ZhPdL3NF0ZgKNww6pqOmo6KqXzqY18JLB7c0epuTp4GPDPDhOh/ou1g==",
-      "requires": {
-        "@jimp/utils": "^0.22.8",
-        "bmp-js": "^0.1.0"
-      }
-    },
-    "@jimp/core": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.22.8.tgz",
-      "integrity": "sha512-vkN28aFikzQieA6bGxN+qe20pseCAemCyUI0YmRkJIArlb6OujtAwWAKyokv2lylV56bq8EQGIz+Y30OXUnRqg==",
-      "requires": {
-        "@jimp/utils": "^0.22.8",
-        "any-base": "^1.1.0",
-        "buffer": "^5.2.0",
-        "exif-parser": "^0.1.12",
-        "file-type": "^16.5.4",
-        "isomorphic-fetch": "^3.0.0",
-        "mkdirp": "^2.1.3",
-        "pixelmatch": "^4.0.2",
-        "tinycolor2": "^1.6.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "isomorphic-fetch": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-          "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "whatwg-fetch": "^3.4.1"
-          }
-        },
-        "mkdirp": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-          "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="
-        },
-        "node-fetch": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-          "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@jimp/custom": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.8.tgz",
-      "integrity": "sha512-u6lP9x/HNeGHB0Oojv4c2mhuDvn7G0ikzYbK4IKLsH4HzHxt62faMjBzQMcFhKJhR6UiiKE/jiHrhGvBT/fMkw==",
-      "requires": {
-        "@jimp/core": "^0.22.8"
-      }
-    },
-    "@jimp/gif": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.22.8.tgz",
-      "integrity": "sha512-I0l6koS67IPU40RPxCJTD1NvePEd8vUIHTejx1ly0jrjGnumbqdarAlBUkDrKfPPc+Fnqp84hBbSN1w5hNPT6w==",
-      "requires": {
-        "@jimp/utils": "^0.22.8",
-        "gifwrap": "^0.9.2",
-        "omggif": "^1.0.9"
-      }
-    },
-    "@jimp/jpeg": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.8.tgz",
-      "integrity": "sha512-hLXrQ7/0QiUhAVAF10dfGCSq3hvyqjKltlpu/87b3wqMDKe9KdvhX1AJHiUUrAbJv1fAcnOmQGTyXGuySa1D6A==",
-      "requires": {
-        "@jimp/utils": "^0.22.8",
-        "jpeg-js": "^0.4.4"
-      }
-    },
-    "@jimp/plugin-blit": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.8.tgz",
-      "integrity": "sha512-rQ19txVCKIwo74HtgFodFt4//0ATPCJK+f24riqzb+nx+1JaOo1xRvpJqg4moirHwKR2fhwdDxmY7KX20kCeYA==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-blur": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.8.tgz",
-      "integrity": "sha512-GWbNK3YW6k2EKiGJdpAFEr0jezPBtiVxj2wG/lCPuWJz7KmzSSN99hQjIy73xQxoBCRdALfJlkhe3leFNRueSQ==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-circle": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.8.tgz",
-      "integrity": "sha512-qPCw8XFW8opT89ciFDuvs+eB3EB1mZIJWVajD2qAlprHiE7YGr34TkM7N5MNr3qZ1pJgkYdW6+HbBrJwBaonqw==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-color": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.8.tgz",
-      "integrity": "sha512-ogkbg6rpDVH/mMLgAQKg17z3oZE0VN7ZWxNoH12fUHchqKz1I57zpa65fxZe2I8T5Xz97HR3x+7V7oI8qQGdSA==",
-      "requires": {
-        "@jimp/utils": "^0.22.8",
-        "tinycolor2": "^1.6.0"
-      }
-    },
-    "@jimp/plugin-contain": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.8.tgz",
-      "integrity": "sha512-oiaPLdJt9Dk+XEEhM/OU3lFemM51mA9NgMCAdburSCjDzKacJYBGFSHjTOhXzcxOie/ZDpOYN/UzFGKy8Dgl9A==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-cover": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.8.tgz",
-      "integrity": "sha512-mO68w1m/LhfuHU8LKHY05a4/hhWnY4t+T+8JCw9t+5yfzA4+LofBZZKtFtWgwf/QGe1y3X2rtUU/avAzDUKyyA==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-crop": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.8.tgz",
-      "integrity": "sha512-ns4oH0h0gezYsbuH8RThcMLY5uTLk/vnqOVjWCehMHEzxi0DHMWCmpcb6bC//vJ+XFNhtVGn1ALN7+ROmPrj+A==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-displace": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.8.tgz",
-      "integrity": "sha512-Cj8nHYgsdFynOIx3dbbiVwRuZn3xO+RVfwkTRy0JBye+K2AU8SQJS+hSFNMQFTZt5djivh6kh0TzvR/6LkOd1w==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-dither": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.8.tgz",
-      "integrity": "sha512-oE0Us/6bEgrgEg56plU3jSBzvB9iGhweKUHmxYMWnQbFCHP4mNCtPAs8+Fmq6c+m98ZgBgRcrJTnC7lphHkGyw==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-fisheye": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.8.tgz",
-      "integrity": "sha512-bWvYY/nfMcKclWEaRyAir+YsT6C5St823HUQAsewZowTrJmme+w4U2a6InsryTHUL01BBcV5BLH0aDHuV3StvA==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-flip": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.8.tgz",
-      "integrity": "sha512-0NFTNzjsdmOQkaIkNjZqO3/yU4SQb9nnWQXsLS1fFo+9QrIL5v8vVkXpk/rhiND6PyTj2mMTNjOa76GuZcC+iQ==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-gaussian": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.8.tgz",
-      "integrity": "sha512-E/f14aLzCS50QAM7K+InI9V61KVy/Zx52vy7Jjfo1h7qKhQHss3PYaydaH0N6qlXRNeXgh+4/32P9JfieLMcdw==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-invert": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.8.tgz",
-      "integrity": "sha512-UauP39FF2cwbA5VU+Tz9VlNa9rtULPSHZb0Huwcjqjm9/G/xVN69VJ8+RKiFC4zM1/kYAUp/6IRwPa6qdKJpSw==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-mask": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.8.tgz",
-      "integrity": "sha512-bhg5+3i8x1CmYj6cjvPBQZLwZEI3iK3gJWF25ZHF+12d3cqDuJngtr8oRQOQLlAgvKmrj9FXIiEPDczUI9cnWQ==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-normalize": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.8.tgz",
-      "integrity": "sha512-Yg5nreAR1JYuSObu3ExlgaLxVeW6VvjVL5qFwiPFxSNlG8JIwL1Ir3K3ChSnnvymyZvJMHb6YKTYNfXKw5Da6g==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-print": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.8.tgz",
-      "integrity": "sha512-86O5ejCDi543IYl0TykSmNWErzAjEYhiAxNQb2F7rFRT38WJYNVsvJ6QhxhDQHKxSmF5iwmqbk0jYk5Wp2Z1kw==",
-      "requires": {
-        "@jimp/utils": "^0.22.8",
-        "load-bmfont": "^1.4.1"
-      }
-    },
-    "@jimp/plugin-resize": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.8.tgz",
-      "integrity": "sha512-kg8ArQRPqv/iU3DWNXCa8kcVIhoq64Ze0aGCAeFLKlAq/59f5pzAci6m6vV4L/uOVdYmUa9/kYwIFY6RWKpfzQ==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-rotate": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.8.tgz",
-      "integrity": "sha512-9a+VPZWMN/Cks76wf8LjM5RVA3ntP9+NAdsS1SZhhXel7U3Re/dWMouIEbo3QTt6K+igRo4txUCdZiw4ZucvkQ==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-scale": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.8.tgz",
-      "integrity": "sha512-dQS4pG6DX6endu8zUpvBBOEtGC+ljDDDNw0scSXY71TxyQdNo5Ro0apfsppjmuAr8rNotRkfyxbITKkXQDRUDQ==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-shadow": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.8.tgz",
-      "integrity": "sha512-HyAhr7OblTQh+BoKHQg4qbS9MweNlH77yfpBqUEyDtfyjI5r06+5chf1ZdLRIPEWv/BdCfdI/g81Wv69muCMwA==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugin-threshold": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.8.tgz",
-      "integrity": "sha512-ZmkfH0PtjvF1UcKsjw0H7V6r+LC0yKzEfg76Jhs2nIqIgsxsSOVfHwS7z0/1IWnyXxSw36m+NjCAotNHRILGmA==",
-      "requires": {
-        "@jimp/utils": "^0.22.8"
-      }
-    },
-    "@jimp/plugins": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.8.tgz",
-      "integrity": "sha512-ieI2+kCpmIfjwVlT7B67ULCzxMizfj7LspJh9HnIZCDXQB9GBOZ9KImLYc75Krae0dP/3FR7FglLiSI7fkOHbw==",
-      "requires": {
-        "@jimp/plugin-blit": "^0.22.8",
-        "@jimp/plugin-blur": "^0.22.8",
-        "@jimp/plugin-circle": "^0.22.8",
-        "@jimp/plugin-color": "^0.22.8",
-        "@jimp/plugin-contain": "^0.22.8",
-        "@jimp/plugin-cover": "^0.22.8",
-        "@jimp/plugin-crop": "^0.22.8",
-        "@jimp/plugin-displace": "^0.22.8",
-        "@jimp/plugin-dither": "^0.22.8",
-        "@jimp/plugin-fisheye": "^0.22.8",
-        "@jimp/plugin-flip": "^0.22.8",
-        "@jimp/plugin-gaussian": "^0.22.8",
-        "@jimp/plugin-invert": "^0.22.8",
-        "@jimp/plugin-mask": "^0.22.8",
-        "@jimp/plugin-normalize": "^0.22.8",
-        "@jimp/plugin-print": "^0.22.8",
-        "@jimp/plugin-resize": "^0.22.8",
-        "@jimp/plugin-rotate": "^0.22.8",
-        "@jimp/plugin-scale": "^0.22.8",
-        "@jimp/plugin-shadow": "^0.22.8",
-        "@jimp/plugin-threshold": "^0.22.8",
-        "timm": "^1.6.1"
-      }
-    },
-    "@jimp/png": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.22.8.tgz",
-      "integrity": "sha512-XOj11kcCr8zKg24QSwlRfH9k4hbV6rkMGUVxMS3puRzzB0FBSQy42NBYEfYf2XlY2QJSAByPl4AYerOtKb805w==",
-      "requires": {
-        "@jimp/utils": "^0.22.8",
-        "pngjs": "^6.0.0"
-      }
-    },
-    "@jimp/tiff": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.8.tgz",
-      "integrity": "sha512-K0hYUVW5MLgwq3jiHVHa6LvP05J1rXOlRCC+5dMTUnAXVwi45+MKsqA/8lzzwhHYJ65CNhZwy6D3+ZNzM9SIBQ==",
-      "requires": {
-        "utif2": "^4.0.1"
-      }
-    },
-    "@jimp/types": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.22.8.tgz",
-      "integrity": "sha512-9+xc+mzuYwu0i+6dsnhXiUgfcS+Ktqn5q2jczoKyyBT0cOKgsk+57EIeFLgpTfVGRKRR0y/UIdHByeCzGguF3A==",
-      "requires": {
-        "@jimp/bmp": "^0.22.8",
-        "@jimp/gif": "^0.22.8",
-        "@jimp/jpeg": "^0.22.8",
-        "@jimp/png": "^0.22.8",
-        "@jimp/tiff": "^0.22.8",
-        "timm": "^1.6.1"
-      }
-    },
-    "@jimp/utils": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.22.8.tgz",
-      "integrity": "sha512-AaqjfqDeLzSFzrbGRKHMXg/ntiWKvoG9tpVgWzgOx5/gPWj/IyGfztojLTTvY8HqZCr25z8z91u2lAQD2v46Jw==",
-      "requires": {
-        "regenerator-runtime": "^0.13.3"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-        }
       }
     },
     "@jridgewell/gen-mapping": {
@@ -59498,11 +58393,6 @@
         }
       }
     },
-    "@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -60689,11 +59579,6 @@
         "entities": "^2.0.0"
       }
     },
-    "any-base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
-    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -61659,7 +60544,8 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
     },
     "batch": {
       "version": "0.6.1",
@@ -61753,11 +60639,6 @@
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
       "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
-    },
-    "bmp-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "bn.js": {
       "version": "5.1.3",
@@ -62103,11 +60984,6 @@
           "dev": true
         }
       }
-    },
-    "buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -65905,11 +64781,6 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "exif-parser": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
-    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -66440,16 +65311,6 @@
           "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
           "dev": true
         }
-      }
-    },
-    "file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "requires": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
       }
     },
     "file-uri-to-path": {
@@ -67458,15 +66319,6 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
-    "gifwrap": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
-      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
-      "requires": {
-        "image-q": "^4.0.0",
-        "omggif": "^1.0.10"
-      }
-    },
     "github-slugger": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
@@ -68347,7 +67199,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "iferr": {
       "version": "0.1.5",
@@ -68360,21 +67213,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
-    },
-    "image-q": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
-      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
-      "requires": {
-        "@types/node": "16.9.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.9.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-          "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
-        }
-      }
     },
     "immediate": {
       "version": "3.0.6",
@@ -68932,7 +67770,8 @@
     "is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -71965,29 +70804,6 @@
         }
       }
     },
-    "jimp": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.22.8.tgz",
-      "integrity": "sha512-pBbrooJMX7795sDcxx1XpwNZC8B/ITyDV+JK2/1qNbQl/1UWqWeh5Dq7qQpMZl5jLdcFDv5IVTM+OhpafSqSFA==",
-      "requires": {
-        "@jimp/custom": "^0.22.8",
-        "@jimp/plugins": "^0.22.8",
-        "@jimp/types": "^0.22.8",
-        "regenerator-runtime": "^0.13.3"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-        }
-      }
-    },
-    "jpeg-js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -72391,21 +71207,6 @@
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
       "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
       "dev": true
-    },
-    "load-bmfont": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-      "requires": {
-        "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.4",
-        "phin": "^2.9.1",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
-      }
     },
     "load-json-file": {
       "version": "5.3.0",
@@ -73641,7 +72442,8 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.52.0",
@@ -74389,11 +73191,6 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "omggif": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
-    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -74757,25 +73554,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-bmfont-ascii": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
-    },
-    "parse-bmfont-binary": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
-    },
-    "parse-bmfont-xml": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-      "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-      "requires": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
-      }
-    },
     "parse-entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
@@ -74789,11 +73567,6 @@
         "is-decimal": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
       }
-    },
-    "parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "parse-json": {
       "version": "4.0.0",
@@ -75030,20 +73803,10 @@
         "sha.js": "^2.4.8"
       }
     },
-    "peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "phin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -75082,21 +73845,6 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
-    },
-    "pixelmatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-      "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
-      "requires": {
-        "pngjs": "^3.0.0"
-      },
-      "dependencies": {
-        "pngjs": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-          "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
-        }
-      }
     },
     "pixi-simple-gesture": {
       "version": "git+ssh://git@github.com/4ian/pixi-simple-gesture.git#c84e0cc3c62edeca019e708d9897ef6b97a0d18a",
@@ -75298,11 +74046,6 @@
           "dev": true
         }
       }
-    },
-    "pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -78470,26 +77213,6 @@
         }
       }
     },
-    "readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -79742,7 +78465,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "saxes": {
       "version": "5.0.1",
@@ -80958,15 +79682,6 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-      "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      }
-    },
     "style-dictionary": {
       "version": "2.10.2",
       "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-2.10.2.tgz",
@@ -81606,11 +80321,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "timm": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
-      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
-    },
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -81713,15 +80423,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
-    },
-    "token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-      "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      }
     },
     "tough-cookie": {
       "version": "4.0.0",
@@ -82407,14 +81108,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
-    },
-    "utif2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
-      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
-      "requires": {
-        "pako": "^1.0.11"
-      }
     },
     "util": {
       "version": "0.11.1",
@@ -83878,41 +82571,11 @@
         "default-browser-id": "^1.0.4"
       }
     },
-    "xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "requires": {
-        "global": "~4.4.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
-    },
-    "xml-parse-from-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",
@@ -83928,7 +82591,8 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "xxhashjs": {
       "version": "0.2.2",

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -50,7 +50,6 @@
     "firebase": "9.0.0-beta.2",
     "fontfaceobserver": "2.0.13",
     "fuse.js": "^6.5.3",
-    "jimp": "0.22.8",
     "js-worker-search": "^1.4.1",
     "jss-rtl": "^0.3.0",
     "lodash": "4.17.4",

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMaskHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMaskHelper.js
@@ -1,147 +1,154 @@
 // @flow
-import axios from 'axios';
-import optionalLazyRequire from '../../../../Utils/OptionalLazyRequire';
 import { checkIfCredentialsRequired } from '../../../../Utils/CrossOrigin';
-import Jimp from 'jimp/es';
-const lazyRequireFs = optionalLazyRequire('fs');
 
 const gd: libGDevelop = global.gd;
-
-async function getJimpImage(pathToFile: string) {
-  try {
-    if (pathToFile.startsWith('http://') || pathToFile.startsWith('https://')) {
-      const response = await axios.get(pathToFile, {
-        responseType: 'arraybuffer',
-        withCredentials: checkIfCredentialsRequired(pathToFile),
-      });
-
-      const imageBuffer = response.data;
-      const jimpImage = await Jimp.read(imageBuffer);
-
-      return jimpImage;
-    } else if (pathToFile.startsWith('file://')) {
-      const cleanedPath = pathToFile.replace('file://', '').split('?')[0];
-      // For some reason, calling directly Jimp.read with a path does not work
-      // in the renderer process of Electron. So we read the file ourselves
-      // and pass the ArrayBuffer to Jimp.
-      const fs = lazyRequireFs();
-      if (!fs) return null;
-      const file = fs.readFileSync(cleanedPath);
-      const imageBuffer = new Uint8Array(file).buffer;
-      const jimpImage = await Jimp.read(imageBuffer);
-
-      return jimpImage;
-    } else {
-      console.error(
-        'Unsupported image path. Only http://, https:// and file:// are supported.'
-      );
-      return null;
-    }
-  } catch (error) {
-    console.error('Error fetching image:', error);
-    return null;
-  }
-}
 
 // 25% of 255 to accept pixels that are not fully transparent (like effects)
 const PIXEL_TRANSPARENCY_THRESHOLD = 64;
 
-export const getMatchingCollisionMask = async (imageFile: string) => {
+export const getMatchingCollisionMask = async (
+  pathToFile: string
+): Promise<gdVectorPolygon2d> => {
   // First detect, the most left, right, top and bottom pixels that are not transparent.
   // This will be used to crop the image.
   // To do so, we scan the image starting from the borders and going to the center,
   // until we find a non-transparent pixel. (To avoid going through the whole image)
-  if (!Jimp) return null;
-  const jimpImage = await getJimpImage(imageFile);
-  if (!jimpImage) return null;
-  const { width, height } = jimpImage.bitmap;
-  if (!width || !height) return null;
-  let minX = null;
-  let maxX = null;
-  let minY = null;
-  let maxY = null;
+  return new Promise((resolve, reject) => {
+    const img = new Image();
 
-  // Step 1: Scanning Rows from Top to Bottom, until we find a non-transparent pixel
-  for (let y = 0; y < height; y++) {
-    let foundNonTransparent = false;
-    for (let x = 0; x < width; x++) {
-      const idx = (y * width + x) << 2; // Calculate the pixel index
-
-      const alpha = jimpImage.bitmap.data[idx + 3];
-      if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-        minY = y;
-        foundNonTransparent = true;
-        break;
-      }
+    if (pathToFile.startsWith('http://') || pathToFile.startsWith('https://')) {
+      img.crossOrigin = checkIfCredentialsRequired(pathToFile)
+        ? 'use-credentials'
+        : 'anonymous';
     }
-    if (foundNonTransparent) break;
-  }
-  if (minY === null) return null;
 
-  // Step 2: Scanning Rows from Bottom to Top, until we find a non-transparent pixel
-  for (let y = height - 1; y >= 0; y--) {
-    let foundNonTransparent = false;
-    for (let x = 0; x < width; x++) {
-      const idx = (y * width + x) << 2; // Calculate the pixel index
-
-      const alpha = jimpImage.bitmap.data[idx + 3];
-      if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-        maxY = y;
-        foundNonTransparent = true;
-        break;
+    img.addEventListener('load', () => {
+      const canvas = document.createElement('canvas');
+      const width = img.width;
+      const height = img.height;
+      canvas.width = width;
+      canvas.height = height;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Unable to get 2D context.'));
+        return;
       }
-    }
-    if (foundNonTransparent) break;
-  }
-  if (maxY === null) return null;
 
-  // Step 3: Scanning Columns from Left to Right, until we find a non-transparent pixel
-  for (let x = 0; x < width; x++) {
-    let foundNonTransparent = false;
-    for (let y = minY; y <= maxY; y++) {
-      const idx = (y * width + x) << 2; // Calculate the pixel index
+      context.drawImage(img, 0, 0);
+      // Get the pixel data from the canvas
+      var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+      var pixels = imageData.data;
 
-      const alpha = jimpImage.bitmap.data[idx + 3];
-      if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-        minX = x;
-        foundNonTransparent = true;
-        break;
+      let minX = null;
+      let maxX = null;
+      let minY = null;
+      let maxY = null;
+
+      // Step 1: Scanning Rows from Top to Bottom, until we find a non-transparent pixel
+      for (let y = 0; y < height; y++) {
+        let foundNonTransparent = false;
+        for (let x = 0; x < width; x++) {
+          const idx = (y * width + x) << 2; // Calculate the pixel index
+
+          const alpha = pixels[idx + 3];
+          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
+            minY = y;
+            foundNonTransparent = true;
+            break;
+          }
+        }
+        if (foundNonTransparent) break;
       }
-    }
-    if (foundNonTransparent) break;
-  }
-  if (minX === null) return null;
-
-  // Step 4: Scanning Columns from Right to Left, until we find a non-transparent pixel
-  for (let x = width - 1; x >= 0; x--) {
-    let foundNonTransparent = false;
-    for (let y = minY; y <= maxY; y++) {
-      const idx = (y * width + x) << 2; // Calculate the pixel index
-
-      const alpha = jimpImage.bitmap.data[idx + 3];
-      if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-        maxX = x;
-        foundNonTransparent = true;
-        break;
+      if (minY === null) {
+        reject(new Error('No non-transparent pixel found.'));
+        return;
       }
-    }
-    if (foundNonTransparent) break;
-  }
-  if (maxX === null) return null;
 
-  const collisionMaskWidth = maxX - minX + 1;
-  const collisionMaskHeight = maxY - minY + 1;
-  const collisionMaskXCenter = (minX + maxX + 1) / 2;
-  const collisionMaskYCenter = (minY + maxY + 1) / 2;
-  if (collisionMaskWidth <= 0 || collisionMaskHeight <= 0) return null;
+      // Step 2: Scanning Rows from Bottom to Top, until we find a non-transparent pixel
+      for (let y = height - 1; y >= 0; y--) {
+        let foundNonTransparent = false;
+        for (let x = 0; x < width; x++) {
+          const idx = (y * width + x) << 2; // Calculate the pixel index
 
-  const newPolygon = gd.Polygon2d.createRectangle(
-    collisionMaskWidth,
-    collisionMaskHeight
-  );
-  newPolygon.move(collisionMaskXCenter, collisionMaskYCenter);
-  const polygons = new gd.VectorPolygon2d();
-  polygons.push_back(newPolygon);
+          const alpha = pixels[idx + 3];
+          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
+            maxY = y;
+            foundNonTransparent = true;
+            break;
+          }
+        }
+        if (foundNonTransparent) break;
+      }
+      if (maxY === null) {
+        reject(new Error('No non-transparent pixel found.'));
+        return;
+      }
 
-  return polygons;
+      // Step 3: Scanning Columns from Left to Right, until we find a non-transparent pixel
+      for (let x = 0; x < width; x++) {
+        let foundNonTransparent = false;
+        for (let y = minY; y <= maxY; y++) {
+          const idx = (y * width + x) << 2; // Calculate the pixel index
+
+          const alpha = pixels[idx + 3];
+          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
+            minX = x;
+            foundNonTransparent = true;
+            break;
+          }
+        }
+        if (foundNonTransparent) break;
+      }
+      if (minX === null) {
+        reject(new Error('No non-transparent pixel found.'));
+        return;
+      }
+
+      // Step 4: Scanning Columns from Right to Left, until we find a non-transparent pixel
+      for (let x = width - 1; x >= 0; x--) {
+        let foundNonTransparent = false;
+        for (let y = minY; y <= maxY; y++) {
+          const idx = (y * width + x) << 2; // Calculate the pixel index
+
+          const alpha = pixels[idx + 3];
+          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
+            maxX = x;
+            foundNonTransparent = true;
+            break;
+          }
+        }
+        if (foundNonTransparent) break;
+      }
+      if (maxX === null) {
+        reject(new Error('No non-transparent pixel found.'));
+        return;
+      }
+
+      const collisionMaskWidth = maxX - minX + 1;
+      const collisionMaskHeight = maxY - minY + 1;
+      const collisionMaskXCenter = (minX + maxX + 1) / 2;
+      const collisionMaskYCenter = (minY + maxY + 1) / 2;
+      if (collisionMaskWidth <= 0 || collisionMaskHeight <= 0) {
+        reject(new Error('Invalid collision mask size.'));
+        return;
+      }
+
+      const newPolygon = gd.Polygon2d.createRectangle(
+        collisionMaskWidth,
+        collisionMaskHeight
+      );
+      newPolygon.move(collisionMaskXCenter, collisionMaskYCenter);
+      const polygons = new gd.VectorPolygon2d();
+      polygons.push_back(newPolygon);
+
+      resolve(polygons);
+    });
+    img.addEventListener('error', () => {
+      console.error('Error loading image:', pathToFile);
+      reject(new Error('Error loading image.'));
+      return;
+    });
+
+    img.src = pathToFile;
+  });
 };

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMaskHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMaskHelper.js
@@ -36,8 +36,8 @@ export const getMatchingCollisionMask = async (
 
       context.drawImage(img, 0, 0);
       // Get the pixel data from the canvas
-      var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-      var pixels = imageData.data;
+      const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+      const pixels = imageData.data;
 
       let minX = null;
       let maxX = null;

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMaskHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/CollisionMaskHelper.js
@@ -6,6 +6,27 @@ const gd: libGDevelop = global.gd;
 // 25% of 255 to accept pixels that are not fully transparent (like effects)
 const PIXEL_TRANSPARENCY_THRESHOLD = 64;
 
+const loadImage = (img: Image, pathToFile: string) => {
+  return new Promise((resolve, reject) => {
+    img.addEventListener('load', () => resolve(img));
+    img.addEventListener('error', () =>
+      reject(new Error('Failed to load image'))
+    );
+    img.src = pathToFile;
+  });
+};
+
+const isPixelAboveTransparencyThreshold = (
+  pixels: Uint8ClampedArray,
+  x: number,
+  y: number,
+  width: number
+) => {
+  const idx = (y * width + x) << 2; // Calculate the pixel index
+  const alpha = pixels[idx + 3];
+  return alpha >= PIXEL_TRANSPARENCY_THRESHOLD;
+};
+
 export const getMatchingCollisionMask = async (
   pathToFile: string
 ): Promise<gdVectorPolygon2d> => {
@@ -13,142 +34,127 @@ export const getMatchingCollisionMask = async (
   // This will be used to crop the image.
   // To do so, we scan the image starting from the borders and going to the center,
   // until we find a non-transparent pixel. (To avoid going through the whole image)
-  return new Promise((resolve, reject) => {
-    const img = new Image();
+  const img = new Image();
 
-    if (pathToFile.startsWith('http://') || pathToFile.startsWith('https://')) {
-      img.crossOrigin = checkIfCredentialsRequired(pathToFile)
-        ? 'use-credentials'
-        : 'anonymous';
+  if (pathToFile.startsWith('http://') || pathToFile.startsWith('https://')) {
+    img.crossOrigin = checkIfCredentialsRequired(pathToFile)
+      ? 'use-credentials'
+      : 'anonymous';
+  }
+
+  try {
+    await loadImage(img, pathToFile);
+
+    const canvas = document.createElement('canvas');
+    const width = img.width;
+    const height = img.height;
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Unable to get 2D context.');
     }
 
-    img.addEventListener('load', () => {
-      const canvas = document.createElement('canvas');
-      const width = img.width;
-      const height = img.height;
-      canvas.width = width;
-      canvas.height = height;
-      const context = canvas.getContext('2d');
-      if (!context) {
-        reject(new Error('Unable to get 2D context.'));
-        return;
-      }
+    context.drawImage(img, 0, 0);
+    // Get the pixel data from the canvas
+    const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+    const pixels = imageData.data;
 
-      context.drawImage(img, 0, 0);
-      // Get the pixel data from the canvas
-      const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-      const pixels = imageData.data;
+    let minX = null;
+    let maxX = null;
+    let minY = null;
+    let maxY = null;
 
-      let minX = null;
-      let maxX = null;
-      let minY = null;
-      let maxY = null;
-
-      // Step 1: Scanning Rows from Top to Bottom, until we find a non-transparent pixel
-      for (let y = 0; y < height; y++) {
-        let foundNonTransparent = false;
-        for (let x = 0; x < width; x++) {
-          const idx = (y * width + x) << 2; // Calculate the pixel index
-
-          const alpha = pixels[idx + 3];
-          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-            minY = y;
-            foundNonTransparent = true;
-            break;
-          }
-        }
-        if (foundNonTransparent) break;
-      }
-      if (minY === null) {
-        reject(new Error('No non-transparent pixel found.'));
-        return;
-      }
-
-      // Step 2: Scanning Rows from Bottom to Top, until we find a non-transparent pixel
-      for (let y = height - 1; y >= 0; y--) {
-        let foundNonTransparent = false;
-        for (let x = 0; x < width; x++) {
-          const idx = (y * width + x) << 2; // Calculate the pixel index
-
-          const alpha = pixels[idx + 3];
-          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-            maxY = y;
-            foundNonTransparent = true;
-            break;
-          }
-        }
-        if (foundNonTransparent) break;
-      }
-      if (maxY === null) {
-        reject(new Error('No non-transparent pixel found.'));
-        return;
-      }
-
-      // Step 3: Scanning Columns from Left to Right, until we find a non-transparent pixel
+    // Step 1: Scanning Rows from Top to Bottom, until we find a non-transparent pixel
+    for (let y = 0; y < height; y++) {
+      let foundNonTransparent = false;
       for (let x = 0; x < width; x++) {
-        let foundNonTransparent = false;
-        for (let y = minY; y <= maxY; y++) {
-          const idx = (y * width + x) << 2; // Calculate the pixel index
-
-          const alpha = pixels[idx + 3];
-          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-            minX = x;
-            foundNonTransparent = true;
-            break;
-          }
+        if (isPixelAboveTransparencyThreshold(pixels, x, y, width)) {
+          minY = y;
+          foundNonTransparent = true;
+          break;
         }
-        if (foundNonTransparent) break;
       }
-      if (minX === null) {
-        reject(new Error('No non-transparent pixel found.'));
-        return;
-      }
-
-      // Step 4: Scanning Columns from Right to Left, until we find a non-transparent pixel
-      for (let x = width - 1; x >= 0; x--) {
-        let foundNonTransparent = false;
-        for (let y = minY; y <= maxY; y++) {
-          const idx = (y * width + x) << 2; // Calculate the pixel index
-
-          const alpha = pixels[idx + 3];
-          if (alpha >= PIXEL_TRANSPARENCY_THRESHOLD) {
-            maxX = x;
-            foundNonTransparent = true;
-            break;
-          }
-        }
-        if (foundNonTransparent) break;
-      }
-      if (maxX === null) {
-        reject(new Error('No non-transparent pixel found.'));
-        return;
-      }
-
-      const collisionMaskWidth = maxX - minX + 1;
-      const collisionMaskHeight = maxY - minY + 1;
-      const collisionMaskXCenter = (minX + maxX + 1) / 2;
-      const collisionMaskYCenter = (minY + maxY + 1) / 2;
-      if (collisionMaskWidth <= 0 || collisionMaskHeight <= 0) {
-        reject(new Error('Invalid collision mask size.'));
-        return;
-      }
-
-      const newPolygon = gd.Polygon2d.createRectangle(
-        collisionMaskWidth,
-        collisionMaskHeight
+      if (foundNonTransparent) break;
+    }
+    if (minY === null) {
+      throw new Error(
+        'No non-transparent pixel found while scanning rows from top to bottom.'
       );
-      newPolygon.move(collisionMaskXCenter, collisionMaskYCenter);
-      const polygons = new gd.VectorPolygon2d();
-      polygons.push_back(newPolygon);
+    }
 
-      resolve(polygons);
-    });
-    img.addEventListener('error', () => {
-      console.error('Error loading image:', pathToFile);
-      reject(new Error('Error loading image.'));
-      return;
-    });
+    // Step 2: Scanning Rows from Bottom to Top, until we find a non-transparent pixel
+    for (let y = height - 1; y >= 0; y--) {
+      let foundNonTransparent = false;
+      for (let x = 0; x < width; x++) {
+        if (isPixelAboveTransparencyThreshold(pixels, x, y, width)) {
+          maxY = y;
+          foundNonTransparent = true;
+          break;
+        }
+      }
+      if (foundNonTransparent) break;
+    }
+    if (maxY === null) {
+      throw new Error(
+        'No non-transparent pixel found while scanning rows from bottom to top.'
+      );
+    }
 
-    img.src = pathToFile;
-  });
+    // Step 3: Scanning Columns from Left to Right, until we find a non-transparent pixel
+    for (let x = 0; x < width; x++) {
+      let foundNonTransparent = false;
+      for (let y = minY; y <= maxY; y++) {
+        if (isPixelAboveTransparencyThreshold(pixels, x, y, width)) {
+          minX = x;
+          foundNonTransparent = true;
+          break;
+        }
+      }
+      if (foundNonTransparent) break;
+    }
+    if (minX === null) {
+      throw new Error(
+        'No non-transparent pixel found while scanning columns from left to right.'
+      );
+    }
+
+    // Step 4: Scanning Columns from Right to Left, until we find a non-transparent pixel
+    for (let x = width - 1; x >= 0; x--) {
+      let foundNonTransparent = false;
+      for (let y = minY; y <= maxY; y++) {
+        if (isPixelAboveTransparencyThreshold(pixels, x, y, width)) {
+          maxX = x;
+          foundNonTransparent = true;
+          break;
+        }
+      }
+      if (foundNonTransparent) break;
+    }
+    if (maxX === null) {
+      throw new Error(
+        'No non-transparent pixel found while scanning columns from right to left.'
+      );
+    }
+
+    const collisionMaskWidth = maxX - minX + 1;
+    const collisionMaskHeight = maxY - minY + 1;
+    const collisionMaskXCenter = (minX + maxX + 1) / 2;
+    const collisionMaskYCenter = (minY + maxY + 1) / 2;
+    if (collisionMaskWidth <= 0 || collisionMaskHeight <= 0) {
+      throw new Error('Invalid collision mask size.');
+    }
+
+    const newPolygon = gd.Polygon2d.createRectangle(
+      collisionMaskWidth,
+      collisionMaskHeight
+    );
+    newPolygon.move(collisionMaskXCenter, collisionMaskYCenter);
+    const polygons = new gd.VectorPolygon2d();
+    polygons.push_back(newPolygon);
+
+    return polygons;
+  } catch (e) {
+    throw new Error('Unable to load image: ' + e);
+  }
 };

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -114,7 +114,6 @@ const SortableList = SortableContainer(
               <ImageThumbnail
                 key={sprite.ptr}
                 selectable
-                key={sprite.ptr}
                 selected={!!selectedSprites[sprite.ptr]}
                 onSelect={selected => onSelectSprite(sprite, selected)}
                 onContextMenu={(x, y) => onOpenSpriteContextMenu(x, y, sprite)}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -178,13 +178,18 @@ export default function SpriteEditor({
         firstSpriteResourceName,
         {}
       );
-      const matchingCollisionMask = await getMatchingCollisionMask(
-        firstAnimationResourceSource
-      );
-
-      if (!matchingCollisionMask) {
-        return;
+      let matchingCollisionMask = null;
+      try {
+        matchingCollisionMask = await getMatchingCollisionMask(
+          firstAnimationResourceSource
+        );
+      } catch (e) {
+        console.error(
+          'Unable to create a matching collision mask for the sprite, fallback to full image collision mask.',
+          e
+        );
       }
+
       for (
         let animationIndex = 0;
         animationIndex < spriteConfiguration.getAnimationsCount();
@@ -203,8 +208,9 @@ export default function SpriteEditor({
             spriteIndex++
           ) {
             const sprite = direction.getSprite(spriteIndex);
-            sprite.setFullImageCollisionMask(false);
-            sprite.setCustomCollisionMask(matchingCollisionMask);
+            sprite.setFullImageCollisionMask(!matchingCollisionMask);
+            if (matchingCollisionMask)
+              sprite.setCustomCollisionMask(matchingCollisionMask);
           }
         }
       }


### PR DESCRIPTION
Particularly useful because jimp uses "path" which will force us to use a polyfill if we upgrade to webpack 5

This is the same behavior as with jimp.
Also added a fallback to the full image, in case the mask cannot be generated.

Tested on transparent image, the fallback works well (this is the result after uploading the image/asking for automatic):
![Capture d’écran 2023-07-03 à 09 39 12](https://github.com/4ian/GDevelop/assets/4895034/c2ca8bb1-befb-4622-a110-99025c34f7fd)
