### PR TITLE
Fix heavy assets failing to download on slow connections.

### DIFF
--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -114,6 +114,9 @@ namespace gdjs {
       if (!loader) {
         return;
       }
+      if (this._loadedThreeModels.getFromName(resource.name)) {
+        return;
+      }
       const url = this._resourceLoader.getFullUrl(resource.file);
       try {
         const response = await fetch(url, {


### PR DESCRIPTION
### Changes
- Use a pool to limit concurrent downloads to 20.
- Avoid 3D models used in different scenes to be downloaded several times