### PR TITLE
Display errors on objects with missing behaviors in the event sheet

### DIFF
--- a/Core/GDCore/Project/Layout.cpp
+++ b/Core/GDCore/Project/Layout.cpp
@@ -524,6 +524,7 @@ void GD_CORE_API FilterBehaviorNamesFromObject(
     if (!object.HasBehaviorNamed(behaviorName) ||
         object.GetBehavior(behaviorName).GetTypeName() != behaviorType) {
       behaviorNames.erase(behaviorNames.begin() + i);
+      --i;
     }
   }
 }

--- a/Core/GDCore/Project/Layout.cpp
+++ b/Core/GDCore/Project/Layout.cpp
@@ -519,12 +519,13 @@ gd::String GD_CORE_API GetTypeOfObject(const gd::ObjectsContainer& project,
 void GD_CORE_API FilterBehaviorNamesFromObject(
     const gd::Object &object, const gd::String &behaviorType,
     std::vector<gd::String> &behaviorNames) {
-  for (size_t i = 0; i < behaviorNames.size(); i++) {
+  for (size_t i = 0; i < behaviorNames.size();) {
     auto &behaviorName = behaviorNames[i];
     if (!object.HasBehaviorNamed(behaviorName) ||
         object.GetBehavior(behaviorName).GetTypeName() != behaviorType) {
       behaviorNames.erase(behaviorNames.begin() + i);
-      --i;
+    } else {
+      ++i;
     }
   }
 }

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -45,8 +45,8 @@ import {
 import { enumerateParametersUsableInExpressions } from '../ParameterFields/EnumerateFunctionParameters';
 import { getFunctionNameFromType } from '../../EventsFunctionsExtensionsLoader';
 import { ExtensionStoreContext } from '../../AssetStore/ExtensionStore/ExtensionStoreContext';
-import { getRequiredBehaviorTypes } from '../ParameterFields/ObjectField';
-import { checkHasRequiredCapability } from '../../ObjectsList/ObjectSelector';
+import { getAllRequiredBehaviorTypes } from '../ParameterFields/ObjectField';
+import { checkHasRequiredBehaviors } from '../../ObjectsList/ObjectSelector';
 import Warning from '../../UI/CustomSvgIcons/Warning';
 import { getRootVariableName } from '../../EventsSheet/ParameterFields/VariableField';
 
@@ -339,25 +339,19 @@ const Instruction = (props: Props) => {
               const objectOrGroupName = instruction
                 .getParameter(parameterIndex)
                 .getPlainString();
+              const objectsContainersList = projectScopedContainers.getObjectsContainersList();
               expressionIsValid =
-                (globalObjectsContainer.hasObjectNamed(objectOrGroupName) ||
-                  objectsContainer.hasObjectNamed(objectOrGroupName) ||
-                  globalObjectsContainer
-                    .getObjectGroups()
-                    .has(objectOrGroupName) ||
-                  objectsContainer.getObjectGroups().has(objectOrGroupName)) &&
+                objectsContainersList.hasObjectOrGroupNamed(
+                  objectOrGroupName
+                ) &&
                 (!parameterMetadata.getExtraInfo() ||
-                  gd.getTypeOfObject(
-                    globalObjectsContainer,
-                    objectsContainer,
-                    objectOrGroupName,
-                    /*searchInGroups=*/ true
-                  ) === parameterMetadata.getExtraInfo()) &&
-                checkHasRequiredCapability({
+                  objectsContainersList.getTypeOfObject(objectOrGroupName) ===
+                    parameterMetadata.getExtraInfo()) &&
+                checkHasRequiredBehaviors({
                   globalObjectsContainer,
                   objectsContainer,
                   objectName: objectOrGroupName,
-                  requiredBehaviorTypes: getRequiredBehaviorTypes(
+                  requiredBehaviorTypes: getAllRequiredBehaviorTypes(
                     platform,
                     metadata,
                     parameterIndex

--- a/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/BehaviorField.js
@@ -146,7 +146,11 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       allowedBehaviorType !== '' ? (
         <Trans>
           The behavior is not attached to this object. Please select another
-          object or add this behavior.
+          object or add this behavior:{' '}
+          {gd.MetadataProvider.getBehaviorMetadata(
+            gd.JsPlatform.get(),
+            allowedBehaviorType
+          ).getFullName() || allowedBehaviorType}
         </Trans>
       ) : (
         <Trans>


### PR DESCRIPTION
### Known issue

It won't show any error on the object parameter when a behavior parameter is empty but the object do have the behavior attached. This can happen when the behavior is attached after the instruction was added.

In this case:
- The game won't run as expected
- The diagnostic report will show up
- The behavior parameter is filled automatically when users open the instruction editor (and they won't understand what was the issue)

We could launch a refactor on the events to fill behavior parameter when a behavior is attached to an object.

### Changes

- There is a double error message when 1st selecting an instruction.

![image](https://github.com/4ian/GDevelop/assets/2611977/e3c3da3f-91b5-449d-82ac-3ddab35da4b4)

- When coming back to the instruction editor, the error on the behavior is still understandable by itself.
 
![image](https://github.com/4ian/GDevelop/assets/2611977/aaa02fa9-8465-4e05-93b9-724b402f44bd)

- The error is displayed directly in the event sheet.

![image](https://github.com/4ian/GDevelop/assets/2611977/78f0098d-3010-4608-a13e-1d8d9bcca6e2)

- Contrary to what is done for capabilities, object with missing behavior can still be selected to allow users to realize they must add it to them.

![image](https://github.com/4ian/GDevelop/assets/2611977/37198bda-d6bf-4dcf-bbee-38be61bc1524)
