### PR TITLE
Simplify deletion of leaderboard

### DIFF
--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -430,14 +430,17 @@ export const LeaderboardAdmin = ({
 
   const onDeleteLeaderboard = async (i18n: I18nType) => {
     if (!currentLeaderboard) return;
-    const answer = await showDeleteConfirmation({
-      title: t`Delete leaderboard ${currentLeaderboard.name}`,
-      message: t`Are you sure you want to delete this leaderboard and all of its entries? This can't be undone.`,
+    // Extract word translation to ensure it is not wrongly translated in the sentence.
+    const translatedConfirmText = i18n._(t`delete`);
+
+    const deleteAnswer = await showDeleteConfirmation({
+      title: t`Do you really want to permanently delete the leaderboard ${currentLeaderboard.name}?`,
+      message: t`You’re about to permanently delete this leaderboard and all of its entries. This can't be undone.`,
+      fieldMessage: t`To confirm, type "${translatedConfirmText}"`,
+      confirmText: translatedConfirmText,
       confirmButtonLabel: t`Delete Leaderboard`,
-      confirmText: currentLeaderboard.name,
-      fieldMessage: t`Type the name of the leaderboard:`,
     });
-    if (!answer) return;
+    if (!deleteAnswer) return;
 
     setIsLoading(true);
     setApiError(null);

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -434,7 +434,9 @@ export const LeaderboardAdmin = ({
     const translatedConfirmText = i18n._(t`delete`);
 
     const deleteAnswer = await showDeleteConfirmation({
-      title: t`Do you really want to permanently delete the leaderboard ${currentLeaderboard.name}?`,
+      title: t`Do you really want to permanently delete the leaderboard ${
+        currentLeaderboard.name
+      }?`,
       message: t`You’re about to permanently delete this leaderboard and all of its entries. This can't be undone.`,
       fieldMessage: t`To confirm, type "${translatedConfirmText}"`,
       confirmText: translatedConfirmText,


### PR DESCRIPTION
Close https://github.com/4ian/GDevelop/issues/5587
Like when we delete a project cloud it ask to type "Delete".

![image](https://github.com/4ian/GDevelop/assets/1670670/dd4935a7-cb97-47a2-8d53-9b5eec19c2c1)


This PR now replicate it on Leaderboard deletion in the game dashboard instead of typing the whole leaderboard name.