### PR TITLE
Fix undefined resources when opening cloud project autosave when cookie is expired/not fetched

### DIFF
--- a/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudProjectOpener.js
+++ b/newIDE/app/src/ProjectsStorage/CloudStorageProvider/CloudProjectOpener.js
@@ -66,6 +66,7 @@ export const generateOnOpen = (authenticatedUser: AuthenticatedUser) => async (
         `Could not find cache entry for project id ${cloudProjectId}.`
       );
     }
+    await getCredentialsForCloudProject(authenticatedUser, cloudProjectId);
     return { content: JSON.parse(project) };
   }
 


### PR DESCRIPTION
Fetch cloud project credentials when opening autosave