### PR TITLE
Fill empty behavior parameters in instructions when a behavior is attached to an object

### DIFF
--- a/Core/GDCore/IDE/Events/BehaviorParametersFiller.cpp
+++ b/Core/GDCore/IDE/Events/BehaviorParametersFiller.cpp
@@ -25,7 +25,6 @@ bool BehaviorParametersFiller::DoVisitInstruction(gd::Instruction &instruction,
                              : gd::MetadataProvider::GetActionMetadata(
                                    platform, instruction.GetType());
 
-  gd::String lastLayerName;
   gd::ParameterMetadataTools::IterateOverParametersWithIndex(
       instruction.GetParameters(), metadata.GetParameters(),
       [&](const gd::ParameterMetadata &parameterMetadata,
@@ -42,18 +41,18 @@ bool BehaviorParametersFiller::DoVisitInstruction(gd::Instruction &instruction,
           auto behaviorNames =
               objectsContainersList.GetBehaviorsOfObject(lastObjectName, true);
 
-          gd::String *foundBehaviorName = nullptr;
+          gd::String foundBehaviorName = "";
           for (auto &behaviorName : behaviorNames) {
             auto behaviorTypeName =
                 objectsContainersList.GetTypeOfBehavior(behaviorName, false);
             if (behaviorTypeName == expectedBehaviorTypeName) {
-              foundBehaviorName = &behaviorName;
+              foundBehaviorName = behaviorName;
               break;
             }
           }
-          if (foundBehaviorName) {
+          if (!foundBehaviorName.empty()) {
             instruction.SetParameter(parameterIndex,
-                                     gd::Expression(*foundBehaviorName));
+                                     gd::Expression(foundBehaviorName));
           }
         }
       });

--- a/Core/GDCore/IDE/Events/BehaviorParametersFiller.cpp
+++ b/Core/GDCore/IDE/Events/BehaviorParametersFiller.cpp
@@ -1,0 +1,66 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2024 Florian Rival (Florian.Rival@gmail.com). All rights
+ * reserved. This project is released under the MIT License.
+ */
+#include "BehaviorParametersFiller.h"
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "GDCore/Events/Instruction.h"
+#include "GDCore/Extensions/Metadata/MetadataProvider.h"
+#include "GDCore/Extensions/Metadata/ParameterMetadataTools.h"
+#include "GDCore/String.h"
+#include "GDCore/Tools/Log.h"
+
+namespace gd {
+
+bool BehaviorParametersFiller::DoVisitInstruction(gd::Instruction &instruction,
+                                                  bool isCondition) {
+  const auto &metadata = isCondition
+                             ? gd::MetadataProvider::GetConditionMetadata(
+                                   platform, instruction.GetType())
+                             : gd::MetadataProvider::GetActionMetadata(
+                                   platform, instruction.GetType());
+
+  gd::String lastLayerName;
+  gd::ParameterMetadataTools::IterateOverParametersWithIndex(
+      instruction.GetParameters(), metadata.GetParameters(),
+      [&](const gd::ParameterMetadata &parameterMetadata,
+          const gd::Expression &parameterValue, size_t parameterIndex,
+          const gd::String &lastObjectName) {
+        if (parameterMetadata.GetValueTypeMetadata().IsBehavior() &&
+            parameterValue.GetPlainString().length() == 0) {
+
+          auto &expectedBehaviorTypeName =
+              parameterMetadata.GetValueTypeMetadata().GetExtraInfo();
+
+          auto &objectsContainersList =
+              projectScopedContainers.GetObjectsContainersList();
+          auto behaviorNames =
+              objectsContainersList.GetBehaviorsOfObject(lastObjectName, true);
+
+          gd::String *foundBehaviorName = nullptr;
+          for (auto &behaviorName : behaviorNames) {
+            auto behaviorTypeName =
+                objectsContainersList.GetTypeOfBehavior(behaviorName, false);
+            if (behaviorTypeName == expectedBehaviorTypeName) {
+              foundBehaviorName = &behaviorName;
+              break;
+            }
+          }
+          if (foundBehaviorName) {
+            instruction.SetParameter(parameterIndex,
+                                     gd::Expression(*foundBehaviorName));
+          }
+        }
+      });
+
+  return false;
+}
+
+BehaviorParametersFiller::~BehaviorParametersFiller() {}
+
+} // namespace gd

--- a/Core/GDCore/IDE/Events/BehaviorParametersFiller.h
+++ b/Core/GDCore/IDE/Events/BehaviorParametersFiller.h
@@ -1,0 +1,45 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2024 Florian Rival (Florian.Rival@gmail.com). All rights
+ * reserved. This project is released under the MIT License.
+ */
+#pragma once
+
+#include "GDCore/IDE/Events/ArbitraryEventsWorker.h"
+#include "GDCore/String.h"
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace gd {
+class Instruction;
+class Platform;
+class ProjectScopedContainers;
+} // namespace gd
+
+namespace gd {
+
+/**
+ * \brief Fill empty behavior parameters with any behavior that matches the
+ * required behavior type.
+ *
+ * \ingroup IDE
+ */
+class GD_CORE_API BehaviorParametersFiller : public ArbitraryEventsWorker {
+public:
+  BehaviorParametersFiller(
+      const gd::Platform &platform_,
+      const gd::ProjectScopedContainers &projectScopedContainers_)
+      : platform(platform_),
+        projectScopedContainers(projectScopedContainers_){};
+  virtual ~BehaviorParametersFiller();
+
+private:
+  bool DoVisitInstruction(gd::Instruction &instruction,
+                          bool isCondition) override;
+
+  const gd::Platform &platform;
+  const gd::ProjectScopedContainers &projectScopedContainers;
+};
+
+} // namespace gd

--- a/Core/GDCore/IDE/WholeProjectRefactorer.cpp
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.cpp
@@ -26,6 +26,7 @@
 #include "GDCore/IDE/Events/InstructionsTypeRenamer.h"
 #include "GDCore/IDE/Events/LinkEventTargetRenamer.h"
 #include "GDCore/IDE/Events/ProjectElementRenamer.h"
+#include "GDCore/IDE/Events/BehaviorParametersFiller.h"
 #include "GDCore/IDE/EventsFunctionTools.h"
 #include "GDCore/IDE/Project/ArbitraryBehaviorSharedDataWorker.h"
 #include "GDCore/IDE/Project/ArbitraryEventBasedBehaviorsWorker.h"
@@ -1537,6 +1538,16 @@ void WholeProjectRefactorer::ObjectRemovedInLayout(
   }
 }
 
