### PR TITLE
Improve lobbies connections

### DIFF
--- a/Extensions/Multiplayer/JsExtension.js
+++ b/Extensions/Multiplayer/JsExtension.js
@@ -447,8 +447,8 @@ module.exports = {
 
     extension
       .addExpression(
-        'LastPlayerLeftNumber',
-        _('Last player left number'),
+        'LastLeftPlayerNumber',
+        _('Last left player number'),
         _('Returns the number of the player that has just left the lobby.'),
         _('Lobbies'),
         'JsPlatform/Extensions/multiplayer.svg'
@@ -523,8 +523,8 @@ module.exports = {
 
     extension
       .addExpression(
-        'LastPlayerJoinedNumber',
-        _('Last player joined number'),
+        'LastJoinedPlayerNumber',
+        _('Last joined player number'),
         _('Returns the number of the player that has just joined the lobby.'),
         _('Lobbies'),
         'JsPlatform/Extensions/multiplayer.svg'

--- a/Extensions/Multiplayer/JsExtension.js
+++ b/Extensions/Multiplayer/JsExtension.js
@@ -417,7 +417,7 @@ module.exports = {
       .addIncludeFile('Extensions/Multiplayer/messageManager.js')
       .addIncludeFile('Extensions/Multiplayer/multiplayerVariablesManager.js')
       .addIncludeFile('Extensions/Multiplayer/multiplayertools.js')
-      .setFunctionName('gdjs.multiplayerMessageManager.hasAnyPlayerLeft');
+      .setFunctionName('gdjs.multiplayerMessageManager.hasAnyPlayerJustLeft');
 
     extension
       .addCondition(
@@ -443,7 +443,108 @@ module.exports = {
       .addIncludeFile('Extensions/Multiplayer/messageManager.js')
       .addIncludeFile('Extensions/Multiplayer/multiplayerVariablesManager.js')
       .addIncludeFile('Extensions/Multiplayer/multiplayertools.js')
-      .setFunctionName('gdjs.multiplayerMessageManager.hasPlayerLeft');
+      .setFunctionName('gdjs.multiplayerMessageManager.hasPlayerJustLeft');
+
+    extension
+      .addExpression(
+        'LastPlayerLeftNumber',
+        _('Last player left number'),
+        _('Returns the number of the player that has just left the lobby.'),
+        _('Lobbies'),
+        'JsPlatform/Extensions/multiplayer.svg'
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/Multiplayer/peer.js')
+      .addIncludeFile('Extensions/Multiplayer/peerJsHelper.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
+      .addIncludeFile('Extensions/Multiplayer/multiplayercomponents.js')
+      .addIncludeFile('Extensions/Multiplayer/messageManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayerVariablesManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayertools.js')
+      .setFunctionName(
+        'gdjs.multiplayerMessageManager.getLatestPlayerWhoJustLeft'
+      );
+
+    extension
+      .addCondition(
+        'HasAnyPlayerJoined',
+        _('Any player has joined'),
+        _('Check if any player has joined the lobby.'),
+        _('Any player has joined'),
+        _('Lobbies'),
+        'JsPlatform/Extensions/multiplayer.svg',
+        'JsPlatform/Extensions/multiplayer.svg'
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/Multiplayer/peer.js')
+      .addIncludeFile('Extensions/Multiplayer/peerJsHelper.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
+      .addIncludeFile('Extensions/Multiplayer/multiplayercomponents.js')
+      .addIncludeFile('Extensions/Multiplayer/messageManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayerVariablesManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayertools.js')
+      .setFunctionName('gdjs.multiplayerMessageManager.hasAnyPlayerJustJoined');
+
+    extension
+      .addCondition(
+        'HasPlayerJoined',
+        _('Player has joined'),
+        _('Check if the player has joined the lobby.'),
+        _('Player _PARAM0_ has joined'),
+        _('Lobbies'),
+        'JsPlatform/Extensions/multiplayer.svg',
+        'JsPlatform/Extensions/multiplayer.svg'
+      )
+      .getCodeExtraInformation()
+      .addParameter('number', _('Player number'), '', false)
+      .setIncludeFile('Extensions/Multiplayer/peer.js')
+      .addIncludeFile('Extensions/Multiplayer/peerJsHelper.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
+      .addIncludeFile('Extensions/Multiplayer/multiplayercomponents.js')
+      .addIncludeFile('Extensions/Multiplayer/messageManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayerVariablesManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayertools.js')
+      .setFunctionName('gdjs.multiplayerMessageManager.hasPlayerJustJoined');
+
+    extension
+      .addExpression(
+        'LastPlayerJoinedNumber',
+        _('Last player joined number'),
+        _('Returns the number of the player that has just joined the lobby.'),
+        _('Lobbies'),
+        'JsPlatform/Extensions/multiplayer.svg'
+      )
+      .getCodeExtraInformation()
+      .setIncludeFile('Extensions/Multiplayer/peer.js')
+      .addIncludeFile('Extensions/Multiplayer/peerJsHelper.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
+      .addIncludeFile('Extensions/Multiplayer/multiplayercomponents.js')
+      .addIncludeFile('Extensions/Multiplayer/messageManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayerVariablesManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayertools.js')
+      .setFunctionName(
+        'gdjs.multiplayerMessageManager.getLatestPlayerWhoJustJoined'
+      );
 
     extension
       .addStrExpression(

--- a/Extensions/Multiplayer/messageManager.ts
+++ b/Extensions/Multiplayer/messageManager.ts
@@ -1942,7 +1942,10 @@ namespace gdjs {
       };
     };
     const hasSentHeartbeatRecently = () => {
-      return getTimeNow() - lastHeartbeatTimestamp < 1000 / heartbeatTickRate;
+      return (
+        !!lastHeartbeatTimestamp &&
+        getTimeNow() - lastHeartbeatTimestamp < 1000 / heartbeatTickRate
+      );
     };
     const handleHeartbeatsToSend = () => {
       // Only host sends heartbeats to all players regularly:
@@ -2302,10 +2305,6 @@ namespace gdjs {
       gdjs.multiplayer.handleLobbyGameEnded();
     };
 
-    const updatePlayersInfoForTests = (playersInfo) => {
-      _playersInfo = playersInfo;
-    };
-
     const clearMessagesTempData = () => {
       _playersLastRoundTripTimes = {};
       _playersInfo = {};
@@ -2365,7 +2364,6 @@ namespace gdjs {
       getCurrentPlayerPing,
       getPlayerUsername,
       getPlayerId,
-      updatePlayersInfoForTests,
       // Connected players.
       handleJustDisconnectedPeers,
       getConnectedPlayers,

--- a/Extensions/Multiplayer/messageManager.ts
+++ b/Extensions/Multiplayer/messageManager.ts
@@ -98,7 +98,8 @@ namespace gdjs {
     let lastSentGameSyncData: GameNetworkSyncData | null = null;
     let numberOfForcedGameUpdates = 0;
 
-    // Send heartbeat messages to host to ensure the connection is still alive.
+    // Send heartbeat messages from host to players, sensuring their connection is still alive,
+    // measure the ping, and send other useful info.
     const heartbeatTickRate = 1;
     let lastHeartbeatTimestamp = 0;
     let _playersLastHeartbeatInfo: {
@@ -1868,6 +1869,7 @@ namespace gdjs {
           // If we are not the host, save what the host told us about the pings and respond
           // with a heartbeat immediately.
           if (!gdjs.multiplayer.isPlayerHost()) {
+            const currentPlayerNumber = gdjs.multiplayer.getCurrentPlayerNumber();
             _playersPings = messageData.playersPings;
             const {
               messageName: answerMessageName,
@@ -1876,6 +1878,12 @@ namespace gdjs {
               heartbeatSentAt: messageData.now, // We send back the time we received, so that the host can compute the ping.
             });
             sendDataTo([messageSender], answerMessageName, answerMessageData);
+            // We have received a heartbeat from the host, informing us of our ping,
+            // so we can consider the connection as working.
+            if (_playersPings[currentPlayerNumber] !== undefined) {
+              gdjs.multiplayer.markConnectionAsConnected();
+            }
+
             return;
           }
 

--- a/Extensions/Multiplayer/multiplayerVariablesManager.ts
+++ b/Extensions/Multiplayer/multiplayerVariablesManager.ts
@@ -208,7 +208,10 @@ namespace gdjs {
     };
 
     const handleChangeVariableOwnerMessagesToSend = function () {
-      if (!gdjs.multiplayer.isLobbyGameRunning()) {
+      if (
+        !gdjs.multiplayer.isLobbyGameRunning() ||
+        !gdjs.multiplayer.isReadyToSendOrReceiveGameUpdateMessages()
+      ) {
         return;
       }
 

--- a/Extensions/Multiplayer/multiplayercomponents.ts
+++ b/Extensions/Multiplayer/multiplayercomponents.ts
@@ -11,6 +11,8 @@ namespace gdjs {
 
     let canLobbyBeClosed = true;
 
+    const notificationContainerIds: string[] = [];
+
     export const getDomElementContainer = (
       runtimeScene: gdjs.RuntimeScene
     ): HTMLDivElement | null => {
@@ -387,7 +389,7 @@ namespace gdjs {
       // to allow the player to leave the lobby.
       setTimeout(() => {
         closeContainer.style.visibility = 'inherit';
-      }, 5000);
+      }, 10000);
     };
 
     /**
@@ -398,7 +400,6 @@ namespace gdjs {
     ) {
       showNotification(
         runtimeScene,
-        'error-notification',
         'An error occurred while displaying the game lobbies, please try again.',
         'error'
       );
@@ -411,26 +412,58 @@ namespace gdjs {
       runtimeScene: gdjs.RuntimeScene,
       playerName: string
     ) {
-      showNotification(
-        runtimeScene,
-        'player-left-notification',
-        `${playerName} has left the game.`,
-        'warning'
-      );
+      showNotification(runtimeScene, `${playerName} left.`, 'warning');
     };
 
     /**
-     * Create, display, and hide a notification when a player leaves the game.
+     * Create, display, and hide a notification when a player joins the game.
+     */
+    export const displayPlayerJoinedNotification = function (
+      runtimeScene: gdjs.RuntimeScene,
+      playerName: string
+    ) {
+      showNotification(runtimeScene, `${playerName} joined.`, 'success');
+    };
+
+    /**
+     * Create, display, and hide a notification when an error happens on connection.
      */
     export const displayConnectionErrorNotification = function (
       runtimeScene: gdjs.RuntimeScene
     ) {
       showNotification(
         runtimeScene,
-        'connection-error-notification',
         'Could not connect to other players.',
         'error'
       );
+    };
+
+    const removeNotificationAndShiftOthers = function (
+      notificationContainerId: string
+    ) {
+      logger.info('Removing notification:', notificationContainerId);
+      const notification = document.getElementById(notificationContainerId);
+      if (!notification) {
+        logger.error('Notification not found.');
+        return;
+      }
+      const index = notificationContainerIds.indexOf(notificationContainerId);
+      if (index !== -1) {
+        notificationContainerIds.splice(index, 1);
+      }
+      notification.remove();
+
+      // Shift the other notifications up.
+      for (let i = 0; i < notificationContainerIds.length; i++) {
+        const notification = document.getElementById(
+          notificationContainerIds[i]
+        );
+        if (!notification) {
+          logger.error('Notification not found.');
+          continue;
+        }
+        notification.style.top = `${12 + i * 32}px`;
+      }
     };
 
     /**
@@ -438,10 +471,24 @@ namespace gdjs {
      */
     export const showNotification = function (
       runtimeScene: gdjs.RuntimeScene,
-      id: string,
       content: string,
       type: 'success' | 'warning' | 'error'
     ) {
+      // When we show a notification, we add it below the other ones.
+      // We also remove the oldest one if there are too many > 5.
+      if (notificationContainerIds.length > 5) {
+        const oldestNotificationId = notificationContainerIds.shift();
+        if (!oldestNotificationId) {
+          logger.error('No oldest notification ID found.');
+          return;
+        }
+
+        removeNotificationAndShiftOthers(oldestNotificationId);
+      }
+
+      // We generate a random ID for the notification, so they can stack.
+      const id = `notification-${Math.random().toString(36).substring(7)}`;
+
       const domContainer = runtimeScene
         .getGame()
         .getRenderer()
@@ -461,7 +508,8 @@ namespace gdjs {
           : type === 'warning'
           ? '#FFA500'
           : '#FF0000';
-      divContainer.style.top = '12px';
+      // Space the notifications vertically, based on how many there are.
+      divContainer.style.top = `${12 + notificationContainerIds.length * 32}px`;
       divContainer.style.right = '16px';
       divContainer.style.padding = '6px 32px 6px 6px';
       // Use zIndex 1 to make sure it is below the iframe.
@@ -496,8 +544,9 @@ namespace gdjs {
       loggedText.style.margin = '0px';
 
       divContainer.appendChild(loggedText);
-
       domContainer.appendChild(divContainer);
+      notificationContainerIds.push(id);
+
       const animationTime = 700;
       const notificationTime = 5000;
       setTimeout(() => {
@@ -518,7 +567,7 @@ namespace gdjs {
       }, notificationTime);
       // Use timeout because onanimationend listener does not work.
       setTimeout(() => {
-        divContainer.remove();
+        removeNotificationAndShiftOthers(id);
       }, notificationTime + animationTime);
     };
 

--- a/Extensions/Multiplayer/multiplayercomponents.ts
+++ b/Extensions/Multiplayer/multiplayercomponents.ts
@@ -441,7 +441,6 @@ namespace gdjs {
     const removeNotificationAndShiftOthers = function (
       notificationContainerId: string
     ) {
-      logger.info('Removing notification:', notificationContainerId);
       const notification = document.getElementById(notificationContainerId);
       if (!notification) {
         logger.error('Notification not found.');

--- a/Extensions/Multiplayer/multiplayertools.ts
+++ b/Extensions/Multiplayer/multiplayertools.ts
@@ -11,7 +11,7 @@ namespace gdjs {
     /** Set to true in testing to avoid relying on the multiplayer extension. */
     export let disableMultiplayerForTesting = false;
 
-    let isReadyToSendOrReceiveGameUpdateMessages = false;
+    export let _isReadyToSendOrReceiveGameUpdateMessages = false;
 
     let _isGameRegistered: boolean | null = null;
     let _isCheckingIfGameIsRegistered = false;
@@ -50,7 +50,7 @@ namespace gdjs {
 
         gdjs.multiplayerMessageManager.handleHeartbeatsToSend();
 
-        if (!isReadyToSendOrReceiveGameUpdateMessages) return;
+        if (!_isReadyToSendOrReceiveGameUpdateMessages) return;
 
         gdjs.multiplayerMessageManager.handleChangeInstanceOwnerMessagesReceived(
           runtimeScene
@@ -82,7 +82,7 @@ namespace gdjs {
 
         gdjs.multiplayerMessageManager.handleHeartbeatsReceived();
 
-        if (!isReadyToSendOrReceiveGameUpdateMessages) return;
+        if (!_isReadyToSendOrReceiveGameUpdateMessages) return;
 
         gdjs.multiplayerMessageManager.handleDestroyInstanceMessagesReceived(
           runtimeScene
@@ -794,7 +794,7 @@ namespace gdjs {
 
       // If we are connected to players, then the game can start.
       logger.info('Lobby game has started.');
-      isReadyToSendOrReceiveGameUpdateMessages = true;
+      _isReadyToSendOrReceiveGameUpdateMessages = true;
       _hasLobbyGameJustStarted = true;
       _isLobbyGameRunning = true;
       removeLobbiesContainer(runtimeScene);
@@ -816,7 +816,7 @@ namespace gdjs {
       _lobbyId = null;
       _lobby = null;
       playerNumber = null;
-      isReadyToSendOrReceiveGameUpdateMessages = false;
+      _isReadyToSendOrReceiveGameUpdateMessages = false;
       if (_lobbyHeartbeatInterval) {
         clearInterval(_lobbyHeartbeatInterval);
       }
@@ -892,7 +892,7 @@ namespace gdjs {
       );
 
       // As the host, start sending messages to the players.
-      isReadyToSendOrReceiveGameUpdateMessages = true;
+      _isReadyToSendOrReceiveGameUpdateMessages = true;
     };
 
     /**

--- a/Extensions/Multiplayer/multiplayertools.ts
+++ b/Extensions/Multiplayer/multiplayertools.ts
@@ -72,9 +72,11 @@ namespace gdjs {
       (runtimeScene: gdjs.RuntimeScene) => {
         if (disableMultiplayerForTesting) return;
 
+        // Handle joining and leaving players to show notifications accordingly.
         handleLeavingPlayer(runtimeScene);
         handleJoiningPlayer(runtimeScene);
-        // Joining players are handled in the heartbeats directly.
+
+        // Then look at the heartbeats received to know if a new player has joined/left.
         gdjs.multiplayerMessageManager.handleHeartbeatsReceived();
 
         gdjs.multiplayerMessageManager.handleDestroyInstanceMessagesReceived(
@@ -171,7 +173,7 @@ namespace gdjs {
      * Returns the number of players in the lobby.
      */
     export const getPlayersInLobbyCount = () => {
-      // Wether the lobby game has started or not, the number of players in the lobby
+      // Whether the lobby game has started or not, the number of players in the lobby
       // is the number of connected players.
       return gdjs.multiplayerMessageManager.getNumberOfConnectedPlayers();
     };
@@ -543,8 +545,8 @@ namespace gdjs {
         },
         // Specify the origin to avoid leaking the playerToken.
         // Replace with '*' to test locally.
-        // 'https://gd.games'
-        '*'
+        'https://gd.games'
+        // '*'
       );
     };
 
@@ -691,12 +693,7 @@ namespace gdjs {
       // If we are connected to players, then the game can start.
       logger.info('Lobby game has started.');
       // In case we're joining an existing lobby, read the saved messages to catch-up with the game state.
-      gdjs.multiplayerMessageManager.handleUpdateGameMessagesSaved(
-        runtimeScene
-      );
-      gdjs.multiplayerMessageManager.handleUpdateSceneMessagesSaved(
-        runtimeScene
-      );
+      gdjs.multiplayerMessageManager.handleSavedUpdateMessages(runtimeScene);
       _isReadyToSendOrReceiveGameUpdateMessages = true;
       _hasLobbyGameJustStarted = true;
       _isLobbyGameRunning = true;

--- a/Extensions/Multiplayer/peerJsHelper.ts
+++ b/Extensions/Multiplayer/peerJsHelper.ts
@@ -428,7 +428,7 @@ namespace gdjs {
     export const isReady = () => ready;
 
     /**
-     * Return any disconnected peers.
+     * Return peers that have disconnected in the frame.
      */
     export const getJustDisconnectedPeers = () => justDisconnectedPeers;
 

--- a/Extensions/Multiplayer/peerJsHelper.ts
+++ b/Extensions/Multiplayer/peerJsHelper.ts
@@ -254,6 +254,11 @@ namespace gdjs {
       connection.on('close', () => {
         _onDisconnect(connection.peer);
       });
+      connection.on('iceStateChanged', (state) => {
+        if (state === 'disconnected') {
+          _onDisconnect(connection.peer);
+        }
+      });
 
       // Regularly check for disconnection as the built in way is not reliable.
       (function disconnectChecker() {

--- a/Extensions/Multiplayer/tests/multiplayer.spec.js
+++ b/Extensions/Multiplayer/tests/multiplayer.spec.js
@@ -42,8 +42,8 @@ describe('Multiplayer', () => {
               actionOnPlayerDisconnect: 'Destroy',
             },
             {
-              name: 'AnchorBehavior',
-              type: 'AnchorBehavior::AnchorBehavior',
+              name: 'DummyBehavior',
+              type: 'MyDummyExtension::DummyBehavior',
             },
           ],
           effects: [],
@@ -313,14 +313,14 @@ describe('Multiplayer', () => {
   };
 
   beforeEach(() => {
-    _originalP2pIfAny = gdjs.evtTools.p2p;
+    _originalP2pIfAny = gdjs.multiplayerPeerJsHelper;
     gdjs.multiplayer.disableMultiplayerForTesting = false;
     gdjs.multiplayer._isLobbyGameRunning = true;
     gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = true;
     gdjs.multiplayer._lobby = fakeLobby;
   });
   afterEach(() => {
-    gdjs.evtTools.p2p = _originalP2pIfAny;
+    gdjs.multiplayerPeerJsHelper = _originalP2pIfAny;
     gdjs.multiplayer.disableMultiplayerForTesting = true;
     gdjs.multiplayer._isLobbyGameRunning = false;
     gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = false;
@@ -2087,15 +2087,14 @@ describe('Multiplayer', () => {
         p1RuntimeScene,
         'MySpriteObject'
       )[0];
-      // Ensure anchor behavior is there.
-      /** @type {gdjs.AnchorRuntimeBehavior | null} */
-      // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-      const p1AnchorBehaviorOriginal = p1SpriteObjectOriginal.getBehavior(
-        'AnchorBehavior'
+      // Ensure dummy behavior is there.
+      /** @type {gdjs.DummyRuntimeBehavior | null} */
+      // @ts-ignore - We know this returns an DummyRuntimeBehavior
+      const p1DummyBehaviorOriginal = p1SpriteObjectOriginal.getBehavior(
+        'DummyBehavior'
       );
-      if (!p1AnchorBehaviorOriginal)
-        throw new Error('No anchor behavior found');
-      expect(p1AnchorBehaviorOriginal._activated).to.be(true);
+      if (!p1DummyBehaviorOriginal) throw new Error('No dummy behavior found');
+      expect(p1DummyBehaviorOriginal._activated).to.be(true);
 
       p1RuntimeScene.renderAndStep(1000 / 60);
 
@@ -2114,15 +2113,14 @@ describe('Multiplayer', () => {
         p2RuntimeScene,
         'MySpriteObject'
       )[0];
-      // Ensure anchor behavior is there.
-      /** @type {gdjs.AnchorRuntimeBehavior | null} */
-      // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-      const p2AnchorBehaviorOriginal = p2SpriteObjectOriginal.getBehavior(
-        'AnchorBehavior'
+      // Ensure dummy behavior is there.
+      /** @type {gdjs.DummyRuntimeBehavior | null} */
+      // @ts-ignore - We know this returns an DummyRuntimeBehavior
+      const p2DummyBehaviorOriginal = p2SpriteObjectOriginal.getBehavior(
+        'DummyBehavior'
       );
-      if (!p2AnchorBehaviorOriginal)
-        throw new Error('No anchor behavior found');
-      expect(p2AnchorBehaviorOriginal._activated).to.be(true);
+      if (!p2DummyBehaviorOriginal) throw new Error('No dummy behavior found');
+      expect(p2DummyBehaviorOriginal._activated).to.be(true);
 
       // Deactivate the behavior on the player 2
       {
@@ -2138,12 +2136,12 @@ describe('Multiplayer', () => {
           p2RuntimeScene,
           'MySpriteObject'
         )[0];
-        /** @type {gdjs.AnchorRuntimeBehavior | null} */
-        // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-        const p2AnchorBehavior = p2SpriteObject.getBehavior('AnchorBehavior');
-        if (!p2AnchorBehavior) throw new Error('No anchor behavior found');
-        expect(p2AnchorBehavior._activated).to.be(true);
-        p2AnchorBehavior.activate(false);
+        /** @type {gdjs.DummyRuntimeBehavior | null} */
+        // @ts-ignore - We know this returns an DummyRuntimeBehavior
+        const p2DummyBehavior = p2SpriteObject.getBehavior('DummyBehavior');
+        if (!p2DummyBehavior) throw new Error('No dummy behavior found');
+        expect(p2DummyBehavior._activated).to.be(true);
+        p2DummyBehavior.activate(false);
         p2RuntimeScene.renderAndStep(1000 / 60);
       }
 
@@ -2176,11 +2174,11 @@ describe('Multiplayer', () => {
           p2RuntimeScene,
           'MySpriteObject'
         )[0];
-        /** @type {gdjs.AnchorRuntimeBehavior | null} */
-        // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-        const p2AnchorBehavior = p2SpriteObject.getBehavior('AnchorBehavior');
-        if (!p2AnchorBehavior) throw new Error('No anchor behavior found');
-        expect(p2AnchorBehavior._activated).to.be(true);
+        /** @type {gdjs.DummyRuntimeBehavior | null} */
+        // @ts-ignore - We know this returns an DummyRuntimeBehavior
+        const p2DummyBehavior = p2SpriteObject.getBehavior('DummyBehavior');
+        if (!p2DummyBehavior) throw new Error('No dummy behavior found');
+        expect(p2DummyBehavior._activated).to.be(true);
       }
 
       // Deactivate the behavior on the host.
@@ -2197,11 +2195,11 @@ describe('Multiplayer', () => {
           p1RuntimeScene,
           'MySpriteObject'
         )[0];
-        /** @type {gdjs.AnchorRuntimeBehavior | null} */
-        // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-        const p1AnchorBehavior = p1SpriteObject.getBehavior('AnchorBehavior');
-        if (!p1AnchorBehavior) throw new Error('No anchor behavior found');
-        p1AnchorBehavior.activate(false);
+        /** @type {gdjs.DummyRuntimeBehavior | null} */
+        // @ts-ignore - We know this returns an DummyRuntimeBehavior
+        const p1DummyBehavior = p1SpriteObject.getBehavior('DummyBehavior');
+        if (!p1DummyBehavior) throw new Error('No dummy behavior found');
+        p1DummyBehavior.activate(false);
         // As the object is not moving, it will not be synced a lot, so we need to wait a bit.
         await delay(20);
         p1RuntimeScene.renderAndStep(1000 / 60);
@@ -2224,11 +2222,11 @@ describe('Multiplayer', () => {
           p2RuntimeScene,
           'MySpriteObject'
         )[0];
-        /** @type {gdjs.AnchorRuntimeBehavior | null} */
-        // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-        const p2AnchorBehavior = p2SpriteObject.getBehavior('AnchorBehavior');
-        if (!p2AnchorBehavior) throw new Error('No anchor behavior found');
-        expect(p2AnchorBehavior._activated).to.be(false);
+        /** @type {gdjs.DummyRuntimeBehavior | null} */
+        // @ts-ignore - We know this returns an DummyRuntimeBehavior
+        const p2DummyBehavior = p2SpriteObject.getBehavior('DummyBehavior');
+        if (!p2DummyBehavior) throw new Error('No dummy behavior found');
+        expect(p2DummyBehavior._activated).to.be(false);
       }
     });
 
@@ -2251,19 +2249,18 @@ describe('Multiplayer', () => {
         p1RuntimeScene,
         'MySpriteObject'
       )[0];
-      // Ensure anchor behavior is there.
-      /** @type {gdjs.AnchorRuntimeBehavior | null} */
-      // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-      const p1AnchorBehaviorOriginal = p1SpriteObjectOriginal.getBehavior(
-        'AnchorBehavior'
+      // Ensure dummy behavior is there.
+      /** @type {gdjs.DummyRuntimeBehavior | null} */
+      // @ts-ignore - We know this returns an DummyRuntimeBehavior
+      const p1DummyBehaviorOriginal = p1SpriteObjectOriginal.getBehavior(
+        'DummyBehavior'
       );
-      if (!p1AnchorBehaviorOriginal)
-        throw new Error('No anchor behavior found');
-      expect(p1AnchorBehaviorOriginal._activated).to.be(true);
+      if (!p1DummyBehaviorOriginal) throw new Error('No dummy behavior found');
+      expect(p1DummyBehaviorOriginal._activated).to.be(true);
       // Deactivate it and mark it as not synchronized.
-      p1AnchorBehaviorOriginal.activate(false);
+      p1DummyBehaviorOriginal.activate(false);
       p1SpriteMultiplayerObjectBehavior.enableBehaviorSynchronization(
-        'AnchorBehavior',
+        'DummyBehavior',
         false
       );
 
@@ -2284,17 +2281,16 @@ describe('Multiplayer', () => {
         p2RuntimeScene,
         'MySpriteObject'
       )[0];
-      // Ensure anchor behavior is there.
-      /** @type {gdjs.AnchorRuntimeBehavior | null} */
-      // @ts-ignore - We know this returns an AnchorRuntimeBehavior
-      const p2AnchorBehaviorOriginal = p2SpriteObjectOriginal.getBehavior(
-        'AnchorBehavior'
+      // Ensure dummy behavior is there.
+      /** @type {gdjs.DummyRuntimeBehavior | null} */
+      // @ts-ignore - We know this returns an DummyRuntimeBehavior
+      const p2DummyBehaviorOriginal = p2SpriteObjectOriginal.getBehavior(
+        'DummyBehavior'
       );
-      if (!p2AnchorBehaviorOriginal)
-        throw new Error('No anchor behavior found');
+      if (!p2DummyBehaviorOriginal) throw new Error('No dummy behavior found');
 
       // It is activated as it is not synchronized.
-      expect(p2AnchorBehaviorOriginal._activated).to.be(true);
+      expect(p2DummyBehaviorOriginal._activated).to.be(true);
     });
   });
 

--- a/Extensions/Multiplayer/tests/multiplayer.spec.js
+++ b/Extensions/Multiplayer/tests/multiplayer.spec.js
@@ -316,12 +316,14 @@ describe('Multiplayer', () => {
     _originalP2pIfAny = gdjs.evtTools.p2p;
     gdjs.multiplayer.disableMultiplayerForTesting = false;
     gdjs.multiplayer._isLobbyGameRunning = true;
+    gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = true;
     gdjs.multiplayer._lobby = fakeLobby;
   });
   afterEach(() => {
     gdjs.evtTools.p2p = _originalP2pIfAny;
     gdjs.multiplayer.disableMultiplayerForTesting = true;
     gdjs.multiplayer._isLobbyGameRunning = false;
+    gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = false;
     gdjs.multiplayer._lobby = null;
   });
 
@@ -2230,7 +2232,7 @@ describe('Multiplayer', () => {
       }
     });
 
-    it.only('does not synchronize object behaviors if defined as not synchronized', async () => {
+    it('does not synchronize object behaviors if defined as not synchronized', async () => {
       const { switchToPeer } = createMultiplayerManagersMock();
 
       // Create an instance on the host's game:

--- a/Extensions/Multiplayer/tests/multiplayer.spec.js
+++ b/Extensions/Multiplayer/tests/multiplayer.spec.js
@@ -83,6 +83,11 @@ describe('Multiplayer', () => {
 
   const makeTestRuntimeSceneWithNetworkId = (timeDelta = 1000 / 60) => {
     const runtimeGame = gdjs.getPixiRuntimeGame();
+    gdjs.projectData = {
+      properties: {
+        projectUuid: 'fake-hardcoded-project-uuid',
+      },
+    };
     const runtimeScene = new gdjs.TestRuntimeScene(runtimeGame);
     runtimeScene.loadFromScene(
       getFakeSceneAndExtensionData({ name: 'Scene1' })
@@ -252,10 +257,22 @@ describe('Multiplayer', () => {
           gdjs.makeMultiplayerVariablesManager();
 
         // Ensure the messageManager is aware of the other players.
-        gdjs.multiplayerMessageManager.updatePlayersPingsForTests({
-          1: 0,
-          2: 20,
-          3: 40,
+        gdjs.multiplayerMessageManager.updatePlayersInfoForTests({
+          1: {
+            ping: 0,
+            playerId: 'player-1',
+            username: 'Player 1',
+          },
+          2: {
+            ping: 20,
+            playerId: 'player-2',
+            username: 'Player 2',
+          },
+          3: {
+            ping: 40,
+            playerId: 'player-3',
+            username: 'Player 3',
+          },
         });
 
         // Switch the state of the game.
@@ -292,39 +309,17 @@ describe('Multiplayer', () => {
 
   let _originalP2pIfAny = undefined;
 
-  const fakeLobby = {
-    id: 'fake-lobby-id',
-    name: 'Fake lobby',
-    status: 'Playing',
-    players: [
-      {
-        playerId: 'player-1',
-        status: 'Playing',
-      },
-      {
-        playerId: 'player-2',
-        status: 'Playing',
-      },
-      {
-        playerId: 'player-3',
-        status: 'Playing',
-      },
-    ],
-  };
-
   beforeEach(() => {
     _originalP2pIfAny = gdjs.multiplayerPeerJsHelper;
     gdjs.multiplayer.disableMultiplayerForTesting = false;
     gdjs.multiplayer._isLobbyGameRunning = true;
     gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = true;
-    gdjs.multiplayer._lobby = fakeLobby;
   });
   afterEach(() => {
     gdjs.multiplayerPeerJsHelper = _originalP2pIfAny;
     gdjs.multiplayer.disableMultiplayerForTesting = true;
     gdjs.multiplayer._isLobbyGameRunning = false;
     gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = false;
-    gdjs.multiplayer._lobby = null;
   });
 
   describe('Single scene tests', () => {

--- a/Extensions/Multiplayer/tests/multiplayer.spec.js
+++ b/Extensions/Multiplayer/tests/multiplayer.spec.js
@@ -84,6 +84,7 @@ describe('Multiplayer', () => {
   const makeTestRuntimeSceneWithNetworkId = (timeDelta = 1000 / 60) => {
     const runtimeGame = gdjs.getPixiRuntimeGame();
     gdjs.projectData = {
+      // @ts-ignore - we don't set all project props.
       properties: {
         projectUuid: 'fake-hardcoded-project-uuid',
       },

--- a/newIDE/app/src/GameDashboard/MultiplayerAdmin.js
+++ b/newIDE/app/src/GameDashboard/MultiplayerAdmin.js
@@ -22,6 +22,7 @@ import { getHelpLink } from '../Utils/HelpLink';
 import Window from '../Utils/Window';
 import SelectField from '../UI/SelectField';
 import SelectOption from '../UI/SelectOption';
+import InlineCheckbox from '../UI/InlineCheckbox';
 
 const defaultMaximumNumberOfPlayers = 4;
 const minimumValueForMaximumNumberOfPlayers = 2;
@@ -37,6 +38,9 @@ const MultiplayerAdmin = ({ gameId }: Props) => {
   const [isSaving, setIsSaving] = React.useState<boolean>(false);
   const [maxPlayersValue, setMaxPlayersValue] = React.useState<number>(2);
   const [minPlayersValue, setMinPlayersValue] = React.useState<number>(1);
+  const [canJoinAfterStart, setCanJoinAfterStart] = React.useState<boolean>(
+    false
+  );
   const { getAuthorizationHeader, profile, limits } = React.useContext(
     AuthenticatedUserContext
   );
@@ -55,6 +59,7 @@ const MultiplayerAdmin = ({ gameId }: Props) => {
       if (lobbyConfiguration) {
         setMaxPlayersValue(lobbyConfiguration.maxPlayers);
         setMinPlayersValue(lobbyConfiguration.minPlayers);
+        setCanJoinAfterStart(lobbyConfiguration.canJoinAfterStart);
         return;
       }
 
@@ -165,6 +170,7 @@ const MultiplayerAdmin = ({ gameId }: Props) => {
             gameId,
             maxPlayers: maxPlayersValue,
             minPlayers: minPlayersValue,
+            canJoinAfterStart,
           }
         );
         setLobbyConfiguration(updatedLobbyConfiguration);
@@ -183,13 +189,21 @@ const MultiplayerAdmin = ({ gameId }: Props) => {
         setIsSaving(false);
       }
     },
-    [getAuthorizationHeader, gameId, userId, maxPlayersValue, minPlayersValue]
+    [
+      getAuthorizationHeader,
+      gameId,
+      userId,
+      maxPlayersValue,
+      minPlayersValue,
+      canJoinAfterStart,
+    ]
   );
 
   const hasUnsavedModifications =
     lobbyConfiguration &&
     (lobbyConfiguration.maxPlayers !== maxPlayersValue ||
-      lobbyConfiguration.minPlayers !== minPlayersValue);
+      lobbyConfiguration.minPlayers !== minPlayersValue ||
+      lobbyConfiguration.canJoinAfterStart !== canJoinAfterStart);
   const canSave = hasUnsavedModifications;
 
   const helpLink = getHelpLink('/all-features/multiplayer/');
@@ -255,6 +269,17 @@ const MultiplayerAdmin = ({ gameId }: Props) => {
           >
             {maxPlayersSelectOptions}
           </SelectField>
+        </Line>
+        <Line noMargin>
+          <InlineCheckbox
+            label={
+              <Trans>Allow players to join after the game has started</Trans>
+            }
+            checked={canJoinAfterStart}
+            onCheck={(e, checked) => {
+              setCanJoinAfterStart(checked);
+            }}
+          />
         </Line>
         <Line noMargin justifyContent="flex-end">
           <LeftLoader isLoading={isSaving}>

--- a/newIDE/app/src/Utils/GDevelopServices/Play.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Play.js
@@ -95,6 +95,7 @@ export type LobbyConfiguration = {|
   gameId: string,
   maxPlayers: number,
   minPlayers: number,
+  canJoinAfterStart: boolean,
 |};
 
 export const shortenUuidForDisplay = (uuid: string): string =>
@@ -483,16 +484,18 @@ export const updateLobbyConfiguration = async (
     gameId,
     maxPlayers,
     minPlayers,
+    canJoinAfterStart,
   }: {|
     gameId: string,
     maxPlayers: number,
     minPlayers: number,
+    canJoinAfterStart: boolean,
   |}
 ): Promise<LobbyConfiguration> => {
   const authorizationHeader = await getAuthorizationHeader();
   const response = await axios.patch(
     `${GDevelopPlayApi.baseUrl}/game/${gameId}/lobby-configuration`,
-    { maxPlayers, minPlayers },
+    { maxPlayers, minPlayers, canJoinAfterStart },
     {
       params: { userId },
       headers: {


### PR DESCRIPTION
Main things are:
- A player is now considered connected only after a couple heartbeats, allowing to start the lobby faster (or slower) and not based on a random countdown
- A player can now join a lobby mid-game, if defined in the lobby configuration in the game dashboard.
  - New actions & conditions help in case there is a need to handle a new player coming (though the default events should be enough to handle a new player)