### PR TITLE
Add eager completion of children variables in expressions

### DIFF
--- a/Core/GDCore/Events/Parsers/ExpressionParser2NodePrinter.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2NodePrinter.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <vector>
+
 #include "GDCore/Events/Parsers/ExpressionParser2Node.h"
 #include "GDCore/Events/Parsers/ExpressionParser2NodeWorker.h"
 namespace gd {
@@ -43,6 +44,11 @@ class GD_CORE_API ExpressionParser2NodePrinter
    */
   const gd::String& GetOutput() { return output; };
 
+  static gd::String PrintStringLiteral(const gd::String& str) {
+    return "\"" +
+           str.FindAndReplace("\\", "\\\\").FindAndReplace("\"", "\\\"") + "\"";
+  }
+
  protected:
   void OnVisitSubExpressionNode(SubExpressionNode& node) override {
     output += "(";
@@ -69,10 +75,7 @@ class GD_CORE_API ExpressionParser2NodePrinter
   }
   void OnVisitNumberNode(NumberNode& node) override { output += node.number; }
   void OnVisitTextNode(TextNode& node) override {
-    output +=
-        "\"" +
-        node.text.FindAndReplace("\\", "\\\\").FindAndReplace("\"", "\\\"") +
-        "\"";
+    output += PrintStringLiteral(node.text);
   }
   void OnVisitVariableNode(VariableNode& node) override {
     output += node.name;
@@ -97,8 +100,8 @@ class GD_CORE_API ExpressionParser2NodePrinter
   }
   void OnVisitObjectFunctionNameNode(ObjectFunctionNameNode& node) override {
     if (!node.behaviorFunctionName.empty()) {
-      output +=
-          node.objectName + "." + node.objectFunctionOrBehaviorName + "::" + node.behaviorFunctionName;
+      output += node.objectName + "." + node.objectFunctionOrBehaviorName +
+                "::" + node.behaviorFunctionName;
     } else {
       output += node.objectName + "." + node.objectFunctionOrBehaviorName;
     }

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -11,7 +11,9 @@
 
 #include "GDCore/Events/Parsers/ExpressionParser2.h"
 #include "GDCore/Events/Parsers/ExpressionParser2Node.h"
+#include "GDCore/Events/Parsers/ExpressionParser2NodePrinter.h"
 #include "GDCore/Events/Parsers/ExpressionParser2NodeWorker.h"
+#include "GDCore/Events/Parsers/GrammarTerminals.h"
 #include "GDCore/Extensions/Metadata/ExpressionMetadata.h"
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/Extensions/Metadata/ValueTypeMetadata.h"
@@ -487,6 +489,7 @@ class GD_CORE_API ExpressionCompletionFinder
     auto type = gd::ExpressionTypeFinder::GetType(
         platform, projectScopedContainers, rootType, node);
 
+    bool eagerlyCompleteIfExactMatch = node.child == nullptr;
     if (gd::ValueTypeMetadata::IsTypeLegacyPreScopedVariable(type)) {
       if (type == "globalvar" || type == "scenevar") {
         const auto* variablesContainer =
@@ -496,28 +499,40 @@ class GD_CORE_API ExpressionCompletionFinder
                 : projectScopedContainers.GetVariablesContainersList()
                       .GetBottomMostVariablesContainer();
         if (variablesContainer) {
-          AddCompletionsForVariablesMatchingSearch(
-              *variablesContainer, node.name, node.nameLocation);
+          AddCompletionsForVariablesMatchingSearch(*variablesContainer,
+                                                   node.name,
+                                                   node.nameLocation,
+                                                   eagerlyCompleteIfExactMatch);
         }
       } else if (type == "objectvar") {
         auto objectName = gd::ExpressionVariableOwnerFinder::GetObjectName(
             platform, objectsContainersList, rootObjectName, node);
 
         AddCompletionsForObjectOrGroupVariablesMatchingSearch(
-            objectsContainersList, objectName, node.name, node.nameLocation);
+            objectsContainersList,
+            objectName,
+            node.name,
+            node.nameLocation,
+            eagerlyCompleteIfExactMatch);
       }
     } else {
       AddCompletionsForObjectsAndVariablesMatchingSearch(
-          node.name, type, node.nameLocation);
+          node.name, type, node.nameLocation, eagerlyCompleteIfExactMatch);
     }
   }
   void OnVisitVariableAccessorNode(VariableAccessorNode& node) override {
-    VariableOrVariablesContainer variableOrVariablesContainer =
+    VariableAndItsParent variableAndItsParent =
         gd::ExpressionVariableParentFinder::GetLastParentOfNode(
             platform, projectScopedContainers, node);
 
-    AddCompletionsForChildrenVariablesOf(variableOrVariablesContainer,
-                                         node.nameLocation);
+    // If no child, we're at the end of a variable (like `GrandChild` in
+    // `Something.Child.GrandChild`) so we can complete eagerly children if we
+    // can.
+    gd::String eagerlyCompleteForVariableName =
+        node.child == nullptr ? node.name : "";
+    AddCompletionsForChildrenVariablesOf(variableAndItsParent,
+                                         node.nameLocation,
+                                         eagerlyCompleteForVariableName);
   }
   void OnVisitVariableBracketAccessorNode(
       VariableBracketAccessorNode& node) override {}
