### PR TITLE
Show a drop-down list for string with choices parameters

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
@@ -115,7 +115,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select an External Layout</Trans>}
+              label={<Trans>Select an external layout</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -124,7 +124,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
@@ -60,7 +60,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       effectName => `"${effectName}"` === props.value
     );
 
-    // If the current value is not in the list of animation names, display an expression field.
+    // If the current value is not in the list, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
       (!!props.value && !isCurrentValueInEffectNamesList) ||
         props.scope.eventsFunctionsExtension
@@ -139,7 +139,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select an Effect</Trans>}
+              label={<Trans>Select an effect</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -148,7 +148,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
@@ -82,7 +82,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       effectParameterName => `"${effectParameterName}"` === props.value
     );
 
-    // If the current value is not in the list of animation names, display an expression field.
+    // If the current value is not in the list, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
       (!!props.value && !isCurrentValueInEffectParameterNamesList) ||
         props.scope.eventsFunctionsExtension
@@ -165,7 +165,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select an Effect Property</Trans>}
+              label={<Trans>Select an effect property</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -174,7 +174,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
@@ -32,6 +32,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
     }));
 
     const { layout } = props.scope;
+    // The list is not kept with a memo because layers could be changed by
+    // another component without this one to know.
     const layerNames = layout
       ? mapFor(0, layout.getLayersCount(), i => {
           const layer = layout.getLayerAt(i);

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
@@ -126,7 +126,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select a Layer</Trans>}
+              label={<Trans>Select a layer</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -135,7 +135,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -177,7 +177,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select an Animation</Trans>}
+              label={<Trans>Select an animation</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -186,7 +186,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
@@ -87,7 +87,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       effectName => `"${effectName}"` === props.value
     );
 
-    // If the current value is not in the list of animation names, display an expression field.
+    // If the current value is not in the list, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
       (!!props.value && !isCurrentValueInEffectNamesList) ||
         props.scope.eventsFunctionsExtension
@@ -166,7 +166,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select an Effect</Trans>}
+              label={<Trans>Select an effect</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -175,7 +175,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
@@ -43,6 +43,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       parameterIndex,
     } = props;
 
+    // We don't memo/callback this, as we want to recompute it every time something changes.
+    // Because of the function getLastObjectParameterValue.
     const getEffectNames = (): Array<string> => {
       const objectOrGroupName = getLastObjectParameterValue({
         instructionMetadata,

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
@@ -129,7 +129,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       effectParameterName => `"${effectParameterName}"` === props.value
     );
 
-    // If the current value is not in the list of animation names, display an expression field.
+    // If the current value is not in the list, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
       (!!props.value && !isCurrentValueInEffectParameterNamesList) ||
         props.scope.eventsFunctionsExtension
@@ -212,7 +212,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select an Effect Property</Trans>}
+              label={<Trans>Select an effect property</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -221,7 +221,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
@@ -38,6 +38,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       focus,
     }));
 
