### PR TITLE
Prevent destorying a null modalWindow

### DIFF
--- a/newIDE/electron-app/app/LocalExternalEditorWindow.js
+++ b/newIDE/electron-app/app/LocalExternalEditorWindow.js
@@ -108,6 +108,7 @@ const loadExternalEditorWindow = ({
     });
 
     modalWindow.on('close', event => {
+      if (!modalWindow) return;
       // use destroy as a workaround to force window closing, which is not done properly otherwise on Windows
       modalWindow.destroy();
       modalWindow = null;


### PR DESCRIPTION
Fix #6043 

Unsure how this can happen. Trying to close multiple times the app maybe triggers multiple 'close' events?