### PR TITLE
Add the 3D particle emitter in the object list

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EffectsCodeGenerator.cpp
@@ -46,10 +46,6 @@ void EffectsCodeGenerator::GenerateEffectsIncludeFiles(
   // TODO Add unit tests on this function.
   
   // TODO Merge with UsedExtensionsFinder.
-  // Default lights rely on the fact that UsedExtensionsFinder doesn't find
-  // extension usages for effects. This has the happy side effect of not
-  // including Three.js when no 3D object are in the scenes.
-  // We need to make something explicit to avoid future bugs.
 
   // See also gd::Project::ExposeResources for a method that traverse the whole
   // project (this time for resources) and

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -30,7 +30,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
           .AddObject<SpriteObject>("Sprite",
                                    _("Sprite"),
                                    _("Animated object which can be used for "
-                                     "most elements of a game"),
+                                     "most elements of a game."),
                                    "CppPlatform/Extensions/spriteicon.png")
           .SetCategoryFullName(_("General"))
           .AddDefaultBehavior("EffectCapability::EffectBehavior")

--- a/Core/GDCore/Extensions/Metadata/ObjectMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ObjectMetadata.h
@@ -303,11 +303,23 @@ class GD_CORE_API ObjectMetadata : public InstructionOrExpressionContainerMetada
     return *this;
   }
 
-
   /**
-   * \brief Return true if the instruction must be hidden in the IDE.
+   * \brief Return true if the object must be hidden in the IDE.
    */
   bool IsHidden() const { return hidden; }
+
+  /**
+   * \brief Declare a usage of the 3D renderer.
+   */
+  ObjectMetadata &MarkAsRenderedIn3D() {
+    isRenderedIn3D = true;
+    return *this;
+  }
+
+  /**
+   * \brief Return true if the object uses the 3D renderer.
+   */
+  bool IsRenderedIn3D() const { return isRenderedIn3D; }
 
   std::map<gd::String, gd::InstructionMetadata> conditionsInfos;
   std::map<gd::String, gd::InstructionMetadata> actionsInfos;
@@ -329,6 +341,7 @@ class GD_CORE_API ObjectMetadata : public InstructionOrExpressionContainerMetada
   gd::String categoryFullName;
   std::set<gd::String> defaultBehaviorTypes;
   bool hidden = false;
+  bool isRenderedIn3D = false;
 
   std::shared_ptr<gd::ObjectConfiguration>
       blueprintObject;  ///< The "blueprint" object to be copied when a new

