### PR TITLE
Add an action to insert a parameter

### DIFF
--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1535,6 +1535,7 @@ interface VectorParameterMetadata {
     [Ref] ParameterMetadata at(unsigned long index);
     void WRAPPED_set(unsigned long index, [Const, Ref] ParameterMetadata parameterMetadata);
     void FREE_removeFromVectorParameterMetadata(unsigned long index);
+    void FREE_insertIntoVectorParameterMetadata(unsigned long index, [Const, Ref] ParameterMetadata parameterMetadata);
     void FREE_swapInVectorParameterMetadata(unsigned long oldIndex, unsigned long newIndex);
     void clear();
 };

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -377,6 +377,12 @@ void removeFromVectorParameterMetadata(std::vector<gd::ParameterMetadata> &vec,
   vec.erase(vec.begin() + pos);
 }
 
+void insertIntoVectorParameterMetadata(std::vector<gd::ParameterMetadata> &vec,
+                                       size_t pos,
+                                       const ParameterMetadata& parameterMetadata) {
+  vec.insert(vec.begin() + pos, parameterMetadata);
+}
+
 void swapInVectorParameterMetadata(std::vector<gd::ParameterMetadata> &vec,
                                    size_t oldIndex,
                                    size_t newIndex) {

--- a/GDevelop.js/types/gdvectorparametermetadata.js
+++ b/GDevelop.js/types/gdvectorparametermetadata.js
@@ -6,6 +6,7 @@ declare class gdVectorParameterMetadata {
   at(index: number): gdParameterMetadata;
   set(index: number, parameterMetadata: gdParameterMetadata): void;
   removeFromVectorParameterMetadata(index: number): void;
+  insertIntoVectorParameterMetadata(index: number, parameterMetadata: gdParameterMetadata): void;
   swapInVectorParameterMetadata(oldIndex: number, newIndex: number): void;
   clear(): void;
   delete(): void;

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -368,7 +368,7 @@ export default class EventsFunctionParametersEditor extends React.Component<
                               click: () => this._removeParameter(i),
                             },
                             {
-                              label: i18n._(t`Add a parameter bellow`),
+                              label: i18n._(t`Add a parameter below`),
                               enabled: !isParameterDisabled(i),
                               click: () => this._addParameterAt(i + 1),
                             },

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -101,6 +101,12 @@ export default class EventsFunctionParametersEditor extends React.Component<
   _addParameter = () => {
     const { eventsFunction } = this.props;
     const parameters = eventsFunction.getParameters();
+    this._addParameterAt(parameters.size());
+  };
+
+  _addParameterAt = index => {
+    const { eventsFunction } = this.props;
+    const parameters = eventsFunction.getParameters();
     const existingParameterNames = mapVector(parameters, parameterMetadata =>
       parameterMetadata.getName()
     );
@@ -111,7 +117,7 @@ export default class EventsFunctionParametersEditor extends React.Component<
       existingParameterNames.includes(name)
     );
     newParameter.setName(newName);
-    parameters.push_back(newParameter);
+    parameters.insertIntoVectorParameterMetadata(index, newParameter);
     newParameter.delete();
     this.forceUpdate();
     this.props.onParametersUpdated();
@@ -360,6 +366,11 @@ export default class EventsFunctionParametersEditor extends React.Component<
                               label: i18n._(t`Delete`),
                               enabled: !isParameterDisabled(i),
                               click: () => this._removeParameter(i),
+                            },
+                            {
+                              label: i18n._(t`Add a parameter bellow`),
+                              enabled: !isParameterDisabled(i),
+                              click: () => this._addParameterAt(i + 1),
                             },
                             { type: 'separator' },
                             {

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -104,7 +104,7 @@ export default class EventsFunctionParametersEditor extends React.Component<
     this._addParameterAt(parameters.size());
   };
 
-  _addParameterAt = index => {
+  _addParameterAt = (index: number) => {
     const { eventsFunction } = this.props;
     const parameters = eventsFunction.getParameters();
     const existingParameterNames = mapVector(parameters, parameterMetadata =>


### PR DESCRIPTION
I've worked on an example with functions that have 3 or 4 object parameters each of them having 1 to 3 behaviors. Adding a behavior at the bottom and moving it up one row after the other was very cumbersome.

This part of the code needs a full rework but I lost so much time on this that it would be silly not to take a quarter to add this feature.