### PR TITLE
Keep 3D model origin as part of the object when used as the object origin

### DIFF
--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -2624,6 +2624,8 @@ module.exports = {
       RenderedCube3DObject3DInstance
     );
 
+    const epsilon = 1 / (1 << 16);
+
     class Model3DRendered2DInstance extends RenderedInstance {
       _modelOriginPoint = [0, 0, 0];
 
@@ -2746,13 +2748,24 @@ module.exports = {
         );
         threeObject.updateMatrixWorld(true);
         const boundingBox = new THREE.Box3().setFromObject(threeObject);
+        const shouldKeepModelOrigin = !this._originPoint;
+        if (shouldKeepModelOrigin) {
+          // Keep the origin as part of the model.
+          // For instance, a model can be 1 face of a cube and we want to keep the
+          // inside as part of the object even if it's just void.
+          // It also avoids to have the origin outside of the object box.
+          boundingBox.expandByPoint(new THREE.Vector3(0, 0, 0));
+        }
 
         const modelWidth = boundingBox.max.x - boundingBox.min.x;
         const modelHeight = boundingBox.max.y - boundingBox.min.y;
         const modelDepth = boundingBox.max.z - boundingBox.min.z;
-        this._modelOriginPoint[0] = -boundingBox.min.x / modelWidth;
-        this._modelOriginPoint[1] = -boundingBox.min.y / modelHeight;
-        this._modelOriginPoint[2] = -boundingBox.min.z / modelDepth;
+        this._modelOriginPoint[0] =
+          modelWidth < epsilon ? 0 : -boundingBox.min.x / modelWidth;
+        this._modelOriginPoint[1] =
+          modelHeight < epsilon ? 0 : -boundingBox.min.y / modelHeight;
+        this._modelOriginPoint[2] =
+          modelDepth < epsilon ? 0 : -boundingBox.min.z / modelDepth;
 
         // The model is flipped on Y axis.
         this._modelOriginPoint[1] = 1 - this._modelOriginPoint[1];
@@ -2761,19 +2774,10 @@ module.exports = {
         const centerPoint = this._centerPoint;
         if (centerPoint) {
           threeObject.position.set(
-            -(
-              boundingBox.min.x +
-              (boundingBox.max.x - boundingBox.min.x) * centerPoint[0]
-            ),
+            -(boundingBox.min.x + modelWidth * centerPoint[0]),
             // The model is flipped on Y axis.
-            -(
-              boundingBox.min.y +
-              (boundingBox.max.y - boundingBox.min.y) * (1 - centerPoint[1])
-            ),
-            -(
-              boundingBox.min.z +
-              (boundingBox.max.z - boundingBox.min.z) * centerPoint[2]
-            )
+            -(boundingBox.min.y + modelHeight * (1 - centerPoint[1])),
+            -(boundingBox.min.z + modelDepth * centerPoint[2])
           );
         }
 
@@ -2786,9 +2790,9 @@ module.exports = {
         );
 
         // Stretch the model in a 1x1x1 cube.
-        const scaleX = 1 / modelWidth;
-        const scaleY = 1 / modelHeight;
-        const scaleZ = 1 / modelDepth;
+        const scaleX = modelWidth < epsilon ? 1 : 1 / modelWidth;
+        const scaleY = modelHeight < epsilon ? 1 : 1 / modelHeight;
+        const scaleZ = modelDepth < epsilon ? 1 : 1 / modelDepth;
 
         const scaleMatrix = new THREE.Matrix4();
         // Flip on Y because the Y axis is on the opposite side of direct basis.
@@ -2799,10 +2803,22 @@ module.exports = {
 
         if (keepAspectRatio) {
           // Reduce the object dimensions to keep aspect ratio.
-          const widthRatio = originalWidth / modelWidth;
-          const heightRatio = originalHeight / modelHeight;
-          const depthRatio = originalDepth / modelDepth;
-          const scaleRatio = Math.min(widthRatio, heightRatio, depthRatio);
+          const widthRatio =
+            modelWidth < epsilon
+              ? Number.POSITIVE_INFINITY
+              : originalWidth / modelWidth;
+          const heightRatio =
+            modelHeight < epsilon
+              ? Number.POSITIVE_INFINITY
+              : originalHeight / modelHeight;
+          const depthRatio =
+            modelDepth < epsilon
+              ? Number.POSITIVE_INFINITY
+              : originalDepth / modelDepth;
+          let scaleRatio = Math.min(widthRatio, heightRatio, depthRatio);
+          if (!Number.isFinite(scaleRatio)) {
+            scaleRatio = 1;
+          }
 
           this._defaultWidth = scaleRatio * modelWidth;
           this._defaultHeight = scaleRatio * modelHeight;
@@ -2989,13 +3005,25 @@ module.exports = {
         );
         threeObject.updateMatrixWorld(true);
         const boundingBox = new THREE.Box3().setFromObject(threeObject);
+        
+        const shouldKeepModelOrigin = !this._originPoint;
+        if (shouldKeepModelOrigin) {
+          // Keep the origin as part of the model.
+          // For instance, a model can be 1 face of a cube and we want to keep the
+          // inside as part of the object even if it's just void.
+          // It also avoids to have the origin outside of the object box.
+          boundingBox.expandByPoint(new THREE.Vector3(0, 0, 0));
+        }
 
         const modelWidth = boundingBox.max.x - boundingBox.min.x;
         const modelHeight = boundingBox.max.y - boundingBox.min.y;
         const modelDepth = boundingBox.max.z - boundingBox.min.z;
-        this._modelOriginPoint[0] = -boundingBox.min.x / modelWidth;
-        this._modelOriginPoint[1] = -boundingBox.min.y / modelHeight;
-        this._modelOriginPoint[2] = -boundingBox.min.z / modelDepth;
+        this._modelOriginPoint[0] =
+          modelWidth < epsilon ? 0 : -boundingBox.min.x / modelWidth;
+        this._modelOriginPoint[1] =
+          modelHeight < epsilon ? 0 : -boundingBox.min.y / modelHeight;
+        this._modelOriginPoint[2] =
+          modelDepth < epsilon ? 0 : -boundingBox.min.z / modelDepth;
 
         // The model is flipped on Y axis.
         this._modelOriginPoint[1] = 1 - this._modelOriginPoint[1];
@@ -3004,19 +3032,10 @@ module.exports = {
         const centerPoint = this._centerPoint;
         if (centerPoint) {
           threeObject.position.set(
-            -(
-              boundingBox.min.x +
-              (boundingBox.max.x - boundingBox.min.x) * centerPoint[0]
-            ),
+            -(boundingBox.min.x + modelWidth * centerPoint[0]),
             // The model is flipped on Y axis.
-            -(
-              boundingBox.min.y +
-              (boundingBox.max.y - boundingBox.min.y) * (1 - centerPoint[1])
-            ),
-            -(
-              boundingBox.min.z +
-              (boundingBox.max.z - boundingBox.min.z) * centerPoint[2]
-            )
+            -(boundingBox.min.y + modelHeight * (1 - centerPoint[1])),
+            -(boundingBox.min.z + modelDepth * centerPoint[2])
           );
         }
 
@@ -3029,9 +3048,9 @@ module.exports = {
         );
 
         // Stretch the model in a 1x1x1 cube.
-        const scaleX = 1 / modelWidth;
-        const scaleY = 1 / modelHeight;
-        const scaleZ = 1 / modelDepth;
+        const scaleX = modelWidth < epsilon ? 1 : 1 / modelWidth;
+        const scaleY = modelHeight < epsilon ? 1 : 1 / modelHeight;
+        const scaleZ = modelDepth < epsilon ? 1 : 1 / modelDepth;
 
         const scaleMatrix = new THREE.Matrix4();
         // Flip on Y because the Y axis is on the opposite side of direct basis.
@@ -3042,10 +3061,22 @@ module.exports = {
 
         if (keepAspectRatio) {
           // Reduce the object dimensions to keep aspect ratio.
-          const widthRatio = originalWidth / modelWidth;
-          const heightRatio = originalHeight / modelHeight;
-          const depthRatio = originalDepth / modelDepth;
-          const scaleRatio = Math.min(widthRatio, heightRatio, depthRatio);
+          const widthRatio =
+            modelWidth < epsilon
+              ? Number.POSITIVE_INFINITY
+              : originalWidth / modelWidth;
+          const heightRatio =
+            modelHeight < epsilon
+              ? Number.POSITIVE_INFINITY
+              : originalHeight / modelHeight;
+          const depthRatio =
+            modelDepth < epsilon
+              ? Number.POSITIVE_INFINITY
+              : originalDepth / modelDepth;
+          let scaleRatio = Math.min(widthRatio, heightRatio, depthRatio);
+          if (!Number.isFinite(scaleRatio)) {
+            scaleRatio = 1;
+          }
 
           this._defaultWidth = scaleRatio * modelWidth;
           this._defaultHeight = scaleRatio * modelHeight;

--- a/newIDE/app/src/ObjectEditor/Editors/Model3DEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/Model3DEditor.js
@@ -55,6 +55,8 @@ const styles = {
   },
 };
 
+const epsilon = 1 / (1 << 16);
+
 const removeTrailingZeroes = (value: string) => {
   for (let index = value.length - 1; index > 0; index--) {
     if (value.charAt(index) === '.') {
@@ -179,6 +181,17 @@ const Model3DEditor = ({
     [gltf]
   );
 
+  const [originLocation, setOriginLocation] = React.useState<string>(() =>
+    properties.get('originLocation').getValue()
+  );
+  const onOriginLocationChange = React.useCallback(
+    (event, index: number, newValue: string) => {
+      onChangeProperty('originLocation', newValue);
+      setOriginLocation(newValue);
+    },
+    [onChangeProperty]
+  );
+
   const [rotationX, setRotationX] = React.useState<number>(
     () => parseFloat(properties.get('rotationX').getValue()) || 0
   );
@@ -211,13 +224,23 @@ const Model3DEditor = ({
       );
       model3D.updateMatrixWorld(true);
       const boundingBox = new THREE.Box3().setFromObject(model3D);
+      if (originLocation === 'ModelOrigin') {
+        // Keep the origin as part of the model.
+        // For instance, a model can be 1 face of a cube and we want to keep the
+        // inside as part of the object even if it's just void.
+        // It also avoids to have the origin outside of the object box.
+        boundingBox.expandByPoint(new THREE.Vector3(0, 0, 0));
+      }
+      const sizeX = boundingBox.max.x - boundingBox.min.x;
+      const sizeY = boundingBox.max.y - boundingBox.min.y;
+      const sizeZ = boundingBox.max.z - boundingBox.min.z;
       return {
-        x: boundingBox.max.x - boundingBox.min.x,
-        y: boundingBox.max.y - boundingBox.min.y,
-        z: boundingBox.max.z - boundingBox.min.z,
+        x: sizeX < epsilon ? 0 : sizeX,
+        y: sizeY < epsilon ? 0 : sizeY,
+        z: sizeZ < epsilon ? 0 : sizeZ,
       };
     },
-    [model3D, rotationX, rotationY, rotationZ]
+    [model3D, originLocation, rotationX, rotationY, rotationZ]
   );
 
   const [width, setWidth] = React.useState<number>(
@@ -243,9 +266,9 @@ const Model3DEditor = ({
         return null;
       }
       return Math.min(
-        width / modelSize.x,
-        height / modelSize.y,
-        depth / modelSize.z
+        modelSize.x < epsilon ? Number.POSITIVE_INFINITY : width / modelSize.x,
+        modelSize.y < epsilon ? Number.POSITIVE_INFINITY : height / modelSize.y,
+        modelSize.z < epsilon ? Number.POSITIVE_INFINITY : depth / modelSize.z
       );
     },
     [depth, height, modelSize, width]
@@ -549,14 +572,12 @@ const Model3DEditor = ({
           </Text>
           <ResponsiveLineStackLayout expand noColumnMargin>
             <SelectField
-              value={properties.get('originLocation').getValue()}
+              value={originLocation}
               floatingLabelText={properties.get('originLocation').getLabel()}
               helperMarkdownText={properties
                 .get('originLocation')
                 .getDescription()}
-              onChange={(event, index, newValue) => {
-                onChangeProperty('originLocation', newValue);
-              }}
+              onChange={onOriginLocationChange}
               fullWidth
             >
               <SelectOption


### PR DESCRIPTION
# Changes
- Keep 3D model origin as part of the object when used as the object origin
  - In case you choose "Model origin" for the "Origin point" property and the model origin is outside of the model, the model size may be smaller than in previous version.
    You can choose one of the other options for the "Origin point" property or reset the "Scaling factor" to its previous value to get back the same size as before.
- Fix the scaling of flat 3D models