### PR TITLE
Fix layers deletion when instances are in several external layouts

### DIFF
--- a/Core/GDCore/IDE/WholeProjectRefactorer.cpp
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.cpp
@@ -1599,6 +1599,54 @@ void WholeProjectRefactorer::GlobalObjectOrGroupRemoved(
   }
 }
 
+void WholeProjectRefactorer::RemoveLayer(gd::Project &project,
+                                         gd::Layout &layout,
+                                         const gd::String &layerName) {
+  if (layerName.empty())
+    return;
+
+  layout.GetInitialInstances().RemoveAllInstancesOnLayer(layerName);
+
+  std::vector<gd::String> externalLayoutsNames =
+      GetAssociatedExternalLayouts(project, layout);
+  for (gd::String name : externalLayoutsNames) {
+    auto &externalLayout = project.GetExternalLayout(name);
+    externalLayout.GetInitialInstances().RemoveAllInstancesOnLayer(layerName);
+  }
+}
+
+void WholeProjectRefactorer::MergeLayers(gd::Project &project,
+                                         gd::Layout &layout,
+                                         const gd::String &originLayerName,
+                                         const gd::String &targetLayerName) {
+  if (originLayerName == targetLayerName || originLayerName.empty())
+    return;
+
+  layout.GetInitialInstances().MoveInstancesToLayer(originLayerName,
+                                                    targetLayerName);
+
+  std::vector<gd::String> externalLayoutsNames =
+      GetAssociatedExternalLayouts(project, layout);
+  for (gd::String name : externalLayoutsNames) {
+    auto &externalLayout = project.GetExternalLayout(name);
+    externalLayout.GetInitialInstances().MoveInstancesToLayer(originLayerName,
+                                                              targetLayerName);
+  }
+}
+
+size_t WholeProjectRefactorer::GetLayoutAndExternalLayoutLayerInstancesCount(
+    gd::Project &project, gd::Layout &layout, const gd::String &layerName) {
+  size_t count = layout.GetInitialInstances().GetLayerInstancesCount(layerName);
+
+  std::vector<gd::String> externalLayoutsNames =
+      GetAssociatedExternalLayouts(project, layout);
+  for (gd::String name : externalLayoutsNames) {
+    auto &externalLayout = project.GetExternalLayout(name);
+    count += externalLayout.GetInitialInstances().GetLayerInstancesCount(layerName);
+  }
+  return count;
+}
+
 std::vector<gd::String>
 WholeProjectRefactorer::GetAssociatedExternalLayouts(gd::Project &project,
                                                      gd::Layout &layout) {

--- a/Core/GDCore/IDE/WholeProjectRefactorer.h
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.h
@@ -456,6 +456,26 @@ class GD_CORE_API WholeProjectRefactorer {
       const gd::EventsFunctionsExtension& eventsFunctionsExtension,
       const gd::EventsBasedObject& eventsBasedObject);
 
+  /**
+   * \brief Remove all the instances from one layer.
+   */
+  static void RemoveLayer(gd::Project &project, gd::Layout &layout,
+                          const gd::String &layerName);
+
+  /**
+   * \brief Move all the instances from one layer into another.
+   */
+  static void MergeLayers(gd::Project &project, gd::Layout &layout,
+                          const gd::String &originLayerName,
+                          const gd::String &targetLayerName);
+
+  /**
+   * \brief Return the number of instances on the layer named \a layerName and
+   * all its associated layouts.
+   */
+  static size_t GetLayoutAndExternalLayoutLayerInstancesCount(
+      gd::Project &project, gd::Layout &layout, const gd::String &layerName);
+
   virtual ~WholeProjectRefactorer(){};
 
  private:

--- a/Core/GDCore/Project/InitialInstancesContainer.cpp
+++ b/Core/GDCore/Project/InitialInstancesContainer.cpp
@@ -134,8 +134,19 @@ void InitialInstancesContainer::MoveInstancesToLayer(
   }
 }
 
