### PR TITLE
Fix treeview search crash when global objects placeholder is displayed

### DIFF
--- a/newIDE/app/src/UI/TreeView/TreeViewRow.js
+++ b/newIDE/app/src/UI/TreeView/TreeViewRow.js
@@ -372,7 +372,8 @@ const TreeViewRow = <Item: ItemBaseAttributes>(props: Props<Item>) => {
                                 />
                               </div>
                             ) : null}
-                            {renamedItemId === node.id ? (
+                            {renamedItemId === node.id &&
+                            typeof node.name === 'string' ? (
                               <SemiControlledRowInput
                                 initialValue={node.name}
                                 onEndRenaming={endRenaming}

--- a/newIDE/app/src/UI/TreeView/index.js
+++ b/newIDE/app/src/UI/TreeView/index.js
@@ -27,7 +27,7 @@ export type ItemBaseAttributes = {
 
 type FlattenedNode<Item> = {|
   id: string,
-  name: string,
+  name: string | React.Node,
   hasChildren: boolean,
   canHaveChildren: boolean,
   extraClass: string,
@@ -112,7 +112,7 @@ type Props<Item> = {|
   height: number,
   width?: number,
   items: Item[],
-  getItemName: Item => string,
+  getItemName: Item => string | React.Node,
   getItemId: Item => string,
   getItemHtmlId?: (Item, index: number) => ?string,
   getItemChildren: Item => ?(Item[]),
@@ -235,7 +235,7 @@ const TreeView = <Item: ItemBaseAttributes>(
         !searchText ||
         forceAllOpened ||
         forceOpen ||
-        name.toLowerCase().includes(searchText) ||
+        (typeof name === 'string' && name.toLowerCase().includes(searchText)) ||
         flattenedChildren.length > 0
       ) {
         const thumbnailSrc = getItemThumbnail ? getItemThumbnail(item) : null;


### PR DESCRIPTION
Fixes #5862 