### PR TITLE
Allow to set 3D models dimensions with a scaling factor

### DIFF
--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -2736,6 +2736,9 @@ module.exports = {
         originalDepth,
         keepAspectRatio
       ) {
+        // These formulas are also used in:
+        // - gdjs.Model3DRuntimeObject3DRenderer._updateDefaultTransformation
+        // - Model3DEditor.modelSize
         threeObject.rotation.set(
           (rotationX * Math.PI) / 180,
           (rotationY * Math.PI) / 180,

--- a/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
@@ -147,6 +147,9 @@ namespace gdjs {
       originalDepth: float,
       keepAspectRatio: boolean
     ) {
+      // These formulas are also used in:
+      // - Model3DEditor.modelSize
+      // - Model3DRendered2DInstance
       threeObject.rotation.set(
         gdjs.toRad(rotationX),
         gdjs.toRad(rotationY),

--- a/newIDE/app/src/ObjectEditor/Editors/Model3DEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/Model3DEditor.js
@@ -59,7 +59,7 @@ const styles = {
   },
 };
 
-const removeTailingZeroes = (value: string) => {
+const removeTrailingZeroes = (value: string) => {
   for (let index = value.length - 1; index > 0; index--) {
     if (value.charAt(index) === '.') {
       return value.substring(0, index);
@@ -297,23 +297,20 @@ const Model3DEditor = ({
   // This doesn't loop indefinitely because the loader always return the same
   // instance of GLTF.
   const [gltf, setGltf] = React.useState<GLTF | null>(null);
-  const getGltf = React.useCallback(
-    (modelResourceName: string) => {
-      PixiResourcesLoader.get3DModel(project, modelResourceName).then(
-        newModel3d => {
-          setGltf(newModel3d);
-        }
+  const loadGltf = React.useCallback(
+    async () => {
+      const modelResourceName = properties.get('modelResourceName').getValue();
+      const newModel3d = await PixiResourcesLoader.get3DModel(
+        project,
+        modelResourceName
       );
+      setGltf(newModel3d);
     },
-    [project]
+    [project, properties]
   );
-  getGltf(properties.get('modelResourceName').getValue());
-  const onChangeModelResourceName = React.useCallback(
-    (modelResourceName: string) => {
-      getGltf(modelResourceName);
-    },
-    [getGltf]
-  );
+  if (!gltf) {
+    loadGltf();
+  }
 
   const model3D = React.useMemo<THREE.Object3D | null>(
     () => {
@@ -330,13 +327,13 @@ const Model3DEditor = ({
   );
 
   const [rotationX, setRotationX] = React.useState<number>(
-    parseFloat(properties.get('rotationX').getValue()) || 0
+    () => parseFloat(properties.get('rotationX').getValue()) || 0
   );
   const [rotationY, setRotationY] = React.useState<number>(
-    parseFloat(properties.get('rotationY').getValue()) || 0
+    () => parseFloat(properties.get('rotationY').getValue()) || 0
   );
   const [rotationZ, setRotationZ] = React.useState<number>(
-    parseFloat(properties.get('rotationZ').getValue()) || 0
+    () => parseFloat(properties.get('rotationZ').getValue()) || 0
   );
   const onRotationChange = React.useCallback(
     () => {
@@ -371,13 +368,13 @@ const Model3DEditor = ({
   );
 
   const [width, setWidth] = React.useState<number>(
-    parseFloat(properties.get('width').getValue()) || 0
+    () => parseFloat(properties.get('width').getValue()) || 0
   );
   const [height, setHeight] = React.useState<number>(
-    parseFloat(properties.get('height').getValue()) || 0
+    () => parseFloat(properties.get('height').getValue()) || 0
   );
   const [depth, setDepth] = React.useState<number>(
-    parseFloat(properties.get('depth').getValue()) || 0
+    () => parseFloat(properties.get('depth').getValue()) || 0
   );
   const onDimensionChange = React.useCallback(
     () => {
@@ -602,7 +599,9 @@ const Model3DEditor = ({
             propertyName="modelResourceName"
             project={project}
             resourceManagementProps={resourceManagementProps}
-            onChange={onChangeModelResourceName}
+            onChange={() => {
+              loadGltf();
+            }}
           />
           <SelectField
             value={properties.get('materialType').getValue()}
@@ -684,7 +683,7 @@ const Model3DEditor = ({
               floatingLabelText={<Trans>Scaling factor</Trans>}
               onChange={value => setScale(parseFloat(value) || 0)}
               value={
-                scale === null ? '' : removeTailingZeroes(scale.toPrecision(5))
+                scale === null ? '' : removeTrailingZeroes(scale.toPrecision(5))
               }
             />
           </Column>

--- a/newIDE/app/src/ObjectEditor/Editors/Model3DEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/Model3DEditor.js
@@ -294,8 +294,6 @@ const Model3DEditor = ({
     [objectConfiguration, forceUpdate]
   );
 
-  // This doesn't loop indefinitely because the loader always return the same
-  // instance of GLTF.
   const [gltf, setGltf] = React.useState<GLTF | null>(null);
   const loadGltf = React.useCallback(
     async () => {


### PR DESCRIPTION
### Changes
- This is only UI sugar, nothing changes in the project file.

It will allow:
- users to set the same scale to all the models from an asset pack they found on the web.
- asset store maintainers to choose the scale used by the script more easily.

![image](https://github.com/4ian/GDevelop/assets/2611977/d2115d58-67e9-484d-86ab-6c8023d66f4d)
