### PR TITLE
Remove dead code about the old Shifty dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,3 @@ Extensions/Multiplayer/peer.js linguist-vendored
 Extensions/Shopify/shopify-buy.umd.polyfilled.min.js linguist-vendored
 Extensions/TileMap/pako/* linguist-vendored
 Extensions/TileMap/pixi-tilemap/* linguist-vendored
-Extensions/TweenBehavior/shifty.js linguist-vendored

--- a/GDJS/Runtime/debugger-client/hot-reloader.ts
+++ b/GDJS/Runtime/debugger-client/hot-reloader.ts
@@ -61,8 +61,6 @@ namespace gdjs {
           endsWith(srcFilename, 'box2d.js') ||
           // Don't reload sha256.js library.
           endsWith(srcFilename, 'sha256.js') ||
-          // Don't reload shifty.js library.
-          endsWith(srcFilename, 'shifty.js') ||
           // Don't reload shopify-buy library.
           endsWith(srcFilename, 'shopify-buy.umd.polyfilled.min.js') ||
           // Don't reload pixi-multistyle-text library.

--- a/GDJS/scripts/lib/runtime-files-list.js
+++ b/GDJS/scripts/lib/runtime-files-list.js
@@ -55,7 +55,6 @@ const untransformedPaths = [
   'Extensions/Physics2Behavior/box2d.js',
   'Extensions/PhysicsBehavior/box2djs',
   'Extensions/Shopify/shopify-buy.umd.polyfilled.min.js',
-  'Extensions/TweenBehavior/shifty.js',
   'Extensions/JsExtensionTypes.flow.js',
   'Extensions/TileMap/pako/dist/pako.min.js',
   'Extensions/TileMap/pixi-tilemap/dist/pixi-tilemap.umd.js',


### PR DESCRIPTION
As explain in this PR https://github.com/4ian/GDevelop/pull/5710#issue-1925028150 , Shifty has been removed from the app to be replaced by a built-in solution.

Some lines has been forgot, this PR remove the dead code.