### PR TITLE
Deactivate PixiJS accessibility plugin

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -109,6 +109,11 @@ namespace gdjs {
         gameCanvas = this._pixiRenderer.view as HTMLCanvasElement;
       }
 
+      // Deactivating accessibility support in PixiJS renderer, as we want to be in control of this.
+      // See https://github.com/pixijs/pixijs/issues/5111#issuecomment-420047824
+      this._pixiRenderer.plugins.accessibility.destroy();
+      delete this._pixiRenderer.plugins.accessibility;
+
       // Add the renderer view element to the DOM
       parentElement.appendChild(gameCanvas);
       this._gameCanvas = gameCanvas;


### PR DESCRIPTION
The plugin was introducing a button in the dom, which was triggered when pressing tab.

![image](https://github.com/4ian/GDevelop/assets/4895034/71c65ed5-32ed-476b-ba82-16421e103361)
