### PR TITLE
Allow applying and closing confirmation dialogs

### DIFF
--- a/newIDE/app/src/UI/Alert/AlertDialog.js
+++ b/newIDE/app/src/UI/Alert/AlertDialog.js
@@ -39,6 +39,8 @@ function AlertDialog(props: Props) {
             />,
           ]}
           maxWidth="xs"
+          onRequestClose={props.onDismiss}
+          onApply={props.onDismiss}
         >
           <Text>{i18n._(props.message)}</Text>
         </Dialog>

--- a/newIDE/app/src/UI/Alert/ConfirmDialog.js
+++ b/newIDE/app/src/UI/Alert/ConfirmDialog.js
@@ -79,6 +79,8 @@ function ConfirmDialog(props: Props) {
             actions={dialogActions}
             maxWidth="xs"
             noMobileFullScreen
+            onRequestClose={props.onDismiss}
+            onApply={props.onConfirm}
           >
             <MarkdownText translatableSource={props.message} isStandaloneText />
           </Dialog>

--- a/newIDE/app/src/UI/Alert/YesNoCancelDialog.js
+++ b/newIDE/app/src/UI/Alert/YesNoCancelDialog.js
@@ -69,6 +69,8 @@ function YesNoCancelDialog(props: Props) {
           ]}
           maxWidth="xs"
           noMobileFullScreen
+          onRequestClose={props.onClickCancel}
+          onApply={props.onClickYes}
         >
           <MarkdownText translatableSource={props.message} isStandaloneText />
         </Dialog>


### PR DESCRIPTION
Partially address #6065 

As this is quite common for dialogs to allow pressing escape or cmd+enter to submit,
This feels right to allow this and prevent having to use the mouse or navigating through buttons with tab

This was already done for the confirmDeleteDialog