### PR TITLE
Use a CSS module for SimpleTextField, to avoid name clashes

### DIFF
--- a/newIDE/app/src/UI/SimpleTextField.js
+++ b/newIDE/app/src/UI/SimpleTextField.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from 'react';
 import { shouldValidate } from './KeyboardShortcuts/InteractionKeys';
-import './SimpleTextField.css';
+import classes from './SimpleTextField.module.css';
+import classNames from 'classnames';
 
 type SimpleTextFieldProps = {|
   disabled: boolean,
@@ -98,9 +99,10 @@ export const SimpleTextField = React.memo<
 
       return (
         <div
-          className={`gd-simple-text-field ${
-            props.disabled ? 'gd-disabled' : ''
-          }`}
+          className={classNames({
+            [classes.simpleTextField]: true,
+            [classes.disabled]: props.disabled,
+          })}
         >
           <input
             id={props.id}

--- a/newIDE/app/src/UI/SimpleTextField.module.css
+++ b/newIDE/app/src/UI/SimpleTextField.module.css
@@ -2,12 +2,12 @@
  * CSS classes for a text field, inspired from Material UI, but lightweight
  * and faster to render.
  */
-.gd-simple-text-field {
+.simpleTextField {
   position: relative;
   width: 100%;
 }
 
-.gd-simple-text-field input {
+.simpleTextField input {
   font-family: var(--gdevelop-modern-font-family);
   font-size: 14px;
   outline: none;
@@ -22,11 +22,11 @@
   width: 100%;
 }
 
-.gd-simple-text-field.gd-disabled input {
+.disabled input {
   color: var(--theme-text-disabled-color);
 }
 
-.gd-simple-text-field:before {
+.simpleTextField:before {
   bottom: -1px;
   left: 0;
   right: 0;
@@ -36,20 +36,20 @@
   position: absolute;
   pointer-events: none;
 }
-.gd-simple-text-field:hover::before {
+.simpleTextField:hover::before {
   border-width: 2px;
 }
-.gd-simple-text-field:focus-within::before {
+.simpleTextField:focus-within::before {
   border-width: 2px;
 }
 
-.gd-simple-text-field.gd-disabled:before {
+.disabled:before {
   border-bottom-style: dotted;
   border-color: var(--theme-text-disabled-color);
 }
-.gd-simple-text-field.gd-disabled:hover::before {
+.disabled:hover::before {
   border-width: 1px;
 }
-.gd-simple-text-field.gd-disabled:focus-within::before {
+.disabled:focus-within::before {
   border-width: 1px;
 }


### PR DESCRIPTION
TODO: double check CSS theme variables declaration in storybook