### PR TITLE
Exclude project files (when configured to save scenes and events in different files) from watcher

### DIFF
--- a/newIDE/app/src/MainFrame/ResourcesWatcher.js
+++ b/newIDE/app/src/MainFrame/ResourcesWatcher.js
@@ -5,12 +5,17 @@ import PreferencesContext from './Preferences/PreferencesContext';
 import { type StorageProvider, type FileMetadata } from '../ProjectsStorage';
 import { type EditorTabsState } from './EditorTabs/EditorTabsHandler';
 
-const useResourcesWatcher = (
+const useResourcesWatcher = ({
+  getStorageProvider,
+  fileMetadata,
+  editorTabs,
+  isProjectSplitInMultipleFiles,
+}: {|
   getStorageProvider: () => StorageProvider,
   fileMetadata: ?FileMetadata,
   editorTabs: EditorTabsState,
   isProjectSplitInMultipleFiles: boolean,
-) => {
+|}) => {
   const {
     values: { watchProjectFolderFilesForLocalProjects },
   } = React.useContext(PreferencesContext);
@@ -43,10 +48,13 @@ const useResourcesWatcher = (
         return;
       }
       if (fileMetadata && storageProvider.setupResourcesWatcher) {
-        const unsubscribe = storageProvider.setupResourcesWatcher(
+        const unsubscribe = storageProvider.setupResourcesWatcher({
           fileMetadata,
-          informEditorsResourceExternallyChanged
-        );
+          callback: informEditorsResourceExternallyChanged,
+          options: {
+            isProjectSplitInMultipleFiles,
+          },
+        });
         return unsubscribe;
       }
     },
@@ -55,6 +63,7 @@ const useResourcesWatcher = (
       informEditorsResourceExternallyChanged,
       getStorageProvider,
       watchProjectFolderFilesForLocalProjects,
+      isProjectSplitInMultipleFiles,
     ]
   );
 };