--- a/Core/GDCore/IDE/Events/UsedExtensionsFinder.cpp
+++ b/Core/GDCore/IDE/Events/UsedExtensionsFinder.cpp
@@ -25,6 +25,9 @@ const UsedExtensionsResult UsedExtensionsFinder::ScanProject(gd::Project& projec
 void UsedExtensionsFinder::DoVisitObject(gd::Object &object) {
   auto metadata = gd::MetadataProvider::GetExtensionAndObjectMetadata(
       project.GetCurrentPlatform(), object.GetType());
+  if (metadata.GetMetadata().IsRenderedIn3D()) {
+    result.MarkAsHaving3DObjects();
+  }
   result.GetUsedExtensions().insert(metadata.GetExtension().GetName());
   for (auto &&includeFile : metadata.GetMetadata().includeFiles) {
     result.GetUsedIncludeFiles().insert(includeFile);

--- a/Core/GDCore/IDE/Events/UsedExtensionsFinder.h
+++ b/Core/GDCore/IDE/Events/UsedExtensionsFinder.h
@@ -45,6 +45,13 @@ public:
   }
 
   /**
+   * \brief Return true when at least 1 object uses the 3D renderer.
+   */
+  bool Has3DObjects() const {
+    return has3DObjects;
+  }
+
+  /**
    * The extensions used by the project (or part of it).
    */
   std::set<gd::String> &GetUsedExtensions() { return usedExtensions; }
@@ -59,10 +66,15 @@ public:
    */
   std::set<gd::String> &GetUsedRequiredFiles() { return usedRequiredFiles; }
 
+  void MarkAsHaving3DObjects() {
+    has3DObjects = true;
+  }
+
 private:
   std::set<gd::String> usedExtensions;
   std::set<gd::String> usedIncludeFiles;
   std::set<gd::String> usedRequiredFiles;
+  bool has3DObjects = false;
 };
 
 class GD_CORE_API UsedExtensionsFinder

--- a/Core/GDCore/Project/EventsBasedObject.cpp
+++ b/Core/GDCore/Project/EventsBasedObject.cpp
@@ -27,6 +27,9 @@ EventsBasedObject::EventsBasedObject(const gd::EventsBasedObject &_eventBasedObj
 
 void EventsBasedObject::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("defaultName", defaultName);
+  if (isRenderedIn3D) {
+    element.SetBoolAttribute("is3D", true);
+  }
 
   AbstractEventsBasedEntity::SerializeTo(element);
   SerializeObjectsTo(element.AddChild("objects"));
@@ -36,6 +39,7 @@ void EventsBasedObject::SerializeTo(SerializerElement& element) const {
 void EventsBasedObject::UnserializeFrom(gd::Project& project,
                                         const SerializerElement& element) {
   defaultName = element.GetStringAttribute("defaultName");
+  isRenderedIn3D = element.GetBoolAttribute("is3D", false);
 
   AbstractEventsBasedEntity::UnserializeFrom(project, element);
   UnserializeObjectsFrom(project, element.GetChild("objects"));

--- a/Core/GDCore/Project/EventsBasedObject.h
+++ b/Core/GDCore/Project/EventsBasedObject.h
@@ -72,6 +72,19 @@ class GD_CORE_API EventsBasedObject: public AbstractEventsBasedEntity, public Ob
     return *this;
   }
 
+  /**
+   * \brief Declare a usage of the 3D renderer.
+   */
+  EventsBasedObject& MarkAsRenderedIn3D(bool isRenderedIn3D_) {
+    isRenderedIn3D = isRenderedIn3D_;
+    return *this;
+  }
+
+  /**
+   * \brief Return true if the object uses the 3D renderer.
+   */
+  bool IsRenderedIn3D() const { return isRenderedIn3D; }
+
   void SerializeTo(SerializerElement& element) const override;
 
   void UnserializeFrom(gd::Project& project,
@@ -79,6 +92,7 @@ class GD_CORE_API EventsBasedObject: public AbstractEventsBasedEntity, public Ob
 
  private:
   gd::String defaultName;
+  bool isRenderedIn3D;
 };
 
 }  // namespace gd

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -1126,7 +1126,7 @@ module.exports = {
       .addObject(
         'Cube3DObject',
         _('3D Box'),
-        _('A box with an image on each face'),
+        _('A box with images for each face'),
         'JsPlatform/Extensions/3d_box.svg',
         Cube3DObject
       )

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -244,17 +244,18 @@ module.exports = {
         .addObject(
           'Model3DObject',
           _('3D Model'),
-          _('A 3D model.'),
+          _('An animated 3D model.'),
           'JsPlatform/Extensions/3d_box.svg',
           new gd.Model3DObjectConfiguration()
         )
-        .setCategoryFullName(_('3D'))
+        .setCategoryFullName(_('General'))
          // Effects are unsupported because the object is not rendered with PIXI.
         .addDefaultBehavior('ResizableCapability::ResizableBehavior')
         .addDefaultBehavior('ScalableCapability::ScalableBehavior')
         .addDefaultBehavior('FlippableCapability::FlippableBehavior')
         .addDefaultBehavior('AnimatableCapability::AnimatableBehavior')
         .addDefaultBehavior('Scene3D::Base3DBehavior')
+        .markAsRenderedIn3D()
         .setIncludeFile('Extensions/3D/A_RuntimeObject3D.js')
         .addIncludeFile('Extensions/3D/A_RuntimeObject3DRenderer.js')
         .addIncludeFile('Extensions/3D/Model3DRuntimeObject.js')
@@ -1125,16 +1126,17 @@ module.exports = {
       .addObject(
         'Cube3DObject',
         _('3D Box'),
-        _('A 3D box.'),
+        _('A box with an image on each face'),
         'JsPlatform/Extensions/3d_box.svg',
         Cube3DObject
       )
-      .setCategoryFullName(_('3D'))
+      .setCategoryFullName(_('General'))
       // Effects are unsupported because the object is not rendered with PIXI.
       .addDefaultBehavior('ResizableCapability::ResizableBehavior')
       .addDefaultBehavior('ScalableCapability::ScalableBehavior')
       .addDefaultBehavior('FlippableCapability::FlippableBehavior')
       .addDefaultBehavior('Scene3D::Base3DBehavior')
+      .markAsRenderedIn3D()
       .setIncludeFile('Extensions/3D/A_RuntimeObject3D.js')
       .addIncludeFile('Extensions/3D/A_RuntimeObject3DRenderer.js')
       .addIncludeFile('Extensions/3D/Cube3DRuntimeObject.js')

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
@@ -131,6 +131,9 @@ gd::ObjectMetadata &MetadataDeclarationHelper::DeclareObjectMetadata(
           .AddDefaultBehavior("ScalableCapability::ScalableBehavior")
           .AddDefaultBehavior("FlippableCapability::FlippableBehavior")
           .AddDefaultBehavior("OpacityCapability::OpacityBehavior");
+  if (eventsBasedObject.IsRenderedIn3D()) {
+    objectMetadata.MarkAsRenderedIn3D();
+  }
 
   // TODO EBO Use full type to identify object to avoid collision.
   // Objects are identified by their name alone.

--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -90,14 +90,10 @@ bool Exporter::ExportWholePixiProject(const ExportOptions &options) {
         fs, exportedProject.GetResourcesManager(), exportDir);
     // end of compatibility code
 
-    bool isUsingScene3DExtension =
-        usedExtensionsResult.GetUsedExtensions().find("Scene3D") !=
-        usedExtensionsResult.GetUsedExtensions().end();
-
     // Export engine libraries
     helper.AddLibsInclude(
         /*pixiRenderers=*/true,
-        /*pixiInThreeRenderers=*/isUsingScene3DExtension,
+        usedExtensionsResult.Has3DObjects(),
         /*includeWebsocketDebuggerClient=*/false,
         /*includeWindowMessageDebuggerClient=*/false,
         exportedProject.GetLoadingScreen().GetGDevelopLogoStyle(),

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -146,13 +146,9 @@ bool ExporterHelper::ExportProjectForPixiPreview(
   auto usedExtensionsResult =
       gd::UsedExtensionsFinder::ScanProject(exportedProject);
 
-  bool isUsingScene3DExtension =
-      usedExtensionsResult.GetUsedExtensions().find("Scene3D") !=
-      usedExtensionsResult.GetUsedExtensions().end();
-
   // Export engine libraries
   AddLibsInclude(/*pixiRenderers=*/true,
-                 /*pixiInThreeRenderers=*/isUsingScene3DExtension,
+                 usedExtensionsResult.Has3DObjects(),
                  /*includeWebsocketDebuggerClient=*/
                  !options.websocketDebuggerServerAddress.empty(),
                  /*includeWindowMessageDebuggerClient=*/

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -1716,6 +1716,9 @@ interface ObjectMetadata {
 
     [Ref] ObjectMetadata SetHidden();
     boolean IsHidden();
+
+    [Ref] ObjectMetadata MarkAsRenderedIn3D();
+    boolean IsRenderedIn3D();
 };
 
 interface BehaviorMetadata {
@@ -2767,6 +2770,9 @@ interface EventsBasedObject {
     [Const, Ref] DOMString GetFullName();
     [Ref] EventsBasedObject SetDefaultName([Const] DOMString defaultName);
     [Const, Ref] DOMString GetDefaultName();
+
+    [Ref] EventsBasedObject MarkAsRenderedIn3D(boolean isRenderedIn3D);
+    boolean IsRenderedIn3D();
 
     [Const, Value] DOMString STATIC_GetPropertyActionName([Const] DOMString propertyName);
     [Const, Value] DOMString STATIC_GetPropertyConditionName([Const] DOMString propertyName);

--- a/GDevelop.js/types/gdeventsbasedobject.js
+++ b/GDevelop.js/types/gdeventsbasedobject.js
@@ -9,6 +9,8 @@ declare class gdEventsBasedObject extends gdAbstractEventsBasedEntity {
   getFullName(): string;
   setDefaultName(defaultName: string): gdEventsBasedObject;
   getDefaultName(): string;
+  markAsRenderedIn3D(isRenderedIn3D: boolean): gdEventsBasedObject;
+  isRenderedIn3D(): boolean;
   static getPropertyActionName(propertyName: string): string;
   static getPropertyConditionName(propertyName: string): string;
   static getPropertyExpressionName(propertyName: string): string;

--- a/GDevelop.js/types/gdobjectmetadata.js
+++ b/GDevelop.js/types/gdobjectmetadata.js
@@ -26,6 +26,8 @@ declare class gdObjectMetadata {
   addDefaultBehavior(behaviorType: string): gdObjectMetadata;
   setHidden(): gdObjectMetadata;
   isHidden(): boolean;
+  markAsRenderedIn3D(): gdObjectMetadata;
+  isRenderedIn3D(): boolean;
   delete(): void;
   ptr: number;
 };

--- a/newIDE/app/src/AssetStore/NewObjectFromScratch.js
+++ b/newIDE/app/src/AssetStore/NewObjectFromScratch.js
@@ -139,6 +139,12 @@ const getMergedInstalledWithDefaultEnumeratedObjectMetadataByCategory = ({
       {
         name: 'PanelSpriteObject::PanelSprite',
       },
+      {
+        name: 'Scene3D::Cube3DObject',
+      },
+      {
+        name: 'Scene3D::Model3DObject',
+      },
     ],
     [translateExtensionCategory('Input', i18n)]: [
       {
@@ -257,6 +263,24 @@ const getMergedInstalledWithDefaultEnumeratedObjectMetadataByCategory = ({
       },
       {
         name: 'ParticleSystem::ParticleEmitter',
+        assetStorePackTag: 'particles emitter',
+        requiredExtensions: [],
+      },
+      {
+        name: 'ParticleEmitter3D::ParticleEmitter3D',
+        fullName: i18n._(t`3D particle emitter`),
+        description: i18n._(
+          t`Displays a large number of particles to create visual effects.`
+        ),
+        iconFilename:
+          'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWZpcmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTcuNjYgMTEuMkMxNy40MyAxMC45IDE3LjE1IDEwLjY0IDE2Ljg5IDEwLjM4QzE2LjIyIDkuNzggMTUuNDYgOS4zNSAxNC44MiA4LjcyQzEzLjMzIDcuMjYgMTMgNC44NSAxMy45NSAzQzEzIDMuMjMgMTIuMTcgMy43NSAxMS40NiA0LjMyQzguODcgNi40IDcuODUgMTAuMDcgOS4wNyAxMy4yMkM5LjExIDEzLjMyIDkuMTUgMTMuNDIgOS4xNSAxMy41NUM5LjE1IDEzLjc3IDkgMTMuOTcgOC44IDE0LjA1QzguNTcgMTQuMTUgOC4zMyAxNC4wOSA4LjE0IDEzLjkzQzguMDggMTMuODggOC4wNCAxMy44MyA4IDEzLjc2QzYuODcgMTIuMzMgNi42OSAxMC4yOCA3LjQ1IDguNjRDNS43OCAxMCA0Ljg3IDEyLjMgNSAxNC40N0M1LjA2IDE0Ljk3IDUuMTIgMTUuNDcgNS4yOSAxNS45N0M1LjQzIDE2LjU3IDUuNyAxNy4xNyA2IDE3LjdDNy4wOCAxOS40MyA4Ljk1IDIwLjY3IDEwLjk2IDIwLjkyQzEzLjEgMjEuMTkgMTUuMzkgMjAuOCAxNy4wMyAxOS4zMkMxOC44NiAxNy42NiAxOS41IDE1IDE4LjU2IDEyLjcyTDE4LjQzIDEyLjQ2QzE4LjIyIDEyIDE3LjY2IDExLjIgMTcuNjYgMTEuMk0xNC41IDE3LjVDMTQuMjIgMTcuNzQgMTMuNzYgMTggMTMuNCAxOC4xQzEyLjI4IDE4LjUgMTEuMTYgMTcuOTQgMTAuNSAxNy4yOEMxMS42OSAxNyAxMi40IDE2LjEyIDEyLjYxIDE1LjIzQzEyLjc4IDE0LjQzIDEyLjQ2IDEzLjc3IDEyLjMzIDEzQzEyLjIxIDEyLjI2IDEyLjIzIDExLjYzIDEyLjUgMTAuOTRDMTIuNjkgMTEuMzIgMTIuODkgMTEuNyAxMy4xMyAxMkMxMy45IDEzIDE1LjExIDEzLjQ0IDE1LjM3IDE0LjhDMTUuNDEgMTQuOTQgMTUuNDMgMTUuMDggMTUuNDMgMTUuMjNDMTUuNDYgMTYuMDUgMTUuMSAxNi45NSAxNC41IDE3LjVIMTQuNVoiIC8+PC9zdmc+',
+        assetStorePackTag: '3d particles',
+        requiredExtensions: [
+          {
+            extensionName: 'ParticleEmitter3D',
+            extensionVersion: '1.0.0',
+          },
+        ],
       },
     ],
     [translateExtensionCategory('Advanced', i18n)]: [

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -10,6 +10,8 @@ import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import AlertMessage from '../UI/AlertMessage';
 import { ColumnStackLayout } from '../UI/Layout';
 import useForceUpdate from '../Utils/UseForceUpdate';
+import Checkbox from '../UI/Checkbox';
+import { Line } from '../UI/Grid';
 
 const gd: libGDevelop = global.gd;
 
@@ -71,18 +73,35 @@ export default function EventsBasedObjectEditor({ eventsBasedObject }: Props) {
       />
       <I18n>
         {({ i18n }) => (
-          <SemiControlledTextField
-            commitOnBlur
-            floatingLabelText={<Trans>Default name for created objects</Trans>}
-            value={
-              eventsBasedObject.getDefaultName() || eventsBasedObject.getName()
-            }
-            onChange={newName => {
-              eventsBasedObject.setDefaultName(gd.Project.getSafeName(newName));
-              forceUpdate();
-            }}
-            fullWidth
-          />
+          <React.Fragment>
+            <SemiControlledTextField
+              commitOnBlur
+              floatingLabelText={
+                <Trans>Default name for created objects</Trans>
+              }
+              value={
+                eventsBasedObject.getDefaultName() ||
+                eventsBasedObject.getName()
+              }
+              onChange={newName => {
+                eventsBasedObject.setDefaultName(
+                  gd.Project.getSafeName(newName)
+                );
+                forceUpdate();
+              }}
+              fullWidth
+            />
+            <Line>
+              <Checkbox
+                label={<Trans>Use 3D rendering</Trans>}
+                checked={eventsBasedObject.isRenderedIn3D()}
+                onCheck={(e, checked) => {
+                  eventsBasedObject.markAsRenderedIn3D(checked);
+                  forceUpdate();
+                }}
+              />
+            </Line>
+          </React.Fragment>
         )}
       </I18n>
       {eventsBasedObject.getEventsFunctions().getEventsFunctionsCount() ===

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -83,16 +83,14 @@ export default function EventsBasedObjectEditor({ eventsBasedObject }: Props) {
         }}
         fullWidth
       />
-      <Line>
-        <Checkbox
-          label={<Trans>Use 3D rendering</Trans>}
-          checked={eventsBasedObject.isRenderedIn3D()}
-          onCheck={(e, checked) => {
-            eventsBasedObject.markAsRenderedIn3D(checked);
-            forceUpdate();
-          }}
-        />
-      </Line>
+      <Checkbox
+        label={<Trans>Use 3D rendering</Trans>}
+        checked={eventsBasedObject.isRenderedIn3D()}
+        onCheck={(e, checked) => {
+          eventsBasedObject.markAsRenderedIn3D(checked);
+          forceUpdate();
+        }}
+      />
       {eventsBasedObject.getEventsFunctions().getEventsFunctionsCount() ===
         0 && (
         <DismissableAlertMessage

--- a/newIDE/app/src/EventsBasedObjectEditor/index.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/index.js
@@ -71,39 +71,28 @@ export default function EventsBasedObjectEditor({ eventsBasedObject }: Props) {
         fullWidth
         rows={3}
       />
-      <I18n>
-        {({ i18n }) => (
-          <React.Fragment>
-            <SemiControlledTextField
-              commitOnBlur
-              floatingLabelText={
-                <Trans>Default name for created objects</Trans>
-              }
-              value={
-                eventsBasedObject.getDefaultName() ||
-                eventsBasedObject.getName()
-              }
-              onChange={newName => {
-                eventsBasedObject.setDefaultName(
-                  gd.Project.getSafeName(newName)
-                );
-                forceUpdate();
-              }}
-              fullWidth
-            />
-            <Line>
-              <Checkbox
-                label={<Trans>Use 3D rendering</Trans>}
-                checked={eventsBasedObject.isRenderedIn3D()}
-                onCheck={(e, checked) => {
-                  eventsBasedObject.markAsRenderedIn3D(checked);
-                  forceUpdate();
-                }}
-              />
-            </Line>
-          </React.Fragment>
-        )}
-      </I18n>
+      <SemiControlledTextField
+        commitOnBlur
+        floatingLabelText={<Trans>Default name for created objects</Trans>}
+        value={
+          eventsBasedObject.getDefaultName() || eventsBasedObject.getName()
+        }
+        onChange={newName => {
+          eventsBasedObject.setDefaultName(gd.Project.getSafeName(newName));
+          forceUpdate();
+        }}
+        fullWidth
+      />
+      <Line>
+        <Checkbox
+          label={<Trans>Use 3D rendering</Trans>}
+          checked={eventsBasedObject.isRenderedIn3D()}
+          onCheck={(e, checked) => {
+            eventsBasedObject.markAsRenderedIn3D(checked);
+            forceUpdate();
+          }}
+        />
+      </Line>
       {eventsBasedObject.getEventsFunctions().getEventsFunctionsCount() ===
         0 && (
         <DismissableAlertMessage


### PR DESCRIPTION
### Changes
- Add the 3D particle emitter in the object list
- Suggest assets from the store when creating a particle emitter (2D or 3D)
- Move 3D model and 3D box up to "General" in the object list
- Allow custom objects to declare their 3D rendering usage