### PR TITLE
Add several animations in a sprite object in one go

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
@@ -1,0 +1,109 @@
+// @flow
+import path from 'path-browserify';
+import groupBy from 'lodash/groupBy';
+
+const findCommonPrefix = (values: Array<string>): string => {
+  if (values.length === 0) {
+    return '';
+  }
+  if (values.length === 1) {
+    return values[0];
+  }
+  let hasFoundBiggerPrefix = true;
+  let prefixLength = 0;
+  for (let index = 0; hasFoundBiggerPrefix; index++) {
+    const character = values[0].charAt(index);
+    hasFoundBiggerPrefix = values.every(
+      value => value.length > index && value.charAt(index) === character
+    );
+    if (!hasFoundBiggerPrefix) {
+      prefixLength = index;
+    }
+  }
+  return values[0].substring(0, prefixLength);
+};
+
+const separators = [' ', '_', '-', '.'];
+
+const trimFromSeparators = (value: string) => {
+  let lowerIndex = 0;
+  for (let index = 0; index < value.length; index++) {
+    if (!separators.some(separator => value.charAt(index))) {
+      lowerIndex = index - 1;
+      break;
+    }
+  }
+  let upperIndex = value.length;
+  for (let index = value.length; index >= lowerIndex; index--) {
+    if (!separators.some(separator => value.charAt(index))) {
+      upperIndex = index + 1;
+      break;
+    }
+  }
+  return value.substring(lowerIndex, upperIndex + 1);
+};
+
+export const groupResourcesByAnimations = (
+  resources: Array<gdResource>
+): Map<string, Array<gdResource>> => {
+  const resourcesByAnimation = new Map<string, Array<gdResource>>();
+
+  if (resources.length === 0) {
+    return resourcesByAnimation;
+  }
+
+  // Extract the frame indexes from the file names.
+  const namedResources = resources.map(resource => {
+    const basename = path.basename(
+      resource.getFile(),
+      path.extname(resource.getFile())
+    );
+    const indexMatches = basename.match(/\(\d+\)$|\d+$/g);
+    const indexNumberMatches =
+      indexMatches && indexMatches[0].match(/\(\d+\)$|\d+$/g);
+    const index = indexNumberMatches ? parseInt(indexNumberMatches[0]) : null;
+    let name = trimFromSeparators(
+      indexMatches
+        ? basename.substring(0, basename.length - indexMatches[0].length)
+        : basename
+    );
+    if (separators.some(separator => name.endsWith(separator))) {
+      name = name.substring(0, name.length - 1);
+    }
+    return {
+      resource,
+      name,
+      index: isNaN(index) ? null : index,
+    };
+  });
+  console.log(namedResources);
+
+  const commonPrefix = findCommonPrefix(
+    namedResources.map(resources => resources.name)
+  );
+  const hasSeveralAnimations =
+    commonPrefix.length !== namedResources[0].name.length;
+  if (hasSeveralAnimations) {
+    // Remove the common prefix as it's probably the object name.
+    for (const namedResource of namedResources) {
+      namedResource.name = namedResource.name.substring(commonPrefix.length);
+    }
+  }
+  for (const namedResource of namedResources) {
+    namedResource.name = trimFromSeparators(namedResource.name);
+  }
+  console.log(namedResources);
+
+  // Index the resources by animation names and frame indexes.
+  const resourcesByName = groupBy(namedResources, ({ name }) => name);
+  for (const name in resourcesByName) {
+    const enumeratedResources = resourcesByName[name];
+    resourcesByAnimation.set(
+      name,
+      enumeratedResources
+        .sort((a, b) => (a.index || 0) - (b.index || 0))
+        .map(resource => resource.resource)
+    );
+  }
+  return resourcesByAnimation;
+};

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
@@ -54,9 +54,11 @@ export const groupResourcesByAnimations = (
 
   // Extract the frame indexes from the file names.
   const namedResources = resources.map(resource => {
+    // The resource name is used instead of the resource file path because
+    // cloud projects are prefixing files names with a UID.
     const basename = path.basename(
-      resource.getFile(),
-      path.extname(resource.getFile())
+      resource.getName(),
+      path.extname(resource.getName())
     );
     const indexMatches = basename.match(/\(\d+\)$|\d+$/g);
     const indexNumberMatches =

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
@@ -28,14 +28,14 @@ const separators = [' ', '_', '-', '.'];
 const trimFromSeparators = (value: string) => {
   let lowerIndex = 0;
   for (let index = 0; index < value.length; index++) {
-    if (!separators.some(separator => value.charAt(index))) {
+    if (!separators.includes(value.charAt(index))) {
       lowerIndex = index - 1;
       break;
     }
   }
-  let upperIndex = value.length;
-  for (let index = value.length; index >= lowerIndex; index--) {
-    if (!separators.some(separator => value.charAt(index))) {
+  let upperIndex = value.length - 1;
+  for (let index = value.length - 1; index >= lowerIndex; index--) {
+    if (!separators.includes(value.charAt(index))) {
       upperIndex = index + 1;
       break;
     }
@@ -76,7 +76,6 @@ export const groupResourcesByAnimations = (
       index: isNaN(index) ? null : index,
     };
   });
-  console.log(namedResources);
 
   const commonPrefix = findCommonPrefix(
     namedResources.map(resources => resources.name)
@@ -90,9 +89,11 @@ export const groupResourcesByAnimations = (
     }
   }
   for (const namedResource of namedResources) {
+    console.log(
+      namedResource.name + ' = ' + trimFromSeparators(namedResource.name)
+    );
     namedResource.name = trimFromSeparators(namedResource.name);
   }
-  console.log(namedResources);
 
   // Index the resources by animation names and frame indexes.
   const resourcesByName = groupBy(namedResources, ({ name }) => name);

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.js
@@ -80,19 +80,9 @@ export const groupResourcesByAnimations = (
   const commonPrefix = findCommonPrefix(
     namedResources.map(resources => resources.name)
   );
-  const hasSeveralAnimations =
-    commonPrefix.length !== namedResources[0].name.length;
-  if (hasSeveralAnimations) {
-    // Remove the common prefix as it's probably the object name.
-    for (const namedResource of namedResources) {
-      namedResource.name = namedResource.name.substring(commonPrefix.length);
-    }
-  }
+  // Remove the common prefix as it's probably the object name.
   for (const namedResource of namedResources) {
-    console.log(
-      namedResource.name + ' = ' + trimFromSeparators(namedResource.name)
-    );
-    namedResource.name = trimFromSeparators(namedResource.name);
+    namedResource.name = namedResource.name.substring(commonPrefix.length);
   }
 
   // Index the resources by animation names and frame indexes.

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
@@ -6,6 +6,7 @@ describe('AnimationImportHelper', () => {
   const createResources = (filePaths: Array<string>): Array<gdResource> =>
     filePaths.map(filePath => {
       const resource = new gd.ImageResource();
+      resource.setName(filePath);
       resource.setFile(filePath);
       return resource;
     });

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
@@ -41,6 +41,20 @@ describe('AnimationImportHelper', () => {
     deleteResources(resources);
   });
 
+  it('can handle 1 frame alone', () => {
+    const resources = createResources([
+      'Assets/Player Jump.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Player Jump')).toBe(
+      1
+    );
+
+    deleteResources(resources);
+  });
+
   it('can handle 1 animation alone', () => {
     const resources = createResources([
       'Assets/Player Run 1.png',

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
@@ -16,6 +16,22 @@ describe('AnimationImportHelper', () => {
     }
   };
 
+  const getAnimationFramesCount = (
+    resourcesByAnimations: Map<string, Array<gdResource>>,
+    animationName: string
+  ): number | null => {
+    const frames = resourcesByAnimations.get(animationName);
+    return frames ? frames.length : null;
+  };
+
+  const getAnimationFramesPaths = (
+    resourcesByAnimations: Map<string, Array<gdResource>>,
+    animationName: string
+  ): Array<string> | null => {
+    const frames = resourcesByAnimations.get(animationName);
+    return frames ? frames.map(resource => resource.getFile()) : null;
+  };
+
   it('can handle empty resource lists', () => {
     const resources = createResources([]);
 
@@ -25,15 +41,141 @@ describe('AnimationImportHelper', () => {
     deleteResources(resources);
   });
 
-  it('can find animation names', () => {
+  it('can handle 1 animation alone', () => {
     const resources = createResources([
-      'Assets/Player Run.png',
+      'Assets/Player Run 1.png',
+      'Assets/Player Run 2.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Player Run')).toBe(
+      2
+    );
+
+    deleteResources(resources);
+  });
+
+  it('can find animation names without frame indexes', () => {
+    const resources = createResources([
+      'Assets/Player Jump.png',
+      'Assets/Player Run 1.png',
+      'Assets/Player Run 2.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Run')).toBe(2);
+
+    deleteResources(resources);
+  });
+
+  it('can find animation names without object name', () => {
+    const resources = createResources([
+      'Assets/Jump.png',
+      'Assets/Run 1.png',
+      'Assets/Run 2.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Run')).toBe(2);
+
+    deleteResources(resources);
+  });
+
+  it('can find animation names without any separator', () => {
+    const resources = createResources([
+      'Assets/PlayerJump.png',
+      'Assets/PlayerRun1.png',
+      'Assets/PlayerRun2.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Run')).toBe(2);
+
+    deleteResources(resources);
+  });
+
+  it('can find animation names when separator contains several characters', () => {
+    const resources = createResources([
+      'Assets/Player - Jump.png',
+      'Assets/Player - Run - 1.png',
+      'Assets/Player - Run - 2.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Run')).toBe(2);
+
+    deleteResources(resources);
+  });
+
+  it('can sort frames by numerical order', () => {
+    const resources = createResources([
+      'Assets/PlayerRun02.png',
+      'Assets/PlayerJump.png',
+      'Assets/PlayerRun1.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesPaths(resourcesByAnimations, 'Run')).toStrictEqual(
+      ['Assets/PlayerRun1.png', 'Assets/PlayerRun02.png']
+    );
+
+    deleteResources(resources);
+  });
+
+  it('can sort frames by numerical order without taking "-" as a negative sign', () => {
+    const resources = createResources([
+      'Assets/Jump.png',
+      'Assets/Run-1.png',
+      'Assets/Run-2.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesPaths(resourcesByAnimations, 'Run')).toStrictEqual(
+      ['Assets/Run-1.png', 'Assets/Run-2.png']
+    );
+
+    deleteResources(resources);
+  });
+
+  it('can find frame index inside parenthesis', () => {
+    const resources = createResources([
+      'Assets/Player Run (1).png',
+      'Assets/Player Run (2).png',
       'Assets/Player Jump.png',
     ]);
 
     const resourcesByAnimations = groupResourcesByAnimations(resources);
     expect(resourcesByAnimations.size).toBe(2);
-    expect([...resourcesByAnimations.keys()]).toStrictEqual(['Run', 'Jump']);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Run')).toBe(2);
+
+    deleteResources(resources);
+  });
+
+  it('can find animation frames when indexes have holes', () => {
+    const resources = createResources([
+      'Assets/Jump.png',
+      'Assets/Run 0.png',
+      'Assets/Run 567.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Jump')).toBe(1);
+    expect(getAnimationFramesCount(resourcesByAnimations, 'Run')).toBe(2);
 
     deleteResources(resources);
   });

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
@@ -1,0 +1,40 @@
+// @flow
+import { groupResourcesByAnimations } from './AnimationImportHelper';
+const gd = global.gd;
+
+describe('AnimationImportHelper', () => {
+  const createResources = (filePaths: Array<string>): Array<gdResource> =>
+    filePaths.map(filePath => {
+      const resource = new gd.ImageResource();
+      resource.setFile(filePath);
+      return resource;
+    });
+
+  const deleteResources = (resources: Array<gdResource>): void => {
+    for (const resource of resources) {
+      resource.delete();
+    }
+  };
+
+  it('can handle empty resource lists', () => {
+    const resources = createResources([]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(0);
+
+    deleteResources(resources);
+  });
+
+  it('can find animation names', () => {
+    const resources = createResources([
+      'Assets/Player Run.png',
+      'Assets/Player Jump.png',
+    ]);
+
+    const resourcesByAnimations = groupResourcesByAnimations(resources);
+    expect(resourcesByAnimations.size).toBe(2);
+    expect([...resourcesByAnimations.keys()]).toStrictEqual(['Run', 'Jump']);
+
+    deleteResources(resources);
+  });
+});

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
@@ -46,9 +46,7 @@ describe('AnimationImportHelper', () => {
 
     const resourcesByAnimations = groupResourcesByAnimations(resources);
     expect(resourcesByAnimations.size).toBe(1);
-    expect(getAnimationFramesCount(resourcesByAnimations, 'Player Jump')).toBe(
-      1
-    );
+    expect(getAnimationFramesCount(resourcesByAnimations, '')).toBe(1);
 
     deleteResources(resources);
   });
@@ -61,9 +59,7 @@ describe('AnimationImportHelper', () => {
 
     const resourcesByAnimations = groupResourcesByAnimations(resources);
     expect(resourcesByAnimations.size).toBe(1);
-    expect(getAnimationFramesCount(resourcesByAnimations, 'Player Run')).toBe(
-      2
-    );
+    expect(getAnimationFramesCount(resourcesByAnimations, '')).toBe(2);
 
     deleteResources(resources);
   });

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/AnimationImportHelper.spec.js
@@ -42,9 +42,7 @@ describe('AnimationImportHelper', () => {
   });
 
   it('can handle 1 frame alone', () => {
-    const resources = createResources([
-      'Assets/Player Jump.png',
-    ]);
+    const resources = createResources(['Assets/Player Jump.png']);
 
     const resourcesByAnimations = groupResourcesByAnimations(resources);
     expect(resourcesByAnimations.size).toBe(1);

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -411,18 +411,21 @@ const SpritesList = ({
         project.getResourcesManager().addResource(resource);
       });
 
-      if (directionSpritesCountBeforeAdding === 0) {
+      if (directionSpritesCountBeforeAdding === 0 && resources.length > 1) {
         const resourcesByAnimation = groupResourcesByAnimations(resources);
-        if (resourcesByAnimation) {
+        if (resourcesByAnimation.size > 1) {
           addAnimations(resourcesByAnimation);
         } else {
-          for (const resource of resources) {
-            addAnimationFrame(
-              spriteConfiguration,
-              direction,
-              resource,
-              onSpriteAdded
-            );
+          // Use `resourcesByAnimation` because frames are sorted.
+          for (const resources of resourcesByAnimation.values()) {
+            for (const resource of resources) {
+              addAnimationFrame(
+                spriteConfiguration,
+                direction,
+                resource,
+                onSpriteAdded
+              );
+            }
           }
         }
       } else {

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -40,7 +40,6 @@ import useAlertDialog from '../../../UI/Alert/useAlertDialog';
 import { groupResourcesByAnimations } from './AnimationImportHelper';
 import { type ResourceExternalEditor } from '../../../ResourcesList/ResourceExternalEditor';
 
-
 const gd: libGDevelop = global.gd;
 
 const SPRITE_SIZE = 100; //TODO: Factor with Thumbnail

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/SpritesList.js
@@ -266,7 +266,7 @@ type Props = {|
   project: gdProject,
   resourcesLoader: typeof ResourcesLoader,
   resourceManagementProps: ResourceManagementProps,
-  editWith: (
+  editDirectionWith: (
     i18n: I18nType,
     ResourceExternalEditor,
     direction: gdDirection
@@ -287,7 +287,7 @@ const SpritesList = ({
   project,
   resourcesLoader,
   resourceManagementProps,
-  editWith,
+  editDirectionWith,
   onReplaceByDirection,
   onSpriteAdded,
   onSpriteUpdated,
@@ -591,7 +591,7 @@ const SpritesList = ({
           resourceManagementProps.resourceExternalEditors
         }
         onEditWith={(i18n, ResourceExternalEditor) =>
-          editWith(i18n, ResourceExternalEditor, direction)
+          editDirectionWith(i18n, ResourceExternalEditor, direction)
         }
         onDirectionUpdated={onSpriteUpdated}
       />

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -529,9 +529,6 @@ export default function SpriteEditor({
 
   const adaptCollisionMaskIfNeeded = React.useCallback(
     () => {
-      // If the first sprite of the first animation is updated,
-      // we update the automatic collision mask of the object,
-      // if the option is enabled.
       if (spriteConfiguration.adaptCollisionMaskAutomatically()) {
         onCreateMatchingSpriteCollisionMask();
       }
@@ -539,7 +536,7 @@ export default function SpriteEditor({
     [onCreateMatchingSpriteCollisionMask, spriteConfiguration]
   );
 
-  const editWith = React.useCallback(
+  const editDirectionWith = React.useCallback(
     async (
       i18n: I18nType,
       externalEditor: ResourceExternalEditor,
@@ -662,9 +659,9 @@ export default function SpriteEditor({
     async (i18n: I18nType, externalEditor: ResourceExternalEditor) => {
       addAnimation();
       const direction = spriteConfiguration.getAnimation(0).getDirection(0);
-      await editWith(i18n, externalEditor, direction, 0, 0);
+      await editDirectionWith(i18n, externalEditor, direction, 0, 0);
     },
-    [addAnimation, editWith, spriteConfiguration]
+    [addAnimation, editDirectionWith, spriteConfiguration]
   );
 
   const imageResourceExternalEditors = resourceManagementProps.resourceExternalEditors.filter(
@@ -829,12 +826,12 @@ export default function SpriteEditor({
                                             resourceManagementProps={
                                               resourceManagementProps
                                             }
-                                            editWith={(
+                                            editDirectionWith={(
                                               i18n,
                                               ResourceExternalEditor,
                                               direction
                                             ) =>
-                                              editWith(
+                                              editDirectionWith(
                                                 i18n,
                                                 ResourceExternalEditor,
                                                 direction,
@@ -859,6 +856,9 @@ export default function SpriteEditor({
                                             }
                                             onSpriteUpdated={onObjectUpdated}
                                             onFirstSpriteUpdated={
+                                              // If the first sprite of the first animation is updated,
+                                              // we update the automatic collision mask of the object,
+                                              // if the option is enabled.
                                               animationIndex === 0
                                                 ? adaptCollisionMaskIfNeeded
                                                 : undefined

--- a/newIDE/app/src/ObjectsList/EnumerateObjects.spec.js
+++ b/newIDE/app/src/ObjectsList/EnumerateObjects.spec.js
@@ -17,9 +17,9 @@ describe('EnumerateObjects', () => {
       allObjectsList,
     } = enumerateObjects(project, testLayout);
 
-    expect(containerObjectsList).toHaveLength(19);
+    expect(containerObjectsList).toHaveLength(20);
     expect(projectObjectsList).toHaveLength(2);
-    expect(allObjectsList).toHaveLength(21);
+    expect(allObjectsList).toHaveLength(22);
   });
 
   it('can enumerate objects with a filter on object type', () => {
@@ -27,7 +27,7 @@ describe('EnumerateObjects', () => {
     const countByType = {
       'Button::PanelSpriteButton': 1,
       'TextObject::Text': 2,
-      Sprite: 12,
+      Sprite: 13,
     };
     Object.entries(countByType).forEach(([type, count]) => {
       const { allObjectsList } = enumerateObjects(project, testLayout, {

--- a/newIDE/app/src/fixtures/TestProject.js
+++ b/newIDE/app/src/fixtures/TestProject.js
@@ -9,8 +9,10 @@ export type TestProject = {|
   tiledSpriteObjectConfiguration: gdObjectConfiguration,
   panelSpriteObject: gdObject,
   spriteObjectConfiguration: gdSpriteObject,
+  emptySpriteObjectConfiguration: gdSpriteObject,
   customObject: gdObject,
   spriteObject: gdObject,
+  emptySpriteObject: gdObject,
   spriteObjectWithBehaviors: gdObject,
   spriteObjectWithoutBehaviors: gdObject,
   testSpriteObjectInstance: gdInitialInstance,
@@ -223,6 +225,12 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
     'MySpriteObject',
     0
   );
+  const emptySpriteObject = testLayout.insertNewObject(
+    project,
+    'Sprite',
+    'MyEmptySpriteObject',
+    0
+  );
   const spriteObjectWithBehaviors = testLayout.insertNewObject(
     project,
     'Sprite',
@@ -261,6 +269,9 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
   );
   const spriteObjectConfiguration = gd.asSpriteConfiguration(
     spriteObject.getConfiguration()
+  );
+  const emptySpriteObjectConfiguration = gd.asSpriteConfiguration(
+    emptySpriteObject.getConfiguration()
   );
   {
     const variablesContainer = spriteObject.getVariables();
@@ -870,6 +881,8 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
     customObject,
     spriteObject,
     spriteObjectConfiguration,
+    emptySpriteObject,
+    emptySpriteObjectConfiguration,
     testSpriteObjectInstance,
     spriteObjectWithBehaviors,
     spriteObjectWithoutBehaviors,

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/SpriteEditor.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/SpriteEditor.stories.js
@@ -56,6 +56,22 @@ export const AnimationLocked = () => (
   </SerializedObjectDisplay>
 );
 
+export const Empty = () => (
+  <SerializedObjectDisplay object={testProject.emptySpriteObjectConfiguration}>
+    <DragAndDropContextProvider>
+      <SpriteEditor
+        objectConfiguration={testProject.emptySpriteObjectConfiguration}
+        project={testProject.project}
+        layout={testProject.testLayout}
+        resourceManagementProps={fakeResourceManagementProps}
+        onSizeUpdated={() => {}}
+        object={testProject.emptySpriteObject}
+        objectName="FakeObjectName"
+      />
+    </DragAndDropContextProvider>
+  </SerializedObjectDisplay>
+);
+
 export const Points = () => (
   <SerializedObjectDisplay object={testProject.spriteObjectConfiguration}>
     <DragAndDropContextProvider>


### PR DESCRIPTION
https://gdevelop-storybook.s3.amazonaws.com/animation-batch/latest/index.html?path=/story/objecteditor-spriteeditor--empty

### Changes
- Fix frames being out of order when selecting several files.
- The placeholder view now give the choice between importing images or draw with Piskel.
- Automatically create animations according to file names.
  - Most naming conversions should work
  - When it's done from an empty animation, the original animation is left empty.