### PR TITLE
[Refactor] Assume the GDJS renderer may not be present

### DIFF
--- a/Extensions/3D/A_RuntimeObject3D.ts
+++ b/Extensions/3D/A_RuntimeObject3D.ts
@@ -22,8 +22,7 @@ namespace gdjs {
       gdjs.Resizable,
       gdjs.Scalable,
       gdjs.Flippable,
-      gdjs.Base3DHandler
-  {
+      gdjs.Base3DHandler {
     /**
      * Position on the Z axis.
      */

--- a/Extensions/3D/A_RuntimeObject3D.ts
+++ b/Extensions/3D/A_RuntimeObject3D.ts
@@ -22,7 +22,8 @@ namespace gdjs {
       gdjs.Resizable,
       gdjs.Scalable,
       gdjs.Flippable,
-      gdjs.Base3DHandler {
+      gdjs.Base3DHandler
+  {
     /**
      * Position on the Z axis.
      */
@@ -89,7 +90,7 @@ namespace gdjs {
     }
 
     get3DRendererObject() {
-      return this.getRenderer().get3DRendererObject();
+      return this.getRenderer()?.get3DRendererObject();
     }
 
     updateFromObjectData(
@@ -120,12 +121,12 @@ namespace gdjs {
 
     setX(x: float): void {
       super.setX(x);
-      this.getRenderer().updatePosition();
+      this.getRenderer()?.updatePosition();
     }
 
     setY(y: float): void {
       super.setY(y);
-      this.getRenderer().updatePosition();
+      this.getRenderer()?.updatePosition();
     }
 
     /**
@@ -134,7 +135,7 @@ namespace gdjs {
     setZ(z: float): void {
       if (z === this._z) return;
       this._z = z;
-      this.getRenderer().updatePosition();
+      this.getRenderer()?.updatePosition();
     }
 
     /**
@@ -146,7 +147,7 @@ namespace gdjs {
 
     setAngle(angle: float): void {
       super.setAngle(angle);
-      this.getRenderer().updateRotation();
+      this.getRenderer()?.updateRotation();
     }
 
     /**
@@ -156,7 +157,7 @@ namespace gdjs {
      */
     setRotationX(angle: float): void {
       this._rotationX = angle;
-      this.getRenderer().updateRotation();
+      this.getRenderer()?.updateRotation();
     }
 
     /**
@@ -166,7 +167,7 @@ namespace gdjs {
      */
     setRotationY(angle: float): void {
       this._rotationY = angle;
-      this.getRenderer().updateRotation();
+      this.getRenderer()?.updateRotation();
     }
 
     /**
@@ -195,11 +196,14 @@ namespace gdjs {
       const axisX = gdjs.RuntimeObject3D._temporaryVector;
       axisX.set(1, 0, 0);
 
-      const mesh = this.getRenderer().get3DRendererObject();
-      mesh.rotateOnWorldAxis(axisX, gdjs.toRad(deltaAngle));
-      this._rotationX = gdjs.toDegrees(mesh.rotation.x);
-      this._rotationY = gdjs.toDegrees(mesh.rotation.y);
-      this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+      const mesh = this.getRenderer()?.get3DRendererObject();
+      if (mesh) {
+        // TODO: Do the rotation logic ourselves, dont rely on the renderer
+        mesh.rotateOnWorldAxis(axisX, gdjs.toRad(deltaAngle));
+        this._rotationX = gdjs.toDegrees(mesh.rotation.x);
+        this._rotationY = gdjs.toDegrees(mesh.rotation.y);
+        this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+      }
     }
 
     /**
@@ -210,11 +214,14 @@ namespace gdjs {
       const axisY = gdjs.RuntimeObject3D._temporaryVector;
       axisY.set(0, 1, 0);
 
-      const mesh = this.getRenderer().get3DRendererObject();
-      mesh.rotateOnWorldAxis(axisY, gdjs.toRad(deltaAngle));
-      this._rotationX = gdjs.toDegrees(mesh.rotation.x);
-      this._rotationY = gdjs.toDegrees(mesh.rotation.y);
-      this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+      const mesh = this.getRenderer()?.get3DRendererObject();
+      if (mesh) {
+        // TODO: Do the rotation logic ourselves, dont rely on the renderer
+        mesh.rotateOnWorldAxis(axisY, gdjs.toRad(deltaAngle));
+        this._rotationX = gdjs.toDegrees(mesh.rotation.x);
+        this._rotationY = gdjs.toDegrees(mesh.rotation.y);
+        this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+      }
     }
 
     /**
@@ -225,11 +232,14 @@ namespace gdjs {
       const axisZ = gdjs.RuntimeObject3D._temporaryVector;
       axisZ.set(0, 0, 1);
 
-      const mesh = this.getRenderer().get3DRendererObject();
-      mesh.rotateOnWorldAxis(axisZ, gdjs.toRad(deltaAngle));
-      this._rotationX = gdjs.toDegrees(mesh.rotation.x);
-      this._rotationY = gdjs.toDegrees(mesh.rotation.y);
-      this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+      const mesh = this.getRenderer()?.get3DRendererObject();
+      if (mesh) {
+        // TODO: Do the rotation logic ourselves, dont rely on the renderer
+        mesh.rotateOnWorldAxis(axisZ, gdjs.toRad(deltaAngle));
+        this._rotationX = gdjs.toDegrees(mesh.rotation.x);
+        this._rotationY = gdjs.toDegrees(mesh.rotation.y);
+        this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+      }
     }
 
     getWidth(): float {
@@ -251,7 +261,7 @@ namespace gdjs {
       if (this._width === width) return;
 
       this._width = width;
-      this.getRenderer().updateSize();
+      this.getRenderer()?.updateSize();
       this.invalidateHitboxes();
     }
 
@@ -259,7 +269,7 @@ namespace gdjs {
       if (this._height === height) return;
 
       this._height = height;
-      this.getRenderer().updateSize();
+      this.getRenderer()?.updateSize();
       this.invalidateHitboxes();
     }
 
@@ -275,7 +285,7 @@ namespace gdjs {
       if (this._depth === depth) return;
 
       this._depth = depth;
-      this.getRenderer().updateSize();
+      this.getRenderer()?.updateSize();
     }
 
     /**
@@ -436,21 +446,21 @@ namespace gdjs {
     flipX(enable: boolean) {
       if (enable !== this._flippedX) {
         this._flippedX = enable;
-        this.getRenderer().updateSize();
+        this.getRenderer()?.updateSize();
       }
     }
 
     flipY(enable: boolean) {
       if (enable !== this._flippedY) {
         this._flippedY = enable;
-        this.getRenderer().updateSize();
+        this.getRenderer()?.updateSize();
       }
     }
 
     flipZ(enable: boolean) {
       if (enable !== this._flippedZ) {
         this._flippedZ = enable;
-        this.getRenderer().updateSize();
+        this.getRenderer()?.updateSize();
       }
     }
 
@@ -468,7 +478,7 @@ namespace gdjs {
 
     hide(enable: boolean): void {
       super.hide(enable);
-      this.getRenderer().updateVisibility();
+      this.getRenderer()?.updateVisibility();
     }
   }
 }

--- a/Extensions/3D/A_RuntimeObject3DRenderer.ts
+++ b/Extensions/3D/A_RuntimeObject3DRenderer.ts
@@ -1,5 +1,5 @@
 namespace gdjs {
-  export abstract class RuntimeObject3DRenderer {
+  export abstract class RuntimeObject3DThreeRenderer {
     protected _object: gdjs.RuntimeObject3D;
     private _threeObject3D: THREE.Object3D;
 
@@ -14,7 +14,7 @@ namespace gdjs {
 
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .add3DRendererObject(this._threeObject3D);
     }
 
@@ -52,4 +52,13 @@ namespace gdjs {
       this._threeObject3D.visible = !this._object.isHidden();
     }
   }
+
+  export type RuntimeObject3DRenderer =
+    | RuntimeObject3DThreeRenderer
+    | undefined;
+  type RuntimeObject3DRendererClass =
+    | typeof RuntimeObject3DThreeRenderer
+    | undefined;
+  export const RuntimeObject3DRenderer: RuntimeObject3DRendererClass =
+    RuntimeObject3DThreeRenderer;
 }

--- a/Extensions/3D/A_RuntimeObject3DRenderer.ts
+++ b/Extensions/3D/A_RuntimeObject3DRenderer.ts
@@ -59,6 +59,5 @@ namespace gdjs {
   type RuntimeObject3DRendererClass =
     | typeof RuntimeObject3DThreeRenderer
     | undefined;
-  export const RuntimeObject3DRenderer: RuntimeObject3DRendererClass =
-    RuntimeObject3DThreeRenderer;
+  export const RuntimeObject3DRenderer: RuntimeObject3DRendererClass = RuntimeObject3DThreeRenderer;
 }

--- a/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
+++ b/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
@@ -56,7 +56,7 @@ namespace gdjs {
     return runtimeObject
       .getInstanceContainer()
       .getGame()
-      .getImageManager()
+      .getImageManager()!
       .getThreeMaterial(runtimeObject.getFaceAtIndexResourceName(faceIndex), {
         useTransparentTexture: runtimeObject.shouldUseTransparentTexture(),
         forceBasicMaterial:
@@ -65,7 +65,7 @@ namespace gdjs {
       });
   };
 
-  class Cube3DRuntimeObjectPixiRenderer extends gdjs.RuntimeObject3DRenderer {
+  class Cube3DRuntimeObjectPixiRenderer extends gdjs.RuntimeObject3DThreeRenderer {
     private _cube3DRuntimeObject: gdjs.Cube3DRuntimeObject;
     private _boxMesh: THREE.Mesh;
 
@@ -121,13 +121,11 @@ namespace gdjs {
      */
     updateTextureUvMapping(faceIndex?: number) {
       // @ts-ignore - position is stored as a Float32BufferAttribute
-      const pos: THREE.BufferAttribute = this._boxMesh.geometry.getAttribute(
-        'position'
-      );
+      const pos: THREE.BufferAttribute =
+        this._boxMesh.geometry.getAttribute('position');
       // @ts-ignore - uv is stored as a Float32BufferAttribute
-      const uvMapping: THREE.BufferAttribute = this._boxMesh.geometry.getAttribute(
-        'uv'
-      );
+      const uvMapping: THREE.BufferAttribute =
+        this._boxMesh.geometry.getAttribute('uv');
       const startIndex =
         faceIndex === undefined ? 0 : faceIndexToMaterialIndex[faceIndex] * 4;
       const endIndex =
@@ -149,9 +147,10 @@ namespace gdjs {
           continue;
         }
 
-        const shouldRepeatTexture = this._cube3DRuntimeObject.shouldRepeatTextureOnFaceAtIndex(
-          materialIndexToFaceIndex[materialIndex]
-        );
+        const shouldRepeatTexture =
+          this._cube3DRuntimeObject.shouldRepeatTextureOnFaceAtIndex(
+            materialIndexToFaceIndex[materialIndex]
+          );
 
         const shouldOrientateFacesTowardsY =
           this._cube3DRuntimeObject.getFacesOrientation() === 'Y';
@@ -180,12 +179,10 @@ namespace gdjs {
               if (shouldOrientateFacesTowardsY) {
                 [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
               } else {
-                [
-                  x,
-                  y,
-                ] = noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
-                  vertexIndex % 4
-                ];
+                [x, y] =
+                  noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
+                    vertexIndex % 4
+                  ];
               }
             }
             break;
@@ -211,12 +208,10 @@ namespace gdjs {
               if (shouldOrientateFacesTowardsY) {
                 [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
               } else {
-                [
-                  x,
-                  y,
-                ] = noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
-                  vertexIndex % 4
-                ];
+                [x, y] =
+                  noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
+                    vertexIndex % 4
+                  ];
                 x = -x;
                 y = -y;
               }

--- a/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
+++ b/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
@@ -121,11 +121,13 @@ namespace gdjs {
      */
     updateTextureUvMapping(faceIndex?: number) {
       // @ts-ignore - position is stored as a Float32BufferAttribute
-      const pos: THREE.BufferAttribute =
-        this._boxMesh.geometry.getAttribute('position');
+      const pos: THREE.BufferAttribute = this._boxMesh.geometry.getAttribute(
+        'position'
+      );
       // @ts-ignore - uv is stored as a Float32BufferAttribute
-      const uvMapping: THREE.BufferAttribute =
-        this._boxMesh.geometry.getAttribute('uv');
+      const uvMapping: THREE.BufferAttribute = this._boxMesh.geometry.getAttribute(
+        'uv'
+      );
       const startIndex =
         faceIndex === undefined ? 0 : faceIndexToMaterialIndex[faceIndex] * 4;
       const endIndex =
@@ -147,10 +149,9 @@ namespace gdjs {
           continue;
         }
 
-        const shouldRepeatTexture =
-          this._cube3DRuntimeObject.shouldRepeatTextureOnFaceAtIndex(
-            materialIndexToFaceIndex[materialIndex]
-          );
+        const shouldRepeatTexture = this._cube3DRuntimeObject.shouldRepeatTextureOnFaceAtIndex(
+          materialIndexToFaceIndex[materialIndex]
+        );
 
         const shouldOrientateFacesTowardsY =
           this._cube3DRuntimeObject.getFacesOrientation() === 'Y';
@@ -179,10 +180,12 @@ namespace gdjs {
               if (shouldOrientateFacesTowardsY) {
                 [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
               } else {
-                [x, y] =
-                  noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
-                    vertexIndex % 4
-                  ];
+                [
+                  x,
+                  y,
+                ] = noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
+                  vertexIndex % 4
+                ];
               }
             }
             break;
@@ -208,10 +211,12 @@ namespace gdjs {
               if (shouldOrientateFacesTowardsY) {
                 [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
               } else {
-                [x, y] =
-                  noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
-                    vertexIndex % 4
-                  ];
+                [
+                  x,
+                  y,
+                ] = noRepeatTextureVertexIndexToUvMappingForLeftAndRightFacesTowardsZ[
+                  vertexIndex % 4
+                ];
                 x = -x;
                 y = -y;
               }

--- a/Extensions/3D/Model3DRuntimeObject.ts
+++ b/Extensions/3D/Model3DRuntimeObject.ts
@@ -50,8 +50,7 @@ namespace gdjs {
    */
   export class Model3DRuntimeObject
     extends gdjs.RuntimeObject3D
-    implements gdjs.Animatable
-  {
+    implements gdjs.Animatable {
     _renderer: gdjs.Model3DRuntimeObjectRenderer;
 
     _modelResourceName: string;

--- a/Extensions/3D/Model3DRuntimeObject.ts
+++ b/Extensions/3D/Model3DRuntimeObject.ts
@@ -50,7 +50,8 @@ namespace gdjs {
    */
   export class Model3DRuntimeObject
     extends gdjs.RuntimeObject3D
-    implements gdjs.Animatable {
+    implements gdjs.Animatable
+  {
     _renderer: gdjs.Model3DRuntimeObjectRenderer;
 
     _modelResourceName: string;
@@ -98,15 +99,17 @@ namespace gdjs {
       this._centerPoint = getPointForLocation(
         objectData.content.centerLocation
       );
-      this._renderer = new gdjs.Model3DRuntimeObjectRenderer(
-        this,
-        instanceContainer
-      );
+      if (gdjs.Model3DRuntimeObjectRenderer) {
+        this._renderer = new gdjs.Model3DRuntimeObjectRenderer(
+          this,
+          instanceContainer
+        );
+      }
       this._materialType = this._convertMaterialType(
         objectData.content.materialType
       );
       this._updateModel(objectData);
-      if (this._animations.length > 0) {
+      if (this._animations.length > 0 && this._renderer) {
         this._renderer.playAnimation(
           this._animations[0].source,
           this._animations[0].loop
@@ -167,15 +170,16 @@ namespace gdjs {
       const rotationY = objectData.content.rotationY || 0;
       const rotationZ = objectData.content.rotationZ || 0;
       const keepAspectRatio = objectData.content.keepAspectRatio;
-      this._renderer._updateModel(
-        rotationX,
-        rotationY,
-        rotationZ,
-        this._getOriginalWidth(),
-        this._getOriginalHeight(),
-        this._getOriginalDepth(),
-        keepAspectRatio
-      );
+      if (this._renderer)
+        this._renderer._updateModel(
+          rotationX,
+          rotationY,
+          rotationZ,
+          this._getOriginalWidth(),
+          this._getOriginalHeight(),
+          this._getOriginalDepth(),
+          keepAspectRatio
+        );
     }
 
     getRenderer(): RuntimeObject3DRenderer {
@@ -196,7 +200,8 @@ namespace gdjs {
 
     update(instanceContainer: gdjs.RuntimeInstanceContainer): void {
       const elapsedTime = this.getElapsedTime() / 1000;
-      this._renderer.updateAnimation(elapsedTime * this._animationSpeedScale);
+      if (this._renderer)
+        this._renderer.updateAnimation(elapsedTime * this._animationSpeedScale);
     }
 
     /**
@@ -220,7 +225,8 @@ namespace gdjs {
       ) {
         const animation = this._animations[animationIndex];
         this._currentAnimationIndex = animationIndex;
-        this._renderer.playAnimation(animation.source, animation.loop);
+        if (this._renderer)
+          this._renderer.playAnimation(animation.source, animation.loop);
       }
     }
 
@@ -263,7 +269,7 @@ namespace gdjs {
      * - the last frame has been displayed long enough.
      */
     hasAnimationEnded(): boolean {
-      return this._renderer.hasAnimationEnded();
+      return this._renderer ? this._renderer.hasAnimationEnded() : true;
     }
 
     isAnimationPaused() {
@@ -272,12 +278,12 @@ namespace gdjs {
 
     pauseAnimation() {
       this._animationPaused = true;
-      return this._renderer.pauseAnimation();
+      if (this._renderer) this._renderer.pauseAnimation();
     }
 
     resumeAnimation() {
       this._animationPaused = false;
-      return this._renderer.resumeAnimation();
+      if (this._renderer) this._renderer.resumeAnimation();
     }
 
     getAnimationSpeedScale() {
@@ -288,23 +294,30 @@ namespace gdjs {
       this._animationSpeedScale = ratio;
     }
 
+    // TODO: The non-null type assertions done on the next 4 methods here are INVALID!!
+    //       the renderer may *not* be present at this point, and this code WILL BREAK
+    //       without a renderer!
+    //       It is necessary to change this in the future to pre-compute the model origin
+    //       and center point on the IDE and embed it in the 3D Model resource to be used
+    //       here through gdjs.RuntimeGame#getResourceBaseDimensions instead of relying
+    //       on the renderer.
     getCenterX(): float {
-      const centerPoint = this._renderer.getCenterPoint();
+      const centerPoint = this._renderer!.getCenterPoint();
       return this.getWidth() * centerPoint[0];
     }
 
     getCenterY(): float {
-      const centerPoint = this._renderer.getCenterPoint();
+      const centerPoint = this._renderer!.getCenterPoint();
       return this.getHeight() * centerPoint[1];
     }
 
     getDrawableX(): float {
-      const originPoint = this._renderer.getOriginPoint();
+      const originPoint = this._renderer!.getOriginPoint();
       return this.getX() - this.getWidth() * originPoint[0];
     }
 
     getDrawableY(): float {
-      const originPoint = this._renderer.getOriginPoint();
+      const originPoint = this._renderer!.getOriginPoint();
       return this.getY() - this.getHeight() * originPoint[1];
     }
   }

--- a/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
@@ -63,7 +63,7 @@ namespace gdjs {
     node: THREE.Object3D<THREE.Event>
   ) => node.traverse(setBasicMaterialTo);
 
-  class Model3DRuntimeObject3DRenderer extends gdjs.RuntimeObject3DRenderer {
+  class Model3DRuntimeObjectThreeRenderer extends gdjs.RuntimeObject3DThreeRenderer {
     private _model3DRuntimeObject: gdjs.Model3DRuntimeObject;
     /**
      * The 3D model stretched in a 1x1x1 cube.
@@ -87,7 +87,7 @@ namespace gdjs {
       // GLB files with skeleton must not have any transformation to work properly.
       const originalModel = instanceContainer
         .getGame()
-        .getModel3DManager()
+        .getModel3DManager()!
         .getModel(runtimeObject._modelResourceName);
       // _updateModel will actually add a clone of the model.
       const model = new THREE.Group();
@@ -350,6 +350,12 @@ namespace gdjs {
     }
   }
 
-  export const Model3DRuntimeObjectRenderer = Model3DRuntimeObject3DRenderer;
-  export type Model3DRuntimeObjectRenderer = Model3DRuntimeObject3DRenderer;
+  export type Model3DRuntimeObjectRenderer =
+    | Model3DRuntimeObjectThreeRenderer
+    | undefined;
+  type Model3DRuntimeObjectRendererClass =
+    | typeof Model3DRuntimeObjectThreeRenderer
+    | undefined;
+  export const Model3DRuntimeObjectRenderer: Model3DRuntimeObjectRendererClass =
+    Model3DRuntimeObjectThreeRenderer;
 }

--- a/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
@@ -356,6 +356,5 @@ namespace gdjs {
   type Model3DRuntimeObjectRendererClass =
     | typeof Model3DRuntimeObjectThreeRenderer
     | undefined;
-  export const Model3DRuntimeObjectRenderer: Model3DRuntimeObjectRendererClass =
-    Model3DRuntimeObjectThreeRenderer;
+  export const Model3DRuntimeObjectRenderer: Model3DRuntimeObjectRendererClass = Model3DRuntimeObjectThreeRenderer;
 }

--- a/Extensions/3D/Scene3DTools.ts
+++ b/Extensions/3D/Scene3DTools.ts
@@ -2,6 +2,10 @@ namespace gdjs {
   export namespace scene3d {
     const assumedFovIn2D = 45;
 
+    // TODO: All functions in this namespace keep 3D camera state in a ThreeJS
+    //       and will default to 0 if it cannot be found. This breaks 3D logic
+    //       when ThreeJS is not present, and needs to be fixed by moving the
+    //       state to the layer object.
     export namespace camera {
       export const getCameraZ = (
         runtimeScene: RuntimeScene,
@@ -10,7 +14,7 @@ namespace gdjs {
       ): float => {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         const fov = threeCamera ? threeCamera.fov : assumedFovIn2D;
         return layer.getCameraZ(fov, cameraIndex);
       };
@@ -23,7 +27,7 @@ namespace gdjs {
       ) => {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         const fov = threeCamera ? threeCamera.fov : assumedFovIn2D;
         layer.setCameraZ(z, fov, cameraIndex);
       };
@@ -36,7 +40,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return 0;
         return gdjs.toDegrees(threeCamera.rotation.x);
       };
@@ -50,7 +54,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return;
 
         threeCamera.rotation.x = gdjs.toRad(angle);
@@ -64,7 +68,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return 0;
         return gdjs.toDegrees(threeCamera.rotation.y);
       };
@@ -78,7 +82,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return;
 
         threeCamera.rotation.y = gdjs.toRad(angle);
@@ -94,7 +98,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return;
 
         if (isStandingOnY) {
@@ -124,7 +128,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return;
 
         if (isStandingOnY) {
@@ -145,7 +149,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return 0;
         return threeCamera.near;
       };
@@ -159,7 +163,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return;
 
         threeCamera.near = Math.min(
@@ -169,7 +173,7 @@ namespace gdjs {
           // Near value cannot exceed far value.
           threeCamera.far
         );
-        layerRenderer.setThreeCameraDirty(true);
+        if (layerRenderer) layerRenderer.setThreeCameraDirty(true);
       };
 
       export const getFarPlane = (
@@ -180,7 +184,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return 0;
         return threeCamera.far;
       };
@@ -194,12 +198,12 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return;
 
         // Far value cannot be lower than near value
         threeCamera.far = Math.max(distance, threeCamera.near);
-        layerRenderer.setThreeCameraDirty(true);
+        if (layerRenderer) layerRenderer.setThreeCameraDirty(true);
       };
 
       export const getFov = (
@@ -210,7 +214,7 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return 45;
         return threeCamera.fov;
       };
@@ -224,11 +228,11 @@ namespace gdjs {
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 
-        const threeCamera = layerRenderer.getThreeCamera();
+        const threeCamera = layerRenderer?.getThreeCamera();
         if (!threeCamera) return;
 
         threeCamera.fov = Math.min(Math.max(angle, 0), 180);
-        layerRenderer.setThreeCameraDirty(true);
+        if (layerRenderer) layerRenderer.setThreeCameraDirty(true);
       };
     }
   }

--- a/Extensions/AdvancedWindow/electron-advancedwindowtools.ts
+++ b/Extensions/AdvancedWindow/electron-advancedwindowtools.ts
@@ -10,7 +10,7 @@ namespace gdjs {
         const electronRemote = runtimeScene
           .getGame()
           .getRenderer()
-          .getElectronRemote();
+          ?.getElectronRemote();
         if (electronRemote) {
           return electronRemote.getCurrentWindow();
         }

--- a/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
@@ -24,7 +24,7 @@ namespace gdjs {
           default: {
             fontFamily: instanceContainer
               .getGame()
-              .getFontManager()
+              .getFontManager()!
               .getFontFamily(runtimeObject._fontFamily),
             fontSize: runtimeObject._fontSize + 'px',
             fill: gdjs.rgbToHexNumber(
@@ -46,7 +46,7 @@ namespace gdjs {
       }
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._pixiObject, runtimeObject.getZOrder());
 
       // Set the anchor in the center, so that the object rotates around
@@ -98,7 +98,7 @@ namespace gdjs {
       this._pixiObject.textStyles.default.fontFamily = this._object
         .getInstanceContainer()
         .getGame()
-        .getFontManager()
+        .getFontManager()!
         .getFontFamily(this._object._fontFamily);
       this._pixiObject.dirty = true;
     }
@@ -132,6 +132,12 @@ namespace gdjs {
     }
   }
 
-  export const BBTextRuntimeObjectRenderer = BBTextRuntimeObjectPixiRenderer;
-  export type BBTextRuntimeObjectRenderer = BBTextRuntimeObjectPixiRenderer;
+  export type BBTextRuntimeObjectRenderer =
+    | BBTextRuntimeObjectPixiRenderer
+    | undefined;
+  type BBTextRuntimeObjectRendererClass =
+    | typeof BBTextRuntimeObjectPixiRenderer
+    | undefined;
+  export const BBTextRuntimeObjectRenderer: BBTextRuntimeObjectRendererClass =
+    BBTextRuntimeObjectPixiRenderer;
 }

--- a/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
@@ -138,6 +138,5 @@ namespace gdjs {
   type BBTextRuntimeObjectRendererClass =
     | typeof BBTextRuntimeObjectPixiRenderer
     | undefined;
-  export const BBTextRuntimeObjectRenderer: BBTextRuntimeObjectRendererClass =
-    BBTextRuntimeObjectPixiRenderer;
+  export const BBTextRuntimeObjectRenderer: BBTextRuntimeObjectRendererClass = BBTextRuntimeObjectPixiRenderer;
 }

--- a/Extensions/BBText/bbtextruntimeobject.ts
+++ b/Extensions/BBText/bbtextruntimeobject.ts
@@ -28,8 +28,7 @@ namespace gdjs {
    */
   export class BBTextRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.OpacityHandler
-  {
+    implements gdjs.OpacityHandler {
     _opacity: float;
 
     _text: string;

--- a/Extensions/BBText/bbtextruntimeobject.ts
+++ b/Extensions/BBText/bbtextruntimeobject.ts
@@ -28,7 +28,8 @@ namespace gdjs {
    */
   export class BBTextRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.OpacityHandler {
+    implements gdjs.OpacityHandler
+  {
     _opacity: float;
 
     _text: string;
@@ -67,10 +68,12 @@ namespace gdjs {
       this._fontSize = parseFloat(objectData.content.fontSize);
       this._wordWrap = objectData.content.wordWrap;
       this._align = objectData.content.align;
-      this._renderer = new gdjs.BBTextRuntimeObjectRenderer(
-        this,
-        instanceContainer
-      );
+      if (gdjs.BBTextRuntimeObjectRenderer) {
+        this._renderer = new gdjs.BBTextRuntimeObjectRenderer(
+          this,
+          instanceContainer
+        );
+      }
       this.hidden = !objectData.content.visible;
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
@@ -78,7 +81,7 @@ namespace gdjs {
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     // @ts-ignore
@@ -97,7 +100,7 @@ namespace gdjs {
       }
       if (oldObjectData.content.color !== newObjectData.content.color) {
         this._color = gdjs.rgbOrHexToRGBColor(newObjectData.content.color);
-        this._renderer.updateColor();
+        if (this._renderer) this._renderer.updateColor();
       }
       if (
         oldObjectData.content.fontFamily !== newObjectData.content.fontFamily
@@ -139,7 +142,7 @@ namespace gdjs {
      */
     setBBText(text): void {
       this._text = text;
-      this._renderer.updateText();
+      if (this._renderer) this._renderer.updateText();
     }
 
     /**
@@ -151,7 +154,7 @@ namespace gdjs {
 
     setColor(rgbColorString): void {
       this._color = gdjs.rgbOrHexToRGBColor(rgbColorString);
-      this._renderer.updateColor();
+      if (this._renderer) this._renderer.updateColor();
     }
 
     /**
@@ -164,7 +167,7 @@ namespace gdjs {
 
     setFontSize(fontSize): void {
       this._fontSize = fontSize;
-      this._renderer.updateFontSize();
+      if (this._renderer) this._renderer.updateFontSize();
     }
 
     getFontSize() {
@@ -173,7 +176,7 @@ namespace gdjs {
 
     setFontFamily(fontFamily): void {
       this._fontFamily = fontFamily;
-      this._renderer.updateFontFamily();
+      if (this._renderer) this._renderer.updateFontFamily();
     }
 
     getFontFamily() {
@@ -182,7 +185,7 @@ namespace gdjs {
 
     setAlignment(align): void {
       this._align = align;
-      this._renderer.updateAlignment();
+      if (this._renderer) this._renderer.updateAlignment();
     }
 
     getAlignment() {
@@ -195,7 +198,7 @@ namespace gdjs {
      */
     setX(x: float): void {
       super.setX(x);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -204,7 +207,7 @@ namespace gdjs {
      */
     setY(y: float): void {
       super.setY(y);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -213,7 +216,7 @@ namespace gdjs {
      */
     setAngle(angle: float): void {
       super.setAngle(angle);
-      this._renderer.updateAngle();
+      if (this._renderer) this._renderer.updateAngle();
     }
 
     /**
@@ -228,7 +231,7 @@ namespace gdjs {
         opacity = 255;
       }
       this._opacity = opacity;
-      this._renderer.updateOpacity();
+      if (this._renderer) this._renderer.updateOpacity();
     }
 
     /**
@@ -246,7 +249,7 @@ namespace gdjs {
       if (this._wrappingWidth === width) return;
 
       this._wrappingWidth = width;
-      this._renderer.updateWrappingWidth();
+      if (this._renderer) this._renderer.updateWrappingWidth();
       this.invalidateHitboxes();
     }
 
@@ -261,7 +264,7 @@ namespace gdjs {
       if (this._wordWrap === wordWrap) return;
 
       this._wordWrap = wordWrap;
-      this._renderer.updateWordWrap();
+      if (this._renderer) this._renderer.updateWordWrap();
       this.invalidateHitboxes();
     }
 
@@ -273,14 +276,33 @@ namespace gdjs {
      * Get the width of the object.
      */
     getWidth(): float {
-      return this._renderer.getWidth();
+      if (this._renderer) return this._renderer.getWidth();
+      // When there is no renderer, we make a very rough assumption about the text size to not break game logic
+      // that might depend on changes of the text size, this is very much an edge case though so we won't
+      // implement a more complex text measuring system.
+      // We get the longest line, and multiply its length by the character size.
+      else
+        return (
+          this._text
+            .split('\n')
+            .reduce(
+              (biggestLength, line) =>
+                line.length > biggestLength ? line.length : biggestLength,
+              0
+            ) * this._fontSize
+        );
     }
 
     /**
      * Get the height of the object.
      */
     getHeight(): float {
-      return this._renderer.getHeight();
+      if (this._renderer) return this._renderer.getHeight();
+      // When there is no renderer, we make a very rough assumption about the text size to not break game logic
+      // that might depend on changes of the text size, this is very much an edge case though so we won't
+      // implement a more complex text measuring system.
+      // We get the amount of lines, and multiply it by the character size.
+      else return this._text.split('\n').length * this._fontSize;
     }
   }
   // @ts-ignore

--- a/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
@@ -21,7 +21,7 @@ namespace gdjs {
       // Obtain the bitmap font to use in the object.
       const bitmapFont = instanceContainer
         .getGame()
-        .getBitmapFontManager()
+        .getBitmapFontManager()!
         .obtainBitmapFont(
           runtimeObject._bitmapFontResourceName,
           runtimeObject._textureAtlasResourceName
@@ -34,7 +34,7 @@ namespace gdjs {
       // Set the object on the scene
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._pixiObject, runtimeObject.getZOrder());
 
       // Set the anchor in the center, so that the object rotates around
@@ -62,7 +62,7 @@ namespace gdjs {
       this._object
         .getInstanceContainer()
         .getGame()
-        .getBitmapFontManager()
+        .getBitmapFontManager()!
         .releaseBitmapFont(this._pixiObject.fontName);
 
       this._pixiObject.destroy();
@@ -77,7 +77,7 @@ namespace gdjs {
       const bitmapFont = this._object
         .getInstanceContainer()
         .getGame()
-        .getBitmapFontManager()
+        .getBitmapFontManager()!
         .obtainBitmapFont(
           this._object._bitmapFontResourceName,
           this._object._textureAtlasResourceName
@@ -87,7 +87,7 @@ namespace gdjs {
       this._object
         .getInstanceContainer()
         .getGame()
-        .getBitmapFontManager()
+        .getBitmapFontManager()!
         .releaseBitmapFont(this._pixiObject.fontName);
 
       // Update the font used by the object:
@@ -175,5 +175,13 @@ namespace gdjs {
       return this._pixiObject.textHeight * this.getScale();
     }
   }
-  export const BitmapTextRuntimeObjectRenderer = BitmapTextRuntimeObjectPixiRenderer;
+
+  export type BitmapTextRuntimeObjectRenderer =
+    | BitmapTextRuntimeObjectPixiRenderer
+    | undefined;
+  type BitmapTextRuntimeObjectRendererClass =
+    | typeof BitmapTextRuntimeObjectPixiRenderer
+    | undefined;
+  export const BitmapTextRuntimeObjectRenderer: BitmapTextRuntimeObjectRendererClass =
+    BitmapTextRuntimeObjectPixiRenderer;
 }

--- a/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
@@ -182,6 +182,5 @@ namespace gdjs {
   type BitmapTextRuntimeObjectRendererClass =
     | typeof BitmapTextRuntimeObjectPixiRenderer
     | undefined;
-  export const BitmapTextRuntimeObjectRenderer: BitmapTextRuntimeObjectRendererClass =
-    BitmapTextRuntimeObjectPixiRenderer;
+  export const BitmapTextRuntimeObjectRenderer: BitmapTextRuntimeObjectRendererClass = BitmapTextRuntimeObjectPixiRenderer;
 }

--- a/Extensions/BitmapText/bitmaptextruntimeobject.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject.ts
@@ -37,7 +37,8 @@ namespace gdjs {
    */
   export class BitmapTextRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.OpacityHandler, gdjs.Scalable {
+    implements gdjs.OpacityHandler, gdjs.Scalable
+  {
     _opacity: float;
     _text: string;
     /** color in format [r, g, b], where each component is in the range [0, 255] */
@@ -50,7 +51,7 @@ namespace gdjs {
     _wrappingWidth: float;
     _align: string;
 
-    _renderer: gdjs.BitmapTextRuntimeObjectPixiRenderer;
+    _renderer: gdjs.BitmapTextRuntimeObjectRenderer;
 
     /**
      * @param instanceContainer The container the object belongs to.
@@ -75,17 +76,19 @@ namespace gdjs {
       this._wrappingWidth = 0;
       this._align = objectData.content.align;
 
-      this._renderer = new gdjs.BitmapTextRuntimeObjectRenderer(
-        this,
-        instanceContainer
-      );
+      if (gdjs.BitmapTextRuntimeObjectRenderer) {
+        this._renderer = new gdjs.BitmapTextRuntimeObjectRenderer(
+          this,
+          instanceContainer
+        );
+      }
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     // @ts-ignore
@@ -101,7 +104,7 @@ namespace gdjs {
       }
       if (oldObjectData.content.tint !== newObjectData.content.tint) {
         this._tint = gdjs.rgbOrHexToRGBColor(newObjectData.content.tint);
-        this._renderer.updateTint();
+        if (this._renderer) this._renderer.updateTint();
       }
       if (
         oldObjectData.content.bitmapFontResourceName !==
@@ -143,7 +146,7 @@ namespace gdjs {
 
     onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
       super.onDestroyFromScene(instanceContainer);
-      this._renderer.onDestroy();
+      if (this._renderer) this._renderer.onDestroy();
     }
 
     /**
@@ -151,7 +154,7 @@ namespace gdjs {
      */
     setText(text: string): void {
       this._text = text;
-      this._renderer.updateTextContent();
+      if (this._renderer) this._renderer.updateTextContent();
       this.invalidateHitboxes();
     }
 
@@ -164,7 +167,7 @@ namespace gdjs {
 
     setTint(rgbColorString: string): void {
       this._tint = gdjs.rgbOrHexToRGBColor(rgbColorString);
-      this._renderer.updateTint();
+      if (this._renderer) this._renderer.updateTint();
     }
 
     getTint(): string {
@@ -197,7 +200,7 @@ namespace gdjs {
       if (this._scaleX === scaleX) return;
 
       this._scaleX = scaleX;
-      this._renderer.updateScale();
+      if (this._renderer) this._renderer.updateScale();
       this.invalidateHitboxes();
     }
 
@@ -208,12 +211,17 @@ namespace gdjs {
       if (this._scaleY === scaleY) return;
 
       this._scaleY = scaleY;
-      this._renderer.updateScale();
+      if (this._renderer) this._renderer.updateScale();
       this.invalidateHitboxes();
     }
 
     getFontSize(): float {
-      return this._renderer.getFontSize();
+      // Ideally, we'd pre-compute and store the font size in the resource from the IDE.
+      // However, since the font is currently extracted from two resources, this is not yet possible.
+      // We use 1 as a sensible default in the meantime when no renderer is present.
+      // TODO: When we add pre-computing of resource dimensions, we should change this to store
+      //       the font size in the bitmap font resource metadata directly.
+      return this._renderer ? this._renderer.getFontSize() : 1;
     }
 
     setBitmapFontAndTextureAtlasResourceName(
@@ -222,11 +230,11 @@ namespace gdjs {
     ): void {
       if (bitmapFontResourceName) {
         this.setBitmapFontResourceName(bitmapFontResourceName);
-        this._renderer.updateFont();
+        if (this._renderer) this._renderer.updateFont();
       }
       if (textureAtlasResourceName) {
         this.setTextureAtlasResourceName(textureAtlasResourceName);
-        this._renderer.updateFont();
+        if (this._renderer) this._renderer.updateFont();
       }
     }
 
@@ -248,7 +256,7 @@ namespace gdjs {
 
     setAlignment(align: string): void {
       this._align = align;
-      this._renderer.updateAlignment();
+      if (this._renderer) this._renderer.updateAlignment();
     }
 
     getAlignment(): string {
@@ -261,7 +269,7 @@ namespace gdjs {
      */
     setX(x: float): void {
       super.setX(x);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -270,7 +278,7 @@ namespace gdjs {
      */
     setY(y: float): void {
       super.setY(y);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -279,7 +287,7 @@ namespace gdjs {
      */
     setAngle(angle: float): void {
       super.setAngle(angle);
-      this._renderer.updateAngle();
+      if (this._renderer) this._renderer.updateAngle();
     }
 
     /**
@@ -294,7 +302,7 @@ namespace gdjs {
         opacity = 255;
       }
       this._opacity = opacity;
-      this._renderer.updateOpacity();
+      if (this._renderer) this._renderer.updateOpacity();
     }
 
     /**
@@ -310,7 +318,7 @@ namespace gdjs {
      */
     setWrappingWidth(width: float): void {
       this._wrappingWidth = width;
-      this._renderer.updateWrappingWidth();
+      if (this._renderer) this._renderer.updateWrappingWidth();
       this.invalidateHitboxes();
     }
 
@@ -323,7 +331,7 @@ namespace gdjs {
 
     setWordWrap(wordWrap: boolean): void {
       this._wordWrap = wordWrap;
-      this._renderer.updateWrappingWidth();
+      if (this._renderer) this._renderer.updateWrappingWidth();
       this.invalidateHitboxes();
     }
 
@@ -335,14 +343,33 @@ namespace gdjs {
      * Get the width of the object.
      */
     getWidth(): float {
-      return this._renderer.getWidth();
+      if (this._renderer) return this._renderer.getWidth();
+      // When there is no renderer, we make a very rough assumption about the text size to not break game logic
+      // that might depend on changes of the text size, this is very much an edge case though so we won't
+      // implement a more complex text measuring system.
+      // We get the longest line, and multiply its length by the character size.
+      else
+        return (
+          this._text
+            .split('\n')
+            .reduce(
+              (biggestLength, line) =>
+                line.length > biggestLength ? line.length : biggestLength,
+              0
+            ) * this.getFontSize()
+        );
     }
 
     /**
      * Get the height of the object.
      */
     getHeight(): float {
-      return this._renderer.getHeight();
+      if (this._renderer) return this._renderer.getHeight();
+      // When there is no renderer, we make a very rough assumption about the text size to not break game logic
+      // that might depend on changes of the text size, this is very much an edge case though so we won't
+      // implement a more complex text measuring system.
+      // We get the amount of lines, and multiply it by the character size.
+      else return this._text.split('\n').length * this.getFontSize();
     }
   }
   gdjs.registerObject(

--- a/Extensions/BitmapText/bitmaptextruntimeobject.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject.ts
@@ -37,8 +37,7 @@ namespace gdjs {
    */
   export class BitmapTextRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.OpacityHandler, gdjs.Scalable
-  {
+    implements gdjs.OpacityHandler, gdjs.Scalable {
     _opacity: float;
     _text: string;
     /** color in format [r, g, b], where each component is in the range [0, 255] */

--- a/Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.ts
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.ts
@@ -88,6 +88,5 @@ namespace gdjs {
   type DummyRuntimeObjectRendererClass =
     | typeof DummyRuntimeObjectPixiRenderer
     | undefined;
-  export const DummyRuntimeObjectRenderer: DummyRuntimeObjectRendererClass =
-    DummyRuntimeObjectPixiRenderer;
+  export const DummyRuntimeObjectRenderer: DummyRuntimeObjectRendererClass = DummyRuntimeObjectPixiRenderer;
 }

--- a/Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.ts
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject-pixi-renderer.ts
@@ -34,7 +34,7 @@ namespace gdjs {
       this._text.anchor.y = 0.5;
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._text, runtimeObject.getZOrder());
       this.updatePosition();
     }
@@ -75,6 +75,19 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export const DummyRuntimeObjectRenderer = DummyRuntimeObjectPixiRenderer;
-  export type DummyRuntimeObjectRenderer = DummyRuntimeObjectPixiRenderer;
+  // Note that we export the type and class in a way that mark that they might always be undefined:
+  //  that is to enforce through static typing that all core engine logic is completely independent
+  //  from the renderer.
+  // This is necessary for "server builds" of the game that do not do any rendering,
+  //  and also to keep the codebase flexible by being able to change renderers without having to re-write
+  //  half the logic of every object because some renderers were not fully "pure" rendering but also state
+  //  containers for the object.
+  export type DummyRuntimeObjectRenderer =
+    | DummyRuntimeObjectPixiRenderer
+    | undefined;
+  type DummyRuntimeObjectRendererClass =
+    | typeof DummyRuntimeObjectPixiRenderer
+    | undefined;
+  export const DummyRuntimeObjectRenderer: DummyRuntimeObjectRendererClass =
+    DummyRuntimeObjectPixiRenderer;
 }

--- a/Extensions/ExampleJsExtension/dummyruntimeobject.ts
+++ b/Extensions/ExampleJsExtension/dummyruntimeobject.ts
@@ -10,7 +10,7 @@ namespace gdjs {
     _property1: string;
 
     // Create the renderer (see dummyruntimeobject-pixi-renderer.js)
-    _renderer: any;
+    _renderer: gdjs.DummyRuntimeObjectRenderer;
     // @ts-expect-error ts-migrate(2564) FIXME: Property 'opacity' has no initializer and is not d... Remove this comment to see the full error message
     opacity: float;
 
@@ -18,17 +18,23 @@ namespace gdjs {
       // *ALWAYS* call the base gdjs.RuntimeObject constructor.
       super(instanceContainer, objectData);
       this._property1 = objectData.content.property1;
-      this._renderer = new gdjs.DummyRuntimeObjectRenderer(
-        this,
-        instanceContainer
-      );
+
+      // All renderer code is potentially undefined! Although TypeScript should already force you
+      // to, make sure to always add a check for undefined before using any renderer code.
+      // This ensures the code is able to run without a renderer, for example in a server build of the game.
+      if (gdjs.DummyRuntimeObjectRenderer) {
+        this._renderer = new gdjs.DummyRuntimeObjectRenderer(
+          this,
+          instanceContainer
+        );
+      }
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     updateFromObjectData(oldObjectData, newObjectData): boolean {
@@ -36,7 +42,7 @@ namespace gdjs {
       // This is useful for "hot-reloading".
       if (oldObjectData.content.property1 !== newObjectData.content.property1) {
         this._property1 = newObjectData.content.property1;
-        this._renderer.updateText();
+        if (this._renderer) this._renderer.updateText();
       }
       return true;
     }
@@ -48,7 +54,7 @@ namespace gdjs {
     update(instanceContainer: gdjs.RuntimeInstanceContainer): void {
       // This is an example: typically you want to make sure the renderer
       // is up to date with the object.
-      this._renderer.ensureUpToDate();
+      if (this._renderer) this._renderer.ensureUpToDate();
     }
 
     /**
@@ -64,7 +70,7 @@ namespace gdjs {
     private _updatePosition() {
       // This is an example: typically you want to tell the renderer to update
       // the position of the object.
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -94,7 +100,7 @@ namespace gdjs {
       super.setAngle(angle);
 
       // Tell the renderer to update the rendered object
-      this._renderer.updateAngle();
+      if (this._renderer) this._renderer.updateAngle();
     }
 
     /**
@@ -110,7 +116,7 @@ namespace gdjs {
       this.opacity = opacity;
 
       // Tell the renderer to update the rendered object
-      this._renderer.updateOpacity();
+      if (this._renderer) this._renderer.updateOpacity();
     }
 
     /**

--- a/Extensions/FileSystem/filesystemtools.ts
+++ b/Extensions/FileSystem/filesystemtools.ts
@@ -47,7 +47,7 @@ namespace gdjs {
       const remote = instanceContainer
         .getGame()
         .getRenderer()
-        .getElectronRemote();
+        ?.getElectronRemote();
       const app = remote ? remote.app : null;
       if (app) {
         return app.getPath('desktop') || '';
@@ -67,7 +67,7 @@ namespace gdjs {
       const remote = instanceContainer
         .getGame()
         .getRenderer()
-        .getElectronRemote();
+        ?.getElectronRemote();
       const app = remote ? remote.app : null;
       if (app) {
         return app.getPath('documents') || '';
@@ -87,7 +87,7 @@ namespace gdjs {
       const remote = instanceContainer
         .getGame()
         .getRenderer()
-        .getElectronRemote();
+        ?.getElectronRemote();
       const app = remote ? remote.app : null;
       if (app) {
         return app.getPath('pictures') || '';
@@ -107,7 +107,7 @@ namespace gdjs {
       const remote = instanceContainer
         .getGame()
         .getRenderer()
-        .getElectronRemote();
+        ?.getElectronRemote();
       const app = remote ? remote.app : null;
       if (app) {
         return app.getPath('exe') || '';
@@ -142,7 +142,7 @@ namespace gdjs {
       const remote = instanceContainer
         .getGame()
         .getRenderer()
-        .getElectronRemote();
+        ?.getElectronRemote();
       const app = remote ? remote.app : null;
       if (app) {
         return app.getPath('userData') || '';
@@ -161,7 +161,7 @@ namespace gdjs {
       const remote = instanceContainer
         .getGame()
         .getRenderer()
-        .getElectronRemote();
+        ?.getElectronRemote();
       const app = remote ? remote.app : null;
       if (app) {
         return app.getPath('home') || '';
@@ -181,7 +181,7 @@ namespace gdjs {
       const remote = instanceContainer
         .getGame()
         .getRenderer()
-        .getElectronRemote();
+        ?.getElectronRemote();
       const app = remote ? remote.app : null;
       if (app) {
         return app.getPath('temp') || '';

--- a/Extensions/Leaderboards/leaderboardstools.ts
+++ b/Extensions/Leaderboards/leaderboardstools.ts
@@ -374,8 +374,10 @@ namespace gdjs {
               new ScoreSavingState());
 
             try {
-              const { closeSaving, closeSavingWithError } =
-                scoreSavingState.startSaving({ playerName, score });
+              const {
+                closeSaving,
+                closeSavingWithError,
+              } = scoreSavingState.startSaving({ playerName, score });
 
               try {
                 const leaderboardEntryId = await saveScore({
@@ -417,8 +419,10 @@ namespace gdjs {
               new ScoreSavingState());
 
             try {
-              const { closeSaving, closeSavingWithError } =
-                scoreSavingState.startSaving({ playerId, score });
+              const {
+                closeSaving,
+                closeSavingWithError,
+              } = scoreSavingState.startSaving({ playerId, score });
 
               try {
                 const leaderboardEntryId = await saveScore({
@@ -764,8 +768,9 @@ namespace gdjs {
 
             resetLeaderboardDisplayErrorTimeout(runtimeScene);
 
-            _leaderboardViewIframe =
-              computeLeaderboardDisplayingIframe(targetUrl);
+            _leaderboardViewIframe = computeLeaderboardDisplayingIframe(
+              targetUrl
+            );
             if (typeof window !== 'undefined') {
               _leaderboardViewClosingCallback = (event: MessageEvent) => {
                 receiveMessageFromLeaderboardView(

--- a/Extensions/Leaderboards/leaderboardstools.ts
+++ b/Extensions/Leaderboards/leaderboardstools.ts
@@ -374,10 +374,8 @@ namespace gdjs {
               new ScoreSavingState());
 
             try {
-              const {
-                closeSaving,
-                closeSavingWithError,
-              } = scoreSavingState.startSaving({ playerName, score });
+              const { closeSaving, closeSavingWithError } =
+                scoreSavingState.startSaving({ playerName, score });
 
               try {
                 const leaderboardEntryId = await saveScore({
@@ -419,10 +417,8 @@ namespace gdjs {
               new ScoreSavingState());
 
             try {
-              const {
-                closeSaving,
-                closeSavingWithError,
-              } = scoreSavingState.startSaving({ playerId, score });
+              const { closeSaving, closeSavingWithError } =
+                scoreSavingState.startSaving({ playerId, score });
 
               try {
                 const leaderboardEntryId = await saveScore({
@@ -610,7 +606,7 @@ namespace gdjs {
         const domElementContainer = runtimeScene
           .getGame()
           .getRenderer()
-          .getDomElementContainer();
+          ?.getDomElementContainer();
         if (!domElementContainer) {
           if (options.callOnErrorIfDomElementContainerMissing) {
             handleErrorDisplayingLeaderboard(
@@ -757,7 +753,7 @@ namespace gdjs {
             const domElementContainer = runtimeScene
               .getGame()
               .getRenderer()
-              .getDomElementContainer();
+              ?.getDomElementContainer();
             if (!domElementContainer) {
               handleErrorDisplayingLeaderboard(
                 runtimeScene,
@@ -768,9 +764,8 @@ namespace gdjs {
 
             resetLeaderboardDisplayErrorTimeout(runtimeScene);
 
-            _leaderboardViewIframe = computeLeaderboardDisplayingIframe(
-              targetUrl
-            );
+            _leaderboardViewIframe =
+              computeLeaderboardDisplayingIframe(targetUrl);
             if (typeof window !== 'undefined') {
               _leaderboardViewClosingCallback = (event: MessageEvent) => {
                 receiveMessageFromLeaderboardView(
@@ -825,7 +820,7 @@ namespace gdjs {
           const domElementContainer = runtimeScene
             .getGame()
             .getRenderer()
-            .getDomElementContainer();
+            ?.getDomElementContainer();
           if (!domElementContainer) {
             logger.info(
               "The div element covering the game couldn't be found, the leaderboard view must be already closed."
@@ -849,7 +844,7 @@ namespace gdjs {
           // but reset the flag indicating the view is loaded (if it was).
           _leaderboardViewIframeLoaded = false;
 
-          const gameCanvas = runtimeScene.getGame().getRenderer().getCanvas();
+          const gameCanvas = runtimeScene.getGame().getRenderer()?.getCanvas();
           if (gameCanvas) gameCanvas.focus();
         }
       };

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -198,11 +198,11 @@ namespace gdjs {
       const texture = this._object.getTexture();
       this._texture =
         texture !== ''
-          ? (
-              this._instanceContainer
-                .getGame()
-                .getImageManager() as gdjs.PixiImageManager
-            ).getPIXITexture(texture)
+          ? (this._instanceContainer
+              .getGame()
+              .getImageManager() as gdjs.PixiImageManager).getPIXITexture(
+              texture
+            )
           : null;
     }
 
@@ -467,38 +467,35 @@ namespace gdjs {
         const xdiff = flattenVertices[i][0] - this._object.x;
         const ydiff = flattenVertices[i][1] - this._object.y;
         const angle = Math.atan2(ydiff, xdiff);
-        const closestVertex =
-          LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
-            this._object,
-            angle,
-            obstaclePolygons,
-            boundingSquareHalfDiag
-          );
+        const closestVertex = LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
+          this._object,
+          angle,
+          obstaclePolygons,
+          boundingSquareHalfDiag
+        );
         if (closestVertex) {
           closestVertices.push({ vertex: closestVertex, angle: angle });
         }
 
         // TODO: Check whether we need to raycast these two extra rays or not.
-        const closestVertexOffsetLeft =
-          LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
-            this._object,
-            angle + 0.0001,
-            obstaclePolygons,
-            boundingSquareHalfDiag
-          );
+        const closestVertexOffsetLeft = LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
+          this._object,
+          angle + 0.0001,
+          obstaclePolygons,
+          boundingSquareHalfDiag
+        );
         if (closestVertexOffsetLeft) {
           closestVertices.push({
             vertex: closestVertexOffsetLeft,
             angle: angle + 0.0001,
           });
         }
-        const closestVertexOffsetRight =
-          LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
-            this._object,
-            angle - 0.0001,
-            obstaclePolygons,
-            boundingSquareHalfDiag
-          );
+        const closestVertexOffsetRight = LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
+          this._object,
+          angle - 0.0001,
+          obstaclePolygons,
+          boundingSquareHalfDiag
+        );
         if (closestVertexOffsetRight) {
           closestVertices.push({
             vertex: closestVertexOffsetRight,
@@ -569,6 +566,5 @@ namespace gdjs {
   type LightRuntimeObjectRendererClass =
     | typeof LightRuntimeObjectPixiRenderer
     | undefined;
-  export const LightRuntimeObjectRenderer: LightRuntimeObjectRendererClass =
-    LightRuntimeObjectPixiRenderer;
+  export const LightRuntimeObjectRenderer: LightRuntimeObjectRendererClass = LightRuntimeObjectPixiRenderer;
 }

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -66,7 +66,7 @@ namespace gdjs {
       if (this._light) {
         instanceContainer
           .getLayer('')
-          .getRenderer()
+          .getRenderer()!
           .addRendererObject(
             this.getRendererObject(),
             runtimeObject.getZOrder()
@@ -198,11 +198,11 @@ namespace gdjs {
       const texture = this._object.getTexture();
       this._texture =
         texture !== ''
-          ? (this._instanceContainer
-              .getGame()
-              .getImageManager() as gdjs.PixiImageManager).getPIXITexture(
-              texture
-            )
+          ? (
+              this._instanceContainer
+                .getGame()
+                .getImageManager() as gdjs.PixiImageManager
+            ).getPIXITexture(texture)
           : null;
     }
 
@@ -467,35 +467,38 @@ namespace gdjs {
         const xdiff = flattenVertices[i][0] - this._object.x;
         const ydiff = flattenVertices[i][1] - this._object.y;
         const angle = Math.atan2(ydiff, xdiff);
-        const closestVertex = LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
-          this._object,
-          angle,
-          obstaclePolygons,
-          boundingSquareHalfDiag
-        );
+        const closestVertex =
+          LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
+            this._object,
+            angle,
+            obstaclePolygons,
+            boundingSquareHalfDiag
+          );
         if (closestVertex) {
           closestVertices.push({ vertex: closestVertex, angle: angle });
         }
 
         // TODO: Check whether we need to raycast these two extra rays or not.
-        const closestVertexOffsetLeft = LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
-          this._object,
-          angle + 0.0001,
-          obstaclePolygons,
-          boundingSquareHalfDiag
-        );
+        const closestVertexOffsetLeft =
+          LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
+            this._object,
+            angle + 0.0001,
+            obstaclePolygons,
+            boundingSquareHalfDiag
+          );
         if (closestVertexOffsetLeft) {
           closestVertices.push({
             vertex: closestVertexOffsetLeft,
             angle: angle + 0.0001,
           });
         }
-        const closestVertexOffsetRight = LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
-          this._object,
-          angle - 0.0001,
-          obstaclePolygons,
-          boundingSquareHalfDiag
-        );
+        const closestVertexOffsetRight =
+          LightRuntimeObjectPixiRenderer._computeClosestIntersectionPoint(
+            this._object,
+            angle - 0.0001,
+            obstaclePolygons,
+            boundingSquareHalfDiag
+          );
         if (closestVertexOffsetRight) {
           closestVertices.push({
             vertex: closestVertexOffsetRight,
@@ -560,7 +563,12 @@ namespace gdjs {
   }`;
   }
 
-  // @ts-ignore - Register the class to let the engine use it.
-  export const LightRuntimeObjectRenderer = LightRuntimeObjectPixiRenderer;
-  export type LightRuntimeObjectRenderer = LightRuntimeObjectPixiRenderer;
+  export type LightRuntimeObjectRenderer =
+    | LightRuntimeObjectPixiRenderer
+    | undefined;
+  type LightRuntimeObjectRendererClass =
+    | typeof LightRuntimeObjectPixiRenderer
+    | undefined;
+  export const LightRuntimeObjectRenderer: LightRuntimeObjectRendererClass =
+    LightRuntimeObjectPixiRenderer;
 }

--- a/Extensions/Lighting/lightruntimeobject.ts
+++ b/Extensions/Lighting/lightruntimeobject.ts
@@ -39,8 +39,9 @@ namespace gdjs {
       this._color = gdjs.rgbOrHexToRGBColor(lightObjectData.content.color);
       this._debugMode = lightObjectData.content.debugMode;
       this._texture = lightObjectData.content.texture;
-      this._obstaclesManager =
-        gdjs.LightObstaclesManager.getManager(runtimeScene);
+      this._obstaclesManager = gdjs.LightObstaclesManager.getManager(
+        runtimeScene
+      );
       if (gdjs.LightRuntimeObjectRenderer)
         this._renderer = new gdjs.LightRuntimeObjectRenderer(
           this,

--- a/Extensions/Lighting/lightruntimeobject.ts
+++ b/Extensions/Lighting/lightruntimeobject.ts
@@ -39,10 +39,13 @@ namespace gdjs {
       this._color = gdjs.rgbOrHexToRGBColor(lightObjectData.content.color);
       this._debugMode = lightObjectData.content.debugMode;
       this._texture = lightObjectData.content.texture;
-      this._obstaclesManager = gdjs.LightObstaclesManager.getManager(
-        runtimeScene
-      );
-      this._renderer = new gdjs.LightRuntimeObjectRenderer(this, runtimeScene);
+      this._obstaclesManager =
+        gdjs.LightObstaclesManager.getManager(runtimeScene);
+      if (gdjs.LightRuntimeObjectRenderer)
+        this._renderer = new gdjs.LightRuntimeObjectRenderer(
+          this,
+          runtimeScene
+        );
       this._instanceContainer = runtimeScene;
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
@@ -55,7 +58,7 @@ namespace gdjs {
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     updateFromObjectData(
@@ -67,21 +70,21 @@ namespace gdjs {
       }
       if (oldObjectData.content.color !== newObjectData.content.color) {
         this._color = gdjs.rgbOrHexToRGBColor(newObjectData.content.color);
-        this._renderer.updateColor();
+        if (this._renderer) this._renderer.updateColor();
       }
       if (oldObjectData.content.texture !== newObjectData.content.texture) {
         this._texture = newObjectData.content.texture;
-        this._renderer.updateMesh();
+        if (this._renderer) this._renderer.updateMesh();
       }
       if (oldObjectData.content.debugMode !== newObjectData.content.debugMode) {
         this._debugMode = newObjectData.content.debugMode;
-        this._renderer.updateDebugMode();
+        if (this._renderer) this._renderer.updateDebugMode();
       }
       return true;
     }
 
     updatePreRender(): void {
-      this._renderer.ensureUpToDate();
+      if (this._renderer) this._renderer.ensureUpToDate();
     }
 
     /**
@@ -97,7 +100,7 @@ namespace gdjs {
      */
     setRadius(radius: number): void {
       this._radius = radius > 0 ? radius : 1;
-      this._renderer.updateRadius();
+      if (this._renderer) this._renderer.updateRadius();
     }
 
     /**
@@ -145,7 +148,7 @@ namespace gdjs {
      */
     setColor(color: string): void {
       this._color = gdjs.rgbOrHexToRGBColor(color);
-      this._renderer.updateColor();
+      if (this._renderer) this._renderer.updateColor();
     }
 
     /**

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
@@ -25,9 +25,11 @@ namespace gdjs {
       tiled: boolean
     ) {
       this._object = runtimeObject;
-      const texture = (
-        instanceContainer.getGame().getImageManager() as gdjs.PixiImageManager
-      ).getPIXITexture(textureName);
+      const texture = (instanceContainer
+        .getGame()
+        .getImageManager() as gdjs.PixiImageManager).getPIXITexture(
+        textureName
+      );
       const StretchedSprite = !tiled ? PIXI.Sprite : PIXI.TilingSprite;
       this._spritesContainer = new PIXI.Container();
       this._wrapperContainer = new PIXI.Container();
@@ -396,6 +398,5 @@ namespace gdjs {
   type PanelSpriteRuntimeObjectRendererClass =
     | typeof PanelSpriteRuntimeObjectPixiRenderer
     | undefined;
-  export const PanelSpriteRuntimeObjectRenderer: PanelSpriteRuntimeObjectRendererClass =
-    PanelSpriteRuntimeObjectPixiRenderer;
+  export const PanelSpriteRuntimeObjectRenderer: PanelSpriteRuntimeObjectRendererClass = PanelSpriteRuntimeObjectPixiRenderer;
 }

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
@@ -25,11 +25,9 @@ namespace gdjs {
       tiled: boolean
     ) {
       this._object = runtimeObject;
-      const texture = (instanceContainer
-        .getGame()
-        .getImageManager() as gdjs.PixiImageManager).getPIXITexture(
-        textureName
-      );
+      const texture = (
+        instanceContainer.getGame().getImageManager() as gdjs.PixiImageManager
+      ).getPIXITexture(textureName);
       const StretchedSprite = !tiled ? PIXI.Sprite : PIXI.TilingSprite;
       this._spritesContainer = new PIXI.Container();
       this._wrapperContainer = new PIXI.Container();
@@ -64,7 +62,7 @@ namespace gdjs {
       this._wrapperContainer.addChild(this._spritesContainer);
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._wrapperContainer, runtimeObject.getZOrder());
     }
 
@@ -200,7 +198,7 @@ namespace gdjs {
       const obj = this._object;
       const texture = instanceContainer
         .getGame()
-        .getImageManager()
+        .getImageManager()!
         .getPIXITexture(textureName).baseTexture;
       this._textureWidth = texture.width;
       this._textureHeight = texture.height;
@@ -392,6 +390,12 @@ namespace gdjs {
     }
   }
 
-  export const PanelSpriteRuntimeObjectRenderer = PanelSpriteRuntimeObjectPixiRenderer;
-  export type PanelSpriteRuntimeObjectRenderer = PanelSpriteRuntimeObjectPixiRenderer;
+  export type PanelSpriteRuntimeObjectRenderer =
+    | PanelSpriteRuntimeObjectPixiRenderer
+    | undefined;
+  type PanelSpriteRuntimeObjectRendererClass =
+    | typeof PanelSpriteRuntimeObjectPixiRenderer
+    | undefined;
+  export const PanelSpriteRuntimeObjectRenderer: PanelSpriteRuntimeObjectRendererClass =
+    PanelSpriteRuntimeObjectPixiRenderer;
 }

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
@@ -29,13 +29,16 @@ namespace gdjs {
    */
   export class PanelSpriteRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.OpacityHandler {
+    implements gdjs.Resizable, gdjs.OpacityHandler
+  {
     _rBorder: integer;
     _lBorder: integer;
     _tBorder: integer;
     _bBorder: integer;
     _tiled: boolean;
     opacity: float = 255;
+    private _color: string = '255;255;255';
+    private _dimensions: { height: number; width: number };
 
     // Width and height can be stored because they do not depend on the
     // size of the texture being used (contrary to most objects).
@@ -60,12 +63,18 @@ namespace gdjs {
       this._tiled = panelSpriteObjectData.tiled;
       this._width = panelSpriteObjectData.width;
       this._height = panelSpriteObjectData.height;
-      this._renderer = new gdjs.PanelSpriteRuntimeObjectRenderer(
-        this,
-        instanceContainer,
-        panelSpriteObjectData.texture,
-        panelSpriteObjectData.tiled
-      );
+      this._dimensions = instanceContainer
+        .getGame()
+        .getResourceBaseDimensions(panelSpriteObjectData.texture);
+
+      if (gdjs.PanelSpriteRuntimeObjectRenderer) {
+        this._renderer = new gdjs.PanelSpriteRuntimeObjectRenderer(
+          this,
+          instanceContainer,
+          panelSpriteObjectData.texture,
+          panelSpriteObjectData.tiled
+        );
+      }
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
@@ -111,7 +120,7 @@ namespace gdjs {
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
@@ -124,7 +133,7 @@ namespace gdjs {
     }
 
     update(instanceContainer: gdjs.RuntimeInstanceContainer): void {
-      this._renderer.ensureUpToDate();
+      if (this._renderer) this._renderer.ensureUpToDate();
     }
 
     /**
@@ -143,7 +152,7 @@ namespace gdjs {
      */
     setX(x: float): void {
       super.setX(x);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -152,7 +161,7 @@ namespace gdjs {
      */
     setY(y: float): void {
       super.setY(y);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -164,7 +173,11 @@ namespace gdjs {
       textureName: string,
       instanceContainer: gdjs.RuntimeInstanceContainer
     ): void {
-      this._renderer.setTexture(textureName, instanceContainer);
+      if (this._renderer)
+        this._renderer.setTexture(textureName, instanceContainer);
+      this._dimensions = instanceContainer
+        .getGame()
+        .getResourceBaseDimensions(textureName);
     }
 
     /**
@@ -173,7 +186,7 @@ namespace gdjs {
      */
     setAngle(angle: float): void {
       super.setAngle(angle);
-      this._renderer.updateAngle();
+      if (this._renderer) this._renderer.updateAngle();
     }
 
     /**
@@ -196,7 +209,7 @@ namespace gdjs {
       if (this._width === width) return;
 
       this._width = width;
-      this._renderer.updateWidth();
+      if (this._renderer) this._renderer.updateWidth();
       this.invalidateHitboxes();
     }
 
@@ -204,7 +217,7 @@ namespace gdjs {
       if (this._height === height) return;
 
       this._height = height;
-      this._renderer.updateHeight();
+      if (this._renderer) this._renderer.updateHeight();
       this.invalidateHitboxes();
     }
 
@@ -221,7 +234,7 @@ namespace gdjs {
         opacity = 255;
       }
       this.opacity = opacity;
-      this._renderer.updateOpacity();
+      if (this._renderer) this._renderer.updateOpacity();
     }
 
     getOpacity(): number {
@@ -234,7 +247,8 @@ namespace gdjs {
      * @param rgbColor The color, in RGB format ("128;200;255").
      */
     setColor(rgbColor: string): void {
-      this._renderer.setColor(rgbColor);
+      this._color = rgbColor;
+      if (this._renderer) this._renderer.setColor(rgbColor);
     }
 
     /**
@@ -243,7 +257,7 @@ namespace gdjs {
      * @returns The color, in RGB format ("128;200;255").
      */
     getColor(): string {
-      return this._renderer.getColor();
+      return this._color;
     }
 
     // Implement support for get/set scale:
@@ -263,14 +277,14 @@ namespace gdjs {
      * Get x-scale of the tiled sprite object.
      */
     getScaleX(): float {
-      return this._width / this._renderer.getTextureWidth();
+      return this._width / this._dimensions.width;
     }
 
     /**
      * Get y-scale of the tiled sprite object.
      */
     getScaleY(): float {
-      return this._height / this._renderer.getTextureHeight();
+      return this._height / this._dimensions.height;
     }
 
     /**
@@ -278,8 +292,8 @@ namespace gdjs {
      * @param newScale The new scale for the tiled sprite object.
      */
     setScale(newScale: float): void {
-      this.setWidth(this._renderer.getTextureWidth() * newScale);
-      this.setHeight(this._renderer.getTextureHeight() * newScale);
+      this.setWidth(this._dimensions.width * newScale);
+      this.setHeight(this._dimensions.height * newScale);
     }
 
     /**
@@ -287,7 +301,7 @@ namespace gdjs {
      * @param newScale The new x-scale for the tiled sprite object.
      */
     setScaleX(newScale: float): void {
-      this.setWidth(this._renderer.getTextureWidth() * newScale);
+      this.setWidth(this._dimensions.width * newScale);
     }
 
     /**
@@ -295,7 +309,7 @@ namespace gdjs {
      * @param newScale The new y-scale for the tiled sprite object.
      */
     setScaleY(newScale: float): void {
-      this.setHeight(this._renderer.getTextureHeight() * newScale);
+      this.setHeight(this._dimensions.height * newScale);
     }
   }
   gdjs.registerObject(

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
@@ -29,8 +29,7 @@ namespace gdjs {
    */
   export class PanelSpriteRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.OpacityHandler
-  {
+    implements gdjs.Resizable, gdjs.OpacityHandler {
     _rBorder: integer;
     _lBorder: integer;
     _tBorder: integer;

--- a/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
+++ b/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
@@ -40,11 +40,11 @@ namespace gdjs {
         );
       } else if (objectData.textureParticleName) {
         const sprite = new PIXI.Sprite(
-          (
-            instanceContainer
-              .getGame()
-              .getImageManager() as gdjs.PixiImageManager
-          ).getPIXITexture(objectData.textureParticleName)
+          (instanceContainer
+            .getGame()
+            .getImageManager() as gdjs.PixiImageManager).getPIXITexture(
+            objectData.textureParticleName
+          )
         );
         sprite.width = objectData.rendererParam1;
         sprite.height = objectData.rendererParam2;
@@ -273,8 +273,10 @@ namespace gdjs {
 
     setFlow(flow: number, tank: number): void {
       this.emitter.frequency = flow < 0 ? 0.0001 : 1.0 / flow;
-      this.emitter.emitterLifetime =
-        ParticleEmitterObjectPixiRenderer.computeLifetime(flow, tank);
+      this.emitter.emitterLifetime = ParticleEmitterObjectPixiRenderer.computeLifetime(
+        flow,
+        tank
+      );
     }
 
     resetEmission(flow: number, tank: number): void {
@@ -355,6 +357,5 @@ namespace gdjs {
   type ParticleEmitterObjectRendererClass =
     | typeof ParticleEmitterObjectPixiRenderer
     | undefined;
-  export const ParticleEmitterObjectRenderer: ParticleEmitterObjectRendererClass =
-    ParticleEmitterObjectPixiRenderer;
+  export const ParticleEmitterObjectRenderer: ParticleEmitterObjectRendererClass = ParticleEmitterObjectPixiRenderer;
 }

--- a/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
+++ b/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.ts
@@ -40,11 +40,11 @@ namespace gdjs {
         );
       } else if (objectData.textureParticleName) {
         const sprite = new PIXI.Sprite(
-          (instanceContainer
-            .getGame()
-            .getImageManager() as gdjs.PixiImageManager).getPIXITexture(
-            objectData.textureParticleName
-          )
+          (
+            instanceContainer
+              .getGame()
+              .getImageManager() as gdjs.PixiImageManager
+          ).getPIXITexture(objectData.textureParticleName)
         );
         sprite.width = objectData.rendererParam1;
         sprite.height = objectData.rendererParam2;
@@ -64,7 +64,7 @@ namespace gdjs {
       // instead of at each object creation.
       const pixiRenderer = instanceContainer
         .getGame()
-        .getRenderer()
+        .getRenderer()!
         .getPIXIRenderer();
       //@ts-expect-error Pixi has wrong type definitions for this method
       texture = pixiRenderer.generateTexture(graphics);
@@ -173,7 +173,7 @@ namespace gdjs {
       const layer = instanceContainer.getLayer(runtimeObject.getLayer());
       if (layer) {
         layer
-          .getRenderer()
+          .getRenderer()!
           .addRendererObject(this.renderer, runtimeObject.getZOrder());
       }
     }
@@ -273,10 +273,8 @@ namespace gdjs {
 
     setFlow(flow: number, tank: number): void {
       this.emitter.frequency = flow < 0 ? 0.0001 : 1.0 / flow;
-      this.emitter.emitterLifetime = ParticleEmitterObjectPixiRenderer.computeLifetime(
-        flow,
-        tank
-      );
+      this.emitter.emitterLifetime =
+        ParticleEmitterObjectPixiRenderer.computeLifetime(flow, tank);
     }
 
     resetEmission(flow: number, tank: number): void {
@@ -293,11 +291,11 @@ namespace gdjs {
     ): boolean {
       const invalidPixiTexture = instanceContainer
         .getGame()
-        .getImageManager()
+        .getImageManager()!
         .getInvalidPIXITexture();
       const pixiTexture = instanceContainer
         .getGame()
-        .getImageManager()
+        .getImageManager()!
         .getPIXITexture(texture);
       return pixiTexture.valid && pixiTexture !== invalidPixiTexture;
     }
@@ -308,11 +306,11 @@ namespace gdjs {
     ): void {
       const invalidPixiTexture = instanceContainer
         .getGame()
-        .getImageManager()
+        .getImageManager()!
         .getInvalidPIXITexture();
       const pixiTexture = instanceContainer
         .getGame()
-        .getImageManager()
+        .getImageManager()!
         .getPIXITexture(texture);
       if (pixiTexture.valid && pixiTexture !== invalidPixiTexture) {
         this.emitter.particleImages[0] = pixiTexture;
@@ -351,6 +349,12 @@ namespace gdjs {
   }
 
   // @ts-ignore - Register the class to let the engine use it.
-  export const ParticleEmitterObjectRenderer = ParticleEmitterObjectPixiRenderer;
-  export type ParticleEmitterObjectRenderer = ParticleEmitterObjectPixiRenderer;
+  export type ParticleEmitterObjectRenderer =
+    | ParticleEmitterObjectPixiRenderer
+    | undefined;
+  type ParticleEmitterObjectRendererClass =
+    | typeof ParticleEmitterObjectPixiRenderer
+    | undefined;
+  export const ParticleEmitterObjectRenderer: ParticleEmitterObjectRendererClass =
+    ParticleEmitterObjectPixiRenderer;
 }

--- a/Extensions/ParticleSystem/particleemitterobject.ts
+++ b/Extensions/ParticleSystem/particleemitterobject.ts
@@ -327,21 +327,9 @@ namespace gdjs {
 
         // Consider every state dirty as the renderer was just re-created, so it needs
         // to be repositioned, angle updated, etc...
-        this._posDirty =
-          this._angleDirty =
-          this._forceDirty =
-          this._zoneRadiusDirty =
-            true;
-        this._lifeTimeDirty =
-          this._gravityDirty =
-          this._colorDirty =
-          this._sizeDirty =
-            true;
-        this._alphaDirty =
-          this._flowDirty =
-          this._tankDirty =
-          this._textureDirty =
-            true;
+        this._posDirty = this._angleDirty = this._forceDirty = this._zoneRadiusDirty = true;
+        this._lifeTimeDirty = this._gravityDirty = this._colorDirty = this._sizeDirty = true;
+        this._alphaDirty = this._flowDirty = this._tankDirty = this._textureDirty = true;
       }
       return true;
     }
@@ -405,25 +393,10 @@ namespace gdjs {
           this._renderer.setTextureName(this.texture, instanceContainer);
         }
       }
-      this._posDirty =
-        this._angleDirty =
-        this._forceDirty =
-        this._zoneRadiusDirty =
-          false;
-      this._lifeTimeDirty =
-        this._gravityDirty =
-        this._colorDirty =
-        this._sizeDirty =
-          false;
-      this._alphaDirty =
-        this._flowDirty =
-        this._textureDirty =
-        this._tankDirty =
-          false;
-      this._additiveRenderingDirty =
-        this._maxParticlesCountDirty =
-        this._particleRotationSpeedDirty =
-          false;
+      this._posDirty = this._angleDirty = this._forceDirty = this._zoneRadiusDirty = false;
+      this._lifeTimeDirty = this._gravityDirty = this._colorDirty = this._sizeDirty = false;
+      this._alphaDirty = this._flowDirty = this._textureDirty = this._tankDirty = false;
+      this._additiveRenderingDirty = this._maxParticlesCountDirty = this._particleRotationSpeedDirty = false;
       if (this._renderer) {
         this._renderer.update(this.getElapsedTime() / 1000.0);
         if (

--- a/Extensions/ParticleSystem/particleemitterobject.ts
+++ b/Extensions/ParticleSystem/particleemitterobject.ts
@@ -126,11 +126,13 @@ namespace gdjs {
       particleObjectData: ParticleEmitterObjectData
     ) {
       super(instanceContainer, particleObjectData);
-      this._renderer = new gdjs.ParticleEmitterObjectRenderer(
-        instanceContainer,
-        this,
-        particleObjectData
-      );
+      if (gdjs.ParticleEmitterObjectRenderer) {
+        this._renderer = new gdjs.ParticleEmitterObjectRenderer(
+          instanceContainer,
+          this,
+          particleObjectData
+        );
+      }
       this.angleA = particleObjectData.emitterAngleA;
       this.angleB = particleObjectData.emitterAngleB;
       this.forceMin = particleObjectData.emitterForceMin;
@@ -191,7 +193,7 @@ namespace gdjs {
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     updateFromObjectData(
@@ -304,109 +306,146 @@ namespace gdjs {
         oldObjectData.rendererParam1 !== newObjectData.rendererParam1 ||
         oldObjectData.rendererParam2 !== newObjectData.rendererParam2
       ) {
-        // Destroy the renderer, ensure it's removed from the layer.
-        const layer = this.getInstanceContainer().getLayer(this.layer);
-        layer
-          .getRenderer()
-          .removeRendererObject(this._renderer.getRendererObject());
-        this._renderer.destroy();
-
-        // and recreate the renderer, which will add itself to the layer.
-        this._renderer = new gdjs.ParticleEmitterObjectRenderer(
-          this.getInstanceContainer(),
-          this,
-          newObjectData
-        );
+        if (this._renderer) {
+          // Destroy the renderer, ensure it's removed from the layer.
+          const layerRenderer = this.getInstanceContainer()
+            .getLayer(this.layer)
+            .getRenderer();
+          if (layerRenderer) {
+            layerRenderer.removeRendererObject(
+              this._renderer.getRendererObject()
+            );
+          }
+          this._renderer.destroy();
+          // and recreate the renderer, which will add itself to the layer.
+          this._renderer = new gdjs.ParticleEmitterObjectRenderer!(
+            this.getInstanceContainer(),
+            this,
+            newObjectData
+          );
+        }
 
         // Consider every state dirty as the renderer was just re-created, so it needs
         // to be repositioned, angle updated, etc...
-        this._posDirty = this._angleDirty = this._forceDirty = this._zoneRadiusDirty = true;
-        this._lifeTimeDirty = this._gravityDirty = this._colorDirty = this._sizeDirty = true;
-        this._alphaDirty = this._flowDirty = this._tankDirty = this._textureDirty = true;
+        this._posDirty =
+          this._angleDirty =
+          this._forceDirty =
+          this._zoneRadiusDirty =
+            true;
+        this._lifeTimeDirty =
+          this._gravityDirty =
+          this._colorDirty =
+          this._sizeDirty =
+            true;
+        this._alphaDirty =
+          this._flowDirty =
+          this._tankDirty =
+          this._textureDirty =
+            true;
       }
       return true;
     }
 
     update(instanceContainer: gdjs.RuntimeInstanceContainer): void {
-      if (this._posDirty) {
-        this._renderer.setPosition(this.getX(), this.getY());
+      if (this._renderer) {
+        if (this._posDirty) {
+          this._renderer.setPosition(this.getX(), this.getY());
+        }
+        if (this._particleRotationSpeedDirty) {
+          this._renderer.setParticleRotationSpeed(
+            this.particleRotationMinSpeed,
+            this.particleRotationMaxSpeed
+          );
+        }
+        if (this._maxParticlesCountDirty) {
+          this._renderer.setMaxParticlesCount(this.maxParticlesCount);
+        }
+        if (this._additiveRenderingDirty) {
+          this._renderer.setAdditiveRendering(this.additiveRendering);
+        }
+        if (this._angleDirty) {
+          const angle = this.getAngle();
+          this._renderer.setAngle(
+            angle - this.angleB / 2.0,
+            angle + this.angleB / 2.0
+          );
+        }
+        if (this._forceDirty) {
+          this._renderer.setForce(this.forceMin, this.forceMax);
+        }
+        if (this._zoneRadiusDirty) {
+          this._renderer.setZoneRadius(this.zoneRadius);
+        }
+        if (this._lifeTimeDirty) {
+          this._renderer.setLifeTime(this.lifeTimeMin, this.lifeTimeMax);
+        }
+        if (this._gravityDirty) {
+          this._renderer.setGravity(this.gravityX, this.gravityY);
+        }
+        if (this._colorDirty) {
+          this._renderer.setColor(
+            this.colorR1,
+            this.colorG1,
+            this.colorB1,
+            this.colorR2,
+            this.colorG2,
+            this.colorB2
+          );
+        }
+        if (this._sizeDirty) {
+          this._renderer.setSize(this.size1, this.size2);
+        }
+        if (this._alphaDirty) {
+          this._renderer.setAlpha(this.alpha1, this.alpha2);
+        }
+        if (this._flowDirty || this._tankDirty) {
+          this._renderer.resetEmission(this.flow, this.tank);
+        }
+        if (this._textureDirty) {
+          this._renderer.setTextureName(this.texture, instanceContainer);
+        }
       }
-      if (this._particleRotationSpeedDirty) {
-        this._renderer.setParticleRotationSpeed(
-          this.particleRotationMinSpeed,
-          this.particleRotationMaxSpeed
-        );
-      }
-      if (this._maxParticlesCountDirty) {
-        this._renderer.setMaxParticlesCount(this.maxParticlesCount);
-      }
-      if (this._additiveRenderingDirty) {
-        this._renderer.setAdditiveRendering(this.additiveRendering);
-      }
-      if (this._angleDirty) {
-        const angle = this.getAngle();
-        this._renderer.setAngle(
-          angle - this.angleB / 2.0,
-          angle + this.angleB / 2.0
-        );
-      }
-      if (this._forceDirty) {
-        this._renderer.setForce(this.forceMin, this.forceMax);
-      }
-      if (this._zoneRadiusDirty) {
-        this._renderer.setZoneRadius(this.zoneRadius);
-      }
-      if (this._lifeTimeDirty) {
-        this._renderer.setLifeTime(this.lifeTimeMin, this.lifeTimeMax);
-      }
-      if (this._gravityDirty) {
-        this._renderer.setGravity(this.gravityX, this.gravityY);
-      }
-      if (this._colorDirty) {
-        this._renderer.setColor(
-          this.colorR1,
-          this.colorG1,
-          this.colorB1,
-          this.colorR2,
-          this.colorG2,
-          this.colorB2
-        );
-      }
-      if (this._sizeDirty) {
-        this._renderer.setSize(this.size1, this.size2);
-      }
-      if (this._alphaDirty) {
-        this._renderer.setAlpha(this.alpha1, this.alpha2);
-      }
-      if (this._flowDirty || this._tankDirty) {
-        this._renderer.resetEmission(this.flow, this.tank);
-      }
-      if (this._textureDirty) {
-        this._renderer.setTextureName(this.texture, instanceContainer);
-      }
-      this._posDirty = this._angleDirty = this._forceDirty = this._zoneRadiusDirty = false;
-      this._lifeTimeDirty = this._gravityDirty = this._colorDirty = this._sizeDirty = false;
-      this._alphaDirty = this._flowDirty = this._textureDirty = this._tankDirty = false;
-      this._additiveRenderingDirty = this._maxParticlesCountDirty = this._particleRotationSpeedDirty = false;
-      this._renderer.update(this.getElapsedTime() / 1000.0);
-      if (
-        this._renderer.hasStarted() &&
-        this.getParticleCount() === 0 &&
-        this.destroyWhenNoParticles
-      ) {
-        this.deleteFromScene(instanceContainer);
+      this._posDirty =
+        this._angleDirty =
+        this._forceDirty =
+        this._zoneRadiusDirty =
+          false;
+      this._lifeTimeDirty =
+        this._gravityDirty =
+        this._colorDirty =
+        this._sizeDirty =
+          false;
+      this._alphaDirty =
+        this._flowDirty =
+        this._textureDirty =
+        this._tankDirty =
+          false;
+      this._additiveRenderingDirty =
+        this._maxParticlesCountDirty =
+        this._particleRotationSpeedDirty =
+          false;
+      if (this._renderer) {
+        this._renderer.update(this.getElapsedTime() / 1000.0);
+        if (
+          this._renderer.hasStarted() &&
+          this.getParticleCount() === 0 &&
+          this.destroyWhenNoParticles
+        ) {
+          this.deleteFromScene(instanceContainer);
+        }
       }
       if (
         this.jumpForwardInTimeOnCreation > 0 &&
         this._jumpForwardInTimeCompleted === false
       ) {
-        this._renderer.update(this.jumpForwardInTimeOnCreation);
+        if (this._renderer)
+          this._renderer.update(this.jumpForwardInTimeOnCreation);
         this._jumpForwardInTimeCompleted = true;
       }
     }
 
     onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
-      this._renderer.destroy();
+      if (this._renderer) this._renderer.destroy();
       super.onDestroyFromScene(instanceContainer);
     }
 
@@ -803,15 +842,15 @@ namespace gdjs {
     }
 
     startEmission(): void {
-      this._renderer.start();
+      if (this._renderer) this._renderer.start();
     }
 
     stopEmission(): void {
-      this._renderer.stop();
+      if (this._renderer) this._renderer.stop();
     }
 
     isEmitting(): boolean {
-      return this._renderer.emitter.emit;
+      return !!this._renderer?.emitter.emit;
     }
 
     noMoreParticles(): boolean {
@@ -819,7 +858,7 @@ namespace gdjs {
     }
 
     recreateParticleSystem(): void {
-      this._renderer.recreate();
+      if (this._renderer) this._renderer.recreate();
     }
 
     getFlow(): number {
@@ -834,7 +873,7 @@ namespace gdjs {
     }
 
     getParticleCount(): number {
-      return this._renderer.getParticleCount();
+      return this._renderer?.getParticleCount() || 0;
     }
 
     getTank(): number {
@@ -855,7 +894,11 @@ namespace gdjs {
       instanceContainer: gdjs.RuntimeInstanceContainer
     ): void {
       if (this.texture !== texture) {
-        if (this._renderer.isTextureNameValid(texture, instanceContainer)) {
+        if (
+          this._renderer
+            ? this._renderer.isTextureNameValid(texture, instanceContainer)
+            : true
+        ) {
           this.texture = texture;
           this._textureDirty = true;
         }
@@ -863,7 +906,7 @@ namespace gdjs {
     }
 
     jumpEmitterForwardInTime(timeSkipped: number): void {
-      this._renderer.update(timeSkipped);
+      if (this._renderer) this._renderer.update(timeSkipped);
     }
   }
   gdjs.registerObject(

--- a/Extensions/PlayerAuthentication/playerauthenticationtools.ts
+++ b/Extensions/PlayerAuthentication/playerauthenticationtools.ts
@@ -25,8 +25,9 @@ namespace gdjs {
     let _authenticationTimeoutId: NodeJS.Timeout | null = null;
 
     // Communication methods.
-    let _authenticationMessageCallback: ((event: MessageEvent) => void) | null =
-      null;
+    let _authenticationMessageCallback:
+      | ((event: MessageEvent) => void)
+      | null = null;
     let _cordovaAuthenticationMessageCallback:
       | ((event: MessageEvent) => void)
       | null = null;
@@ -784,10 +785,13 @@ namespace gdjs {
       if (_authenticationBanner) _authenticationBanner.style.opacity = '0';
 
       const platform = getPlatform(runtimeScene);
-      const { rootContainer, loaderContainer, iframeContainer } =
-        authComponents.computeAuthenticationContainer(
-          onAuthenticationContainerDismissed
-        );
+      const {
+        rootContainer,
+        loaderContainer,
+        iframeContainer,
+      } = authComponents.computeAuthenticationContainer(
+        onAuthenticationContainerDismissed
+      );
       _authenticationRootContainer = rootContainer;
       _authenticationLoaderContainer = loaderContainer;
       _authenticationIframeContainer = iframeContainer;
@@ -812,13 +816,12 @@ namespace gdjs {
                   )
               : null; // Only show a link if we're on electron.
 
-            _authenticationTextContainer =
-              authComponents.addAuthenticationTextsToLoadingContainer(
-                _authenticationLoaderContainer,
-                platform,
-                isGameRegistered,
-                wikiOpenAction
-              );
+            _authenticationTextContainer = authComponents.addAuthenticationTextsToLoadingContainer(
+              _authenticationLoaderContainer,
+              platform,
+              isGameRegistered,
+              wikiOpenAction
+            );
           }
           if (isGameRegistered) {
             startAuthenticationWindowTimeout(runtimeScene);

--- a/Extensions/PlayerAuthentication/playerauthenticationtools.ts
+++ b/Extensions/PlayerAuthentication/playerauthenticationtools.ts
@@ -25,9 +25,8 @@ namespace gdjs {
     let _authenticationTimeoutId: NodeJS.Timeout | null = null;
 
     // Communication methods.
-    let _authenticationMessageCallback:
-      | ((event: MessageEvent) => void)
-      | null = null;
+    let _authenticationMessageCallback: ((event: MessageEvent) => void) | null =
+      null;
     let _cordovaAuthenticationMessageCallback:
       | ((event: MessageEvent) => void)
       | null = null;
@@ -104,7 +103,7 @@ namespace gdjs {
       runtimeScene: RuntimeScene
     ): 'electron' | 'cordova' | 'web' => {
       const runtimeGame = runtimeScene.getGame();
-      const electron = runtimeGame.getRenderer().getElectron();
+      const electron = runtimeGame.getRenderer()?.getElectron();
       if (electron) {
         return 'electron';
       }
@@ -229,7 +228,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         handleAuthenticationError(
           runtimeScene,
@@ -351,7 +350,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         handleAuthenticationError(
           runtimeScene,
@@ -431,7 +430,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         handleAuthenticationError(
           runtimeScene,
@@ -516,7 +515,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         handleAuthenticationError(
           runtimeScene,
@@ -541,7 +540,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         handleAuthenticationError(
           runtimeScene,
@@ -614,7 +613,7 @@ namespace gdjs {
               const electron = runtimeScene
                 .getGame()
                 .getRenderer()
-                .getElectron();
+                ?.getElectron();
               const openWindow = () => electron.shell.openExternal(targetUrl);
 
               openWindow();
@@ -758,7 +757,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         handleAuthenticationError(
           runtimeScene,
@@ -785,13 +784,10 @@ namespace gdjs {
       if (_authenticationBanner) _authenticationBanner.style.opacity = '0';
 
       const platform = getPlatform(runtimeScene);
-      const {
-        rootContainer,
-        loaderContainer,
-        iframeContainer,
-      } = authComponents.computeAuthenticationContainer(
-        onAuthenticationContainerDismissed
-      );
+      const { rootContainer, loaderContainer, iframeContainer } =
+        authComponents.computeAuthenticationContainer(
+          onAuthenticationContainerDismissed
+        );
       _authenticationRootContainer = rootContainer;
       _authenticationLoaderContainer = loaderContainer;
       _authenticationIframeContainer = iframeContainer;
@@ -805,7 +801,10 @@ namespace gdjs {
       checkIfGameIsRegistered(runtimeScene.getGame(), _gameId)
         .then((isGameRegistered) => {
           if (_authenticationLoaderContainer) {
-            const electron = runtimeScene.getGame().getRenderer().getElectron();
+            const electron = runtimeScene
+              .getGame()
+              .getRenderer()
+              ?.getElectron();
             const wikiOpenAction = electron
               ? () =>
                   electron.shell.openExternal(
@@ -813,12 +812,13 @@ namespace gdjs {
                   )
               : null; // Only show a link if we're on electron.
 
-            _authenticationTextContainer = authComponents.addAuthenticationTextsToLoadingContainer(
-              _authenticationLoaderContainer,
-              platform,
-              isGameRegistered,
-              wikiOpenAction
-            );
+            _authenticationTextContainer =
+              authComponents.addAuthenticationTextsToLoadingContainer(
+                _authenticationLoaderContainer,
+                platform,
+                isGameRegistered,
+                wikiOpenAction
+              );
           }
           if (isGameRegistered) {
             startAuthenticationWindowTimeout(runtimeScene);
@@ -869,7 +869,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         logger.info(
           "The div element covering the game couldn't be found, the authentication must be already closed."
@@ -920,7 +920,7 @@ namespace gdjs {
       const domElementContainer = runtimeScene
         .getGame()
         .getRenderer()
-        .getDomElementContainer();
+        ?.getDomElementContainer();
       if (!domElementContainer) {
         logger.info(
           "The div element covering the game couldn't be found, the authentication must be already closed."
@@ -936,7 +936,7 @@ namespace gdjs {
      * Focus on game canvas to allow user to interact with it.
      */
     const focusOnGame = function (runtimeScene: gdjs.RuntimeScene) {
-      const gameCanvas = runtimeScene.getGame().getRenderer().getCanvas();
+      const gameCanvas = runtimeScene.getGame().getRenderer()?.getCanvas();
       if (gameCanvas) gameCanvas.focus();
     };
   }

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -530,6 +530,5 @@ namespace gdjs {
   type ShapePainterRuntimeObjectRendererClass =
     | typeof ShapePainterRuntimeObjectPixiRenderer
     | undefined;
-  export const ShapePainterRuntimeObjectRenderer: ShapePainterRuntimeObjectRendererClass =
-    ShapePainterRuntimeObjectPixiRenderer;
+  export const ShapePainterRuntimeObjectRenderer: ShapePainterRuntimeObjectRendererClass = ShapePainterRuntimeObjectPixiRenderer;
 }

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject-pixi-renderer.ts
@@ -35,7 +35,7 @@ namespace gdjs {
       this._graphics = new PIXI.Graphics();
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._graphics, runtimeObject.getZOrder());
       this.updateAntialiasing();
     }
@@ -524,6 +524,12 @@ namespace gdjs {
     }
   }
 
-  export const ShapePainterRuntimeObjectRenderer = ShapePainterRuntimeObjectPixiRenderer;
-  export type ShapePainterRuntimeObjectRenderer = ShapePainterRuntimeObjectPixiRenderer;
+  export type ShapePainterRuntimeObjectRenderer =
+    | ShapePainterRuntimeObjectPixiRenderer
+    | undefined;
+  type ShapePainterRuntimeObjectRendererClass =
+    | typeof ShapePainterRuntimeObjectPixiRenderer
+    | undefined;
+  export const ShapePainterRuntimeObjectRenderer: ShapePainterRuntimeObjectRendererClass =
+    ShapePainterRuntimeObjectPixiRenderer;
 }

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -42,7 +42,8 @@ namespace gdjs {
    */
   export class ShapePainterRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.Scalable, gdjs.Flippable {
+    implements gdjs.Resizable, gdjs.Scalable, gdjs.Flippable
+  {
     _scaleX: number = 1;
     _scaleY: number = 1;
     _blendMode: number = 0;
@@ -94,17 +95,19 @@ namespace gdjs {
       this._useAbsoluteCoordinates = shapePainterObjectData.absoluteCoordinates;
       this._clearBetweenFrames = shapePainterObjectData.clearBetweenFrames;
       this._antialiasing = shapePainterObjectData.antialiasing;
-      this._renderer = new gdjs.ShapePainterRuntimeObjectRenderer(
-        this,
-        instanceContainer
-      );
+      if (gdjs.ShapePainterRuntimeObjectRenderer) {
+        this._renderer = new gdjs.ShapePainterRuntimeObjectRenderer(
+          this,
+          instanceContainer
+        );
+      }
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     updateFromObjectData(
@@ -152,11 +155,13 @@ namespace gdjs {
         oldObjectData.absoluteCoordinates !== newObjectData.absoluteCoordinates
       ) {
         this._useAbsoluteCoordinates = newObjectData.absoluteCoordinates;
-        this._renderer.updatePositionX();
-        this._renderer.updatePositionY();
-        this._renderer.updateAngle();
-        this._renderer.updateScaleX();
-        this._renderer.updateScaleY();
+        if (this._renderer) {
+          this._renderer.updatePositionX();
+          this._renderer.updatePositionY();
+          this._renderer.updateAngle();
+          this._renderer.updateScaleX();
+          this._renderer.updateScaleY();
+        }
       }
       if (
         oldObjectData.clearBetweenFrames !== newObjectData.clearBetweenFrames
@@ -178,7 +183,7 @@ namespace gdjs {
      * Clear the graphics.
      */
     clear() {
-      this._renderer.clear();
+      if (this._renderer) this._renderer.clear();
     }
 
     getVisibilityAABB() {
@@ -186,23 +191,24 @@ namespace gdjs {
     }
 
     drawRectangle(x1: float, y1: float, x2: float, y2: float) {
-      this._renderer.drawRectangle(x1, y1, x2, y2);
+      if (this._renderer) this._renderer.drawRectangle(x1, y1, x2, y2);
     }
 
     drawCircle(x: float, y: float, radius: float) {
-      this._renderer.drawCircle(x, y, radius);
+      if (this._renderer) this._renderer.drawCircle(x, y, radius);
     }
 
     drawLine(x1: float, y1: float, x2: float, y2: float, thickness: float) {
-      this._renderer.drawLine(x1, y1, x2, y2, thickness);
+      if (this._renderer) this._renderer.drawLine(x1, y1, x2, y2, thickness);
     }
 
     drawLineV2(x1: float, y1: float, x2: float, y2: float, thickness: float) {
-      this._renderer.drawLineV2(x1, y1, x2, y2, thickness);
+      if (this._renderer) this._renderer.drawLineV2(x1, y1, x2, y2, thickness);
     }
 
     drawEllipse(centerX: float, centerY: float, width: float, height: float) {
-      this._renderer.drawEllipse(centerX, centerY, width, height);
+      if (this._renderer)
+        this._renderer.drawEllipse(centerX, centerY, width, height);
     }
 
     drawRoundedRectangle(
@@ -212,13 +218,14 @@ namespace gdjs {
       endY2: float,
       radius: float
     ) {
-      this._renderer.drawRoundedRectangle(
-        startX1,
-        startY1,
-        endX2,
-        endY2,
-        radius
-      );
+      if (this._renderer)
+        this._renderer.drawRoundedRectangle(
+          startX1,
+          startY1,
+          endX2,
+          endY2,
+          radius
+        );
     }
 
     drawStar(
@@ -229,14 +236,15 @@ namespace gdjs {
       innerRadius: float,
       rotation: float
     ) {
-      this._renderer.drawStar(
-        centerX,
-        centerY,
-        points,
-        radius,
-        innerRadius,
-        rotation
-      );
+      if (this._renderer)
+        this._renderer.drawStar(
+          centerX,
+          centerY,
+          points,
+          radius,
+          innerRadius,
+          rotation
+        );
     }
 
     drawArc(
@@ -248,15 +256,16 @@ namespace gdjs {
       anticlockwise: boolean,
       closePath: boolean
     ) {
-      this._renderer.drawArc(
-        centerX,
-        centerY,
-        radius,
-        startAngle,
-        endAngle,
-        anticlockwise,
-        closePath
-      );
+      if (this._renderer)
+        this._renderer.drawArc(
+          centerX,
+          centerY,
+          radius,
+          startAngle,
+          endAngle,
+          anticlockwise,
+          closePath
+        );
     }
 
     drawBezierCurve(
@@ -269,7 +278,8 @@ namespace gdjs {
       x2: float,
       y2: float
     ) {
-      this._renderer.drawBezierCurve(x1, y1, cpX, cpY, cpX2, cpY2, x2, y2);
+      if (this._renderer)
+        this._renderer.drawBezierCurve(x1, y1, cpX, cpY, cpX2, cpY2, x2, y2);
     }
 
     drawQuadraticCurve(
@@ -280,24 +290,25 @@ namespace gdjs {
       x2: float,
       y2: float
     ) {
-      this._renderer.drawQuadraticCurve(x1, y1, cpX, cpY, x2, y2);
+      if (this._renderer)
+        this._renderer.drawQuadraticCurve(x1, y1, cpX, cpY, x2, y2);
     }
 
     beginFillPath(x1: float, y1: float) {
-      this._renderer.beginFillPath();
-      this._renderer.drawPathMoveTo(x1, y1);
+      if (this._renderer) this._renderer.beginFillPath();
+      if (this._renderer) this._renderer.drawPathMoveTo(x1, y1);
     }
 
     endFillPath() {
-      this._renderer.endFillPath();
+      if (this._renderer) this._renderer.endFillPath();
     }
 
     drawPathMoveTo(x1: float, y1: float) {
-      this._renderer.drawPathMoveTo(x1, y1);
+      if (this._renderer) this._renderer.drawPathMoveTo(x1, y1);
     }
 
     drawPathLineTo(x1: float, y1: float) {
-      this._renderer.drawPathLineTo(x1, y1);
+      if (this._renderer) this._renderer.drawPathLineTo(x1, y1);
     }
 
     drawPathBezierCurveTo(
@@ -308,7 +319,8 @@ namespace gdjs {
       toX: float,
       toY: float
     ) {
-      this._renderer.drawPathBezierCurveTo(cpX, cpY, cpX2, cpY2, toX, toY);
+      if (this._renderer)
+        this._renderer.drawPathBezierCurveTo(cpX, cpY, cpX2, cpY2, toX, toY);
     }
 
     drawPathArc(
@@ -319,22 +331,24 @@ namespace gdjs {
       endAngle: float,
       anticlockwise: boolean
     ) {
-      this._renderer.drawPathArc(
-        cx,
-        cy,
-        radius,
-        startAngle,
-        endAngle,
-        anticlockwise
-      );
+      if (this._renderer)
+        this._renderer.drawPathArc(
+          cx,
+          cy,
+          radius,
+          startAngle,
+          endAngle,
+          anticlockwise
+        );
     }
 
     drawPathQuadraticCurveTo(cpX: float, cpY: float, toX: float, toY: float) {
-      this._renderer.drawPathQuadraticCurveTo(cpX, cpY, toX, toY);
+      if (this._renderer)
+        this._renderer.drawPathQuadraticCurveTo(cpX, cpY, toX, toY);
     }
 
     closePath() {
-      this._renderer.closePath();
+      if (this._renderer) this._renderer.closePath();
     }
 
     setClearBetweenFrames(value: boolean): void {
@@ -347,7 +361,7 @@ namespace gdjs {
 
     setAntialiasing(value: Antialiasing): void {
       this._antialiasing = value;
-      this._renderer.updateAntialiasing();
+      if (this._renderer) this._renderer.updateAntialiasing();
     }
 
     getAntialiasing(): Antialiasing {
@@ -412,7 +426,7 @@ namespace gdjs {
         ),
         16
       );
-      this._renderer.updateOutline();
+      if (this._renderer) this._renderer.updateOutline();
     }
 
     getOutlineColorR(): integer {
@@ -427,7 +441,7 @@ namespace gdjs {
 
     setOutlineSize(size: float): void {
       this._outlineSize = size;
-      this._renderer.updateOutline();
+      if (this._renderer) this._renderer.updateOutline();
     }
 
     getOutlineSize() {
@@ -456,7 +470,7 @@ namespace gdjs {
      */
     setOutlineOpacity(opacity: float): void {
       this._outlineOpacity = opacity;
-      this._renderer.updateOutline();
+      if (this._renderer) this._renderer.updateOutline();
     }
 
     /**
@@ -472,7 +486,7 @@ namespace gdjs {
         return;
       }
       super.setX(x);
-      this._renderer.updatePositionX();
+      if (this._renderer) this._renderer.updatePositionX();
     }
 
     setY(y: float): void {
@@ -480,7 +494,7 @@ namespace gdjs {
         return;
       }
       super.setY(y);
-      this._renderer.updatePositionY();
+      if (this._renderer) this._renderer.updatePositionY();
     }
 
     setAngle(angle: float): void {
@@ -488,7 +502,7 @@ namespace gdjs {
         return;
       }
       super.setAngle(angle);
-      this._renderer.updateAngle();
+      if (this._renderer) this._renderer.updateAngle();
       this.invalidateHitboxes();
     }
 
@@ -510,7 +524,7 @@ namespace gdjs {
       }
       this._customCenter[0] = x;
       this._customCenter[1] = y;
-      this._renderer.updateRotationCenter();
+      if (this._renderer) this._renderer.updateRotationCenter();
     }
 
     /**
@@ -518,6 +532,7 @@ namespace gdjs {
      * (whereas `getCenterX()` is relative to the top left drawable bound and scaled).
      */
     getRotationCenterX(): float {
+      if (!this._renderer) return 0;
       return this._customCenter
         ? this._customCenter[0]
         : this._renderer.getUnscaledWidth() / 2 -
@@ -529,6 +544,7 @@ namespace gdjs {
      * (whereas `getCenterY()` is relative to the top left drawable bound and scaled).
      */
     getRotationCenterY(): float {
+      if (!this._renderer) return 0;
       return this._customCenter
         ? this._customCenter[1]
         : this._renderer.getUnscaledHeight() / 2 -
@@ -558,14 +574,18 @@ namespace gdjs {
     }
 
     setWidth(newWidth: float): void {
-      const unscaledWidth = this._renderer.getUnscaledWidth();
+      const unscaledWidth = this._renderer
+        ? this._renderer.getUnscaledWidth()
+        : 1;
       if (unscaledWidth !== 0) {
         this.setScaleX(newWidth / unscaledWidth);
       }
     }
 
     setHeight(newHeight: float): void {
-      const unscaledHeight = this._renderer.getUnscaledHeight();
+      const unscaledHeight = this._renderer
+        ? this._renderer.getUnscaledHeight()
+        : 1;
       if (unscaledHeight !== 0) {
         this.setScaleY(newHeight / unscaledHeight);
       }
@@ -599,7 +619,7 @@ namespace gdjs {
         return;
       }
       this._scaleX = newScale * (this._flippedX ? -1 : 1);
-      this._renderer.updateScaleX();
+      if (this._renderer) this._renderer.updateScaleX();
       this.invalidateHitboxes();
     }
 
@@ -616,7 +636,7 @@ namespace gdjs {
         return;
       }
       this._scaleY = newScale * (this._flippedY ? -1 : 1);
-      this._renderer.updateScaleY();
+      if (this._renderer) this._renderer.updateScaleY();
       this.invalidateHitboxes();
     }
 
@@ -624,7 +644,7 @@ namespace gdjs {
       if (enable !== this._flippedX) {
         this._scaleX *= -1;
         this._flippedX = enable;
-        this._renderer.updateScaleX();
+        if (this._renderer) this._renderer.updateScaleX();
         this.invalidateHitboxes();
       }
     }
@@ -633,7 +653,7 @@ namespace gdjs {
       if (enable !== this._flippedY) {
         this._scaleY *= -1;
         this._flippedY = enable;
-        this._renderer.updateScaleY();
+        if (this._renderer) this._renderer.updateScaleY();
         this.invalidateHitboxes();
       }
     }
@@ -680,26 +700,31 @@ namespace gdjs {
     }
 
     getDrawableX(): float {
+      if (!this._renderer) return 0;
       return this._renderer.getDrawableX();
     }
 
     getDrawableY(): float {
+      if (!this._renderer) return 0;
       return this._renderer.getDrawableY();
     }
 
     getWidth(): float {
+      if (!this._renderer) return 0;
       return this._renderer.getWidth();
     }
 
     getHeight(): float {
+      if (!this._renderer) return 0;
       return this._renderer.getHeight();
     }
 
     updatePreRender(instanceContainer: gdjs.RuntimeInstanceContainer): void {
-      this._renderer.updatePreRender();
+      if (this._renderer) this._renderer.updatePreRender();
     }
 
     transformToDrawing(x: float, y: float) {
+      if (!this._renderer) return [0, 0];
       const point = ShapePainterRuntimeObject._pointForTransformation;
       point[0] = x;
       point[1] = y;
@@ -707,6 +732,7 @@ namespace gdjs {
     }
 
     transformToScene(x: float, y: float) {
+      if (!this._renderer) return [0, 0];
       const point = ShapePainterRuntimeObject._pointForTransformation;
       point[0] = x;
       point[1] = y;
@@ -768,8 +794,8 @@ namespace gdjs {
       const centerY = this.getCenterY();
       const vertices = this.hitBoxes[0].vertices;
       if (this._customCollisionMask) {
-        const customCollisionMaskVertices = this._customCollisionMask[0]
-          .vertices;
+        const customCollisionMaskVertices =
+          this._customCollisionMask[0].vertices;
         for (let i = 0; i < 4; i++) {
           const point = this.transformToScene(
             customCollisionMaskVertices[i][0],

--- a/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
+++ b/Extensions/PrimitiveDrawing/shapepainterruntimeobject.ts
@@ -42,8 +42,7 @@ namespace gdjs {
    */
   export class ShapePainterRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.Scalable, gdjs.Flippable
-  {
+    implements gdjs.Resizable, gdjs.Scalable, gdjs.Flippable {
     _scaleX: number = 1;
     _scaleY: number = 1;
     _blendMode: number = 0;
@@ -794,8 +793,8 @@ namespace gdjs {
       const centerY = this.getCenterY();
       const vertices = this.hitBoxes[0].vertices;
       if (this._customCollisionMask) {
-        const customCollisionMaskVertices =
-          this._customCollisionMask[0].vertices;
+        const customCollisionMaskVertices = this._customCollisionMask[0]
+          .vertices;
         for (let i = 0; i < 4; i++) {
           const point = this.transformToScene(
             customCollisionMaskVertices[i][0],

--- a/Extensions/Screenshot/screenshottools.ts
+++ b/Extensions/Screenshot/screenshottools.ts
@@ -13,7 +13,7 @@ namespace gdjs {
     ) {
       const fs = typeof require !== 'undefined' ? require('fs') : null;
       if (fs) {
-        const canvas = instanceContainer.getGame().getRenderer().getCanvas();
+        const canvas = instanceContainer.getGame().getRenderer()?.getCanvas();
         if (canvas) {
           const content = canvas
             .toDataURL('image/png')

--- a/Extensions/SpatialSound/spatialsoundtools.ts
+++ b/Extensions/SpatialSound/spatialsoundtools.ts
@@ -13,7 +13,7 @@ namespace gdjs {
         const sound = instanceContainer
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) sound.setSpatialPosition(x, y, z);
         else
           logger.error(

--- a/Extensions/Steamworks/steamworkstools.ts
+++ b/Extensions/Steamworks/steamworkstools.ts
@@ -129,8 +129,9 @@ namespace gdjs {
       string,
       import('steamworks.js/client').matchmaking.Lobby
     >();
-    let currentLobby: import('steamworks.js/client').matchmaking.Lobby | null =
-      null;
+    let currentLobby:
+      | import('steamworks.js/client').matchmaking.Lobby
+      | null = null;
 
     export function getKnownLobby(lobbyId: string) {
       if (!steamAPI) {

--- a/Extensions/Steamworks/steamworkstools.ts
+++ b/Extensions/Steamworks/steamworkstools.ts
@@ -4,7 +4,7 @@ namespace gdjs {
     export let steamAPI: import('steamworks.js').Client | null = null;
 
     gdjs.registerFirstRuntimeSceneLoadedCallback((runtimeScene) => {
-      const remote = runtimeScene.getGame().getRenderer().getElectronRemote();
+      const remote = runtimeScene.getGame().getRenderer()?.getElectronRemote();
       if (!remote) return; // Steamworks is only supported on electron
 
       try {
@@ -129,9 +129,8 @@ namespace gdjs {
       string,
       import('steamworks.js/client').matchmaking.Lobby
     >();
-    let currentLobby:
-      | import('steamworks.js/client').matchmaking.Lobby
-      | null = null;
+    let currentLobby: import('steamworks.js/client').matchmaking.Lobby | null =
+      null;
 
     export function getKnownLobby(lobbyId: string) {
       if (!steamAPI) {

--- a/Extensions/SystemInfo/systeminfotools.ts
+++ b/Extensions/SystemInfo/systeminfotools.ts
@@ -39,7 +39,7 @@ namespace gdjs {
       export const isNativeDesktopApp = (
         instanceContainer: gdjs.RuntimeInstanceContainer
       ): boolean => {
-        return !!instanceContainer.getGame().getRenderer().getElectron();
+        return !!instanceContainer.getGame().getRenderer()?.getElectron();
       };
 
       const checkHasTouchScreen = (): boolean => {
@@ -68,7 +68,7 @@ namespace gdjs {
       export const isWebGLSupported = (
         instanceContainer: gdjs.RuntimeInstanceContainer
       ): boolean => {
-        return instanceContainer.getGame().getRenderer().isWebGLSupported();
+        return !!instanceContainer.getGame().getRenderer()?.isWebGLSupported();
       };
 
       /**

--- a/Extensions/TextEntryObject/textentryruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextEntryObject/textentryruntimeobject-pixi-renderer.ts
@@ -81,6 +81,5 @@ namespace gdjs {
   type TextEntryRuntimeObjectRendererClass =
     | typeof TextEntryRuntimeObjectPixiRenderer
     | undefined;
-  export const TextEntryRuntimeObjectRenderer: TextEntryRuntimeObjectRendererClass =
-    TextEntryRuntimeObjectPixiRenderer;
+  export const TextEntryRuntimeObjectRenderer: TextEntryRuntimeObjectRendererClass = TextEntryRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TextEntryObject/textentryruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextEntryObject/textentryruntimeobject-pixi-renderer.ts
@@ -75,6 +75,12 @@ namespace gdjs {
     }
   }
 
-  export const TextEntryRuntimeObjectRenderer = TextEntryRuntimeObjectPixiRenderer;
-  export type TextEntryRuntimeObjectRenderer = TextEntryRuntimeObjectPixiRenderer;
+  export type TextEntryRuntimeObjectRenderer =
+    | TextEntryRuntimeObjectPixiRenderer
+    | undefined;
+  type TextEntryRuntimeObjectRendererClass =
+    | typeof TextEntryRuntimeObjectPixiRenderer
+    | undefined;
+  export const TextEntryRuntimeObjectRenderer: TextEntryRuntimeObjectRendererClass =
+    TextEntryRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TextEntryObject/textentryruntimeobject.ts
+++ b/Extensions/TextEntryObject/textentryruntimeobject.ts
@@ -20,7 +20,8 @@ namespace gdjs {
       textEntryObjectData: ObjectData
     ) {
       super(instanceContainer, textEntryObjectData);
-      this._renderer = new gdjs.TextEntryRuntimeObjectRenderer(this);
+      if (gdjs.TextEntryRuntimeObjectRenderer)
+        this._renderer = new gdjs.TextEntryRuntimeObjectRenderer(this);
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
@@ -33,7 +34,7 @@ namespace gdjs {
 
     onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
       super.onDestroyFromScene(instanceContainer);
-      if (this._renderer.onDestroy) {
+      if (this._renderer?.onDestroy) {
         this._renderer.onDestroy();
       }
     }
@@ -50,7 +51,7 @@ namespace gdjs {
 
     setString(str: string): void {
       this._str = str;
-      this._renderer.updateString();
+      if (this._renderer) this._renderer.updateString();
     }
 
     isActivated(): boolean {
@@ -59,7 +60,7 @@ namespace gdjs {
 
     activate(enable: boolean) {
       this._activated = enable;
-      this._renderer.activate(this._activated);
+      if (this._renderer) this._renderer.activate(this._activated);
     }
   }
   gdjs.registerObject(

--- a/Extensions/TextInput/tests/textinputruntimeobject.pixiruntimegamewithassets.spec.js
+++ b/Extensions/TextInput/tests/textinputruntimeobject.pixiruntimegamewithassets.spec.js
@@ -86,8 +86,11 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   };
 
   it('creates the DOM element', async () => {
-    const { runtimeScene, gameDomElementContainer, object } =
-      await setupObjectAndGetDomElementContainer();
+    const {
+      runtimeScene,
+      gameDomElementContainer,
+      object,
+    } = await setupObjectAndGetDomElementContainer();
 
     // Check the default size.
     expect(object.getWidth()).to.be(300);
@@ -108,8 +111,10 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('destroys the DOM element when the scene is paused/resumed/stopped', async () => {
-    const { runtimeScene, gameDomElementContainer } =
-      await setupObjectAndGetDomElementContainer();
+    const {
+      runtimeScene,
+      gameDomElementContainer,
+    } = await setupObjectAndGetDomElementContainer();
 
     expect(gameDomElementContainer.querySelector('input')).not.to.be(null);
 
@@ -128,8 +133,11 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('changes the DOM element when the object type is updated', async () => {
-    const { runtimeScene, gameDomElementContainer, object } =
-      await setupObjectAndGetDomElementContainer();
+    const {
+      runtimeScene,
+      gameDomElementContainer,
+      object,
+    } = await setupObjectAndGetDomElementContainer();
 
     expect(gameDomElementContainer.querySelector('input')).not.to.be(null);
 
@@ -150,8 +158,11 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('hides the DOM element when the object or layer is hidden', async () => {
-    const { runtimeScene, gameDomElementContainer, object } =
-      await setupObjectAndGetDomElementContainer();
+    const {
+      runtimeScene,
+      gameDomElementContainer,
+      object,
+    } = await setupObjectAndGetDomElementContainer();
 
     const inputElement = gameDomElementContainer.querySelector('input');
     if (!inputElement) throw new Error('Expected input element to be found');
@@ -186,8 +197,11 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('hides the DOM element when the object is far from the camera', async () => {
-    const { runtimeScene, gameDomElementContainer, object } =
-      await setupObjectAndGetDomElementContainer();
+    const {
+      runtimeScene,
+      gameDomElementContainer,
+      object,
+    } = await setupObjectAndGetDomElementContainer();
 
     const inputElement = gameDomElementContainer.querySelector('input');
     if (!inputElement) throw new Error('Expected input element to be found');

--- a/Extensions/TextInput/tests/textinputruntimeobject.pixiruntimegamewithassets.spec.js
+++ b/Extensions/TextInput/tests/textinputruntimeobject.pixiruntimegamewithassets.spec.js
@@ -65,13 +65,16 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
 
     // Make sure the renderer is created (to test the real DOM element creation/update)
     const gameContainer = document.createElement('div');
+    //@ts-ignore In this testing environement the renderer is always defined
     runtimeGame.getRenderer().createStandardCanvas(gameContainer);
 
     const object = makeTextInputRuntimeObject(runtimeScene);
     runtimeScene.addObject(object);
 
     // Check that the DOM element was created
+    // @ts-ignore In this testing environement the renderer is always defined
     const gameDomElementContainer = runtimeGame
+      //@ts-ignore In this testing environement the renderer is always defined
       .getRenderer()
       .getDomElementContainer();
     if (!gameDomElementContainer)
@@ -83,11 +86,8 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   };
 
   it('creates the DOM element', async () => {
-    const {
-      runtimeScene,
-      gameDomElementContainer,
-      object,
-    } = await setupObjectAndGetDomElementContainer();
+    const { runtimeScene, gameDomElementContainer, object } =
+      await setupObjectAndGetDomElementContainer();
 
     // Check the default size.
     expect(object.getWidth()).to.be(300);
@@ -108,10 +108,8 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('destroys the DOM element when the scene is paused/resumed/stopped', async () => {
-    const {
-      runtimeScene,
-      gameDomElementContainer,
-    } = await setupObjectAndGetDomElementContainer();
+    const { runtimeScene, gameDomElementContainer } =
+      await setupObjectAndGetDomElementContainer();
 
     expect(gameDomElementContainer.querySelector('input')).not.to.be(null);
 
@@ -130,11 +128,8 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('changes the DOM element when the object type is updated', async () => {
-    const {
-      runtimeScene,
-      gameDomElementContainer,
-      object,
-    } = await setupObjectAndGetDomElementContainer();
+    const { runtimeScene, gameDomElementContainer, object } =
+      await setupObjectAndGetDomElementContainer();
 
     expect(gameDomElementContainer.querySelector('input')).not.to.be(null);
 
@@ -155,11 +150,8 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('hides the DOM element when the object or layer is hidden', async () => {
-    const {
-      runtimeScene,
-      gameDomElementContainer,
-      object,
-    } = await setupObjectAndGetDomElementContainer();
+    const { runtimeScene, gameDomElementContainer, object } =
+      await setupObjectAndGetDomElementContainer();
 
     const inputElement = gameDomElementContainer.querySelector('input');
     if (!inputElement) throw new Error('Expected input element to be found');
@@ -194,11 +186,8 @@ describe('gdjs.TextInputRuntimeObject (using a PixiJS RuntimeGame with DOM eleme
   });
 
   it('hides the DOM element when the object is far from the camera', async () => {
-    const {
-      runtimeScene,
-      gameDomElementContainer,
-      object,
-    } = await setupObjectAndGetDomElementContainer();
+    const { runtimeScene, gameDomElementContainer, object } =
+      await setupObjectAndGetDomElementContainer();
 
     const inputElement = gameDomElementContainer.querySelector('input');
     if (!inputElement) throw new Error('Expected input element to be found');

--- a/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
@@ -304,6 +304,5 @@ namespace gdjs {
   type TextInputRuntimeObjectRendererClass =
     | typeof TextInputRuntimeObjectPixiRenderer
     | undefined;
-  export const TextInputRuntimeObjectRenderer: TextInputRuntimeObjectRendererClass =
-    TextInputRuntimeObjectPixiRenderer;
+  export const TextInputRuntimeObjectRenderer: TextInputRuntimeObjectRendererClass = TextInputRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextInput/textinputruntimeobject-pixi-renderer.ts
@@ -85,7 +85,7 @@ namespace gdjs {
       this.updateReadOnly();
 
       this._runtimeGame
-        .getRenderer()
+        .getRenderer()!
         .getDomElementContainer()!
         .appendChild(this._input);
     }
@@ -138,7 +138,7 @@ namespace gdjs {
       ) as FloatPoint;
 
       const runtimeGame = this._instanceContainer.getGame();
-      const runtimeGameRenderer = runtimeGame.getRenderer();
+      const runtimeGameRenderer = runtimeGame.getRenderer()!;
       const topLeftCanvasCoordinates = layer.convertInverseCoords(
         this._object.x,
         this._object.y,
@@ -221,7 +221,7 @@ namespace gdjs {
       if (!this._input) return;
       this._input.style.fontFamily = this._instanceContainer
         .getGame()
-        .getFontManager()
+        .getFontManager()!
         .getFontFamily(this._object.getFontResourceName());
     }
 
@@ -298,6 +298,12 @@ namespace gdjs {
     }
   }
 
-  export const TextInputRuntimeObjectRenderer = TextInputRuntimeObjectPixiRenderer;
-  export type TextInputRuntimeObjectRenderer = TextInputRuntimeObjectPixiRenderer;
+  export type TextInputRuntimeObjectRenderer =
+    | TextInputRuntimeObjectPixiRenderer
+    | undefined;
+  type TextInputRuntimeObjectRendererClass =
+    | typeof TextInputRuntimeObjectPixiRenderer
+    | undefined;
+  export const TextInputRuntimeObjectRenderer: TextInputRuntimeObjectRendererClass =
+    TextInputRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TextInput/textinputruntimeobject.ts
+++ b/Extensions/TextInput/textinputruntimeobject.ts
@@ -10,7 +10,7 @@ namespace gdjs {
     'text area',
   ] as const;
 
-  type SupportedInputType = typeof supportedInputTypes[number];
+  type SupportedInputType = (typeof supportedInputTypes)[number];
 
   const parseInputType = (potentialInputType: string): SupportedInputType => {
     const lowercasedNewInputType = potentialInputType.toLowerCase();
@@ -50,7 +50,8 @@ namespace gdjs {
    */
   export class TextInputRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.OpacityHandler {
+    implements gdjs.Resizable, gdjs.OpacityHandler
+  {
     private _string: string;
     private _placeholder: string;
     private opacity: float = 255;
@@ -92,10 +93,12 @@ namespace gdjs {
       this._disabled = objectData.content.disabled;
       this._readOnly = objectData.content.readOnly;
 
-      this._renderer = new gdjs.TextInputRuntimeObjectRenderer(
-        this,
-        instanceContainer
-      );
+      if (gdjs.TextInputRuntimeObjectRenderer) {
+        this._renderer = new gdjs.TextInputRuntimeObjectRenderer(
+          this,
+          instanceContainer
+        );
+      }
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
@@ -171,7 +174,7 @@ namespace gdjs {
     }
 
     updatePreRender(instanceContainer: RuntimeInstanceContainer): void {
-      this._renderer.updatePreRender();
+      if (this._renderer) this._renderer.updatePreRender();
     }
 
     /**
@@ -192,21 +195,21 @@ namespace gdjs {
     }
 
     onScenePaused(runtimeScene: gdjs.RuntimeScene): void {
-      this._renderer.onScenePaused();
+      if (this._renderer) this._renderer.onScenePaused();
     }
 
     onSceneResumed(runtimeScene: gdjs.RuntimeScene): void {
-      this._renderer.onSceneResumed();
+      if (this._renderer) this._renderer.onSceneResumed();
     }
 
     onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
       super.onDestroyFromScene(instanceContainer);
-      this._renderer.onDestroy();
+      if (this._renderer) this._renderer.onDestroy();
     }
 
     setOpacity(opacity: float): void {
       this.opacity = Math.max(0, Math.min(255, opacity));
-      this._renderer.updateOpacity();
+      if (this._renderer) this._renderer.updateOpacity();
     }
 
     getOpacity(): float {
@@ -256,7 +259,7 @@ namespace gdjs {
       if (newString === this._string) return;
 
       this._string = newString;
-      this._renderer.updateString();
+      if (this._renderer) this._renderer.updateString();
     }
 
     /**
@@ -279,7 +282,7 @@ namespace gdjs {
       if (this._fontResourceName === resourceName) return;
 
       this._fontResourceName = resourceName;
-      this._renderer.updateFont();
+      if (this._renderer) this._renderer.updateFont();
     }
 
     getFontSize() {
@@ -304,7 +307,7 @@ namespace gdjs {
       if (newPlaceholder === this._placeholder) return;
 
       this._placeholder = newPlaceholder;
-      this._renderer.updatePlaceholder();
+      if (this._renderer) this._renderer.updatePlaceholder();
     }
 
     /**
@@ -322,12 +325,12 @@ namespace gdjs {
       if (lowercasedNewInputType === this._inputType) return;
 
       this._inputType = parseInputType(lowercasedNewInputType);
-      this._renderer.updateInputType();
+      if (this._renderer) this._renderer.updateInputType();
     }
 
     setTextColor(newColor: string) {
       this._textColor = gdjs.rgbOrHexToRGBColor(newColor);
-      this._renderer.updateTextColor();
+      if (this._renderer) this._renderer.updateTextColor();
     }
 
     getTextColor(): string {
@@ -342,7 +345,7 @@ namespace gdjs {
 
     setFillColor(newColor: string) {
       this._fillColor = gdjs.rgbOrHexToRGBColor(newColor);
-      this._renderer.updateFillColorAndOpacity();
+      if (this._renderer) this._renderer.updateFillColorAndOpacity();
     }
 
     getFillColor(): string {
@@ -357,7 +360,7 @@ namespace gdjs {
 
     setFillOpacity(newOpacity: float) {
       this._fillOpacity = Math.max(0, Math.min(255, newOpacity));
-      this._renderer.updateFillColorAndOpacity();
+      if (this._renderer) this._renderer.updateFillColorAndOpacity();
     }
 
     getFillOpacity(): float {
@@ -366,7 +369,7 @@ namespace gdjs {
 
     setBorderColor(newColor: string) {
       this._borderColor = gdjs.rgbOrHexToRGBColor(newColor);
-      this._renderer.updateBorderColorAndOpacity();
+      if (this._renderer) this._renderer.updateBorderColorAndOpacity();
     }
 
     getBorderColor(): string {
@@ -385,7 +388,7 @@ namespace gdjs {
 
     setBorderOpacity(newOpacity: float) {
       this._borderOpacity = Math.max(0, Math.min(255, newOpacity));
-      this._renderer.updateBorderColorAndOpacity();
+      if (this._renderer) this._renderer.updateBorderColorAndOpacity();
     }
 
     getBorderOpacity(): float {
@@ -394,7 +397,7 @@ namespace gdjs {
 
     setBorderWidth(width: float) {
       this._borderWidth = Math.max(0, width);
-      this._renderer.updateBorderWidth();
+      if (this._renderer) this._renderer.updateBorderWidth();
     }
 
     getBorderWidth(): float {
@@ -403,7 +406,7 @@ namespace gdjs {
 
     setDisabled(value: boolean) {
       this._disabled = value;
-      this._renderer.updateDisabled();
+      if (this._renderer) this._renderer.updateDisabled();
     }
 
     isDisabled(): boolean {
@@ -412,7 +415,7 @@ namespace gdjs {
 
     setReadOnly(value: boolean) {
       this._readOnly = value;
-      this._renderer.updateReadOnly();
+      if (this._renderer) this._renderer.updateReadOnly();
     }
 
     isReadOnly(): boolean {
@@ -420,11 +423,11 @@ namespace gdjs {
     }
 
     isFocused(): boolean {
-      return this._renderer.isFocused();
+      return !!this._renderer?.isFocused();
     }
 
     focus(): void {
-      this._renderer.focus();
+      if (this._renderer) this._renderer.focus();
     }
   }
   gdjs.registerObject(

--- a/Extensions/TextInput/textinputruntimeobject.ts
+++ b/Extensions/TextInput/textinputruntimeobject.ts
@@ -10,7 +10,7 @@ namespace gdjs {
     'text area',
   ] as const;
 
-  type SupportedInputType = (typeof supportedInputTypes)[number];
+  type SupportedInputType = typeof supportedInputTypes[number];
 
   const parseInputType = (potentialInputType: string): SupportedInputType => {
     const lowercasedNewInputType = potentialInputType.toLowerCase();
@@ -50,8 +50,7 @@ namespace gdjs {
    */
   export class TextInputRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.OpacityHandler
-  {
+    implements gdjs.Resizable, gdjs.OpacityHandler {
     private _string: string;
     private _placeholder: string;
     private opacity: float = 255;

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -214,6 +214,5 @@ namespace gdjs {
   type TextRuntimeObjectRendererClass =
     | typeof TextRuntimeObjectPixiRenderer
     | undefined;
-  export const TextRuntimeObjectRenderer: TextRuntimeObjectRendererClass =
-    TextRuntimeObjectPixiRenderer;
+  export const TextRuntimeObjectRenderer: TextRuntimeObjectRendererClass = TextRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -19,7 +19,7 @@ namespace gdjs {
       instanceContainer
         .getLayer('')
         .getRenderer()
-        .addRendererObject(this._text, runtimeObject.getZOrder());
+        ?.addRendererObject(this._text, runtimeObject.getZOrder());
       this._text.text =
         runtimeObject._str.length === 0 ? ' ' : runtimeObject._str;
 
@@ -208,6 +208,12 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export const TextRuntimeObjectRenderer = TextRuntimeObjectPixiRenderer;
-  export type TextRuntimeObjectRenderer = TextRuntimeObjectPixiRenderer;
+  export type TextRuntimeObjectRenderer =
+    | TextRuntimeObjectPixiRenderer
+    | undefined;
+  type TextRuntimeObjectRendererClass =
+    | typeof TextRuntimeObjectPixiRenderer
+    | undefined;
+  export const TextRuntimeObjectRenderer: TextRuntimeObjectRendererClass =
+    TextRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -36,8 +36,7 @@ namespace gdjs {
    */
   export class TextRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.OpacityHandler
-  {
+    implements gdjs.OpacityHandler {
     _characterSize: number;
     _fontName: string;
     _bold: boolean;

--- a/Extensions/TileMap/collision/TileMapCollisionMaskRenderer.ts
+++ b/Extensions/TileMap/collision/TileMapCollisionMaskRenderer.ts
@@ -18,7 +18,7 @@ namespace gdjs {
         this._graphics = new PIXI.Graphics();
         instanceContainer
           .getLayer('')
-          .getRenderer()
+          .getRenderer()!
           .addRendererObject(this._graphics, runtimeObject.getZOrder());
       }
 

--- a/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
+++ b/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
@@ -125,6 +125,5 @@ namespace gdjs {
   }
   export const TileMapRuntimeObjectRenderer =
     gdjs.TileMapRuntimeObjectPixiRenderer;
-  export type TileMapRuntimeObjectRenderer =
-    gdjs.TileMapRuntimeObjectPixiRenderer;
+  export type TileMapRuntimeObjectRenderer = gdjs.TileMapRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
+++ b/Extensions/TileMap/tilemapruntimeobject-pixi-renderer.ts
@@ -31,7 +31,7 @@ namespace gdjs {
 
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._pixiObject, runtimeObject.getZOrder());
       this.updateAngle();
       this.updateOpacity();
@@ -125,5 +125,6 @@ namespace gdjs {
   }
   export const TileMapRuntimeObjectRenderer =
     gdjs.TileMapRuntimeObjectPixiRenderer;
-  export type TileMapRuntimeObjectRenderer = gdjs.TileMapRuntimeObjectPixiRenderer;
+  export type TileMapRuntimeObjectRenderer =
+    gdjs.TileMapRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TileMap/tilemapruntimeobject.ts
+++ b/Extensions/TileMap/tilemapruntimeobject.ts
@@ -139,7 +139,7 @@ namespace gdjs {
                 textureName
               );
               return (game
-                .getImageManager()
+                .getImageManager()!
                 .getPIXITexture(mappedName) as unknown) as PIXI.BaseTexture<
                 PIXI.Resource
               >;

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -135,6 +135,5 @@ namespace gdjs {
   type TiledSpriteRuntimeObjectRendererClass =
     | typeof TiledSpriteRuntimeObjectPixiRenderer
     | undefined;
-  export const TiledSpriteRuntimeObjectRenderer: TiledSpriteRuntimeObjectRendererClass =
-    TiledSpriteRuntimeObjectPixiRenderer;
+  export const TiledSpriteRuntimeObjectRenderer: TiledSpriteRuntimeObjectRendererClass = TiledSpriteRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -13,13 +13,13 @@ namespace gdjs {
       this._object = runtimeObject;
       const texture = instanceContainer
         .getGame()
-        .getImageManager()
+        .getImageManager()!
         .getPIXITexture(textureName);
       this._tiledSprite = new PIXI.TilingSprite(texture, 1024, 1024);
 
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._tiledSprite, runtimeObject.getZOrder());
       this.updatePosition();
       this.updateAngle();
@@ -48,7 +48,7 @@ namespace gdjs {
     ): void {
       const texture = instanceContainer
         .getGame()
-        .getImageManager()
+        .getImageManager()!
         .getPIXITexture(textureName);
       this._tiledSprite.texture = texture;
       this.updatePosition();
@@ -129,6 +129,12 @@ namespace gdjs {
     }
   }
 
-  export const TiledSpriteRuntimeObjectRenderer = TiledSpriteRuntimeObjectPixiRenderer;
-  export type TiledSpriteRuntimeObjectRenderer = TiledSpriteRuntimeObjectPixiRenderer;
+  export type TiledSpriteRuntimeObjectRenderer =
+    | TiledSpriteRuntimeObjectPixiRenderer
+    | undefined;
+  type TiledSpriteRuntimeObjectRendererClass =
+    | typeof TiledSpriteRuntimeObjectPixiRenderer
+    | undefined;
+  export const TiledSpriteRuntimeObjectRenderer: TiledSpriteRuntimeObjectRendererClass =
+    TiledSpriteRuntimeObjectPixiRenderer;
 }

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
@@ -19,7 +19,8 @@ namespace gdjs {
    */
   export class TiledSpriteRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.OpacityHandler {
+    implements gdjs.Resizable, gdjs.OpacityHandler
+  {
     _xOffset: float = 0;
     _yOffset: float = 0;
     opacity: float = 255;
@@ -28,6 +29,8 @@ namespace gdjs {
     // size of the texture being used (contrary to most objects).
     _width: float;
     _height: float;
+    _color: string = '255;255;255';
+    _baseDimensions: { height: number; width: number };
 
     _renderer: gdjs.TiledSpriteRuntimeObjectRenderer;
 
@@ -40,11 +43,16 @@ namespace gdjs {
       tiledSpriteObjectData: TiledSpriteObjectData
     ) {
       super(instanceContainer, tiledSpriteObjectData);
-      this._renderer = new gdjs.TiledSpriteRuntimeObjectRenderer(
-        this,
-        instanceContainer,
-        tiledSpriteObjectData.texture
-      );
+      if (gdjs.TiledSpriteRuntimeObjectRenderer) {
+        this._renderer = new gdjs.TiledSpriteRuntimeObjectRenderer(
+          this,
+          instanceContainer,
+          tiledSpriteObjectData.texture
+        );
+      }
+      this._baseDimensions = instanceContainer
+        .getGame()
+        .getResourceBaseDimensions(tiledSpriteObjectData.texture);
       this._width = 0;
       this._height = 0;
       this.setWidth(tiledSpriteObjectData.width);
@@ -68,7 +76,7 @@ namespace gdjs {
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
@@ -94,7 +102,7 @@ namespace gdjs {
      */
     setX(x: float): void {
       super.setX(x);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -103,7 +111,7 @@ namespace gdjs {
      */
     setY(y: float): void {
       super.setY(y);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -115,7 +123,11 @@ namespace gdjs {
       textureName: string,
       instanceContainer: gdjs.RuntimeInstanceContainer
     ): void {
-      this._renderer.setTexture(textureName, instanceContainer);
+      this._baseDimensions = instanceContainer
+        .getGame()
+        .getResourceBaseDimensions(textureName);
+      if (this._renderer)
+        this._renderer.setTexture(textureName, instanceContainer);
     }
 
     /**
@@ -124,7 +136,7 @@ namespace gdjs {
      */
     setAngle(angle: float): void {
       super.setAngle(angle);
-      this._renderer.updateAngle();
+      if (this._renderer) this._renderer.updateAngle();
     }
 
     /**
@@ -151,7 +163,7 @@ namespace gdjs {
       if (this._width === width) return;
 
       this._width = width;
-      this._renderer.setWidth(width);
+      if (this._renderer) this._renderer.setWidth(width);
       this.invalidateHitboxes();
     }
 
@@ -163,7 +175,7 @@ namespace gdjs {
       if (this._height === height) return;
 
       this._height = height;
-      this._renderer.setHeight(height);
+      if (this._renderer) this._renderer.setHeight(height);
       this.invalidateHitboxes();
     }
 
@@ -183,7 +195,7 @@ namespace gdjs {
      */
     setXOffset(xOffset: number): void {
       this._xOffset = xOffset;
-      this._renderer.updateXOffset();
+      if (this._renderer) this._renderer.updateXOffset();
     }
 
     /**
@@ -192,7 +204,7 @@ namespace gdjs {
      */
     setYOffset(yOffset: number): void {
       this._yOffset = yOffset;
-      this._renderer.updateYOffset();
+      if (this._renderer) this._renderer.updateYOffset();
     }
 
     /**
@@ -219,7 +231,7 @@ namespace gdjs {
         opacity = 255;
       }
       this.opacity = opacity;
-      this._renderer.updateOpacity();
+      if (this._renderer) this._renderer.updateOpacity();
     }
 
     getOpacity(): number {
@@ -232,7 +244,8 @@ namespace gdjs {
      * @param rgbColor The color, in RGB format ("128;200;255").
      */
     setColor(rgbColor: string): void {
-      this._renderer.setColor(rgbColor);
+      this._color = rgbColor;
+      if (this._renderer) this._renderer.setColor(rgbColor);
     }
 
     /**
@@ -241,7 +254,7 @@ namespace gdjs {
      * @returns The color, in RGB format ("128;200;255").
      */
     getColor(): string {
-      return this._renderer.getColor();
+      return this._color;
     }
 
     // Implement support for get/set scale:
@@ -261,14 +274,14 @@ namespace gdjs {
      * Get x-scale of the tiled sprite object.
      */
     getScaleX(): float {
-      return this._width / this._renderer.getTextureWidth();
+      return this._width / this._baseDimensions.width;
     }
 
     /**
      * Get y-scale of the tiled sprite object.
      */
     getScaleY(): float {
-      return this._height / this._renderer.getTextureHeight();
+      return this._height / this._baseDimensions.height;
     }
 
     /**
@@ -276,8 +289,8 @@ namespace gdjs {
      * @param newScale The new scale for the tiled sprite object.
      */
     setScale(newScale: float): void {
-      this.setWidth(this._renderer.getTextureWidth() * newScale);
-      this.setHeight(this._renderer.getTextureHeight() * newScale);
+      this.setWidth(this._baseDimensions.width * newScale);
+      this.setHeight(this._baseDimensions.height * newScale);
     }
 
     /**
@@ -285,7 +298,7 @@ namespace gdjs {
      * @param newScale The new x-scale for the tiled sprite object.
      */
     setScaleX(newScale: float): void {
-      this.setWidth(this._renderer.getTextureWidth() * newScale);
+      this.setWidth(this._baseDimensions.width * newScale);
     }
 
     /**
@@ -293,7 +306,7 @@ namespace gdjs {
      * @param newScale The new y-scale for the tiled sprite object.
      */
     setScaleY(newScale: float): void {
-      this.setHeight(this._renderer.getTextureHeight() * newScale);
+      this.setHeight(this._baseDimensions.height * newScale);
     }
   }
   gdjs.registerObject(

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
@@ -19,8 +19,7 @@ namespace gdjs {
    */
   export class TiledSpriteRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.Resizable, gdjs.OpacityHandler
-  {
+    implements gdjs.Resizable, gdjs.OpacityHandler {
     _xOffset: float = 0;
     _yOffset: float = 0;
     opacity: float = 255;

--- a/Extensions/Video/videoruntimeobject-pixi-renderer.ts
+++ b/Extensions/Video/videoruntimeobject-pixi-renderer.ts
@@ -10,7 +10,7 @@ namespace gdjs {
     _object: gdjs.VideoRuntimeObject;
 
     // Load (or reset) the video
-    _pixiObject: any;
+    _pixiObject?: any;
     _textureWasValid: boolean = false;
 
     /**
@@ -22,11 +22,9 @@ namespace gdjs {
       instanceContainer: gdjs.RuntimeInstanceContainer
     ) {
       this._object = runtimeObject;
+      const imageManager = instanceContainer.getGame().getImageManager()!;
       this._pixiObject = new PIXI.Sprite(
-        instanceContainer
-          .getGame()
-          .getImageManager()
-          .getPIXIVideoTexture(this._object._videoResource)
+        imageManager.getPIXIVideoTexture(this._object._videoResource)
       );
       this._pixiObject._texture.baseTexture.resource.autoPlay = false;
 
@@ -38,7 +36,7 @@ namespace gdjs {
       // Will be set to true when video texture is loaded.
       instanceContainer
         .getLayer('')
-        .getRenderer()
+        .getRenderer()!
         .addRendererObject(this._pixiObject, runtimeObject.getZOrder());
 
       // Set the anchor in the center, so that the object rotates around
@@ -83,7 +81,8 @@ namespace gdjs {
     }
 
     updateLoop(): void {
-      this._pixiObject._texture.baseTexture.resource.source.loop = this._object._loop;
+      this._pixiObject._texture.baseTexture.resource.source.loop =
+        this._object._loop;
     }
 
     updateVolume(): void {
@@ -328,6 +327,12 @@ namespace gdjs {
     }
   }
 
-  export const VideoRuntimeObjectRenderer = VideoRuntimeObjectPixiRenderer;
-  export type VideoRuntimeObjectRenderer = VideoRuntimeObjectPixiRenderer;
+  export type VideoRuntimeObjectRenderer =
+    | VideoRuntimeObjectPixiRenderer
+    | undefined;
+  type VideoRuntimeObjectRendererClass =
+    | typeof VideoRuntimeObjectPixiRenderer
+    | undefined;
+  export const VideoRuntimeObjectRenderer: VideoRuntimeObjectRendererClass =
+    VideoRuntimeObjectPixiRenderer;
 }

--- a/Extensions/Video/videoruntimeobject-pixi-renderer.ts
+++ b/Extensions/Video/videoruntimeobject-pixi-renderer.ts
@@ -81,8 +81,7 @@ namespace gdjs {
     }
 
     updateLoop(): void {
-      this._pixiObject._texture.baseTexture.resource.source.loop =
-        this._object._loop;
+      this._pixiObject._texture.baseTexture.resource.source.loop = this._object._loop;
     }
 
     updateVolume(): void {
@@ -333,6 +332,5 @@ namespace gdjs {
   type VideoRuntimeObjectRendererClass =
     | typeof VideoRuntimeObjectPixiRenderer
     | undefined;
-  export const VideoRuntimeObjectRenderer: VideoRuntimeObjectRendererClass =
-    VideoRuntimeObjectPixiRenderer;
+  export const VideoRuntimeObjectRenderer: VideoRuntimeObjectRendererClass = VideoRuntimeObjectPixiRenderer;
 }

--- a/Extensions/Video/videoruntimeobject.ts
+++ b/Extensions/Video/videoruntimeobject.ts
@@ -26,8 +26,7 @@ namespace gdjs {
    */
   export class VideoRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.OpacityHandler
-  {
+    implements gdjs.OpacityHandler {
     _opacity: float;
     _loop: boolean;
     _volume: float;

--- a/Extensions/Video/videoruntimeobject.ts
+++ b/Extensions/Video/videoruntimeobject.ts
@@ -26,11 +26,18 @@ namespace gdjs {
    */
   export class VideoRuntimeObject
     extends gdjs.RuntimeObject
-    implements gdjs.OpacityHandler {
+    implements gdjs.OpacityHandler
+  {
     _opacity: float;
     _loop: boolean;
     _volume: float;
     _videoResource: string;
+    private _width: number;
+    private _height: number;
+
+    private _playing: boolean = true;
+    private _muted: boolean = false;
+    private _currentTime: number = 0;
 
     // Use a boolean to track if the video was paused because we
     // navigated to another scene, and so should resume if we're back.
@@ -51,17 +58,26 @@ namespace gdjs {
       this._loop = videoObjectData.content.loop;
       this._volume = videoObjectData.content.volume;
       this._videoResource = videoObjectData.content.videoResource;
-      this._renderer = new gdjs.VideoRuntimeObjectRenderer(
-        this,
-        instanceContainer
-      );
+
+      const dimensions = instanceContainer
+        .getGame()
+        .getResourceBaseDimensions(this._videoResource);
+      this._width = dimensions.width;
+      this._height = dimensions.height;
+
+      if (gdjs.VideoRuntimeObjectRenderer) {
+        this._renderer = new gdjs.VideoRuntimeObjectRenderer(
+          this,
+          instanceContainer
+        );
+      }
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     updateFromObjectData(
@@ -99,11 +115,11 @@ namespace gdjs {
 
     onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
       super.onDestroyFromScene(instanceContainer);
-      this._renderer.onDestroy();
+      if (this._renderer) this._renderer.onDestroy();
     }
 
     update(instanceContainer: gdjs.RuntimeInstanceContainer): void {
-      this._renderer.ensureUpToDate();
+      if (this._renderer) this._renderer.ensureUpToDate();
     }
 
     /**
@@ -112,7 +128,7 @@ namespace gdjs {
      */
     setX(x: float): void {
       super.setX(x);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -121,7 +137,7 @@ namespace gdjs {
      */
     setY(y: float): void {
       super.setY(y);
-      this._renderer.updatePosition();
+      if (this._renderer) this._renderer.updatePosition();
     }
 
     /**
@@ -130,7 +146,7 @@ namespace gdjs {
      */
     setAngle(angle: float): void {
       super.setAngle(angle);
-      this._renderer.updateAngle();
+      if (this._renderer) this._renderer.updateAngle();
     }
 
     /**
@@ -139,7 +155,7 @@ namespace gdjs {
      */
     setOpacity(opacity: float): void {
       this._opacity = opacity;
-      this._renderer.updateOpacity();
+      if (this._renderer) this._renderer.updateOpacity();
     }
 
     /**
@@ -155,9 +171,9 @@ namespace gdjs {
      * @param width The new width in pixels.
      */
     setWidth(width: float): void {
-      if (this._renderer.getWidth() === width) return;
-
-      this._renderer.setWidth(width);
+      if (this._width === width) return;
+      this._width = width;
+      if (this._renderer) this._renderer.setWidth(width);
       this.invalidateHitboxes();
     }
 
@@ -166,9 +182,9 @@ namespace gdjs {
      * @param height The new height in pixels.
      */
     setHeight(height: float): void {
-      if (this._renderer.getHeight() === height) return;
-
-      this._renderer.setHeight(height);
+      if (this._height === height) return;
+      this._height = height;
+      if (this._renderer) this._renderer.setHeight(height);
       this.invalidateHitboxes();
     }
 
@@ -177,7 +193,7 @@ namespace gdjs {
      * @returns The current width of the object
      */
     getWidth(): float {
-      return this._renderer.getWidth();
+      return this._width;
     }
 
     /**
@@ -185,21 +201,21 @@ namespace gdjs {
      * @returns The current height of the object
      */
     getHeight(): float {
-      return this._renderer.getHeight();
+      return this._height;
     }
 
     /**
      * Play the video.
      */
     play(): void {
-      this._renderer.play();
+      if (this._renderer) this._renderer.play();
     }
 
     /**
      * Pause the video.
      */
     pause(): void {
-      this._renderer.pause();
+      if (this._renderer) this._renderer.pause();
     }
 
     /**
@@ -207,7 +223,8 @@ namespace gdjs {
      * @param enable true to loop the video
      */
     setLoop(enable: boolean): void {
-      this._renderer.setLoop(enable);
+      this._loop = enable;
+      if (this._renderer) this._renderer.setLoop(enable);
     }
 
     /**
@@ -215,7 +232,8 @@ namespace gdjs {
      * @param enable The new state.
      */
     mute(enable: boolean) {
-      this._renderer.setMute(enable);
+      this._muted = enable;
+      if (this._renderer) this._renderer.setMute(enable);
     }
 
     /**
@@ -223,7 +241,7 @@ namespace gdjs {
      * @returns Is the video muted?
      */
     isMuted(): boolean {
-      return this._renderer.isMuted();
+      return this._muted;
     }
 
     /**
@@ -237,7 +255,7 @@ namespace gdjs {
           0,
           1
         ) * 100;
-      this._renderer.updateVolume();
+      if (this._renderer) this._renderer.updateVolume();
     }
 
     /**
@@ -245,9 +263,7 @@ namespace gdjs {
      * @returns The current video's volume, between 0 and 100.
      */
     getVolume(): number {
-      return (
-        gdjs.evtTools.common.normalize(this._renderer.getVolume(), 0, 1) * 100
-      );
+      return gdjs.evtTools.common.normalize(this._volume, 0, 1) * 100;
     }
 
     /**
@@ -255,7 +271,7 @@ namespace gdjs {
      * @returns Is the video being played?
      */
     isPlayed(): boolean {
-      return this._renderer.isPlayed();
+      return this._renderer ? this._renderer.isPlayed() : this._playing;
     }
 
     /**
@@ -263,7 +279,7 @@ namespace gdjs {
      * @returns Is the video being paused?
      */
     isPaused(): boolean {
-      return !this._renderer.isPlayed();
+      return !this.isPlayed();
     }
 
     /**
@@ -271,7 +287,7 @@ namespace gdjs {
      * @returns Is the video looping?
      */
     isLooped(): boolean {
-      return this._renderer.isLooped();
+      return this._loop;
     }
 
     /**
@@ -279,7 +295,7 @@ namespace gdjs {
      * @returns The duration of the video
      */
     getDuration(): number {
-      return this._renderer.getDuration();
+      return this._renderer ? this._renderer.getDuration() : 0;
     }
 
     /**
@@ -287,7 +303,7 @@ namespace gdjs {
      * @returns Has the video ended?
      */
     isEnded(): boolean {
-      return this._renderer.isEnded();
+      return this._renderer ? this._renderer.isEnded() : false;
     }
 
     /**
@@ -295,7 +311,8 @@ namespace gdjs {
      * @param time The new time.
      */
     setCurrentTime(time: float): void {
-      this._renderer.setCurrentTime(time);
+      this._currentTime = time;
+      if (this._renderer) this._renderer.setCurrentTime(time);
     }
 
     /**
@@ -303,7 +320,9 @@ namespace gdjs {
      * @returns The current time of the video
      */
     getCurrentTime(): float {
-      return this._renderer.getCurrentTime();
+      return this._renderer
+        ? this._renderer.getCurrentTime()
+        : this._currentTime;
     }
 
     /**
@@ -312,7 +331,7 @@ namespace gdjs {
      */
     setPlaybackSpeed(playbackSpeed: number): void {
       this._playbackSpeed = gdjs.evtTools.common.clamp(playbackSpeed, 0.5, 2);
-      this._renderer.setPlaybackSpeed(this._playbackSpeed);
+      if (this._renderer) this._renderer.setPlaybackSpeed(this._playbackSpeed);
     }
 
     /**
@@ -320,7 +339,7 @@ namespace gdjs {
      * @returns The current playback speed of the video.
      */
     getPlaybackSpeed(): number {
-      return this._renderer.getPlaybackSpeed();
+      return this._playbackSpeed;
     }
   }
   gdjs.registerObject('Video::VideoObject', gdjs.VideoRuntimeObject);

--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -58,7 +58,7 @@ namespace gdjs {
       );
 
       this._instanceContainer.loadFrom(objectData);
-      this.getRenderer().reinitialize(this, parent);
+      this.getRenderer()?.reinitialize(this, parent);
 
       // The generated code calls onCreated at the constructor end
       // and onCreated calls its super implementation at its end.
@@ -68,7 +68,7 @@ namespace gdjs {
       super.reinitialize(objectData);
 
       this._instanceContainer.loadFrom(objectData);
-      this.getRenderer().reinitialize(this, this.getParent());
+      this.getRenderer()?.reinitialize(this, this.getParent());
 
       // The generated code calls the onCreated super implementation at the end.
       this.onCreated();
@@ -137,11 +137,11 @@ namespace gdjs {
 
     updatePreRender(parent: gdjs.RuntimeInstanceContainer): void {
       this._instanceContainer._updateObjectsPreRender();
-      this.getRenderer().ensureUpToDate();
+      this.getRenderer()?.ensureUpToDate();
     }
 
     getRendererObject() {
-      return this.getRenderer().getRendererObject();
+      return this.getRenderer()?.getRendererObject();
     }
 
     getRenderer() {
@@ -151,7 +151,7 @@ namespace gdjs {
     onChildrenLocationChanged() {
       this._isUntransformedHitBoxesDirty = true;
       this.invalidateHitboxes();
-      this.getRenderer().update();
+      this.getRenderer()?.update();
     }
 
     updateHitBoxes(): void {
@@ -474,7 +474,7 @@ namespace gdjs {
       this.x = x;
       this._isLocalTransformationDirty = true;
       this.invalidateHitboxes();
-      this.getRenderer().updateX();
+      this.getRenderer()?.updateX();
     }
 
     setY(y: float): void {
@@ -484,7 +484,7 @@ namespace gdjs {
       this.y = y;
       this._isLocalTransformationDirty = true;
       this.invalidateHitboxes();
-      this.getRenderer().updateY();
+      this.getRenderer()?.updateY();
     }
 
     setAngle(angle: float): void {
@@ -494,7 +494,7 @@ namespace gdjs {
       this.angle = angle;
       this._isLocalTransformationDirty = true;
       this.invalidateHitboxes();
-      this.getRenderer().updateAngle();
+      this.getRenderer()?.updateAngle();
     }
 
     /**
@@ -516,7 +516,7 @@ namespace gdjs {
       this._scaleY = newScale * (this._flippedY ? -1 : 1);
       this._isLocalTransformationDirty = true;
       this.invalidateHitboxes();
-      this.getRenderer().update();
+      this.getRenderer()?.update();
     }
 
     /**
@@ -534,7 +534,7 @@ namespace gdjs {
       this._scaleX = newScale * (this._flippedX ? -1 : 1);
       this._isLocalTransformationDirty = true;
       this.invalidateHitboxes();
-      this.getRenderer().update();
+      this.getRenderer()?.update();
     }
 
     /**
@@ -551,7 +551,7 @@ namespace gdjs {
       }
       this._scaleY = newScale * (this._flippedY ? -1 : 1);
       this.invalidateHitboxes();
-      this.getRenderer().update();
+      this.getRenderer()?.update();
     }
 
     /**
@@ -603,7 +603,7 @@ namespace gdjs {
         opacity = 255;
       }
       this.opacity = opacity;
-      this.getRenderer().updateOpacity();
+      this.getRenderer()?.updateOpacity();
     }
 
     getOpacity(): number {
@@ -619,7 +619,7 @@ namespace gdjs {
         enable = true;
       }
       this.hidden = enable;
-      this.getRenderer().updateVisibility();
+      this.getRenderer()?.updateVisibility();
     }
 
     flipX(enable: boolean) {
@@ -627,7 +627,7 @@ namespace gdjs {
         this._scaleX *= -1;
         this._flippedX = enable;
         this.invalidateHitboxes();
-        this.getRenderer().update();
+        this.getRenderer()?.update();
       }
     }
 
@@ -636,7 +636,7 @@ namespace gdjs {
         this._scaleY *= -1;
         this._flippedY = enable;
         this.invalidateHitboxes();
-        this.getRenderer().update();
+        this.getRenderer()?.update();
       }
     }
 

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -35,12 +35,16 @@ namespace gdjs {
       this._parent = parent;
       this._customObject = customObject;
       this._runtimeScene = parent.getScene();
-      this._renderer = new gdjs.CustomObjectRenderer(
-        customObject,
-        this,
-        parent
-      );
-      this._debuggerRenderer = new gdjs.DebuggerRenderer(this);
+      if (gdjs.CustomObjectRenderer) {
+        this._renderer = new gdjs.CustomObjectRenderer(
+          customObject,
+          this,
+          parent
+        );
+      }
+      if (gdjs.DebuggerRenderer) {
+        this._debuggerRenderer = new gdjs.DebuggerRenderer(this);
+      }
     }
 
     addLayer(layerData: LayerData) {
@@ -214,13 +218,13 @@ namespace gdjs {
           if (rendererObject.visible) {
             this.getGame()
               .getEffectsManager()
-              .updatePreRender(object.getRendererEffects(), object);
+              ?.updatePreRender(object.getRendererEffects(), object);
           }
         }
 
         // Set to true to enable debug rendering (look for the implementation in the renderer
         // to see what is rendered).
-        if (this._debugDrawEnabled) {
+        if (this._debugDrawEnabled && this._debuggerRenderer) {
           this._debuggerRenderer.renderDebugDraw(
             allInstancesList,
             this._debugDrawShowHiddenInstances,
@@ -264,8 +268,8 @@ namespace gdjs {
     /**
      * Get the renderer associated to the RuntimeScene.
      */
-    getRenderer(): gdjs.CustomObjectRenderer {
-      return this._renderer;
+    getRenderer() {
+      return this._renderer || null;
     }
 
     getDebuggerRenderer() {

--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -11,7 +11,7 @@ namespace gdjs {
    * Load GLB files (using `Three.js`), using the "model3D" resources
    * registered in the game resources.
    */
-  export class Model3DManager {
+  export class Model3DThreeManager {
     /**
      * Map associating a resource name to the loaded Three.js model.
      */
@@ -138,4 +138,8 @@ namespace gdjs {
       return this._loadedThreeModels.get(resourceName) || this._invalidModel;
     }
   }
+
+  export type Model3DManager = Model3DThreeManager | undefined;
+  type Model3DManagerClass = typeof Model3DThreeManager | undefined;
+  export const Model3DManager: Model3DManagerClass = Model3DThreeManager;
 }

--- a/GDJS/Runtime/RuntimeCustomObjectLayer.ts
+++ b/GDJS/Runtime/RuntimeCustomObjectLayer.ts
@@ -20,7 +20,7 @@ namespace gdjs {
       super(layerData, instanceContainer);
 
       // Let the renderer do its final set up:
-      this._renderer.onCreated();
+      this._renderer?.onCreated();
     }
 
     onGameResolutionResized(

--- a/GDJS/Runtime/RuntimeInstanceContainer.ts
+++ b/GDJS/Runtime/RuntimeInstanceContainer.ts
@@ -61,12 +61,12 @@ namespace gdjs {
     /**
      * Get the renderer associated to the container.
      */
-    abstract getRenderer(): gdjs.RuntimeInstanceContainerRenderer;
+    abstract getRenderer(): gdjs.RuntimeInstanceContainerRenderer | null;
 
     /**
      * Get the renderer for visual debugging associated to the container.
      */
-    abstract getDebuggerRenderer(): gdjs.DebuggerRenderer;
+    abstract getDebuggerRenderer(): gdjs.DebuggerRenderer | null;
 
     /**
      * Get the {@link gdjs.RuntimeGame} associated to this.
@@ -149,7 +149,7 @@ namespace gdjs {
       showCustomPoints: boolean
     ): void {
       if (this._debugDrawEnabled && !enableDebugDraw) {
-        this.getDebuggerRenderer().clearDebugDraw();
+        this.getDebuggerRenderer()?.clearDebugDraw();
       }
 
       this._debugDrawEnabled = enableDebugDraw;
@@ -382,7 +382,7 @@ namespace gdjs {
           // Update effects, only for visible objects.
           if (rendererObject.visible) {
             this.getGame()
-              .getEffectsManager()
+              .getEffectsManager()!
               .updatePreRender(object.getRendererEffects(), object);
           }
         }
@@ -671,7 +671,7 @@ namespace gdjs {
       this._orderedLayers.splice(layerIndex, 1);
       this._orderedLayers.splice(newIndex, 0, layer);
 
-      this.getRenderer().setLayerIndex(layer, newIndex);
+      this.getRenderer()?.setLayerIndex(layer, newIndex);
     }
 
     /**

--- a/GDJS/Runtime/RuntimeLayer.ts
+++ b/GDJS/Runtime/RuntimeLayer.ts
@@ -47,7 +47,7 @@ namespace gdjs {
     _clearColor: Array<integer>;
 
     _rendererEffects: Record<string, gdjs.PixiFiltersTools.Filter> = {};
-    _renderer: gdjs.LayerRenderer;
+    _renderer?: gdjs.LayerRenderer;
 
     /**
      * @param layerData The data used to initialize the layer
@@ -76,11 +76,13 @@ namespace gdjs {
         layerData.ambientLightColorB / 255,
         1.0,
       ];
-      this._renderer = new gdjs.LayerRenderer(
-        this,
-        instanceContainer.getRenderer(),
-        instanceContainer.getGame().getRenderer()
-      );
+      if (gdjs.LayerRenderer) {
+        this._renderer = new gdjs.LayerRenderer(
+          this,
+          instanceContainer.getRenderer()!,
+          instanceContainer.getGame().getRenderer()
+        );
+      }
       this.show(!this._hidden);
       for (let i = 0; i < layerData.effects.length; ++i) {
         this.addEffect(layerData.effects[i]);
@@ -92,11 +94,11 @@ namespace gdjs {
     }
 
     getRendererObject() {
-      return this._renderer.getRendererObject();
+      return this._renderer?.getRendererObject();
     }
 
     get3DRendererObject() {
-      return this._renderer.getThreeScene();
+      return this._renderer?.getThreeScene();
     }
 
     getRenderingType(): RuntimeLayerRenderingType {
@@ -143,8 +145,10 @@ namespace gdjs {
       if (this._followBaseLayerCamera) {
         this.followBaseLayer();
       }
-      this._renderer.updatePreRender();
-      this._effectsManager.updatePreRender(this._rendererEffects, this);
+      if (this._renderer && this._effectsManager) {
+        this._renderer.updatePreRender();
+        this._effectsManager.updatePreRender(this._rendererEffects, this);
+      }
     }
 
     /**
@@ -211,7 +215,7 @@ namespace gdjs {
      */
     show(enable: boolean): void {
       this._hidden = !enable;
-      this._renderer.updateVisibility(enable);
+      this._renderer?.updateVisibility(enable);
     }
 
     /**
@@ -375,7 +379,7 @@ namespace gdjs {
      * @param effectData The data of the effect to add.
      */
     addEffect(effectData: EffectData): void {
-      this._effectsManager.addEffect(effectData, this._rendererEffects, this);
+      this._effectsManager?.addEffect(effectData, this._rendererEffects, this);
     }
 
     /**
@@ -383,7 +387,7 @@ namespace gdjs {
      * @param effectName The name of the effect.
      */
     removeEffect(effectName: string): void {
-      this._effectsManager.removeEffect(
+      this._effectsManager?.removeEffect(
         this._rendererEffects,
         this,
         effectName
@@ -401,7 +405,7 @@ namespace gdjs {
       parameterName: string,
       value: float
     ): void {
-      this._effectsManager.setEffectDoubleParameter(
+      this._effectsManager?.setEffectDoubleParameter(
         this._rendererEffects,
         name,
         parameterName,
@@ -420,7 +424,7 @@ namespace gdjs {
       parameterName: string,
       value: string
     ): void {
-      this._effectsManager.setEffectStringParameter(
+      this._effectsManager?.setEffectStringParameter(
         this._rendererEffects,
         name,
         parameterName,
@@ -439,7 +443,7 @@ namespace gdjs {
       parameterName: string,
       value: boolean
     ): void {
-      this._effectsManager.setEffectBooleanParameter(
+      this._effectsManager?.setEffectBooleanParameter(
         this._rendererEffects,
         name,
         parameterName,
@@ -453,7 +457,7 @@ namespace gdjs {
      * @param enable true to enable, false to disable
      */
     enableEffect(name: string, enable: boolean): void {
-      this._effectsManager.enableEffect(
+      this._effectsManager?.enableEffect(
         this._rendererEffects,
         this,
         name,
@@ -467,7 +471,7 @@ namespace gdjs {
      * @return true if the effect is enabled, false otherwise.
      */
     isEffectEnabled(name: string): boolean {
-      return this._effectsManager.isEffectEnabled(
+      return !!this._effectsManager?.isEffectEnabled(
         this._rendererEffects,
         this,
         name
@@ -480,7 +484,7 @@ namespace gdjs {
      * @return true if the effect exists, false otherwise.
      */
     hasEffect(name: string): boolean {
-      return this._effectsManager.hasEffect(this._rendererEffects, name);
+      return !!this._effectsManager?.hasEffect(this._rendererEffects, name);
     }
 
     /**
@@ -541,7 +545,7 @@ namespace gdjs {
       this._clearColor[0] = r / 255;
       this._clearColor[1] = g / 255;
       this._clearColor[2] = b / 255;
-      this._renderer.updateClearColor();
+      this._renderer?.updateClearColor();
     }
 
     /**

--- a/GDJS/Runtime/debugger-client/hot-reloader.ts
+++ b/GDJS/Runtime/debugger-client/hot-reloader.ts
@@ -546,7 +546,7 @@ namespace gdjs {
         runtimeScene
           .getGame()
           .getRenderer()
-          .setWindowTitle(newLayoutData.title);
+          ?.setWindowTitle(newLayoutData.title);
       }
       this._hotReloadVariablesContainer(
         oldLayoutData.variables as Required<VariableData>[],

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -247,13 +247,13 @@ namespace gdjs {
       export const hideCursor = function (
         instanceContainer: gdjs.RuntimeScene
       ) {
-        instanceContainer.getScene().getRenderer().hideCursor();
+        instanceContainer.getScene().getRenderer()?.hideCursor();
       };
 
       export const showCursor = function (
         instanceContainer: gdjs.RuntimeScene
       ) {
-        instanceContainer.getScene().getRenderer().showCursor();
+        instanceContainer.getScene().getRenderer()?.showCursor();
       };
 
       export const getMouseWheelDelta = function (

--- a/GDJS/Runtime/events-tools/soundtools.ts
+++ b/GDJS/Runtime/events-tools/soundtools.ts
@@ -11,20 +11,25 @@ namespace gdjs {
       export const getGlobalVolume = function (
         runtimeScene: gdjs.RuntimeScene
       ): float {
-        return runtimeScene.getScene().getSoundManager().getGlobalVolume();
+        return (
+          runtimeScene.getScene().getSoundManager()?.getGlobalVolume() || 0
+        );
       };
 
       export const setGlobalVolume = function (
         runtimeScene: gdjs.RuntimeScene,
         globalVolume: float
       ): void {
-        runtimeScene.getScene().getSoundManager().setGlobalVolume(globalVolume);
+        runtimeScene
+          .getScene()
+          .getSoundManager()
+          ?.setGlobalVolume(globalVolume);
       };
 
       export const unloadAllAudio = function (
         runtimeScene: gdjs.RuntimeScene
       ): void {
-        runtimeScene.getScene().getSoundManager().unloadAll();
+        runtimeScene.getScene().getSoundManager()?.unloadAll();
       };
 
       // Sounds:
@@ -38,7 +43,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .playSound(soundFile, loop, volume, pitch);
+          ?.playSound(soundFile, loop, volume, pitch);
       };
 
       export const playSoundOnChannel = function (
@@ -52,7 +57,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .playSoundOnChannel(soundFile, channel, loop, volume, pitch);
+          ?.playSoundOnChannel(soundFile, channel, loop, volume, pitch);
       };
 
       export const stopSoundOnChannel = function (
@@ -62,7 +67,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) sound.stop();
         else {
           logger.error(`Cannot stop non-existing sound on channel ${channel}.`);
@@ -76,7 +81,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) sound.pause();
         else {
           logger.error(
@@ -92,7 +97,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) {
           if (!sound.playing()) sound.play();
         } else {
@@ -109,7 +114,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         return sound ? sound.playing() : false;
       };
 
@@ -120,7 +125,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) return sound.paused();
         else {
           logger.error(
@@ -137,7 +142,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) return sound.stopped();
         else {
           logger.error(
@@ -154,7 +159,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) return sound.getVolume() * 100;
         else {
           logger.error(
@@ -172,7 +177,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) sound.setVolume(volume / 100);
         else {
           logger.error(
@@ -188,7 +193,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) return sound.getSeek();
         else {
           logger.error(
@@ -206,7 +211,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) sound.setSeek(playingOffset);
         else {
           logger.error(
@@ -222,7 +227,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) return sound.getRate();
         else {
           logger.error(
@@ -240,7 +245,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) sound.setRate(pitch);
         else {
           logger.error(
@@ -256,7 +261,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .loadAudio(soundFile, /* isMusic= */ false);
+          ?.loadAudio(soundFile, /* isMusic= */ false);
 
       export const unloadSound = (
         runtimeScene: gdjs.RuntimeScene,
@@ -265,7 +270,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .unloadAudio(soundFile, /* isMusic= */ false);
+          ?.unloadAudio(soundFile, /* isMusic= */ false);
 
       // Musics:
       export const playMusic = function (
@@ -278,7 +283,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .playMusic(soundFile, loop, volume, pitch);
+          ?.playMusic(soundFile, loop, volume, pitch);
       };
 
       export const playMusicOnChannel = function (
@@ -292,7 +297,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .playMusicOnChannel(soundFile, channel, loop, volume, pitch);
+          ?.playMusicOnChannel(soundFile, channel, loop, volume, pitch);
       };
 
       export const stopMusicOnChannel = function (
@@ -302,7 +307,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) music.stop();
         else {
           logger.error(
@@ -318,7 +323,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) music.pause();
         else {
           logger.error(
@@ -334,7 +339,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) {
           if (!music.playing()) music.play();
         } else {
@@ -351,7 +356,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         return music ? music.playing() : false;
       };
 
@@ -362,7 +367,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) return music.paused();
         else {
           logger.error(
@@ -379,7 +384,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) return music.stopped();
         else {
           logger.error(
@@ -396,7 +401,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) return music.getVolume() * 100;
         else {
           logger.error(
@@ -414,7 +419,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) music.setVolume(volume / 100);
         else {
           logger.error(
@@ -430,7 +435,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) return music.getSeek();
         else {
           logger.error(
@@ -448,7 +453,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) music.setSeek(playingOffset);
         else {
           logger.error(
@@ -464,7 +469,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) return music.getRate();
         else {
           logger.error(
@@ -482,7 +487,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) music.setRate(pitch);
         else {
           logger.error(
@@ -498,7 +503,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .loadAudio(soundFile, /* isMusic= */ true);
+          ?.loadAudio(soundFile, /* isMusic= */ true);
 
       export const unloadMusic = (
         runtimeScene: gdjs.RuntimeScene,
@@ -507,7 +512,7 @@ namespace gdjs {
         runtimeScene
           .getScene()
           .getSoundManager()
-          .unloadAudio(soundFile, /* isMusic= */ true);
+          ?.unloadAudio(soundFile, /* isMusic= */ true);
 
       export const fadeSoundVolume = (
         runtimeScene: gdjs.RuntimeScene,
@@ -518,7 +523,7 @@ namespace gdjs {
         const sound = runtimeScene
           .getScene()
           .getSoundManager()
-          .getSoundOnChannel(channel);
+          ?.getSoundOnChannel(channel);
         if (sound) {
           sound.fade(sound.getVolume(), toVolume / 100, timeOfFade * 1000);
         } else {
@@ -536,7 +541,7 @@ namespace gdjs {
         const music = runtimeScene
           .getScene()
           .getSoundManager()
-          .getMusicOnChannel(channel);
+          ?.getMusicOnChannel(channel);
         if (music) {
           music.fade(music.getVolume(), toVolume / 100, timeOfFade * 1000);
         } else {

--- a/GDJS/Runtime/events-tools/windowtools.ts
+++ b/GDJS/Runtime/events-tools/windowtools.ts
@@ -19,7 +19,7 @@ namespace gdjs {
         runtimeScene
           .getGame()
           .getRenderer()
-          .setMargins(top, right, bottom, left);
+          ?.setMargins(top, right, bottom, left);
       };
 
       export const setFullScreen = function (
@@ -27,14 +27,14 @@ namespace gdjs {
         enable: boolean,
         keepAspectRatio: boolean
       ) {
-        runtimeScene.getGame().getRenderer().keepAspectRatio(keepAspectRatio);
-        runtimeScene.getGame().getRenderer().setFullScreen(enable);
+        runtimeScene.getGame().getRenderer()?.keepAspectRatio(keepAspectRatio);
+        runtimeScene.getGame().getRenderer()?.setFullScreen(enable);
       };
 
       export const isFullScreen = function (
         runtimeScene: gdjs.RuntimeScene
       ): boolean {
-        return runtimeScene.getGame().getRenderer().isFullScreen();
+        return !!runtimeScene.getGame().getRenderer()?.isFullScreen();
       };
 
       export const setWindowSize = function (
@@ -43,14 +43,14 @@ namespace gdjs {
         height: float,
         updateGameResolution: boolean
       ) {
-        runtimeScene.getGame().getRenderer().setWindowSize(width, height);
+        runtimeScene.getGame().getRenderer()?.setWindowSize(width, height);
         if (updateGameResolution) {
           runtimeScene.getGame().setGameResolutionSize(width, height);
         }
       };
 
       export const centerWindow = function (runtimeScene: gdjs.RuntimeScene) {
-        runtimeScene.getGame().getRenderer().centerWindow();
+        runtimeScene.getGame().getRenderer()?.centerWindow();
       };
 
       export const setGameResolutionSize = function (
@@ -79,13 +79,13 @@ namespace gdjs {
         runtimeScene: gdjs.RuntimeScene,
         title: string
       ) {
-        runtimeScene.getGame().getRenderer().setWindowTitle(title);
+        runtimeScene.getGame().getRenderer()?.setWindowTitle(title);
       };
 
       export const getWindowTitle = function (
         runtimeScene: gdjs.RuntimeScene
       ): string {
-        return runtimeScene.getGame().getRenderer().getWindowTitle();
+        return runtimeScene.getGame().getRenderer()?.getWindowTitle() || '';
       };
 
       export const getWindowInnerWidth = function (): number {
@@ -126,7 +126,7 @@ namespace gdjs {
         url: string,
         runtimeScene: gdjs.RuntimeScene
       ) {
-        return runtimeScene.getGame().getRenderer().openURL(url);
+        runtimeScene.getGame().getRenderer()?.openURL(url);
       };
     }
   }

--- a/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
+++ b/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
@@ -241,6 +241,7 @@ namespace gdjs {
   }
 
   //Register the class to let the engine use it.
-  export type FontManager = FontFaceObserverFontManager;
-  export const FontManager = FontFaceObserverFontManager;
+  export type FontManager = FontFaceObserverFontManager | undefined;
+  type FontManagerClass = typeof FontFaceObserverFontManager | undefined;
+  export const FontManager: FontManagerClass = FontFaceObserverFontManager;
 }

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -871,6 +871,7 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export const SoundManager = HowlerSoundManager;
-  export type SoundManager = HowlerSoundManager;
+  export type SoundManager = HowlerSoundManager | undefined;
+  type SoundManagerClass = typeof HowlerSoundManager | undefined;
+  export const SoundManager: SoundManagerClass = HowlerSoundManager;
 }

--- a/GDJS/Runtime/layer.ts
+++ b/GDJS/Runtime/layer.ts
@@ -32,7 +32,7 @@ namespace gdjs {
       this._cameraY = this.getHeight() / 2;
 
       // Let the renderer do its final set up:
-      this._renderer.onCreated();
+      this._renderer?.onCreated();
     }
 
     /**
@@ -54,7 +54,7 @@ namespace gdjs {
         this._runtimeScene.getViewportOriginX() - oldGameResolutionOriginX;
       this._cameraY +=
         this._runtimeScene.getViewportOriginY() - oldGameResolutionOriginY;
-      this._renderer.updatePosition();
+      this._renderer?.updatePosition();
     }
 
     /**
@@ -88,7 +88,7 @@ namespace gdjs {
     setCameraX(x: float, cameraId?: integer): void {
       this._forceDimensionUpdate();
       this._cameraX = x;
-      this._renderer.updatePosition();
+      this._renderer?.updatePosition();
     }
 
     /**
@@ -100,7 +100,7 @@ namespace gdjs {
     setCameraY(y: float, cameraId?: integer): void {
       this._forceDimensionUpdate();
       this._cameraY = y;
-      this._renderer.updatePosition();
+      this._renderer?.updatePosition();
     }
 
     /**
@@ -134,7 +134,7 @@ namespace gdjs {
     setCameraZoom(newZoom: float, cameraId?: integer): void {
       this._zoomFactor = newZoom;
       this._isCameraZDirty = true;
-      this._renderer.updatePosition();
+      this._renderer?.updatePosition();
     }
 
     /**
@@ -170,7 +170,7 @@ namespace gdjs {
 
       this._cameraZ = z;
       this._isCameraZDirty = false;
-      this._renderer.updatePosition();
+      this._renderer?.updatePosition();
     }
 
     /**
@@ -216,7 +216,7 @@ namespace gdjs {
      */
     setCameraRotation(rotation: float, cameraId?: integer): void {
       this._cameraRotation = rotation;
-      this._renderer.updatePosition();
+      this._renderer?.updatePosition();
     }
 
     /**
@@ -241,7 +241,8 @@ namespace gdjs {
       // The result parameter used to be optional.
       let position = result || [0, 0];
 
-      if (this._renderer.isCameraRotatedIn3D()) {
+      // TODO: Check if that doesn't break any 3D logic
+      if (this._renderer?.isCameraRotatedIn3D()) {
         return this._renderer.transformTo3DWorld(x, y, 0, cameraId, result);
       }
 

--- a/GDJS/Runtime/pixi-renderers/CustomObjectPixiRenderer.ts
+++ b/GDJS/Runtime/pixi-renderers/CustomObjectPixiRenderer.ts
@@ -5,7 +5,7 @@ namespace gdjs {
    * The renderer for a {@link gdjs.CustomRuntimeObject} using Pixi.js.
    */
   export class CustomObjectPixiRenderer
-    implements gdjs.RuntimeInstanceContainerPixiRenderer {
+    implements gdjs.RuntimeInstanceContainerRenderer {
     _object: gdjs.CustomRuntimeObject;
     _instanceContainer: gdjs.CustomRuntimeObjectInstanceContainer;
     _pixiContainer: PIXI.Container;
@@ -43,10 +43,10 @@ namespace gdjs {
       const layer = parent.getLayer('');
       if (layer) {
         layer
-          .getRenderer()
+          .getRenderer()!
           .addRendererObject(this._pixiContainer, object.getZOrder());
         if (this._threeGroup) {
-          layer.getRenderer().add3DRendererObject(this._threeGroup);
+          layer.getRenderer()!.add3DRendererObject(this._threeGroup);
         }
       }
     }
@@ -60,10 +60,10 @@ namespace gdjs {
       const layer = parent.getLayer('');
       if (layer) {
         layer
-          .getRenderer()
+          .getRenderer()!
           .addRendererObject(this._pixiContainer, object.getZOrder());
         if (this._threeGroup) {
-          layer.getRenderer().add3DRendererObject(this._threeGroup);
+          layer.getRenderer()!.add3DRendererObject(this._threeGroup);
         }
       }
     }
@@ -176,7 +176,7 @@ namespace gdjs {
     }
 
     setLayerIndex(layer: gdjs.RuntimeLayer, index: float): void {
-      const layerPixiRenderer: gdjs.LayerPixiRenderer = layer.getRenderer();
+      const layerPixiRenderer: gdjs.LayerPixiRenderer = layer.getRenderer()!;
       let layerPixiObject:
         | PIXI.Container
         | PIXI.Sprite
@@ -196,6 +196,8 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export type CustomObjectRenderer = gdjs.CustomObjectPixiRenderer;
-  export const CustomObjectRenderer = gdjs.CustomObjectPixiRenderer;
+  export type CustomObjectRenderer = gdjs.CustomObjectPixiRenderer | undefined;
+  type CustomObjectRendererClass = typeof CustomObjectPixiRenderer | undefined;
+  export const CustomObjectRenderer: CustomObjectRendererClass =
+    gdjs.CustomObjectPixiRenderer;
 }

--- a/GDJS/Runtime/pixi-renderers/DebuggerPixiRenderer.ts
+++ b/GDJS/Runtime/pixi-renderers/DebuggerPixiRenderer.ts
@@ -40,7 +40,7 @@ namespace gdjs {
       showCustomPoints: boolean
     ) {
       const pixiContainer = this._instanceContainer
-        .getRenderer()
+        .getRenderer()!
         .getRendererObject();
       if (!this._debugDraw || !this._debugDrawContainer) {
         this._debugDrawContainer = new PIXI.Container();
@@ -313,7 +313,7 @@ namespace gdjs {
           children: true,
         });
         const pixiContainer: PIXI.Container = this._instanceContainer
-          .getRenderer()
+          .getRenderer()!
           .getRendererObject();
         pixiContainer.removeChild(this._debugDrawContainer);
       }
@@ -324,6 +324,8 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export type DebuggerRenderer = gdjs.DebuggerPixiRenderer;
-  export const DebuggerRenderer = gdjs.DebuggerPixiRenderer;
+  export type DebuggerRenderer = gdjs.DebuggerPixiRenderer | undefined;
+  type DebuggerRendererClass = typeof DebuggerPixiRenderer | undefined;
+  export const DebuggerRenderer: DebuggerRendererClass =
+    gdjs.DebuggerPixiRenderer;
 }

--- a/GDJS/Runtime/pixi-renderers/RuntimeInstanceContainerPixiRenderer.d.ts
+++ b/GDJS/Runtime/pixi-renderers/RuntimeInstanceContainerPixiRenderer.d.ts
@@ -3,7 +3,7 @@
  * Copyright 2013-2016 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
  * This project is released under the MIT License.
  */
-namespace gdjs {
+declare namespace gdjs {
   import PIXI = GlobalPIXIModule.PIXI;
 
   /**

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -72,7 +72,7 @@ namespace gdjs {
       this._pixiContainer.filters = [];
 
       // Setup rendering for lighting or 3D rendering:
-      const pixiRenderer = runtimeGameRenderer.getPIXIRenderer();
+      const pixiRenderer = runtimeGameRenderer!.getPIXIRenderer();
       if (this._isLightingLayer) {
         this._clearColor = layer.getClearColor();
         this._setupLightingRendering(
@@ -615,6 +615,7 @@ namespace gdjs {
   }
 
   //Register the class to let the engine use it.
-  export type LayerRenderer = gdjs.LayerPixiRenderer;
-  export const LayerRenderer = gdjs.LayerPixiRenderer;
+  export type LayerRenderer = gdjs.LayerPixiRenderer | undefined;
+  type LayerRendererClass = typeof LayerPixiRenderer | undefined;
+  export const LayerRenderer: LayerRendererClass = gdjs.LayerPixiRenderer;
 }

--- a/GDJS/Runtime/pixi-renderers/loadingscreen-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/loadingscreen-pixi-renderer.ts
@@ -251,5 +251,9 @@ namespace gdjs {
   }
 
   //Register the class to let the engine use it.
-  export const LoadingScreenRenderer = LoadingScreenPixiRenderer;
+  export type LoadingScreenRenderer = LoadingScreenPixiRenderer | undefined;
+  type LoadingScreenRendererClass =
+    | typeof LoadingScreenPixiRenderer
+    | undefined;
+  export const LoadingScreenRenderer: LoadingScreenRendererClass = LoadingScreenPixiRenderer;
 }

--- a/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
@@ -302,6 +302,8 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export const BitmapFontManager = gdjs.PixiBitmapFontManager;
-  export type BitmapFontManager = gdjs.PixiBitmapFontManager;
+  export type BitmapFontManager = gdjs.PixiBitmapFontManager | undefined;
+  type BitmapFontManagerClass = typeof PixiBitmapFontManager | undefined;
+  export const BitmapFontManager: BitmapFontManagerClass =
+    gdjs.PixiBitmapFontManager;
 }

--- a/GDJS/Runtime/pixi-renderers/pixi-effects-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-effects-manager.ts
@@ -277,6 +277,7 @@ namespace gdjs {
   }
 
   // Expose the effect manager to the game engine.
-  export const EffectsManager = PixiEffectsManager;
-  export type EffectsManager = PixiEffectsManager;
+  export type EffectsManager = PixiEffectsManager | undefined;
+  type EffectsManagerClass = typeof PixiEffectsManager | undefined;
+  export const EffectsManager: EffectsManagerClass = PixiEffectsManager;
 }

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -178,7 +178,7 @@ namespace gdjs {
       const pixiTexture = this.getPIXITexture(resourceName);
       const pixiRenderer = this._resourcesLoader._runtimeGame
         .getRenderer()
-        .getPIXIRenderer();
+        ?.getPIXIRenderer();
       if (!pixiRenderer) throw new Error('No PIXI renderer was found.');
 
       // @ts-ignore - source does exist on resource.
@@ -382,6 +382,7 @@ namespace gdjs {
   }
 
   //Register the class to let the engine use it.
-  export const ImageManager = gdjs.PixiImageManager;
-  export type ImageManager = gdjs.PixiImageManager;
+  export type ImageManager = gdjs.PixiImageManager | undefined;
+  type ImageManagerClass = typeof PixiImageManager | undefined;
+  export const ImageManager: ImageManagerClass = gdjs.PixiImageManager;
 }

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -921,6 +921,7 @@ namespace gdjs {
   }
 
   //Register the class to let the engine use it.
-  export type RuntimeGameRenderer = RuntimeGamePixiRenderer;
-  export const RuntimeGameRenderer = RuntimeGamePixiRenderer;
+  export type RuntimeGameRenderer = RuntimeGamePixiRenderer | undefined;
+  type RuntimeGameRendererClass = typeof RuntimeGamePixiRenderer | undefined;
+  export const RuntimeGameRenderer: RuntimeGameRendererClass = RuntimeGamePixiRenderer;
 }

--- a/GDJS/Runtime/pixi-renderers/runtimescene-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimescene-pixi-renderer.ts
@@ -5,7 +5,7 @@ namespace gdjs {
    * The renderer for a gdjs.RuntimeScene using Pixi.js.
    */
   export class RuntimeScenePixiRenderer
-    implements gdjs.RuntimeInstanceContainerPixiRenderer {
+    implements gdjs.RuntimeInstanceContainerRenderer {
     private _runtimeGameRenderer: gdjs.RuntimeGamePixiRenderer | null;
     private _runtimeScene: gdjs.RuntimeScene;
     private _pixiContainer: PIXI.Container;
@@ -53,7 +53,7 @@ namespace gdjs {
         pixiRenderer.height / runtimeGame.getGameResolutionHeight();
 
       for (const runtimeLayer of this._runtimeScene._orderedLayers) {
-        runtimeLayer.getRenderer().onGameResolutionResized();
+        runtimeLayer.getRenderer()!.onGameResolutionResized();
       }
     }
 
@@ -98,7 +98,7 @@ namespace gdjs {
           const runtimeLayer = this._runtimeScene._orderedLayers[i];
           if (!runtimeLayer.isVisible()) continue;
 
-          const runtimeLayerRenderer = runtimeLayer.getRenderer();
+          const runtimeLayerRenderer = runtimeLayer.getRenderer()!;
           const runtimeLayerRenderingType = runtimeLayer.getRenderingType();
           const layerHas3DObjectsToRender = runtimeLayerRenderer.has3DObjects();
           if (
@@ -217,7 +217,7 @@ namespace gdjs {
 
         const debugContainer = this._runtimeScene
           .getDebuggerRenderer()
-          .getRendererObject();
+          ?.getRendererObject();
 
         if (debugContainer) {
           threeRenderer.resetState();
@@ -241,7 +241,7 @@ namespace gdjs {
         for (const runtimeLayer of this._runtimeScene._orderedLayers) {
           if (runtimeLayer.isLightingLayer()) {
             // Render the lights on the render texture used then by the lighting Sprite.
-            const runtimeLayerRenderer = runtimeLayer.getRenderer();
+            const runtimeLayerRenderer = runtimeLayer.getRenderer()!;
             runtimeLayerRenderer.renderOnPixiRenderTexture(pixiRenderer);
           }
         }
@@ -325,7 +325,7 @@ namespace gdjs {
     }
 
     setLayerIndex(layer: gdjs.RuntimeLayer, index: float): void {
-      const layerPixiRenderer: gdjs.LayerPixiRenderer = layer.getRenderer();
+      const layerPixiRenderer: gdjs.LayerPixiRenderer = layer.getRenderer()!;
       let layerPixiObject:
         | PIXI.Container
         | PIXI.Sprite
@@ -346,6 +346,8 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export type RuntimeSceneRenderer = gdjs.RuntimeScenePixiRenderer;
-  export const RuntimeSceneRenderer = gdjs.RuntimeScenePixiRenderer;
+  export type RuntimeSceneRenderer = gdjs.RuntimeScenePixiRenderer | undefined;
+  type RuntimeSceneRendererClass = typeof RuntimeScenePixiRenderer | undefined;
+  export const RuntimeSceneRenderer: RuntimeSceneRendererClass =
+    gdjs.RuntimeScenePixiRenderer;
 }

--- a/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
@@ -22,12 +22,12 @@ namespace gdjs {
     ) {
       this._object = runtimeObject;
       this._sprite = new PIXI.Sprite(
-        instanceContainer.getGame().getImageManager().getInvalidPIXITexture()
+        instanceContainer.getGame().getImageManager()!.getInvalidPIXITexture()
       );
       const layer = instanceContainer.getLayer('');
       if (layer) {
         layer
-          .getRenderer()
+          .getRenderer()!
           .addRendererObject(this._sprite, runtimeObject.getZOrder());
       }
     }
@@ -43,7 +43,7 @@ namespace gdjs {
       const layer = instanceContainer.getLayer('');
       if (layer) {
         layer
-          .getRenderer()
+          .getRenderer()!
           .addRendererObject(this._sprite, runtimeObject.getZOrder());
       }
     }
@@ -200,6 +200,11 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export const SpriteRuntimeObjectRenderer = SpriteRuntimeObjectPixiRenderer;
-  export type SpriteRuntimeObjectRenderer = SpriteRuntimeObjectPixiRenderer;
+  export type SpriteRuntimeObjectRenderer =
+    | SpriteRuntimeObjectPixiRenderer
+    | undefined;
+  type SpriteRuntimeObjectRendererClass =
+    | typeof SpriteRuntimeObjectPixiRenderer
+    | undefined;
+  export const SpriteRuntimeObjectRenderer: SpriteRuntimeObjectRendererClass = SpriteRuntimeObjectPixiRenderer;
 }

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -794,6 +794,7 @@ namespace gdjs {
     static fallbackGameLoopStarter(
       requestFrameRun: (deltaTime: number) => boolean
     ) {
+      const yieldToRuntime = setImmediate ?? setTimeout;
       let oldTime = 0;
       const gameLoop = () => {
         const now = Date.now();
@@ -801,7 +802,7 @@ namespace gdjs {
         oldTime = now;
         if (requestFrameRun(dt)) {
           // As long as RuntimeGame does not request the game to stop, continue running the loop.
-          setImmediate(gameLoop);
+          yieldToRuntime(gameLoop);
         }
       };
       gameLoop();

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -161,7 +161,7 @@ namespace gdjs {
     _renderer: RuntimeGameRenderer;
     _sessionId: string | null;
     _playerId: string | null;
-    _watermark: watermark.RuntimeWatermark;
+    _watermark: RuntimeWatermark;
 
     _sceneStack: SceneStack;
     /**
@@ -213,32 +213,7 @@ namespace gdjs {
       this._resourcesLoader = new gdjs.RuntimeGameResourcesLoader(this);
 
       const resources = this._data.resources.resources;
-      this._imageManager = new gdjs.ImageManager(
-        resources,
-        this._resourcesLoader
-      );
-      this._soundManager = new gdjs.SoundManager(
-        resources,
-        this._resourcesLoader
-      );
-      this._fontManager = new gdjs.FontManager(
-        resources,
-        this._resourcesLoader
-      );
-      this._jsonManager = new gdjs.JsonManager(
-        resources,
-        this._resourcesLoader
-      );
-      this._bitmapFontManager = new gdjs.BitmapFontManager(
-        resources,
-        this._resourcesLoader,
-        this._imageManager
-      );
-      this._model3DManager = new gdjs.Model3DManager(
-        resources,
-        this._resourcesLoader
-      );
-      this._effectsManager = new gdjs.EffectsManager();
+
       this._maxFPS = this._data.properties.maxFPS;
       this._minFPS = this._data.properties.minFPS;
       this._gameResolutionWidth = this._data.properties.windowWidth;
@@ -251,15 +226,72 @@ namespace gdjs {
       this._pixelsRounding = this._data.properties.pixelsRounding;
       this._antialiasingMode = this._data.properties.antialiasingMode;
       this._isAntialisingEnabledOnMobile = this._data.properties.antialisingEnabledOnMobile;
-      this._renderer = new gdjs.RuntimeGameRenderer(
-        this,
-        this._options.forceFullscreen || false
+
+      // The JSON manager, unlike other managers, is always guaranteed to be present,
+      // since it does not manage purely presentational aspects of the game but actual
+      // game logic that is always needed for the game to run correctly.
+      this._jsonManager = new gdjs.JsonManager(
+        resources,
+        this._resourcesLoader
       );
-      this._watermark = new gdjs.watermark.RuntimeWatermark(
-        this,
-        data.properties.authorUsernames,
-        this._data.properties.watermark
-      );
+
+      // Presentational managers and the renderer are provided by the "renderer extension" of gdjs,
+      // and might not be present in server builds that do not include any renderer.
+      if (gdjs.ImageManager) {
+        this._imageManager = new gdjs.ImageManager(
+          resources,
+          this._resourcesLoader
+        );
+      }
+
+      if (gdjs.SoundManager) {
+        this._soundManager = new gdjs.SoundManager(
+          resources,
+          this._resourcesLoader
+        );
+      }
+
+      if (gdjs.FontManager) {
+        this._fontManager = new gdjs.FontManager(
+          resources,
+          this._resourcesLoader
+        );
+      }
+
+      if (gdjs.BitmapFontManager) {
+        this._bitmapFontManager = new gdjs.BitmapFontManager(
+          resources,
+          this._resourcesLoader,
+          this._imageManager!
+        );
+      }
+
+      if (gdjs.Model3DManager) {
+        this._model3DManager = new gdjs.Model3DManager(
+          resources,
+          this._resourcesLoader
+        );
+      }
+
+      if (gdjs.EffectsManager) {
+        this._effectsManager = new gdjs.EffectsManager();
+      }
+
+      if (gdjs.RuntimeGameRenderer) {
+        this._renderer = new gdjs.RuntimeGameRenderer(
+          this,
+          this._options.forceFullscreen || false
+        );
+      }
+
+      if (gdjs.RuntimeWatermark) {
+        this._watermark = new gdjs.RuntimeWatermark(
+          this,
+          data.properties.authorUsernames,
+          this._data.properties.watermark
+        );
+      }
+
       this._sceneStack = new gdjs.SceneStack(this);
       this._inputManager = new gdjs.InputManager();
       this._injectExternalLayout = this._options.injectExternalLayout || '';
@@ -315,12 +347,20 @@ namespace gdjs {
      */
     setProjectData(projectData: ProjectData): void {
       this._data = projectData;
-      this._imageManager.setResources(this._data.resources.resources);
-      this._soundManager.setResources(this._data.resources.resources);
-      this._fontManager.setResources(this._data.resources.resources);
+      if (
+        this._imageManager &&
+        this._soundManager &&
+        this._fontManager &&
+        this._bitmapFontManager &&
+        this._model3DManager
+      ) {
+        this._imageManager.setResources(this._data.resources.resources);
+        this._soundManager.setResources(this._data.resources.resources);
+        this._fontManager.setResources(this._data.resources.resources);
+        this._bitmapFontManager.setResources(this._data.resources.resources);
+        this._model3DManager.setResources(this._data.resources.resources);
+      }
       this._jsonManager.setResources(this._data.resources.resources);
-      this._bitmapFontManager.setResources(this._data.resources.resources);
-      this._model3DManager.setResources(this._data.resources.resources);
     }
 
     /**
@@ -347,7 +387,7 @@ namespace gdjs {
      * Get the gdjs.SoundManager of the RuntimeGame.
      * @return The sound manager.
      */
-    getSoundManager(): gdjs.HowlerSoundManager {
+    getSoundManager(): gdjs.HowlerSoundManager | undefined {
       return this._soundManager;
     }
 
@@ -355,7 +395,7 @@ namespace gdjs {
      * Get the gdjs.ImageManager of the RuntimeGame.
      * @return The image manager.
      */
-    getImageManager(): gdjs.PixiImageManager {
+    getImageManager(): gdjs.PixiImageManager | undefined {
       return this._imageManager;
     }
 
@@ -363,7 +403,7 @@ namespace gdjs {
      * Get the gdjs.FontManager of the RuntimeGame.
      * @return The font manager.
      */
-    getFontManager(): gdjs.FontFaceObserverFontManager {
+    getFontManager(): gdjs.FontFaceObserverFontManager | undefined {
       return this._fontManager;
     }
 
@@ -371,7 +411,7 @@ namespace gdjs {
      * Get the gdjs.BitmapFontManager of the RuntimeGame.
      * @return The bitmap font manager.
      */
-    getBitmapFontManager(): gdjs.BitmapFontManager {
+    getBitmapFontManager(): gdjs.BitmapFontManager | undefined {
       // @ts-ignore
       return this._bitmapFontManager;
     }
@@ -399,7 +439,7 @@ namespace gdjs {
      * resources.
      * @return The 3D model manager for the game
      */
-    getModel3DManager(): gdjs.Model3DManager {
+    getModel3DManager(): gdjs.Model3DManager | undefined {
       return this._model3DManager;
     }
 
@@ -408,7 +448,7 @@ namespace gdjs {
      * effects on runtime objects or runtime layers.
      * @return The effects manager for the game
      */
-    getEffectsManager(): gdjs.EffectsManager {
+    getEffectsManager(): gdjs.EffectsManager | undefined {
       return this._effectsManager;
     }
 
@@ -571,7 +611,7 @@ namespace gdjs {
       // Notify the renderer that game resolution changed (so that the renderer size
       // can be updated, and maybe other things like the canvas size), and let the
       // scenes know too.
-      this._renderer.updateRendererSize();
+      this._renderer?.updateRendererSize();
       this._notifyScenesForGameResolutionResize = true;
     }
 
@@ -696,11 +736,13 @@ namespace gdjs {
     loadAllAssetsAsync = async (
       progressCallback?: (progress: float) => void
     ) => {
-      const loadingScreen = new gdjs.LoadingScreenRenderer(
-        this.getRenderer(),
-        this._imageManager,
-        this._data.properties.loadingScreen
-      );
+      const loadingScreen = gdjs.LoadingScreenRenderer
+        ? new gdjs.LoadingScreenRenderer(
+            this.getRenderer()!,
+            this._imageManager!,
+            this._data.properties.loadingScreen
+          )
+        : null;
       const allAssetsTotal = this._data.resources.resources.length;
       let loadedAssets = 0;
 
@@ -708,22 +750,62 @@ namespace gdjs {
         const percent = Math.floor(
           (100 * (loadedAssets + count)) / allAssetsTotal
         );
-        loadingScreen.setPercent(percent);
+        if (loadingScreen) loadingScreen.setPercent(percent);
         if (progressCallback) {
           progressCallback(percent);
         }
       };
 
-      loadedAssets += await this._imageManager.loadTextures(onProgress);
-      loadedAssets += await this._soundManager.preloadAudio(onProgress);
-      loadedAssets += await this._fontManager.loadFonts(onProgress);
+      if (this._imageManager)
+        loadedAssets += await this._imageManager.loadTextures(onProgress);
+      if (this._soundManager)
+        loadedAssets += await this._soundManager.preloadAudio(onProgress);
+      if (this._fontManager)
+        loadedAssets += await this._fontManager.loadFonts(onProgress);
       loadedAssets += await this._jsonManager.preloadJsons(onProgress);
-      loadedAssets += await this._model3DManager.loadModels(onProgress);
-      await this._bitmapFontManager.loadBitmapFontData(onProgress);
+      if (this._model3DManager)
+        loadedAssets += await this._model3DManager.loadModels(onProgress);
+      if (this._bitmapFontManager)
+        loadedAssets += await this._bitmapFontManager.loadBitmapFontData(
+          onProgress
+        );
 
-      await loadingScreen.unload();
+      if (loadingScreen) await loadingScreen.unload();
       await gdjs.getAllAsynchronouslyLoadingLibraryPromise();
     };
+
+    /**
+     * It is up to the RuntimeGameRenderer to tell the RuntimeGame when to step;
+     * However, it is not guaranteed that a renderer is present, this function is used
+     * as a fallback for that case and uses the most likely correct way of doing things.
+     *
+     * JavaScript runtimes will not work correctly when running an unbreakable while loop,
+     * they expect that we give them back control every now and then to run timers,
+     * microtasks, promises, necessary system calls for calls to APIs like fetch or Node fs,
+     * ...
+     *
+     * The most widely supported way to stop running code, thus yielding back to the runtime,
+     * but then call back into our code again, is the timers API. Thus, this fallback being intended
+     * to work in any JS environement, it uses Timers, although they might not be ideal.
+     *
+     * If the game runs in an anvironement like a browser, a renderer for that platform should be
+     * in-use, providing a more pertinent API like `requestAnimationFrame`.
+     */
+    static fallbackGameLoopStarter(
+      requestFrameRun: (deltaTime: number) => boolean
+    ) {
+      let oldTime = 0;
+      const gameLoop = () => {
+        const now = Date.now();
+        const dt = oldTime ? now - oldTime : 0;
+        oldTime = now;
+        if (requestFrameRun(dt)) {
+          // As long as RuntimeGame does not request the game to stop, continue running the loop.
+          setImmediate(gameLoop);
+        }
+      };
+      gameLoop();
+    }
 
     /**
      * Start the game loop, to be called once assets are loaded.
@@ -745,7 +827,7 @@ namespace gdjs {
               this.getSceneData().name,
           this._injectExternalLayout
         );
-        this._watermark.displayAtStartup();
+        if (this._watermark) this._watermark.displayAtStartup();
 
         //Uncomment to profile the first x frames of the game.
         // var x = 500;
@@ -765,7 +847,12 @@ namespace gdjs {
         const that = this;
         let accumulatedElapsedTime = 0;
         this._hasJustResumed = false;
-        this._renderer.startGameLoop(function (lastCallElapsedTime) {
+
+        const startGameLoop = this._renderer
+          ? this._renderer.startGameLoop.bind(this._renderer)
+          : gdjs.RuntimeGame.fallbackGameLoopStarter;
+
+        startGameLoop(function (lastCallElapsedTime) {
           if (that._paused) {
             return true;
           }
@@ -1122,6 +1209,49 @@ namespace gdjs {
       return mapping && mapping[embeddedResourceName]
         ? mapping[embeddedResourceName]
         : embeddedResourceName;
+    }
+
+    /**
+     * Gets the base dimensions, height and width, of any resource.
+     *
+     * TODO:
+     * This is part of RuntimeGame because, in the future, we should have the dimensions
+     * pre-computed by the IDE and stored in the {@link ProjectData}, since dimensions are *very*
+     * important for the game logic, and thus we want them to be ultra-consistent, there should not
+     * be any discrepancy between a build with different renderers (or none at all)!
+     *
+     * This is out of scope for the PR implementing this function, and will need to be done in a follow-up PR.
+     */
+    getResourceBaseDimensions(
+      resourceName: string
+    ): { height: number; width: number } {
+      // TODO: This is *NOT VALID*, and must be fixed before introducing builds of games without a renderer.
+      if (!this._renderer) return { height: 1, width: 1 };
+      // TODO: This function couples RuntimeGame with the PIXI Renderer, since this is a "temporary fix".
+      //       The function will work regardless of renderers once the resource dimensions are pre-computed
+      //       and stored onto the resource by the IDE.
+      const resource = this._data.resources.resources.find(
+        (resource) => resource.name === resourceName
+      );
+      if (!resource) {
+        logger.warn(
+          'Tried to find dimensions of a resource that does not exist!'
+        );
+        return { height: 1, width: 1 };
+      }
+      if (resource.kind === 'image') {
+        const texture = this.getImageManager()!.getPIXITexture(resource.name);
+        return { height: texture.height, width: texture.width };
+      }
+      if (resource.kind === 'video') {
+        const texture = this.getImageManager()!.getPIXIVideoTexture(
+          resource.name
+        );
+        return { height: texture.height, width: texture.width };
+      }
+      throw new Error(
+        `Tried to get the dimensions of unsupported resource kind '${resource.kind}' - please implement support for this resource kind in RuntimeGame#getResourceBaseDimensions!`
+      );
     }
   }
 }

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -239,12 +239,16 @@ namespace gdjs {
       );
       this._averageForce = new gdjs.Force(0, 0, 0);
       this._behaviorsTable = new Hashtable();
-      for (let i = 0; i < objectData.effects.length; ++i) {
-        this._runtimeScene
-          .getGame()
-          .getEffectsManager()
-          .initializeEffect(objectData.effects[i], this._rendererEffects, this);
-        this.updateAllEffectParameters(objectData.effects[i]);
+      const effectsManager = this._runtimeScene.getGame().getEffectsManager();
+      if (effectsManager) {
+        for (let i = 0; i < objectData.effects.length; ++i) {
+          effectsManager.initializeEffect(
+            objectData.effects[i],
+            this._rendererEffects,
+            this
+          );
+          this.updateAllEffectParameters(objectData.effects[i]);
+        }
       }
       //Also contains the behaviors: Used when a behavior is accessed by its name ( see getBehavior ).
       for (let i = 0, len = objectData.behaviors.length; i < len; ++i) {
@@ -347,12 +351,16 @@ namespace gdjs {
       this._behaviors.length = behaviorsUsingLifecycleFunctionCount;
 
       // Reinitialize effects.
-      for (let i = 0; i < objectData.effects.length; ++i) {
-        this._runtimeScene
-          .getGame()
-          .getEffectsManager()
-          .initializeEffect(objectData.effects[i], this._rendererEffects, this);
-        this.updateAllEffectParameters(objectData.effects[i]);
+      const effectsManager = this._runtimeScene.getGame().getEffectsManager();
+      if (effectsManager) {
+        for (let i = 0; i < objectData.effects.length; ++i) {
+          effectsManager.initializeEffect(
+            objectData.effects[i],
+            this._rendererEffects,
+            this
+          );
+          this.updateAllEffectParameters(objectData.effects[i]);
+        }
       }
 
       // Make sure to delete existing timers.
@@ -469,11 +477,11 @@ namespace gdjs {
       const theLayer = instanceContainer.getLayer(this.layer);
       const rendererObject = this.getRendererObject();
       if (rendererObject) {
-        theLayer.getRenderer().removeRendererObject(rendererObject);
+        theLayer.getRenderer()?.removeRendererObject(rendererObject);
       }
       const rendererObject3D = this.get3DRendererObject();
       if (rendererObject3D) {
-        theLayer.getRenderer().remove3DRendererObject(rendererObject3D);
+        theLayer.getRenderer()?.remove3DRendererObject(rendererObject3D);
       }
       for (let j = 0, lenj = this._behaviors.length; j < lenj; ++j) {
         this._behaviors[j].onDestroy();
@@ -746,13 +754,13 @@ namespace gdjs {
       const newLayer = this._runtimeScene.getLayer(this.layer);
       const rendererObject = this.getRendererObject();
       if (rendererObject) {
-        oldLayer.getRenderer().removeRendererObject(rendererObject);
-        newLayer.getRenderer().addRendererObject(rendererObject, this.zOrder);
+        oldLayer.getRenderer()?.removeRendererObject(rendererObject);
+        newLayer.getRenderer()?.addRendererObject(rendererObject, this.zOrder);
       }
       const rendererObject3D = this.get3DRendererObject();
       if (rendererObject3D) {
-        oldLayer.getRenderer().remove3DRendererObject(rendererObject3D);
-        newLayer.getRenderer().add3DRendererObject(rendererObject3D);
+        oldLayer.getRenderer()?.remove3DRendererObject(rendererObject3D);
+        newLayer.getRenderer()?.add3DRendererObject(rendererObject3D);
       }
     }
 
@@ -788,7 +796,7 @@ namespace gdjs {
       const rendererObject = this.getRendererObject();
       if (rendererObject) {
         const theLayer = this._runtimeScene.getLayer(this.layer);
-        theLayer.getRenderer().changeRendererObjectZOrder(rendererObject, z);
+        theLayer.getRenderer()?.changeRendererObjectZOrder(rendererObject, z);
       }
     }
 
@@ -1040,10 +1048,10 @@ namespace gdjs {
       const rendererObject = this.getRendererObject();
       if (!rendererObject) return false;
 
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .addEffect(effectData, this._rendererEffects, this);
+        ?.addEffect(effectData, this._rendererEffects, this);
     }
 
     /**
@@ -1054,10 +1062,10 @@ namespace gdjs {
       const rendererObject = this.getRendererObject();
       if (!rendererObject) return false;
 
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .removeEffect(this._rendererEffects, this, effectName);
+        ?.removeEffect(this._rendererEffects, this, effectName);
     }
 
     /**
@@ -1068,13 +1076,11 @@ namespace gdjs {
       if (!rendererObject) return false;
 
       this._rendererEffects = {};
-      return (
-        this._runtimeScene
-          .getGame()
-          .getEffectsManager()
-          // @ts-expect-error - the effects manager is typed with the PIXI object.
-          .clearEffects(rendererObject)
-      );
+      return !!this._runtimeScene
+        .getGame()
+        .getEffectsManager()
+        // @ts-expect-error - the effects manager is typed with the PIXI object.
+        ?.clearEffects(rendererObject);
     }
 
     /**
@@ -1088,10 +1094,10 @@ namespace gdjs {
       parameterName: string,
       value: float
     ): boolean {
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .setEffectDoubleParameter(
+        ?.setEffectDoubleParameter(
           this._rendererEffects,
           name,
           parameterName,
@@ -1110,10 +1116,10 @@ namespace gdjs {
       parameterName: string,
       value: string
     ): boolean {
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .setEffectStringParameter(
+        ?.setEffectStringParameter(
           this._rendererEffects,
           name,
           parameterName,
@@ -1132,10 +1138,10 @@ namespace gdjs {
       parameterName: string,
       value: boolean
     ): boolean {
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .setEffectBooleanParameter(
+        ?.setEffectBooleanParameter(
           this._rendererEffects,
           name,
           parameterName,
@@ -1148,10 +1154,10 @@ namespace gdjs {
      * @param effectData The data describing the effect
      */
     updateAllEffectParameters(effectData: EffectData): boolean {
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .updateAllEffectParameters(this._rendererEffects, effectData);
+        ?.updateAllEffectParameters(this._rendererEffects, effectData);
     }
 
     /**
@@ -1163,7 +1169,7 @@ namespace gdjs {
       this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .enableEffect(this._rendererEffects, this, name, enable);
+        ?.enableEffect(this._rendererEffects, this, name, enable);
     }
 
     /**
@@ -1172,10 +1178,10 @@ namespace gdjs {
      * @return true if the effect is enabled, false otherwise.
      */
     isEffectEnabled(name: string): boolean {
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .isEffectEnabled(this._rendererEffects, this, name);
+        ?.isEffectEnabled(this._rendererEffects, this, name);
     }
 
     /**
@@ -1184,10 +1190,10 @@ namespace gdjs {
      * @return true if the effect exists, false otherwise.
      */
     hasEffect(name: string): boolean {
-      return this._runtimeScene
+      return !!this._runtimeScene
         .getGame()
         .getEffectsManager()
-        .hasEffect(this._rendererEffects, name);
+        ?.hasEffect(this._rendererEffects, name);
     }
 
     /**

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -13,8 +13,8 @@ namespace gdjs {
   export class RuntimeScene extends gdjs.RuntimeInstanceContainer {
     _eventsFunction: null | ((runtimeScene: RuntimeScene) => void) = null;
 
-    _renderer: RuntimeSceneRenderer;
-    _debuggerRenderer: gdjs.DebuggerRenderer;
+    _renderer?: RuntimeSceneRenderer;
+    _debuggerRenderer?: gdjs.DebuggerRenderer;
     _variables: gdjs.VariablesContainer;
     _runtimeGame: gdjs.RuntimeGame;
     _lastId: integer = 0;
@@ -62,12 +62,15 @@ namespace gdjs {
         ? runtimeGame.getGameResolutionHeight()
         : 0;
 
-      this._renderer = new gdjs.RuntimeSceneRenderer(
-        this,
-        // @ts-ignore This is needed because of test. They should mock RuntimeGame instead.
-        runtimeGame ? runtimeGame.getRenderer() : null
-      );
-      this._debuggerRenderer = new gdjs.DebuggerRenderer(this);
+      if (gdjs.RuntimeSceneRenderer) {
+        this._renderer = new gdjs.RuntimeSceneRenderer(
+          this,
+          // @ts-ignore This is needed because of test. They should mock RuntimeGame instead.
+          runtimeGame ? runtimeGame.getRenderer() : null
+        );
+      }
+      if (gdjs.DebuggerRenderer)
+        this._debuggerRenderer = new gdjs.DebuggerRenderer(this);
 
       // What to do after the frame is rendered.
 
@@ -103,7 +106,7 @@ namespace gdjs {
           );
         }
       }
-      this._renderer.onGameResolutionResized();
+      this._renderer?.onGameResolutionResized();
     }
 
     /**
@@ -123,7 +126,7 @@ namespace gdjs {
 
       //Setup main properties
       if (this._runtimeGame) {
-        this._runtimeGame.getRenderer().setWindowTitle(sceneData.title);
+        this._runtimeGame.getRenderer()?.setWindowTitle(sceneData.title);
       }
       this._name = sceneData.name;
       this.setBackgroundColor(sceneData.r, sceneData.v, sceneData.b);
@@ -186,7 +189,7 @@ namespace gdjs {
         gdjs.callbacksRuntimeSceneLoaded[i](this);
       }
       if (sceneData.stopSoundsOnStartup && this._runtimeGame) {
-        this._runtimeGame.getSoundManager().clearAll();
+        this._runtimeGame.getSoundManager()?.clearAll();
       }
       this._isLoaded = true;
       this._timeManager.reset();
@@ -388,39 +391,43 @@ namespace gdjs {
       if (this._profiler) {
         this._profiler.end('callbacks and extensions (post-events)');
       }
-      if (this._profiler) {
-        this._profiler.begin('objects (pre-render, effects update)');
-      }
-      this._updateObjectsPreRender();
-      if (this._profiler) {
-        this._profiler.end('objects (pre-render, effects update)');
-      }
-      if (this._profiler) {
-        this._profiler.begin('layers (effects update)');
-      }
-      this._updateLayersPreRender();
-      if (this._profiler) {
-        this._profiler.end('layers (effects update)');
-      }
-      if (this._profiler) {
-        this._profiler.begin('render');
-      }
 
-      // Set to true to enable debug rendering (look for the implementation in the renderer
-      // to see what is rendered).
-      if (this._debugDrawEnabled) {
-        this._debuggerRenderer.renderDebugDraw(
-          this.getAdhocListOfAllInstances(),
-          this._debugDrawShowHiddenInstances,
-          this._debugDrawShowPointsNames,
-          this._debugDrawShowCustomPoints
-        );
-      }
+      const shouldRender = Boolean(this._renderer);
+      if (shouldRender) {
+        if (this._profiler) {
+          this._profiler.begin('objects (pre-render, effects update)');
+        }
+        this._updateObjectsPreRender();
+        if (this._profiler) {
+          this._profiler.end('objects (pre-render, effects update)');
+        }
+        if (this._profiler) {
+          this._profiler.begin('layers (effects update)');
+        }
+        this._updateLayersPreRender();
+        if (this._profiler) {
+          this._profiler.end('layers (effects update)');
+        }
+        if (this._profiler) {
+          this._profiler.begin('render');
+        }
 
-      this._isJustResumed = false;
-      this.render();
-      if (this._profiler) {
-        this._profiler.end('render');
+        // Set to true to enable debug rendering (look for the implementation in the renderer
+        // to see what is rendered).
+        if (this._debugDrawEnabled && this._debuggerRenderer) {
+          this._debuggerRenderer.renderDebugDraw(
+            this.getAdhocListOfAllInstances(),
+            this._debugDrawShowHiddenInstances,
+            this._debugDrawShowPointsNames,
+            this._debugDrawShowCustomPoints
+          );
+        }
+
+        this._isJustResumed = false;
+        this.render();
+        if (this._profiler) {
+          this._profiler.end('render');
+        }
       }
       if (this._profiler) {
         this._profiler.endFrame();
@@ -432,7 +439,7 @@ namespace gdjs {
      * Render the PIXI container associated to the runtimeScene.
      */
     render() {
-      this._renderer.render();
+      this._renderer?.render();
     }
 
     /**
@@ -493,7 +500,7 @@ namespace gdjs {
             if (rendererObject.visible) {
               this._runtimeGame
                 .getEffectsManager()
-                .updatePreRender(object.getRendererEffects(), object);
+                ?.updatePreRender(object.getRendererEffects(), object);
 
               // Perform pre-render update only if the object is visible
               // (including if there is no visibility AABB returned previously).
@@ -559,12 +566,12 @@ namespace gdjs {
       return this._lastId;
     }
 
-    getRenderer(): gdjs.RuntimeScenePixiRenderer {
-      return this._renderer;
+    getRenderer(): gdjs.RuntimeScenePixiRenderer | null {
+      return this._renderer || null;
     }
 
-    getDebuggerRenderer() {
-      return this._debuggerRenderer;
+    getDebuggerRenderer(): gdjs.DebuggerRenderer | null {
+      return this._debuggerRenderer || null;
     }
 
     getGame() {

--- a/GDJS/Runtime/runtimewatermark.ts
+++ b/GDJS/Runtime/runtimewatermark.ts
@@ -1,345 +1,344 @@
 namespace gdjs {
-  export namespace watermark {
-    export class RuntimeWatermark {
-      _gameRenderer: RuntimeGameRenderer;
-      _isDevEnvironment: boolean;
+  class RuntimeWatermarkDOMRenderer {
+    _gameRenderer: RuntimeGameRenderer;
+    _isDevEnvironment: boolean;
 
-      // Configuration
-      _placement:
-        | 'top-left'
-        | 'top-right'
-        | 'bottom-left'
-        | 'bottom-right'
-        | 'bottom'
-        | 'top';
-      _showAtStartup: boolean;
-      _authorUsername: string | undefined;
-      _gameId: string | undefined;
+    // Configuration
+    _placement:
+      | 'top-left'
+      | 'top-right'
+      | 'bottom-left'
+      | 'bottom-right'
+      | 'bottom'
+      | 'top';
+    _showAtStartup: boolean;
+    _authorUsername: string | undefined;
+    _gameId: string | undefined;
 
-      // Dom elements
-      _linkElement: HTMLAnchorElement | null = null;
-      _containerElement: HTMLDivElement | null = null;
-      _backgroundElement: HTMLDivElement | null = null;
-      _svgElement: SVGElement | null = null;
-      _usernameTextElement: HTMLSpanElement | null = null;
-      _madeWithTextElement: HTMLSpanElement | null = null;
+    // Dom elements
+    _linkElement: HTMLAnchorElement | null = null;
+    _containerElement: HTMLDivElement | null = null;
+    _backgroundElement: HTMLDivElement | null = null;
+    _svgElement: SVGElement | null = null;
+    _usernameTextElement: HTMLSpanElement | null = null;
+    _madeWithTextElement: HTMLSpanElement | null = null;
 
-      _resizeObserver: ResizeObserver | null = null;
+    _resizeObserver: ResizeObserver | null = null;
 
-      // Durations in seconds
-      _displayDuration: number = 20;
-      _changeTextDelay: number = 7;
-      _fadeInDelayAfterGameLoaded: number = 1;
-      _fadeDuration: number = 0.3;
+    // Durations in seconds
+    _displayDuration: number = 20;
+    _changeTextDelay: number = 7;
+    _fadeInDelayAfterGameLoaded: number = 1;
+    _fadeDuration: number = 0.3;
 
-      // Timeout registration
-      _fadeOutTimeout: NodeJS.Timeout | null = null;
-      _hideTimeout: NodeJS.Timeout | null = null;
-      _fadeOutFirstTextTimeout: NodeJS.Timeout | null = null;
-      _fadeInSecondTextTimeout: NodeJS.Timeout | null = null;
+    // Timeout registration
+    _fadeOutTimeout: NodeJS.Timeout | null = null;
+    _hideTimeout: NodeJS.Timeout | null = null;
+    _fadeOutFirstTextTimeout: NodeJS.Timeout | null = null;
+    _fadeInSecondTextTimeout: NodeJS.Timeout | null = null;
 
-      // Sizes
-      _textFontSize: number = 14;
-      _logoWidth: number = 56;
-      _logoHeight: number = 45;
-      _backgroundHeight: number = 150;
-      _margin: number = 10;
+    // Sizes
+    _textFontSize: number = 14;
+    _logoWidth: number = 56;
+    _logoHeight: number = 45;
+    _backgroundHeight: number = 150;
+    _margin: number = 10;
 
-      constructor(
-        game: RuntimeGame,
-        authorUsernames: Array<string>,
-        watermarkData: WatermarkData
-      ) {
-        this._gameId = game._data.properties.projectUuid;
-        this._gameRenderer = game.getRenderer();
-        this._authorUsername = authorUsernames[0];
-        this._placement = watermarkData.placement;
-        this._showAtStartup = watermarkData.showWatermark;
-        this._isDevEnvironment = game.isUsingGDevelopDevelopmentEnvironment();
-        this.addStyle();
+    constructor(
+      game: RuntimeGame,
+      authorUsernames: Array<string>,
+      watermarkData: WatermarkData
+    ) {
+      this._gameId = game._data.properties.projectUuid;
+      this._gameRenderer = game.getRenderer();
+      this._authorUsername = authorUsernames[0];
+      this._placement = watermarkData.placement;
+      this._showAtStartup = watermarkData.showWatermark;
+      this._isDevEnvironment = game.isUsingGDevelopDevelopmentEnvironment();
+      this.addStyle();
+    }
+
+    displayAtStartup() {
+      if (this._showAtStartup) {
+        this.display();
       }
+    }
 
-      displayAtStartup() {
-        if (this._showAtStartup) {
-          this.display();
-        }
+    display() {
+      const gameContainer = this._gameRenderer?.getDomElementContainer();
+      if (gameContainer) {
+        this.addWatermarkToGameContainer(gameContainer);
+        this._resizeObserver = new ResizeObserver(() => {
+          const gameContainerRectangle = gameContainer.getBoundingClientRect();
+          this.onResizeGameContainer(gameContainerRectangle.height);
+        });
+        this._resizeObserver.observe(gameContainer);
       }
+    }
 
-      display() {
-        const gameContainer = this._gameRenderer.getDomElementContainer();
-        if (gameContainer) {
-          this.addWatermarkToGameContainer(gameContainer);
-          this._resizeObserver = new ResizeObserver(() => {
-            const gameContainerRectangle = gameContainer.getBoundingClientRect();
-            this.onResizeGameContainer(gameContainerRectangle.height);
-          });
-          this._resizeObserver.observe(gameContainer);
-        }
+    private updateFontSize(height: number) {
+      this._textFontSize = Math.max(0.025 * height, 12);
+    }
+    private updateLogoSize(height: number) {
+      this._logoWidth = Math.max(0.06 * height, 25);
+      this._logoHeight = Math.round((45 / 56) * this._logoWidth);
+    }
+    private updateBackgroundHeight(height: number) {
+      this._backgroundHeight = Math.max(0.13 * height, 45);
+    }
+    private updateMargin(height: number) {
+      this._margin = Math.max(0.025 * height, 8);
+    }
+
+    private onResizeGameContainer(height: number) {
+      this.updateFontSize(height);
+      if (this._madeWithTextElement) {
+        this._madeWithTextElement.style.fontSize = `${this._textFontSize}px`;
       }
-
-      private updateFontSize(height: number) {
-        this._textFontSize = Math.max(0.025 * height, 12);
+      if (this._usernameTextElement) {
+        this._usernameTextElement.style.fontSize = `${this._textFontSize}px`;
       }
-      private updateLogoSize(height: number) {
-        this._logoWidth = Math.max(0.06 * height, 25);
-        this._logoHeight = Math.round((45 / 56) * this._logoWidth);
+      this.updateLogoSize(height);
+      if (this._svgElement) {
+        this._svgElement.setAttribute('height', this._logoHeight.toString());
+        this._svgElement.setAttribute('width', this._logoWidth.toString());
       }
-      private updateBackgroundHeight(height: number) {
-        this._backgroundHeight = Math.max(0.13 * height, 45);
-      }
-      private updateMargin(height: number) {
-        this._margin = Math.max(0.025 * height, 8);
-      }
-
-      private onResizeGameContainer(height: number) {
-        this.updateFontSize(height);
-        if (this._madeWithTextElement) {
-          this._madeWithTextElement.style.fontSize = `${this._textFontSize}px`;
-        }
-        if (this._usernameTextElement) {
-          this._usernameTextElement.style.fontSize = `${this._textFontSize}px`;
-        }
-        this.updateLogoSize(height);
-        if (this._svgElement) {
-          this._svgElement.setAttribute('height', this._logoHeight.toString());
-          this._svgElement.setAttribute('width', this._logoWidth.toString());
-        }
-        this.updateBackgroundHeight(height);
-        if (this._backgroundElement) {
-          this._backgroundElement.style.height = `${this._backgroundHeight}px`;
-        }
-        this.updateMargin(height);
-        if (this._linkElement) {
-          this.updateElementMargins(this._linkElement);
-        }
-      }
-
-      private addWatermarkToGameContainer(container: HTMLElement) {
-        const gameContainerRectangle = container.getBoundingClientRect();
-        this.updateFontSize(gameContainerRectangle.height);
-        this.updateLogoSize(gameContainerRectangle.height);
-        this.updateBackgroundHeight(gameContainerRectangle.height);
-
-        this._containerElement = this.createDivContainer();
-        this.createBackground();
-        const textContainer = document.createElement('div');
-
-        this.generateSVGLogo(gameContainerRectangle.height);
-        this.createMadeWithTextElement();
-        this.createUsernameTextElement();
-
-        this._linkElement = this.createLinkElement();
-
-        if (this._svgElement)
-          this._containerElement.appendChild(this._svgElement);
-        if (this._madeWithTextElement)
-          textContainer.appendChild(this._madeWithTextElement);
-        if (this._usernameTextElement)
-          textContainer.appendChild(this._usernameTextElement);
-        this._containerElement.appendChild(textContainer);
-        if (this._backgroundElement)
-          container.appendChild(this._backgroundElement);
-
-        this._linkElement.append(this._containerElement);
-        container.appendChild(this._linkElement);
-
-        this.setupAnimations();
-      }
-
-      private createBackground() {
-        this._backgroundElement = document.createElement('div');
-        this._backgroundElement.setAttribute('id', 'watermark-background');
+      this.updateBackgroundHeight(height);
+      if (this._backgroundElement) {
         this._backgroundElement.style.height = `${this._backgroundHeight}px`;
-        this._backgroundElement.style.opacity = '0';
-        if (this._placement.startsWith('top')) {
-          this._backgroundElement.style.top = '0';
-          this._backgroundElement.style.backgroundImage =
-            'linear-gradient(180deg, rgba(38, 38, 38, .6) 0%, rgba(38, 38, 38, 0) 100% )';
-        } else {
-          this._backgroundElement.style.bottom = '0';
-          this._backgroundElement.style.backgroundImage =
-            'linear-gradient(0deg, rgba(38, 38, 38, .6) 0%, rgba(38, 38, 38, 0) 100% )';
-        }
       }
+      this.updateMargin(height);
+      if (this._linkElement) {
+        this.updateElementMargins(this._linkElement);
+      }
+    }
 
-      private setupAnimations() {
-        // Necessary to trigger fade in transition
-        requestAnimationFrame(() => {
-          // Display the watermark
-          setTimeout(() => {
+    private addWatermarkToGameContainer(container: HTMLElement) {
+      const gameContainerRectangle = container.getBoundingClientRect();
+      this.updateFontSize(gameContainerRectangle.height);
+      this.updateLogoSize(gameContainerRectangle.height);
+      this.updateBackgroundHeight(gameContainerRectangle.height);
+
+      this._containerElement = this.createDivContainer();
+      this.createBackground();
+      const textContainer = document.createElement('div');
+
+      this.generateSVGLogo(gameContainerRectangle.height);
+      this.createMadeWithTextElement();
+      this.createUsernameTextElement();
+
+      this._linkElement = this.createLinkElement();
+
+      if (this._svgElement)
+        this._containerElement.appendChild(this._svgElement);
+      if (this._madeWithTextElement)
+        textContainer.appendChild(this._madeWithTextElement);
+      if (this._usernameTextElement)
+        textContainer.appendChild(this._usernameTextElement);
+      this._containerElement.appendChild(textContainer);
+      if (this._backgroundElement)
+        container.appendChild(this._backgroundElement);
+
+      this._linkElement.append(this._containerElement);
+      container.appendChild(this._linkElement);
+
+      this.setupAnimations();
+    }
+
+    private createBackground() {
+      this._backgroundElement = document.createElement('div');
+      this._backgroundElement.setAttribute('id', 'watermark-background');
+      this._backgroundElement.style.height = `${this._backgroundHeight}px`;
+      this._backgroundElement.style.opacity = '0';
+      if (this._placement.startsWith('top')) {
+        this._backgroundElement.style.top = '0';
+        this._backgroundElement.style.backgroundImage =
+          'linear-gradient(180deg, rgba(38, 38, 38, .6) 0%, rgba(38, 38, 38, 0) 100% )';
+      } else {
+        this._backgroundElement.style.bottom = '0';
+        this._backgroundElement.style.backgroundImage =
+          'linear-gradient(0deg, rgba(38, 38, 38, .6) 0%, rgba(38, 38, 38, 0) 100% )';
+      }
+    }
+
+    private setupAnimations() {
+      // Necessary to trigger fade in transition
+      requestAnimationFrame(() => {
+        // Display the watermark
+        setTimeout(() => {
+          if (
+            !this._containerElement ||
+            !this._backgroundElement ||
+            !this._linkElement
+          )
+            return;
+          this._containerElement.style.opacity = '1';
+          this._backgroundElement.style.opacity = '1';
+          this._linkElement.style.pointerEvents = 'all';
+          if (this._svgElement) this._svgElement.classList.add('spinning');
+        }, this._fadeInDelayAfterGameLoaded * 1000);
+      });
+
+      // Hide the watermark
+      this._fadeOutTimeout = setTimeout(() => {
+        if (!this._containerElement || !this._backgroundElement) {
+          return;
+        }
+        this._containerElement.style.opacity = '0';
+        this._backgroundElement.style.opacity = '0';
+
+        // Completely remove the watermark once the fade out duration has ended.
+        this._hideTimeout = setTimeout(
+          () => {
             if (
               !this._containerElement ||
               !this._backgroundElement ||
               !this._linkElement
             )
               return;
-            this._containerElement.style.opacity = '1';
-            this._backgroundElement.style.opacity = '1';
-            this._linkElement.style.pointerEvents = 'all';
-            if (this._svgElement) this._svgElement.classList.add('spinning');
-          }, this._fadeInDelayAfterGameLoaded * 1000);
-        });
+            this._linkElement.style.pointerEvents = 'none';
+            this._containerElement.style.display = 'none';
+            this._backgroundElement.style.display = 'none';
+            if (this._resizeObserver) this._resizeObserver.disconnect();
+          },
+          // Deactivate all interaction possibilities with watermark at
+          // the end of the animation to make sure it doesn't deactivate too early
+          this._fadeDuration * 1000
+        );
+      }, (this._fadeInDelayAfterGameLoaded + this._displayDuration) * 1000);
 
-        // Hide the watermark
-        this._fadeOutTimeout = setTimeout(() => {
-          if (!this._containerElement || !this._backgroundElement) {
-            return;
-          }
-          this._containerElement.style.opacity = '0';
-          this._backgroundElement.style.opacity = '0';
+      // Change text below watermark
+      this._fadeOutFirstTextTimeout = setTimeout(() => {
+        const { _madeWithTextElement, _usernameTextElement } = this;
+        if (!_madeWithTextElement) return;
 
-          // Completely remove the watermark once the fade out duration has ended.
-          this._hideTimeout = setTimeout(
-            () => {
-              if (
-                !this._containerElement ||
-                !this._backgroundElement ||
-                !this._linkElement
-              )
-                return;
-              this._linkElement.style.pointerEvents = 'none';
-              this._containerElement.style.display = 'none';
-              this._backgroundElement.style.display = 'none';
-              if (this._resizeObserver) this._resizeObserver.disconnect();
-            },
-            // Deactivate all interaction possibilities with watermark at
-            // the end of the animation to make sure it doesn't deactivate too early
-            this._fadeDuration * 1000
-          );
-        }, (this._fadeInDelayAfterGameLoaded + this._displayDuration) * 1000);
+        // Do not hide madeWith text if there is no author username to display.
+        if (_usernameTextElement) {
+          _madeWithTextElement.style.opacity = '0';
+          this._fadeInSecondTextTimeout = setTimeout(() => {
+            _usernameTextElement.style.lineHeight = 'normal';
+            _usernameTextElement.style.opacity = '1';
+            _madeWithTextElement.style.lineHeight = '0';
+          }, this._fadeDuration * 1000);
+        }
+      }, (this._fadeInDelayAfterGameLoaded + this._changeTextDelay) * 1000);
+    }
 
-        // Change text below watermark
-        this._fadeOutFirstTextTimeout = setTimeout(() => {
-          const { _madeWithTextElement, _usernameTextElement } = this;
-          if (!_madeWithTextElement) return;
+    private createMadeWithTextElement() {
+      this._madeWithTextElement = document.createElement('span');
+      this._madeWithTextElement.innerText = 'Made with GDevelop';
+      this._madeWithTextElement.style.fontSize = `${this._textFontSize}px`;
+    }
 
-          // Do not hide madeWith text if there is no author username to display.
-          if (_usernameTextElement) {
-            _madeWithTextElement.style.opacity = '0';
-            this._fadeInSecondTextTimeout = setTimeout(() => {
-              _usernameTextElement.style.lineHeight = 'normal';
-              _usernameTextElement.style.opacity = '1';
-              _madeWithTextElement.style.lineHeight = '0';
-            }, this._fadeDuration * 1000);
-          }
-        }, (this._fadeInDelayAfterGameLoaded + this._changeTextDelay) * 1000);
+    private createUsernameTextElement() {
+      if (!this._authorUsername) return;
+      this._usernameTextElement = document.createElement('span');
+      this._usernameTextElement.innerText = `@${this._authorUsername}`;
+      this._usernameTextElement.style.fontSize = `${this._textFontSize}px`;
+      this._usernameTextElement.style.opacity = '0';
+      this._usernameTextElement.style.lineHeight = '0';
+    }
+
+    private updateElementMargins(element: HTMLElement) {
+      switch (this._placement) {
+        case 'top-left':
+          element.style.top = `${this._margin}px`;
+          element.style.left = `${this._margin}px`;
+          break;
+        case 'top-right':
+          element.style.top = `${this._margin}px`;
+          element.style.right = `${this._margin}px`;
+          break;
+        case 'bottom-left':
+          element.style.bottom = `${this._margin}px`;
+          element.style.left = `${this._margin}px`;
+          break;
+        case 'bottom-right':
+          element.style.bottom = `${this._margin}px`;
+          element.style.right = `${this._margin}px`;
+          break;
+        case 'top':
+          element.style.top = `${this._margin}px`;
+          element.style.left = '50%';
+          element.style.transform = 'translate(-50%, 0)';
+          break;
+        case 'bottom':
+        default:
+          element.style.bottom = `${this._margin}px`;
+          element.style.left = '50%';
+          element.style.transform = 'translate(-50%, 0)';
+          break;
       }
+    }
 
-      private createMadeWithTextElement() {
-        this._madeWithTextElement = document.createElement('span');
-        this._madeWithTextElement.innerText = 'Made with GDevelop';
-        this._madeWithTextElement.style.fontSize = `${this._textFontSize}px`;
-      }
+    private createLinkElement(): HTMLAnchorElement {
+      const linkElement = document.createElement('a');
+      linkElement.id = 'watermark-link';
 
-      private createUsernameTextElement() {
-        if (!this._authorUsername) return;
-        this._usernameTextElement = document.createElement('span');
-        this._usernameTextElement.innerText = `@${this._authorUsername}`;
-        this._usernameTextElement.style.fontSize = `${this._textFontSize}px`;
-        this._usernameTextElement.style.opacity = '0';
-        this._usernameTextElement.style.lineHeight = '0';
-      }
+      let targetUrl = this._authorUsername
+        ? new URL(`https://gd.games/${this._authorUsername}`)
+        : new URL('https://gd.games');
 
-      private updateElementMargins(element: HTMLElement) {
-        switch (this._placement) {
-          case 'top-left':
-            element.style.top = `${this._margin}px`;
-            element.style.left = `${this._margin}px`;
-            break;
-          case 'top-right':
-            element.style.top = `${this._margin}px`;
-            element.style.right = `${this._margin}px`;
-            break;
-          case 'bottom-left':
-            element.style.bottom = `${this._margin}px`;
-            element.style.left = `${this._margin}px`;
-            break;
-          case 'bottom-right':
-            element.style.bottom = `${this._margin}px`;
-            element.style.right = `${this._margin}px`;
-            break;
-          case 'top':
-            element.style.top = `${this._margin}px`;
-            element.style.left = '50%';
-            element.style.transform = 'translate(-50%, 0)';
-            break;
-          case 'bottom':
-          default:
-            element.style.bottom = `${this._margin}px`;
-            element.style.left = '50%';
-            element.style.transform = 'translate(-50%, 0)';
-            break;
+      if (this._isDevEnvironment) {
+        targetUrl.searchParams.set('dev', 'true');
+      } else {
+        targetUrl.searchParams.set('utm_source', 'gdevelop-game');
+        targetUrl.searchParams.set('utm_medium', 'game-watermark');
+
+        if (this._gameId) {
+          targetUrl.searchParams.set('utm_campaign', this._gameId);
         }
       }
+      linkElement.href = targetUrl.href;
+      linkElement.target = '_blank';
 
-      private createLinkElement(): HTMLAnchorElement {
-        const linkElement = document.createElement('a');
-        linkElement.id = 'watermark-link';
+      this.updateElementMargins(linkElement);
 
-        let targetUrl = this._authorUsername
-          ? new URL(`https://gd.games/${this._authorUsername}`)
-          : new URL('https://gd.games');
+      return linkElement;
+    }
 
-        if (this._isDevEnvironment) {
-          targetUrl.searchParams.set('dev', 'true');
-        } else {
-          targetUrl.searchParams.set('utm_source', 'gdevelop-game');
-          targetUrl.searchParams.set('utm_medium', 'game-watermark');
+    private createDivContainer(): HTMLDivElement {
+      const divContainer = document.createElement('div');
+      divContainer.setAttribute('id', 'watermark');
 
-          if (this._gameId) {
-            targetUrl.searchParams.set('utm_campaign', this._gameId);
-          }
-        }
-        linkElement.href = targetUrl.href;
-        linkElement.target = '_blank';
+      divContainer.style.opacity = '0';
+      return divContainer;
+    }
 
-        this.updateElementMargins(linkElement);
+    private generateSVGLogo(height: number) {
+      this._svgElement = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      );
 
-        return linkElement;
-      }
+      this.updateLogoSize(height);
+      this._svgElement.setAttribute('height', this._logoHeight.toString());
+      this._svgElement.setAttribute('width', this._logoWidth.toString());
+      this._svgElement.setAttribute('viewBox', '-2 -2 59 48');
+      this._svgElement.setAttribute('fill', 'none');
+      const path1 = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path'
+      );
+      const path2 = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path'
+      );
+      path1.setAttribute(
+        'd',
+        'M29.3447 33C25.1061 33 21.0255 31.8475 17.4207 29.3381C14.9081 27.5897 12 23.6418 12 16.9488C12 4.53178 18.3074 0 30.9827 0H53.8027L56 7.07232H32.7217C24.3558 7.07232 19.3813 7.72835 19.3813 16.9488C19.3813 19.9944 20.2354 22.1618 21.9933 23.574C24.9642 25.9612 30.7388 26.0628 34.2673 25.7208C34.2673 25.7208 35.715 21.0394 35.9534 20.2794C36.2327 19.3888 36.1104 19.1763 35.2392 19.1763C33.9808 19.1763 31.7185 19.1763 29.3175 19.1763C27.6349 19.1763 25.9818 18.3247 25.9818 16.2793C25.9818 14.3039 27.5198 13.1573 29.6281 13.1573C33.2786 13.1573 40.7969 13.1573 42.2041 13.1573C44.0489 13.1573 45.9315 13.4233 44.971 16.3601L39.8842 31.8734C39.8845 31.8738 35.7287 33 29.3447 33Z'
+      );
+      path2.setAttribute(
+        'd',
+        'M43.3039 35.3278C40.7894 37.1212 37.0648 38.1124 30.7449 38.1124C19.852 38.1124 11.8797 34.1251 8.62927 26.3952C7.0925 22.7415 7.24041 18.6005 7.24041 13H0.00129513C0.00129513 18.9056 -0.0984386 23.5361 1.45249 27.8011C5.51933 38.989 15.992 45 30.0606 45C43.6783 45 49.3213 41.0443 53 35.3278H43.3039Z'
+      );
+      this._svgElement.appendChild(path1);
+      this._svgElement.appendChild(path2);
+    }
 
-      private createDivContainer(): HTMLDivElement {
-        const divContainer = document.createElement('div');
-        divContainer.setAttribute('id', 'watermark');
-
-        divContainer.style.opacity = '0';
-        return divContainer;
-      }
-
-      private generateSVGLogo(height: number) {
-        this._svgElement = document.createElementNS(
-          'http://www.w3.org/2000/svg',
-          'svg'
-        );
-
-        this.updateLogoSize(height);
-        this._svgElement.setAttribute('height', this._logoHeight.toString());
-        this._svgElement.setAttribute('width', this._logoWidth.toString());
-        this._svgElement.setAttribute('viewBox', '-2 -2 59 48');
-        this._svgElement.setAttribute('fill', 'none');
-        const path1 = document.createElementNS(
-          'http://www.w3.org/2000/svg',
-          'path'
-        );
-        const path2 = document.createElementNS(
-          'http://www.w3.org/2000/svg',
-          'path'
-        );
-        path1.setAttribute(
-          'd',
-          'M29.3447 33C25.1061 33 21.0255 31.8475 17.4207 29.3381C14.9081 27.5897 12 23.6418 12 16.9488C12 4.53178 18.3074 0 30.9827 0H53.8027L56 7.07232H32.7217C24.3558 7.07232 19.3813 7.72835 19.3813 16.9488C19.3813 19.9944 20.2354 22.1618 21.9933 23.574C24.9642 25.9612 30.7388 26.0628 34.2673 25.7208C34.2673 25.7208 35.715 21.0394 35.9534 20.2794C36.2327 19.3888 36.1104 19.1763 35.2392 19.1763C33.9808 19.1763 31.7185 19.1763 29.3175 19.1763C27.6349 19.1763 25.9818 18.3247 25.9818 16.2793C25.9818 14.3039 27.5198 13.1573 29.6281 13.1573C33.2786 13.1573 40.7969 13.1573 42.2041 13.1573C44.0489 13.1573 45.9315 13.4233 44.971 16.3601L39.8842 31.8734C39.8845 31.8738 35.7287 33 29.3447 33Z'
-        );
-        path2.setAttribute(
-          'd',
-          'M43.3039 35.3278C40.7894 37.1212 37.0648 38.1124 30.7449 38.1124C19.852 38.1124 11.8797 34.1251 8.62927 26.3952C7.0925 22.7415 7.24041 18.6005 7.24041 13H0.00129513C0.00129513 18.9056 -0.0984386 23.5361 1.45249 27.8011C5.51933 38.989 15.992 45 30.0606 45C43.6783 45 49.3213 41.0443 53 35.3278H43.3039Z'
-        );
-        this._svgElement.appendChild(path1);
-        this._svgElement.appendChild(path2);
-      }
-
-      private addStyle() {
-        const styleElement = document.createElement('style');
-        styleElement.innerHTML = `
+    private addStyle() {
+      const styleElement = document.createElement('style');
+      styleElement.innerHTML = `
         @keyframes spin {
           0% {
             transform: rotate(0deg);
@@ -438,8 +437,11 @@ namespace gdjs {
           }
         }
         `;
-        document.head.appendChild(styleElement);
-      }
+      document.head.appendChild(styleElement);
     }
   }
+
+  export type RuntimeWatermark = RuntimeWatermarkDOMRenderer | undefined;
+  type RuntimeWatermarkClass = typeof RuntimeWatermarkDOMRenderer | undefined;
+  export const RuntimeWatermark: RuntimeWatermarkClass = RuntimeWatermarkDOMRenderer;
 }

--- a/GDJS/Runtime/scenestack.ts
+++ b/GDJS/Runtime/scenestack.ts
@@ -40,7 +40,7 @@ namespace gdjs {
 
         //Something special was requested by the current scene.
         if (request === gdjs.SceneChangeRequest.STOP_GAME) {
-          this._runtimeGame.getRenderer().stopGame();
+          this._runtimeGame.getRenderer()?.stopGame();
           return true;
         } else if (request === gdjs.SceneChangeRequest.POP_SCENE) {
           this.pop();

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -1268,7 +1268,7 @@ namespace gdjs {
       ) {
         return;
       }
-      this.setScaleX(newHeight / this._animationFrame.dimensions.height);
+      this.setScaleY(newHeight / this._animationFrame.dimensions.height);
     }
 
     setSize(newWidth: float, newHeight: float): void {

--- a/GDJS/tests/tests/runtimewatermark.js
+++ b/GDJS/tests/tests/runtimewatermark.js
@@ -29,9 +29,12 @@ describe('gdjs.RuntimeWatermark integration tests', () => {
 
       // Make sure the renderer is created (to test the real DOM element creation/update)
       const gameContainer = document.createElement('div');
+      // @ts-ignore In this testing environement the renderer is always defined
       runtimeGame.getRenderer().createStandardCanvas(gameContainer);
 
-      const watermark = runtimeGame._watermark;
+      const watermark = /** @type {Exclude<gdjs.RuntimeWatermark, undefined>} */ (
+        /** @type {unknown} */ (runtimeGame._watermark)
+      );
 
       expect(watermark._backgroundElement).to.be(null);
       expect(watermark._containerElement).to.be(null);
@@ -120,9 +123,12 @@ describe('gdjs.RuntimeWatermark integration tests', () => {
 
       // Make sure the renderer is created (to test the real DOM element creation/update)
       const gameContainer = document.createElement('div');
+      // @ts-ignore In this testing environement the renderer is always defined
       runtimeGame.getRenderer().createStandardCanvas(gameContainer);
 
-      const watermark = runtimeGame._watermark;
+      const watermark = /** @type {Exclude<gdjs.RuntimeWatermark, undefined>} */ (
+        /** @type {unknown} */ (runtimeGame._watermark)
+      );
 
       expect(watermark._backgroundElement).to.be(null);
       expect(watermark._containerElement).to.be(null);


### PR DESCRIPTION
This PR aims at uncoupling all core runtime classes of GDJS from their renderers. A few things have been done to that effect:

- The classes of the renderers have been marked as potentially undefined, enforcing the check of their presence before initializing an instance.
- The type of the classes instances have been marked as potentially undefined, forcing all classes that keeps a reference to a renderer class instance to check for undefined before every usage of a renderer class instance.
- Renderer classes assume the existence of each other, since they require each other to function, thus they use a non-null type cast (`x!`), other classes which only send messages to the renderer classes but do not (should not) rely on it check for existence (`x?`/`if(x) x`)
- When the RuntimeScene renderer is not present, the rendering related parts of the event loop (`updatePreRender`, `updatePostRender`, `render`...) are disabled
- Some state that was previously stored on renderers, like the tint for certain objects, have been moved to the object to be get and set even when a renderer is not present, to not break game logic that might depend on these
- Dimensions of the resources is crucial in GDJS to determine the base size/scale factor of an object, which in turn determines the AABB of the object, etc. Those dimensions were obtained from the renderer, and this PR addresses this only in-part. The obtaining of the base dimension has been moved to a method in RuntimeGame, and objects adapted to use that instead of the renderer provided base dimensions. However, the method in RuntimeGame still relies on the renderer classes to obtain the base size of a resource. The idea behind that move is that, in a follow-up PR, we will read the resources base size at export time and embed them in the resources project data, and RuntimeGame will read from that instead of relying on the renderers. We cannot put this on the managers of the individual resources types, since those are provided by the renderer.
- When the RuntimeGame renderer is not present, it will fallback to a `setImmediate`/`setTimeout` based game loop. Since there is no rendering when that happens, `setImmediate`/`setTimeout` is a better match than `requestAnimationFrame` since syncing with browser rendering is useless, and it will provide more ticks per second, and it is supported by NodeJS.

Although this PR does not fully adds support for those to GDJS yet, it paves the way for making server builds and multi-threading in GDevelop.

About performance, there may be an impact, but I believe it would be benign, since checks for undefined is something the JS engine is doing anyways on any property access?

### Overview of changes that require closer inspection

Those changes were made over multiple weeks so I hope I am not missing any. Here is a list of the parts that were not as simple as "add `if (this._renderer) ` in front of it", and how I decided to handle them:


#### 3D

I have very little experience with working with ThreeJS and the GDevelop 3D extension, and thus 3D is the one thing I haven't really adapted to work without a renderer. I plastered all the places that need to be changed with TODO comments, help would be welcome here! This PR can still be merged in spite of that - this will just need to be taken care of before GDJS truly supports being ran without renderers.

#### Shape Painter

The shape painter is by nature something graphical. However, its dimensions are defined by what is drawn inside of it, and those can be used for collision checks and may be depended on for the game logic to work properly. However, I believe this is too much of an edge case for it to justify the complexity required to implement computing of bounding box changes independently of the renderer, and thus implemented it as returning 0 for dimensions. I think it is fine to pass of to users as a "Gotcha" of server builds that the shape painter will not draw anything and as such its bounds will remain at 0.

#### Texts

Texts get their dimensions measured by looking at the texture size of the rendered image of the text. This is not possible without rendering, obviously. On a render-less build, exact text dimensions cannot be obtained, but it could be used for game logic, although ill-advised. To minimize potentially game-breaking impacts of the dimensions not being known, they are approximated by multiplying the amount of lines/the length of the biggest line with the font size when the renderer is not present.

#### Bitmap text

On other texts, the font size is set as a property of the object, but on Bitmap text, it is defined by the font file. Like the other resources, in a follow up PR we'll embed that font size on the resource data and get it from RuntimeGame. However, it does not yet call `RuntimeGame#getResourceBaseDimensions`, since when using the renderer to find the dimensions, two resources are needed (the image and bitmap font), however `getResourceBaseDimensions` cannot know which image to use for a given bitmap font (and it makes no sense for it to take in a second resource).

The bitmap fontsize will need to be adapted in the follow up PR that add export-time measuring of resources to get it from `RuntimeGame#getResourceBaseDimensions`.