### PR TITLE
Fix cloud project autosave crashing on Firefox versions <=125

### DIFF
--- a/newIDE/app/src/Utils/ProjectCache.js
+++ b/newIDE/app/src/Utils/ProjectCache.js
@@ -12,7 +12,14 @@ class ProjectCache {
   databasePromise: Promise<IDBDatabase> | null;
 
   static isAvailable() {
-    return typeof window !== 'undefined' && 'indexedDB' in window;
+    return (
+      typeof window !== 'undefined' &&
+      'indexedDB' in window &&
+      // Firefox <= 125 does not support the `databases()` method that is necessary to
+      // fix the issue of corrupted databases (that do not contain the object store `objectStoreScope`).
+      'databases' in window.indexedDB &&
+      typeof window.indexedDB.databases === 'function'
+    );
   }
 
   static async burst() {


### PR DESCRIPTION
Test for availability of method databases for cloud project autosave