@@ -545,14 +560,18 @@ class GD_CORE_API ExpressionCompletionFinder
             if (variablesContainer->Has(node.identifierName)) {
               AddCompletionsForChildrenVariablesOf(
                   &variablesContainer->Get(node.identifierName),
-                  node.childIdentifierNameLocation);
+                  node.childIdentifierNameLocation,
+                  node.childIdentifierName);
             }
           } else {
             // Complete a root variable of the scene or project:
+            bool eagerlyCompleteIfPossible =
+                !node.identifierNameDotLocation.IsValid();
             AddCompletionsForVariablesMatchingSearch(
                 *variablesContainer,
                 node.identifierName,
-                node.identifierNameLocation);
+                node.identifierNameLocation,
+                eagerlyCompleteIfPossible);
           }
         }
       } else if (type == "objectvar") {
@@ -569,23 +588,31 @@ class GD_CORE_API ExpressionCompletionFinder
               variablesContainer->Has(node.identifierName)) {
             AddCompletionsForChildrenVariablesOf(
                 &variablesContainer->Get(node.identifierName),
-                node.childIdentifierNameLocation);
+                node.childIdentifierNameLocation,
+                node.childIdentifierName);
           }
         } else {
           // Complete a root variable of the object:
+          bool eagerlyCompleteIfPossible =
+              !node.identifierNameDotLocation.IsValid();
           AddCompletionsForObjectOrGroupVariablesMatchingSearch(
               objectsContainersList,
               objectName,
               node.identifierName,
-              node.identifierNameLocation);
+              node.identifierNameLocation,
+              eagerlyCompleteIfPossible);
         }
       }
     } else {
       // Object function, behavior name, variable, object variable.
       if (IsCaretOn(node.identifierNameLocation)) {
-        // Is this the proper position?
+        bool eagerlyCompleteIfPossible =
+            !node.identifierNameDotLocation.IsValid();
         AddCompletionsForAllIdentifiersMatchingSearch(
-            node.identifierName, type, node.identifierNameLocation);
+            node.identifierName,
+            type,
+            node.identifierNameLocation,
+            eagerlyCompleteIfPossible);
         if (!node.identifierNameDotLocation.IsValid()) {
           completions.push_back(
               ExpressionCompletionDescription::ForExpressionWithPrefix(
@@ -608,7 +635,9 @@ class GD_CORE_API ExpressionCompletionFinder
                   objectsContainersList,
                   objectName,
                   node.childIdentifierName,
-                  node.childIdentifierNameLocation);
+                  node.childIdentifierNameLocation,
+                  true);
+
               completions.push_back(
                   ExpressionCompletionDescription::ForBehaviorWithPrefix(
                       node.childIdentifierName,
@@ -625,13 +654,14 @@ class GD_CORE_API ExpressionCompletionFinder
             },
             [&]() {
               // This is a variable.
-              VariableOrVariablesContainer variableOrVariablesContainer =
+              VariableAndItsParent variableAndItsParent =
                   gd::ExpressionVariableParentFinder::GetLastParentOfNode(
                       platform, projectScopedContainers, node);
 
               AddCompletionsForChildrenVariablesOf(
-                  variableOrVariablesContainer,
-                  node.childIdentifierNameLocation);
+                  variableAndItsParent,
+                  node.childIdentifierNameLocation,
+                  node.childIdentifierName);
             },
             [&]() {
               // Ignore properties here.
@@ -793,24 +823,46 @@ class GD_CORE_API ExpressionCompletionFinder
              (inclusive && searchedPosition <= location.GetEndPosition())));
   }
 
