### PR TITLE
Fix some crashes when conditions with `objectList` are used without any behavior

### DIFF
--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -586,7 +586,8 @@ module.exports = {
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Time scale (1 by default)'))
       .getCodeExtraInformation()
-      .setIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2runtimebehavior.js')
       .setFunctionName('gdjs.physics2.setTimeScale');
 
     aut
@@ -4094,7 +4095,8 @@ module.exports = {
       .addParameter('objectList', _('Object'), '', false)
       .addCodeOnlyParameter('conditionInverted', '')
       .getCodeExtraInformation()
-      .setIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2runtimebehavior.js')
       .setFunctionName('gdjs.physics2.objectsCollide');
 
     extension
@@ -4112,7 +4114,8 @@ module.exports = {
       .addParameter('objectList', _('Object'), '', false)
       .addCodeOnlyParameter('conditionInverted', '')
       .getCodeExtraInformation()
-      .setIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2runtimebehavior.js')
       .setFunctionName('gdjs.physics2.haveObjectsStartedColliding');
 
     extension
@@ -4130,7 +4133,8 @@ module.exports = {
       .addParameter('objectList', _('Object'), '', false)
       .addCodeOnlyParameter('conditionInverted', '')
       .getCodeExtraInformation()
-      .setIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2tools.js')
+      .addIncludeFile('Extensions/Physics2Behavior/physics2runtimebehavior.js')
       .setFunctionName('gdjs.physics2.haveObjectsStoppedColliding');
 
     return extension;

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -872,6 +872,5 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension& extension) {
            .AddParameter("objectList", _("Object"), "", false)
            .AddParameter("behavior", _("Behavior"), "PlatformerObjectBehavior")
            .AddParameter("objectList", _("Platforms"), "", false)
-           .AddCodeOnlyParameter("conditionInverted", "")
-           .SetFunctionName("gdjs.evtTools.platform.isOnPlatform");
+           .AddCodeOnlyParameter("conditionInverted", "");
 }

--- a/Extensions/PlatformBehavior/JsExtension.cpp
+++ b/Extensions/PlatformBehavior/JsExtension.cpp
@@ -62,6 +62,14 @@ class PlatformBehaviorJsExtension : public gd::PlatformExtension {
       autConditions["PlatformBehavior::IsFalling"].SetFunctionName("isFalling");
       autConditions["PlatformBehavior::IsGrabbingPlatform"].SetFunctionName(
           "isGrabbingPlatform");
+      autConditions["PlatformBehavior::IsObjectOnGivenFloor"].SetFunctionName(
+          "gdjs.evtTools.platform.isOnPlatform")
+        .AddIncludeFile(
+            "Extensions/PlatformBehavior/platformruntimebehavior.js")
+        .AddIncludeFile(
+            "Extensions/PlatformBehavior/platformerobjectruntimebehavior.js")
+        .AddIncludeFile(
+            "Extensions/PlatformBehavior/platformtools.js");
 
       autConditions["PlatformBehavior::Gravity"].SetFunctionName("getGravity");
       autActions["PlatformBehavior::Gravity"]

--- a/Extensions/PlatformBehavior/platformruntimebehavior.ts
+++ b/Extensions/PlatformBehavior/platformruntimebehavior.ts
@@ -262,6 +262,9 @@ namespace gdjs {
       const behavior1 = object1.getBehavior(
         behaviorName
       ) as PlatformerObjectRuntimeBehavior;
+      if (!behavior1) {
+        return false;
+      }
       return behavior1.isOnFloorObject(object2);
     }
   }


### PR DESCRIPTION
I think it's better to include the behavior code instead of checking in the code if they are present as they can't do anything useful without the behaviors anyway.

This is an issue only since the search allow to add instruction from behavior that are not used in the scene.

Beginners may experience this issue because Physics collision condition could be chosen instead of the standard one.