### PR TITLE
Improve game templates and examples display on build page

### DIFF
--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { t } from '@lingui/macro';
 import { type Filters } from '../Utils/GDevelopServices/Filters';
 import {
   type AssetShortHeader,
@@ -32,14 +33,13 @@ import {
   assetStoreHomePageState,
 } from './AssetStoreNavigator';
 import { type ChosenCategory } from '../UI/Search/FiltersChooser';
-import shuffle from 'lodash/shuffle';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
 import {
   getAssetPackFromUserFriendlySlug,
   getPrivateAssetPackListingDataFromUserFriendlySlug,
 } from './AssetStoreUtils';
 import useAlertDialog from '../UI/Alert/useAlertDialog';
-import { t } from '@lingui/macro';
+import { getStableRandomArray } from '../Utils/Random';
 
 const defaultSearchText = '';
 
@@ -185,12 +185,6 @@ const getPublicAssetPackSearchTerms = (assetPack: PublicAssetPack) =>
 const getPrivateAssetPackListingDataSearchTerms = (
   privateAssetPack: PrivateAssetPackListingData
 ) => privateAssetPack.name + '\n' + privateAssetPack.description;
-
-const getAssetPackRandomOrdering = (length: number): Array<number> => {
-  const array = new Array(length).fill(0).map((_, index) => index);
-
-  return shuffle(array);
-};
 
 export const AssetStoreStateProvider = ({
   onlyAppStorePrivateAssetPacks,
@@ -504,8 +498,8 @@ export const AssetStoreStateProvider = ({
         return;
       }
       setAssetPackRandomOrdering({
-        starterPacks: getAssetPackRandomOrdering(assetPackCount),
-        privateAssetPacks: getAssetPackRandomOrdering(privateAssetPackCount),
+        starterPacks: getStableRandomArray(assetPackCount),
+        privateAssetPacks: getStableRandomArray(privateAssetPackCount),
       });
     },
     [assetPackCount, privateAssetPackCount]

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -25,6 +25,7 @@ import {
   PublicAssetPackTile,
   PrivateGameTemplateTile,
 } from './ShopTiles';
+import { shuffleArrayWith } from '../Utils/Random';
 
 const cellSpacing = 2;
 
@@ -203,25 +204,20 @@ export const AssetsHome = React.forwardRef<Props, AssetsHomeInterface>(
       ? shopCategories[openedShopCategory].title
       : null;
 
-    const starterPacksTiles: Array<React.Node> = starterPacks
-      .filter(
+    const starterPacksTiles: Array<React.Node> = shuffleArrayWith(
+      starterPacks.filter(
         assetPack =>
           !openedShopCategory ||
           assetPack.categories.includes(openedShopCategory)
-      )
-      .map((pack, index) => ({
-        pos: assetPackRandomOrdering.starterPacks[index],
-        pack,
-      }))
-      .sort((a, b) => a.pos - b.pos)
-      .map(sortObject => sortObject.pack)
-      .map((assetPack, index) => (
-        <PublicAssetPackTile
-          assetPack={assetPack}
-          onSelect={() => onPublicAssetPackSelection(assetPack)}
-          key={`${assetPack.tag}-${index}`}
-        />
-      ));
+      ),
+      assetPackRandomOrdering.starterPacks
+    ).map((assetPack, index) => (
+      <PublicAssetPackTile
+        assetPack={assetPack}
+        onSelect={() => onPublicAssetPackSelection(assetPack)}
+        key={`${assetPack.tag}-${index}`}
+      />
+    ));
 
     const { allStandAloneTiles, allBundleTiles } = React.useMemo(
       () => {
@@ -230,19 +226,14 @@ export const AssetsHome = React.forwardRef<Props, AssetsHomeInterface>(
         const privateAssetPackBundleTiles: Array<React.Node> = [];
         const privateOwnedAssetPackBundleTiles: Array<React.Node> = [];
 
-        privateAssetPackListingDatas
-          .filter(
+        shuffleArrayWith(
+          privateAssetPackListingDatas.filter(
             assetPackListingData =>
               !openedShopCategory ||
               assetPackListingData.categories.includes(openedShopCategory)
-          )
-          .map((listingData, index) => ({
-            pos: assetPackRandomOrdering.privateAssetPacks[index],
-            listingData,
-          }))
-          .sort((a, b) => a.pos - b.pos)
-          .map(sortObject => sortObject.listingData)
-          .filter(Boolean)
+          ),
+          assetPackRandomOrdering.privateAssetPacks
+        )
           .forEach(assetPackListingData => {
             const isPackOwned =
               !!receivedAssetPacks &&

--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -233,40 +233,39 @@ export const AssetsHome = React.forwardRef<Props, AssetsHomeInterface>(
               assetPackListingData.categories.includes(openedShopCategory)
           ),
           assetPackRandomOrdering.privateAssetPacks
-        )
-          .forEach(assetPackListingData => {
-            const isPackOwned =
-              !!receivedAssetPacks &&
-              !!receivedAssetPacks.find(
-                pack => pack.id === assetPackListingData.id
-              );
-            const tile = (
-              <PrivateAssetPackTile
-                assetPackListingData={assetPackListingData}
-                onSelect={() => {
-                  onPrivateAssetPackSelection(assetPackListingData);
-                }}
-                owned={isPackOwned}
-                key={assetPackListingData.id}
-              />
+        ).forEach(assetPackListingData => {
+          const isPackOwned =
+            !!receivedAssetPacks &&
+            !!receivedAssetPacks.find(
+              pack => pack.id === assetPackListingData.id
             );
-            if (
-              assetPackListingData.includedListableProductIds &&
-              !!assetPackListingData.includedListableProductIds.length
-            ) {
-              if (isPackOwned) {
-                privateOwnedAssetPackBundleTiles.push(tile);
-              } else {
-                privateAssetPackBundleTiles.push(tile);
-              }
+          const tile = (
+            <PrivateAssetPackTile
+              assetPackListingData={assetPackListingData}
+              onSelect={() => {
+                onPrivateAssetPackSelection(assetPackListingData);
+              }}
+              owned={isPackOwned}
+              key={assetPackListingData.id}
+            />
+          );
+          if (
+            assetPackListingData.includedListableProductIds &&
+            !!assetPackListingData.includedListableProductIds.length
+          ) {
+            if (isPackOwned) {
+              privateOwnedAssetPackBundleTiles.push(tile);
             } else {
-              if (isPackOwned) {
-                privateOwnedAssetPackStandAloneTiles.push(tile);
-              } else {
-                privateAssetPackStandAloneTiles.push(tile);
-              }
+              privateAssetPackBundleTiles.push(tile);
             }
-          });
+          } else {
+            if (isPackOwned) {
+              privateOwnedAssetPackStandAloneTiles.push(tile);
+            } else {
+              privateAssetPackStandAloneTiles.push(tile);
+            }
+          }
+        });
 
         const allBundleTiles = [
           ...privateOwnedAssetPackBundleTiles, // Display owned bundles first.

--- a/newIDE/app/src/AssetStore/ExampleStore/index.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/index.js
@@ -22,37 +22,6 @@ import PrivateGameTemplateListItem from '../PrivateGameTemplates/PrivateGameTemp
 import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
 import { PrivateGameTemplateStoreContext } from '../PrivateGameTemplates/PrivateGameTemplateStoreContext';
 
-// When showing examples, always put the starters first.
-export const prepareExampleShortHeaders = (
-  examples: Array<ExampleShortHeader>
-): Array<ExampleShortHeader> =>
-  examples.sort((example1, example2) => {
-    const isExample1Starter = example1.tags.includes('Starter');
-    const isExample2Starter = example2.tags.includes('Starter');
-    // Don't change starters order.
-    if (isExample1Starter && isExample2Starter) {
-      return 0;
-    }
-    let difference = (isExample2Starter ? 1 : 0) - (isExample1Starter ? 1 : 0);
-    if (difference) {
-      return difference;
-    }
-    difference =
-      (example2.tags.includes('game') ? 1 : 0) -
-      (example1.tags.includes('game') ? 1 : 0);
-    if (difference) {
-      return difference;
-    }
-    difference =
-      (example2.previewImageUrls.length ? 1 : 0) -
-      (example1.previewImageUrls.length ? 1 : 0);
-    if (difference) {
-      return difference;
-    }
-
-    return 0;
-  });
-
 const getItemUniqueId = (
   item: ExampleShortHeader | PrivateGameTemplateListingData
 ) => item.id;

--- a/newIDE/app/src/AssetStore/ShopTiles.js
+++ b/newIDE/app/src/AssetStore/ShopTiles.js
@@ -10,6 +10,7 @@ import {
   type PrivateAssetPackListingData,
   type PrivateGameTemplateListingData,
 } from '../Utils/GDevelopServices/Shop';
+import type { ExampleShortHeader } from '../Utils/GDevelopServices/Example';
 import GridListTile from '@material-ui/core/GridListTile';
 import createStyles from '@material-ui/core/styles/createStyles';
 import makeStyles from '@material-ui/core/styles/makeStyles';
@@ -455,6 +456,52 @@ export const PrivateGameTemplateTile = ({
           <Line justifyContent="flex-start" noMargin>
             <Text style={styles.packTitle} size="body2">
               {privateGameTemplateListingData.name}
+            </Text>
+          </Line>
+        </Column>
+      </Paper>
+    </GridListTile>
+  );
+};
+
+export const ExampleTile = ({
+  exampleShortHeader,
+  onSelect,
+  style,
+}: {|
+  exampleShortHeader: ExampleShortHeader,
+  onSelect: () => void,
+  /** Props needed so that GridList component can adjust tile size */
+  style?: any,
+|}) => {
+  const classesForGridListItem = useStylesForGridListItem();
+  return (
+    <GridListTile
+      classes={classesForGridListItem}
+      tabIndex={0}
+      onKeyPress={(event: SyntheticKeyboardEvent<HTMLLIElement>): void => {
+        if (shouldValidate(event)) {
+          onSelect();
+        }
+      }}
+      style={style}
+      onClick={onSelect}
+    >
+      <Paper elevation={2} style={styles.paper} background="light">
+        <CorsAwareImage
+          key={exampleShortHeader.name}
+          style={styles.previewImage}
+          src={
+            exampleShortHeader.previewImageUrls
+              ? exampleShortHeader.previewImageUrls[0]
+              : ''
+          }
+          alt={`Preview image of example ${exampleShortHeader.name}`}
+        />
+        <Column>
+          <Line justifyContent="flex-start" noMargin>
+            <Text style={styles.packTitle} size="body2">
+              {exampleShortHeader.name}
             </Text>
           </Line>
         </Column>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
@@ -19,7 +19,6 @@ const styles = {
     display: 'flex',
   },
   buttonBackground: { width: '100%', height: '100%', padding: 20 },
-  textContainer: { marginLeft: 25, marginRight: 25 },
 };
 
 const useStyles = () =>
@@ -64,11 +63,9 @@ const CreateNewProjectButton = (props: Props) => {
             alignItems="center"
           >
             <Add fontSize="large" />
-            <div style={styles.textContainer}>
-              <Text noMargin>
-                <Trans>Create a project</Trans>
-              </Text>
-            </div>
+            <Text noMargin>
+              <Trans>Create a project</Trans>
+            </Text>
           </ColumnStackLayout>
         </Line>
       </Paper>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
@@ -22,16 +22,15 @@ const styles = {
   textContainer: { marginLeft: 25, marginRight: 25 },
 };
 
-const useStyles = (isSelected?: boolean) =>
+const useStyles = () =>
   makeStyles(theme =>
     createStyles({
       root: {
         '&:hover': {
-          filter: isSelected
-            ? undefined
-            : theme.palette.type === 'dark'
-            ? 'brightness(130%)'
-            : 'brightness(90%)',
+          filter:
+            theme.palette.type === 'dark'
+              ? 'brightness(130%)'
+              : 'brightness(90%)',
         },
         transition: 'filter 100ms ease',
       },

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
@@ -40,6 +40,7 @@ const useStyles = (isSelected?: boolean) =>
 
 type Props = {|
   onClick: () => void,
+  fullWidth?: boolean,
 |};
 
 const CreateNewProjectButton = (props: Props) => {
@@ -48,7 +49,11 @@ const CreateNewProjectButton = (props: Props) => {
   const classes = useStyles();
   return (
     <ButtonBase
-      style={{ ...styles.button, borderColor: muiTheme.palette.text.primary }}
+      style={{
+        ...styles.button,
+        width: props.fullWidth ? '100%' : undefined,
+        borderColor: muiTheme.palette.text.primary,
+      }}
       classes={classes}
       onClick={props.onClick}
     >

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/CreateNewProjectButton.js
@@ -1,0 +1,75 @@
+// @flow
+
+import * as React from 'react';
+import { Trans } from '@lingui/macro';
+import { Line } from '../../../../UI/Grid';
+import { createStyles, makeStyles, useTheme } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import ButtonBase from '@material-ui/core/ButtonBase';
+import Text from '../../../../UI/Text';
+import Add from '../../../../UI/CustomSvgIcons/Add';
+import { ColumnStackLayout } from '../../../../UI/Layout';
+
+const styles = {
+  button: {
+    border: 'solid',
+    borderWidth: 1,
+    borderRadius: 8,
+    height: '100%',
+    display: 'flex',
+  },
+  buttonBackground: { width: '100%', height: '100%', padding: 20 },
+  textContainer: { marginLeft: 25, marginRight: 25 },
+};
+
+const useStyles = (isSelected?: boolean) =>
+  makeStyles(theme =>
+    createStyles({
+      root: {
+        '&:hover': {
+          filter: isSelected
+            ? undefined
+            : theme.palette.type === 'dark'
+            ? 'brightness(130%)'
+            : 'brightness(90%)',
+        },
+        transition: 'filter 100ms ease',
+      },
+    })
+  )();
+
+type Props = {|
+  onClick: () => void,
+|};
+
+const CreateNewProjectButton = (props: Props) => {
+  const muiTheme = useTheme();
+
+  const classes = useStyles();
+  return (
+    <ButtonBase
+      style={{ ...styles.button, borderColor: muiTheme.palette.text.primary }}
+      classes={classes}
+      onClick={props.onClick}
+    >
+      <Paper square={false} background="medium" style={styles.buttonBackground}>
+        <Line justifyContent="center" noMargin>
+          <ColumnStackLayout
+            noMargin
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Add fontSize="large" />
+            <div style={styles.textContainer}>
+              <Text noMargin>
+                <Trans>Create a project</Trans>
+              </Text>
+            </div>
+          </ColumnStackLayout>
+        </Line>
+      </Paper>
+    </ButtonBase>
+  );
+};
+
+export default CreateNewProjectButton;

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -48,6 +48,7 @@ import InfoBar from '../../../../UI/Messages/InfoBar';
 import CreateNewProjectButton from './CreateNewProjectButton';
 import GridList from '@material-ui/core/GridList';
 import type { WidthType } from '../../../../UI/Reponsive/ResponsiveWindowMeasurer';
+import { GridListTile } from '@material-ui/core';
 
 const cellSpacing = 2;
 
@@ -264,12 +265,21 @@ const BuildSection = ({
       >
         {projectFiles.length === 0 && (
           <SectionRow>
-            <Line noMargin>
-              <CreateNewProjectButton
-                onClick={onOpenNewProjectSetupDialog}
-                fullWidth={isMobile}
-              />
-            </Line>
+            <GridList
+              cols={getItemsColumns(windowWidth)}
+              style={styles.grid}
+              cellHeight="auto"
+              spacing={cellSpacing}
+            >
+              <GridListTile>
+                <Line noMargin>
+                  <CreateNewProjectButton
+                    onClick={onOpenNewProjectSetupDialog}
+                    fullWidth
+                  />
+                </Line>
+              </GridListTile>
+            </GridList>
           </SectionRow>
         )}
         {shouldShowCarousel && (

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -228,6 +228,7 @@ const BuildSection = ({
         numberOfItemsInCarousel:
           !shouldShowCarousel || showAllGameTemplates ? 0 : isMobile ? 8 : 12,
         numberOfItemsInGrid: showAllGameTemplates ? 60 : isMobile ? 16 : 20,
+        privateGameTemplatesPeriodicity: isMobile ? 2 : 3,
       }),
     [
       authenticatedUser.receivedGameTemplates,

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -209,21 +209,25 @@ const BuildSection = ({
     return b.fileMetadata.lastModifiedDate - a.fileMetadata.lastModifiedDate;
   });
 
+  const shouldShowCarousel =
+    !!authenticatedUser.authenticated && projectFiles.length > 0;
+
   const examplesAndTemplatesToDisplay = React.useMemo(
     () =>
       getExampleAndTemplateItemsForBuildSection({
-        authenticatedUser,
+        receivedGameTemplates: authenticatedUser.receivedGameTemplates,
         privateGameTemplateListingDatas,
         exampleShortHeaders,
         onSelectPrivateGameTemplateListingData,
         onSelectExampleShortHeader,
         i18n,
-        carouselExclusiveItemsCount: isMobile ? 3 : 5,
-        numberOfItemsInCarousel: isMobile ? 8 : 12,
-        numberOfItemsInGrid: isMobile ? 12 : 20,
+        carouselExclusiveItemsCount: !shouldShowCarousel ? 0 : isMobile ? 3 : 5,
+        numberOfItemsInCarousel: !shouldShowCarousel ? 0 : isMobile ? 8 : 12,
+        numberOfItemsInGrid: isMobile ? 16 : 20,
       }),
     [
-      authenticatedUser,
+      authenticatedUser.receivedGameTemplates,
+      shouldShowCarousel,
       exampleShortHeaders,
       onSelectExampleShortHeader,
       onSelectPrivateGameTemplateListingData,
@@ -268,18 +272,20 @@ const BuildSection = ({
             </Line>
           </SectionRow>
         )}
-        <SectionRow>
-          <Carousel
-            title={<Trans>Game templates</Trans>}
-            displayItemTitles={false}
-            browseAllLabel={<Trans>Browse all templates</Trans>}
-            onBrowseAllClick={onShowAllExamples}
-            items={examplesAndTemplatesToDisplay.carouselItems}
-            browseAllIcon={<ChevronArrowRight fontSize="small" />}
-            roundedImages
-            displayArrowsOnDesktop
-          />
-        </SectionRow>
+        {shouldShowCarousel && (
+          <SectionRow>
+            <Carousel
+              title={<Trans>Game templates</Trans>}
+              displayItemTitles={false}
+              browseAllLabel={<Trans>Browse all templates</Trans>}
+              onBrowseAllClick={onShowAllExamples}
+              items={examplesAndTemplatesToDisplay.carouselItems}
+              browseAllIcon={<ChevronArrowRight fontSize="small" />}
+              roundedImages
+              displayArrowsOnDesktop
+            />
+          </SectionRow>
+        )}
         {projectFiles.length > 0 && (
           <SectionRow>
             <ResponsiveLineStackLayout

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -92,7 +92,6 @@ type Props = {|
   onChooseProject: () => void,
   onOpenRecentFile: (file: FileMetadataAndStorageProviderName) => Promise<void>,
   onOpenNewProjectSetupDialog: () => void,
-  onShowAllExamples: () => void,
   onSelectExampleShortHeader: (exampleShortHeader: ExampleShortHeader) => void,
   onSelectPrivateGameTemplateListingData: (
     privateGameTemplateListingData: PrivateGameTemplateListingData
@@ -109,7 +108,6 @@ const BuildSection = ({
   canOpen,
   onChooseProject,
   onOpenNewProjectSetupDialog,
-  onShowAllExamples,
   onSelectExampleShortHeader,
   onSelectPrivateGameTemplateListingData,
   onOpenRecentFile,
@@ -120,7 +118,10 @@ const BuildSection = ({
 }: Props) => {
   const { getRecentProjectFiles } = React.useContext(PreferencesContext);
   const { exampleShortHeaders } = React.useContext(ExampleStoreContext);
-
+  const [
+    showAllGameTemplates,
+    setShowAllGameTemplates,
+  ] = React.useState<boolean>(false);
   const { privateGameTemplateListingDatas } = React.useContext(
     PrivateGameTemplateStoreContext
   );
@@ -222,12 +223,15 @@ const BuildSection = ({
         onSelectPrivateGameTemplateListingData,
         onSelectExampleShortHeader,
         i18n,
-        carouselExclusiveItemsCount: !shouldShowCarousel ? 0 : isMobile ? 3 : 5,
-        numberOfItemsInCarousel: !shouldShowCarousel ? 0 : isMobile ? 8 : 12,
-        numberOfItemsInGrid: isMobile ? 16 : 20,
+        carouselExclusiveItemsCount:
+          !shouldShowCarousel || showAllGameTemplates ? 0 : isMobile ? 3 : 5,
+        numberOfItemsInCarousel:
+          !shouldShowCarousel || showAllGameTemplates ? 0 : isMobile ? 8 : 12,
+        numberOfItemsInGrid: showAllGameTemplates ? 60 : isMobile ? 16 : 20,
       }),
     [
       authenticatedUser.receivedGameTemplates,
+      showAllGameTemplates,
       shouldShowCarousel,
       exampleShortHeaders,
       onSelectExampleShortHeader,
@@ -237,6 +241,26 @@ const BuildSection = ({
       isMobile,
     ]
   );
+
+  if (showAllGameTemplates) {
+    return (
+      <SectionContainer
+        title={<Trans>All templates</Trans>}
+        backAction={() => setShowAllGameTemplates(false)}
+      >
+        <SectionRow>
+          <GridList
+            cols={getItemsColumns(windowWidth)}
+            style={styles.grid}
+            cellHeight="auto"
+            spacing={cellSpacing}
+          >
+            {examplesAndTemplatesToDisplay.gridItems}
+          </GridList>
+        </SectionRow>
+      </SectionContainer>
+    );
+  }
 
   return (
     <>
@@ -285,10 +309,10 @@ const BuildSection = ({
         {shouldShowCarousel && (
           <SectionRow>
             <Carousel
-              title={<Trans>Game templates</Trans>}
+              title={<Trans>Ready-made games</Trans>}
               displayItemTitles={false}
               browseAllLabel={<Trans>Browse all templates</Trans>}
-              onBrowseAllClick={onShowAllExamples}
+              onBrowseAllClick={() => setShowAllGameTemplates(true)}
               items={examplesAndTemplatesToDisplay.carouselItems}
               browseAllIcon={<ChevronArrowRight fontSize="small" />}
               roundedImages
@@ -415,18 +439,13 @@ const BuildSection = ({
           </SectionRow>
         )}
         <SectionRow>
-          <LineStackLayout
-            justifyContent="space-between"
-            alignItems="center"
-            noMargin
-            expand
-          >
+          <Line alignItems="center" noMargin expand>
             <Column noMargin>
               <Text size="section-title">
                 <Trans>Start with a template</Trans>
               </Text>
             </Column>
-          </LineStackLayout>
+          </Line>
           <GridList
             cols={getItemsColumns(windowWidth)}
             style={styles.grid}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -257,139 +257,141 @@ const BuildSection = ({
             hideArrows
           />
         </SectionRow>
-        <SectionRow>
-          <ResponsiveLineStackLayout
-            justifyContent="space-between"
-            alignItems="center"
-            noMargin
-            expand
-          >
-            <Column noMargin>
-              <LineStackLayout noMargin alignItems="center">
-                <Text size="section-title">
-                  <Trans>My projects</Trans>
-                </Text>
-                <IconButton
-                  size="small"
-                  onClick={refreshCloudProjects}
-                  disabled={isRefreshing}
-                  tooltip={t`Refresh cloud projects`}
-                >
-                  <div style={styles.refreshIconContainer}>
-                    <Refresh fontSize="inherit" />
-                  </div>
-                </IconButton>
-              </LineStackLayout>
-            </Column>
-            <Column noMargin>
-              <LineStackLayout noMargin>
-                <RaisedButton
-                  primary
-                  fullWidth={!canOpen}
-                  label={
-                    isMobile ? (
-                      <Trans>Create</Trans>
-                    ) : (
-                      <Trans>Create a project</Trans>
-                    )
-                  }
-                  onClick={onOpenNewProjectSetupDialog}
-                  icon={<Add fontSize="small" />}
-                  id="home-create-project-button"
-                />
-                {canOpen && (
-                  <>
-                    <Text>
-                      <Trans>or</Trans>
-                    </Text>
-                    <Spacer />
-                    <TextButton
-                      primary
-                      label={
-                        isMobile ? (
-                          <Trans>Open</Trans>
-                        ) : (
-                          <Trans>Open a project</Trans>
-                        )
-                      }
-                      onClick={onChooseProject}
-                    />
-                  </>
-                )}
-              </LineStackLayout>
-            </Column>
-          </ResponsiveLineStackLayout>
-          {cloudProjectsFetchingErrorLabel && (
-            <Line>
-              <PlaceholderError onRetry={onCloudProjectsChanged}>
-                <AlertMessage kind="warning">
-                  {cloudProjectsFetchingErrorLabel}
-                </AlertMessage>
-              </PlaceholderError>
-            </Line>
-          )}
-          <Line>
-            {(projectFiles.length > 0 || shouldDisplaySkeleton) && (
-              <Column noMargin expand>
-                {!isMobile && (
-                  <Line justifyContent="space-between">
-                    <Column expand>
-                      <Text color="secondary">
-                        <Trans>File name</Trans>
-                      </Text>
-                    </Column>
-                    <Column expand>
-                      <Text color="secondary">
-                        <Trans>Location</Trans>
-                      </Text>
-                    </Column>
-                    <Column expand>
-                      <Text color="secondary">
-                        <Trans>Last edited</Trans>
-                      </Text>
-                    </Column>
-                  </Line>
-                )}
-                <List>
-                  {shouldDisplaySkeleton // Only show skeleton on first load
-                    ? new Array(10).fill(0).map((_, index) => (
-                        <ListItem
-                          style={styles.listItem}
-                          key={`skeleton-${index}`}
-                        >
-                          <Line expand>
-                            <Column expand>
-                              <Skeleton
-                                variant="rect"
-                                height={skeletonLineHeight}
-                                style={styles.projectSkeleton}
-                              />
-                            </Column>
-                          </Line>
-                        </ListItem>
-                      ))
-                    : projectFiles.map(file => (
-                        <ProjectFileListItem
-                          key={file.fileMetadata.fileIdentifier}
-                          file={file}
-                          currentFileMetadata={currentFileMetadata}
-                          storageProviders={storageProviders}
-                          isWindowWidthMediumOrLarger={!isMobile}
-                          onOpenRecentFile={onOpenRecentFile}
-                          lastModifiedInfo={
-                            lastModifiedInfoByProjectId[
-                              file.fileMetadata.fileIdentifier
-                            ]
-                          }
-                          onManageGame={onManageGame}
-                          canManageGame={canManageGame}
-                        />
-                      ))}
-                </List>
+        {projectFiles.length > 0 && (
+          <SectionRow>
+            <ResponsiveLineStackLayout
+              justifyContent="space-between"
+              alignItems="center"
+              noMargin
+              expand
+            >
+              <Column noMargin>
+                <LineStackLayout noMargin alignItems="center">
+                  <Text size="section-title">
+                    <Trans>My projects</Trans>
+                  </Text>
+                  <IconButton
+                    size="small"
+                    onClick={refreshCloudProjects}
+                    disabled={isRefreshing}
+                    tooltip={t`Refresh cloud projects`}
+                  >
+                    <div style={styles.refreshIconContainer}>
+                      <Refresh fontSize="inherit" />
+                    </div>
+                  </IconButton>
+                </LineStackLayout>
               </Column>
+              <Column noMargin>
+                <LineStackLayout noMargin>
+                  <RaisedButton
+                    primary
+                    fullWidth={!canOpen}
+                    label={
+                      isMobile ? (
+                        <Trans>Create</Trans>
+                      ) : (
+                        <Trans>Create a project</Trans>
+                      )
+                    }
+                    onClick={onOpenNewProjectSetupDialog}
+                    icon={<Add fontSize="small" />}
+                    id="home-create-project-button"
+                  />
+                  {canOpen && (
+                    <>
+                      <Text>
+                        <Trans>or</Trans>
+                      </Text>
+                      <Spacer />
+                      <TextButton
+                        primary
+                        label={
+                          isMobile ? (
+                            <Trans>Open</Trans>
+                          ) : (
+                            <Trans>Open a project</Trans>
+                          )
+                        }
+                        onClick={onChooseProject}
+                      />
+                    </>
+                  )}
+                </LineStackLayout>
+              </Column>
+            </ResponsiveLineStackLayout>
+            {cloudProjectsFetchingErrorLabel && (
+              <Line>
+                <PlaceholderError onRetry={onCloudProjectsChanged}>
+                  <AlertMessage kind="warning">
+                    {cloudProjectsFetchingErrorLabel}
+                  </AlertMessage>
+                </PlaceholderError>
+              </Line>
             )}
-          </Line>
-        </SectionRow>
+            <Line>
+              {(projectFiles.length > 0 || shouldDisplaySkeleton) && (
+                <Column noMargin expand>
+                  {!isMobile && (
+                    <Line justifyContent="space-between">
+                      <Column expand>
+                        <Text color="secondary">
+                          <Trans>File name</Trans>
+                        </Text>
+                      </Column>
+                      <Column expand>
+                        <Text color="secondary">
+                          <Trans>Location</Trans>
+                        </Text>
+                      </Column>
+                      <Column expand>
+                        <Text color="secondary">
+                          <Trans>Last edited</Trans>
+                        </Text>
+                      </Column>
+                    </Line>
+                  )}
+                  <List>
+                    {shouldDisplaySkeleton // Only show skeleton on first load
+                      ? new Array(10).fill(0).map((_, index) => (
+                          <ListItem
+                            style={styles.listItem}
+                            key={`skeleton-${index}`}
+                          >
+                            <Line expand>
+                              <Column expand>
+                                <Skeleton
+                                  variant="rect"
+                                  height={skeletonLineHeight}
+                                  style={styles.projectSkeleton}
+                                />
+                              </Column>
+                            </Line>
+                          </ListItem>
+                        ))
+                      : projectFiles.map(file => (
+                          <ProjectFileListItem
+                            key={file.fileMetadata.fileIdentifier}
+                            file={file}
+                            currentFileMetadata={currentFileMetadata}
+                            storageProviders={storageProviders}
+                            isWindowWidthMediumOrLarger={!isMobile}
+                            onOpenRecentFile={onOpenRecentFile}
+                            lastModifiedInfo={
+                              lastModifiedInfoByProjectId[
+                                file.fileMetadata.fileIdentifier
+                              ]
+                            }
+                            onManageGame={onManageGame}
+                            canManageGame={canManageGame}
+                          />
+                        ))}
+                  </List>
+                </Column>
+              )}
+            </Line>
+          </SectionRow>
+        )}
       </SectionContainer>
       <InfoBar
         message={<Trans>Log in to see your cloud projects.</Trans>}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { type I18n as I18nType } from '@lingui/core';
 import { Trans, t } from '@lingui/macro';
 import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
 
 import Text from '../../../../UI/Text';
 import TextButton from '../../../../UI/TextButton';
@@ -31,7 +30,6 @@ import { ExampleStoreContext } from '../../../../AssetStore/ExampleStore/Example
 import { SubscriptionSuggestionContext } from '../../../../Profile/Subscription/SubscriptionSuggestionContext';
 import { type ExampleShortHeader } from '../../../../Utils/GDevelopServices/Example';
 import Add from '../../../../UI/CustomSvgIcons/Add';
-import Skeleton from '@material-ui/lab/Skeleton';
 import PlaceholderError from '../../../../UI/PlaceholderError';
 import AlertMessage from '../../../../UI/AlertMessage';
 import IconButton from '../../../../UI/IconButton';
@@ -43,7 +41,6 @@ import ProjectFileListItem from './ProjectFileListItem';
 import {
   getExampleAndTemplateItemsForCarousel,
   getLastModifiedInfoByProjectId,
-  getProjectLineHeight,
   transformCloudProjectsIntoFileMetadataWithStorageProviderName,
 } from './utils';
 import ErrorBoundary from '../../../../UI/ErrorBoundary';
@@ -186,8 +183,6 @@ const BuildSection = ({
     if (!b.fileMetadata.lastModifiedDate) return -1;
     return b.fileMetadata.lastModifiedDate - a.fileMetadata.lastModifiedDate;
   });
-
-  const skeletonLineHeight = getProjectLineHeight(windowWidth);
 
   // Show a premium game template every 3 examples.
   const examplesAndTemplatesToDisplay = React.useMemo(
@@ -352,40 +347,23 @@ const BuildSection = ({
                     </Line>
                   )}
                   <List>
-                    {shouldDisplaySkeleton // Only show skeleton on first load
-                      ? new Array(10).fill(0).map((_, index) => (
-                          <ListItem
-                            style={styles.listItem}
-                            key={`skeleton-${index}`}
-                          >
-                            <Line expand>
-                              <Column expand>
-                                <Skeleton
-                                  variant="rect"
-                                  height={skeletonLineHeight}
-                                  style={styles.projectSkeleton}
-                                />
-                              </Column>
-                            </Line>
-                          </ListItem>
-                        ))
-                      : projectFiles.map(file => (
-                          <ProjectFileListItem
-                            key={file.fileMetadata.fileIdentifier}
-                            file={file}
-                            currentFileMetadata={currentFileMetadata}
-                            storageProviders={storageProviders}
-                            isWindowWidthMediumOrLarger={!isMobile}
-                            onOpenRecentFile={onOpenRecentFile}
-                            lastModifiedInfo={
-                              lastModifiedInfoByProjectId[
-                                file.fileMetadata.fileIdentifier
-                              ]
-                            }
-                            onManageGame={onManageGame}
-                            canManageGame={canManageGame}
-                          />
-                        ))}
+                    {projectFiles.map(file => (
+                      <ProjectFileListItem
+                        key={file.fileMetadata.fileIdentifier}
+                        file={file}
+                        currentFileMetadata={currentFileMetadata}
+                        storageProviders={storageProviders}
+                        isWindowWidthMediumOrLarger={!isMobile}
+                        onOpenRecentFile={onOpenRecentFile}
+                        lastModifiedInfo={
+                          lastModifiedInfoByProjectId[
+                            file.fileMetadata.fileIdentifier
+                          ]
+                        }
+                        onManageGame={onManageGame}
+                        canManageGame={canManageGame}
+                      />
+                    ))}
                   </List>
                 </Column>
               )}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -252,7 +252,7 @@ const BuildSection = ({
             items={examplesAndTemplatesToDisplay}
             browseAllIcon={<ChevronArrowRight fontSize="small" />}
             roundedImages
-            hideArrows
+            displayArrowsOnDesktop
           />
         </SectionRow>
         {projectFiles.length > 0 && (

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -39,7 +39,7 @@ import ChevronArrowRight from '../../../../UI/CustomSvgIcons/ChevronArrowRight';
 import Refresh from '../../../../UI/CustomSvgIcons/Refresh';
 import ProjectFileListItem from './ProjectFileListItem';
 import {
-  getExampleAndTemplateItemsForCarousel,
+  getExampleAndTemplateItemsForBuildSection,
   getLastModifiedInfoByProjectId,
   transformCloudProjectsIntoFileMetadataWithStorageProviderName,
 } from './utils';
@@ -48,7 +48,6 @@ import InfoBar from '../../../../UI/Messages/InfoBar';
 import CreateNewProjectButton from './CreateNewProjectButton';
 import GridList from '@material-ui/core/GridList';
 import type { WidthType } from '../../../../UI/Reponsive/ResponsiveWindowMeasurer';
-import { PrivateGameTemplateTile } from '../../../../AssetStore/ShopTiles';
 
 const cellSpacing = 2;
 
@@ -120,7 +119,6 @@ const BuildSection = ({
 }: Props) => {
   const { getRecentProjectFiles } = React.useContext(PreferencesContext);
   const { exampleShortHeaders } = React.useContext(ExampleStoreContext);
-  const { receivedGameTemplates } = React.useContext(AuthenticatedUserContext);
 
   const { privateGameTemplateListingDatas } = React.useContext(
     PrivateGameTemplateStoreContext
@@ -211,16 +209,16 @@ const BuildSection = ({
     return b.fileMetadata.lastModifiedDate - a.fileMetadata.lastModifiedDate;
   });
 
-  // Show a premium game template every 3 examples.
   const examplesAndTemplatesToDisplay = React.useMemo(
     () =>
-      getExampleAndTemplateItemsForCarousel({
+      getExampleAndTemplateItemsForBuildSection({
         authenticatedUser,
         privateGameTemplateListingDatas,
         exampleShortHeaders,
         onSelectPrivateGameTemplateListingData,
         onSelectExampleShortHeader,
         i18n,
+        carouselExclusiveItemsCount: isMobile ? 2 : 5,
       }),
     [
       authenticatedUser,
@@ -229,36 +227,7 @@ const BuildSection = ({
       onSelectPrivateGameTemplateListingData,
       privateGameTemplateListingDatas,
       i18n,
-    ]
-  );
-
-  const gameTemplateTiles = React.useMemo(
-    () => {
-      if (!privateGameTemplateListingDatas) return [];
-      // Only show game templates if the category is not set or is set to "game-template".
-      return privateGameTemplateListingDatas.map(
-        (privateGameTemplateListingData, index) => (
-          <PrivateGameTemplateTile
-            privateGameTemplateListingData={privateGameTemplateListingData}
-            onSelect={() => {
-              console.log('OnSelect');
-              // onPrivateGameTemplateSelection(privateGameTemplateListingData);
-            }}
-            owned={
-              !!receivedGameTemplates &&
-              !!receivedGameTemplates.find(
-                pack => pack.id === privateGameTemplateListingData.id
-              )
-            }
-            key={privateGameTemplateListingData.id}
-          />
-        )
-      );
-    },
-    [
-      privateGameTemplateListingDatas,
-      // onPrivateGameTemplateSelection,
-      receivedGameTemplates,
+      isMobile,
     ]
   );
 
@@ -303,7 +272,7 @@ const BuildSection = ({
             displayItemTitles={false}
             browseAllLabel={<Trans>Browse all templates</Trans>}
             onBrowseAllClick={onShowAllExamples}
-            items={examplesAndTemplatesToDisplay}
+            items={examplesAndTemplatesToDisplay.carouselItems}
             browseAllIcon={<ChevronArrowRight fontSize="small" />}
             roundedImages
             displayArrowsOnDesktop
@@ -446,7 +415,7 @@ const BuildSection = ({
             cellHeight="auto"
             spacing={cellSpacing}
           >
-            {gameTemplateTiles}
+            {examplesAndTemplatesToDisplay.gridItems}
           </GridList>
         </SectionRow>
       </SectionContainer>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -236,7 +236,10 @@ const BuildSection = ({
         {projectFiles.length === 0 && (
           <SectionRow>
             <Line noMargin>
-              <CreateNewProjectButton onClick={onOpenNewProjectSetupDialog} />
+              <CreateNewProjectButton
+                onClick={onOpenNewProjectSetupDialog}
+                fullWidth={isMobile}
+              />
             </Line>
           </SectionRow>
         )}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -223,7 +223,7 @@ const BuildSection = ({
         onSelectPrivateGameTemplateListingData,
         onSelectExampleShortHeader,
         i18n,
-        carouselExclusiveItemsCount:
+        numberOfItemsExclusivelyInCarousel:
           !shouldShowCarousel || showAllGameTemplates ? 0 : isMobile ? 3 : 5,
         numberOfItemsInCarousel:
           !shouldShowCarousel || showAllGameTemplates ? 0 : isMobile ? 8 : 12,

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -218,7 +218,9 @@ const BuildSection = ({
         onSelectPrivateGameTemplateListingData,
         onSelectExampleShortHeader,
         i18n,
-        carouselExclusiveItemsCount: isMobile ? 2 : 5,
+        carouselExclusiveItemsCount: isMobile ? 3 : 5,
+        numberOfItemsInCarousel: isMobile ? 8 : 12,
+        numberOfItemsInGrid: isMobile ? 12 : 20,
       }),
     [
       authenticatedUser,

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -48,6 +48,7 @@ import {
 } from './utils';
 import ErrorBoundary from '../../../../UI/ErrorBoundary';
 import InfoBar from '../../../../UI/Messages/InfoBar';
+import CreateNewProjectButton from './CreateNewProjectButton';
 
 const styles = {
   listItem: {
@@ -237,6 +238,13 @@ const BuildSection = ({
             : undefined
         }
       >
+        {projectFiles.length === 0 && (
+          <SectionRow>
+            <Line noMargin>
+              <CreateNewProjectButton onClick={onOpenNewProjectSetupDialog} />
+            </Line>
+          </SectionRow>
+        )}
         <SectionRow>
           <Carousel
             title={<Trans>Game templates</Trans>}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -32,8 +32,6 @@ import { SubscriptionSuggestionContext } from '../../../../Profile/Subscription/
 import { type ExampleShortHeader } from '../../../../Utils/GDevelopServices/Example';
 import Add from '../../../../UI/CustomSvgIcons/Add';
 import Skeleton from '@material-ui/lab/Skeleton';
-import BackgroundText from '../../../../UI/BackgroundText';
-import Paper from '../../../../UI/Paper';
 import PlaceholderError from '../../../../UI/PlaceholderError';
 import AlertMessage from '../../../../UI/AlertMessage';
 import IconButton from '../../../../UI/IconButton';
@@ -211,6 +209,9 @@ const BuildSection = ({
     ]
   );
 
+  const shouldDisplaySkeleton =
+    authenticatedUser.loginState === 'loggingIn' && projectFiles.length === 0;
+
   return (
     <>
       <SectionContainer
@@ -320,83 +321,65 @@ const BuildSection = ({
             </Line>
           )}
           <Line>
-            <Column noMargin expand>
-              {!isMobile && (
-                <Line justifyContent="space-between">
-                  <Column expand>
-                    <Text color="secondary">
-                      <Trans>File name</Trans>
-                    </Text>
-                  </Column>
-                  <Column expand>
-                    <Text color="secondary">
-                      <Trans>Location</Trans>
-                    </Text>
-                  </Column>
-                  <Column expand>
-                    <Text color="secondary">
-                      <Trans>Last edited</Trans>
-                    </Text>
-                  </Column>
-                </Line>
-              )}
-              <List>
-                {authenticatedUser.loginState === 'loggingIn' &&
-                projectFiles.length === 0 ? ( // Only show skeleton on first load
-                  new Array(10).fill(0).map((_, index) => (
-                    <ListItem style={styles.listItem} key={`skeleton-${index}`}>
-                      <Line expand>
-                        <Column expand>
-                          <Skeleton
-                            variant="rect"
-                            height={skeletonLineHeight}
-                            style={styles.projectSkeleton}
-                          />
-                        </Column>
-                      </Line>
-                    </ListItem>
-                  ))
-                ) : projectFiles.length > 0 ? (
-                  projectFiles.map(file => (
-                    <ProjectFileListItem
-                      key={file.fileMetadata.fileIdentifier}
-                      file={file}
-                      currentFileMetadata={currentFileMetadata}
-                      storageProviders={storageProviders}
-                      isWindowWidthMediumOrLarger={!isMobile}
-                      onOpenRecentFile={onOpenRecentFile}
-                      lastModifiedInfo={
-                        lastModifiedInfoByProjectId[
-                          file.fileMetadata.fileIdentifier
-                        ]
-                      }
-                      onManageGame={onManageGame}
-                      canManageGame={canManageGame}
-                    />
-                  ))
-                ) : (
-                  <ListItem style={styles.listItem}>
+            {(projectFiles.length > 0 || shouldDisplaySkeleton) && (
+              <Column noMargin expand>
+                {!isMobile && (
+                  <Line justifyContent="space-between">
                     <Column expand>
-                      <Paper
-                        variant="outlined"
-                        background="dark"
-                        style={styles.noProjectsContainer}
-                      >
-                        <BackgroundText>
-                          <Trans>No projects yet.</Trans>
-                        </BackgroundText>
-                        <BackgroundText>
-                          <Trans>
-                            Create your first project using one of our templates
-                            or start from scratch.
-                          </Trans>
-                        </BackgroundText>
-                      </Paper>
+                      <Text color="secondary">
+                        <Trans>File name</Trans>
+                      </Text>
                     </Column>
-                  </ListItem>
+                    <Column expand>
+                      <Text color="secondary">
+                        <Trans>Location</Trans>
+                      </Text>
+                    </Column>
+                    <Column expand>
+                      <Text color="secondary">
+                        <Trans>Last edited</Trans>
+                      </Text>
+                    </Column>
+                  </Line>
                 )}
-              </List>
-            </Column>
+                <List>
+                  {shouldDisplaySkeleton // Only show skeleton on first load
+                    ? new Array(10).fill(0).map((_, index) => (
+                        <ListItem
+                          style={styles.listItem}
+                          key={`skeleton-${index}`}
+                        >
+                          <Line expand>
+                            <Column expand>
+                              <Skeleton
+                                variant="rect"
+                                height={skeletonLineHeight}
+                                style={styles.projectSkeleton}
+                              />
+                            </Column>
+                          </Line>
+                        </ListItem>
+                      ))
+                    : projectFiles.map(file => (
+                        <ProjectFileListItem
+                          key={file.fileMetadata.fileIdentifier}
+                          file={file}
+                          currentFileMetadata={currentFileMetadata}
+                          storageProviders={storageProviders}
+                          isWindowWidthMediumOrLarger={!isMobile}
+                          onOpenRecentFile={onOpenRecentFile}
+                          lastModifiedInfo={
+                            lastModifiedInfoByProjectId[
+                              file.fileMetadata.fileIdentifier
+                            ]
+                          }
+                          onManageGame={onManageGame}
+                          canManageGame={canManageGame}
+                        />
+                      ))}
+                </List>
+              </Column>
+            )}
           </Line>
         </SectionRow>
       </SectionContainer>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { type I18n as I18nType } from '@lingui/core';
 import { getUserPublicProfilesByIds } from '../../../../Utils/GDevelopServices/User';
-import { type AuthenticatedUser } from '../../../../Profile/AuthenticatedUserContext';
 import { type Profile } from '../../../../Utils/GDevelopServices/Authentication';
 import { type CloudProjectWithUserAccessInfo } from '../../../../Utils/GDevelopServices/Project';
 import { type FileMetadataAndStorageProviderName } from '../../../../ProjectsStorage';
@@ -167,7 +166,7 @@ const formatExampleShortHeaderForCarousel = ({
 };
 
 export const getExampleAndTemplateItemsForBuildSection = ({
-  authenticatedUser,
+  receivedGameTemplates,
   privateGameTemplateListingDatas,
   exampleShortHeaders,
   onSelectPrivateGameTemplateListingData,
@@ -177,7 +176,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   numberOfItemsInCarousel,
   numberOfItemsInGrid,
 }: {|
-  authenticatedUser: AuthenticatedUser,
+  receivedGameTemplates: ?Array<PrivateGameTemplate>,
   privateGameTemplateListingDatas?: ?Array<PrivateGameTemplateListingData>,
   exampleShortHeaders?: ?Array<ExampleShortHeader>,
   onSelectPrivateGameTemplateListingData: (
@@ -219,7 +218,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
               onSelectGameTemplate: onSelectPrivateGameTemplateListingData,
               gameTemplateListingData:
                 privateGameTemplateListingDatas[privateGameTemplateIndex],
-              receivedGameTemplates: authenticatedUser.receivedGameTemplates,
+              receivedGameTemplates: receivedGameTemplates,
             })
           : formatExampleShortHeaderForCarousel({
               exampleShortHeader:
@@ -233,8 +232,8 @@ export const getExampleAndTemplateItemsForBuildSection = ({
         const privateGameTemplateListingData =
           privateGameTemplateListingDatas[privateGameTemplateIndex];
         const isTemplateOwned =
-          !!authenticatedUser.receivedGameTemplates &&
-          !!authenticatedUser.receivedGameTemplates.find(
+          !!receivedGameTemplates &&
+          !!receivedGameTemplates.find(
             receivedGameTemplate =>
               receivedGameTemplate.id === privateGameTemplateListingData.id
           );

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
@@ -165,6 +165,13 @@ const formatExampleShortHeaderForCarousel = ({
   };
 };
 
+/**
+ * This method allocates examples and private game templates between the
+ * build section carousel and grid.
+ * `numberOfItemsExclusivelyInCarousel` controls the number of items that
+ * should appear in the carousel only. The rest appears in both the carousel
+ * and the grid.
+ */
 export const getExampleAndTemplateItemsForBuildSection = ({
   receivedGameTemplates,
   privateGameTemplateListingDatas,
@@ -172,7 +179,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   onSelectPrivateGameTemplateListingData,
   onSelectExampleShortHeader,
   i18n,
-  carouselExclusiveItemsCount,
+  numberOfItemsExclusivelyInCarousel,
   numberOfItemsInCarousel,
   numberOfItemsInGrid,
   privateGameTemplatesPeriodicity,
@@ -185,7 +192,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   ) => void,
   onSelectExampleShortHeader: (exampleShortHeader: ExampleShortHeader) => void,
   i18n: I18nType,
-  carouselExclusiveItemsCount: number,
+  numberOfItemsExclusivelyInCarousel: number,
   numberOfItemsInCarousel: number,
   numberOfItemsInGrid: number,
   privateGameTemplatesPeriodicity: number,
@@ -206,11 +213,19 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   const gridItems = [];
   let exampleIndex = 0;
   let privateGameTemplateIndex = 0;
-  for (let i = 0; i < numberOfItemsInGrid + carouselExclusiveItemsCount; ++i) {
+  for (
+    let i = 0;
+    i < numberOfItemsInGrid + numberOfItemsExclusivelyInCarousel;
+    ++i
+  ) {
     const shouldAddPrivateGameTemplate =
       i % privateGameTemplatesPeriodicity ===
       privateGameTemplatesPeriodicity - 1;
 
+    // At one point, we might run out of private game templates to display while
+    // it is assumed that we have enough examples to display. This boolean is used
+    // to know if we actually could add a private game template. This way, indices
+    // can be increased accordingly.
     let privateGameTemplateActuallyAdded = false;
     if (i < numberOfItemsInCarousel) {
       // There should always be enough private game templates to sparsely fill the carousel.
@@ -231,7 +246,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
             })
       );
     }
-    if (i >= carouselExclusiveItemsCount) {
+    if (i >= numberOfItemsExclusivelyInCarousel) {
       if (shouldAddPrivateGameTemplate) {
         const privateGameTemplateListingData =
           privateGameTemplateListingDatas[privateGameTemplateIndex];

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
@@ -13,6 +13,7 @@ import { prepareExampleShortHeaders } from '../../../../AssetStore/ExampleStore'
 import { type PrivateGameTemplateListingData } from '../../../../Utils/GDevelopServices/Shop';
 import { type ExampleShortHeader } from '../../../../Utils/GDevelopServices/Example';
 import { type CarouselThumbnail } from '../../../../UI/Carousel';
+import { shuffleArray } from '../../../../Utils/Random';
 
 export type LastModifiedInfo = {|
   lastModifiedByUsername: ?string,
@@ -128,35 +129,37 @@ export const getExampleAndTemplateItemsForCarousel = ({
   const allItems: Array<CarouselThumbnail> = [];
   const privateGameTemplateItems = [
     ...(privateGameTemplateListingDatas
-      ? privateGameTemplateListingDatas.map(privateGameTemplateListingData => {
-          const isTemplateOwned =
-            !!authenticatedUser.receivedGameTemplates &&
-            !!authenticatedUser.receivedGameTemplates.find(
-              receivedGameTemplate =>
-                receivedGameTemplate.id === privateGameTemplateListingData.id
-            );
-          return {
-            id: privateGameTemplateListingData.id,
-            title: privateGameTemplateListingData.name,
-            thumbnailUrl: privateGameTemplateListingData.thumbnailUrls[0],
-            onClick: () => {
-              sendGameTemplateInformationOpened({
-                gameTemplateName: privateGameTemplateListingData.name,
-                gameTemplateId: privateGameTemplateListingData.id,
-                source: 'homepage',
-              });
-              onSelectPrivateGameTemplateListingData(
-                privateGameTemplateListingData
+      ? shuffleArray(privateGameTemplateListingDatas).map(
+          privateGameTemplateListingData => {
+            const isTemplateOwned =
+              !!authenticatedUser.receivedGameTemplates &&
+              !!authenticatedUser.receivedGameTemplates.find(
+                receivedGameTemplate =>
+                  receivedGameTemplate.id === privateGameTemplateListingData.id
               );
-            },
-            overlayText: getProductPriceOrOwnedLabel({
-              i18n,
-              productListingData: privateGameTemplateListingData,
-              owned: isTemplateOwned,
-            }),
-            overlayTextPosition: 'topLeft',
-          };
-        })
+            return {
+              id: privateGameTemplateListingData.id,
+              title: privateGameTemplateListingData.name,
+              thumbnailUrl: privateGameTemplateListingData.thumbnailUrls[0],
+              onClick: () => {
+                sendGameTemplateInformationOpened({
+                  gameTemplateName: privateGameTemplateListingData.name,
+                  gameTemplateId: privateGameTemplateListingData.id,
+                  source: 'homepage',
+                });
+                onSelectPrivateGameTemplateListingData(
+                  privateGameTemplateListingData
+                );
+              },
+              overlayText: getProductPriceOrOwnedLabel({
+                i18n,
+                productListingData: privateGameTemplateListingData,
+                owned: isTemplateOwned,
+              }),
+              overlayTextPosition: 'topLeft',
+            };
+          }
+        )
       : []),
   ];
 

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
@@ -175,6 +175,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   carouselExclusiveItemsCount,
   numberOfItemsInCarousel,
   numberOfItemsInGrid,
+  privateGameTemplatesPeriodicity,
 }: {|
   receivedGameTemplates: ?Array<PrivateGameTemplate>,
   privateGameTemplateListingDatas?: ?Array<PrivateGameTemplateListingData>,
@@ -187,6 +188,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   carouselExclusiveItemsCount: number,
   numberOfItemsInCarousel: number,
   numberOfItemsInGrid: number,
+  privateGameTemplatesPeriodicity: number,
 |}): {|
   carouselItems: Array<CarouselThumbnail>,
   gridItems: Array<React.Node>,
@@ -202,13 +204,12 @@ export const getExampleAndTemplateItemsForBuildSection = ({
 
   const carouselItems: Array<CarouselThumbnail> = [];
   const gridItems = [];
-  const privateGameTemplatePeriodicity =
-    carouselExclusiveItemsCount <= 3 ? 2 : 3;
   let exampleIndex = 0;
   let privateGameTemplateIndex = 0;
   for (let i = 0; i < numberOfItemsInGrid + carouselExclusiveItemsCount; ++i) {
     const shouldAddPrivateGameTemplate =
-      i % privateGameTemplatePeriodicity === privateGameTemplatePeriodicity - 1;
+      i % privateGameTemplatesPeriodicity ===
+      privateGameTemplatesPeriodicity - 1;
 
     let privateGameTemplateActuallyAdded = false;
     if (i < numberOfItemsInCarousel) {

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
@@ -174,6 +174,8 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   onSelectExampleShortHeader,
   i18n,
   carouselExclusiveItemsCount,
+  numberOfItemsInCarousel,
+  numberOfItemsInGrid,
 }: {|
   authenticatedUser: AuthenticatedUser,
   privateGameTemplateListingDatas?: ?Array<PrivateGameTemplateListingData>,
@@ -184,6 +186,8 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   onSelectExampleShortHeader: (exampleShortHeader: ExampleShortHeader) => void,
   i18n: I18nType,
   carouselExclusiveItemsCount: number,
+  numberOfItemsInCarousel: number,
+  numberOfItemsInGrid: number,
 |}): {|
   carouselItems: Array<CarouselThumbnail>,
   gridItems: Array<React.Node>,
@@ -201,8 +205,6 @@ export const getExampleAndTemplateItemsForBuildSection = ({
   const gridItems = [];
   const privateGameTemplatePeriodicity =
     carouselExclusiveItemsCount <= 3 ? 2 : 3;
-  const numberOfItemsInCarousel = 12;
-  const numberOfItemsInGrid = 20;
   let exampleIndex = 0;
   let privateGameTemplateIndex = 0;
   for (let i = 0; i < numberOfItemsInGrid + carouselExclusiveItemsCount; ++i) {

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/utils.js
@@ -210,7 +210,10 @@ export const getExampleAndTemplateItemsForBuildSection = ({
     const shouldAddPrivateGameTemplate =
       i % privateGameTemplatePeriodicity === privateGameTemplatePeriodicity - 1;
 
+    let privateGameTemplateActuallyAdded = false;
     if (i < numberOfItemsInCarousel) {
+      // There should always be enough private game templates to sparsely fill the carousel.
+      privateGameTemplateActuallyAdded = shouldAddPrivateGameTemplate;
       carouselItems.push(
         shouldAddPrivateGameTemplate
           ? formatGameTemplateListingDataForCarousel({
@@ -231,25 +234,29 @@ export const getExampleAndTemplateItemsForBuildSection = ({
       if (shouldAddPrivateGameTemplate) {
         const privateGameTemplateListingData =
           privateGameTemplateListingDatas[privateGameTemplateIndex];
-        const isTemplateOwned =
-          !!receivedGameTemplates &&
-          !!receivedGameTemplates.find(
-            receivedGameTemplate =>
-              receivedGameTemplate.id === privateGameTemplateListingData.id
+        if (privateGameTemplateListingData) {
+          const isTemplateOwned =
+            !!receivedGameTemplates &&
+            !!receivedGameTemplates.find(
+              receivedGameTemplate =>
+                receivedGameTemplate.id === privateGameTemplateListingData.id
+            );
+          gridItems.push(
+            <PrivateGameTemplateTile
+              privateGameTemplateListingData={privateGameTemplateListingData}
+              onSelect={() => {
+                onSelectPrivateGameTemplateListingData(
+                  privateGameTemplateListingData
+                );
+              }}
+              owned={isTemplateOwned}
+              key={privateGameTemplateListingData.id}
+            />
           );
-        gridItems.push(
-          <PrivateGameTemplateTile
-            privateGameTemplateListingData={privateGameTemplateListingData}
-            onSelect={() => {
-              onSelectPrivateGameTemplateListingData(
-                privateGameTemplateListingData
-              );
-            }}
-            owned={isTemplateOwned}
-            key={privateGameTemplateListingData.id}
-          />
-        );
-      } else {
+          privateGameTemplateActuallyAdded = true;
+        }
+      }
+      if (!privateGameTemplateActuallyAdded) {
         const exampleShortHeader =
           exampleShortHeadersWithThumbnails[exampleIndex];
         gridItems.push(
@@ -261,7 +268,7 @@ export const getExampleAndTemplateItemsForBuildSection = ({
         );
       }
     }
-    if (shouldAddPrivateGameTemplate) privateGameTemplateIndex++;
+    if (privateGameTemplateActuallyAdded) privateGameTemplateIndex++;
     else exampleIndex++;
   }
 

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/CardWidget.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/CardWidget.js
@@ -27,6 +27,7 @@ const useStylesForWidget = (useDefaultDisabledStyle?: boolean) =>
       root: {
         border: `1px solid ${theme.palette.text.primary}`,
         borderBottom: `6px solid ${theme.palette.text.primary}`,
+        transition: 'background-color 100ms ease',
         '&:focus': {
           backgroundColor: theme.palette.action.hover,
         },

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -530,7 +530,6 @@ export const HomePage = React.memo<Props>(
                       canOpen={canOpen}
                       onChooseProject={onChooseProject}
                       onOpenNewProjectSetupDialog={onOpenNewProjectSetupDialog}
-                      onShowAllExamples={onOpenExampleStore}
                       onSelectExampleShortHeader={
                         onOpenExampleStoreWithExampleShortHeader
                       }

--- a/newIDE/app/src/UI/Carousel.js
+++ b/newIDE/app/src/UI/Carousel.js
@@ -52,7 +52,7 @@ type Props<ThumbnailType> = {|
   displayItemTitles?: boolean,
   error?: React.Node,
   roundedImages?: boolean,
-  hideArrows?: boolean,
+  displayArrowsOnDesktop?: boolean,
 |};
 
 const referenceSizesByWindowSize = {
@@ -61,12 +61,6 @@ const referenceSizesByWindowSize = {
     medium: 130,
     large: 150,
     xlarge: 170,
-  },
-  arrowWidth: {
-    small: 20,
-    medium: 30,
-    large: 36,
-    xlarge: 42,
   },
 };
 
@@ -107,6 +101,7 @@ const styles = {
     position: 'absolute',
     borderRadius: 4,
   },
+  container: { display: 'flex', position: 'relative' },
   overlay: {
     position: 'absolute',
     borderRadius: 4,
@@ -204,7 +199,7 @@ const Carousel = <ThumbnailType: CarouselThumbnail>({
   error,
   displayItemTitles = true,
   roundedImages = false,
-  hideArrows = false,
+  displayArrowsOnDesktop = false,
 }: Props<ThumbnailType>) => {
   const [
     shouldDisplayLeftArrow,
@@ -213,7 +208,11 @@ const Carousel = <ThumbnailType: CarouselThumbnail>({
   const [
     shouldDisplayRightArrow,
     setShouldDisplayRightArrow,
-  ] = React.useState<boolean>(!hideArrows);
+  ] = React.useState<boolean>(displayArrowsOnDesktop);
+  const [
+    isMouseOverContainer,
+    setIsMouseOverContainer,
+  ] = React.useState<boolean>(false);
   const windowWidth = useResponsiveWindowWidth();
   const isMobileScreen = windowWidth === 'small';
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
@@ -255,7 +254,7 @@ const Carousel = <ThumbnailType: CarouselThumbnail>({
 
   const windowSize = useResponsiveWindowWidth();
   const imageHeight = referenceSizesByWindowSize.imageHeight[windowSize];
-  const arrowWidth = referenceSizesByWindowSize.arrowWidth[windowSize];
+  const arrowWidth = 30;
   const cellWidth = (16 / 9) * imageHeight;
   const widthUnit = cellWidth + cellSpacing;
 
@@ -395,7 +394,7 @@ const Carousel = <ThumbnailType: CarouselThumbnail>({
     (): void => {
       const scrollViewElement = scrollView.current;
       if (!scrollViewElement) return;
-      if (!!hideArrows) return;
+      if (!displayArrowsOnDesktop) return;
 
       const isScrollAtStart = scrollViewElement.scrollLeft === 0;
       const isScrollAtEnd =
@@ -413,7 +412,7 @@ const Carousel = <ThumbnailType: CarouselThumbnail>({
       if (shouldToggleRightArrowVisibility)
         setShouldDisplayRightArrow(!shouldDisplayRightArrow);
     },
-    [shouldDisplayLeftArrow, shouldDisplayRightArrow, hideArrows]
+    [shouldDisplayLeftArrow, shouldDisplayRightArrow, displayArrowsOnDesktop]
   );
 
   const handleScrollEnd = React.useCallback(
@@ -507,24 +506,32 @@ const Carousel = <ThumbnailType: CarouselThumbnail>({
         </Line>
       </Line>
 
-      <div style={{ display: 'flex', position: 'relative' }}>
-        {!hideArrows && shouldDisplayLeftArrow && areItemsSet && (
-          <div
-            className={classesForArrowButtons.root}
-            style={{
-              ...styles.arrowContainer,
-              backgroundColor: gdevelopTheme.paper.backgroundColor.light,
-              width: arrowWidth,
-              height: arrowWidth,
-              left: 5,
-              zIndex: 1,
-              top: `calc(50% - ${Math.floor(arrowWidth / 2)}px)`,
-            }}
-            onClick={() => onClickArrow('left')}
-          >
-            <ChevronArrowLeft />
-          </div>
-        )}
+      <div
+        style={styles.container}
+        onMouseEnter={() => setIsMouseOverContainer(true)}
+        onMouseLeave={() => setIsMouseOverContainer(false)}
+      >
+        {displayArrowsOnDesktop &&
+          isMouseOverContainer &&
+          !isMobileScreen &&
+          shouldDisplayLeftArrow &&
+          areItemsSet && (
+            <div
+              className={classesForArrowButtons.root}
+              style={{
+                ...styles.arrowContainer,
+                backgroundColor: gdevelopTheme.paper.backgroundColor.light,
+                width: arrowWidth,
+                height: arrowWidth,
+                left: 5,
+                zIndex: 1,
+                top: `calc(50% - ${Math.floor(arrowWidth / 2)}px)`,
+              }}
+              onClick={() => onClickArrow('left')}
+            >
+              <ChevronArrowLeft />
+            </div>
+          )}
         <div
           style={{
             width: '100%',
@@ -581,22 +588,26 @@ const Carousel = <ThumbnailType: CarouselThumbnail>({
             </GridList>
           )}
         </div>
-        {!hideArrows && shouldDisplayRightArrow && areItemsSet && (
-          <div
-            className={classesForArrowButtons.root}
-            style={{
-              ...styles.arrowContainer,
-              backgroundColor: gdevelopTheme.paper.backgroundColor.light,
-              width: arrowWidth,
-              height: arrowWidth,
-              right: 0,
-              top: `calc(50% - ${Math.floor(arrowWidth / 2)}px)`,
-            }}
-            onClick={() => onClickArrow('right')}
-          >
-            <ChevronArrowRight />
-          </div>
-        )}
+        {displayArrowsOnDesktop &&
+          isMouseOverContainer &&
+          !isMobileScreen &&
+          shouldDisplayRightArrow &&
+          areItemsSet && (
+            <div
+              className={classesForArrowButtons.root}
+              style={{
+                ...styles.arrowContainer,
+                backgroundColor: gdevelopTheme.paper.backgroundColor.light,
+                width: arrowWidth,
+                height: arrowWidth,
+                right: 0,
+                top: `calc(50% - ${Math.floor(arrowWidth / 2)}px)`,
+              }}
+              onClick={() => onClickArrow('right')}
+            >
+              <ChevronArrowRight />
+            </div>
+          )}
       </div>
     </Column>
   );

--- a/newIDE/app/src/Utils/Random.js
+++ b/newIDE/app/src/Utils/Random.js
@@ -1,0 +1,35 @@
+// @flow
+import shuffle from 'lodash/shuffle';
+
+const randomArrays: {| [size: number]: number[] |} = {};
+
+export const getStableRandomArray = (size: number): number[] => {
+  if (randomArrays[size]) return randomArrays[size];
+
+  const randomArray = shuffle(new Array(size).fill(0).map((_, index) => index));
+  randomArrays[size] = randomArray;
+  return randomArrays[size];
+};
+
+export const shuffleArrayWith = <T>(
+  array: T[],
+  positionArray: number[]
+): T[] => {
+  if (positionArray.length < array.length) {
+    throw new Error(
+      'Cannot shuffle an array with a position array of a lesser size.'
+    );
+  }
+  return array
+    .map((item, index) => ({ item, position: positionArray[index] }))
+    .sort((a, b) => a.position - b.position)
+    .map(sortingItem => sortingItem.item);
+};
+
+/**
+ * Shuffles array. The result will change only if the app is restarted.
+ */
+export const shuffleArray = <T>(array: T[]): T[] => {
+  const randomArray = getStableRandomArray(array.length);
+  return shuffleArrayWith(array, randomArray);
+};

--- a/newIDE/app/src/Utils/Random.js
+++ b/newIDE/app/src/Utils/Random.js
@@ -29,7 +29,7 @@ export const shuffleArrayWith = <T>(
 /**
  * Shuffles array. The result will change only if the app is restarted.
  */
-export const shuffleArray = <T>(array: T[]): T[] => {
+export const shuffleStableArray = <T>(array: T[]): T[] => {
   const randomArray = getStableRandomArray(array.length);
   return shuffleArrayWith(array, randomArray);
 };

--- a/newIDE/app/src/stories/componentStories/Carousel.stories.js
+++ b/newIDE/app/src/stories/componentStories/Carousel.stories.js
@@ -22,6 +22,7 @@ export const LoadingWithoutTitleSkeleton = () => (
     displayItemTitles={false}
     browseAllLabel={<Trans>Browse all</Trans>}
     browseAllIcon={<ChevronArrowRight fontSize="small" />}
+    displayArrowsOnDesktop
   />
 );
 export const OnlyFewSquareImages = () => {
@@ -65,6 +66,7 @@ export const OnlyFewSquareImages = () => {
       items={items}
       displayItemTitles={false}
       browseAllLink="https://www.youtube.com/c/GDevelopApp/videos"
+      displayArrowsOnDesktop
     />
   );
 };
@@ -171,6 +173,7 @@ export const RoundedImagesWithOverlay = () => {
       onBrowseAllClick={() => action('Browse all button clicked')}
       browseAllIcon={<ChevronArrowRight fontSize="small" />}
       roundedImages
+      displayArrowsOnDesktop
     />
   );
 };
@@ -184,7 +187,6 @@ export const WithoutArrows = () => {
       onBrowseAllClick={() => action('Browse all button clicked')}
       browseAllIcon={<ChevronArrowRight fontSize="small" />}
       roundedImages
-      hideArrows
     />
   );
 };
@@ -196,5 +198,6 @@ export const WithError = () => (
     browseAllLabel={<Trans>Browse all</Trans>}
     error={<Trans>Unexpected error</Trans>}
     browseAllIcon={<ChevronArrowRight fontSize="small" />}
+    displayArrowsOnDesktop
   />
 );


### PR DESCRIPTION
With a logged in user with 1 project:

<img width="1204" alt="image" src="https://github.com/4ian/GDevelop/assets/32449369/8406b329-027c-49de-b4df-03264ed1e08c">

<img width="1203" alt="image" src="https://github.com/4ian/GDevelop/assets/32449369/117180b0-a08c-4c67-88bb-9d1c9b251db1">

With a logged in user without any project (Or not logged in user):

<img width="1203" alt="image" src="https://github.com/4ian/GDevelop/assets/32449369/643ac5aa-6c42-4cda-b218-fa9ee6a67183">
