### PR TITLE
Fix a regression on the object selection in the instruction editor

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditor.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditor.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {
   enumerateObjectAndBehaviorsInstructions,
-  enumerateAllInstructions,
+  isObjectInstruction,
   getObjectParameterIndex,
 } from '../../InstructionOrExpression/EnumerateInstructions';
 import {
@@ -139,12 +139,22 @@ export const useInstructionEditor = ({
             project.getCurrentPlatform(),
             instructionType
           );
-      const objectParameterIndex = getObjectParameterIndex(instructionMetadata);
-      if (objectParameterIndex !== -1) {
-        return getChosenObjectState(
-          instruction.getParameter(objectParameterIndex).getPlainString(),
-          false /* Even if the instruction is invalid for the object, show it as it's what we have already */
+      if (
+        isObjectInstruction(
+          project.getCurrentPlatform(),
+          instruction,
+          isCondition
+        )
+      ) {
+        const objectParameterIndex = getObjectParameterIndex(
+          instructionMetadata
         );
+        if (objectParameterIndex !== -1) {
+          return getChosenObjectState(
+            instruction.getParameter(objectParameterIndex).getPlainString(),
+            false /* Even if the instruction is invalid for the object, show it as it's what we have already */
+          );
+        }
       }
     }
 

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
@@ -68,6 +68,44 @@ const freeInstructionsToRemove = {
   ],
 };
 
+/**
+ * @returns `true` if the instruction in shown as an object instruction.
+ */
+export const isObjectInstruction = (
+  platform: gdPlatformExtension,
+  instruction: gdInstruction,
+  isCondition: boolean
+) => {
+  const instructionType: string = instruction.getType();
+  const extensionAndInstructionMetadata = isCondition
+    ? gd.MetadataProvider.getExtensionAndConditionMetadata(
+        platform,
+        instructionType
+      )
+    : gd.MetadataProvider.getExtensionAndActionMetadata(
+        platform,
+        instructionType
+      );
+  const extension = extensionAndInstructionMetadata.getExtension();
+  const instructionMetadata = extensionAndInstructionMetadata.getMetadata();
+  for (const extensionName in freeInstructionsToRemove) {
+    if (extensionName !== extension.getName()) {
+      continue;
+    }
+    for (const instructionToRemoveName of freeInstructionsToRemove[
+      extensionName
+    ]) {
+      if (instructionType === instructionToRemoveName) {
+        return true;
+      }
+    }
+  }
+  return (
+    instructionMetadata.getParametersCount() >= 1 &&
+    gd.ParameterMetadata.isObject(instructionMetadata.getParameter(0).getType())
+  );
+};
+
 export const getExtensionPrefix = (extension: gdPlatformExtension): string => {
   return extension.getCategory() + GROUP_DELIMITER + extension.getFullName();
 };

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
@@ -72,7 +72,7 @@ const freeInstructionsToRemove = {
  * @returns `true` if the instruction in shown as an object instruction.
  */
 export const isObjectInstruction = (
-  platform: gdPlatformExtension,
+  platform: gdPlatform,
   instruction: gdInstruction,
   isCondition: boolean
 ) => {


### PR DESCRIPTION
The "create" action is on both lists and, with this implementation, the one from the free function list is used. I'm not sure it's the best solution but this way the "create from a group" is shown next to it.