### PR TITLE
Delete files not existent in project directory

### DIFF
--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -36,17 +36,17 @@ const deleteExistingFilesFromDirs = (
     if (!splittedProjectFolderNames.includes(entry)) return;
 
     const dirPath = path.join(projectPath, entry);
-    if (fs.statSync(dirPath).isDirectory()) {
-      const filenames = fs.readdirSync(dirPath);
-      filenames.forEach(file => {
-        const fileToRemovePath = path.join(dirPath, file);
-        try {
-          fs.unlinkSync(fileToRemovePath);
-        } catch (e) {
-          throw new Error(`Unable to remove file ${file}: ${e.message}`);
-        }
-      });
-    }
+    if (!fs.statSync(dirPath).isDirectory()) return;
+
+    const filenames = fs.readdirSync(dirPath);
+    filenames.forEach(file => {
+      const fileToRemovePath = path.join(dirPath, file);
+      try {
+        fs.unlinkSync(fileToRemovePath);
+      } catch (e) {
+        throw new Error(`Unable to remove file ${file}: ${e.message}`);
+      }
+    });
   });
 };
 
@@ -155,9 +155,7 @@ export const onSaveProject = async (
   const filePath = fileMetadata.fileIdentifier;
   const now = Date.now();
   if (!filePath) {
-    return Promise.reject(
-      'Project file is empty, "Save as" should have been called?'
-    );
+    throw new Error('Unable to find file path before saving.');
   }
   // Ensure we always pick the latest name and gameId.
   const newFileMetadata = {
@@ -172,9 +170,7 @@ export const onSaveProject = async (
   try {
     deleteExistingFilesFromDirs(project, projectPath);
   } catch (e) {
-    return Promise.reject(
-      'Unable to clean project folder before saving project'
-    );
+    console.warn('Unable to clean project folder before saving project: ', e);
   }
 
   await writeProjectFiles(project, filePath, projectPath);

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -33,13 +33,16 @@ const deleteExistingFilesFromDirs = (projectPath: string) => {
     //If multiFile enabled in settings and directories exist!
     entries.forEach(entry => {
       let dirPath = projectPath.concat('\\', entry);
-      if (fs.statSync(dirPath).isDirectory()) {
+      if (
+        fs.statSync(dirPath).isDirectory() &&
+        splittedProjectFolderNames.includes(entry)
+      ) {
         const filenames = fs.readdirSync(dirPath);
         filenames.forEach(file => {
           let result = dirPath.concat('\\', file);
-          fs.unlink(result, (err => {
+          fs.unlink(result, err => {
             if (err) return reject(err);
-          }));
+          });
         });
       }
     });

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -28,28 +28,26 @@ const deleteExistingFilesFromDirs = (
   project: gdProject,
   projectPath: string
 ) => {
-  const entries = fs.readdirSync(projectPath);
+  //If multiFile is not enabled in settings and directories do not exist.
+  if (!project.isFolderProject()) return;
 
-  if (project.isFolderProject()) {
-    //If multiFile enabled in settings and directories exist!
-    entries.forEach(entry => {
-      let dirPath = projectPath.concat('\\', entry);
-      if (
-        fs.statSync(dirPath).isDirectory() &&
-        splittedProjectFolderNames.includes(entry)
-      ) {
-        const filenames = fs.readdirSync(dirPath);
-        filenames.forEach(file => {
-          let result = dirPath.concat('\\', file);
-          try {
-            fs.unlinkSync(result);
-          } catch (e) {
-            throw new Error(`Unable to remove file ${file}: ${e.message}`);
-          }
-        });
-      }
-    });
-  }
+  const entries = fs.readdirSync(projectPath);
+  entries.forEach(entry => {
+    if (!splittedProjectFolderNames.includes(entry)) return;
+
+    const dirPath = path.join(projectPath, entry);
+    if (fs.statSync(dirPath).isDirectory()) {
+      const filenames = fs.readdirSync(dirPath);
+      filenames.forEach(file => {
+        const fileToRemovePath = path.join(dirPath, file);
+        try {
+          fs.unlinkSync(fileToRemovePath);
+        } catch (e) {
+          throw new Error(`Unable to remove file ${file}: ${e.message}`);
+        }
+      });
+    }
+  });
 };
 
 const checkFileContent = (filePath: string, expectedContent: string) => {


### PR DESCRIPTION
Fix #4120 : When renaming scenes/extensions/external events/external layouts, duplicate files exist, one with the old name and one with the new name. Similarly, when deleting this items, the respective files are also not removed from the project directory. This is due to the fact that when saving the project, only the existing files in the project editor are written and saved, and nothing more is done.  There may still remain old files that should not be there, potentially creating duplicates and confusion. Therefore, when saving, we can resolve this issue by deleting all files from the scenes/extensions/external events/external layouts directories, before writing the correct files.