### PR TITLE
Fix parameters not accessible in expressions for 'Action With Operator' functions

### DIFF
--- a/Core/GDCore/IDE/ProjectBrowserHelper.cpp
+++ b/Core/GDCore/IDE/ProjectBrowserHelper.cpp
@@ -140,7 +140,7 @@ void ProjectBrowserHelper::ExposeProjectEvents(
           globalObjectsAndGroups, objectsAndGroups);
       auto projectScopedContainers =
         gd::ProjectScopedContainers::MakeNewProjectScopedContainersFor(globalObjectsAndGroups, objectsAndGroups);
-      projectScopedContainers.AddParameters(eventsFunction->GetParameters());
+      projectScopedContainers.AddParameters(eventsFunction->GetParametersForEvents(eventsFunctionsExtension));
 
       worker.Launch(eventsFunction->GetEvents(), projectScopedContainers);
     }
@@ -183,7 +183,7 @@ void ProjectBrowserHelper::ExposeEventsBasedBehaviorEvents(
       gd::ProjectScopedContainers::MakeNewProjectScopedContainersFor(globalObjectsAndGroups, objectsAndGroups);
     projectScopedContainers.AddPropertiesContainer(eventsBasedBehavior.GetSharedPropertyDescriptors());
     projectScopedContainers.AddPropertiesContainer(eventsBasedBehavior.GetPropertyDescriptors());
-    projectScopedContainers.AddParameters(eventsFunction->GetParameters());
+    projectScopedContainers.AddParameters(eventsFunction->GetParametersForEvents(eventsBasedBehavior.GetEventsFunctions()));
 
     worker.Launch(eventsFunction->GetEvents(), projectScopedContainers);
   }
@@ -202,7 +202,7 @@ void ProjectBrowserHelper::ExposeEventsBasedObjectEvents(
     auto projectScopedContainers =
       gd::ProjectScopedContainers::MakeNewProjectScopedContainersFor(globalObjectsAndGroups, objectsAndGroups);
     projectScopedContainers.AddPropertiesContainer(eventsBasedObject.GetPropertyDescriptors());
-    projectScopedContainers.AddParameters(eventsFunction->GetParameters());
+    projectScopedContainers.AddParameters(eventsFunction->GetParametersForEvents(eventsBasedObject.GetEventsFunctions()));
 
     worker.Launch(eventsFunction->GetEvents(), projectScopedContainers);
   }

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -130,7 +130,8 @@ gd::String EventsCodeGenerator::GenerateEventsFunctionCode(
   gd::ProjectScopedContainers projectScopedContainers =
       gd::ProjectScopedContainers::MakeNewProjectScopedContainersFor(
           globalObjectsAndGroups, objectsAndGroups);
-  projectScopedContainers.AddParameters(eventsFunction.GetParameters());
+  projectScopedContainers.AddParameters(
+      eventsFunction.GetParametersForEvents(functionsContainer));
 
   EventsCodeGenerator codeGenerator(projectScopedContainers);
   codeGenerator.SetCodeNamespace(codeNamespace);
@@ -180,7 +181,8 @@ gd::String EventsCodeGenerator::GenerateBehaviorEventsFunctionCode(
       eventsBasedBehavior.GetSharedPropertyDescriptors());
   projectScopedContainers.AddPropertiesContainer(
       eventsBasedBehavior.GetPropertyDescriptors());
-  projectScopedContainers.AddParameters(eventsFunction.GetParameters());
+  projectScopedContainers.AddParameters(eventsFunction.GetParametersForEvents(
+      eventsBasedBehavior.GetEventsFunctions()));
 
   EventsCodeGenerator codeGenerator(projectScopedContainers);
   codeGenerator.SetCodeNamespace(codeNamespace);
@@ -255,7 +257,8 @@ gd::String EventsCodeGenerator::GenerateObjectEventsFunctionCode(
           globalObjectsAndGroups, objectsAndGroups);
   projectScopedContainers.AddPropertiesContainer(
       eventsBasedObject.GetPropertyDescriptors());
-  projectScopedContainers.AddParameters(eventsFunction.GetParameters());
+  projectScopedContainers.AddParameters(eventsFunction.GetParametersForEvents(
+      eventsBasedObject.GetEventsFunctions()));
 
   EventsCodeGenerator codeGenerator(projectScopedContainers);
   codeGenerator.SetCodeNamespace(codeNamespace);
@@ -487,7 +490,8 @@ gd::String EventsCodeGenerator::GenerateEventsFunctionContext(
   for (const auto& parameter : parameters) {
     if (parameter.GetName().empty()) continue;
 
-    gd::String parameterMangledName = EventsCodeNameMangler::GetMangledName(parameter.GetName());
+    gd::String parameterMangledName =
+        EventsCodeNameMangler::GetMangledName(parameter.GetName());
 
     if (gd::ParameterMetadata::IsObject(parameter.GetType())) {
       if (parameter.GetName() == thisObjectName) {
@@ -851,7 +855,8 @@ gd::String EventsCodeGenerator::GenerateRelationalOperation(
   if (relationalOperator == "contains") {
     return "(" + lhs + ").includes(" + rhs + ")";
   }
-  return gd::EventsCodeGenerator::GenerateRelationalOperation(relationalOperator, lhs, rhs);
+  return gd::EventsCodeGenerator::GenerateRelationalOperation(
+      relationalOperator, lhs, rhs);
 }
 
 gd::String EventsCodeGenerator::GenerateObjectAction(

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/EventsFunctionPropertiesEditor.js
@@ -427,7 +427,10 @@ export default class EventsFunctionPropertiesEditor extends React.Component<
                     getterFunction
                       ? 'Change ' +
                         getterFunction.getSentence() +
-                        ' of _PARAM0_'
+                        (eventsBasedBehavior || eventsBasedObject
+                          ? ' of _PARAM0_'
+                          : '') +
+                        ': [...]'
                       : ''
                   }
                   onChange={text => {}}

--- a/newIDE/app/src/InstructionOrExpression/EventsScope.flow.js
+++ b/newIDE/app/src/InstructionOrExpression/EventsScope.flow.js
@@ -23,6 +23,7 @@ export const getProjectScopedContainersFromScope = (
   const {
     project,
     layout,
+    eventsFunctionsExtension,
     eventsBasedBehavior,
     eventsBasedObject,
     eventsFunction,
@@ -55,7 +56,21 @@ export const getProjectScopedContainersFromScope = (
   }
 
   if (eventsFunction) {
-    projectScopedContainers.addParameters(eventsFunction.getParameters());
+    const eventsFunctionsContainer =
+      (eventsBasedObject && eventsBasedObject.getEventsFunctions()) ||
+      (eventsBasedBehavior && eventsBasedBehavior.getEventsFunctions()) ||
+      eventsFunctionsExtension ||
+      null;
+
+    if (eventsFunctionsContainer) {
+      projectScopedContainers.addParameters(
+        eventsFunction.getParametersForEvents(eventsFunctionsContainer)
+      );
+    } else {
+      throw new Error(
+        'Called `getProjectScopedContainersFromScope` with an eventsFunction but without eventsBasedBehavior, eventsBasedObject or eventsFunctionsExtension'
+      );
+    }
   }
 
   return projectScopedContainers;


### PR DESCRIPTION
<img width="670" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/8894ac7c-fc6d-4f43-a0a1-5dc3cee6314a">
<img width="768" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/4d44eafc-1cc5-4866-8436-84c3b8041f0a">

- Manually tested on a function Action With Operator using an expression using `Value`. Also tested with additional parameters