### PR TITLE
Simplify display of leaderboard entries

### DIFF
--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardEntriesTable.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardEntriesTable.js
@@ -15,7 +15,7 @@ import PlaceholderLoader from '../../UI/PlaceholderLoader';
 import Text from '../../UI/Text';
 import { textEllipsisStyle } from '../../UI/TextEllipsis';
 import {
-  type LeaderboardDisplayData,
+  type LeaderboardEntry,
   type LeaderboardCustomizationSettings,
 } from '../../Utils/GDevelopServices/Play';
 import { formatScore } from '../../Leaderboard/LeaderboardScoreFormatter';
@@ -26,9 +26,9 @@ import SkipBack from '../../UI/CustomSvgIcons/SkipBack';
 import Error from '../../UI/CustomSvgIcons/Error';
 
 type Props = {|
-  entries: ?Array<LeaderboardDisplayData>,
+  entries: ?Array<LeaderboardEntry>,
   customizationSettings: ?LeaderboardCustomizationSettings,
-  onDeleteEntry: (entry: LeaderboardDisplayData) => Promise<void>,
+  onDeleteEntry: (entry: LeaderboardEntry) => Promise<void>,
   isLoading: boolean,
   erroredEntry?: {| entryId: string, message: React.Node |},
   navigation: {|

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -48,7 +48,7 @@ import {
   type Leaderboard,
   type LeaderboardCustomizationSettings,
   type LeaderboardUpdatePayload,
-  type LeaderboardDisplayData,
+  type LeaderboardEntry,
   shortenUuidForDisplay,
 } from '../../Utils/GDevelopServices/Play';
 import LeaderboardContext from '../../Leaderboard/LeaderboardContext';
@@ -460,7 +460,7 @@ export const LeaderboardAdmin = ({
 
   const onDeleteEntry = async (
     i18n: I18nType,
-    entry: LeaderboardDisplayData
+    entry: LeaderboardEntry
   ) => {
     if (!currentLeaderboard) return;
     const answer = await showConfirmation({

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -458,10 +458,7 @@ export const LeaderboardAdmin = ({
     }
   };
 
-  const onDeleteEntry = async (
-    i18n: I18nType,
-    entry: LeaderboardEntry
-  ) => {
+  const onDeleteEntry = async (i18n: I18nType, entry: LeaderboardEntry) => {
     if (!currentLeaderboard) return;
     const answer = await showConfirmation({
       title: t`Delete score ${entry.score} from ${entry.playerName}`,

--- a/newIDE/app/src/Leaderboard/LeaderboardContext.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardContext.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {
   type Leaderboard,
   type LeaderboardSortOption,
-  type LeaderboardDisplayData,
+  type LeaderboardEntry,
   type LeaderboardUpdatePayload,
 } from '../Utils/GDevelopServices/Play';
 
@@ -12,7 +12,7 @@ export type LeaderboardState = {|
   currentLeaderboard: ?Leaderboard,
   displayOnlyBestEntry: boolean,
   browsing: {|
-    entries: ?Array<LeaderboardDisplayData>,
+    entries: ?Array<LeaderboardEntry>,
     goToNextPage: ?() => Promise<void>,
     goToPreviousPage: ?() => Promise<void>,
     goToFirstPage: ?() => Promise<void>,

--- a/newIDE/app/src/Leaderboard/LeaderboardProvider.js
+++ b/newIDE/app/src/Leaderboard/LeaderboardProvider.js
@@ -4,18 +4,14 @@ import * as React from 'react';
 import LeaderboardContext from './LeaderboardContext';
 import {
   type Leaderboard,
-  type LeaderboardEntry,
-  type LeaderboardExtremePlayerScore,
   type LeaderboardSortOption,
-  type LeaderboardDisplayData,
+  type LeaderboardEntry,
   type LeaderboardUpdatePayload,
   createLeaderboard as doCreateLeaderboard,
   updateLeaderboard as doUpdateLeaderboard,
   resetLeaderboard as doResetLeaderboard,
   deleteLeaderboardEntry as doDeleteLeaderboardEntry,
   deleteLeaderboard as doDeleteLeaderboard,
-  extractExtremeScoreDisplayData,
-  extractEntryDisplayData,
   listLeaderboardEntries,
   listGameActiveLeaderboards,
 } from '../Utils/GDevelopServices/Play';
@@ -34,14 +30,14 @@ type ReducerState = {|
   currentLeaderboard: ?Leaderboard,
   leaderboardsByIds: ?{| [string]: Leaderboard |},
   displayOnlyBestEntry: boolean,
-  entries: ?Array<LeaderboardDisplayData>,
+  entries: ?Array<LeaderboardEntry>,
   mapPageIndexToUri: {| [number]: string |},
   pageIndex: number,
 |};
 
 type ReducerAction =
   | {| type: 'SET_LEADERBOARDS', payload: ?Array<Leaderboard> |}
-  | {| type: 'SET_ENTRIES', payload: ?Array<LeaderboardDisplayData> |}
+  | {| type: 'SET_ENTRIES', payload: ?Array<LeaderboardEntry> |}
   | {| type: 'SET_NEXT_PAGE_URI', payload: string |}
   | {| type: 'SELECT_LEADERBOARD', payload: string |}
   | {| type: 'SET_PAGE_INDEX', payload: number |}
@@ -266,27 +262,13 @@ const LeaderboardProvider = ({ gameId, children }: Props) => {
         forceUri: uriToUse,
       });
       if (!data) return;
-      const fetchedEntries:
-        | LeaderboardEntry[]
-        | LeaderboardExtremePlayerScore[] = data.entries;
+      const fetchedEntries: LeaderboardEntry[] = data.entries;
 
       if (data.nextPageUri) {
         dispatch({ type: 'SET_NEXT_PAGE_URI', payload: data.nextPageUri });
       }
 
-      let entriesToDisplay: LeaderboardDisplayData[] = [];
-      if (displayOnlyBestEntry) {
-        entriesToDisplay = fetchedEntries.map(entry =>
-          // $FlowFixMe
-          extractExtremeScoreDisplayData(entry)
-        );
-      } else {
-        entriesToDisplay = fetchedEntries.map(entry =>
-          // $FlowFixMe
-          extractEntryDisplayData(entry)
-        );
-      }
-      dispatch({ type: 'SET_ENTRIES', payload: entriesToDisplay });
+      dispatch({ type: 'SET_ENTRIES', payload: fetchedEntries });
     },
     [currentLeaderboardId, displayOnlyBestEntry, gameId]
   );

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -87,49 +87,7 @@ export type LeaderboardEntry = {|
   playerName: string,
   createdAt: string,
   score: number,
-  deletedAt?: string,
-  outdatedAt?: string,
 |};
-
-export type LeaderboardDisplayData = {|
-  +id: string,
-  +playerName: string,
-  +createdAt: string,
-  +score: number,
-|};
-
-export type LeaderboardExtremePlayerScore = {|
-  leaderboardId: string,
-  playerId?: string,
-  playerName: string,
-  relatedEntryCreatedAt: string,
-  score: number,
-  relatedEntryId: string,
-|};
-
-export const extractEntryDisplayData = ({
-  playerName,
-  id,
-  score,
-  createdAt,
-}: LeaderboardEntry): LeaderboardDisplayData => ({
-  id,
-  createdAt,
-  playerName,
-  score,
-});
-
-export const extractExtremeScoreDisplayData = ({
-  playerName,
-  relatedEntryId,
-  score,
-  relatedEntryCreatedAt,
-}: LeaderboardExtremePlayerScore): LeaderboardDisplayData => ({
-  id: relatedEntryId,
-  createdAt: relatedEntryCreatedAt,
-  playerName,
-  score,
-});
 
 export const shortenUuidForDisplay = (uuid: string): string =>
   `${uuid.split('-')[0]}-...`;
@@ -176,7 +134,7 @@ export const listLeaderboardEntries = async (
   leaderboardId: string,
   options: {| pageSize: number, onlyBestEntry: boolean, forceUri: ?string |}
 ): Promise<{|
-  entries: LeaderboardEntry[] | LeaderboardExtremePlayerScore[],
+  entries: LeaderboardEntry[],
   nextPageUri: ?string,
 |}> => {
   const uri =

--- a/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardAdmin.stories.js
+++ b/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardAdmin.stories.js
@@ -32,6 +32,7 @@ const mockedLeaderboards = Array(5)
 const mockedEntries = Array(8)
   .fill(0)
   .map((_, index) => ({
+    leaderboardId: '489165zad49-a8ad6-4a984-dcz8da-hjqn983qh0',
     id: `fze8f4ze9f489ze4f9zef4${index}`,
     playerName: `player${index % 2}`,
     score: Math.round(Math.random() * 20 + 150),

--- a/newIDE/app/src/stories/componentStories/ParameterFields/LeaderboardIdField.stories.js
+++ b/newIDE/app/src/stories/componentStories/ParameterFields/LeaderboardIdField.stories.js
@@ -32,6 +32,7 @@ const mockedLeaderboards = Array(5)
 const mockedEntries = Array(8)
   .fill(0)
   .map((_, index) => ({
+    leaderboardId: '489165zad49-a8ad6-4a984-dcz8da-hjqn983qh0',
     id: `fze8f4ze9f489ze4f9zef4${index}`,
     playerName: `player${index % 2}`,
     score: Math.round(Math.random() * 20 + 150),


### PR DESCRIPTION
Wait for backend services to be deployed.

Don't show in the changelog

<img width="913" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/943ff4be-de1f-42a0-958a-3077751e164a">
<img width="623" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/ade298fb-7a0b-4adb-b5af-06a37ef413ca">
