### PR TITLE
Mobile version optimizations

### DIFF
--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -592,13 +592,6 @@ const ObjectGroupsList = React.forwardRef<Props, ObjectGroupsListInterface>(
                         canMoveSelectionToItem={canMoveSelectionTo}
                         reactDndType={groupWithContextReactDndType}
                         initiallyOpenedNodeIds={initiallyOpenedNodeIds}
-                        renderHiddenElements={
-                          // More elements are rendered:
-                          // - on mobile to avoid jumping screens. This can happen when an item
-                          //   name is edited, the keyboard opens and reduces the window height
-                          //   making the item disappear (because or virtualization).
-                          isMobileScreen
-                        }
                       />
                     )}
                   </AutoSizer>

--- a/newIDE/app/src/ObjectGroupsList/index.js
+++ b/newIDE/app/src/ObjectGroupsList/index.js
@@ -25,6 +25,7 @@ import { type EmptyPlaceholder } from '../ObjectsList';
 import TreeView, { type TreeViewInterface } from '../UI/TreeView';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import useAlertDialog from '../UI/Alert/useAlertDialog';
+import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 
 export const groupWithContextReactDndType = 'GD_GROUP_WITH_CONTEXT';
 
@@ -126,6 +127,8 @@ const ObjectGroupsList = React.forwardRef<Props, ObjectGroupsListInterface>(
       showConfirmation,
       showAlert,
     } = useAlertDialog();
+    const windowWidth = useResponsiveWindowWidth();
+    const isMobileScreen = windowWidth === 'small';
 
     React.useImperativeHandle(ref, () => ({ forceUpdate }));
 
@@ -589,6 +592,13 @@ const ObjectGroupsList = React.forwardRef<Props, ObjectGroupsListInterface>(
                         canMoveSelectionToItem={canMoveSelectionTo}
                         reactDndType={groupWithContextReactDndType}
                         initiallyOpenedNodeIds={initiallyOpenedNodeIds}
+                        renderHiddenElements={
+                          // More elements are rendered:
+                          // - on mobile to avoid jumping screens. This can happen when an item
+                          //   name is edited, the keyboard opens and reduces the window height
+                          //   making the item disappear (because or virtualization).
+                          isMobileScreen
+                        }
                       />
                     )}
                   </AutoSizer>

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -656,10 +656,17 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
     const editName = React.useCallback(
       (objectFolderOrObjectWithContext: ?ObjectFolderOrObjectWithContext) => {
         if (!objectFolderOrObjectWithContext) return;
-        if (treeViewRef.current)
-          treeViewRef.current.renameItem(objectFolderOrObjectWithContext);
+        const treeView = treeViewRef.current;
+        if (treeView) {
+          if (isMobileScreen) {
+            // Position item at top of the screen to make sure it will be visible
+            // once the keyboard is open.
+            treeView.scrollToItem(objectFolderOrObjectWithContext, 'start');
+          }
+          treeView.renameItem(objectFolderOrObjectWithContext);
+        }
       },
-      []
+      [isMobileScreen]
     );
 
     const duplicateObject = React.useCallback(

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -1543,15 +1543,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
                       canMoveSelectionToItem={canMoveSelectionTo}
                       reactDndType={objectWithContextReactDndType}
                       initiallyOpenedNodeIds={initiallyOpenedNodeIds}
-                      renderHiddenElements={
-                        // More elements are rendered:
-                        // - during in-app tutorials to make sure the tooltip displayer finds
-                        //   the elements to highlight
-                        // - on mobile to avoid jumping screens. This can happen when an item
-                        //   name is edited, the keyboard opens and reduces the window height
-                        //   making the item disappear (because or virtualization).
-                        !!currentlyRunningInAppTutorial || isMobileScreen
-                      }
                       arrowKeyNavigationProps={arrowKeyNavigationProps}
                     />
                   )}

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -49,6 +49,7 @@ import KeyboardShortcuts from '../UI/KeyboardShortcuts';
 import Link from '../UI/Link';
 import { getHelpLink } from '../Utils/HelpLink';
 import useAlertDialog from '../UI/Alert/useAlertDialog';
+import { useResponsiveWindowWidth } from '../UI/Reponsive/ResponsiveWindowMeasurer';
 
 const gd: libGDevelop = global.gd;
 const sceneObjectsRootFolderId = 'scene-objects';
@@ -264,6 +265,8 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
     const { showDeleteConfirmation } = useAlertDialog();
     const treeViewRef = React.useRef<?TreeViewInterface<TreeViewItem>>(null);
     const forceUpdate = useForceUpdate();
