### PR TITLE
Refactor resource loading in Runtime

### DIFF
--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -100,7 +100,7 @@ namespace gdjs {
 
       let loadedCount = 0;
       await Promise.all(
-        gdjs.mapIterable(this._resources.values(), async (resource) => {
+        [...this._resources.values()].map(async (resource) => {
           const url = this._resourcesLoader.getFullUrl(resource.file);
           loader.withCredentials = this._resourcesLoader.checkIfCredentialsRequired(
             url
@@ -124,34 +124,6 @@ namespace gdjs {
         })
       );
       return loadedCount;
-    }
-
-    getAllResourcesPromises(): Iterable<Promise<void>> {
-      const loader = this._loader;
-      if (this._resources.size === 0 || !loader) {
-        return gdjs.emptyIterable;
-      }
-
-      return gdjs.mapIterable(this._resources.values(), async (resource) => {
-        const url = this._resourcesLoader.getFullUrl(resource.file);
-        loader.withCredentials = this._resourcesLoader.checkIfCredentialsRequired(
-          url
-        );
-        try {
-          const gltf: THREE_ADDONS.GLTF = await loader.loadAsync(
-            url,
-            (event) => {}
-          );
-          this._loadedThreeModels.set(resource.name, gltf);
-        } catch (error) {
-          logger.error(
-            "Can't fetch the 3D model file " +
-              resource.file +
-              ', error: ' +
-              error
-          );
-        }
-      });
     }
 
     /**

--- a/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
+++ b/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
@@ -184,7 +184,10 @@ namespace gdjs {
      * @param onProgress Callback called each time a new file is loaded.
      * @param onComplete Callback called when loading is done.
      */
-    loadFonts(onProgress, onComplete) {
+    loadFonts(
+      onProgress: (loadingCount: integer, totalCount: integer) => void,
+      onComplete: (totalCount: integer) => void
+    ) {
       const resources = this._resources;
 
       // Construct the list of files to be loaded.

--- a/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
+++ b/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
@@ -182,9 +182,19 @@ namespace gdjs {
      * Load the specified resources, so that fonts are loaded and can then be
      * used by using the font family returned by getFontFamily.
      * @param onProgress Callback called each time a new file is loaded.
-     * @param onComplete Callback called when loading is done.
      */
     loadFonts(
+      onProgress: (loadedCount: integer, totalCount: integer) => void
+    ): Promise<integer> {
+      const that = this;
+      return new Promise((resolve, reject) => {
+        that.loadFontsWithCallback(onProgress, (totalCount: integer) => {
+          resolve(totalCount);
+        });
+      });
+    }
+
+    private loadFontsWithCallback(
       onProgress: (loadingCount: integer, totalCount: integer) => void,
       onComplete: (totalCount: integer) => void
     ) {

--- a/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
+++ b/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
@@ -13,7 +13,7 @@ namespace gdjs {
    */
   export class FontFaceObserverFontManager {
     _resourcesLoader: RuntimeGameResourcesLoader;
-    _resources: ResourceData[];
+    _resources: Map<string, ResourceData>;
     // Associate font resource names to the loaded font family
     _loadedFontFamily: { [key: string]: string } = {};
     // Associate font resource names to the resources, for faster access
@@ -25,10 +25,11 @@ namespace gdjs {
      * @param resourcesLoader The resources loader of the game.
      */
     constructor(
-      resources: ResourceData[],
+      resourceDataArray: ResourceData[],
       resourcesLoader: RuntimeGameResourcesLoader
     ) {
-      this._resources = resources;
+      this._resources = new Map<string, ResourceData>();
+      this.setResources(resourceDataArray);
       this._resourcesLoader = resourcesLoader;
     }
 
@@ -38,8 +39,13 @@ namespace gdjs {
      *
      * @param resources The resources data of the game.
      */
-    setResources(resources: ResourceData[]): void {
-      this._resources = resources;
+    setResources(resourceDataArray: ResourceData[]): void {
+      this._resources.clear();
+      for (const resourceData of resourceDataArray) {
+        if (resourceData.kind === 'font') {
+          this._resources.set(resourceData.name, resourceData);
+        }
+      }
     }
 
     /**
@@ -204,9 +210,8 @@ namespace gdjs {
       // For one loaded file, it can have one or more resources
       // that use it.
       const filesResources: { [key: string]: ResourceData[] } = {};
-      for (let i = 0, len = resources.length; i < len; ++i) {
-        const res = resources[i];
-        if (res.file && res.kind === 'font') {
+      for (const res of resources.values()) {
+        if (res.file) {
           if (!!this._loadedFonts[res.name]) {
             continue;
           }

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -600,13 +600,28 @@ namespace gdjs {
   };
 
   export function* mapIterable<S, T>(
-    iterator: Iterable<S>,
+    iterable: Iterable<S>,
     mapping: (source: S) => T
   ): Iterable<T> {
-    for (let i of iterator) {
-      yield mapping(i);
+    for (const element of iterable) {
+      yield mapping(element);
     }
   }
+
+  export function* filterIterable<T>(
+    iterable: Iterable<T>,
+    predicate: (value: T) => unknown,
+    thisArg?: any
+  ): Iterable<T> {
+    for (const element of iterable) {
+      if (predicate(element)) {
+        yield element;
+      }
+    }
+  }
+
+  function* createEmptyIterable<T>(): Iterable<T> {}
+  export const emptyIterable = createEmptyIterable<any>();
 }
 
 // Make sure console.warn and console.error are available.

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -598,6 +598,15 @@ namespace gdjs {
   > => {
     return Promise.all(asynchronouslyLoadingLibraryPromises);
   };
+
+  export function* mapIterable<S, T>(
+    iterator: Iterable<S>,
+    mapping: (source: S) => T
+  ): Iterable<T> {
+    for (let i of iterator) {
+      yield mapping(i);
+    }
+  }
 }
 
 // Make sure console.warn and console.error are available.

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -598,30 +598,6 @@ namespace gdjs {
   > => {
     return Promise.all(asynchronouslyLoadingLibraryPromises);
   };
-
-  export function* mapIterable<S, T>(
-    iterable: Iterable<S>,
-    mapping: (source: S) => T
-  ): Iterable<T> {
-    for (const element of iterable) {
-      yield mapping(element);
-    }
-  }
-
-  export function* filterIterable<T>(
-    iterable: Iterable<T>,
-    predicate: (value: T) => unknown,
-    thisArg?: any
-  ): Iterable<T> {
-    for (const element of iterable) {
-      if (predicate(element)) {
-        yield element;
-      }
-    }
-  }
-
-  function* createEmptyIterable<T>(): Iterable<T> {}
-  export const emptyIterable = createEmptyIterable<any>();
 }
 
 // Make sure console.warn and console.error are available.

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -759,6 +759,22 @@ namespace gdjs {
 
     preloadAudio(
       onProgress: (loadedCount: integer, totalCount: integer) => void,
+      resources?: ResourceData[]
+    ): Promise<integer> {
+      const that = this;
+      return new Promise((resolve, reject) => {
+        that.preloadAudioWithCallback(
+          onProgress,
+          (totalCount: integer) => {
+            resolve(totalCount);
+          },
+          resources
+        );
+      });
+    }
+
+    private preloadAudioWithCallback(
+      onProgress: (loadedCount: integer, totalCount: integer) => void,
       onComplete: (totalCount: integer) => void,
       resources?: ResourceData[]
     ) {

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -763,27 +763,10 @@ namespace gdjs {
       this._pausedSounds.length = 0;
     }
 
-    preloadAudio(
+    async preloadAudio(
       onProgress: (loadedCount: integer, totalCount: integer) => void,
       resources?: ResourceData[]
     ): Promise<integer> {
-      const that = this;
-      return new Promise((resolve, reject) => {
-        that.preloadAudioWithCallback(
-          onProgress,
-          (totalCount: integer) => {
-            resolve(totalCount);
-          },
-          resources
-        );
-      });
-    }
-
-    private preloadAudioWithCallback(
-      onProgress: (loadedCount: integer, totalCount: integer) => void,
-      onComplete: (totalCount: integer) => void,
-      resources?: ResourceData[]
-    ) {
       // Construct the list of files to be loaded.
       // For one loaded file, it can have one or more resources
       // that use it.
@@ -802,90 +785,88 @@ namespace gdjs {
 
       const filesToLoad = Object.keys(files);
       const totalCount = filesToLoad.length;
-      if (totalCount === 0) return onComplete(totalCount); // Nothing to load.
-
-      let loadedCount: integer = 0;
-      const onLoad = (_?: any, error?: string) => {
-        if (error)
-          logger.warn(
-            'There was an error while preloading an audio file: ' + error
-          );
-
-        loadedCount++;
-        if (loadedCount === totalCount) return onComplete(totalCount);
-
-        onProgress(loadedCount, totalCount);
-        loadNextFile();
-      };
+      if (totalCount === 0) {
+        // Nothing to load.
+        return 0;
+      }
 
       const preloadAudioFile = (
         file: string,
-        onLoadCallback: HowlCallback,
         isMusic: boolean
-      ) => {
-        const container = isMusic ? this._loadedMusics : this._loadedSounds;
-        container[file] = new Howl(
-          Object.assign({}, HowlParameters, {
-            src: [this._resourcesLoader.getFullUrl(file)],
-            onload: onLoadCallback,
-            onloaderror: onLoadCallback,
-            html5: isMusic,
-            xhr: {
-              withCredentials: this._resourcesLoader.checkIfCredentialsRequired(
-                file
-              ),
-            },
-            // Cache the sound with no volume. This avoids a bug where it plays at full volume
-            // for a split second before setting its correct volume.
-            volume: 0,
-          })
-        );
+      ): Promise<number> => {
+        return new Promise((resolve, reject) => {
+          const container = isMusic ? this._loadedMusics : this._loadedSounds;
+          container[file] = new Howl(
+            Object.assign({}, HowlParameters, {
+              src: [this._resourcesLoader.getFullUrl(file)],
+              onload: resolve,
+              onloaderror: (soundId: number, error?: string) => reject(error),
+              html5: isMusic,
+              xhr: {
+                withCredentials: this._resourcesLoader.checkIfCredentialsRequired(
+                  file
+                ),
+              },
+              // Cache the sound with no volume. This avoids a bug where it plays at full volume
+              // for a split second before setting its correct volume.
+              volume: 0,
+            })
+          );
+        });
       };
 
-      const loadNextFile = () => {
-        if (!filesToLoad.length) return;
-        const file = filesToLoad.shift()!;
-        const fileData = files[file][0];
+      let loadedCount: integer = 0;
+      await Promise.all(
+        filesToLoad.map(async (file) => {
+          const fileData = files[file][0];
 
-        let loadCounter = 0;
-        const callback = (_?: any, error?: string) => {
-          loadCounter--;
-          if (!loadCounter) {
-            onLoad(_, error);
+          if (fileData.preloadAsMusic) {
+            try {
+              await preloadAudioFile(file, /* isMusic= */ true);
+            } catch (error) {
+              logger.warn(
+                'There was an error while preloading an audio file: ' + error
+              );
+            }
           }
-        };
 
-        if (fileData.preloadAsMusic) {
-          loadCounter++;
-          preloadAudioFile(file, callback, /* isMusic= */ true);
-        }
-
-        if (fileData.preloadAsSound) {
-          loadCounter++;
-          preloadAudioFile(file, callback, /* isMusic= */ false);
-        } else if (fileData.preloadInCache) {
-          // preloading as sound already does a XHR request, hence "else if"
-          loadCounter++;
-          const sound = new XMLHttpRequest();
-          sound.withCredentials = this._resourcesLoader.checkIfCredentialsRequired(
-            file
-          );
-          sound.addEventListener('load', callback);
-          sound.addEventListener('error', (_) =>
-            callback(_, 'XHR error: ' + file)
-          );
-          sound.addEventListener('abort', (_) =>
-            callback(_, 'XHR abort: ' + file)
-          );
-          sound.open('GET', this._resourcesLoader.getFullUrl(file));
-          sound.send();
-        }
-
-        if (!loadCounter) {
-          onLoad();
-        }
-      };
-      loadNextFile();
+          if (fileData.preloadAsSound) {
+            try {
+              await preloadAudioFile(file, /* isMusic= */ false);
+            } catch (error) {
+              logger.warn(
+                'There was an error while preloading an audio file: ' + error
+              );
+            }
+          } else if (fileData.preloadInCache) {
+            // preloading as sound already does a XHR request, hence "else if"
+            try {
+              await new Promise((resolve, reject) => {
+                const sound = new XMLHttpRequest();
+                sound.withCredentials = this._resourcesLoader.checkIfCredentialsRequired(
+                  file
+                );
+                sound.addEventListener('load', resolve);
+                sound.addEventListener('error', (_) =>
+                  reject('XHR error: ' + file)
+                );
+                sound.addEventListener('abort', (_) =>
+                  reject('XHR abort: ' + file)
+                );
+                sound.open('GET', this._resourcesLoader.getFullUrl(file));
+                sound.send();
+              });
+            } catch (error) {
+              logger.warn(
+                'There was an error while preloading an audio file: ' + error
+              );
+            }
+          }
+          loadedCount++;
+          onProgress(loadedCount, totalCount);
+        })
+      );
+      return totalCount;
     }
   }
 

--- a/GDJS/Runtime/jsonmanager.ts
+++ b/GDJS/Runtime/jsonmanager.ts
@@ -80,7 +80,7 @@ namespace gdjs {
       await Promise.all(
         gdjs.mapIterable(preloadedResources, async (resource) => {
           try {
-            this.loadJsonAsync(resource.name);
+            await this.loadJsonAsync(resource.name);
           } catch (error) {
             logger.error('Error while preloading a json resource:' + error);
           }

--- a/GDJS/Runtime/jsonmanager.ts
+++ b/GDJS/Runtime/jsonmanager.ts
@@ -60,9 +60,19 @@ namespace gdjs {
      * as JSON files can have been modified without the editor knowing).
      *
      * @param onProgress The function called after each json is loaded.
-     * @param onComplete The function called when all jsons are loaded.
      */
     preloadJsons(
+      onProgress: (loadedCount: integer, totalCount: integer) => void
+    ): Promise<integer> {
+      const that = this;
+      return new Promise((resolve, reject) => {
+        that.preloadJsonsWithCallback(onProgress, (totalCount: integer) => {
+          resolve(totalCount);
+        });
+      });
+    }
+
+    private preloadJsonsWithCallback(
       onProgress: JsonManagerOnProgressCallback,
       onComplete: JsonManagerOnCompleteCallback
     ): void {

--- a/GDJS/Runtime/jsonmanager.ts
+++ b/GDJS/Runtime/jsonmanager.ts
@@ -69,16 +69,13 @@ namespace gdjs {
     async preloadJsons(
       onProgress: (loadedCount: integer, totalCount: integer) => void
     ): Promise<integer> {
-      const preloadedResources = [
-        ...gdjs.filterIterable(
-          this._resources.values(),
-          (resource) => !resource.disablePreload
-        ),
-      ];
+      const preloadedResources = [...this._resources.values()].filter(
+        (resource) => !resource.disablePreload
+      );
 
       let loadedCount = 0;
       await Promise.all(
-        gdjs.mapIterable(preloadedResources, async (resource) => {
+        preloadedResources.map(async (resource) => {
           try {
             await this.loadJsonAsync(resource.name);
           } catch (error) {

--- a/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
@@ -262,16 +262,13 @@ namespace gdjs {
     async loadBitmapFontData(
       onProgress: (count: integer, total: integer) => void
     ): Promise<integer> {
-      const preloadedResources = [
-        ...gdjs.filterIterable(
-          this._resources.values(),
-          (resource) => !resource.disablePreload
-        ),
-      ];
+      const preloadedResources = [...this._resources.values()].filter(
+        (resource) => !resource.disablePreload
+      );
 
       let loadedCount = 0;
       await Promise.all(
-        gdjs.mapIterable(preloadedResources, async (bitmapFontResource) => {
+        preloadedResources.map(async (bitmapFontResource) => {
           try {
             const response = await fetch(
               this._resourcesLoader.getFullUrl(bitmapFontResource.file),

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -310,7 +310,10 @@ namespace gdjs {
      * @param onProgress Callback called each time a new file is loaded.
      * @param onComplete Callback called when loading is done.
      */
-    loadTextures(onProgress, onComplete) {
+    loadTextures(
+      onProgress: (loadingCount: integer, totalCount: integer) => void,
+      onComplete: (totalCount: integer) => void
+    ) {
       const resources = this._resources;
 
       // Construct the list of files to be loaded.

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -308,7 +308,6 @@ namespace gdjs {
      * Load the specified resources, so that textures are loaded and can then be
      * used by calling `getPIXITexture`.
      * @param onProgress Callback called each time a new file is loaded.
-     * @param onComplete Callback called when loading is done.
      */
     loadTextures(
       onProgress: (loadingCount: integer, totalCount: integer) => void

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -681,7 +681,7 @@ namespace gdjs {
     /**
      * Load all assets, displaying progress in renderer.
      */
-    loadAllAssets(callback: () => void, progressCallback?: (float) => void) {
+    loadAllAssets(callback: () => void, progressCallback?: (progress: float) => void) {
       const loadingScreen = new gdjs.LoadingScreenRenderer(
         this.getRenderer(),
         this._imageManager,

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -681,117 +681,47 @@ namespace gdjs {
     /**
      * Load all assets, displaying progress in renderer.
      */
-    loadAllAssets(callback: () => void, progressCallback?: (progress: float) => void) {
+    loadAllAssets(
+      callback: () => void,
+      progressCallback?: (progress: float) => void
+    ) {
+      this.loadAllAssetsAsync(progressCallback).then(callback);
+    }
+
+    /**
+     * Load all assets, displaying progress in renderer.
+     */
+    loadAllAssetsAsync = async (
+      progressCallback?: (progress: float) => void
+    ) => {
       const loadingScreen = new gdjs.LoadingScreenRenderer(
         this.getRenderer(),
         this._imageManager,
         this._data.properties.loadingScreen
       );
       const allAssetsTotal = this._data.resources.resources.length;
-      const that = this;
+      let loadedAssets = 0;
 
-      // TODO: All the `loadXXX` (or `preloadXXX`) methods would be
-      // better converted to return promises, for better readability of the code.
-      // See how `loadBitmapFontData` is done.
-      this._imageManager.loadTextures(
-        function (count, total) {
-          const percent = Math.floor((count / allAssetsTotal) * 100);
-          loadingScreen.setPercent(percent);
-          if (progressCallback) {
-            progressCallback(percent);
-          }
-        },
-        function (texturesTotalCount) {
-          that._soundManager.preloadAudio(
-            function (count, total) {
-              const percent = Math.floor(
-                ((texturesTotalCount + count) / allAssetsTotal) * 100
-              );
-              loadingScreen.setPercent(percent);
-              if (progressCallback) {
-                progressCallback(percent);
-              }
-            },
-            function (audioTotalCount) {
-              that._fontManager.loadFonts(
-                function (count, total) {
-                  const percent = Math.floor(
-                    ((texturesTotalCount + audioTotalCount + count) /
-                      allAssetsTotal) *
-                      100
-                  );
-                  loadingScreen.setPercent(percent);
-                  if (progressCallback) {
-                    progressCallback(percent);
-                  }
-                },
-                function (fontTotalCount) {
-                  that._jsonManager.preloadJsons(
-                    function (count, total) {
-                      const percent = Math.floor(
-                        ((texturesTotalCount +
-                          audioTotalCount +
-                          fontTotalCount +
-                          count) /
-                          allAssetsTotal) *
-                          100
-                      );
-                      loadingScreen.setPercent(percent);
-                      if (progressCallback) {
-                        progressCallback(percent);
-                      }
-                    },
-                    function (jsonTotalCount) {
-                      that._model3DManager.loadModels(
-                        function (count, total) {
-                          const percent = Math.floor(
-                            ((texturesTotalCount +
-                              audioTotalCount +
-                              fontTotalCount +
-                              jsonTotalCount +
-                              count) /
-                              allAssetsTotal) *
-                              100
-                          );
-                          loadingScreen.setPercent(percent);
-                          if (progressCallback) {
-                            progressCallback(percent);
-                          }
-                        },
-                        function (model3DTotalCount) {
-                          that._bitmapFontManager
-                            .loadBitmapFontData((count) => {
-                              var percent = Math.floor(
-                                ((texturesTotalCount +
-                                  audioTotalCount +
-                                  fontTotalCount +
-                                  jsonTotalCount +
-                                  model3DTotalCount +
-                                  count) /
-                                  allAssetsTotal) *
-                                  100
-                              );
-                              loadingScreen.setPercent(percent);
-                              if (progressCallback) progressCallback(percent);
-                            })
-                            .then(() => loadingScreen.unload())
-                            .then(() =>
-                              gdjs.getAllAsynchronouslyLoadingLibraryPromise()
-                            )
-                            .then(() => {
-                              callback();
-                            });
-                        }
-                      );
-                    }
-                  );
-                }
-              );
-            }
-          );
+      const onProgress = (count: integer, total: integer) => {
+        const percent = Math.floor(
+          (100 * (loadedAssets + count)) / allAssetsTotal
+        );
+        loadingScreen.setPercent(percent);
+        if (progressCallback) {
+          progressCallback(percent);
         }
-      );
-    }
+      };
+
+      loadedAssets += await this._imageManager.loadTextures(onProgress);
+      loadedAssets += await this._soundManager.preloadAudio(onProgress);
+      loadedAssets += await this._fontManager.loadFonts(onProgress);
+      loadedAssets += await this._jsonManager.preloadJsons(onProgress);
+      loadedAssets += await this._model3DManager.loadModels(onProgress);
+      await this._bitmapFontManager.loadBitmapFontData(onProgress);
+
+      await loadingScreen.unload();
+      await gdjs.getAllAsynchronouslyLoadingLibraryPromise();
+    };
 
     /**
      * Start the game loop, to be called once assets are loaded.

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -211,29 +211,31 @@ namespace gdjs {
       this._variables = new gdjs.VariablesContainer(data.variables);
       this._data = data;
       this._resourcesLoader = new gdjs.RuntimeGameResourcesLoader(this);
+
+      const resources = this._data.resources.resources;
       this._imageManager = new gdjs.ImageManager(
-        this._data.resources.resources,
+        resources,
         this._resourcesLoader
       );
       this._soundManager = new gdjs.SoundManager(
-        this._data.resources.resources,
+        resources,
         this._resourcesLoader
       );
       this._fontManager = new gdjs.FontManager(
-        this._data.resources.resources,
+        resources,
         this._resourcesLoader
       );
       this._jsonManager = new gdjs.JsonManager(
-        this._data.resources.resources,
+        resources,
         this._resourcesLoader
       );
       this._bitmapFontManager = new gdjs.BitmapFontManager(
-        this._data.resources.resources,
+        resources,
         this._resourcesLoader,
         this._imageManager
       );
       this._model3DManager = new gdjs.Model3DManager(
-        this._data.resources.resources,
+        resources,
         this._resourcesLoader
       );
       this._effectsManager = new gdjs.EffectsManager();


### PR DESCRIPTION
### Changes
- Use async/await
- Pre-filter assets by types (it's iterated only once currently, but it will be useful for loading per layout)
- Use a Map for resources because loading per layout will need an access by resource names.