### PR TITLE
Swap properties to keep them at the same place in the instance properties

### DIFF
--- a/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/CompactPropertiesSchema.js
+++ b/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/CompactPropertiesSchema.js
@@ -507,9 +507,17 @@ export const makeSchema = ({
         title: i18n._(t`Rotation`),
         preventWrap: true,
         removeSpacers: true,
-        children: getRotationXAndRotationYFields({ i18n }),
+        children: [],
       },
-      getRotationZField({ i18n }),
+      {
+        children: [
+          getRotationZField({ i18n }),
+          {
+            type: 'row',
+            children: getRotationXAndRotationYFields({ i18n }),
+          },
+        ],
+      },
     ];
   }
 

--- a/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/CompactPropertiesSchema.js
+++ b/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/CompactPropertiesSchema.js
@@ -504,18 +504,12 @@ export const makeSchema = ({
       {
         name: 'Rotation',
         type: 'row',
-        title: i18n._(t`Rotation`),
         preventWrap: true,
         removeSpacers: true,
-        children: [],
-      },
-      {
+        title: i18n._(t`Rotation`),
         children: [
           getRotationZField({ i18n }),
-          {
-            type: 'row',
-            children: getRotationXAndRotationYFields({ i18n }),
-          },
+          ...getRotationXAndRotationYFields({ i18n }),
         ],
       },
     ];

--- a/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/CompactPropertiesSchema.js
+++ b/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/CompactPropertiesSchema.js
@@ -523,7 +523,6 @@ export const makeSchema = ({
       removeSpacers: true,
       children: getXAndYFields({ i18n }),
     },
-    getZOrderField({ i18n }),
     {
       name: 'Size',
       type: 'row',
@@ -562,6 +561,7 @@ export const makeSchema = ({
         },
       ],
     },
+    getZOrderField({ i18n }),
     getLayerField({ i18n, layout }),
     {
       name: 'Rotation',


### PR DESCRIPTION
Now the W H Z properties and Z rotation stay at the exact same place in the interface, whether it's a 2D or 3D instance.

In this PR, 2D and 3D:
![image](https://github.com/4ian/GDevelop/assets/1670670/9443acff-1772-43d0-83cb-efbfe81d9969)


Before this PR, 2D and 3D:

![image](https://github.com/4ian/GDevelop/assets/1670670/beeaf73b-6de0-4be6-9424-cb9879d2cd0b)
