### PR TITLE
Allow player authentication in leaderboard

### DIFF
--- a/Extensions/Leaderboards/JsExtension.js
+++ b/Extensions/Leaderboards/JsExtension.js
@@ -62,6 +62,12 @@ module.exports = {
       .getCodeExtraInformation()
       .setIncludeFile('Extensions/Leaderboards/sha256.js')
       .addIncludeFile('Extensions/Leaderboards/leaderboardstools.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
       .setFunctionName('gdjs.evtTools.leaderboards.savePlayerScore')
       .setAsyncFunctionName('gdjs.evtTools.leaderboards.savePlayerScore');
 
@@ -89,6 +95,12 @@ module.exports = {
       .getCodeExtraInformation()
       .setIncludeFile('Extensions/Leaderboards/sha256.js')
       .addIncludeFile('Extensions/Leaderboards/leaderboardstools.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
       .setFunctionName('gdjs.evtTools.leaderboards.saveConnectedPlayerScore')
       .setAsyncFunctionName(
         'gdjs.evtTools.leaderboards.saveConnectedPlayerScore'
@@ -97,7 +109,7 @@ module.exports = {
     extension
       .addAction(
         'SetPreferSendConnectedPlayerScore',
-        _('Enable the score to the connected player'),
+        _('Always attach scores to the connected player'),
         _(
           'Set if the score sent to a leaderboard is always attached to the connected player - if any. This is on by default.'
         ),
@@ -114,7 +126,6 @@ module.exports = {
       .setFunctionName(
         'gdjs.evtTools.leaderboards.setPreferSendConnectedPlayerScore'
       );
-    // TODO: add player authentication files.
 
     extension
       .addCondition(
@@ -297,6 +308,12 @@ module.exports = {
       .setHelpPath('/all-features/leaderboards')
       .getCodeExtraInformation()
       .setIncludeFile('Extensions/Leaderboards/leaderboardstools.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
       .setFunctionName('gdjs.evtTools.leaderboards.displayLeaderboard');
 
     extension

--- a/Extensions/Leaderboards/JsExtension.js
+++ b/Extensions/Leaderboards/JsExtension.js
@@ -34,7 +34,9 @@ module.exports = {
       .addAction(
         'SavePlayerScore',
         _('Save player score'),
-        _("Save the player's score to the given leaderboard."),
+        _(
+          "Save the player's score to the given leaderboard. If the player is connected, the score will be attached to the connected player (unless disabled)."
+        ),
         _(
           'Send to leaderboard _PARAM1_ the score _PARAM2_ with player name: _PARAM3_'
         ),
@@ -91,6 +93,28 @@ module.exports = {
       .setAsyncFunctionName(
         'gdjs.evtTools.leaderboards.saveConnectedPlayerScore'
       );
+
+    extension
+      .addAction(
+        'SetPreferSendConnectedPlayerScore',
+        _('Enable the score to the connected player'),
+        _(
+          'Set if the score sent to a leaderboard is always attached to the connected player - if any. This is on by default.'
+        ),
+        _('Always attach the score to the connected player: _PARAM0_'),
+        _('Setup'),
+        'JsPlatform/Extensions/leaderboard.svg',
+        'JsPlatform/Extensions/leaderboard.svg'
+      )
+      .addCodeOnlyParameter('currentScene', '')
+      .addParameter('yesorno', _('Enable?'), '', false)
+      .setHelpPath('/all-features/leaderboards')
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/Leaderboards/leaderboardstools.js')
+      .setFunctionName(
+        'gdjs.evtTools.leaderboards.setPreferSendConnectedPlayerScore'
+      );
+    // TODO: add player authentication files.
 
     extension
       .addCondition(

--- a/Extensions/Leaderboards/JsExtension.js
+++ b/Extensions/Leaderboards/JsExtension.js
@@ -113,7 +113,7 @@ module.exports = {
         _(
           'Set if the score sent to a leaderboard is always attached to the connected player - if any. This is on by default.'
         ),
-        _('Always attach the score to the connected player: _PARAM0_'),
+        _('Always attach the score to the connected player: _PARAM1_'),
         _('Setup'),
         'JsPlatform/Extensions/leaderboard.svg',
         'JsPlatform/Extensions/leaderboard.svg'

--- a/Extensions/Leaderboards/leaderboardstools.ts
+++ b/Extensions/Leaderboards/leaderboardstools.ts
@@ -368,7 +368,10 @@ namespace gdjs {
         }
       };
 
-      export const setPreferSendConnectedPlayerScore = (enable: boolean) => {
+      export const setPreferSendConnectedPlayerScore = (
+        runtimeScene: gdjs.RuntimeScene,
+        enable: boolean
+      ) => {
         _preferSendConnectedPlayerScore = enable;
       };
 

--- a/Extensions/Leaderboards/leaderboardstools.ts
+++ b/Extensions/Leaderboards/leaderboardstools.ts
@@ -223,8 +223,9 @@ namespace gdjs {
       let _leaderboardViewIframeLoading: boolean = false;
       let _leaderboardViewIframeLoaded: boolean = false;
       let _errorTimeoutId: NodeJS.Timeout | null = null;
-      let _leaderboardMessageListener: ((event: MessageEvent) => void) | null =
-        null;
+      let _leaderboardMessageListener:
+        | ((event: MessageEvent) => void)
+        | null = null;
 
       const _loaderContainer: HTMLDivElement = document.createElement('div');
       _loaderContainer.style.backgroundColor = '#000000';
@@ -393,8 +394,10 @@ namespace gdjs {
               new ScoreSavingState());
 
             try {
-              const { closeSaving, closeSavingWithError } =
-                scoreSavingState.startSaving({ playerName, score });
+              const {
+                closeSaving,
+                closeSavingWithError,
+              } = scoreSavingState.startSaving({ playerName, score });
 
               try {
                 const leaderboardEntry = await saveScore({
@@ -437,8 +440,10 @@ namespace gdjs {
               new ScoreSavingState());
 
             try {
-              const { closeSaving, closeSavingWithError } =
-                scoreSavingState.startSaving({ playerId, score });
+              const {
+                closeSaving,
+                closeSavingWithError,
+              } = scoreSavingState.startSaving({ playerId, score });
 
               try {
                 const leaderboardEntryId = await saveScore({
@@ -672,7 +677,7 @@ namespace gdjs {
               'Leaderboard page did not send message in time. Closing leaderboard view.'
             );
           }
-        }, 5000);
+        }, 15000);
       };
 
       const displayLoaderInLeaderboardView = function (
@@ -858,8 +863,9 @@ namespace gdjs {
 
             resetLeaderboardDisplayErrorTimeout(runtimeScene);
 
-            _leaderboardViewIframe =
-              computeLeaderboardDisplayingIframe(targetUrl);
+            _leaderboardViewIframe = computeLeaderboardDisplayingIframe(
+              targetUrl
+            );
             if (typeof window !== 'undefined') {
               _leaderboardMessageListener = (event: MessageEvent) => {
                 receiveMessageFromLeaderboardView(

--- a/Extensions/PlayerAuthentication/JsExtension.js
+++ b/Extensions/PlayerAuthentication/JsExtension.js
@@ -100,7 +100,8 @@ module.exports = {
       .addIncludeFile(
         'Extensions/PlayerAuthentication/playerauthenticationtools.js'
       )
-      .setFunctionName('gdjs.playerAuthentication.openAuthenticationWindow');
+      .setFunctionName('gdjs.playerAuthentication.openAuthenticationWindow')
+      .setAsyncFunctionName('gdjs.playerAuthentication.openAuthenticationWindow');
 
     extension
       .addCondition(

--- a/Extensions/PlayerAuthentication/JsExtension.js
+++ b/Extensions/PlayerAuthentication/JsExtension.js
@@ -101,7 +101,9 @@ module.exports = {
         'Extensions/PlayerAuthentication/playerauthenticationtools.js'
       )
       .setFunctionName('gdjs.playerAuthentication.openAuthenticationWindow')
-      .setAsyncFunctionName('gdjs.playerAuthentication.openAuthenticationWindow');
+      .setAsyncFunctionName(
+        'gdjs.playerAuthentication.openAuthenticationWindow'
+      );
 
     extension
       .addCondition(

--- a/Extensions/PlayerAuthentication/playerauthenticationcomponents.ts
+++ b/Extensions/PlayerAuthentication/playerauthenticationcomponents.ts
@@ -16,7 +16,9 @@ namespace gdjs {
                 ? "One moment, we're opening a window for you to log in."
                 : "One moment, we're opening a new page with your web browser for you to log in.",
             text2:
-              'If the window did not open, please check your pop-up blocker and click the button below to try again.',
+              platform === 'cordova'
+                ? ''
+                : 'If the window did not open, please check your pop-up blocker and click the button below to try again.',
           }
         : {
             title: 'Publish your game!',

--- a/Extensions/PlayerAuthentication/playerauthenticationcomponents.ts
+++ b/Extensions/PlayerAuthentication/playerauthenticationcomponents.ts
@@ -5,7 +5,7 @@ namespace gdjs {
       platform,
       isGameRegistered,
     }: {
-      platform: 'cordova' | 'electron' | 'web';
+      platform: 'cordova' | 'electron' | 'web-iframe' | 'web';
       isGameRegistered: boolean;
     }) =>
       isGameRegistered
@@ -166,9 +166,9 @@ namespace gdjs {
      */
     export const addAuthenticationTextsToLoadingContainer = (
       loaderContainer: HTMLDivElement,
-      platform,
-      isGameRegistered,
-      wikiOpenAction
+      platform: 'cordova' | 'electron' | 'web-iframe' | 'web',
+      isGameRegistered: boolean,
+      wikiOpenAction: (() => void) | null
     ) => {
       const textContainer: HTMLDivElement = document.createElement('div');
       textContainer.id = 'authentication-container-texts';

--- a/Extensions/PlayerAuthentication/playerauthenticationcomponents.ts
+++ b/Extensions/PlayerAuthentication/playerauthenticationcomponents.ts
@@ -5,18 +5,23 @@ namespace gdjs {
       platform,
       isGameRegistered,
     }: {
-      platform: 'cordova' | 'electron' | 'web-iframe' | 'web';
+      platform:
+        | 'cordova'
+        | 'cordova-websocket'
+        | 'electron'
+        | 'web-iframe'
+        | 'web';
       isGameRegistered: boolean;
     }) =>
       isGameRegistered
         ? {
             title: 'Logging in...',
             text1:
-              platform === 'cordova'
+              platform === 'cordova' || platform === 'cordova-websocket'
                 ? "One moment, we're opening a window for you to log in."
                 : "One moment, we're opening a new page with your web browser for you to log in.",
             text2:
-              platform === 'cordova'
+              platform === 'cordova' || platform === 'cordova-websocket'
                 ? ''
                 : 'If the window did not open, please check your pop-up blocker and click the button below to try again.',
           }
@@ -168,7 +173,12 @@ namespace gdjs {
      */
     export const addAuthenticationTextsToLoadingContainer = (
       loaderContainer: HTMLDivElement,
-      platform: 'cordova' | 'electron' | 'web-iframe' | 'web',
+      platform:
+        | 'cordova'
+        | 'cordova-websocket'
+        | 'electron'
+        | 'web-iframe'
+        | 'web',
       isGameRegistered: boolean,
       wikiOpenAction: (() => void) | null
     ) => {

--- a/Extensions/PlayerAuthentication/playerauthenticationtools.ts
+++ b/Extensions/PlayerAuthentication/playerauthenticationtools.ts
@@ -25,8 +25,9 @@ namespace gdjs {
     let _authenticationTimeoutId: NodeJS.Timeout | null = null;
 
     // Communication methods.
-    let _authenticationMessageCallback: ((event: MessageEvent) => void) | null =
-      null;
+    let _authenticationMessageCallback:
+      | ((event: MessageEvent) => void)
+      | null = null;
     let _websocket: WebSocket | null = null;
 
     type PlayerAuthenticationCallbacks = {
@@ -377,7 +378,10 @@ namespace gdjs {
     const receiveAuthenticationMessage = function (
       runtimeScene: gdjs.RuntimeScene,
       event: MessageEvent,
-      { checkOrigin, callbacks }: { checkOrigin: boolean, callbacks?: PlayerAuthenticationCallbacks }
+      {
+        checkOrigin,
+        callbacks,
+      }: { checkOrigin: boolean; callbacks?: PlayerAuthenticationCallbacks }
     ) {
       const allowedOrigins = ['https://liluo.io', 'https://gd.games'];
 
@@ -493,7 +497,7 @@ namespace gdjs {
       const onOpenAuthenticationWindow = () => {
         openAuthenticationWindow(runtimeScene);
       };
-      console.log({_userToken, _userId, _username});
+
       return _userToken
         ? authComponents.computeAuthenticatedBanner(
             onOpenAuthenticationWindow,
@@ -727,8 +731,12 @@ namespace gdjs {
       const top = screen.height / 2 - 600 / 2;
       const windowFeatures = `left=${left},top=${top},width=500,height=600`;
       const openWindow = () => {
-        _authenticationWindow = window.open(targetUrl, 'authentication', windowFeatures);
-      }
+        _authenticationWindow = window.open(
+          targetUrl,
+          'authentication',
+          windowFeatures
+        );
+      };
 
       openWindow();
 
@@ -825,10 +833,13 @@ namespace gdjs {
       if (_authenticationBanner) _authenticationBanner.style.opacity = '0';
 
       const playerAuthPlatform = getPlayerAuthPlatform(runtimeScene);
-      const { rootContainer, loaderContainer, iframeContainer } =
-        authComponents.computeAuthenticationContainer(
-          onAuthenticationContainerDismissed
-        );
+      const {
+        rootContainer,
+        loaderContainer,
+        iframeContainer,
+      } = authComponents.computeAuthenticationContainer(
+        onAuthenticationContainerDismissed
+      );
       _authenticationRootContainer = rootContainer;
       _authenticationLoaderContainer = loaderContainer;
       _authenticationIframeContainer = iframeContainer;
@@ -850,13 +861,12 @@ namespace gdjs {
                   )
               : null; // Only show a link if we're on electron.
 
-            _authenticationTextContainer =
-              authComponents.addAuthenticationTextsToLoadingContainer(
-                _authenticationLoaderContainer,
-                playerAuthPlatform,
-                isGameRegistered,
-                wikiOpenAction
-              );
+            _authenticationTextContainer = authComponents.addAuthenticationTextsToLoadingContainer(
+              _authenticationLoaderContainer,
+              playerAuthPlatform,
+              isGameRegistered,
+              wikiOpenAction
+            );
           }
           if (isGameRegistered) {
             startAuthenticationWindowTimeout(runtimeScene);
@@ -865,17 +875,33 @@ namespace gdjs {
             // with a different window, with or without a websocket.
             switch (playerAuthPlatform) {
               case 'electron':
-                openAuthenticationWindowForElectron(runtimeScene, _gameId, callbacks);
+                openAuthenticationWindowForElectron(
+                  runtimeScene,
+                  _gameId,
+                  callbacks
+                );
                 break;
               case 'cordova':
-                openAuthenticationWindowForCordova(runtimeScene, _gameId, callbacks);
+                openAuthenticationWindowForCordova(
+                  runtimeScene,
+                  _gameId,
+                  callbacks
+                );
                 break;
               case 'web-iframe':
-                openAuthenticationIframeForWeb(runtimeScene, _gameId, callbacks);
+                openAuthenticationIframeForWeb(
+                  runtimeScene,
+                  _gameId,
+                  callbacks
+                );
                 break;
               case 'web':
               default:
-                openAuthenticationWindowForWeb(runtimeScene, _gameId, callbacks);
+                openAuthenticationWindowForWeb(
+                  runtimeScene,
+                  _gameId,
+                  callbacks
+                );
                 break;
             }
           }

--- a/GDJS/Runtime/AsyncTasksManager.ts
+++ b/GDJS/Runtime/AsyncTasksManager.ts
@@ -93,11 +93,11 @@ namespace gdjs {
   /**
    * A task that resolves with a promise.
    */
-  export class PromiseTask extends AsyncTask {
+  export class PromiseTask<ResultType = void> extends AsyncTask {
     private isResolved: boolean = false;
-    promise: Promise<void>;
+    promise: Promise<ResultType>;
 
-    constructor(promise: Promise<void>) {
+    constructor(promise: Promise<ResultType>) {
       super();
       this.promise = promise
         .catch((error) => {
@@ -107,9 +107,12 @@ If you are using JavaScript promises in an asynchronous action, make sure to add
 Otherwise, report this as a bug on the GDevelop forums!
 ${error ? 'The following error was thrown: ' + error : ''}`
           );
+          return undefined as ResultType;
         })
-        .then(() => {
+        .then((result) => {
           this.isResolved = true;
+
+          return result;
         });
     }
 

--- a/GDJS/Runtime/AsyncTasksManager.ts
+++ b/GDJS/Runtime/AsyncTasksManager.ts
@@ -107,6 +107,8 @@ If you are using JavaScript promises in an asynchronous action, make sure to add
 Otherwise, report this as a bug on the GDevelop forums!
 ${error ? 'The following error was thrown: ' + error : ''}`
           );
+
+          // @ts-ignore
           return undefined as ResultType;
         })
         .then((result) => {

--- a/GDJS/Runtime/Cordova/config.xml
+++ b/GDJS/Runtime/Cordova/config.xml
@@ -12,6 +12,10 @@
     <allow-intent href="sms:*" />
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
+
+    <!-- Allow iframes on iOS like leaderboards, including those in development that are not served via https. -->
+    <allow-navigation href="*" />
+
     <platform name="android">
         <allow-intent href="market:*" />
 

--- a/GDJS/Runtime/Cordova/www/index.html
+++ b/GDJS/Runtime/Cordova/www/index.html
@@ -8,7 +8,7 @@
 		/* Prevent copy paste for all elements except text fields */
 		*  { -webkit-user-select:none; -webkit-tap-highlight-color:rgba(255, 255, 255, 0); }
 		input, textarea  { -webkit-user-select:text; }
-		body { background-color:black; color:white }
+		body { background-color:black; }
         /* GDJS_CUSTOM_STYLE */
 	</style>
 	<script src='cordova.js'></script>

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardOptionsDialog.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/LeaderboardOptionsDialog.js
@@ -12,37 +12,50 @@ import SelectOption from '../../UI/SelectOption';
 import Text from '../../UI/Text';
 import TextField from '../../UI/TextField';
 
-import { type LeaderboardSortOption } from '../../Utils/GDevelopServices/Play';
+import {
+  type LeaderboardSortOption,
+  type Leaderboard,
+} from '../../Utils/GDevelopServices/Play';
 import { Column, LargeSpacer, Line } from '../../UI/Grid';
 import HelpButton from '../../UI/HelpButton';
 import Checkbox from '../../UI/Checkbox';
 import { FormHelperText } from '@material-ui/core';
 import { MarkdownText } from '../../UI/MarkdownText';
+import SemiControlledTextField from '../../UI/SemiControlledTextField';
+import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
+import GetSubscriptionCard from '../../Profile/Subscription/GetSubscriptionCard';
 
-type SortOptions = {|
+export type LeaderboardOptions = {|
   sort: LeaderboardSortOption,
   extremeAllowedScore: ?number,
+  autoPlayerNamePrefix: string,
+  ignoreCustomPlayerNames: boolean,
+  disableLoginInLeaderboard: boolean,
 |};
 
 type Props = {
   open: boolean,
-  sort: LeaderboardSortOption,
-  extremeAllowedScore?: number,
-  onSave: SortOptions => Promise<void>,
+  leaderboard: Leaderboard,
+  onSave: LeaderboardOptions => Promise<void>,
   onClose: () => void,
 };
 
 const extremeAllowedScoreMax = Number.MAX_SAFE_INTEGER;
 const extremeAllowedScoreMin = Number.MIN_SAFE_INTEGER;
 
-function LeaderboardSortOptionsDialog({
+function LeaderboardOptionsDialog({
   open,
   onClose,
   onSave,
-  sort,
-  extremeAllowedScore,
+  leaderboard,
 }: Props) {
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const authenticatedUser = React.useContext(AuthenticatedUserContext);
+  const canDisableLoginInLeaderboard =
+    (authenticatedUser.limits &&
+      authenticatedUser.limits.capabilities.leaderboards
+        .canDisableLoginInLeaderboard) ||
+    false;
 
   const [
     extremeAllowedScoreError,
@@ -51,15 +64,28 @@ function LeaderboardSortOptionsDialog({
   const [
     displayExtremeAllowedScoreInput,
     setDisplayExtremeAllowedScoreInput,
-  ] = React.useState<boolean>(extremeAllowedScore !== undefined);
+  ] = React.useState<boolean>(leaderboard.extremeAllowedScore !== undefined);
   const [
     extremeAllowedScoreValue,
     setExtremeAllowedScoreValue,
-  ] = React.useState<number>(extremeAllowedScore || 0);
+  ] = React.useState<number>(leaderboard.extremeAllowedScore || 0);
 
   const [sortOrder, setSortOrder] = React.useState<LeaderboardSortOption>(
-    sort || 'ASC'
+    leaderboard.sort || 'ASC'
   );
+
+  const [
+    autoPlayerNamePrefix,
+    setAutoPlayerNamePrefix,
+  ] = React.useState<string>(leaderboard.autoPlayerNamePrefix || '');
+  const [
+    ignoreCustomPlayerNames,
+    setIgnoreCustomPlayerNames,
+  ] = React.useState<boolean>(!!leaderboard.ignoreCustomPlayerNames);
+  const [
+    disableLoginInLeaderboard,
+    setDisableLoginInLeaderboard,
+  ] = React.useState<boolean>(!!leaderboard.disableLoginInLeaderboard);
 
   const onSaveSettings = async (i18n: I18nType) => {
     if (displayExtremeAllowedScoreInput) {
@@ -92,6 +118,9 @@ function LeaderboardSortOptionsDialog({
       extremeAllowedScore: displayExtremeAllowedScoreInput
         ? extremeAllowedScoreValue
         : null,
+      autoPlayerNamePrefix,
+      ignoreCustomPlayerNames,
+      disableLoginInLeaderboard,
     };
     await onSave(sortOrderSettings);
   };
@@ -179,40 +208,95 @@ function LeaderboardSortOptionsDialog({
                 )
               }
             />
-          </ColumnStackLayout>
-          {displayExtremeAllowedScoreInput && (
-            <Column noMargin>
-              <Line>
-                <LargeSpacer />
-                <TextField
-                  fullWidth
-                  type="number"
-                  floatingLabelText={
-                    sortOrder === 'ASC' ? (
-                      <Trans>Minimum score</Trans>
-                    ) : (
-                      <Trans>Maximum score</Trans>
-                    )
-                  }
-                  value={extremeAllowedScoreValue}
-                  errorText={extremeAllowedScoreError}
-                  min={extremeAllowedScoreMin}
-                  max={extremeAllowedScoreMax}
-                  onChange={(e, newValue: string) => {
-                    if (!!extremeAllowedScoreError) {
-                      setExtremeAllowedScoreError(null);
+            {displayExtremeAllowedScoreInput && (
+              <Column noMargin>
+                <Line>
+                  <LargeSpacer />
+                  <TextField
+                    fullWidth
+                    type="number"
+                    floatingLabelText={
+                      sortOrder === 'ASC' ? (
+                        <Trans>Minimum score</Trans>
+                      ) : (
+                        <Trans>Maximum score</Trans>
+                      )
                     }
+                    value={extremeAllowedScoreValue}
+                    errorText={extremeAllowedScoreError}
+                    min={extremeAllowedScoreMin}
+                    max={extremeAllowedScoreMax}
+                    onChange={(e, newValue: string) => {
+                      if (!!extremeAllowedScoreError) {
+                        setExtremeAllowedScoreError(null);
+                      }
 
-                    setExtremeAllowedScoreValue(parseFloat(newValue));
-                  }}
-                />
-              </Line>
-            </Column>
-          )}
+                      setExtremeAllowedScoreValue(parseFloat(newValue));
+                    }}
+                  />
+                </Line>
+              </Column>
+            )}
+            <Text size="block-title">
+              <Trans>Connected players</Trans>
+            </Text>
+            <Checkbox
+              label={<Trans>Disable login buttons in leaderboard</Trans>}
+              checked={disableLoginInLeaderboard}
+              disabled={!canDisableLoginInLeaderboard}
+              onCheck={(e, checked) => setDisableLoginInLeaderboard(checked)}
+              tooltipOrHelperText={
+                <Trans>
+                  If activated, players won't be able to log in and claim a
+                  score just sent without being already logged in to the game.
+                </Trans>
+              }
+            />
+            {!canDisableLoginInLeaderboard && (
+              <GetSubscriptionCard subscriptionDialogOpeningReason="Leaderboard customization">
+                <Line>
+                  <Column noMargin>
+                    <Text noMargin>
+                      <Trans>
+                        Get a pro subscription to get full leaderboard
+                        customization.
+                      </Trans>
+                    </Text>
+                  </Column>
+                </Line>
+              </GetSubscriptionCard>
+            )}
+            <Text size="block-title">
+              <Trans>Anonymous players</Trans>
+            </Text>
+            <SemiControlledTextField
+              floatingLabelText={
+                <Trans>
+                  Player name prefix (for auto-generated player names)
+                </Trans>
+              }
+              fullWidth
+              maxLength={40}
+              value={autoPlayerNamePrefix}
+              onChange={text => setAutoPlayerNamePrefix(text)}
+            />
+            <Checkbox
+              label={<Trans>Enforce only auto-generated player names</Trans>}
+              checked={ignoreCustomPlayerNames}
+              onCheck={(e, checked) => setIgnoreCustomPlayerNames(checked)}
+              tooltipOrHelperText={
+                <Trans>
+                  If checked, player names will always be auto-generated, even
+                  if the game sent a custom name. Helpful if you're having a
+                  leaderboard where you want full anonymity.
+                </Trans>
+              }
+            />
+          </ColumnStackLayout>
         </Dialog>
       )}
     </I18n>
   );
 }
 
-export default LeaderboardSortOptionsDialog;
+export default LeaderboardOptionsDialog;

--- a/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
+++ b/newIDE/app/src/GameDashboard/LeaderboardAdmin/index.js
@@ -28,8 +28,6 @@ import Refresh from '../../UI/CustomSvgIcons/Refresh';
 import Trash from '../../UI/CustomSvgIcons/Trash';
 import Visibility from '../../UI/CustomSvgIcons/Visibility';
 import VisibilityOff from '../../UI/CustomSvgIcons/VisibilityOff';
-import Lock from '../../UI/CustomSvgIcons/Lock';
-import LockOpen from '../../UI/CustomSvgIcons/LockOpen';
 import Copy from '../../UI/CustomSvgIcons/Copy';
 
 import PlaceholderLoader from '../../UI/PlaceholderLoader';
@@ -62,8 +60,9 @@ import Text from '../../UI/Text';
 import { GameRegistration } from '../GameRegistration';
 import LeaderboardAppearanceDialog from './LeaderboardAppearanceDialog';
 import FlatButton from '../../UI/FlatButton';
-import LeaderboardSortOptionsDialog from './LeaderboardSortOptionsDialog';
-import { type LeaderboardSortOption } from '../../Utils/GDevelopServices/Play';
+import LeaderboardOptionsDialog, {
+  type LeaderboardOptions,
+} from './LeaderboardOptionsDialog';
 import { formatScore } from '../../Leaderboard/LeaderboardScoreFormatter';
 import Toggle from '../../UI/Toggle';
 import AuthenticatedUserContext from '../../Profile/AuthenticatedUserContext';
@@ -90,8 +89,6 @@ type ApiError = {|
     | 'leaderboardNameUpdate'
     | 'leaderboardSortUpdate'
     | 'leaderboardVisibilityUpdate'
-    | 'leaderboardAutoPlayerNamePrefixUpdate'
-    | 'leaderboardIgnoreCustomPlayerNamesUpdate'
     | 'leaderboardPrimaryUpdate'
     | 'leaderboardAppearanceUpdate'
     | 'leaderboardPlayerUnicityDisplayChoiceUpdate'
@@ -132,10 +129,6 @@ const getApiError = (payload: LeaderboardUpdatePayload): ApiError => ({
     ? 'leaderboardSortUpdate'
     : payload.visibility
     ? 'leaderboardVisibilityUpdate'
-    : payload.ignoreCustomPlayerNames !== undefined
-    ? 'leaderboardIgnoreCustomPlayerNamesUpdate'
-    : payload.autoPlayerNamePrefix !== undefined
-    ? 'leaderboardAutoPlayerNamePrefixUpdate'
     : payload.primary
     ? 'leaderboardPrimaryUpdate'
     : payload.customizationSettings
@@ -155,16 +148,6 @@ const getApiError = (payload: LeaderboardUpdatePayload): ApiError => ({
     <Trans>
       An error occurred when updating the visibility of the leaderboard, please
       close the dialog, come back and try again.
-    </Trans>
-  ) : payload.ignoreCustomPlayerNames !== undefined ? (
-    <Trans>
-      An error occurred when updating the handling of player names of the
-      leaderboard, please close the dialog, come back and try again.
-    </Trans>
-  ) : payload.autoPlayerNamePrefix !== undefined ? (
-    <Trans>
-      An error occurred when updating the handling of player names of the
-      leaderboard, please close the dialog, come back and try again.
     </Trans>
   ) : payload.primary ? (
     <Trans>
@@ -222,28 +205,16 @@ export const LeaderboardAdmin = ({
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const { limits } = authenticatedUser;
 
-  const [
-    isEditingSortOptions,
-    setIsEditingSortOptions,
-  ] = React.useState<boolean>(false);
+  const [isEditingOptions, setIsEditingOptions] = React.useState<boolean>(
+    false
+  );
   const [isEditingName, setIsEditingName] = React.useState<boolean>(false);
-  const [
-    isEditingAutoPlayerNamePrefix,
-    setIsEditingAutoPlayerNamePrefix,
-  ] = React.useState<boolean>(false);
   const [isRequestPending, setIsRequestPending] = React.useState<boolean>(
     false
   );
   const [newName, setNewName] = React.useState<string>('');
   const [newNameError, setNewNameError] = React.useState<?string>(null);
-  const [
-    newAutoPlayerNamePrefix,
-    setNewAutoPlayerNamePrefix,
-  ] = React.useState<string>('');
   const newNameTextFieldRef = React.useRef<?TextFieldInterface>(null);
-  const newAutoPlayerNamePrefixTextFieldRef = React.useRef<?TextFieldInterface>(
-    null
-  );
   const [apiError, setApiError] = React.useState<?ApiError>(null);
   const [
     displayGameRegistration,
@@ -295,8 +266,6 @@ export const LeaderboardAdmin = ({
     try {
       await updateLeaderboard(payload);
       if (payload.name) setIsEditingName(false);
-      if (payload.autoPlayerNamePrefix !== undefined)
-        setIsEditingAutoPlayerNamePrefix(false);
     } catch (err) {
       console.error('An error occurred when updating leaderboard', err);
       setApiError(getApiError(payload));
@@ -772,7 +741,7 @@ export const LeaderboardAdmin = ({
         ) : null,
       secondaryAction: (
         <IconButton
-          onClick={() => setIsEditingSortOptions(true)}
+          onClick={() => setIsEditingOptions(true)}
           tooltip={t`Edit`}
           edge="end"
           disabled={isRequestPending || isEditingName}
@@ -835,148 +804,22 @@ export const LeaderboardAdmin = ({
       ),
     },
     {
-      key: 'ignoreCustomPlayerNames',
-      avatar: currentLeaderboard.ignoreCustomPlayerNames ? (
-        <Lock />
-      ) : (
-        <LockOpen />
-      ),
+      key: 'options',
+      avatar: <Tag />,
       text: (
-        <Tooltip
-          title={i18n._(
-            currentLeaderboard.ignoreCustomPlayerNames
-              ? t`Even if the action is used to send a score with a custom player username, this name will be ignored by the leaderboard.`
-              : t`The player name sent in the action to send a score will be used.`
-          )}
-        >
-          <Text size="body2">
-            {currentLeaderboard.ignoreCustomPlayerNames ? (
-              <Trans>Ignore unauthenticated player usernames</Trans>
-            ) : (
-              <Trans>Allow unauthenticated player usernames</Trans>
-            )}
-          </Text>
-        </Tooltip>
+        <Text size="body2">
+          <Trans>Configuration</Trans>
+        </Text>
       ),
-      secondaryText:
-        apiError &&
-        apiError.action === 'leaderboardIgnoreCustomPlayerNamesUpdate' ? (
-          <Text color="error" size="body2">
-            {apiError.message}
-          </Text>
-        ) : null,
+      secondaryText: null,
       secondaryAction: (
         <IconButton
-          onClick={async () => {
-            await onUpdateLeaderboard(i18n, {
-              ignoreCustomPlayerNames: !currentLeaderboard.ignoreCustomPlayerNames,
-            });
-          }}
-          tooltip={
-            currentLeaderboard.ignoreCustomPlayerNames
-              ? t`Change to allow custom player usernames`
-              : t`Change to ignore custom player usernames`
-          }
+          onClick={() => setIsEditingOptions(true)}
+          tooltip={t`Edit`}
           edge="end"
           disabled={isRequestPending || isEditingName}
         >
-          <SwitchHorizontal />
-        </IconButton>
-      ),
-    },
-    {
-      key: 'autoPlayerNamePrefix',
-      avatar: <Tag />,
-      text: isEditingAutoPlayerNamePrefix ? (
-        <Line alignItems="center" expand noMargin>
-          <TextField
-            id="edit-autoPlayerNamePrefix-field"
-            ref={newAutoPlayerNamePrefixTextFieldRef}
-            margin="none"
-            style={styles.leaderboardNameTextField}
-            maxLength={40}
-            value={newAutoPlayerNamePrefix}
-            onChange={(e, text) => setNewAutoPlayerNamePrefix(text)}
-            onKeyPress={event => {
-              if (shouldValidate(event) && !isRequestPending) {
-                onUpdateLeaderboard(i18n, {
-                  autoPlayerNamePrefix: newAutoPlayerNamePrefix,
-                });
-              }
-            }}
-            disabled={isRequestPending}
-          />
-          {!isRequestPending && (
-            <>
-              <Spacer />
-              <IconButton
-                tooltip={t`Cancel`}
-                style={{ padding: 0 }}
-                onClick={() => {
-                  setIsEditingAutoPlayerNamePrefix(false);
-                }}
-              >
-                <Cross />
-              </IconButton>
-            </>
-          )}
-        </Line>
-      ) : (
-        <Tooltip
-          title={
-            currentLeaderboard.autoPlayerNamePrefix ||
-            i18n._('No custom prefix for auto-generated player names')
-          }
-        >
-          <Text size="body2" style={styles.leaderboardNameText}>
-            {currentLeaderboard.autoPlayerNamePrefix ||
-              i18n._('No custom prefix for auto-generated player names')}
-          </Text>
-        </Tooltip>
-      ),
-      secondaryText:
-        apiError &&
-        apiError.action === 'leaderboardAutoPlayerNamePrefixUpdate' ? (
-          <Text color="error" size="body2">
-            {apiError.message}
-          </Text>
-        ) : null,
-      secondaryAction: (
-        <IconButton
-          onClick={() => {
-            if (isEditingAutoPlayerNamePrefix) {
-              onUpdateLeaderboard(i18n, {
-                autoPlayerNamePrefix: newAutoPlayerNamePrefix,
-              });
-            } else {
-              setNewAutoPlayerNamePrefix(
-                currentLeaderboard.autoPlayerNamePrefix || ''
-              );
-              setIsEditingAutoPlayerNamePrefix(true);
-            }
-          }}
-          tooltip={
-            isEditingAutoPlayerNamePrefix
-              ? t`Save`
-              : t`Change the default prefix for player names`
-          }
-          disabled={isRequestPending}
-          edge="end"
-          id={
-            isEditingAutoPlayerNamePrefix
-              ? 'save-autoPlayerNamePrefix-button'
-              : 'edit-autoPlayerNamePrefix-button'
-          }
-        >
-          {isEditingAutoPlayerNamePrefix ? (
-            isRequestPending ? (
-              <CircularProgress size={20} />
-            ) : (
-              <Save />
-            )
-          ) : (
-            <Edit />
-          )}
+          <EditFile />
         </IconButton>
       ),
     },
@@ -985,7 +828,7 @@ export const LeaderboardAdmin = ({
       avatar: <TextFormat />,
       text: (
         <Text size="body2">
-          <Trans>Leaderboard appearance</Trans>
+          <Trans>Appearance</Trans>
         </Text>
       ),
       secondaryText:
@@ -1290,24 +1133,20 @@ export const LeaderboardAdmin = ({
               }}
             />
           ) : null}
-          {isEditingSortOptions && currentLeaderboard ? (
-            <LeaderboardSortOptionsDialog
+          {isEditingOptions && currentLeaderboard ? (
+            <LeaderboardOptionsDialog
               open
-              onClose={() => setIsEditingSortOptions(false)}
-              onSave={async (sortOptions: {|
-                sort: LeaderboardSortOption,
-                extremeAllowedScore: ?number,
-              |}) => {
+              onClose={() => setIsEditingOptions(false)}
+              onSave={async (options: LeaderboardOptions) => {
                 try {
                   await onUpdateLeaderboard(i18n, {
-                    ...sortOptions,
+                    ...options,
                   });
                 } finally {
-                  setIsEditingSortOptions(false);
+                  setIsEditingOptions(false);
                 }
               }}
-              sort={currentLeaderboard.sort}
-              extremeAllowedScore={currentLeaderboard.extremeAllowedScore}
+              leaderboard={currentLeaderboard}
             />
           ) : null}
         </>

--- a/newIDE/app/src/GameEngineFinder/BrowserS3GDJSFinder.js
+++ b/newIDE/app/src/GameEngineFinder/BrowserS3GDJSFinder.js
@@ -51,7 +51,7 @@ export const findGDJS = (
   // If you want to test your local changes to the game engine on the local web-app,
   // run `npx serve --cors -p 5001` (or another CORS enabled http server on port 5001)
   // in `newIDE/app/resources/GDJS` and uncomment this line:
-  // gdjsRoot = `http://localhost:5000`;
+  // gdjsRoot = `http://localhost:5001`;
 
   return Promise.all(
     filesToDownload[fileSet].map(relativeFilePath => {

--- a/newIDE/app/src/GameEngineFinder/BrowserS3GDJSFinder.js
+++ b/newIDE/app/src/GameEngineFinder/BrowserS3GDJSFinder.js
@@ -49,7 +49,7 @@ export const findGDJS = (
   let gdjsRoot = `https://resources.gdevelop-app.com/GDJS-${getIDEVersion()}`;
 
   // If you want to test your local changes to the game engine on the local web-app,
-  // run `npx serve --cors` (or another CORS enabled http server on port 5000)
+  // run `npx serve --cors -p 5001` (or another CORS enabled http server on port 5001)
   // in `newIDE/app/resources/GDJS` and uncomment this line:
   // gdjsRoot = `http://localhost:5000`;
 

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -66,6 +66,7 @@ export type Leaderboard = {|
   extremeAllowedScore?: number,
   ignoreCustomPlayerNames?: boolean,
   autoPlayerNamePrefix?: string,
+  disableLoginInLeaderboard?: string,
 |};
 
 export type LeaderboardUpdatePayload = {|

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -79,6 +79,7 @@ export type LeaderboardUpdatePayload = {|
   extremeAllowedScore?: number | null,
   ignoreCustomPlayerNames?: boolean,
   autoPlayerNamePrefix?: string,
+  disableLoginInLeaderboard?: boolean,
 |};
 
 export type LeaderboardEntry = {|

--- a/newIDE/app/src/Utils/GDevelopServices/Usage.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Usage.js
@@ -69,6 +69,7 @@ export type Capabilities = {|
     canMaximumCountPerGameBeIncreased: boolean,
     themeCustomizationCapabilities: 'NONE' | 'BASIC' | 'FULL',
     canUseCustomCss: boolean,
+    canDisableLoginInLeaderboard: boolean,
   },
   privateTutorials?: {
     allowedIdPrefixes: Array<string>,

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData/index.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData/index.js
@@ -2334,6 +2334,7 @@ export const limitsForNoSubscriptionUser: Limits = {
       canMaximumCountPerGameBeIncreased: true,
       themeCustomizationCapabilities: 'NONE',
       canUseCustomCss: false,
+      canDisableLoginInLeaderboard: false,
     },
   },
   quotas: {
@@ -2377,6 +2378,7 @@ export const limitsForSilverUser: Limits = {
       canMaximumCountPerGameBeIncreased: false,
       themeCustomizationCapabilities: 'BASIC',
       canUseCustomCss: false,
+      canDisableLoginInLeaderboard: false,
     },
   },
   quotas: {
@@ -2420,6 +2422,7 @@ export const limitsForGoldUser: Limits = {
       canMaximumCountPerGameBeIncreased: false,
       themeCustomizationCapabilities: 'FULL',
       canUseCustomCss: false,
+      canDisableLoginInLeaderboard: false,
     },
   },
   quotas: {
@@ -2463,6 +2466,7 @@ export const limitsForTeacherUser: Limits = {
       canMaximumCountPerGameBeIncreased: false,
       themeCustomizationCapabilities: 'FULL',
       canUseCustomCss: false,
+      canDisableLoginInLeaderboard: false,
     },
     privateTutorials: {
       allowedIdPrefixes: ['education-curriculum-'],
@@ -2514,6 +2518,7 @@ export const limitsForStudentUser: Limits = {
       canMaximumCountPerGameBeIncreased: false,
       themeCustomizationCapabilities: 'FULL',
       canUseCustomCss: false,
+      canDisableLoginInLeaderboard: false,
     },
     classrooms: {
       hidePlayTab: true,
@@ -2562,6 +2567,7 @@ export const limitsForStartupUser: Limits = {
       canMaximumCountPerGameBeIncreased: false,
       themeCustomizationCapabilities: 'FULL',
       canUseCustomCss: true,
+      canDisableLoginInLeaderboard: true,
     },
   },
   quotas: {
@@ -2605,6 +2611,7 @@ export const limitsForBusinessUser: Limits = {
       canMaximumCountPerGameBeIncreased: false,
       themeCustomizationCapabilities: 'FULL',
       canUseCustomCss: true,
+      canDisableLoginInLeaderboard: true,
     },
   },
   quotas: {
@@ -2648,6 +2655,7 @@ export const limitsReached: Limits = {
       canMaximumCountPerGameBeIncreased: true,
       themeCustomizationCapabilities: 'BASIC',
       canUseCustomCss: false,
+      canDisableLoginInLeaderboard: false,
     },
   },
   quotas: {
@@ -2691,6 +2699,7 @@ export const limitsForNoSubscriptionUserWithCredits: Limits = {
       canMaximumCountPerGameBeIncreased: true,
       themeCustomizationCapabilities: 'NONE',
       canUseCustomCss: false,
+      canDisableLoginInLeaderboard: false,
     },
   },
   quotas: {

--- a/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardSortOptionsDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardSortOptionsDialog.stories.js
@@ -4,6 +4,9 @@ import { action } from '@storybook/addon-actions';
 
 import paperDecorator from '../../PaperDecorator';
 import LeaderboardOptionsDialog from '../../../GameDashboard/LeaderboardAdmin/LeaderboardOptionsDialog';
+import { type Leaderboard } from '../../../Utils/GDevelopServices/Play';
+import { fakeStartupAuthenticatedUser } from '../../../fixtures/GDevelopServicesTestData';
+import AuthenticatedUserContext from '../../../Profile/AuthenticatedUserContext';
 
 export default {
   title: 'Leaderboard/LeaderboardOptionsDialog',
@@ -11,12 +14,36 @@ export default {
   decorators: [paperDecorator],
 };
 
+const fakeLeaderboard: Leaderboard = {
+  id: 'fake-leaderboard-id',
+  gameId: 'fake-game-id',
+  name: 'My leaderboard',
+  sort: 'ASC',
+  startDatetime: '123',
+  playerUnicityDisplayChoice: 'FREE',
+  visibility: 'PUBLIC',
+};
+
 export const Default = () => (
   <LeaderboardOptionsDialog
     open
     onClose={() => action('onClose')()}
-    onSave={() => action('onSave')()}
+    onSave={action('onSave')}
     sort={'ASC'}
     extremeAllowedScore={undefined}
+    leaderboard={fakeLeaderboard}
   />
+);
+
+export const WithProSubscription = () => (
+  <AuthenticatedUserContext.Provider value={fakeStartupAuthenticatedUser}>
+    <LeaderboardOptionsDialog
+      open
+      onClose={() => action('onClose')()}
+      onSave={action('onSave')}
+      sort={'ASC'}
+      extremeAllowedScore={undefined}
+      leaderboard={fakeLeaderboard}
+    />
+  </AuthenticatedUserContext.Provider>
 );

--- a/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardSortOptionsDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/Leaderboard/LeaderboardSortOptionsDialog.stories.js
@@ -3,16 +3,16 @@ import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import paperDecorator from '../../PaperDecorator';
-import LeaderboardSortOptionsDialog from '../../../GameDashboard/LeaderboardAdmin/LeaderboardSortOptionsDialog';
+import LeaderboardOptionsDialog from '../../../GameDashboard/LeaderboardAdmin/LeaderboardOptionsDialog';
 
 export default {
-  title: 'Leaderboard/LeaderboardSortOptionsDialog',
-  component: LeaderboardSortOptionsDialog,
+  title: 'Leaderboard/LeaderboardOptionsDialog',
+  component: LeaderboardOptionsDialog,
   decorators: [paperDecorator],
 };
 
 export const Default = () => (
-  <LeaderboardSortOptionsDialog
+  <LeaderboardOptionsDialog
     open
     onClose={() => action('onClose')()}
     onSave={() => action('onSave')()}


### PR DESCRIPTION
Games (leaderboards):
- Allow passing the connected player to the leaderboard iframe
- Allow communication with the leaderboard iframe to:
  - Get a request to authenticate the player
  - Communicate the result of it
- Fix display of leaderboard iframes in development on iOS
- Add a setting (that can be disabled with an action) to prefer to send a score for the connected player (even if the action to send as an anonymous player is used).

Games (authentication):
- Fix iOS app authentication (postMessage does not work in a Cordova In App Browser, use websocket instead).
- Rework authentication so that the caller code can know when it's done.
- Allow the action that opens the authentication window to wait for the authentication to be done (or closed)

Editor:
- Add option to avoid displaying login buttons in the leaderboards
