### PR TITLE
Add a shortcut to move selected events in a new group

### DIFF
--- a/newIDE/app/src/CommandPalette/CommandsList.js
+++ b/newIDE/app/src/CommandPalette/CommandsList.js
@@ -56,6 +56,7 @@ export type CommandName =
   | 'TOGGLE_EVENT_DISABLED'
   | 'TOGGLE_CONDITION_INVERTED'
   | 'CHOOSE_AND_ADD_EVENT'
+  | 'MOVE_EVENTS_IN_NEW_GROUP'
   | 'EVENTS_EDITOR_UNDO'
   | 'EVENTS_EDITOR_REDO'
   | 'DELETE_SELECTION'
@@ -297,6 +298,10 @@ const commandsList: { [CommandName]: CommandMetadata } = {
   CHOOSE_AND_ADD_EVENT: {
     area: 'EVENTS',
     displayText: t`Choose and add an event...`,
+  },
+  MOVE_EVENTS_IN_NEW_GROUP: {
+    area: 'EVENTS',
+    displayText: t`Move events into a new group`,
   },
   EVENTS_EDITOR_UNDO: {
     area: 'EVENTS',

--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -38,6 +38,8 @@ type Props = {|
   onToggleSearchPanel: () => void,
   onOpenSettings?: ?() => void,
   settingsIcon?: React.Node,
+  moveEventsIntoNewGroup: () => void,
+  canMoveEventsIntoNewGroup: boolean,
 |};
 
 const Toolbar = ({
@@ -60,6 +62,8 @@ const Toolbar = ({
   onToggleSearchPanel,
   onOpenSettings,
   settingsIcon,
+  moveEventsIntoNewGroup,
+  canMoveEventsIntoNewGroup,
 }: Props) => {
   const shortcutMap = useShortcutMap();
 
@@ -84,6 +88,8 @@ const Toolbar = ({
         canRedo={canRedo}
         onToggleSearchPanel={onToggleSearchPanel}
         onOpenSettings={onOpenSettings}
+        moveEventsIntoNewGroup={moveEventsIntoNewGroup}
+        canMoveEventsIntoNewGroup={canMoveEventsIntoNewGroup}
       />
       <ToolbarGroup lastChild>
         <IconButton

--- a/newIDE/app/src/EventsSheet/ToolbarCommands.js
+++ b/newIDE/app/src/EventsSheet/ToolbarCommands.js
@@ -25,6 +25,8 @@ type Props = {|
   canRedo: boolean,
   onToggleSearchPanel: () => void,
   onOpenSettings?: ?() => void,
+  moveEventsIntoNewGroup: () => void,
+  canMoveEventsIntoNewGroup: boolean,
 |};
 
 const ToolbarCommands = (props: Props) => {
@@ -61,6 +63,10 @@ const ToolbarCommands = (props: Props) => {
         })),
       [props.allEventsMetadata, onAddEvent]
     ),
+  });
+
+  useCommand('MOVE_EVENTS_IN_NEW_GROUP', props.canMoveEventsIntoNewGroup, {
+    handler: props.moveEventsIntoNewGroup,
   });
 
   useCommand('DELETE_SELECTION', props.canRemove, {

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -343,6 +343,8 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
         onOpenSettings={this.props.onOpenSettings}
         settingsIcon={this.props.settingsIcon}
         onToggleSearchPanel={this._toggleSearchPanel}
+        canMoveEventsIntoNewGroup={hasSomethingSelected(this.state.selection)}
+        moveEventsIntoNewGroup={this.moveEventsIntoNewGroup}
       />
     );
   }
@@ -823,6 +825,9 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
         {
           label: i18n._(t`Move Events into a Group`),
           click: () => this.moveEventsIntoNewGroup(),
+          accelerator: getShortcutDisplayName(
+            this.props.shortcutMap['MOVE_EVENTS_IN_NEW_GROUP']
+          ),
         },
         {
           label: i18n._(t`Analyze Objects Used in this Event`),

--- a/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
+++ b/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
@@ -55,6 +55,7 @@ const defaultShortcuts: ShortcutMap = {
   TOGGLE_EVENT_DISABLED: 'KeyD',
   TOGGLE_CONDITION_INVERTED: 'KeyJ',
   CHOOSE_AND_ADD_EVENT: 'Shift+KeyW',
+  MOVE_EVENTS_IN_NEW_GROUP: 'CmdOrCtrl+KeyG',
   OPEN_EXTENSION_SETTINGS: '',
 };
 


### PR DESCRIPTION
The default shortcut is Ctrl+G/Cmd+G (as this "groups" the selection, like in a design tool)