### PR TITLE
Allow object variables to take the same name as an object

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
@@ -5,7 +5,7 @@ import VariableField, {
   renderVariableWithIcon,
   type VariableFieldInterface,
 } from './VariableField';
-import SceneVariablesDialog from '../../SceneEditor/SceneVariablesDialog';
+import SceneVariablesDialog from '../../VariablesList/SceneVariablesDialog';
 import {
   type ParameterFieldProps,
   type ParameterFieldInterface,

--- a/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/index.js
@@ -199,6 +199,7 @@ const CompactInstancePropertiesEditor = ({
                 directlyStoreValueChangesWhileEditing
                 inheritedVariablesContainer={object.getVariables()}
                 variablesContainer={instance.getVariables()}
+                areObjectVariables
                 size="small"
                 onComputeAllVariableNames={() =>
                   object

--- a/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancePropertiesEditor/index.js
@@ -393,6 +393,7 @@ const InstancePropertiesEditor = ({
               directlyStoreValueChangesWhileEditing
               inheritedVariablesContainer={object.getVariables()}
               variablesContainer={instance.getVariables()}
+              areObjectVariables
               size="small"
               onComputeAllVariableNames={() =>
                 object

--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -299,6 +299,7 @@ const InnerDialog = (props: InnerDialogProps) => {
               props.projectScopedContainersAccessor
             }
             variablesContainer={props.object.getVariables()}
+            areObjectVariables
             emptyPlaceholderTitle={
               <Trans>Add your first object variable</Trans>
             }

--- a/newIDE/app/src/ProjectManager/index.js
+++ b/newIDE/app/src/ProjectManager/index.js
@@ -11,7 +11,7 @@ import ProjectPropertiesDialog from './ProjectPropertiesDialog';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import ExtensionsSearchDialog from '../AssetStore/ExtensionStore/ExtensionsSearchDialog';
 import ScenePropertiesDialog from '../SceneEditor/ScenePropertiesDialog';
-import SceneVariablesDialog from '../SceneEditor/SceneVariablesDialog';
+import SceneVariablesDialog from '../VariablesList/SceneVariablesDialog';
 import { isExtensionNameTaken } from './EventFunctionExtensionNameVerifier';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 import ProjectManagerCommands from './ProjectManagerCommands';

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -46,7 +46,7 @@ import {
 } from '../ObjectsList/EnumerateObjects';
 import InfoBar from '../UI/Messages/InfoBar';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
-import SceneVariablesDialog from './SceneVariablesDialog';
+import SceneVariablesDialog from '../VariablesList/SceneVariablesDialog';
 import { onObjectAdded, onInstanceAdded } from '../Hints/ObjectsAdditionalWork';
 import { type InfoBarDetails } from '../Hints/ObjectsAdditionalWork';
 import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewButton';

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -7,7 +7,7 @@ import { t } from '@lingui/macro';
 import * as React from 'react';
 import LayerRemoveDialog from '../LayersList/LayerRemoveDialog';
 import LayerEditorDialog from '../LayersList/LayerEditorDialog';
-import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
+import ObjectInstanceVariablesDialog from '../VariablesList/ObjectInstanceVariablesDialog';
 import ObjectEditorDialog from '../ObjectEditor/ObjectEditorDialog';
 import ObjectExporterDialog from '../ObjectEditor/ObjectExporterDialog';
 import ObjectGroupEditorDialog from '../ObjectGroupEditor/ObjectGroupEditorDialog';
@@ -1881,63 +1881,23 @@ export default class SceneEditor extends React.Component<Props, State> {
               )}
               {!!this.state.variablesEditedInstance &&
                 !!variablesEditedAssociatedObject && (
-                  <VariablesEditorDialog
+                  <ObjectInstanceVariablesDialog
                     project={project}
+                    layout={layout}
                     projectScopedContainersAccessor={
                       projectScopedContainersAccessor
                     }
+                    objectInstance={this.state.variablesEditedInstance}
                     open
                     onCancel={() => this.editInstanceVariables(null)}
                     onApply={() => this.editInstanceVariables(null)}
-                    tabs={[
-                      {
-                        id: 'instance-variables',
-                        label: <Trans>Scene variables</Trans>,
-                        variablesContainer: this.state.variablesEditedInstance.getVariables(),
-                        inheritedVariablesContainer: variablesEditedAssociatedObject.getVariables(),
-                        emptyPlaceholderTitle: (
-                          <Trans>Add your first instance variable</Trans>
-                        ),
-                        emptyPlaceholderDescription: (
-                          <Trans>
-                            Instance variables overwrite the default values of
-                            the variables of the object.
-                          </Trans>
-                        ),
-                        onComputeAllVariableNames: () => {
-                          const { variablesEditedInstance } = this.state;
-                          if (!variablesEditedInstance) {
-                            return [];
-                          }
-                          const variablesEditedObject = getObjectByName(
-                            project,
-                            layout,
-                            variablesEditedInstance.getObjectName()
-                          );
-                          return variablesEditedObject
-                            ? EventsRootVariablesFinder.findAllObjectVariables(
-                                project.getCurrentPlatform(),
-                                project,
-                                layout,
-                                variablesEditedObject.getName()
-                              )
-                            : [];
-                        },
-                      },
-                    ]}
-                    helpPagePath={'/all-features/variables/instance-variables'}
-                    title={<Trans>Instance Variables</Trans>}
-                    onEditObjectVariables={
-                      variablesEditedAssociatedObject
-                        ? () => {
-                            this.editObject(
-                              variablesEditedAssociatedObject,
-                              'variables'
-                            );
-                            this.editInstanceVariables(null);
-                          }
-                        : undefined
-                    }
+                    onEditObjectVariables={() => {
+                      this.editObject(
+                        variablesEditedAssociatedObject,
+                        'variables'
+                      );
+                      this.editInstanceVariables(null);
+                    }}
                     hotReloadPreviewButtonProps={
                       this.props.hotReloadPreviewButtonProps
                     }

--- a/newIDE/app/src/VariablesList/ObjectInstanceVariablesDialog.js
+++ b/newIDE/app/src/VariablesList/ObjectInstanceVariablesDialog.js
@@ -51,7 +51,7 @@ const ObjectInstanceVariablesDialog = ({
         ? [
             {
               id: 'instance-variables',
-              label: <Trans>Scene variables</Trans>,
+              label: <Trans>Instance variables</Trans>,
               variablesContainer: objectInstance.getVariables(),
               inheritedVariablesContainer: variablesEditedAssociatedObject.getVariables(),
               emptyPlaceholderTitle: (

--- a/newIDE/app/src/VariablesList/ObjectInstanceVariablesDialog.js
+++ b/newIDE/app/src/VariablesList/ObjectInstanceVariablesDialog.js
@@ -1,0 +1,102 @@
+// @flow
+import * as React from 'react';
+import { Trans } from '@lingui/macro';
+import VariablesEditorDialog from './VariablesEditorDialog';
+import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewButton';
+import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
+import { ProjectScopedContainersAccessor } from '../InstructionOrExpression/EventsScope.flow';
+import getObjectByName from '../Utils/GetObjectByName';
+
+type Props = {|
+  open: boolean,
+  project: gdProject,
+  layout: gdLayout,
+  projectScopedContainersAccessor: ProjectScopedContainersAccessor,
+  objectInstance: gdInitialInstance,
+  onApply: (selectedVariableName: string | null) => void,
+  onCancel: () => void,
+  hotReloadPreviewButtonProps?: ?HotReloadPreviewButtonProps,
+  /**
+   * If set to true, a deleted variable won't trigger a confirmation asking if the
+   * project must be refactored to delete any reference to it.
+   */
+  preventRefactoringToDeleteInstructions?: boolean,
+  initiallySelectedVariableName?: string,
+  onEditObjectVariables: () => void,
+|};
+
+const ObjectInstanceVariablesDialog = ({
+  project,
+  layout,
+  objectInstance,
+  open,
+  onCancel,
+  onApply,
+  hotReloadPreviewButtonProps,
+  preventRefactoringToDeleteInstructions,
+  initiallySelectedVariableName,
+  projectScopedContainersAccessor,
+  onEditObjectVariables,
+}: Props) => {
+  const tabs = React.useMemo(
+    () => {
+      const objectName = objectInstance.getObjectName();
+      // TODO Use projectScopedContainers to get the object
+      const variablesEditedAssociatedObject = getObjectByName(
+        project,
+        layout,
+        objectName
+      );
+      return variablesEditedAssociatedObject
+        ? [
+            {
+              id: 'instance-variables',
+              label: <Trans>Scene variables</Trans>,
+              variablesContainer: objectInstance.getVariables(),
+              inheritedVariablesContainer: variablesEditedAssociatedObject.getVariables(),
+              emptyPlaceholderTitle: (
+                <Trans>Add your first instance variable</Trans>
+              ),
+              emptyPlaceholderDescription: (
+                <Trans>
+                  Instance variables overwrite the default values of the
+                  variables of the object.
+                </Trans>
+              ),
+              onComputeAllVariableNames: () =>
+                EventsRootVariablesFinder.findAllObjectVariables(
+                  project.getCurrentPlatform(),
+                  project,
+                  layout,
+                  objectName
+                ),
+            },
+          ]
+        : [];
+    },
+    [layout, objectInstance, project]
+  );
+
+  return (
+    <VariablesEditorDialog
+      project={project}
+      projectScopedContainersAccessor={projectScopedContainersAccessor}
+      areObjectVariables
+      open={open}
+      onCancel={onCancel}
+      onApply={onApply}
+      title={<Trans>Instance variables</Trans>}
+      tabs={tabs}
+      initiallySelectedVariableName={initiallySelectedVariableName}
+      helpPagePath={'/all-features/variables/instance-variables'}
+      hotReloadPreviewButtonProps={hotReloadPreviewButtonProps}
+      preventRefactoringToDeleteInstructions={
+        preventRefactoringToDeleteInstructions
+      }
+      id="instance-variables-dialog"
+      onEditObjectVariables={onEditObjectVariables}
+    />
+  );
+};
+
+export default ObjectInstanceVariablesDialog;

--- a/newIDE/app/src/VariablesList/ObjectVariablesDialog.js
+++ b/newIDE/app/src/VariablesList/ObjectVariablesDialog.js
@@ -21,7 +21,6 @@ type Props = {|
    * project must be refactored to delete any reference to it.
    */
   preventRefactoringToDeleteInstructions?: boolean,
-  isGlobalTabInitiallyOpen?: boolean,
   initiallySelectedVariableName?: string,
 |};
 
@@ -35,7 +34,6 @@ const ObjectVariablesDialog = ({
   onApply,
   hotReloadPreviewButtonProps,
   preventRefactoringToDeleteInstructions,
-  isGlobalTabInitiallyOpen,
   initiallySelectedVariableName,
   projectScopedContainersAccessor,
 }: Props) => {
@@ -53,21 +51,20 @@ const ObjectVariablesDialog = ({
   );
 
   const tabs = React.useMemo(
-    () =>
-      [
-        {
-          id: 'object-variables',
-          label: <Trans>Object variables</Trans>,
-          variablesContainer: variablesContainer,
-          emptyPlaceholderTitle: <Trans>Add your first object variable</Trans>,
-          emptyPlaceholderDescription: (
-            <Trans>
-              These variables hold additional information on an object.
-            </Trans>
-          ),
-          onComputeAllVariableNames,
-        },
-      ].filter(Boolean),
+    () => [
+      {
+        id: 'object-variables',
+        label: <Trans>Object variables</Trans>,
+        variablesContainer: variablesContainer,
+        emptyPlaceholderTitle: <Trans>Add your first object variable</Trans>,
+        emptyPlaceholderDescription: (
+          <Trans>
+            These variables hold additional information on an object.
+          </Trans>
+        ),
+        onComputeAllVariableNames,
+      },
+    ],
     [onComputeAllVariableNames, variablesContainer]
   );
 
@@ -75,6 +72,7 @@ const ObjectVariablesDialog = ({
     <VariablesEditorDialog
       project={project}
       projectScopedContainersAccessor={projectScopedContainersAccessor}
+      areObjectVariables
       open={open}
       onCancel={onCancel}
       onApply={onApply}

--- a/newIDE/app/src/VariablesList/SceneVariablesDialog.js
+++ b/newIDE/app/src/VariablesList/SceneVariablesDialog.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { Trans } from '@lingui/macro';
-import VariablesEditorDialog from '../VariablesList/VariablesEditorDialog';
+import VariablesEditorDialog from './VariablesEditorDialog';
 import { type HotReloadPreviewButtonProps } from '../HotReload/HotReloadPreviewButton';
 import EventsRootVariablesFinder from '../Utils/EventsRootVariablesFinder';
 import { ProjectScopedContainersAccessor } from '../InstructionOrExpression/EventsScope.flow';

--- a/newIDE/app/src/VariablesList/VariablesEditorDialog.js
+++ b/newIDE/app/src/VariablesList/VariablesEditorDialog.js
@@ -53,6 +53,7 @@ type Props = {|
   onEditObjectVariables?: () => void,
   title: React.Node,
   tabs: Array<TabProps>,
+  areObjectVariables?: boolean,
   initiallyOpenTabId?: string,
   initiallySelectedVariableName?: string,
 
@@ -84,6 +85,7 @@ const VariablesEditorDialog = ({
   initiallyOpenTabId,
   initiallySelectedVariableName,
   projectScopedContainersAccessor,
+  areObjectVariables,
 }: Props) => {
   const serializableObjects = React.useMemo(
     () =>
@@ -262,6 +264,7 @@ const VariablesEditorDialog = ({
                     projectScopedContainersAccessor
                   }
                   variablesContainer={variablesContainer}
+                  areObjectVariables={areObjectVariables}
                   initiallySelectedVariableName={initiallySelectedVariableName}
                   inheritedVariablesContainer={inheritedVariablesContainer}
                   emptyPlaceholderTitle={emptyPlaceholderTitle}

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -100,6 +100,7 @@ export type HistoryHandler = {|
 type Props = {|
   projectScopedContainersAccessor: ProjectScopedContainersAccessor,
   variablesContainer: gdVariablesContainer,
+  areObjectVariables?: boolean,
   inheritedVariablesContainer?: gdVariablesContainer,
   initiallySelectedVariableName?: string,
   /** Callback executed at mount to compute suggestions. */
@@ -1487,10 +1488,11 @@ const VariablesList = (props: Props) => {
           (parentVariable && parentVariable.hasChild(tentativeNewName)) ||
           (!parentVariable &&
             (props.variablesContainer.has(tentativeNewName) ||
-              props.projectScopedContainersAccessor
-                .get()
-                .getObjectsContainersList()
-                .hasObjectOrGroupNamed(tentativeNewName)))
+              (!props.areObjectVariables &&
+                props.projectScopedContainersAccessor
+                  .get()
+                  .getObjectsContainersList()
+                  .hasObjectOrGroupNamed(tentativeNewName))))
       );
 
       if (!parentVariable) {
@@ -1508,6 +1510,7 @@ const VariablesList = (props: Props) => {
     },
     [
       props.variablesContainer,
+      props.areObjectVariables,
       props.projectScopedContainersAccessor,
       _onChange,
       updateExpandedAndSelectedNodesFollowingNameChange,

--- a/newIDE/app/src/stories/componentStories/VariablesList.stories.js
+++ b/newIDE/app/src/stories/componentStories/VariablesList.stories.js
@@ -37,6 +37,7 @@ export const InstanceWithObjectVariables = () => (
           testProject.testSceneProjectScopedContainersAccessor
         }
         variablesContainer={testProject.testSpriteObjectInstance.getVariables()}
+        areObjectVariables
         emptyPlaceholderDescription="Variables help you store data"
         emptyPlaceholderTitle="Variables"
         helpPagePath="/variables"


### PR DESCRIPTION
It also fixes the variable instance dialog cancellation.