+  /**
+   * A slightly less strict check than `gd::Project::IsNameSafe` as child variables can be completed
+   * even if they start with a number.
+   */
+  bool IsIdentifierSafe(const gd::String& name) {
+    if (name.empty()) return false;
+
+    for (auto character : name) {
+      if (!GrammarTerminals::IsAllowedInIdentifier(character)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   void AddCompletionsForChildrenVariablesOf(
-      VariableOrVariablesContainer variableOrVariablesContainer,
-      const ExpressionParserLocation& location) {
-    if (variableOrVariablesContainer.variable) {
-      return AddCompletionsForChildrenVariablesOf(
-          variableOrVariablesContainer.variable, location);
-    } else if (variableOrVariablesContainer.variablesContainer) {
-      return AddCompletionsForVariablesMatchingSearch(
-          *variableOrVariablesContainer.variablesContainer, "", location);
+      VariableAndItsParent variableAndItsParent,
+      const ExpressionParserLocation& location,
+      gd::String eagerlyCompleteForVariableName = "") {
+    if (variableAndItsParent.parentVariable) {
+      AddCompletionsForChildrenVariablesOf(variableAndItsParent.parentVariable,
+                                           location,
+                                           eagerlyCompleteForVariableName);
+    } else if (variableAndItsParent.parentVariablesContainer) {
+      AddCompletionsForVariablesMatchingSearch(
+          *variableAndItsParent.parentVariablesContainer, "", location);
     }
   }
 
   void AddCompletionsForChildrenVariablesOf(
-      const gd::Variable* variable, const ExpressionParserLocation& location) {
+      const gd::Variable* variable,
+      const ExpressionParserLocation& location,
+      gd::String eagerlyCompleteForVariableName = "") {
     if (!variable) return;
 
     if (variable->GetType() == gd::Variable::Structure) {
       for (const auto& name : variable->GetAllChildrenNames()) {
+        if (!IsIdentifierSafe(name)) continue;
+
         const auto& childVariable = variable->GetChild(name);
         ExpressionCompletionDescription description(
             ExpressionCompletionDescription::Variable,
@@ -819,6 +871,10 @@ class GD_CORE_API ExpressionCompletionFinder
         description.SetCompletion(name);
         description.SetVariableType(childVariable.GetType());
         completions.push_back(description);
+
+        if (name == eagerlyCompleteForVariableName) {
+          AddEagerCompletionForVariableChildren(childVariable, name, location);
+        }
       }
     } else {
       // TODO: we could do a "comment only completion" to indicate that nothing
@@ -826,10 +882,32 @@ class GD_CORE_API ExpressionCompletionFinder
     }
   }
 
+  void AddEagerCompletionForVariableChildren(
+      const gd::Variable& variable,
+      const gd::String& variableName,
+      const ExpressionParserLocation& location) {
+    if (variable.GetType() == gd::Variable::Structure) {
+      gd::String prefix = variableName + ".";
+      for (const auto& name : variable.GetAllChildrenNames()) {
+        if (!IsIdentifierSafe(name)) continue;
+
+        const auto& childVariable = variable.GetChild(name);
+        ExpressionCompletionDescription description(
+            ExpressionCompletionDescription::Variable,
+            location.GetStartPosition(),
+            location.GetEndPosition());
+        description.SetCompletion(prefix + name);
+        description.SetVariableType(childVariable.GetType());
+        completions.push_back(description);
+      }
+    }
+  }
+
   void AddCompletionsForVariablesMatchingSearch(
       const gd::VariablesContainer& variablesContainer,
       const gd::String& search,
-      const ExpressionParserLocation& location) {
+      const ExpressionParserLocation& location,
+      bool eagerlyCompleteIfExactMatch = false) {
     variablesContainer.ForEachVariableMatchingSearch(
         search,
         [&](const gd::String& variableName, const gd::Variable& variable) {
@@ -840,6 +918,11 @@ class GD_CORE_API ExpressionCompletionFinder
           description.SetCompletion(variableName);
           description.SetVariableType(variable.GetType());
           completions.push_back(description);
+
+          if (eagerlyCompleteIfExactMatch && variableName == search) {
+            AddEagerCompletionForVariableChildren(
+                variable, variableName, location);
+          }
         });
   }
 
@@ -847,7 +930,8 @@ class GD_CORE_API ExpressionCompletionFinder
       const gd::ObjectsContainersList& objectsContainersList,
       const gd::String& objectOrGroupName,
       const gd::String& search,
-      const ExpressionParserLocation& location) {
+      const ExpressionParserLocation& location,
+      bool eagerlyCompleteIfExactMatch) {
     objectsContainersList.ForEachObjectOrGroupVariableMatchingSearch(
         objectOrGroupName,
         search,
@@ -859,6 +943,11 @@ class GD_CORE_API ExpressionCompletionFinder
           description.SetCompletion(variableName);
           description.SetVariableType(variable.GetType());
           completions.push_back(description);
+
+          if (eagerlyCompleteIfExactMatch && variableName == search) {
+            AddEagerCompletionForVariableChildren(
+                variable, variableName, location);
+          }
         });
   }
 
@@ -885,7 +974,8 @@ class GD_CORE_API ExpressionCompletionFinder
   void AddCompletionsForObjectsAndVariablesMatchingSearch(
       const gd::String& search,
       const gd::String& type,
-      const ExpressionParserLocation& location) {
+      const ExpressionParserLocation& location,
+      bool eagerlyCompleteIfExactMatch) {
     projectScopedContainers.ForEachIdentifierMatchingSearch(
         search,
         [&](const gd::String& objectName,
@@ -907,6 +997,11 @@ class GD_CORE_API ExpressionCompletionFinder
           description.SetCompletion(variableName);
           description.SetVariableType(variable.GetType());
           completions.push_back(description);
+
+          if (eagerlyCompleteIfExactMatch && variableName == search) {
+            AddEagerCompletionForVariableChildren(
+                variable, variableName, location);
+          }
         },
         [&](const gd::NamedPropertyDescriptor& property) {
           // Ignore properties here.
@@ -927,7 +1022,8 @@ class GD_CORE_API ExpressionCompletionFinder
   void AddCompletionsForAllIdentifiersMatchingSearch(
       const gd::String& search,
       const gd::String& type,
-      const ExpressionParserLocation& location) {
+      const ExpressionParserLocation& location,
+      bool eagerlyCompleteIfExactMatch = false) {
     projectScopedContainers.ForEachIdentifierMatchingSearch(
         search,
         [&](const gd::String& objectName,
@@ -949,6 +1045,11 @@ class GD_CORE_API ExpressionCompletionFinder
           description.SetCompletion(variableName);
           description.SetVariableType(variable.GetType());
           completions.push_back(description);
+
+          if (eagerlyCompleteIfExactMatch && variableName == search) {
+            AddEagerCompletionForVariableChildren(
+                variable, variableName, location);
+          }
         },
         [&](const gd::NamedPropertyDescriptor& property) {
           ExpressionCompletionDescription description(

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -489,7 +489,10 @@ class GD_CORE_API ExpressionCompletionFinder
     auto type = gd::ExpressionTypeFinder::GetType(
         platform, projectScopedContainers, rootType, node);
 
+    // Only attempt to complete with the children of the variable
+    // if it's the last child (no more `.AnotherVariable` written after).
     bool eagerlyCompleteIfExactMatch = node.child == nullptr;
+
     if (gd::ValueTypeMetadata::IsTypeLegacyPreScopedVariable(type)) {
       if (type == "globalvar" || type == "scenevar") {
         const auto* variablesContainer =
@@ -564,7 +567,10 @@ class GD_CORE_API ExpressionCompletionFinder
                   node.childIdentifierName);
             }
           } else {
-            // Complete a root variable of the scene or project:
+            // Complete a root variable of the scene or project.
+
+            // Don't attempt to complete children variables if there is
+            // already a dot written (`MyVariable.`).
             bool eagerlyCompleteIfPossible =
                 !node.identifierNameDotLocation.IsValid();
             AddCompletionsForVariablesMatchingSearch(
@@ -592,7 +598,10 @@ class GD_CORE_API ExpressionCompletionFinder
                 node.childIdentifierName);
           }
         } else {
-          // Complete a root variable of the object:
+          // Complete a root variable of the object.
+
+          // Don't attempt to complete children variables if there is
+          // already a dot written (`MyVariable.`).
           bool eagerlyCompleteIfPossible =
               !node.identifierNameDotLocation.IsValid();
           AddCompletionsForObjectOrGroupVariablesMatchingSearch(

--- a/Core/GDCore/IDE/Events/ExpressionValidator.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.cpp
@@ -263,11 +263,17 @@ ExpressionValidator::Type ExpressionValidator::ValidateFunction(
   }
 
   if (gd::MetadataProvider::IsBadExpressionMetadata(metadata)) {
-    RaiseError("invalid_function_name",
+    if (function.functionName.empty()) {
+      RaiseError("invalid_function_name",
+               _("Enter the name of the function to call."),
+               function.location);
+    } else {
+      RaiseError("invalid_function_name",
                _("Cannot find an expression with this name: ") +
                    function.functionName + "\n" +
                    _("Double check that you've not made any typo in the name."),
                function.location);
+    }
     return returnType;
   }
 

--- a/Core/GDCore/IDE/Events/ExpressionVariableParentFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionVariableParentFinder.h
@@ -33,9 +33,9 @@ namespace gd {
  * to refer to the parent of a variable (which can be a VariablesContainer
  * or another Variable).
  */
-struct VariableOrVariablesContainer {
-  const gd::VariablesContainer* variablesContainer;
-  const gd::Variable* variable;
+struct VariableAndItsParent {
+  const gd::VariablesContainer* parentVariablesContainer;
+  const gd::Variable* parentVariable;
 };
 
 /**
@@ -49,14 +49,14 @@ class GD_CORE_API ExpressionVariableParentFinder
     : public ExpressionParser2NodeWorker {
  public:
 
-  static VariableOrVariablesContainer GetLastParentOfNode(
+  static VariableAndItsParent GetLastParentOfNode(
       const gd::Platform& platform,
       const gd::ProjectScopedContainers& projectScopedContainers,
       gd::ExpressionNode& node) {
     gd::ExpressionVariableParentFinder typeFinder(
         platform, projectScopedContainers);
     node.Visit(typeFinder);
-    return typeFinder.lastParentOfNode;
+    return typeFinder.variableAndItsParent;
   }
 
   virtual ~ExpressionVariableParentFinder(){};
@@ -69,6 +69,7 @@ class GD_CORE_API ExpressionVariableParentFinder
         projectScopedContainers(projectScopedContainers_),
         variableNode(nullptr),
         thisIsALegacyPrescopedVariable(false),
+        bailOutBecauseEmptyVariableName(false),
         legacyPrescopedVariablesContainer(nullptr){};
 
   void OnVisitSubExpressionNode(SubExpressionNode& node) override {}
@@ -92,7 +93,7 @@ class GD_CORE_API ExpressionVariableParentFinder
       // containing it was identified in the FunctionCallNode.
       childVariableNames.insert(childVariableNames.begin(), node.name);
       if (legacyPrescopedVariablesContainer)
-        lastParentOfNode = WalkUntilLastParent(
+        variableAndItsParent = WalkUntilLastParent(
             *legacyPrescopedVariablesContainer, childVariableNames);
     } else {
       // Otherwise, the identifier is to be interpreted as usual:
@@ -106,14 +107,14 @@ class GD_CORE_API ExpressionVariableParentFinder
                 projectScopedContainers.GetObjectsContainersList()
                     .GetObjectOrGroupVariablesContainer(node.name);
             if (variablesContainer)
-              lastParentOfNode =
+              variableAndItsParent =
                   WalkUntilLastParent(*variablesContainer, childVariableNames);
           },
           [&]() {
             // This is a variable.
             if (projectScopedContainers.GetVariablesContainersList().Has(
                     node.name)) {
-              lastParentOfNode = WalkUntilLastParent(
+              variableAndItsParent = WalkUntilLastParent(
                   projectScopedContainers.GetVariablesContainersList().Get(
                       node.name),
                   childVariableNames);
@@ -133,6 +134,13 @@ class GD_CORE_API ExpressionVariableParentFinder
     }
   }
   void OnVisitVariableAccessorNode(VariableAccessorNode& node) override {
+    if (node.name.empty() && node.child) {
+      // A variable accessor should always have a name if it has a child (i.e: another accessor).
+      // While the parser may have generated an empty name,
+      // flag this so we avoid finding a wrong parent (and so, run the risk of giving
+      // wrong autocompletions).
+      bailOutBecauseEmptyVariableName = true;
+    }
     childVariableNames.insert(childVariableNames.begin(), node.name);
     if (node.parent) node.parent->Visit(*this);
   }
@@ -159,7 +167,7 @@ class GD_CORE_API ExpressionVariableParentFinder
                                 node.identifierName);
 
       if (legacyPrescopedVariablesContainer)
-        lastParentOfNode = WalkUntilLastParent(
+        variableAndItsParent = WalkUntilLastParent(
             *legacyPrescopedVariablesContainer, childVariableNames);
 
     } else {
@@ -178,7 +186,7 @@ class GD_CORE_API ExpressionVariableParentFinder
                 projectScopedContainers.GetObjectsContainersList()
                     .GetObjectOrGroupVariablesContainer(node.identifierName);
             if (variablesContainer)
-              lastParentOfNode =
+              variableAndItsParent =
                   WalkUntilLastParent(*variablesContainer, childVariableNames);
           },
           [&]() {
@@ -189,7 +197,7 @@ class GD_CORE_API ExpressionVariableParentFinder
 
             if (projectScopedContainers.GetVariablesContainersList().Has(
                     node.identifierName)) {
-              lastParentOfNode = WalkUntilLastParent(
+              variableAndItsParent = WalkUntilLastParent(
                   projectScopedContainers.GetVariablesContainersList().Get(
                       node.identifierName),
                   childVariableNames);
@@ -287,10 +295,13 @@ class GD_CORE_API ExpressionVariableParentFinder
   }
 
  private:
-  static VariableOrVariablesContainer WalkUntilLastParent(
+  VariableAndItsParent WalkUntilLastParent(
       const gd::Variable& variable,
       const std::vector<gd::String>& childVariableNames,
       size_t startIndex = 0) {
+    if (bailOutBecauseEmptyVariableName)
+      return {}; // Do not even attempt to find the parent if we had an issue when visiting nodes.
+
     const gd::Variable* currentVariable = &variable;
 
     // Walk until size - 1 as we want the last parent.
@@ -323,33 +334,35 @@ class GD_CORE_API ExpressionVariableParentFinder
 
     // Return the last parent of the chain of variables (so not the last variable
     // but the one before it).
-    return {.variable = currentVariable};
+    return {.parentVariable = currentVariable};
   }
 
-  static VariableOrVariablesContainer WalkUntilLastParent(
+  VariableAndItsParent WalkUntilLastParent(
       const gd::VariablesContainer& variablesContainer,
       const std::vector<gd::String>& childVariableNames) {
+    if (bailOutBecauseEmptyVariableName)
+      return {}; // Do not even attempt to find the parent if we had an issue when visiting nodes.
     if (childVariableNames.empty())
       return {};  // There is no "parent" to the variables container itself.
-    if (childVariableNames.size() == 1)
-      return {// Only one child: the parent is the variables container itself.
-              .variablesContainer = &variablesContainer};
 
     const gd::String& firstChildName = *childVariableNames.begin();
-    if (!variablesContainer.Has(firstChildName)) {
-      // The child does not exist - there is no "parent".
-      return {};
-    }
 
-    return WalkUntilLastParent(
-        variablesContainer.Get(firstChildName), childVariableNames, 1);
+// TODO: move again?
+    const gd::Variable* variable = variablesContainer.Has(firstChildName) ?
+      &variablesContainer.Get(firstChildName) : nullptr;
+    if (childVariableNames.size() == 1 || !variable)
+      return {// Only one child: the parent is the variables container itself.
+              .parentVariablesContainer = &variablesContainer};
+
+    return WalkUntilLastParent(*variable, childVariableNames, 1);
   }
 
   gd::ExpressionNode* variableNode;
   std::vector<gd::String> childVariableNames;
   bool thisIsALegacyPrescopedVariable;
+  bool bailOutBecauseEmptyVariableName;
   const gd::VariablesContainer* legacyPrescopedVariablesContainer;
-  VariableOrVariablesContainer lastParentOfNode;
+  VariableAndItsParent variableAndItsParent;
 
   const gd::Platform& platform;
   const gd::ProjectScopedContainers& projectScopedContainers;

--- a/Core/GDCore/IDE/Events/ExpressionVariableParentFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionVariableParentFinder.h
@@ -347,7 +347,6 @@ class GD_CORE_API ExpressionVariableParentFinder
 
     const gd::String& firstChildName = *childVariableNames.begin();
 
-// TODO: move again?
     const gd::Variable* variable = variablesContainer.Has(firstChildName) ?
       &variablesContainer.Get(firstChildName) : nullptr;
     if (childVariableNames.size() == 1 || !variable)

--- a/GDevelop.js/__tests__/ExpressionCompletionFinder.spec.js
+++ b/GDevelop.js/__tests__/ExpressionCompletionFinder.spec.js
@@ -83,7 +83,7 @@ describe('gd.ExpressionCompletionFinder', function () {
         structureChild1.getChild('Child1StructureChild2');
         structureChild1.getChild('Child1StructureChild3');
         structureChild1.getChild(
-          'Child1 Unsafe Because of Spaces so not listed'
+          'Child1Structure with unsafe "`/+ characters and spaces'
         );
 
         // With a child array, containing 2 structures and a number.
@@ -272,6 +272,7 @@ describe('gd.ExpressionCompletionFinder', function () {
         ).toMatchInlineSnapshot(`
           [
             "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure["Child1Structure with unsafe \\"\`/+ characters and spaces"], no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
@@ -317,6 +318,7 @@ describe('gd.ExpressionCompletionFinder', function () {
         ).toMatchInlineSnapshot(`
           [
             "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure["Child1Structure with unsafe \\"\`/+ characters and spaces"], no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
@@ -829,6 +831,7 @@ describe('gd.ExpressionCompletionFinder', function () {
         ).toMatchInlineSnapshot(`
           [
             "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure["Child1Structure with unsafe \\"\`/+ characters and spaces"], no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
@@ -865,6 +868,7 @@ describe('gd.ExpressionCompletionFinder', function () {
         ).toMatchInlineSnapshot(`
           [
             "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure["Child1Structure with unsafe \\"\`/+ characters and spaces"], no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",

--- a/GDevelop.js/__tests__/ExpressionCompletionFinder.spec.js
+++ b/GDevelop.js/__tests__/ExpressionCompletionFinder.spec.js
@@ -82,6 +82,9 @@ describe('gd.ExpressionCompletionFinder', function () {
         structureChild1.getChild('Child1StructureChild1');
         structureChild1.getChild('Child1StructureChild2');
         structureChild1.getChild('Child1StructureChild3');
+        structureChild1.getChild(
+          'Child1 Unsafe Because of Spaces so not listed'
+        );
 
         // With a child array, containing 2 structures and a number.
         // Useful to test completion of the array children.
@@ -178,6 +181,21 @@ describe('gd.ExpressionCompletionFinder', function () {
         `);
       });
 
+      test('Root variables (eager completion of children)', () => {
+        expect(
+          testCompletions('number', 'MySpriteObject.MyObjectVariableStructure|')
+        ).toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, MyObjectVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 3, no prefix, MyObjectVariableStructure.Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, MyObjectVariableStructure.Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, MyObjectVariableStructure.Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 1, no type, 1, MyObjectVariableStructure, no completion, MySpriteObject, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 2, number, 1, MyObjectVariableStructure, no completion, MySpriteObject, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
+      });
+
       test('Root variables (objectvar parameter)', () => {
         expect(testCompletions('number', 'MySpriteObject.Variable(MyObject|'))
           .toMatchInlineSnapshot(`
@@ -185,6 +203,22 @@ describe('gd.ExpressionCompletionFinder', function () {
             "{ 3, no type, 1, no prefix, MyObjectVariableNumber, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 1, no prefix, MyObjectVariableString, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
             "{ 3, no type, 3, no prefix, MyObjectVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
+      });
+
+      test('Root variables (objectvar parameter, eager completion of children)', () => {
+        expect(
+          testCompletions(
+            'number',
+            'MySpriteObject.Variable(MyObjectVariableStructure|'
+          )
+        ).toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, MyObjectVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 3, no prefix, MyObjectVariableStructure.Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, MyObjectVariableStructure.Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, MyObjectVariableStructure.Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
           ]
         `);
       });
@@ -229,6 +263,24 @@ describe('gd.ExpressionCompletionFinder', function () {
         `);
       });
 
+      test('Structure, 1 level (eager completion of children)', () => {
+        expect(
+          testCompletions(
+            'number',
+            'MySpriteObject.MyObjectVariableStructure.Child1Structure|'
+          )
+        ).toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
+      });
+
       test('Structure, 1 level (objectvar parameter)', () => {
         expect(
           testCompletions(
@@ -252,6 +304,24 @@ describe('gd.ExpressionCompletionFinder', function () {
         ).toMatchInlineSnapshot(`
           [
             "{ 3, no type, 3, no prefix, MyObjectVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
+      });
+
+      test('Structure, 1 level (objectvar parameter, eager completion of children)', () => {
+        expect(
+          testCompletions(
+            'number',
+            'MySpriteObject.Variable(MyObjectVariableStructure.Child1Structure|'
+          )
+        ).toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
           ]
         `);
       });
@@ -490,7 +560,7 @@ describe('gd.ExpressionCompletionFinder', function () {
         `);
       });
 
-      test('Structure, 1 level (scenevar parameter)', () => {
+      test('Structure, 1 level (objectvar parameter)', () => {
         // Completions of children:
         expect(
           testCompletions(
@@ -690,13 +760,26 @@ describe('gd.ExpressionCompletionFinder', function () {
     describe('Scene variables completion', () => {
       test('Root variables', () => {
         expect(testCompletions('number', 'MyVariab|')).toMatchInlineSnapshot(`
-                  [
-                    "{ 3, no type, 1, no prefix, MyVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
-                    "{ 3, no type, 1, no prefix, MyVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
-                    "{ 3, no type, 3, no prefix, MyVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
-                    "{ 2, number, 1, MyVariab, no completion, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
-                  ]
-              `);
+          [
+            "{ 3, no type, 1, no prefix, MyVariable, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, MyVariable2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 3, no prefix, MyVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 2, number, 1, MyVariab, no completion, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
+      });
+
+      test('Root variables (eager completion of children)', () => {
+        expect(testCompletions('number', 'MyVariableStructure|'))
+          .toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, MyVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 3, no prefix, MyVariableStructure.Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, MyVariableStructure.Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, MyVariableStructure.Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 2, number, 1, MyVariableStructure, no completion, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
       });
 
       test('Root variables (scenevar parameter)', () => {
@@ -708,6 +791,18 @@ describe('gd.ExpressionCompletionFinder', function () {
                     "{ 3, no type, 3, no prefix, MyVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
                   ]
               `);
+      });
+
+      test('Root variables (scenevar parameter, eager completion of children)', () => {
+        expect(testCompletions('number', 'Variable(MyVariableStructure|)'))
+          .toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, MyVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 3, no prefix, MyVariableStructure.Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, MyVariableStructure.Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, MyVariableStructure.Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
       });
 
       test('Structure, 1 level', () => {
@@ -728,6 +823,21 @@ describe('gd.ExpressionCompletionFinder', function () {
         `);
       });
 
+      test('Structure, 1 level (eager completion of children)', () => {
+        expect(
+          testCompletions('number', 'MyVariableStructure.Child1Structure|')
+        ).toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
+      });
+
       test('Structure, 1 level (scenevar parameter)', () => {
         expect(testCompletions('number', 'Variable(MyVariableStructure.|'))
           .toMatchInlineSnapshot(`
@@ -742,6 +852,24 @@ describe('gd.ExpressionCompletionFinder', function () {
           .toMatchInlineSnapshot(`
           [
             "{ 3, no type, 3, no prefix, MyVariableStructure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+          ]
+        `);
+      });
+
+      test('Structure, 1 level (scenevar parameter, eager completion of children)', () => {
+        expect(
+          testCompletions(
+            'number',
+            'Variable(MyVariableStructure.Child1Structure|'
+          )
+        ).toMatchInlineSnapshot(`
+          [
+            "{ 3, no type, 3, no prefix, Child1Structure, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild1, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild2, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child1Structure.Child1StructureChild3, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 4, no prefix, Child2Array, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
+            "{ 3, no type, 1, no prefix, Child3Boolean, no object name, no behavior name, non-exact, not last parameter, no parameter metadata, no object configuration }",
           ]
         `);
       });

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/ExpressionAutocompletionsDisplayer.js
@@ -98,6 +98,8 @@ const AutocompletionRow = React.forwardRef(
     |},
     ref
   ) => {
+    const trimmedLabel = label.length > 46 ? label.substr(0, 46) + '…' : label;
+
     return (
       <ButtonBase
         style={styles.button}
@@ -112,7 +114,7 @@ const AutocompletionRow = React.forwardRef(
         {icon || (iconSrc ? <AutocompletionIcon src={iconSrc} /> : null)}
         <Spacer />
         <Text style={defaultTextStyle} noMargin align="left">
-          {isSelected ? <b>{label}</b> : label}
+          {isSelected ? <b>{trimmedLabel}</b> : trimmedLabel}
           {parametersLabel && (
             <>
               (<i>{parametersLabel}</i>)


### PR DESCRIPTION
In addition to traditional completions:
<img width="381" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/00816409-5cec-4e90-b67b-8c46e0aab90d">

Also display completions for children variables if the exact name of the variable is entered.
<img width="405" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/3cfdf728-e99e-483d-9442-15975454e9d6">

This means a full structure can be browsed by choosing the right children, without entering a dot manually.

- [x] ~~Also avoid listing children with names that can't be used in expressions~~
  - [x] List them with [""] syntax.
- [x] Parser fixes
  - [x] Improve error messages so that `Variable..` is not accepted.
  - [x] Fix `Variable.["test"]` that should not be accepted