### PR TITLE
Add missing Spine Runtime license agreement and link to Spine website

### DIFF
--- a/Extensions/Spine/pixi-spine/Spine-Runtimes-License-Agreement.txt
+++ b/Extensions/Spine/pixi-spine/Spine-Runtimes-License-Agreement.txt
@@ -1,0 +1,11 @@
+Spine Runtimes License Agreement
+Last updated February 20, 2024. Replaces all prior versions.
+
+Copyright (c) 2013-2024, Esoteric Software LLC
+
+Integration of the Spine Runtimes into software or otherwise creating derivative works of the Spine Runtimes is permitted under the terms and conditions of Section 2 of the Spine Editor License Agreement:
+http://esotericsoftware.com/spine-editor-license
+
+Otherwise, it is permitted to integrate the Spine Runtimes into software or otherwise create derivative works of the Spine Runtimes (collectively, "Products"), provided that each user of the Products must obtain their own Spine Editor license and redistribution of the Products in any form must include this license and copyright notice.
+
+THE SPINE RUNTIMES ARE PROVIDED BY ESOTERIC SOFTWARE LLC "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ESOTERIC SOFTWARE LLC BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, BUSINESS INTERRUPTION, OR LOSS OF USE, DATA, OR PROFITS) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THE SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/newIDE/app/src/ObjectEditor/Editors/SpineEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpineEditor.js
@@ -30,6 +30,7 @@ import PixiResourcesLoader, {
 import useAlertDialog from '../../UI/Alert/useAlertDialog';
 import { PropertyResourceSelector, PropertyField } from './PropertyFields';
 import AlertMessage from '../../UI/AlertMessage';
+import Window from '../../Utils/Window';
 
 const gd: libGDevelop = global.gd;
 
@@ -47,6 +48,9 @@ const styles = {
     display: 'flex',
     flex: 1,
     alignItems: 'center',
+  },
+  neverShrinkingButton: {
+    flexShrink: 0,
   },
 };
 
@@ -307,9 +311,22 @@ const SpineEditor = ({
       <ScrollView ref={scrollView}>
         <ColumnStackLayout noMargin>
           {renderObjectNameField && renderObjectNameField()}
-          <AlertMessage kind="warning">
+          <AlertMessage
+            kind="warning"
+            renderRightButton={() => (
+              <FlatButton
+                style={styles.neverShrinkingButton}
+                label={<Trans>Purchase Spine</Trans>}
+                onClick={() =>
+                  Window.openExternalURL(
+                    'https://esotericsoftware.com/spine-purchase'
+                  )
+                }
+              />
+            )}
+          >
             <Trans>
-              You need to own a license of Spine to publish a game with a Spine
+              You must own a Spine license to publish a game with a Spine
               object.
             </Trans>
           </AlertMessage>


### PR DESCRIPTION
Fix #6679

<img width="633" alt="image" src="https://github.com/4ian/GDevelop/assets/1280130/5597a170-d9f9-468b-a072-29fe17846682">
