### PR TITLE
Fix games from crashing when a scene contains a wrapped text object with a big font size

### DIFF
--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -56,7 +56,8 @@ namespace gdjs {
     opacity: float = 255;
     _textAlign: string = 'left';
     _wrapping: boolean = false;
-    _wrappingWidth: float = 1;
+    // A wrapping of 1 make games crash on Firefox
+    _wrappingWidth: float = 100;
 
     _isOutlineEnabled: boolean;
     _outlineThickness: float;
@@ -194,8 +195,8 @@ namespace gdjs {
      */
     extraInitializationFromInitialInstance(initialInstanceData: InstanceData) {
       if (initialInstanceData.customSize) {
-        this.setWrapping(true);
         this.setWrappingWidth(initialInstanceData.width);
+        this.setWrapping(true);
       } else {
         this.setWrapping(false);
       }
@@ -513,11 +514,15 @@ namespace gdjs {
       if (width <= 1) {
         width = 1;
       }
-      if (this._wrappingWidth === width) return;
-
+      if (this._wrappingWidth === width) {
+        return;
+      }
       this._wrappingWidth = width;
-      this._renderer.updateStyle();
-      this.invalidateHitboxes();
+
+      if (this._wrapping) {
+        this._renderer.updateStyle();
+        this.invalidateHitboxes();
+      }
     }
 
     /**

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -56,7 +56,7 @@ namespace gdjs {
     opacity: float = 255;
     _textAlign: string = 'left';
     _wrapping: boolean = false;
-    // A wrapping of 1 make games crash on Firefox
+    // A wrapping of 1 makes games crash on Firefox
     _wrappingWidth: float = 100;
 
     _isOutlineEnabled: boolean;


### PR DESCRIPTION
Also avoid to evaluate the text size twice at scene creation when text objects are wrapped.