+void WholeProjectRefactorer::BehaviorsAddedToObjectInLayout(
+    gd::Project &project, gd::Layout &layout, const gd::String &objectName) {
+  auto projectScopedContainers = gd::ProjectScopedContainers::
+      MakeNewProjectScopedContainersForProjectAndLayout(project, layout);
+  gd::BehaviorParametersFiller behaviorParameterFiller(
+      project.GetCurrentPlatform(), projectScopedContainers);
+  gd::ProjectBrowserHelper::ExposeLayoutEventsAndExternalEvents(
+      project, layout, behaviorParameterFiller);
+}
+
 void WholeProjectRefactorer::ObjectOrGroupRenamedInLayout(
     gd::Project &project, gd::Layout &layout, const gd::String &oldName,
     const gd::String &newName, bool isObjectGroup) {
@@ -1798,6 +1809,17 @@ void WholeProjectRefactorer::GlobalObjectRemoved(
       continue;
 
     ObjectRemovedInLayout(project, layout, objectName);
+  }
+}
+
+void WholeProjectRefactorer::BehaviorsAddedToGlobalObject(
+    gd::Project &project, const gd::String &objectName) {
+  for (std::size_t i = 0; i < project.GetLayoutsCount(); ++i) {
+    gd::Layout &layout = project.GetLayout(i);
+    if (layout.HasObjectNamed(objectName))
+      continue;
+
+    BehaviorsAddedToObjectInLayout(project, layout, objectName);
   }
 }
 

--- a/Core/GDCore/IDE/WholeProjectRefactorer.h
+++ b/Core/GDCore/IDE/WholeProjectRefactorer.h
@@ -396,6 +396,18 @@ class GD_CORE_API WholeProjectRefactorer {
                                            const gd::String& objectName);
 
   /**
+   * \brief Refactor the project after behaviors are added to an object in a
+   * layout.
+   *
+   * This will update the layout, all external events associated with it.
+   * The refactor is actually applied to all objects because it allow to handle
+   * groups.
+   */
+  static void BehaviorsAddedToObjectInLayout(gd::Project &project,
+                                             gd::Layout &layout,
+                                             const gd::String &objectName);
+
+  /**
    * \brief Refactor the project after an object is removed in an events-based
    * object.
    *
@@ -466,6 +478,16 @@ class GD_CORE_API WholeProjectRefactorer {
    */
   static void GlobalObjectRemoved(gd::Project& project,
                                          const gd::String& objectName);
