### PR TITLE
Fix collision mask when adding new sprites with default image

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -13,6 +13,7 @@ import {
   allDirectionSpritesHaveSameCollisionMasksAs,
   deleteSpritesFromAnimation,
   duplicateSpritesInAnimation,
+  isFirstSpriteUsingFullImageCollisionMask,
 } from './Utils/SpriteObjectHelper';
 import ResourcesLoader from '../../../ResourcesLoader';
 import {
@@ -295,6 +296,9 @@ const SpritesList = ({
         allDirectionSpritesHaveSameCollisionMasks,
         allDirectionSpritesHaveSamePoints,
       } = checkDirectionPointsAndCollisionsMasks(direction);
+      const shouldUseFullImageCollisionMask = isFirstSpriteUsingFullImageCollisionMask(
+        spriteConfiguration
+      );
       const spritesCountBeforeAdding = direction.getSpritesCount();
 
       const resources = await resourceManagementProps.onChooseResource({
@@ -314,6 +318,9 @@ const SpritesList = ({
         }
         if (allDirectionSpritesHaveSameCollisionMasks) {
           copySpritePolygons(direction.getSprite(0), sprite);
+        }
+        if (shouldUseFullImageCollisionMask) {
+          sprite.setFullImageCollisionMask(true);
         }
         onSpriteAdded(sprite); // Call the callback before `addSprite`, as `addSprite` will store a copy of it.
         direction.addSprite(sprite);
@@ -342,6 +349,7 @@ const SpritesList = ({
       onSpriteUpdated,
       onSpriteAdded,
       onFirstSpriteUpdated,
+      spriteConfiguration,
     ]
   );
 
@@ -355,6 +363,9 @@ const SpritesList = ({
         allDirectionSpritesHaveSameCollisionMasks,
         allDirectionSpritesHaveSamePoints,
       } = checkDirectionPointsAndCollisionsMasks(direction);
+      const shouldUseFullImageCollisionMask = isFirstSpriteUsingFullImageCollisionMask(
+        spriteConfiguration
+      );
 
       try {
         setExternalEditorOpened(true);
@@ -409,6 +420,9 @@ const SpritesList = ({
               copySpritePolygons(direction.getSprite(0), sprite);
             }
           }
+          if (shouldUseFullImageCollisionMask) {
+            sprite.setFullImageCollisionMask(true);
+          }
           onSpriteAdded(sprite); // Call the callback before `addSprite`, as `addSprite` will store a copy of it.
           newDirection.addSprite(sprite);
           sprite.delete();
@@ -457,6 +471,7 @@ const SpritesList = ({
       resourceManagementProps,
       resourcesLoader,
       onChangeName,
+      spriteConfiguration,
     ]
   );
 

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper.js
@@ -275,6 +275,28 @@ export const allSpritesHaveSameCollisionMasksAs = (
   );
 };
 
+export const isFirstSpriteUsingFullImageCollisionMask = (
+  spriteObject: gdSpriteObject
+) => {
+  if (
+    spriteObject.getAnimationsCount() > 0 &&
+    spriteObject.getAnimation(0).getDirectionsCount() > 0 &&
+    spriteObject
+      .getAnimation(0)
+      .getDirection(0)
+      .getSpritesCount() > 0
+  ) {
+    // We look at the first sprite of the first animation as the reference.
+    const firstSprite = spriteObject
+      .getAnimation(0)
+      .getDirection(0)
+      .getSprite(0);
+
+    return firstSprite.isFullImageCollisionMask();
+  }
+  return false;
+};
+
 export const deleteSpritesFromAnimation = (
   animation: gdAnimation,
   spritePtrs: {


### PR DESCRIPTION
Fixes https://forum.gdevelop.io/t/automatic-collision-mask-on-old-sprites-makes-the-game-freeze/49063

As the property is not true by default now, adding a new sprite with a default mask (full image) does not activate the default mask for the new sprite