### PR TITLE
Minor Fix Updating Extensions

### DIFF
--- a/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
+++ b/newIDE/app/src/AssetStore/ExtensionStore/ExtensionInstallDialog.js
@@ -176,7 +176,7 @@ const ExtensionInstallDialog = ({
                   <Trans>Not compatible</Trans>
                 ) : isAlreadyInstalled ? (
                   isFromStore ? (
-                    extensionUpdate ? (
+                    extensionUpdate && installedExtension && extensionShortHeader.version !== installedExtension.getVersion() ? (
                       extensionShortHeader.tier === 'community' ? (
                         <Trans>Update (could break the project)</Trans>
                       ) : (
@@ -241,7 +241,7 @@ const ExtensionInstallDialog = ({
           />
           <Column expand>
             <Text noMargin size="body2">
-              {extensionUpdate && installedExtension ? (
+              {extensionUpdate && installedExtension && extensionShortHeader.version !== installedExtension.getVersion() ? (
                 <Trans>{`Version ${installedExtension.getVersion()} (${
                   extensionShortHeader.version
                 } available)`}</Trans>


### PR DESCRIPTION
When an extension is updated, the install/update is not immediately displayed by the UI in the ExtensionInstallDialog, it is only showing after closing and reopening the ExtensionInstallDialog:

**Before updating extension:**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/69288c01-556c-472e-a863-27cfe1969f44">


**After updating extension:**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d82f3e45-5a0d-4d62-a486-d2d0a623bd17">


**After closing and reopening extension:**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/6771cf7c-58dc-4f4e-971b-b17a3c278e04">

This fix ensures that when the extension is updated (so the installed extension version is the same as the newest version) the button and version header immediately reflect that.
