### PR TITLE
Fix a memory and CPU leak when a finished tween is replaced

### DIFF
--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -1587,7 +1587,7 @@ namespace gdjs {
 
           tween.step();
           if (!tween.hasFinished()) {
-            this._activeTweens[readIndex] = tween;
+            this._activeTweens[writeIndex] = tween;
             writeIndex++;
           }
         }

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -1577,9 +1577,21 @@ namespace gdjs {
        * @param layoutTimeDelta the duration from the previous step ignoring layer time scale in seconds
        */
       step(): void {
-        for (const tween of this._activeTweens) {
+        let writeIndex = 0;
+        for (
+          let readIndex = 0;
+          readIndex < this._activeTweens.length;
+          readIndex++
+        ) {
+          const tween = this._activeTweens[readIndex];
+
           tween.step();
+          if (!tween.hasFinished()) {
+            this._activeTweens[readIndex] = tween;
+            writeIndex++;
+          }
         }
+        this._activeTweens.length = writeIndex;
       }
 
       /**


### PR DESCRIPTION
Fixes:
- https://forum.gdevelop.io/t/tween-object-pre-event-gets-continuiously-increases/51958