### PR TITLE
Revert "Use python3 to update bindings (#6068)"

### DIFF
--- a/GDevelop.js/README.md
+++ b/GDevelop.js/README.md
@@ -10,7 +10,7 @@ These are the bindings of GDevelop core classes to WebAssembly+JavaScript. This 
 
   - [CMake 3.17+](http://www.cmake.org/) (3.5+ should work on Linux/macOS). On macOS, you can install it via Homebrew (recommended for Apple M1 Architectures).
   - [Node.js](https://nodejs.org/). (We recommend using [nvm](https://github.com/nvm-sh/nvm) to be able to switch between Node versions easily).
-  - Python3 (via [pyenv](https://github.com/pyenv/pyenv) for versions management).
+  - Python (via [pyenv](https://github.com/pyenv/pyenv) for versions management).
 
 - Install [Emscripten](https://github.com/kripken/emscripten) version `3.1.21`, as explained below or on the [Emscripten installation instructions](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html):
 

--- a/GDevelop.js/update-bindings.js
+++ b/GDevelop.js/update-bindings.js
@@ -40,7 +40,7 @@ function generateGlueFromBinding(cb) {
     }
 
     exec(
-      'python3 "' + webIdlBinderPath + '" Bindings/Bindings.idl Bindings/glue',
+      'python "' + webIdlBinderPath + '" Bindings/Bindings.idl Bindings/glue',
       function(err, stdout, stderr) {
         if (err) {
           cb({ message: 'Error while running WebIDL binder:', output: err });


### PR DESCRIPTION
This reverts commit 6edf63e98f896d453ad0bf35d73951a7af52b857.

Windows machines don't know about python3. So something else should be done for Mac and Linux having troubles with it. Felt complicated, might do it in the future, idk.