### PR TITLE
Fix plugin-consent version for admob

### DIFF
--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -34,6 +34,14 @@ module.exports = {
       .setIcon('JsPlatform/Extensions/admobicon24.png');
 
     extension
+      .addDependency()
+      .setName('Consent Cordova plugin')
+      .setDependencyType('cordova')
+      .setExportName('cordova-plugin-consent')
+      .setVersion('2.4.0')
+      .onlyIfOtherDependencyIsExported('AdMob Cordova plugin');
+
+    extension
       .registerProperty('AdMobAppIdAndroid')
       .setLabel(_('AdMob Android App ID'))
       .setDescription('ca-app-pub-XXXXXXXXXXXXXXXX~YYYYYYYYYY')
@@ -62,13 +70,6 @@ module.exports = {
         new gd.PropertyDescriptor('AdMobAppIdIos').setType('ExtensionProperty')
       )
       .onlyIfSomeExtraSettingsNonEmpty();
-
-    extension
-      .addDependency()
-      .setName('Consent Cordova plugin')
-      .setDependencyType('cordova')
-      .setExportName('cordova-plugin-consent')
-      .onlyIfOtherDependencyIsExported('AdMob Cordova plugin');
 
     extension
       .addAction(


### PR DESCRIPTION
Without version, I believe it was getting the latest 3.0.0 alpha ones which didn't have the requirements on this environement.

![image](https://github.com/4ian/GDevelop/assets/4895034/3aa81c57-aaa3-40d1-adca-7ad1d9c3ab95)
