### PR TITLE
At project opening, reopen the tabs that were opened when it was closed

### DIFF
--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -46,10 +46,10 @@ export type EditorTab = {|
   closable: boolean,
 |};
 
-export type EditorTabsState = {
+export type EditorTabsState = {|
   editors: Array<EditorTab>,
   currentTab: number,
-};
+|};
 
 export type EditorKind =
   | 'layout'
@@ -68,10 +68,10 @@ type EditorTabMetadata = {|
   editorKind: EditorKind,
 |};
 
-export type EditorTabsPersistedState = {
+export type EditorTabsPersistedState = {|
   editors: Array<EditorTabMetadata>,
   currentTab: number,
-};
+|};
 
 export type EditorOpeningOptions = {|
   label?: string,

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -51,6 +51,47 @@ export type EditorTabsState = {
   currentTab: number,
 };
 
+type EditorTabMetadata = {|
+  /** The name of the layout/external layout/external events/extension. */
+  projectItemName: ?string,
+  /** The editor kind. */
+  editorKind:
+    | 'scene'
+    | 'scene-events'
+    | 'external-layout'
+    | 'external-events'
+    | 'extension'
+    | 'debugger'
+    | 'resources',
+|};
+
+export type EditorTabsPersistedState = {
+  editors: Array<EditorTabMetadata>,
+  currentTab: number,
+};
+
+export const getEditorTabMetadata = (
+  editorTab: EditorTab
+): EditorTabMetadata => {
+  return {
+    projectItemName: editorTab.projectItemName,
+    editorKind:
+      editorTab.editorRef instanceof SceneEditorContainer
+        ? 'scene'
+        : editorTab.editorRef instanceof ExternalEventsEditorContainer
+        ? 'external-events'
+        : editorTab.editorRef instanceof ExternalLayoutEditorContainer
+        ? 'external-layout'
+        : editorTab.editorRef instanceof ResourcesEditorContainer
+        ? 'resources'
+        : editorTab.editorRef instanceof EventsEditorContainer
+        ? 'scene-events'
+        : editorTab.editorRef instanceof EventsFunctionsExtensionEditorContainer
+        ? 'extension'
+        : 'debugger',
+  };
+};
+
 export const getEditorTabsInitialState = (): EditorTabsState => {
   return {
     editors: [],

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -73,6 +73,20 @@ export type EditorTabsPersistedState = {
   currentTab: number,
 };
 
+export type EditorOpeningOptions = {|
+  label?: string,
+  icon?: React.Node,
+  projectItemName: ?string,
+  tabOptions?: TabOptions,
+  renderEditorContainer: (
+    props: RenderEditorContainerPropsWithRef
+  ) => React.Node,
+  key: string,
+  extraEditorProps?: EditorContainerExtraProps,
+  dontFocusTab?: boolean,
+  closable?: boolean,
+|};
+
 export const getEditorTabMetadata = (
   editorTab: EditorTab
 ): EditorTabMetadata => {
@@ -116,19 +130,7 @@ export const openEditorTab = (
     extraEditorProps,
     dontFocusTab,
     closable,
-  }: {|
-    label?: string,
-    icon?: React.Node,
-    projectItemName: ?string,
-    tabOptions?: TabOptions,
-    renderEditorContainer: (
-      props: RenderEditorContainerPropsWithRef
-    ) => React.Node,
-    key: string,
-    extraEditorProps?: EditorContainerExtraProps,
-    dontFocusTab?: boolean,
-    closable?: boolean,
-  |}
+  }: EditorOpeningOptions
 ): EditorTabsState => {
   const existingEditorId = findIndex(
     state.editors,

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -51,18 +51,21 @@ export type EditorTabsState = {
   currentTab: number,
 };
 
+export type EditorKind =
+  | 'scene'
+  | 'scene-events'
+  | 'external-layout'
+  | 'external-events'
+  | 'extension'
+  | 'debugger'
+  | 'resources'
+  | 'home';
+
 type EditorTabMetadata = {|
   /** The name of the layout/external layout/external events/extension. */
   projectItemName: ?string,
   /** The editor kind. */
-  editorKind:
-    | 'scene'
-    | 'scene-events'
-    | 'external-layout'
-    | 'external-events'
-    | 'extension'
-    | 'debugger'
-    | 'resources',
+  editorKind: EditorKind,
 |};
 
 export type EditorTabsPersistedState = {
@@ -88,7 +91,9 @@ export const getEditorTabMetadata = (
         ? 'scene-events'
         : editorTab.editorRef instanceof EventsFunctionsExtensionEditorContainer
         ? 'extension'
-        : 'debugger',
+        : editorTab.editorRef instanceof DebuggerEditorContainer
+        ? 'debugger'
+        : 'home',
   };
 };
 

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -172,6 +172,10 @@ export const changeCurrentTab = (
   };
 };
 
+export const isStartPageTabPresent = (state: EditorTabsState): boolean => {
+  return state.editors.some(editor => editor.key === 'start page');
+};
+
 export const closeTabsExceptIf = (
   state: EditorTabsState,
   keepPredicate: (editorTab: EditorTab) => boolean

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -52,14 +52,14 @@ export type EditorTabsState = {
 };
 
 export type EditorKind =
-  | 'scene'
-  | 'scene-events'
-  | 'external-layout'
-  | 'external-events'
-  | 'extension'
+  | 'layout'
+  | 'layout events'
+  | 'external layout'
+  | 'external events'
+  | 'events functions extension'
   | 'debugger'
   | 'resources'
-  | 'home';
+  | 'start page';
 
 type EditorTabMetadata = {|
   /** The name of the layout/external layout/external events/extension. */
@@ -94,20 +94,20 @@ export const getEditorTabMetadata = (
     projectItemName: editorTab.projectItemName,
     editorKind:
       editorTab.editorRef instanceof SceneEditorContainer
-        ? 'scene'
+        ? 'layout'
         : editorTab.editorRef instanceof ExternalEventsEditorContainer
-        ? 'external-events'
+        ? 'external events'
         : editorTab.editorRef instanceof ExternalLayoutEditorContainer
-        ? 'external-layout'
+        ? 'external layout'
         : editorTab.editorRef instanceof ResourcesEditorContainer
         ? 'resources'
         : editorTab.editorRef instanceof EventsEditorContainer
-        ? 'scene-events'
+        ? 'layout events'
         : editorTab.editorRef instanceof EventsFunctionsExtensionEditorContainer
-        ? 'extension'
+        ? 'events functions extension'
         : editorTab.editorRef instanceof DebuggerEditorContainer
         ? 'debugger'
-        : 'home',
+        : 'start page',
   };
 };
 

--- a/newIDE/app/src/MainFrame/EditorTabs/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/UseEditorTabsStateSaving.js
@@ -10,9 +10,9 @@ import {
   changeCurrentTab,
   isStartPageTabPresent,
   closeAllEditorTabs,
-} from '../MainFrame/EditorTabs/EditorTabsHandler';
-import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
-import { useDebounce } from './UseDebounce';
+} from './EditorTabsHandler';
+import PreferencesContext from '../Preferences/PreferencesContext';
+import { useDebounce } from '../../Utils/UseDebounce';
 
 type Props = {|
   editorTabs: EditorTabsState,

--- a/newIDE/app/src/MainFrame/EditorTabs/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/UseEditorTabsStateSaving.js
@@ -84,7 +84,7 @@ const useEditorTabsStateSaving = ({
 
   const saveEditorStateDebounced = useDebounce(
     saveEditorState,
-    // Debounce should be deactivated when there is currentProjectId.
+    // Debounce should be deactivated when currentProjectId is null.
     // Otherwise, if a project is open and the user switches
     // to the Home tab and then selects another project, this might save the
     // second project tabs state for the first project.

--- a/newIDE/app/src/MainFrame/EditorTabs/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/UseEditorTabsStateSaving.js
@@ -103,7 +103,7 @@ const useEditorTabsStateSaving = ({
     ]
   );
 
-  const hasARecordForEditorTabs = React.useCallback(
+  const hasAPreviousSaveForEditorTabsState = React.useCallback(
     (project: gdProject) => {
       const projectId = project.getProjectUuid();
       return !!getEditorStateForProject(projectId);
@@ -111,7 +111,7 @@ const useEditorTabsStateSaving = ({
     [getEditorStateForProject]
   );
 
-  const openEditorsAccordingToPersistedState = React.useCallback(
+  const openEditorTabsFromPersistedState = React.useCallback(
     (project: gdProject) => {
       const projectId = project.getProjectUuid();
       const editorState = getEditorStateForProject(projectId);
@@ -177,8 +177,8 @@ const useEditorTabsStateSaving = ({
   );
 
   return {
-    hasARecordForEditorTabs,
-    openEditorsAccordingToPersistedState,
+    hasAPreviousSaveForEditorTabsState,
+    openEditorTabsFromPersistedState,
   };
 };
 

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -298,7 +298,7 @@ export type Preferences = {|
   ) => ?{| editorTabs: EditorTabsPersistedState |},
   setEditorStateForProject: (
     projectId: string,
-    options: {| editorTabs: EditorTabsPersistedState |}
+    editorState?: {| editorTabs: EditorTabsPersistedState |}
   ) => void,
 |};
 
@@ -404,7 +404,7 @@ export const initialPreferences = {
   setUseShortcutToClosePreviewWindow: () => {},
   setAllowUsageOfUnicodeIdentifierNames: () => {},
   getEditorStateForProject: projectId => {},
-  setEditorStateForProject: (projectId, options) => {},
+  setEditorStateForProject: (projectId, editorState) => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -6,6 +6,7 @@ import { type EditorMosaicNode } from '../../UI/EditorMosaic';
 import { type FileMetadataAndStorageProviderName } from '../../ProjectsStorage';
 import { type ShortcutMap } from '../../KeyboardShortcuts/DefaultShortcuts';
 import { type CommandName } from '../../CommandPalette/CommandsList';
+import { type EditorTabsPersistedState } from '../EditorTabs/EditorTabsHandler';
 import optionalRequire from '../../Utils/OptionalRequire';
 import { findDefaultFolder } from '../../ProjectsStorage/LocalFileStorageProvider/LocalPathFinder';
 import { isWebGLSupported } from '../../Utils/WebGL';
@@ -213,6 +214,7 @@ export type PreferencesValues = {|
   newProjectsDefaultStorageProviderName: string,
   useShortcutToClosePreviewWindow: boolean,
   allowUsageOfUnicodeIdentifierNames: boolean,
+  editorStateByProject: { [string]: { editorTabs: EditorTabsPersistedState } },
 |};
 
 /**
@@ -291,6 +293,13 @@ export type Preferences = {|
   setNewProjectsDefaultFolder: (newProjectsDefaultFolder: string) => void,
   setUseShortcutToClosePreviewWindow: (enabled: boolean) => void,
   setAllowUsageOfUnicodeIdentifierNames: (enabled: boolean) => void,
+  getEditorStateForProject: (
+    projectId: string
+  ) => ?{| editorTabs: EditorTabsPersistedState |},
+  setEditorStateForProject: (
+    projectId: string,
+    options: {| editorTabs: EditorTabsPersistedState |}
+  ) => void,
 |};
 
 export const initialPreferences = {
@@ -336,6 +345,7 @@ export const initialPreferences = {
     newProjectsDefaultStorageProviderName: 'Cloud',
     useShortcutToClosePreviewWindow: true,
     allowUsageOfUnicodeIdentifierNames: false,
+    editorStateByProject: {},
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -393,6 +403,8 @@ export const initialPreferences = {
   setNewProjectsDefaultStorageProviderName: () => {},
   setUseShortcutToClosePreviewWindow: () => {},
   setAllowUsageOfUnicodeIdentifierNames: () => {},
+  getEditorStateForProject: projectId => {},
+  setEditorStateForProject: (projectId, options) => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -851,7 +851,7 @@ export default class PreferencesProvider extends React.Component<Props, State> {
 
   _setEditorStateForProject(
     projectId: string,
-    editorState: {| editorTabs: EditorTabsPersistedState |}
+    editorState?: {| editorTabs: EditorTabsPersistedState |}
   ) {
     this.setState(
       state => ({

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -17,6 +17,7 @@ import { type EditorMosaicNode } from '../../UI/EditorMosaic';
 import { type FileMetadataAndStorageProviderName } from '../../ProjectsStorage';
 import defaultShortcuts from '../../KeyboardShortcuts/DefaultShortcuts';
 import { type CommandName } from '../../CommandPalette/CommandsList';
+import { type EditorTabsPersistedState } from '../EditorTabs/EditorTabsHandler';
 import {
   getBrowserLanguageOrLocale,
   setLanguageInDOM,
@@ -168,6 +169,8 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     setAllowUsageOfUnicodeIdentifierNames: this._setAllowUsageOfUnicodeIdentifierNames.bind(
       this
     ),
+    getEditorStateForProject: this._getEditorStateForProject.bind(this),
+    setEditorStateForProject: this._setEditorStateForProject.bind(this),
   };
 
   componentDidMount() {
@@ -831,12 +834,33 @@ export default class PreferencesProvider extends React.Component<Props, State> {
   _setAllowUsageOfUnicodeIdentifierNames(enable: boolean) {
     const gd: libGDevelop = global.gd;
     gd.Project.allowUsageOfUnicodeIdentifierNames(enable);
-
     this.setState(
       state => ({
         values: {
           ...state.values,
           allowUsageOfUnicodeIdentifierNames: enable,
+        },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _getEditorStateForProject(projectId: string) {
+    return this.state.values.editorStateByProject[projectId];
+  }
+
+  _setEditorStateForProject(
+    projectId: string,
+    editorState: {| editorTabs: EditorTabsPersistedState |}
+  ) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          editorStateByProject: {
+            ...state.values.editorStateByProject,
+            [projectId]: editorState,
+          },
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -174,6 +174,7 @@ import useCreateProject from '../Utils/UseCreateProject';
 import { isTryingToSaveInForbiddenPath } from '../ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import { addDefaultLightToAllLayers } from '../ProjectCreation/CreateProjectDialog';
+import useEditorTabsStateSaving from '../Utils/UseEditorTabsStateSaving';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -378,6 +379,12 @@ const MainFrame = (props: Props) => {
   const inAppTutorialOrchestratorRef = React.useRef<?InAppTutorialOrchestratorInterface>(
     null
   );
+  useEditorTabsStateSaving({
+    projectId: state.currentProject
+      ? state.currentProject.getProjectUuid()
+      : null,
+    editorTabs: state.editorTabs,
+  });
 
   const eventsFunctionsExtensionsContext = React.useContext(
     EventsFunctionsExtensionsContext

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -647,8 +647,8 @@ const MainFrame = (props: Props) => {
   );
 
   const {
-    hasARecordForEditorTabs,
-    openEditorsAccordingToPersistedState,
+    hasAPreviousSaveForEditorTabsState,
+    openEditorTabsFromPersistedState,
   } = useEditorTabsStateSaving({
     currentProjectId: state.currentProject
       ? state.currentProject.getProjectUuid()
@@ -1979,8 +1979,11 @@ const MainFrame = (props: Props) => {
           return openFromFileMetadata(fileMetadata).then(state => {
             if (state) {
               const { currentProject } = state;
-              if (currentProject && hasARecordForEditorTabs(currentProject)) {
-                openEditorsAccordingToPersistedState(currentProject);
+              if (
+                currentProject &&
+                hasAPreviousSaveForEditorTabsState(currentProject)
+              ) {
+                openEditorTabsFromPersistedState(currentProject);
                 setIsLoadingProject(false);
                 setLoaderModalProgress(null, null);
                 openProjectManager(false);
@@ -2013,8 +2016,8 @@ const MainFrame = (props: Props) => {
     },
     [
       i18n,
-      hasARecordForEditorTabs,
-      openEditorsAccordingToPersistedState,
+      hasAPreviousSaveForEditorTabsState,
+      openEditorTabsFromPersistedState,
       getStorageProviderOperations,
       openFromFileMetadata,
       openSceneOrProjectManager,
@@ -2059,9 +2062,9 @@ const MainFrame = (props: Props) => {
               });
             } else if (
               currentProject &&
-              hasARecordForEditorTabs(currentProject)
+              hasAPreviousSaveForEditorTabsState(currentProject)
             ) {
-              openEditorsAccordingToPersistedState(currentProject);
+              openEditorTabsFromPersistedState(currentProject);
               setIsLoadingProject(false);
               setLoaderModalProgress(null, null);
               openProjectManager(false);
@@ -2091,8 +2094,8 @@ const MainFrame = (props: Props) => {
       getStorageProvider,
       setHasProjectOpened,
       openAllScenes,
-      hasARecordForEditorTabs,
-      openEditorsAccordingToPersistedState,
+      hasAPreviousSaveForEditorTabsState,
+      openEditorTabsFromPersistedState,
     ]
   );
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -195,12 +195,12 @@ const editorKindToRenderer: {
   [key: EditorKind]: (props: RenderEditorContainerPropsWithRef) => React.Node,
 } = {
   debugger: renderDebuggerEditorContainer,
-  'scene-events': renderEventsEditorContainer,
-  'external-events': renderExternalEventsEditorContainer,
-  scene: renderSceneEditorContainer,
-  'external-layout': renderExternalLayoutEditorContainer,
-  extension: renderEventsFunctionsExtensionEditorContainer,
-  home: renderHomePageContainer,
+  'layout events': renderEventsEditorContainer,
+  'external events': renderExternalEventsEditorContainer,
+  layout: renderSceneEditorContainer,
+  'external layout': renderExternalLayoutEditorContainer,
+  'events functions extension': renderEventsFunctionsExtensionEditorContainer,
+  'start page': renderHomePageContainer,
   resources: renderResourcesEditorContainer,
 };
 
@@ -580,44 +580,37 @@ const MainFrame = (props: Props) => {
       const label =
         kind === 'resources'
           ? i18n._(t`Resources`)
-          : kind === 'home'
+          : kind === 'start page'
           ? i18n._(t`Home`)
           : kind === 'debugger'
           ? i18n._(t`Debugger`)
-          : kind === 'scene-events'
+          : kind === 'layout events'
           ? name + ` ${i18n._(t`(Events)`)}`
-          : kind === 'extension'
+          : kind === 'events functions extension'
           ? name + ` ${i18n._(t`(Extension)`)}`
           : name;
       const tabOptions =
-        kind === 'scene'
+        kind === 'layout'
           ? { data: { scene: name, type: 'layout' } }
-          : kind === 'scene-events'
+          : kind === 'layout events'
           ? { data: { scene: name, type: 'layout-events' } }
           : undefined;
-      const key =
-        kind === 'scene'
-          ? 'layout ' + name
-          : kind === 'scene-events'
-          ? 'layout events ' + name
-          : kind === 'external-events'
-          ? 'external events ' + name
-          : kind === 'external-layout'
-          ? 'external layout ' + name
-          : kind === 'extension'
-          ? 'events functions extension ' + name
-          : kind === 'resources'
-          ? 'resources'
-          : kind === 'home'
-          ? 'start page'
-          : 'debugger';
+      const key = [
+        'layout',
+        'layout events',
+        'external events',
+        'external layout',
+        'events functions extension',
+      ].includes(kind)
+        ? `${kind} ${name}`
+        : kind;
       const icon =
-        kind === 'home' ? <HomeIcon titleAccess="Home" /> : undefined;
-      const closable = kind !== 'home';
+        kind === 'start page' ? <HomeIcon titleAccess="Home" /> : undefined;
+      const closable = kind !== 'start page';
       const extraEditorProps =
         kind === 'resources'
           ? { fileMetadata: currentFileMetadata }
-          : kind === 'home'
+          : kind === 'start page'
           ? { storageProviders: props.storageProviders }
           : undefined;
       return {
@@ -641,7 +634,6 @@ const MainFrame = (props: Props) => {
     editorTabs: state.editorTabs,
     getEditorOpeningOptions,
   });
-
 
   useOpenInitialDialog({
     openInAppTutorialDialog: (tutorialId: string) => {
@@ -1608,9 +1600,9 @@ const MainFrame = (props: Props) => {
       }: { openEventsEditor: boolean, openSceneEditor: boolean } = {},
       editorTabs = state.editorTabs
     ): EditorTabsState => {
-      const sceneEditorOptions = getEditorOpeningOptions('scene', name);
+      const sceneEditorOptions = getEditorOpeningOptions('layout', name);
       const eventsEditorOptions = {
-        ...getEditorOpeningOptions('scene-events', name),
+        ...getEditorOpeningOptions('layout events', name),
         dontFocusTab: openSceneEditor,
       };
 
@@ -1639,7 +1631,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions('external-events', name)
+          getEditorOpeningOptions('external events', name)
         ),
       }));
       openProjectManager(false);
@@ -1653,7 +1645,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions('external-layout', name)
+          getEditorOpeningOptions('external layout', name)
         ),
       }));
       openProjectManager(false);
@@ -1670,7 +1662,7 @@ const MainFrame = (props: Props) => {
       setState(state => ({
         ...state,
         editorTabs: openEditorTab(state.editorTabs, {
-          ...getEditorOpeningOptions('extension', name),
+          ...getEditorOpeningOptions('events functions extension', name),
           extraEditorProps: {
             initiallyFocusedFunctionName,
             initiallyFocusedBehaviorName,
@@ -1701,7 +1693,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions('home', '')
+          getEditorOpeningOptions('start page', '')
         ),
       }));
     },

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -176,7 +176,7 @@ import useCreateProject from '../Utils/UseCreateProject';
 import { isTryingToSaveInForbiddenPath } from '../ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import { addDefaultLightToAllLayers } from '../ProjectCreation/CreateProjectDialog';
-import useEditorTabsStateSaving from '../Utils/UseEditorTabsStateSaving';
+import useEditorTabsStateSaving from './EditorTabs/UseEditorTabsStateSaving';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -394,12 +394,6 @@ const MainFrame = (props: Props) => {
   const inAppTutorialOrchestratorRef = React.useRef<?InAppTutorialOrchestratorInterface>(
     null
   );
-  useEditorTabsStateSaving({
-    projectId: state.currentProject
-      ? state.currentProject.getProjectUuid()
-      : null,
-    editorTabs: state.editorTabs,
-  });
 
   const eventsFunctionsExtensionsContext = React.useContext(
     EventsFunctionsExtensionsContext
@@ -580,6 +574,74 @@ const MainFrame = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
+
+  const getEditorOpeningOptions = React.useCallback(
+    (kind: EditorKind, name: string) => {
+      const label =
+        kind === 'resources'
+          ? i18n._(t`Resources`)
+          : kind === 'home'
+          ? i18n._(t`Home`)
+          : kind === 'debugger'
+          ? i18n._(t`Debugger`)
+          : kind === 'scene-events'
+          ? name + ` ${i18n._(t`(Events)`)}`
+          : kind === 'extension'
+          ? name + ` ${i18n._(t`(Extension)`)}`
+          : name;
+      const tabOptions =
+        kind === 'scene'
+          ? { data: { scene: name, type: 'layout' } }
+          : kind === 'scene-events'
+          ? { data: { scene: name, type: 'layout-events' } }
+          : undefined;
+      const key =
+        kind === 'scene'
+          ? 'layout ' + name
+          : kind === 'scene-events'
+          ? 'layout events ' + name
+          : kind === 'external-events'
+          ? 'external events ' + name
+          : kind === 'external-layout'
+          ? 'external layout ' + name
+          : kind === 'extension'
+          ? 'events functions extension ' + name
+          : kind === 'resources'
+          ? 'resources'
+          : kind === 'home'
+          ? 'start page'
+          : 'debugger';
+      const icon =
+        kind === 'home' ? <HomeIcon titleAccess="Home" /> : undefined;
+      const closable = kind !== 'home';
+      const extraEditorProps =
+        kind === 'resources'
+          ? { fileMetadata: currentFileMetadata }
+          : kind === 'home'
+          ? { storageProviders: props.storageProviders }
+          : undefined;
+      return {
+        icon,
+        closable,
+        label,
+        projectItemName: name,
+        tabOptions,
+        renderEditorContainer: editorKindToRenderer[kind],
+        extraEditorProps,
+        key,
+      };
+    },
+    [i18n, currentFileMetadata, props.storageProviders]
+  );
+
+  useEditorTabsStateSaving({
+    projectId: state.currentProject
+      ? state.currentProject.getProjectUuid()
+      : null,
+    editorTabs: state.editorTabs,
+    getEditorOpeningOptions,
+  });
+
 
   useOpenInitialDialog({
     openInAppTutorialDialog: (tutorialId: string) => {
@@ -1537,65 +1599,6 @@ const MainFrame = (props: Props) => {
     [hasPreviewsRunning, launchPreview]
   );
 
-  const getEditorOpeningOptions = React.useCallback(
-    (name: string, kind: EditorKind) => {
-      const label =
-        kind === 'resources'
-          ? i18n._(t`Resources`)
-          : kind === 'home'
-          ? i18n._(t`Home`)
-          : kind === 'debugger'
-          ? i18n._(t`Debugger`)
-          : kind === 'scene-events'
-          ? name + ` ${i18n._(t`(Events)`)}`
-          : kind === 'extension'
-          ? name + ` ${i18n._(t`(Extension)`)}`
-          : name;
-      const tabOptions =
-        kind === 'scene'
-          ? { data: { scene: name, type: 'layout' } }
-          : kind === 'scene-events'
-          ? { data: { scene: name, type: 'layout-events' } }
-          : undefined;
-      const key =
-        kind === 'scene'
-          ? 'layout ' + name
-          : kind === 'scene-events'
-          ? 'layout events ' + name
-          : kind === 'external-events'
-          ? 'external events ' + name
-          : kind === 'external-layout'
-          ? 'external layout ' + name
-          : kind === 'extension'
-          ? 'events functions extension ' + name
-          : kind === 'resources'
-          ? 'resources'
-          : kind === 'home'
-          ? 'start page'
-          : 'debugger';
-      const icon =
-        kind === 'home' ? <HomeIcon titleAccess="Home" /> : undefined;
-      const closable = kind !== 'home';
-      const extraEditorProps =
-        kind === 'resources'
-          ? { fileMetadata: currentFileMetadata }
-          : kind === 'home'
-          ? { storageProviders: props.storageProviders }
-          : undefined;
-      return {
-        icon,
-        closable,
-        label,
-        projectItemName: name,
-        tabOptions,
-        renderEditorContainer: editorKindToRenderer[kind],
-        extraEditorProps,
-        key,
-      };
-    },
-    [i18n, currentFileMetadata, props.storageProviders]
-  );
-
   const openLayout = React.useCallback(
     (
       name: string,
@@ -1605,9 +1608,9 @@ const MainFrame = (props: Props) => {
       }: { openEventsEditor: boolean, openSceneEditor: boolean } = {},
       editorTabs = state.editorTabs
     ): EditorTabsState => {
-      const sceneEditorOptions = getEditorOpeningOptions(name, 'scene');
+      const sceneEditorOptions = getEditorOpeningOptions('scene', name);
       const eventsEditorOptions = {
-        ...getEditorOpeningOptions(name, 'scene-events'),
+        ...getEditorOpeningOptions('scene-events', name),
         dontFocusTab: openSceneEditor,
       };
 
@@ -1636,7 +1639,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions(name, 'external-events')
+          getEditorOpeningOptions('external-events', name)
         ),
       }));
       openProjectManager(false);
@@ -1650,7 +1653,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions(name, 'external-layout')
+          getEditorOpeningOptions('external-layout', name)
         ),
       }));
       openProjectManager(false);
@@ -1667,7 +1670,7 @@ const MainFrame = (props: Props) => {
       setState(state => ({
         ...state,
         editorTabs: openEditorTab(state.editorTabs, {
-          ...getEditorOpeningOptions(name, 'extension'),
+          ...getEditorOpeningOptions('extension', name),
           extraEditorProps: {
             initiallyFocusedFunctionName,
             initiallyFocusedBehaviorName,
@@ -1685,7 +1688,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions('', 'resources')
+          getEditorOpeningOptions('resources', '')
         ),
       }));
     },
@@ -1698,7 +1701,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions('', 'home')
+          getEditorOpeningOptions('home', '')
         ),
       }));
     },
@@ -1711,7 +1714,7 @@ const MainFrame = (props: Props) => {
         ...state,
         editorTabs: openEditorTab(
           state.editorTabs,
-          getEditorOpeningOptions('', 'debugger')
+          getEditorOpeningOptions('debugger', '')
         ),
       }));
     },

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/styles.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/styles.js
@@ -1,3 +1,4 @@
+// @flow
 const styles = {
   coordinateColumn: {
     width: 96,

--- a/newIDE/app/src/UI/Table.js
+++ b/newIDE/app/src/UI/Table.js
@@ -6,6 +6,18 @@ import MUITableCell from '@material-ui/core/TableCell';
 import MUITableHead from '@material-ui/core/TableHead';
 import MUITableRow from '@material-ui/core/TableRow';
 
+type TableCellCommonProps = {|
+  children?: React.Node, // Content for the cell
+  style?: {|
+    height?: number,
+    width?: number | string,
+    paddingLeft?: number,
+    paddingRight?: number,
+    textAlign?: string,
+    wordBreak?: 'break-word',
+  |},
+|}
+
 type TableProps = {|
   children: React.Node, // Should be TableHeader, TableBody or TableFooter
 |};
@@ -47,14 +59,8 @@ export class TableHeader extends React.Component<TableHeaderProps, {||}> {
 }
 
 type TableHeaderColumnProps = {|
-  children?: React.Node, // Text of the column
+  ...TableCellCommonProps,
   padding?: 'none',
-  style?: {|
-    height?: number,
-    width?: number | string,
-    textAlign?: 'left' | 'right',
-    paddingRight?: number,
-  |},
 |};
 
 /**
@@ -89,16 +95,8 @@ export class TableRow extends React.Component<TableRowProps, {||}> {
 }
 
 type TableRowColumnProps = {|
-  children?: React.Node, // Content for the cell
+  ...TableCellCommonProps,
   padding?: 'none',
-  style?: {|
-    height?: number,
-    width?: number | string,
-    paddingLeft?: number,
-    paddingRight?: number,
-    textAlign?: string,
-    wordBreak?: 'break-word',
-  |},
 |};
 
 /**

--- a/newIDE/app/src/UI/Table.js
+++ b/newIDE/app/src/UI/Table.js
@@ -16,7 +16,7 @@ type TableCellCommonProps = {|
     textAlign?: string,
     wordBreak?: 'break-word',
   |},
-|}
+|};
 
 type TableProps = {|
   children: React.Node, // Should be TableHeader, TableBody or TableFooter

--- a/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
@@ -24,7 +24,13 @@ const useEditorTabsStateSaving = ({ projectId, editorTabs }: Props) => {
           .filter(editor => editor.key !== 'start page')
           .map(getEditorTabMetadata),
       };
-      setEditorStateForProject(projectId, { editorTabs: editorState });
+
+      setEditorStateForProject(
+        projectId,
+        editorState.editors.length === 0
+          ? undefined
+          : { editorTabs: editorState }
+      );
     },
     [projectId, editorTabs, setEditorStateForProject]
   );

--- a/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
@@ -37,7 +37,8 @@ const useEditorTabsStateSaving = ({
   } = React.useContext(PreferencesContext);
   const saveEditorState = React.useCallback(
     () => {
-      if (!currentProjectId) return;
+      // Do not save the state if the user is on the start page
+      if (!currentProjectId || editorTabs.currentTab === 0) return;
       const editorState = {
         currentTab: editorTabs.currentTab,
         editors: editorTabs.editors

--- a/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
@@ -1,0 +1,32 @@
+// @flow
+import * as React from 'react';
+
+import {
+  getEditorTabMetadata,
+  type EditorTabsState,
+} from '../MainFrame/EditorTabs/EditorTabsHandler';
+import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
+
+type Props = {|
+  editorTabs: EditorTabsState,
+  projectId: string | null,
+|};
+
+const useEditorTabsStateSaving = ({ projectId, editorTabs }: Props) => {
+  const { setEditorStateForProject } = React.useContext(PreferencesContext);
+  React.useEffect(
+    () => {
+      if (!projectId) return;
+      const editorState = {
+        currentTab: editorTabs.currentTab,
+        editors: editorTabs.editors
+          .filter(editor => editor.key !== 'start page')
+          .map(getEditorTabMetadata),
+      };
+      setEditorStateForProject(projectId, { editorTabs: editorState });
+    },
+    [projectId, editorTabs, setEditorStateForProject]
+  );
+};
+
+export default useEditorTabsStateSaving;

--- a/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
@@ -6,6 +6,7 @@ import {
   type EditorTabsState,
 } from '../MainFrame/EditorTabs/EditorTabsHandler';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
+import { useDebounce } from './UseDebounce';
 
 type Props = {|
   editorTabs: EditorTabsState,
@@ -14,7 +15,7 @@ type Props = {|
 
 const useEditorTabsStateSaving = ({ projectId, editorTabs }: Props) => {
   const { setEditorStateForProject } = React.useContext(PreferencesContext);
-  React.useEffect(
+  const saveEditorState = React.useCallback(
     () => {
       if (!projectId) return;
       const editorState = {
@@ -26,6 +27,15 @@ const useEditorTabsStateSaving = ({ projectId, editorTabs }: Props) => {
       setEditorStateForProject(projectId, { editorTabs: editorState });
     },
     [projectId, editorTabs, setEditorStateForProject]
+  );
+
+  const saveEditorStateDebounced = useDebounce(saveEditorState, 1000);
+
+  React.useEffect(
+    () => {
+      saveEditorStateDebounced();
+    },
+    [saveEditorStateDebounced, projectId, editorTabs, setEditorStateForProject]
   );
 };
 

--- a/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
+++ b/newIDE/app/src/Utils/UseEditorTabsStateSaving.js
@@ -4,6 +4,8 @@ import * as React from 'react';
 import {
   getEditorTabMetadata,
   type EditorTabsState,
+  type EditorOpeningOptions,
+  type EditorKind,
 } from '../MainFrame/EditorTabs/EditorTabsHandler';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import { useDebounce } from './UseDebounce';
@@ -11,10 +13,21 @@ import { useDebounce } from './UseDebounce';
 type Props = {|
   editorTabs: EditorTabsState,
   projectId: string | null,
+  getEditorOpeningOptions: (
+    kind: EditorKind,
+    name: string
+  ) => EditorOpeningOptions,
 |};
 
-const useEditorTabsStateSaving = ({ projectId, editorTabs }: Props) => {
-  const { setEditorStateForProject } = React.useContext(PreferencesContext);
+const useEditorTabsStateSaving = ({
+  projectId,
+  editorTabs,
+  getEditorOpeningOptions,
+}: Props) => {
+  const {
+    setEditorStateForProject,
+    getEditorStateForProject,
+  } = React.useContext(PreferencesContext);
   const saveEditorState = React.useCallback(
     () => {
       if (!projectId) return;
@@ -42,6 +55,22 @@ const useEditorTabsStateSaving = ({ projectId, editorTabs }: Props) => {
       saveEditorStateDebounced();
     },
     [saveEditorStateDebounced, projectId, editorTabs, setEditorStateForProject]
+  );
+
+  const openEditorsAccordingToPersistedState = React.useCallback(
+    () => {
+      if (!projectId) return;
+      const editorState = getEditorStateForProject(projectId);
+      if (!editorState) return;
+      const editorsOpeningOptions = editorState.editorTabs.editors.map(
+        editorMetadata =>
+          getEditorOpeningOptions(
+            editorMetadata.editorKind,
+            editorMetadata.projectItemName || ''
+          )
+      );
+    },
+    [getEditorOpeningOptions, projectId]
   );
 };
 


### PR DESCRIPTION
I used the projectUuid to store the values in the preferences but I wonder if I could use the project file metadata identifier instead.

TODO:
- [x] Fix unrelated Flow issue