### PR TITLE
Allow to use the new variable syntax for groups

### DIFF
--- a/Core/GDCore/IDE/Events/ExpressionValidator.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.cpp
@@ -98,8 +98,20 @@ bool ExpressionValidator::ValidateObjectVariableOrVariableOrProperty(
         return true; // We should have found a variable.
       }
 
-      if (!objectsContainersList.HasObjectOrGroupWithVariableNamed(identifier.identifierName, identifier.childIdentifierName)) {
+      auto variableExistence = objectsContainersList.HasObjectOrGroupWithVariableNamed(identifier.identifierName, identifier.childIdentifierName);
+
+      if (variableExistence == gd::ObjectsContainersList::DoesNotExist) {
         RaiseTypeError(_("This variable does not exist on this object or group."),
+                        identifier.identifierNameLocation);
+        return true; // We should have found a variable.
+      }
+      else if (variableExistence == gd::ObjectsContainersList::ExistsOnlyOnSomeObjectsOfTheGroup) {
+        RaiseTypeError(_("This variable only exists on some objects of the group. It must be declared for all objects."),
+                        identifier.identifierNameLocation);
+        return true; // We should have found a variable.
+      }
+      else if (variableExistence == gd::ObjectsContainersList::GroupIsEmpty) {
+        RaiseTypeError(_("This group is empty. Add an object to this group first."),
                         identifier.identifierNameLocation);
         return true; // We should have found a variable.
       }

--- a/Core/GDCore/IDE/Events/ExpressionValidator.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.cpp
@@ -102,12 +102,12 @@ bool ExpressionValidator::ValidateObjectVariableOrVariableOrProperty(
 
       if (variableExistence == gd::ObjectsContainersList::DoesNotExist) {
         RaiseTypeError(_("This variable does not exist on this object or group."),
-                        identifier.identifierNameLocation);
+                        identifier.childIdentifierNameLocation);
         return true; // We should have found a variable.
       }
       else if (variableExistence == gd::ObjectsContainersList::ExistsOnlyOnSomeObjectsOfTheGroup) {
         RaiseTypeError(_("This variable only exists on some objects of the group. It must be declared for all objects."),
-                        identifier.identifierNameLocation);
+                        identifier.childIdentifierNameLocation);
         return true; // We should have found a variable.
       }
       else if (variableExistence == gd::ObjectsContainersList::GroupIsEmpty) {

--- a/Core/GDCore/Project/Layout.cpp
+++ b/Core/GDCore/Project/Layout.cpp
@@ -451,7 +451,7 @@ gd::String GD_CORE_API GetTypeOfObject(const gd::ObjectsContainer& project,
     type = project.GetObject(name).GetType();
 
   // Search in groups.
-  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Currently, a group is considered as the "intersection" of all of its objects.
   // Search "groups is the intersection of its objects" in the codebase.
   else if (searchInGroups) {
     for (std::size_t i = 0; i < layout.GetObjectGroups().size(); ++i) {
@@ -545,7 +545,7 @@ std::vector<gd::String> GD_CORE_API GetBehaviorNamesInObjectOrGroup(
   }
 
   // Search in groups.
-  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Currently, a group is considered as the "intersection" of all of its objects.
   // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
@@ -606,7 +606,7 @@ bool GD_CORE_API HasBehaviorInObjectOrGroup(const gd::ObjectsContainer &project,
   }
 
   // Search in groups.
-  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Currently, a group is considered as the "intersection" of all of its objects.
   // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
@@ -656,7 +656,7 @@ bool GD_CORE_API IsDefaultBehavior(const gd::ObjectsContainer& project,
   }
 
   // Search in groups.
-  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Currently, a group is considered as the "intersection" of all of its objects.
   // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
@@ -706,7 +706,7 @@ gd::String GD_CORE_API GetTypeOfBehaviorInObjectOrGroup(const gd::ObjectsContain
   }
 
   // Search in groups.
-  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Currently, a group is considered as the "intersection" of all of its objects.
   // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
@@ -785,7 +785,7 @@ GetBehaviorsOfObject(const gd::ObjectsContainer& project,
   }
 
   // Search in groups
-  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Currently, a group is considered as the "intersection" of all of its objects.
   // Search "groups is the intersection of its objects" in the codebase.
   if (searchInGroups) {
     for (std::size_t i = 0; i < layout.GetObjectGroups().size(); ++i) {

--- a/Core/GDCore/Project/Layout.cpp
+++ b/Core/GDCore/Project/Layout.cpp
@@ -444,13 +444,15 @@ gd::String GD_CORE_API GetTypeOfObject(const gd::ObjectsContainer& project,
                                        bool searchInGroups) {
   gd::String type;
 
-  // Search in objects
+  // Search in objects.
   if (layout.HasObjectNamed(name))
     type = layout.GetObject(name).GetType();
   else if (project.HasObjectNamed(name))
     type = project.GetObject(name).GetType();
 
-  // Search in groups
+  // Search in groups.
+  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Search "groups is the intersection of its objects" in the codebase.
   else if (searchInGroups) {
     for (std::size_t i = 0; i < layout.GetObjectGroups().size(); ++i) {
       if (layout.GetObjectGroups()[i].GetName() == name) {
@@ -523,7 +525,7 @@ std::vector<gd::String> GD_CORE_API GetBehaviorNamesInObjectOrGroup(
     const gd::ObjectsContainer &project, const gd::ObjectsContainer &layout,
     const gd::String &objectOrGroupName, const gd::String &behaviorType,
     bool searchInGroups) {
-  // Search in objects
+  // Search in objects.
   if (layout.HasObjectNamed(objectOrGroupName)) {
     auto &object = layout.GetObject(objectOrGroupName);
     auto behaviorNames = object.GetAllBehaviorNames();
@@ -542,7 +544,9 @@ std::vector<gd::String> GD_CORE_API GetBehaviorNamesInObjectOrGroup(
     return behaviorNames;
   }
 
-  // Search in groups
+  // Search in groups.
+  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
     container = &layout;
@@ -554,12 +558,14 @@ std::vector<gd::String> GD_CORE_API GetBehaviorNamesInObjectOrGroup(
   }
   const vector<gd::String> &groupsObjects =
       container->GetObjectGroups().Get(objectOrGroupName).GetAllObjectsNames();
+
   // Empty groups don't contain any behavior.
   if (groupsObjects.empty()) {
     std::vector<gd::String> behaviorNames;
     return behaviorNames;
   }
 
+  // Compute the intersection of the behaviors of all objects.
   auto behaviorNames = GetBehaviorNamesInObjectOrGroup(
       project, layout, groupsObjects[0], behaviorType, false);
   for (size_t i = 1; i < groupsObjects.size(); i++) {
@@ -587,7 +593,7 @@ bool GD_CORE_API HasBehaviorInObjectOrGroup(const gd::ObjectsContainer &project,
                                             const gd::String &objectOrGroupName,
                                             const gd::String &behaviorName,
                                             bool searchInGroups) {
-  // Search in objects
+  // Search in objects.
   if (layout.HasObjectNamed(objectOrGroupName)) {
     return layout.GetObject(objectOrGroupName).HasBehaviorNamed(behaviorName);
   }
@@ -599,7 +605,9 @@ bool GD_CORE_API HasBehaviorInObjectOrGroup(const gd::ObjectsContainer &project,
     return false;
   }
 
-  // Search in groups
+  // Search in groups.
+  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
     container = &layout;
@@ -610,10 +618,12 @@ bool GD_CORE_API HasBehaviorInObjectOrGroup(const gd::ObjectsContainer &project,
   }
   const vector<gd::String> &groupsObjects =
       container->GetObjectGroups().Get(objectOrGroupName).GetAllObjectsNames();
+
   // Empty groups don't contain any behavior.
   if (groupsObjects.empty()) {
     return false;
   }
+
   // Check that all objects have the behavior.
   for (auto &&object : groupsObjects) {
     if (!HasBehaviorInObjectOrGroup(project, layout, object, behaviorName,
@@ -629,7 +639,7 @@ bool GD_CORE_API IsDefaultBehavior(const gd::ObjectsContainer& project,
                                          gd::String objectOrGroupName,
                                          gd::String behaviorName,
                                          bool searchInGroups) {
-  // Search in objects
+  // Search in objects.
   if (layout.HasObjectNamed(objectOrGroupName)) {
     auto &object = layout.GetObject(objectOrGroupName);
     return object.HasBehaviorNamed(behaviorName) &&
@@ -645,7 +655,9 @@ bool GD_CORE_API IsDefaultBehavior(const gd::ObjectsContainer& project,
     return false;
   }
 
-  // Search in groups
+  // Search in groups.
+  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
     container = &layout;
@@ -656,10 +668,12 @@ bool GD_CORE_API IsDefaultBehavior(const gd::ObjectsContainer& project,
   }
   const vector<gd::String> &groupsObjects =
       container->GetObjectGroups().Get(objectOrGroupName).GetAllObjectsNames();
+
   // Empty groups don't contain any behavior.
   if (groupsObjects.empty()) {
     return false;
   }
+
   // Check that all objects have the same type.
   for (auto &&object : groupsObjects) {
     if (!IsDefaultBehavior(project, layout, object, behaviorName,
@@ -675,7 +689,7 @@ gd::String GD_CORE_API GetTypeOfBehaviorInObjectOrGroup(const gd::ObjectsContain
                                          const gd::String& objectOrGroupName,
                                          const gd::String& behaviorName,
                                          bool searchInGroups) {
-  // Search in objects
+  // Search in objects.
   if (layout.HasObjectNamed(objectOrGroupName)) {
     auto &object = layout.GetObject(objectOrGroupName);
     return object.HasBehaviorNamed(behaviorName) ?
@@ -691,7 +705,9 @@ gd::String GD_CORE_API GetTypeOfBehaviorInObjectOrGroup(const gd::ObjectsContain
     return "";
   }
 
-  // Search in groups
+  // Search in groups.
+  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Search "groups is the intersection of its objects" in the codebase.
   const gd::ObjectsContainer *container;
   if (layout.GetObjectGroups().Has(objectOrGroupName)) {
     container = &layout;
@@ -702,10 +718,12 @@ gd::String GD_CORE_API GetTypeOfBehaviorInObjectOrGroup(const gd::ObjectsContain
   }
   const vector<gd::String> &groupsObjects =
       container->GetObjectGroups().Get(objectOrGroupName).GetAllObjectsNames();
+
   // Empty groups don't contain any behavior.
   if (groupsObjects.empty()) {
     return "";
   }
+
   // Check that all objects have the behavior with the same type.
   auto behaviorType = GetTypeOfBehaviorInObjectOrGroup(
       project, layout, groupsObjects[0], behaviorName, false);
@@ -767,6 +785,8 @@ GetBehaviorsOfObject(const gd::ObjectsContainer& project,
   }
 
   // Search in groups
+  // Currently, a groups is considered as the "intersection" of all of its objects.
+  // Search "groups is the intersection of its objects" in the codebase.
   if (searchInGroups) {
     for (std::size_t i = 0; i < layout.GetObjectGroups().size(); ++i) {
       if (layout.GetObjectGroups()[i].GetName() == name) {

--- a/Core/GDCore/Project/ObjectsContainer.cpp
+++ b/Core/GDCore/Project/ObjectsContainer.cpp
@@ -48,17 +48,17 @@ void ObjectsContainer::UnserializeObjectsFrom(
 bool ObjectsContainer::HasObjectNamed(const gd::String& name) const {
   return (find_if(initialObjects.begin(),
                   initialObjects.end(),
-                  bind2nd(gd::ObjectHasName(), name)) != initialObjects.end());
+                  [&](const std::unique_ptr<gd::Object>& object) { return object->GetName() == name; }) != initialObjects.end());
 }
 gd::Object& ObjectsContainer::GetObject(const gd::String& name) {
   return *(*find_if(initialObjects.begin(),
                     initialObjects.end(),
-                    bind2nd(gd::ObjectHasName(), name)));
+                    [&](const std::unique_ptr<gd::Object>& object) { return object->GetName() == name; }));
 }
 const gd::Object& ObjectsContainer::GetObject(const gd::String& name) const {
   return *(*find_if(initialObjects.begin(),
                     initialObjects.end(),
-                    bind2nd(gd::ObjectHasName(), name)));
+                    [&](const std::unique_ptr<gd::Object>& object) { return object->GetName() == name; }));
 }
 gd::Object& ObjectsContainer::GetObject(std::size_t index) {
   return *initialObjects[index];
@@ -120,7 +120,7 @@ void ObjectsContainer::RemoveObject(const gd::String& name) {
   std::vector<std::unique_ptr<gd::Object>>::iterator objectIt =
       find_if(initialObjects.begin(),
               initialObjects.end(),
-              bind2nd(ObjectHasName(), name));
+              [&](const std::unique_ptr<gd::Object>& object) { return object->GetName() == name; });
   if (objectIt == initialObjects.end()) return;
 
   initialObjects.erase(objectIt);
@@ -133,7 +133,7 @@ void ObjectsContainer::MoveObjectToAnotherContainer(
   std::vector<std::unique_ptr<gd::Object>>::iterator objectIt =
       find_if(initialObjects.begin(),
               initialObjects.end(),
-              bind2nd(ObjectHasName(), name));
+              [&](const std::unique_ptr<gd::Object>& object) { return object->GetName() == name; });
   if (objectIt == initialObjects.end()) return;
 
   std::unique_ptr<gd::Object> object = std::move(*objectIt);

--- a/Core/GDCore/Project/ObjectsContainersList.cpp
+++ b/Core/GDCore/Project/ObjectsContainersList.cpp
@@ -65,7 +65,7 @@ ObjectsContainersList::HasObjectOrGroupWithVariableNamed(
     if ((*it)->GetObjectGroups().Has(objectOrGroupName)) {
       // This could be adapted if objects groups have variables in the future.
 
-      // Currently, a groups is considered as the "intersection" of all of its
+      // Currently, a group is considered as the "intersection" of all of its
       // objects. Search "groups is the intersection of its objects" in the
       // codebase. Consider that a group has a variable if all objects of the
       // group have it:
@@ -163,7 +163,7 @@ void ObjectsContainersList::ForEachObjectOrGroupVariableWithPrefix(
     if ((*it)->GetObjectGroups().Has(objectOrGroupName)) {
       // This could be adapted if objects groups have variables in the future.
 
-      // Currently, a groups is considered as the "intersection" of all of its
+      // Currently, a group is considered as the "intersection" of all of its
       // objects. Search "groups is the intersection of its objects" in the
       // codebase. Consider that a group has a variable if all objects of the
       // group have it:

--- a/Core/GDCore/Project/ObjectsContainersList.cpp
+++ b/Core/GDCore/Project/ObjectsContainersList.cpp
@@ -51,36 +51,53 @@ bool ObjectsContainersList::HasObjectNamed(const gd::String& name) const {
   return false;
 }
 
-bool ObjectsContainersList::HasObjectOrGroupWithVariableNamed(
+ObjectsContainersList::VariableExistence
+ObjectsContainersList::HasObjectOrGroupWithVariableNamed(
     const gd::String& objectOrGroupName, const gd::String& variableName) const {
   for (auto it = objectsContainers.rbegin(); it != objectsContainers.rend();
        ++it) {
     if ((*it)->HasObjectNamed(objectOrGroupName)) {
       const auto& variables =
           (*it)->GetObject(objectOrGroupName).GetVariables();
-      return variables.Has(variableName);
+      return variables.Has(variableName) ? VariableExistence::Exists
+                                         : VariableExistence::DoesNotExist;
     }
     if ((*it)->GetObjectGroups().Has(objectOrGroupName)) {
       // This could be adapted if objects groups have variables in the future.
 
-      // Currently, a groups is considered as the "intersection" of all of its objects.
-      // Search "groups is the intersection of its objects" in the codebase.
-      // Consider that a group has a variable if all objects of the group have it:
+      // Currently, a groups is considered as the "intersection" of all of its
+      // objects. Search "groups is the intersection of its objects" in the
+      // codebase. Consider that a group has a variable if all objects of the
+      // group have it:
       const auto& objectGroup = (*it)->GetObjectGroups().Get(objectOrGroupName);
       const auto& objectNames = objectGroup.GetAllObjectsNames();
-      if (objectNames.empty()) return false;
+      if (objectNames.empty()) return VariableExistence::GroupIsEmpty;
 
-      for(const auto& objectName: objectNames) {
+      bool existsOnAtLeastOneObject = false;
+      bool missingOnAtLeastOneObject = false;
+      for (const auto& objectName : objectNames) {
         if (!HasObjectWithVariableNamed(objectName, variableName)) {
-          return false;
+          missingOnAtLeastOneObject = true;
+          if (existsOnAtLeastOneObject) {
+            return VariableExistence::ExistsOnlyOnSomeObjectsOfTheGroup;
+          }
+        } else {
+          existsOnAtLeastOneObject = true;
+          if (missingOnAtLeastOneObject) {
+            return VariableExistence::ExistsOnlyOnSomeObjectsOfTheGroup;
+          }
         }
       }
 
-      return true;
+      if (missingOnAtLeastOneObject) {
+        return VariableExistence::DoesNotExist;
+      }
+
+      return VariableExistence::Exists;
     }
   }
 
-  return false;
+  return VariableExistence::DoesNotExist;
 }
 
 bool ObjectsContainersList::HasObjectWithVariableNamed(
@@ -107,6 +124,7 @@ bool ObjectsContainersList::HasVariablesContainer(
     }
     if ((*it)->GetObjectGroups().Has(objectOrGroupName)) {
       // Could be adapted if objects groups have variables in the future.
+      // This would allow handling the renaming of variables of an object group.
     }
   }
 
@@ -123,13 +141,18 @@ ObjectsContainersList::GetObjectOrGroupVariablesContainer(
     }
     if ((*it)->GetObjectGroups().Has(objectOrGroupName)) {
       // Could be adapted if objects groups have variables in the future.
+      // This would allow handling the renaming of variables of an object group.
     }
   }
 
   return nullptr;
 }
 
-void ObjectsContainersList::ForEachObjectOrGroupVariableWithPrefix(const gd::String& objectOrGroupName, const gd::String& prefix, std::function<void(const gd::String& variableName, const gd::Variable& variable)> fn) const {
+void ObjectsContainersList::ForEachObjectOrGroupVariableWithPrefix(
+    const gd::String& objectOrGroupName,
+    const gd::String& prefix,
+    std::function<void(const gd::String& variableName,
+                       const gd::Variable& variable)> fn) const {
   for (auto it = objectsContainers.rbegin(); it != objectsContainers.rend();
        ++it) {
     if ((*it)->HasObjectNamed(objectOrGroupName)) {
@@ -140,30 +163,39 @@ void ObjectsContainersList::ForEachObjectOrGroupVariableWithPrefix(const gd::Str
     if ((*it)->GetObjectGroups().Has(objectOrGroupName)) {
       // This could be adapted if objects groups have variables in the future.
 
-      // Currently, a groups is considered as the "intersection" of all of its objects.
-      // Search "groups is the intersection of its objects" in the codebase.
-      // Consider that a group has a variable if all objects of the group have it:
+      // Currently, a groups is considered as the "intersection" of all of its
+      // objects. Search "groups is the intersection of its objects" in the
+      // codebase. Consider that a group has a variable if all objects of the
+      // group have it:
       const auto& objectGroup = (*it)->GetObjectGroups().Get(objectOrGroupName);
       const auto& objectNames = objectGroup.GetAllObjectsNames();
 
       if (objectNames.empty()) return;
       const auto& firstObjectName = objectNames.front();
-      ForEachObjectVariableWithPrefix(firstObjectName, prefix, [&](const gd::String& variableName, const gd::Variable& variable) {
-        for(const auto& objectName: objectGroup.GetAllObjectsNames()) {
-          if (!HasObjectWithVariableNamed(objectName, variableName)) {
-            return; // This variable is not shared by all objects of the group.
-          }
-        }
+      ForEachObjectVariableWithPrefix(
+          firstObjectName,
+          prefix,
+          [&](const gd::String& variableName, const gd::Variable& variable) {
+            for (const auto& objectName : objectGroup.GetAllObjectsNames()) {
+              if (!HasObjectWithVariableNamed(objectName, variableName)) {
+                return;  // This variable is not shared by all objects of the
+                         // group.
+              }
+            }
 
-        // This variable is shared by all objects in the group. Note that other objects
-        // can have it with a different type - we allow this.
-        fn(variableName, variable);
-      });
+            // This variable is shared by all objects in the group. Note that
+            // other objects can have it with a different type - we allow this.
+            fn(variableName, variable);
+          });
     }
   }
 }
 
-void ObjectsContainersList::ForEachObjectVariableWithPrefix(const gd::String& objectOrGroupName, const gd::String& prefix, std::function<void(const gd::String& variableName, const gd::Variable& variable)> fn) const {
+void ObjectsContainersList::ForEachObjectVariableWithPrefix(
+    const gd::String& objectOrGroupName,
+    const gd::String& prefix,
+    std::function<void(const gd::String& variableName,
+                       const gd::Variable& variable)> fn) const {
   for (auto it = objectsContainers.rbegin(); it != objectsContainers.rend();
        ++it) {
     if ((*it)->HasObjectNamed(objectOrGroupName)) {
@@ -302,8 +334,10 @@ gd::String ObjectsContainersList::GetTypeOfBehavior(
         "ObjectsContainersList::GetTypeOfObject called with objectsContainers "
         "not being exactly 2. This is a logical error and will crash.");
   }
-  return gd::GetTypeOfBehavior(
-      *objectsContainers[0], *objectsContainers[1], behaviorName, searchInGroups);
+  return gd::GetTypeOfBehavior(*objectsContainers[0],
+                               *objectsContainers[1],
+                               behaviorName,
+                               searchInGroups);
 }
 
 std::vector<gd::String> ObjectsContainersList::GetBehaviorsOfObject(

--- a/Core/GDCore/Project/ObjectsContainersList.h
+++ b/Core/GDCore/Project/ObjectsContainersList.h
@@ -125,12 +125,21 @@ class GD_CORE_API ObjectsContainersList {
    */
   void ForEachNameWithPrefix(const gd::String& prefix, std::function<void(const gd::String& name, const gd::ObjectConfiguration* objectConfiguration)> fn) const;
 
+  /**
+   * \brief Call the callback for each variable of the object (or group) starting with the prefix passed in parameter.
+   */
+  void ForEachObjectOrGroupVariableWithPrefix(const gd::String& objectOrGroupName, const gd::String& prefix, std::function<void(const gd::String& variableName, const gd::Variable& variable)> fn) const;
+
   /** Do not use - should be private but accessible to let Emscripten create a
    * temporary. */
   ObjectsContainersList(){};
 
  private:
   bool HasObjectNamed(const gd::String& name) const;
+
+  bool HasObjectWithVariableNamed(const gd::String& objectName, const gd::String& variableName) const;
+
+  void ForEachObjectVariableWithPrefix(const gd::String& objectOrGroupName, const gd::String& prefix, std::function<void(const gd::String& variableName, const gd::Variable& variable)> fn) const;
 
   void Add(const gd::ObjectsContainer& objectsContainer) {
     objectsContainers.push_back(&objectsContainer);

--- a/Core/GDCore/Project/ObjectsContainersList.h
+++ b/Core/GDCore/Project/ObjectsContainersList.h
@@ -42,12 +42,20 @@ class GD_CORE_API ObjectsContainersList {
    */
   bool HasObjectOrGroupNamed(const gd::String& name) const;
 
+  enum VariableExistence {
+    DoesNotExist,
+    Exists,
+    GroupIsEmpty,
+    ExistsOnlyOnSomeObjectsOfTheGroup
+  };
+
   /**
    * \brief Check if the specified object or group has the specified variable in
    * its declared variables.
    */
-  bool HasObjectOrGroupWithVariableNamed(const gd::String& objectOrGroupName,
-                                         const gd::String& variableName) const;
+  VariableExistence HasObjectOrGroupWithVariableNamed(
+      const gd::String& objectOrGroupName,
+      const gd::String& variableName) const;
 
   /**
    * \brief Check if the specified object or group has the specified variables
@@ -81,18 +89,21 @@ class GD_CORE_API ObjectsContainersList {
                                   const gd::String& behaviorName) const;
 
   /**
-    * \brief Get the type of a behavior if an object or all objects of a group has it.
-    */
-  gd::String GetTypeOfBehaviorInObjectOrGroup(const gd::String &objectOrGroupName,
-                                              const gd::String &behaviorName,
-                                              bool searchInGroups = true) const;
+   * \brief Get the type of a behavior if an object or all objects of a group
+   * has it.
+   */
+  gd::String GetTypeOfBehaviorInObjectOrGroup(
+      const gd::String& objectOrGroupName,
+      const gd::String& behaviorName,
+      bool searchInGroups = true) const;
 
   /**
    * \brief Get a type from a behavior name
    * @return Type of the behavior.
    * @deprecated - Use GetTypeOfBehaviorInObjectOrGroup instead.
    */
-  gd::String GetTypeOfBehavior(const gd::String& behaviorName, bool searchInGroups = true) const;
+  gd::String GetTypeOfBehavior(const gd::String& behaviorName,
+                               bool searchInGroups = true) const;
 
   /**
    * \brief Get behaviors of an object/group
@@ -101,9 +112,8 @@ class GD_CORE_API ObjectsContainersList {
    *
    * @return Vector containing names of behaviors
    */
-  std::vector<gd::String>
-  GetBehaviorsOfObject(const gd::String& objectName,
-                       bool searchInGroups = true) const;
+  std::vector<gd::String> GetBehaviorsOfObject(
+      const gd::String& objectName, bool searchInGroups = true) const;
 
   /**
    * \brief Return a list containing all objects refered to by the group.
@@ -121,14 +131,24 @@ class GD_CORE_API ObjectsContainersList {
   void ForEachObject(std::function<void(const gd::Object& object)> fn) const;
 
   /**
-   * \brief Call the callback for each object or group name starting with the prefix passed in parameter.
+   * \brief Call the callback for each object or group name starting with the
+   * prefix passed in parameter.
    */
-  void ForEachNameWithPrefix(const gd::String& prefix, std::function<void(const gd::String& name, const gd::ObjectConfiguration* objectConfiguration)> fn) const;
+  void ForEachNameWithPrefix(
+      const gd::String& prefix,
+      std::function<void(const gd::String& name,
+                         const gd::ObjectConfiguration* objectConfiguration)>
+          fn) const;
 
   /**
-   * \brief Call the callback for each variable of the object (or group) starting with the prefix passed in parameter.
+   * \brief Call the callback for each variable of the object (or group)
+   * starting with the prefix passed in parameter.
    */
-  void ForEachObjectOrGroupVariableWithPrefix(const gd::String& objectOrGroupName, const gd::String& prefix, std::function<void(const gd::String& variableName, const gd::Variable& variable)> fn) const;
+  void ForEachObjectOrGroupVariableWithPrefix(
+      const gd::String& objectOrGroupName,
+      const gd::String& prefix,
+      std::function<void(const gd::String& variableName,
+                         const gd::Variable& variable)> fn) const;
 
   /** Do not use - should be private but accessible to let Emscripten create a
    * temporary. */
@@ -137,9 +157,14 @@ class GD_CORE_API ObjectsContainersList {
  private:
   bool HasObjectNamed(const gd::String& name) const;
 
-  bool HasObjectWithVariableNamed(const gd::String& objectName, const gd::String& variableName) const;
+  bool HasObjectWithVariableNamed(const gd::String& objectName,
+                                  const gd::String& variableName) const;
 
-  void ForEachObjectVariableWithPrefix(const gd::String& objectOrGroupName, const gd::String& prefix, std::function<void(const gd::String& variableName, const gd::Variable& variable)> fn) const;
+  void ForEachObjectVariableWithPrefix(
+      const gd::String& objectOrGroupName,
+      const gd::String& prefix,
+      std::function<void(const gd::String& variableName,
+                         const gd::Variable& variable)> fn) const;
 
   void Add(const gd::ObjectsContainer& objectsContainer) {
     objectsContainers.push_back(&objectsContainer);

--- a/Core/tests/ExpressionCodeGenerator.cpp
+++ b/Core/tests/ExpressionCodeGenerator.cpp
@@ -48,6 +48,10 @@ TEST_CASE("ExpressionCodeGenerator", "[common][events]") {
   group.AddObject("MyOtherSpriteObject");
   group.AddObject("FakeObjectWithDefaultBehavior");
 
+  auto &spriteGroup = layout1.GetObjectGroups().InsertNew("MySpriteObjects");
+  spriteGroup.AddObject("MySpriteObject");
+  spriteGroup.AddObject("MyOtherSpriteObject");
+
   gd::ExpressionParser2 parser;
 
   unsigned int maxDepth = 0;
@@ -612,6 +616,20 @@ TEST_CASE("ExpressionCodeGenerator", "[common][events]") {
       REQUIRE(node);
       node->Visit(expressionCodeGenerator);
       REQUIRE(expressionCodeGenerator.GetOutput() == "getVariableForObject(MySpriteObject, MyVariable).getAsNumber() + getVariableForObject(MySpriteObject, MyVariable2).getAsNumber()");
+    }
+  }
+  SECTION("Object variables (1 level, object group)") {
+    {
+      auto node =
+        parser.ParseExpression("MySpriteObjects.MyVariable + 1");
+      gd::ExpressionCodeGenerator expressionCodeGenerator("number",
+                                                          "",
+                                                          codeGenerator,
+                                                          context);
+
+      REQUIRE(node);
+      node->Visit(expressionCodeGenerator);
+      REQUIRE(expressionCodeGenerator.GetOutput() == "getVariableForObject(MySpriteObjects, MyVariable).getAsNumber() + 1");
     }
   }
   SECTION("Object variables (conflict with a scene variable)") {

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -3710,7 +3710,22 @@ describe('libGD.js', function () {
         0
       );
       object.getVariables().insertNew('MyObjectVariable', 0);
-      layout.insertNewObject(project, 'Sprite', 'MySpriteObject2', 1);
+      object.getVariables().insertNew('MyObjectGroupVariable1', 0);
+      object.getVariables().insertNew('MyObjectGroupVariable2', 0);
+      object.getVariables().insertNew('MyObjectGroupVariable3', 0);
+      const object2 = layout.insertNewObject(
+        project,
+        'Sprite',
+        'MySpriteObject2',
+        1
+      );
+      object2.getVariables().insertNew('MyObjectGroupVariable1', 0);
+      object2.getVariables().insertNew('MyObjectGroupVariable2', 0);
+      const objectGroup = layout
+        .getObjectGroups()
+        .insertNew('MyObjectGroup', 0);
+      objectGroup.addObject('MySpriteObject');
+      objectGroup.addObject('MySpriteObject2');
       layout.insertNewObject(project, 'Sprite', 'UnrelatedSpriteObject3', 2);
       layout.getVariables().insertNew('MyVariable', 0);
       layout.getVariables().insertNew('MyVariable2', 1);
@@ -3790,6 +3805,7 @@ Array [
   "{ 0, number, 1, no prefix, MySpriteObject, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, with object configuration }",
   "{ 0, number, 1, no prefix, MySpriteObject2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, with object configuration }",
   "{ 0, number, 1, no prefix, UnrelatedSpriteObject3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, with object configuration }",
+  "{ 0, number, 1, no prefix, MyObjectGroup, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, UnrelatedVariable3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
@@ -3814,6 +3830,7 @@ Array [
 Array [
   "{ 0, number, 1, no prefix, MySpriteObject, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, with object configuration }",
   "{ 0, number, 1, no prefix, MySpriteObject2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, with object configuration }",
+  "{ 0, number, 1, no prefix, MyObjectGroup, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyGlobalVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
@@ -3831,6 +3848,9 @@ Array [
       expect(testCompletions('number', '1 + MySpriteObject.My| '))
         .toMatchInlineSnapshot(`
 Array [
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyObjectVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 1, no type, 1, My, no completion, MySpriteObject, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 2, number, 1, My, no completion, MySpriteObject, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
@@ -3842,6 +3862,27 @@ Array [
 Array [
   "{ 1, no type, 1, Func, no completion, MySpriteObject, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 2, number, 1, Func, no completion, MySpriteObject, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+]
+`);
+    });
+
+    it('completes an expression with an object group function, behavior or variable', function () {
+      // List variables, expressions and behaviors, if all of them are present:
+      expect(testCompletions('number', '1 + MyObjectGroup.My| '))
+        .toMatchInlineSnapshot(`
+Array [
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 1, no type, 1, My, no completion, MyObjectGroup, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 2, number, 1, My, no completion, MyObjectGroup, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+]
+`);
+      // Only list expressions and behaviors if no matching variables:
+      expect(testCompletions('number', '1 + MyObjectGroup.Func| '))
+        .toMatchInlineSnapshot(`
+Array [
+  "{ 1, no type, 1, Func, no completion, MyObjectGroup, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 2, number, 1, Func, no completion, MyObjectGroup, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
 ]
 `);
     });
@@ -3861,6 +3902,7 @@ Array [
 Array [
   "{ 0, string, 1, no prefix, MySpriteObject, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, with object configuration }",
   "{ 0, string, 1, no prefix, MySpriteObject2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, with object configuration }",
+  "{ 0, string, 1, no prefix, MyObjectGroup, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyGlobalVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
@@ -3894,6 +3936,9 @@ Array [
       expect(testCompletions('number', '1 + MySpriteObject.Variable(My| '))
         .toMatchInlineSnapshot(`
 Array [
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyObjectVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
 ]
 `);
@@ -3904,7 +3949,32 @@ Array [
         )
       ).toMatchInlineSnapshot(`
 Array [
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
   "{ 3, no type, 1, no prefix, MyObjectVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+]
+`);
+    });
+
+    it('completes an expression parameters (group, legacy pre-scoped variable)', function () {
+      // Verify only the object group variable is autocompleted:
+      expect(testCompletions('number', '1 + MyObjectGroup.Variable(My| '))
+        .toMatchInlineSnapshot(`
+Array [
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+]
+`);
+      expect(
+        testCompletions(
+          'string',
+          '"Score:" + MyObjectGroup.VariableString(My| '
+        )
+      ).toMatchInlineSnapshot(`
+Array [
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+  "{ 3, no type, 1, no prefix, MyObjectGroupVariable1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
 ]
 `);
     });


### PR DESCRIPTION
- Autocompletion works, when a group contains objects that have all the same variables.
- The error message will be different if a group contains no object with the required variables, or only some objects.
- Code generation was already working - just had to tweak the validation.

<img width="585" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/ff81531e-d6c0-4307-bc1e-b358fc87b59c">
<img width="719" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/cb7ce2d0-26ec-40fb-9da9-d337a7db0afd">
<img width="539" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/9edff8fb-feaa-4f25-b0ae-300e5eeaca45">

