### PR TITLE
Rename liluo to gdgames

### DIFF
--- a/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
+++ b/newIDE/app/src/PlatformSpecificAssetsEditor/PlatformSpecificAssetsDialog.js
@@ -80,7 +80,7 @@ export default class PlatformSpecificAssetsDialog extends React.Component<
   _loadFrom(project: gdProject): State {
     const platformSpecificAssets = project.getPlatformSpecificAssets();
     return {
-      thumbnailResourceName: platformSpecificAssets.get('liluo', 'thumbnail'),
+      thumbnailResourceName: platformSpecificAssets.get('gdgames', 'thumbnail'),
       desktopIconResourceNames: desktopSizes.map(size =>
         platformSpecificAssets.get('desktop', `icon-${size}`)
       ),

--- a/newIDE/app/src/Utils/GDevelopServices/Build.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Build.js
@@ -97,7 +97,7 @@ export const getWebBuildThumbnailUrl = (
   const resourceManager = project.getResourcesManager();
   const resourceName = project
     .getPlatformSpecificAssets()
-    .get('liluo', `thumbnail`);
+    .get('gdgames', `thumbnail`);
   if (!resourceManager.hasResource(resourceName)) {
     return '';
   }


### PR DESCRIPTION
This rename the liluo key of the thumbnail from the project into gdgames.