--- a/newIDE/app/src/MainFrame/ResourcesWatcher.js
+++ b/newIDE/app/src/MainFrame/ResourcesWatcher.js
@@ -8,7 +8,8 @@ import { type EditorTabsState } from './EditorTabs/EditorTabsHandler';
 const useResourcesWatcher = (
   getStorageProvider: () => StorageProvider,
   fileMetadata: ?FileMetadata,
-  editorTabs: EditorTabsState
+  editorTabs: EditorTabsState,
+  isProjectSplitInMultipleFiles: boolean,
 ) => {
   const {
     values: { watchProjectFolderFilesForLocalProjects },

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -502,7 +502,8 @@ const MainFrame = (props: Props) => {
   useResourcesWatcher(
     getStorageProvider,
     currentFileMetadata,
-    state.editorTabs
+    state.editorTabs,
+    currentProject ? currentProject.isFolderProject() : false,
   );
 
   /**

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -499,12 +499,14 @@ const MainFrame = (props: Props) => {
     ensureResourcesAreFetched,
     renderResourceFetcherDialog,
   } = useResourceFetcher({ resourceFetcher });
-  useResourcesWatcher(
+  useResourcesWatcher({
     getStorageProvider,
-    currentFileMetadata,
-    state.editorTabs,
-    currentProject ? currentProject.isFolderProject() : false,
-  );
+    fileMetadata: currentFileMetadata,
+    editorTabs: state.editorTabs,
+    isProjectSplitInMultipleFiles: currentProject
+      ? currentProject.isFolderProject()
+      : false,
+  });
 
   /**
    * This reference is useful to get the current opened project,

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
@@ -3,6 +3,7 @@ import optionalRequire from '../../Utils/OptionalRequire';
 import debounce from 'lodash/debounce';
 import wrap from 'lodash/wrap';
 import memoize from 'lodash/memoize';
+import { splittedProjectFolderNames } from './LocalProjectWriter';
 
 const path = optionalRequire('path');
 const electron = optionalRequire('electron');
@@ -54,9 +55,7 @@ export const setupResourcesWatcher =
           path.join(folderPath, autosaveFile),
         ];
         if (options && options.isProjectSplitInMultipleFiles) {
-          ignore.push(
-            `{layouts,externalLayouts,externalEvents,eventsFunctionsExtensions}/*.json`
-          );
+          ignore.push(`{${splittedProjectFolderNames.join(',')}}/*.json`);
         }
         const subscriptionIdPromise = ipcRenderer.invoke(
           'local-filesystem-watcher-setup',

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
@@ -45,7 +45,6 @@ export const setupResourcesWatcher =
           // TODO: Is it safe to let it like that since the OS could for some reason
           // do never-ending operations on the folder or its children, making the debounce
           // never ending.
-          console.log('CHANGE', path);
           debouncedCallback(path);
         });
         const ignore = [
@@ -55,11 +54,9 @@ export const setupResourcesWatcher =
           path.join(folderPath, autosaveFile),
         ];
         if (options && options.isProjectSplitInMultipleFiles) {
-          console.log('IGNORE');
           ignore.push(
-            `${folderPath}/(layouts|externalLayouts|externalEvents|eventsFunctionsExtensions)/*json`
+            `**/{layouts,externalLayouts,externalEvents,eventsFunctionsExtensions}/*.json`
           );
-          console.log(ignore);
         }
         const subscriptionIdPromise = ipcRenderer.invoke(
           'local-filesystem-watcher-setup',

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
@@ -1,6 +1,5 @@
 // @flow
 import optionalRequire from '../../Utils/OptionalRequire';
-import { type FileMetadata } from '..';
 import debounce from 'lodash/debounce';
 import wrap from 'lodash/wrap';
 import memoize from 'lodash/memoize';
@@ -12,11 +11,11 @@ const ipcRenderer = electron ? electron.ipcRenderer : null;
 export const setupResourcesWatcher =
   ipcRenderer && path
     ? ({
-        fileMetadata,
+        fileIdentifier,
         callback,
         options,
       }: {
-        fileMetadata: FileMetadata,
+        fileIdentifier: string,
         callback: ({| identifier: string |}) => void,
         options?: {| isProjectSplitInMultipleFiles: boolean |},
       }) => {
@@ -39,8 +38,8 @@ export const setupResourcesWatcher =
           ),
           (getMemoizedFunc, obj) => getMemoizedFunc(obj)(obj)
         );
-        const folderPath = path.dirname(fileMetadata.fileIdentifier);
-        const gameFile = path.basename(fileMetadata.fileIdentifier);
+        const folderPath = path.dirname(fileIdentifier);
+        const gameFile = path.basename(fileIdentifier);
         const autosaveFile = gameFile + '.autosave';
         ipcRenderer.on('project-file-changed', (event, path) => {
           // TODO: Is it safe to let it like that since the OS could for some reason

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalFileResourcesWatcher.js
@@ -55,7 +55,7 @@ export const setupResourcesWatcher =
         ];
         if (options && options.isProjectSplitInMultipleFiles) {
           ignore.push(
-            `**/{layouts,externalLayouts,externalEvents,eventsFunctionsExtensions}/*.json`
+            `{layouts,externalLayouts,externalEvents,eventsFunctionsExtensions}/*.json`
           );
         }
         const subscriptionIdPromise = ipcRenderer.invoke(

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -17,6 +17,13 @@ const path = optionalRequire('path');
 const remote = optionalRequire('@electron/remote');
 const dialog = remote ? remote.dialog : null;
 
+export const splittedProjectFolderNames = [
+  'layouts',
+  'externalLayouts',
+  'externalEvents',
+  'eventsFunctionsExtensions',
+];
+
 const checkFileContent = (filePath: string, expectedContent: string) => {
   const time = performance.now();
   return new Promise((resolve, reject) => {
@@ -75,12 +82,9 @@ const writeProjectFiles = (
       pathSeparator: '/',
       getArrayItemReferenceName: getSlugifiedUniqueNameFromProperty('name'),
       shouldSplit: splitPaths(
-        new Set([
-          '/layouts/*',
-          '/externalLayouts/*',
-          '/externalEvents/*',
-          '/eventsFunctionsExtensions/*',
-        ])
+        new Set(
+          splittedProjectFolderNames.map(folderName => `/${folderName}/*`)
+        )
       ),
       isReferenceMagicPropertyName: '__REFERENCE_TO_SPLIT_OBJECT',
     });

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -42,7 +42,7 @@ const checkFileContent = (filePath: string, expectedContent: string) => {
   });
 };
 
-export const writeAndCheckFile = async (
+const writeAndCheckFile = async (
   content: string,
   filePath: string
 ): Promise<void> => {

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -79,7 +79,6 @@ const writeProjectFiles = (
           '/layouts/*',
           '/externalLayouts/*',
           '/externalEvents/*',
-          '/layouts/*',
           '/eventsFunctionsExtensions/*',
         ])
       ),

--- a/newIDE/app/src/ProjectsStorage/index.js
+++ b/newIDE/app/src/ProjectsStorage/index.js
@@ -195,7 +195,7 @@ export type StorageProvider = {|
   |}) => ResourcesActionsMenuBuilder,
   /** Resources external changes */
   setupResourcesWatcher?: ({|
-    fileMetadata: FileMetadata,
+    fileIdentifier: string,
     callback: ({| identifier: string |}) => void,
     options?: any,
   |}) => () => void,

--- a/newIDE/app/src/ProjectsStorage/index.js
+++ b/newIDE/app/src/ProjectsStorage/index.js
@@ -194,8 +194,9 @@ export type StorageProvider = {|
     authenticatedUser: AuthenticatedUser,
   |}) => ResourcesActionsMenuBuilder,
   /** Resources external changes */
-  setupResourcesWatcher?: (
+  setupResourcesWatcher?: ({|
     fileMetadata: FileMetadata,
-    callback: ({| identifier: string |}) => void
-  ) => () => void,
+    callback: ({| identifier: string |}) => void,
+    options?: any,
+  |}) => () => void,
 |};


### PR DESCRIPTION
To fix https://forum.gdevelop.io/t/project-saving-quite-slow-freezing-the-ui/51551/10

How to reproduce:
- Start from this PR
- Create a project
- Set the project setting
- Create a few external events/layouts
- Save the project
- See in the console logs for changes detected in the json files.

✅ Also, find a way to not subscribe&unsubscribe watchers when switching tabs (editorTabs changing, triggering the hook).