### PR TITLE
Avoid to use an intermediate ThreeGroup for custom objects in the editor

### DIFF
--- a/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.js
@@ -561,6 +561,8 @@ export interface ChildRenderedInstance {
   _pixiObject: { height: number };
   getDefaultWidth(): number;
   getDefaultHeight(): number;
+  getOriginX(): number;
+  getOriginY(): number;
   update(): void;
 }
 
@@ -591,6 +593,9 @@ export const applyChildLayouts = <T: ChildRenderedInstance>(
     const childInstance = parent.childrenInstances[index];
     const childLayout = parent.childrenLayouts[index];
 
+    const childOriginX = renderedInstance.getOriginX();
+    const childOriginY = renderedInstance.getOriginY();
+
     if (childLayout.horizontalLayout.anchorOrigin == null) {
       const childMinX =
         childLayout.horizontalLayout.minSideAbsoluteMargin ||
@@ -601,7 +606,7 @@ export const applyChildLayouts = <T: ChildRenderedInstance>(
           (childLayout.horizontalLayout.maxSideProportionalMargin || 0) *
             width);
 
-      childInstance.x = childMinX;
+      childInstance.x = childMinX + childOriginX;
       childInstance.setCustomWidth(childMaxX - childMinX);
     } else {
       const anchorOrigin = childLayout.horizontalLayout.anchorOrigin || 0;
@@ -622,10 +627,12 @@ export const applyChildLayouts = <T: ChildRenderedInstance>(
         : renderedInstance.getDefaultWidth();
 
       childInstance.x =
-        targetInstance.getX() +
+        targetInstance.getX() -
+        targetRenderedInstance.getOriginX() +
         (childLayout.horizontalLayout.anchorDelta || 0) +
         anchorTarget * targetInstanceWidth -
-        anchorOrigin * width;
+        anchorOrigin * width +
+        childOriginX;
       childInstance.setCustomWidth(width);
     }
 
@@ -638,7 +645,7 @@ export const applyChildLayouts = <T: ChildRenderedInstance>(
         (childLayout.verticalLayout.maxSideAbsoluteMargin ||
           (childLayout.verticalLayout.maxSideProportionalMargin || 0) * height);
 
-      childInstance.y = childMinY;
+      childInstance.y = childMinY + childOriginY;
       const expectedHeight = childMaxY - childMinY;
       childInstance.setCustomHeight(childMaxY - childMinY);
 
@@ -667,10 +674,12 @@ export const applyChildLayouts = <T: ChildRenderedInstance>(
         : renderedInstance.getDefaultHeight();
 
       childInstance.y =
-        targetInstance.getY() +
+        targetInstance.getY() -
+        targetRenderedInstance.getOriginY() +
         (childLayout.verticalLayout.anchorDelta || 0) +
         anchorTarget * targetInstanceHeight -
-        anchorOrigin * height;
+        anchorOrigin * height +
+        childOriginY;
       childInstance.setCustomHeight(height);
     }
 

--- a/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.spec.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/CustomObjectLayoutingModel.spec.js
@@ -475,6 +475,8 @@ class MockedChildRenderedInstance implements ChildRenderedInstance {
   _pixiObject: { height: number };
   defaultWidth: number;
   defaultHeight: number;
+  originX: number;
+  originY: number;
   heightAfterUpdate: ?number;
 
   constructor(
@@ -487,6 +489,9 @@ class MockedChildRenderedInstance implements ChildRenderedInstance {
     this._pixiObject = { height: 0 };
     this.defaultWidth = defaultWidth;
     this.defaultHeight = defaultHeight;
+    // TODO Add tests with custom origin.
+    this.originX = 0;
+    this.originY = 0;
     this.heightAfterUpdate = heightAfterUpdate;
   }
 
@@ -496,6 +501,14 @@ class MockedChildRenderedInstance implements ChildRenderedInstance {
 
   getDefaultHeight(): number {
     return this.defaultHeight;
+  }
+
+  getOriginX(): number {
+    return this.originX;
+  }
+
+  getOriginY(): number {
+    return this.originY;
   }
 
   update(): void {


### PR DESCRIPTION
### Changes
- Avoid to use an intermediate ThreeGroup for rotation.
- Custom objects now use the custom origin of their first child if an origin is not forced by properties.
  - 3D models can keep their origin
  - 2D custom objects origin can still be forced to top-left or center
 - Remove the hack that was forcing the 2 previous cases