### PR TITLE
Add the proportional scaling for the depth on 3D objects

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -5,8 +5,6 @@ import { type InstancesEditorSettings } from './InstancesEditorSettings';
 import { type InstanceMeasurer } from './InstancesRenderer';
 import getObjectByName from '../Utils/GetObjectByName';
 
-
-
 export type ResizeGrabbingLocation =
   | 'TopLeft'
   | 'BottomLeft'

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -3,6 +3,9 @@ import Rectangle from '../Utils/Rectangle';
 import { roundPositionForResizing } from '../Utils/GridHelpers';
 import { type InstancesEditorSettings } from './InstancesEditorSettings';
 import { type InstanceMeasurer } from './InstancesRenderer';
+import getObjectByName from '../Utils/GetObjectByName';
+
+
 
 export type ResizeGrabbingLocation =
   | 'TopLeft'
@@ -36,10 +39,10 @@ export const resizeGrabbingRelativePositions = {
   Right: [1, 0.5],
 };
 
-export const canMoveOnX = (location: ResizeGrabbingLocation) =>
+export const canMoveOnX = (location: ResizeGrabbingLocation): boolean =>
   location !== 'Top' && location !== 'Bottom';
 
-export const canMoveOnY = (location: ResizeGrabbingLocation) =>
+export const canMoveOnY = (location: ResizeGrabbingLocation): boolean =>
   location !== 'Left' && location !== 'Right';
 
 const areAnyInstancesNotStraight = (instances: gdInitialInstance[]) => {
@@ -83,7 +86,7 @@ export default class InstancesResizer {
     this.instancesEditorSettings = instancesEditorSettings;
   }
 
-  _getOrCreateInstanceAABB(instance: gdInitialInstance) {
+  _getOrCreateInstanceAABB(instance: gdInitialInstance): Rectangle {
     const initialInstanceAABB = this._instanceAABBs[instance.ptr];
     if (initialInstanceAABB) return initialInstanceAABB;
 
@@ -92,7 +95,7 @@ export default class InstancesResizer {
     ] = this.instanceMeasurer.getInstanceAABB(instance, new Rectangle()));
   }
 
-  _getOrCreateUnrotatedInstanceAABB(instance: gdInitialInstance) {
+  _getOrCreateUnrotatedInstanceAABB(instance: gdInitialInstance): Rectangle {
     const initialUnrotatedInstanceAABB = this._unrotatedInstanceAABBs[
       instance.ptr
     ];
@@ -106,7 +109,7 @@ export default class InstancesResizer {
     ));
   }
 
-  _getOrCreateInstanceOriginPosition(instance: gdInitialInstance) {
+  _getOrCreateInstanceOriginPosition(instance: gdInitialInstance): {} {
     const initialPosition = this._instancePositions[instance.ptr];
     if (initialPosition) return initialPosition;
 

--- a/newIDE/app/src/InstancesEditor/InstancesResizer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesResizer.js
@@ -107,7 +107,7 @@ export default class InstancesResizer {
     ));
   }
 
-  _getOrCreateInstanceOriginPosition(instance: gdInitialInstance): {} {
+  _getOrCreateInstanceOriginPosition(instance: gdInitialInstance) {
     const initialPosition = this._instancePositions[instance.ptr];
     if (initialPosition) return initialPosition;
 

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -846,7 +846,9 @@ export default class InstancesEditor extends Component<Props> {
       sceneDeltaY,
       grabbingLocation,
       proportional,
-      this.keyboardShortcuts.shouldNotSnapToGrid()
+      this.keyboardShortcuts.shouldNotSnapToGrid(),
+      this.props.project,
+      this.props.layout
     );
   };
 


### PR DESCRIPTION
When using Shift to resize a 3D object, the depth is not proportional to width and height.
This PR aim to solve this problem.

I can't run the dev env, this wasn't tested that is why the draft.