### PR TITLE
No caching in preview server

### DIFF
--- a/newIDE/electron-app/app/ServeFolder.js
+++ b/newIDE/electron-app/app/ServeFolder.js
@@ -30,6 +30,8 @@ module.exports = {
           watch: [],
           middleware: [
             // Disable caching, as it can lead to older generated code being served
+            // in case preview files are proxied through a CDN (see 
+            // https://github.com/4ian/GDevelop/pull/6553 for example)
             function noCache(_, res, next) {
               res.setHeader('Surrogate-Control', 'no-store');
               res.setHeader(

--- a/newIDE/electron-app/app/ServeFolder.js
+++ b/newIDE/electron-app/app/ServeFolder.js
@@ -2,6 +2,7 @@ const liveServer = require('live-server');
 const httpsConfiguration = require('./Utils/DevServerHttpsConfiguration.js');
 const { getAvailablePort } = require('./Utils/AvailablePortFinder');
 
+/** @type {import("live-server").LiveServerParams} */
 let currentServerParams = null;
 
 module.exports = {
@@ -27,6 +28,19 @@ module.exports = {
           // the hot-reloading built into the game engine is what should
           // be used - and the user can still reload manually on its browser.
           watch: [],
+          middleware: [
+            // Disable caching, as it can lead to older generated code being served
+            function noCache(_, res, next) {
+              res.setHeader('Surrogate-Control', 'no-store');
+              res.setHeader(
+                'Cache-Control',
+                'no-store, no-cache, must-revalidate, proxy-revalidate'
+              );
+              res.setHeader('Expires', '0');
+
+              next();
+            },
+          ],
         };
         liveServer.start(currentServerParams);
         onDone(null, currentServerParams);

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -295,7 +295,10 @@ app.on('ready', function() {
     log.info('Received event to server folder with options=', options);
 
     serveFolder(options, (err, serverParams) => {
-      event.sender.send('serve-folder-done', err, serverParams);
+      // Using JSON to copy the config strips unserializable properties
+      // (like middleware functions) automatically.
+      const configCopy = JSON.parse(JSON.stringify(serverParams));
+      event.sender.send('serve-folder-done', err, configCopy);
     });
   });
 


### PR DESCRIPTION
Adds no-cache headers to the network preview. This changes nothing when accessing the preview server directly, but allows proxying the network preview, while instructing the proxy not to indefinitely cache the files.

In my use case, I use a cloudflare tunnel for accessing my network previews over https (for some web APIs) and over different networks, but I need to use devtools to add no-cache headers to browser requests every time I want to reload the page, because the generated code files get cached by Cloudflare CDN.