+std::size_t InitialInstancesContainer::GetLayerInstancesCount(
+    const gd::String &layerName) const {
+  std::size_t count = 0;
+  for (const gd::InitialInstance &instance : initialInstances) {
+    if (instance.GetLayer() == layerName) {
+      count++;
+    }
+  }
+  return count;
+}
+
 bool InitialInstancesContainer::SomeInstancesAreOnLayer(
-    const gd::String& layerName) {
+    const gd::String& layerName) const {
   return std::any_of(initialInstances.begin(),
                      initialInstances.end(),
                      [&layerName](const InitialInstance& currentInstance) {
@@ -144,7 +155,7 @@ bool InitialInstancesContainer::SomeInstancesAreOnLayer(
 }
 
 bool InitialInstancesContainer::HasInstancesOfObject(
-    const gd::String& objectName) {
+    const gd::String& objectName) const {
   return std::any_of(initialInstances.begin(),
                      initialInstances.end(),
                      [&objectName](const InitialInstance& currentInstance) {

--- a/Core/GDCore/Project/InitialInstancesContainer.h
+++ b/Core/GDCore/Project/InitialInstancesContainer.h
@@ -4,8 +4,8 @@
  * reserved. This project is released under the MIT License.
  */
 
-#ifndef GDCORE_INITIALINSTANCESCONTAINER_H
-#define GDCORE_INITIALINSTANCESCONTAINER_H
+#pragma once
+
 #include <list>
 #include "GDCore/Project/InitialInstance.h"
 #include "GDCore/String.h"
@@ -54,7 +54,6 @@ class GD_CORE_API InitialInstancesContainer {
     return new InitialInstancesContainer(*this);
   };
 
-#if defined(GD_IDE_ONLY)
   /**
    * Must construct the class from the source
    * A such method is needed as the IDE may want to store copies of some
@@ -71,7 +70,6 @@ class GD_CORE_API InitialInstancesContainer {
    * from an object which is not a MyContainer"; } \endcode
    */
   void Create(const InitialInstancesContainer &source);
-#endif
 
   /** \name Instances management
    * Members functions related to managing the instances
@@ -100,7 +98,6 @@ class GD_CORE_API InitialInstancesContainer {
   void IterateOverInstancesWithZOrdering(InitialInstanceFunctor &func,
                                          const gd::String &layer);
 
-#if defined(GD_IDE_ONLY)
   /**
    * \brief Insert the specified \a instance into the list and return a
    * a reference to the newly added instance.
@@ -141,21 +138,26 @@ class GD_CORE_API InitialInstancesContainer {
                                const gd::String &newName);
 
   /**
+   * \brief Return the number of instances on the layer named \a layerName.
+   */
+  std::size_t GetLayerInstancesCount(const gd::String &layerName) const;
+
+  /**
    * \brief Return true if there is at least one instance on the layer named \a
    * layerName.
    */
-  bool SomeInstancesAreOnLayer(const gd::String &layerName);
+  bool SomeInstancesAreOnLayer(const gd::String &layerName) const;
 
   /**
    * \brief Return true if there is at least one instance of the given object.
    */
-  bool HasInstancesOfObject(const gd::String &objectName);
+  bool HasInstancesOfObject(const gd::String &objectName) const;
 
   /**
    * \brief Remove all instances
    */
   void Clear();
-#endif
+
   ///@}
 
   /** \name Saving and loading
@@ -163,12 +165,10 @@ class GD_CORE_API InitialInstancesContainer {
    */
   ///@{
 
-#if defined(GD_IDE_ONLY)
   /**
    * \brief Serialize instances container.
    */
   virtual void SerializeTo(SerializerElement &element) const;
-#endif
 
   /**
    * \brief Unserialize the instances container.
@@ -265,5 +265,3 @@ class GD_CORE_API HighestZOrderFinder : public gd::InitialInstanceFunctor {
 };
 
 }  // namespace gd
-
-#endif  // GDCORE_INITIALINSTANCESCONTAINER_H

--- a/Core/tests/WholeProjectRefactorer.cpp
+++ b/Core/tests/WholeProjectRefactorer.cpp
@@ -3837,11 +3837,11 @@ TEST_CASE("MergeLayers", "[common]") {
     REQUIRE(initialInstances.GetLayerInstancesCount("My layer") == 0);
     REQUIRE(externalInitialInstances.GetLayerInstancesCount("My layer") == 0);
 
-    // But layers with the same name in other layouts are untouched.
+    // Layers with the same name in other layouts are untouched.
     REQUIRE(otherInitialInstances.GetLayerInstancesCount("My layer") == 1);
     REQUIRE(otherExternalInitialInstances.GetLayerInstancesCount("My layer") == 1);
 
-    // But other layers from the same layout are untouched.
+    // Other layers from the same layout are untouched.
     REQUIRE(initialInstances.GetLayerInstancesCount("My other layer") == 1);
     REQUIRE(externalInitialInstances.GetLayerInstancesCount("My other layer") == 1);
   }

--- a/Core/tests/WholeProjectRefactorer.cpp
+++ b/Core/tests/WholeProjectRefactorer.cpp
@@ -3809,7 +3809,7 @@ TEST_CASE("MergeLayers", "[common]") {
     externalInitialInstances.InsertNewInitialInstance().SetLayer("My layer");
     externalInitialInstances.InsertNewInitialInstance().SetLayer("My layer");
     externalInitialInstances.InsertNewInitialInstance().SetLayer("");
-    initialInstances.InsertNewInitialInstance().SetLayer("My other layer");
+    externalInitialInstances.InsertNewInitialInstance().SetLayer("My other layer");
 
     auto &otherInitialInstances = otherLayout.GetInitialInstances();
     otherInitialInstances.InsertNewInitialInstance().SetLayer("My layer");

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1120,6 +1120,7 @@ interface InitialInstancesContainer {
     boolean SomeInstancesAreOnLayer([Const] DOMString layer);
     void RenameInstancesOfObject([Const] DOMString oldName, [Const] DOMString newName);
     void RemoveInstance([Const, Ref] InitialInstance inst);
+    unsigned long GetLayerInstancesCount([Const] DOMString layerName);
 
     [Ref] InitialInstance InsertNewInitialInstance();
     [Ref] InitialInstance InsertInitialInstance([Const, Ref] InitialInstance inst);
@@ -2374,6 +2375,9 @@ interface WholeProjectRefactorer {
     [Value] VectorUnfilledRequiredBehaviorPropertyProblem STATIC_FindInvalidRequiredBehaviorProperties([Const, Ref] Project project);
     [Value] VectorString STATIC_GetBehaviorsWithType([Const, Ref] gdObject obj, [Const] DOMString type);
     boolean STATIC_FixInvalidRequiredBehaviorProperties([Ref] Project project);
+    void STATIC_RemoveLayer([Ref] Project project, [Ref] Layout layout, [Const] DOMString layerName);
+    void STATIC_MergeLayers([Ref] Project project, [Ref] Layout layout, [Const] DOMString originLayerName, [Const] DOMString targetLayerName);
+    unsigned long STATIC_GetLayoutAndExternalLayoutLayerInstancesCount([Ref] Project project, [Ref] Layout layout, [Const] DOMString layerName);
 };
 
 interface PropertyFunctionGenerator {

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -615,6 +615,10 @@ typedef ExtensionAndMetadata<ExpressionMetadata> ExtensionAndExpressionMetadata;
   GetBehaviorsWithType
 #define STATIC_FixInvalidRequiredBehaviorProperties \
   FixInvalidRequiredBehaviorProperties
+#define STATIC_RemoveLayer RemoveLayer
+#define STATIC_MergeLayers MergeLayers
+#define STATIC_GetLayoutAndExternalLayoutLayerInstancesCount GetLayoutAndExternalLayoutLayerInstancesCount
+
 #define STATIC_GenerateBehaviorGetterAndSetter GenerateBehaviorGetterAndSetter
 #define STATIC_GenerateObjectGetterAndSetter GenerateObjectGetterAndSetter
 #define STATIC_CanGenerateGetterAndSetter CanGenerateGetterAndSetter

--- a/GDevelop.js/types/gdinitialinstancescontainer.js
+++ b/GDevelop.js/types/gdinitialinstancescontainer.js
@@ -12,6 +12,7 @@ declare class gdInitialInstancesContainer {
   someInstancesAreOnLayer(layer: string): boolean;
   renameInstancesOfObject(oldName: string, newName: string): void;
   removeInstance(inst: gdInitialInstance): void;
+  getLayerInstancesCount(layerName: string): number;
   insertNewInitialInstance(): gdInitialInstance;
   insertInitialInstance(inst: gdInitialInstance): gdInitialInstance;
   serializeTo(element: gdSerializerElement): void;

--- a/GDevelop.js/types/gdwholeprojectrefactorer.js
+++ b/GDevelop.js/types/gdwholeprojectrefactorer.js
@@ -38,6 +38,9 @@ declare class gdWholeProjectRefactorer {
   static findInvalidRequiredBehaviorProperties(project: gdProject): gdVectorUnfilledRequiredBehaviorPropertyProblem;
   static getBehaviorsWithType(obj: gdObject, type: string): gdVectorString;
   static fixInvalidRequiredBehaviorProperties(project: gdProject): boolean;
+  static removeLayer(project: gdProject, layout: gdLayout, layerName: string): void;
+  static mergeLayers(project: gdProject, layout: gdLayout, originLayerName: string, targetLayerName: string): void;
+  static getLayoutAndExternalLayoutLayerInstancesCount(project: gdProject, layout: gdLayout, layerName: string): number;
   delete(): void;
   ptr: number;
 };

--- a/newIDE/app/src/LayersList/LayerRemoveDialog.js
+++ b/newIDE/app/src/LayersList/LayerRemoveDialog.js
@@ -7,10 +7,12 @@ import SelectField from '../UI/SelectField';
 import SelectOption from '../UI/SelectOption';
 import Text from '../UI/Text';
 import enumerateLayers from './EnumerateLayers';
-import { getInstanceCountInLayoutForLayer } from '../Utils/Layout';
+
+const gd: libGDevelop = global.gd;
 
 type Props = {|
   open: boolean,
+  project: gdProject,
   layersContainer: gdLayout,
   layerRemoved: string,
   onClose: (doRemove: boolean, newLayer: string | null) => void,
@@ -41,9 +43,9 @@ export default class LayerRemoveDialog extends Component<Props, State> {
   render() {
     if (!this.props.layersContainer || !this.props.open) return null;
 
-    // TODO Create an helper function to take into account instances from external layouts.
-    const instancesCountInLayout = getInstanceCountInLayoutForLayer(
-      this.props.layersContainer.getInitialInstances(),
+    const instancesCountInLayout = gd.WholeProjectRefactorer.getLayoutAndExternalLayoutLayerInstancesCount(
+      this.props.project,
+      this.props.layersContainer,
       this.props.layerRemoved
     );
 

--- a/newIDE/app/src/LayersList/LayerRemoveDialog.js
+++ b/newIDE/app/src/LayersList/LayerRemoveDialog.js
@@ -119,15 +119,17 @@ export default class LayerRemoveDialog extends Component<Props, State> {
             </Trans>
           ) : (
             <Trans>
-              There are {instancesCountInLayout} object instances on this
-              layout. What do you want to do?
+              There are {instancesCountInLayout} object instances on this layer.
+              Should they be moved to another layer?
             </Trans>
           )}
         </Text>
         {instancesCountInLayout > 0 && (
           <>
             <Text>
-              <Trans>Move objects on layer {this.props.layerRemoved} to:</Trans>
+              <Trans>
+                Move objects from layer {this.props.layerRemoved} to:
+              </Trans>
             </Text>
             <SelectField
               value={this.state.selectedLayer}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -716,14 +716,16 @@ export default class SceneEditor extends React.Component<Props, State> {
           if (doRemove) {
             if (newLayer === null) {
               this.instancesSelection.unselectInstancesOnLayer(layerName);
-              this.props.initialInstances.removeAllInstancesOnLayer(layerName);
+              gd.WholeProjectRefactorer.removeLayer(
+                this.props.project,
+                this.props.layout,
+                layerName
+              );
             } else {
-              // TODO Make the instances move on the layout and its external layout.
-              // This code only moves the instances from the current layout or
-              // external layout. It results to instances with an invalid layer.
-
               // Instances are not invalidated, so we can keep the selection.
-              this.props.initialInstances.moveInstancesToLayer(
+              gd.WholeProjectRefactorer.mergeLayers(
+                this.props.project,
+                this.props.layout,
                 layerName,
                 newLayer
               );
@@ -1766,6 +1768,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                 this.state.onCloseLayerRemoveDialog && (
                   <LayerRemoveDialog
                     open
+                    project={project}
                     layersContainer={layout}
                     layerRemoved={this.state.layerRemoved}
                     onClose={this.state.onCloseLayerRemoveDialog}

--- a/newIDE/app/src/Utils/Layout.js
+++ b/newIDE/app/src/Utils/Layout.js
@@ -56,11 +56,3 @@ export const getInstanceCountInLayoutForObject = (
   return getInstancesInLayoutForObject(initialInstancesContainer, objectName)
     .length;
 };
-
-export const getInstanceCountInLayoutForLayer = (
-  initialInstancesContainer: gdInitialInstancesContainer,
-  layerName: string
-): number => {
-  return getInstancesInLayoutForLayer(initialInstancesContainer, layerName)
-    .length;
-};

--- a/newIDE/app/src/stories/componentStories/LayerRemoveDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayerRemoveDialog.stories.js
@@ -23,7 +23,8 @@ export const LayerWithInstances = () => {
   instance2.setObjectName('Object');
   instance2.setLayer('GUI');
 
-  const layout = new gd.Layout();
+  const project = new gd.Project();
+  const layout = project.insertNewLayout('NewScene', 0);
 
   layout.insertNewLayer('GUI', 0);
   layout.insertNewLayer('OtherLayer', 0);
@@ -37,7 +38,7 @@ export const LayerWithInstances = () => {
 
   React.useEffect(() => {
     return () => {
-      layout.delete();
+      project.delete();
     };
     // Delete layout on unmount
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -46,6 +47,7 @@ export const LayerWithInstances = () => {
   return (
     <LayerRemoveDialog
       open
+      project={project}
       layersContainer={layout}
       layerRemoved="GUI"
       onClose={action('onClose')}
@@ -53,13 +55,14 @@ export const LayerWithInstances = () => {
   );
 };
 export const LayerWithoutInstances = () => {
-  const layout = new gd.Layout();
+  const project = new gd.Project();
+  const layout = project.insertNewLayout('NewScene', 0);
   layout.insertNewLayer('GUI', 0);
   layout.insertNewLayer('OtherLayer', 0);
 
   React.useEffect(() => {
     return () => {
-      layout.delete();
+      project.delete();
     };
     // Delete layout on unmount
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -67,6 +70,7 @@ export const LayerWithoutInstances = () => {
   return (
     <LayerRemoveDialog
       open
+      project={project}
       layersContainer={layout}
       layerRemoved="GUI"
       onClose={action('onClose')}

--- a/newIDE/app/src/stories/componentStories/LayerRemoveDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayerRemoveDialog.stories.js
@@ -40,7 +40,7 @@ export const LayerWithInstances = () => {
     return () => {
       project.delete();
     };
-    // Delete layout on unmount
+    // Delete project on unmount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -64,7 +64,7 @@ export const LayerWithoutInstances = () => {
     return () => {
       project.delete();
     };
-    // Delete layout on unmount
+    // Delete project on unmount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (


### PR DESCRIPTION
The stories are not working because Core needs to be rebuilt but they are working locally.
https://gdevelop-storybook.s3.amazonaws.com/fix-layer-deletion/latest/index.html?path=/story/layerremovedialog--layer-with-instances