### PR TITLE
Fix actions disappearing when wrongly translated with the same name in a non english language translation

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionsTreeListItem.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionsTreeListItem.js
@@ -62,8 +62,7 @@ export const renderInstructionOrExpressionTree = <
               // TODO: This id is used by in app tutorials. When in app tutorials
               // are linked to GDevelop versions, change this id to be more accurate
               // using getInstructionOrExpressionIdentifier
-              'instruction-item-' +
-              instructionMetadata.type.replace(/:/g, '-')
+              'instruction-item-' + instructionMetadata.type.replace(/:/g, '-')
             }
             leftIcon={
               <ListIcon

--- a/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionsTreeListItem.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/SelectorInstructionsTreeListItem.js
@@ -50,29 +50,29 @@ export const renderInstructionOrExpressionTree = <
 
       if (typeof instructionOrGroup.type === 'string') {
         // $FlowFixMe - see above
-        const instructionInformation: T = instructionOrGroup;
+        const instructionMetadata: T = instructionOrGroup;
         const value = getInstructionListItemValue(instructionOrGroup.type);
         const selected = selectedValue === value;
         return (
           <ListItem
             key={value}
-            primaryText={key}
+            primaryText={instructionMetadata.displayedName}
             selected={selected}
             id={
               // TODO: This id is used by in app tutorials. When in app tutorials
               // are linked to GDevelop versions, change this id to be more accurate
               // using getInstructionOrExpressionIdentifier
               'instruction-item-' +
-              instructionInformation.type.replace(/:/g, '-')
+              instructionMetadata.type.replace(/:/g, '-')
             }
             leftIcon={
               <ListIcon
                 iconSize={iconSize}
-                src={instructionInformation.iconFilename}
+                src={instructionMetadata.iconFilename}
               />
             }
             onClick={() => {
-              onChoose(instructionInformation.type, instructionInformation);
+              onChoose(instructionMetadata.type, instructionMetadata);
             }}
             ref={selected ? selectedItemRef : undefined}
           />

--- a/newIDE/app/src/InstructionOrExpression/CreateTree.js
+++ b/newIDE/app/src/InstructionOrExpression/CreateTree.js
@@ -38,7 +38,7 @@ export const createTree = <T: EnumeratedInstructionOrExpressionMetadata>(
       const existingGroupInfo = groupInfo || {};
       return {
         ...existingGroupInfo,
-        [expressionInfo.displayedName]: expressionInfo,
+        [expressionInfo.type]: expressionInfo,
       };
     });
   });
@@ -65,9 +65,9 @@ export const findInTree = <T: Object>(
 
     if (typeof instructionOrGroup.type === 'string') {
       // $FlowFixMe - see above
-      const instructionInformation: EnumeratedInstructionOrExpressionMetadata = instructionOrGroup;
+      const instructionMetadata: EnumeratedInstructionOrExpressionMetadata = instructionOrGroup;
 
-      if (instructionInformation.type === instructionType) {
+      if (instructionMetadata.type === instructionType) {
         return [];
       }
     } else {

--- a/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
@@ -137,7 +137,7 @@ describe('EnumerateExpressions', () => {
         },
       },
       'Movement using forces': {
-        'X coordinate of the sum of forces': {
+        ForceX: {
           displayedName: 'X coordinate of the sum of forces',
           fullGroupName: 'Movement using forces',
           name: 'ForceX',
@@ -217,7 +217,7 @@ describe('EnumerateExpressions', () => {
       allExpressionsTree['General'];
     expect(generalTreeNode).toMatchObject({
       'Timers and time': {
-        'Current time': {
+        Time: {
           displayedName: 'Current time',
           fullGroupName: 'General/Timers and time',
           iconFilename: 'res/actions/time.png',
@@ -258,7 +258,7 @@ describe('EnumerateExpressions', () => {
     // $FlowFixMe
     expect(generalTreeNode['Sprite']).toMatchObject({
       Position: {
-        'X position of a point': {
+        PointX: {
           displayedName: 'X position of a point',
           fullGroupName: 'General/Sprite/Position',
           iconFilename: 'res/actions/position_black.png',
@@ -280,7 +280,7 @@ describe('EnumerateExpressions', () => {
     // $FlowFixMe
     expect(movementTreeNode['Platform behavior']).toMatchObject({
       Options: {
-        'Maximum horizontal speed': {
+        MaxSpeed: {
           displayedName: 'Maximum horizontal speed',
           fullGroupName: 'Movement/Platform behavior/Options',
           iconFilename: 'CppPlatform/Extensions/platformerobjecticon.png',

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.spec.js
@@ -62,7 +62,7 @@ describe('EnumerateInstructions', () => {
     expect(tree).toMatchObject({
       Advanced: {
         'Events and control flow': {
-          'Trigger once while true': {
+          'BuiltinCommonInstructions::Once': {
             displayedName: 'Trigger once while true',
             fullGroupName: 'Advanced/Events and control flow',
             type: 'BuiltinCommonInstructions::Once',
@@ -71,7 +71,7 @@ describe('EnumerateInstructions', () => {
       },
       Audio: {
         'Sounds and music': {
-          'Global volume': {
+          GlobalVolume: {
             displayedName: 'Global volume',
             fullGroupName: 'Audio/Sounds and music',
             type: 'GlobalVolume',


### PR DESCRIPTION
Fix #5565