### PR TITLE
Show error in error boundary for easier debugging

### DIFF
--- a/newIDE/app/src/UI/ErrorBoundary.js
+++ b/newIDE/app/src/UI/ErrorBoundary.js
@@ -10,7 +10,7 @@ import RaisedButton from './RaisedButton';
 import { sendErrorMessage } from '../Utils/Analytics/EventSender';
 import Window from '../Utils/Window';
 import Text from './Text';
-import { Column, Line, Spacer } from './Grid';
+import { Line, Spacer } from './Grid';
 import { getIDEVersion, getIDEVersionWithHash } from '../Version';
 import {
   getArch,
@@ -21,6 +21,14 @@ import {
 import { ColumnStackLayout } from './Layout';
 import AlertMessage from './AlertMessage';
 import Link from './Link';
+import BackgroundText from './BackgroundText';
+
+const styles = {
+  errorMessage: {
+    maxWidth: 600,
+    textAlign: 'left',
+  },
+};
 
 type ErrorBoundaryScope =
   | 'mainframe'
@@ -73,7 +81,7 @@ export const ErrorFallbackComponent = ({
         <Text size="block-title">{title}</Text>
       </Line>
       <Divider />
-      <Column>
+      <ColumnStackLayout>
         <AlertMessage kind="warning">
           <Text>
             <Trans>
@@ -82,8 +90,6 @@ export const ErrorFallbackComponent = ({
             </Trans>
           </Text>
         </AlertMessage>
-      </Column>
-      <Column>
         <Text>
           <Trans>
             To help us fix this issue, you can create a{' '}
@@ -96,7 +102,17 @@ export const ErrorFallbackComponent = ({
             then report the issue with the button below.
           </Trans>
         </Text>
-      </Column>
+        {error && error.stack && (
+          <BackgroundText style={styles.errorMessage}>
+            {error.stack.slice(0, 200)}...
+          </BackgroundText>
+        )}
+        {componentStack && (
+          <BackgroundText style={styles.errorMessage}>
+            {componentStack.slice(0, 200)}...
+          </BackgroundText>
+        )}
+      </ColumnStackLayout>
       <Line justifyContent="flex-end">
         <RaisedButton
           label={<Trans>Report the issue on GitHub</Trans>}

--- a/newIDE/app/src/stories/everything-else.stories.js
+++ b/newIDE/app/src/stories/everything-else.stories.js
@@ -2,9 +2,7 @@
 import * as React from 'react';
 
 // Keep first as it creates the `global.gd` object:
-import GDevelopJsInitializerDecorator, {
-  testProject,
-} from './GDevelopJsInitializerDecorator';
+import { testProject } from './GDevelopJsInitializerDecorator';
 
 import { storiesOf } from '@storybook/react';
 import { action, configureActions } from '@storybook/addon-actions';
@@ -2474,6 +2472,7 @@ storiesOf('ErrorBoundary', module)
       componentStack="Fake stack"
       error={fakeError}
       title="Error customizable title"
+      uniqueErrorId="unique-error-id"
     />
   ));
 


### PR DESCRIPTION
Not a perfect solution, but would help tracking the exact issue with the generated ID when users open an issue without the stacktrace

![Capture d’écran 2023-11-02 à 18 27 57](https://github.com/4ian/GDevelop/assets/4895034/c758804a-3fa7-459e-8ad8-806bbe0fc13b)

