### PR TITLE
Fix 3D distance sorting by using a default near plane of 3

### DIFF
--- a/Core/GDCore/Project/Layer.cpp
+++ b/Core/GDCore/Project/Layer.cpp
@@ -19,7 +19,7 @@ Layer::Layer()
       isLocked(false),
       isLightingLayer(false),
       followBaseLayerCamera(false),
-      camera3DNearPlaneDistance(0.1),
+      camera3DNearPlaneDistance(3),
       camera3DFarPlaneDistance(10000),
       camera3DFieldOfView(45),
       ambientLightColorR(200),

--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -520,7 +520,7 @@ export default class LayerRenderer {
     lightGroup.add(light);
     threeScene.add(lightGroup);
 
-    const threeCamera = new THREE.PerspectiveCamera(45, 1, 0.1, 2000);
+    const threeCamera = new THREE.PerspectiveCamera(45, 1, 3, 2000);
     threeCamera.rotation.order = 'ZYX';
     this._threeCamera = threeCamera;
 


### PR DESCRIPTION
* The far/near plane ratio was probably too big for the 3D renderer to make precise sorting.

3D models usually use meters so 0.1 it's 10cm. The assets from the store have a ratio of at least 30px = 1m. So objects are 30 times bigger than usual.
It means that a good default value could be 3 for GDevelop.

We could warn, but it's complicated to know when a setting will actually cause issues.