### PR TITLE
Fix game properties editor to avoid empty values to make project saving fail

### DIFF
--- a/newIDE/app/src/ProjectManager/LoadingScreenEditor.js
+++ b/newIDE/app/src/ProjectManager/LoadingScreenEditor.js
@@ -328,7 +328,7 @@ export const LoadingScreenEditor = ({
                 const currentProgressBarMinWidth = loadingScreen.getProgressBarMinWidth();
                 const newProgressBarMinWidth = Math.max(
                   0,
-                  parseFloat(newValue)
+                  parseFloat(newValue) || 0
                 );
                 if (currentProgressBarMinWidth === newProgressBarMinWidth) {
                   return;
@@ -347,7 +347,7 @@ export const LoadingScreenEditor = ({
                 const currentProgressBarWidthPercent = loadingScreen.getProgressBarWidthPercent();
                 const newProgressBarWidthPercent = Math.min(
                   100,
-                  Math.max(1, parseFloat(newValue))
+                  Math.max(1, parseFloat(newValue) || 0)
                 );
                 if (
                   currentProgressBarWidthPercent === newProgressBarWidthPercent
@@ -371,7 +371,7 @@ export const LoadingScreenEditor = ({
                 const currentProgressBarMaxWidth = loadingScreen.getProgressBarMaxWidth();
                 const newProgressBarMaxWidth = Math.max(
                   0,
-                  parseFloat(newValue)
+                  parseFloat(newValue) || 0
                 );
                 if (currentProgressBarMaxWidth === newProgressBarMaxWidth) {
                   return;
@@ -390,7 +390,10 @@ export const LoadingScreenEditor = ({
               value={'' + loadingScreen.getProgressBarHeight()}
               onChange={newValue => {
                 const currentProgressBarHeight = loadingScreen.getProgressBarHeight();
-                const newProgressBarHeight = Math.max(1, parseFloat(newValue));
+                const newProgressBarHeight = Math.max(
+                  1,
+                  parseFloat(newValue) || 0
+                );
                 if (currentProgressBarHeight === newProgressBarHeight) {
                   return;
                 }
@@ -427,7 +430,7 @@ export const LoadingScreenEditor = ({
             type="number"
             value={'' + loadingScreen.getMinDuration()}
             onChange={newValue => {
-              const newMinDuration = Math.max(0, parseFloat(newValue));
+              const newMinDuration = Math.max(0, parseFloat(newValue) || 0);
               if (
                 newMinDuration < forcedLogo.minDuration &&
                 !watermark.isGDevelopWatermarkShown() &&
@@ -466,7 +469,7 @@ export const LoadingScreenEditor = ({
               onChange={newValue => {
                 const newLogoAndProgressLogoFadeInDelay = Math.max(
                   0,
-                  parseFloat(newValue)
+                  parseFloat(newValue) || 0
                 );
                 if (
                   newLogoAndProgressLogoFadeInDelay >
@@ -507,7 +510,7 @@ export const LoadingScreenEditor = ({
               onChange={newValue => {
                 const newLogoAndProgressFadeInDuration = Math.max(
                   0,
-                  parseFloat(newValue)
+                  parseFloat(newValue) || 0
                 );
                 if (
                   newLogoAndProgressFadeInDuration >

--- a/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
+++ b/newIDE/app/src/ProjectManager/ProjectPropertiesDialog.js
@@ -491,7 +491,7 @@ const ProjectPropertiesDialog = (props: Props) => {
                     onChange={value => {
                       const newResolutionWidth = Math.max(
                         1,
-                        parseInt(value, 10)
+                        parseInt(value, 10) || 0
                       );
                       if (newResolutionWidth === gameResolutionWidth) {
                         return;
@@ -509,7 +509,7 @@ const ProjectPropertiesDialog = (props: Props) => {
                     onChange={value => {
                       const newResolutionHeight = Math.max(
                         1,
-                        parseInt(value, 10)
+                        parseInt(value, 10) || 0
                       );
                       if (newResolutionHeight === gameResolutionHeight) {
                         return;
@@ -570,7 +570,7 @@ const ProjectPropertiesDialog = (props: Props) => {
                     type="number"
                     value={'' + minFPS}
                     onChange={value => {
-                      const newMinFPS = Math.max(0, parseInt(value, 10));
+                      const newMinFPS = Math.max(0, parseInt(value, 10) || 0);
                       if (newMinFPS === minFPS) {
                         return;
                       }
@@ -586,7 +586,7 @@ const ProjectPropertiesDialog = (props: Props) => {
                     type="number"
                     value={'' + maxFPS}
                     onChange={value => {
-                      const newMaxFPS = Math.max(0, parseInt(value, 10));
+                      const newMaxFPS = Math.max(0, parseInt(value, 10) || 0);
                       if (newMaxFPS === maxFPS) {
                         return;
                       }


### PR DESCRIPTION
Fixes:
- https://forum.gdevelop.io/t/changing-minimum-loading-screen-duration-corrupts-file/57243

* Empty fields from `LoadingScreenEditor` were writing NaN in the project which leads to serialization error.
  ![image](https://github.com/4ian/GDevelop/assets/2611977/969d9e60-1421-4fcf-b103-eb5b8837457e)
* In `ProjectPropertiesDialog`, empty field were not causing any issue, but fields with a minimal value of `1` could be set to `0` as `NaN` go though `max` and was serialized as `0`