### PR TITLE
Fix to avoid new variables from being added at the top

### DIFF
--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -538,7 +538,8 @@ const VariablesList = (props: Props) => {
   );
   // TODO Scroll to the initially selected variable and focus on the name.
   const [selectedNodes, doSetSelectedNodes] = React.useState<Array<string>>(
-    props.initiallySelectedVariableName
+    props.initiallySelectedVariableName &&
+      props.variablesContainer.has(props.initiallySelectedVariableName)
       ? [getNodeIdFromVariableName(props.initiallySelectedVariableName)]
       : []
   );


### PR DESCRIPTION
It happens when the variable from the parameter field doesn't exist.