### PR TITLE
Remember collapsed state of object behaviors

### DIFF
--- a/Core/GDCore/Project/BehaviorConfigurationContainer.h
+++ b/Core/GDCore/Project/BehaviorConfigurationContainer.h
@@ -31,10 +31,10 @@ namespace gd {
  */
 class GD_CORE_API BehaviorConfigurationContainer {
  public:
-
-  BehaviorConfigurationContainer(){};
-  BehaviorConfigurationContainer(const gd::String& name_, const gd::String& type_)
-      : name(name_), type(type_){};
+  BehaviorConfigurationContainer() : folded(false){};
+  BehaviorConfigurationContainer(const gd::String& name_,
+                                 const gd::String& type_)
+      : name(name_), type(type_), folded(false){};
   virtual ~BehaviorConfigurationContainer();
   virtual BehaviorConfigurationContainer* Clone() const { return new BehaviorConfigurationContainer(*this); }
 
@@ -61,7 +61,7 @@ class GD_CORE_API BehaviorConfigurationContainer {
   /**
    * \brief Called when the IDE wants to know about the custom properties of the
    * behavior.
-   * 
+   *
    * \return a std::map with properties names as key.
    * \see gd::PropertyDescriptor
    */
@@ -103,6 +103,17 @@ class GD_CORE_API BehaviorConfigurationContainer {
 
   const gd::SerializerElement& GetContent() const { return content; };
   gd::SerializerElement& GetContent() { return content; };
+
+  /**
+   * \brief Set if the behavior configuration panel should be folded in the UI.
+   */
+  void SetFolded(bool fold = true) { folded = fold; }
+
+  /**
+   * \brief True if the behavior configuration panel should be folded in the UI.
+   */
+  bool IsFolded() const { return folded; }
+
 
 protected:
   /**
@@ -148,6 +159,7 @@ protected:
                     ///< in the form "ExtensionName::BehaviorTypeName"
 
   gd::SerializerElement content;  // Storage for the behavior properties
+  bool folded;
 };
 
 }  // namespace gd

--- a/Core/GDCore/Project/Object.cpp
+++ b/Core/GDCore/Project/Object.cpp
@@ -167,6 +167,7 @@ void Object::UnserializeFrom(gd::Project& project,
       gd::String name = behaviorElement.GetStringAttribute("name");
 
       auto behavior = gd::Object::AddNewBehavior(project, type, name);
+      behavior->SetFolded(behaviorElement.GetBoolAttribute("folded", false));
       // Compatibility with GD <= 4.0.98
       // If there is only one child called "content" (in addition to "type" and
       // "name"), it's the content of a JavaScript behavior. Move the content
@@ -219,6 +220,7 @@ void Object::SerializeTo(SerializerElement& element) const {
     behavior.SerializeTo(behaviorElement);
     behaviorElement.RemoveChild("type");  // The content can contain type or
                                           // name properties, remove them.
+    if (behavior.IsFolded()) behaviorElement.SetAttribute("folded", true);
     behaviorElement.RemoveChild("name");
     behaviorElement.SetAttribute("type", behavior.GetTypeName());
     behaviorElement.SetAttribute("name", behavior.GetName());

--- a/Core/GDCore/Project/Object.cpp
+++ b/Core/GDCore/Project/Object.cpp
@@ -167,7 +167,6 @@ void Object::UnserializeFrom(gd::Project& project,
       gd::String name = behaviorElement.GetStringAttribute("name");
 
       auto behavior = gd::Object::AddNewBehavior(project, type, name);
-      behavior->SetFolded(behaviorElement.GetBoolAttribute("folded", false));
       // Compatibility with GD <= 4.0.98
       // If there is only one child called "content" (in addition to "type" and
       // "name"), it's the content of a JavaScript behavior. Move the content
@@ -220,7 +219,6 @@ void Object::SerializeTo(SerializerElement& element) const {
     behavior.SerializeTo(behaviorElement);
     behaviorElement.RemoveChild("type");  // The content can contain type or
                                           // name properties, remove them.
-    if (behavior.IsFolded()) behaviorElement.SetAttribute("folded", true);
     behaviorElement.RemoveChild("name");
     behaviorElement.SetAttribute("type", behavior.GetTypeName());
     behaviorElement.SetAttribute("name", behavior.GetName());

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -573,6 +573,9 @@ interface Behavior {
     void SerializeTo([Ref] SerializerElement element);
     void UnserializeFrom([Const, Ref] SerializerElement element);
 
+    boolean IsFolded();
+    void SetFolded(boolean folded);
+
     boolean IsDefaultBehavior();
 };
 

--- a/GDevelop.js/types/gdbehavior.js
+++ b/GDevelop.js/types/gdbehavior.js
@@ -10,6 +10,8 @@ declare class gdBehavior {
   initializeContent(): void;
   serializeTo(element: gdSerializerElement): void;
   unserializeFrom(element: gdSerializerElement): void;
+  isFolded(): boolean;
+  setFolded(folded: boolean): void;
   isDefaultBehavior(): boolean;
   delete(): void;
   ptr: number;

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -72,6 +72,7 @@ type BehaviorConfigurationEditorProps = {|
   onChangeBehaviorName: (behavior: gdBehavior, newName: string) => void,
   onRemoveBehavior: (behaviorName: string) => void,
   copyBehavior: (behaviorName: string) => void,
+  canPasteBehaviors: boolean,
   pasteBehaviors: () => Promise<void>,
   openExtension: (behaviorType: string) => void,
 |};
@@ -90,6 +91,7 @@ const BehaviorConfigurationEditor = React.forwardRef<
       onChangeBehaviorName,
       onRemoveBehavior,
       copyBehavior,
+      canPasteBehaviors,
       pasteBehaviors,
       openExtension,
     },
@@ -166,13 +168,8 @@ const BehaviorConfigurationEditor = React.forwardRef<
     );
     const iconUrl = behaviorMetadata.getIconFilename();
 
-    const isClipboardContainingBehaviors = Clipboard.has(
-      BEHAVIORS_CLIPBOARD_KIND
-    );
-
     return (
       <Accordion
-        key={behaviorName}
         expanded={expanded}
         onChange={(_, newExpanded) => {
           setExpanded(newExpanded);
@@ -206,7 +203,7 @@ const BehaviorConfigurationEditor = React.forwardRef<
                 {
                   label: i18n._(t`Paste`),
                   click: pasteBehaviors,
-                  enabled: isClipboardContainingBehaviors,
+                  enabled: canPasteBehaviors,
                 },
                 ...(project.hasEventsBasedBehavior(behaviorTypeName)
                   ? [
@@ -641,6 +638,7 @@ const BehaviorsEditor = (props: Props) => {
                   onBehaviorsUpdated={onBehaviorsUpdated}
                   onChangeBehaviorName={onChangeBehaviorName}
                   openExtension={openExtension}
+                  canPasteBehaviors={isClipboardContainingBehaviors}
                   pasteBehaviors={pasteBehaviors}
                   resourceManagementProps={props.resourceManagementProps}
                 />

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -98,22 +98,15 @@ const BehaviorConfigurationEditor = React.forwardRef<
     ref
   ) => {
     const { values } = React.useContext(PreferencesContext);
-    const [expanded, setExpanded] = React.useState<boolean>(
-      !behavior.isFolded()
-    );
+    const forceUpdate = useForceUpdate();
     const behaviorName = behavior.getName();
     const behaviorTypeName = behavior.getTypeName();
-
-    React.useEffect(
-      () => {
-        behavior.setFolded(!expanded);
-      },
-      [expanded, behavior]
-    );
 
     if (behavior.isDefaultBehavior()) {
       return null;
     }
+
+    const expanded = !behavior.isFolded();
 
     const behaviorMetadata = gd.MetadataProvider.getBehaviorMetadata(
       gd.JsPlatform.get(),
@@ -172,7 +165,8 @@ const BehaviorConfigurationEditor = React.forwardRef<
       <Accordion
         expanded={expanded}
         onChange={(_, newExpanded) => {
-          setExpanded(newExpanded);
+          behavior.setFolded(!newExpanded);
+          forceUpdate();
         }}
         id={`behavior-parameters-${behaviorName}`}
         ref={ref}

--- a/newIDE/app/src/BehaviorsEditor/index.js
+++ b/newIDE/app/src/BehaviorsEditor/index.js
@@ -62,6 +62,219 @@ export const useBehaviorOverridingAlertDialog = () => {
   };
 };
 
+type BehaviorConfigurationEditorInterface = {||};
+type BehaviorConfigurationEditorProps = {|
+  project: gdProject,
+  object: gdObject,
+  behavior: gdBehavior,
+  resourceManagementProps: ResourceManagementProps,
+  onBehaviorsUpdated: () => void,
+  onChangeBehaviorName: (behavior: gdBehavior, newName: string) => void,
+  onRemoveBehavior: (behaviorName: string) => void,
+  copyBehavior: (behaviorName: string) => void,
+  pasteBehaviors: () => Promise<void>,
+  openExtension: (behaviorType: string) => void,
+|};
+
+const BehaviorConfigurationEditor = React.forwardRef<
+  BehaviorConfigurationEditorProps,
+  BehaviorConfigurationEditorInterface
+>(
+  (
+    {
+      project,
+      object,
+      behavior,
+      resourceManagementProps,
+      onBehaviorsUpdated,
+      onChangeBehaviorName,
+      onRemoveBehavior,
+      copyBehavior,
+      pasteBehaviors,
+      openExtension,
+    },
+    ref
+  ) => {
+    const { values } = React.useContext(PreferencesContext);
+    const [expanded, setExpanded] = React.useState<boolean>(
+      !behavior.isFolded()
+    );
+    const behaviorName = behavior.getName();
+    const behaviorTypeName = behavior.getTypeName();
+
+    React.useEffect(
+      () => {
+        behavior.setFolded(!expanded);
+      },
+      [expanded, behavior]
+    );
+
+    if (behavior.isDefaultBehavior()) {
+      return null;
+    }
+
+    const behaviorMetadata = gd.MetadataProvider.getBehaviorMetadata(
+      gd.JsPlatform.get(),
+      behaviorTypeName
+    );
+    if (gd.MetadataProvider.isBadBehaviorMetadata(behaviorMetadata)) {
+      return (
+        <Accordion
+          defaultExpanded
+          id={`behavior-parameters-${behaviorName}`}
+          ref={ref}
+        >
+          <AccordionHeader
+            actions={[
+              <IconButton
+                key="delete"
+                onClick={ev => {
+                  ev.stopPropagation();
+                  onRemoveBehavior(behaviorName);
+                }}
+              >
+                <Trash />
+              </IconButton>,
+            ]}
+          >
+            <MiniToolbarText firstChild>
+              <Trans>Unknown behavior</Trans>{' '}
+            </MiniToolbarText>
+            <Column noMargin expand>
+              <TextField margin="none" value={behaviorName} disabled />
+            </Column>
+          </AccordionHeader>
+          <AccordionBody>
+            <EmptyMessage>
+              <Trans>
+                This behavior is unknown. It might be a behavior that was
+                defined in an extension and that was later removed. You should
+                delete it.
+              </Trans>
+            </EmptyMessage>
+          </AccordionBody>
+        </Accordion>
+      );
+    }
+
+    const BehaviorComponent = BehaviorsEditorService.getEditor(
+      behaviorTypeName
+    );
+    const tutorialIds = getBehaviorTutorialIds(behaviorTypeName);
+    const enabledTutorialIds = tutorialIds.filter(
+      tutorialId => !values.hiddenTutorialHints[tutorialId]
+    );
+    const iconUrl = behaviorMetadata.getIconFilename();
+
+    const isClipboardContainingBehaviors = Clipboard.has(
+      BEHAVIORS_CLIPBOARD_KIND
+    );
+
+    return (
+      <Accordion
+        key={behaviorName}
+        expanded={expanded}
+        onChange={(_, newExpanded) => {
+          setExpanded(newExpanded);
+        }}
+        id={`behavior-parameters-${behaviorName}`}
+        ref={ref}
+      >
+        <AccordionHeader
+          actions={[
+            <HelpIcon
+              key="help"
+              size="small"
+              helpPagePath={behaviorMetadata.getHelpPath()}
+            />,
+            <ElementWithMenu
+              key="menu"
+              element={
+                <IconButton size="small">
+                  <ThreeDotsMenu />
+                </IconButton>
+              }
+              buildMenuTemplate={(i18n: I18nType) => [
+                {
+                  label: i18n._(t`Delete`),
+                  click: () => onRemoveBehavior(behaviorName),
+                },
+                {
+                  label: i18n._(t`Copy`),
+                  click: () => copyBehavior(behaviorName),
+                },
+                {
+                  label: i18n._(t`Paste`),
+                  click: pasteBehaviors,
+                  enabled: isClipboardContainingBehaviors,
+                },
+                ...(project.hasEventsBasedBehavior(behaviorTypeName)
+                  ? [
+                      { type: 'separator' },
+                      {
+                        label: i18n._(t`Edit this behavior`),
+                        click: () => openExtension(behaviorTypeName),
+                      },
+                    ]
+                  : []),
+              ]}
+            />,
+          ]}
+        >
+          {iconUrl ? (
+            <IconContainer
+              src={iconUrl}
+              alt={behaviorMetadata.getFullName()}
+              size={20}
+            />
+          ) : null}
+          <Column expand>
+            <TextField
+              value={behaviorName}
+              translatableHintText={t`Behavior name`}
+              margin="none"
+              fullWidth
+              disabled
+              onChange={(e, text) => onChangeBehaviorName(behavior, text)}
+              id={`behavior-${behaviorName}-name-text-field`}
+            />
+          </Column>
+        </AccordionHeader>
+        <AccordionBody>
+          <Column
+            expand
+            noMargin
+            // Avoid Physics2 behavior overflow on small screens
+            noOverflowParent
+          >
+            {enabledTutorialIds.length ? (
+              <Line>
+                <ColumnStackLayout expand>
+                  {tutorialIds.map(tutorialId => (
+                    <DismissableTutorialMessage
+                      key={tutorialId}
+                      tutorialId={tutorialId}
+                    />
+                  ))}
+                </ColumnStackLayout>
+              </Line>
+            ) : null}
+            <Line>
+              <BehaviorComponent
+                behavior={behavior}
+                project={project}
+                object={object}
+                resourceManagementProps={resourceManagementProps}
+                onBehaviorUpdated={onBehaviorsUpdated}
+              />
+            </Line>
+          </Column>
+        </AccordionBody>
+      </Accordion>
+    );
+  }
+);
+
 type Props = {|
   project: gdProject,
   eventsFunctionsExtension?: gdEventsFunctionsExtension,
@@ -82,8 +295,8 @@ const BehaviorsEditor = (props: Props) => {
     justAddedBehaviorName,
     setJustAddedBehaviorName,
   ] = React.useState<?string>(null);
-  const justAddedBehaviorAccordionElement = React.useRef(
-    (null: ?React$Component<any, any>)
+  const justAddedBehaviorAccordionElement = React.useRef<?BehaviorConfigurationEditorInterface>(
+    null
   );
 
   React.useEffect(
@@ -124,8 +337,6 @@ const BehaviorsEditor = (props: Props) => {
     .map(behaviorName => object.getBehavior(behaviorName))
     .filter(behavior => !behavior.isDefaultBehavior());
   const forceUpdate = useForceUpdate();
-
-  const { values } = React.useContext(PreferencesContext);
 
   const addBehavior = React.useCallback(
     (type: string, defaultName: string) => {
@@ -412,68 +623,6 @@ const BehaviorsEditor = (props: Props) => {
           <ScrollView ref={scrollView}>
             {allVisibleBehaviors.map((behavior, index) => {
               const behaviorName = behavior.getName();
-              const behaviorTypeName = behavior.getTypeName();
-
-              if (behavior.isDefaultBehavior()) {
-                return null;
-              }
-
-              const behaviorMetadata = gd.MetadataProvider.getBehaviorMetadata(
-                gd.JsPlatform.get(),
-                behaviorTypeName
-              );
-              if (gd.MetadataProvider.isBadBehaviorMetadata(behaviorMetadata)) {
-                return (
-                  <Accordion
-                    key={behaviorName}
-                    defaultExpanded
-                    id={`behavior-parameters-${behaviorName}`}
-                  >
-                    <AccordionHeader
-                      actions={[
-                        <IconButton
-                          key="delete"
-                          onClick={ev => {
-                            ev.stopPropagation();
-                            onRemoveBehavior(behaviorName);
-                          }}
-                        >
-                          <Trash />
-                        </IconButton>,
-                      ]}
-                    >
-                      <MiniToolbarText firstChild>
-                        <Trans>Unknown behavior</Trans>{' '}
-                      </MiniToolbarText>
-                      <Column noMargin expand>
-                        <TextField
-                          margin="none"
-                          value={behaviorName}
-                          disabled
-                        />
-                      </Column>
-                    </AccordionHeader>
-                    <AccordionBody>
-                      <EmptyMessage>
-                        <Trans>
-                          This behavior is unknown. It might be a behavior that
-                          was defined in an extension and that was later
-                          removed. You should delete it.
-                        </Trans>
-                      </EmptyMessage>
-                    </AccordionBody>
-                  </Accordion>
-                );
-              }
-
-              const BehaviorComponent = BehaviorsEditorService.getEditor(
-                behaviorTypeName
-              );
-              const tutorialIds = getBehaviorTutorialIds(behaviorTypeName);
-              const enabledTutorialIds = tutorialIds.filter(
-                tutorialId => !values.hiddenTutorialHints[tutorialId]
-              );
-              const iconUrl = behaviorMetadata.getIconFilename();
 
               const ref =
                 justAddedBehaviorName === behaviorName
@@ -481,107 +630,20 @@ const BehaviorsEditor = (props: Props) => {
                   : null;
 
               return (
-                <Accordion
-                  key={behaviorName}
-                  defaultExpanded
-                  id={`behavior-parameters-${behaviorName}`}
+                <BehaviorConfigurationEditor
                   ref={ref}
-                >
-                  <AccordionHeader
-                    actions={[
-                      <HelpIcon
-                        key="help"
-                        size="small"
-                        helpPagePath={behaviorMetadata.getHelpPath()}
-                      />,
-                      <ElementWithMenu
-                        key="menu"
-                        element={
-                          <IconButton size="small">
-                            <ThreeDotsMenu />
-                          </IconButton>
-                        }
-                        buildMenuTemplate={(i18n: I18nType) => [
-                          {
-                            label: i18n._(t`Delete`),
-                            click: () => onRemoveBehavior(behaviorName),
-                          },
-                          {
-                            label: i18n._(t`Copy`),
-                            click: () => copyBehavior(behaviorName),
-                          },
-                          {
-                            label: i18n._(t`Paste`),
-                            click: pasteBehaviors,
-                            enabled: isClipboardContainingBehaviors,
-                          },
-                          ...(project.hasEventsBasedBehavior(behaviorTypeName)
-                            ? [
-                                { type: 'separator' },
-                                {
-                                  label: i18n._(t`Edit this behavior`),
-                                  click: () => openExtension(behaviorTypeName),
-                                },
-                              ]
-                            : []),
-                        ]}
-                      />,
-                    ]}
-                  >
-                    {iconUrl ? (
-                      <IconContainer
-                        src={iconUrl}
-                        alt={behaviorMetadata.getFullName()}
-                        size={20}
-                      />
-                    ) : null}
-                    <Column expand>
-                      <TextField
-                        value={behaviorName}
-                        translatableHintText={t`Behavior name`}
-                        margin="none"
-                        fullWidth
-                        disabled
-                        onChange={(e, text) =>
-                          onChangeBehaviorName(behavior, text)
-                        }
-                        id={`behavior-${behaviorName}-name-text-field`}
-                      />
-                    </Column>
-                  </AccordionHeader>
-                  <AccordionBody>
-                    <Column
-                      expand
-                      noMargin
-                      // Avoid Physics2 behavior overflow on small screens
-                      noOverflowParent
-                    >
-                      {enabledTutorialIds.length ? (
-                        <Line>
-                          <ColumnStackLayout expand>
-                            {tutorialIds.map(tutorialId => (
-                              <DismissableTutorialMessage
-                                key={tutorialId}
-                                tutorialId={tutorialId}
-                              />
-                            ))}
-                          </ColumnStackLayout>
-                        </Line>
-                      ) : null}
-                      <Line>
-                        <BehaviorComponent
-                          behavior={behavior}
-                          project={project}
-                          object={object}
-                          resourceManagementProps={
-                            props.resourceManagementProps
-                          }
-                          onBehaviorUpdated={onBehaviorsUpdated}
-                        />
-                      </Line>
-                    </Column>
-                  </AccordionBody>
-                </Accordion>
+                  key={behaviorName}
+                  project={project}
+                  object={object}
+                  behavior={behavior}
+                  copyBehavior={copyBehavior}
+                  onRemoveBehavior={onRemoveBehavior}
+                  onBehaviorsUpdated={onBehaviorsUpdated}
+                  onChangeBehaviorName={onChangeBehaviorName}
+                  openExtension={openExtension}
+                  pasteBehaviors={pasteBehaviors}
+                  resourceManagementProps={props.resourceManagementProps}
+                />
               );
             })}
           </ScrollView>

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -43,7 +43,7 @@ const styles = {
 };
 
 // Those names are used internally by GDevelop.
-const PROTECTED_PROPERTY_NAMES = ['name', 'type', 'folded'];
+const PROTECTED_PROPERTY_NAMES = ['name', 'type'];
 
 const getValidatedPropertyName = (
   i18n: I18nType,

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -42,6 +42,9 @@ const styles = {
   },
 };
 
+// Those names are used internally by GDevelop.
+const PROTECTED_PROPERTY_NAMES = ['name', 'type', 'folded'];
+
 const getValidatedPropertyName = (
   i18n: I18nType,
   properties: gdNamedPropertyDescriptorsList,
@@ -52,8 +55,7 @@ const getValidatedPropertyName = (
     tentativeNewName => {
       if (
         properties.has(tentativeNewName) ||
-        // The name of a property cannot be "name" or "type", as they are used by GDevelop internally.
-        (tentativeNewName === 'name' || tentativeNewName === 'type')
+        PROTECTED_PROPERTY_NAMES.includes(tentativeNewName)
       ) {
         return true;
       }

--- a/newIDE/app/src/UI/Accordion.js
+++ b/newIDE/app/src/UI/Accordion.js
@@ -122,7 +122,7 @@ type AccordionProps = {|
 
   // Use accordion in controlled mode
   expanded?: boolean,
-  onChange?: (open: boolean) => void,
+  onChange?: (event: any, open: boolean) => void,
   id?: string,
 |};
 

--- a/newIDE/app/src/UI/ScrollView.js
+++ b/newIDE/app/src/UI/ScrollView.js
@@ -24,7 +24,9 @@ type Props = {|
 
 export type ScrollViewInterface = {|
   getScrollPosition: () => number,
-  scrollTo: (target: ?React$Component<any, any> | ?React.ElementRef<any>) => void,
+  scrollTo: (
+    target: ?React$Component<any, any> | ?React.ElementRef<any>
+  ) => void,
   scrollToPosition: (number: number) => void,
   scrollToBottom: () => void,
 |};

--- a/newIDE/app/src/UI/ScrollView.js
+++ b/newIDE/app/src/UI/ScrollView.js
@@ -24,7 +24,7 @@ type Props = {|
 
 export type ScrollViewInterface = {|
   getScrollPosition: () => number,
-  scrollTo: (target: ?React$Component<any, any>) => void,
+  scrollTo: (target: ?React$Component<any, any> | ?React.ElementRef<any>) => void,
   scrollToPosition: (number: number) => void,
   scrollToBottom: () => void,
 |};


### PR DESCRIPTION
Resolves #5562 
~~I checked no extension has a behavior with a property `folded`.~~ => not necessary anymore since we don't save the collapsed state in the project
As discussed together, the collapsed state is not saved in the project to avoid polluting the behavior state with a UI consideration.
So each time the project is reopened, behavior panels will be uncollapsed.