### PR TITLE
Fix missing effect tab on some objects

### DIFF
--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -175,6 +175,7 @@ module.exports = {
         'Extensions/BBText/pixi-multistyle-text/dist/pixi-multistyle-text.umd.js'
       )
       .setCategoryFullName(_('Text'))
+      .addDefaultBehavior('EffectCapability::EffectBehavior')
       .addDefaultBehavior("OpacityCapability::OpacityBehavior");
 
     /**

--- a/Extensions/BBText/bbtextruntimeobject.ts
+++ b/Extensions/BBText/bbtextruntimeobject.ts
@@ -26,7 +26,9 @@ namespace gdjs {
   /**
    * Displays a rich text using BBCode markup (allowing to set parts of the text as bold, italic, use different colors and shadows).
    */
-  export class BBTextRuntimeObject extends gdjs.RuntimeObject {
+  export class BBTextRuntimeObject
+    extends gdjs.RuntimeObject
+    implements gdjs.OpacityHandler {
     _opacity: float;
 
     _text: string;

--- a/Extensions/BitmapText/JsExtension.js
+++ b/Extensions/BitmapText/JsExtension.js
@@ -176,6 +176,7 @@ module.exports = {
         'Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.js'
       )
       .setCategoryFullName(_('Text'))
+      .addDefaultBehavior('EffectCapability::EffectBehavior')
       .addDefaultBehavior('OpacityCapability::OpacityBehavior')
       .addDefaultBehavior('ScalableCapability::ScalableBehavior');
 

--- a/Extensions/Lighting/JsExtension.js
+++ b/Extensions/Lighting/JsExtension.js
@@ -197,7 +197,8 @@ module.exports = {
       .setIncludeFile('Extensions/Lighting/lightruntimeobject.js')
       .addIncludeFile('Extensions/Lighting/lightruntimeobject-pixi-renderer.js')
       .addIncludeFile('Extensions/Lighting/lightobstacleruntimebehavior.js')
-      .setCategoryFullName(_('Visual effect'));
+      .setCategoryFullName(_('Visual effect'))
+      .addDefaultBehavior('EffectCapability::EffectBehavior');
 
     object
       .addAction(

--- a/Extensions/PanelSpriteObject/Extension.cpp
+++ b/Extensions/PanelSpriteObject/Extension.cpp
@@ -43,6 +43,7 @@ void DeclarePanelSpriteObjectExtension(gd::PlatformExtension& extension) {
           .AddDefaultBehavior("ResizableCapability::ResizableBehavior")
           .AddDefaultBehavior("OpacityCapability::OpacityBehavior");
 
+  // Deprecated
   obj.AddCondition("Opacity",
                    _("Opacity"),
                    _("Compare the opacity of a Panel Sprite, between 0 (fully "
@@ -56,8 +57,10 @@ void DeclarePanelSpriteObjectExtension(gd::PlatformExtension& extension) {
       .UseStandardRelationalOperatorParameters(
           "number",
           gd::ParameterOptions::MakeNewOptions().SetDescription(
-              _("Opacity to compare to (0-255)")));
+              _("Opacity to compare to (0-255)")))
+      .SetHidden();
 
+  // Deprecated
   obj.AddAction(
          "SetOpacity",
          _("Change Panel Sprite opacity"),
@@ -72,14 +75,17 @@ void DeclarePanelSpriteObjectExtension(gd::PlatformExtension& extension) {
       .UseStandardOperatorParameters(
           "number",
           gd::ParameterOptions::MakeNewOptions().SetDescription(
-              _("Opacity (0-255)")));
+              _("Opacity (0-255)")))
+      .SetHidden();
 
+  // Deprecated
   obj.AddExpression("Opacity",
                     _("Opacity"),
                     _("Opacity"),
                     _("Visibility"),
                     "res/actions/opacity.png")
-      .AddParameter("object", _("Panel Sprite"), "PanelSprite");
+      .AddParameter("object", _("Panel Sprite"), "PanelSprite")
+      .SetHidden();
 
   obj.AddAction(
          "SetColor",

--- a/Extensions/ParticleSystem/Extension.cpp
+++ b/Extensions/ParticleSystem/Extension.cpp
@@ -40,7 +40,8 @@ void DeclareParticleSystemExtension(gd::PlatformExtension& extension) {
                 _("Displays a large number of small particles to create visual "
                   "effects."),
                 "CppPlatform/Extensions/particleSystemicon.png")
-            .SetCategoryFullName(_("Visual effect"));
+            .SetCategoryFullName(_("Visual effect"))
+            .AddDefaultBehavior("EffectCapability::EffectBehavior");
 
     // Declaration is too big to be compiled by GCC in one file, unless you have
     // 4GB+ ram. :/

--- a/Extensions/TextObject/Extension.cpp
+++ b/Extensions/TextObject/Extension.cpp
@@ -257,7 +257,8 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
           gd::ParameterOptions::MakeNewOptions().SetDescription(
               _("Opacity (0-255)")))
       .SetFunctionName("SetOpacity")
-      .SetGetter("GetOpacity");
+      .SetGetter("GetOpacity")
+      .SetHidden();
 
   // Deprecated
   obj.AddCondition("Opacity",
@@ -274,7 +275,8 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
           "number",
           gd::ParameterOptions::MakeNewOptions().SetDescription(
               _("Opacity to compare to (0-255)")))
-      .SetFunctionName("GetOpacity");
+      .SetFunctionName("GetOpacity")
+      .SetHidden();
 
   obj.AddAction("SetSmooth",
                 _("Smoothing"),
@@ -539,7 +541,8 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
                     _("Opacity"),
                     "res/actions/opacity.png")
       .AddParameter("object", _("Object"), "Text")
-      .SetFunctionName("GetOpacity");
+      .SetFunctionName("GetOpacity")
+      .SetHidden();
 
   obj.AddExpression("Angle",
                     _("Angle"),

--- a/Extensions/Video/JsExtension.js
+++ b/Extensions/Video/JsExtension.js
@@ -136,7 +136,9 @@ module.exports = {
       )
       .setIncludeFile('Extensions/Video/videoruntimeobject.js')
       .addIncludeFile('Extensions/Video/videoruntimeobject-pixi-renderer.js')
-      .setCategoryFullName(_('User interface'));
+      .setCategoryFullName(_('User interface'))
+      .addDefaultBehavior('EffectCapability::EffectBehavior')
+      .addDefaultBehavior("OpacityCapability::OpacityBehavior");
 
     object
       .addAction(
@@ -425,8 +427,10 @@ module.exports = {
       )
       .getCodeExtraInformation()
       .setFunctionName('setOpacity')
-      .setGetter('getOpacity');
+      .setGetter('getOpacity')
+      .setHidden();
 
+    // Deprecated
     object
       .addCondition(
         'GetOpacity',
@@ -445,8 +449,10 @@ module.exports = {
         )
       )
       .getCodeExtraInformation()
-      .setFunctionName('getOpacity');
+      .setFunctionName('getOpacity')
+      .setHidden();
 
+    // Deprecated
     object
       .addExpression(
         'Opacity',
@@ -457,7 +463,8 @@ module.exports = {
       )
       .addParameter('object', _('Object'), 'VideoObject', false)
       .getCodeExtraInformation()
-      .setFunctionName('getOpacity');
+      .setFunctionName('getOpacity')
+      .setHidden();
 
     object
       .addAction(

--- a/Extensions/Video/videoruntimeobject.ts
+++ b/Extensions/Video/videoruntimeobject.ts
@@ -24,7 +24,9 @@ namespace gdjs {
    * video will have the same state for this video (paused/playing, current time,
    * volume, etc...).
    */
-  export class VideoRuntimeObject extends gdjs.RuntimeObject {
+  export class VideoRuntimeObject
+    extends gdjs.RuntimeObject
+    implements gdjs.OpacityHandler {
     _opacity: float;
     _loop: boolean;
     _volume: float;


### PR DESCRIPTION
### Changes
- Add back effect capabilities to BB text, bitmap text, video, light and particle emitter
- Hide old opacity instructions for 9-patch sprites, text and video