### PR TITLE
Simplify events sheet context menus

### DIFF
--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -16,6 +16,7 @@ import UndoIcon from '../UI/CustomSvgIcons/Undo';
 import RedoIcon from '../UI/CustomSvgIcons/Redo';
 import ToolbarSearchIcon from '../UI/CustomSvgIcons/ToolbarSearch';
 import EditSceneIcon from '../UI/CustomSvgIcons/EditScene';
+import { getShortcutDisplayName, useShortcutMap } from '../KeyboardShortcuts';
 
 type Props = {|
   onAddStandardEvent: () => void,
@@ -60,6 +61,8 @@ const Toolbar = ({
   onOpenSettings,
   settingsIcon,
 }: Props) => {
+  const shortcutMap = useShortcutMap();
+
   return (
     <>
       <ToolbarCommands
@@ -89,6 +92,9 @@ const Toolbar = ({
           onClick={onAddStandardEvent}
           id="toolbar-add-event-button"
           tooltip={t`Add a new empty event`}
+          acceleratorString={getShortcutDisplayName(
+            shortcutMap['ADD_STANDARD_EVENT']
+          )}
         >
           <AddEventIcon />
         </IconButton>
@@ -100,6 +106,9 @@ const Toolbar = ({
           disabled={!canAddSubEvent}
           id="toolbar-add-sub-event-button"
           tooltip={t`Add a sub-event to the selected event`}
+          acceleratorString={getShortcutDisplayName(
+            shortcutMap['ADD_SUBEVENT']
+          )}
         >
           <AddSubEventIcon />
         </IconButton>
@@ -110,6 +119,9 @@ const Toolbar = ({
           onClick={onAddCommentEvent}
           id="toolbar-add-comment-button"
           tooltip={t`Add a comment`}
+          acceleratorString={getShortcutDisplayName(
+            shortcutMap['ADD_COMMENT_EVENT']
+          )}
         >
           <AddCommentIcon />
         </IconButton>
@@ -119,6 +131,9 @@ const Toolbar = ({
               size="small"
               color="default"
               tooltip={t`Choose and add an event`}
+              acceleratorString={getShortcutDisplayName(
+                shortcutMap['CHOOSE_AND_ADD_EVENT']
+              )}
             >
               <CircledAddIcon />
             </IconButton>

--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -142,6 +142,7 @@ const Toolbar = ({
           onClick={onRemove}
           disabled={!canRemove}
           tooltip={t`Delete the selected event(s)`}
+          acceleratorString={'Delete'}
         >
           <TrashIcon />
         </IconButton>
@@ -152,6 +153,7 @@ const Toolbar = ({
           onClick={undo}
           disabled={!canUndo}
           tooltip={t`Undo the last changes`}
+          acceleratorString={'CmdOrCtrl+Z'}
         >
           <UndoIcon />
         </IconButton>
@@ -162,6 +164,7 @@ const Toolbar = ({
           onClick={redo}
           disabled={!canRedo}
           tooltip={t`Redo the last changes`}
+          acceleratorString={'CmdOrCtrl+Shift+Z'}
         >
           <RedoIcon />
         </IconButton>

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -12,7 +12,8 @@ import EventTextDialog, {
 } from './InstructionEditor/EventTextDialog';
 import Toolbar from './Toolbar';
 import KeyboardShortcuts from '../UI/KeyboardShortcuts';
-import { getShortcutDisplayName } from '../KeyboardShortcuts';
+import { getShortcutDisplayName, useShortcutMap } from '../KeyboardShortcuts';
+import { type ShortcutMap } from '../KeyboardShortcuts/DefaultShortcuts';
 import InlineParameterEditor from './InlineParameterEditor';
 import ContextMenu, { type ContextMenuInterface } from '../UI/Menu/ContextMenu';
 import { serializeToJSObject } from '../Utils/Serializer';
@@ -143,6 +144,7 @@ type ComponentProps = {|
   preferences: Preferences,
   tutorials: ?Array<Tutorial>,
   leaderboardsManager: ?LeaderboardState,
+  shortcutMap: ShortcutMap,
 |};
 
 type State = {|
@@ -571,9 +573,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
             label: i18n._(t`Invert Condition`),
             click: () => this._invertSelectedConditions(),
             accelerator: getShortcutDisplayName(
-              this.props.preferences.values.userShortcutMap[
-                'TOGGLE_CONDITION_INVERTED'
-              ] || 'KeyJ'
+              this.props.shortcutMap['TOGGLE_CONDITION_INVERTED']
             ),
           }
         : null,
@@ -766,9 +766,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       click: () => this.toggleDisabled(),
       enabled: this._selectionCanToggleDisabled(),
       accelerator: getShortcutDisplayName(
-        this.props.preferences.values.userShortcutMap[
-          'TOGGLE_EVENT_DISABLED'
-        ] || 'KeyD'
+        this.props.shortcutMap['TOGGLE_EVENT_DISABLED'] || 'KeyD'
       ),
     },
     { type: 'separator' },
@@ -780,15 +778,32 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
           click: () => {
             this.addNewEvent('BuiltinCommonInstructions::Standard');
           },
+          accelerator: getShortcutDisplayName(
+            this.props.shortcutMap['ADD_STANDARD_EVENT']
+          ),
         },
         {
           label: i18n._(t`Add Sub Event`),
           click: () => this.addSubEvent(),
           enabled: this._selectionCanHaveSubEvents(),
+          accelerator: getShortcutDisplayName(
+            this.props.shortcutMap['ADD_SUBEVENT']
+          ),
+        },
+        {
+          label: i18n._(t`Add Comment`),
+          click: () => {
+            this.addNewEvent('BuiltinCommonInstructions::Comment');
+          },
+          accelerator: getShortcutDisplayName(
+            this.props.shortcutMap['ADD_COMMENT_EVENT']
+          ),
         },
         ...this.state.allEventsMetadata
           .filter(
-            metadata => metadata.type !== 'BuiltinCommonInstructions::Standard'
+            metadata =>
+              metadata.type !== 'BuiltinCommonInstructions::Standard' &&
+              metadata.type !== 'BuiltinCommonInstructions::Comment'
           )
           .map(metadata => ({
             label: i18n._(t`Add ${metadata.fullName}`),
@@ -1948,6 +1963,7 @@ const EventsSheet = (props, ref) => {
   const preferences = React.useContext(PreferencesContext);
   const { tutorials } = React.useContext(TutorialContext);
   const leaderboardsManager = React.useContext(LeaderboardContext);
+  const shortcutMap = useShortcutMap();
   return (
     <EventsSheetComponentWithoutHandle
       ref={component}
@@ -1955,6 +1971,7 @@ const EventsSheet = (props, ref) => {
       preferences={preferences}
       tutorials={tutorials}
       leaderboardsManager={leaderboardsManager}
+      shortcutMap={shortcutMap}
       {...props}
     />
   );

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -543,58 +543,47 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     });
   };
 
-  _buildInstructionContextMenu = (i18n: I18nType) => [
-    {
-      label: i18n._(t`Copy`),
-      click: () => this.copySelection(),
-      accelerator: 'CmdOrCtrl+C',
-    },
-    {
-      label: i18n._(t`Cut`),
-      click: () => this.cutSelection(),
-      accelerator: 'CmdOrCtrl+X',
-    },
-    {
-      label: i18n._(t`Paste`),
-      click: () => this.pasteInstructions(),
-      enabled: hasClipboardConditions() || hasClipboardActions(),
-      accelerator: 'CmdOrCtrl+V',
-    },
-    { type: 'separator' },
-    {
-      label: i18n._(t`Delete`),
-      click: () => this.deleteSelection(),
-      accelerator: 'Delete',
-    },
-    { type: 'separator' },
-    {
-      label: i18n._(t`Undo`),
-      click: this.undo,
-      enabled: canUndo(this.state.eventsHistory),
-      accelerator: 'CmdOrCtrl+Z',
-    },
-    {
-      label: i18n._(t`Redo`),
-      click: this.redo,
-      enabled: canRedo(this.state.eventsHistory),
-      accelerator: 'CmdOrCtrl+Shift+Z',
-    },
-    {
-      label: i18n._(t`Invert Condition`),
-      click: () => this._invertSelectedConditions(),
-      visible: hasSelectedAtLeastOneCondition(this.state.selection),
-      accelerator: getShortcutDisplayName(
-        this.props.preferences.values.userShortcutMap[
-          'TOGGLE_CONDITION_INVERTED'
-        ] || 'KeyJ'
-      ),
-    },
-    {
-      label: i18n._(t`Toggle Wait the Action to End`),
-      click: () => this._toggleAwaitingActions(),
-      visible: this._hasSelectedOptionallyAsyncActions(),
-    },
-  ];
+  _buildInstructionContextMenu = (i18n: I18nType) =>
+    [
+      {
+        label: i18n._(t`Copy`),
+        click: () => this.copySelection(),
+        accelerator: 'CmdOrCtrl+C',
+      },
+      {
+        label: i18n._(t`Cut`),
+        click: () => this.cutSelection(),
+        accelerator: 'CmdOrCtrl+X',
+      },
+      {
+        label: i18n._(t`Paste`),
+        click: () => this.pasteInstructions(),
+        enabled: hasClipboardConditions() || hasClipboardActions(),
+        accelerator: 'CmdOrCtrl+V',
+      },
+      {
+        label: i18n._(t`Delete`),
+        click: () => this.deleteSelection(),
+        accelerator: 'Delete',
+      },
+      hasSelectedAtLeastOneCondition(this.state.selection)
+        ? {
+            label: i18n._(t`Invert Condition`),
+            click: () => this._invertSelectedConditions(),
+            accelerator: getShortcutDisplayName(
+              this.props.preferences.values.userShortcutMap[
+                'TOGGLE_CONDITION_INVERTED'
+              ] || 'KeyJ'
+            ),
+          }
+        : null,
+      this._hasSelectedOptionallyAsyncActions()
+        ? {
+            label: i18n._(t`Toggle Wait the Action to End`),
+            click: () => this._toggleAwaitingActions(),
+          }
+        : null,
+    ].filter(Boolean);
 
   openAddInstructionContextMenu = (
     eventContext: EventContext,
@@ -784,88 +773,88 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     },
     { type: 'separator' },
     {
-      label: i18n._(t`Add New Event Below`),
-      click: () => {
-        this.addNewEvent('BuiltinCommonInstructions::Standard');
-      },
-    },
-    {
-      label: i18n._(t`Add Sub Event`),
-      click: () => this.addSubEvent(),
-      enabled: this._selectionCanHaveSubEvents(),
-    },
-    {
-      label: i18n._(t`Add Other`),
-      submenu: this.state.allEventsMetadata.map(metadata => {
-        return {
-          label: metadata.fullName,
-          click: () => {
-            this.addNewEvent(metadata.type);
-          },
-        };
-      }),
-    },
-    { type: 'separator' },
-    {
-      label: i18n._(t`Undo`),
-      click: this.undo,
-      enabled: canUndo(this.state.eventsHistory),
-      accelerator: 'CmdOrCtrl+Z',
-    },
-    {
-      label: i18n._(t`Redo`),
-      click: this.redo,
-      enabled: canRedo(this.state.eventsHistory),
-      accelerator: 'CmdOrCtrl+Shift+Z',
-    },
-    { type: 'separator' },
-    {
-      label: i18n._(t`Collapse all`),
-      click: this.collapseAll,
-    },
-    {
-      label: i18n._(t`Expand all to level`),
+      label: i18n._(t`Add`),
       submenu: [
         {
-          label: i18n._(t`All`),
-          click: () => this.expandToLevel(-1),
+          label: i18n._(t`Add New Event Below`),
+          click: () => {
+            this.addNewEvent('BuiltinCommonInstructions::Standard');
+          },
         },
-        { type: 'separator' },
-        ...[0, 1, 2, 3, 4, 5, 6, 7, 8].map(index => {
-          return {
-            label: i18n._(t`Level ${index + 1}`),
-            click: () => this.expandToLevel(index),
-          };
-        }),
+        {
+          label: i18n._(t`Add Sub Event`),
+          click: () => this.addSubEvent(),
+          enabled: this._selectionCanHaveSubEvents(),
+        },
+        ...this.state.allEventsMetadata
+          .filter(
+            metadata => metadata.type !== 'BuiltinCommonInstructions::Standard'
+          )
+          .map(metadata => ({
+            label: metadata.fullName,
+            click: () => {
+              this.addNewEvent(metadata.type);
+            },
+          })),
+      ],
+    },
+    {
+      label: i18n._(t`Replace`),
+      submenu: [
+        {
+          label: i18n._(t`Extract Events to a Function`),
+          click: () => this.extractEventsToFunction(),
+        },
+        {
+          label: i18n._(t`Move Events into a Group`),
+          click: () => this.moveEventsIntoNewGroup(),
+        },
+        {
+          label: i18n._(t`Analyze Objects Used in this Event`),
+          click: this._openEventsContextAnalyzer,
+        },
       ],
     },
     { type: 'separator' },
     {
-      label: i18n._(t`Extract Events to a Function`),
-      click: () => this.extractEventsToFunction(),
-    },
-    {
-      label: i18n._(t`Move Events into a Group`),
-      click: () => this.moveEventsIntoNewGroup(),
-    },
-    {
-      label: i18n._(t`Analyze Objects Used in this Event`),
-      click: this._openEventsContextAnalyzer,
-    },
-    { type: 'separator' },
-    {
-      label: i18n._(t`Zoom In`),
-      click: () => this.onZoomEvent('IN')(),
-      accelerator: 'CmdOrCtrl+=',
-      enabled:
-        this.props.preferences.values.eventsSheetZoomLevel < zoomLevel.max,
-    },
-    {
-      label: i18n._(t`Zoom Out`),
-      click: () => this.onZoomEvent('OUT')(),
-      accelerator: 'CmdOrCtrl+-',
-      enabled:
-        this.props.preferences.values.eventsSheetZoomLevel > zoomLevel.min,
+      label: i18n._(t`Events Sheet`),
+      submenu: [
+        {
+          label: i18n._(t`Zoom In`),
+          click: () => this.onZoomEvent('IN')(),
+          accelerator: 'CmdOrCtrl+=',
+          enabled:
+            this.props.preferences.values.eventsSheetZoomLevel < zoomLevel.max,
+        },
+        {
+          label: i18n._(t`Zoom Out`),
+          click: () => this.onZoomEvent('OUT')(),
+          accelerator: 'CmdOrCtrl+-',
+          enabled:
+            this.props.preferences.values.eventsSheetZoomLevel > zoomLevel.min,
+        },
+        { type: 'separator' },
+        {
+          label: i18n._(t`Collapse all`),
+          click: this.collapseAll,
+        },
+        {
+          label: i18n._(t`Expand all to level`),
+          submenu: [
+            {
+              label: i18n._(t`All`),
+              click: () => this.expandToLevel(-1),
+            },
+            { type: 'separator' },
+            ...[0, 1, 2, 3, 4, 5, 6, 7, 8].map(index => {
+              return {
+                label: i18n._(t`Level ${index + 1}`),
+                click: () => this.expandToLevel(index),
+              };
+            }),
+          ],
+        },
+      ],
     },
   ];
 

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -762,7 +762,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       accelerator: 'Delete',
     },
     {
-      label: i18n._(t`Toggle disabled`),
+      label: i18n._(t`Toggle Disabled`),
       click: () => this.toggleDisabled(),
       enabled: this._selectionCanToggleDisabled(),
       accelerator: getShortcutDisplayName(
@@ -791,7 +791,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
             metadata => metadata.type !== 'BuiltinCommonInstructions::Standard'
           )
           .map(metadata => ({
-            label: metadata.fullName,
+            label: i18n._(t`Add ${metadata.fullName}`),
             click: () => {
               this.addNewEvent(metadata.type);
             },
@@ -835,11 +835,11 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
         },
         { type: 'separator' },
         {
-          label: i18n._(t`Collapse all`),
+          label: i18n._(t`Collapse All`),
           click: this.collapseAll,
         },
         {
-          label: i18n._(t`Expand all to level`),
+          label: i18n._(t`Expand All to Level`),
           submenu: [
             {
               label: i18n._(t`All`),

--- a/newIDE/app/src/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/KeyboardShortcuts/index.js
@@ -151,7 +151,9 @@ const getKeyDisplayName = (code: string) => {
 /**
  * Parses shortcut string into array of platform-specific key strings
  */
-export const getShortcutDisplayName = (shortcutString: string) => {
+export const getShortcutDisplayName = (shortcutString: ?string) => {
+  if (!shortcutString) return '';
+
   return shortcutString
     .split('+')
     .map<string>(keyCode => {

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -120,7 +120,7 @@ const IconButton = React.forwardRef<Props, {||}>((props: Props, ref) => {
           title={
             i18n._(tooltip) +
             (acceleratorString
-              ? ' ' + adaptAcceleratorString(acceleratorString)
+              ? ' (' + adaptAcceleratorString(acceleratorString) + ')'
               : '')
           }
           placement="bottom"


### PR DESCRIPTION
- Move zoom in/out to “events sheet”. Move “collapse” to Events Sheet.
- Move “Add …” into a single submenu.
- Remove undo/redo.

## Before:
<img width="263" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/9c45933a-3de3-4723-a72f-3b0b874549b0">

## After:
<img width="165" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/e5151001-5a6d-4c17-8537-31ae6737f633">

## After (sub menus)
<img width="495" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/f3b35d56-b144-4de4-927c-17782d174925">
<img width="411" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/4d88d436-5cc1-456a-b0d2-892d464323eb">
<img width="350" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/af5fbeeb-1e0e-4053-88aa-0d5c14bd7e9b">

## For actions/conditions:

Cleaner with the undo/redo:

<img width="125" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/2cfbf678-4396-4554-82ff-b4a3428c0a9f">
<img width="160" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/2f356e99-3efa-4c8b-8abc-c1389caa1c39">
