### PR TITLE
Allow hot-reloading of model resource

### DIFF
--- a/Extensions/3D/Model3DRuntimeObject.ts
+++ b/Extensions/3D/Model3DRuntimeObject.ts
@@ -63,7 +63,8 @@ namespace gdjs {
    */
   export class Model3DRuntimeObject
     extends gdjs.RuntimeObject3D
-    implements gdjs.Animatable {
+    implements gdjs.Animatable
+  {
     _renderer: gdjs.Model3DRuntimeObjectRenderer;
 
     _modelResourceName: string;
@@ -119,14 +120,19 @@ namespace gdjs {
         objectData.content.materialType
       );
 
-      this.onChangeModelResourceName(objectData);
+      this.onModelChanged(objectData);
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
     }
 
-    private onChangeModelResourceName(objectData) {
-      this._renderer._reloadModel(this, this._runtimeScene, objectData);
+    /**
+     * To be called after the renderer loaded a Model resource:
+     * - After the renderer was instantiated
+     * - After reloading the model
+     */
+    private onModelChanged(objectData) {
+      this._updateModel(objectData);
       if (this._animations.length > 0) {
         this._renderer.playAnimation(
           this._animations[0].source,
@@ -153,8 +159,7 @@ namespace gdjs {
         oldObjectData.content.modelResourceName !==
         newObjectData.content.modelResourceName
       ) {
-        this._modelResourceName = newObjectData.content.modelResourceName;
-        this.onChangeModelResourceName(newObjectData);
+        this._reloadModel(newObjectData);
       } else if (
         oldObjectData.content.width !== newObjectData.content.width ||
         oldObjectData.content.height !== newObjectData.content.height ||
@@ -229,6 +234,12 @@ namespace gdjs {
           networkSyncData.ap ? this.pauseAnimation() : this.resumeAnimation();
         }
       }
+    }
+
+    _reloadModel(objectData: Model3DObjectData) {
+      this._modelResourceName = objectData.content.modelResourceName;
+      this._renderer._reloadModel(this, this._runtimeScene);
+      this.onModelChanged(objectData);
     }
 
     _updateModel(objectData: Model3DObjectData) {

--- a/Extensions/3D/Model3DRuntimeObject.ts
+++ b/Extensions/3D/Model3DRuntimeObject.ts
@@ -63,7 +63,8 @@ namespace gdjs {
    */
   export class Model3DRuntimeObject
     extends gdjs.RuntimeObject3D
-    implements gdjs.Animatable {
+    implements gdjs.Animatable
+  {
     _renderer: gdjs.Model3DRuntimeObjectRenderer;
 
     _modelResourceName: string;
@@ -118,16 +119,21 @@ namespace gdjs {
       this._materialType = this._convertMaterialType(
         objectData.content.materialType
       );
-      this._updateModel(objectData);
+
+      this.onChangeModelResourceName(objectData);
+
+      // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
+      this.onCreated();
+    }
+
+    private onChangeModelResourceName(objectData) {
+      this._renderer._reloadModel(this, this._runtimeScene, objectData);
       if (this._animations.length > 0) {
         this._renderer.playAnimation(
           this._animations[0].source,
           this._animations[0].loop
         );
       }
-
-      // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
-      this.onCreated();
     }
 
     updateFromObjectData(
@@ -135,7 +141,22 @@ namespace gdjs {
       newObjectData: Model3DObjectData
     ): boolean {
       super.updateFromObjectData(oldObjectData, newObjectData);
+
       if (
+        oldObjectData.content.materialType !==
+        newObjectData.content.materialType
+      ) {
+        this._materialType = this._convertMaterialType(
+          newObjectData.content.materialType
+        );
+      }
+      if (
+        oldObjectData.content.modelResourceName !==
+        newObjectData.content.modelResourceName
+      ) {
+        this._modelResourceName = newObjectData.content.modelResourceName;
+        this.onChangeModelResourceName(newObjectData);
+      } else if (
         oldObjectData.content.width !== newObjectData.content.width ||
         oldObjectData.content.height !== newObjectData.content.height ||
         oldObjectData.content.depth !== newObjectData.content.depth ||
@@ -143,7 +164,9 @@ namespace gdjs {
         oldObjectData.content.rotationY !== newObjectData.content.rotationY ||
         oldObjectData.content.rotationZ !== newObjectData.content.rotationZ ||
         oldObjectData.content.keepAspectRatio !==
-          newObjectData.content.keepAspectRatio
+          newObjectData.content.keepAspectRatio ||
+        oldObjectData.content.materialType !==
+          newObjectData.content.materialType
       ) {
         this._updateModel(newObjectData);
       }

--- a/Extensions/3D/Model3DRuntimeObject.ts
+++ b/Extensions/3D/Model3DRuntimeObject.ts
@@ -171,15 +171,6 @@ namespace gdjs {
         this._updateModel(newObjectData);
       }
       if (
-        oldObjectData.content.materialType !==
-        newObjectData.content.materialType
-      ) {
-        this._materialType = this._convertMaterialType(
-          newObjectData.content.materialType
-        );
-        this._updateModel(newObjectData);
-      }
-      if (
         oldObjectData.content.originLocation !==
         newObjectData.content.originLocation
       ) {

--- a/Extensions/3D/Model3DRuntimeObject.ts
+++ b/Extensions/3D/Model3DRuntimeObject.ts
@@ -63,8 +63,7 @@ namespace gdjs {
    */
   export class Model3DRuntimeObject
     extends gdjs.RuntimeObject3D
-    implements gdjs.Animatable
-  {
+    implements gdjs.Animatable {
     _renderer: gdjs.Model3DRuntimeObjectRenderer;
 
     _modelResourceName: string;

--- a/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
@@ -236,6 +236,31 @@ namespace gdjs {
       }
     }
 
+    _reloadModel(
+      runtimeObject: Model3DRuntimeObject,
+      instanceContainer: gdjs.RuntimeInstanceContainer,
+      objectData: Model3DObjectData
+    ) {
+      this._originalModel = instanceContainer
+        .getGame()
+        .getModel3DManager()
+        .getModel(runtimeObject._modelResourceName);
+
+      const rotationX = objectData.content.rotationX || 0;
+      const rotationY = objectData.content.rotationY || 0;
+      const rotationZ = objectData.content.rotationZ || 0;
+      const keepAspectRatio = objectData.content.keepAspectRatio;
+      this._updateModel(
+        rotationX,
+        rotationY,
+        rotationZ,
+        runtimeObject._getOriginalWidth(),
+        runtimeObject._getOriginalHeight(),
+        runtimeObject._getOriginalDepth(),
+        keepAspectRatio
+      );
+    }
+
     _updateModel(
       rotationX: float,
       rotationY: float,

--- a/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
@@ -236,29 +236,18 @@ namespace gdjs {
       }
     }
 
+    /**
+     * `_updateModel` should always be called after this method.
+     * Ideally, use `Model3DRuntimeObject#_reloadModel` instead.
+     */
     _reloadModel(
       runtimeObject: Model3DRuntimeObject,
-      instanceContainer: gdjs.RuntimeInstanceContainer,
-      objectData: Model3DObjectData
+      instanceContainer: gdjs.RuntimeInstanceContainer
     ) {
       this._originalModel = instanceContainer
         .getGame()
         .getModel3DManager()
         .getModel(runtimeObject._modelResourceName);
-
-      const rotationX = objectData.content.rotationX || 0;
-      const rotationY = objectData.content.rotationY || 0;
-      const rotationZ = objectData.content.rotationZ || 0;
-      const keepAspectRatio = objectData.content.keepAspectRatio;
-      this._updateModel(
-        rotationX,
-        rotationY,
-        rotationZ,
-        runtimeObject._getOriginalWidth(),
-        runtimeObject._getOriginalHeight(),
-        runtimeObject._getOriginalDepth(),
-        keepAspectRatio
-      );
     }
 
     _updateModel(


### PR DESCRIPTION
Allows hot-reloading to properly hot-reload the change in resource in a 3D model. Useful when evaluating different model files quickly in GDevelop.