### PR TITLE
Only allow opening project folder if on desktop with local project

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
@@ -27,6 +27,7 @@ export type RenderEditorContainerProps = {|
   projectItemName: ?string,
   project: ?gdProject,
   fileMetadata: ?FileMetadata,
+  storageProvider: StorageProvider,
   setToolbar: (?React.Node) => void,
 
   // Some optional extra props to pass to the rendered editor

--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -54,6 +54,7 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
         ref={editor => (this.editor = editor)}
         fileMetadata={this.props.fileMetadata}
         project={project}
+        storageProvider={this.props.storageProvider}
       />
     );
   }

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3125,6 +3125,7 @@ const MainFrame = (props: Props) => {
                     extraEditorProps: editorTab.extraEditorProps,
                     project: currentProject,
                     fileMetadata: currentFileMetadata,
+                    storageProvider: getStorageProvider(),
                     ref: editorRef => (editorTab.editorRef = editorRef),
                     setToolbar: editorToolbar =>
                       setEditorToolbar(editorToolbar, isCurrentTab),

--- a/newIDE/app/src/ResourcesEditor/Toolbar.js
+++ b/newIDE/app/src/ResourcesEditor/Toolbar.js
@@ -10,6 +10,7 @@ import IconButton from '../UI/IconButton';
 
 type Props = {|
   onOpenProjectFolder: () => void,
+  canOpenProjectFolder: boolean,
   onDeleteSelection: () => void,
   canDelete: boolean,
   onToggleProperties: () => void,
@@ -24,15 +25,19 @@ export class Toolbar extends PureComponent<Props, State> {
 
     return (
       <ToolbarGroup lastChild>
-        <IconButton
-          size="small"
-          color="default"
-          onClick={this.props.onOpenProjectFolder}
-          tooltip={t`Open the project folder`}
-        >
-          <FolderIcon />
-        </IconButton>
-        <ToolbarSeparator />
+        {this.props.canOpenProjectFolder && (
+          <>
+            <IconButton
+              size="small"
+              color="default"
+              onClick={this.props.onOpenProjectFolder}
+              tooltip={t`Open the project folder`}
+            >
+              <FolderIcon />
+            </IconButton>
+            <ToolbarSeparator />
+          </>
+        )}
         <IconButton
           size="small"
           color="default"

--- a/newIDE/app/src/ResourcesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/index.js
@@ -18,6 +18,7 @@ import {
 } from '../ResourcesList/ResourceSource';
 import { type FileMetadata } from '../ProjectsStorage';
 import { getResourceFilePathStatus } from '../ResourcesList/ResourceUtils';
+import type { StorageProvider } from '../ProjectsStorage';
 
 const gd: libGDevelop = global.gd;
 
@@ -50,6 +51,7 @@ type Props = {|
   ) => void,
   resourceManagementProps: ResourceManagementProps,
   fileMetadata: ?FileMetadata,
+  storageProvider: StorageProvider,
 |};
 
 const initialMosaicEditorNodes = {
@@ -84,6 +86,11 @@ export default class ResourcesEditor extends React.Component<Props, State> {
     this.props.setToolbar(
       <Toolbar
         onOpenProjectFolder={this.openProjectFolder}
+        canOpenProjectFolder={
+          !!remote &&
+          !!this.props.fileMetadata &&
+          this.props.storageProvider.internalName === 'LocalFile'
+        }
         onToggleProperties={this.toggleProperties}
         isPropertiesShown={openedEditorNames.includes('properties')}
         canDelete={!!this.state.selectedResource}
@@ -186,9 +193,8 @@ export default class ResourcesEditor extends React.Component<Props, State> {
   };
 
   openProjectFolder = () => {
-    const project = this.props.project;
-
-    if (remote) remote.shell.openPath(path.dirname(project.getProjectFile()));
+    if (remote)
+      remote.shell.openPath(path.dirname(this.props.project.getProjectFile()));
   };
 
   toggleProperties = () => {


### PR DESCRIPTION
Prevent showing the "open project folder icon" all the time in the Resources tab, even for cloud projects, or on web/mobile.

Desktop/local:
![Capture d’écran 2023-11-02 à 11 43 00](https://github.com/4ian/GDevelop/assets/4895034/0ed3ef47-afaa-48e8-b16e-2958ec92dfc5)

Other:
![Capture d’écran 2023-11-02 à 11 43 21](https://github.com/4ian/GDevelop/assets/4895034/5a103140-d70c-45bc-8c06-3b876ec3a97f)
