### PR TITLE
Revert "Update `createObjectsFrom` and `createObjectsFromExternalLayout` to return a list of objects that it creates."

### DIFF
--- a/GDJS/Runtime/RuntimeInstanceContainer.ts
+++ b/GDJS/Runtime/RuntimeInstanceContainer.ts
@@ -239,15 +239,13 @@ namespace gdjs {
      * @param yPos The offset on Y axis
      * @param trackByPersistentUuid If true, objects are tracked by setting their `persistentUuid`
      * to the same as the associated instance. Useful for hot-reloading when instances are changed.
-     * @returns A list of objects created.
      */
     createObjectsFrom(
       data: InstanceData[],
       xPos: float,
       yPos: float,
       trackByPersistentUuid: boolean
-    ): gdjs.RuntimeObject[] {
-      let newObjects: gdjs.RuntimeObject[] = [];
+    ) {
       for (let i = 0, len = data.length; i < len; ++i) {
         const instanceData = data[i];
         const objectName = instanceData.name;
@@ -277,10 +275,8 @@ namespace gdjs {
             .getVariables()
             .initFrom(instanceData.initialVariables, true);
           newObject.extraInitializationFromInitialInstance(instanceData);
-          newObjects.push(newObject);
         }
       }
-      return newObjects;
     }
 
     /**

--- a/GDJS/Runtime/events-tools/runtimescenetools.ts
+++ b/GDJS/Runtime/events-tools/runtimescenetools.ts
@@ -282,17 +282,17 @@ namespace gdjs {
         externalLayout: string,
         xPos: float,
         yPos: float
-      ): gdjs.RuntimeObject[] {
+      ) {
         const externalLayoutData = scene
           .getGame()
           .getExternalLayoutData(externalLayout);
         if (externalLayoutData === null) {
-          return [];
+          return;
         }
 
         // trackByPersistentUuid is set to false as we don't want external layouts
         // instantiated at runtime to be hot-reloaded.
-        return scene.getScene().createObjectsFrom(
+        scene.getScene().createObjectsFrom(
           externalLayoutData.instances,
           xPos,
           yPos,


### PR DESCRIPTION
Reverts 4ian/GDevelop#5658