### PR TITLE
Avoid children variables to collapse in the editor after an undo

### DIFF
--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -1194,8 +1194,8 @@ const VariablesList = (props: Props) => {
       } else if (type === gd.Variable.Array) {
         variable.pushNew();
       }
-      _onChange();
       if (variable.isFolded()) variable.setFolded(false);
+      _onChange();
       forceUpdate();
     },
     [_onChange, forceUpdate, props.variablesContainer]


### PR DESCRIPTION
Fixes:
- https://forum.gdevelop.io/t/variables-panel-undo-bug/59742