### PR TITLE
Allow changing Sync Rate of a multiplayer game

### DIFF
--- a/Extensions/Multiplayer/JsExtension.js
+++ b/Extensions/Multiplayer/JsExtension.js
@@ -370,6 +370,36 @@ module.exports = {
       );
 
     extension
+      .addExpressionAndConditionAndAction(
+        'number',
+        'ObjectsSynchronizationRate',
+        _('Objects synchronization rate'),
+        _(
+          'objects synchronization rate (between 1 and 60, default is 30 times per second)'
+        ),
+        _('objects synchronization rate'),
+        _('Advanced'),
+        'JsPlatform/Extensions/multiplayer.svg'
+      )
+      .useStandardParameters(
+        'number',
+        gd.ParameterOptions.makeNewOptions().setDescription(_('Sync rate'))
+      )
+      .setIncludeFile('Extensions/Multiplayer/peer.js')
+      .addIncludeFile('Extensions/Multiplayer/peerJsHelper.js')
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationcomponents.js'
+      )
+      .addIncludeFile(
+        'Extensions/PlayerAuthentication/playerauthenticationtools.js'
+      )
+      .addIncludeFile('Extensions/Multiplayer/messageManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayerVariablesManager.js')
+      .addIncludeFile('Extensions/Multiplayer/multiplayertools.js')
+      .setFunctionName('gdjs.multiplayer.setObjectsSynchronizationRate')
+      .setGetter('gdjs.multiplayer.getObjectsSynchronizationRate');
+
+    extension
       .addCondition(
         'IsPlayerHost',
         _('Player is host'),

--- a/Extensions/Multiplayer/messageManager.ts
+++ b/Extensions/Multiplayer/messageManager.ts
@@ -145,7 +145,7 @@ namespace gdjs {
     } = {};
 
     // The number of times per second the scene data should be synchronized.
-    const sceneSyncDataTickRate = 1;
+    const sceneSyncDataSyncRate = 1;
     let lastSceneSyncTimestamp = 0;
     let lastSentSceneSyncData: LayoutNetworkSyncData | null = null;
     let numberOfForcedSceneUpdates = 0;
@@ -154,7 +154,7 @@ namespace gdjs {
     >();
 
     // The number of times per second the game data should be synchronized.
-    const gameSyncDataTickRate = 1;
+    const gameSyncDataSyncRate = 1;
     let lastGameSyncTimestamp = 0;
     let lastSentGameSyncData: GameNetworkSyncData | null = null;
     let numberOfForcedGameUpdates = 0;
@@ -164,7 +164,7 @@ namespace gdjs {
 
     // Send heartbeat messages from host to players, ensuring their connection is still alive,
     // measure the ping, and send other useful info.
-    const heartbeatTickRate = 1;
+    const heartbeatSyncRate = 1;
     let lastHeartbeatTimestamp = 0;
     let _playersLastRoundTripTimes: {
       [playerNumber: number]: number[];
@@ -1650,7 +1650,7 @@ namespace gdjs {
 
     const hasSceneBeenSyncedRecently = () => {
       return (
-        getTimeNow() - lastSceneSyncTimestamp < 1000 / sceneSyncDataTickRate
+        getTimeNow() - lastSceneSyncTimestamp < 1000 / sceneSyncDataSyncRate
       );
     };
 
@@ -1814,7 +1814,7 @@ namespace gdjs {
     };
 
     const hasGameBeenSyncedRecently = () => {
-      return getTimeNow() - lastGameSyncTimestamp < 1000 / gameSyncDataTickRate;
+      return getTimeNow() - lastGameSyncTimestamp < 1000 / gameSyncDataSyncRate;
     };
 
     const handleUpdateGameMessagesToSend = (
@@ -1977,7 +1977,7 @@ namespace gdjs {
     const hasSentHeartbeatRecently = () => {
       return (
         !!lastHeartbeatTimestamp &&
-        getTimeNow() - lastHeartbeatTimestamp < 1000 / heartbeatTickRate
+        getTimeNow() - lastHeartbeatTimestamp < 1000 / heartbeatSyncRate
       );
     };
     const handleHeartbeatsToSend = () => {

--- a/Extensions/Multiplayer/multiplayerobjectruntimebehavior.ts
+++ b/Extensions/Multiplayer/multiplayerobjectruntimebehavior.ts
@@ -24,48 +24,46 @@ namespace gdjs {
     actionOnPlayerDisconnect: string;
 
     // The last time the object has been synchronized.
-    // This is to avoid synchronizing the object too often, see _objectMaxTickRate.
+    // This is to avoid synchronizing the object too often, see _objectMaxSyncRate.
     _lastObjectSyncTimestamp: number = 0;
-    // The number of times per second the object should be synchronized if it keeps changing.
-    _objectMaxTickRate: number = 60;
 
     // The last time the basic object info has been synchronized.
     _lastBasicObjectSyncTimestamp: number = 0;
     // The number of times per second the object basic info should be synchronized when it doesn't change.
-    _objectBasicInfoTickRate: number = 5;
+    _objectBasicInfoSyncRate: number = 5;
     // The last data sent to synchronize the basic info of the object.
     _lastSentBasicObjectSyncData: BasicObjectNetworkSyncData | undefined;
     // When we know that the basic info of the object has been updated, we can force sending them
-    // on the max tickrate for a number of times to ensure they are received, without the need of an acknowledgment.
+    // on the max SyncRate for a number of times to ensure they are received, without the need of an acknowledgment.
     _numberOfForcedBasicObjectUpdates: number = 0;
 
     // The last time the variables have been synchronized.
     _lastVariablesSyncTimestamp: number = 0;
     // The number of times per second the variables should be synchronized.
-    _variablesTickRate: number = 1;
+    _variablesSyncRate: number = 1;
     // The last data sent to synchronize the variables.
     _lastSentVariableSyncData: VariableNetworkSyncData[] | undefined;
     // When we know that the variables have been updated, we can force sending them
-    // on the same tickrate as the object update for a number of times
+    // on the same syncRate as the object update for a number of times
     // to ensure they are received, without the need of an acknowledgment.
     _numberOfForcedVariablesUpdates: number = 0;
 
     // The last time the effects have been synchronized.
     _lastEffectsSyncTimestamp: number = 0;
     // The number of times per second the effects should be synchronized.
-    _effectsTickRate: number = 1;
+    _effectsSyncRate: number = 1;
     // The last data sent to synchronize the effects.
     _lastSentEffectSyncData:
       | { [effectName: string]: EffectNetworkSyncData }
       | undefined;
     // When we know that the effects have been updated, we can force sending them
-    // on the same tickrate as the object update for a number of times
+    // on the same syncRate as the object update for a number of times
     // to ensure they are received, without the need of an acknowledgment.
     _numberOfForcedEffectsUpdates: number = 0;
 
     // To avoid seeing too many logs.
     _lastLogTimestamp: number = 0;
-    _logTickRate: number = 1;
+    _logSyncRate: number = 1;
     // Clock to be incremented every time we send a message, to ensure they are ordered
     // and old messages are ignored.
     _clock: number = 0;
@@ -131,35 +129,35 @@ namespace gdjs {
     }
 
     private _hasObjectBeenSyncedWithinMaxRate() {
+      const objectMaxSyncRate = gdjs.multiplayer.getObjectsSynchronizationRate();
       return (
-        getTimeNow() - this._lastObjectSyncTimestamp <
-        1000 / this._objectMaxTickRate
+        getTimeNow() - this._lastObjectSyncTimestamp < 1000 / objectMaxSyncRate
       );
     }
 
     private _hasObjectBasicInfoBeenSyncedRecently() {
       return (
         getTimeNow() - this._lastBasicObjectSyncTimestamp <
-        1000 / this._objectBasicInfoTickRate
+        1000 / this._objectBasicInfoSyncRate
       );
     }
 
     private _haveVariablesBeenSyncedRecently() {
       return (
         getTimeNow() - this._lastVariablesSyncTimestamp <
-        1000 / this._variablesTickRate
+        1000 / this._variablesSyncRate
       );
     }
 
     private _haveEffectsBeenSyncedRecently() {
       return (
         getTimeNow() - this._lastEffectsSyncTimestamp <
-        1000 / this._effectsTickRate
+        1000 / this._effectsSyncRate
       );
     }
 
     // private _logToConsoleWithThrottle(message: string) {
-    //   if (getTimeNow() - this._lastLogTimestamp > 1000 / this._logTickRate) {
+    //   if (getTimeNow() - this._lastLogTimestamp > 1000 / this._logSyncRate) {
     //     logger.info(message);
     //     this._lastLogTimestamp = getTimeNow();
     //   }

--- a/Extensions/Multiplayer/multiplayertools.ts
+++ b/Extensions/Multiplayer/multiplayertools.ts
@@ -27,9 +27,9 @@ namespace gdjs {
     const DEFAULT_LOBBY_HEARTBEAT_INTERVAL = 30000;
     const DEFAULT_COUNTDOWN_SECONDS_TO_START = 5;
 
-    const DEFAULT_OBJECT_MAX_SYNC_RATE = 30;
+    export const DEFAULT_OBJECT_MAX_SYNC_RATE = 30;
     // The number of times per second an object should be synchronized if it keeps changing.
-    let _objectMaxSyncRate = DEFAULT_OBJECT_MAX_SYNC_RATE;
+    export let _objectMaxSyncRate = DEFAULT_OBJECT_MAX_SYNC_RATE;
 
     // Save if we are on dev environment so we don't need to use the runtimeGame every time.
     let isUsingGDevelopDevelopmentEnvironment = false;

--- a/Extensions/Multiplayer/multiplayertools.ts
+++ b/Extensions/Multiplayer/multiplayertools.ts
@@ -27,6 +27,10 @@ namespace gdjs {
     const DEFAULT_LOBBY_HEARTBEAT_INTERVAL = 30000;
     const DEFAULT_COUNTDOWN_SECONDS_TO_START = 5;
 
+    const DEFAULT_OBJECT_MAX_SYNC_RATE = 30;
+    // The number of times per second an object should be synchronized if it keeps changing.
+    let _objectMaxSyncRate = DEFAULT_OBJECT_MAX_SYNC_RATE;
+
     // Save if we are on dev environment so we don't need to use the runtimeGame every time.
     let isUsingGDevelopDevelopmentEnvironment = false;
 
@@ -160,6 +164,19 @@ namespace gdjs {
 
       return url.toString();
     };
+
+    export const setObjectsSynchronizationRate = (rate: number) => {
+      if (rate < 1 || rate > 60) {
+        logger.warn(
+          `Invalid rate ${rate} for object synchronization. Defaulting to ${DEFAULT_OBJECT_MAX_SYNC_RATE}.`
+        );
+        _objectMaxSyncRate = DEFAULT_OBJECT_MAX_SYNC_RATE;
+      } else {
+        _objectMaxSyncRate = rate;
+      }
+    };
+
+    export const getObjectsSynchronizationRate = () => _objectMaxSyncRate;
 
     /**
      * Returns true if the game has just started,

--- a/Extensions/Multiplayer/tests/multiplayer.spec.js
+++ b/Extensions/Multiplayer/tests/multiplayer.spec.js
@@ -1087,7 +1087,7 @@ describe('Multiplayer', () => {
           'MySpriteObject'
         )[0];
 
-        p1SpriteObjectBehavior._objectMaxTickRate = Infinity;
+        p1SpriteObjectBehavior._objectMaxSyncRate = Infinity;
         p1SpriteObject.setX(242);
         p1SpriteObject.setY(243);
         p1RuntimeScene.renderAndStep(1000 / 60);
@@ -1243,7 +1243,7 @@ describe('Multiplayer', () => {
           'MySpriteObject'
         )[0];
 
-        p2SpriteObjectBehavior._objectMaxTickRate = Infinity;
+        p2SpriteObjectBehavior._objectMaxSyncRate = Infinity;
         p2SpriteObject.setX(242);
         p2SpriteObject.setY(243);
         p2RuntimeScene.renderAndStep(1000 / 60);
@@ -2145,7 +2145,7 @@ describe('Multiplayer', () => {
           p2RuntimeScene,
           'MySpriteObject'
         )[0];
-        p2SpriteMultiplayerObjectBehavior._objectMaxTickRate = Infinity;
+        p2SpriteMultiplayerObjectBehavior._objectMaxSyncRate = Infinity;
         p2SpriteObject.setX(242);
         p2SpriteObject.setY(243);
         p2RuntimeScene.renderAndStep(1000 / 60);

--- a/Extensions/Multiplayer/tests/multiplayer.spec.js
+++ b/Extensions/Multiplayer/tests/multiplayer.spec.js
@@ -395,12 +395,16 @@ describe('Multiplayer', () => {
     gdjs.multiplayer.disableMultiplayerForTesting = false;
     gdjs.multiplayer._isLobbyGameRunning = true;
     gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = true;
+    // Sync as fast as possible for tests.
+    gdjs.multiplayer._objectMaxSyncRate = Infinity;
   });
   afterEach(() => {
     gdjs.multiplayerPeerJsHelper = _originalP2pIfAny;
     gdjs.multiplayer.disableMultiplayerForTesting = true;
     gdjs.multiplayer._isLobbyGameRunning = false;
     gdjs.multiplayer._isReadyToSendOrReceiveGameUpdateMessages = false;
+    gdjs.multiplayer._objectMaxSyncRate =
+      gdjs.multiplayer.DEFAULT_OBJECT_MAX_SYNC_RATE;
   });
 
   describe('Single scene tests', () => {
@@ -1081,13 +1085,11 @@ describe('Multiplayer', () => {
 
         const {
           object: p1SpriteObject,
-          behavior: p1SpriteObjectBehavior,
         } = getObjectAndMultiplayerBehaviorsFromScene(
           p1RuntimeScene,
           'MySpriteObject'
         )[0];
 
-        p1SpriteObjectBehavior._objectMaxSyncRate = Infinity;
         p1SpriteObject.setX(242);
         p1SpriteObject.setY(243);
         p1RuntimeScene.renderAndStep(1000 / 60);
@@ -1237,13 +1239,11 @@ describe('Multiplayer', () => {
 
         const {
           object: p2SpriteObject,
-          behavior: p2SpriteObjectBehavior,
         } = getObjectAndMultiplayerBehaviorsFromScene(
           p2RuntimeScene,
           'MySpriteObject'
         )[0];
 
-        p2SpriteObjectBehavior._objectMaxSyncRate = Infinity;
         p2SpriteObject.setX(242);
         p2SpriteObject.setY(243);
         p2RuntimeScene.renderAndStep(1000 / 60);
@@ -2140,12 +2140,10 @@ describe('Multiplayer', () => {
 
         const {
           object: p2SpriteObject,
-          behavior: p2SpriteMultiplayerObjectBehavior,
         } = getObjectAndMultiplayerBehaviorsFromScene(
           p2RuntimeScene,
           'MySpriteObject'
         )[0];
-        p2SpriteMultiplayerObjectBehavior._objectMaxSyncRate = Infinity;
         p2SpriteObject.setX(242);
         p2SpriteObject.setY(243);
         p2RuntimeScene.renderAndStep(1000 / 60);

--- a/Extensions/Physics2Behavior/physics2runtimebehavior.ts
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.ts
@@ -15,6 +15,8 @@ namespace gdjs {
     lvy: number | undefined;
     av: number | undefined;
     aw: boolean | undefined;
+    layers: number;
+    masks: number;
   }
 
   export interface Physics2NetworkSyncData extends BehaviorNetworkSyncData {
@@ -513,6 +515,8 @@ namespace gdjs {
         ...super.getNetworkSyncData(),
         props: {
           ...bodyProps,
+          layers: this.layers,
+          masks: this.masks,
         },
       };
     }
@@ -555,6 +559,14 @@ namespace gdjs {
         if (this._body) {
           this._body.SetAwake(behaviorSpecificProps.aw);
         }
+      }
+
+      if (behaviorSpecificProps.layers !== undefined) {
+        this.layers = behaviorSpecificProps.layers;
+      }
+
+      if (behaviorSpecificProps.masks !== undefined) {
+        this.masks = behaviorSpecificProps.masks;
       }
     }
 


### PR DESCRIPTION
With this, I can easily change the Jump Game to a Sync Rate of 10 without seeing much impact (as predictions of the physics object take over)