### PR TITLE
Fix crash with 'Put the object around another' action when target object is not existing

### DIFF
--- a/Extensions/3D/Scene3DTools.ts
+++ b/Extensions/3D/Scene3DTools.ts
@@ -86,11 +86,13 @@ namespace gdjs {
 
       export const turnCameraTowardObject = (
         runtimeScene: RuntimeScene,
-        object: gdjs.RuntimeObject,
+        object: gdjs.RuntimeObject | null,
         layerName: string,
         cameraIndex: integer,
         isStandingOnY: boolean
       ) => {
+        if (!object) return;
+
         const layer = runtimeScene.getLayer(layerName);
         const layerRenderer = layer.getRenderer();
 

--- a/Extensions/LinkedObjects/linkedobjects.ts
+++ b/Extensions/LinkedObjects/linkedobjects.ts
@@ -195,8 +195,8 @@ namespace gdjs {
 
       export const linkObjects = function (
         instanceContainer: gdjs.RuntimeInstanceContainer,
-        objA: gdjs.RuntimeObject,
-        objB: gdjs.RuntimeObject
+        objA: gdjs.RuntimeObject | null,
+        objB: gdjs.RuntimeObject | null
       ) {
         if (objA === null || objB === null) {
           return;
@@ -206,8 +206,8 @@ namespace gdjs {
 
       export const removeLinkBetween = function (
         instanceContainer: gdjs.RuntimeInstanceContainer,
-        objA: gdjs.RuntimeObject,
-        objB: gdjs.RuntimeObject
+        objA: gdjs.RuntimeObject | null,
+        objB: gdjs.RuntimeObject | null
       ) {
         if (objA === null || objB === null) {
           return;
@@ -231,7 +231,7 @@ namespace gdjs {
       export const pickObjectsLinkedTo = function (
         instanceContainer: gdjs.RuntimeInstanceContainer,
         objectsLists: Hashtable<gdjs.RuntimeObject[]>,
-        obj: gdjs.RuntimeObject,
+        obj: gdjs.RuntimeObject | null,
         eventsFunctionContext: EventsFunctionContext | undefined
       ) {
         if (obj === null) {

--- a/Extensions/Physics2Behavior/physics2runtimebehavior.ts
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.ts
@@ -1837,7 +1837,7 @@ namespace gdjs {
     addDistanceJoint(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       length: float,
@@ -2083,7 +2083,7 @@ namespace gdjs {
     addRevoluteJointBetweenTwoBodies(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       enableLimit: boolean,
@@ -2383,7 +2383,7 @@ namespace gdjs {
     addPrismaticJoint(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       axisAngle: float,
@@ -2754,7 +2754,7 @@ namespace gdjs {
     addPulleyJoint(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       groundX1: float,
@@ -3237,7 +3237,7 @@ namespace gdjs {
     addWheelJoint(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       axisAngle: float,
@@ -3522,7 +3522,7 @@ namespace gdjs {
     addWeldJoint(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       referenceAngle: float,
@@ -3673,7 +3673,7 @@ namespace gdjs {
     addRopeJoint(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       maxLength: float,
@@ -3782,7 +3782,7 @@ namespace gdjs {
     addFrictionJoint(
       x1: float,
       y1: float,
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       x2: float,
       y2: float,
       maxForce: float,
@@ -3914,7 +3914,7 @@ namespace gdjs {
 
     // Motor joint
     addMotorJoint(
-      other: gdjs.RuntimeObject,
+      other: gdjs.RuntimeObject | null,
       offsetX: float,
       offsetY: float,
       offsetAngle: float,

--- a/GDJS/Runtime/events-tools/inputtools.ts
+++ b/GDJS/Runtime/events-tools/inputtools.ts
@@ -380,7 +380,7 @@ namespace gdjs {
           .isMouseInsideCanvas();
       };
 
-      export const _cursorIsOnObject = function (
+      const _cursorIsOnObject = function (
         obj: gdjs.RuntimeObject,
         instanceContainer: gdjs.RuntimeInstanceContainer
       ) {
@@ -394,7 +394,7 @@ namespace gdjs {
         inverted: boolean
       ) {
         return gdjs.evtTools.object.pickObjectsIf(
-          gdjs.evtTools.input._cursorIsOnObject,
+          _cursorIsOnObject,
           objectsLists,
           inverted,
           instanceContainer

--- a/GDJS/Runtime/events-tools/networktools.ts
+++ b/GDJS/Runtime/events-tools/networktools.ts
@@ -168,7 +168,7 @@ namespace gdjs {
        * @deprecated Use `JSON.stringify(variable.toJSObject())` instead.
        */
       export const objectVariableStructureToJSON = function (
-        object: gdjs.RuntimeObject,
+        object: gdjs.RuntimeObject | null,
         variable: gdjs.Variable
       ): string {
         return JSON.stringify(variable.toJSObject());
@@ -205,7 +205,7 @@ namespace gdjs {
        */
       export const jsonToObjectVariableStructure = function (
         jsonStr: string,
-        object: gdjs.RuntimeObject,
+        object: gdjs.RuntimeObject | null,
         variable: gdjs.Variable
       ) {
         variable.fromJSON(jsonStr);

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -1410,7 +1410,7 @@ namespace gdjs {
      * @param multiplier Set the force multiplier
      */
     addForceTowardObject(
-      object: gdjs.RuntimeObject,
+      object: gdjs.RuntimeObject | null,
       len: float,
       multiplier: integer
     ): void {
@@ -2276,10 +2276,12 @@ namespace gdjs {
      * @param angleInDegrees The angle between the object and the target, in degrees.
      */
     putAroundObject(
-      obj: gdjs.RuntimeObject,
+      obj: gdjs.RuntimeObject | null,
       distance: float,
       angleInDegrees: float
     ): void {
+      if (!obj) return;
+
       this.putAround(
         obj.getDrawableX() + obj.getCenterX(),
         obj.getDrawableY() + obj.getCenterY(),

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -1379,7 +1379,7 @@ namespace gdjs {
      * @param scene The scene containing the object
      * @deprecated
      */
-    turnTowardObject(obj: gdjs.RuntimeObject, scene: gdjs.RuntimeScene) {
+    turnTowardObject(obj: gdjs.RuntimeObject | null, scene: gdjs.RuntimeScene) {
       if (obj === null) {
         return;
       }


### PR DESCRIPTION
Fix #5924