### PR TITLE
Fix a performance regression on scenes with a lot of sprites

### DIFF
--- a/GDJS/Runtime/object-capabilities/AnimatableBehavior.ts
+++ b/GDJS/Runtime/object-capabilities/AnimatableBehavior.ts
@@ -68,6 +68,10 @@ namespace gdjs {
       this.object = owner;
     }
 
+    usesLifecycleFunction(): boolean {
+      return false;
+    }
+
     updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
       // Nothing to update.
       return true;

--- a/GDJS/Runtime/object-capabilities/EffectBehavior.ts
+++ b/GDJS/Runtime/object-capabilities/EffectBehavior.ts
@@ -73,6 +73,10 @@ namespace gdjs {
       this.object = owner;
     }
 
+    usesLifecycleFunction(): boolean {
+      return false;
+    }
+
     updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
       // Nothing to update.
       return true;

--- a/GDJS/Runtime/object-capabilities/FlippableBehavior.ts
+++ b/GDJS/Runtime/object-capabilities/FlippableBehavior.ts
@@ -31,6 +31,10 @@ namespace gdjs {
       this.object = owner;
     }
 
+    usesLifecycleFunction(): boolean {
+      return false;
+    }
+
     updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
       // Nothing to update.
       return true;

--- a/GDJS/Runtime/object-capabilities/OpacityBehavior.ts
+++ b/GDJS/Runtime/object-capabilities/OpacityBehavior.ts
@@ -35,6 +35,10 @@ namespace gdjs {
       this.object = owner;
     }
 
+    usesLifecycleFunction(): boolean {
+      return false;
+    }
+
     updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
       // Nothing to update.
       return true;

--- a/GDJS/Runtime/object-capabilities/ResizableBehavior.ts
+++ b/GDJS/Runtime/object-capabilities/ResizableBehavior.ts
@@ -57,6 +57,10 @@ namespace gdjs {
       this.object = owner;
     }
 
+    usesLifecycleFunction(): boolean {
+      return false;
+    }
+
     updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
       // Nothing to update.
       return true;

--- a/GDJS/Runtime/object-capabilities/ScalableBehavior.ts
+++ b/GDJS/Runtime/object-capabilities/ScalableBehavior.ts
@@ -67,6 +67,10 @@ namespace gdjs {
       this.object = owner;
     }
 
+    usesLifecycleFunction(): boolean {
+      return false;
+    }
+
     updateFromBehaviorData(oldBehaviorData, newBehaviorData): boolean {
       // Nothing to update.
       return true;

--- a/GDJS/Runtime/runtimebehavior.ts
+++ b/GDJS/Runtime/runtimebehavior.ts
@@ -196,6 +196,16 @@ namespace gdjs {
      * of events.
      */
     onObjectHotReloaded(): void {}
+
+    /**
+     * Capabilities behaviors set it to false because they don't need their
+     * life-cycle functions to be called. This avoids decorative Sprite
+     * instances to use CPU.
+     * @returns
+     */
+    usesLifecycleFunction(): boolean {
+      return true;
+    }
   }
   gdjs.registerBehavior('', gdjs.RuntimeBehavior);
 }

--- a/GDJS/Runtime/runtimebehavior.ts
+++ b/GDJS/Runtime/runtimebehavior.ts
@@ -200,7 +200,7 @@ namespace gdjs {
     /**
      * Should return `false` if the behavior does not need any lifecycle function to
      * be called.
-     * Default, hidden, "capability" behaviors set it to `false`. 
+     * Default, hidden, "capability" behaviors set it to `false`.
      * This avoids useless calls to empty lifecycle functions, which would waste CPU
      * time (and have a sizeable impact for example when lots of static instances
      * are living in the scene).

--- a/GDJS/Runtime/runtimebehavior.ts
+++ b/GDJS/Runtime/runtimebehavior.ts
@@ -198,9 +198,12 @@ namespace gdjs {
     onObjectHotReloaded(): void {}
 
     /**
-     * Capabilities behaviors set it to false because they don't need their
-     * life-cycle functions to be called. This avoids decorative Sprite
-     * instances to use CPU.
+     * Should return `false` if the behavior does not need any lifecycle function to
+     * be called.
+     * Default, hidden, "capability" behaviors set it to `false`. 
+     * This avoids useless calls to empty lifecycle functions, which would waste CPU
+     * time (and have a sizeable impact for example when lots of static instances
+     * are living in the scene).
      * @returns
      */
     usesLifecycleFunction(): boolean {

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -203,17 +203,18 @@ namespace gdjs {
     _averageForce: gdjs.Force;
 
     /**
-     * Contains the behaviors of the object.
+     * Contains the behaviors of the object, except those not having lifecycle functions.
      *
-     * It doesn't includes capabilities behaviors because they don't need their
-     * life-cycle functions to be called. This avoids decorative Sprite
-     * instances to use CPU.
+     * This means default, hidden, "capability" behaviors are not included in this array.
+     * This avoids wasting time iterating on them when we know their lifecycle functions
+     * are never used.
      */
     protected _behaviors: gdjs.RuntimeBehavior[] = [];
     /**
      * Contains the behaviors of the object by name.
      *
-     * It includes capabilities behaviors.
+     * This includes the default, hidden, "capability" behaviors (those to handle opacity,
+     * effects, scale, size...).
      */
     protected _behaviorsTable: Hashtable<gdjs.RuntimeBehavior>;
     protected _timers: Hashtable<gdjs.Timer>;


### PR DESCRIPTION
* Top-down RPG template with 18,000 trees on 171

![image](https://github.com/4ian/GDevelop/assets/2611977/0d4826a6-671e-48b1-916f-48ca492c16c6)

* Top-down RPG template with 18,000 trees on 169

![image](https://github.com/4ian/GDevelop/assets/2611977/06ed7506-e538-4317-a67e-4f1eec062717)

* With the fix

![image](https://github.com/4ian/GDevelop/assets/2611977/2e7d4578-85fb-40db-94ff-dde892341bb8)

