### PR TITLE
Fix platformer characters turn back speed when the deceleration is greater than the acceleration

### DIFF
--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -150,7 +150,6 @@ PlatformerObjectBehavior::GetProperties(
   properties["UseLegacyTrajectory"]
       .SetLabel(_("Use frame rate dependent trajectories (deprecated, it's "
                   "recommended to leave this unchecked)"))
-
       .SetGroup(_("Deprecated options"))
       .SetDeprecated()
       .SetValue(behaviorContent.GetBoolAttribute("useLegacyTrajectory", true)

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.ts
@@ -62,7 +62,7 @@ namespace gdjs {
     private _yGrabOffset: any;
     private _xGrabTolerance: any;
 
-    _useLegacyTrajectory: boolean = true;
+    _useLegacyTrajectory: boolean;
 
     _canGoDownFromJumpthru: boolean = false;
 
@@ -355,13 +355,25 @@ namespace gdjs {
 
     private _updateSpeed(timeDelta: float): float {
       const previousSpeed = this._currentSpeed;
-      //Change the speed according to the player's input.
-      // @ts-ignore
-      if (this._leftKey) {
-        this._currentSpeed -= this._acceleration * timeDelta;
-      }
-      if (this._rightKey) {
-        this._currentSpeed += this._acceleration * timeDelta;
+      // Change the speed according to the player's input.
+      // TODO Give priority to the last key for faster reaction time.
+      if (this._leftKey !== this._rightKey) {
+        if (this._leftKey) {
+          if (this._currentSpeed <= 0) {
+            this._currentSpeed -= this._acceleration * timeDelta;
+          } else {
+            // Turn back at least as fast as it would stop.
+            this._currentSpeed -=
+              Math.max(this._acceleration, this._deceleration) * timeDelta;
+          }
+        } else if (this._rightKey) {
+          if (this._currentSpeed >= 0) {
+            this._currentSpeed += this._acceleration * timeDelta;
+          } else {
+            this._currentSpeed +=
+              Math.max(this._acceleration, this._deceleration) * timeDelta;
+          }
+        }
       }
 
       //Take deceleration into account only if no key is pressed.


### PR DESCRIPTION
### Changes
- Keep the exact same behavior as before when acceleration is greater or equals to deceleration
- When deceleration > acceleration, it now uses the deceleration instead of the acceleration to go back until it reaches a speed of 0.

New behavior
- https://games.gdevelop-app.com/game-0afc325b-ef80-4dd9-a103-8f0d86aa4779/index.html

Old behavior
- https://games.gdevelop-app.com/game-b50989f3-d5d8-4482-a27f-6a056114d6e5/index.html