### PR TITLE
Fix dimensions set to 0 0 0 on instance when switching layer

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
+++ b/newIDE/app/src/InstancesEditor/InstancesRenderer/LayerRenderer.js
@@ -259,7 +259,7 @@ export default class LayerRenderer {
   };
 
   getUnrotatedInstanceSize = (instance: gdInitialInstance) => {
-    const renderedInstance = this.renderedInstances[instance.ptr];
+    const renderedInstance = this.getRendererOfInstance(instance);
     const hasCustomSize = instance.hasCustomSize();
     const hasCustomDepth = instance.hasCustomDepth();
     const width = hasCustomSize


### PR DESCRIPTION
Use dedicated method to retrieve instance renderer