### PR TITLE
Fix focus on a confirmation dialog

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -176,7 +176,7 @@ export default function SpriteEditor({
     },
     [justAddedAnimationName]
   );
-  const { showConfirmation } = useAlertDialog();
+  const { showDeleteConfirmation } = useAlertDialog();
 
   const draggedAnimationIndex = React.useRef<number | null>(null);
 
@@ -377,7 +377,7 @@ export default function SpriteEditor({
       const message = shouldWarnBecauseLosingCustomCollisionMask
         ? t`Are you sure you want to remove this animation? You will lose the custom collision mask you have set for this object.`
         : t`Are you sure you want to remove this animation?`;
-      const deleteAnswer = await showConfirmation({
+      const deleteAnswer = await showDeleteConfirmation({
         title: t`Remove the animation`,
         message,
         confirmButtonLabel: t`Remove`,
@@ -409,7 +409,7 @@ export default function SpriteEditor({
       forceUpdate,
       onObjectUpdated,
       onSizeUpdated,
-      showConfirmation,
+      showDeleteConfirmation,
       spriteConfiguration,
       onCreateMatchingSpriteCollisionMask,
     ]


### PR DESCRIPTION
Fix the focus on the delete choice.
# Before

Focus was not present: 
![image](https://github.com/4ian/GDevelop/assets/1670670/ed0ed9a5-eb8c-4f2e-b0eb-48f021e1df3a)

# After
Focus and shortcut works:
![image](https://github.com/4ian/GDevelop/assets/1670670/2b707fc9-dc0c-4a49-9819-d1014122c849)

- [x] Tested on local in web editor.

Fix last comment from https://github.com/4ian/GDevelop/issues/6065

