### PR TITLE
Fixed action sentence for BBtext alignment

### DIFF
--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -176,7 +176,7 @@ module.exports = {
       )
       .setCategoryFullName(_('Text'))
       .addDefaultBehavior('EffectCapability::EffectBehavior')
-      .addDefaultBehavior("OpacityCapability::OpacityBehavior");
+      .addDefaultBehavior('OpacityCapability::OpacityBehavior');
 
     /**
      * Utility function to add both a setter and a getter to a property from a list.
@@ -398,7 +398,7 @@ module.exports = {
         conditionDescription: _('Check the current text alignment.'),
         conditionSentence: _('The text alignment of _PARAM0_ is _PARAM1_'),
         actionDescription: _('Change the alignment of the text.'),
-        actionSentence: _('Set text alignment of _PARAM0_ to _PARAM1_'),
+        actionSentence: _('text alignment'),
         expressionLabel: _('Get the text alignment'),
         expressionDescription: _('Get the text alignment'),
       },


### PR DESCRIPTION
Fixed action sentence for BBtext alignment.
Prettier also changed one line with double-quotes to single-quotes.

Thanks planktonfun for reporting this!

### Before:

![image](https://github.com/4ian/GDevelop/assets/8879811/4ec77698-b132-457b-8803-7ef0b3a77974)

### After:

![image](https://github.com/4ian/GDevelop/assets/8879811/0478319e-374a-4c21-ba33-54eec4f49370)

