### PR TITLE
Use event which property rather than code property when possible

### DIFF
--- a/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
+++ b/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
@@ -3,37 +3,59 @@ import {
   getShortcutStringFromEvent,
   isValidShortcutEvent,
   getElectronAccelerator,
+  getShortcutDisplayName,
 } from './index';
 
 /**
  * Creates a KeyboardEvent-like object for testing
  * functions that take event objects as input
  */
-const makeKeyEvent = (ctrlKey, shiftKey, altKey, code): KeyboardEvent => {
+const makeKeyEvent = (
+  ctrlKey,
+  shiftKey,
+  altKey,
+  code,
+  which
+): KeyboardEvent => {
   // $FlowIgnore - create fake KeyboardEvent object
-  return { ctrlKey, shiftKey, altKey, code };
+  return { ctrlKey, shiftKey, altKey, code, which };
 };
 
-// Action key, with various modifiers
-const keyA = makeKeyEvent(false, false, false, 'KeyA'); // A
-const ctrlA = makeKeyEvent(true, false, false, 'KeyA'); // Ctrl+A
-const shiftA = makeKeyEvent(false, true, false, 'KeyA'); // Shift+A
-const altA = makeKeyEvent(false, false, true, 'KeyA'); // Alt+A
-const ctrlShiftAltA = makeKeyEvent(true, true, true, 'KeyA'); // Ctrl+Shift+Alt+A
+// Action key, with various modifiers, when code corresponds to key
+const keyA = makeKeyEvent(false, false, false, 'KeyA', 65); // A
+const ctrlA = makeKeyEvent(true, false, false, 'KeyA', 65); // Ctrl+A
+const shiftA = makeKeyEvent(false, true, false, 'KeyA', 65); // Shift+A
+const altA = makeKeyEvent(false, false, true, 'KeyA', 65); // Alt+A
+const ctrlShiftAltA = makeKeyEvent(true, true, true, 'KeyA', 65); // Ctrl+Shift+Alt+A
+
+// Action key, with various modifiers, when code does not correspond to key (m key on Azerty that is ; on Qwerty)
+const keyM = makeKeyEvent(false, false, false, 'Semicolon', 77); // M
+const ctrlM = makeKeyEvent(true, false, false, 'Semicolon', 77); // Ctrl+M
+const shiftM = makeKeyEvent(false, true, false, 'Semicolon', 77); // Shift+M
+const altM = makeKeyEvent(false, false, true, 'Semicolon', 77); // Alt+M
+const ctrlShiftAltM = makeKeyEvent(true, true, true, 'Semicolon', 77); // Ctrl+Shift+Alt+M
+
+// Action key, with various modifiers, when code does not correspond to key (, key on Azerty that is M on Qwerty)
+const keyComma = makeKeyEvent(false, false, false, 'KeyM', 188); // ,
+const ctrlComma = makeKeyEvent(true, false, false, 'KeyM', 188); // Ctrl+,
+// TODO: Find a way to handle using Question mark in azerty.
+// const shiftComma = makeKeyEvent(false, true, false, 'KeyM', 191); // Shift+, (Question mark?)
+const altComma = makeKeyEvent(false, false, true, 'KeyM', 188); // Alt+,
+const ctrlShiftAltComma = makeKeyEvent(true, true, true, 'KeyM', 188); // Ctrl+Shift+Alt+,
 
 // Partial or invalid shortcut keypresses
-const ctrlShiftAlt = makeKeyEvent(true, true, true, ''); // Ctrl+Shift+Alt+
-const ctrlShiftAltUp = makeKeyEvent(true, true, true, 'ArrowUp'); // Ctrl+Shift+Alt+Up
+const ctrlShiftAlt = makeKeyEvent(true, true, true, '', ''); // Ctrl+Shift+Alt+
+const ctrlShiftAltUp = makeKeyEvent(true, true, true, 'ArrowUp', 'ArrowUp'); // Ctrl+Shift+Alt+Up
 
 // Edge cases of restricted shortcuts
-const keyTab = makeKeyEvent(false, false, false, 'Tab'); // Tab
-const shiftTab = makeKeyEvent(false, true, false, 'Tab'); // Shift+Tab
-const ctrlTab = makeKeyEvent(true, false, false, 'Tab'); // Ctrl+Tab
-const altTab = makeKeyEvent(false, false, true, 'Tab'); // Alt+Tab
-const keySpace = makeKeyEvent(false, false, false, 'Space'); // Space
-const shiftSpace = makeKeyEvent(false, true, false, 'Space'); // Shift+Space
-const ctrlSpace = makeKeyEvent(true, false, false, 'Space'); // Ctrl+Space
-const altSpace = makeKeyEvent(false, false, true, 'Space'); // Alt+Space
+const keyTab = makeKeyEvent(false, false, false, 'Tab', 'Tab'); // Tab
+const shiftTab = makeKeyEvent(false, true, false, 'Tab', 'Tab'); // Shift+Tab
+const ctrlTab = makeKeyEvent(true, false, false, 'Tab', 'Tab'); // Ctrl+Tab
+const altTab = makeKeyEvent(false, false, true, 'Tab', 'Tab'); // Alt+Tab
+const keySpace = makeKeyEvent(false, false, false, 'Space', ' '); // Space
+const shiftSpace = makeKeyEvent(false, true, false, 'Space', ' '); // Shift+Space
+const ctrlSpace = makeKeyEvent(true, false, false, 'Space', ' '); // Ctrl+Space
+const altSpace = makeKeyEvent(false, false, true, 'Space', ' '); // Alt+Space
 
 describe('KeyboardShortcuts', () => {
   it('creates shortcut strings from events correctly', () => {
@@ -44,6 +66,45 @@ describe('KeyboardShortcuts', () => {
     expect(getShortcutStringFromEvent(altA)).toBe('Alt+KeyA');
     expect(getShortcutStringFromEvent(ctrlShiftAltA)).toBe(
       'CmdOrCtrl+Shift+Alt+KeyA'
+    );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(keyA))).toBe('A');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlA))).toBe('Ctrl + A');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftA))).toBe('Shift + A');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(altA))).toBe('Alt + A');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltA))).toBe(
+      'Ctrl + Shift + Alt + A'
+    );
+
+    expect(getShortcutStringFromEvent(keyM)).toBe('KeyM');
+    expect(getShortcutStringFromEvent(ctrlM)).toBe('CmdOrCtrl+KeyM');
+    expect(getShortcutStringFromEvent(shiftM)).toBe('Shift+KeyM');
+    expect(getShortcutStringFromEvent(altM)).toBe('Alt+KeyM');
+    expect(getShortcutStringFromEvent(ctrlShiftAltM)).toBe(
+      'CmdOrCtrl+Shift+Alt+KeyM'
+    );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(keyM))).toBe('M');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlM))).toBe('Ctrl + M');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftM))).toBe('Shift + M');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(altM))).toBe('Alt + M');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltM))).toBe(
+      'Ctrl + Shift + Alt + M'
+    );
+
+    expect(getShortcutStringFromEvent(keyComma)).toBe('Comma');
+    expect(getShortcutStringFromEvent(ctrlComma)).toBe('CmdOrCtrl+Comma');
+    // TODO: Find a way to handle using Question mark in azerty.
+    // expect(getShortcutStringFromEvent(shiftComma)).toBe('Shift+Comma');
+    expect(getShortcutStringFromEvent(altComma)).toBe('Alt+Comma');
+    expect(getShortcutStringFromEvent(ctrlShiftAltComma)).toBe(
+      'CmdOrCtrl+Shift+Alt+Comma'
+    );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(keyComma))).toBe(',');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlComma))).toBe('Ctrl + ,');
+    // TODO: Find a way to handle using Question mark in azerty.
+    // expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftComma))).toBe('Shift + ,');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(altComma))).toBe('Alt + ,');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltComma))).toBe(
+      'Ctrl + Shift + Alt + ,'
     );
 
     // Partial or incorrect shortcut keypresses