+    const windowWidth = useResponsiveWindowWidth();
+    const isMobileScreen = windowWidth === 'small';
 
     const forceUpdateList = React.useCallback(
       () => {
@@ -1533,7 +1536,15 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
                       canMoveSelectionToItem={canMoveSelectionTo}
                       reactDndType={objectWithContextReactDndType}
                       initiallyOpenedNodeIds={initiallyOpenedNodeIds}
-                      renderHiddenElements={!!currentlyRunningInAppTutorial}
+                      renderHiddenElements={
+                        // More elements are rendered:
+                        // - during in-app tutorials to make sure the tooltip displayer finds
+                        //   the elements to highlight
+                        // - on mobile to avoid jumping screens. This can happen when an item
+                        //   name is edited, the keyboard opens and reduces the window height
+                        //   making the item disappear (because or virtualization).
+                        !!currentlyRunningInAppTutorial || isMobileScreen
+                      }
                       arrowKeyNavigationProps={arrowKeyNavigationProps}
                     />
                   )}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -639,7 +639,10 @@ export default class SceneEditor extends React.Component<Props, State> {
 
   _onInstancesSelected = (instances: Array<gdInitialInstance>) => {
     if (instances.length === 0) {
-      this.setState({ selectedObjectFolderOrObjectsWithContext: [] });
+      this.setState(
+        { selectedObjectFolderOrObjectsWithContext: [] },
+        this.updateToolbar
+      );
       return;
     }
     const { project, layout } = this.props;
@@ -648,27 +651,33 @@ export default class SceneEditor extends React.Component<Props, State> {
     const lastSelectedInstance = instances[instances.length - 1];
     const objectName = lastSelectedInstance.getObjectName();
     if (project.hasObjectNamed(objectName)) {
-      this.setState({
-        selectedObjectFolderOrObjectsWithContext: [
-          {
-            objectFolderOrObject: project
-              .getRootFolder()
-              .getObjectNamed(objectName),
-            global: true,
-          },
-        ],
-      });
+      this.setState(
+        {
+          selectedObjectFolderOrObjectsWithContext: [
+            {
+              objectFolderOrObject: project
+                .getRootFolder()
+                .getObjectNamed(objectName),
+              global: true,
+            },
+          ],
+        },
+        this.updateToolbar
+      );
     } else if (layout.hasObjectNamed(objectName)) {
-      this.setState({
-        selectedObjectFolderOrObjectsWithContext: [
-          {
-            objectFolderOrObject: layout
-              .getRootFolder()
-              .getObjectNamed(objectName),
-            global: false,
-          },
-        ],
-      });
+      this.setState(
+        {
+          selectedObjectFolderOrObjectsWithContext: [
+            {
+              objectFolderOrObject: layout
+                .getRootFolder()
+                .getObjectNamed(objectName),
+              global: false,
+            },
+          ],
+        },
+        this.updateToolbar
+      );
     }
   };
 

--- a/newIDE/app/src/UI/TreeView/index.js
+++ b/newIDE/app/src/UI/TreeView/index.js
@@ -103,7 +103,7 @@ const getItemProps = memoizeOne(
 
 export type TreeViewInterface<Item> = {|
   forceUpdateList: () => void,
-  scrollToItem: Item => void,
+  scrollToItem: (Item, placement?: 'smart' | 'start') => void,
   renameItem: Item => void,
   openItems: (string[]) => void,
   closeItems: (string[]) => void,
@@ -365,7 +365,7 @@ const TreeView = <Item: ItemBaseAttributes>(
   );
 
   const scrollToItem = React.useCallback(
-    (item: Item) => {
+    (item: Item, placement?: 'smart' | 'start' = 'smart') => {
       const list = listRef.current;
       if (list) {
         const itemId = getItemId(item);
@@ -374,7 +374,7 @@ const TreeView = <Item: ItemBaseAttributes>(
         // $FlowFixMe - Method introduced in 2022.
         const index = flattenedData.findLastIndex(node => node.id === itemId);
         if (index >= 0) {
-          list.scrollToItem(index, 'smart');
+          list.scrollToItem(index, placement);
         }
       }
     },

--- a/newIDE/app/src/UI/TreeView/index.js
+++ b/newIDE/app/src/UI/TreeView/index.js
@@ -136,7 +136,6 @@ type Props<Item> = {|
   reactDndType: string,
   forceAllOpened?: boolean,
   initiallyOpenedNodeIds?: string[],
-  renderHiddenElements?: boolean,
   arrowKeyNavigationProps?: {|
     onGetItemInside: (item: Item) => ?Item,
     onGetItemOutside: (item: Item) => ?Item,
@@ -166,7 +165,6 @@ const TreeView = <Item: ItemBaseAttributes>(
     reactDndType,
     forceAllOpened,
     initiallyOpenedNodeIds,
-    renderHiddenElements,
     arrowKeyNavigationProps,
   }: Props<Item>,
   ref: TreeViewInterface<Item>
@@ -637,7 +635,13 @@ const TreeView = <Item: ItemBaseAttributes>(
           // $FlowFixMe
           itemData={itemData}
           ref={listRef}
-          overscanCount={renderHiddenElements ? 20 : 2}
+          // Keep overscanCount relatively high so that:
+          // - during in-app tutorials we make sure the tooltip displayer finds
+          //   the elements to highlight
+          // - on mobile it avoids jumping screens. This can happen when an item
+          //   name is edited, the keyboard opens and reduces the window height
+          //   making the item disappear (because or virtualization).
+          overscanCount={20}
         >
           {TreeViewRow}
         </FixedSizeList>


### PR DESCRIPTION
- to avoid issues when renaming an item and the keyboard opens:
  - render more item in treeview on mobile 
  - scroll treeview to have item at top of the list
- update toolbar on instances selected (trash icon was not updating on instance selected on the canvas)