### PR TITLE
Improve first screen layouts

### DIFF
--- a/newIDE/app/src/AssetStore/AssetsHome.js
+++ b/newIDE/app/src/AssetStore/AssetsHome.js
@@ -26,6 +26,8 @@ import {
   PrivateGameTemplateTile,
 } from './ShopTiles';
 import { useDebounce } from '../Utils/UseDebounce';
+import PromotionsSlideshow from '../Promotions/PromotionsSlideshow';
+import { ColumnStackLayout } from '../UI/Layout';
 
 const cellSpacing = 2;
 
@@ -157,6 +159,7 @@ type Props = {|
   onCategorySelection: string => void,
   openedShopCategory: string | null,
   hideGameTemplates?: boolean,
+  displayPromotions?: boolean,
 |};
 
 export const AssetsHome = React.forwardRef<Props, AssetsHomeInterface>(
@@ -171,6 +174,7 @@ export const AssetsHome = React.forwardRef<Props, AssetsHomeInterface>(
       onCategorySelection,
       openedShopCategory,
       hideGameTemplates,
+      displayPromotions,
     }: Props,
     ref
   ) => {
@@ -383,6 +387,15 @@ export const AssetsHome = React.forwardRef<Props, AssetsHomeInterface>(
             </GridList>
           </>
         )}
