### PR TITLE
Invalidate cache when updating Panel Sprite opacity

### DIFF
--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
@@ -95,6 +95,10 @@ namespace gdjs {
       // in Pixi will create a flicker when cacheAsBitmap is set to true.
       // (see https://github.com/pixijs/pixijs/issues/4610)
       this._wrapperContainer.alpha = this._object.opacity / 255;
+      // When the opacity is updated, the cache must be invalidated, otherwise
+      // there is a risk of the panel sprite has been cached previously with a
+      // different opacity (and cannot be updated anymore).
+      this._spritesContainer.cacheAsBitmap = false;
     }
 
     updateAngle(): void {


### PR DESCRIPTION
Fix #5761 

The problem is that when an objet appears the first time with a non-full opacity, it is put in cache by Pixi (with `cacheAsBitmap = true` that we use in the `ensureUpToDate()` and we can never retrieve the original full opacity.

We could optimize this by:

- only invalidating cache when the opacity goes up and save a temp `maxKnownOpacity` variable in the object to compare the new value to. But I feel that it's overkill optimisation