--- a/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
+++ b/newIDE/app/src/KeyboardShortcuts/KeyboardShortcuts.spec.js
@@ -68,12 +68,18 @@ describe('KeyboardShortcuts', () => {
       'CmdOrCtrl+Shift+Alt+KeyA'
     );
     expect(getShortcutDisplayName(getShortcutStringFromEvent(keyA))).toBe('A');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlA))).toBe('Ctrl + A');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftA))).toBe('Shift + A');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(altA))).toBe('Alt + A');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltA))).toBe(
-      'Ctrl + Shift + Alt + A'
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlA))).toBe(
+      'Ctrl + A'
     );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftA))).toBe(
+      'Shift + A'
+    );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(altA))).toBe(
+      'Alt + A'
+    );
+    expect(
+      getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltA))
+    ).toBe('Ctrl + Shift + Alt + A');
 
     expect(getShortcutStringFromEvent(keyM)).toBe('KeyM');
     expect(getShortcutStringFromEvent(ctrlM)).toBe('CmdOrCtrl+KeyM');
@@ -83,12 +89,18 @@ describe('KeyboardShortcuts', () => {
       'CmdOrCtrl+Shift+Alt+KeyM'
     );
     expect(getShortcutDisplayName(getShortcutStringFromEvent(keyM))).toBe('M');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlM))).toBe('Ctrl + M');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftM))).toBe('Shift + M');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(altM))).toBe('Alt + M');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltM))).toBe(
-      'Ctrl + Shift + Alt + M'
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlM))).toBe(
+      'Ctrl + M'
     );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftM))).toBe(
+      'Shift + M'
+    );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(altM))).toBe(
+      'Alt + M'
+    );
+    expect(
+      getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltM))
+    ).toBe('Ctrl + Shift + Alt + M');
 
     expect(getShortcutStringFromEvent(keyComma)).toBe('Comma');
     expect(getShortcutStringFromEvent(ctrlComma)).toBe('CmdOrCtrl+Comma');
