### PR TITLE
[Bug Fix] Fix Indent Scale dragging bug on higher scale.

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/DropContainer.js
@@ -139,6 +139,8 @@ type DropContainerProps = {|
 
   // Computes drop areas and drop indicator indent.
   windowSize: WindowSizeType,
+  // The Indent Scale used for the Events Sheet.
+  indentScale: number,
   // Used only for the node just above dragged node if it is an only child,
   // so that drop area covers the whole dragged node's row in height.
   draggedNodeHeight: number,
@@ -225,6 +227,7 @@ export function DropContainer({
   onDrop,
   activateTargets,
   windowSize,
+  indentScale,
   draggedNodeHeight,
   getNodeAtPath,
 }: DropContainerProps) {
@@ -234,7 +237,7 @@ export function DropContainer({
   // child of the event is the dragged one.
   const canHaveSubEvents = !!node.event && node.event.canHaveSubEvents();
 
-  const indentWidth = getIndentWidth(windowSize);
+  const indentWidth = getIndentWidth(windowSize) * indentScale;
   const dropAreaStyles = getTargetPositionStyles(
     indentWidth,
     draggedNodeHeight,

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -934,6 +934,7 @@ export default class ThemableEventsTree extends Component<
                   onDrop={this._onDrop}
                   activateTargets={!isDragged && !!this.state.draggedNode}
                   windowSize={this.props.windowSize}
+                  indentScale={this.props.indentScale}
                   getNodeAtPath={path =>
                     getNodeAtPath({
                       path,


### PR DESCRIPTION
Sorry guys! Apparently the indent scale introduced a bug which prevents you from dragging the top of the inner stack of events at higher scales. This was due to `getIndentWidth()` being used at DropContainer as well. I've included 'indentScale' to DropContainer as well to account for this. This will end up changing the "indentWidth" of the DropContainer to the necessary width.

And this time around, I've run `npm run flow` ("No errors!") and `npm run format`. :)

Sorry for the troubles guys.