### PR TITLE
Add new objects under the selected one in the list

### DIFF
--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -345,6 +345,15 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
             objectFolderOrObject: parentFolder.getObjectChild(name),
             global: false,
           };
+
+          if (treeViewRef.current) {
+            treeViewRef.current.openItems([
+              getTreeViewItemId({
+                objectFolderOrObject: parentFolder,
+                global: false,
+              }),
+            ]);
+          }
         } else {
           object = objectsContainer.insertNewObject(
             project,

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -323,17 +323,23 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         if (
           newObjectDialogOpen &&
           newObjectDialogOpen.from &&
-          !newObjectDialogOpen.from.global &&
-          newObjectDialogOpen.from.objectFolderOrObject.isFolder()
+          !newObjectDialogOpen.from.global
         ) {
+          const selectedItem = newObjectDialogOpen.from.objectFolderOrObject;
+          const parentFolder = selectedItem.isFolder()
+            ? selectedItem
+            : selectedItem.getParent();
+          const insertionIndex = selectedItem.isFolder()
+            ? parentFolder.getChildrenCount()
+            : parentFolder.getChildPosition(selectedItem) + 1;
+
           // If a scene folder is selected, insert object in the folder.
-          const parentFolder = newObjectDialogOpen.from.objectFolderOrObject;
           object = objectsContainer.insertNewObjectInFolder(
             project,
             objectType,
             name,
             parentFolder,
-            0
+            insertionIndex
           );
           objectFolderOrObjectWithContext = {
             objectFolderOrObject: parentFolder.getObjectChild(name),

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -1329,6 +1329,10 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
                 })
               ),
             },
+            {
+              label: i18n._(t`Add a new object`),
+              click: onAddNewObject,
+            },
             { type: 'separator' },
             {
               label: i18n._(t`Expand all sub folders`),
@@ -1463,11 +1467,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
                 enabled: instanceCountOnScene > 0,
               }
             : undefined,
-          { type: 'separator' },
-          {
-            label: i18n._(t`Add a new object...`),
-            click: onAddNewObject,
-          },
         ].filter(Boolean);
       },
       [


### PR DESCRIPTION
https://gdevelop-storybook.s3.amazonaws.com/menu-add-object/latest/index.html?path=/story/layouteditor-objectslist--default

### Changes
- Objects can be added to folders using their menu
  - In this case, it uses the folder of the menu
- Objects are added under the select object or at the end of the selected folder