### PR TITLE
Hide game templates when searching in asset store

### DIFF
--- a/newIDE/app/src/AssetStore/AssetsList.js
+++ b/newIDE/app/src/AssetStore/AssetsList.js
@@ -252,6 +252,7 @@ type Props = {|
   // Or it can display arbitrary content, like the list of assets in a pack, or similar assets,
   // then currentPage is null.
   currentPage?: AssetStorePageState,
+  hideGameTemplates?: boolean,
 |};
 
 const AssetsList = React.forwardRef<Props, AssetsListInterface>(
@@ -270,6 +271,7 @@ const AssetsList = React.forwardRef<Props, AssetsListInterface>(
       onGoBackToFolderIndex,
       noScroll,
       currentPage,
+      hideGameTemplates,
     }: Props,
     ref
   ) => {
@@ -600,7 +602,8 @@ const AssetsList = React.forwardRef<Props, AssetsListInterface>(
           // Don't show private game templates if filtering on assets.
           hasAssetFiltersApplied ||
           // Don't show private game templates if filtering on asset packs.
-          hasAssetPackFiltersApplied
+          hasAssetPackFiltersApplied ||
+          hideGameTemplates
         )
           return [];
 
@@ -628,6 +631,7 @@ const AssetsList = React.forwardRef<Props, AssetsListInterface>(
         receivedGameTemplates,
         hasAssetFiltersApplied,
         hasAssetPackFiltersApplied,
+        hideGameTemplates,
       ]
     );
 

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -724,6 +724,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
               onFolderSelection={selectFolder}
               onGoBackToFolderIndex={goBackToFolderIndex}
               currentPage={shopNavigationState.getCurrentPage()}
+              hideGameTemplates={hideGameTemplates}
             />
           ) : openedAssetShortHeader ? (
             <AssetDetails


### PR DESCRIPTION
Still shown in the shop

Asset store Before:
![image](https://github.com/4ian/GDevelop/assets/4895034/30eaf23e-a016-481b-9360-b902ad1e3b95)

Asset store After:
![image](https://github.com/4ian/GDevelop/assets/4895034/3994a658-70ca-4ceb-a590-99948ddba26b)
