### PR TITLE
Separate 3D effects from 2D effects

### DIFF
--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -238,12 +238,8 @@ const Effect = ({
                       value={effectMetadata.type}
                       label={effectMetadata.fullName}
                       disabled={
-                        (target === 'object' &&
-                          effectMetadata.isMarkedAsNotWorkingForObjects) ||
-                        (layerRenderingType === '3d' &&
-                          effectMetadata.isMarkedAsOnlyWorkingFor2D) ||
-                        (layerRenderingType === '2d' &&
-                          effectMetadata.isMarkedAsOnlyWorkingFor3D)
+                        target === 'object' &&
+                        effectMetadata.isMarkedAsNotWorkingForObjects
                       }
                     />
                   ))}
@@ -722,7 +718,7 @@ export default function EffectsList(props: Props) {
                                 : null;
 
                             return !effectMetadata ||
-                              effectMetadata.isMarkedAsOnlyWorkingFor3D ? (
+                              !effectMetadata.isMarkedAsOnlyWorkingFor2D ? (
                               <DragSourceAndDropTarget
                                 key={effect.ptr}
                                 beginDrag={() => {
@@ -811,7 +807,7 @@ export default function EffectsList(props: Props) {
                                 : null;
 
                             return !effectMetadata ||
-                              effectMetadata.isMarkedAsOnlyWorkingFor2D ? (
+                              !effectMetadata.isMarkedAsOnlyWorkingFor3D ? (
                               <DragSourceAndDropTarget
                                 key={effect.ptr}
                                 beginDrag={() => {

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -58,7 +58,12 @@ const gd: libGDevelop = global.gd;
 
 const EFFECTS_CLIPBOARD_KIND = 'Effects';
 
-const DragSourceAndDropTarget = makeDragSourceAndDropTarget('effects-list');
+const DragSourceAndDropTarget2D = makeDragSourceAndDropTarget(
+  '2d-effects-list'
+);
+const DragSourceAndDropTarget3D = makeDragSourceAndDropTarget(
+  '3d-effects-list'
+);
 
 const styles = {
   rowContainer: {
@@ -739,7 +744,7 @@ export default function EffectsList(props: Props) {
 
                             return !effectMetadata ||
                               !effectMetadata.isMarkedAsOnlyWorkingFor2D ? (
-                              <DragSourceAndDropTarget
+                              <DragSourceAndDropTarget3D
                                 key={effect.ptr}
                                 beginDrag={() => {
                                   draggedEffect.current = effect;
@@ -789,7 +794,7 @@ export default function EffectsList(props: Props) {
                                     </div>
                                   )
                                 }
-                              </DragSourceAndDropTarget>
+                              </DragSourceAndDropTarget3D>
                             ) : null;
                           }
                         )}
@@ -830,7 +835,7 @@ export default function EffectsList(props: Props) {
 
                             return !effectMetadata ||
                               !effectMetadata.isMarkedAsOnlyWorkingFor3D ? (
-                              <DragSourceAndDropTarget
+                              <DragSourceAndDropTarget2D
                                 key={effect.ptr}
                                 beginDrag={() => {
                                   draggedEffect.current = effect;
@@ -880,7 +885,7 @@ export default function EffectsList(props: Props) {
                                     </div>
                                   )
                                 }
-                              </DragSourceAndDropTarget>
+                              </DragSourceAndDropTarget2D>
                             ) : null;
                           }
                         )}

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -92,232 +92,236 @@ export const useEffectOverridingAlertDialog = () => {
   };
 };
 
-const Effect = ({
-  layerRenderingType,
-  target,
-  project,
-  resourceManagementProps,
-  effectsContainer,
-  effect,
-  effectRef,
-  removeEffect,
-  copyEffect,
-  pasteEffectsBefore,
-  chooseEffectType,
-  allEffectMetadata,
-  onEffectsUpdated,
-  onEffectsRenamed,
-  nameErrors,
-  setNameErrors,
-  connectDragSource,
-}: {|
-  layerRenderingType: '2d' | '3d',
-  target: 'object' | 'layer',
-  project: gdProject,
-  resourceManagementProps: ResourceManagementProps,
-  effectsContainer: gdEffectsContainer,
-  effect: gdEffect,
-  effectRef: {| current: ?any |} | null,
-  onEffectsUpdated: () => void,
-  onEffectsRenamed: (oldName: string, newName: string) => void,
-  removeEffect: (effect: gdEffect) => void,
-  copyEffect: (effect: gdEffect) => void,
-  pasteEffectsBefore: (effect: gdEffect) => Promise<void>,
-  chooseEffectType: (effect: gdEffect, newEffectType: string) => void,
-  allEffectMetadata: Array<EnumeratedEffectMetadata>,
-  nameErrors: { [number]: React.Node },
-  setNameErrors: (nameErrors: { [number]: React.Node }) => void,
-  connectDragSource: ConnectDragSource,
-|}) => {
-  const gdevelopTheme = React.useContext(GDevelopThemeContext);
-
-  const preferences = React.useContext(PreferencesContext);
-  const showEffectParameterNames = preferences.values.showEffectParameterNames;
-  const setShowEffectParameterNames = preferences.setShowEffectParameterNames;
-
-  const forceUpdate = useForceUpdate();
-
-  const isClipboardContainingEffects = Clipboard.has(EFFECTS_CLIPBOARD_KIND);
-
-  const renameEffect = React.useCallback(
-    (effect: gdEffect, newName: string) => {
-      if (newName === effect.getName()) return;
-      if (nameErrors[effect.ptr]) {
-        const newNameErrors = { ...nameErrors };
-        delete newNameErrors[effect.ptr];
-        setNameErrors(newNameErrors);
-      }
-
-      if (!newName) {
-        setNameErrors({
-          ...nameErrors,
-          [effect.ptr]: <Trans>Effects cannot have empty names</Trans>,
-        });
-        return;
-      }
-
-      if (effectsContainer.hasEffectNamed(newName)) {
-        setNameErrors({
-          ...nameErrors,
-          [effect.ptr]: (
-            <Trans>The effect name {newName} is already taken</Trans>
-          ),
-        });
-        return;
-      }
-      const oldName = effect.getName();
-      effect.setName(newName);
-      forceUpdate();
-      onEffectsRenamed(oldName, newName);
-      onEffectsUpdated();
-    },
-    [
+const Effect = React.forwardRef(
+  (
+    {
+      layerRenderingType,
+      target,
+      project,
+      resourceManagementProps,
       effectsContainer,
-      forceUpdate,
-      nameErrors,
-      onEffectsRenamed,
+      effect,
+      removeEffect,
+      copyEffect,
+      pasteEffectsBefore,
+      chooseEffectType,
+      allEffectMetadata,
       onEffectsUpdated,
+      onEffectsRenamed,
+      nameErrors,
       setNameErrors,
-    ]
-  );
+      connectDragSource,
+    }: {|
+      layerRenderingType: '2d' | '3d',
+      target: 'object' | 'layer',
+      project: gdProject,
+      resourceManagementProps: ResourceManagementProps,
+      effectsContainer: gdEffectsContainer,
+      effect: gdEffect,
+      onEffectsUpdated: () => void,
+      onEffectsRenamed: (oldName: string, newName: string) => void,
+      removeEffect: (effect: gdEffect) => void,
+      copyEffect: (effect: gdEffect) => void,
+      pasteEffectsBefore: (effect: gdEffect) => Promise<void>,
+      chooseEffectType: (effect: gdEffect, newEffectType: string) => void,
+      allEffectMetadata: Array<EnumeratedEffectMetadata>,
+      nameErrors: { [number]: React.Node },
+      setNameErrors: (nameErrors: { [number]: React.Node }) => void,
+      connectDragSource: ConnectDragSource,
+    |},
+    ref
+  ) => {
+    const gdevelopTheme = React.useContext(GDevelopThemeContext);
 
-  const effectType = effect.getEffectType();
-  const effectMetadata = getEnumeratedEffectMetadata(
-    allEffectMetadata,
-    effectType
-  );
+    const preferences = React.useContext(PreferencesContext);
+    const showEffectParameterNames =
+      preferences.values.showEffectParameterNames;
+    const setShowEffectParameterNames = preferences.setShowEffectParameterNames;
 
-  return (
-    <I18n>
-      {({ i18n }) => (
-        <React.Fragment>
-          <div
-            ref={effectRef}
-            style={{
-              ...styles.rowContent,
-              backgroundColor: gdevelopTheme.list.itemsBackgroundColor,
-            }}
-          >
-            {connectDragSource(
-              <span>
-                <Column>
-                  <DragHandleIcon />
+    const forceUpdate = useForceUpdate();
+
+    const isClipboardContainingEffects = Clipboard.has(EFFECTS_CLIPBOARD_KIND);
+
+    const renameEffect = React.useCallback(
+      (effect: gdEffect, newName: string) => {
+        if (newName === effect.getName()) return;
+        if (nameErrors[effect.ptr]) {
+          const newNameErrors = { ...nameErrors };
+          delete newNameErrors[effect.ptr];
+          setNameErrors(newNameErrors);
+        }
+
+        if (!newName) {
+          setNameErrors({
+            ...nameErrors,
+            [effect.ptr]: <Trans>Effects cannot have empty names</Trans>,
+          });
+          return;
+        }
+
+        if (effectsContainer.hasEffectNamed(newName)) {
+          setNameErrors({
+            ...nameErrors,
+            [effect.ptr]: (
+              <Trans>The effect name {newName} is already taken</Trans>
+            ),
+          });
+          return;
+        }
+        const oldName = effect.getName();
+        effect.setName(newName);
+        forceUpdate();
+        onEffectsRenamed(oldName, newName);
+        onEffectsUpdated();
+      },
+      [
+        effectsContainer,
+        forceUpdate,
+        nameErrors,
+        onEffectsRenamed,
+        onEffectsUpdated,
+        setNameErrors,
+      ]
+    );
+
+    const effectType = effect.getEffectType();
+    const effectMetadata = getEnumeratedEffectMetadata(
+      allEffectMetadata,
+      effectType
+    );
+
+    return (
+      <I18n>
+        {({ i18n }) => (
+          <React.Fragment>
+            <div
+              ref={ref}
+              style={{
+                ...styles.rowContent,
+                backgroundColor: gdevelopTheme.list.itemsBackgroundColor,
+              }}
+            >
+              {connectDragSource(
+                <span>
+                  <Column>
+                    <DragHandleIcon />
+                  </Column>
+                </span>
+              )}
+              <ResponsiveLineStackLayout expand>
+                <Line noMargin expand alignItems="center">
+                  <Text noMargin noShrink>
+                    <Trans>Effect name:</Trans>
+                  </Text>
+                  <Spacer />
+                  <SemiControlledTextField
+                    margin="none"
+                    commitOnBlur
+                    errorText={nameErrors[effect.ptr]}
+                    translatableHintText={t`Enter the effect name`}
+                    value={effect.getName()}
+                    onChange={newName => {
+                      renameEffect(effect, newName);
+                    }}
+                    fullWidth
+                  />
+                </Line>
+                <Line noMargin expand alignItems="center">
+                  <Text noMargin noShrink>
+                    <Trans>Type:</Trans>
+                  </Text>
+                  <Spacer />
+                  <SelectField
+                    margin="none"
+                    value={effectType}
+                    onChange={(e, i, newEffectType: string) =>
+                      chooseEffectType(effect, newEffectType)
+                    }
+                    fullWidth
+                    translatableHintText={t`Choose the effect to apply`}
+                  >
+                    {allEffectMetadata.map(effectMetadata => (
+                      <SelectOption
+                        key={effectMetadata.type}
+                        value={effectMetadata.type}
+                        label={effectMetadata.fullName}
+                        disabled={
+                          target === 'object' &&
+                          effectMetadata.isMarkedAsNotWorkingForObjects
+                        }
+                      />
+                    ))}
+                  </SelectField>
+                </Line>
+              </ResponsiveLineStackLayout>
+              <ElementWithMenu
+                element={
+                  <IconButton size="small">
+                    <ThreeDotsMenu />
+                  </IconButton>
+                }
+                buildMenuTemplate={(i18n: I18nType) => [
+                  {
+                    label: i18n._(t`Delete`),
+                    click: () => removeEffect(effect),
+                  },
+                  {
+                    label: i18n._(t`Copy`),
+                    click: () => copyEffect(effect),
+                  },
+                  {
+                    label: i18n._(t`Paste`),
+                    click: () => pasteEffectsBefore(effect),
+                    enabled: isClipboardContainingEffects,
+                  },
+                  { type: 'separator' },
+                  {
+                    type: 'checkbox',
+                    label: i18n._(t`Show Parameter Names`),
+                    checked: showEffectParameterNames,
+                    click: () =>
+                      setShowEffectParameterNames(!showEffectParameterNames),
+                  },
+                ]}
+              />
+              <Spacer />
+            </div>
+            {effectType && (
+              <Line expand noMargin>
+                <Column expand>
+                  {effectMetadata ? (
+                    <React.Fragment>
+                      <Line>
+                        <BackgroundText>
+                          <MarkdownText source={effectMetadata.description} />
+                        </BackgroundText>
+                      </Line>
+                      <PropertiesEditor
+                        instances={[effect]}
+                        schema={effectMetadata.parametersSchema}
+                        project={project}
+                        resourceManagementProps={resourceManagementProps}
+                        renderExtraDescriptionText={
+                          showEffectParameterNames
+                            ? parameterName =>
+                                i18n._(
+                                  t`Parameter name in events: \`${parameterName}\` `
+                                )
+                            : undefined
+                        }
+                      />
+                    </React.Fragment>
+                  ) : null}
+                  <Spacer />
                 </Column>
-              </span>
+              </Line>
             )}
-            <ResponsiveLineStackLayout expand>
-              <Line noMargin expand alignItems="center">
-                <Text noMargin noShrink>
-                  <Trans>Effect name:</Trans>
-                </Text>
-                <Spacer />
-                <SemiControlledTextField
-                  margin="none"
-                  commitOnBlur
-                  errorText={nameErrors[effect.ptr]}
-                  translatableHintText={t`Enter the effect name`}
-                  value={effect.getName()}
-                  onChange={newName => {
-                    renameEffect(effect, newName);
-                  }}
-                  fullWidth
-                />
-              </Line>
-              <Line noMargin expand alignItems="center">
-                <Text noMargin noShrink>
-                  <Trans>Type:</Trans>
-                </Text>
-                <Spacer />
-                <SelectField
-                  margin="none"
-                  value={effectType}
-                  onChange={(e, i, newEffectType: string) =>
-                    chooseEffectType(effect, newEffectType)
-                  }
-                  fullWidth
-                  translatableHintText={t`Choose the effect to apply`}
-                >
-                  {allEffectMetadata.map(effectMetadata => (
-                    <SelectOption
-                      key={effectMetadata.type}
-                      value={effectMetadata.type}
-                      label={effectMetadata.fullName}
-                      disabled={
-                        target === 'object' &&
-                        effectMetadata.isMarkedAsNotWorkingForObjects
-                      }
-                    />
-                  ))}
-                </SelectField>
-              </Line>
-            </ResponsiveLineStackLayout>
-            <ElementWithMenu
-              element={
-                <IconButton size="small">
-                  <ThreeDotsMenu />
-                </IconButton>
-              }
-              buildMenuTemplate={(i18n: I18nType) => [
-                {
-                  label: i18n._(t`Delete`),
-                  click: () => removeEffect(effect),
-                },
-                {
-                  label: i18n._(t`Copy`),
-                  click: () => copyEffect(effect),
-                },
-                {
-                  label: i18n._(t`Paste`),
-                  click: () => pasteEffectsBefore(effect),
-                  enabled: isClipboardContainingEffects,
-                },
-                { type: 'separator' },
-                {
-                  type: 'checkbox',
-                  label: i18n._(t`Show Parameter Names`),
-                  checked: showEffectParameterNames,
-                  click: () =>
-                    setShowEffectParameterNames(!showEffectParameterNames),
-                },
-              ]}
-            />
-            <Spacer />
-          </div>
-          {effectType && (
-            <Line expand noMargin>
-              <Column expand>
-                {effectMetadata ? (
-                  <React.Fragment>
-                    <Line>
-                      <BackgroundText>
-                        <MarkdownText source={effectMetadata.description} />
-                      </BackgroundText>
-                    </Line>
-                    <PropertiesEditor
-                      instances={[effect]}
-                      schema={effectMetadata.parametersSchema}
-                      project={project}
-                      resourceManagementProps={resourceManagementProps}
-                      renderExtraDescriptionText={
-                        showEffectParameterNames
-                          ? parameterName =>
-                              i18n._(
-                                t`Parameter name in events: \`${parameterName}\` `
-                              )
-                          : undefined
-                      }
-                    />
-                  </React.Fragment>
-                ) : null}
-                <Spacer />
-              </Column>
-            </Line>
-          )}
-        </React.Fragment>
-      )}
-    </I18n>
-  );
-};
+          </React.Fragment>
+        )}
+      </I18n>
+    );
+  }
+);
 
 type Props = {|
   project: gdProject,
@@ -771,6 +775,7 @@ export default function EffectsList(props: Props) {
                                         <DropIndicator canDrop={canDrop} />
                                       )}
                                       <Effect
+                                        ref={effectRef}
                                         layerRenderingType={'3d'}
                                         target={target}
                                         project={project}
@@ -779,7 +784,6 @@ export default function EffectsList(props: Props) {
                                         }
                                         effectsContainer={effectsContainer}
                                         effect={effect}
-                                        effectRef={effectRef}
                                         removeEffect={removeEffect}
                                         copyEffect={copyEffect}
                                         pasteEffectsBefore={pasteEffectsBefore}
@@ -862,6 +866,7 @@ export default function EffectsList(props: Props) {
                                         <DropIndicator canDrop={canDrop} />
                                       )}
                                       <Effect
+                                        ref={effectRef}
                                         layerRenderingType={'2d'}
                                         target={target}
                                         project={project}
@@ -870,7 +875,6 @@ export default function EffectsList(props: Props) {
                                         }
                                         effectsContainer={effectsContainer}
                                         effect={effect}
-                                        effectRef={effectRef}
                                         removeEffect={removeEffect}
                                         copyEffect={copyEffect}
                                         pasteEffectsBefore={pasteEffectsBefore}

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -651,6 +651,24 @@ export default function EffectsList(props: Props) {
 
   const duplicatedUniqueEffectMetadata = getDuplicatedUniqueEffectMetadata();
 
+  // Count the number of effects to hide titles of empty sections.
+  let effect2DCount = 0;
+  let effect3DCount = 0;
+  for (let i = 0; i < effectsContainer.getEffectsCount(); i++) {
+    const effect: gdEffect = effectsContainer.getEffectAt(i);
+    const effectMetadata = getEnumeratedEffectMetadata(
+      allEffectMetadata,
+      effect.getEffectType()
+    );
+
+    if (!effectMetadata || !effectMetadata.isMarkedAsOnlyWorkingFor2D) {
+      effect3DCount++;
+    }
+    if (!effectMetadata || !effectMetadata.isMarkedAsOnlyWorkingFor3D) {
+      effect2DCount++;
+    }
+  }
+
   return (
     <I18n>
       {({ i18n }) => (
@@ -688,7 +706,7 @@ export default function EffectsList(props: Props) {
                     </Column>
                   </Line>
                 )}
-                {props.layerRenderingType !== '2d' && (
+                {props.layerRenderingType !== '2d' && effect3DCount > 0 && (
                   <Column noMargin expand>
                     {props.layerRenderingType !== '2d' && (
                       <Column noMargin>
@@ -779,7 +797,7 @@ export default function EffectsList(props: Props) {
                     </Line>
                   </Column>
                 )}
-                {props.layerRenderingType !== '3d' && (
+                {props.layerRenderingType !== '3d' && effect2DCount > 0 && (
                   <Column noMargin expand>
                     {props.layerRenderingType !== '2d' && (
                       <Column noMargin>

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -689,14 +689,16 @@ export default function EffectsList(props: Props) {
                   </Line>
                 )}
                 {props.layerRenderingType !== '2d' && (
-                  <Column>
-                    <Column>
-                      <Line>
-                        <Text size="block-title">
-                          <Trans>3D effects</Trans>
-                        </Text>
-                      </Line>
-                    </Column>
+                  <Column noMargin expand>
+                    {props.layerRenderingType !== '2d' && (
+                      <Column>
+                        <Line>
+                          <Text size="block-title">
+                            <Trans>3D effects</Trans>
+                          </Text>
+                        </Line>
+                      </Column>
+                    )}
                     <Line>
                       <Column noMargin expand>
                         {mapFor(
@@ -778,14 +780,16 @@ export default function EffectsList(props: Props) {
                   </Column>
                 )}
                 {props.layerRenderingType !== '3d' && (
-                  <Column>
-                    <Column>
-                      <Line>
-                        <Text size="block-title">
-                          <Trans>2D effects</Trans>
-                        </Text>
-                      </Line>
-                    </Column>
+                  <Column noMargin expand>
+                    {props.layerRenderingType !== '2d' && (
+                      <Column>
+                        <Line>
+                          <Text size="block-title">
+                            <Trans>2D effects</Trans>
+                          </Text>
+                        </Line>
+                      </Column>
+                    )}
                     <Line>
                       <Column noMargin expand>
                         {mapFor(

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -717,7 +717,7 @@ export default function EffectsList(props: Props) {
                 )}
                 {props.layerRenderingType !== '2d' && effect3DCount > 0 && (
                   <Column noMargin expand>
-                    {props.layerRenderingType !== '2d' && (
+                    {props.layerRenderingType !== '3d' && (
                       <Column noMargin>
                         <Line>
                           <Text size="block-title">

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -691,7 +691,7 @@ export default function EffectsList(props: Props) {
                 {props.layerRenderingType !== '2d' && (
                   <Column noMargin expand>
                     {props.layerRenderingType !== '2d' && (
-                      <Column>
+                      <Column noMargin>
                         <Line>
                           <Text size="block-title">
                             <Trans>3D effects</Trans>
@@ -782,7 +782,7 @@ export default function EffectsList(props: Props) {
                 {props.layerRenderingType !== '3d' && (
                   <Column noMargin expand>
                     {props.layerRenderingType !== '2d' && (
-                      <Column>
+                      <Column noMargin>
                         <Line>
                           <Text size="block-title">
                             <Trans>2D effects</Trans>

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -52,6 +52,7 @@ import PasteIcon from '../UI/CustomSvgIcons/Clipboard';
 import CopyIcon from '../UI/CustomSvgIcons/Copy';
 import FlatButton from '../UI/FlatButton';
 import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
+import { type ConnectDragSource } from 'react-dnd';
 
 const gd: libGDevelop = global.gd;
 
@@ -84,6 +85,237 @@ export const useEffectOverridingAlertDialog = () => {
       dismissButtonLabel: t`Omit`,
     });
   };
+};
+
+const Effect = ({
+  layerRenderingType,
+  target,
+  project,
+  resourceManagementProps,
+  effectsContainer,
+  effect,
+  effectRef,
+  removeEffect,
+  copyEffect,
+  pasteEffectsBefore,
+  chooseEffectType,
+  allEffectMetadata,
+  onEffectsUpdated,
+  onEffectsRenamed,
+  nameErrors,
+  setNameErrors,
+  connectDragSource,
+}: {|
+  layerRenderingType: '2d' | '3d',
+  target: 'object' | 'layer',
+  project: gdProject,
+  resourceManagementProps: ResourceManagementProps,
+  effectsContainer: gdEffectsContainer,
+  effect: gdEffect,
+  effectRef: {| current: ?any |} | null,
+  onEffectsUpdated: () => void,
+  onEffectsRenamed: (oldName: string, newName: string) => void,
+  removeEffect: (effect: gdEffect) => void,
+  copyEffect: (effect: gdEffect) => void,
+  pasteEffectsBefore: (effect: gdEffect) => Promise<void>,
+  chooseEffectType: (effect: gdEffect, newEffectType: string) => void,
+  allEffectMetadata: Array<EnumeratedEffectMetadata>,
+  nameErrors: { [number]: React.Node },
+  setNameErrors: (nameErrors: { [number]: React.Node }) => void,
+  connectDragSource: ConnectDragSource,
+|}) => {
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
+
+  const preferences = React.useContext(PreferencesContext);
+  const showEffectParameterNames = preferences.values.showEffectParameterNames;
+  const setShowEffectParameterNames = preferences.setShowEffectParameterNames;
+
+  const forceUpdate = useForceUpdate();
+
+  const isClipboardContainingEffects = Clipboard.has(EFFECTS_CLIPBOARD_KIND);
+
+  const renameEffect = React.useCallback(
+    (effect: gdEffect, newName: string) => {
+      if (newName === effect.getName()) return;
+      if (nameErrors[effect.ptr]) {
+        const newNameErrors = { ...nameErrors };
+        delete newNameErrors[effect.ptr];
+        setNameErrors(newNameErrors);
+      }
+
+      if (!newName) {
+        setNameErrors({
+          ...nameErrors,
+          [effect.ptr]: <Trans>Effects cannot have empty names</Trans>,
+        });
+        return;
+      }
+
+      if (effectsContainer.hasEffectNamed(newName)) {
+        setNameErrors({
+          ...nameErrors,
+          [effect.ptr]: (
+            <Trans>The effect name {newName} is already taken</Trans>
+          ),
+        });
+        return;
+      }
+      const oldName = effect.getName();
+      effect.setName(newName);
+      forceUpdate();
+      onEffectsRenamed(oldName, newName);
+      onEffectsUpdated();
+    },
+    [
+      effectsContainer,
+      forceUpdate,
+      nameErrors,
+      onEffectsRenamed,
+      onEffectsUpdated,
+      setNameErrors,
+    ]
+  );
+
+  const effectType = effect.getEffectType();
+  const effectMetadata = getEnumeratedEffectMetadata(
+    allEffectMetadata,
+    effectType
+  );
+
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <React.Fragment>
+          <div
+            ref={effectRef}
+            style={{
+              ...styles.rowContent,
+              backgroundColor: gdevelopTheme.list.itemsBackgroundColor,
+            }}
+          >
+            {connectDragSource(
+              <span>
+                <Column>
+                  <DragHandleIcon />
+                </Column>
+              </span>
+            )}
+            <ResponsiveLineStackLayout expand>
+              <Line noMargin expand alignItems="center">
+                <Text noMargin noShrink>
+                  <Trans>Effect name:</Trans>
+                </Text>
+                <Spacer />
+                <SemiControlledTextField
+                  margin="none"
+                  commitOnBlur
+                  errorText={nameErrors[effect.ptr]}
+                  translatableHintText={t`Enter the effect name`}
+                  value={effect.getName()}
+                  onChange={newName => {
+                    renameEffect(effect, newName);
+                  }}
+                  fullWidth
+                />
+              </Line>
+              <Line noMargin expand alignItems="center">
+                <Text noMargin noShrink>
+                  <Trans>Type:</Trans>
+                </Text>
+                <Spacer />
+                <SelectField
+                  margin="none"
+                  value={effectType}
+                  onChange={(e, i, newEffectType: string) =>
+                    chooseEffectType(effect, newEffectType)
+                  }
+                  fullWidth
+                  translatableHintText={t`Choose the effect to apply`}
+                >
+                  {allEffectMetadata.map(effectMetadata => (
+                    <SelectOption
+                      key={effectMetadata.type}
+                      value={effectMetadata.type}
+                      label={effectMetadata.fullName}
+                      disabled={
+                        (target === 'object' &&
+                          effectMetadata.isMarkedAsNotWorkingForObjects) ||
+                        (layerRenderingType === '3d' &&
+                          effectMetadata.isMarkedAsOnlyWorkingFor2D) ||
+                        (layerRenderingType === '2d' &&
+                          effectMetadata.isMarkedAsOnlyWorkingFor3D)
+                      }
+                    />
+                  ))}
+                </SelectField>
+              </Line>
+            </ResponsiveLineStackLayout>
+            <ElementWithMenu
+              element={
+                <IconButton size="small">
+                  <ThreeDotsMenu />
+                </IconButton>
+              }
+              buildMenuTemplate={(i18n: I18nType) => [
+                {
+                  label: i18n._(t`Delete`),
+                  click: () => removeEffect(effect),
+                },
+                {
+                  label: i18n._(t`Copy`),
+                  click: () => copyEffect(effect),
+                },
+                {
+                  label: i18n._(t`Paste`),
+                  click: () => pasteEffectsBefore(effect),
+                  enabled: isClipboardContainingEffects,
+                },
+                { type: 'separator' },
+                {
+                  type: 'checkbox',
+                  label: i18n._(t`Show Parameter Names`),
+                  checked: showEffectParameterNames,
+                  click: () =>
+                    setShowEffectParameterNames(!showEffectParameterNames),
+                },
+              ]}
+            />
+            <Spacer />
+          </div>
+          {effectType && (
+            <Line expand noMargin>
+              <Column expand>
+                {effectMetadata ? (
+                  <React.Fragment>
+                    <Line>
+                      <BackgroundText>
+                        <MarkdownText source={effectMetadata.description} />
+                      </BackgroundText>
+                    </Line>
+                    <PropertiesEditor
+                      instances={[effect]}
+                      schema={effectMetadata.parametersSchema}
+                      project={project}
+                      resourceManagementProps={resourceManagementProps}
+                      renderExtraDescriptionText={
+                        showEffectParameterNames
+                          ? parameterName =>
+                              i18n._(
+                                t`Parameter name in events: \`${parameterName}\` `
+                              )
+                          : undefined
+                      }
+                    />
+                  </React.Fragment>
+                ) : null}
+                <Spacer />
+              </Column>
+            </Line>
+          )}
+        </React.Fragment>
+      )}
+    </I18n>
+  );
 };
 
 type Props = {|
@@ -141,12 +373,7 @@ export default function EffectsList(props: Props) {
 
   const draggedEffect = React.useRef<?gdEffect>(null);
 
-  const gdevelopTheme = React.useContext(GDevelopThemeContext);
-
-  const preferences = React.useContext(PreferencesContext);
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
-  const showEffectParameterNames = preferences.values.showEffectParameterNames;
-  const setShowEffectParameterNames = preferences.setShowEffectParameterNames;
   const [nameErrors, setNameErrors] = React.useState<{ [number]: React.Node }>(
     {}
   );
@@ -156,25 +383,59 @@ export default function EffectsList(props: Props) {
     [props.project]
   );
 
+  const all3DEffectMetadata = React.useMemo(
+    () => allEffectMetadata.filter(effect => effect.isMarkedAsOnlyWorkingFor3D),
+    [allEffectMetadata]
+  );
+
+  const all2DEffectMetadata = React.useMemo(
+    () => allEffectMetadata.filter(effect => effect.isMarkedAsOnlyWorkingFor2D),
+    [allEffectMetadata]
+  );
+
   const showEffectOverridingConfirmation = useEffectOverridingAlertDialog();
 
   const forceUpdate = useForceUpdate();
 
+  const chooseEffectType = React.useCallback(
+    (effect: gdEffect, newEffectType: string) => {
+      effect.setEffectType(newEffectType);
+      const effectMetadata = getEnumeratedEffectMetadata(
+        allEffectMetadata,
+        newEffectType
+      );
+
+      if (effectMetadata) {
+        setEffectDefaultParameters(effect, effectMetadata.effectMetadata);
+      }
+
+      forceUpdate();
+      onEffectsUpdated();
+    },
+    [allEffectMetadata, forceUpdate, onEffectsUpdated]
+  );
+
   const _addEffect = React.useCallback(
-    () => {
+    (is3D: boolean) => {
       const newName = newNameGenerator('Effect', name =>
         effectsContainer.hasEffectNamed(name)
       );
-      effectsContainer.insertNewEffect(
+      const effect = effectsContainer.insertNewEffect(
         newName,
         effectsContainer.getEffectsCount()
       );
+
+      if (is3D) {
+        chooseEffectType(effect, 'Scene3D::DirectionalLight');
+      } else {
+        chooseEffectType(effect, 'Outline');
+      }
 
       forceUpdate();
       onEffectsUpdated();
       setJustAddedEffectName(newName);
     },
-    [effectsContainer, forceUpdate, onEffectsUpdated]
+    [chooseEffectType, effectsContainer, forceUpdate, onEffectsUpdated]
   );
 
   const addEffect = addCreateBadgePreHookIfNotClaimed(
@@ -355,65 +616,6 @@ export default function EffectsList(props: Props) {
     [effectsContainer, forceUpdate, onEffectsUpdated]
   );
 
-  const renameEffect = React.useCallback(
-    (effect: gdEffect, newName: string) => {
-      if (newName === effect.getName()) return;
-      if (nameErrors[effect.ptr]) {
-        const newNameErrors = { ...nameErrors };
-        delete newNameErrors[effect.ptr];
-        setNameErrors(newNameErrors);
-      }
-
-      if (!newName) {
-        setNameErrors({
-          ...nameErrors,
-          [effect.ptr]: <Trans>Effects cannot have empty names</Trans>,
-        });
-        return;
-      }
-
-      if (effectsContainer.hasEffectNamed(newName)) {
-        setNameErrors({
-          ...nameErrors,
-          [effect.ptr]: (
-            <Trans>The effect name {newName} is already taken</Trans>
-          ),
-        });
-        return;
-      }
-      const oldName = effect.getName();
-      effect.setName(newName);
-      forceUpdate();
-      onEffectsRenamed(oldName, newName);
-      onEffectsUpdated();
-    },
-    [
-      effectsContainer,
-      forceUpdate,
-      nameErrors,
-      onEffectsRenamed,
-      onEffectsUpdated,
-    ]
-  );
-
-  const chooseEffectType = React.useCallback(
-    (effect: gdEffect, newEffectType: string) => {
-      effect.setEffectType(newEffectType);
-      const effectMetadata = getEnumeratedEffectMetadata(
-        allEffectMetadata,
-        newEffectType
-      );
-
-      if (effectMetadata) {
-        setEffectDefaultParameters(effect, effectMetadata.effectMetadata);
-      }
-
-      forceUpdate();
-      onEffectsUpdated();
-    },
-    [allEffectMetadata, forceUpdate, onEffectsUpdated]
-  );
-
   const isClipboardContainingEffects = Clipboard.has(EFFECTS_CLIPBOARD_KIND);
 
   const windowWidth = useResponsiveWindowWidth();
@@ -435,7 +637,11 @@ export default function EffectsList(props: Props) {
         if (!effectMetadata) {
           continue;
         }
-        if (effectMetadata.isMarkedAsOnlyWorkingFor3D) {
+        // TODO Add an `isUnique` attribute in effect metadata if more effect are unique.
+        if (
+          effectType === 'Scene3D::LinearFog' ||
+          effectType === 'Scene3D::ExponentialFog'
+        ) {
           if (uniqueEffectTypes.includes(effectType)) {
             return effectMetadata;
           }
@@ -486,213 +692,184 @@ export default function EffectsList(props: Props) {
                     </Column>
                   </Line>
                 )}
-                <Line>
-                  <Column noMargin expand>
-                    {mapFor(
-                      0,
-                      effectsContainer.getEffectsCount(),
-                      (i: number) => {
-                        const effect: gdEffect = effectsContainer.getEffectAt(
-                          i
-                        );
-                        const effectType = effect.getEffectType();
-                        const effectMetadata = getEnumeratedEffectMetadata(
-                          allEffectMetadata,
-                          effectType
-                        );
+                {props.layerRenderingType !== '2d' && (
+                  <Column>
+                    <Column>
+                      <Line>
+                        <Text size="block-title">
+                          <Trans>3D effects</Trans>
+                        </Text>
+                      </Line>
+                    </Column>
+                    <Line>
+                      <Column noMargin expand>
+                        {mapFor(
+                          0,
+                          effectsContainer.getEffectsCount(),
+                          (i: number) => {
+                            const effect: gdEffect = effectsContainer.getEffectAt(
+                              i
+                            );
+                            const effectType = effect.getEffectType();
+                            const effectMetadata = getEnumeratedEffectMetadata(
+                              allEffectMetadata,
+                              effectType
+                            );
 
-                        const effectRef =
-                          justAddedEffectName === effect.getName()
-                            ? justAddedEffectElement
-                            : null;
+                            const effectRef =
+                              justAddedEffectName === effect.getName()
+                                ? justAddedEffectElement
+                                : null;
 
-                        return (
-                          <DragSourceAndDropTarget
-                            key={effect.ptr}
-                            beginDrag={() => {
-                              draggedEffect.current = effect;
-                              return {};
-                            }}
-                            canDrag={() => true}
-                            canDrop={() => true}
-                            drop={() => {
-                              moveEffect(effect);
-                            }}
-                          >
-                            {({
-                              connectDragSource,
-                              connectDropTarget,
-                              isOver,
-                              canDrop,
-                            }) =>
-                              connectDropTarget(
-                                <div
-                                  key={effect.ptr}
-                                  style={styles.rowContainer}
-                                >
-                                  {isOver && (
-                                    <DropIndicator canDrop={canDrop} />
-                                  )}
-                                  <div
-                                    ref={effectRef}
-                                    style={{
-                                      ...styles.rowContent,
-                                      backgroundColor:
-                                        gdevelopTheme.list.itemsBackgroundColor,
-                                    }}
-                                  >
-                                    {connectDragSource(
-                                      <span>
-                                        <Column>
-                                          <DragHandleIcon />
-                                        </Column>
-                                      </span>
-                                    )}
-                                    <ResponsiveLineStackLayout expand>
-                                      <Line noMargin expand alignItems="center">
-                                        <Text noMargin noShrink>
-                                          <Trans>Effect name:</Trans>
-                                        </Text>
-                                        <Spacer />
-                                        <SemiControlledTextField
-                                          margin="none"
-                                          commitOnBlur
-                                          errorText={nameErrors[effect.ptr]}
-                                          translatableHintText={t`Enter the effect name`}
-                                          value={effect.getName()}
-                                          onChange={newName => {
-                                            renameEffect(effect, newName);
-                                          }}
-                                          fullWidth
-                                        />
-                                      </Line>
-                                      <Line noMargin expand alignItems="center">
-                                        <Text noMargin noShrink>
-                                          <Trans>Type:</Trans>
-                                        </Text>
-                                        <Spacer />
-                                        <SelectField
-                                          margin="none"
-                                          value={effectType}
-                                          onChange={(
-                                            e,
-                                            i,
-                                            newEffectType: string
-                                          ) =>
-                                            chooseEffectType(
-                                              effect,
-                                              newEffectType
-                                            )
-                                          }
-                                          fullWidth
-                                          translatableHintText={t`Choose the effect to apply`}
-                                        >
-                                          {allEffectMetadata.map(
-                                            effectMetadata => (
-                                              <SelectOption
-                                                key={effectMetadata.type}
-                                                value={effectMetadata.type}
-                                                label={effectMetadata.fullName}
-                                                disabled={
-                                                  (props.target === 'object' &&
-                                                    effectMetadata.isMarkedAsNotWorkingForObjects) ||
-                                                  (props.layerRenderingType ===
-                                                    '3d' &&
-                                                    effectMetadata.isMarkedAsOnlyWorkingFor2D) ||
-                                                  (props.layerRenderingType ===
-                                                    '2d' &&
-                                                    effectMetadata.isMarkedAsOnlyWorkingFor3D)
-                                                }
-                                              />
-                                            )
-                                          )}
-                                        </SelectField>
-                                      </Line>
-                                    </ResponsiveLineStackLayout>
-                                    <ElementWithMenu
-                                      element={
-                                        <IconButton size="small">
-                                          <ThreeDotsMenu />
-                                        </IconButton>
-                                      }
-                                      buildMenuTemplate={(i18n: I18nType) => [
-                                        {
-                                          label: i18n._(t`Delete`),
-                                          click: () => removeEffect(effect),
-                                        },
-                                        {
-                                          label: i18n._(t`Copy`),
-                                          click: () => copyEffect(effect),
-                                        },
-                                        {
-                                          label: i18n._(t`Paste`),
-                                          click: () =>
-                                            pasteEffectsBefore(effect),
-                                          enabled: isClipboardContainingEffects,
-                                        },
-                                        { type: 'separator' },
-                                        {
-                                          type: 'checkbox',
-                                          label: i18n._(
-                                            t`Show Parameter Names`
-                                          ),
-                                          checked: showEffectParameterNames,
-                                          click: () =>
-                                            setShowEffectParameterNames(
-                                              !showEffectParameterNames
-                                            ),
-                                        },
-                                      ]}
-                                    />
-                                    <Spacer />
-                                  </div>
-                                  {effectType && (
-                                    <Line expand noMargin>
-                                      <Column expand>
-                                        {effectMetadata ? (
-                                          <React.Fragment>
-                                            <Line>
-                                              <BackgroundText>
-                                                <MarkdownText
-                                                  source={
-                                                    effectMetadata.description
-                                                  }
-                                                />
-                                              </BackgroundText>
-                                            </Line>
-                                            <PropertiesEditor
-                                              instances={[effect]}
-                                              schema={
-                                                effectMetadata.parametersSchema
-                                              }
-                                              project={props.project}
-                                              resourceManagementProps={
-                                                props.resourceManagementProps
-                                              }
-                                              renderExtraDescriptionText={
-                                                showEffectParameterNames
-                                                  ? parameterName =>
-                                                      i18n._(
-                                                        t`Parameter name in events: \`${parameterName}\` `
-                                                      )
-                                                  : undefined
-                                              }
-                                            />
-                                          </React.Fragment>
-                                        ) : null}
-                                        <Spacer />
-                                      </Column>
-                                    </Line>
-                                  )}
-                                </div>
-                              )
-                            }
-                          </DragSourceAndDropTarget>
-                        );
-                      }
-                    )}
+                            return !effectMetadata ||
+                              effectMetadata.isMarkedAsOnlyWorkingFor3D ? (
+                              <DragSourceAndDropTarget
+                                key={effect.ptr}
+                                beginDrag={() => {
+                                  draggedEffect.current = effect;
+                                  return {};
+                                }}
+                                canDrag={() => true}
+                                canDrop={() => true}
+                                drop={() => {
+                                  moveEffect(effect);
+                                }}
+                              >
+                                {({
+                                  connectDragSource,
+                                  connectDropTarget,
+                                  isOver,
+                                  canDrop,
+                                }) =>
+                                  connectDropTarget(
+                                    <div
+                                      key={effect.ptr}
+                                      style={styles.rowContainer}
+                                    >
+                                      {isOver && (
+                                        <DropIndicator canDrop={canDrop} />
+                                      )}
+                                      <Effect
+                                        layerRenderingType={'3d'}
+                                        target={target}
+                                        project={project}
+                                        resourceManagementProps={
+                                          props.resourceManagementProps
+                                        }
+                                        effectsContainer={effectsContainer}
+                                        effect={effect}
+                                        effectRef={effectRef}
+                                        removeEffect={removeEffect}
+                                        copyEffect={copyEffect}
+                                        pasteEffectsBefore={pasteEffectsBefore}
+                                        chooseEffectType={chooseEffectType}
+                                        allEffectMetadata={all3DEffectMetadata}
+                                        onEffectsUpdated={onEffectsUpdated}
+                                        onEffectsRenamed={onEffectsRenamed}
+                                        nameErrors={nameErrors}
+                                        setNameErrors={setNameErrors}
+                                        connectDragSource={connectDragSource}
+                                      />
+                                    </div>
+                                  )
+                                }
+                              </DragSourceAndDropTarget>
+                            ) : null;
+                          }
+                        )}
+                      </Column>
+                    </Line>
                   </Column>
-                </Line>
+                )}
+                {props.layerRenderingType !== '3d' && (
+                  <Column>
+                    <Column>
+                      <Line>
+                        <Text size="block-title">
+                          <Trans>2D effects</Trans>
+                        </Text>
+                      </Line>
+                    </Column>
+                    <Line>
+                      <Column noMargin expand>
+                        {mapFor(
+                          0,
+                          effectsContainer.getEffectsCount(),
+                          (i: number) => {
+                            const effect: gdEffect = effectsContainer.getEffectAt(
+                              i
+                            );
+                            const effectType = effect.getEffectType();
+                            const effectMetadata = getEnumeratedEffectMetadata(
+                              allEffectMetadata,
+                              effectType
+                            );
+
+                            const effectRef =
+                              justAddedEffectName === effect.getName()
+                                ? justAddedEffectElement
+                                : null;
+
+                            return !effectMetadata ||
+                              effectMetadata.isMarkedAsOnlyWorkingFor2D ? (
+                              <DragSourceAndDropTarget
+                                key={effect.ptr}
+                                beginDrag={() => {
+                                  draggedEffect.current = effect;
+                                  return {};
+                                }}
+                                canDrag={() => true}
+                                canDrop={() => true}
+                                drop={() => {
+                                  moveEffect(effect);
+                                }}
+                              >
+                                {({
+                                  connectDragSource,
+                                  connectDropTarget,
+                                  isOver,
+                                  canDrop,
+                                }) =>
+                                  connectDropTarget(
+                                    <div
+                                      key={effect.ptr}
+                                      style={styles.rowContainer}
+                                    >
+                                      {isOver && (
+                                        <DropIndicator canDrop={canDrop} />
+                                      )}
+                                      <Effect
+                                        layerRenderingType={'2d'}
+                                        target={target}
+                                        project={project}
+                                        resourceManagementProps={
+                                          props.resourceManagementProps
+                                        }
+                                        effectsContainer={effectsContainer}
+                                        effect={effect}
+                                        effectRef={effectRef}
+                                        removeEffect={removeEffect}
+                                        copyEffect={copyEffect}
+                                        pasteEffectsBefore={pasteEffectsBefore}
+                                        chooseEffectType={chooseEffectType}
+                                        allEffectMetadata={all2DEffectMetadata}
+                                        onEffectsUpdated={onEffectsUpdated}
+                                        onEffectsRenamed={onEffectsRenamed}
+                                        nameErrors={nameErrors}
+                                        setNameErrors={setNameErrors}
+                                        connectDragSource={connectDragSource}
+                                      />
+                                    </div>
+                                  )
+                                }
+                              </DragSourceAndDropTarget>
+                            ) : null;
+                          }
+                        )}
+                      </Column>
+                    </Line>
+                  </Column>
+                )}
               </ScrollView>
               <Column>
                 <Line noMargin>
@@ -716,38 +893,74 @@ export default function EffectsList(props: Props) {
                     />
                   </LineStackLayout>
                   <LineStackLayout justifyContent="flex-end" expand>
-                    <RaisedButton
-                      primary
-                      label={<Trans>Add an effect</Trans>}
-                      onClick={addEffect}
-                      icon={<Add />}
-                    />
+                    {props.layerRenderingType !== '2d' && (
+                      <RaisedButton
+                        primary
+                        label={<Trans>Add a 3D effect</Trans>}
+                        onClick={() => addEffect(true)}
+                        icon={<Add />}
+                      />
+                    )}
+                    {props.layerRenderingType !== '3d' && (
+                      <RaisedButton
+                        primary
+                        label={<Trans>Add a 2D effect</Trans>}
+                        onClick={() => addEffect(false)}
+                        icon={<Add />}
+                      />
+                    )}
                   </LineStackLayout>
                 </Line>
               </Column>
             </React.Fragment>
           ) : (
             <Column noMargin expand justifyContent="center">
-              <EmptyPlaceholder
-                title={<Trans>Add your first effect</Trans>}
-                description={
-                  <Trans>Effects create visual changes to the object.</Trans>
-                }
-                actionLabel={<Trans>Add an effect</Trans>}
-                helpPagePath={
-                  props.target === 'object'
-                    ? '/objects/effects'
-                    : '/interface/scene-editor/layer-effects'
-                }
-                onAction={addEffect}
-                secondaryActionIcon={<PasteIcon />}
-                secondaryActionLabel={
-                  isClipboardContainingEffects ? <Trans>Paste</Trans> : null
-                }
-                onSecondaryAction={() => {
-                  pasteEffectsAtTheEnd();
-                }}
-              />
+              {props.layerRenderingType === '' ||
+              props.layerRenderingType === '2d+3d' ? (
+                <EmptyPlaceholder
+                  title={<Trans>Add your first effect</Trans>}
+                  description={
+                    <Trans>Effects create visual changes to the object.</Trans>
+                  }
+                  actionLabel={<Trans>Add a 2D effect</Trans>}
+                  helpPagePath={
+                    props.target === 'object'
+                      ? '/objects/effects'
+                      : '/interface/scene-editor/layer-effects'
+                  }
+                  onAction={() => addEffect(false)}
+                  secondaryActionIcon={<Add />}
+                  secondaryActionLabel={<Trans>Add a 3D effect</Trans>}
+                  onSecondaryAction={() => addEffect(true)}
+                />
+              ) : (
+                <EmptyPlaceholder
+                  title={<Trans>Add your first effect</Trans>}
+                  description={
+                    <Trans>Effects create visual changes to the object.</Trans>
+                  }
+                  actionLabel={
+                    props.layerRenderingType === '3d' ? (
+                      <Trans>Add a 3D effect</Trans>
+                    ) : (
+                      <Trans>Add a 2D effect</Trans>
+                    )
+                  }
+                  helpPagePath={
+                    props.target === 'object'
+                      ? '/objects/effects'
+                      : '/interface/scene-editor/layer-effects'
+                  }
+                  onAction={() => addEffect(props.layerRenderingType === '3d')}
+                  secondaryActionIcon={<PasteIcon />}
+                  secondaryActionLabel={
+                    isClipboardContainingEffects ? <Trans>Paste</Trans> : null
+                  }
+                  onSecondaryAction={() => {
+                    pasteEffectsAtTheEnd();
+                  }}
+                />
+              )}
             </Column>
           )}
         </Column>

--- a/newIDE/app/src/LayersList/LayerEditorDialog.js
+++ b/newIDE/app/src/LayersList/LayerEditorDialog.js
@@ -281,7 +281,7 @@ const LayerEditorDialog = (props: Props) => {
                   disabled={layer.isLightingLayer()}
                 />
               </SelectField>
-              {layer.getRenderingType().includes('3d') && (
+              {layer.getRenderingType() !== '2d' && (
                 <ResponsiveLineStackLayout>
                   <SemiControlledTextField
                     commitOnBlur

--- a/newIDE/app/src/fixtures/TestExtensions.js
+++ b/newIDE/app/src/fixtures/TestExtensions.js
@@ -27,6 +27,7 @@ export const makeTestExtensions = (gd: libGDevelop) => {
       .addEffect('FakeSepia')
       .setFullName('Fake Sepia Effect')
       .setDescription('A fake sepia effect')
+      .markAsOnlyWorkingFor2D()
       .addIncludeFile('Extensions/Effects/fake-sepia.js');
     const sepiaProperties = sepiaEffect.getProperties();
     sepiaProperties
@@ -40,6 +41,7 @@ export const makeTestExtensions = (gd: libGDevelop) => {
       .setFullName('Fake Sepia Effect only for layers')
       .setDescription('A fake sepia effect only for layers')
       .addIncludeFile('Extensions/Effects/fake-sepia-only-for-layers.js')
+      .markAsOnlyWorkingFor2D()
       .markAsNotWorkingForObjects();
     const layerOnlySepiaProperties = layerOnlySepiaEffect.getProperties();
     layerOnlySepiaProperties
@@ -52,6 +54,7 @@ export const makeTestExtensions = (gd: libGDevelop) => {
       .addEffect('FakeNight')
       .setFullName('Fake Night Effect')
       .setDescription('A fake night effect')
+      .markAsOnlyWorkingFor2D()
       .addIncludeFile('Extensions/Effects/fake-night.js');
     const nightProperties = nightEffect.getProperties();
     nightProperties
@@ -69,6 +72,7 @@ export const makeTestExtensions = (gd: libGDevelop) => {
       .addEffect('FakeEffectWithVariousParameters')
       .setFullName('Fake Effect With Various Parameters')
       .setDescription('A fake effect using different parameters')
+      .markAsOnlyWorkingFor2D()
       .addIncludeFile(
         'Extensions/Effects/fake-effect-with-various-parameters.js'
       );
@@ -104,7 +108,47 @@ export const makeTestExtensions = (gd: libGDevelop) => {
       .setLabel('Some setting to enable or not for the effect')
       .setType('boolean')
       .setDescription('And some *optional* description.');
-
+    {
+      const effect3D = extension
+        .addEffect('FakeDirectionalLight')
+        .setFullName('Fake directional light')
+        .setDescription('An effect for 3D layers')
+        .markAsNotWorkingForObjects()
+        .markAsOnlyWorkingFor3D()
+        .addIncludeFile('Extensions/3D/fake-DirectionalLight.js');
+      const properties = effect3D.getProperties();
+      properties
+        .getOrCreate('color')
+        .setValue('255;255;255')
+        .setLabel('Light color')
+        .setType('color');
+      properties
+        .getOrCreate('intensity')
+        .setValue('0.5')
+        .setLabel('Intensity')
+        .setType('number');
+      properties
+        .getOrCreate('top')
+        .setValue('Y-')
+        .setLabel('3D world top')
+        .setType('choice')
+        .addExtraInfo('Y-')
+        .addExtraInfo('Z+')
+        .setGroup('Orientation');
+      properties
+        .getOrCreate('elevation')
+        .setValue('45')
+        .setLabel('Elevation (in degrees)')
+        .setType('number')
+        .setGroup('Orientation')
+        .setDescription('Maximal elevation is reached at 90°.');
+      properties
+        .getOrCreate('rotation')
+        .setValue('0')
+        .setLabel('Rotation (in degrees)')
+        .setType('number')
+        .setGroup('Orientation');
+    }
     platform.addNewExtension(extension);
     extension.delete(); // Release the extension as it was copied inside gd.JsPlatform
   }

--- a/newIDE/app/src/fixtures/TestProject.js
+++ b/newIDE/app/src/fixtures/TestProject.js
@@ -35,6 +35,8 @@ export type TestProject = {|
   testEventsBasedObject: gdEventsBasedObject,
   testObjectEventsFunction: gdEventsFunction,
   layerWithEffects: gdLayer,
+  layerWith3DEffects: gdLayer,
+  layerWith2DEffects: gdLayer,
   layerWithEffectWithoutEffectType: gdLayer,
   layerWithoutEffects: gdLayer,
   spriteObjectWithEffects: gdObject,
@@ -747,21 +749,61 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
 
   // Create a layer with some effects
   const layerWithEffects = new gd.Layer();
+  {
+    const effect1 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect1', 0);
+    const effect2 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect2', 1);
+    const effect3 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect3', 1);
+    const effect4 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect4', 1);
 
-  const effect1 = layerWithEffects.getEffects().insertNewEffect('MyEffect1', 0);
-  const effect2 = layerWithEffects.getEffects().insertNewEffect('MyEffect2', 1);
-  const effect3 = layerWithEffects.getEffects().insertNewEffect('MyEffect3', 1);
-  const effect4 = layerWithEffects.getEffects().insertNewEffect('MyEffect4', 1);
+    effect1.setEffectType('FakeSepia');
+    effect1.setDoubleParameter('opacity', 0.6);
+    effect2.setEffectType('FakeNight');
+    effect2.setDoubleParameter('intensity', 0.1);
+    effect2.setDoubleParameter('opacity', 0.2);
+    effect3.setEffectType('FakeEffectWithVariousParameters');
+    effect3.setDoubleParameter('intensity', 0.1);
+    effect3.setStringParameter('image', 'my-image');
+    effect4.setEffectType('FakeDirectionalLight');
+  }
+  // Create a layer with some 3D effects
+  const layerWith3DEffects = new gd.Layer();
+  {
+    const effect4 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect4', 1);
 
-  effect1.setEffectType('FakeSepia');
-  effect1.setDoubleParameter('opacity', 0.6);
-  effect2.setEffectType('FakeNight');
-  effect2.setDoubleParameter('intensity', 0.1);
-  effect2.setDoubleParameter('opacity', 0.2);
-  effect3.setEffectType('FakeEffectWithVariousParameters');
-  effect3.setDoubleParameter('intensity', 0.1);
-  effect3.setStringParameter('image', 'my-image');
-  effect4.setEffectType('FakeDirectionalLight');
+    effect4.setEffectType('FakeDirectionalLight');
+  }
+  // Create a layer with some 2D effects
+  const layerWith2DEffects = new gd.Layer();
+  {
+    const effect1 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect1', 0);
+    const effect2 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect2', 1);
+    const effect3 = layerWithEffects
+      .getEffects()
+      .insertNewEffect('MyEffect3', 1);
+
+    effect1.setEffectType('FakeSepia');
+    effect1.setDoubleParameter('opacity', 0.6);
+    effect2.setEffectType('FakeNight');
+    effect2.setDoubleParameter('intensity', 0.1);
+    effect2.setDoubleParameter('opacity', 0.2);
+    effect3.setEffectType('FakeEffectWithVariousParameters');
+    effect3.setDoubleParameter('intensity', 0.1);
+    effect3.setStringParameter('image', 'my-image');
+  }
 
   const layerWithEffectWithoutEffectType = new gd.Layer();
   layerWithEffectWithoutEffectType
@@ -856,6 +898,8 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
     testEventsBasedObject: buttonEventBasedObject,
     testObjectEventsFunction,
     layerWithEffects,
+    layerWith3DEffects,
+    layerWith2DEffects,
     layerWithEffectWithoutEffectType,
     layerWithoutEffects,
     spriteObjectWithEffects,

--- a/newIDE/app/src/fixtures/TestProject.js
+++ b/newIDE/app/src/fixtures/TestProject.js
@@ -751,6 +751,7 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
   const effect1 = layerWithEffects.getEffects().insertNewEffect('MyEffect1', 0);
   const effect2 = layerWithEffects.getEffects().insertNewEffect('MyEffect2', 1);
   const effect3 = layerWithEffects.getEffects().insertNewEffect('MyEffect3', 1);
+  const effect4 = layerWithEffects.getEffects().insertNewEffect('MyEffect4', 1);
 
   effect1.setEffectType('FakeSepia');
   effect1.setDoubleParameter('opacity', 0.6);
@@ -760,6 +761,7 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
   effect3.setEffectType('FakeEffectWithVariousParameters');
   effect3.setDoubleParameter('intensity', 0.1);
   effect3.setStringParameter('image', 'my-image');
+  effect4.setEffectType('FakeDirectionalLight');
 
   const layerWithEffectWithoutEffectType = new gd.Layer();
   layerWithEffectWithoutEffectType

--- a/newIDE/app/src/fixtures/TestProject.js
+++ b/newIDE/app/src/fixtures/TestProject.js
@@ -776,7 +776,7 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
   // Create a layer with some 3D effects
   const layerWith3DEffects = new gd.Layer();
   {
-    const effect4 = layerWithEffects
+    const effect4 = layerWith3DEffects
       .getEffects()
       .insertNewEffect('MyEffect4', 1);
 
@@ -785,13 +785,13 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
   // Create a layer with some 2D effects
   const layerWith2DEffects = new gd.Layer();
   {
-    const effect1 = layerWithEffects
+    const effect1 = layerWith2DEffects
       .getEffects()
       .insertNewEffect('MyEffect1', 0);
-    const effect2 = layerWithEffects
+    const effect2 = layerWith2DEffects
       .getEffects()
       .insertNewEffect('MyEffect2', 1);
-    const effect3 = layerWithEffects
+    const effect3 = layerWith2DEffects
       .getEffects()
       .insertNewEffect('MyEffect3', 1);
 

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
@@ -45,7 +45,7 @@ export const withSomeEffectsForA2DLayer = () => (
 );
 
 // TODO Add a story with 2 effects of the same type that should be unique.
-// Note that this can be done until the list of unique effect is hardcoded.
+// Note that this can't be done until the list of unique effect is hardcoded.
 
 export const withSomeEffectsForA3DLayer = () => (
   <DragAndDropContextProvider>

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
@@ -36,7 +36,7 @@ export const withSomeEffectsForA2DLayer = () => (
         layerRenderingType="2d"
         project={testProject.project}
         resourceManagementProps={fakeResourceManagementProps}
-        effectsContainer={testProject.layerWithEffects.getEffects()}
+        effectsContainer={testProject.layerWith2DEffects.getEffects()}
         onEffectsRenamed={action('effects renamed')}
         onEffectsUpdated={action('effects updated')}
       />
@@ -55,7 +55,7 @@ export const withSomeEffectsForA3DLayer = () => (
         layerRenderingType="3d"
         project={testProject.project}
         resourceManagementProps={fakeResourceManagementProps}
-        effectsContainer={testProject.layerWithEffects.getEffects()}
+        effectsContainer={testProject.layerWith3DEffects.getEffects()}
         onEffectsRenamed={action('effects renamed')}
         onEffectsUpdated={action('effects updated')}
       />

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
@@ -12,12 +12,47 @@ import fakeResourceManagementProps from '../../FakeResourceManagement';
 import { emptyStorageProvider } from '../../../ProjectsStorage/ProjectStorageProviders';
 import fakeResourceExternalEditors from '../../FakeResourceExternalEditors';
 
-export const withSomeEffectsForALayer = () => (
+export const withSomeEffectsForAMixedLayer = () => (
+  <DragAndDropContextProvider>
+    <FixedHeightFlexContainer height={600}>
+      <EffectsList
+        target="layer"
+        layerRenderingType="2d+3d"
+        project={testProject.project}
+        resourceManagementProps={fakeResourceManagementProps}
+        effectsContainer={testProject.layerWithEffects.getEffects()}
+        onEffectsRenamed={action('effects renamed')}
+        onEffectsUpdated={action('effects updated')}
+      />
+    </FixedHeightFlexContainer>
+  </DragAndDropContextProvider>
+);
+
+export const withSomeEffectsForA2DLayer = () => (
   <DragAndDropContextProvider>
     <FixedHeightFlexContainer height={600}>
       <EffectsList
         target="layer"
         layerRenderingType="2d"
+        project={testProject.project}
+        resourceManagementProps={fakeResourceManagementProps}
+        effectsContainer={testProject.layerWithEffects.getEffects()}
+        onEffectsRenamed={action('effects renamed')}
+        onEffectsUpdated={action('effects updated')}
+      />
+    </FixedHeightFlexContainer>
+  </DragAndDropContextProvider>
+);
+
+// TODO Add a story with 2 effects of the same type that should be unique.
+// Note that this can be done until the list of unique effect is hardcoded.
+
+export const withSomeEffectsForA3DLayer = () => (
+  <DragAndDropContextProvider>
+    <FixedHeightFlexContainer height={600}>
+      <EffectsList
+        target="layer"
+        layerRenderingType="3d"
         project={testProject.project}
         resourceManagementProps={fakeResourceManagementProps}
         effectsContainer={testProject.layerWithEffects.getEffects()}
@@ -60,7 +95,23 @@ export const withAnEffectWithoutEffectTypeForALayer = () => (
   </DragAndDropContextProvider>
 );
 
-export const withoutEffectsForALayer2D = () => (
+export const withoutEffectsForAMixedLayer = () => (
+  <DragAndDropContextProvider>
+    <FixedHeightFlexContainer height={600}>
+      <EffectsList
+        target="layer"
+        layerRenderingType="2d+3d"
+        project={testProject.project}
+        resourceManagementProps={fakeResourceManagementProps}
+        effectsContainer={testProject.layerWithoutEffects.getEffects()}
+        onEffectsRenamed={action('effects renamed')}
+        onEffectsUpdated={action('effects updated')}
+      />
+    </FixedHeightFlexContainer>
+  </DragAndDropContextProvider>
+);
+
+export const withoutEffectsForA2DLayer = () => (
   <DragAndDropContextProvider>
     <FixedHeightFlexContainer height={600}>
       <EffectsList
@@ -83,7 +134,7 @@ export const withoutEffectsForALayer2D = () => (
   </DragAndDropContextProvider>
 );
 
-export const withoutEffectsForALayer3D = () => (
+export const withoutEffectsForA3DLayer = () => (
   <DragAndDropContextProvider>
     <FixedHeightFlexContainer height={600}>
       <EffectsList
@@ -98,24 +149,6 @@ export const withoutEffectsForALayer3D = () => (
           onChooseResource: () => Promise.reject('Unimplemented'),
           resourceExternalEditors: fakeResourceExternalEditors,
         }}
-        effectsContainer={testProject.layerWithoutEffects.getEffects()}
-        onEffectsRenamed={action('effects renamed')}
-        onEffectsUpdated={action('effects updated')}
-      />
-    </FixedHeightFlexContainer>
-  </DragAndDropContextProvider>
-);
-
-// TODO Add a story with 2 effects of the same type that should be unique.
-
-export const withoutEffectsForAMixedLayer = () => (
-  <DragAndDropContextProvider>
-    <FixedHeightFlexContainer height={600}>
-      <EffectsList
-        target="layer"
-        layerRenderingType="2d+3d"
-        project={testProject.project}
-        resourceManagementProps={fakeResourceManagementProps}
         effectsContainer={testProject.layerWithoutEffects.getEffects()}
         onEffectsRenamed={action('effects renamed')}
         onEffectsUpdated={action('effects updated')}


### PR DESCRIPTION
Changes
- The effect list is split only visually
- 2D+3D layers have 2 button to add effects
  - a default type is chosen to make it either 2D or 3D (this doesn't work in stories because the type used as default don't exist)
  - "Outline" is the default type for 2D
  - "Directional light" is the default type for 3D
- When a layer is changed from 2D+3D to 3D, the 2D effects are still in the list but not shown (I don't think it's important enough to fix it and make the code harder to follow)
- Empty 2D+3D place holder doesn't have a "paste" button because there is already 2 buttons to add effects.

https://gdevelop-storybook.s3.amazonaws.com/effect-split/latest/index.html?path=/story/objecteditor-effectslist--with-some-effects-for-a-mixed-layer