### PR TITLE
Fix a camera flickering since Pixi 7 upgrade when "pixel rounding" is enabled

### DIFF
--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -341,12 +341,32 @@ namespace gdjs {
         // onScreenPosition = floor(980.75 - 200)
         // onScreenPosition = floor(780.75)
         // onScreenPosition = 780
-        this._pixiContainer.position.x = Math.ceil(
-          this._pixiContainer.position.x
-        );
-        this._pixiContainer.position.y = Math.ceil(
-          this._pixiContainer.position.y
-        );
+
+        if (
+          this._layer
+            .getRuntimeScene()
+            .getGame()
+            .getRenderer()
+            .getPIXIRenderer() instanceof PIXI.Renderer
+        ) {
+          // TODO Revert from `round` to `ceil` when the issue is fixed in Pixi.
+          // Since the upgrade to Pixi 7, sprites are rounded with `round`
+          // instead of `floor`.
+          // https://github.com/pixijs/pixijs/issues/9868
+          this._pixiContainer.position.x = Math.round(
+            this._pixiContainer.position.x
+          );
+          this._pixiContainer.position.y = Math.round(
+            this._pixiContainer.position.y
+          );
+        } else {
+          this._pixiContainer.position.x = Math.ceil(
+            this._pixiContainer.position.x
+          );
+          this._pixiContainer.position.y = Math.ceil(
+            this._pixiContainer.position.y
+          );
+        }
       }
 
       if (this._threeCamera) {


### PR DESCRIPTION
Fixes https://github.com/4ian/GDevelop/issues/5904

Related to:
- https://github.com/pixijs/pixijs/issues/9868