### PR TITLE
Fix a 0-size frame buffer exception

### DIFF
--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -517,8 +517,9 @@ namespace gdjs {
       const height = this._oldHeight;
       const resolution = pixiRenderer.resolution;
       this._renderTexture = PIXI.RenderTexture.create({
-        width,
-        height,
+        // A size of 0 is forbidden by Pixi.
+        width: width || 100,
+        height: height || 100,
         resolution,
       });
       this._renderTexture.baseTexture.scaleMode = PIXI.SCALE_MODES.LINEAR;

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -623,8 +623,9 @@ export default class LayerRenderer {
     const height = this._oldHeight;
     const resolution = pixiRenderer.resolution;
     this._renderTexture = PIXI.RenderTexture.create({
-      width,
-      height,
+      // A size of 0 is forbidden by Pixi.
+      width: width || 100,
+      height: height || 100,
       resolution,
     });
     this._renderTexture.baseTexture.scaleMode = PIXI.SCALE_MODES.LINEAR;


### PR DESCRIPTION
It was done on the `resize`, but I forgot the `create`.
```JS
      // A size of 0 is forbidden by Pixi.
      this._renderTexture.resize(
        pixiRenderer.screen.width || 100,
        pixiRenderer.screen.height || 100
      );
```