### PR TITLE
Exclude pixi effects renderer from debugger

### DIFF
--- a/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
@@ -351,6 +351,7 @@ namespace gdjs {
         '_renderer',
         '_gameRenderer',
         '_imageManager',
+        '_rendererEffects',
         // Exclude PIXI textures:
         'baseTexture',
         '_baseTexture',


### PR DESCRIPTION
Fix #5922 

Looks like the pixi upgrade includes new `_rendererEffects` object for the pixi filters, which adds the **whole renderer** for each effect.

Excluding this key should remove this from both the `_layers` and the `_orderedLayers` objects, reducing drastically the size of the payload.

![Capture d’écran 2023-11-20 à 15 51 55](https://github.com/4ian/GDevelop/assets/4895034/360c11a9-4744-4a28-8e5f-75e7dcf5f45a)
![Capture d’écran 2023-11-20 à 15 53 32](https://github.com/4ian/GDevelop/assets/4895034/b4dc17c7-432c-47c9-b08f-9ac30e6995e6)
![Capture d’écran 2023-11-20 à 15 51 26](https://github.com/4ian/GDevelop/assets/4895034/c34c9f52-f83c-4b18-be4e-3d78f602490b)

After fix:
<img width="383" alt="image" src="https://github.com/4ian/GDevelop/assets/4895034/6a9a42b7-1643-4528-82fb-1b7415d0c53f">

