### PR TITLE
Fix 3D filters making 2D games crash

### DIFF
--- a/Extensions/3D/AmbientLight.ts
+++ b/Extensions/3D/AmbientLight.ts
@@ -6,6 +6,9 @@ namespace gdjs {
         target: EffectsTarget,
         effectData: EffectData
       ): gdjs.PixiFiltersTools.Filter {
+        if (typeof THREE === 'undefined') {
+          return new gdjs.PixiFiltersTools.EmptyFilter();
+        }
         return new (class implements gdjs.PixiFiltersTools.Filter {
           light: THREE.AmbientLight;
           _isEnabled: boolean;

--- a/Extensions/3D/DirectionalLight.ts
+++ b/Extensions/3D/DirectionalLight.ts
@@ -6,6 +6,9 @@ namespace gdjs {
         target: EffectsTarget,
         effectData: EffectData
       ): gdjs.PixiFiltersTools.Filter {
+        if (typeof THREE === 'undefined') {
+          return new gdjs.PixiFiltersTools.EmptyFilter();
+        }
         return new (class implements gdjs.PixiFiltersTools.Filter {
           light: THREE.DirectionalLight;
           rotationObject: THREE.Group;

--- a/Extensions/3D/ExponentialFog.ts
+++ b/Extensions/3D/ExponentialFog.ts
@@ -6,6 +6,9 @@ namespace gdjs {
         target: EffectsTarget,
         effectData: EffectData
       ): gdjs.PixiFiltersTools.Filter {
+        if (typeof THREE === 'undefined') {
+          return new gdjs.PixiFiltersTools.EmptyFilter();
+        }
         return new (class implements gdjs.PixiFiltersTools.Filter {
           fog: THREE.FogExp2;
 

--- a/Extensions/3D/HemisphereLight.ts
+++ b/Extensions/3D/HemisphereLight.ts
@@ -6,6 +6,9 @@ namespace gdjs {
         target: EffectsTarget,
         effectData: EffectData
       ): gdjs.PixiFiltersTools.Filter {
+        if (typeof THREE === 'undefined') {
+          return new gdjs.PixiFiltersTools.EmptyFilter();
+        }
         return new (class implements gdjs.PixiFiltersTools.Filter {
           light: THREE.HemisphereLight;
           rotationObject: THREE.Group;

--- a/Extensions/3D/LinearFog.ts
+++ b/Extensions/3D/LinearFog.ts
@@ -6,6 +6,9 @@ namespace gdjs {
         target: EffectsTarget,
         effectData: EffectData
       ): gdjs.PixiFiltersTools.Filter {
+        if (typeof THREE === 'undefined') {
+          return new gdjs.PixiFiltersTools.EmptyFilter();
+        }
         return new (class implements gdjs.PixiFiltersTools.Filter {
           fog: THREE.Fog;
 

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
@@ -227,5 +227,24 @@ namespace gdjs {
         );
       }
     }
+
+    export class EmptyFilter {
+      isEnabled(target: EffectsTarget): boolean {
+        return false;
+      }
+      setEnabled(target: EffectsTarget, enabled: boolean): boolean {
+        return false;
+      }
+      applyEffect(target: EffectsTarget): boolean {
+        return false;
+      }
+      removeEffect(target: EffectsTarget): boolean {
+        return false;
+      }
+      updatePreRender(target: gdjs.EffectsTarget): any {}
+      updateDoubleParameter(parameterName: string, value: number): void {}
+      updateStringParameter(parameterName: string, value: string): void {}
+      updateBooleanParameter(parameterName: string, value: boolean): void {}
+    }
   }
 }


### PR DESCRIPTION
This is a quick fix. The effects should be removed from exported project data when there is no 3D objects.