### PR TITLE
Prevent throwing when leaderboards cannot be fetched

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/LeaderboardIdField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LeaderboardIdField.js
@@ -37,7 +37,12 @@ const useFetchLeaderboards = () => {
   );
   const fetchLeaderboards = React.useCallback(
     async () => {
-      await listLeaderboards();
+      try {
+        await listLeaderboards();
+      } catch (e) {
+        // Do not throw or show alert as this can be triggered every time the field is seen.
+        console.error('Unable to fetch leaderboards', e);
+      }
     },
     [listLeaderboards]
   );


### PR DESCRIPTION
If cannot be fetched, it is triggered on every render, so almost on every scroll of the sheet