+    // We don't memo/callback this, as we want to recompute it every time something changes.
+    // Because of the function getLastObjectParameterValue.
     const getEffectParameterNames = (): Array<string> => {
       const {
         project,

--- a/newIDE/app/src/EventsSheet/ParameterFields/ParameterMetadataTools.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ParameterMetadataTools.js
@@ -134,18 +134,23 @@ export const tryExtractStringLiteralContent = (
   return null;
 };
 
-export const getParameterChoices = (
+export const getParameterChoiceAutocompletions = (
   parameterMetadata: ?gdParameterMetadata
-): Array<ExpressionAutocompletion> => {
+): Array<ExpressionAutocompletion> =>
+  getParameterChoiceValues(parameterMetadata).map(choice => ({
+    kind: 'Text',
+    completion: `"${choice}"`,
+  }));
+
+export const getParameterChoiceValues = (
+  parameterMetadata: ?gdParameterMetadata
+): Array<string> => {
   if (!parameterMetadata) {
     return [];
   }
 
   try {
-    return JSON.parse(parameterMetadata.getExtraInfo()).map(choice => ({
-      kind: 'Text',
-      completion: `"${choice}"`,
-    }));
+    return JSON.parse(parameterMetadata.getExtraInfo());
   } catch (exception) {
     console.error(
       'The parameter seems misconfigured, as an array of choices could not be extracted - verify that your properly wrote a list of choices in JSON format. Full exception is:',

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
@@ -29,6 +29,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       focus,
     }));
 
+    // The list is not kept with a memo because scenes could be added by
+    // another component without this one to know.
     const layoutNames = props.project
       ? enumerateLayouts(props.project).map(layout => layout.getName())
       : [];

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
@@ -37,7 +37,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       layoutName => `"${layoutName}"` === props.value
     );
 
-    // If the current value is not in the list of layouts, display an expression field.
+    // If the current value is not in the list of scenes, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
       (!!props.value && !isCurrentValueInLayoutsList) ||
         props.scope.eventsFunctionsExtension
@@ -114,7 +114,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select a Scene</Trans>}
+              label={<Trans>Select a scene</Trans>}
               onClick={switchFieldType}
             />
           ) : (
@@ -123,7 +123,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               icon={<Functions />}
               style={style}
               primary
-              label={<Trans>Use an Expression</Trans>}
+              label={<Trans>Use an expression</Trans>}
               onClick={switchFieldType}
             />
           )

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
@@ -19,6 +19,14 @@ import { getParameterChoiceValues } from './ParameterMetadataTools';
 
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function StringWithSelectorField(props: ParameterFieldProps, ref) {
+    const {
+      value,
+      onChange,
+      parameterIndex,
+      parameterMetadata,
+      isInline,
+    } = props;
+
     const field = React.useRef<?(
       | GenericExpressionField
       | SelectFieldInterface
@@ -31,24 +39,24 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       focus,
     }));
 
