### PR TITLE
Move some Tween actions in "Size" and "Visibility" groups

### DIFF
--- a/Extensions/TweenBehavior/JsExtension.js
+++ b/Extensions/TweenBehavior/JsExtension.js
@@ -708,7 +708,7 @@ module.exports = {
         _(
           'Tween the scale of _PARAM0_ to X-scale: _PARAM3_, Y-scale: _PARAM4_ (from center: _PARAM8_) with easing _PARAM5_ over _PARAM6_ms as _PARAM2_'
         ),
-        _('Scale'),
+        _('Size'),
         'JsPlatform/Extensions/tween_behavior24.png',
         'JsPlatform/Extensions/tween_behavior32.png'
       )
@@ -742,7 +742,7 @@ module.exports = {
         _(
           'Tween the X-scale of _PARAM0_ to _PARAM3_ (from center: _PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
         ),
-        _('Scale'),
+        _('Size'),
         'JsPlatform/Extensions/tween_behavior24.png',
         'JsPlatform/Extensions/tween_behavior32.png'
       )
@@ -775,7 +775,7 @@ module.exports = {
         _(
           'Tween the Y-scale of _PARAM0_ to _PARAM3_ (from center: _PARAM7_) with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
         ),
-        _('Scale'),
+        _('Size'),
         'JsPlatform/Extensions/tween_behavior24.png',
         'JsPlatform/Extensions/tween_behavior32.png'
       )
@@ -839,7 +839,7 @@ module.exports = {
         _(
           'Tween the opacity of _PARAM0_ to _PARAM3_ with easing _PARAM4_ over _PARAM5_ms as _PARAM2_'
         ),
-        _('Opacity'),
+        _('Visibility'),
         'JsPlatform/Extensions/tween_behavior24.png',
         'JsPlatform/Extensions/tween_behavior32.png'
       )


### PR DESCRIPTION
It now uses the same group names as the BaseObject extension.