### PR TITLE
Update runtimegame-pixi-renderer.ts 

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -104,6 +104,7 @@ namespace gdjs {
           height: this._game.getGameResolutionHeight(),
           preserveDrawingBuffer: true,
           antialias: false,
+          backgroundAlpha: 0,
         }) as PIXI.Renderer;
 
         gameCanvas = this._pixiRenderer.view as HTMLCanvasElement;


### PR DESCRIPTION
This is necessary to make it possible to change the transparency of the GD background. 
Without this change background.alpha simply doesn't make sense, it just doesn't work.
Test code:
const { background } = runtimeScene.getGame().getRenderer().getPIXIRenderer();
background.clearBeforeRender = false;
background.alpha = 0; //or 0 - 1, 