-    const choices = getParameterChoiceValues(props.parameterMetadata);
+    const choices = getParameterChoiceValues(parameterMetadata);
 
     const isCurrentValueInList = choices.some(
-      choice => `"${choice}"` === props.value
+      choice => `"${choice}"` === value
     );
 
     // If the current value is not in the list, display an expression field.
     const [isExpressionField, setIsExpressionField] = React.useState(
-      !!props.value && !isCurrentValueInList
+      !!value && !isCurrentValueInList
     );
 
     React.useEffect(
       () => {
-        if (!isExpressionField && !props.value && choices.length > 0) {
-          props.onChange(`"${choices[0]}"`);
+        if (!isExpressionField && !value && choices.length > 0) {
+          onChange(`"${choices[0]}"`);
         }
       },
-      [choices, isExpressionField, props]
+      [choices, isExpressionField, onChange, value]
     );
 
     const switchFieldType = () => {
@@ -56,15 +64,15 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
     };
 
     const onChangeSelectValue = (event, value) => {
-      props.onChange(event.target.value);
+      onChange(event.target.value);
     };
 
     const onChangeTextValue = (value: string) => {
-      props.onChange(value);
+      onChange(value);
     };
 
-    const fieldLabel = props.parameterMetadata
-      ? props.parameterMetadata.getDescription()
+    const fieldLabel = parameterMetadata
+      ? parameterMetadata.getDescription()
       : undefined;
 
     const selectOptions = choices.map(choice => {
@@ -85,19 +93,18 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
             <SelectField
               ref={field}
               id={
-                props.parameterIndex !== undefined
-                  ? `parameter-${props.parameterIndex}-layer-field`
+                parameterIndex !== undefined
+                  ? `parameter-${parameterIndex}-string-with-selector`
                   : undefined
               }
-              value={props.value}
+              value={value}
               onChange={onChangeSelectValue}
-              margin={props.isInline ? 'none' : 'dense'}
+              margin={isInline ? 'none' : 'dense'}
               fullWidth
               floatingLabelText={fieldLabel}
               translatableHintText={t`Choose a value`}
               helperMarkdownText={
-                (props.parameterMetadata &&
-                  props.parameterMetadata.getLongDescription()) ||
+                (parameterMetadata && parameterMetadata.getLongDescription()) ||
                 null
               }
             >
@@ -108,8 +115,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               expressionType="string"
               ref={field}
               id={
-                props.parameterIndex !== undefined
-                  ? `parameter-${props.parameterIndex}-string-with-selector`
+                parameterIndex !== undefined
+                  ? `parameter-${parameterIndex}-string-with-selector`
                   : undefined
               }
               {...props}
@@ -118,7 +125,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
+          isExpressionField ? (
             <FlatButton
               id="switch-expression-select"
               leftIcon={<TypeCursorSelect />}

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
@@ -1,16 +1,29 @@
 // @flow
-import * as React from 'react';
-import GenericExpressionField from './GenericExpressionField';
+import React from 'react';
+import { Trans, t } from '@lingui/macro';
 import {
   type ParameterFieldProps,
   type ParameterFieldInterface,
   type FieldFocusFunction,
 } from './ParameterFieldCommons';
-import { getParameterChoices } from './ParameterMetadataTools';
+import SelectField, { type SelectFieldInterface } from '../../UI/SelectField';
+
+import GenericExpressionField from './GenericExpressionField';
+import SelectOption from '../../UI/SelectOption';
+import { TextFieldWithButtonLayout } from '../../UI/Layout';
+import RaisedButton from '../../UI/RaisedButton';
+import Functions from '@material-ui/icons/Functions';
+import FlatButton from '../../UI/FlatButton';
+import TypeCursorSelect from '../../UI/CustomSvgIcons/TypeCursorSelect';
+import { getParameterChoiceValues } from './ParameterMetadataTools';
 
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function StringWithSelectorField(props: ParameterFieldProps, ref) {
-    const field = React.useRef<?GenericExpressionField>(null);
+    const field = React.useRef<?(
+      | GenericExpressionField
+      | SelectFieldInterface
+    )>(null);
+
     const focus: FieldFocusFunction = options => {
       if (field.current) field.current.focus(options);
     };
@@ -18,21 +31,113 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       focus,
     }));
 
+    const choices = getParameterChoiceValues(props.parameterMetadata);
+
+    const isCurrentValueInList = choices.some(
+      choice => `"${choice}"` === props.value
+    );
+
+    // If the current value is not in the list, display an expression field.
+    const [isExpressionField, setIsExpressionField] = React.useState(
+      !!props.value && !isCurrentValueInList
+    );
+
+    React.useEffect(
+      () => {
+        if (!isExpressionField && !props.value && choices.length > 0) {
+          props.onChange(`"${choices[0]}"`);
+        }
+      },
+      [choices, isExpressionField, props]
+    );
+
+    const switchFieldType = () => {
+      setIsExpressionField(!isExpressionField);
+    };
+
+    const onChangeSelectValue = (event, value) => {
+      props.onChange(event.target.value);
+    };
+
+    const onChangeTextValue = (value: string) => {
+      props.onChange(value);
+    };
+
+    const fieldLabel = props.parameterMetadata
+      ? props.parameterMetadata.getDescription()
+      : undefined;
+
+    const selectOptions = choices.map(choice => {
+      return (
+        <SelectOption
+          key={choice}
+          value={`"${choice}"`}
+          label={choice}
+          shouldNotTranslate={true}
+        />
+      );
+    });
+
     return (
-      <GenericExpressionField
-        expressionType="string"
-        onGetAdditionalAutocompletions={expression =>
-          getParameterChoices(props.parameterMetadata).filter(
-            ({ completion }) => completion.indexOf(expression) === 0
+      <TextFieldWithButtonLayout
+        renderTextField={() =>
+          !isExpressionField ? (
+            <SelectField
+              ref={field}
+              id={
+                props.parameterIndex !== undefined
+                  ? `parameter-${props.parameterIndex}-layer-field`
+                  : undefined
+              }
+              value={props.value}
+              onChange={onChangeSelectValue}
+              margin={props.isInline ? 'none' : 'dense'}
+              fullWidth
+              floatingLabelText={fieldLabel}
+              translatableHintText={t`Choose a value`}
+              helperMarkdownText={
+                (props.parameterMetadata &&
+                  props.parameterMetadata.getLongDescription()) ||
+                null
+              }
+            >
+              {selectOptions}
+            </SelectField>
+          ) : (
+            <GenericExpressionField
+              expressionType="string"
+              ref={field}
+              id={
+                props.parameterIndex !== undefined
+                  ? `parameter-${props.parameterIndex}-string-with-selector`
+                  : undefined
+              }
+              {...props}
+              onChange={onChangeTextValue}
+            />
           )
         }
-        ref={field}
-        id={
-          props.parameterIndex !== undefined
-            ? `parameter-${props.parameterIndex}-string-with-selector`
-            : undefined
+        renderButton={style =>
+          props.scope.eventsFunctionsExtension ? null : isExpressionField ? (
+            <FlatButton
+              id="switch-expression-select"
+              leftIcon={<TypeCursorSelect />}
+              style={style}
+              primary
+              label={<Trans>Select a value</Trans>}
+              onClick={switchFieldType}
+            />
+          ) : (
+            <RaisedButton
+              id="switch-expression-select"
+              icon={<Functions />}
+              style={style}
+              primary
+              label={<Trans>Use an expression</Trans>}
+              onClick={switchFieldType}
+            />
+          )
         }
-        {...props}
       />
     );
   }

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
@@ -67,10 +67,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       onChange(event.target.value);
     };
 
-    const onChangeTextValue = (value: string) => {
-      onChange(value);
-    };
-
     const fieldLabel = parameterMetadata
       ? parameterMetadata.getDescription()
       : undefined;
@@ -120,7 +116,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                   : undefined
               }
               {...props}
-              onChange={onChangeTextValue}
+              onChange={onChange}
             />
           )
         }

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
@@ -39,6 +39,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       focus,
     }));
 
