### PR TITLE
Rename layout object in global group

### DIFF
--- a/Core/GDCore/IDE/WholeProjectRefactorer.cpp
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.cpp
@@ -1441,7 +1441,7 @@ void WholeProjectRefactorer::ObjectOrGroupRemovedInLayout(
   }
 }
 
-void WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
+void WholeProjectRefactorer::RenameObjectOrGroupInLayout(
     gd::Project &project, gd::Layout &layout, const gd::String &oldName,
     const gd::String &newName, bool isObjectGroup) {
   if (oldName == newName || newName.empty() || oldName.empty())
@@ -1479,6 +1479,21 @@ void WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
       auto &externalLayout = project.GetExternalLayout(name);
       externalLayout.GetInitialInstances().RenameInstancesOfObject(oldName,
                                                                    newName);
+    }
+  }
+}
+
+void WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
+    gd::Project &project,
+    gd::Layout &layout,
+    const gd::String &oldName,
+    const gd::String &newName,
+    bool isObjectGroup) {
+  RenameObjectOrGroupInLayout(project, layout, oldName, newName, isObjectGroup);
+  // Rename object in global groups
+  if (!isObjectGroup) {
+    for (std::size_t g = 0; g < project.GetObjectGroups().size(); ++g) {
+      project.GetObjectGroups()[g].RenameObject(oldName, newName);
     }
   }
 }
@@ -1684,7 +1699,7 @@ void WholeProjectRefactorer::GlobalObjectOrGroupRenamed(
     if (layout.HasObjectNamed(oldName))
       continue;
 
-    ObjectOrGroupRenamedInLayout(project, layout, oldName, newName,
+    RenameObjectOrGroupInLayout(project, layout, oldName, newName,
                                  isObjectGroup);
   }
 }

--- a/Core/GDCore/IDE/WholeProjectRefactorer.h
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.h
@@ -517,6 +517,11 @@ class GD_CORE_API WholeProjectRefactorer {
   static std::vector<gd::String>
   GetAssociatedExternalEvents(gd::Project &project,
                                const gd::String &layoutName);
+  static void RenameObjectOrGroupInLayout(gd::Project& project,
+                                   gd::Layout& layout,
+                                   const gd::String& oldName,
+                                   const gd::String& newName,
+                                   bool isObjectGroup);
 
   static void DoRenameEventsFunction(gd::Project& project,
                                      const gd::EventsFunction& eventsFunction,

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -3677,9 +3677,9 @@ describe('libGD.js', function () {
       );
     });
 
-    it('should rename a scene object in scene groups and project groups', function () {
+    it('should rename a scene object in project groups', function () {
       let project = new gd.ProjectHelper.createNewGDJSProject();
-      const group = project.getObjectGroups().insertNew('Group', 0);
+      const globalGroup = project.getObjectGroups().insertNew('Group', 0);
       let layout = project.insertNewLayout('Scene', 0);
       const object = layout.insertNewObject(
         project,
@@ -3688,7 +3688,7 @@ describe('libGD.js', function () {
         0
       );
 
-      group.addObject(object.getName());
+      globalGroup.addObject(object.getName());
 
       gd.WholeProjectRefactorer.objectOrGroupRenamedInLayout(
         project,
@@ -3698,8 +3698,8 @@ describe('libGD.js', function () {
         /* isObjectGroup=*/ false
       );
 
-      expect(group.find('MySpriteObject')).toBe(false);
-      expect(group.find('Player')).toBe(true);
+      expect(globalGroup.find('MySpriteObject')).toBe(false);
+      expect(globalGroup.find('Player')).toBe(true);
     });
     // See other tests in WholeProjectRefactorer.cpp
   });

--- a/GDevelop.js/__tests__/Core.js
+++ b/GDevelop.js/__tests__/Core.js
@@ -3676,6 +3676,31 @@ describe('libGD.js', function () {
         false
       );
     });
+
+    it('should rename a scene object in scene groups and project groups', function () {
+      let project = new gd.ProjectHelper.createNewGDJSProject();
+      const group = project.getObjectGroups().insertNew('Group', 0);
+      let layout = project.insertNewLayout('Scene', 0);
+      const object = layout.insertNewObject(
+        project,
+        'Sprite',
+        'MySpriteObject',
+        0
+      );
+
+      group.addObject(object.getName());
+
+      gd.WholeProjectRefactorer.objectOrGroupRenamedInLayout(
+        project,
+        layout,
+        'MySpriteObject',
+        'Player',
+        /* isObjectGroup=*/ false
+      );
+
+      expect(group.find('MySpriteObject')).toBe(false);
+      expect(group.find('Player')).toBe(true);
+    });
     // See other tests in WholeProjectRefactorer.cpp
   });
 


### PR DESCRIPTION
To fix https://forum.gdevelop.io/t/objects-at-object-groups-wont-have-their-name-updated/50971/5
Fixes #5683 