### PR TITLE
Use relative links to extension reference pages

### DIFF
--- a/newIDE/app/scripts/lib/WikiHelpLink.js
+++ b/newIDE/app/scripts/lib/WikiHelpLink.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const gdevelopWikiUrlRoot = 'https://wiki.gdevelop.io/gdevelop5';
+const gdevelopWikiUrlRoot = '/gdevelop5';
 const improperlyFormattedHelpPaths = new Set();
 
 /** @param {string} str */


### PR DESCRIPTION
Absolute links make navigation in the preview difficult because it links to the production.