### PR TITLE
Allow to properly open an example from a link or command line argument

### DIFF
--- a/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
+++ b/newIDE/app/src/AssetStore/ExampleStore/ExampleDialog.js
@@ -41,7 +41,7 @@ export const openExampleInWebApp = (example: Example) => {
   Window.openExternalURL(
     `${
       isDev ? 'http://localhost:3000' : 'https://editor.gdevelop.io'
-    }/?project=${example.projectFileUrl}`
+    }/?create-from-example=${example.slug}`
   );
 };
 

--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -102,6 +102,7 @@ export const create = (authentication: Authentication) => {
                 filterExamples: !Window.isDev(),
               })}
               initialFileMetadataToOpen={initialFileMetadataToOpen}
+              initialExampleSlugToOpen={appArguments['create-from-example'] || null}
             />
           )}
         </ProjectStorageProviders>

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -114,6 +114,7 @@ export const create = (authentication: Authentication) => {
                 filterExamples: !isDev,
               })}
               initialFileMetadataToOpen={initialFileMetadataToOpen}
+              initialExampleSlugToOpen={appArguments['create-from-example'] || null}
             />
           )}
         </ProjectStorageProviders>

--- a/newIDE/app/src/MainFrame/UseExampleOrGameTemplateDialogs.js
+++ b/newIDE/app/src/MainFrame/UseExampleOrGameTemplateDialogs.js
@@ -1,13 +1,17 @@
 // @flow
 
 import * as React from 'react';
-import type { ExampleShortHeader } from '../Utils/GDevelopServices/Example';
+import {
+  listAllExamples,
+  type ExampleShortHeader,
+} from '../Utils/GDevelopServices/Example';
 import type { PrivateGameTemplateListingData } from '../Utils/GDevelopServices/Shop';
 import ExampleStoreDialog from '../AssetStore/ExampleStore/ExampleStoreDialog';
 import { ExampleDialog } from '../AssetStore/ExampleStore/ExampleDialog';
 import PrivateGameTemplateInformationDialog from '../AssetStore/PrivateGameTemplates/PrivateGameTemplateInformationDialog';
 import { PrivateGameTemplateStoreContext } from '../AssetStore/PrivateGameTemplates/PrivateGameTemplateStoreContext';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
+import LoaderModal from '../UI/LoaderModal';
 
 type Props = {|
   isProjectOpening: boolean,
@@ -18,6 +22,7 @@ const useExampleOrGameTemplateDialogs = ({
   isProjectOpening,
   onOpenNewProjectSetupDialog,
 }: Props) => {
+  const [isFetchingExample, setIsFetchingExample] = React.useState(false);
   const [
     exampleStoreDialogOpen,
     setExampleStoreDialogOpen,
@@ -100,9 +105,37 @@ const useExampleOrGameTemplateDialogs = ({
     ]
   );
 
+  const fetchAndOpenNewProjectSetupDialogForExample = React.useCallback(
+    async (exampleSlug: string) => {
+      try {
+        setIsFetchingExample(true);
+        const fetchedAllExamples = await listAllExamples();
+        const exampleShortHeader = fetchedAllExamples.exampleShortHeaders.find(
+          exampleShortHeader => exampleShortHeader.slug === exampleSlug
+        );
+        if (!exampleShortHeader) {
+          throw new Error(
+            `Unable to find the example with slug "${exampleSlug}"`
+          );
+        }
+
+        setSelectedExampleShortHeader(exampleShortHeader);
+      } catch (error) {
+        console.error('Error caught while opening example:', error);
+        return;
+      } finally {
+        setIsFetchingExample(false);
+      }
+
+      onOpenNewProjectSetupDialog();
+    },
+    [setSelectedExampleShortHeader, onOpenNewProjectSetupDialog]
+  );
+
   const renderExampleOrGameTemplateDialogs = () => {
     return (
       <>
+        {isFetchingExample && <LoaderModal show />}
         {exampleStoreDialogOpen && (
           <ExampleStoreDialog
             open
@@ -168,6 +201,7 @@ const useExampleOrGameTemplateDialogs = ({
     onSelectExampleShortHeader: setSelectedExampleShortHeader,
     onSelectPrivateGameTemplate: setSelectedPrivateGameTemplate,
     renderExampleOrGameTemplateDialogs,
+    fetchAndOpenNewProjectSetupDialogForExample,
   };
 };
 

--- a/newIDE/app/src/ProjectCreation/CreateProject.js
+++ b/newIDE/app/src/ProjectCreation/CreateProject.js
@@ -15,6 +15,7 @@ export type NewProjectSource = {|
   project: ?gdProject,
   storageProvider: ?StorageProvider,
   fileMetadata: ?FileMetadata,
+  templateSlug?: ?string,
 |};
 
 const getNewProjectSourceFromUrl = (projectUrl: string): NewProjectSource => {
@@ -88,7 +89,9 @@ export const createNewProjectFromAIGeneratedProject = (
     exampleUrl: generatedProjectUrl,
     exampleSlug: 'generated-project',
   });
-  return getNewProjectSourceFromUrl(generatedProjectUrl);
+  const newProjectSource = getNewProjectSourceFromUrl(generatedProjectUrl);
+  newProjectSource.templateSlug = 'generated-project';
+  return newProjectSource;
 };
 
 export const createNewProjectFromTutorialTemplate = (
@@ -99,7 +102,9 @@ export const createNewProjectFromTutorialTemplate = (
     exampleUrl: tutorialTemplateUrl,
     exampleSlug: tutorialId,
   });
-  return getNewProjectSourceFromUrl(tutorialTemplateUrl);
+  const newProjectSource = getNewProjectSourceFromUrl(tutorialTemplateUrl);
+  newProjectSource.templateSlug = tutorialId;
+  return newProjectSource;
 };
 
 export const createNewProjectFromPrivateGameTemplate = (
@@ -110,7 +115,9 @@ export const createNewProjectFromPrivateGameTemplate = (
     exampleUrl: privateGameTemplateUrl,
     exampleSlug: privateGameTemplateTag,
   });
-  return getNewProjectSourceFromUrl(privateGameTemplateUrl);
+  const newProjectSource = getNewProjectSourceFromUrl(privateGameTemplateUrl);
+  newProjectSource.templateSlug = privateGameTemplateTag;
+  return newProjectSource;
 };
 
 export const createNewProjectFromExampleShortHeader = async ({
@@ -127,7 +134,9 @@ export const createNewProjectFromExampleShortHeader = async ({
       exampleUrl: example.projectFileUrl,
       exampleSlug: exampleShortHeader.slug,
     });
-    return getNewProjectSourceFromUrl(example.projectFileUrl);
+    const newProjectSource = getNewProjectSourceFromUrl(example.projectFileUrl);
+    newProjectSource.templateSlug = exampleShortHeader.slug;
+    return newProjectSource;
   } catch (error) {
     showErrorBox({
       message:

--- a/newIDE/app/src/ProjectCreation/NewProjectSetupDialog.js
+++ b/newIDE/app/src/ProjectCreation/NewProjectSetupDialog.js
@@ -67,7 +67,6 @@ export type NewProjectSetup = {|
   orientation?: 'landscape' | 'portrait' | 'default',
   optimizeForPixelArt?: boolean,
   allowPlayersToLogIn?: boolean,
-  templateSlug?: string,
 |};
 
 type Props = {|

--- a/newIDE/app/src/Utils/UseCreateProject.js
+++ b/newIDE/app/src/Utils/UseCreateProject.js
@@ -88,9 +88,6 @@ const useCreateProject = ({
     project.setVersion('1.0.0');
     project.getAuthorIds().clear();
     project.setAuthor('');
-    if (newProjectSetup.templateSlug) {
-      project.setTemplateSlug(newProjectSetup.templateSlug);
-    }
     if (newProjectSetup.width && newProjectSetup.height) {
       project.setGameResolutionSize(
         newProjectSetup.width,
@@ -141,6 +138,9 @@ const useCreateProject = ({
 
         const oldProjectId = currentProject.getProjectUuid();
         initialiseProjectProperties(currentProject, newProjectSetup);
+        if (newProjectSource.templateSlug) {
+          currentProject.setTemplateSlug(newProjectSource.templateSlug);
+        }
 
         if (authenticatedUser.profile) {
           // if the user is connected, try to register the game to avoid
@@ -276,10 +276,7 @@ const useCreateProject = ({
         i18n,
         exampleShortHeader,
       });
-      await createProject(newProjectSource, {
-        ...newProjectSetup,
-        templateSlug: exampleShortHeader.slug,
-      });
+      await createProject(newProjectSource, newProjectSetup);
     },
     [beforeCreatingProject, createProject]
   );


### PR DESCRIPTION
- Adds support for `editor.gdevelop.io?create-from-example=platformer` which opens the dialog like if the example was selected:


https://github.com/4ian/GDevelop/assets/1280130/7cafdef9-bfb9-4803-b6c9-4a0f50714a62

- This also works from the command line for the desktop app (pass `--create-from-example=...` on the command line).
- It's still possible to use an url with `editor.gdevelop.io?project=https://...` (useful for opening projects on GitHub. We could also have a `create-from-url=https://...` that properly creates a new project, and does the leaderboard duplication and all the usual work, but this would mean additional work to adapt the Create New Project dialog).