### PR TITLE
Prevent triggering screen resize changes when user is typing, letting…

### DIFF
--- a/newIDE/app/src/UI/Reponsive/ResponsiveWindowMeasurer.js
+++ b/newIDE/app/src/UI/Reponsive/ResponsiveWindowMeasurer.js
@@ -8,6 +8,11 @@ import useOnResize from '../../Utils/UseOnResize';
 // Large corresponds to most laptop and desktop screens.
 // Xlarge corresponds to large desktop screens.
 export type WidthType = 'small' | 'medium' | 'large' | 'xlarge';
+const sizeThresholds = {
+  small: 500,
+  medium: 1150,
+  large: 1500,
+};
 
 type Props = {|
   children: (width: WidthType) => React.Node,
@@ -31,11 +36,12 @@ export const useResponsiveWindowWidth = (): WidthType => {
     return 'medium';
   }
 
-  return window.innerWidth < 500 || window.innerHeight < 500
+  return window.innerWidth < sizeThresholds.small ||
+    window.innerHeight < sizeThresholds.small // Mobile devices can be in landscape mode, so check both width and height.
     ? 'small'
-    : window.innerWidth < 1150
+    : window.innerWidth < sizeThresholds.medium
     ? 'medium'
-    : window.innerWidth < 1500
+    : window.innerWidth < sizeThresholds.large
     ? 'large'
     : 'xlarge';
 };

--- a/newIDE/app/src/Utils/UseOnResize.js
+++ b/newIDE/app/src/Utils/UseOnResize.js
@@ -11,6 +11,22 @@ if (typeof window !== 'undefined') {
   const callListeners = () => listeners.forEach(callback => callback());
   let timeout;
   window.addEventListener('resize', () => {
+    const activeElement = document.activeElement;
+    if (
+      activeElement &&
+      (activeElement.tagName === 'INPUT' ||
+        activeElement.tagName === 'TEXTAREA')
+    ) {
+      // Do not call listeners if the user is typing in an input or textarea.
+      // This is particularly helpful on mobile devices, where the virtual
+      // keyboard will trigger a resize event.
+      // NOTE: this is not perfect, as this does not detect if the virtual
+      // keyboard is actually open or not, but it's better than nothing as
+      // we assume the user will not resize the window while typing.
+      // See https://stackoverflow.com/questions/14902321/how-to-determine-if-a-resize-event-was-triggered-by-soft-keyboard-in-mobile-brow
+      // for why we cannot have a perfect solution.
+      return;
+    }
     clearTimeout(timeout);
     timeout = setTimeout(callListeners, 200);
   });


### PR DESCRIPTION
… the navigator handle it.

It fixes a bug on mobile where starting typing would show the virtual keyboard and change the layout.