### PR TITLE
Automatically fix object/group/function/behavior/object/property names when an incorrect one is entered

### DIFF
--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -993,7 +993,7 @@ void Project::SerializeTo(SerializerElement& element) const {
         externalSourceFilesElement.AddChild("sourceFile"));
 }
 
-bool Project::ValidateName(const gd::String& name) {
+bool Project::IsNameSafe(const gd::String& name) {
   if (name.empty()) return false;
 
   if (isdigit(name[0])) return false;
@@ -1001,6 +1001,26 @@ bool Project::ValidateName(const gd::String& name) {
   gd::String allowedCharacters =
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
   return !(name.find_first_not_of(allowedCharacters) != gd::String::npos);
+}
+
+gd::String Project::GetSafeName(const gd::String& name) {
+  if (name.empty()) return "Unnamed";
+
+  gd::String newName = name;
+
+  if (isdigit(name[0])) newName = "_" + newName;
+
+  gd::String allowedCharacters =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+  
+  for (size_t i = 0;i < newName.size();++i) {
+    // Replace all unallowed letters by an underscore.
+    if (allowedCharacters.find_first_of(std::u32string(1, newName[i])) == gd::String::npos) {
+      newName.replace(i, 1, '_');
+    }
+  }
+
+  return newName;
 }
 
 void Project::ExposeResources(gd::ArbitraryResourceWorker& worker) {

--- a/Core/GDCore/Project/Project.h
+++ b/Core/GDCore/Project/Project.h
@@ -983,7 +983,13 @@ class GD_CORE_API Project : public ObjectsContainer {
    * Return true if \a name is valid (can be used safely for an object,
    * behavior, events function name, etc...).
    */
-  static bool ValidateName(const gd::String& name);
+  static bool IsNameSafe(const gd::String& name);
+
+  /**
+   * Return a name, based on the one passed in parameter, that can be safely used
+   * for an object, behavior, events function name, etc...
+   */
+  static gd::String GetSafeName(const gd::String& name); 
   ///@}
 
   /** \name External source files

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -515,10 +515,14 @@ interface Project {
 
     [Ref] VariablesContainer GetVariables();
     [Ref] ResourcesManager GetResourcesManager();
+
     void ExposeResources([Ref] ArbitraryResourceWorker worker);
-    boolean STATIC_ValidateName([Const] DOMString name);
+
     void SerializeTo([Ref] SerializerElement element);
     void UnserializeFrom([Const, Ref] SerializerElement element);
+
+    boolean STATIC_IsNameSafe([Const] DOMString name);
+    [Const, Value] DOMString STATIC_GetSafeName([Const] DOMString name);
 
     [Const, Value] DOMString FREE_GetTypeOfBehavior([Const, Ref] Layout layout, [Const] DOMString name, boolean searchInGroups);
     [Const, Value] DOMString FREE_GetTypeOfObject([Const, Ref] Layout layout, [Const] DOMString name, boolean searchInGroups);

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -522,7 +522,8 @@ typedef ExtensionAndMetadata<ExpressionMetadata> ExtensionAndExpressionMetadata;
 
 #define STATIC_CreateNewGDJSProject CreateNewGDJSProject
 #define STATIC_InitializePlatforms InitializePlatforms
-#define STATIC_ValidateName ValidateName
+#define STATIC_IsNameSafe IsNameSafe
+#define STATIC_GetSafeName GetSafeName
 #define STATIC_ToJSON ToJSON
 #define STATIC_FromJSON(x) FromJSON(x)
 #define STATIC_IsObject IsObject

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -100,9 +100,17 @@ describe('libGD.js', function () {
     });
 
     it('should validate object names', function () {
-      expect(gd.Project.validateName('ThisNameIs_Ok_123')).toBe(true);
-      expect(gd.Project.validateName('ThisName IsNot_Ok_123')).toBe(false);
-      expect(gd.Project.validateName('ThisNameIsNot_Ok!')).toBe(false);
+      expect(gd.Project.isNameSafe('ThisNameIs_Ok_123')).toBe(true);
+      expect(gd.Project.isNameSafe('ThisName IsNot_Ok_123')).toBe(false);
+      expect(gd.Project.isNameSafe('ThisNameIsNot_Ok!')).toBe(false);
+      expect(gd.Project.isNameSafe('1ThisNameIsNot_Ok_123')).toBe(false);
+      expect(gd.Project.getSafeName('ThisNameIs_Ok_123')).toBe('ThisNameIs_Ok_123');
+      expect(gd.Project.getSafeName('ThisName IsNot_Ok_123')).toBe('ThisName_IsNot_Ok_123');
+      expect(gd.Project.getSafeName('ThisNameIsNot_Ok!')).toBe('ThisNameIsNot_Ok_');
+      expect(gd.Project.getSafeName('1ThisNameIsNot_Ok_123')).toBe('_1ThisNameIsNot_Ok_123');
+      expect(gd.Project.getSafeName('官话 name')).toBe('___name');
+      expect(gd.Project.getSafeName('')).toBe('Unnamed');
+      expect(gd.Project.getSafeName('9')).toBe('_9');
     });
 
     it('should have a list of extensions', function () {

--- a/GDevelop.js/types/gdproject.js
+++ b/GDevelop.js/types/gdproject.js
@@ -102,9 +102,10 @@ declare class gdProject extends gdObjectsContainer {
   getVariables(): gdVariablesContainer;
   getResourcesManager(): gdResourcesManager;
   exposeResources(worker: gdArbitraryResourceWorker): void;
-  static validateName(name: string): boolean;
   serializeTo(element: gdSerializerElement): void;
   unserializeFrom(element: gdSerializerElement): void;
+  static isNameSafe(name: string): boolean;
+  static getSafeName(name: string): string;
   getTypeOfBehavior(layout: gdLayout, name: string, searchInGroups: boolean): string;
   getTypeOfObject(layout: gdLayout, name: string, searchInGroups: boolean): string;
   getBehaviorsOfObject(layout: gdLayout, name: string, searchInGroups: boolean): gdVectorString;

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -117,7 +117,7 @@ const validatePropertyName = (
     );
     return false;
   }
-  if (!gd.Project.validateName(newName)) {
+  if (!gd.Project.isNameSafe(newName)) {
     showWarningBox(
       i18n._(
         t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -13,7 +13,6 @@ import RaisedButton from '../UI/RaisedButton';
 import IconButton from '../UI/IconButton';
 import ElementWithMenu from '../UI/Menu/ElementWithMenu';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import InlineCheckbox from '../UI/InlineCheckbox';
 import { ResponsiveLineStackLayout, ColumnStackLayout } from '../UI/Layout';
@@ -88,46 +87,27 @@ type Props = {|
   behaviorObjectType?: string,
 |};
 
-const validatePropertyName = (
+const getValidatedPropertyName = (
   i18n: I18nType,
   properties: gdNamedPropertyDescriptorsList,
   newName: string
-) => {
-  if (!newName) {
-    showWarningBox(i18n._(t`The name of a property cannot be empty.`), {
-      delayToNextTick: true,
-    });
-    return false;
-  }
-  if (newName === 'name' || newName === 'type') {
-    showWarningBox(
-      i18n._(
-        t`The name of a property cannot be "name" or "type", as they are used by GDevelop internally.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
-  if (properties.has(newName)) {
-    showWarningBox(
-      i18n._(
-        t`This name is already used by another property. Choose a unique name for each property.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
-  if (!gd.Project.isNameSafe(newName)) {
-    showWarningBox(
-      i18n._(
-        t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
+): string => {
+  const safeAndUniqueNewName = newNameGenerator(
+    gd.Project.getSafeName(newName),
+    tentativeNewName => {
+      if (
+        properties.has(tentativeNewName) ||
+        // The name of a property cannot be "name" or "type", as they are used by GDevelop internally.
+        (tentativeNewName === 'name' || tentativeNewName === 'type')
+      ) {
+        return true;
+      }
 
-  return true;
+      return false;
+    }
+  );
+
+  return safeAndUniqueNewName;
 };
 
 const getExtraInfoArray = (property: gdNamedPropertyDescriptor) => {
@@ -426,21 +406,18 @@ export default function EventsBasedBehaviorPropertiesEditor(props: Props) {
                                           onChange={newName => {
                                             if (newName === property.getName())
                                               return;
-                                            if (
-                                              !validatePropertyName(
-                                                i18n,
-                                                properties,
-                                                newName
-                                              )
-                                            )
-                                              return;
 
-                                            props.onRenameProperty(
-                                              property.getName(),
+                                            const validatedNewName = getValidatedPropertyName(
+                                              i18n,
+                                              properties,
                                               newName
                                             );
+                                            props.onRenameProperty(
+                                              property.getName(),
+                                              validatedNewName
+                                            );
+                                            property.setName(validatedNewName);
 
-                                            property.setName(newName);
                                             forceUpdate();
                                             props.onPropertiesUpdated &&
                                               props.onPropertiesUpdated();

--- a/newIDE/app/src/EventsBasedBehaviorsList/index.js
+++ b/newIDE/app/src/EventsBasedBehaviorsList/index.js
@@ -8,7 +8,6 @@ import * as React from 'react';
 import { AutoSizer } from 'react-virtualized';
 import SortableVirtualizedItemList from '../UI/SortableVirtualizedItemList';
 import SearchBar from '../UI/SearchBar';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import Background from '../UI/Background';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import {
@@ -154,26 +153,18 @@ export default class EventsBasedBehaviorsList extends React.Component<
   };
 
   _rename = (eventsBasedBehavior: gdEventsBasedBehavior, newName: string) => {
-    const { eventsBasedBehaviorsList } = this.props;
     this.setState({
       renamedEventsBasedBehavior: null,
     });
 
     if (eventsBasedBehavior.getName() === newName) return;
 
-    if (eventsBasedBehaviorsList.has(newName)) {
-      showWarningBox('Another behavior with this name already exists.', {
-        delayToNextTick: true,
-      });
-      return;
-    }
-
     this.props.onRenameEventsBasedBehavior(
       eventsBasedBehavior,
       newName,
       doRename => {
         if (!doRename) return;
-        eventsBasedBehavior.setName(newName);
+
         this._onEventsBasedBehaviorModified();
         this.props.onEventsBasedBehaviorRenamed(eventsBasedBehavior);
       }

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -76,9 +76,8 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
   _getValidatedObjectOrGroupName = (newName: string, i18n: I18nType) => {
     const { eventsBasedObject } = this.props;
 
-    const safeNewName = gd.Project.getSafeName(newName);
     const safeAndUniqueNewName = newNameGenerator(
-      safeNewName,
+      gd.Project.getSafeName(newName),
       tentativeNewName => {
         if (
           eventsBasedObject.hasObjectNamed(tentativeNewName) ||

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { Line } from '../UI/Grid';
 import ObjectsList, { type ObjectsListInterface } from '../ObjectsList';
 import ObjectsRenderingService from '../ObjectsRendering/ObjectsRenderingService';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import type { ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import Window from '../Utils/Window';
 import ObjectEditorDialog from '../ObjectEditor/ObjectEditorDialog';

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -81,7 +81,9 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
       tentativeNewName => {
         if (
           eventsBasedObject.hasObjectNamed(tentativeNewName) ||
-          eventsBasedObject.getObjectGroups().has(tentativeNewName)
+          eventsBasedObject.getObjectGroups().has(tentativeNewName) ||
+          // TODO EBO Use a constant instead a hard coded value "Object".
+          tentativeNewName === 'Object'
         ) {
           return true;
         }
@@ -124,19 +126,6 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
     done: boolean => void,
     i18n: I18nType
   ) => {
-    // TODO EBO Use a constant instead a hard coded value "Object".
-    if (newName === 'Object') {
-      showWarningBox(
-        i18n._(
-          t`"Object" is a reserved name, used for the parent object in the events (actions, conditions, expressions...). Please choose another name.`
-        ),
-        {
-          delayToNextTick: true,
-        }
-      );
-      return;
-    }
-
     const { object } = objectWithContext;
     const { project, globalObjectsContainer, eventsBasedObject } = this.props;
 

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -14,7 +14,6 @@ import EmptyMessage from '../UI/EmptyMessage';
 import ElementWithMenu from '../UI/Menu/ElementWithMenu';
 import SemiControlledTextField from '../UI/SemiControlledTextField';
 import MiniToolbar from '../UI/MiniToolbar';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import InlineCheckbox from '../UI/InlineCheckbox';
 import { ResponsiveLineStackLayout, ColumnStackLayout } from '../UI/Layout';
@@ -43,46 +42,27 @@ const styles = {
   },
 };
 
-const validatePropertyName = (
+const getValidatedPropertyName = (
   i18n: I18nType,
   properties: gdNamedPropertyDescriptorsList,
   newName: string
-) => {
-  if (!newName) {
-    showWarningBox(i18n._(t`The name of a property cannot be empty.`), {
-      delayToNextTick: true,
-    });
-    return false;
-  }
-  if (newName === 'name' || newName === 'type') {
-    showWarningBox(
-      i18n._(
-        t`The name of a property cannot be "name" or "type", as they are used by GDevelop internally.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
-  if (properties.has(newName)) {
-    showWarningBox(
-      i18n._(
-        t`This name is already used by another property. Choose a unique name for each property.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
-  if (!gd.Project.isNameSafe(newName)) {
-    showWarningBox(
-      i18n._(
-        t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
+): string => {
+  const safeAndUniqueNewName = newNameGenerator(
+    gd.Project.getSafeName(newName),
+    tentativeNewName => {
+      if (
+        properties.has(tentativeNewName) ||
+        // The name of a property cannot be "name" or "type", as they are used by GDevelop internally.
+        (tentativeNewName === 'name' || tentativeNewName === 'type')
+      ) {
+        return true;
+      }
 
-  return true;
+      return false;
+    }
+  );
+
+  return safeAndUniqueNewName;
 };
 
 const getExtraInfoArray = (property: gdNamedPropertyDescriptor) => {
@@ -174,17 +154,18 @@ export default class EventsBasedObjectPropertiesEditor extends React.Component<
                             value={property.getName()}
                             onChange={newName => {
                               if (newName === property.getName()) return;
-                              if (
-                                !validatePropertyName(i18n, properties, newName)
-                              )
-                                return;
 
-                              this.props.onRenameProperty(
-                                property.getName(),
+                              const validatedNewName = getValidatedPropertyName(
+                                i18n,
+                                properties,
                                 newName
                               );
+                              this.props.onRenameProperty(
+                                property.getName(),
+                                validatedNewName
+                              );
+                              property.setName(validatedNewName);
 
-                              property.setName(newName);
                               this.forceUpdate();
                               this.props.onPropertiesUpdated &&
                                 this.props.onPropertiesUpdated();

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -72,7 +72,7 @@ const validatePropertyName = (
     );
     return false;
   }
-  if (!gd.Project.validateName(newName)) {
+  if (!gd.Project.isNameSafe(newName)) {
     showWarningBox(
       i18n._(
         t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -9,7 +9,6 @@ import SemiControlledTextField from '../UI/SemiControlledTextField';
 import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import AlertMessage from '../UI/AlertMessage';
 import { ColumnStackLayout } from '../UI/Layout';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import useForceUpdate from '../Utils/UseForceUpdate';
 
 const gd: libGDevelop = global.gd;
@@ -78,18 +77,9 @@ export default function EventsBasedObjectEditor({ eventsBasedObject }: Props) {
             value={
               eventsBasedObject.getDefaultName() || eventsBasedObject.getName()
             }
-            onChange={text => {
-              if (gd.Project.isNameSafe(text)) {
-                eventsBasedObject.setDefaultName(text);
-                forceUpdate();
-              } else {
-                showWarningBox(
-                  i18n._(
-                    t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-                  ),
-                  { delayToNextTick: true }
-                );
-              }
+            onChange={newName => {
+              eventsBasedObject.setDefaultName(gd.Project.getSafeName(newName));
+              forceUpdate();
             }}
             fullWidth
           />

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -79,7 +79,7 @@ export default function EventsBasedObjectEditor({ eventsBasedObject }: Props) {
               eventsBasedObject.getDefaultName() || eventsBasedObject.getName()
             }
             onChange={text => {
-              if (gd.Project.validateName(text)) {
+              if (gd.Project.isNameSafe(text)) {
                 eventsBasedObject.setDefaultName(text);
                 forceUpdate();
               } else {

--- a/newIDE/app/src/EventsBasedObjectsList/index.js
+++ b/newIDE/app/src/EventsBasedObjectsList/index.js
@@ -8,7 +8,6 @@ import * as React from 'react';
 import { AutoSizer } from 'react-virtualized';
 import SortableVirtualizedItemList from '../UI/SortableVirtualizedItemList';
 import SearchBar from '../UI/SearchBar';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import Background from '../UI/Background';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import {
@@ -116,26 +115,18 @@ export default class EventsBasedObjectsList extends React.Component<
   };
 
   _rename = (eventsBasedObject: gdEventsBasedObject, newName: string) => {
-    const { eventsBasedObjectsList } = this.props;
     this.setState({
       renamedEventsBasedObject: null,
     });
 
     if (eventsBasedObject.getName() === newName) return;
 
-    if (eventsBasedObjectsList.has(newName)) {
-      showWarningBox('Another object with this name already exists.', {
-        delayToNextTick: true,
-      });
-      return;
-    }
-
     this.props.onRenameEventsBasedObject(
       eventsBasedObject,
       newName,
       doRename => {
         if (!doRename) return;
-        eventsBasedObject.setName(newName);
+
         this._onEventsBasedObjectModified();
         this.props.onEventsBasedObjectRenamed(eventsBasedObject);
       }

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -74,7 +74,7 @@ const validateParameterName = (i18n: I18nType, newName: string) => {
     return false;
   }
 
-  if (!gd.Project.validateName(newName)) {
+  if (!gd.Project.isNameSafe(newName)) {
     showWarningBox(
       i18n._(
         t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionParametersEditor.js
@@ -13,7 +13,6 @@ import ElementWithMenu from '../../UI/Menu/ElementWithMenu';
 import HelpButton from '../../UI/HelpButton';
 import SemiControlledTextField from '../../UI/SemiControlledTextField';
 import MiniToolbar, { MiniToolbarText } from '../../UI/MiniToolbar';
-import { showWarningBox } from '../../UI/Messages/MessageBox';
 import { ParametersIndexOffsets } from '../../EventsFunctionsExtensionsLoader';
 import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
 import { ColumnStackLayout } from '../../UI/Layout';
@@ -61,30 +60,6 @@ const styles = {
   parametersContainer: {
     flex: 1,
   },
-};
-
-const validateParameterName = (i18n: I18nType, newName: string) => {
-  if (!newName) {
-    showWarningBox(
-      i18n._(
-        t`The name of a parameter can not be empty. Enter a name for the parameter or you won't be able to use it.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
-
-  if (!gd.Project.isNameSafe(newName)) {
-    showWarningBox(
-      i18n._(
-        t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-      ),
-      { delayToNextTick: true }
-    );
-    return false;
-  }
-
-  return true;
 };
 
 export const EventsFunctionParametersEditor = ({
@@ -358,9 +333,7 @@ export const EventsFunctionParametersEditor = ({
                           translatableHintText={t`Enter the parameter name (mandatory)`}
                           value={parameter.getName()}
                           onChange={text => {
-                            if (!validateParameterName(i18n, text)) return;
-
-                            parameter.setName(text);
+                            parameter.setName(gd.Project.getSafeName(text));
                             forceUpdate();
                             onParametersUpdated();
                           }}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -12,6 +12,7 @@ import { showWarningBox } from '../../UI/Messages/MessageBox';
 import Window from '../../Utils/Window';
 import { type GroupWithContext } from '../../ObjectsList/EnumerateObjects';
 import { type UnsavedChanges } from '../../MainFrame/UnsavedChangesContext';
+import newNameGenerator from '../../Utils/NewNameGenerator';
 
 const gd: libGDevelop = global.gd;
 
@@ -67,29 +68,27 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
     currentTab: 'config',
   };
 
-  _canObjectOrGroupUseNewName = (newName: string) => {
+  _getValidatedObjectOrGroupName = (newName: string) => {
     const { objectsContainer, globalObjectsContainer } = this.props;
 
-    if (
-      objectsContainer.hasObjectNamed(newName) ||
-      globalObjectsContainer.hasObjectNamed(newName) ||
-      objectsContainer.getObjectGroups().has(newName) ||
-      globalObjectsContainer.getObjectGroups().has(newName)
-    ) {
-      showWarningBox(
-        'Another object or group with this name already exists in this function.',
-        { delayToNextTick: true }
-      );
-      return false;
-    } else if (!gd.Project.validateName(newName)) {
-      showWarningBox(
-        'This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.',
-        { delayToNextTick: true }
-      );
-      return false;
-    }
+    const safeNewName = gd.Project.getSafeName(newName);
+    const safeAndUniqueNewName = newNameGenerator(
+      safeNewName,
+      tentativeNewName => {
+        if (
+          objectsContainer.hasObjectNamed(tentativeNewName) ||
+          globalObjectsContainer.hasObjectNamed(tentativeNewName) ||
+          objectsContainer.getObjectGroups().has(tentativeNewName) ||
+          globalObjectsContainer.getObjectGroups().has(tentativeNewName)
+        ) {
+          return true;
+        }
 
-    return true;
+        return false;
+      }
+    );
+
+    return safeAndUniqueNewName;
   };
 
   _onDeleteGroup = (
@@ -246,7 +245,7 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
             objectsContainer={objectsContainer}
             globalObjectGroups={globalObjectsContainer.getObjectGroups()}
             objectGroups={eventsFunction.getObjectGroups()}
-            canRenameGroup={this._canObjectOrGroupUseNewName}
+            getValidatedObjectOrGroupName={this._getValidatedObjectOrGroupName}
             onRenameGroup={this._onRenameGroup}
             onDeleteGroup={this._onDeleteGroup}
             onGroupsUpdated={onParametersOrGroupsUpdated}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -8,7 +8,6 @@ import { EventsFunctionParametersEditor } from './EventsFunctionParametersEditor
 import EventsFunctionPropertiesEditor from './EventsFunctionPropertiesEditor';
 import ScrollView from '../../UI/ScrollView';
 import { Column, Line } from '../../UI/Grid';
-import { showWarningBox } from '../../UI/Messages/MessageBox';
 import Window from '../../Utils/Window';
 import { type GroupWithContext } from '../../ObjectsList/EnumerateObjects';
 import { type UnsavedChanges } from '../../MainFrame/UnsavedChangesContext';
@@ -71,9 +70,8 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
   _getValidatedObjectOrGroupName = (newName: string) => {
     const { objectsContainer, globalObjectsContainer } = this.props;
 
-    const safeNewName = gd.Project.getSafeName(newName);
     const safeAndUniqueNewName = newNameGenerator(
-      safeNewName,
+      gd.Project.getSafeName(newName),
       tentativeNewName => {
         if (
           objectsContainer.hasObjectNamed(tentativeNewName) ||

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -16,7 +16,6 @@ import EventsBasedBehaviorsList from '../EventsBasedBehaviorsList';
 import EventsBasedObjectsList from '../EventsBasedObjectsList';
 import Background from '../UI/Background';
 import OptionsEditorDialog from './OptionsEditorDialog';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import EventsBasedBehaviorEditorDialog from '../EventsBasedBehaviorEditor/EventsBasedBehaviorEditorDialog';
 import EventsBasedObjectEditorDialog from '../EventsBasedObjectEditor/EventsBasedObjectEditorDialog';
 import { type ResourceManagementProps } from '../ResourcesList/ResourceSource';
@@ -37,6 +36,7 @@ import IconButton from '../UI/IconButton';
 import ExtensionEditIcon from '../UI/CustomSvgIcons/ExtensionEdit';
 import Tune from '../UI/CustomSvgIcons/Tune';
 import Mark from '../UI/CustomSvgIcons/Mark';
+import newNameGenerator from '../Utils/NewNameGenerator';
 const gd: libGDevelop = global.gd;
 
 type Props = {|
@@ -304,34 +304,31 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.isNameSafe(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-        ),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-    if (
-      gd.MetadataDeclarationHelper.isExtensionLifecycleEventsFunction(newName)
-    ) {
-      showWarningBox(
-        i18n._(
-          t`This name is reserved for a lifecycle function of the extension. Choose another name for your function.`
-        ),
-        { delayToNextTick: true }
-      );
-      return done(false);
-    }
-
     const { project, eventsFunctionsExtension } = this.props;
+
+    const safeAndUniqueNewName = newNameGenerator(
+      gd.Project.getSafeName(newName),
+      tentativeNewName => {
+        if (
+          gd.MetadataDeclarationHelper.isExtensionLifecycleEventsFunction(
+            tentativeNewName
+          ) ||
+          eventsFunctionsExtension.hasEventsFunctionNamed(tentativeNewName)
+        ) {
+          return true;
+        }
+
+        return false;
+      }
+    );
+
     gd.WholeProjectRefactorer.renameEventsFunction(
       project,
       eventsFunctionsExtension,
       eventsFunction.getName(),
-      newName
+      safeAndUniqueNewName
     );
+    eventsFunction.setName(safeAndUniqueNewName);
 
     done(true);
     if (this.props.onFunctionEdited) {
@@ -345,26 +342,23 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.isNameSafe(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-        ),
-        { delayToNextTick: true }
-      );
-      return done(false);
-    }
-    if (
-      gd.MetadataDeclarationHelper.isBehaviorLifecycleEventsFunction(newName)
-    ) {
-      showWarningBox(
-        i18n._(
-          t`This name is reserved for a lifecycle method of the behavior. Choose another name for your custom function.`
-        ),
-        { delayToNextTick: true }
-      );
-      return done(false);
-    }
+    const safeAndUniqueNewName = newNameGenerator(
+      gd.Project.getSafeName(newName),
+      tentativeNewName => {
+        if (
+          gd.MetadataDeclarationHelper.isBehaviorLifecycleEventsFunction(
+            tentativeNewName
+          ) ||
+          eventsBasedBehavior
+            .getEventsFunctions()
+            .hasEventsFunctionNamed(tentativeNewName)
+        ) {
+          return true;
+        }
+
+        return false;
+      }
+    );
 
     const { project, eventsFunctionsExtension } = this.props;
     gd.WholeProjectRefactorer.renameBehaviorEventsFunction(
@@ -372,8 +366,9 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
       eventsFunctionsExtension,
       eventsBasedBehavior,
       eventsFunction.getName(),
-      newName
+      safeAndUniqueNewName
     );
+    eventsFunction.setName(safeAndUniqueNewName);
 
     done(true);
     if (this.props.onFunctionEdited) {
@@ -387,24 +382,23 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.isNameSafe(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-        ),
-        { delayToNextTick: true }
-      );
-      return done(false);
-    }
-    if (gd.MetadataDeclarationHelper.isObjectLifecycleEventsFunction(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is reserved for a lifecycle method of the object. Choose another name for your custom function.`
-        ),
-        { delayToNextTick: true }
-      );
-      return done(false);
-    }
+    const safeAndUniqueNewName = newNameGenerator(
+      gd.Project.getSafeName(newName),
+      tentativeNewName => {
+        if (
+          gd.MetadataDeclarationHelper.isObjectLifecycleEventsFunction(
+            tentativeNewName
+          ) ||
+          eventsBasedObject
+            .getEventsFunctions()
+            .hasEventsFunctionNamed(tentativeNewName)
+        ) {
+          return true;
+        }
+
+        return false;
+      }
+    );
 
     const { project, eventsFunctionsExtension } = this.props;
     gd.WholeProjectRefactorer.renameObjectEventsFunction(
@@ -412,8 +406,9 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
       eventsFunctionsExtension,
       eventsBasedObject,
       eventsFunction.getName(),
-      newName
+      safeAndUniqueNewName
     );
+    eventsFunction.setName(safeAndUniqueNewName);
 
     done(true);
     if (this.props.onFunctionEdited) {
@@ -570,23 +565,29 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.isNameSafe(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-        ),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
     const { project, eventsFunctionsExtension } = this.props;
+    const safeAndUniqueNewName = newNameGenerator(
+      gd.Project.getSafeName(newName),
+      tentativeNewName => {
+        if (
+          eventsFunctionsExtension
+            .getEventsBasedBehaviors()
+            .has(tentativeNewName)
+        ) {
+          return true;
+        }
+
+        return false;
+      }
+    );
+
     gd.WholeProjectRefactorer.renameEventsBasedBehavior(
       project,
       eventsFunctionsExtension,
       eventsBasedBehavior.getName(),
-      newName
+      safeAndUniqueNewName
     );
+    eventsBasedBehavior.setName(safeAndUniqueNewName);
 
     done(true);
   };
@@ -596,23 +597,27 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.isNameSafe(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-        ),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
     const { project, eventsFunctionsExtension } = this.props;
+    const safeAndUniqueNewName = newNameGenerator(
+      gd.Project.getSafeName(newName),
+      tentativeNewName => {
+        if (
+          eventsFunctionsExtension.getEventsBasedObjects().has(tentativeNewName)
+        ) {
+          return true;
+        }
+
+        return false;
+      }
+    );
+
     gd.WholeProjectRefactorer.renameEventsBasedObject(
       project,
       eventsFunctionsExtension,
       eventsBasedObject.getName(),
-      newName
+      safeAndUniqueNewName
     );
+    eventsBasedObject.setName(safeAndUniqueNewName);
 
     done(true);
   };

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -304,7 +304,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.validateName(newName)) {
+    if (!gd.Project.isNameSafe(newName)) {
       showWarningBox(
         i18n._(
           t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
@@ -345,7 +345,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.validateName(newName)) {
+    if (!gd.Project.isNameSafe(newName)) {
       showWarningBox(
         i18n._(
           t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
@@ -387,7 +387,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.validateName(newName)) {
+    if (!gd.Project.isNameSafe(newName)) {
       showWarningBox(
         i18n._(
           t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
@@ -570,7 +570,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.validateName(newName)) {
+    if (!gd.Project.isNameSafe(newName)) {
       showWarningBox(
         i18n._(
           t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
@@ -596,7 +596,7 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     newName: string,
     done: boolean => void
   ) => {
-    if (!gd.Project.validateName(newName)) {
+    if (!gd.Project.isNameSafe(newName)) {
       showWarningBox(
         i18n._(
           t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`

--- a/newIDE/app/src/EventsFunctionsList/index.js
+++ b/newIDE/app/src/EventsFunctionsList/index.js
@@ -8,7 +8,6 @@ import * as React from 'react';
 import { AutoSizer } from 'react-virtualized';
 import SortableVirtualizedItemList from '../UI/SortableVirtualizedItemList';
 import SearchBar from '../UI/SearchBar';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import Background from '../UI/Background';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -217,23 +216,14 @@ export default class EventsFunctionsList extends React.Component<Props, State> {
     }
   };
   _rename = (eventsFunction: gdEventsFunction, newName: string) => {
-    const { eventsFunctionsContainer } = this.props;
     this.setState({
       renamedEventsFunction: null,
     });
 
     if (eventsFunction.getName() === newName) return;
 
-    if (eventsFunctionsContainer.hasEventsFunctionNamed(newName)) {
-      showWarningBox('Another function with this name already exists.', {
-        delayToNextTick: true,
-      });
-      return;
-    }
-
     this.props.onRenameEventsFunction(eventsFunction, newName, doRename => {
       if (!doRename) return;
-      eventsFunction.setName(newName);
       this._onEventsFunctionModified();
     });
   };

--- a/newIDE/app/src/EventsSheet/EventsFunctionExtractor/index.js
+++ b/newIDE/app/src/EventsSheet/EventsFunctionExtractor/index.js
@@ -161,14 +161,14 @@ export const createNewInstructionForEventsFunction = (
  * Validate that a function name is valid.
  */
 export const validateEventsFunctionName = (functionName: string) => {
-  return gd.Project.validateName(functionName);
+  return gd.Project.isNameSafe(functionName);
 };
 
 /**
  * Validate that an events functions extension name is valid.
  */
 export const validateExtensionName = (extensionName: string) => {
-  return gd.Project.validateName(extensionName);
+  return gd.Project.isNameSafe(extensionName);
 };
 
 /**

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -173,6 +173,7 @@ import CloudProjectSaveChoiceDialog from '../ProjectsStorage/CloudStorageProvide
 import { dataObjectToProps } from '../Utils/HTMLDataset';
 import useCreateProject from '../Utils/UseCreateProject';
 import { isTryingToSaveInForbiddenPath } from '../ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter';
+import newNameGenerator from '../Utils/NewNameGenerator';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -1193,20 +1194,12 @@ const MainFrame = (props: Props) => {
 
     if (!currentProject.hasLayoutNamed(oldName) || newName === oldName) return;
 
-    if (newName === '') {
-      showWarningBox(
-        i18n._(t`This name cannot be empty, please enter a new name.`),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
-    if (currentProject.hasLayoutNamed(newName)) {
-      showWarningBox(i18n._(t`Another scene with this name already exists.`), {
-        delayToNextTick: true,
-      });
-      return;
-    }
+    const uniqueNewName = newNameGenerator(
+      newName || i18n._(t`Unnamed`),
+      tentativeNewName => {
+        return currentProject.hasLayoutNamed(tentativeNewName);
+      }
+    );
 
     const layout = currentProject.getLayout(oldName);
     const shouldChangeProjectFirstLayout =
@@ -1215,13 +1208,17 @@ const MainFrame = (props: Props) => {
       ...state,
       editorTabs: closeLayoutTabs(state.editorTabs, layout),
     })).then(state => {
-      layout.setName(newName);
-      gd.WholeProjectRefactorer.renameLayout(currentProject, oldName, newName);
+      layout.setName(uniqueNewName);
+      gd.WholeProjectRefactorer.renameLayout(
+        currentProject,
+        oldName,
+        uniqueNewName
+      );
       if (inAppTutorialOrchestratorRef.current) {
-        inAppTutorialOrchestratorRef.current.changeData(oldName, newName);
+        inAppTutorialOrchestratorRef.current.changeData(oldName, uniqueNewName);
       }
       if (shouldChangeProjectFirstLayout)
-        currentProject.setFirstLayout(newName);
+        currentProject.setFirstLayout(uniqueNewName);
       _onProjectItemModified();
     });
   };
@@ -1234,32 +1231,23 @@ const MainFrame = (props: Props) => {
     if (!currentProject.hasExternalLayoutNamed(oldName) || newName === oldName)
       return;
 
-    if (newName === '') {
-      showWarningBox(
-        i18n._(t`This name cannot be empty, please enter a new name.`),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
-    if (currentProject.hasExternalLayoutNamed(newName)) {
-      showWarningBox(
-        i18n._(t`Another external layout with this name already exists.`),
-        { delayToNextTick: true }
-      );
-      return;
-    }
+    const uniqueNewName = newNameGenerator(
+      newName || i18n._(t`Unnamed`),
+      tentativeNewName => {
+        return currentProject.hasExternalLayoutNamed(tentativeNewName);
+      }
+    );
 
     const externalLayout = currentProject.getExternalLayout(oldName);
     setState(state => ({
       ...state,
       editorTabs: closeExternalLayoutTabs(state.editorTabs, externalLayout),
     })).then(state => {
-      externalLayout.setName(newName);
+      externalLayout.setName(uniqueNewName);
       gd.WholeProjectRefactorer.renameExternalLayout(
         currentProject,
         oldName,
-        newName
+        uniqueNewName
       );
       _onProjectItemModified();
     });
@@ -1273,32 +1261,23 @@ const MainFrame = (props: Props) => {
     if (!currentProject.hasExternalEventsNamed(oldName) || newName === oldName)
       return;
 
-    if (newName === '') {
-      showWarningBox(
-        i18n._(t`This name cannot be empty, please enter a new name.`),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
-    if (currentProject.hasExternalEventsNamed(newName)) {
-      showWarningBox(
-        i18n._(t`Other external events with this name already exist.`),
-        { delayToNextTick: true }
-      );
-      return;
-    }
+    const uniqueNewName = newNameGenerator(
+      newName || i18n._(t`Unnamed`),
+      tentativeNewName => {
+        return currentProject.hasExternalEventsNamed(tentativeNewName);
+      }
+    );
 
     const externalEvents = currentProject.getExternalEvents(oldName);
     setState(state => ({
       ...state,
       editorTabs: closeExternalEventsTabs(state.editorTabs, externalEvents),
     })).then(state => {
-      externalEvents.setName(newName);
+      externalEvents.setName(uniqueNewName);
       gd.WholeProjectRefactorer.renameExternalEvents(
         currentProject,
         oldName,
-        newName
+        uniqueNewName
       );
       _onProjectItemModified();
     });
@@ -1306,7 +1285,6 @@ const MainFrame = (props: Props) => {
 
   const renameEventsFunctionsExtension = (oldName: string, newName: string) => {
     const { currentProject } = state;
-    const { i18n } = props;
     if (!currentProject) return;
 
     if (
@@ -1315,33 +1293,12 @@ const MainFrame = (props: Props) => {
     )
       return;
 
-    if (newName === '') {
-      showWarningBox(
-        i18n._(t`This name cannot be empty, please enter a new name.`),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
-    if (isExtensionNameTaken(newName, currentProject)) {
-      showWarningBox(
-        i18n._(
-          t`Another extension with this name already exists (or you used a reserved extension name). Please choose another name.`
-        ),
-        { delayToNextTick: true }
-      );
-      return;
-    }
-
-    if (!gd.Project.validateName(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-        ),
-        { delayToNextTick: true }
-      );
-      return;
-    }
+    const safeAndUniqueNewName = newNameGenerator(
+      gd.Project.getSafeName(newName),
+      tentativeNewName => {
+        return isExtensionNameTaken(tentativeNewName, currentProject);
+      }
+    );
 
     const eventsFunctionsExtension = currentProject.getEventsFunctionsExtension(
       oldName
@@ -1353,9 +1310,9 @@ const MainFrame = (props: Props) => {
       currentProject,
       eventsFunctionsExtension,
       oldName,
-      newName
+      safeAndUniqueNewName
     );
-    eventsFunctionsExtension.setName(newName);
+    eventsFunctionsExtension.setName(safeAndUniqueNewName);
     eventsFunctionsExtensionsState.unloadProjectEventsFunctionsExtension(
       currentProject,
       oldName

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -41,7 +41,7 @@ type Props = {|
 
   // Object renaming:
   onRename: string => void,
-  canRenameObject: string => boolean,
+  getValidatedObjectOrGroupName: string => string,
 
   // Passed down to object editors:
   project: gdProject,
@@ -219,10 +219,10 @@ const InnerDialog = (props: InnerDialogProps) => {
                 onChange={newObjectName => {
                   if (newObjectName === objectName) return;
 
-                  if (props.canRenameObject(newObjectName)) {
-                    setObjectName(newObjectName);
-                    notifyOfChange();
-                  }
+                  setObjectName(
+                    props.getValidatedObjectOrGroupName(newObjectName)
+                  );
+                  notifyOfChange();
                 }}
                 autoFocus="desktop"
               />

--- a/newIDE/app/src/ObjectGroupsList/ObjectGroupsListWithObjectGroupEditor.js
+++ b/newIDE/app/src/ObjectGroupsList/ObjectGroupsListWithObjectGroupEditor.js
@@ -11,7 +11,7 @@ type Props = {|
   objectsContainer: gdObjectsContainer,
   globalObjectGroups: gdObjectGroupsContainer,
   objectGroups: gdObjectGroupsContainer,
-  canRenameGroup: (newName: string) => boolean,
+  getValidatedObjectOrGroupName: (newName: string, global: boolean) => string,
   onDeleteGroup: (
     groupWithScope: GroupWithContext,
     done: (boolean) => void
@@ -60,7 +60,9 @@ export default class ObjectGroupsListWithObjectGroupEditor extends React.Compone
           onEditGroup={this.editGroup}
           onDeleteGroup={this.props.onDeleteGroup}
           onRenameGroup={this.props.onRenameGroup}
-          canRenameGroup={this.props.canRenameGroup}
+          getValidatedObjectOrGroupName={
+            this.props.getValidatedObjectOrGroupName
+          }
           onGroupAdded={this.props.onGroupsUpdated}
           onGroupRemoved={this.props.onGroupsUpdated}
           onGroupRenamed={this.props.onGroupsUpdated}

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -137,7 +137,7 @@ type Props = {|
   onObjectCreated: gdObject => void,
   onObjectSelected: (?ObjectWithContext) => void,
   onObjectPasted?: gdObject => void,
-  canRenameObject: (newName: string, global: boolean) => boolean,
+  getValidatedObjectOrGroupName: (newName: string, global: boolean) => string,
   onAddObjectInstance: (objectName: string) => void,
 
   getThumbnail: (
@@ -176,7 +176,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
       onObjectCreated,
       onObjectSelected,
       onObjectPasted,
-      canRenameObject,
+      getValidatedObjectOrGroupName,
       onAddObjectInstance,
 
       getThumbnail,
@@ -469,17 +469,17 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
 
         if (getObjectWithContextName(objectWithContext) === newName) return;
 
-        if (canRenameObject(newName, global)) {
-          onRenameObjectFinish(objectWithContext, newName, doRename => {
-            if (!doRename) return;
+        const validatedNewName = getValidatedObjectOrGroupName(newName, global);
+        onRenameObjectFinish(objectWithContext, validatedNewName, doRename => {
+          if (!doRename) return;
 
-            object.setName(newName);
-            onObjectModified(false);
-          });
-        }
+          // TODO: still useful?
+          object.setName(validatedNewName);
+          onObjectModified(false);
+        });
       },
       [
-        canRenameObject,
+        getValidatedObjectOrGroupName,
         onObjectModified,
         onRenameObjectStart,
         onRenameObjectFinish,

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -464,7 +464,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
 
     const rename = React.useCallback(
       (objectWithContext: ObjectWithContext, newName: string) => {
-        const { object, global } = objectWithContext;
+        const { global } = objectWithContext;
         onRenameObjectStart(null);
 
         if (getObjectWithContextName(objectWithContext) === newName) return;
@@ -473,8 +473,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         onRenameObjectFinish(objectWithContext, validatedNewName, doRename => {
           if (!doRename) return;
 
-          // TODO: still useful?
-          object.setName(validatedNewName);
           onObjectModified(false);
         });
       },

--- a/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
+++ b/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
@@ -70,7 +70,7 @@ export type SceneEditorsDisplayProps = {|
     newName: string,
     done: (boolean) => void
   ) => void,
-  canRenameObjectGroup: (
+  getValidatedObjectOrGroupName: (
     newName: string,
     global: boolean,
     i18n: I18nType

--- a/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
+++ b/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
@@ -74,15 +74,10 @@ export type SceneEditorsDisplayProps = {|
     newName: string,
     global: boolean,
     i18n: I18nType
-  ) => boolean,
+  ) => string,
   canObjectOrGroupBeGlobal: (
     i18n: I18nType,
     objectOrGroupName: string
-  ) => boolean,
-  canObjectOrGroupUseNewName: (
-    newName: string,
-    global: boolean,
-    i18n: I18nType
   ) => boolean,
 
   updateBehaviorsSharedData: () => void,

--- a/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
@@ -357,8 +357,8 @@ const MosaicEditorsDisplay = React.forwardRef<
               onDeleteObject={(objectWithContext, cb) =>
                 props.onDeleteObject(i18n, objectWithContext, cb)
               }
-              canRenameObject={(newName, global) =>
-                props.canObjectOrGroupUseNewName(newName, global, i18n)
+              getValidatedObjectOrGroupName={(newName, global) =>
+                props.getValidatedObjectOrGroupName(newName, global, i18n)
               }
               onObjectCreated={props.onObjectCreated}
               onObjectSelected={props.onObjectSelected}
@@ -394,8 +394,8 @@ const MosaicEditorsDisplay = React.forwardRef<
               onEditGroup={props.onEditObjectGroup}
               onDeleteGroup={props.onDeleteObjectGroup}
               onRenameGroup={props.onRenameObjectGroup}
-              canRenameGroup={(newName, global) =>
-                props.canRenameObjectGroup(newName, global, i18n)
+              getValidatedObjectOrGroupName={(newName, global) =>
+                props.getValidatedObjectOrGroupName(newName, global, i18n)
               }
               beforeSetAsGlobalGroup={groupName =>
                 props.canObjectOrGroupBeGlobal(i18n, groupName)

--- a/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
@@ -298,8 +298,12 @@ const SwipeableDrawerEditorsDisplay = React.forwardRef<
                       onDeleteObject={(objectWithContext, cb) =>
                         props.onDeleteObject(i18n, objectWithContext, cb)
                       }
-                      canRenameObject={(newName, global) =>
-                        props.canObjectOrGroupUseNewName(newName, global, i18n)
+                      getValidatedObjectOrGroupName={(newName, global) =>
+                        props.getValidatedObjectOrGroupName(
+                          newName,
+                          global,
+                          i18n
+                        )
                       }
                       onObjectCreated={props.onObjectCreated}
                       onObjectSelected={props.onObjectSelected}
@@ -354,8 +358,12 @@ const SwipeableDrawerEditorsDisplay = React.forwardRef<
                       onEditGroup={props.onEditObjectGroup}
                       onDeleteGroup={props.onDeleteObjectGroup}
                       onRenameGroup={props.onRenameObjectGroup}
-                      canRenameGroup={(newName, global) =>
-                        props.canRenameObjectGroup(newName, global, i18n)
+                      getValidatedObjectOrGroupName={(newName, global) =>
+                        props.getValidatedObjectOrGroupName(
+                          newName,
+                          global,
+                          i18n
+                        )
                       }
                       beforeSetAsGlobalGroup={groupName =>
                         props.canObjectOrGroupBeGlobal(i18n, groupName)

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -24,7 +24,6 @@ import Window from '../Utils/Window';
 import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 import DismissableInfoBar from '../UI/Messages/DismissableInfoBar';
 import ContextMenu, { type ContextMenuInterface } from '../UI/Menu/ContextMenu';
-import { showWarningBox } from '../UI/Messages/MessageBox';
 import { shortenString } from '../Utils/StringHelpers';
 import getObjectByName from '../Utils/GetObjectByName';
 import UseSceneEditorCommands from './UseSceneEditorCommands';
@@ -833,9 +832,8 @@ export default class SceneEditor extends React.Component<Props, State> {
   ) => {
     const { project, layout } = this.props;
 
-    const safeNewName = gd.Project.getSafeName(newName);
     const safeAndUniqueNewName = newNameGenerator(
-      safeNewName,
+      gd.Project.getSafeName(newName),
       tentativeNewName => {
         if (
           layout.hasObjectNamed(tentativeNewName) ||
@@ -846,7 +844,6 @@ export default class SceneEditor extends React.Component<Props, State> {
           return true;
         }
 
-        // TODO: factor?
         if (global) {
           // If object or group is global, also check for other layouts' objects and groups names.
           const layoutName = layout.getName();

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -62,6 +62,7 @@ import { mapFor } from '../Utils/MapFor';
 import MosaicEditorsDisplay from './MosaicEditorsDisplay';
 import SwipeableDrawerEditorsDisplay from './SwipeableDrawerEditorsDisplay';
 import { type SceneEditorsDisplayInterface } from './EditorsDisplay.flow';
+import newNameGenerator from '../Utils/NewNameGenerator';
 
 const gd: libGDevelop = global.gd;
 
@@ -825,74 +826,59 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.updateToolbar();
   };
 
-  _canObjectOrGroupUseNewName = (
+  _getValidatedObjectOrGroupName = (
     newName: string,
     global: boolean,
     i18n: I18nType
   ) => {
     const { project, layout } = this.props;
 
-    if (
-      layout.hasObjectNamed(newName) ||
-      project.hasObjectNamed(newName) ||
-      layout.getObjectGroups().has(newName) ||
-      project.getObjectGroups().has(newName)
-    ) {
-      showWarningBox(
-        i18n._(t`Another object or group with this name already exists.`),
-        {
-          delayToNextTick: true,
+    const safeNewName = gd.Project.getSafeName(newName);
+    const safeAndUniqueNewName = newNameGenerator(
+      safeNewName,
+      tentativeNewName => {
+        if (
+          layout.hasObjectNamed(tentativeNewName) ||
+          project.hasObjectNamed(tentativeNewName) ||
+          layout.getObjectGroups().has(tentativeNewName) ||
+          project.getObjectGroups().has(tentativeNewName)
+        ) {
+          return true;
         }
-      );
-      return false;
-    }
-    if (!gd.Project.validateName(newName)) {
-      showWarningBox(
-        i18n._(
-          t`This name is invalid. Only use alphanumeric characters (0-9, a-z) and underscores. Digits are not allowed as the first character.`
-        ),
-        { delayToNextTick: true }
-      );
-      return false;
-    }
 
-    if (global) {
-      // If object or group is global, also check for other layouts' objects and groups names.
-      const { layout, project } = this.props;
-      const layoutName = layout.getName();
-      const layoutsWithObjectOrGroupWithSameName: Array<string> = mapFor(
-        0,
-        project.getLayoutsCount(),
-        i => {
-          const otherLayout = project.getLayoutAt(i);
-          const otherLayoutName = otherLayout.getName();
-          if (layoutName !== otherLayoutName) {
-            if (otherLayout.hasObjectNamed(newName)) {
-              return otherLayoutName;
+        // TODO: factor?
+        if (global) {
+          // If object or group is global, also check for other layouts' objects and groups names.
+          const layoutName = layout.getName();
+          const layoutsWithObjectOrGroupWithSameName: Array<string> = mapFor(
+            0,
+            project.getLayoutsCount(),
+            i => {
+              const otherLayout = project.getLayoutAt(i);
+              const otherLayoutName = otherLayout.getName();
+              if (layoutName !== otherLayoutName) {
+                if (otherLayout.hasObjectNamed(tentativeNewName)) {
+                  return otherLayoutName;
+                }
+                const groupContainer = otherLayout.getObjectGroups();
+                if (groupContainer.has(tentativeNewName)) {
+                  return otherLayoutName;
+                }
+              }
+              return null;
             }
-            const groupContainer = otherLayout.getObjectGroups();
-            if (groupContainer.has(newName)) {
-              return otherLayoutName;
-            }
+          ).filter(Boolean);
+
+          if (layoutsWithObjectOrGroupWithSameName.length > 0) {
+            return true;
           }
-          return null;
         }
-      ).filter(Boolean);
 
-      if (layoutsWithObjectOrGroupWithSameName.length > 0) {
-        return Window.showConfirmDialog(
-          i18n._(
-            t`Renaming the global object/group "${newName}" would conflict with the following scenes that have a group or an object with that name:${'\n\n - ' +
-              layoutsWithObjectOrGroupWithSameName.join('\n\n - ') +
-              '\n\n'}Continue only if you know what you're doing.`
-          ),
-          'warning'
-        );
+        return false;
       }
-      return true;
-    }
+    );
 
-    return true;
+    return safeAndUniqueNewName;
   };
 
   _onRenameEditedObject = (newName: string) => {
@@ -911,7 +897,7 @@ export default class SceneEditor extends React.Component<Props, State> {
     const { object, global } = objectWithContext;
     const { project, layout } = this.props;
 
-    // newName is supposed to have been already validated
+    // newName is supposed to have been already validated.
 
     // Avoid triggering renaming refactoring if name has not really changed
     if (object.getName() !== newName) {
@@ -1552,11 +1538,12 @@ export default class SceneEditor extends React.Component<Props, State> {
                 }
                 onExportObject={this.openObjectExporterDialog}
                 onDeleteObject={this._onDeleteObject}
-                canObjectOrGroupUseNewName={this._canObjectOrGroupUseNewName}
+                getValidatedObjectOrGroupName={
+                  this._getValidatedObjectOrGroupName
+                }
                 onEditObjectGroup={this.editGroup}
                 onDeleteObjectGroup={this._onDeleteGroup}
                 onRenameObjectGroup={this._onRenameGroup}
-                canRenameObjectGroup={this._canObjectOrGroupUseNewName}
                 canObjectOrGroupBeGlobal={this.canObjectOrGroupBeGlobal}
                 updateBehaviorsSharedData={this.updateBehaviorsSharedData}
                 onEditObject={this.props.onEditObject || this.editObject}
@@ -1647,8 +1634,8 @@ export default class SceneEditor extends React.Component<Props, State> {
                           }
                           this.editObject(null);
                         }}
-                        canRenameObject={newName =>
-                          this._canObjectOrGroupUseNewName(
+                        getValidatedObjectOrGroupName={newName =>
+                          this._getValidatedObjectOrGroupName(
                             newName,
                             editedObjectWithContext.global,
                             i18n

--- a/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
+++ b/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
@@ -272,7 +272,7 @@ export const WithObjectsList = () => (
                   selectedObjectTags={[]}
                   onChangeSelectedObjectTags={() => {}}
                   getAllObjectTags={() => []}
-                  canRenameObject={() => true}
+                  getValidatedObjectOrGroupName={newName => newName}
                   onDeleteObject={(objectWithContext, cb) => cb(true)}
                   onRenameObjectStart={() => {}}
                   onRenameObjectFinish={(objectWithContext, newName, cb) =>

--- a/newIDE/app/src/stories/componentStories/EventsFunctionsExtensionEditor/EventsFunctionsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/EventsFunctionsExtensionEditor/EventsFunctionsList.stories.js
@@ -30,7 +30,10 @@ export const Default = () => (
         onDeleteEventsFunction={(eventsFunction, cb) => cb(true)}
         onAddEventsFunction={cb => cb({ functionType: 0, name: null })}
         onEventsFunctionAdded={() => {}}
-        onRenameEventsFunction={(eventsFunction, newName, cb) => cb(true)}
+        onRenameEventsFunction={(eventsFunction, newName, cb) => {
+          eventsFunction.setName(newName);
+          cb(true);
+        }}
         canRename={() => true}
       />
     </FixedHeightFlexContainer>

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectGroupsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectGroupsList.stories.js
@@ -25,7 +25,7 @@ export const Default = () => (
           globalObjectGroups={testProject.project.getObjectGroups()}
           objectGroups={testProject.testLayout.getObjectGroups()}
           onEditGroup={() => {}}
-          canRenameGroup={() => true}
+          getValidatedObjectOrGroupName={newName => newName}
         />
       </div>
     </SerializedObjectDisplay>

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
@@ -37,7 +37,7 @@ export const Default = () => (
         selectedObjectTags={[]}
         onChangeSelectedObjectTags={selectedObjectTags => {}}
         getAllObjectTags={() => []}
-        canRenameObject={() => true}
+        getValidatedObjectOrGroupName={newName => newName}
         onDeleteObject={(objectWithContext, cb) => cb(true)}
         onRenameObjectStart={() => {}}
         onRenameObjectFinish={(objectWithContext, newName, cb) => cb(true)}
@@ -68,7 +68,7 @@ export const WithSerializedObjectView = () => (
           selectedObjectTags={[]}
           onChangeSelectedObjectTags={selectedObjectTags => {}}
           getAllObjectTags={() => []}
-          canRenameObject={() => true}
+          getValidatedObjectOrGroupName={newName => newName}
           onDeleteObject={(objectWithContext, cb) => cb(true)}
           onRenameObjectStart={() => {}}
           onRenameObjectFinish={(objectWithContext, newName, cb) => cb(true)}
@@ -104,7 +104,7 @@ export const WithTags = () => (
           'Looooooooooong Tag 3',
           'Unselected Tag 4',
         ]}
-        canRenameObject={() => true}
+        getValidatedObjectOrGroupName={newName => newName}
         onDeleteObject={(objectWithContext, cb) => cb(true)}
         onRenameObjectStart={() => {}}
         onRenameObjectFinish={(objectWithContext, newName, cb) => cb(true)}

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/ObjectEditorDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/ObjectEditorDialog.stories.js
@@ -25,7 +25,7 @@ export const CustomObject = () => (
       onApply={() => action('Apply changes')}
       onCancel={() => action('Cancel changes')}
       onRename={() => action('Rename object')}
-      canRenameObject={name => true}
+      getValidatedObjectOrGroupName={newName => newName}
       project={testProject.project}
       layout={testProject.testLayout}
       resourceManagementProps={fakeResourceManagementProps}
@@ -50,7 +50,7 @@ export const StandardObject = () => (
       onApply={() => action('Apply changes')}
       onCancel={() => action('Cancel changes')}
       onRename={() => action('Rename object')}
-      canRenameObject={name => true}
+      getValidatedObjectOrGroupName={newName => newName}
       project={testProject.project}
       layout={testProject.testLayout}
       resourceManagementProps={fakeResourceManagementProps}


### PR DESCRIPTION
And also for scenes, external events, external layouts and extensions in the project manager.

This removes all the "flow breaking" message boxes. While this might make the reason for the renaming harder to understand, I think it will be well understood. For example in Figma, if you rename a shape to an empty string, it will override it with a default name.
In the future, we could show a snack bar at the bottom that gives an explanation, but not even sure it's required (could be added in the docs, and that's it - the important is that GDevelop fixes the name for you).

Fix #5557
