### PR TITLE
Allow custom objects to be used as 3D objects

### DIFF
--- a/Core/GDCore/Extensions/Metadata/AbstractFunctionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/AbstractFunctionMetadata.h
@@ -114,6 +114,8 @@ public:
 
   /**
    * \brief Erase any existing include file and add the specified include.
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
    */
   virtual AbstractFunctionMetadata &
   SetIncludeFile(const gd::String &includeFile) = 0;

--- a/Core/GDCore/Extensions/Metadata/BehaviorMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/BehaviorMetadata.h
@@ -205,6 +205,8 @@ class GD_CORE_API BehaviorMetadata : public InstructionOrExpressionContainerMeta
    * \brief Erase any existing include file and add the specified include.
    * \note The requirement may vary depending on the platform: Most of the time,
    * the include file contains the declaration of the behavior.
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
    */
   BehaviorMetadata& SetIncludeFile(const gd::String& includeFile) override;
 

--- a/Core/GDCore/Extensions/Metadata/EffectMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/EffectMetadata.h
@@ -65,6 +65,8 @@ class GD_CORE_API EffectMetadata {
 
   /**
    * \brief Clear any existing include file and add the specified include file.
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
    */
   EffectMetadata& SetIncludeFile(const gd::String& includeFile);
 

--- a/Core/GDCore/Extensions/Metadata/ExpressionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ExpressionMetadata.h
@@ -288,6 +288,8 @@ class GD_CORE_API ExpressionMetadata : public gd::AbstractFunctionMetadata {
 
   /**
    * \brief Erase any existing include file and add the specified include.
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
    */
   ExpressionMetadata& SetIncludeFile(
       const gd::String& includeFile) override {

--- a/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/InstructionMetadata.h
@@ -494,6 +494,8 @@ class GD_CORE_API InstructionMetadata : public gd::AbstractFunctionMetadata {
 
   /**
    * \brief Erase any existing include file and add the specified include.
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
    */
   InstructionMetadata &SetIncludeFile(const gd::String &includeFile) override {
     codeExtraInformation.includeFiles.clear();

--- a/Core/GDCore/Extensions/Metadata/InstructionOrExpressionContainerMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/InstructionOrExpressionContainerMetadata.h
@@ -142,6 +142,8 @@ public:
    * \brief Erase any existing include file and add the specified include.
    * \note The requirement may vary depending on the platform: Most of the time,
    * the include file contains the declaration of the behavior.
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
    */
   virtual InstructionOrExpressionContainerMetadata &
   SetIncludeFile(const gd::String &includeFile) = 0;

--- a/Core/GDCore/Extensions/Metadata/MultipleInstructionMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/MultipleInstructionMetadata.h
@@ -150,6 +150,10 @@ class GD_CORE_API MultipleInstructionMetadata : public AbstractFunctionMetadata 
     return *this;
   }
 
+  /**
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
+   */
   MultipleInstructionMetadata &SetIncludeFile(const gd::String &includeFile) override {
     if (expression)
       expression->SetIncludeFile(includeFile);

--- a/Core/GDCore/Extensions/Metadata/ObjectMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ObjectMetadata.h
@@ -264,6 +264,8 @@ class GD_CORE_API ObjectMetadata : public InstructionOrExpressionContainerMetada
    * \brief Erase any existing include file and add the specified include.
    * \note The requirement may vary depending on the platform: Most of the time,
    * the include file contains the declaration of the object.
+   * \deprecated Use `AddIncludeFile` instead as clearing the list is more
+   * error prone.
    */
   ObjectMetadata& SetIncludeFile(const gd::String& includeFile) override;
 

--- a/Core/GDCore/Project/EventsBasedObject.cpp
+++ b/Core/GDCore/Project/EventsBasedObject.cpp
@@ -13,7 +13,8 @@ EventsBasedObject::EventsBasedObject()
     : AbstractEventsBasedEntity(
         "MyObject",
         gd::EventsFunctionsContainer::FunctionOwner::Object),
-    ObjectsContainer() {
+    ObjectsContainer(),
+    isRenderedIn3D(false) {
 }
 
 EventsBasedObject::~EventsBasedObject() {}

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -120,9 +120,6 @@ class GD_CORE_API Object {
    */
   const gd::String& GetType() const { return configuration->GetType(); }
 
-  /** \brief Shortcut to check if the object is a 3D object.
-   */
-  bool Is3DObject() const { return configuration->Is3DObject(); }
   ///@}
 
   /** \name Behaviors management

--- a/Core/GDCore/Project/ObjectConfiguration.cpp
+++ b/Core/GDCore/Project/ObjectConfiguration.cpp
@@ -5,11 +5,8 @@
  */
 #include "GDCore/Project/ObjectConfiguration.h"
 
-#include "GDCore/Extensions/Metadata/BehaviorMetadata.h"
 #include "GDCore/Extensions/Metadata/MetadataProvider.h"
 #include "GDCore/Extensions/Platform.h"
-#include "GDCore/Project/Behavior.h"
-#include "GDCore/Project/CustomBehavior.h"
 #include "GDCore/Project/Layout.h"
 #include "GDCore/Project/Project.h"
 #include "GDCore/Serialization/SerializerElement.h"
@@ -20,7 +17,7 @@ namespace gd {
 
 ObjectConfiguration::~ObjectConfiguration() {}
 
-ObjectConfiguration::ObjectConfiguration(): is3DObject(false) {}
+ObjectConfiguration::ObjectConfiguration() {}
 
 std::map<gd::String, gd::PropertyDescriptor> ObjectConfiguration::GetProperties() const {
   std::map<gd::String, gd::PropertyDescriptor> nothing;

--- a/Core/GDCore/Project/ObjectConfiguration.h
+++ b/Core/GDCore/Project/ObjectConfiguration.h
@@ -63,19 +63,11 @@ class GD_CORE_API ObjectConfiguration {
    */
   void SetType(const gd::String& type_) {
     type = type_;
-
-    // For now, as a shortcut, consider only the objects from the built-in 3D extension
-    // to be 3D object.
-    is3DObject = type.find("Scene3D::") == 0;
   }
 
   /** \brief Return the type of the object.
    */
   const gd::String& GetType() const { return type; }
-
-  /** \brief Shortcut to check if the object is a 3D object.
-   */
-  bool Is3DObject() const { return is3DObject; }
 
   /** \name Object properties
    * Reading and updating object configuration properties
@@ -180,7 +172,6 @@ class GD_CORE_API ObjectConfiguration {
  protected:
   gd::String type; ///< Which type of object is represented by this
                    ///< configuration.
-  bool is3DObject;
 
   /**
    * \brief Derived object configuration can redefine this method to load

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -102,11 +102,19 @@ std::unique_ptr<gd::Object> Project::CreateObject(
     behavior->SetDefaultBehavior(true);
   };
 
-  if (Project::HasEventsBasedObject(objectType)) {
+  if (project.HasEventsBasedObject(objectType)) {
+    // Event-based object metadata may not be generated yet.
     addDefaultBehavior("EffectCapability::EffectBehavior");
     addDefaultBehavior("ResizableCapability::ResizableBehavior");
     addDefaultBehavior("ScalableCapability::ScalableBehavior");
     addDefaultBehavior("FlippableCapability::FlippableBehavior");
+    auto& eventBasedObject = project.GetEventsBasedObject(objectType);
+    if (eventBasedObject.IsRenderedIn3D()) {
+      addDefaultBehavior("Scene3D::Base3DBehavior");
+    }
+    else {
+      addDefaultBehavior("OpacityCapability::OpacityBehavior");
+    }
   } else {
     auto& objectMetadata =
         gd::MetadataProvider::GetObjectMetadata(platform, objectType);

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -103,7 +103,8 @@ std::unique_ptr<gd::Object> Project::CreateObject(
   };
 
   if (project.HasEventsBasedObject(objectType)) {
-    // Event-based object metadata may not be generated yet.
+    // During project deserialization, event-based object metadata are not yet
+    // generated.
     addDefaultBehavior("EffectCapability::EffectBehavior");
     addDefaultBehavior("ResizableCapability::ResizableBehavior");
     addDefaultBehavior("ScalableCapability::ScalableBehavior");

--- a/Extensions/3D/A_RuntimeObject3D.ts
+++ b/Extensions/3D/A_RuntimeObject3D.ts
@@ -154,14 +154,14 @@ namespace gdjs {
      * @return The Z position of the rendered object.
      */
     getDrawableZ(): float {
-      return this.getZ();
+      return this._z;
     }
 
     /**
      * Return the bottom Z of the object.
      * Rotations around X and Y are not taken into account.
      */
-    getAABBMinZ(): number {
+    getUnrotatedAABBMinZ(): number {
       return this.getDrawableZ();
     }
 
@@ -169,7 +169,7 @@ namespace gdjs {
      * Return the top Z of the object.
      * Rotations around X and Y are not taken into account.
      */
-    getAABBMaxZ(): number {
+    getUnrotatedAABBMaxZ(): number {
       return this.getDrawableZ() + this.getDepth();
     }
 
@@ -191,7 +191,7 @@ namespace gdjs {
     }
 
     setCenterZInScene(z: float): void {
-      this.setZ(z + this.getZ() - (this.getDrawableZ() + this.getCenterZ()));
+      this.setZ(z + this._z - (this.getDrawableZ() + this.getCenterZ()));
     }
 
     setAngle(angle: float): void {

--- a/Extensions/3D/A_RuntimeObject3D.ts
+++ b/Extensions/3D/A_RuntimeObject3D.ts
@@ -158,6 +158,22 @@ namespace gdjs {
     }
 
     /**
+     * Return the bottom Z of the object.
+     * Rotations around X and Y are not taken into account.
+     */
+    getAABBMinZ(): number {
+      return this.getDrawableZ();
+    }
+
+    /**
+     * Return the top Z of the object.
+     * Rotations around X and Y are not taken into account.
+     */
+    getAABBMaxZ(): number {
+      return this.getDrawableZ() + this.getDepth();
+    }
+
+    /**
      * Return the Z position of the object center, **relative to the object Z
      * position** (`getDrawableX`).
      *
@@ -175,7 +191,7 @@ namespace gdjs {
     }
 
     setCenterZInScene(z: float): void {
-      this.setZ(z + this._z - (this.getDrawableZ() + this.getCenterZ()));
+      this.setZ(z + this.getZ() - (this.getDrawableZ() + this.getCenterZ()));
     }
 
     setAngle(angle: float): void {

--- a/Extensions/3D/A_RuntimeObject3DRenderer.ts
+++ b/Extensions/3D/A_RuntimeObject3DRenderer.ts
@@ -24,8 +24,8 @@ namespace gdjs {
 
     updatePosition() {
       this._threeObject3D.position.set(
-        this._object.x + this._object.getWidth() / 2,
-        this._object.y + this._object.getHeight() / 2,
+        this._object.getX() + this._object.getWidth() / 2,
+        this._object.getY() + this._object.getHeight() / 2,
         this._object.getZ() + this._object.getDepth() / 2
       );
     }

--- a/Extensions/3D/Base3DBehavior.ts
+++ b/Extensions/3D/Base3DBehavior.ts
@@ -105,6 +105,15 @@ namespace gdjs {
     isFlippedZ(): boolean;
   }
 
+  export namespace Base3DHandler {
+    export const is3D = (
+      o: gdjs.RuntimeObject
+    ): o is gdjs.RuntimeObject & gdjs.Base3DHandler => {
+      //@ts-ignore We are checking if the methods are present.
+      return o.getZ && o.setZ;
+    };
+  }
+
   /**
    * A behavior that forwards the Base3D interface to its object.
    */

--- a/Extensions/3D/Base3DBehavior.ts
+++ b/Extensions/3D/Base3DBehavior.ts
@@ -228,7 +228,7 @@ namespace gdjs {
       return this.object.getAABBMinZ();
     }
 
-    getAABBMaxZ(): number{
+    getAABBMaxZ(): number {
       return this.object.getAABBMaxZ();
     }
   }

--- a/Extensions/3D/Base3DBehavior.ts
+++ b/Extensions/3D/Base3DBehavior.ts
@@ -108,13 +108,13 @@ namespace gdjs {
      * Return the bottom Z of the object.
      * Rotations around X and Y are not taken into account.
      */
-    getAABBMinZ(): number;
+    getUnrotatedAABBMinZ(): number;
 
     /**
      * Return the top Z of the object.
      * Rotations around X and Y are not taken into account.
      */
-    getAABBMaxZ(): number;
+    getUnrotatedAABBMaxZ(): number;
   }
 
   export namespace Base3DHandler {
@@ -224,12 +224,12 @@ namespace gdjs {
       return this.object.isFlippedZ();
     }
 
-    getAABBMinZ(): number {
-      return this.object.getAABBMinZ();
+    getUnrotatedAABBMinZ(): number {
+      return this.object.getUnrotatedAABBMinZ();
     }
 
-    getAABBMaxZ(): number {
-      return this.object.getAABBMaxZ();
+    getUnrotatedAABBMaxZ(): number {
+      return this.object.getUnrotatedAABBMaxZ();
     }
   }
 

--- a/Extensions/3D/Base3DBehavior.ts
+++ b/Extensions/3D/Base3DBehavior.ts
@@ -223,6 +223,14 @@ namespace gdjs {
     isFlippedZ(): boolean {
       return this.object.isFlippedZ();
     }
+
+    getAABBMinZ(): number {
+      return this.object.getAABBMinZ();
+    }
+
+    getAABBMaxZ(): number{
+      return this.object.getAABBMaxZ();
+    }
   }
 
   gdjs.registerBehavior('Scene3D::Base3DBehavior', gdjs.Base3DBehavior);

--- a/Extensions/3D/Base3DBehavior.ts
+++ b/Extensions/3D/Base3DBehavior.ts
@@ -119,10 +119,10 @@ namespace gdjs {
 
   export namespace Base3DHandler {
     export const is3D = (
-      o: gdjs.RuntimeObject
-    ): o is gdjs.RuntimeObject & gdjs.Base3DHandler => {
+      object: gdjs.RuntimeObject
+    ): object is gdjs.RuntimeObject & gdjs.Base3DHandler => {
       //@ts-ignore We are checking if the methods are present.
-      return o.getZ && o.setZ;
+      return object.getZ && object.setZ;
     };
   }
 

--- a/Extensions/3D/Base3DBehavior.ts
+++ b/Extensions/3D/Base3DBehavior.ts
@@ -103,6 +103,18 @@ namespace gdjs {
     flipZ(enable: boolean): void;
 
     isFlippedZ(): boolean;
+
+    /**
+     * Return the bottom Z of the object.
+     * Rotations around X and Y are not taken into account.
+     */
+    getAABBMinZ(): number;
+
+    /**
+     * Return the top Z of the object.
+     * Rotations around X and Y are not taken into account.
+     */
+    getAABBMaxZ(): number;
   }
 
   export namespace Base3DHandler {

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -133,7 +133,7 @@ namespace gdjs {
      * Return the bottom Z of the object.
      * Rotations around X and Y are not taken into account.
      */
-    getAABBMinZ(): number {
+    getUnrotatedAABBMinZ(): number {
       return this.getDrawableZ();
     }
 
@@ -141,7 +141,7 @@ namespace gdjs {
      * Return the top Z of the object.
      * Rotations around X and Y are not taken into account.
      */
-    getAABBMaxZ(): number {
+    getUnrotatedAABBMaxZ(): number {
       return this.getDrawableZ() + this.getDepth();
     }
 
@@ -250,8 +250,8 @@ namespace gdjs {
         if (!gdjs.Base3DHandler.is3D(childInstance)) {
           continue;
         }
-        minZ = Math.min(minZ, childInstance.getAABBMinZ());
-        maxZ = Math.max(maxZ, childInstance.getAABBMaxZ());
+        minZ = Math.min(minZ, childInstance.getUnrotatedAABBMinZ());
+        maxZ = Math.max(maxZ, childInstance.getUnrotatedAABBMaxZ());
       }
       if (minZ === Number.MAX_VALUE) {
         // The unscaled size can't be 0 because setWidth and setHeight wouldn't

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -1,0 +1,340 @@
+namespace gdjs {
+  export interface Object3DDataContent {
+    width: float;
+    height: float;
+    depth: float;
+  }
+  /** Base parameters for {@link gdjs.RuntimeObject3D} */
+  export interface Object3DData extends ObjectData {
+    /** The base parameters of the RuntimeObject3D */
+    content: Object3DDataContent;
+  }
+
+  /**
+   * Base class for 3D custom objects.
+   */
+  export class CustomRuntimeObject3D
+    extends gdjs.CustomRuntimeObject
+    implements
+      gdjs.Resizable,
+      gdjs.Scalable,
+      gdjs.Flippable,
+      gdjs.Base3DHandler {
+    /**
+     * Position on the Z axis.
+     */
+    private _z: float = 0;
+    private _minZ: float = 0;
+    private _maxZ: float = 0;
+    private _scaleZ: float = 1;
+    private _flippedZ: boolean = false;
+    /**
+     * Euler angle with the `ZYX` order.
+     *
+     * Note that `_rotationZ` is `angle` from `gdjs.RuntimeObject`.
+     */
+    private _rotationX: float = 0;
+    /**
+     * Euler angle with the `ZYX` order.
+     *
+     * Note that `_rotationZ` is `angle` from `gdjs.RuntimeObject`.
+     */
+    private _rotationY: float = 0;
+    private static _temporaryVector = new THREE.Vector3();
+
+    constructor(
+      instanceContainer: gdjs.RuntimeInstanceContainer,
+      objectData: Object3DData & CustomObjectConfiguration
+    ) {
+      super(instanceContainer, objectData);
+      this.setRotationCenter(0, 0);
+    }
+
+    protected _createRender() {
+      const parent = this._runtimeScene;
+      return new gdjs.CustomRuntimeObject3DRenderer(
+        this,
+        this._instanceContainer,
+        parent
+      );
+    }
+
+    getRenderer(): gdjs.CustomRuntimeObject3DRenderer {
+      return super.getRenderer() as gdjs.CustomRuntimeObject3DRenderer;
+    }
+
+    get3DRendererObject() {
+      // It can't be null because Three.js is always loaded
+      // when a custom 3D object is used.
+      return this.getRenderer().get3DRendererObject()!;
+    }
+
+    updateFromObjectData(
+      oldObjectData: Object3DData,
+      newObjectData: Object3DData
+    ): boolean {
+      return true;
+    }
+
+    extraInitializationFromInitialInstance(initialInstanceData: InstanceData) {
+      if (initialInstanceData.customSize) {
+        this.setWidth(initialInstanceData.width);
+        this.setHeight(initialInstanceData.height);
+      }
+      if (initialInstanceData.depth !== undefined)
+        this.setDepth(initialInstanceData.depth);
+    }
+
+    /**
+     * Set the object position on the Z axis.
+     */
+    setZ(z: float): void {
+      if (z === this._z) return;
+      this._z = z;
+      this.getRenderer().updatePosition();
+    }
+
+    /**
+     * Get the object position on the Z axis.
+     */
+    getZ(): float {
+      return this._z;
+    }
+
+    /**
+     * Get the Z position of the rendered object.
+     *
+     * For most objects, this will returns the same value as getZ(). But if the
+     * object has an origin that is not the same as the point (0,0,0) of the
+     * object displayed, getDrawableZ will differ.
+     *
+     * @return The Z position of the rendered object.
+     */
+    getDrawableZ(): float {
+      return this.getZ();
+    }
+
+    /**
+     * Return the Z position of the object center, **relative to the object Z
+     * position** (`getDrawableX`).
+     *
+     * Use `getCenterZInScene` to get the position of the center in the scene.
+     *
+     * @return the Z position of the object center, relative to
+     * `getDrawableZ()`.
+     */
+    getCenterZ(): float {
+      return this.getDepth() / 2;
+    }
+
+    getCenterZInScene(): float {
+      return this.getDrawableZ() + this.getCenterZ();
+    }
+
+    setCenterZInScene(z: float): void {
+      this.setZ(z + this._z - (this.getDrawableZ() + this.getCenterZ()));
+    }
+
+    /**
+     * Set the object rotation on the X axis.
+     *
+     * This is an Euler angle. Objects use the `ZYX` order.
+     */
+    setRotationX(angle: float): void {
+      this._rotationX = angle;
+      this.getRenderer().updateRotation();
+    }
+
+    /**
+     * Set the object rotation on the Y axis.
+     *
+     * This is an Euler angle. Objects use the `ZYX` order.
+     */
+    setRotationY(angle: float): void {
+      this._rotationY = angle;
+      this.getRenderer().updateRotation();
+    }
+
+    /**
+     * Get the object rotation on the X axis.
+     *
+     * This is an Euler angle. Objects use the `ZYX` order.
+     */
+    getRotationX(): float {
+      return this._rotationX;
+    }
+
+    /**
+     * Get the object rotation on the Y axis.
+     *
+     * This is an Euler angle. Objects use the `ZYX` order.
+     */
+    getRotationY(): float {
+      return this._rotationY;
+    }
+
+    /**
+     * Turn the object around the scene x axis at its center.
+     * @param deltaAngle the rotation angle
+     */
+    turnAroundX(deltaAngle: float): void {
+      const axisX = gdjs.CustomRuntimeObject3D._temporaryVector;
+      axisX.set(1, 0, 0);
+
+      const mesh = this.get3DRendererObject();
+      mesh.rotateOnWorldAxis(axisX, gdjs.toRad(deltaAngle));
+      this._rotationX = gdjs.toDegrees(mesh.rotation.x);
+      this._rotationY = gdjs.toDegrees(mesh.rotation.y);
+      this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+    }
+
+    /**
+     * Turn the object around the scene y axis at its center.
+     * @param deltaAngle the rotation angle
+     */
+    turnAroundY(deltaAngle: float): void {
+      const axisY = gdjs.CustomRuntimeObject3D._temporaryVector;
+      axisY.set(0, 1, 0);
+
+      const mesh = this.get3DRendererObject();
+      mesh.rotateOnWorldAxis(axisY, gdjs.toRad(deltaAngle));
+      this._rotationX = gdjs.toDegrees(mesh.rotation.x);
+      this._rotationY = gdjs.toDegrees(mesh.rotation.y);
+      this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+    }
+
+    /**
+     * Turn the object around the scene z axis at its center.
+     * @param deltaAngle the rotation angle
+     */
+    turnAroundZ(deltaAngle: float): void {
+      const axisZ = gdjs.CustomRuntimeObject3D._temporaryVector;
+      axisZ.set(0, 0, 1);
+
+      const mesh = this.get3DRendererObject();
+      mesh.rotateOnWorldAxis(axisZ, gdjs.toRad(deltaAngle));
+      this._rotationX = gdjs.toDegrees(mesh.rotation.x);
+      this._rotationY = gdjs.toDegrees(mesh.rotation.y);
+      this.setAngle(gdjs.toDegrees(mesh.rotation.z));
+    }
+
+    /**
+     * @return the internal width of the object according to its children.
+     */
+    getUnscaledDepth(): float {
+      if (this._isUntransformedHitBoxesDirty) {
+        this._updateUntransformedHitBoxes();
+      }
+      return this._maxZ - this._minZ;
+    }
+
+    _updateUntransformedHitBoxes(): void {
+      super._updateUntransformedHitBoxes();
+
+      if (this._instanceContainer.getAdhocListOfAllInstances().length === 0) {
+        this._minZ = 0;
+        this._maxZ = 0;
+      } else {
+        let minZ = Number.MAX_VALUE;
+        let maxZ = -Number.MAX_VALUE;
+        for (const childInstance of this._instanceContainer.getAdhocListOfAllInstances()) {
+          if (!childInstance.isIncludedInParentCollisionMask()) {
+            continue;
+          }
+          if (!(childInstance instanceof gdjs.RuntimeObject3D)) {
+            continue;
+          }
+          minZ = Math.min(minZ, childInstance.getAABBMinZ());
+          maxZ = Math.max(maxZ, childInstance.getAABBMaxZ());
+        }
+        this._minZ = minZ;
+        this._maxZ = maxZ;
+      }
+    }
+
+    /**
+     * @returns the center X from the local origin (0;0).
+     */
+    getUnscaledCenterZ(): float {
+      return 0;
+    }
+
+    /**
+     * Get the object size on the Z axis (called "depth").
+     */
+    getDepth(): float {
+      return this.getUnscaledDepth() * this.getScaleZ();
+    }
+
+    /**
+     * Set the object size on the Z axis (called "depth").
+     */
+    setDepth(depth: float): void {
+      const unscaledDepth = this.getUnscaledDepth();
+      if (unscaledDepth !== 0) {
+        this.setScaleX(depth / unscaledDepth);
+      }
+    }
+
+    /**
+     * Change the scale on X, Y and Z axis of the object.
+     *
+     * @param newScale The new scale (must be greater than 0).
+     */
+    setScale(newScale: number): void {
+      super.setScale(newScale);
+      this.setScaleZ(newScale);
+    }
+
+    /**
+     * Change the scale on Z axis of the object (changing its height).
+     *
+     * @param newScale The new scale (must be greater than 0).
+     */
+    setScaleZ(newScale: number): void {
+      if (newScale < 0) {
+        newScale = 0;
+      }
+      if (newScale === Math.abs(this._scaleZ)) {
+        return;
+      }
+      this._scaleZ = newScale * (this._flippedZ ? -1 : 1);
+      this.getRenderer().updateSize();
+    }
+
+    /**
+     * Get the scale of the object (or the geometric average of X, Y and Z scale in case they are different).
+     *
+     * @return the scale of the object (or the geometric average of X, Y and Z scale in case they are different).
+     */
+    getScale(): number {
+      const scaleX = this.getScaleX();
+      const scaleY = this.getScaleY();
+      const scaleZ = this.getScaleZ();
+      return scaleX === scaleY && scaleX === scaleZ
+        ? scaleX
+        : Math.pow(scaleX * scaleY * scaleZ, 1 / 3);
+    }
+
+    /**
+     * Get the scale of the object on Z axis.
+     *
+     * @return the scale of the object on Z axis
+     */
+    getScaleZ(): float {
+      return Math.abs(this._scaleZ);
+    }
+
+    flipZ(enable: boolean) {
+      if (enable === this._flippedZ) {
+        return;
+      }
+      this._flippedZ = enable;
+      this.getRenderer().updateSize();
+    }
+
+    isFlippedZ(): boolean {
+      return this._flippedZ;
+    }
+  }
+}

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -241,7 +241,7 @@ namespace gdjs {
           if (!childInstance.isIncludedInParentCollisionMask()) {
             continue;
           }
-          if (!(childInstance instanceof gdjs.RuntimeObject3D)) {
+          if (!gdjs.Base3DHandler.is3D(childInstance)) {
             continue;
           }
           minZ = Math.min(minZ, childInstance.getAABBMinZ());

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -56,7 +56,7 @@ namespace gdjs {
       );
     }
 
-    protected _reinitializeRender(): void {
+    protected _reinitializeRenderer(): void {
       this.getRenderer().reinitialize(this, this.getParent());
     }
 

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -70,13 +70,6 @@ namespace gdjs {
       return this.getRenderer().get3DRendererObject()!;
     }
 
-    updateFromObjectData(
-      oldObjectData: Object3DData,
-      newObjectData: Object3DData
-    ): boolean {
-      return true;
-    }
-
     extraInitializationFromInitialInstance(initialInstanceData: InstanceData) {
       super.extraInitializationFromInitialInstance(initialInstanceData);
       if (initialInstanceData.depth !== undefined)

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -109,7 +109,10 @@ namespace gdjs {
      * @return The Z position of the rendered object.
      */
     getDrawableZ(): float {
-      return this.getZ();
+      if (this._isUntransformedHitBoxesDirty) {
+        this._updateUntransformedHitBoxes();
+      }
+      return this._minZ;
     }
 
     /**

--- a/Extensions/3D/CustomRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/CustomRuntimeObject3DRenderer.ts
@@ -1,60 +1,125 @@
 namespace gdjs {
-  export class CustomRuntimeObject3DRenderer extends gdjs.CustomObjectRenderer {
+  export class CustomRuntimeObject3DRenderer
+    implements gdjs.RuntimeInstanceContainerRenderer {
     _object: gdjs.CustomRuntimeObject3D;
+    _instanceContainer: gdjs.CustomRuntimeObjectInstanceContainer;
+    _isContainerDirty: boolean = true;
+    _threeGroup: THREE.Group;
 
     constructor(
       object: gdjs.CustomRuntimeObject3D,
       instanceContainer: gdjs.CustomRuntimeObjectInstanceContainer,
       parent: gdjs.RuntimeInstanceContainer
     ) {
-      super(object, instanceContainer, parent);
       this._object = object;
+      this._instanceContainer = instanceContainer;
+
+      this._threeGroup = new THREE.Group();
+      this._threeGroup.rotation.order = 'ZYX';
+
+      const layer = parent.getLayer('');
+      if (layer) {
+        layer.getRenderer().add3DRendererObject(this._threeGroup);
+      }
     }
 
-    updatePosition() {
-      const threeObject3D = this.get3DRendererObject();
-      if (!threeObject3D) {
-        return;
-      }
-      threeObject3D.position.set(
-        this._object.x + this._object.getWidth() / 2,
-        this._object.y + this._object.getHeight() / 2,
-        this._object.getZ() + this._object.getDepth() / 2
-      );
+    get3DRendererObject(): THREE.Object3D {
+      return this._threeGroup;
     }
 
-    updateRotation() {
-      const threeObject3D = this.get3DRendererObject();
-      if (!threeObject3D) {
-        return;
+    getRendererObject() {
+      return null;
+    }
+
+    reinitialize(
+      object: gdjs.CustomRuntimeObject3D,
+      parent: gdjs.RuntimeInstanceContainer
+    ) {
+      this._object = object;
+      this._isContainerDirty = true;
+      const layer = parent.getLayer('');
+      if (layer) {
+        layer.getRenderer().add3DRendererObject(this._threeGroup);
       }
+    }
+
+    _updateThreeGroup() {
+      const threeObject3D = this.get3DRendererObject();
+
+      const pivotX = this._object.getUnscaledCenterX();
+      const pivotY = this._object.getUnscaledCenterY();
+      const pivotZ = this._object.getUnscaledCenterZ();
+      const scaleX = this._object.getScaleX();
+      const scaleY = this._object.getScaleY();
+      const scaleZ = this._object.getScaleZ();
+
       threeObject3D.rotation.set(
         gdjs.toRad(this._object.getRotationX()),
         gdjs.toRad(this._object.getRotationY()),
         gdjs.toRad(this._object.angle)
       );
+
+      // TODO does it work with scaling and flipping?
+      threeObject3D.position.set(-pivotX, -pivotY, -pivotZ);
+      threeObject3D.position.applyEuler(threeObject3D.rotation);
+      threeObject3D.position.x += this._object.getX() + pivotX;
+      threeObject3D.position.y += this._object.getY() + pivotY;
+      threeObject3D.position.z += this._object.getZ() + pivotZ;
+
+      threeObject3D.scale.set(scaleX, scaleY, scaleZ);
+
+      threeObject3D.visible = !this._object.hidden;
+
+      this._isContainerDirty = true;
+    }
+
+    /**
+     * Call this to make sure the object is ready to be rendered.
+     */
+    ensureUpToDate() {
+      if (this._isContainerDirty) {
+        this._updateThreeGroup();
+      }
+    }
+
+    update(): void {
+      this._isContainerDirty = true;
+    }
+
+    updateX(): void {
+      this._isContainerDirty = true;
+    }
+
+    updateY(): void {
+      this._isContainerDirty = true;
+    }
+
+    updateAngle(): void {
+      this._isContainerDirty = true;
+    }
+
+    updatePosition() {
+      this._isContainerDirty = true;
+    }
+
+    updateRotation() {
+      this._isContainerDirty = true;
     }
 
     updateSize() {
-      const threeObject3D = this.get3DRendererObject();
-      if (!threeObject3D) {
-        return;
-      }
-      const object = this._object;
-      threeObject3D.scale.set(
-        object.isFlippedX() ? -object.getWidth() : object.getWidth(),
-        object.isFlippedY() ? -object.getHeight() : object.getHeight(),
-        object.isFlippedZ() ? -object.getDepth() : object.getDepth()
-      );
-      this.updatePosition();
+      this._isContainerDirty = true;
     }
 
-    updateVisibility() {
-      const threeObject3D = this.get3DRendererObject();
-      if (!threeObject3D) {
-        return;
-      }
-      threeObject3D.visible = !this._object.isHidden();
+    updateVisibility(): void {
+      this._threeGroup.visible = !this._object.hidden;
+    }
+
+    updateOpacity(): void {
+      // Opacity is not handled by 3D custom objects.
+    }
+
+    setLayerIndex(layer: gdjs.RuntimeLayer, index: float): void {
+      // Layers are not handled for 3D custom objects.
     }
   }
 }

--- a/Extensions/3D/CustomRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/CustomRuntimeObject3DRenderer.ts
@@ -1,4 +1,7 @@
 namespace gdjs {
+  /**
+   * The renderer for a {@link gdjs.CustomRuntimeObject3D} using Three.js.
+   */
   export class CustomRuntimeObject3DRenderer
     implements gdjs.RuntimeInstanceContainerRenderer {
     _object: gdjs.CustomRuntimeObject3D;

--- a/Extensions/3D/CustomRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/CustomRuntimeObject3DRenderer.ts
@@ -1,0 +1,60 @@
+namespace gdjs {
+  export class CustomRuntimeObject3DRenderer extends gdjs.CustomObjectRenderer {
+    _object: gdjs.CustomRuntimeObject3D;
+
+    constructor(
+      object: gdjs.CustomRuntimeObject3D,
+      instanceContainer: gdjs.CustomRuntimeObjectInstanceContainer,
+      parent: gdjs.RuntimeInstanceContainer
+    ) {
+      super(object, instanceContainer, parent);
+      this._object = object;
+    }
+
+    updatePosition() {
+      const threeObject3D = this.get3DRendererObject();
+      if (!threeObject3D) {
+        return;
+      }
+      threeObject3D.position.set(
+        this._object.x + this._object.getWidth() / 2,
+        this._object.y + this._object.getHeight() / 2,
+        this._object.getZ() + this._object.getDepth() / 2
+      );
+    }
+
+    updateRotation() {
+      const threeObject3D = this.get3DRendererObject();
+      if (!threeObject3D) {
+        return;
+      }
+      threeObject3D.rotation.set(
+        gdjs.toRad(this._object.getRotationX()),
+        gdjs.toRad(this._object.getRotationY()),
+        gdjs.toRad(this._object.angle)
+      );
+    }
+
+    updateSize() {
+      const threeObject3D = this.get3DRendererObject();
+      if (!threeObject3D) {
+        return;
+      }
+      const object = this._object;
+      threeObject3D.scale.set(
+        object.isFlippedX() ? -object.getWidth() : object.getWidth(),
+        object.isFlippedY() ? -object.getHeight() : object.getHeight(),
+        object.isFlippedZ() ? -object.getDepth() : object.getDepth()
+      );
+      this.updatePosition();
+    }
+
+    updateVisibility() {
+      const threeObject3D = this.get3DRendererObject();
+      if (!threeObject3D) {
+        return;
+      }
+      threeObject3D.visible = !this._object.isHidden();
+    }
+  }
+}

--- a/Extensions/3D/CustomRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/CustomRuntimeObject3DRenderer.ts
@@ -46,12 +46,12 @@ namespace gdjs {
     _updateThreeGroup() {
       const threeObject3D = this.get3DRendererObject();
 
-      const pivotX = this._object.getUnscaledCenterX();
-      const pivotY = this._object.getUnscaledCenterY();
-      const pivotZ = this._object.getUnscaledCenterZ();
       const scaleX = this._object.getScaleX();
       const scaleY = this._object.getScaleY();
       const scaleZ = this._object.getScaleZ();
+      const pivotX = this._object.getUnscaledCenterX() * scaleX;
+      const pivotY = this._object.getUnscaledCenterY() * scaleY;
+      const pivotZ = this._object.getUnscaledCenterZ() * scaleZ;
 
       threeObject3D.rotation.set(
         gdjs.toRad(this._object.getRotationX()),
@@ -59,14 +59,21 @@ namespace gdjs {
         gdjs.toRad(this._object.angle)
       );
 
-      // TODO does it work with scaling and flipping?
-      threeObject3D.position.set(-pivotX, -pivotY, -pivotZ);
+      threeObject3D.position.set(
+        this._object.isFlippedX() ? pivotX : -pivotX,
+        this._object.isFlippedY() ? pivotY : -pivotY,
+        this._object.isFlippedZ() ? pivotZ : -pivotZ
+      );
       threeObject3D.position.applyEuler(threeObject3D.rotation);
       threeObject3D.position.x += this._object.getX() + pivotX;
       threeObject3D.position.y += this._object.getY() + pivotY;
       threeObject3D.position.z += this._object.getZ() + pivotZ;
 
-      threeObject3D.scale.set(scaleX, scaleY, scaleZ);
+      threeObject3D.scale.set(
+        this._object.isFlippedX() ? -scaleX : scaleX,
+        this._object.isFlippedY() ? -scaleY : scaleY,
+        this._object.isFlippedZ() ? -scaleZ : scaleZ
+      );
 
       threeObject3D.visible = !this._object.hidden;
 

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -3066,6 +3066,11 @@ module.exports = {
         return this.getHeight() * originPoint[1];
       }
 
+      getOriginZ() {
+        const originPoint = this.getOriginPoint();
+        return this.getDepth() * originPoint[2];
+      }
+
       getCenterX() {
         const centerPoint = this.getCenterPoint();
         return this.getWidth() * centerPoint[0];
@@ -3074,6 +3079,11 @@ module.exports = {
       getCenterY() {
         const centerPoint = this.getCenterPoint();
         return this.getHeight() * centerPoint[1];
+      }
+
+      getCenterZ() {
+        const centerPoint = this.getCenterPoint();
+        return this.getDepth() * centerPoint[2];
       }
 
       getOriginPoint() {

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -15,34 +15,44 @@ namespace gdjs {
   }
 
   function isScalable(
-    o: gdjs.RuntimeObject
-  ): o is gdjs.RuntimeObject & gdjs.Scalable {
-    //@ts-ignore We are checking if the methods are present.
-    return o.setScaleX && o.setScaleY && o.getScaleX && o.getScaleY;
+    object: gdjs.RuntimeObject
+  ): object is gdjs.RuntimeObject & gdjs.Scalable {
+    return (
+      //@ts-ignore We are checking if the methods are present.
+      object.setScaleX &&
+      //@ts-ignore
+      object.setScaleY &&
+      //@ts-ignore
+      object.getScaleX &&
+      //@ts-ignore
+      object.getScaleY
+    );
   }
 
   function isOpaque(
-    o: gdjs.RuntimeObject
-  ): o is gdjs.RuntimeObject & gdjs.OpacityHandler {
+    object: gdjs.RuntimeObject
+  ): object is gdjs.RuntimeObject & gdjs.OpacityHandler {
     //@ts-ignore We are checking if the methods are present.
-    return o.setOpacity && o.getOpacity;
+    return object.setOpacity && object.getOpacity;
   }
 
   function is3D(
-    o: gdjs.RuntimeObject
-  ): o is gdjs.RuntimeObject & gdjs.Base3DHandler {
+    object: gdjs.RuntimeObject
+  ): object is gdjs.RuntimeObject & gdjs.Base3DHandler {
     //@ts-ignore We are checking if the methods are present.
-    return o.getZ && o.setZ;
+    return object.getZ && object.setZ;
   }
 
-  function isColorable(o: gdjs.RuntimeObject): o is IColorable {
+  function isColorable(object: gdjs.RuntimeObject): object is IColorable {
     //@ts-ignore We are checking if the methods are present.
-    return o.setColor && o.getColor;
+    return object.setColor && object.getColor;
   }
 
-  function isCharacterScalable(o: gdjs.RuntimeObject): o is ICharacterScalable {
+  function isCharacterScalable(
+    object: gdjs.RuntimeObject
+  ): object is ICharacterScalable {
     //@ts-ignore We are checking if the methods are present.
-    return o.setCharacterSize && o.getCharacterSize;
+    return object.setCharacterSize && object.getCharacterSize;
   }
 
   const linearInterpolation = gdjs.evtTools.common.lerp;

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -28,6 +28,13 @@ namespace gdjs {
     return o.setOpacity && o.getOpacity;
   }
 
+  function is3D(
+    o: gdjs.RuntimeObject
+  ): o is gdjs.RuntimeObject & gdjs.Base3DHandler {
+    //@ts-ignore We are checking if the methods are present.
+    return o.getZ && o.setZ;
+  }
+
   function isColorable(o: gdjs.RuntimeObject): o is IColorable {
     //@ts-ignore We are checking if the methods are present.
     return o.setColor && o.getColor;
@@ -516,7 +523,7 @@ namespace gdjs {
       timeSource: gdjs.evtTools.tween.TimeSource
     ) {
       const { owner } = this;
-      if (!(owner instanceof gdjs.RuntimeObject3D)) return;
+      if (!is3D(owner)) return;
 
       this._tweens.addSimpleTween(
         identifier,
@@ -621,7 +628,7 @@ namespace gdjs {
       destroyObjectWhenFinished: boolean
     ) {
       const { owner } = this;
-      if (!(owner instanceof gdjs.RuntimeObject3D)) return;
+      if (!is3D(owner)) return;
 
       this._tweens.addSimpleTween(
         identifier,
@@ -654,7 +661,7 @@ namespace gdjs {
       destroyObjectWhenFinished: boolean
     ) {
       const { owner } = this;
-      if (!(owner instanceof gdjs.RuntimeObject3D)) return;
+      if (!is3D(owner)) return;
 
       this._tweens.addSimpleTween(
         identifier,
@@ -811,10 +818,7 @@ namespace gdjs {
       // This action doesn't require 3D capabilities.
       // So, gdjs.RuntimeObject3D may not exist
       // when the 3D extension is not used.
-      const owner3d =
-        gdjs.RuntimeObject3D && owner instanceof gdjs.RuntimeObject3D
-          ? owner
-          : null;
+      const owner3d = is3D(owner) ? owner : null;
 
       const setValue = scaleFromCenterOfObject
         ? (scale: float) => {
@@ -1756,7 +1760,7 @@ namespace gdjs {
       timeSource: gdjs.evtTools.tween.TimeSource
     ) {
       const { owner } = this;
-      if (!(owner instanceof gdjs.RuntimeObject3D)) return;
+      if (!is3D(owner)) return;
 
       this._tweens.addSimpleTween(
         identifier,

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
@@ -125,14 +125,18 @@ gd::ObjectMetadata &MetadataDeclarationHelper::DeclareObjectMetadata(
           // Note: EventsFunctionsExtension should be used instead of
           // PlatformExtension but this line will be removed soon.
           .SetCategoryFullName(extension.GetCategory())
-          // Update Project::CreateObject when default behavior are added.
+          // Update Project::CreateObject when default behaviors are added.
           .AddDefaultBehavior("EffectCapability::EffectBehavior")
           .AddDefaultBehavior("ResizableCapability::ResizableBehavior")
           .AddDefaultBehavior("ScalableCapability::ScalableBehavior")
-          .AddDefaultBehavior("FlippableCapability::FlippableBehavior")
-          .AddDefaultBehavior("OpacityCapability::OpacityBehavior");
+          .AddDefaultBehavior("FlippableCapability::FlippableBehavior");
   if (eventsBasedObject.IsRenderedIn3D()) {
-    objectMetadata.MarkAsRenderedIn3D();
+    objectMetadata
+        .MarkAsRenderedIn3D()
+        .AddDefaultBehavior("Scene3D::Base3DBehavior");
+  }
+  else {
+    objectMetadata.AddDefaultBehavior("OpacityCapability::OpacityBehavior");
   }
 
   // TODO EBO Use full type to identify object to avoid collision.

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
@@ -1218,20 +1218,39 @@ void MetadataDeclarationHelper::DeclareObjectInternalInstructions(
   // Objects are identified by their name alone.
   auto &objectType = eventsBasedObject.GetName();
 
-  objectMetadata
-      .AddScopedAction(
-          "SetRotationCenter", _("Center of rotation"),
-          _("Change the center of rotation of an object relatively to the "
-            "object origin."),
-          _("Change the center of rotation of _PARAM0_ to _PARAM1_, _PARAM2_"),
-          _("Angle"), "res/actions/position24_black.png",
-          "res/actions/position_black.png")
-      .AddParameter("object", _("Object"), objectType)
-      .AddParameter("number", _("X position"))
-      .AddParameter("number", _("Y position"))
-      .MarkAsAdvanced()
-      .SetPrivate()
-      .SetFunctionName("setRotationCenter");
+  if (eventsBasedObject.IsRenderedIn3D()) {
+    objectMetadata
+        .AddScopedAction(
+            "SetRotationCenter", _("Center of rotation"),
+            _("Change the center of rotation of an object relatively to the "
+              "object origin."),
+            _("Change the center of rotation of _PARAM0_ to _PARAM1_ ; _PARAM2_ ; _PARAM3_"),
+            _("Angle"), "res/actions/position24_black.png",
+            "res/actions/position_black.png")
+        .AddParameter("object", _("Object"), objectType)
+        .AddParameter("number", _("X position"))
+        .AddParameter("number", _("Y position"))
+        .AddParameter("number", _("Z position"))
+        .MarkAsAdvanced()
+        .SetPrivate()
+        .SetFunctionName("setRotationCenter3D");
+  }
+  else {
+    objectMetadata
+        .AddScopedAction(
+            "SetRotationCenter", _("Center of rotation"),
+            _("Change the center of rotation of an object relatively to the "
+              "object origin."),
+            _("Change the center of rotation of _PARAM0_ to _PARAM1_ ; _PARAM2_"),
+            _("Angle"), "res/actions/position24_black.png",
+            "res/actions/position_black.png")
+        .AddParameter("object", _("Object"), objectType)
+        .AddParameter("number", _("X position"))
+        .AddParameter("number", _("Y position"))
+        .MarkAsAdvanced()
+        .SetPrivate()
+        .SetFunctionName("setRotationCenter");
+  }
 }
 
 void MetadataDeclarationHelper::AddParameter(

--- a/GDJS/GDJS/Events/CodeGeneration/ObjectCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/ObjectCodeGenerator.cpp
@@ -126,7 +126,7 @@ CODE_NAMESPACE = CODE_NAMESPACE || {};
 /**
  * Object generated from OBJECT_FULL_NAME
  */
-CODE_NAMESPACE.RUNTIME_OBJECT_CLASSNAME = class RUNTIME_OBJECT_CLASSNAME extends gdjs.CustomRuntimeObject {
+CODE_NAMESPACE.RUNTIME_OBJECT_CLASSNAME = class RUNTIME_OBJECT_CLASSNAME extends RUNTIME_OBJECT_BASE_CLASS_NAME {
   constructor(parentInstanceContainer, objectData) {
     super(parentInstanceContainer, objectData);
     this._parentInstanceContainer = parentInstanceContainer;
@@ -161,6 +161,8 @@ gdjs.registerObject("EXTENSION_NAME::OBJECT_NAME", CODE_NAMESPACE.RUNTIME_OBJECT
       .FindAndReplace("OBJECT_FULL_NAME", eventsBasedObject.GetFullName())
       .FindAndReplace("RUNTIME_OBJECT_CLASSNAME",
                       eventsBasedObject.GetName())
+      .FindAndReplace("RUNTIME_OBJECT_BASE_CLASS_NAME",
+                      eventsBasedObject.IsRenderedIn3D() ? "gdjs.CustomRuntimeObject3D" : "gdjs.CustomRuntimeObject")
       .FindAndReplace("CODE_NAMESPACE", codeNamespace)
       .FindAndReplace("INITIALIZE_PROPERTIES_CODE",
                       generateInitializePropertiesCode())

--- a/GDJS/GDJS/Events/CodeGeneration/ObjectCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/ObjectCodeGenerator.cpp
@@ -162,7 +162,7 @@ gdjs.registerObject("EXTENSION_NAME::OBJECT_NAME", CODE_NAMESPACE.RUNTIME_OBJECT
       .FindAndReplace("RUNTIME_OBJECT_CLASSNAME",
                       eventsBasedObject.GetName())
       .FindAndReplace("RUNTIME_OBJECT_BASE_CLASS_NAME",
-                      eventsBasedObject.IsRenderedIn3D() ? "gdjs.CustomRuntimeObject3D" : "gdjs.CustomRuntimeObject")
+                      eventsBasedObject.IsRenderedIn3D() ? "gdjs.CustomRuntimeObject3D" : "gdjs.CustomRuntimeObject2D")
       .FindAndReplace("CODE_NAMESPACE", codeNamespace)
       .FindAndReplace("INITIALIZE_PROPERTIES_CODE",
                       generateInitializePropertiesCode())

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -756,6 +756,12 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
         includesFiles,
         "fontfaceobserver-font-manager/fontfaceobserver-font-manager.js");
   }
+  if (pixiInThreeRenderers) {
+    InsertUnique(includesFiles, "Extensions/3D/A_RuntimeObject3D.js");
+    InsertUnique(includesFiles, "Extensions/3D/A_RuntimeObject3DRenderer.js");
+    InsertUnique(includesFiles, "Extensions/3D/CustomRuntimeObject3D.js");
+    InsertUnique(includesFiles, "Extensions/3D/CustomRuntimeObject3DRenderer.js");
+  }
 }
 
 void ExporterHelper::RemoveIncludes(bool pixiRenderers,

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -744,7 +744,7 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
     InsertUnique(includesFiles, "pixi-renderers/pixi-bitmapfont-manager.js");
     InsertUnique(includesFiles,
                  "pixi-renderers/spriteruntimeobject-pixi-renderer.js");
-    InsertUnique(includesFiles, "pixi-renderers/CustomObjectPixiRenderer.js");
+    InsertUnique(includesFiles, "pixi-renderers/CustomRuntimeObject2DPixiRenderer.js");
     InsertUnique(includesFiles, "pixi-renderers/DebuggerPixiRenderer.js");
     InsertUnique(includesFiles,
                  "pixi-renderers/loadingscreen-pixi-renderer.js");

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -690,6 +690,7 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
   InsertUnique(includesFiles, "affinetransformation.js");
   InsertUnique(includesFiles, "CustomRuntimeObjectInstanceContainer.js");
   InsertUnique(includesFiles, "CustomRuntimeObject.js");
+  InsertUnique(includesFiles, "CustomRuntimeObject2D.js");
 
   // Common includes for events only.
   InsertUnique(includesFiles, "events-tools/commontools.js");

--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -70,13 +70,13 @@ namespace gdjs {
     protected abstract _createRender():
       | gdjs.CustomRuntimeObject2DRenderer
       | gdjs.CustomRuntimeObject3DRenderer;
-    protected abstract _reinitializeRender(): void;
+    protected abstract _reinitializeRenderer(): void;
 
     reinitialize(objectData: ObjectData & CustomObjectConfiguration) {
       super.reinitialize(objectData);
 
       this._instanceContainer.loadFrom(objectData);
-      this._reinitializeRender();
+      this._reinitializeRenderer();
 
       // The generated code calls the onCreated super implementation at the end.
       this.onCreated();

--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -26,22 +26,23 @@ namespace gdjs {
       gdjs.Scalable,
       gdjs.Flippable,
       gdjs.OpacityHandler {
+    _renderer: gdjs.CustomObjectRenderer;
     /** It contains the children of this object. */
     _instanceContainer: gdjs.CustomRuntimeObjectInstanceContainer;
     _isUntransformedHitBoxesDirty: boolean = true;
     /** It contains shallow copies of the children hitboxes */
-    _untransformedHitBoxes: gdjs.Polygon[] = [];
+    private _untransformedHitBoxes: gdjs.Polygon[] = [];
     /** The dimension of this object is calculated from its children AABBs. */
-    _unrotatedAABB: AABB = { min: [0, 0], max: [0, 0] };
-    _scaleX: float = 1;
-    _scaleY: float = 1;
-    _flippedX: boolean = false;
-    _flippedY: boolean = false;
-    opacity: float = 255;
-    _customCenter: FloatPoint | null = null;
-    _localTransformation: gdjs.AffineTransformation = new gdjs.AffineTransformation();
-    _localInverseTransformation: gdjs.AffineTransformation = new gdjs.AffineTransformation();
-    _isLocalTransformationDirty: boolean = true;
+    private _unrotatedAABB: AABB = { min: [0, 0], max: [0, 0] };
+    private _scaleX: float = 1;
+    private _scaleY: float = 1;
+    private _flippedX: boolean = false;
+    private _flippedY: boolean = false;
+    private opacity: float = 255;
+    private _customCenter: FloatPoint | null = null;
+    private _localTransformation: gdjs.AffineTransformation = new gdjs.AffineTransformation();
+    private _localInverseTransformation: gdjs.AffineTransformation = new gdjs.AffineTransformation();
+    private _isLocalTransformationDirty: boolean = true;
 
     /**
      * @param parent The container the object belongs to
@@ -56,12 +57,22 @@ namespace gdjs {
         parent,
         this
       );
+      this._renderer = this._createRender();
 
       this._instanceContainer.loadFrom(objectData);
       this.getRenderer().reinitialize(this, parent);
 
       // The generated code calls onCreated at the constructor end
       // and onCreated calls its super implementation at its end.
+    }
+
+    protected _createRender() {
+      const parent = this._runtimeScene;
+      return new gdjs.CustomObjectRenderer(
+        this,
+        this._instanceContainer,
+        parent
+      );
     }
 
     reinitialize(objectData: ObjectData & CustomObjectConfiguration) {
@@ -145,7 +156,7 @@ namespace gdjs {
     }
 
     getRenderer() {
-      return this._instanceContainer.getRenderer();
+      return this._renderer;
     }
 
     onChildrenLocationChanged() {

--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -26,7 +26,9 @@ namespace gdjs {
       gdjs.Scalable,
       gdjs.Flippable,
       gdjs.OpacityHandler {
-    _renderer: gdjs.CustomObjectRenderer | gdjs.CustomRuntimeObject3DRenderer;
+    _renderer:
+      | gdjs.CustomRuntimeObject2DRenderer
+      | gdjs.CustomRuntimeObject3DRenderer;
     /** It contains the children of this object. */
     _instanceContainer: gdjs.CustomRuntimeObjectInstanceContainer;
     _isUntransformedHitBoxesDirty: boolean = true;
@@ -66,7 +68,7 @@ namespace gdjs {
     }
 
     protected abstract _createRender():
-      | gdjs.CustomObjectRenderer
+      | gdjs.CustomRuntimeObject2DRenderer
       | gdjs.CustomRuntimeObject3DRenderer;
     protected abstract _reinitializeRender(): void;
 
@@ -147,7 +149,7 @@ namespace gdjs {
     }
 
     getRenderer():
-      | gdjs.CustomObjectRenderer
+      | gdjs.CustomRuntimeObject2DRenderer
       | gdjs.CustomRuntimeObject3DRenderer {
       return this._renderer;
     }

--- a/GDJS/Runtime/CustomRuntimeObject2D.ts
+++ b/GDJS/Runtime/CustomRuntimeObject2D.ts
@@ -11,9 +11,9 @@ namespace gdjs {
       this.getRenderer().reinitialize(this, parent);
     }
 
-    protected _createRender(): gdjs.CustomObjectRenderer {
+    protected _createRender(): gdjs.CustomRuntimeObject2DRenderer {
       const parent = this._runtimeScene;
-      return new gdjs.CustomObjectRenderer(
+      return new gdjs.CustomRuntimeObject2DRenderer(
         this,
         this._instanceContainer,
         parent
@@ -24,8 +24,8 @@ namespace gdjs {
       this.getRenderer().reinitialize(this, this.getParent());
     }
 
-    getRenderer(): gdjs.CustomObjectRenderer {
-      return super.getRenderer() as gdjs.CustomObjectRenderer;
+    getRenderer(): gdjs.CustomRuntimeObject2DRenderer {
+      return super.getRenderer() as gdjs.CustomRuntimeObject2DRenderer;
     }
 
     getRendererObject() {

--- a/GDJS/Runtime/CustomRuntimeObject2D.ts
+++ b/GDJS/Runtime/CustomRuntimeObject2D.ts
@@ -31,12 +31,5 @@ namespace gdjs {
     getRendererObject() {
       return this.getRenderer().getRendererObject();
     }
-
-    updateFromObjectData(
-      oldObjectData: Object3DData,
-      newObjectData: Object3DData
-    ): boolean {
-      return true;
-    }
   }
 }

--- a/GDJS/Runtime/CustomRuntimeObject2D.ts
+++ b/GDJS/Runtime/CustomRuntimeObject2D.ts
@@ -20,7 +20,7 @@ namespace gdjs {
       );
     }
 
-    protected _reinitializeRender(): void {
+    protected _reinitializeRenderer(): void {
       this.getRenderer().reinitialize(this, this.getParent());
     }
 

--- a/GDJS/Runtime/CustomRuntimeObject2D.ts
+++ b/GDJS/Runtime/CustomRuntimeObject2D.ts
@@ -1,0 +1,42 @@
+namespace gdjs {
+  /**
+   * Base class for 2D custom objects.
+   */
+  export class CustomRuntimeObject2D extends gdjs.CustomRuntimeObject {
+    constructor(
+      parent: gdjs.RuntimeInstanceContainer,
+      objectData: ObjectData & CustomObjectConfiguration
+    ) {
+      super(parent, objectData);
+      this.getRenderer().reinitialize(this, parent);
+    }
+
+    protected _createRender(): gdjs.CustomObjectRenderer {
+      const parent = this._runtimeScene;
+      return new gdjs.CustomObjectRenderer(
+        this,
+        this._instanceContainer,
+        parent
+      );
+    }
+
+    protected _reinitializeRender(): void {
+      this.getRenderer().reinitialize(this, this.getParent());
+    }
+
+    getRenderer(): gdjs.CustomObjectRenderer {
+      return super.getRenderer() as gdjs.CustomObjectRenderer;
+    }
+
+    getRendererObject() {
+      return this.getRenderer().getRendererObject();
+    }
+
+    updateFromObjectData(
+      oldObjectData: Object3DData,
+      newObjectData: Object3DData
+    ): boolean {
+      return true;
+    }
+  }
+}

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -12,7 +12,6 @@ namespace gdjs {
    * @see gdjs.CustomRuntimeObject
    */
   export class CustomRuntimeObjectInstanceContainer extends gdjs.RuntimeInstanceContainer {
-    _renderer: gdjs.CustomObjectRenderer;
     _debuggerRenderer: gdjs.DebuggerRenderer;
     _runtimeScene: gdjs.RuntimeScene;
     /** The parent container that contains the object associated with this container. */
@@ -35,11 +34,6 @@ namespace gdjs {
       this._parent = parent;
       this._customObject = customObject;
       this._runtimeScene = parent.getScene();
-      this._renderer = new gdjs.CustomObjectRenderer(
-        customObject,
-        this,
-        parent
-      );
       this._debuggerRenderer = new gdjs.DebuggerRenderer(this);
     }
 
@@ -265,7 +259,7 @@ namespace gdjs {
      * Get the renderer associated to the RuntimeScene.
      */
     getRenderer(): gdjs.CustomObjectRenderer {
-      return this._renderer;
+      return this._customObject.getRenderer();
     }
 
     getDebuggerRenderer() {

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -258,7 +258,9 @@ namespace gdjs {
     /**
      * Get the renderer associated to the RuntimeScene.
      */
-    getRenderer(): gdjs.CustomObjectRenderer {
+    getRenderer():
+      | gdjs.CustomObjectRenderer
+      | gdjs.CustomRuntimeObject3DRenderer {
       return this._customObject.getRenderer();
     }
 

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -259,7 +259,7 @@ namespace gdjs {
      * Get the renderer associated to the RuntimeScene.
      */
     getRenderer():
-      | gdjs.CustomObjectRenderer
+      | gdjs.CustomRuntimeObject2DRenderer
       | gdjs.CustomRuntimeObject3DRenderer {
       return this._customObject.getRenderer();
     }

--- a/GDJS/Runtime/RuntimeInstanceContainer.ts
+++ b/GDJS/Runtime/RuntimeInstanceContainer.ts
@@ -275,10 +275,7 @@ namespace gdjs {
           }
           newObject.setPosition(instanceData.x + xPos, instanceData.y + yPos);
           newObject.setAngle(instanceData.angle);
-          if (
-            gdjs.RuntimeObject3D &&
-            newObject instanceof gdjs.RuntimeObject3D
-          ) {
+          if (gdjs.Base3DHandler && gdjs.Base3DHandler.is3D(newObject)) {
             if (instanceData.z !== undefined)
               newObject.setZ(instanceData.z + zOffset);
             if (instanceData.rotationX !== undefined)

--- a/GDJS/Runtime/debugger-client/hot-reloader.ts
+++ b/GDJS/Runtime/debugger-client/hot-reloader.ts
@@ -1258,10 +1258,7 @@ namespace gdjs {
         runtimeObject.setLayer(newInstance.layer);
         somethingChanged = true;
       }
-      if (
-        gdjs.RuntimeObject3D &&
-        runtimeObject instanceof gdjs.RuntimeObject3D
-      ) {
+      if (gdjs.Base3DHandler && gdjs.Base3DHandler.is3D(runtimeObject)) {
         if (oldInstance.z !== newInstance.z && newInstance.z !== undefined) {
           runtimeObject.setZ(newInstance.z);
           somethingChanged = true;
@@ -1312,10 +1309,7 @@ namespace gdjs {
           sizeChanged = true;
         }
       }
-      if (
-        gdjs.RuntimeObject3D &&
-        runtimeObject instanceof gdjs.RuntimeObject3D
-      ) {
+      if (gdjs.Base3DHandler && gdjs.Base3DHandler.is3D(runtimeObject)) {
         // A custom depth was set or changed
         if (
           oldInstance.depth !== newInstance.depth &&

--- a/GDJS/Runtime/pixi-renderers/CustomObjectPixiRenderer.ts
+++ b/GDJS/Runtime/pixi-renderers/CustomObjectPixiRenderer.ts
@@ -30,8 +30,12 @@ namespace gdjs {
       // TODO (3D) - optimization: don't create a PixiJS container if only 3D objects.
       // And same, in reverse, for 2D only objects.
       this._pixiContainer = new PIXI.Container();
-      this._threeGroup =
-        typeof THREE !== 'undefined' ? new THREE.Group() : null;
+      if (typeof THREE !== 'undefined') {
+        this._threeGroup = new THREE.Group();
+        this._threeGroup.rotation.order = 'ZYX';
+      } else {
+        this._threeGroup = null;
+      }
       this._debugDrawRenderedObjectsPoints = {};
 
       // Contains the layers of the scene (and, optionally, debug PIXI objects).
@@ -78,20 +82,21 @@ namespace gdjs {
      * Update the internal PIXI.Container position, angle...
      */
     _updatePIXIContainer() {
+      const scaleX = this._object.getScaleX();
+      const scaleY = this._object.getScaleY();
+      const opacity = this._object.getOpacity();
       this._pixiContainer.pivot.x = this._object.getUnscaledCenterX();
       this._pixiContainer.pivot.y = this._object.getUnscaledCenterY();
       this._pixiContainer.position.x =
-        this._object.getX() +
-        this._pixiContainer.pivot.x * Math.abs(this._object._scaleX);
+        this._object.getX() + this._pixiContainer.pivot.x * Math.abs(scaleX);
       this._pixiContainer.position.y =
-        this._object.getY() +
-        this._pixiContainer.pivot.y * Math.abs(this._object._scaleY);
+        this._object.getY() + this._pixiContainer.pivot.y * Math.abs(scaleY);
 
       this._pixiContainer.rotation = gdjs.toRad(this._object.angle);
-      this._pixiContainer.scale.x = this._object._scaleX;
-      this._pixiContainer.scale.y = this._object._scaleY;
+      this._pixiContainer.scale.x = scaleX;
+      this._pixiContainer.scale.y = scaleY;
       this._pixiContainer.visible = !this._object.hidden;
-      this._pixiContainer.alpha = this._object.opacity / 255;
+      this._pixiContainer.alpha = opacity / 255;
 
       this._isContainerDirty = false;
     }
@@ -101,16 +106,18 @@ namespace gdjs {
 
       const pivotX = this._object.getUnscaledCenterX();
       const pivotY = this._object.getUnscaledCenterY();
+      const scaleX = this._object.getScaleX();
+      const scaleY = this._object.getScaleY();
 
       // TODO (3D): fix the pivot point for custom objects.
       this._threeGroup.position.x =
-        this._object.getX() + pivotX * Math.abs(this._object._scaleX);
+        this._object.getX() + pivotX * Math.abs(scaleX);
       this._threeGroup.position.y =
-        this._object.getY() + pivotY * Math.abs(this._object._scaleY);
+        this._object.getY() + pivotY * Math.abs(scaleY);
 
       this._threeGroup.rotation.z = gdjs.toRad(this._object.angle);
-      this._threeGroup.scale.x = this._object._scaleX;
-      this._threeGroup.scale.y = this._object._scaleY;
+      this._threeGroup.scale.x = scaleX;
+      this._threeGroup.scale.y = scaleY;
       this._threeGroup.visible = !this._object.hidden;
     }
 
@@ -129,25 +136,25 @@ namespace gdjs {
     }
 
     updateX(): void {
+      const scaleX = this._object.getScaleX();
       this._pixiContainer.position.x =
-        this._object.x +
-        this._pixiContainer.pivot.x * Math.abs(this._object._scaleX);
+        this._object.x + this._pixiContainer.pivot.x * Math.abs(scaleX);
 
       if (this._threeGroup)
         this._threeGroup.position.x =
           this._object.getX() +
-          /*this._threeGroup.pivot.x*/ 0.5 * Math.abs(this._object._scaleX);
+          /*this._threeGroup.pivot.x*/ 0.5 * Math.abs(scaleX);
     }
 
     updateY(): void {
+      const scaleY = this._object.getScaleY();
       this._pixiContainer.position.y =
-        this._object.y +
-        this._pixiContainer.pivot.y * Math.abs(this._object._scaleY);
+        this._object.y + this._pixiContainer.pivot.y * Math.abs(scaleY);
 
       if (this._threeGroup)
         this._threeGroup.position.y =
           this._object.getY() +
-          /*this._threeGroup.pivot.y*/ 0.5 * Math.abs(this._object._scaleY);
+          /*this._threeGroup.pivot.y*/ 0.5 * Math.abs(scaleY);
     }
 
     updateAngle(): void {
@@ -157,7 +164,8 @@ namespace gdjs {
     }
 
     updateOpacity(): void {
-      this._pixiContainer.alpha = this._object.opacity / 255;
+      const opacity = this._object.getOpacity();
+      this._pixiContainer.alpha = opacity / 255;
     }
 
     updateVisibility(): void {

--- a/GDJS/Runtime/pixi-renderers/CustomRuntimeObject2DPixiRenderer.ts
+++ b/GDJS/Runtime/pixi-renderers/CustomRuntimeObject2DPixiRenderer.ts
@@ -1,8 +1,8 @@
 namespace gdjs {
   /**
-   * The renderer for a {@link gdjs.CustomRuntimeObject} using Pixi.js.
+   * The renderer for a {@link gdjs.CustomRuntimeObject2D} using Pixi.js.
    */
-  export class CustomObjectPixiRenderer
+  export class CustomRuntimeObject2DPixiRenderer
     implements gdjs.RuntimeInstanceContainerPixiRenderer {
     _object: gdjs.CustomRuntimeObject;
     _instanceContainer: gdjs.CustomRuntimeObjectInstanceContainer;
@@ -155,6 +155,7 @@ namespace gdjs {
   }
 
   // Register the class to let the engine use it.
-  export type CustomObjectRenderer = gdjs.CustomObjectPixiRenderer;
-  export const CustomObjectRenderer = gdjs.CustomObjectPixiRenderer;
+  export type CustomRuntimeObject2DRenderer = gdjs.CustomRuntimeObject2DPixiRenderer;
+  export const CustomRuntimeObject2DRenderer =
+    gdjs.CustomRuntimeObject2DPixiRenderer;
 }

--- a/GDJS/Runtime/pixi-renderers/DebuggerPixiRenderer.ts
+++ b/GDJS/Runtime/pixi-renderers/DebuggerPixiRenderer.ts
@@ -2,7 +2,7 @@ namespace gdjs {
   /**
    * A renderer for debug instances location of a container using Pixi.js.
    *
-   * @see gdjs.CustomObjectPixiRenderer
+   * @see gdjs.CustomRuntimeObject2DPixiRenderer
    */
   export class DebuggerPixiRenderer {
     _instanceContainer: gdjs.RuntimeInstanceContainer;

--- a/GDJS/Runtime/pixi-renderers/DebuggerPixiRenderer.ts
+++ b/GDJS/Runtime/pixi-renderers/DebuggerPixiRenderer.ts
@@ -46,7 +46,9 @@ namespace gdjs {
 
         // Add on top of all layers:
         this._debugDrawContainer.addChild(this._debugDraw);
-        pixiContainer.addChild(this._debugDrawContainer);
+        if (pixiContainer) {
+          pixiContainer.addChild(this._debugDrawContainer);
+        }
       }
       const debugDraw = this._debugDraw;
 
@@ -310,10 +312,12 @@ namespace gdjs {
         this._debugDrawContainer.destroy({
           children: true,
         });
-        const pixiContainer: PIXI.Container = this._instanceContainer
+        const pixiContainer: PIXI.Container | null = this._instanceContainer
           .getRenderer()
           .getRendererObject();
-        pixiContainer.removeChild(this._debugDrawContainer);
+        if (pixiContainer) {
+          pixiContainer.removeChild(this._debugDrawContainer);
+        }
       }
       this._debugDraw = null;
       this._debugDrawContainer = null;

--- a/GDJS/Runtime/pixi-renderers/RuntimeInstanceContainerPixiRenderer.ts
+++ b/GDJS/Runtime/pixi-renderers/RuntimeInstanceContainerPixiRenderer.ts
@@ -20,7 +20,7 @@ namespace gdjs {
      */
     setLayerIndex(layer: gdjs.RuntimeLayer, index: integer): void;
 
-    getRendererObject(): PIXI.Container;
+    getRendererObject(): PIXI.Container | null;
 
     get3DRendererObject(): THREE.Object3D | null;
   }

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -68,9 +68,10 @@ namespace gdjs {
       this._pixiContainer.sortableChildren = true;
       this._layer = layer;
       this._isLightingLayer = layer.isLightingLayer();
-      runtimeInstanceContainerRenderer
-        .getRendererObject()
-        .addChild(this._pixiContainer);
+      const parentRendererObject = runtimeInstanceContainerRenderer.getRendererObject();
+      if (parentRendererObject) {
+        parentRendererObject.addChild(this._pixiContainer);
+      }
       this._pixiContainer.filters = [];
 
       // Setup rendering for lighting or 3D rendering:
@@ -761,9 +762,11 @@ namespace gdjs {
       this._lightingSprite = new PIXI.Sprite(this._renderTexture);
       this._lightingSprite.blendMode = PIXI.BLEND_MODES.MULTIPLY;
       const parentPixiContainer = runtimeInstanceContainerRenderer.getRendererObject();
-      const index = parentPixiContainer.getChildIndex(this._pixiContainer);
-      parentPixiContainer.addChildAt(this._lightingSprite, index);
-      parentPixiContainer.removeChild(this._pixiContainer);
+      if (parentPixiContainer) {
+        const index = parentPixiContainer.getChildIndex(this._pixiContainer);
+        parentPixiContainer.addChildAt(this._lightingSprite, index);
+        parentPixiContainer.removeChild(this._pixiContainer);
+      }
     }
   }
 

--- a/GDJS/tests/karma.conf.js
+++ b/GDJS/tests/karma.conf.js
@@ -73,6 +73,7 @@ module.exports = function (config) {
       './newIDE/app/resources/GDJS/Runtime/runtimebehavior.js',
       './newIDE/app/resources/GDJS/Runtime/spriteruntimeobject.js',
       './newIDE/app/resources/GDJS/Runtime/CustomRuntimeObject.js',
+      './newIDE/app/resources/GDJS/Runtime/CustomRuntimeObject2D.js',
       './newIDE/app/resources/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.js',
       './newIDE/app/resources/GDJS/Runtime/events-tools/commontools.js',
       './newIDE/app/resources/GDJS/Runtime/events-tools/runtimescenetools.js',

--- a/GDJS/tests/tests/CustomRuntimeObject.js
+++ b/GDJS/tests/tests/CustomRuntimeObject.js
@@ -12,7 +12,7 @@ describe('gdjs.CustomRuntimeObject', function () {
   const createCustomObject = (instanceContainer) => {
     // The corresponding event-based object declaration is done by
     // getPixiRuntimeGameWithAssets.
-    const customObject = new gdjs.CustomRuntimeObject(instanceContainer, {
+    const customObject = new gdjs.CustomRuntimeObject2D(instanceContainer, {
       name: 'MyCustomObject',
       type: 'MyExtension::MyEventsBasedObject',
       variables: [],

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -713,7 +713,6 @@ interface gdObject {
     [Const, Ref] DOMString GetAssetStoreId();
     void SetType([Const] DOMString type);
     [Const, Ref] DOMString GetType();
-    boolean Is3DObject();
 
     [Ref] ObjectConfiguration GetConfiguration();
 

--- a/GDevelop.js/TestUtils/GDJSMocks.js
+++ b/GDevelop.js/TestUtils/GDJSMocks.js
@@ -386,7 +386,7 @@ class RuntimeObject {
   }
 }
 
-class CustomRuntimeObject extends RuntimeObject {
+class CustomRuntimeObject2D extends RuntimeObject {
   constructor(parentInstanceContainer, objectData) {
     super(parentInstanceContainer, objectData);
     this._instanceContainer = parentInstanceContainer;
@@ -760,7 +760,7 @@ function makeMinimalGDJSMock(options) {
       Hashtable,
       LongLivedObjectsList,
       TaskGroup,
-      CustomRuntimeObject,
+      CustomRuntimeObject2D,
       ManuallyResolvableTask,
       Variable,
     },

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -638,7 +638,6 @@ export class gdObject extends EmscriptenObject {
   getAssetStoreId(): string;
   setType(type: string): void;
   getType(): string;
-  is3DObject(): boolean;
   getConfiguration(): ObjectConfiguration;
   getVariables(): VariablesContainer;
   getEffects(): EffectsContainer;

--- a/GDevelop.js/types/gdobject.js
+++ b/GDevelop.js/types/gdobject.js
@@ -8,7 +8,6 @@ declare class gdObject {
   getAssetStoreId(): string;
   setType(type: string): void;
   getType(): string;
-  is3DObject(): boolean;
   getConfiguration(): gdObjectConfiguration;
   getVariables(): gdVariablesContainer;
   getEffects(): gdEffectsContainer;

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
@@ -389,7 +389,7 @@ const generateFreeFunctionMetadata = (
   const functionFile = options.eventsFunctionCodeWriter.getIncludeFileFor(
     functionName
   );
-  instructionOrExpression.setIncludeFile(functionFile);
+  instructionOrExpression.addIncludeFile(functionFile);
 
   // Always include the extension include files when using a free function.
   codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
@@ -498,7 +498,7 @@ function generateBehaviorMetadata(
     codeNamespace
   );
 
-  behaviorMetadata.setIncludeFile(includeFile);
+  behaviorMetadata.addIncludeFile(includeFile);
 
   // Always include the extension include files when using a behavior.
   codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
@@ -601,7 +601,7 @@ function generateObjectMetadata(
     codeNamespace
   );
 
-  objectMetadata.setIncludeFile(includeFile);
+  objectMetadata.addIncludeFile(includeFile);
 
   // Always include the extension include files when using an object.
   codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {

--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
@@ -600,7 +600,7 @@ function generateObjectMetadata(
   const includeFile = options.eventsFunctionCodeWriter.getIncludeFileFor(
     codeNamespace
   );
-
+  // Objects may already have included files for 3D for instance.
   objectMetadata.addIncludeFile(includeFile);
 
   // Always include the extension include files when using an object.

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -24,6 +24,8 @@ import ShareExternal from '../../UI/CustomSvgIcons/ShareExternal';
 import useForceUpdate from '../../Utils/UseForceUpdate';
 import ErrorBoundary from '../../UI/ErrorBoundary';
 
+const gd: libGDevelop = global.gd;
+
 type Props = {|
   project: gdProject,
   layout: gdLayout,
@@ -326,8 +328,10 @@ const InstancePropertiesEditor = ({
       const properties = instance.getCustomProperties(project, layout);
       if (!object) return {};
 
-      // TODO (3D): Use 3D fields if any of the selected instances is 3D.
-      const is3DInstance = object.is3DObject();
+      const is3DInstance = gd.MetadataProvider.getObjectMetadata(
+        project.getCurrentPlatform(),
+        object.getType()
+      ).isRenderedIn3D();
       const instanceSchemaForCustomProperties = propertiesMapToSchema(
         properties,
         (instance: gdInitialInstance) =>

--- a/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.spec.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.spec.js
@@ -188,7 +188,9 @@ describe('getLayouts', () => {
         anchorTargetObject: 'Border',
         isScaledProportionally: true,
       },
-      depthLayout: {},
+      depthLayout: {
+        isScaledProportionally: true,
+      },
     });
   });
 });

--- a/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.spec.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.spec.js
@@ -39,6 +39,7 @@ describe('getLayouts', () => {
       isShown: false,
       horizontalLayout: {},
       verticalLayout: {},
+      depthLayout: {},
     });
   });
 
@@ -67,6 +68,7 @@ describe('getLayouts', () => {
         maxSideAbsoluteMargin: 20,
       },
       verticalLayout: { minSideAbsoluteMargin: 30, maxSideAbsoluteMargin: 40 },
+      depthLayout: {},
     });
   });
 
@@ -107,6 +109,7 @@ describe('getLayouts', () => {
         anchorTarget: 0.5,
         anchorTargetObject: '',
       },
+      depthLayout: {},
     });
   });
 
@@ -142,6 +145,7 @@ describe('getLayouts', () => {
         anchorTarget: 0.5,
         anchorTargetObject: 'PanelBar',
       },
+      depthLayout: {},
     });
   });
 
@@ -184,6 +188,7 @@ describe('getLayouts', () => {
         anchorTargetObject: 'Border',
         isScaledProportionally: true,
       },
+      depthLayout: {},
     });
   });
 });
@@ -197,6 +202,7 @@ describe('applyChildLayouts', () => {
       isShown: true,
       horizontalLayout: {},
       verticalLayout: {},
+      depthLayout: {},
     });
 
     applyChildLayouts(parent);
@@ -218,6 +224,7 @@ describe('applyChildLayouts', () => {
       isShown: false,
       horizontalLayout: {},
       verticalLayout: {},
+      depthLayout: {},
     });
 
     applyChildLayouts(parent);
@@ -238,6 +245,7 @@ describe('applyChildLayouts', () => {
         maxSideAbsoluteMargin: 20,
       },
       verticalLayout: { minSideAbsoluteMargin: 30, maxSideAbsoluteMargin: 40 },
+      depthLayout: {},
     });
 
     applyChildLayouts(parent);
@@ -263,6 +271,7 @@ describe('applyChildLayouts', () => {
           minSideAbsoluteMargin: 30,
           maxSideAbsoluteMargin: 40,
         },
+        depthLayout: {},
       },
       { heightAfterUpdate: 20 }
     );
@@ -281,6 +290,7 @@ describe('applyChildLayouts', () => {
       isShown: true,
       horizontalLayout: {},
       verticalLayout: {},
+      depthLayout: {},
     });
     const tiledBar = parent.addChild(
       'TiledBar',
@@ -291,6 +301,7 @@ describe('applyChildLayouts', () => {
           maxSideAbsoluteMargin: 20,
         },
         verticalLayout: { anchorOrigin: 0.5, anchorTarget: 0.5 },
+        depthLayout: {},
       },
       { defaultWidth: 30, defaultHeight: 40 }
     );
@@ -310,6 +321,7 @@ describe('applyChildLayouts', () => {
       isShown: true,
       horizontalLayout: {},
       verticalLayout: {},
+      depthLayout: {},
     });
     parent.addChild('PanelBar', {
       isShown: true,
@@ -318,6 +330,7 @@ describe('applyChildLayouts', () => {
         maxSideAbsoluteMargin: 20,
       },
       verticalLayout: { minSideAbsoluteMargin: 30, maxSideAbsoluteMargin: 40 },
+      depthLayout: {},
     });
     const thumb = parent.addChild(
       'Thumb',
@@ -333,6 +346,7 @@ describe('applyChildLayouts', () => {
           anchorTarget: 0.5,
           anchorTargetObject: 'PanelBar',
         },
+        depthLayout: {},
       },
       { defaultWidth: 50, defaultHeight: 60 }
     );
@@ -354,6 +368,7 @@ describe('applyChildLayouts', () => {
         isShown: true,
         horizontalLayout: {},
         verticalLayout: {},
+        depthLayout: {},
       },
       { defaultWidth: 25, defaultHeight: 50 }
     );
@@ -373,6 +388,7 @@ describe('applyChildLayouts', () => {
           anchorTargetObject: 'Border',
           isScaledProportionally: true,
         },
+        depthLayout: {},
       },
       { defaultWidth: 10, defaultHeight: 15 }
     );
@@ -515,6 +531,10 @@ class MockedParent implements LayoutedParent<MockedChildRenderedInstance> {
 
   getHeight() {
     return this.height;
+  }
+
+  getDepth() {
+    return 0;
   }
 
   addChild(

--- a/newIDE/app/src/ObjectsRendering/Renderers/Rendered3DInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/Rendered3DInstance.js
@@ -3,6 +3,8 @@ import * as PIXI from 'pixi.js-legacy';
 import * as THREE from 'three';
 import PixiResourcesLoader from '../PixiResourcesLoader';
 
+const gd: libGDevelop = global.gd;
+
 /**
  * Rendered3DInstance is the base class used for creating 3D renderers of instances,
  * which display on the scene editor, using Three.js, the instance of an object (see InstancesEditor).
@@ -86,12 +88,20 @@ export default class Rendered3DInstance {
     return 0;
   }
 
+  getOriginZ() {
+    return 0;
+  }
+
   getCenterX() {
     return this.getWidth() / 2;
   }
 
   getCenterY() {
     return this.getHeight() / 2;
+  }
+
+  getCenterZ() {
+    return this.getDepth() / 2;
   }
 
   getWidth(): number {

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -219,7 +219,8 @@ export default class RenderedCustomObjectInstance extends Rendered3DInstance
       if (
         childType === 'Sprite' ||
         childType === 'TiledSpriteObject::TiledSprite' ||
-        childType === 'PanelSpriteObject::PanelSprite'
+        childType === 'PanelSpriteObject::PanelSprite' ||
+        childType === 'Scene3D::Cube3DObject'
       ) {
         const thumbnail = ObjectsRenderingService.getThumbnail(
           project,

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -61,13 +61,14 @@ export default class RenderedCustomObjectInstance extends Rendered3DInstance
 
     if (this._threeGroup) {
       // No Three group means the instance should only be rendered in 2D.
-      this._threeObject = new THREE.Group();
-      this._threeObject.rotation.order = 'ZYX';
-      this._threeGroup.add(this._threeObject);
+      const threeObject = new THREE.Group();
+      threeObject.rotation.order = 'ZYX';
+      this._threeGroup.add(threeObject);
 
       this._threeObjectPivot = new THREE.Group();
       this._threeObjectPivot.rotation.order = 'ZYX';
-      this._threeObject.add(this._threeObjectPivot);
+      threeObject.add(this._threeObjectPivot);
+      this._threeObject = threeObject
     }
 
     const customObjectConfiguration = gd.asCustomObjectConfiguration(
@@ -228,18 +229,20 @@ export default class RenderedCustomObjectInstance extends Rendered3DInstance
     const firstInstance = this.childrenRenderedInstances[0];
     const is3D = firstInstance && firstInstance instanceof Rendered3DInstance;
 
-    if (is3D) {
-      this._threeObject.position.set(
+    const threeObject = this._threeObject;
+    const threeObjectPivot = this._threeObjectPivot;
+    if (threeObject && threeObjectPivot && is3D) {
+      threeObject.position.set(
         this._instance.getX() + centerX - originX,
         this._instance.getY() + centerY - originY,
         this._instance.getZ() + centerZ - originZ
       );
-      this._threeObjectPivot.position.set(
+      threeObjectPivot.position.set(
         -centerX + originX,
         -centerY + originY,
         -centerZ + originZ
       );
-      this._threeObject.rotation.set(
+      threeObject.rotation.set(
         RenderedInstance.toRad(this._instance.getRotationX()),
         RenderedInstance.toRad(this._instance.getRotationY()),
         RenderedInstance.toRad(this._instance.getAngle())

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -145,6 +145,7 @@ export default class RenderedCustomObjectInstance extends Rendered3DInstance
       );
       if (!childLayout.isShown) {
         this._pixiObject.removeChild(renderer._pixiObject);
+        this._threeObjectPivot.remove(renderer._threeObject);
       }
 
       if (renderer instanceof RenderedTextInstance) {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1365,7 +1365,13 @@ export default class SceneEditor extends React.Component<Props, State> {
     const { project, layout } = this.props;
 
     const object = getObjectByName(project, layout, instance.getObjectName());
-    return !!object && object.is3DObject();
+    return (
+      !!object &&
+      gd.MetadataProvider.getObjectMetadata(
+        project.getCurrentPlatform(),
+        object.getType()
+      ).isRenderedIn3D()
+    );
   };
 
   buildContextMenu = (i18n: I18nType, layout: gdLayout, options: any) => {


### PR DESCRIPTION
### Changes
- Custom objects can be used as any other 3D object
  - with the same set of actions and conditions thanks to the 3D capability
  - in the scene editor, their Z position and 3D rotations can be set
- Custom object renderers now only display either 2D or 3D child-objects
- Fix child creation in `doStepPostEvent`

### Technical changes
- Generated custom object implementations are extending either `CustomRuntimeObject3D` or `CustomRuntimeObject2D`
- As theere is no base class for any 3D runtime objects and `instanceof` doesn't work with interface, a loose check is done by `gdjs.Base3DHandler.is3D`