@@ -98,14 +110,20 @@ describe('KeyboardShortcuts', () => {
     expect(getShortcutStringFromEvent(ctrlShiftAltComma)).toBe(
       'CmdOrCtrl+Shift+Alt+Comma'
     );
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(keyComma))).toBe(',');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlComma))).toBe('Ctrl + ,');
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(keyComma))).toBe(
+      ','
+    );
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlComma))).toBe(
+      'Ctrl + ,'
+    );
     // TODO: Find a way to handle using Question mark in azerty.
     // expect(getShortcutDisplayName(getShortcutStringFromEvent(shiftComma))).toBe('Shift + ,');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(altComma))).toBe('Alt + ,');
-    expect(getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltComma))).toBe(
-      'Ctrl + Shift + Alt + ,'
+    expect(getShortcutDisplayName(getShortcutStringFromEvent(altComma))).toBe(
+      'Alt + ,'
     );
+    expect(
+      getShortcutDisplayName(getShortcutStringFromEvent(ctrlShiftAltComma))
+    ).toBe('Ctrl + Shift + Alt + ,');
 
     // Partial or incorrect shortcut keypresses
     expect(getShortcutStringFromEvent(ctrlShiftAlt)).toBe(

--- a/newIDE/app/src/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/KeyboardShortcuts/index.js
@@ -19,6 +19,69 @@ type KeyType =
   | 'numrow-arith' // Numrow-, Numrow=
   | 'other'; // Tab, Space
 
+const eventWhichToCode = {
+  '48': 'Digit0',
+  '49': 'Digit1',
+  '50': 'Digit2',
+  '51': 'Digit3',
+  '52': 'Digit4',
+  '53': 'Digit5',
+  '54': 'Digit6',
+  '55': 'Digit7',
+  '56': 'Digit8',
+  '57': 'Digit9',
+  '65': 'KeyA',
+  '66': 'KeyB',
+  '67': 'KeyC',
+  '68': 'KeyD',
+  '69': 'KeyE',
+  '70': 'KeyF',
+  '71': 'KeyG',
+  '72': 'KeyH',
+  '73': 'KeyI',
+  '74': 'KeyJ',
+  '75': 'KeyK',
+  '76': 'KeyL',
+  '77': 'KeyM',
+  '78': 'KeyN',
+  '79': 'KeyO',
+  '80': 'KeyP',
+  '81': 'KeyQ',
+  '82': 'KeyR',
+  '83': 'KeyS',
+  '84': 'KeyT',
+  '85': 'KeyU',
+  '86': 'KeyV',
+  '87': 'KeyW',
+  '88': 'KeyX',
+  '89': 'KeyY',
+  '90': 'KeyZ',
+  '112': 'F1',
+  '113': 'F2',
+  '114': 'F3',
+  '115': 'F4',
+  '116': 'F5',
+  '117': 'F6',
+  '118': 'F7',
+  '119': 'F8',
+  '120': 'F9',
+  '121': 'F10',
+  '122': 'F11',
+  '123': 'F12',
+  '188': 'Comma',
+};
+
+const getCodeFromEvent = (e: KeyboardEvent): string => {
+  if (
+    (e.which >= 65 && e.which <= 90) ||
+    (e.which >= 48 && e.which <= 57) ||
+    (e.which >= 112 && e.which <= 123) ||
+    e.which === 188
+  )
+    return eventWhichToCode[e.which.toString()];
+  return e.code || ''; // Somehow `code` was sometimes reported to be undefined.
+};
+
 /**
  * Given a key code, gives the associated KeyType.
  * Returns null if the key code can't be categorised.
@@ -30,7 +93,7 @@ const getKeyTypeFromCode = (code: string): KeyType | null => {
   if (code.indexOf('F') === 0) return 'fn-row';
   if (code === 'NumpadAdd' || code === 'NumpadSubtract') return 'numpad-arith';
   if (code === 'Equal' || code === 'Minus') return 'numrow-arith';
-  if (code === 'Tab' || code === 'Space') return 'other';
+  if (code === 'Tab' || code === 'Space' || code === 'Comma') return 'other';
   return null;
 };
 
@@ -43,7 +106,7 @@ export const getShortcutStringFromEvent = (e: KeyboardEvent): string => {
   if (e.shiftKey) shortcutString += 'Shift+';
   if (e.altKey) shortcutString += 'Alt+';
 
-  const code = e.code || ''; // Somehow `code` was sometimes reported to be undefined.
+  const code = getCodeFromEvent(e);
   const keyType = getKeyTypeFromCode(code);
   if (keyType) shortcutString += code;
   return shortcutString;
@@ -55,7 +118,7 @@ export const getShortcutStringFromEvent = (e: KeyboardEvent): string => {
  */
 export const isValidShortcutEvent = (e: KeyboardEvent): boolean => {
   // Check if action key is a shortcut supported key
-  const code = e.code || ''; // Somehow `code` was sometimes reported to be undefined.
+  const code = getCodeFromEvent(e);
   const keyType = getKeyTypeFromCode(code);
   if (!keyType) return false;
 
@@ -145,6 +208,7 @@ const getKeyDisplayName = (code: string) => {
   if (keyType === 'fn-row') return code;
   if (keyType === 'numpad-arith') return code === 'NumpadAdd' ? 'Num+' : 'Num-';
   if (keyType === 'numrow-arith') return code === 'Minus' ? '-' : '=';
+  if (code === 'Comma') return ',';
   return code; // Tab, Space
 };
 

--- a/newIDE/app/src/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/KeyboardShortcuts/index.js
@@ -72,12 +72,7 @@ const eventWhichToCode = {
 };
 
 const getCodeFromEvent = (e: KeyboardEvent): string => {
-  if (
-    (e.which >= 65 && e.which <= 90) ||
-    (e.which >= 48 && e.which <= 57) ||
-    (e.which >= 112 && e.which <= 123) ||
-    e.which === 188
-  )
+  if (e.which.toString() in eventWhichToCode)
     return eventWhichToCode[e.which.toString()];
   return e.code || ''; // Somehow `code` was sometimes reported to be undefined.
 };


### PR DESCRIPTION
Fixes Ctrl + Z on AZERTY layout that closes the project rather than undoing something