### PR TITLE
Fix property name case in action sentences

### DIFF
--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.cpp
@@ -190,7 +190,7 @@ InstructionMetadata::UseStandardRelationalOperatorParameters(
       gd::String templateSentence = _("<subject> of _PARAM0_ <operator> <value>");
 
       sentence =
-          templateSentence.FindAndReplace("<subject>", sentence)
+          templateSentence.FindAndReplace("<subject>", sentence.CapitalizeFirstLetter())
               .FindAndReplace(
                   "<operator>",
                   "_PARAM" + gd::String::From(operatorParamIndex) + "_")
@@ -200,7 +200,7 @@ InstructionMetadata::UseStandardRelationalOperatorParameters(
       gd::String templateSentence = _("<subject> <operator> <value>");
 
       sentence =
-          templateSentence.FindAndReplace("<subject>", sentence)
+          templateSentence.FindAndReplace("<subject>", sentence.CapitalizeFirstLetter())
               .FindAndReplace(
                   "<operator>",
                   "_PARAM" + gd::String::From(operatorParamIndex) + "_")

--- a/Core/GDCore/String.cpp
+++ b/Core/GDCore/String.cpp
@@ -403,6 +403,11 @@ String String::LowerCase() const
     return lowerCasedStr;
 }
 
+String String::CapitalizeFirstLetter() const
+{
+  return size() < 1 ? *this : substr(0, 1).UpperCase() + substr(1);
+}
+
 String String::FindAndReplace(String search, String replacement, bool all) const
 {
     gd::String result(*this);

--- a/Core/GDCore/String.h
+++ b/Core/GDCore/String.h
@@ -523,6 +523,11 @@ public:
     String LowerCase() const;
 
     /**
+     * \brief Returns the string with the first letter in upper case.
+     */
+    String CapitalizeFirstLetter() const;
+
+    /**
      * \brief Searches a string for a specified substring and returns a new string where all occurrences of this substring is replaced.
      * \param search The string that will be replaced by the new string.
      * \param replacement The value to replace the old substring with.

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
@@ -953,12 +953,6 @@ MetadataDeclarationHelper::UncapitalizeFirstLetter(const gd::String &string) {
                            : string.substr(0, 1).LowerCase() + string.substr(1);
 }
 
-gd::String
-MetadataDeclarationHelper::CapitalizeFirstLetter(const gd::String &string) {
-  return string.size() < 1 ? string
-                           : string.substr(0, 1).UpperCase() + string.substr(1);
-}
-
 void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
     gd::PlatformExtension &extension,
     gd::InstructionOrExpressionContainerMetadata &entityMetadata,
@@ -975,7 +969,7 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
   auto &propertyType = property.GetType();
 
   auto uncapitalizedLabel =
-      UncapitalizeFirstLetter(property.GetLabel() || property.GetName());
+      UncapitalizeFirstLetter(property.GetLabel()) || property.GetName();
   if (propertyType == "Boolean") {
     auto &conditionMetadata = entityMetadata.AddScopedCondition(
         conditionName, propertyLabel,

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.h
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.h
@@ -318,7 +318,6 @@ private:
   static gd::String
   GetStringifiedExtraInfo(const gd::PropertyDescriptor &property);
 
-  static gd::String CapitalizeFirstLetter(const gd::String &string);
   static gd::String UncapitalizeFirstLetter(const gd::String &string);
 
   std::vector<gd::MultipleInstructionMetadata> expressionAndConditions;

--- a/GDevelop.js/__tests__/MetadataDeclarationHelper.js
+++ b/GDevelop.js/__tests__/MetadataDeclarationHelper.js
@@ -178,7 +178,7 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getFullName()).toBe('Some value');
     expect(condition.getDescription()).toBe('Compare some value.');
     // The IDE fixes the first letter case.
-    expect(condition.getSentence()).toBe('some value _PARAM1_ _PARAM2_');
+    expect(condition.getSentence()).toBe('Some value _PARAM1_ _PARAM2_');
 
     extension.delete();
     project.delete();
@@ -486,7 +486,7 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getDescription()).toBe('Compare some value.');
     // The IDE fixes the first letter case.
     expect(condition.getSentence()).toBe(
-      'some value of _PARAM0_ _PARAM2_ _PARAM3_'
+      'Some value of _PARAM0_ _PARAM2_ _PARAM3_'
     );
 
     expect(condition.getParametersCount()).toBe(5);
@@ -635,7 +635,7 @@ describe('MetadataDeclarationHelper', () => {
     );
     // The IDE fixes the first letter case.
     expect(condition.getSentence()).toBe(
-      'the property value for the some value of _PARAM0_ _PARAM2_ _PARAM3_'
+      'The property value for the some value of _PARAM0_ _PARAM2_ _PARAM3_'
     );
     expect(condition.isHidden()).toBe(false);
     expect(condition.isPrivate()).toBe(true);
@@ -819,7 +819,7 @@ describe('MetadataDeclarationHelper', () => {
     );
     // The IDE fixes the first letter case.
     expect(condition.getSentence()).toBe(
-      'the property value for the some value of _PARAM0_ _PARAM2_ _PARAM3_'
+      'The property value for the some value of _PARAM0_ _PARAM2_ _PARAM3_'
     );
     expect(condition.isHidden()).toBe(false);
     expect(condition.isPrivate()).toBe(true);
@@ -1233,7 +1233,7 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getDescription()).toBe('Compare some value.');
     // The IDE fixes the first letter case.
     expect(condition.getSentence()).toBe(
-      'some value of _PARAM0_ _PARAM1_ _PARAM2_'
+      'Some value of _PARAM0_ _PARAM1_ _PARAM2_'
     );
 
     expect(condition.getParametersCount()).toBe(4);
@@ -1369,7 +1369,7 @@ describe('MetadataDeclarationHelper', () => {
     );
     // The IDE fixes the first letter case.
     expect(condition.getSentence()).toBe(
-      'the property value for the some value of _PARAM0_ _PARAM1_ _PARAM2_'
+      'The property value for the some value of _PARAM0_ _PARAM1_ _PARAM2_'
     );
     expect(condition.isHidden()).toBe(false);
     expect(condition.isPrivate()).toBe(true);

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -235,7 +235,6 @@ const Instruction = (props: Props) => {
     i18n: I18nType
   ) => {
     const { instruction, disabled, renderObjectThumbnail } = props;
-    console.log(metadata.getSentence());
     const formattedTexts = instrFormatter.getAsFormattedText(
       instruction,
       metadata

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -235,6 +235,7 @@ const Instruction = (props: Props) => {
     i18n: I18nType
   ) => {
     const { instruction, disabled, renderObjectThumbnail } = props;
+    console.log(metadata.getSentence());
     const formattedTexts = instrFormatter.getAsFormattedText(
       instruction,
       metadata
@@ -268,7 +269,7 @@ const Instruction = (props: Props) => {
                 />
               );
             }
-            return <span key={i}>{i === 0 ? capitalize(value) : value}</span>;
+            return <span key={i}>{value}</span>;
           }
 
           const parameterMetadata = metadata.getParameter(parameterIndex);


### PR DESCRIPTION
It avoids property names to be in lower case in sentences. This issue could have happen with trade marks too.