### PR TITLE
Import export extension web app

### DIFF
--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -27,6 +27,7 @@ import DownloadFileStorageProvider from './ProjectsStorage/DownloadFileStoragePr
 import CloudStorageProvider from './ProjectsStorage/CloudStorageProvider';
 import BrowserResourceMover from './ProjectsStorage/ResourceMover/BrowserResourceMover';
 import BrowserResourceFetcher from './ProjectsStorage/ResourceFetcher/BrowserResourceFetcher';
+import BrowserEventsFunctionsExtensionOpener from './EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener';
 
 export const create = (authentication: Authentication) => {
   Window.setUpContextMenu();
@@ -40,7 +41,7 @@ export const create = (authentication: Authentication) => {
       disableCheckForUpdates={!!appArguments['disable-update-check']}
       makeEventsFunctionCodeWriter={makeBrowserS3EventsFunctionCodeWriter}
       eventsFunctionsExtensionWriter={null}
-      eventsFunctionsExtensionOpener={null}
+      eventsFunctionsExtensionOpener={BrowserEventsFunctionsExtensionOpener}
     >
       {({ i18n }) => (
         <ProjectStorageProviders

--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -28,6 +28,7 @@ import CloudStorageProvider from './ProjectsStorage/CloudStorageProvider';
 import BrowserResourceMover from './ProjectsStorage/ResourceMover/BrowserResourceMover';
 import BrowserResourceFetcher from './ProjectsStorage/ResourceFetcher/BrowserResourceFetcher';
 import BrowserEventsFunctionsExtensionOpener from './EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener';
+import BrowserEventsFunctionsExtensionWriter from './EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter';
 
 export const create = (authentication: Authentication) => {
   Window.setUpContextMenu();
@@ -40,7 +41,7 @@ export const create = (authentication: Authentication) => {
       authentication={authentication}
       disableCheckForUpdates={!!appArguments['disable-update-check']}
       makeEventsFunctionCodeWriter={makeBrowserS3EventsFunctionCodeWriter}
-      eventsFunctionsExtensionWriter={null}
+      eventsFunctionsExtensionWriter={BrowserEventsFunctionsExtensionWriter}
       eventsFunctionsExtensionOpener={BrowserEventsFunctionsExtensionOpener}
     >
       {({ i18n }) => (

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
@@ -48,13 +48,20 @@ export default class BrowserEventsFunctionsExtensionOpener {
       try {
         const reader = new FileReader();
         reader.onloadend = event => {
-          const content = reader.result;
-          if (!content) {
-            throw new Error('The selected file is empty');
+          try {
+            const content = reader.result;
+            if (!content) {
+              throw new Error('The selected file is empty');
+            }
+            // content should be a string since the method readAsText guarantees it.
+            // $FlowExpectedError
+            return resolve(JSON.parse(content));
+          } catch (error) {
+            console.error('An error occurred when parsing the file content: ', {
+              error,
+            });
+            reject(error);
           }
-          // content should be a string since the method readAsText guarantees it.
-          // $FlowExpectedError
-          return resolve(JSON.parse(content));
         };
         reader.readAsText(file, 'UTF-8');
       } catch (error) {

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
@@ -1,0 +1,34 @@
+// @flow
+
+export default class BrowserEventsFunctionsExtensionOpener {
+  static chooseEventsFunctionExtensionFile = (): Promise<?any> => {
+    return new Promise(resolve => {
+      const adhocInput = document.createElement('input');
+      adhocInput.type = 'file';
+      adhocInput.multiple = false;
+      adhocInput.onchange = e => {
+        const file = e.target.files[0];
+        return resolve(file);
+      };
+
+      adhocInput.click();
+    });
+  };
+
+  static readEventsFunctionExtensionFile = (file: any): Promise<Object> => {
+    return new Promise(resolve => {
+      const reader = new FileReader();
+      reader.onloadend = event => {
+        const content = reader.result;
+        if (!content) {
+          throw new Error('The selected file is empty')
+        }
+        // content should be a string since the method readAsText guarantees it.
+        // $FlowExpectedError
+        return resolve(JSON.parse(content))
+      };
+      reader.readAsText(file, 'UTF-8');
+
+    })
+  };
+}

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
@@ -17,19 +17,25 @@ export default class BrowserEventsFunctionsExtensionOpener {
   };
 
   static readEventsFunctionExtensionFile = (file: any): Promise<Object> => {
-    return new Promise(resolve => {
-      const reader = new FileReader();
-      reader.onloadend = event => {
-        const content = reader.result;
-        if (!content) {
-          throw new Error('The selected file is empty')
-        }
-        // content should be a string since the method readAsText guarantees it.
-        // $FlowExpectedError
-        return resolve(JSON.parse(content))
-      };
-      reader.readAsText(file, 'UTF-8');
-
-    })
+    return new Promise((resolve, reject) => {
+      try {
+        const reader = new FileReader();
+        reader.onloadend = event => {
+          const content = reader.result;
+          if (!content) {
+            throw new Error('The selected file is empty');
+          }
+          // content should be a string since the method readAsText guarantees it.
+          // $FlowExpectedError
+          return resolve(JSON.parse(content));
+        };
+        reader.readAsText(file, 'UTF-8');
+      } catch (error) {
+        console.error('An error occurred when reading the file: ', {
+          error,
+        });
+        reject(error);
+      }
+    });
   };
 }

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
@@ -69,33 +69,24 @@ export default class BrowserEventsFunctionsExtensionOpener {
     });
   };
 
-  static readEventsFunctionExtensionFile = (file: any): Promise<Object> => {
-    return new Promise((resolve, reject) => {
-      try {
-        const reader = new FileReader();
-        reader.onloadend = event => {
-          try {
-            const content = reader.result;
-            if (!content) {
-              throw new Error('The selected file is empty');
-            }
-            // content should be a string since the method readAsText guarantees it.
-            // $FlowExpectedError
-            return resolve(JSON.parse(content));
-          } catch (error) {
-            console.error('An error occurred when parsing the file content: ', {
-              error,
-            });
-            reject(error);
-          }
-        };
-        reader.readAsText(file, 'UTF-8');
-      } catch (error) {
-        console.error('An error occurred when reading the file: ', {
-          error,
-        });
-        reject(error);
-      }
-    });
+  static readEventsFunctionExtensionFile = async (
+    file: any
+  ): Promise<Object> => {
+    if (!(file instanceof File)) {
+      console.error('Given file is not a JS File object. Instead it is:', {
+        file,
+      });
+      throw new Error('Given file is not a JS File object.');
+    }
+
+    try {
+      const content = await file.text();
+      return JSON.parse(content);
+    } catch (error) {
+      console.error('An error occurred when parsing the file content: ', {
+        error,
+      });
+      throw error;
+    }
   };
 }

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
@@ -12,6 +12,33 @@ export default class BrowserEventsFunctionsExtensionOpener {
         return resolve(file);
       };
 
+      // There is no built-in way to know if the user closed the file picking dialog
+      // with the cancel button. What follows is an implementation that follows
+      // https://stackoverflow.com/questions/71435515/how-can-i-detect-that-the-cancel-button-has-been-clicked-on-a-input-type-file.
+
+      const onFocusBackWindow = () => {
+        window.removeEventListener('focus', onFocusBackWindow);
+        if (document.body) {
+          document.body.addEventListener(
+            'pointermove',
+            onFilePickingDialogFinishedClosing
+          );
+        }
+      };
+      const onFilePickingDialogFinishedClosing = () => {
+        if (document.body) {
+          document.body.removeEventListener(
+            'pointermove',
+            onFilePickingDialogFinishedClosing
+          );
+        }
+        if (!adhocInput.files.length) {
+          console.log('No file selected.');
+          resolve(null);
+        }
+      };
+      window.addEventListener('focus', onFocusBackWindow);
+
       adhocInput.click();
     });
   };

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
@@ -59,7 +59,6 @@ export default class BrowserEventsFunctionsExtensionOpener {
             );
           }
           if (!adhocInput.files.length) {
-            console.log('No file selected.');
             resolve(null);
           }
         };

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionOpener.js
@@ -6,6 +6,7 @@ export default class BrowserEventsFunctionsExtensionOpener {
       const adhocInput = document.createElement('input');
       adhocInput.type = 'file';
       adhocInput.multiple = false;
+      adhocInput.accept = 'application/json,.json';
       adhocInput.onchange = e => {
         const file = e.target.files[0];
         return resolve(file);

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
@@ -1,0 +1,69 @@
+// @flow
+import { serializeToJSObject } from '../../Utils/Serializer';
+
+const downloadStringContentAsFile = (
+  filename: string,
+  content: string
+): Promise<void> => {
+  const blob = new Blob([content], { type: 'application/json' });
+  const blobUrl = URL.createObjectURL(blob);
+
+  const adhocLink = document.createElement('a');
+  adhocLink.href = blobUrl;
+  adhocLink.download = filename;
+  adhocLink.innerHTML = 'Click here to download the file';
+  if (document.body) {
+    document.body.appendChild(adhocLink);
+    adhocLink.click();
+    adhocLink.remove();
+  }
+  return Promise.resolve();
+};
+
+export default class BrowserEventsFunctionsExtensionWriter {
+  static chooseEventsFunctionExtensionFile = (
+    extensionName?: string
+  ): Promise<?string> => {
+    return Promise.resolve(extensionName);
+  };
+
+  static writeEventsFunctionsExtension = (
+    extension: gdEventsFunctionsExtension,
+    filename: string
+  ): Promise<void> => {
+    const serializedObject = serializeToJSObject(extension);
+    return downloadStringContentAsFile(
+      filename,
+      JSON.stringify(serializedObject)
+    ).catch(err => {
+      console.error('Unable to write the events function extension:', err);
+      throw err;
+    });
+  };
+
+  static chooseCustomObjectFile = (objectName?: string): Promise<?string> => {
+    return Promise.resolve(objectName);
+  };
+
+  static writeCustomObject = (
+    customObject: gdObject,
+    filename: string
+  ): Promise<void> => {
+    const exportedObject = customObject.clone().get();
+    exportedObject.setTags('');
+    exportedObject.getVariables().clear();
+    exportedObject.getEffects().clear();
+    exportedObject
+      .getAllBehaviorNames()
+      .toJSArray()
+      .forEach(name => exportedObject.removeBehavior(name));
+    const serializedObject = serializeToJSObject(exportedObject);
+    return downloadStringContentAsFile(
+      filename,
+      JSON.stringify(serializedObject)
+    ).catch(err => {
+      console.error('Unable to write the events function extension:', err);
+      throw err;
+    });
+  };
+}

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
@@ -11,7 +11,6 @@ const downloadStringContentAsFile = (
   const adhocLink = document.createElement('a');
   adhocLink.href = blobUrl;
   adhocLink.download = filename;
-  adhocLink.innerHTML = 'Click here to download the file';
   if (document.body) {
     document.body.appendChild(adhocLink);
     adhocLink.click();

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
@@ -16,6 +16,8 @@ const downloadStringContentAsFile = (
     document.body.appendChild(adhocLink);
     adhocLink.click();
     adhocLink.remove();
+  } else {
+    return Promise.reject(new Error("Document body couldn't be found."));
   }
   return Promise.resolve();
 };

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
@@ -1,7 +1,7 @@
 // @flow
 import { serializeToJSObject } from '../../Utils/Serializer';
 
-const downloadStringContentAsFile = (
+const downloadStringContentAsFile = async (
   filename: string,
   content: string
 ): Promise<void> => {
@@ -16,30 +16,32 @@ const downloadStringContentAsFile = (
     adhocLink.click();
     adhocLink.remove();
   } else {
-    return Promise.reject(new Error("Document body couldn't be found."));
+    throw new Error("Document body couldn't be found.");
   }
-  return Promise.resolve();
+  return;
 };
 
 export default class BrowserEventsFunctionsExtensionWriter {
-  static chooseEventsFunctionExtensionFile = (
+  static chooseEventsFunctionExtensionFile = async (
     extensionName?: string
   ): Promise<?string> => {
-    return Promise.resolve(extensionName);
+    return extensionName;
   };
 
-  static writeEventsFunctionsExtension = (
+  static writeEventsFunctionsExtension = async (
     extension: gdEventsFunctionsExtension,
     filename: string
   ): Promise<void> => {
     const serializedObject = serializeToJSObject(extension);
-    return downloadStringContentAsFile(
-      filename,
-      JSON.stringify(serializedObject)
-    ).catch(err => {
-      console.error('Unable to write the events function extension:', err);
-      throw err;
-    });
+    try {
+      await downloadStringContentAsFile(
+        filename,
+        JSON.stringify(serializedObject)
+      );
+    } catch (error) {
+      console.error('Unable to write the events function extension:', error);
+      throw error;
+    }
   };
 
   static chooseCustomObjectFile = (objectName?: string): Promise<?string> => {

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/BrowserEventsFunctionsExtensionWriter.js
@@ -44,8 +44,10 @@ export default class BrowserEventsFunctionsExtensionWriter {
     }
   };
 
-  static chooseCustomObjectFile = (objectName?: string): Promise<?string> => {
-    return Promise.resolve(objectName);
+  static chooseCustomObjectFile = async (
+    objectName?: string
+  ): Promise<?string> => {
+    return objectName;
   };
 
   static writeCustomObject = (

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/Storage/index.js
@@ -1,8 +1,8 @@
 // @flow
 
 export type EventsFunctionsExtensionOpener = {
-  chooseEventsFunctionExtensionFile: () => Promise<?string>,
-  readEventsFunctionExtensionFile: (filepath: string) => Promise<Object>,
+  chooseEventsFunctionExtensionFile: () => Promise<?any>,
+  readEventsFunctionExtensionFile: (filepath: any) => Promise<Object>,
 };
 
 export type EventsFunctionsExtensionWriter = {


### PR DESCRIPTION
Fixes #5345 

Adds extension writer and opener in order to import/export extension in/from the web app.

TODO:
- [x] Find a way to detect if the user clicked cancel on the file picking dialog OR set the `isInstalling` flag of ExtensionsSearchDialog **after** the user has picked a file