### PR TITLE
Update `createObjectsFrom` and `createObjectsFromExternalLayout` to return a list of objects that it creates.

### DIFF
--- a/GDJS/Runtime/RuntimeInstanceContainer.ts
+++ b/GDJS/Runtime/RuntimeInstanceContainer.ts
@@ -247,7 +247,7 @@ namespace gdjs {
       yPos: float,
       trackByPersistentUuid: boolean
     ): gdjs.RuntimeObject[] {
-      let newObjects = [];
+      let newObjects: gdjs.RuntimeObject[] = [];
       for (let i = 0, len = data.length; i < len; ++i) {
         const instanceData = data[i];
         const objectName = instanceData.name;

--- a/GDJS/Runtime/RuntimeInstanceContainer.ts
+++ b/GDJS/Runtime/RuntimeInstanceContainer.ts
@@ -239,6 +239,7 @@ namespace gdjs {
      * @param yPos The offset on Y axis
      * @param trackByPersistentUuid If true, objects are tracked by setting their `persistentUuid`
      * to the same as the associated instance. Useful for hot-reloading when instances are changed.
+     * @returns A list of objects created.
      */
     createObjectsFrom(
       data: InstanceData[],
@@ -246,6 +247,7 @@ namespace gdjs {
       yPos: float,
       trackByPersistentUuid: boolean
     ) {
+      let newObjects = [];
       for (let i = 0, len = data.length; i < len; ++i) {
         const instanceData = data[i];
         const objectName = instanceData.name;
@@ -275,8 +277,10 @@ namespace gdjs {
             .getVariables()
             .initFrom(instanceData.initialVariables, true);
           newObject.extraInitializationFromInitialInstance(instanceData);
+          newObjects.push(newObject);
         }
       }
+      return newObjects;
     }
 
     /**

--- a/GDJS/Runtime/RuntimeInstanceContainer.ts
+++ b/GDJS/Runtime/RuntimeInstanceContainer.ts
@@ -246,7 +246,7 @@ namespace gdjs {
       xPos: float,
       yPos: float,
       trackByPersistentUuid: boolean
-    ) {
+    ): gdjs.RuntimeObject[] {
       let newObjects = [];
       for (let i = 0, len = data.length; i < len; ++i) {
         const instanceData = data[i];

--- a/GDJS/Runtime/events-tools/runtimescenetools.ts
+++ b/GDJS/Runtime/events-tools/runtimescenetools.ts
@@ -287,7 +287,7 @@ namespace gdjs {
           .getGame()
           .getExternalLayoutData(externalLayout);
         if (externalLayoutData === null) {
-          return;
+          return [];
         }
 
         // trackByPersistentUuid is set to false as we don't want external layouts

--- a/GDJS/Runtime/events-tools/runtimescenetools.ts
+++ b/GDJS/Runtime/events-tools/runtimescenetools.ts
@@ -282,7 +282,7 @@ namespace gdjs {
         externalLayout: string,
         xPos: float,
         yPos: float
-      ) {
+      ): gdjs.RuntimeObject[] {
         const externalLayoutData = scene
           .getGame()
           .getExternalLayoutData(externalLayout);

--- a/GDJS/Runtime/events-tools/runtimescenetools.ts
+++ b/GDJS/Runtime/events-tools/runtimescenetools.ts
@@ -292,7 +292,7 @@ namespace gdjs {
 
         // trackByPersistentUuid is set to false as we don't want external layouts
         // instantiated at runtime to be hot-reloaded.
-        scene.getScene().createObjectsFrom(
+        return scene.getScene().createObjectsFrom(
           externalLayoutData.instances,
           xPos,
           yPos,


### PR DESCRIPTION
This is a small change to the API of `createObjectsFrom` to return a list of objects created, and exposing it further to JS via `createObjectsFromExternalLayout`

This way clients of this API can keep track of the objects that were created from an external layout and manage them further.

Example use-case: being able to unload all objects created from an external layout.

See:
https://forum.gdevelop.io/t/how-can-i-delete-an-external-layout/44511/6?u=dawidfatyga

(FYI: I am located in Zurich so please expect some delay in the response)