### PR TITLE
Add possibility to force loading of texture

### DIFF
--- a/GDJS/Runtime/pixi-renderers/loadingscreen-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/loadingscreen-pixi-renderer.ts
@@ -53,7 +53,8 @@ namespace gdjs {
       this._pixiRenderer.background.color = this._loadingScreenData.backgroundColor;
 
       const backgroundTexture = imageManager.getPIXITexture(
-        loadingScreenData.backgroundImageResourceName
+        loadingScreenData.backgroundImageResourceName,
+        { loadIfMissing: true }
       );
       if (backgroundTexture !== imageManager.getInvalidPIXITexture()) {
         this._backgroundSprite = PIXI.Sprite.from(backgroundTexture);

--- a/GDJS/Runtime/pixi-renderers/loadingscreen-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/loadingscreen-pixi-renderer.ts
@@ -52,9 +52,8 @@ namespace gdjs {
       }
       this._pixiRenderer.background.color = this._loadingScreenData.backgroundColor;
 
-      const backgroundTexture = imageManager.getPIXITexture(
-        loadingScreenData.backgroundImageResourceName,
-        { loadIfMissing: true }
+      const backgroundTexture = imageManager.getOrLoadPIXITexture(
+        loadingScreenData.backgroundImageResourceName
       );
       if (backgroundTexture !== imageManager.getInvalidPIXITexture()) {
         this._backgroundSprite = PIXI.Sprite.from(backgroundTexture);

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -105,15 +105,9 @@ namespace gdjs {
      * Return the PIXI texture associated to the specified resource name.
      * Returns a placeholder texture if not found.
      * @param resourceName The name of the resource
-     * @param options
-     *   - loadIfMissing: If the texture could not be found in the loaded textures (it should be after the game has loaded), try to load it.
-     *     This option should only be used for resources that have to be displayed before game resources have been loaded (loading screen).
      * @returns The requested texture, or a placeholder if not found.
      */
-    getPIXITexture(
-      resourceName: string,
-      options: undefined | { loadIfMissing: boolean } = undefined
-    ): PIXI.Texture {
+    getPIXITexture(resourceName: string): PIXI.Texture {
       if (this._loadedTextures.containsKey(resourceName)) {
         const texture = this._loadedTextures.get(resourceName);
         if (texture.valid) {
@@ -125,50 +119,74 @@ namespace gdjs {
               ' is not valid anymore (or never was).'
           );
         }
-      } else if (options && options.loadIfMissing) {
-        // Texture is not loaded, load it now from the resources list.
-        const resource = findResourceWithNameAndKind(
-          this._resources,
-          resourceName,
-          'image'
-        );
+      }
+      return this._invalidTexture;
+    }
 
-        if (!resource) {
-          logger.warn(
-            'Unable to find texture for resource "' + resourceName + '".'
+    /**
+     * Return the PIXI texture associated to the specified resource name.
+     * If not found in the loaded textures, this method will try to load it.
+     * Warning: this method should only be used in specific cases that cannot rely on
+     * the initial resources loading of the game, such as the splashscreen.
+     * @param resourceName The name of the resource
+     * @returns The requested texture, or a placeholder if not valid.
+     */
+    getOrLoadPIXITexture(resourceName: string): PIXI.Texture {
+      if (this._loadedTextures.containsKey(resourceName)) {
+        const texture = this._loadedTextures.get(resourceName);
+        if (texture.valid) {
+          return texture;
+        } else {
+          logger.error(
+            'Texture for ' +
+              resourceName +
+              ' is not valid anymore (or never was).'
           );
           return this._invalidTexture;
         }
-
-        logger.log('Loading texture for resource "' + resourceName + '"...');
-        const file = resource.file;
-        const url = this._resourcesLoader.getFullUrl(file);
-        const texture = PIXI.Texture.from(url, {
-          resourceOptions: {
-            // Note that using `false`
-            // to not having `crossorigin` at all would NOT work because the browser would taint the
-            // loaded resource so that it can't be read/used in a canvas (it's only working for display `<img>` on screen).
-            crossorigin: this._resourcesLoader.checkIfCredentialsRequired(file)
-              ? 'use-credentials'
-              : 'anonymous',
-          },
-        }).on('error', (error) => {
-          logFileLoadingError(file, error);
-        });
-        if (!texture) {
-          throw new Error(
-            'Texture loading by PIXI returned nothing for file ' +
-              file +
-              ' behind url ' +
-              url
-          );
-        }
-        applyTextureSettings(texture, resource);
-
-        this._loadedTextures.put(resourceName, texture);
-        return texture;
       }
-      return this._invalidTexture;
+
+      // Texture is not loaded, load it now from the resources list.
+      const resource = findResourceWithNameAndKind(
+        this._resources,
+        resourceName,
+        'image'
+      );
+
+      if (!resource) {
+        logger.warn(
+          'Unable to find texture for resource "' + resourceName + '".'
+        );
+        return this._invalidTexture;
+      }
+
+      logger.log('Loading texture for resource "' + resourceName + '"...');
+      const file = resource.file;
+      const url = this._resourcesLoader.getFullUrl(file);
+      const texture = PIXI.Texture.from(url, {
+        resourceOptions: {
+          // Note that using `false`
+          // to not having `crossorigin` at all would NOT work because the browser would taint the
+          // loaded resource so that it can't be read/used in a canvas (it's only working for display `<img>` on screen).
+          crossorigin: this._resourcesLoader.checkIfCredentialsRequired(file)
+            ? 'use-credentials'
+            : 'anonymous',
+        },
+      }).on('error', (error) => {
+        logFileLoadingError(file, error);
+      });
+      if (!texture) {
+        throw new Error(
+          'Texture loading by PIXI returned nothing for file ' +
+            file +
+            ' behind url ' +
+            url
+        );
+      }
+      applyTextureSettings(texture, resource);
+
+      this._loadedTextures.put(resourceName, texture);
+      return texture;
     }
 
     /**

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -105,9 +105,15 @@ namespace gdjs {
      * Return the PIXI texture associated to the specified resource name.
      * Returns a placeholder texture if not found.
      * @param resourceName The name of the resource
+     * @param options
+     *   - loadIfMissing: If the texture could not be found in the loaded textures (it should be after the game has loaded), try to load it.
+     *     This option should only be used for resources that have to be displayed before game resources have been loaded (loading screen).
      * @returns The requested texture, or a placeholder if not found.
      */
-    getPIXITexture(resourceName: string): PIXI.Texture {
+    getPIXITexture(
+      resourceName: string,
+      options: undefined | { loadIfMissing: boolean } = undefined
+    ): PIXI.Texture {
       if (this._loadedTextures.containsKey(resourceName)) {
         const texture = this._loadedTextures.get(resourceName);
         if (texture.valid) {
@@ -119,6 +125,48 @@ namespace gdjs {
               ' is not valid anymore (or never was).'
           );
         }
+      } else if (options && options.loadIfMissing) {
+        // Texture is not loaded, load it now from the resources list.
+        const resource = findResourceWithNameAndKind(
+          this._resources,
+          resourceName,
+          'image'
+        );
+
+        if (!resource) {
+          logger.warn(
+            'Unable to find texture for resource "' + resourceName + '".'
+          );
+          return this._invalidTexture;
+        }
+
+        logger.log('Loading texture for resource "' + resourceName + '"...');
+        const file = resource.file;
+        const url = this._resourcesLoader.getFullUrl(file);
+        const texture = PIXI.Texture.from(url, {
+          resourceOptions: {
+            // Note that using `false`
+            // to not having `crossorigin` at all would NOT work because the browser would taint the
+            // loaded resource so that it can't be read/used in a canvas (it's only working for display `<img>` on screen).
+            crossorigin: this._resourcesLoader.checkIfCredentialsRequired(file)
+              ? 'use-credentials'
+              : 'anonymous',
+          },
+        }).on('error', (error) => {
+          logFileLoadingError(file, error);
+        });
+        if (!texture) {
+          throw new Error(
+            'Texture loading by PIXI returned nothing for file ' +
+              file +
+              ' behind url ' +
+              url
+          );
+        }
+        applyTextureSettings(texture, resource);
+
+        this._loadedTextures.put(resourceName, texture);
+        return texture;
       }
       return this._invalidTexture;
     }

--- a/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
@@ -106,7 +106,6 @@ const getSubSectionIcon = (
 // Styles to improve the interaction with the button.
 const useStylesForWidget = (highlighted: boolean) =>
   makeStyles(theme => {
-    console.log(theme);
     return createStyles({
       root: {
         border: highlighted


### PR DESCRIPTION
Fixes #5859 

When cleaning Pixi image manager, I forgot that we could need textures before the splash screen has finished loading.
This should fix it. I don't think we would need this somewhere else.