### PR TITLE
Change how filemetadata is given to editors to avoid outdated value

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
@@ -19,15 +19,13 @@ export type EditorContainerExtraProps = {|
   // Homepage
   storageProviders?: Array<StorageProvider>,
   initialTab?: ?string,
-
-  // Resources editor
-  fileMetadata?: ?FileMetadata,
 |};
 
 export type RenderEditorContainerProps = {|
   isActive: boolean,
   projectItemName: ?string,
   project: ?gdProject,
+  fileMetadata: ?FileMetadata,
   setToolbar: (?React.Node) => void,
 
   // Some optional extra props to pass to the rendered editor

--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -42,7 +42,7 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
   }
 
   render() {
-    const { project } = this.props;
+    const { project, extraEditorProps } = this.props;
     if (!project) return null;
 
     return (
@@ -52,11 +52,7 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
         onRenameResource={this.props.onRenameResource}
         resourceManagementProps={this.props.resourceManagementProps}
         ref={editor => (this.editor = editor)}
-        fileMetadata={
-          this.props.extraEditorProps
-            ? this.props.extraEditorProps.fileMetadata
-            : null
-        }
+        fileMetadata={extraEditorProps ? extraEditorProps.fileMetadata : null}
         project={project}
       />
     );

--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -42,7 +42,7 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
   }
 
   render() {
-    const { project, extraEditorProps } = this.props;
+    const { project } = this.props;
     if (!project) return null;
 
     return (
@@ -52,7 +52,7 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
         onRenameResource={this.props.onRenameResource}
         resourceManagementProps={this.props.resourceManagementProps}
         ref={editor => (this.editor = editor)}
-        fileMetadata={extraEditorProps ? extraEditorProps.fileMetadata : null}
+        fileMetadata={this.props.fileMetadata}
         project={project}
       />
     );

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -42,8 +42,6 @@ export type EditorTab = {|
   key: string,
   /** Extra props to pass to editors. */
   extraEditorProps: ?EditorContainerExtraProps,
-  /** To indicate if the editor needs the most up-to-date fileMetadata in its extra props. */
-  withFileMetadata?: boolean,
   /** If set to false, the tab can't be closed. */
   closable: boolean,
 |};
@@ -155,7 +153,6 @@ export const openEditorTab = (
     extraEditorProps,
     editorRef: null,
     closable: typeof closable === 'undefined' ? true : !!closable,
-    withFileMetadata: key === 'resources',
   };
 
   return {

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -42,6 +42,8 @@ export type EditorTab = {|
   key: string,
   /** Extra props to pass to editors. */
   extraEditorProps: ?EditorContainerExtraProps,
+  /** To indicate if the editor needs the most up-to-date fileMetadata in its extra props. */
+  withFileMetadata?: boolean,
   /** If set to false, the tab can't be closed. */
   closable: boolean,
 |};
@@ -153,6 +155,7 @@ export const openEditorTab = (
     extraEditorProps,
     editorRef: null,
     closable: typeof closable === 'undefined' ? true : !!closable,
+    withFileMetadata: key === 'resources',
   };
 
   return {

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3047,13 +3047,6 @@ const MainFrame = (props: Props) => {
         {getEditors(state.editorTabs).map((editorTab, id) => {
           const isCurrentTab = getCurrentTabIndex(state.editorTabs) === id;
 
-          const extraEditorProps = editorTab.withFileMetadata
-            ? {
-                ...(editorTab.extraEditorProps || undefined),
-                fileMetadata: currentFileMetadata,
-              }
-            : editorTab.extraEditorProps;
-
           return (
             <TabContentContainer key={editorTab.key} active={isCurrentTab}>
               <CommandsContextScopedProvider active={isCurrentTab}>
@@ -3063,8 +3056,9 @@ const MainFrame = (props: Props) => {
                 >
                   {editorTab.renderEditorContainer({
                     isActive: isCurrentTab,
-                    extraEditorProps,
+                    extraEditorProps: editorTab.extraEditorProps,
                     project: currentProject,
+                    fileMetadata: currentFileMetadata,
                     ref: editorRef => (editorTab.editorRef = editorRef),
                     setToolbar: editorToolbar =>
                       setEditorToolbar(editorToolbar, isCurrentTab),

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -616,9 +616,7 @@ const MainFrame = (props: Props) => {
         kind === 'start page' ? <HomeIcon titleAccess="Home" /> : undefined;
       const closable = kind !== 'start page';
       const extraEditorProps =
-        kind === 'resources'
-          ? { fileMetadata: currentFileMetadata }
-          : kind === 'start page'
+        kind === 'start page'
           ? { storageProviders: props.storageProviders }
           : undefined;
       return {
@@ -633,7 +631,7 @@ const MainFrame = (props: Props) => {
         dontFocusTab,
       };
     },
-    [i18n, currentFileMetadata, props.storageProviders]
+    [i18n, props.storageProviders]
   );
 
   const setEditorTabs = React.useCallback(
@@ -3048,6 +3046,14 @@ const MainFrame = (props: Props) => {
       >
         {getEditors(state.editorTabs).map((editorTab, id) => {
           const isCurrentTab = getCurrentTabIndex(state.editorTabs) === id;
+
+          const extraEditorProps = editorTab.withFileMetadata
+            ? {
+                ...(editorTab.extraEditorProps || undefined),
+                fileMetadata: currentFileMetadata,
+              }
+            : editorTab.extraEditorProps;
+
           return (
             <TabContentContainer key={editorTab.key} active={isCurrentTab}>
               <CommandsContextScopedProvider active={isCurrentTab}>
@@ -3057,7 +3063,7 @@ const MainFrame = (props: Props) => {
                 >
                   {editorTab.renderEditorContainer({
                     isActive: isCurrentTab,
-                    extraEditorProps: editorTab.extraEditorProps,
+                    extraEditorProps,
                     project: currentProject,
                     ref: editorRef => (editorTab.editorRef = editorRef),
                     setToolbar: editorToolbar =>


### PR DESCRIPTION
Fixes the fact that the resources operations were not available when opening a project and the resources tab was restored from the tabs persisted state.
It was opening too quickly and was given an outdated fileMetadata (`null`). The impact was that a right-click on an item in the resources list was not displaying the resources operations that are particular to the project storage provider ("Locate file" for instance)