+
+  /**
+   * \brief Refactor the project after behaviors are added a global object.
+   *
+   * This will update all the layouts, all external events associated with them.
+   * The refactor is actually applied to all objects because it allow to handle
+   * groups.
+   */
+  void BehaviorsAddedToGlobalObject(gd::Project &project,
+                                    const gd::String &objectName);
 
   /**
    * \brief Return the set of all the types of the objects that are using the

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -2438,6 +2438,10 @@ interface WholeProjectRefactorer {
         [Ref] Project project,
         [Ref] Layout layout,
         [Const] DOMString objectName);
+    void STATIC_BehaviorsAddedToObjectInLayout(
+        [Ref] Project project,
+        [Ref] Layout layout,
+        [Const] DOMString objectName);
     void STATIC_ObjectOrGroupRenamedInEventsFunction([Ref] Project project, [Ref] EventsFunction eventsFunction, [Ref] ObjectsContainer globalObjectsContainer, [Ref] ObjectsContainer objectsContainer, [Const] DOMString oldName, [Const] DOMString newName, boolean isObjectGroup);
     void STATIC_ObjectRemovedInEventsFunction(
         [Ref] Project project,
@@ -2454,6 +2458,9 @@ interface WholeProjectRefactorer {
         [Const] DOMString objectName);
     void STATIC_GlobalObjectOrGroupRenamed([Ref] Project project, [Const] DOMString oldName, [Const] DOMString newName, boolean isObjectGroup);
     void STATIC_GlobalObjectRemoved(
+        [Ref] Project project,
+        [Const] DOMString objectName);
+    void STATIC_BehaviorsAddedToGlobalObject(
         [Ref] Project project,
         [Const] DOMString objectName);
     [Value] SetString STATIC_GetAllObjectTypesUsingEventsBasedBehavior([Const, Ref] Project project, [Const, Ref] EventsFunctionsExtension eventsFunctionsExtension, [Const, Ref] EventsBasedBehavior eventsBasedBehavior);

--- a/GDevelop.js/Bindings/Wrapper.cpp
+++ b/GDevelop.js/Bindings/Wrapper.cpp
@@ -644,6 +644,7 @@ typedef ExtensionAndMetadata<ExpressionMetadata> ExtensionAndExpressionMetadata;
 #define STATIC_Date Date
 #define STATIC_ObjectOrGroupRenamedInLayout ObjectOrGroupRenamedInLayout
 #define STATIC_ObjectRemovedInLayout ObjectRemovedInLayout
+#define STATIC_BehaviorsAddedToObjectInLayout BehaviorsAddedToObjectInLayout
 #define STATIC_ObjectRemovedInEventsFunction \
   ObjectRemovedInEventsFunction
 #define STATIC_ObjectOrGroupRenamedInEventsFunction \
@@ -654,6 +655,7 @@ typedef ExtensionAndMetadata<ExpressionMetadata> ExtensionAndExpressionMetadata;
   ObjectOrGroupRenamedInEventsBasedObject
 #define STATIC_GlobalObjectOrGroupRenamed GlobalObjectOrGroupRenamed
 #define STATIC_GlobalObjectRemoved GlobalObjectRemoved
+#define STATIC_BehaviorsAddedToGlobalObject BehaviorsAddedToGlobalObject
 #define STATIC_GetAllObjectTypesUsingEventsBasedBehavior \
   GetAllObjectTypesUsingEventsBasedBehavior
 #define STATIC_EnsureBehaviorEventsFunctionsProperParameters \

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -1829,12 +1829,14 @@ export class WholeProjectRefactorer extends EmscriptenObject {
   static renameObjectEffect(project: Project, layout: Layout, gdObject: gdObject, oldName: string, newName: string): void;
   static objectOrGroupRenamedInLayout(project: Project, layout: Layout, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectRemovedInLayout(project: Project, layout: Layout, objectName: string): void;
+  static behaviorsAddedToObjectInLayout(project: Project, layout: Layout, objectName: string): void;
   static objectOrGroupRenamedInEventsFunction(project: Project, eventsFunction: EventsFunction, globalObjectsContainer: ObjectsContainer, objectsContainer: ObjectsContainer, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectRemovedInEventsFunction(project: Project, eventsFunction: EventsFunction, globalObjectsContainer: ObjectsContainer, objectsContainer: ObjectsContainer, objectName: string): void;
   static objectOrGroupRenamedInEventsBasedObject(project: Project, globalObjectsContainer: ObjectsContainer, eventsBasedObject: EventsBasedObject, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectRemovedInEventsBasedObject(project: Project, eventsBasedObject: EventsBasedObject, globalObjectsContainer: ObjectsContainer, objectsContainer: ObjectsContainer, objectName: string): void;
   static globalObjectOrGroupRenamed(project: Project, oldName: string, newName: string, isObjectGroup: boolean): void;
   static globalObjectRemoved(project: Project, objectName: string): void;
+  static behaviorsAddedToGlobalObject(project: Project, objectName: string): void;
   static getAllObjectTypesUsingEventsBasedBehavior(project: Project, eventsFunctionsExtension: EventsFunctionsExtension, eventsBasedBehavior: EventsBasedBehavior): SetString;
   static ensureBehaviorEventsFunctionsProperParameters(eventsFunctionsExtension: EventsFunctionsExtension, eventsBasedBehavior: EventsBasedBehavior): void;
   static ensureObjectEventsFunctionsProperParameters(eventsFunctionsExtension: EventsFunctionsExtension, eventsBasedObject: EventsBasedObject): void;

--- a/GDevelop.js/types/gdwholeprojectrefactorer.js
+++ b/GDevelop.js/types/gdwholeprojectrefactorer.js
@@ -25,12 +25,14 @@ declare class gdWholeProjectRefactorer {
   static renameObjectEffect(project: gdProject, layout: gdLayout, gdObject: gdObject, oldName: string, newName: string): void;
   static objectOrGroupRenamedInLayout(project: gdProject, layout: gdLayout, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectRemovedInLayout(project: gdProject, layout: gdLayout, objectName: string): void;
+  static behaviorsAddedToObjectInLayout(project: gdProject, layout: gdLayout, objectName: string): void;
   static objectOrGroupRenamedInEventsFunction(project: gdProject, eventsFunction: gdEventsFunction, globalObjectsContainer: gdObjectsContainer, objectsContainer: gdObjectsContainer, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectRemovedInEventsFunction(project: gdProject, eventsFunction: gdEventsFunction, globalObjectsContainer: gdObjectsContainer, objectsContainer: gdObjectsContainer, objectName: string): void;
   static objectOrGroupRenamedInEventsBasedObject(project: gdProject, globalObjectsContainer: gdObjectsContainer, eventsBasedObject: gdEventsBasedObject, oldName: string, newName: string, isObjectGroup: boolean): void;
   static objectRemovedInEventsBasedObject(project: gdProject, eventsBasedObject: gdEventsBasedObject, globalObjectsContainer: gdObjectsContainer, objectsContainer: gdObjectsContainer, objectName: string): void;
   static globalObjectOrGroupRenamed(project: gdProject, oldName: string, newName: string, isObjectGroup: boolean): void;
   static globalObjectRemoved(project: gdProject, objectName: string): void;
+  static behaviorsAddedToGlobalObject(project: gdProject, objectName: string): void;
   static getAllObjectTypesUsingEventsBasedBehavior(project: gdProject, eventsFunctionsExtension: gdEventsFunctionsExtension, eventsBasedBehavior: gdEventsBasedBehavior): gdSetString;
   static ensureBehaviorEventsFunctionsProperParameters(eventsFunctionsExtension: gdEventsFunctionsExtension, eventsBasedBehavior: gdEventsBasedBehavior): void;
   static ensureObjectEventsFunctionsProperParameters(eventsFunctionsExtension: gdEventsFunctionsExtension, eventsBasedObject: gdEventsBasedObject): void;

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1832,6 +1832,18 @@ export default class SceneEditor extends React.Component<Props, State> {
                             this.reloadResourcesFor(
                               editedObjectWithContext.object
                             );
+                            if (editedObjectWithContext.global) {
+                              gd.WholeProjectRefactorer.behaviorsAddedToGlobalObject(
+                                project,
+                                editedObjectWithContext.object.getName()
+                              );
+                            } else {
+                              gd.WholeProjectRefactorer.behaviorsAddedToObjectInLayout(
+                                project,
+                                layout,
+                                editedObjectWithContext.object.getName()
+                              );
+                            }
                           }
                           this.editObject(null);
                           this.updateBehaviorsSharedData();


### PR DESCRIPTION
There is also something to do to refactor extension events when:
- behavior parameters are added
- required behavior properties are added
- behaviors are attached to child-objects

But it's more complicated, I leave it for another day.