### PR TITLE
Fix effects on custom objects child-objects that weren't displayed at runtime

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.cpp
@@ -15,15 +15,44 @@
 #include "GDCore/Project/Layout.h"
 #include "GDCore/Project/Object.h"
 #include "GDCore/Project/Project.h"
+#include "GDCore/IDE/ProjectBrowserHelper.h"
 
 namespace gd {
 
-void ExposeProjectEffects(
-    const gd::Project& project,
-    const std::function<void(const gd::Effect& effect)>& worker) {
+void EffectsCodeGenerator::DoVisitObject(gd::Object &object) {
+  auto &effects = object.GetEffects();
+  for (std::size_t e = 0; e < effects.GetEffectsCount(); e++) {
+    auto &effect = effects.GetEffect(e);
+    AddEffectIncludeFiles(effect);
+  }
+};
+
+void EffectsCodeGenerator::AddEffectIncludeFiles(const gd::Effect &effect) {
+  // TODO: this browse all the extensions every time we're trying to find
+  // a new effect. Might be a good idea to rework MetadataProvider to be
+  // faster (not sure if it is a bottleneck at all though - but could be
+  // for events code generation).
+  const gd::EffectMetadata &effectMetadata =
+      MetadataProvider::GetEffectMetadata(platform, effect.GetEffectType());
+
+  for (auto &includeFile : effectMetadata.GetIncludeFiles())
+    includeFiles.insert(includeFile);
+};
+
+void EffectsCodeGenerator::GenerateEffectsIncludeFiles(
+    const gd::Platform &platform,
+    gd::Project &project,
+    std::set<gd::String> &includeFiles) {
+  // TODO Add unit tests on this function.
+  
+  // TODO Merge with UsedExtensionsFinder.
+  // Beware that default lights must not include Three.js.
+
   // See also gd::Project::ExposeResources for a method that traverse the whole
   // project (this time for resources) and
   // WholeProjectRefactorer::ExposeProjectEvents.
+
+  EffectsCodeGenerator effectsCodeGenerator(platform, includeFiles);
 
   // Add layouts effects
   for (std::size_t s = 0; s < project.GetLayoutsCount(); s++) {
@@ -33,47 +62,13 @@ void ExposeProjectEffects(
       auto& effects = layout.GetLayer(l).GetEffects();
       for (std::size_t e = 0; e < effects.GetEffectsCount(); ++e) {
         auto& effect = effects.GetEffect(e);
-        worker(effect);
-      }
-    }
-
-    for (std::size_t i = 0; i < layout.GetObjectsCount(); i++) {
-      auto& object = layout.GetObject(i);
-      auto& effects = object.GetEffects();
-      for (std::size_t e = 0; e < effects.GetEffectsCount(); e++) {
-        auto& effect = effects.GetEffect(e);
-        worker(effect);
+        effectsCodeGenerator.AddEffectIncludeFiles(effect);
       }
     }
   }
 
-  // Add global object effects
-  for (std::size_t s = 0; s < project.GetObjectsCount(); s++) {
-    auto& effects = project.GetObject(s).GetEffects();
-    for (std::size_t e = 0; e < effects.GetEffectsCount(); e++) {
-      auto& effect = effects.GetEffect(e);
-      worker(effect);
-    }
-  }
-}
-
-void EffectsCodeGenerator::GenerateEffectsIncludeFiles(
-    const gd::Platform& platform,
-    const gd::Project& project,
-    std::set<gd::String>& includeFiles) {
-  ExposeProjectEffects(
-      project, [&platform, &includeFiles](const gd::Effect& effect) {
-        // TODO: this browse all the extensions every time we're trying to find
-        // a new effect. Might be a good idea to rework MetadataProvider to be
-        // faster (not sure if it is a bottleneck at all though - but could be
-        // for events code generation).
-        const gd::EffectMetadata& effectMetadata =
-            MetadataProvider::GetEffectMetadata(platform,
-                                                effect.GetEffectType());
-
-        for (auto& includeFile : effectMetadata.GetIncludeFiles())
-          includeFiles.insert(includeFile);
-      });
+  // Add objects effects
+  gd::ProjectBrowserHelper::ExposeProjectObjects(project, effectsCodeGenerator);
 }
 
 }  // namespace gd

--- a/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.cpp
@@ -46,7 +46,10 @@ void EffectsCodeGenerator::GenerateEffectsIncludeFiles(
   // TODO Add unit tests on this function.
   
   // TODO Merge with UsedExtensionsFinder.
-  // Beware that default lights must not include Three.js.
+  // Default lights rely on the fact that UsedExtensionsFinder doesn't find
+  // extension usages for effects. This has the happy side effect of not
+  // including Three.js when no 3D object are in the scenes.
+  // We need to make something explicit to avoid future bugs.
 
   // See also gd::Project::ExposeResources for a method that traverse the whole
   // project (this time for resources) and

--- a/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.h
+++ b/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.h
@@ -38,7 +38,6 @@ private:
 
   void AddEffectIncludeFiles(const gd::Effect& effect);
 
-  // Object Visitor
   void DoVisitObject(gd::Object &object) override;
 
   const gd::Platform &platform;

--- a/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.h
+++ b/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.h
@@ -3,16 +3,18 @@
  * Copyright 2008-present Florian Rival (Florian.Rival@gmail.com). All rights
  * reserved. This project is released under the MIT License.
  */
-#ifndef GDCORE_EffectsCodeGenerator_H
-#define GDCORE_EffectsCodeGenerator_H
+#pragma once
 
 #include <set>
 #include <utility>
 #include <vector>
 #include "GDCore/String.h"
+#include "GDCore/IDE/Project/ArbitraryObjectsWorker.h"
+
 namespace gd {
 class Project;
 class Platform;
+class Effect;
 }  // namespace gd
 
 namespace gd {
@@ -20,16 +22,27 @@ namespace gd {
 /**
  * \brief Internal class used to generate code from events
  */
-class GD_CORE_API EffectsCodeGenerator {
- public:
+class GD_CORE_API EffectsCodeGenerator : public ArbitraryObjectsWorker {
+public:
   /**
    * \brief Add all the include files required by the project effects.
    */
   static void GenerateEffectsIncludeFiles(const gd::Platform& platform,
-                                          const gd::Project& project,
+                                          gd::Project& project,
                                           std::set<gd::String>& includeFiles);
+
+private:
+  EffectsCodeGenerator(const gd::Platform &platform_,
+                       std::set<gd::String> &includeFiles_)
+      : platform(platform_), includeFiles(includeFiles_){};
+
+  void AddEffectIncludeFiles(const gd::Effect& effect);
+
+  // Object Visitor
+  void DoVisitObject(gd::Object &object) override;
+
+  const gd::Platform &platform;
+  std::set<gd::String> &includeFiles;
 };
 
 }  // namespace gd
-
-#endif  // GDCORE_EffectsCodeGenerator_H

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -170,7 +170,7 @@ bool ExporterHelper::ExportProjectForPixiPreview(
 
   // Export effects (after engine libraries as they auto-register themselves to
   // the engine)
-  ExportEffectIncludes(immutableProject, includesFiles);
+  ExportEffectIncludes(exportedProject, includesFiles);
 
   previousTime = LogTimeSpent("Include files export", previousTime);
 
@@ -729,7 +729,7 @@ void ExporterHelper::RemoveIncludes(bool pixiRenderers,
 }
 
 bool ExporterHelper::ExportEffectIncludes(
-    const gd::Project &project, std::vector<gd::String> &includesFiles) {
+    gd::Project &project, std::vector<gd::String> &includesFiles) {
   std::set<gd::String> effectIncludes;
 
   gd::EffectsCodeGenerator::GenerateEffectsIncludeFiles(

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -331,7 +331,7 @@ class ExporterHelper {
   /**
    * \brief Add the project effects include files.
    */
-  bool ExportEffectIncludes(const gd::Project &project,
+  bool ExportEffectIncludes(gd::Project &project,
                             std::vector<gd::String> &includesFiles);
 
   /**


### PR DESCRIPTION
### Changes
- Use `gd::ProjectBrowserHelper::ExposeProjectObjects` instead of custom loops on objects.
- Some `const` has been dropped because `ArbitraryObjectsWorker` doesn't have a constant version.