### PR TITLE
Allow custom objects and behaviors to use resources from properties

### DIFF
--- a/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ValueTypeMetadata.h
@@ -210,8 +210,8 @@ class GD_CORE_API ValueTypeMetadata {
              parameterType == "scenevar";
     } else if (type == "resource") {
       return parameterType == "fontResource" ||
-             parameterType == "soundfile" ||
-             parameterType == "musicfile" ||
+             parameterType == "audioResource" ||
+             parameterType == "videoResource" ||
              parameterType == "bitmapFontResource" ||
              parameterType == "imageResource" ||
              parameterType == "jsonResource" ||
@@ -219,7 +219,10 @@ class GD_CORE_API ValueTypeMetadata {
              parameterType == "tilesetResource" ||
              parameterType == "model3DResource" ||
              parameterType == "atlasResource" ||
-             parameterType == "spineResource";
+             parameterType == "spineResource" ||
+             // Deprecated, old parameter types:
+             parameterType == "soundfile" ||
+             parameterType == "musicfile";
     }
     return false;
   }

--- a/Core/GDCore/Project/CustomConfigurationHelper.cpp
+++ b/Core/GDCore/Project/CustomConfigurationHelper.cpp
@@ -26,7 +26,7 @@ void CustomConfigurationHelper::InitializeContent(
 
     if (propertyType == "String" || propertyType == "Choice" ||
         propertyType == "Color" || propertyType == "Behavior" ||
-        propertyType == "resource") {
+        propertyType == "Resource") {
       element.SetStringValue(property->GetValue());
     } else if (propertyType == "Number") {
       element.SetDoubleValue(property->GetValue().To<double>());
@@ -53,7 +53,7 @@ std::map<gd::String, gd::PropertyDescriptor> CustomConfigurationHelper::GetPrope
     if (configurationContent.HasChild(propertyName)) {
       if (propertyType == "String" || propertyType == "Choice" ||
           propertyType == "Color" || propertyType == "Behavior" ||
-          propertyType == "resource") {
+          propertyType == "Resource") {
         newProperty.SetValue(
             configurationContent.GetChild(propertyName).GetStringValue());
       } else if (propertyType == "Number") {
@@ -89,7 +89,7 @@ bool CustomConfigurationHelper::UpdateProperty(
 
   if (propertyType == "String" || propertyType == "Choice" ||
       propertyType == "Color" || propertyType == "Behavior" ||
-      propertyType == "resource") {
+      propertyType == "Resource") {
     element.SetStringValue(newValue);
   } else if (propertyType == "Number") {
     element.SetDoubleValue(newValue.To<double>());

--- a/GDJS/GDJS/Events/CodeGeneration/BehaviorCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/BehaviorCodeGenerator.cpp
@@ -421,7 +421,8 @@ gd::String BehaviorCodeGenerator::GenerateUpdatePropertyFromNetworkSyncDataCode(
 gd::String BehaviorCodeGenerator::GeneratePropertyValueCode(
     const gd::PropertyDescriptor& property) {
   if (property.GetType() == "String" || property.GetType() == "Choice" ||
-      property.GetType() == "Color" || property.GetType() == "Behavior") {
+      property.GetType() == "Color" || property.GetType() == "Behavior" ||
+      property.GetType() == "Resource") {
     return EventsCodeGenerator::ConvertToStringExplicit(property.GetValue());
   } else if (property.GetType() == "Number") {
     return "Number(" +

--- a/GDJS/GDJS/Events/CodeGeneration/ObjectCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/ObjectCodeGenerator.cpp
@@ -327,15 +327,14 @@ gd::String ObjectCodeGenerator::GenerateUpdatePropertyFromObjectDataCode(
 
 gd::String ObjectCodeGenerator::GeneratePropertyValueCode(
     const gd::PropertyDescriptor& property) {
-  if (property.GetType() == "String" ||
-      property.GetType() == "Choice" ||
-      property.GetType() == "Color") {
+  if (property.GetType() == "String" || property.GetType() == "Choice" ||
+      property.GetType() == "Color" || property.GetType() == "Resource") {
     return EventsCodeGenerator::ConvertToStringExplicit(property.GetValue());
   } else if (property.GetType() == "Number") {
     return "Number(" +
            EventsCodeGenerator::ConvertToStringExplicit(property.GetValue()) +
            ") || 0";
-  } else if (property.GetType() == "Boolean") {  // TODO: Check if working
+  } else if (property.GetType() == "Boolean") { // TODO: Check if working
     return property.GetValue() == "true" ? "true" : "false";
   }
 

--- a/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedBehaviorEditor/EventsBasedBehaviorPropertiesEditor.js
@@ -39,6 +39,7 @@ import { EmptyPlaceholder } from '../UI/EmptyPlaceholder';
 import useAlertDialog from '../UI/Alert/useAlertDialog';
 import SearchBar from '../UI/SearchBar';
 import { renderQuickCustomizationMenuItems } from '../QuickCustomization/QuickCustomizationMenuItems';
+import ResourceTypeSelectField from '../EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ResourceTypeSelectField';
 
 const gd: libGDevelop = global.gd;
 
@@ -73,6 +74,16 @@ export const usePropertyOverridingAlertDialog = () => {
       dismissButtonLabel: t`Omit`,
     });
   };
+};
+
+const setExtraInfoString = (
+  property: gdNamedPropertyDescriptor,
+  value: string
+) => {
+  const vectorString = new gd.VectorString();
+  vectorString.push_back(value);
+  property.setExtraInfo(vectorString);
+  vectorString.delete();
 };
 
 type Props = {|
@@ -657,6 +668,12 @@ export default function EventsBasedBehaviorPropertiesEditor({
                                             if (value === 'Behavior') {
                                               property.setHidden(false);
                                             }
+                                            if (value === 'Resource') {
+                                              setExtraInfoString(
+                                                property,
+                                                'json'
+                                              );
+                                            }
                                             forceUpdate();
                                             onPropertiesUpdated &&
                                               onPropertiesUpdated();
@@ -687,6 +704,11 @@ export default function EventsBasedBehaviorPropertiesEditor({
                                             key="property-type-color"
                                             value="Color"
                                             label={t`Color (text)`}
+                                          />
+                                          <SelectOption
+                                            key="property-type-resource"
+                                            value="Resource"
+                                            label={t`Resource (JavaScript only)`}
                                           />
                                           {!isSceneProperties && (
                                             <SelectOption
@@ -839,6 +861,25 @@ export default function EventsBasedBehaviorPropertiesEditor({
                                               onPropertiesUpdated &&
                                                 onPropertiesUpdated();
                                             }}
+                                          />
+                                        )}
+                                        {property.getType() === 'Resource' && (
+                                          <ResourceTypeSelectField
+                                            value={
+                                              property.getExtraInfo().size() > 0
+                                                ? property.getExtraInfo().at(0)
+                                                : ''
+                                            }
+                                            onChange={(e, i, value) => {
+                                              setExtraInfoString(
+                                                property,
+                                                value
+                                              );
+                                              forceUpdate();
+                                              onPropertiesUpdated &&
+                                                onPropertiesUpdated();
+                                            }}
+                                            fullWidth
                                           />
                                         )}
                                         {property.getType() === 'Choice' && (

--- a/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsBasedObjectEditor/EventsBasedObjectPropertiesEditor.js
@@ -37,6 +37,7 @@ import ResponsiveFlatButton from '../UI/ResponsiveFlatButton';
 import { EmptyPlaceholder } from '../UI/EmptyPlaceholder';
 import useAlertDialog from '../UI/Alert/useAlertDialog';
 import SearchBar from '../UI/SearchBar';
+import ResourceTypeSelectField from '../EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ResourceTypeSelectField';
 
 const gd: libGDevelop = global.gd;
 
@@ -71,6 +72,16 @@ export const usePropertyOverridingAlertDialog = () => {
       dismissButtonLabel: t`Omit`,
     });
   };
+};
+
+const setExtraInfoString = (
+  property: gdNamedPropertyDescriptor,
+  value: string
+) => {
+  const vectorString = new gd.VectorString();
+  vectorString.push_back(value);
+  property.setExtraInfo(vectorString);
+  vectorString.delete();
 };
 
 type Props = {|
@@ -651,6 +662,12 @@ export default function EventsBasedObjectPropertiesEditor({
                                           value={property.getType()}
                                           onChange={(e, i, value: string) => {
                                             property.setType(value);
+                                            if (value === 'Resource') {
+                                              setExtraInfoString(
+                                                property,
+                                                'json'
+                                              );
+                                            }
                                             forceUpdate();
                                             onPropertiesUpdated &&
                                               onPropertiesUpdated();
@@ -676,6 +693,11 @@ export default function EventsBasedObjectPropertiesEditor({
                                           <SelectOption
                                             value="Color"
                                             label={t`Color (text)`}
+                                          />
+                                          <SelectOption
+                                            key="property-type-resource"
+                                            value="Resource"
+                                            label={t`Resource (JavaScript only)`}
                                           />
                                         </SelectField>
                                         {property.getType() === 'Number' && (
@@ -813,6 +835,25 @@ export default function EventsBasedObjectPropertiesEditor({
                                               )
                                             )}
                                           </SelectField>
+                                        )}
+                                        {property.getType() === 'Resource' && (
+                                          <ResourceTypeSelectField
+                                            value={
+                                              property.getExtraInfo().size() > 0
+                                                ? property.getExtraInfo().at(0)
+                                                : ''
+                                            }
+                                            onChange={(e, i, value) => {
+                                              setExtraInfoString(
+                                                property,
+                                                value
+                                              );
+                                              forceUpdate();
+                                              onPropertiesUpdated &&
+                                                onPropertiesUpdated();
+                                            }}
+                                            fullWidth
+                                          />
                                         )}
                                       </ResponsiveLineStackLayout>
                                       {property.getType() === 'Choice' && (

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ResourceTypeSelectField.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ResourceTypeSelectField.js
@@ -1,0 +1,41 @@
+// @flow
+import { Trans } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+import * as React from 'react';
+import SelectField from '../../UI/SelectField';
+import SelectOption from '../../UI/SelectOption';
+import { allResourceKindsAndMetadata } from '../../ResourcesList/ResourceSource';
+
+type Props = {|
+  value: number | string,
+  // event and index should not be used, and be removed eventually
+  onChange?: (
+    event: {| target: {| value: string |} |},
+    index: number,
+    text: string
+  ) => void,
+  fullWidth?: boolean,
+|};
+
+export default function ResourceTypeSelectField({
+  value,
+  onChange,
+  fullWidth,
+}: Props) {
+  return (
+    <I18n>
+      {({ i18n }) => (
+        <SelectField
+          floatingLabelText={<Trans>Resource type</Trans>}
+          value={value}
+          onChange={onChange}
+          fullWidth={fullWidth}
+        >
+          {allResourceKindsAndMetadata.map(({ kind, displayName }) => (
+            <SelectOption key={kind} value={kind} label={displayName} />
+          ))}
+        </SelectField>
+      )}
+    </I18n>
+  );
+}

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ValueTypeEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/ValueTypeEditor.js
@@ -11,6 +11,7 @@ import BehaviorTypeSelector from '../../BehaviorTypeSelector';
 import { ColumnStackLayout, ResponsiveLineStackLayout } from '../../UI/Layout';
 import StringArrayEditor from '../../StringArrayEditor';
 import useForceUpdate from '../../Utils/UseForceUpdate';
+import ResourceTypeSelectField from './ResourceTypeSelectField';
 
 type Props = {|
   project: gdProject,
@@ -43,6 +44,12 @@ const getIdentifierName = (scopedIdentifier: string) =>
     ? scopedIdentifier.substring('object'.length)
     : scopedIdentifier.substring('scene'.length);
 
+const convertTypeToSelectorValue = (value: string) =>
+  value.endsWith('Resource') ? 'jsonResource' : value;
+
+const convertParameterTypeToPropertyType = (value: string) =>
+  value.substring(0, value.length - 'Resource'.length);
+
 export default function ValueTypeEditor({
   project,
   eventsFunctionsExtension,
@@ -63,7 +70,7 @@ export default function ValueTypeEditor({
             {isTypeSelectorShown && (
               <SelectField
                 floatingLabelText={<Trans>Type</Trans>}
-                value={valueTypeMetadata.getName()}
+                value={convertTypeToSelectorValue(valueTypeMetadata.getName())}
                 onChange={(e, i, value: string) => {
                   valueTypeMetadata.setName(value);
                   valueTypeMetadata.setOptional(false);
@@ -148,32 +155,8 @@ export default function ValueTypeEditor({
                 )}
                 {!isExpressionType && (
                   <SelectOption
-                    value="imageResource"
-                    label={t`Image resource (JavaScript only)`}
-                  />
-                )}
-                {!isExpressionType && (
-                  <SelectOption
-                    value="audioResource"
-                    label={t`Audio resource (JavaScript only)`}
-                  />
-                )}
-                {!isExpressionType && (
-                  <SelectOption
                     value="jsonResource"
-                    label={t`JSON resource (JavaScript only)`}
-                  />
-                )}
-                {!isExpressionType && (
-                  <SelectOption
-                    value="fontResource"
-                    label={t`Font resource (JavaScript only)`}
-                  />
-                )}
-                {!isExpressionType && (
-                  <SelectOption
-                    value="bitmapFontResource"
-                    label={t`Bitmap font resource (JavaScript only)`}
+                    label={t`Resource (JavaScript only)`}
                   />
                 )}
               </SelectField>
@@ -271,6 +254,19 @@ export default function ValueTypeEditor({
                     valueTypeMetadata.getExtraInfo()
                   );
                   valueTypeMetadata.setExtraInfo(scope + value);
+                  forceUpdate();
+                  onTypeUpdated();
+                }}
+                fullWidth
+              />
+            )}
+            {valueTypeMetadata.getName().endsWith('Resource') && (
+              <ResourceTypeSelectField
+                value={convertParameterTypeToPropertyType(
+                  valueTypeMetadata.getName()
+                )}
+                onChange={(e, i, value) => {
+                  valueTypeMetadata.setName(value + 'Resource');
                   forceUpdate();
                   onTypeUpdated();
                 }}


### PR DESCRIPTION
I've manually tested it with this behavior and I can hear the sound.

![image](https://github.com/user-attachments/assets/9b5d0d99-9a65-4624-9642-d2f2eeb3267f)
