### PR TITLE
Fix dialog asking about user shown even when filled

### DIFF
--- a/newIDE/app/src/Profile/AuthenticatedUserProvider.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserProvider.js
@@ -449,12 +449,12 @@ export default class AuthenticatedUserProvider extends React.Component<
         profile: userProfile,
         loginState: 'done',
       },
-    }));
-
-    // We call this function every time the user is fetched, as it will
-    // automatically prevent the event to be sent if the user attributes haven't changed.
-    identifyUserForAnalytics(this.state.authenticatedUser);
-    this._notifyUserAboutEmailVerificationAndAdditionalInfo();
+    }), () => {
+      // We call this function every time the user is fetched, as it will
+      // automatically prevent the event to be sent if the user attributes haven't changed.
+      identifyUserForAnalytics(this.state.authenticatedUser);
+      this._notifyUserAboutEmailVerificationAndAdditionalInfo();
+    });
   };
 
   _fetchUserSubscriptionLimitsAndUsages = async () => {

--- a/newIDE/app/src/Profile/AuthenticatedUserProvider.js
+++ b/newIDE/app/src/Profile/AuthenticatedUserProvider.js
@@ -443,18 +443,21 @@ export default class AuthenticatedUserProvider extends React.Component<
       }
     }
 
-    this.setState(({ authenticatedUser }) => ({
-      authenticatedUser: {
-        ...authenticatedUser,
-        profile: userProfile,
-        loginState: 'done',
-      },
-    }), () => {
-      // We call this function every time the user is fetched, as it will
-      // automatically prevent the event to be sent if the user attributes haven't changed.
-      identifyUserForAnalytics(this.state.authenticatedUser);
-      this._notifyUserAboutEmailVerificationAndAdditionalInfo();
-    });
+    this.setState(
+      ({ authenticatedUser }) => ({
+        authenticatedUser: {
+          ...authenticatedUser,
+          profile: userProfile,
+          loginState: 'done',
+        },
+      }),
+      () => {
+        // We call this function every time the user is fetched, as it will
+        // automatically prevent the event to be sent if the user attributes haven't changed.
+        identifyUserForAnalytics(this.state.authenticatedUser);
+        this._notifyUserAboutEmailVerificationAndAdditionalInfo();
+      }
+    );
   };
 
   _fetchUserSubscriptionLimitsAndUsages = async () => {


### PR DESCRIPTION
Could have a race condition because state would not be saved before the user is checked (read from the state)