### PR TITLE
Fix "Help > About GDevelop" menu option for non-Mac users

### DIFF
--- a/newIDE/app/src/MainFrame/MainMenu.js
+++ b/newIDE/app/src/MainFrame/MainMenu.js
@@ -341,7 +341,7 @@ export const buildMainMenuDeclarativeTemplate = ({
         label: i18n._(t`Report a wrong translation`),
         onClickOpenLink: 'https://github.com/4ian/GDevelop/issues/969',
       },
-      ...(!isMacLike() && isApplicationTopLevelMenu
+      ...(!isMacLike()
         ? [
             { type: 'separator' },
             {


### PR DESCRIPTION
Fixes #5739.  This is working in the web app and in Electron!  I simply removed the check for top-level menu, since the Help menu is a submenu.  

Does anyone know why the top-level check was used?  Will there be regressions or side effects since I simply removed that condition?

@AlexandreSi For some reason, this PR is failing "npm test" and "npm flow".  Can anyone help me resolve those?

https://github.com/4ian/GDevelop/assets/8879811/279e8ad7-650c-41bd-a2a3-f00c46b20344
