### PR TITLE
Fix #5837: resize/rotating shouldn't be possible while holding space

### DIFF
--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -449,6 +449,9 @@ export default class InstancesEditor extends Component<Props> {
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),
       toCanvasCoordinates: this.viewPosition.toCanvasCoordinates,
       screenType: this.props.screenType,
+      keyboardShortcuts: this.keyboardShortcuts,
+      onPanMove: this._onPanMove,
+      onPanEnd: this._onPanEnd,
     });
     this.highlightedInstance = new HighlightedInstance({
       instanceMeasurer: this.instancesRenderer.getInstanceMeasurer(),


### PR DESCRIPTION
Fix Bug #5837
The bug was happening because the event associated with the resize/rotate handles would get triggered instead of moving the screen with space bar. To fix this, I changed the event of the resize/rotate handles so that when the space bar is pressed, the event would call the correct method.