### PR TITLE
Add a drop-down menu item to swap assets of sprites and 3D models

### DIFF
--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.cpp
@@ -24,18 +24,23 @@
 namespace gd {
 
 SpriteObject::SpriteObject()
-    : updateIfNotVisible(false) {}
+    : updateIfNotVisible(false),
+      preScale(1) {}
 
 SpriteObject::~SpriteObject(){};
 
 void SpriteObject::DoUnserializeFrom(gd::Project& project,
                                      const gd::SerializerElement& element) {
   updateIfNotVisible = element.GetBoolAttribute("updateIfNotVisible", true);
+  preScale = element.GetDoubleAttribute("preScale", 1);
   animations.UnserializeFrom(element);
 }
 
 void SpriteObject::DoSerializeTo(gd::SerializerElement& element) const {
   element.SetAttribute("updateIfNotVisible", updateIfNotVisible);
+  if (preScale != 1) {
+    element.SetAttribute("preScale", preScale);
+  }
   animations.SerializeTo(element);
 }
 

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.h
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.h
@@ -82,6 +82,23 @@ class GD_CORE_API SpriteObject : public gd::ObjectConfiguration {
    */
   bool GetUpdateIfNotVisible() const { return updateIfNotVisible; }
 
+  /**
+   * \brief Return the scale applied to object to evaluate the default dimensions.
+   */
+  double GetPreScale() { return preScale; }
+
+  /**
+   * \brief Set the scale applied to object to evaluate the default dimensions.
+   * 
+   * Its value must be strictly positive.
+   */
+  void SetPreScale(double preScale_) {
+    if (preScale_ <= 0) {
+      return;
+    }
+    preScale = preScale_;
+  }
+
  private:
   void DoUnserializeFrom(gd::Project& project,
                          const gd::SerializerElement& element) override;
@@ -92,6 +109,7 @@ class GD_CORE_API SpriteObject : public gd::ObjectConfiguration {
   bool updateIfNotVisible;  ///< If set to true, ask the game engine to play
                             ///< object animation even if hidden or far from
                             ///< the screen.
+  double preScale;
 };
 
 }  // namespace gd

--- a/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
@@ -58,6 +58,8 @@ namespace gdjs {
     _updatePIXISprite() {
       const animationFrame = this._object._animator.getCurrentFrame();
       if (animationFrame !== null) {
+        const scaleX = this._object._scaleX * this._object._preScale;
+        const scaleY = this._object._scaleY * this._object._preScale;
         this._sprite.anchor.x =
           animationFrame.center.x / this._sprite.texture.frame.width;
         this._sprite.anchor.y =
@@ -65,17 +67,17 @@ namespace gdjs {
         this._sprite.position.x =
           this._object.x +
           (animationFrame.center.x - animationFrame.origin.x) *
-            Math.abs(this._object._scaleX);
+            Math.abs(scaleX);
         this._sprite.position.y =
           this._object.y +
           (animationFrame.center.y - animationFrame.origin.y) *
-            Math.abs(this._object._scaleY);
+            Math.abs(scaleY);
         this._sprite.rotation = gdjs.toRad(this._object.angle);
         this._sprite.visible = !this._object.hidden;
         this._sprite.blendMode = this._object._blendMode;
         this._sprite.alpha = this._object.opacity / 255;
-        this._sprite.scale.x = this._object._scaleX;
-        this._sprite.scale.y = this._object._scaleY;
+        this._sprite.scale.x = scaleX;
+        this._sprite.scale.y = scaleY;
         this._cachedWidth = Math.abs(this._sprite.width);
         this._cachedHeight = Math.abs(this._sprite.height);
       } else {
@@ -115,7 +117,7 @@ namespace gdjs {
       this._sprite.position.x =
         this._object.x +
         (animationFrame.center.x - animationFrame.origin.x) *
-          Math.abs(this._object._scaleX);
+          Math.abs(this._object._scaleX * this._object._preScale);
     }
 
     updateY(): void {
@@ -125,7 +127,7 @@ namespace gdjs {
       this._sprite.position.y =
         this._object.y +
         (animationFrame.center.y - animationFrame.origin.y) *
-          Math.abs(this._object._scaleY);
+          Math.abs(this._object._scaleY * this._object._preScale);
     }
 
     updateAngle(): void {

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -9,7 +9,7 @@ namespace gdjs {
     /** Update the object even if he is not visible?. */
     updateIfNotVisible: boolean;
     /** The scale applied to object to evaluate the default dimensions */
-    preScale: float;
+    preScale?: float;
     /** The list of {@link SpriteAnimationData} representing {@link gdjs.SpriteAnimation} instances. */
     animations: Array<SpriteAnimationData>;
   };

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -8,6 +8,8 @@ namespace gdjs {
   export type SpriteObjectDataType = {
     /** Update the object even if he is not visible?. */
     updateIfNotVisible: boolean;
+    /** The scale applied to object to evaluate the default dimensions */
+    preScale: float;
     /** The list of {@link SpriteAnimationData} representing {@link gdjs.SpriteAnimation} instances. */
     animations: Array<SpriteAnimationData>;
   };
@@ -46,6 +48,7 @@ namespace gdjs {
     _flippedY: boolean = false;
     opacity: float = 255;
     _updateIfNotVisible: boolean;
+    _preScale: float = 1;
 
     _renderer: gdjs.SpriteRuntimeObjectRenderer;
     _animationFrameDirty = true;
@@ -60,6 +63,7 @@ namespace gdjs {
     ) {
       super(instanceContainer, spriteObjectData);
       this._updateIfNotVisible = !!spriteObjectData.updateIfNotVisible;
+      this._preScale = spriteObjectData.preScale || 1;
       this._renderer = new gdjs.SpriteRuntimeObjectRenderer(
         this,
         instanceContainer
@@ -87,6 +91,7 @@ namespace gdjs {
       this._flippedY = false;
       this.opacity = 255;
       this._updateIfNotVisible = !!spriteObjectData.updateIfNotVisible;
+      this._preScale = spriteObjectData.preScale || 1;
       this._renderer.reinitialize(this, instanceContainer);
       this._updateAnimationFrame();
 
@@ -98,6 +103,7 @@ namespace gdjs {
       oldObjectData: SpriteObjectData,
       newObjectData: SpriteObjectData
     ): boolean {
+      this._preScale = newObjectData.preScale || 1;
       this._animator.updateFromObjectData(
         oldObjectData.animations,
         newObjectData.animations
@@ -534,8 +540,8 @@ namespace gdjs {
       }
 
       //Scale
-      const absScaleX = Math.abs(this._scaleX);
-      const absScaleY = Math.abs(this._scaleY);
+      const absScaleX = Math.abs(this._scaleX * this._preScale);
+      const absScaleY = Math.abs(this._scaleY * this._preScale);
       x *= absScaleX;
       y *= absScaleY;
       cx *= absScaleX;
@@ -566,7 +572,7 @@ namespace gdjs {
       if (animationFrame === null) {
         return this.x;
       }
-      const absScaleX = Math.abs(this._scaleX);
+      const absScaleX = Math.abs(this._scaleX * this._preScale);
       if (!this._flippedX) {
         return this.x - animationFrame.origin.x * absScaleX;
       } else {
@@ -589,7 +595,7 @@ namespace gdjs {
       if (animationFrame === null) {
         return this.y;
       }
-      const absScaleY = Math.abs(this._scaleY);
+      const absScaleY = Math.abs(this._scaleY * this._preScale);
       if (!this._flippedY) {
         return this.y - animationFrame.origin.y * absScaleY;
       } else {
@@ -614,11 +620,13 @@ namespace gdjs {
       }
       if (!this._flippedX) {
         //Just need to multiply by the scale as it is the center.
-        return animationFrame.center.x * Math.abs(this._scaleX);
+        return (
+          animationFrame.center.x * Math.abs(this._scaleX * this._preScale)
+        );
       } else {
         return (
           (this._renderer.getUnscaledWidth() - animationFrame.center.x) *
-          Math.abs(this._scaleX)
+          Math.abs(this._scaleX * this._preScale)
         );
       }
     }
@@ -634,11 +642,13 @@ namespace gdjs {
       }
       if (!this._flippedY) {
         //Just need to multiply by the scale as it is the center.
-        return animationFrame.center.y * Math.abs(this._scaleY);
+        return (
+          animationFrame.center.y * Math.abs(this._scaleY * this._preScale)
+        );
       } else {
         return (
           (this._renderer.getUnscaledHeight() - animationFrame.center.y) *
-          Math.abs(this._scaleY)
+          Math.abs(this._scaleY * this._preScale)
         );
       }
     }

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -3329,6 +3329,8 @@ interface SpriteObject {
 
     void SetUpdateIfNotVisible(boolean updateIfNotVisible);
     boolean GetUpdateIfNotVisible();
+    void SetPreScale(double value);
+    double GetPreScale();
 };
 SpriteObject implements ObjectConfiguration;
 

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -800,6 +800,8 @@ interface ObjectConfiguration {
 
     void SerializeTo([Ref] SerializerElement element);
     void UnserializeFrom([Ref] Project project, [Const, Ref] SerializerElement element);
+
+    unsigned long GetAnimationsCount();
 };
 
 interface UniquePtrObjectConfiguration {

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -785,6 +785,8 @@ interface ObjectConfiguration {
     [Value] UniquePtrObjectConfiguration Clone();
 
     [Const, Ref] DOMString GetType();
+    // SetType must only be used by tests.
+    void SetType([Const] DOMString typeName);
 
     [Value] MapStringPropertyDescriptor GetProperties();
     boolean UpdateProperty([Const] DOMString name, [Const] DOMString value);

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -671,6 +671,7 @@ export class ObjectConfiguration extends EmscriptenObject {
   exposeResources(worker: ArbitraryResourceWorker): void;
   serializeTo(element: SerializerElement): void;
   unserializeFrom(project: Project, element: SerializerElement): void;
+  getAnimationsCount(): number;
 }
 
 export class UniquePtrObjectConfiguration extends EmscriptenObject {

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -664,6 +664,7 @@ export class ObjectConfiguration extends EmscriptenObject {
   constructor();
   clone(): UniquePtrObjectConfiguration;
   getType(): string;
+  setType(typeName: string): void;
   getProperties(): MapStringPropertyDescriptor;
   updateProperty(name: string, value: string): boolean;
   getInitialInstanceProperties(instance: InitialInstance): MapStringPropertyDescriptor;

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -2463,6 +2463,8 @@ export class SpriteObject extends ObjectConfiguration {
   getAnimations(): SpriteAnimationList;
   setUpdateIfNotVisible(updateIfNotVisible: boolean): void;
   getUpdateIfNotVisible(): boolean;
+  setPreScale(value: number): void;
+  getPreScale(): number;
 }
 
 export class Model3DAnimation extends EmscriptenObject {

--- a/GDevelop.js/types/gdobjectconfiguration.js
+++ b/GDevelop.js/types/gdobjectconfiguration.js
@@ -10,6 +10,7 @@ declare class gdObjectConfiguration {
   exposeResources(worker: gdArbitraryResourceWorker): void;
   serializeTo(element: gdSerializerElement): void;
   unserializeFrom(project: gdProject, element: gdSerializerElement): void;
+  getAnimationsCount(): number;
   delete(): void;
   ptr: number;
 };

--- a/GDevelop.js/types/gdobjectconfiguration.js
+++ b/GDevelop.js/types/gdobjectconfiguration.js
@@ -3,6 +3,7 @@ declare class gdObjectConfiguration {
   constructor(): void;
   clone(): gdUniquePtrObjectConfiguration;
   getType(): string;
+  setType(typeName: string): void;
   getProperties(): gdMapStringPropertyDescriptor;
   updateProperty(name: string, value: string): boolean;
   getInitialInstanceProperties(instance: gdInitialInstance): gdMapStringPropertyDescriptor;

--- a/GDevelop.js/types/gdspriteobject.js
+++ b/GDevelop.js/types/gdspriteobject.js
@@ -4,6 +4,8 @@ declare class gdSpriteObject extends gdObjectConfiguration {
   getAnimations(): gdSpriteAnimationList;
   setUpdateIfNotVisible(updateIfNotVisible: boolean): void;
   getUpdateIfNotVisible(): boolean;
+  setPreScale(value: number): void;
+  getPreScale(): number;
   delete(): void;
   ptr: number;
 };

--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -92,9 +92,7 @@ type AssetStoreState = {|
     searchFilters: Array<SearchFilter<AssetShortHeader>>
   ) => ?Array<AssetShortHeader>,
   setInitialPackUserFriendlySlug: (initialPackUserFriendlySlug: string) => void,
-  assetShortHeadersById: ?{
-    [string]: AssetShortHeader,
-  },
+  getAssetShortHeaderFromId: (id: string) => AssetShortHeader | null,
 |};
 
 export const initialAssetStoreState: AssetStoreState = {
@@ -162,7 +160,7 @@ export const initialAssetStoreState: AssetStoreState = {
   useSearchItem: (searchText, chosenCategory, chosenFilters, searchFilters) =>
     null,
   setInitialPackUserFriendlySlug: (initialPackUserFriendlySlug: string) => {},
-  assetShortHeadersById: null,
+  getAssetShortHeaderFromId: (id: string) => null,
 };
 
 export const AssetStoreContext = React.createContext<AssetStoreState>(
@@ -198,6 +196,11 @@ export const AssetStoreStateProvider = ({
   const [assetShortHeadersById, setAssetShortHeadersById] = React.useState<?{
     [string]: AssetShortHeader,
   }>(null);
+  const getAssetShortHeaderFromId = React.useCallback(
+    (id: string): AssetShortHeader | null =>
+      (assetShortHeadersById && assetShortHeadersById[id]) || null,
+    [assetShortHeadersById]
+  );
   const [
     publicAssetShortHeaders,
     setPublicAssetShortHeaders,
@@ -626,7 +629,7 @@ export const AssetStoreStateProvider = ({
           searchFilters
         ),
       setInitialPackUserFriendlySlug,
-      assetShortHeadersById,
+      getAssetShortHeaderFromId,
     }),
     [
       hidePremiumProducts,
@@ -648,7 +651,7 @@ export const AssetStoreStateProvider = ({
       assetFiltersState,
       assetPackFiltersState,
       clearAllFilters,
-      assetShortHeadersById,
+      getAssetShortHeaderFromId,
       setInitialPackUserFriendlySlug,
     ]
   );

--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -136,6 +136,7 @@ export const initialAssetStoreState: AssetStoreState = {
   shopNavigationState: {
     getCurrentPage: () => assetStoreHomePageState,
     isRootPage: true,
+    isAssetSwappingHistory: false,
     backToPreviousPage: () => assetStoreHomePageState,
     openHome: () => assetStoreHomePageState,
     openAssetSwapping: () => assetStoreHomePageState,

--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -26,6 +26,7 @@ import {
   LicenseAssetStoreSearchFilter,
   DimensionAssetStoreSearchFilter,
   AssetPackTypeStoreSearchFilter,
+  AssetSwappingAssetStoreSearchFilter,
 } from './AssetStoreSearchFilter';
 import {
   type NavigationState,
@@ -55,6 +56,8 @@ export type AssetFiltersState = {|
   setColorFilter: ColorAssetStoreSearchFilter => void,
   licenseFilter: LicenseAssetStoreSearchFilter,
   setLicenseFilter: LicenseAssetStoreSearchFilter => void,
+  assetSwappingFilter: AssetSwappingAssetStoreSearchFilter,
+  setAssetSwappingFilter: AssetSwappingAssetStoreSearchFilter => void,
 |};
 
 export type AssetPackFiltersState = {|
@@ -89,6 +92,9 @@ type AssetStoreState = {|
     searchFilters: Array<SearchFilter<AssetShortHeader>>
   ) => ?Array<AssetShortHeader>,
   setInitialPackUserFriendlySlug: (initialPackUserFriendlySlug: string) => void,
+  assetShortHeadersById: ?{
+    [string]: AssetShortHeader,
+  },
 |};
 
 export const initialAssetStoreState: AssetStoreState = {
@@ -119,6 +125,8 @@ export const initialAssetStoreState: AssetStoreState = {
     setColorFilter: filter => {},
     licenseFilter: new LicenseAssetStoreSearchFilter(),
     setLicenseFilter: filter => {},
+    assetSwappingFilter: new AssetSwappingAssetStoreSearchFilter(),
+    setAssetSwappingFilter: filter => {},
   },
   assetPackFiltersState: {
     typeFilter: new AssetPackTypeStoreSearchFilter({}),
@@ -127,8 +135,10 @@ export const initialAssetStoreState: AssetStoreState = {
   clearAllFilters: () => {},
   shopNavigationState: {
     getCurrentPage: () => assetStoreHomePageState,
+    isRootPage: true,
     backToPreviousPage: () => assetStoreHomePageState,
     openHome: () => assetStoreHomePageState,
+    openAssetSwapping: () => assetStoreHomePageState,
     clearHistory: () => {},
     clearPreviousPageFromHistory: () => {},
     openSearchResultPage: () => {},
@@ -151,6 +161,7 @@ export const initialAssetStoreState: AssetStoreState = {
   useSearchItem: (searchText, chosenCategory, chosenFilters, searchFilters) =>
     null,
   setInitialPackUserFriendlySlug: (initialPackUserFriendlySlug: string) => {},
+  assetShortHeadersById: null,
 };
 
 export const AssetStoreContext = React.createContext<AssetStoreState>(
@@ -253,6 +264,12 @@ export const AssetStoreStateProvider = ({
   ] = React.useState<LicenseAssetStoreSearchFilter>(
     new LicenseAssetStoreSearchFilter()
   );
+  const [
+    assetSwappingFilter,
+    setAssetSwappingFilter,
+  ] = React.useState<AssetSwappingAssetStoreSearchFilter>(
+    new AssetSwappingAssetStoreSearchFilter()
+  );
   // When one of the filter change, we need to rebuild the array
   // for the search.
   const assetSearchFilters = React.useMemo<
@@ -265,6 +282,7 @@ export const AssetStoreStateProvider = ({
       objectTypeFilter,
       colorFilter,
       licenseFilter,
+      assetSwappingFilter,
     ],
     [
       animatedFilter,
@@ -273,6 +291,7 @@ export const AssetStoreStateProvider = ({
       objectTypeFilter,
       colorFilter,
       licenseFilter,
+      assetSwappingFilter,
     ]
   );
 
@@ -517,6 +536,8 @@ export const AssetStoreStateProvider = ({
       setColorFilter,
       licenseFilter,
       setLicenseFilter,
+      assetSwappingFilter,
+      setAssetSwappingFilter,
     }),
     [
       animatedFilter,
@@ -531,6 +552,8 @@ export const AssetStoreStateProvider = ({
       setColorFilter,
       licenseFilter,
       setLicenseFilter,
+      assetSwappingFilter,
+      setAssetSwappingFilter,
     ]
   );
 
@@ -557,6 +580,7 @@ export const AssetStoreStateProvider = ({
       assetPackFiltersState.setTypeFilter(
         new AssetPackTypeStoreSearchFilter({})
       );
+      // Keep assetSwappingFilter as its not a user filter.
     },
     [assetFiltersState, assetPackFiltersState]
   );
@@ -601,6 +625,7 @@ export const AssetStoreStateProvider = ({
           searchFilters
         ),
       setInitialPackUserFriendlySlug,
+      assetShortHeadersById,
     }),
     [
       hidePremiumProducts,

--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -632,9 +632,9 @@ export const AssetStoreStateProvider = ({
       getAssetShortHeaderFromId,
     }),
     [
-      hidePremiumProducts,
       assetShortHeadersSearchResults,
       publicAssetPacksSearchResults,
+      hidePremiumProducts,
       privateAssetPackListingDatasSearchResults,
       fetchAssetsAndFilters,
       filters,
@@ -643,7 +643,6 @@ export const AssetStoreStateProvider = ({
       authors,
       licenses,
       environment,
-      setEnvironment,
       error,
       shopNavigationState,
       currentPage,
@@ -652,7 +651,7 @@ export const AssetStoreStateProvider = ({
       assetPackFiltersState,
       clearAllFilters,
       getAssetShortHeaderFromId,
-      setInitialPackUserFriendlySlug,
+      assetShortHeadersById,
     ]
   );
 

--- a/newIDE/app/src/AssetStore/AssetStoreFilterPanel.js
+++ b/newIDE/app/src/AssetStore/AssetStoreFilterPanel.js
@@ -335,23 +335,25 @@ export const AssetStoreFilterPanel = ({
           onChoiceChange();
         }}
       />
-      {assetSwappedObject ? null : (<SetFilter
-        filterKey="ObjectType"
-        title={<Trans>Type of objects</Trans>}
-        choices={[
-          { label: t`Sprite`, value: 'sprite' },
-          { label: t`Tiled sprite`, value: 'tiled' },
-          { label: t`Panel sprite`, value: '9patch' },
-          { label: t`3D model`, value: 'Scene3D::Model3DObject' },
-        ]}
-        values={assetFiltersState.objectTypeFilter.objectTypes}
-        setValues={values => {
-          assetFiltersState.setObjectTypeFilter(
-            new ObjectTypeAssetStoreSearchFilter(values)
-          );
-          onChoiceChange();
-        }}
-      />)}
+      {assetSwappedObject ? null : (
+        <SetFilter
+          filterKey="ObjectType"
+          title={<Trans>Type of objects</Trans>}
+          choices={[
+            { label: t`Sprite`, value: 'sprite' },
+            { label: t`Tiled sprite`, value: 'tiled' },
+            { label: t`Panel sprite`, value: '9patch' },
+            { label: t`3D model`, value: 'Scene3D::Model3DObject' },
+          ]}
+          values={assetFiltersState.objectTypeFilter.objectTypes}
+          setValues={values => {
+            assetFiltersState.setObjectTypeFilter(
+              new ObjectTypeAssetStoreSearchFilter(values)
+            );
+            onChoiceChange();
+          }}
+        />
+      )}
       <ColorFilter
         filterKey="Color"
         title={<Trans>Color</Trans>}

--- a/newIDE/app/src/AssetStore/AssetStoreFilterPanel.js
+++ b/newIDE/app/src/AssetStore/AssetStoreFilterPanel.js
@@ -220,7 +220,11 @@ const ColorFilter = ({
   );
 };
 
-export const AssetStoreFilterPanel = () => {
+export const AssetStoreFilterPanel = ({
+  assetSwappedObject,
+}: {
+  assetSwappedObject?: ?gdObject,
+}) => {
   const {
     assetFiltersState,
     assetPackFiltersState,
@@ -236,37 +240,39 @@ export const AssetStoreFilterPanel = () => {
   );
   return (
     <Column noMargin>
-      <MultipleChoiceFilter
-        filterKey="PackType"
-        title={<Trans>Pack type</Trans>}
-        choices={[
-          { label: t`Free`, value: 'free' },
-          { label: t`Premium`, value: 'premium' },
-          { label: t`Owned`, value: 'owned' },
-        ]}
-        isChoiceChecked={choice =>
-          (choice === 'free' && assetPackFiltersState.typeFilter.isFree) ||
-          (choice === 'premium' &&
-            assetPackFiltersState.typeFilter.isPremium) ||
-          (choice === 'owned' && assetPackFiltersState.typeFilter.isOwned)
-        }
-        setChoiceChecked={(choice, checked) => {
-          const typeFilter = assetPackFiltersState.typeFilter;
-          const isFree = choice === 'free' ? checked : typeFilter.isFree;
-          const isPremium =
-            choice === 'premium' ? checked : typeFilter.isPremium;
-          const isOwned = choice === 'owned' ? checked : typeFilter.isOwned;
-          assetPackFiltersState.setTypeFilter(
-            new AssetPackTypeStoreSearchFilter({
-              isFree,
-              isPremium,
-              isOwned,
-              receivedAssetPacks,
-            })
-          );
-          onChoiceChange();
-        }}
-      />
+      {assetSwappedObject ? null : (
+        <MultipleChoiceFilter
+          filterKey="PackType"
+          title={<Trans>Pack type</Trans>}
+          choices={[
+            { label: t`Free`, value: 'free' },
+            { label: t`Premium`, value: 'premium' },
+            { label: t`Owned`, value: 'owned' },
+          ]}
+          isChoiceChecked={choice =>
+            (choice === 'free' && assetPackFiltersState.typeFilter.isFree) ||
+            (choice === 'premium' &&
+              assetPackFiltersState.typeFilter.isPremium) ||
+            (choice === 'owned' && assetPackFiltersState.typeFilter.isOwned)
+          }
+          setChoiceChecked={(choice, checked) => {
+            const typeFilter = assetPackFiltersState.typeFilter;
+            const isFree = choice === 'free' ? checked : typeFilter.isFree;
+            const isPremium =
+              choice === 'premium' ? checked : typeFilter.isPremium;
+            const isOwned = choice === 'owned' ? checked : typeFilter.isOwned;
+            assetPackFiltersState.setTypeFilter(
+              new AssetPackTypeStoreSearchFilter({
+                isFree,
+                isPremium,
+                isOwned,
+                receivedAssetPacks,
+              })
+            );
+            onChoiceChange();
+          }}
+        />
+      )}
       <MultipleChoiceFilter
         filterKey="Animation"
         title={<Trans>Animation</Trans>}
@@ -329,7 +335,7 @@ export const AssetStoreFilterPanel = () => {
           onChoiceChange();
         }}
       />
-      <SetFilter
+      {assetSwappedObject ? null : (<SetFilter
         filterKey="ObjectType"
         title={<Trans>Type of objects</Trans>}
         choices={[
@@ -345,7 +351,7 @@ export const AssetStoreFilterPanel = () => {
           );
           onChoiceChange();
         }}
-      />
+      />)}
       <ColorFilter
         filterKey="Color"
         title={<Trans>Color</Trans>}

--- a/newIDE/app/src/AssetStore/AssetStoreNavigator.js
+++ b/newIDE/app/src/AssetStore/AssetStoreNavigator.js
@@ -27,6 +27,8 @@ export type AssetStorePageState = {|
 
 export type NavigationState = {|
   getCurrentPage: () => AssetStorePageState,
+  isRootPage: boolean,
+  isAssetSwappingHistory: boolean,
   backToPreviousPage: () => AssetStorePageState,
   openHome: () => AssetStorePageState,
   clearHistory: () => void,
@@ -118,6 +120,8 @@ export const useShopNavigation = (): NavigationState => {
   return React.useMemo(
     () => ({
       getCurrentPage: () => previousPages[previousPages.length - 1],
+      isRootPage: previousPages.length <= 1,
+      isAssetSwappingHistory: previousPages[0] !== assetStoreHomePageState,
       backToPreviousPage: () => {
         if (previousPages.length > 1) {
           const newPreviousPages = previousPages.slice(
@@ -135,6 +139,11 @@ export const useShopNavigation = (): NavigationState => {
       openHome: () => {
         setHistory({ previousPages: [assetStoreHomePageState] });
         return assetStoreHomePageState;
+      },
+      openAssetSwapping: () => {
+        const assetSwappingState = {...searchPageState, };
+        setHistory({ previousPages: [assetSwappingState] });
+        return assetSwappingState;
       },
       clearHistory: () => {
         setHistory(previousHistory => {

--- a/newIDE/app/src/AssetStore/AssetStoreNavigator.js
+++ b/newIDE/app/src/AssetStore/AssetStoreNavigator.js
@@ -28,9 +28,9 @@ export type AssetStorePageState = {|
 export type NavigationState = {|
   getCurrentPage: () => AssetStorePageState,
   isRootPage: boolean,
-  isAssetSwappingHistory: boolean,
   backToPreviousPage: () => AssetStorePageState,
   openHome: () => AssetStorePageState,
+  openAssetSwapping: () => AssetStorePageState,
   clearHistory: () => void,
   clearPreviousPageFromHistory: () => void,
   openSearchResultPage: () => void,
@@ -121,7 +121,6 @@ export const useShopNavigation = (): NavigationState => {
     () => ({
       getCurrentPage: () => previousPages[previousPages.length - 1],
       isRootPage: previousPages.length <= 1,
-      isAssetSwappingHistory: previousPages[0] !== assetStoreHomePageState,
       backToPreviousPage: () => {
         if (previousPages.length > 1) {
           const newPreviousPages = previousPages.slice(
@@ -141,7 +140,7 @@ export const useShopNavigation = (): NavigationState => {
         return assetStoreHomePageState;
       },
       openAssetSwapping: () => {
-        const assetSwappingState = {...searchPageState, };
+        const assetSwappingState = { ...searchPageState };
         setHistory({ previousPages: [assetSwappingState] });
         return assetSwappingState;
       },

--- a/newIDE/app/src/AssetStore/AssetStoreNavigator.js
+++ b/newIDE/app/src/AssetStore/AssetStoreNavigator.js
@@ -28,6 +28,7 @@ export type AssetStorePageState = {|
 export type NavigationState = {|
   getCurrentPage: () => AssetStorePageState,
   isRootPage: boolean,
+  isAssetSwappingHistory: boolean,
   backToPreviousPage: () => AssetStorePageState,
   openHome: () => AssetStorePageState,
   openAssetSwapping: () => AssetStorePageState,
@@ -121,6 +122,7 @@ export const useShopNavigation = (): NavigationState => {
     () => ({
       getCurrentPage: () => previousPages[previousPages.length - 1],
       isRootPage: previousPages.length <= 1,
+      isAssetSwappingHistory: previousPages[0] !== assetStoreHomePageState,
       backToPreviousPage: () => {
         if (previousPages.length > 1) {
           const newPreviousPages = previousPages.slice(

--- a/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
+++ b/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
@@ -393,8 +393,8 @@ export class AssetSwappingAssetStoreSearchFilter
 
     const hasAnimatedState = searchItem.maxFramesCount > 1;
     const hasSeveralState = searchItem.animationsCount > 1;
-    const otherHasAnimatedState = this.other.maxFramesCount > 1;
-    const otherHasSeveralState = this.other.animationsCount > 1;
+    const otherHasAnimatedState = other.maxFramesCount > 1;
+    const otherHasSeveralState = other.animationsCount > 1;
     if (
       hasAnimatedState === otherHasAnimatedState &&
       hasSeveralState === otherHasSeveralState

--- a/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
+++ b/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
@@ -261,7 +261,6 @@ export class ColorAssetStoreSearchFilter
   }
 }
 
-// TODO
 const toAssetStoreType = (type: string) => {
   return type === 'Sprite' ? 'sprite' : type;
 };

--- a/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
+++ b/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
@@ -322,10 +322,7 @@ export class AssetSwappingAssetStoreSearchFilter
     if (!this.isEnabled) {
       return 1;
     }
-    if (
-      this.other === searchItem ||
-      this.objectType !== searchItem.objectType
-    ) {
+    if (this.objectType !== searchItem.objectType) {
       return 0;
     }
 

--- a/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
+++ b/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
@@ -396,6 +396,7 @@ export class AssetSwappingAssetStoreSearchFilter
     const otherHasAnimatedState = other.maxFramesCount > 1;
     const otherHasSeveralState = other.animationsCount > 1;
     if (
+      (otherHasAnimatedState || otherHasSeveralState) &&
       hasAnimatedState === otherHasAnimatedState &&
       hasSeveralState === otherHasSeveralState
     ) {

--- a/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
+++ b/newIDE/app/src/AssetStore/AssetStoreSearchFilter.js
@@ -129,9 +129,9 @@ export class AnimatedAssetStoreSearchFilter
 
   getPertinence(searchItem: AssetShortHeader): number {
     const hasAnimatedState = searchItem.maxFramesCount > 1;
-    const hasSeveralState = searchItem.animationsCount > 1;
+    const hasSeveralStates = searchItem.animationsCount > 1;
     return (!this.mustBeAnimated || hasAnimatedState) &&
-      (!this.mustHaveSeveralState || hasSeveralState)
+      (!this.mustHaveSeveralState || hasSeveralStates)
       ? 1
       : 0;
   }
@@ -286,7 +286,7 @@ export class AssetSwappingAssetStoreSearchFilter
   implements SearchFilter<AssetShortHeader> {
   isEnabled: boolean;
   objectType: string;
-  hasSeveralState: boolean;
+  hasSeveralStates: boolean;
   other: AssetShortHeader | null;
   tags: Array<string>;
 
@@ -299,9 +299,10 @@ export class AssetSwappingAssetStoreSearchFilter
       this.objectType = assetShortHeader
         ? assetShortHeader.objectType
         : toAssetStoreType(object.getType());
-      this.hasSeveralState = object.getConfiguration().getAnimationsCount() > 0;
+      this.hasSeveralStates =
+        object.getConfiguration().getAnimationsCount() > 0;
       this.other = assetShortHeader;
-      // The asset pack tag is not relevent.
+      // The asset pack tag (which is the first tag) is not relevant.
       this.tags = assetShortHeader
         ? assetShortHeader.tags
             .slice(1)
@@ -310,7 +311,7 @@ export class AssetSwappingAssetStoreSearchFilter
     } else {
       this.isEnabled = false;
       this.objectType = '';
-      this.hasSeveralState = false;
+      this.hasSeveralStates = false;
       this.other = null;
       this.tags = [];
     }
@@ -330,8 +331,8 @@ export class AssetSwappingAssetStoreSearchFilter
 
     const { other } = this;
     if (!other) {
-      const hasSeveralState = searchItem.animationsCount > 1;
-      if (this.hasSeveralState && !hasSeveralState) {
+      const hasSeveralStates = searchItem.animationsCount > 1;
+      if (this.hasSeveralStates && !hasSeveralStates) {
         similitude *= 0.8;
       }
 
@@ -389,13 +390,13 @@ export class AssetSwappingAssetStoreSearchFilter
     }
 
     const hasAnimatedState = searchItem.maxFramesCount > 1;
-    const hasSeveralState = searchItem.animationsCount > 1;
+    const hasSeveralStates = searchItem.animationsCount > 1;
     const otherHasAnimatedState = other.maxFramesCount > 1;
     const otherHasSeveralState = other.animationsCount > 1;
     if (
       (otherHasAnimatedState || otherHasSeveralState) &&
       hasAnimatedState === otherHasAnimatedState &&
-      hasSeveralState === otherHasSeveralState
+      hasSeveralStates === otherHasSeveralState
     ) {
       // There is not a lot of animated assets in the store.
       // This ensures they are shown.
@@ -428,12 +429,12 @@ export class SimilarAssetStoreSearchFilter
 
     {
       const hasAnimatedState = searchItem.maxFramesCount > 1;
-      const hasSeveralState = searchItem.animationsCount > 1;
+      const hasSeveralStates = searchItem.animationsCount > 1;
       const otherHasAnimatedState = this.other.maxFramesCount > 1;
       const otherHasSeveralState = this.other.animationsCount > 1;
       if (
         hasAnimatedState !== otherHasAnimatedState ||
-        hasSeveralState !== otherHasSeveralState
+        hasSeveralStates !== otherHasSeveralState
       ) {
         return 0;
       }

--- a/newIDE/app/src/AssetStore/AssetSwapper.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.js
@@ -72,11 +72,11 @@ type SpriteAnimationData = {
 };
 
 /** Represents the data of a {@link gdjs.SpriteRuntimeObject}. */
-export type SpriteObjectDataType = {
+type SpriteObjectDataType = {
   /** Update the object even if he is not visible?. */
   updateIfNotVisible: boolean,
   /** The scale applied to object to evaluate the default dimensions */
-  preScale: number,
+  preScale?: number,
   /** The list of {@link SpriteAnimationData} representing {@link gdjs.SpriteAnimation} instances. */
   animations: Array<SpriteAnimationData>,
 };

--- a/newIDE/app/src/AssetStore/AssetSwapper.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.js
@@ -364,6 +364,7 @@ export const swapAsset = (
       originLocation: serializedObject.content.originLocation,
       centerLocation: serializedObject.content.centerLocation,
     };
+    serializedObject.assetStoreId = serializedAssetObject.assetStoreId;
   }
   unserializeFromJSObject(object, serializedObject, 'unserializeFrom', project);
 };

--- a/newIDE/app/src/AssetStore/AssetSwapper.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.js
@@ -195,7 +195,11 @@ const evaluatePreScale = (
     assetShortHeader
   );
   const objectPreScale = serializedObject.preScale || 1;
-  return objectPreScale / Math.sqrt(scaleX * scaleY);
+  const assetPreScale = objectPreScale / Math.sqrt(scaleX * scaleY);
+  return assetPreScale > 0.5 &&
+    Math.abs(Math.round(assetPreScale) - assetPreScale) < 0.001
+    ? Math.round(assetPreScale)
+    : assetPreScale;
 };
 
 const scalePoint = function<P: { x: number, y: number }>(

--- a/newIDE/app/src/AssetStore/AssetSwapper.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.js
@@ -127,8 +127,13 @@ const mergeSpriteAnimation = (
     directions: [
       {
         ...assetDirection,
-        sprites: objectDirection.sprites.map((frame, frameIndex) =>
-          mergeSpriteFrame(frame, assetDirection.sprites[frameIndex])
+        sprites: assetDirection.sprites.map((frame, frameIndex) =>
+          mergeSpriteFrame(
+            frameIndex < objectDirection.sprites.length
+              ? objectDirection.sprites[frameIndex]
+              : objectDirection.sprites[0],
+            frame
+          )
         ),
       },
     ],

--- a/newIDE/app/src/AssetStore/AssetSwapper.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.js
@@ -1,0 +1,79 @@
+// @flow
+import {
+  serializeToJSObject,
+  unserializeFromJSObject,
+} from '../Utils/Serializer';
+
+export const canSwapAssetOfObject = (object: gdObject) => {
+  const type = object.getType();
+  return type === 'Scene3D::Model3DObject' || type === 'Sprite';
+};
+
+const mergeAnimations = (
+  objectsAnimations: Array<{ name: string }>,
+  assetAnimations: Array<{ name: string }>
+) => {
+  const animations = [];
+  // Ensure the object don't loose any animation.
+  for (const objectAnimation of objectsAnimations) {
+    const assetAnimation = assetAnimations.find(
+      assetAnimation => assetAnimation.name === objectAnimation.name
+    ) || {
+      ...assetAnimations[0],
+      name: objectAnimation.name,
+    };
+    animations.push(assetAnimation);
+  }
+  // Add extra animations from the asset.
+  for (const assetAnimation of assetAnimations) {
+    if (
+      !objectsAnimations.some(
+        objectAnimation => objectAnimation.name === assetAnimation.name
+      )
+    ) {
+      animations.push(assetAnimation);
+    }
+  }
+  return animations;
+};
+
+export const swapAsset = (
+  project: gdProject,
+  object: gdObject,
+  assetObject: gdObject
+) => {
+  const serializedObject = serializeToJSObject(object);
+  const serializedAssetObject = serializeToJSObject(assetObject);
+
+  if (object.getType() === 'Sprite') {
+    serializedObject.animations = mergeAnimations(
+      serializedObject.animations,
+      serializedAssetObject.animations
+    );
+  } else if (object.getType() === 'Scene3D::Model3DObject') {
+    const objectVolume =
+      serializedObject.content.width *
+      serializedObject.content.height *
+      serializedObject.content.depth;
+    const assetVolume =
+      serializedAssetObject.content.width *
+      serializedAssetObject.content.height *
+      serializedAssetObject.content.depth;
+    const sizeRatio = Math.pow(objectVolume / assetVolume, 1 / 3);
+
+    serializedObject.content = {
+      ...serializedAssetObject.content,
+      animations: mergeAnimations(
+        serializedObject.content.animations,
+        serializedAssetObject.content.animations
+      ),
+      width: serializedAssetObject.content.width * sizeRatio,
+      height: serializedAssetObject.content.height * sizeRatio,
+      depth: serializedAssetObject.content.depth * sizeRatio,
+      // Keep the origin and center as they may be important for the game to work.
+      originLocation: serializedObject.content.originLocation,
+      centerLocation: serializedObject.content.centerLocation,
+    };
+  }
+  unserializeFromJSObject(object, serializedObject, 'unserializeFrom', project);
+};

--- a/newIDE/app/src/AssetStore/AssetSwapper.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.js
@@ -4,15 +4,82 @@ import {
   unserializeFromJSObject,
 } from '../Utils/Serializer';
 
+/** Represents a point in a coordinate system. */
+type SpritePoint = {
+  /** X position of the point. */
+  x: number,
+  /** Y position of the point. */
+  y: number,
+};
+
+/** Represents a custom point in a frame. */
+type SpriteCustomPointData = {
+  /** Name of the point. */
+  name: string,
+  /** X position of the point. */
+  x: number,
+  /** Y position of the point. */
+  y: number,
+};
+
+/** Represents the center point in a frame. */
+type SpriteCenterPointData = {
+  /** Name of the point. */
+  name: string,
+  /** Is the center automatically computed? */
+  automatic: boolean,
+  /** X position of the point. */
+  x: number,
+  /** Y position of the point. */
+  y: number,
+};
+
+/** Represents a {@link gdjs.SpriteAnimationFrame}. */
+type SpriteFrameData = {
+  /** The resource name of the image used in this frame. */
+  image: string,
+  /** The points of the frame. */
+  points: Array<SpriteCustomPointData>,
+  /** The origin point. */
+  originPoint: SpriteCustomPointData,
+  /** The center of the frame. */
+  centerPoint: SpriteCenterPointData,
+  /** Is The collision mask custom? */
+  hasCustomCollisionMask: boolean,
+  /** The collision mask if it is custom. */
+  customCollisionMask: Array<Array<SpritePoint>>,
+};
+
+/** Represents the data of a {@link gdjs.SpriteAnimationDirection}. */
+type SpriteDirectionData = {
+  /** Time between each frame, in seconds. */
+  timeBetweenFrames: number,
+  /** Is the animation looping? */
+  looping: boolean,
+  /** The list of frames. */
+  sprites: Array<SpriteFrameData>,
+};
+
+/** Represents the data of a {@link gdjs.SpriteAnimation}. */
+type SpriteAnimationData = {
+  /** The name of the animation. */
+  name: string,
+  /** Does the animation use multiple {@link gdjs.SpriteAnimationDirection}? */
+  useMultipleDirections: boolean,
+  /** The list of {@link SpriteDirectionData} representing {@link gdjs.SpriteAnimationDirection} instances. */
+  directions: Array<SpriteDirectionData>,
+};
+
 export const canSwapAssetOfObject = (object: gdObject) => {
   const type = object.getType();
   return type === 'Scene3D::Model3DObject' || type === 'Sprite';
 };
 
-const mergeAnimations = (
-  objectsAnimations: Array<{ name: string }>,
-  assetAnimations: Array<{ name: string }>
-) => {
+const mergeAnimations = function<A: { name: string }>(
+  objectsAnimations: Array<A>,
+  assetAnimations: Array<A>,
+  mergeAnimation: (objectsAnimation: A, assetAnimation: A) => A
+) {
   const animations = [];
   // Ensure the object don't loose any animation.
   for (const objectAnimation of objectsAnimations) {
@@ -22,7 +89,7 @@ const mergeAnimations = (
       ...assetAnimations[0],
       name: objectAnimation.name,
     };
-    animations.push(assetAnimation);
+    animations.push(mergeAnimation(objectAnimation, assetAnimation));
   }
   // Add extra animations from the asset.
   for (const assetAnimation of assetAnimations) {
@@ -37,6 +104,60 @@ const mergeAnimations = (
   return animations;
 };
 
+const mergeSpriteFrame = (
+  objectsAnimation: SpriteFrameData,
+  assetAnimation: SpriteFrameData
+): SpriteFrameData => {
+  return {
+    ...assetAnimation,
+    originPoint: objectsAnimation.originPoint,
+    centerPoint: objectsAnimation.centerPoint,
+    points: objectsAnimation.points,
+  };
+};
+
+const mergeSpriteAnimation = (
+  objectAnimation: SpriteAnimationData,
+  assetAnimation: SpriteAnimationData
+): SpriteAnimationData => {
+  const objectDirection = objectAnimation.directions[0];
+  const assetDirection = assetAnimation.directions[0];
+  return {
+    ...assetAnimation,
+    directions: [
+      {
+        ...assetDirection,
+        sprites: objectDirection.sprites.map((frame, frameIndex) =>
+          mergeSpriteFrame(frame, assetDirection.sprites[frameIndex])
+        ),
+      },
+    ],
+  };
+};
+
+const mergeSpriteAnimations = (
+  objectAnimations: Array<SpriteAnimationData>,
+  assetAnimations: Array<SpriteAnimationData>
+) =>
+  mergeAnimations<SpriteAnimationData>(
+    objectAnimations,
+    assetAnimations,
+    mergeSpriteAnimation
+  );
+
+const mergeModel3DAnimation = (objectsAnimation, assetAnimation) =>
+  assetAnimation;
+
+const mergeModel3DAnimations = (
+  objectsAnimations: Array<{ name: string }>,
+  assetAnimations: Array<{ name: string }>
+) =>
+  mergeAnimations<{ name: string }>(
+    objectsAnimations,
+    assetAnimations,
+    mergeModel3DAnimation
+  );
+
 export const swapAsset = (
   project: gdProject,
   object: gdObject,
@@ -46,7 +167,7 @@ export const swapAsset = (
   const serializedAssetObject = serializeToJSObject(assetObject);
 
   if (object.getType() === 'Sprite') {
-    serializedObject.animations = mergeAnimations(
+    serializedObject.animations = mergeSpriteAnimations(
       serializedObject.animations,
       serializedAssetObject.animations
     );
@@ -63,7 +184,7 @@ export const swapAsset = (
 
     serializedObject.content = {
       ...serializedAssetObject.content,
-      animations: mergeAnimations(
+      animations: mergeModel3DAnimations(
         serializedObject.content.animations,
         serializedAssetObject.content.animations
       ),

--- a/newIDE/app/src/AssetStore/AssetSwapper.spec.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.spec.js
@@ -3,6 +3,19 @@ import { swapAsset } from './AssetSwapper';
 
 const gd: libGDevelop = global.gd;
 
+const PixiResourcesLoaderMock = {
+  getPIXITexture: (project: gdProject, resourceName: string) => {
+    switch (resourceName) {
+      case 'AssetIdle':
+        return { valid: true, width: 100, height: 240 };
+      case 'ObjectIdle':
+        return { valid: true, width: 50, height: 120 };
+      default:
+        return { valid: false, width: 0, height: 0 };
+    }
+  },
+};
+
 describe('swapAsset (Sprite)', () => {
   const makeNewTestProject = (): {|
     project: gdProject,
@@ -88,7 +101,7 @@ describe('swapAsset (Sprite)', () => {
     addAnimation(assetConfiguration, 'Run', 'AssetRun');
     addAnimation(assetConfiguration, 'Fire', 'AssetFire');
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     const objectNewConfiguration = gd.asSpriteConfiguration(
       object.getConfiguration()
@@ -123,7 +136,7 @@ describe('swapAsset (Sprite)', () => {
   test('can keep the object name', () => {
     const { project, object, assetObject } = makeNewTestProject();
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     expect(object.getName()).toEqual('Object');
 
@@ -135,7 +148,7 @@ describe('swapAsset (Sprite)', () => {
 
     object.getVariables().insertNew('MyVariable', 0);
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     expect(object.getVariables().has('MyVariable'));
 
@@ -177,7 +190,7 @@ describe('swapAsset (Sprite)', () => {
 
     addAnimation(assetConfiguration, 'Idle', 'AssetIdle');
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     const objectNewConfiguration = gd.asSpriteConfiguration(
       object.getConfiguration()
@@ -188,20 +201,22 @@ describe('swapAsset (Sprite)', () => {
       .getDirection(0)
       .getSprite(0);
 
-    expect(newFrame.getOrigin().getX()).toEqual(8);
-    expect(newFrame.getOrigin().getY()).toEqual(16);
+    // The coordinates are divided by 2 according to the images dimensions
+    // given by PixiResourcesLoaderMock.
+    expect(newFrame.getOrigin().getX()).toEqual(4);
+    expect(newFrame.getOrigin().getY()).toEqual(8);
 
     expect(!newFrame.isDefaultCenterPoint());
-    expect(newFrame.getCenter().getX()).toEqual(24);
-    expect(newFrame.getCenter().getY()).toEqual(32);
+    expect(newFrame.getCenter().getX()).toEqual(12);
+    expect(newFrame.getCenter().getY()).toEqual(16);
 
     expect(newFrame.hasPoint('CustomPointA'));
-    expect(newFrame.getPoint('CustomPointA').getX()).toEqual(40);
-    expect(newFrame.getPoint('CustomPointA').getY()).toEqual(48);
+    expect(newFrame.getPoint('CustomPointA').getX()).toEqual(20);
+    expect(newFrame.getPoint('CustomPointA').getY()).toEqual(24);
 
     expect(newFrame.hasPoint('CustomPointB'));
-    expect(newFrame.getPoint('CustomPointB').getX()).toEqual(56);
-    expect(newFrame.getPoint('CustomPointB').getY()).toEqual(64);
+    expect(newFrame.getPoint('CustomPointB').getX()).toEqual(28);
+    expect(newFrame.getPoint('CustomPointB').getY()).toEqual(32);
 
     project.delete();
   });
@@ -235,7 +250,7 @@ describe('swapAsset (Sprite)', () => {
       .getDirection(0)
       .addSprite(frame2);
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     const objectNewConfiguration = gd.asSpriteConfiguration(
       object.getConfiguration()
@@ -247,11 +262,15 @@ describe('swapAsset (Sprite)', () => {
     const frame0 = newDirection.getSprite(0);
     const frame1 = newDirection.getSprite(0);
 
-    expect(frame0.getOrigin().getX()).toEqual(8);
-    expect(frame0.getOrigin().getY()).toEqual(16);
-    // It defaults to the points from the 1st frame.
-    expect(frame1.getOrigin().getX()).toEqual(8);
-    expect(frame1.getOrigin().getY()).toEqual(16);
+    // The coordinates are divided by 2 according to the images dimensions
+    // given by PixiResourcesLoaderMock.
+    expect(frame0.getOrigin().getX()).toEqual(4);
+    expect(frame0.getOrigin().getY()).toEqual(8);
+    // The points from the 1st frame is used for every frame because points
+    // defined frame by frame will likely become irrelevant with the new asset
+    // animations.
+    expect(frame1.getOrigin().getX()).toEqual(4);
+    expect(frame1.getOrigin().getY()).toEqual(8);
 
     project.delete();
   });
@@ -332,7 +351,7 @@ describe('swapAsset (Model)', () => {
     addAnimation(assetConfiguration, 'Run', 'AssetRun');
     addAnimation(assetConfiguration, 'Fire', 'AssetFire');
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     const objectNewConfiguration = gd.asModel3DConfiguration(
       object.getConfiguration()
@@ -390,7 +409,7 @@ describe('swapAsset (Model)', () => {
     assetConfiguration.updateProperty('height', '25');
     assetConfiguration.updateProperty('depth', '50');
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     const objectNewConfiguration = gd.asModel3DConfiguration(
       object.getConfiguration()
@@ -418,7 +437,7 @@ describe('swapAsset (Model)', () => {
     assetConfiguration.updateProperty('originLocation', 'ModelOrigin');
     assetConfiguration.updateProperty('centerLocation', 'ModelCenter');
 
-    swapAsset(project, object, assetObject);
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
     const objectNewConfiguration = gd.asModel3DConfiguration(
       object.getConfiguration()

--- a/newIDE/app/src/AssetStore/AssetSwapper.spec.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.spec.js
@@ -1,0 +1,322 @@
+// @flow
+import { swapAsset } from './AssetSwapper';
+
+const gd: libGDevelop = global.gd;
+
+describe('swapAsset (Sprite)', () => {
+  const makeNewTestProject = (): {|
+    project: gdProject,
+    object: gdObject,
+    assetObject: gdObject,
+    objectConfiguration: gdSpriteObject,
+    assetConfiguration: gdSpriteObject,
+  |} => {
+    const project = gd.ProjectHelper.createNewGDJSProject();
+    const scene = project.insertNewLayout('Scene', 0);
+
+    const object = scene
+      .getObjects()
+      .insertNewObject(project, 'Sprite', 'Object', 0);
+    const objectConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    const assetObject = scene
+      .getObjects()
+      .insertNewObject(project, 'Sprite', 'AssetObject', 0);
+    const assetConfiguration = gd.asSpriteConfiguration(
+      assetObject.getConfiguration()
+    );
+
+    return {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    };
+  };
+
+  const addAnimation = (
+    objectConfiguration: gdSpriteObject,
+    animationName: string,
+    resourceName: string
+  ) => {
+    const sprite = new gd.Sprite();
+    sprite.setImageName(resourceName);
+
+    const animation = new gd.Animation();
+    animation.setName(animationName);
+    animation.setDirectionsCount(1);
+    animation.getDirection(0).addSprite(sprite);
+
+    const objectAnimations = objectConfiguration.getAnimations();
+    objectAnimations.addAnimation(animation);
+  };
+
+  const getAnimationNameAndResource = (
+    objectConfiguration: gdSpriteObject,
+    animationIndex
+  ) => [
+    objectConfiguration
+      .getAnimations()
+      .getAnimation(animationIndex)
+      .getName(),
+    objectConfiguration
+      .getAnimations()
+      .getAnimation(animationIndex)
+      .getDirection(0)
+      .getSprite(0)
+      .getImageName(),
+  ];
+
+  test('can copy asset animations', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    addAnimation(objectConfiguration, 'Idle', 'ObjectIdle');
+    addAnimation(objectConfiguration, 'Run', 'ObjectRun');
+    addAnimation(objectConfiguration, 'Jump', 'ObjectJump');
+    addAnimation(objectConfiguration, 'Fall', 'ObjectFall');
+
+    addAnimation(assetConfiguration, 'Idle', 'AssetIdle');
+    addAnimation(assetConfiguration, 'Run', 'AssetRun');
+    addAnimation(assetConfiguration, 'Fire', 'AssetFire');
+
+    swapAsset(project, object, assetObject);
+
+    const objectNewConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(getAnimationNameAndResource(objectNewConfiguration, 0)).toEqual([
+      'Idle',
+      'AssetIdle',
+    ]);
+    expect(getAnimationNameAndResource(objectNewConfiguration, 1)).toEqual([
+      'Run',
+      'AssetRun',
+    ]);
+    // Missing animations default on "idle"
+    expect(getAnimationNameAndResource(objectNewConfiguration, 2)).toEqual([
+      'Jump',
+      'AssetIdle',
+    ]);
+    expect(getAnimationNameAndResource(objectNewConfiguration, 3)).toEqual([
+      'Fall',
+      'AssetIdle',
+    ]);
+    // New animation from the asset
+    expect(getAnimationNameAndResource(objectNewConfiguration, 4)).toEqual([
+      'Fire',
+      'AssetFire',
+    ]);
+
+    project.delete();
+  });
+
+  test('can keep the object name', () => {
+    const { project, object, assetObject } = makeNewTestProject();
+
+    swapAsset(project, object, assetObject);
+
+    expect(object.getName()).toEqual('Object');
+
+    project.delete();
+  });
+
+  test('can keep the object variables', () => {
+    const { project, object, assetObject } = makeNewTestProject();
+
+    object.getVariables().insertNew('MyVariable', 0);
+
+    swapAsset(project, object, assetObject);
+
+    expect(object.getVariables().has('MyVariable'));
+
+    project.delete();
+  });
+});
+
+describe('swapAsset (Model)', () => {
+  const makeNewTestProject = (): {|
+    project: gdProject,
+    object: gdObject,
+    assetObject: gdObject,
+    objectConfiguration: gdModel3DObjectConfiguration,
+    assetConfiguration: gdModel3DObjectConfiguration,
+  |} => {
+    const project = gd.ProjectHelper.createNewGDJSProject();
+    const scene = project.insertNewLayout('Scene', 0);
+
+    const objectConfiguration = new gd.Model3DObjectConfiguration();
+    const object = new gd.gdObject(
+      'Scene3D::Model3DObject',
+      'Object',
+      objectConfiguration
+    );
+    objectConfiguration.setType('Scene3D::Model3DObject');
+    scene.getObjects().insertObject(object, 0);
+
+    const assetConfiguration = new gd.Model3DObjectConfiguration();
+    const assetObject = new gd.gdObject(
+      'Scene3D::Model3DObject',
+      'AssetObject',
+      assetConfiguration
+    );
+    assetConfiguration.setType('Scene3D::Model3DObject');
+    scene.getObjects().insertObject(assetObject, 0);
+
+    return {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    };
+  };
+
+  const addAnimation = (
+    objectConfiguration: gdModel3DObjectConfiguration,
+    animationName: string,
+    resourceName: string
+  ) => {
+    const animation = new gd.Model3DAnimation();
+    animation.setName(animationName);
+    animation.setSource(resourceName);
+    objectConfiguration.addAnimation(animation);
+  };
+
+  const getAnimationNameAndResource = (
+    objectConfiguration: gdModel3DObjectConfiguration,
+    animationIndex
+  ) => [
+    objectConfiguration.getAnimation(animationIndex).getName(),
+    objectConfiguration.getAnimation(animationIndex).getSource(),
+  ];
+
+  test('can copy asset animations', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    addAnimation(objectConfiguration, 'Idle', 'ObjectIdle');
+    addAnimation(objectConfiguration, 'Run', 'ObjectRun');
+    addAnimation(objectConfiguration, 'Jump', 'ObjectJump');
+    addAnimation(objectConfiguration, 'Fall', 'ObjectFall');
+
+    addAnimation(assetConfiguration, 'Idle', 'AssetIdle');
+    addAnimation(assetConfiguration, 'Run', 'AssetRun');
+    addAnimation(assetConfiguration, 'Fire', 'AssetFire');
+
+    swapAsset(project, object, assetObject);
+
+    const objectNewConfiguration = gd.asModel3DConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(getAnimationNameAndResource(objectNewConfiguration, 0)).toEqual([
+      'Idle',
+      'AssetIdle',
+    ]);
+    expect(getAnimationNameAndResource(objectNewConfiguration, 1)).toEqual([
+      'Run',
+      'AssetRun',
+    ]);
+    // Missing animations default on "idle"
+    expect(getAnimationNameAndResource(objectNewConfiguration, 2)).toEqual([
+      'Jump',
+      'AssetIdle',
+    ]);
+    expect(getAnimationNameAndResource(objectNewConfiguration, 3)).toEqual([
+      'Fall',
+      'AssetIdle',
+    ]);
+    // New animation from the asset
+    expect(getAnimationNameAndResource(objectNewConfiguration, 4)).toEqual([
+      'Fire',
+      'AssetFire',
+    ]);
+
+    project.delete();
+  });
+
+  const getPropertyValue = (
+    objectConfiguration: gdObjectConfiguration,
+    name: string
+  ) =>
+    objectConfiguration
+      .getProperties()
+      .get(name)
+      .getValue();
+
+  test('can adapt the dimensions to keep the same volume', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    objectConfiguration.updateProperty('width', '100');
+    objectConfiguration.updateProperty('height', '200');
+    objectConfiguration.updateProperty('depth', '50');
+
+    assetConfiguration.updateProperty('width', '100');
+    assetConfiguration.updateProperty('height', '25');
+    assetConfiguration.updateProperty('depth', '50');
+
+    swapAsset(project, object, assetObject);
+
+    const objectNewConfiguration = gd.asModel3DConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(getPropertyValue(objectNewConfiguration, 'width')).toEqual('200');
+    expect(getPropertyValue(objectNewConfiguration, 'height')).toEqual('50');
+    expect(getPropertyValue(objectNewConfiguration, 'depth')).toEqual('100');
+
+    project.delete();
+  });
+
+  test('can keep the object origin and center', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    objectConfiguration.updateProperty('originLocation', 'TopLeft');
+    objectConfiguration.updateProperty('centerLocation', 'ObjectCenter');
+
+    assetConfiguration.updateProperty('originLocation', 'ModelOrigin');
+    assetConfiguration.updateProperty('centerLocation', 'ModelCenter');
+
+    swapAsset(project, object, assetObject);
+
+    const objectNewConfiguration = gd.asModel3DConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(getPropertyValue(objectNewConfiguration, 'originLocation')).toEqual(
+      'TopLeft'
+    );
+    expect(getPropertyValue(objectNewConfiguration, 'centerLocation')).toEqual(
+      'ObjectCenter'
+    );
+
+    project.delete();
+  });
+});

--- a/newIDE/app/src/AssetStore/AssetSwapper.spec.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.spec.js
@@ -6,9 +6,9 @@ const gd: libGDevelop = global.gd;
 const PixiResourcesLoaderMock = {
   getPIXITexture: (project: gdProject, resourceName: string) => {
     switch (resourceName) {
-      case 'AssetIdle':
+      case 'Frame100x240':
         return { valid: true, width: 100, height: 240 };
-      case 'ObjectIdle':
+      case 'Frame50x120':
         return { valid: true, width: 50, height: 120 };
       default:
         return { valid: false, width: 0, height: 0 };
@@ -164,7 +164,7 @@ describe('swapAsset (Sprite)', () => {
       assetConfiguration,
     } = makeNewTestProject();
 
-    addAnimation(objectConfiguration, 'Idle', 'ObjectIdle');
+    addAnimation(objectConfiguration, 'Idle', 'Frame50x120');
     const frame = objectConfiguration
       .getAnimations()
       .getAnimation(0)
@@ -188,7 +188,7 @@ describe('swapAsset (Sprite)', () => {
     frame.addPoint(customPoint);
     customPoint.delete();
 
-    addAnimation(assetConfiguration, 'Idle', 'AssetIdle');
+    addAnimation(assetConfiguration, 'Idle', 'Frame100x240');
 
     swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 
@@ -231,7 +231,7 @@ describe('swapAsset (Sprite)', () => {
     } = makeNewTestProject();
 
     // The object only has 1 frame in the Idle animation.
-    addAnimation(objectConfiguration, 'Idle', 'ObjectIdle');
+    addAnimation(objectConfiguration, 'Idle', 'Frame50x120');
     objectConfiguration
       .getAnimations()
       .getAnimation(0)
@@ -241,7 +241,7 @@ describe('swapAsset (Sprite)', () => {
       .setXY(8, 16);
 
     // The asset has a 2nd frame in the Idle animation.
-    addAnimation(assetConfiguration, 'Idle', 'AssetIdle');
+    addAnimation(assetConfiguration, 'Idle', 'Frame100x240');
     const frame2 = new gd.Sprite();
     frame2.setImageName('AssetIdle2');
     assetConfiguration
@@ -271,6 +271,100 @@ describe('swapAsset (Sprite)', () => {
     // animations.
     expect(frame1.getOrigin().getX()).toEqual(4);
     expect(frame1.getOrigin().getY()).toEqual(8);
+
+    project.delete();
+  });
+
+  test('can keep the object default size similar (smaller asset)', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    addAnimation(objectConfiguration, 'Idle', 'Frame100x240');
+    addAnimation(assetConfiguration, 'Idle', 'Frame50x120');
+
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
+
+    const objectNewConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(objectNewConfiguration.getPreScale()).toEqual(2);
+
+    project.delete();
+  });
+
+  test('can keep the object default size similar (bigger asset)', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    addAnimation(objectConfiguration, 'Idle', 'Frame50x120');
+    addAnimation(assetConfiguration, 'Idle', 'Frame100x240');
+
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
+
+    const objectNewConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(objectNewConfiguration.getPreScale()).toEqual(0.5);
+
+    project.delete();
+  });
+
+  test('can keep the object default size similar (smaller asset and object already up-scaled)', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    gd.asSpriteConfiguration(object.getConfiguration()).setPreScale(2);
+    addAnimation(objectConfiguration, 'Idle', 'Frame100x240');
+    addAnimation(assetConfiguration, 'Idle', 'Frame50x120');
+
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
+
+    const objectNewConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(objectNewConfiguration.getPreScale()).toEqual(4);
+
+    project.delete();
+  });
+
+  test('can keep the object default size similar (bigger asset, but object already up-scaled)', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    gd.asSpriteConfiguration(object.getConfiguration()).setPreScale(2);
+    addAnimation(objectConfiguration, 'Idle', 'Frame50x120');
+    addAnimation(assetConfiguration, 'Idle', 'Frame100x240');
+
+    swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
+
+    const objectNewConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+
+    expect(objectNewConfiguration.getPreScale()).toEqual(1);
 
     project.delete();
   });

--- a/newIDE/app/src/AssetStore/AssetSwapper.spec.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.spec.js
@@ -205,6 +205,56 @@ describe('swapAsset (Sprite)', () => {
 
     project.delete();
   });
+
+  test('can keep the object points when the object has less frames than the asset', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    // The object only has 1 frame in the Idle animation.
+    addAnimation(objectConfiguration, 'Idle', 'ObjectIdle');
+    objectConfiguration
+      .getAnimations()
+      .getAnimation(0)
+      .getDirection(0)
+      .getSprite(0)
+      .getOrigin()
+      .setXY(8, 16);
+
+    // The asset has a 2nd frame in the Idle animation.
+    addAnimation(assetConfiguration, 'Idle', 'AssetIdle');
+    const frame2 = new gd.Sprite();
+    frame2.setImageName('AssetIdle2');
+    assetConfiguration
+      .getAnimations()
+      .getAnimation(0)
+      .getDirection(0)
+      .addSprite(frame2);
+
+    swapAsset(project, object, assetObject);
+
+    const objectNewConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+    const newDirection = objectNewConfiguration
+      .getAnimations()
+      .getAnimation(0)
+      .getDirection(0);
+    const frame0 = newDirection.getSprite(0);
+    const frame1 = newDirection.getSprite(0);
+
+    expect(frame0.getOrigin().getX()).toEqual(8);
+    expect(frame0.getOrigin().getY()).toEqual(16);
+    // It defaults to the points from the 1st frame.
+    expect(frame1.getOrigin().getX()).toEqual(8);
+    expect(frame1.getOrigin().getY()).toEqual(16);
+
+    project.delete();
+  });
 });
 
 describe('swapAsset (Model)', () => {

--- a/newIDE/app/src/AssetStore/AssetSwapper.spec.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.spec.js
@@ -65,6 +65,9 @@ describe('swapAsset (Sprite)', () => {
 
     const objectAnimations = objectConfiguration.getAnimations();
     objectAnimations.addAnimation(animation);
+
+    sprite.delete();
+    animation.delete();
   };
 
   const getAnimationNameAndResource = (
@@ -249,6 +252,7 @@ describe('swapAsset (Sprite)', () => {
       .getAnimation(0)
       .getDirection(0)
       .addSprite(frame2);
+    frame2.delete();
 
     swapAsset(project, PixiResourcesLoaderMock, object, assetObject);
 

--- a/newIDE/app/src/AssetStore/AssetSwapper.spec.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.spec.js
@@ -201,22 +201,22 @@ describe('swapAsset (Sprite)', () => {
       .getDirection(0)
       .getSprite(0);
 
-    // The coordinates are divided by 2 according to the images dimensions
+    // The coordinates are multiplied by 2 according to the images dimensions
     // given by PixiResourcesLoaderMock.
-    expect(newFrame.getOrigin().getX()).toEqual(4);
-    expect(newFrame.getOrigin().getY()).toEqual(8);
+    expect(newFrame.getOrigin().getX()).toEqual(16);
+    expect(newFrame.getOrigin().getY()).toEqual(32);
 
     expect(!newFrame.isDefaultCenterPoint());
-    expect(newFrame.getCenter().getX()).toEqual(12);
-    expect(newFrame.getCenter().getY()).toEqual(16);
+    expect(newFrame.getCenter().getX()).toEqual(48);
+    expect(newFrame.getCenter().getY()).toEqual(64);
 
     expect(newFrame.hasPoint('CustomPointA'));
-    expect(newFrame.getPoint('CustomPointA').getX()).toEqual(20);
-    expect(newFrame.getPoint('CustomPointA').getY()).toEqual(24);
+    expect(newFrame.getPoint('CustomPointA').getX()).toEqual(80);
+    expect(newFrame.getPoint('CustomPointA').getY()).toEqual(96);
 
     expect(newFrame.hasPoint('CustomPointB'));
-    expect(newFrame.getPoint('CustomPointB').getX()).toEqual(28);
-    expect(newFrame.getPoint('CustomPointB').getY()).toEqual(32);
+    expect(newFrame.getPoint('CustomPointB').getX()).toEqual(112);
+    expect(newFrame.getPoint('CustomPointB').getY()).toEqual(128);
 
     project.delete();
   });
@@ -262,15 +262,15 @@ describe('swapAsset (Sprite)', () => {
     const frame0 = newDirection.getSprite(0);
     const frame1 = newDirection.getSprite(0);
 
-    // The coordinates are divided by 2 according to the images dimensions
+    // The coordinates are multiplied by 2 according to the images dimensions
     // given by PixiResourcesLoaderMock.
-    expect(frame0.getOrigin().getX()).toEqual(4);
-    expect(frame0.getOrigin().getY()).toEqual(8);
+    expect(frame0.getOrigin().getX()).toEqual(16);
+    expect(frame0.getOrigin().getY()).toEqual(32);
     // The points from the 1st frame is used for every frame because points
     // defined frame by frame will likely become irrelevant with the new asset
     // animations.
-    expect(frame1.getOrigin().getX()).toEqual(4);
-    expect(frame1.getOrigin().getY()).toEqual(8);
+    expect(frame1.getOrigin().getX()).toEqual(16);
+    expect(frame1.getOrigin().getY()).toEqual(32);
 
     project.delete();
   });

--- a/newIDE/app/src/AssetStore/AssetSwapper.spec.js
+++ b/newIDE/app/src/AssetStore/AssetSwapper.spec.js
@@ -141,6 +141,70 @@ describe('swapAsset (Sprite)', () => {
 
     project.delete();
   });
+
+  test('can keep the object points', () => {
+    const {
+      project,
+      object,
+      assetObject,
+      objectConfiguration,
+      assetConfiguration,
+    } = makeNewTestProject();
+
+    addAnimation(objectConfiguration, 'Idle', 'ObjectIdle');
+    const frame = objectConfiguration
+      .getAnimations()
+      .getAnimation(0)
+      .getDirection(0)
+      .getSprite(0);
+
+    const origin = frame.getOrigin();
+    origin.setXY(8, 16);
+
+    frame.setDefaultCenterPoint(false);
+    const center = frame.getCenter();
+    center.setXY(24, 32);
+
+    const customPoint = new gd.Point('');
+    customPoint.setName('CustomPointA');
+    customPoint.setXY(40, 48);
+    frame.addPoint(customPoint);
+
+    customPoint.setName('CustomPointB');
+    customPoint.setXY(56, 64);
+    frame.addPoint(customPoint);
+    customPoint.delete();
+
+    addAnimation(assetConfiguration, 'Idle', 'AssetIdle');
+
+    swapAsset(project, object, assetObject);
+
+    const objectNewConfiguration = gd.asSpriteConfiguration(
+      object.getConfiguration()
+    );
+    const newFrame = objectNewConfiguration
+      .getAnimations()
+      .getAnimation(0)
+      .getDirection(0)
+      .getSprite(0);
+
+    expect(newFrame.getOrigin().getX()).toEqual(8);
+    expect(newFrame.getOrigin().getY()).toEqual(16);
+
+    expect(!newFrame.isDefaultCenterPoint());
+    expect(newFrame.getCenter().getX()).toEqual(24);
+    expect(newFrame.getCenter().getY()).toEqual(32);
+
+    expect(newFrame.hasPoint('CustomPointA'));
+    expect(newFrame.getPoint('CustomPointA').getX()).toEqual(40);
+    expect(newFrame.getPoint('CustomPointA').getY()).toEqual(48);
+
+    expect(newFrame.hasPoint('CustomPointB'));
+    expect(newFrame.getPoint('CustomPointB').getX()).toEqual(56);
+    expect(newFrame.getPoint('CustomPointB').getY()).toEqual(64);
+
+    project.delete();
+  });
 });
 
 describe('swapAsset (Model)', () => {

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -90,12 +90,13 @@ const swapAsset = (
       serializedAssetObject.content.width *
       serializedAssetObject.content.height *
       serializedAssetObject.content.depth;
+    const ratio = Math.pow(objectVolume / assetVolume, 1/3);
 
     serializedObject.content = serializedAssetObject.content;
     serializedObject.content.animation = animations;
-    serializedObject.content.width *= objectVolume / assetVolume;
-    serializedObject.content.height *= objectVolume / assetVolume;
-    serializedObject.content.depth *= objectVolume / assetVolume;
+    serializedObject.content.width *= ratio;
+    serializedObject.content.height *= ratio;
+    serializedObject.content.depth *= ratio;
   }
   unserializeFromJSObject(object, serializedObject, 'unserializeFrom', project);
 };

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -351,13 +351,7 @@ function AssetSwappingDialog({
       key="add-asset"
       primary={!isAssetAddedToScene}
       label={
-        isAssetBeingInstalled ? (
-          <Trans>Adding...</Trans>
-        ) : isAssetAddedToScene ? (
-          <Trans>Swap</Trans>
-        ) : (
-          <Trans>Get and swap</Trans>
-        )
+        isAssetBeingInstalled ? <Trans>Adding...</Trans> : <Trans>Swap</Trans>
       }
       onClick={async () => {
         onInstallAsset(openedAssetShortHeader);

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -321,7 +321,7 @@ function AssetSwappingDialog({
       {({ i18n }) => (
         <>
           <Dialog
-            title={<Trans>Asset swapping</Trans>}
+            title={<Trans>Asset swapping of {object.getName()}</Trans>}
             secondaryActions={[
               <HelpButton helpPagePath="/objects" key="help" />,
             ]}

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -164,7 +164,8 @@ function AssetSwappingDialog({
             project,
             PixiResourcesLoader,
             object,
-            installOutput.createdObjects[0]
+            installOutput.createdObjects[0],
+            assetShortHeader
           );
         }
         for (const createdObject of installOutput.createdObjects) {

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -30,6 +30,7 @@ import {
   useExtensionUpdateAlertDialog,
 } from './NewObjectDialog';
 import { swapAsset } from './AssetSwapper';
+import PixiResourcesLoader from '../ObjectsRendering/PixiResourcesLoader';
 
 const isDev = Window.isDev();
 
@@ -159,7 +160,12 @@ function AssetSwappingDialog({
         });
 
         if (installOutput.createdObjects.length > 0) {
-          swapAsset(project, object, installOutput.createdObjects[0]);
+          swapAsset(
+            project,
+            PixiResourcesLoader,
+            object,
+            installOutput.createdObjects[0]
+          );
         }
         for (const createdObject of installOutput.createdObjects) {
           objectsContainer.removeObject(createdObject.getName());

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -1,5 +1,5 @@
 // @flow
-import { t, Trans } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import * as React from 'react';
 import Dialog from '../UI/Dialog';

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -1,0 +1,394 @@
+// @flow
+import { t, Trans } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+import * as React from 'react';
+import Dialog from '../UI/Dialog';
+import FlatButton from '../UI/FlatButton';
+import HelpButton from '../UI/HelpButton';
+import { AssetStore, type AssetStoreInterface } from '.';
+import { type ResourceManagementProps } from '../ResourcesList/ResourceSource';
+import { sendAssetAddedToProject } from '../Utils/Analytics/EventSender';
+import RaisedButton from '../UI/RaisedButton';
+import { AssetStoreContext } from './AssetStoreContext';
+import AssetPackInstallDialog from './AssetPackInstallDialog';
+import {
+  installRequiredExtensions,
+  installPublicAsset,
+  checkRequiredExtensionsUpdateForAssets,
+} from './InstallAsset';
+import {
+  type Asset,
+  type AssetShortHeader,
+  getPublicAsset,
+  isPrivateAsset,
+} from '../Utils/GDevelopServices/Asset';
+import { type ExtensionShortHeader } from '../Utils/GDevelopServices/Extension';
+import EventsFunctionsExtensionsContext from '../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsContext';
+import Window from '../Utils/Window';
+import PrivateAssetsAuthorizationContext from './PrivateAssets/PrivateAssetsAuthorizationContext';
+import useAlertDialog from '../UI/Alert/useAlertDialog';
+import { enumerateAssetStoreIds } from './EnumerateAssetStoreIds';
+import PromisePool from '@supercharge/promise-pool';
+import { getAssetShortHeadersToDisplay } from './AssetsList';
+import ErrorBoundary from '../UI/ErrorBoundary';
+import type { ObjectFolderOrObjectWithContext } from '../ObjectsList/EnumerateObjectFolderOrObject';
+import LoaderModal from '../UI/LoaderModal';
+
+const isDev = Window.isDev();
+
+export const useExtensionUpdateAlertDialog = () => {
+  const { showConfirmation } = useAlertDialog();
+  return async (
+    outOfDateExtensionShortHeaders: Array<ExtensionShortHeader>
+  ): Promise<boolean> => {
+    return await showConfirmation({
+      title: t`Extension update`,
+      message: t`Before installing this asset, it's strongly recommended to update these extensions${'\n\n - ' +
+        outOfDateExtensionShortHeaders
+          .map(extension => extension.fullName)
+          .join('\n\n - ') +
+        '\n\n'}Do you want to update it now ?`,
+      confirmButtonLabel: t`Update the extension`,
+      dismissButtonLabel: t`Skip the update`,
+    });
+  };
+};
+
+export const useFetchAssets = () => {
+  const { environment } = React.useContext(AssetStoreContext);
+
+  const { fetchPrivateAsset } = React.useContext(
+    PrivateAssetsAuthorizationContext
+  );
+
+  return async (
+    assetShortHeaders: Array<AssetShortHeader>
+  ): Promise<Array<Asset>> => {
+    const fetchedAssets = await PromisePool.withConcurrency(6)
+      .for(assetShortHeaders)
+      .process<Asset>(async assetShortHeader => {
+        const asset = isPrivateAsset(assetShortHeader)
+          ? await fetchPrivateAsset(assetShortHeader, {
+              environment,
+            })
+          : await getPublicAsset(assetShortHeader, { environment });
+        if (!asset) {
+          throw new Error(
+            'Unable to install the asset because it could not be fetched.'
+          );
+        }
+        return asset;
+      });
+    if (fetchedAssets.errors.length) {
+      throw new Error(
+        'Error(s) while installing assets. The first error is: ' +
+          fetchedAssets.errors[0].message
+      );
+    }
+    const assets = fetchedAssets.results;
+    return assets;
+  };
+};
+
+type Props = {|
+  project: gdProject,
+  layout: ?gdLayout,
+  eventsBasedObject: gdEventsBasedObject | null,
+  objectsContainer: gdObjectsContainer,
+  object: gdObject,
+  resourceManagementProps: ResourceManagementProps,
+  onClose: () => void,
+  onCreateNewObject: (type: string) => void,
+  onObjectsAddedFromAssets: (Array<gdObject>) => void,
+  canInstallPrivateAsset: () => boolean,
+  targetObjectFolderOrObjectWithContext?: ?ObjectFolderOrObjectWithContext,
+|};
+
+function AssetSwappingDialog({
+  project,
+  layout,
+  eventsBasedObject,
+  objectsContainer,
+  object,
+  resourceManagementProps,
+  onClose,
+  onCreateNewObject,
+  onObjectsAddedFromAssets,
+  canInstallPrivateAsset,
+  targetObjectFolderOrObjectWithContext,
+}: Props) {
+  const {
+    assetShortHeadersSearchResults,
+    shopNavigationState,
+    environment,
+    setEnvironment,
+  } = React.useContext(AssetStoreContext);
+  const {
+    openedAssetPack,
+    openedAssetShortHeader,
+    selectedFolders,
+  } = shopNavigationState.getCurrentPage();
+  const [
+    isAssetPackDialogInstallOpen,
+    setIsAssetPackDialogInstallOpen,
+  ] = React.useState(false);
+  // Avoid memoizing the result of enumerateAssetStoreIds, as it does not get updated
+  // when adding assets.
+  const existingAssetStoreIds = enumerateAssetStoreIds(
+    project,
+    objectsContainer
+  );
+  const [
+    isAssetBeingInstalled,
+    setIsAssetBeingInstalled,
+  ] = React.useState<boolean>(false);
+  const eventsFunctionsExtensionsState = React.useContext(
+    EventsFunctionsExtensionsContext
+  );
+  const isAssetAddedToScene =
+    openedAssetShortHeader &&
+    existingAssetStoreIds.has(openedAssetShortHeader.id);
+  const { installPrivateAsset } = React.useContext(
+    PrivateAssetsAuthorizationContext
+  );
+  const { showAlert } = useAlertDialog();
+
+  const fetchAssets = useFetchAssets();
+  const showExtensionUpdateConfirmation = useExtensionUpdateAlertDialog();
+
+  const onInstallAsset = React.useCallback(
+    async (assetShortHeader): Promise<boolean> => {
+      if (!assetShortHeader) return false;
+      setIsAssetBeingInstalled(true);
+      try {
+        const isPrivate = isPrivateAsset(assetShortHeader);
+        if (isPrivate) {
+          const canUserInstallPrivateAsset = await canInstallPrivateAsset();
+          if (!canUserInstallPrivateAsset) {
+            await showAlert({
+              title: t`Save your project`,
+              message: t`You need to save this project as a cloud project to install this asset. Please save your project and try again.`,
+            });
+            setIsAssetBeingInstalled(false);
+            return false;
+          }
+        }
+        const assets = await fetchAssets([assetShortHeader]);
+        const asset = assets[0];
+        const requiredExtensionInstallation = await checkRequiredExtensionsUpdateForAssets(
+          {
+            assets,
+            project,
+          }
+        );
+        const shouldUpdateExtension =
+          requiredExtensionInstallation.outOfDateExtensionShortHeaders.length >
+            0 &&
+          (await showExtensionUpdateConfirmation(
+            requiredExtensionInstallation.outOfDateExtensionShortHeaders
+          ));
+        await installRequiredExtensions({
+          requiredExtensionInstallation,
+          shouldUpdateExtension,
+          eventsFunctionsExtensionsState,
+          project,
+        });
+        const installOutput = isPrivate
+          ? await installPrivateAsset({
+              asset,
+              project,
+              objectsContainer,
+              targetObjectFolderOrObject:
+                targetObjectFolderOrObjectWithContext &&
+                !targetObjectFolderOrObjectWithContext.global
+                  ? targetObjectFolderOrObjectWithContext.objectFolderOrObject
+                  : null,
+            })
+          : await installPublicAsset({
+              asset,
+              project,
+              objectsContainer,
+              targetObjectFolderOrObject:
+                targetObjectFolderOrObjectWithContext &&
+                !targetObjectFolderOrObjectWithContext.global
+                  ? targetObjectFolderOrObjectWithContext.objectFolderOrObject
+                  : null,
+            });
+        if (!installOutput) {
+          throw new Error('Unable to install private Asset.');
+        }
+        sendAssetAddedToProject({
+          id: assetShortHeader.id,
+          name: assetShortHeader.name,
+          assetPackName: openedAssetPack ? openedAssetPack.name : null,
+          assetPackTag: openedAssetPack ? openedAssetPack.tag : null,
+          assetPackId:
+            openedAssetPack && openedAssetPack.id ? openedAssetPack.id : null,
+          assetPackKind: isPrivate ? 'private' : 'public',
+        });
+
+        onObjectsAddedFromAssets(installOutput.createdObjects);
+
+        await resourceManagementProps.onFetchNewlyAddedResources();
+        setIsAssetBeingInstalled(false);
+        return true;
+      } catch (error) {
+        console.error('Error while installing the asset:', error);
+        showAlert({
+          title: t`Could not install the asset`,
+          message: t`There was an error while installing the asset "${
+            assetShortHeader.name
+          }". Verify your internet connection or try again later.`,
+        });
+        setIsAssetBeingInstalled(false);
+        return false;
+      }
+    },
+    [
+      fetchAssets,
+      project,
+      showExtensionUpdateConfirmation,
+      installPrivateAsset,
+      eventsFunctionsExtensionsState,
+      objectsContainer,
+      openedAssetPack,
+      resourceManagementProps,
+      canInstallPrivateAsset,
+      showAlert,
+      onObjectsAddedFromAssets,
+      targetObjectFolderOrObjectWithContext,
+    ]
+  );
+
+  const displayedAssetShortHeaders = React.useMemo(
+    () => {
+      return assetShortHeadersSearchResults
+        ? getAssetShortHeadersToDisplay(
+            assetShortHeadersSearchResults,
+            selectedFolders
+          )
+        : [];
+    },
+    [assetShortHeadersSearchResults, selectedFolders]
+  );
+
+  const mainAction = openedAssetShortHeader ? (
+    <RaisedButton
+      key="add-asset"
+      primary={!isAssetAddedToScene}
+      label={
+        isAssetBeingInstalled ? (
+          <Trans>Adding...</Trans>
+        ) : isAssetAddedToScene ? (
+          <Trans>Swap</Trans>
+        ) : (
+          <Trans>Get and swap</Trans>
+        )
+      }
+      onClick={async () => {
+        onInstallAsset(openedAssetShortHeader);
+      }}
+      disabled={isAssetBeingInstalled}
+      id="add-asset-button"
+    />
+  ) : isDev ? (
+    <RaisedButton
+      key="show-dev-assets"
+      label={
+        environment === 'staging' ? (
+          <Trans>Show live assets</Trans>
+        ) : (
+          <Trans>Show staging assets</Trans>
+        )
+      }
+      onClick={() => {
+        setEnvironment(environment === 'staging' ? 'live' : 'staging');
+      }}
+    />
+  ) : null;
+
+  const assetStore = React.useRef<?AssetStoreInterface>(null);
+  const handleClose = React.useCallback(
+    () => {
+      assetStore.current && assetStore.current.onClose();
+      onClose();
+    },
+    [onClose]
+  );
+
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <>
+          <Dialog
+            title={<Trans>Asset swapping</Trans>}
+            secondaryActions={[
+              <HelpButton helpPagePath="/objects" key="help" />,
+            ]}
+            actions={[
+              <FlatButton
+                key="close"
+                label={<Trans>Close</Trans>}
+                primary={false}
+                onClick={handleClose}
+                id="close-button"
+              />,
+              mainAction,
+            ]}
+            onRequestClose={handleClose}
+            onApply={
+              openedAssetPack
+                ? () => setIsAssetPackDialogInstallOpen(true)
+                : openedAssetShortHeader
+                ? async () => {
+                    await onInstallAsset(openedAssetShortHeader);
+                  }
+                : undefined
+            }
+            open
+            flexBody
+            fullHeight
+            id="new-object-dialog"
+          >
+            <AssetStore
+              ref={assetStore}
+              hideGameTemplates
+              assetSwappedObject={object}
+            />
+          </Dialog>
+          {isAssetBeingInstalled && <LoaderModal show={true} />}
+          {isAssetPackDialogInstallOpen &&
+            displayedAssetShortHeaders &&
+            openedAssetPack && (
+              <AssetPackInstallDialog
+                assetPack={openedAssetPack}
+                assetShortHeaders={displayedAssetShortHeaders}
+                addedAssetIds={existingAssetStoreIds}
+                onClose={() => setIsAssetPackDialogInstallOpen(false)}
+                onAssetsAdded={() => {
+                  setIsAssetPackDialogInstallOpen(false);
+                }}
+                project={project}
+                objectsContainer={objectsContainer}
+                onObjectsAddedFromAssets={onObjectsAddedFromAssets}
+                canInstallPrivateAsset={canInstallPrivateAsset}
+                resourceManagementProps={resourceManagementProps}
+              />
+            )}
+        </>
+      )}
+    </I18n>
+  );
+}
+
+const AssetSwappingDialogWithErrorBoundary = (props: Props) => (
+  <ErrorBoundary
+    componentTitle={<Trans>Asset store dialog</Trans>}
+    scope="new-object-dialog"
+    onClose={props.onClose}
+  >
+    <AssetSwappingDialog {...props} />
+  </ErrorBoundary>
+);
+
+export default AssetSwappingDialogWithErrorBoundary;

--- a/newIDE/app/src/AssetStore/AssetSwappingDialog.js
+++ b/newIDE/app/src/AssetStore/AssetSwappingDialog.js
@@ -77,11 +77,6 @@ const swapAsset = (
       serializedAssetObject.animations
     );
   } else if (object.getType() === 'Scene3D::Model3DObject') {
-    const animations = (serializedObject.animations = mergeAnimations(
-      serializedObject.content.animations,
-      serializedAssetObject.content.animations
-    ));
-
     const objectVolume =
       serializedObject.content.width *
       serializedObject.content.height *
@@ -90,13 +85,21 @@ const swapAsset = (
       serializedAssetObject.content.width *
       serializedAssetObject.content.height *
       serializedAssetObject.content.depth;
-    const ratio = Math.pow(objectVolume / assetVolume, 1/3);
+    const sizeRatio = Math.pow(objectVolume / assetVolume, 1 / 3);
 
-    serializedObject.content = serializedAssetObject.content;
-    serializedObject.content.animation = animations;
-    serializedObject.content.width *= ratio;
-    serializedObject.content.height *= ratio;
-    serializedObject.content.depth *= ratio;
+    serializedObject.content = {
+      ...serializedAssetObject.content,
+      animation: mergeAnimations(
+        serializedObject.content.animations,
+        serializedAssetObject.content.animations
+      ),
+      width: serializedAssetObject.content.width * sizeRatio,
+      height: serializedAssetObject.content.height * sizeRatio,
+      depth: serializedAssetObject.content.depth * sizeRatio,
+      // Keep the origin and center as they may be important for the game to work.
+      originLocation: serializedObject.content.originLocation,
+      centerLocation: serializedObject.content.centerLocation,
+    };
   }
   unserializeFromJSObject(object, serializedObject, 'unserializeFrom', project);
 };

--- a/newIDE/app/src/AssetStore/NewObjectDialog.js
+++ b/newIDE/app/src/AssetStore/NewObjectDialog.js
@@ -19,6 +19,7 @@ import {
   installPublicAsset,
   checkRequiredExtensionsUpdate,
   checkRequiredExtensionsUpdateForAssets,
+  type InstallAssetOutput,
 } from './InstallAsset';
 import {
   type Asset,
@@ -118,6 +119,115 @@ export const useFetchAssets = () => {
   };
 };
 
+export const useInstallAsset = ({
+  project,
+  objectsContainer,
+  targetObjectFolderOrObjectWithContext,
+  resourceManagementProps,
+  canInstallPrivateAsset,
+  onObjectsAddedFromAssets,
+}: {|
+  project: gdProject,
+  objectsContainer: gdObjectsContainer,
+  targetObjectFolderOrObjectWithContext?: ?ObjectFolderOrObjectWithContext,
+  resourceManagementProps: ResourceManagementProps,
+  canInstallPrivateAsset: () => boolean,
+  onObjectsAddedFromAssets: (Array<gdObject>) => void,
+|}) => {
+  const { shopNavigationState } = React.useContext(AssetStoreContext);
+  const { openedAssetPack } = shopNavigationState.getCurrentPage();
+  const eventsFunctionsExtensionsState = React.useContext(
+    EventsFunctionsExtensionsContext
+  );
+  const { installPrivateAsset } = React.useContext(
+    PrivateAssetsAuthorizationContext
+  );
+  const { showAlert } = useAlertDialog();
+  const fetchAssets = useFetchAssets();
+  const showExtensionUpdateConfirmation = useExtensionUpdateAlertDialog();
+  const showProjectNeedToBeSaved = useProjectNeedToBeSavedAlertDialog(
+    canInstallPrivateAsset
+  );
+
+  return async (
+    assetShortHeader: AssetShortHeader
+  ): Promise<InstallAssetOutput | null> => {
+    try {
+      if (await showProjectNeedToBeSaved(assetShortHeader)) {
+        return null;
+      }
+      const assets = await fetchAssets([assetShortHeader]);
+      const asset = assets[0];
+      const requiredExtensionInstallation = await checkRequiredExtensionsUpdateForAssets(
+        {
+          assets,
+          project,
+        }
+      );
+      const shouldUpdateExtension =
+        requiredExtensionInstallation.outOfDateExtensionShortHeaders.length >
+          0 &&
+        (await showExtensionUpdateConfirmation(
+          requiredExtensionInstallation.outOfDateExtensionShortHeaders
+        ));
+      await installRequiredExtensions({
+        requiredExtensionInstallation,
+        shouldUpdateExtension,
+        eventsFunctionsExtensionsState,
+        project,
+      });
+      const isPrivate = isPrivateAsset(assetShortHeader);
+      const installOutput = isPrivate
+        ? await installPrivateAsset({
+            asset,
+            project,
+            objectsContainer,
+            targetObjectFolderOrObject:
+              targetObjectFolderOrObjectWithContext &&
+              !targetObjectFolderOrObjectWithContext.global
+                ? targetObjectFolderOrObjectWithContext.objectFolderOrObject
+                : null,
+          })
+        : await installPublicAsset({
+            asset,
+            project,
+            objectsContainer,
+            targetObjectFolderOrObject:
+              targetObjectFolderOrObjectWithContext &&
+              !targetObjectFolderOrObjectWithContext.global
+                ? targetObjectFolderOrObjectWithContext.objectFolderOrObject
+                : null,
+          });
+      if (!installOutput) {
+        throw new Error('Unable to install private Asset.');
+      }
+      sendAssetAddedToProject({
+        id: assetShortHeader.id,
+        name: assetShortHeader.name,
+        assetPackName: openedAssetPack ? openedAssetPack.name : null,
+        assetPackTag: openedAssetPack ? openedAssetPack.tag : null,
+        assetPackId:
+          openedAssetPack && openedAssetPack.id ? openedAssetPack.id : null,
+        assetPackKind: isPrivate ? 'private' : 'public',
+      });
+
+      onObjectsAddedFromAssets(installOutput.createdObjects);
+
+      await resourceManagementProps.onFetchNewlyAddedResources();
+      return installOutput;
+    } catch (error) {
+      console.error('Error while installing the asset:', error);
+      showAlert({
+        title: t`Could not install the asset`,
+        message: t`There was an error while installing the asset "${
+          assetShortHeader.name
+        }". Verify your internet connection or try again later.`,
+      });
+      return null;
+    }
+  };
+};
+
 type Props = {|
   project: gdProject,
   layout: ?gdLayout,
@@ -192,113 +302,27 @@ function NewObjectDialog({
   const isAssetAddedToScene =
     openedAssetShortHeader &&
     existingAssetStoreIds.has(openedAssetShortHeader.id);
-  const { installPrivateAsset } = React.useContext(
-    PrivateAssetsAuthorizationContext
-  );
   const { showAlert } = useAlertDialog();
 
-  const fetchAssets = useFetchAssets();
   const showExtensionUpdateConfirmation = useExtensionUpdateAlertDialog();
-  const showProjectNeedToBeSaved = useProjectNeedToBeSavedAlertDialog(
-    canInstallPrivateAsset
-  );
+  const installAsset = useInstallAsset({
+    project,
+    objectsContainer,
+    resourceManagementProps,
+    canInstallPrivateAsset,
+    onObjectsAddedFromAssets,
+  });
 
   const onInstallAsset = React.useCallback(
     async (assetShortHeader): Promise<boolean> => {
       if (!assetShortHeader) return false;
+
       setIsAssetBeingInstalled(true);
-
-      try {
-        if (await showProjectNeedToBeSaved(assetShortHeader)) {
-          setIsAssetBeingInstalled(false);
-          return false;
-        }
-        const assets = await fetchAssets([assetShortHeader]);
-        const asset = assets[0];
-        const requiredExtensionInstallation = await checkRequiredExtensionsUpdateForAssets(
-          {
-            assets,
-            project,
-          }
-        );
-        const shouldUpdateExtension =
-          requiredExtensionInstallation.outOfDateExtensionShortHeaders.length >
-            0 &&
-          (await showExtensionUpdateConfirmation(
-            requiredExtensionInstallation.outOfDateExtensionShortHeaders
-          ));
-        await installRequiredExtensions({
-          requiredExtensionInstallation,
-          shouldUpdateExtension,
-          eventsFunctionsExtensionsState,
-          project,
-        });
-        const isPrivate = isPrivateAsset(assetShortHeader);
-        const installOutput = isPrivate
-          ? await installPrivateAsset({
-              asset,
-              project,
-              objectsContainer,
-              targetObjectFolderOrObject:
-                targetObjectFolderOrObjectWithContext &&
-                !targetObjectFolderOrObjectWithContext.global
-                  ? targetObjectFolderOrObjectWithContext.objectFolderOrObject
-                  : null,
-            })
-          : await installPublicAsset({
-              asset,
-              project,
-              objectsContainer,
-              targetObjectFolderOrObject:
-                targetObjectFolderOrObjectWithContext &&
-                !targetObjectFolderOrObjectWithContext.global
-                  ? targetObjectFolderOrObjectWithContext.objectFolderOrObject
-                  : null,
-            });
-        if (!installOutput) {
-          throw new Error('Unable to install private Asset.');
-        }
-        sendAssetAddedToProject({
-          id: assetShortHeader.id,
-          name: assetShortHeader.name,
-          assetPackName: openedAssetPack ? openedAssetPack.name : null,
-          assetPackTag: openedAssetPack ? openedAssetPack.tag : null,
-          assetPackId:
-            openedAssetPack && openedAssetPack.id ? openedAssetPack.id : null,
-          assetPackKind: isPrivate ? 'private' : 'public',
-        });
-
-        onObjectsAddedFromAssets(installOutput.createdObjects);
-
-        await resourceManagementProps.onFetchNewlyAddedResources();
-        setIsAssetBeingInstalled(false);
-        return true;
-      } catch (error) {
-        console.error('Error while installing the asset:', error);
-        showAlert({
-          title: t`Could not install the asset`,
-          message: t`There was an error while installing the asset "${
-            assetShortHeader.name
-          }". Verify your internet connection or try again later.`,
-        });
-        setIsAssetBeingInstalled(false);
-        return false;
-      }
+      const installAssetOutput = await installAsset(assetShortHeader);
+      setIsAssetBeingInstalled(false);
+      return !!installAssetOutput;
     },
-    [
-      showProjectNeedToBeSaved,
-      fetchAssets,
-      project,
-      showExtensionUpdateConfirmation,
-      eventsFunctionsExtensionsState,
-      installPrivateAsset,
-      objectsContainer,
-      targetObjectFolderOrObjectWithContext,
-      openedAssetPack,
-      onObjectsAddedFromAssets,
-      resourceManagementProps,
-      showAlert,
-    ]
+    [installAsset]
   );
 
   const onInstallEmptyCustomObject = React.useCallback(

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -55,6 +55,7 @@ import { capitalize } from 'lodash';
 import PrivateGameTemplateInformationPage from './PrivateGameTemplates/PrivateGameTemplateInformationPage';
 import { PrivateGameTemplateStoreContext } from './PrivateGameTemplates/PrivateGameTemplateStoreContext';
 import { AssetSwappingAssetStoreSearchFilter } from './AssetStoreSearchFilter';
+import { delay } from '../Utils/Delay';
 
 type Props = {|
   hideGameTemplates?: boolean, // TODO: if we add more options, use an array instead.
@@ -119,7 +120,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       setSearchText: setAssetStoreSearchText,
       clearAllFilters: clearAllAssetStoreFilters,
       assetFiltersState,
-      assetShortHeadersById,
+      getAssetShortHeaderFromId,
     } = React.useContext(AssetStoreContext);
 
     const assetSwappedObjectPtr = React.useRef<number | null>(null);
@@ -130,9 +131,9 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
             shopNavigationState.openAssetSwapping();
             setAssetStoreSearchText('');
             clearAllAssetStoreFilters();
-            const assetShortHeader = assetShortHeadersById
-              ? assetShortHeadersById[assetSwappedObject.getAssetStoreId()]
-              : null;
+            const assetShortHeader = getAssetShortHeaderFromId(
+              assetSwappedObject.getAssetStoreId()
+            );
             assetFiltersState.setAssetSwappingFilter(
               new AssetSwappingAssetStoreSearchFilter(
                 assetSwappedObject,
@@ -155,9 +156,9 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       },
       [
         assetFiltersState,
-        assetShortHeadersById,
         assetSwappedObject,
         clearAllAssetStoreFilters,
+        getAssetShortHeaderFromId,
         setAssetStoreSearchText,
         shopNavigationState,
       ]
@@ -676,9 +677,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                         if (isUpdatingSearchtext) {
                           // Updating the search is not instant, so we cannot apply the scroll position
                           // right away. We force a wait as there's no easy way to know when results are completely updated.
-                          await new Promise(resolve =>
-                            setTimeout(resolve, 500)
-                          );
+                          await delay(500);
                           setScrollUpdateIsNeeded(page);
                           applyBackScrollPosition(page); // We apply it manually, because the layout effect won't be called again.
                         } else {

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -129,6 +129,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
           if (assetSwappedObjectPtr.current !== assetSwappedObject.ptr) {
             shopNavigationState.openAssetSwapping();
             setAssetStoreSearchText('');
+            clearAllAssetStoreFilters();
             const assetShortHeader = assetShortHeadersById
               ? assetShortHeadersById[assetSwappedObject.getAssetStoreId()]
               : null;
@@ -140,20 +141,18 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
             );
           }
           assetSwappedObjectPtr.current = assetSwappedObject.ptr;
-        } else {
-          if (assetSwappedObjectPtr.current !== 0) {
-            shopNavigationState.openHome();
-            assetFiltersState.setAssetSwappingFilter(
-              new AssetSwappingAssetStoreSearchFilter()
-            );
-          }
-          assetSwappedObjectPtr.current = 0;
+        } else if (shopNavigationState.isAssetSwappingHistory) {
+          shopNavigationState.openHome();
+          assetFiltersState.setAssetSwappingFilter(
+            new AssetSwappingAssetStoreSearchFilter()
+          );
         }
       },
       [
         assetFiltersState,
         assetShortHeadersById,
         assetSwappedObject,
+        clearAllAssetStoreFilters,
         setAssetStoreSearchText,
         shopNavigationState,
       ]

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -139,6 +139,11 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
                 assetShortHeader
               )
             );
+            const assetsListInterface = assetsList.current;
+            if (assetsListInterface) {
+              assetsListInterface.scrollToPosition(0);
+              assetsListInterface.setPageBreakIndex(0);
+            }
           }
           assetSwappedObjectPtr.current = assetSwappedObject.ptr;
         } else if (shopNavigationState.isAssetSwappingHistory) {

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -54,7 +54,7 @@ import Text from '../UI/Text';
 import { capitalize } from 'lodash';
 import PrivateGameTemplateInformationPage from './PrivateGameTemplates/PrivateGameTemplateInformationPage';
 import { PrivateGameTemplateStoreContext } from './PrivateGameTemplates/PrivateGameTemplateStoreContext';
-import { ObjectTypeAssetStoreSearchFilter } from './AssetStoreSearchFilter';
+import { AssetSwappingAssetStoreSearchFilter } from './AssetStoreSearchFilter';
 
 type Props = {|
   hideGameTemplates?: boolean, // TODO: if we add more options, use an array instead.
@@ -69,11 +69,6 @@ type Props = {|
 export type AssetStoreInterface = {|
   onClose: () => void,
 |};
-
-// TODO
-const toAssetStoreType = (type: string) => {
-  return type === 'Sprite' ? 'sprite' : type;
-};
 
 const identifyAssetPackKind = ({
   privateAssetPackListingDatas,
@@ -124,34 +119,42 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       setSearchText: setAssetStoreSearchText,
       clearAllFilters: clearAllAssetStoreFilters,
       assetFiltersState,
+      assetShortHeadersById,
     } = React.useContext(AssetStoreContext);
 
     const assetSwappedObjectPtr = React.useRef<number | null>(null);
     React.useEffect(
       () => {
         if (assetSwappedObject) {
-          if (
-            assetSwappedObjectPtr.current !== assetSwappedObject.ptr
-          ) {
+          if (assetSwappedObjectPtr.current !== assetSwappedObject.ptr) {
             shopNavigationState.openAssetSwapping();
-            const assetSwappingType = toAssetStoreType(assetSwappedObject.getType());
-            assetFiltersState.setObjectTypeFilter(
-              new ObjectTypeAssetStoreSearchFilter(new Set([assetSwappingType]))
+            const assetShortHeader = assetShortHeadersById
+              ? assetShortHeadersById[assetSwappedObject.getAssetStoreId()]
+              : null;
+            assetFiltersState.setAssetSwappingFilter(
+              new AssetSwappingAssetStoreSearchFilter(
+                assetSwappedObject,
+                assetShortHeader
+              )
             );
           }
           assetSwappedObjectPtr.current = assetSwappedObject.ptr;
-        }
-        else {
+        } else {
           if (assetSwappedObjectPtr.current !== 0) {
             shopNavigationState.openHome();
-            assetFiltersState.setObjectTypeFilter(
-              new ObjectTypeAssetStoreSearchFilter(new Set())
+            assetFiltersState.setAssetSwappingFilter(
+              new AssetSwappingAssetStoreSearchFilter()
             );
           }
           assetSwappedObjectPtr.current = 0;
         }
       },
-      [assetFiltersState, assetSwappedObject, shopNavigationState]
+      [
+        assetFiltersState,
+        assetShortHeadersById,
+        assetSwappedObject,
+        shopNavigationState,
+      ]
     );
 
     const {

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -126,36 +126,29 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
       assetFiltersState,
     } = React.useContext(AssetStoreContext);
 
+    const assetSwappedObjectPtr = React.useRef<number | null>(null);
     React.useEffect(
       () => {
-        if (!assetSwappedObject && shopNavigationState.isAssetSwappingHistory) {
-          shopNavigationState.openHome();
+        if (assetSwappedObject) {
+          if (
+            assetSwappedObjectPtr.current !== assetSwappedObject.ptr
+          ) {
+            shopNavigationState.openAssetSwapping();
+            const assetSwappingType = toAssetStoreType(assetSwappedObject.getType());
+            assetFiltersState.setObjectTypeFilter(
+              new ObjectTypeAssetStoreSearchFilter(new Set([assetSwappingType]))
+            );
+          }
+          assetSwappedObjectPtr.current = assetSwappedObject.ptr;
         }
-        if (
-          assetSwappedObject &&
-          (!shopNavigationState.isAssetSwappingHistory ||
-            !shopNavigationState.isRootPage)
-        ) {
-          shopNavigationState.openAssetSwapping();
-        }
-      },
-      [assetSwappedObject, shopNavigationState]
-    );
-    React.useEffect(
-      () => {
-        if (!assetSwappedObject) {
-          return;
-        }
-        const assetSwappingType = toAssetStoreType(
-          assetSwappedObject.getType()
-        );
-        if (
-          assetFiltersState.objectTypeFilter.objectTypes.size !== 1 ||
-          !assetFiltersState.objectTypeFilter.objectTypes.has(assetSwappingType)
-        ) {
-          assetFiltersState.setObjectTypeFilter(
-            new ObjectTypeAssetStoreSearchFilter(new Set([assetSwappingType]))
-          );
+        else {
+          if (assetSwappedObjectPtr.current !== 0) {
+            shopNavigationState.openHome();
+            assetFiltersState.setObjectTypeFilter(
+              new ObjectTypeAssetStoreSearchFilter(new Set())
+            );
+          }
+          assetSwappedObjectPtr.current = 0;
         }
       },
       [assetFiltersState, assetSwappedObject, shopNavigationState]

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -625,6 +625,9 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
               }
               value={searchText}
               onChange={(newValue: string) => {
+                if (searchText === newValue) {
+                  return;
+                }
                 setSearchText(newValue);
                 if (isOnSearchResultPage) {
                   // An existing search is already being done: just move to the

--- a/newIDE/app/src/AssetStore/index.js
+++ b/newIDE/app/src/AssetStore/index.js
@@ -128,6 +128,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         if (assetSwappedObject) {
           if (assetSwappedObjectPtr.current !== assetSwappedObject.ptr) {
             shopNavigationState.openAssetSwapping();
+            setAssetStoreSearchText('');
             const assetShortHeader = assetShortHeadersById
               ? assetShortHeadersById[assetSwappedObject.getAssetStoreId()]
               : null;
@@ -153,6 +154,7 @@ export const AssetStore = React.forwardRef<Props, AssetStoreInterface>(
         assetFiltersState,
         assetShortHeadersById,
         assetSwappedObject,
+        setAssetStoreSearchText,
         shopNavigationState,
       ]
     );

--- a/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventBasedObjectChildrenEditor.js
@@ -230,7 +230,6 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 project={project}
                 eventsBasedObject={eventsBasedObject}
                 unsavedChanges={this.props.unsavedChanges}
-                // $FlowFixMe gdObjectsContainer should be a member of gdEventsBasedObject instead of a base class.
                 objectsContainer={eventsBasedObject.getObjects()}
                 globalObjectsContainer={null}
                 layout={null}
@@ -255,6 +254,8 @@ export default class EventBasedObjectChildrenEditor extends React.Component<
                 }
                 // Nothing special to do.
                 onObjectCreated={() => {}}
+                // Nothing special to do.
+                onObjectEdited={() => {}}
                 onObjectFolderOrObjectWithContextSelected={
                   this._onObjectFolderOrObjectWithContextSelected
                 }

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -245,14 +245,14 @@ export default function SpriteEditor({
                 />
                 <SemiControlledTextField
                   fullWidth
-                  value={spriteConfiguration.getPreScale()}
+                  value={spriteConfiguration.getPreScale().toString(10)}
                   floatingLabelText={
                     <Trans>
                       Scaling factor to apply to the default dimensions
                     </Trans>
                   }
                   onChange={value => {
-                    spriteConfiguration.setPreScale(value);
+                    spriteConfiguration.setPreScale(parseFloat(value) || 0);
 
                     forceUpdate();
                     if (onObjectUpdated) onObjectUpdated();

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/index.js
@@ -13,7 +13,10 @@ import PointsEditor from './PointsEditor';
 import CollisionMasksEditor from './CollisionMasksEditor';
 import { type EditorProps } from '../EditorProps.flow';
 import { Column } from '../../../UI/Grid';
-import { ResponsiveLineStackLayout } from '../../../UI/Layout';
+import {
+  ResponsiveLineStackLayout,
+  ColumnStackLayout,
+} from '../../../UI/Layout';
 import ScrollView, { type ScrollViewInterface } from '../../../UI/ScrollView';
 import Checkbox from '../../../UI/Checkbox';
 import useForceUpdate from '../../../Utils/UseForceUpdate';
@@ -27,6 +30,7 @@ import {
   getFirstAnimationFrame,
   setCollisionMaskOnAllFrames,
 } from './Utils/SpriteObjectHelper';
+import SemiControlledTextField from '../../../UI/SemiControlledTextField';
 
 const gd: libGDevelop = global.gd;
 
@@ -223,7 +227,7 @@ export default function SpriteEditor({
               onRequestClose={() => setAdvancedOptionsOpen(false)}
               open
             >
-              <Column noMargin>
+              <ColumnStackLayout noMargin>
                 <Checkbox
                   label={
                     <Trans>
@@ -239,7 +243,23 @@ export default function SpriteEditor({
                     if (onObjectUpdated) onObjectUpdated();
                   }}
                 />
-              </Column>
+                <SemiControlledTextField
+                  fullWidth
+                  value={spriteConfiguration.getPreScale()}
+                  floatingLabelText={
+                    <Trans>
+                      Scaling factor to apply to the default dimensions
+                    </Trans>
+                  }
+                  onChange={value => {
+                    spriteConfiguration.setPreScale(value);
+
+                    forceUpdate();
+                    if (onObjectUpdated) onObjectUpdated();
+                  }}
+                  type="number"
+                />
+              </ColumnStackLayout>
             </Dialog>
           )}
           {pointsEditorOpen && (

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -51,6 +51,7 @@ import useAlertDialog from '../UI/Alert/useAlertDialog';
 import { useResponsiveWindowSize } from '../UI/Responsive/ResponsiveWindowMeasurer';
 import ErrorBoundary from '../UI/ErrorBoundary';
 import { getInsertionParentAndPositionFromSelection } from '../Utils/ObjectFolders';
+import { canSwapAssetOfObject } from '../AssetStore/AssetSwapper';
 
 const gd: libGDevelop = global.gd;
 const sceneObjectsRootFolderId = 'scene-objects';
@@ -441,11 +442,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
 
     const swapObjectAsset = React.useCallback((object: gdObject) => {
       setObjectAssetSwappingDialogOpen({ object });
-    }, []);
-
-    const canSwapAssetOfObject = React.useCallback((object: gdObject) => {
-      const type = object.getType();
-      return type === 'Scene3D::Model3DObject' || type === 'Sprite';
     }, []);
 
     const onAddNewObject = React.useCallback(
@@ -1498,7 +1494,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
           },
           { type: 'separator' },
           {
-            label: i18n._(t`Swap asset`),
+            label: i18n._(t`Swap assets`),
             click: () => swapObjectAsset(object),
             enabled: canSwapAssetOfObject(object),
           },
@@ -1550,7 +1546,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         objectsContainer,
         initialInstances,
         project,
-        canSwapAssetOfObject,
         canSetAsGlobalObject,
         onSelectAllInstancesOfObjectInLayout,
         onExportAssets,

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -216,6 +216,7 @@ type Props = {|
   onEditObject: (object: gdObject, initialTab: ?ObjectEditorTab) => void,
   onExportAssets: () => void,
   onObjectCreated: gdObject => void,
+  onObjectEdited: gdObject => void,
   onObjectFolderOrObjectWithContextSelected: (
     ?ObjectFolderOrObjectWithContext
   ) => void,
@@ -253,6 +254,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
       onEditObject,
       onExportAssets,
       onObjectCreated,
+      onObjectEdited,
       onObjectFolderOrObjectWithContextSelected,
       onObjectPasted,
       getValidatedObjectOrGroupName,
@@ -1714,8 +1716,10 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         {objectAssetSwappingDialogOpen && (
           <AssetSwappingDialog
             onClose={() => setObjectAssetSwappingDialogOpen(null)}
-            onCreateNewObject={() => {}}
-            onObjectsAddedFromAssets={() => {}}
+            onObjectsConfigurationSwapped={() => {
+              onObjectEdited(objectAssetSwappingDialogOpen.object);
+              setObjectAssetSwappingDialogOpen(null);
+            }}
             project={project}
             layout={layout}
             eventsBasedObject={eventsBasedObject}
@@ -1723,7 +1727,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
             object={objectAssetSwappingDialogOpen.object}
             resourceManagementProps={resourceManagementProps}
             canInstallPrivateAsset={canInstallPrivateAsset}
-            targetObjectFolderOrObjectWithContext={null}
           />
         )}
       </Background>

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -9,6 +9,7 @@ import { AutoSizer } from 'react-virtualized';
 import Background from '../UI/Background';
 import SearchBar from '../UI/SearchBar';
 import NewObjectDialog from '../AssetStore/NewObjectDialog';
+import AssetSwappingDialog from '../AssetStore/AssetSwappingDialog';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import Clipboard, { SafeExtractor } from '../Utils/Clipboard';
 import Window from '../Utils/Window';
@@ -297,6 +298,11 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
       },
     }));
 
+    const [
+      objectAssetSwappingDialogOpen,
+      setObjectAssetSwappingDialogOpen,
+    ] = React.useState<{ object: gdObject } | null>(null);
+
     // Initialize keyboard shortcuts as empty.
     // onDelete, onDuplicate and onRename callbacks are set in an effect because it applies
     // to the selected item (that is a props). As it is stored in a ref, the keyboard shortcut
@@ -430,6 +436,15 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
       },
       [onObjectCreated, objectsContainer]
     );
+
+    const swapObjectAsset = React.useCallback((object: gdObject) => {
+      setObjectAssetSwappingDialogOpen({ object });
+    }, []);
+
+    const canSwapAssetOfObject = React.useCallback((object: gdObject) => {
+      const type = object.getType();
+      return type === 'Scene3D::Model3DObject' || type === 'Sprite';
+    }, []);
 
     const onAddNewObject = React.useCallback(
       (item: ObjectFolderOrObjectWithContext | null) => {
@@ -1480,6 +1495,12 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
             ),
           },
           { type: 'separator' },
+          {
+            label: i18n._(t`Swap asset`),
+            click: () => swapObjectAsset(object),
+            enabled: canSwapAssetOfObject(object),
+          },
+          { type: 'separator' },
           globalObjectsContainer && {
             label: i18n._(t`Set as global object`),
             enabled: !isObjectFolderOrObjectWithContextGlobal(item),
@@ -1527,6 +1548,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         objectsContainer,
         initialInstances,
         project,
+        canSwapAssetOfObject,
         canSetAsGlobalObject,
         onSelectAllInstancesOfObjectInLayout,
         onExportAssets,
@@ -1541,6 +1563,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         cutObjectFolderOrObjectWithContext,
         duplicateObjectFolderOrObjectWithContext,
         onEditObject,
+        swapObjectAsset,
         selectObjectFolderOrObjectWithContext,
         setAsGlobalObject,
         onAddObjectInstance,
@@ -1686,6 +1709,21 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
             resourceManagementProps={resourceManagementProps}
             canInstallPrivateAsset={canInstallPrivateAsset}
             targetObjectFolderOrObjectWithContext={newObjectDialogOpen.from}
+          />
+        )}
+        {objectAssetSwappingDialogOpen && (
+          <AssetSwappingDialog
+            onClose={() => setObjectAssetSwappingDialogOpen(null)}
+            onCreateNewObject={() => {}}
+            onObjectsAddedFromAssets={() => {}}
+            project={project}
+            layout={layout}
+            eventsBasedObject={eventsBasedObject}
+            objectsContainer={objectsContainer}
+            object={objectAssetSwappingDialogOpen.object}
+            resourceManagementProps={resourceManagementProps}
+            canInstallPrivateAsset={canInstallPrivateAsset}
+            targetObjectFolderOrObjectWithContext={null}
           />
         )}
       </Background>

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
@@ -17,6 +17,7 @@ export default class RenderedSpriteInstance extends RenderedInstance {
   _originY: number;
   _sprite: ?gdSprite = null;
   _shouldNotRotate: boolean = false;
+  _preScale = 1;
 
   constructor(
     project: gdProject,
@@ -100,8 +101,8 @@ export default class RenderedSpriteInstance extends RenderedInstance {
       this._pixiObject.scale.y =
         this.getCustomHeight() / objectTextureFrame.height;
     } else {
-      this._pixiObject.scale.x = 1;
-      this._pixiObject.scale.y = 1;
+      this._pixiObject.scale.x = this._preScale;
+      this._pixiObject.scale.y = this._preScale;
     }
     this._pixiObject.position.x =
       this._instance.getX() +
@@ -118,6 +119,7 @@ export default class RenderedSpriteInstance extends RenderedInstance {
     const spriteConfiguration = gd.asSpriteConfiguration(
       this._associatedObjectConfiguration
     );
+    this._preScale = spriteConfiguration.getPreScale();
     const animations = spriteConfiguration.getAnimations();
     if (animations.hasNoAnimations()) return false;
 
@@ -207,7 +209,7 @@ export default class RenderedSpriteInstance extends RenderedInstance {
     // In case the texture is not loaded yet, we don't want to crash.
     if (!objectTextureFrame) return 32;
 
-    return Math.abs(objectTextureFrame.width);
+    return Math.abs(objectTextureFrame.width) * this._preScale;
   }
 
   getDefaultHeight(): number {
@@ -215,7 +217,7 @@ export default class RenderedSpriteInstance extends RenderedInstance {
     // In case the texture is not loaded yet, we don't want to crash.
     if (!objectTextureFrame) return 32;
 
-    return Math.abs(objectTextureFrame.height);
+    return Math.abs(objectTextureFrame.height) * this._preScale;
   }
 
   getCenterX(): number {

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedSpriteInstance.js
@@ -53,6 +53,9 @@ export default class RenderedSpriteInstance extends RenderedInstance {
     super.onRemovedFromScene();
     // Keep textures because they are shared by all sprites.
     this._pixiObject.destroy(false);
+    // Avoid to use _pixiObject after destroy is called.
+    // It can happen when onRemovedFromScene and update cross each other.
+    this._pixiObject = null;
   }
 
   /**
@@ -86,6 +89,11 @@ export default class RenderedSpriteInstance extends RenderedInstance {
   }
 
   updatePIXISprite(): void {
+    // Avoid to use _pixiObject after destroy is called.
+    // It can happen when onRemovedFromScene and update cross each other.
+    if (!this._pixiObject) {
+      return;
+    }
     const objectTextureFrame = this._pixiObject.texture.frame;
     // In case the texture is not loaded yet, we don't want to crash.
     if (!objectTextureFrame) return;
@@ -151,6 +159,11 @@ export default class RenderedSpriteInstance extends RenderedInstance {
   }
 
   updatePIXITextureAndSprite(): void {
+    // Avoid to use _pixiObject after destroy is called.
+    // It can happen when onRemovedFromScene and update cross each other.
+    if (!this._pixiObject) {
+      return;
+    }
     this.updateSprite();
     const sprite = this._sprite;
     if (!sprite) return;

--- a/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
+++ b/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
@@ -47,6 +47,7 @@ export type SceneEditorsDisplayProps = {|
   onRemoveLayer: (layerName: string, done: (boolean) => void) => void,
   onLayerRenamed: () => void,
   onObjectCreated: gdObject => void,
+  onObjectEdited: gdObject => void,
   onObjectFolderOrObjectWithContextSelected: (
     ?ObjectFolderOrObjectWithContext
   ) => void,

--- a/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
@@ -379,6 +379,7 @@ const MosaicEditorsDisplay = React.forwardRef<
                 props.getValidatedObjectOrGroupName(newName, global, i18n)
               }
               onObjectCreated={props.onObjectCreated}
+              onObjectEdited={props.onObjectEdited}
               onObjectFolderOrObjectWithContextSelected={
                 props.onObjectFolderOrObjectWithContextSelected
               }

--- a/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
@@ -316,6 +316,7 @@ const SwipeableDrawerEditorsDisplay = React.forwardRef<
                         )
                       }
                       onObjectCreated={props.onObjectCreated}
+                      onObjectEdited={props.onObjectEdited}
                       onObjectFolderOrObjectWithContextSelected={
                         props.onObjectFolderOrObjectWithContextSelected
                       }

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -838,6 +838,12 @@ export default class SceneEditor extends React.Component<Props, State> {
     this._addInstanceForNewObject(object.getName());
   };
 
+  _onObjectEdited = (object: gdObject) => {
+    this.reloadResourcesFor(object);
+    if (this.props.unsavedChanges)
+      this.props.unsavedChanges.triggerUnsavedChanges();
+  };
+
   _onRemoveLayer = (layerName: string, done: boolean => void) => {
     const getNewState = (doRemove: boolean) => {
       const newState: {| layerRemoved: null, selectedLayer?: string |} = {
@@ -1838,6 +1844,7 @@ export default class SceneEditor extends React.Component<Props, State> {
                   this._onRenameObjectFolderOrObjectWithContextFinish
                 }
                 onObjectCreated={this._onObjectCreated}
+                onObjectEdited={this._onObjectEdited}
                 onObjectFolderOrObjectWithContextSelected={
                   this._onObjectFolderOrObjectWithContextSelected
                 }

--- a/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
+++ b/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
@@ -278,6 +278,7 @@ export const WithObjectsList = () => (
                     cb
                   ) => cb(true)}
                   onObjectCreated={() => {}}
+                  onObjectEdited={() => {}}
                   onObjectFolderOrObjectWithContextSelected={() => {}}
                   hotReloadPreviewButtonProps={hotReloadPreviewButtonProps}
                   canInstallPrivateAsset={() => false}

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
@@ -35,6 +35,7 @@ export const Default = () => (
         onExportAssets={action('On export assets')}
         onAddObjectInstance={action('On add instance to the scene')}
         onObjectCreated={action('On object created')}
+        onObjectEdited={action('On object edited')}
         selectedObjectFolderOrObjectsWithContext={[]}
         getValidatedObjectOrGroupName={newName => newName}
         onDeleteObjects={(objectsWithContext, cb) => cb(true)}
@@ -67,6 +68,7 @@ export const WithSerializedObjectView = () => (
           onExportAssets={action('On export assets')}
           onAddObjectInstance={action('On add instance to the scene')}
           onObjectCreated={action('On object created')}
+          onObjectEdited={action('On object edited')}
           selectedObjectFolderOrObjectsWithContext={[]}
           getValidatedObjectOrGroupName={newName => newName}
           onDeleteObjects={(objectsWithContext, cb) => cb(true)}


### PR DESCRIPTION
Asset store navigation in asset swapping mode:
- The home page is a search page showing similar assets first.
- Only assets of the same object type are shown.
- It has the side effect of clearing the asset store history.

Object adaptations:
- Animation of the object that are missing in the asset are replaced by a copy of the 1st asset animation
- 3D model volume is adjusted to stay the same while keeping asset proportions