### PR TITLE
Fix export flow and show warning when game is not owned

### DIFF
--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineWebExportFlow.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineWebExportFlow.js
@@ -61,8 +61,10 @@ const OnlineWebExportFlow = ({
           primary
           id={`launch-export-and-publish-${exportPipelineName}-web-button`}
           onClick={async () => {
-            setAutomaticallyOpenGameProperties(true);
             await launchExport();
+            // Set to true after the export is done, so that the game properties
+            // are automatically opened only when the build is finished.
+            setAutomaticallyOpenGameProperties(true);
           }}
           disabled={disabled}
         />

--- a/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/PublishHome.js
@@ -38,6 +38,7 @@ import { isNativeMobileApp } from '../../Utils/Platform';
 import GDevelopThemeContext from '../../UI/Theme/GDevelopThemeContext';
 import useAlertDialog from '../../UI/Alert/useAlertDialog';
 import { useResponsiveWindowSize } from '../../UI/Responsive/ResponsiveWindowMeasurer';
+import { type GameAvailabilityError } from '../../GameDashboard/GameRegistration';
 
 const styles = {
   buttonBase: {
@@ -276,6 +277,7 @@ type PublishHomeProps = {|
   chosenSection: ?ExporterSection,
   chosenSubSection: ?ExporterSubSection,
   game: ?Game,
+  gameAvailabilityError: ?GameAvailabilityError,
   allExportersRequireOnline?: boolean,
   showOnlineWebExporterOnly?: boolean,
 |};
@@ -294,6 +296,7 @@ const PublishHome = ({
   chosenSection,
   chosenSubSection,
   game,
+  gameAvailabilityError,
   allExportersRequireOnline,
   showOnlineWebExporterOnly,
 }: PublishHomeProps) => {
@@ -585,6 +588,7 @@ const PublishHome = ({
           onChangeSubscription={onChangeSubscription}
           setIsNavigationDisabled={setIsNavigationDisabled}
           game={game}
+          gameAvailabilityError={gameAvailabilityError}
           builds={builds}
           onRefreshBuilds={refreshBuilds}
         />

--- a/newIDE/app/src/ExportAndShare/ShareDialog/index.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/index.js
@@ -19,6 +19,7 @@ import { type FileMetadata, type StorageProvider } from '../../ProjectsStorage';
 import { useOnlineStatus } from '../../Utils/OnlineStatus';
 import ErrorBoundary from '../../UI/ErrorBoundary';
 import { extractGDevelopApiErrorStatusAndCode } from '../../Utils/GDevelopServices/Errors';
+import { type GameAvailabilityError } from '../../GameDashboard/GameRegistration';
 
 export type ShareTab = 'invite' | 'publish';
 export type ExporterSection = 'browser' | 'desktop' | 'android' | 'ios';
@@ -150,9 +151,10 @@ const ShareDialog = ({
     setIsNavigationDisabled,
   ] = React.useState<boolean>(false);
   const [game, setGame] = React.useState<?Game>(null);
-  const [gameError, setGameError] = React.useState<?'not-found' | 'not-owned'>(
-    null
-  );
+  const [
+    gameAvailabilityError,
+    setGameAvailabilityError,
+  ] = React.useState<?GameAvailabilityError>(null);
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const { profile, getAuthorizationHeader } = authenticatedUser;
   const { showAlert } = useAlertDialog();
@@ -161,9 +163,9 @@ const ShareDialog = ({
     if (!game) {
       const title = t`Cannot see the exports`;
       const message =
-        gameError === 'not-found'
+        gameAvailabilityError === 'not-found'
           ? t`Register or publish your game first to see its exports.`
-          : gameError === 'not-owned'
+          : gameAvailabilityError === 'not-owned'
           ? t`You are not the owner of this game, ask the owner to add you as an owner to see its exports.`
           : t`Either this game is not registered or you are not its owner, so you cannot see its builds.`;
 
@@ -182,7 +184,7 @@ const ShareDialog = ({
 
       const { id } = profile;
       try {
-        setGameError(null);
+        setGameAvailabilityError(null);
         const game = await getGame(
           getAuthorizationHeader,
           id,
@@ -195,13 +197,14 @@ const ShareDialog = ({
           error
         );
         if (extractedStatusAndCode && extractedStatusAndCode.status === 404) {
-          setGameError('not-found');
+          setGameAvailabilityError('not-found');
           return;
         }
         if (extractedStatusAndCode && extractedStatusAndCode.status === 403) {
-          setGameError('not-owned');
+          setGameAvailabilityError('not-owned');
           return;
         }
+        setGameAvailabilityError('unexpected');
       }
     },
     [project, getAuthorizationHeader, profile]
@@ -333,6 +336,7 @@ const ShareDialog = ({
           chosenSection={chosenExporterSection}
           chosenSubSection={chosenExporterSubSection}
           game={game}
+          gameAvailabilityError={gameAvailabilityError}
           allExportersRequireOnline={allExportersRequireOnline}
           showOnlineWebExporterOnly={showOnlineWebExporterOnly}
         />

--- a/newIDE/app/src/GameDashboard/GameRegistration.js
+++ b/newIDE/app/src/GameDashboard/GameRegistration.js
@@ -29,7 +29,7 @@ export type GameRegistrationProps = {|
   onGameRegistered?: () => void | Promise<void>,
 |};
 
-type UnavailableReason = 'unauthorized' | 'not-existing' | null;
+export type GameAvailabilityError = 'not-found' | 'not-owned' | 'unexpected';
 
 export const GameRegistration = ({
   project,
@@ -47,9 +47,9 @@ export const GameRegistration = ({
   const { showAlert } = useAlertDialog();
   const [error, setError] = React.useState<Error | null>(null);
   const [
-    unavailableReason,
-    setUnavailableReason,
-  ] = React.useState<UnavailableReason>(null);
+    gameAvailabilityError,
+    setGameAvailabilityError,
+  ] = React.useState<?GameAvailabilityError>(null);
   const [game, setGame] = React.useState<Game | null>(null);
   const [registrationInProgress, setRegistrationInProgress] = React.useState(
     false
@@ -79,7 +79,7 @@ export const GameRegistration = ({
           id,
           project.getProjectUuid()
         );
-        setUnavailableReason(null);
+        setGameAvailabilityError(null);
         setGame(game);
       } catch (error) {
         console.error(
@@ -91,12 +91,13 @@ export const GameRegistration = ({
         );
         if (extractedStatusAndCode) {
           if (extractedStatusAndCode.status === 403) {
-            setUnavailableReason('unauthorized');
+            setGameAvailabilityError('not-owned');
             return;
           } else if (extractedStatusAndCode.status === 404) {
-            setUnavailableReason('not-existing');
+            setGameAvailabilityError('not-found');
             return;
           }
+          setGameAvailabilityError('unexpected');
         }
 
         setError(error);
@@ -207,7 +208,7 @@ export const GameRegistration = ({
     );
   }
 
-  if (unavailableReason === 'not-existing') {
+  if (gameAvailabilityError === 'not-found') {
     return (
       <AlertMessage
         kind="info"
@@ -228,7 +229,7 @@ export const GameRegistration = ({
     );
   }
 
-  if (unavailableReason === 'unauthorized') {
+  if (gameAvailabilityError === 'not-owned') {
     return (
       <AlertMessage kind="error">
         <Trans>

--- a/newIDE/app/src/stories/componentStories/Share/ShareDialog/PublishHome.stories.js
+++ b/newIDE/app/src/stories/componentStories/Share/ShareDialog/PublishHome.stories.js
@@ -55,6 +55,7 @@ export const Default = () => {
       chosenSection={chosenExporterSection}
       chosenSubSection={chosenExporterSubSection}
       game={null}
+      gameAvailabilityError={null}
     />
   );
 };
@@ -84,6 +85,38 @@ export const OnlineWebExporterSelected = () => {
         chosenSection={chosenExporterSection}
         chosenSubSection={chosenExporterSubSection}
         game={null}
+        gameAvailabilityError={null}
+      />
+    </AuthenticatedUserContext.Provider>
+  );
+};
+
+export const OnlineWebExporterSelectedForGameNotOwned = () => {
+  const [
+    chosenExporterSection,
+    setChosenExporterSection,
+  ] = React.useState<?ExporterSection>('browser');
+  const [
+    chosenExporterSubSection,
+    setChosenExporterSubSection,
+  ] = React.useState<?ExporterSubSection>('online');
+  return (
+    <AuthenticatedUserContext.Provider value={fakeStartupAuthenticatedUser}>
+      <PublishHome
+        project={testProject.project}
+        onSaveProject={action('onSaveProject')}
+        isSavingProject={false}
+        onGameUpdated={action('onGameUpdated')}
+        onChangeSubscription={action('onChangeSubscription')}
+        isNavigationDisabled={false}
+        setIsNavigationDisabled={action('setIsNavigationDisabled')}
+        selectedExporter={onlineWebExporter}
+        onChooseSection={setChosenExporterSection}
+        onChooseSubSection={setChosenExporterSubSection}
+        chosenSection={chosenExporterSection}
+        chosenSubSection={chosenExporterSubSection}
+        game={null}
+        gameAvailabilityError="not-owned"
       />
     </AuthenticatedUserContext.Provider>
   );
@@ -114,6 +147,7 @@ export const OnlyOnlineWebExporter = () => {
         chosenSection={chosenExporterSection}
         chosenSubSection={chosenExporterSubSection}
         game={null}
+        gameAvailabilityError={null}
         showOnlineWebExporterOnly
       />
     </AuthenticatedUserContext.Provider>


### PR DESCRIPTION
Fixes automatically registering a game on link creation + show warning earlier when game is owned by someone else + fix opening a publish dialog too soon after another build was successful

![Capture d’écran 2024-03-01 à 11 54 58](https://github.com/4ian/GDevelop/assets/4895034/e6bd7931-ddc2-437c-b4f8-a4ca3d3eb69c)
