### PR TITLE
Fix having to select another function to reopen the same function on mobile in the extension editor

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -1450,7 +1450,10 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
                     nextIcon: <Tune />,
                     nextLabel: <Trans>Parameters</Trans>,
                     nextEditor: 'parameters',
-                    previousEditor: () => 'functions-list',
+                    previousEditor: () => {
+                      this._selectEventsFunction(null, null, null);
+                      return 'functions-list';
+                    },
                   },
                   parameters: {
                     nextIcon: <Mark />,


### PR DESCRIPTION
Resolves https://forum.gdevelop.io/t/impossible-to-edit-function/54213

Reset state when hitting back on mobile function navigation