+    // The list is not kept with a memo because choices could be changed by
+    // another component without this one to know.
     const choices = getParameterChoiceValues(parameterMetadata);
 
     const isCurrentValueInList = choices.some(

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -14,7 +14,7 @@ import {
   filterEnumeratedInstructionOrExpressionMetadataByScope,
 } from '../InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata';
 import { getVisibleParameterTypes } from '../EventsSheet/ParameterFields/GenericExpressionField/FormatExpressionCall';
-import { getParameterChoices } from '../EventsSheet/ParameterFields/ParameterMetadataTools';
+import { getParameterChoiceAutocompletions } from '../EventsSheet/ParameterFields/ParameterMetadataTools';
 import getObjectByName from '../Utils/GetObjectByName';
 import { getAllPointNames } from '../ObjectEditor/Editors/SpriteEditor/Utils/SpriteObjectHelper';
 import { enumerateParametersUsableInExpressions } from '../EventsSheet/ParameterFields/EnumerateFunctionParameters';
@@ -269,7 +269,7 @@ const getAutocompletionsForText = function(
       }
     }
   } else if (type === 'stringWithSelector') {
-    autocompletionTexts = getParameterChoices(
+    autocompletionTexts = getParameterChoiceAutocompletions(
       completionDescription.getParameterMetadata()
     ).map(autocompletion => autocompletion.completion);
   } else if (type === 'objectPointName') {


### PR DESCRIPTION
### Changes
- Use the toggle between drop-down list and expression field.
- Set the first choice by default (as for operator parameter, it doesn't fill the parameter when the instruction is added with the quick instruction editor).
- Fix some typo in other fields.