### PR TITLE
Better highlight the recommend paths in Share dialog

### DIFF
--- a/newIDE/app/src/ExportAndShare/GenericExporters/HTML5Export.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/HTML5Export.js
@@ -128,6 +128,6 @@ export const DoneFooter = ({
 export const html5Exporter = {
   key: 'webexport',
   tabName: <Trans>Web</Trans>,
-  name: <Trans>Web</Trans>,
+  name: <Trans>HTML5</Trans>,
   helpPage: '/publishing/html5_game_in_a_local_folder',
 };

--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineElectronExport.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineElectronExport.js
@@ -75,6 +75,6 @@ export const SetupExportHeader = ({
 export const onlineElectronExporter = {
   key: 'onlineelectronexport',
   tabName: <Trans>Desktop</Trans>,
-  name: <Trans>Windows/macOS/Linux</Trans>,
+  name: <Trans>Windows, macOS &amp; Linux</Trans>,
   helpPage: '/publishing/windows-macos-linux',
 };

--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineGameLink.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineGameLink.js
@@ -30,7 +30,10 @@ import { type PartialGameChange } from '../../../GameDashboard/PublicGamePropert
 import ShareLink from '../../../UI/ShareDialog/ShareLink';
 import SocialShareButtons from '../../../UI/ShareDialog/SocialShareButtons';
 import ShareButton from '../../../UI/ShareDialog/ShareButton';
-import { ResponsiveLineStackLayout } from '../../../UI/Layout';
+import {
+  ColumnStackLayout,
+  ResponsiveLineStackLayout,
+} from '../../../UI/Layout';
 import LinearProgress from '../../../UI/LinearProgress';
 import useAlertDialog from '../../../UI/Alert/useAlertDialog';
 import CircularProgress from '../../../UI/CircularProgress';
@@ -291,7 +294,7 @@ const OnlineGameLink = ({
           {exportPending && (
             <>
               <Text>
-                <Trans>Just a few seconds while we generate the link...</Trans>
+                <Trans>The game is being exported and the link generated...</Trans>
               </Text>
               <Line expand>
                 <LinearProgress
@@ -313,6 +316,7 @@ const OnlineGameLink = ({
             <Dialog
               title={<Trans>Share your game</Trans>}
               id="export-game-share-dialog"
+              minHeight="sm"
               actions={dialogActions}
               open
               onRequestClose={() => setIsShareDialogOpen(false)}
@@ -323,57 +327,49 @@ const OnlineGameLink = ({
               }}
             >
               {buildUrl && !isGameLoading ? (
-                <Column noMargin>
+                <ColumnStackLayout noMargin>
                   <ShareLink url={buildUrl} />
                   {isBuildPublished && navigator.share && (
                     <ShareButton url={buildUrl} />
                   )}
                   {isBuildPublished && !navigator.share && (
-                    <Line expand>
-                      <ResponsiveLineStackLayout
+                    <ColumnStackLayout noMargin expand>
+                      <Column
                         expand
-                        justifyContent="space-between"
+                        justifyContent="flex-end"
                         noMargin
+                        alignItems="flex-end"
                       >
-                        <Column justifyContent="center" noMargin>
-                          <AlertMessage kind="info">
-                            <Trans>
-                              Your game is published! Share it with the
-                              community!
-                            </Trans>
-                          </AlertMessage>
-                        </Column>
-                        <Column
-                          justifyContent="flex-end"
-                          noMargin
-                          alignItems="center"
-                        >
-                          <SocialShareButtons url={buildUrl} />
-                        </Column>
-                      </ResponsiveLineStackLayout>
-                    </Line>
-                  )}
-                  {!isBuildPublished && game && (
-                    <Line>
+                        <SocialShareButtons url={buildUrl} />
+                      </Column>
                       <AlertMessage kind="info">
                         <Trans>
-                          This link is private so you can share it with friends
-                          and testers. When you're ready you can update your
-                          gd.games game page.
+                          Your game has a page on gd.games. You can administrate
+                          it from the Games Dashboard in GDevelop.
                         </Trans>
                       </AlertMessage>
-                    </Line>
+                    </ColumnStackLayout>
                   )}
-                </Column>
+                  {!isBuildPublished && game && (
+                    <AlertMessage kind="info">
+                      <Trans>
+                        This link is private. You can share it with
+                        collaborators, friends or testers. When you're ready you
+                        can publish it so that your game has its own page on
+                        gd.games - GDevelop gaming platform.
+                      </Trans>
+                    </AlertMessage>
+                  )}
+                </ColumnStackLayout>
               ) : (
-                <Column alignItems="center">
+                <ColumnStackLayout alignItems="center">
                   <Line>
                     <CircularProgress size={40} />
                   </Line>
                   <Text>
                     <Trans>Loading your link...</Trans>
                   </Text>
-                </Column>
+                </ColumnStackLayout>
               )}
               <InfoBar
                 message={<Trans>Copied to clipboard!</Trans>}

--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineGameLink.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineGameLink.js
@@ -294,7 +294,9 @@ const OnlineGameLink = ({
           {exportPending && (
             <>
               <Text>
-                <Trans>The game is being exported and the link generated...</Trans>
+                <Trans>
+                  The game is being exported and the link generated...
+                </Trans>
               </Text>
               <Line expand>
                 <LinearProgress

--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/index.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/index.js
@@ -51,9 +51,6 @@ const ExplanationHeader = ({ game }: Props) => {
           </Trans>
         </Text>
       </Line>
-      <Line justifyContent="center">
-        <GdGames color="secondary" style={iconStyle} />
-      </Line>
       {!!isGamePublishedOnGdGames ? (
         <AlertMessage kind="info">
           <Trans>
@@ -77,7 +74,7 @@ const ExplanationHeader = ({ game }: Props) => {
 const onlineWebExporter = {
   key: 'onlinewebexport',
   tabName: 'Web',
-  name: <Trans>Web</Trans>,
+  name: <Trans>gd.games</Trans>,
   helpPage: '/publishing/web',
 };
 

--- a/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
@@ -290,12 +290,16 @@ const PublishHome = ({
                 alignItems="center"
                 justifyContent="center"
               >
-                {selectedExporter ? undefined : getSectionIcon({
-                  section: chosenSection,
-                  small: true,
-                })}
+                {selectedExporter
+                  ? undefined
+                  : getSectionIcon({
+                      section: chosenSection,
+                      small: true,
+                    })}
                 <Text size="block-title" noMargin>
-                  {selectedExporter ? selectedExporter.name : capitalize(chosenSection)}
+                  {selectedExporter
+                    ? selectedExporter.name
+                    : capitalize(chosenSection)}
                 </Text>
               </LineStackLayout>
             )}

--- a/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
@@ -104,7 +104,7 @@ const getSubSectionIcon = (
 };
 
 // Styles to improve the interaction with the button.
-const useStylesForWidget = (highlighted: boolean, small: boolean) =>
+const useStylesForWidget = (highlighted: boolean) =>
   makeStyles(theme => {
     console.log(theme);
     return createStyles({
@@ -152,7 +152,7 @@ const SectionLine = ({
   highlighted?: boolean,
   id: string,
 |}) => {
-  const classes = useStylesForWidget(!!highlighted, small);
+  const classes = useStylesForWidget(!!highlighted);
   return (
     <ButtonBase
       onClick={onClick}
@@ -284,18 +284,18 @@ const PublishHome = ({
             )}
           </Column>
           <Column expand alignItems="center">
-            {!!chosenSection && !selectedExporter && (
+            {!!chosenSection && (
               <LineStackLayout
                 noMargin
                 alignItems="center"
                 justifyContent="center"
               >
-                {getSectionIcon({
+                {selectedExporter ? undefined : getSectionIcon({
                   section: chosenSection,
                   small: true,
                 })}
                 <Text size="block-title" noMargin>
-                  {capitalize(chosenSection)}
+                  {selectedExporter ? selectedExporter.name : capitalize(chosenSection)}
                 </Text>
               </LineStackLayout>
             )}
@@ -371,7 +371,7 @@ const PublishHome = ({
           />
           {!showOnlineWebExporterOnly && (
             <SectionLine
-              label={<Trans>External websites</Trans>}
+              label={<Trans>HTML5 (external websites)</Trans>}
               icon={getSubSectionIcon('browser', 'offline')}
               description={<Trans>Itch.io, Poki, CrazyGames...</Trans>}
               onClick={() => onChooseSubSection('offline')}
@@ -381,9 +381,9 @@ const PublishHome = ({
           )}
           {!showOnlineWebExporterOnly && (
             <SectionLine
-              label={<Trans>Facebook</Trans>}
+              label={<Trans>Facebook Games</Trans>}
               icon={getSubSectionIcon('browser', 'facebook')}
-              description={<Trans>Facebook Instant Games</Trans>}
+              description={<Trans>Instant Games</Trans>}
               onClick={() => onChooseSubSection('facebook')}
               disabled={allExportersRequireOnline && !isOnline}
               id="publish-facebook"

--- a/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
@@ -104,25 +104,34 @@ const getSubSectionIcon = (
 };
 
 // Styles to improve the interaction with the button.
-const useStylesForWidget = (highlighted: boolean) =>
-  makeStyles(theme =>
-    createStyles({
+const useStylesForWidget = (highlighted: boolean, small: boolean) =>
+  makeStyles(theme => {
+    console.log(theme);
+    return createStyles({
       root: {
         border: highlighted
-          ? `1px solid ${theme.palette.text.primary}`
+          ? `1px solid ${theme.palette.primary.light}`
           : `1px solid ${theme.palette.text.disabled}`,
+        backgroundColor: highlighted ? theme.palette.primary.light : undefined,
+        color: highlighted ? theme.palette.primary.contrastText : undefined,
         '&:focus': {
-          backgroundColor: theme.palette.action.hover,
+          borderColor: highlighted ? theme.palette.primary.main : undefined,
+          backgroundColor: highlighted
+            ? theme.palette.primary.main
+            : theme.palette.action.hover,
         },
         '&:hover': {
-          backgroundColor: theme.palette.action.hover,
+          borderColor: highlighted ? theme.palette.primary.main : undefined,
+          backgroundColor: highlighted
+            ? theme.palette.primary.main
+            : theme.palette.action.hover,
         },
         '&:disabled': {
           opacity: theme.palette.action.disabledOpacity,
         },
       },
-    })
-  )();
+    });
+  })();
 
 const SectionLine = ({
   icon,
@@ -143,7 +152,7 @@ const SectionLine = ({
   highlighted?: boolean,
   id: string,
 |}) => {
-  const classes = useStylesForWidget(!!highlighted);
+  const classes = useStylesForWidget(!!highlighted, small);
   return (
     <ButtonBase
       onClick={onClick}
@@ -173,6 +182,7 @@ const SectionLine = ({
               noMargin
               size={small ? 'sub-title' : 'block-title'}
               align="left"
+              color={highlighted ? 'inherit' : 'primary'}
             >
               {label}
             </Text>
@@ -180,10 +190,14 @@ const SectionLine = ({
         </Column>
         <Column noMargin>
           <LineStackLayout expand noMargin alignItems="center">
-            <Text color="secondary" size="body2" align="right">
+            <Text
+              color={highlighted ? 'inherit' : 'secondary'}
+              size="body2"
+              align="right"
+            >
               {description}
             </Text>
-            <ChevronArrowRight color="secondary" />
+            <ChevronArrowRight color={highlighted ? 'inherit' : 'secondary'} />
           </LineStackLayout>
         </Column>
       </LineStackLayout>
@@ -300,7 +314,7 @@ const PublishHome = ({
           <SectionLine
             label={<Trans>gd.games</Trans>}
             icon={getSubSectionIcon('browser', 'online')}
-            description={<Trans>Free link on GDevelop gaming platform</Trans>}
+            description={<Trans>Generate a shareable link to your game.</Trans>}
             onClick={() => {
               setHasSkippedSubSectionSelection(true);
               onChooseSection('browser');
@@ -349,7 +363,7 @@ const PublishHome = ({
           <SectionLine
             label={<Trans>gd.games</Trans>}
             icon={getSubSectionIcon('browser', 'online')}
-            description={<Trans>Free link on GDevelop gaming platform</Trans>}
+            description={<Trans>Generate a shareable link to your game.</Trans>}
             onClick={() => onChooseSubSection('online')}
             highlighted
             disabled={!isOnline}
@@ -380,7 +394,7 @@ const PublishHome = ({
       {chosenSection === 'desktop' && !chosenSubSection && (
         <ColumnStackLayout expand noMargin>
           <SectionLine
-            label={<Trans>Cloud build</Trans>}
+            label={<Trans>One-click packaging</Trans>}
             icon={getSubSectionIcon('desktop', 'online')}
             description={<Trans>Windows, MacOS and Linux</Trans>}
             onClick={() => onChooseSubSection('online')}
@@ -391,7 +405,7 @@ const PublishHome = ({
           <SectionLine
             label={<Trans>Manual build</Trans>}
             icon={getSubSectionIcon('desktop', 'offline')}
-            description={<Trans>Advanced usage for manual packaging</Trans>}
+            description={<Trans>Development tools required</Trans>}
             onClick={() => onChooseSubSection('offline')}
             disabled={allExportersRequireOnline && !isOnline}
             small
@@ -402,7 +416,7 @@ const PublishHome = ({
       {chosenSection === 'mobile' && !chosenSubSection && (
         <ColumnStackLayout expand noMargin>
           <SectionLine
-            label={<Trans>Cloud build</Trans>}
+            label={<Trans>One-click packaging</Trans>}
             icon={getSubSectionIcon('mobile', 'online')}
             description={<Trans>Android only</Trans>}
             onClick={() => onChooseSubSection('online')}
@@ -413,7 +427,7 @@ const PublishHome = ({
           <SectionLine
             label={<Trans>Manual build</Trans>}
             icon={getSubSectionIcon('desktop', 'offline')}
-            description={<Trans>Advanced usage for manual packaging</Trans>}
+            description={<Trans>Development tools required</Trans>}
             onClick={() => onChooseSubSection('offline')}
             small
             disabled={allExportersRequireOnline && !isOnline}

--- a/newIDE/app/src/ExportAndShare/ShareDialog/index.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/index.js
@@ -302,15 +302,15 @@ const ShareDialog = ({
           onChange={setCurrentTab}
           options={[
             {
-              value: 'invite',
-              label: <Trans>Invite</Trans>,
-              id: 'invite-tab',
-              disabled: isNavigationDisabled,
-            },
-            {
               value: 'publish',
               label: <Trans>Publish</Trans>,
               id: 'publish-tab',
+              disabled: isNavigationDisabled,
+            },
+            {
+              value: 'invite',
+              label: <Trans>Invite</Trans>,
+              id: 'invite-tab',
               disabled: isNavigationDisabled,
             },
           ]}

--- a/newIDE/app/src/ExportAndShare/ShareDialog/index.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/index.js
@@ -290,7 +290,7 @@ const ShareDialog = ({
     <Dialog
       // Keep ID for backward compatibility with guided lessons.
       id="export-dialog"
-      maxWidth={'sm'}
+      maxWidth={'md'}
       title={<Trans>Share</Trans>}
       actions={mainActions}
       secondaryActions={secondaryActions}

--- a/newIDE/app/src/ExportAndShare/ShareDialog/index.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/index.js
@@ -291,6 +291,7 @@ const ShareDialog = ({
       // Keep ID for backward compatibility with guided lessons.
       id="export-dialog"
       maxWidth={'md'}
+      minHeight={'lg'}
       title={<Trans>Share</Trans>}
       actions={mainActions}
       secondaryActions={secondaryActions}

--- a/newIDE/app/src/GameDashboard/ShareGameDialog.js
+++ b/newIDE/app/src/GameDashboard/ShareGameDialog.js
@@ -24,6 +24,7 @@ const ShareDialog = ({ game, onClose }: Props) => {
       title={<Trans>Share your game</Trans>}
       open
       id="game-card-share-dialog"
+      minHeight="sm"
       actions={[
         <FlatButton
           key="close"

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -335,7 +335,7 @@ export const initialPreferences = {
     hasProjectOpened: false,
     userShortcutMap: {},
     newObjectDialogDefaultTab: electron ? 'new-object' : 'asset-store',
-    shareDialogDefaultTab: 'invite',
+    shareDialogDefaultTab: 'publish',
     isMenuBarHiddenInPreview: true,
     isAlwaysOnTopInPreview: false,
     backdropClickBehavior: 'nothing',

--- a/newIDE/app/src/Profile/CurrentUsageDisplayer.js
+++ b/newIDE/app/src/Profile/CurrentUsageDisplayer.js
@@ -3,7 +3,6 @@ import { Trans } from '@lingui/macro';
 
 import * as React from 'react';
 import RaisedButton from '../UI/RaisedButton';
-import { Column, Line } from '../UI/Grid';
 import {
   hasValidSubscriptionPlan,
   type CurrentUsage,
@@ -12,6 +11,9 @@ import {
 import PlaceholderLoader from '../UI/PlaceholderLoader';
 import Text from '../UI/Text';
 import { SubscriptionSuggestionContext } from './Subscription/SubscriptionSuggestionContext';
+import GetSubscriptionCard from './Subscription/GetSubscriptionCard';
+import AlertMessage from '../UI/AlertMessage';
+import { ColumnStackLayout } from '../UI/Layout';
 
 type Props = {|
   subscription: ?Subscription,
@@ -33,53 +35,35 @@ const CurrentUsageDisplayer = ({
     subscription && !hasValidSubscriptionPlan(subscription);
 
   return (
-    <Column noMargin>
-      <Text>
-        <Trans>
-          You have {Math.max(currentUsage.max - currentUsage.current, 0)}{' '}
-          remaining builds for today (out of {currentUsage.max}).
-        </Trans>
-      </Text>
-      {hasSubscription && currentUsage.limitReached && (
+    <ColumnStackLayout noMargin>
+      <AlertMessage kind="info">
         <Text>
           <Trans>
-            Need more power? You can upgrade to a new plan to increase the
-            limit!
+            You have {Math.max(currentUsage.max - currentUsage.current, 0)}{' '}
+            remaining builds for today (out of {currentUsage.max}).
           </Trans>
         </Text>
-      )}
+      </AlertMessage>
       {hasSubscription && currentUsage.limitReached && (
-        <Line justifyContent="center" alignItems="center">
-          <RaisedButton
-            label={<Trans>Upgrade my account</Trans>}
-            onClick={() => {
-              onChangeSubscription();
-              openSubscriptionDialog({ reason: 'Build limit reached' });
-            }}
-            primary
-          />
-        </Line>
+        <GetSubscriptionCard subscriptionDialogOpeningReason="Build limit reached">
+          <Text>
+            <Trans>
+              Need more power? You can upgrade to a new plan to increase the
+              limit!
+            </Trans>
+          </Text>
+        </GetSubscriptionCard>
       )}
       {loadedButHasNoSubscription && (
-        <Text>
-          <Trans>
-            You don't have a subscription. Get one to increase the limits!
-          </Trans>
-        </Text>
+        <GetSubscriptionCard subscriptionDialogOpeningReason="Build limit reached">
+          <Text>
+            <Trans>
+              You don't have a subscription. Get one to increase the limits!
+            </Trans>
+          </Text>
+        </GetSubscriptionCard>
       )}
-      {loadedButHasNoSubscription && (
-        <Line justifyContent="center" alignItems="center">
-          <RaisedButton
-            label={<Trans>Get a subscription</Trans>}
-            onClick={() => {
-              onChangeSubscription();
-              openSubscriptionDialog({ reason: 'Build limit reached' });
-            }}
-            primary
-          />
-        </Line>
-      )}
-    </Column>
+    </ColumnStackLayout>
   );
 };
 

--- a/newIDE/app/src/UI/Dialog.js
+++ b/newIDE/app/src/UI/Dialog.js
@@ -119,9 +119,9 @@ const styles = {
     display: 'flex',
     justifyContent: 'space-between',
   },
-  fullHeightModal: {
-    minHeight: 'calc(100% - 64px)',
-  },
+  minHeightForFullHeightModal: 'calc(100% - 64px)',
+  minHeightForSmallHeightModal: 'min(100% - 64px, 350px)',
+  minHeightForLargeHeightModal: 'min(100% - 64px, 800px)',
 };
 
 const useDangerousStylesForDialog = (dangerLevel?: 'warning' | 'danger') =>
@@ -211,6 +211,7 @@ type DialogProps = {|
 
   // Size
   maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false,
+  minHeight?: 'sm' | 'lg',
   fullHeight?: boolean,
   noMobileFullScreen?: boolean,
 
@@ -231,6 +232,7 @@ const Dialog = ({
   open,
   onRequestClose,
   maxWidth,
+  minHeight,
   title,
   fixedContent,
   children,
@@ -351,7 +353,13 @@ const Dialog = ({
         id,
         style: {
           backgroundColor: gdevelopTheme.dialog.backgroundColor,
-          ...(fullHeight ? styles.fullHeightModal : {}),
+          minHeight: fullHeight
+            ? styles.minHeightForFullHeightModal
+            : minHeight === 'lg'
+            ? styles.minHeightForLargeHeightModal
+            : minHeight === 'sm'
+            ? styles.minHeightForSmallHeightModal
+            : undefined,
         },
       }}
       maxWidth={


### PR DESCRIPTION
- Publish tab by default. And invert tab order, Publish first.
- "Cloud build" => "One-click packaging"
- "Generate a shareable link to your game."
- "Advanced usage for manual packaging" => "Development tools required"
- Add titles everywhere
- Ensure a minimum height to avoid too many changes between screens
- More visible highlighted sections

<img width="992" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/f4a48186-df13-4d8c-b88c-53264cd615dd">

<img width="981" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/8cb9bbff-55c7-48e5-a43f-52ffe3226ae6">
