### PR TITLE
Handle encoding filename when displaying it in the IDE

### DIFF
--- a/newIDE/app/src/UI/CorsAwareImage.spec.js
+++ b/newIDE/app/src/UI/CorsAwareImage.spec.js
@@ -1,0 +1,104 @@
+// @flow
+import { encodeUrlAndAddEncodedSearchParameter } from './CorsAwareImage';
+
+describe('encodeUrlAndAddEncodedSearchParameter', () => {
+  it('should add search parameter to http url', () => {
+    const url = 'http://resources.gdevelop-app.com/file.png';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'http://resources.gdevelop-app.com/file.png?param=value'
+    );
+  });
+
+  it('should add search parameter to http url with existing params', () => {
+    const url = 'http://resources.gdevelop-app.com/file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'http://resources.gdevelop-app.com/file.png?existing=param&param=value'
+    );
+  });
+
+  it('should encode properly the http url', () => {
+    const url =
+      'http://resources.gdevelop-app.com/folder/my file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'http://resources.gdevelop-app.com/folder/my%20file.png?existing=param&param=value'
+    );
+  });
+
+  it('should add search parameter to https url', () => {
+    const url = 'https://resources.gdevelop-app.com/file.png';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'https://resources.gdevelop-app.com/file.png?param=value'
+    );
+  });
+
+  it('should add search parameter to https url with existing params', () => {
+    const url = 'https://resources.gdevelop-app.com/file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'https://resources.gdevelop-app.com/file.png?existing=param&param=value'
+    );
+  });
+
+  it('should encode properly the https url', () => {
+    const url =
+      'https://resources.gdevelop-app.com/my folder/my file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'https://resources.gdevelop-app.com/my%20folder/my%20file.png?existing=param&param=value'
+    );
+  });
+
+  it('should add search parameter to ftp url', () => {
+    const url = 'ftp://example.com/file.png';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe('ftp://example.com/file.png?param=value');
+  });
+
+  it('should add search parameter to ftp url with existing params', () => {
+    const url = 'ftp://example.com/file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'ftp://example.com/file.png?existing=param&param=value'
+    );
+  });
+
+  it('should encode properly the ftp url', () => {
+    const url = 'ftp://example.com/my folder/my file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'ftp://example.com/my%20folder/my%20file.png?existing=param&param=value'
+    );
+  });
+
+  it('should add search parameter to file url', () => {
+    const url = 'file://User/My folder/file.png';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe('file://User/My%20folder/file.png?param=value');
+  });
+
+  it('should add search parameter to file url with existing params', () => {
+    const url = 'file://User/My folder/file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'file://User/My%20folder/file.png?existing=param&param=value'
+    );
+  });
+
+  it('should encode properly the file url', () => {
+    const url = 'file://User/My #folder/my #file.png?existing=param';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(
+      'file://User/My%20%23folder/my%20%23file.png?existing=param&param=value'
+    );
+  });
+
+  it('should return original url for blob/data protocol or static images', () => {
+    const url = 'blob://example.com/file.png';
+    const result = encodeUrlAndAddEncodedSearchParameter(url, 'param', 'value');
+    expect(result).toBe(url);
+  });
+});


### PR DESCRIPTION
Fix #6195 

Logic is ugly as only the filename should be encoded and we have files and urls being used by the same component.
I have to test if we can use URL searchparams in a smart way.

Before:
![image](https://github.com/4ian/GDevelop/assets/4895034/2f8227c2-39df-4209-afa6-b7267c98f475)
![image](https://github.com/4ian/GDevelop/assets/4895034/76810dff-cac6-4c37-97b6-5f969b0d9e25)


After
![image](https://github.com/4ian/GDevelop/assets/4895034/00c316c3-3b80-4028-a1a5-b90aa36b36f4)