+        {displayPromotions ? (
+          <ColumnStackLayout>
+            <Text size="block-title">
+              <Trans>Promotions</Trans>
+            </Text>
+
+            <PromotionsSlideshow />
+          </ColumnStackLayout>
+        ) : null}
         {allBundleTiles.length ? (
           <>
             <Column>

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -59,6 +59,7 @@ import { PrivateGameTemplateStoreContext } from './PrivateGameTemplates/PrivateG
 
 type Props = {|
   hideGameTemplates?: boolean, // TODO: if we add more options, use an array instead.
+  displayPromotions?: boolean,
   onOpenPrivateGameTemplateListingData?: (
     privateGameTemplateListingData: PrivateGameTemplateListingData
   ) => void,
@@ -94,7 +95,14 @@ const identifyAssetPackKind = ({
 };
 
 export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
-  ({ hideGameTemplates, onOpenPrivateGameTemplateListingData }: Props, ref) => {
+  (
+    {
+      hideGameTemplates,
+      displayPromotions,
+      onOpenPrivateGameTemplateListingData,
+    }: Props,
+    ref
+  ) => {
     const {
       assetShortHeadersSearchResults,
       publicAssetPacksSearchResults,
@@ -737,6 +745,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                 onCategorySelection={selectShopCategory}
                 openedShopCategory={openedShopCategory}
                 hideGameTemplates={hideGameTemplates}
+                displayPromotions={displayPromotions}
               />
             ) : (
               <PlaceholderLoader />

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/index.js
@@ -63,6 +63,7 @@ import ContextMenu, {
   type ContextMenuInterface,
 } from '../../../../UI/Menu/ContextMenu';
 import type { ClientCoordinates } from '../../../../Utils/UseLongTouch';
+import PromotionsSlideshow from '../../../../Promotions/PromotionsSlideshow';
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
 
@@ -419,7 +420,7 @@ const BuildSection = ({
   ) : (
     <SectionContainer
       title={<Trans>My projects</Trans>}
-      showAnnouncementsAndPromotions
+      showUrgentAnnouncements
       renderFooter={
         limits && hasTooManyCloudProjects
           ? () => (
@@ -452,6 +453,10 @@ const BuildSection = ({
           roundedImages
           displayArrowsOnDesktop
         />
+        <Spacer />
+        <Column noMargin>
+          <PromotionsSlideshow />
+        </Column>
       </SectionRow>
       <SectionRow>
         <ResponsiveLineStackLayout

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/CommunitySection.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/CommunitySection.js
@@ -17,6 +17,7 @@ import List from '@material-ui/core/List';
 import ErrorBoundary from '../../../UI/ErrorBoundary';
 import { AnnouncementsFeed } from '../../../AnnouncementsFeed';
 import { AnnouncementsFeedContext } from '../../../AnnouncementsFeed/AnnouncementsFeedContext';
+import PromotionsSlideshow from '../../../Promotions/PromotionsSlideshow';
 
 const styles = {
   list: {
@@ -71,10 +72,7 @@ const CommunitySection = () => {
     announcements && announcements.length > 0;
 
   return (
-    <SectionContainer
-      title={<Trans>Community</Trans>}
-      showAnnouncementsAndPromotions
-    >
+    <SectionContainer title={<Trans>Community</Trans>} showUrgentAnnouncements>
       <SectionRow>
         <ColumnStackLayout noMargin expand>
           {shouldDisplayAnnouncementsTitle && (
@@ -82,6 +80,7 @@ const CommunitySection = () => {
               <Trans>News and announcements</Trans>
             </Text>
           )}
+          <PromotionsSlideshow />
           <AnnouncementsFeed canClose={false} level="normal" />
           <Text size="title">
             <Trans>Join the conversation</Trans>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/GetStartedSection/RecommendationList.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/GetStartedSection/RecommendationList.js
@@ -18,7 +18,7 @@ import {
   type WindowSizeType,
 } from '../../../../UI/Responsive/ResponsiveWindowMeasurer';
 import Text from '../../../../UI/Text';
-import { Column } from '../../../../UI/Grid';
+import { Column, Spacer } from '../../../../UI/Grid';
 import { type Tutorial } from '../../../../Utils/GDevelopServices/Tutorial';
 import { type SubscriptionPlanWithPricingSystems } from '../../../../Utils/GDevelopServices/Usage';
 import { CardWidget } from '../CardWidget';
@@ -32,6 +32,7 @@ import PreferencesContext from '../../../Preferences/PreferencesContext';
 import PlanRecommendationRow from './PlanRecommendationRow';
 import { SurveyCard } from './SurveyCard';
 import PlaceholderLoader from '../../../../UI/PlaceholderLoader';
+import PromotionsSlideshow from '../../../../Promotions/PromotionsSlideshow';
 
 const styles = {
   textTutorialContent: {
@@ -299,6 +300,16 @@ const RecommendationList = ({
               />
             </SectionRow>
           );
+
+        items.push(
+          <SectionRow key="promotions">
+            <Text size="section-title" noMargin>
+              <Trans>Discover the ecosystem</Trans>
+            </Text>
+            <Spacer />
+            <PromotionsSlideshow />
+          </SectionRow>
+        );
 
         if (recommendedTextTutorials.length) {
           items.push(

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/GetStartedSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/GetStartedSection/index.js
@@ -628,16 +628,10 @@ const GetStartedSection = ({
     return (
       <>
         <SectionContainer
-          title={
-            profile && profile.username ? (
-              <Trans>Hello {profile.username}!</Trans>
-            ) : (
-              <Trans>Hello!</Trans>
-            )
-          }
+          title={<Trans>Start making games</Trans>}
           renderSubtitle={renderSubtitle}
           flexBody
-          showAnnouncementsAndPromotions
+          showUrgentAnnouncements
         >
           <RecommendationList
             authenticatedUser={authenticatedUser}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageHeader.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageHeader.js
@@ -11,11 +11,11 @@ import ProjectManagerIcon from '../../../UI/CustomSvgIcons/ProjectManager';
 import FloppyIcon from '../../../UI/CustomSvgIcons/Floppy';
 import Window from '../../../Utils/Window';
 import optionalRequire from '../../../Utils/OptionalRequire';
-import { useResponsiveWindowSize } from '../../../UI/Responsive/ResponsiveWindowMeasurer';
 import TextButton from '../../../UI/TextButton';
 import IconButton from '../../../UI/IconButton';
 import { isNativeMobileApp } from '../../../Utils/Platform';
 import NotificationChip from '../../../UI/User/NotificationChip';
+import { useResponsiveWindowSize } from '../../../UI/Responsive/ResponsiveWindowMeasurer';
 const electron = optionalRequire('electron');
 
 type Props = {|
@@ -36,6 +36,7 @@ export const HomePageHeader = ({
   canSave,
 }: Props) => {
   const { isMobile } = useResponsiveWindowSize();
+
   return (
     <I18n>
       {({ i18n }) => (
@@ -73,9 +74,9 @@ export const HomePageHeader = ({
           </Column>
           <Column>
             <LineStackLayout noMargin alignItems="center">
-              {!electron && !isNativeMobileApp() && !isMobile && (
+              {!electron && !isNativeMobileApp() && (
                 <FlatButton
-                  label={<Trans>Download desktop app</Trans>}
+                  label={<Trans>Get the app</Trans>}
                   onClick={() =>
                     Window.openExternalURL('https://gdevelop.io/download')
                   }
@@ -83,11 +84,17 @@ export const HomePageHeader = ({
               )}
               <UserChip onOpenProfile={onOpenProfile} />
               <NotificationChip />
-              <TextButton
-                label={i18n.language.toUpperCase()}
-                onClick={onOpenLanguageDialog}
-                icon={<TranslateIcon fontSize="small" />}
-              />
+              {isMobile ? (
+                <IconButton size="small" onClick={onOpenLanguageDialog}>
+                  <TranslateIcon fontSize="small" />
+                </IconButton>
+              ) : (
+                <TextButton
+                  label={i18n.language.toUpperCase()}
+                  onClick={onOpenLanguageDialog}
+                  icon={<TranslateIcon fontSize="small" />}
+                />
+              )}
             </LineStackLayout>
           </Column>
         </LineStackLayout>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageMenuBar.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageMenuBar.js
@@ -79,7 +79,7 @@ const HomePageMenuBar = ({
   const theme = React.useContext(GDevelopThemeContext);
   const { profile } = React.useContext(AuthenticatedUserContext);
   const tabsToDisplay = getTabsToDisplay({ profile });
-  const buttons: {
+  const largeScreenOnlyButtons: {
     label: React.Node,
     getIcon: GetIconFunction,
     id: string,
@@ -139,29 +139,6 @@ const HomePageMenuBar = ({
                 </IconButton>
               );
             })}
-            <span
-              style={{
-                width: 1,
-                backgroundColor: theme.home.separator.color,
-                height: '70%',
-                margin: '0 3px',
-              }}
-            />
-            {buttons.map(({ label, onClick, getIcon, id }) => (
-              <IconButton
-                color="default"
-                key={id}
-                disableRipple
-                disableFocusRipple
-                style={styles.mobileButton}
-                onClick={onClick}
-                id={id}
-              >
-                <span style={styles.buttonLabel}>
-                  {getIcon({ color: 'secondary', fontSize: 'inherit' })}
-                </span>
-              </IconButton>
-            ))}
           </ToolbarGroup>
         </Toolbar>
       </Paper>
@@ -198,7 +175,7 @@ const HomePageMenuBar = ({
 
       <div style={styles.bottomButtonsContainer}>
         <Column>
-          {buttons.map(({ label, getIcon, onClick, id }) => (
+          {largeScreenOnlyButtons.map(({ label, getIcon, onClick, id }) => (
             <VerticalTabButton
               key={id}
               label={label}

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/LearnSection/MainPage.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/LearnSection/MainPage.js
@@ -162,9 +162,6 @@ const MainPage = ({
   return (
     <SectionContainer title={<Trans>Help and guides</Trans>}>
       <SectionRow>
-        <Text>
-          <Trans>Quick search</Trans>
-        </Text>
         <WikiSearchBar />
       </SectionRow>
       <SectionRow>

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/SectionContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/SectionContainer.js
@@ -9,7 +9,6 @@ import { Trans } from '@lingui/macro';
 import Paper from '../../../UI/Paper';
 import { LineStackLayout } from '../../../UI/Layout';
 import { AnnouncementsFeed } from '../../../AnnouncementsFeed';
-import PromotionsSlideshow from '../../../Promotions/PromotionsSlideshow';
 import { AnnouncementsFeedContext } from '../../../AnnouncementsFeed/AnnouncementsFeedContext';
 
 export const SECTION_PADDING = 30;
@@ -58,7 +57,7 @@ type Props = {|
   flexBody?: boolean,
   renderFooter?: () => React.Node,
   noScroll?: boolean,
-  showAnnouncementsAndPromotions?: boolean,
+  showUrgentAnnouncements?: boolean,
 |};
 
 const SectionContainer = ({
@@ -71,7 +70,7 @@ const SectionContainer = ({
   flexBody,
   renderFooter,
   noScroll,
-  showAnnouncementsAndPromotions,
+  showUrgentAnnouncements,
 }: Props) => {
   const { isMobile } = useResponsiveWindowSize();
   const { announcements } = React.useContext(AnnouncementsFeedContext);
@@ -94,14 +93,10 @@ const SectionContainer = ({
     <Column useFullHeight noMargin expand>
       <Paper style={paperStyle} square background="dark">
         <Column noOverflowParent expand>
-          {showAnnouncementsAndPromotions && (
+          {showUrgentAnnouncements && (
             <>
               <AnnouncementsFeed canClose level="urgent" hideLoader />
               {announcements && announcements.length > 0 && <Spacer />}
-              <Column noMargin>
-                <PromotionsSlideshow />
-              </Column>
-              <Spacer />
             </>
           )}
           {backAction && (

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/StoreSection/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/StoreSection/index.js
@@ -83,6 +83,7 @@ const StoreSection = ({
         onOpenPrivateGameTemplateListingData={
           onOpenPrivateGameTemplateListingData
         }
+        displayPromotions
       />
       {(openedAssetPack || openedAssetShortHeader) && (
         <Line justifyContent="flex-end">

--- a/newIDE/app/src/UI/User/UserChip.js
+++ b/newIDE/app/src/UI/User/UserChip.js
@@ -3,16 +3,13 @@ import * as React from 'react';
 import { Trans } from '@lingui/macro';
 import Avatar from '@material-ui/core/Avatar';
 import { getGravatarUrl } from '../GravatarUrl';
-import DotBadge from '../DotBadge';
 import RaisedButton from '../RaisedButton';
 import { shortenString } from '../../Utils/StringHelpers';
 import TextButton from '../TextButton';
 import { LineStackLayout } from '../Layout';
-import FlatButton from '../FlatButton';
 import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
 import CircularProgress from '../CircularProgress';
 import User from '../CustomSvgIcons/User';
-import { hasPendingBadgeNotifications } from '../../Utils/GDevelopServices/Badge';
 
 const styles = {
   avatar: {
@@ -28,45 +25,25 @@ type Props = {|
 
 const UserChip = ({ onOpenProfile }: Props) => {
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
-  const {
-    profile,
-    onOpenLoginDialog,
-    onOpenCreateAccountDialog,
-    loginState,
-  } = authenticatedUser;
-  // TODO: Remove the badge on the user chip and handle badge notifications
-  // with user notifications.
-  const displayNotificationBadge = hasPendingBadgeNotifications(
-    authenticatedUser
-  );
+  const { profile, onOpenCreateAccountDialog, loginState } = authenticatedUser;
+
   return !profile && loginState === 'loggingIn' ? (
     <CircularProgress size={25} />
   ) : profile ? (
-    <DotBadge overlap="circle" invisible={!displayNotificationBadge}>
-      <TextButton
-        label={shortenString(profile.username || profile.email, 20)}
-        onClick={onOpenProfile}
-        allowBrowserAutoTranslate={false}
-        icon={
-          <Avatar
-            src={getGravatarUrl(profile.email || '', { size: 50 })}
-            style={styles.avatar}
-          />
-        }
-      />
-    </DotBadge>
+    <TextButton
+      label={shortenString(profile.username || profile.email, 20)}
+      onClick={onOpenProfile}
+      allowBrowserAutoTranslate={false}
+      icon={
+        <Avatar
+          src={getGravatarUrl(profile.email || '', { size: 50 })}
+          style={styles.avatar}
+        />
+      }
+    />
   ) : (
     <div style={styles.buttonContainer}>
       <LineStackLayout noMargin alignItems="center">
-        <FlatButton
-          label={
-            <span>
-              <Trans>Log in</Trans>
-            </span>
-          }
-          onClick={onOpenLoginDialog}
-          leftIcon={<User fontSize="small" />}
-        />
         <RaisedButton
           label={
             <span>

--- a/newIDE/app/src/Utils/GDevelopServices/Badge.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Badge.js
@@ -183,16 +183,3 @@ export const compareAchievements = (
     return 0;
   }
 };
-
-export const hasPendingBadgeNotifications = (
-  authenticatedUser: AuthenticatedUser
-): boolean => {
-  if (!authenticatedUser.authenticated) return false;
-
-  const { badges } = authenticatedUser;
-  if (badges && badges.length > 0) {
-    return badges.some(badge => !badge.seen);
-  }
-
-  return false;
-};

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -56,10 +56,17 @@ const Wrapper = ({ children }: { children: React.Node }) => {
 
 export const Default = () => (
   <Wrapper>
-    <AssetStore />
+    <AssetStore displayPromotions />
   </Wrapper>
 );
 Default.parameters = apiDataFakePacks;
+
+export const WithoutPromotions = () => (
+  <Wrapper>
+    <AssetStore displayPromotions={false} />
+  </Wrapper>
+);
+WithoutPromotions.parameters = apiDataFakePacks;
 
 export const LoadingError = () => (
   <Wrapper>


### PR DESCRIPTION
- Display promotion banner inside the Build page (inside a section, just below the games), not above the title.
- Display promotion banner inside the Community page (inside a section), not above the title. 
- Display promotion banners inside the Shop (but not in the asset store when adding an object)
- Display promotion banner inside the Get Started page (at the end of the Get Started to not distract new users, instead of at the top)
- Remove the last two icons on a small screen, as they are distracting, 100% useless for a new user and accessible from the burger menu.
- Remove a useless text
- Hide language label on small screens
- Remove "login" and keep just "Create an account" (someone who logged already will figure out they can click here and choose "I already have an account" or find another login button)
- Change the Get Started title to give the promise of GDevelop: "Start making games"

iPhone SE dimensions (web, so consider "Get the app" is not there for the mobile app):
<img width="370" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/223f3c51-be86-48cb-83f2-142ba8ac5215">
<img width="373" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/d57532fd-7966-4003-a950-b131961a3158">
<img width="374" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/fa9d13a9-5703-48c0-b691-2b39fdfbdba8">
<img width="373" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/c1bcfd4a-6cb1-4bb8-922f-c0eecd2ef588">

Bigger screen:
<img width="992" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/96ac5087-b33a-4062-a338-7f4f9058c330">
<img width="989" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/e9425746-7941-4fea-9b49-68d7bee153b6">
