### PR TITLE
Fix crash when trying to access a child of a non existing object in an expression

### DIFF
--- a/Core/GDCore/IDE/Events/ExpressionVariableParentFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionVariableParentFinder.h
@@ -39,7 +39,8 @@ struct VariableAndItsParent {
 };
 
 /**
- * \brief Find the last parent (i.e: the variables container) of a node representing a variable.
+ * \brief Find the last parent (i.e: the variables container) of a node
+ * representing a variable.
  *
  * Useful for completions, to know which variables can be entered in a node.
  *
@@ -48,13 +49,12 @@ struct VariableAndItsParent {
 class GD_CORE_API ExpressionVariableParentFinder
     : public ExpressionParser2NodeWorker {
  public:
-
   static VariableAndItsParent GetLastParentOfNode(
       const gd::Platform& platform,
       const gd::ProjectScopedContainers& projectScopedContainers,
       gd::ExpressionNode& node) {
-    gd::ExpressionVariableParentFinder typeFinder(
-        platform, projectScopedContainers);
+    gd::ExpressionVariableParentFinder typeFinder(platform,
+                                                  projectScopedContainers);
     node.Visit(typeFinder);
     return typeFinder.variableAndItsParent;
   }
@@ -70,7 +70,8 @@ class GD_CORE_API ExpressionVariableParentFinder
         variableNode(nullptr),
         thisIsALegacyPrescopedVariable(false),
         bailOutBecauseEmptyVariableName(false),
-        legacyPrescopedVariablesContainer(nullptr){};
+        legacyPrescopedVariablesContainer(nullptr),
+        variableAndItsParent{} {};
 
   void OnVisitSubExpressionNode(SubExpressionNode& node) override {}
   void OnVisitOperatorNode(OperatorNode& node) override {}
@@ -135,10 +136,10 @@ class GD_CORE_API ExpressionVariableParentFinder
   }
   void OnVisitVariableAccessorNode(VariableAccessorNode& node) override {
     if (node.name.empty() && node.child) {
-      // A variable accessor should always have a name if it has a child (i.e: another accessor).
-      // While the parser may have generated an empty name,
-      // flag this so we avoid finding a wrong parent (and so, run the risk of giving
-      // wrong autocompletions).
+      // A variable accessor should always have a name if it has a child (i.e:
+      // another accessor). While the parser may have generated an empty name,
+      // flag this so we avoid finding a wrong parent (and so, run the risk of
+      // giving wrong autocompletions).
       bailOutBecauseEmptyVariableName = true;
     }
     childVariableNames.insert(childVariableNames.begin(), node.name);
@@ -300,7 +301,8 @@ class GD_CORE_API ExpressionVariableParentFinder
       const std::vector<gd::String>& childVariableNames,
       size_t startIndex = 0) {
     if (bailOutBecauseEmptyVariableName)
-      return {}; // Do not even attempt to find the parent if we had an issue when visiting nodes.
+      return {};  // Do not even attempt to find the parent if we had an issue
+                  // when visiting nodes.
 
     const gd::Variable* currentVariable = &variable;
 
@@ -332,8 +334,8 @@ class GD_CORE_API ExpressionVariableParentFinder
       }
     }
 
-    // Return the last parent of the chain of variables (so not the last variable
-    // but the one before it).
+    // Return the last parent of the chain of variables (so not the last
+    // variable but the one before it).
     return {.parentVariable = currentVariable};
   }
 
@@ -341,14 +343,16 @@ class GD_CORE_API ExpressionVariableParentFinder
       const gd::VariablesContainer& variablesContainer,
       const std::vector<gd::String>& childVariableNames) {
     if (bailOutBecauseEmptyVariableName)
-      return {}; // Do not even attempt to find the parent if we had an issue when visiting nodes.
+      return {};  // Do not even attempt to find the parent if we had an issue
+                  // when visiting nodes.
     if (childVariableNames.empty())
       return {};  // There is no "parent" to the variables container itself.
 
     const gd::String& firstChildName = *childVariableNames.begin();
 
-    const gd::Variable* variable = variablesContainer.Has(firstChildName) ?
-      &variablesContainer.Get(firstChildName) : nullptr;
+    const gd::Variable* variable = variablesContainer.Has(firstChildName)
+                                       ? &variablesContainer.Get(firstChildName)
+                                       : nullptr;
     if (childVariableNames.size() == 1 || !variable)
       return {// Only one child: the parent is the variables container itself.
               .parentVariablesContainer = &variablesContainer};

--- a/Core/tests/ExpressionParser2.cpp
+++ b/Core/tests/ExpressionParser2.cpp
@@ -203,6 +203,23 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       auto node = parser.ParseExpression("abcd[0]");
       REQUIRE(node != nullptr);
 
+      // Also check that if we try to find the last parent of node, it is not defined.
+      auto lastParentOfNode = gd::ExpressionVariableParentFinder::GetLastParentOfNode(
+          platform, projectScopedContainers, *node);
+      REQUIRE(lastParentOfNode.parentVariable == nullptr);
+      REQUIRE(lastParentOfNode.parentVariablesContainer == nullptr);
+
+      gd::ExpressionValidator validator(platform, projectScopedContainers, "string");
+      node->Visit(validator);
+      REQUIRE(validator.GetFatalErrors().size() == 1);
+      REQUIRE(validator.GetFatalErrors()[0]->GetMessage() ==
+              "No object, variable or property with this name found.");
+      REQUIRE(validator.GetFatalErrors()[0]->GetStartPosition() == 0);
+    }
+    {
+      auto node = parser.ParseExpression("abcd[0].efg");
+      REQUIRE(node != nullptr);
+
       gd::ExpressionValidator validator(platform, projectScopedContainers, "string");
       node->Visit(validator);
       REQUIRE(validator.GetFatalErrors().size() == 1);
@@ -213,6 +230,12 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
     {
       auto node = parser.ParseExpression("abcd.efg.hij");
       REQUIRE(node != nullptr);
+
+      // Also check that if we try to find the last parent of node, it is not defined.
+      auto lastParentOfNode = gd::ExpressionVariableParentFinder::GetLastParentOfNode(
+          platform, projectScopedContainers, *node);
+      REQUIRE(lastParentOfNode.parentVariable == nullptr);
+      REQUIRE(lastParentOfNode.parentVariablesContainer == nullptr);
 
       gd::ExpressionValidator validator(platform, projectScopedContainers, "string");
       node->Visit(validator);
@@ -761,6 +784,12 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
     {
       auto node = parser.ParseExpression("abcd.efg.hij");
       REQUIRE(node != nullptr);
+
+      // Also check that if we try to find the last parent of node, it is not defined.
+      auto lastParentOfNode = gd::ExpressionVariableParentFinder::GetLastParentOfNode(
+          platform, projectScopedContainers, *node);
+      REQUIRE(lastParentOfNode.parentVariable == nullptr);
+      REQUIRE(lastParentOfNode.parentVariablesContainer == nullptr);
 
       gd::ExpressionValidator validator(platform, projectScopedContainers, "number");
       node->Visit(validator);
@@ -1495,6 +1524,12 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       auto node =
           parser.ParseExpression("MyNonExistingSceneVariable");
 
+      // Also check that if we try to find the last parent of node, it is not defined.
+      auto lastParentOfNode = gd::ExpressionVariableParentFinder::GetLastParentOfNode(
+          platform, projectScopedContainers, *node);
+      REQUIRE(lastParentOfNode.parentVariable == nullptr);
+      REQUIRE(lastParentOfNode.parentVariablesContainer == nullptr);
+
       gd::ExpressionValidator validator(platform, projectScopedContainers, "number|string");
       node->Visit(validator);
       REQUIRE(validator.GetFatalErrors().size() == 1);
@@ -1513,6 +1548,25 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
       REQUIRE(validator.GetFatalErrors().size() == 1);
       REQUIRE(validator.GetFatalErrors()[0]->GetMessage() ==
               "No child variable with this name found.");
+    }
+  }
+
+  SECTION("Invalid scene variables (2 levels, variable and child do not exist)") {
+    {
+      auto node =
+          parser.ParseExpression("MyNonExistingSceneVariable.MyNonExistingChild");
+
+      // Also check that if we try to find the last parent of node, it is not defined.
+      auto lastParentOfNode = gd::ExpressionVariableParentFinder::GetLastParentOfNode(
+          platform, projectScopedContainers, *node);
+      REQUIRE(lastParentOfNode.parentVariable == nullptr);
+      REQUIRE(lastParentOfNode.parentVariablesContainer == nullptr);
+
+      gd::ExpressionValidator validator(platform, projectScopedContainers, "number|string");
+      node->Visit(validator);
+      REQUIRE(validator.GetFatalErrors().size() == 1);
+      REQUIRE(validator.GetFatalErrors()[0]->GetMessage() ==
+              "You must enter a number or a text, wrapped inside double quotes (example: \"Hello world\"), or a variable name.");
     }
   }
 
@@ -1585,6 +1639,12 @@ TEST_CASE("ExpressionParser2", "[common][events]") {
     {
       auto node =
           parser.ParseExpression("MyNonExistingSpriteObject.MyVariable");
+
+      // Also check that if we try to find the last parent of node, it is not defined.
+      auto lastParentOfNode = gd::ExpressionVariableParentFinder::GetLastParentOfNode(
+          platform, projectScopedContainers, *node);
+      REQUIRE(lastParentOfNode.parentVariable == nullptr);
+      REQUIRE(lastParentOfNode.parentVariablesContainer == nullptr);
 
       gd::ExpressionValidator validator(platform, projectScopedContainers, "number|string");
       node->Visit(validator);

--- a/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GenericExpressionField/index.js
@@ -193,6 +193,10 @@ export default class ExpressionField extends React.Component<Props, State> {
     }
   }
 
+  componentWillUnmount() {
+    this._enqueueValidation.cancel();
+  }
+
   focus: FieldFocusFunction = options => {
     if (this._field) {
       this._field.focus(options);


### PR DESCRIPTION
Fix #6137 