### PR TITLE
Fix text input to be deleted with their custom object

### DIFF
--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -151,7 +151,7 @@ namespace gdjs {
         // The object can free all its resource directly...
         object.onDestroyed();
       }
-      // ...as its container cache is also destroy.
+      // ...as its container cache `_instancesRemoved` is also destroy.
       this._destroy();
 
       this._isLoaded = false;

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -148,8 +148,10 @@ namespace gdjs {
       for (let i = 0, len = allInstancesList.length; i < len; ++i) {
         const object = allInstancesList[i];
         object.onDeletedFromScene(this);
+        // The object can free all its resource directly...
+        object.onDestroyed();
       }
-
+      // ...as its container cache is also destroy.
       this._destroy();
 
       this._isLoaded = false;


### PR DESCRIPTION
It also fixes a memory leak on children objects as `onDestroyed()` wasn't called and cached textures were never deleted.