### PR TITLE
Add automated crash reporting from previews

### DIFF
--- a/GDJS/GDJS/IDE/Exporter.cpp
+++ b/GDJS/GDJS/IDE/Exporter.cpp
@@ -101,6 +101,7 @@ bool Exporter::ExportWholePixiProject(const ExportOptions &options) {
         usedExtensionsResult.Has3DObjects(),
         /*includeWebsocketDebuggerClient=*/false,
         /*includeWindowMessageDebuggerClient=*/false,
+        /*includeMinimalDebuggerClient=*/false,
         exportedProject.GetLoadingScreen().GetGDevelopLogoStyle(),
         includesFiles);
 

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -96,7 +96,7 @@ static gd::String CleanProjectName(gd::String projectName) {
 ExporterHelper::ExporterHelper(gd::AbstractFileSystem &fileSystem,
                                gd::String gdjsRoot_,
                                gd::String codeOutputDir_)
-    : fs(fileSystem), gdjsRoot(gdjsRoot_), codeOutputDir(codeOutputDir_){};
+    : fs(fileSystem), gdjsRoot(gdjsRoot_), codeOutputDir(codeOutputDir_) {};
 
 bool ExporterHelper::ExportProjectForPixiPreview(
     const PreviewExportOptions &options) {
@@ -154,6 +154,8 @@ bool ExporterHelper::ExportProjectForPixiPreview(
                  !options.websocketDebuggerServerAddress.empty(),
                  /*includeWindowMessageDebuggerClient=*/
                  options.useWindowMessageDebuggerClient,
+                 /*includeMinimalDebuggerClient=*/
+                 options.useMinimalDebuggerClient,
                  immutableProject.GetLoadingScreen().GetGDevelopLogoStyle(),
                  includesFiles);
 
@@ -247,6 +249,24 @@ bool ExporterHelper::ExportProjectForPixiPreview(
     runtimeGameOptions.AddChild("playerId").SetStringValue(options.playerId);
     runtimeGameOptions.AddChild("playerToken")
         .SetStringValue(options.playerToken);
+  }
+  if (!options.crashReportUploadLevel.empty()) {
+    runtimeGameOptions.AddChild("crashReportUploadLevel")
+        .SetStringValue(options.crashReportUploadLevel);
+  }
+  if (!options.previewContext.empty()) {
+    runtimeGameOptions.AddChild("previewContext")
+        .SetStringValue(options.previewContext);
+  }
+  runtimeGameOptions.AddChild("gdevelopVersionWithHash")
+      .SetStringValue(options.gdevelopVersionWithHash);
+  if (!options.projectTemplateSlug.empty()) {
+    runtimeGameOptions.AddChild("projectTemplateSlug")
+        .SetStringValue(options.projectTemplateSlug);
+  }
+  if (!options.sourceGameId.empty()) {
+    runtimeGameOptions.AddChild("sourceGameId")
+        .SetStringValue(options.sourceGameId);
   }
 
   // Pass in the options the list of scripts files - useful for hot-reloading.
@@ -735,6 +755,7 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
                                     bool pixiInThreeRenderers,
                                     bool includeWebsocketDebuggerClient,
                                     bool includeWindowMessageDebuggerClient,
+                                    bool includeMinimalDebuggerClient,
                                     gd::String gdevelopLogoStyle,
                                     std::vector<gd::String> &includesFiles) {
   // First, do not forget common includes (they must be included before events
@@ -808,6 +829,9 @@ void ExporterHelper::AddLibsInclude(bool pixiRenderers,
   if (includeWindowMessageDebuggerClient) {
     InsertUnique(includesFiles,
                  "debugger-client/window-message-debugger-client.js");
+  }
+  if (includeMinimalDebuggerClient) {
+    InsertUnique(includesFiles, "debugger-client/minimal-debugger-client.js");
   }
 
   if (pixiInThreeRenderers) {

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -37,6 +37,7 @@ struct PreviewExportOptions {
       : project(project_),
         exportPath(exportPath_),
         useWindowMessageDebuggerClient(false),
+        useMinimalDebuggerClient(false),
         nativeMobileApp(false),
         projectDataOnlyExport(false),
         fullLoadingScreen(false),
@@ -90,6 +91,14 @@ struct PreviewExportOptions {
    */
   PreviewExportOptions &UseWindowMessageDebuggerClient() {
     useWindowMessageDebuggerClient = true;
+    return *this;
+  }
+
+  /**
+   * \brief Set that the game should have a minimal debugger client.
+   */
+  PreviewExportOptions &UseMinimalDebuggerClient() {
+    useMinimalDebuggerClient = true;
     return *this;
   }
 
@@ -203,11 +212,56 @@ struct PreviewExportOptions {
     return *this;
   }
 
+  /**
+   * \brief Set the level of crash reports to be sent to GDevelop APIs.
+   */
+  PreviewExportOptions &SetCrashReportUploadLevel(
+      const gd::String& crashReportUploadLevel_) {
+    crashReportUploadLevel = crashReportUploadLevel_;
+    return *this;
+  }
+
+  /**
+   * \brief Set the context of the preview.
+   */
+  PreviewExportOptions &SetPreviewContext(
+      const gd::String& previewContext_) {
+    previewContext = previewContext_;
+    return *this;
+  }
+
+  /**
+   * \brief Set the GDevelop version so the game is aware of it.
+   */
+  PreviewExportOptions &SetGDevelopVersionWithHash(
+      const gd::String& gdevelopVersionWithHash_) {
+    gdevelopVersionWithHash = gdevelopVersionWithHash_;
+    return *this;
+  }
+
+  /**
+   * \brief Set the template slug that was used to create the project.
+   */
+  PreviewExportOptions &SetProjectTemplateSlug(
+      const gd::String& projectTemplateSlug_) {
+    projectTemplateSlug = projectTemplateSlug_;
+    return *this;
+  }
+
+  /**
+   * \brief Set the source game id that was used to create the project.
+   */
+  PreviewExportOptions &SetSourceGameId(const gd::String& sourceGameId_) {
+    sourceGameId = sourceGameId_;
+    return *this;
+  }
+
   gd::Project &project;
   gd::String exportPath;
   gd::String websocketDebuggerServerAddress;
   gd::String websocketDebuggerServerPort;
   bool useWindowMessageDebuggerClient;
+  bool useMinimalDebuggerClient;
   gd::String layoutName;
   gd::String externalLayoutName;
   gd::String fallbackAuthorUsername;
@@ -224,6 +278,11 @@ struct PreviewExportOptions {
   gd::String electronRemoteRequirePath;
   gd::String gdevelopResourceToken;
   bool allowAuthenticationUsingIframeForPreview;
+  gd::String crashReportUploadLevel;
+  gd::String previewContext;
+  gd::String gdevelopVersionWithHash;
+  gd::String projectTemplateSlug;
+  gd::String sourceGameId;
 };
 
 /**
@@ -326,6 +385,7 @@ class ExporterHelper {
                       bool pixiInThreeRenderers,
                       bool includeWebsocketDebuggerClient,
                       bool includeWindowMessageDebuggerClient,
+                      bool includeMinimalDebuggerClient,
                       gd::String gdevelopLogoStyle,
                       std::vector<gd::String> &includesFiles);
 

--- a/GDJS/Runtime/debugger-client/InGameDebugger.tsx
+++ b/GDJS/Runtime/debugger-client/InGameDebugger.tsx
@@ -79,14 +79,6 @@ namespace gdjs {
     },
   };
 
-  const isErrorComingFromJavaScriptCode = (
-    exception: Error | null
-  ): boolean => {
-    if (!exception || !exception.stack) return false;
-
-    return exception.stack.includes('GDJSInlineCode');
-  };
-
   /**
    * Displays uncaught exceptions on top of the game.
    * Could be reworked in the future to support a minimal debugger inside the game.
@@ -120,7 +112,7 @@ namespace gdjs {
       }
 
       if (this._uncaughtException) {
-        const errorIsInJs = isErrorComingFromJavaScriptCode(
+        const errorIsInJs = gdjs.AbstractDebuggerClient.isErrorComingFromJavaScriptCode(
           this._uncaughtException
         );
         this._uncaughtExceptionElement = (

--- a/GDJS/Runtime/debugger-client/minimal-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/minimal-debugger-client.ts
@@ -1,0 +1,16 @@
+namespace gdjs {
+  /**
+   * Does nothing apart from allowing to reporting errors.
+   */
+  export class MinimalDebuggerClient extends gdjs.AbstractDebuggerClient {
+    constructor(runtimeGame: RuntimeGame) {
+      super(runtimeGame);
+    }
+
+    protected _sendMessage(message: string) {}
+  }
+
+  //Register the class to let the engine use it.
+  // @ts-ignore
+  export const DebuggerClient = WindowMessageDebuggerClient;
+}

--- a/GDJS/Runtime/debugger-client/websocket-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/websocket-debugger-client.ts
@@ -8,9 +8,6 @@ namespace gdjs {
   export class WebsocketDebuggerClient extends gdjs.AbstractDebuggerClient {
     _ws: WebSocket | null;
 
-    /**
-     * @param path - The path of the property to modify, starting from the RuntimeGame.
-     */
     constructor(runtimeGame: RuntimeGame) {
       super(runtimeGame);
       this._ws = null;

--- a/GDJS/Runtime/debugger-client/window-message-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/window-message-debugger-client.ts
@@ -8,9 +8,6 @@ namespace gdjs {
   export class WindowMessageDebuggerClient extends gdjs.AbstractDebuggerClient {
     _opener: Window | null = null;
 
-    /**
-     * @param path - The path of the property to modify, starting from the RuntimeGame.
-     */
     constructor(runtimeGame: RuntimeGame) {
       super(runtimeGame);
 

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -72,7 +72,7 @@ namespace gdjs {
     electronRemoteRequirePath?: string;
 
     /**
-     * the token to use by the game engine when requiring any resource stored on
+     * The token to use by the game engine when requiring any resource stored on
      * GDevelop Cloud buckets. Note that this is only useful during previews.
      */
     gdevelopResourceToken?: string;
@@ -84,6 +84,21 @@ namespace gdjs {
      * window is a genuine one. It's only to be used in trusted contexts.
      */
     allowAuthenticationUsingIframeForPreview?: boolean;
+
+    /** If set, the game will send crash reports to GDevelop APIs. */
+    crashReportUploadLevel?: 'all' | 'exclude-javascript-code-events' | 'none';
+
+    /** Arbitrary string explaining in which context the game is being played. */
+    previewContext?: string;
+
+    /** The GDevelop version used to build the game. */
+    gdevelopVersionWithHash?: string;
+
+    /** The template slug that was used to create the project. */
+    projectTemplateSlug?: string;
+
+    /** The source game id that was used to create the project. */
+    sourceGameId?: string;
 
     /**
      * If set, this data is used to authenticate automatically when launching the game.

--- a/GDJS/Runtime/scenestack.ts
+++ b/GDJS/Runtime/scenestack.ts
@@ -208,6 +208,10 @@ namespace gdjs {
       return this._wasFirstSceneLoaded;
     }
 
+    getAllSceneNames(): Array<string> {
+      return this._stack.map((scene) => scene.getName());
+    }
+
     getNetworkSyncData(
       syncOptions: GetNetworkSyncDataOptions
     ): SceneStackNetworkSyncData | null {

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -3720,6 +3720,7 @@ interface PreviewExportOptions {
     void PreviewExportOptions([Ref] Project project, [Const] DOMString outputPath);
     [Ref] PreviewExportOptions UseWebsocketDebuggerClientWithServerAddress([Const] DOMString address, [Const] DOMString port);
     [Ref] PreviewExportOptions UseWindowMessageDebuggerClient();
+    [Ref] PreviewExportOptions UseMinimalDebuggerClient();
     [Ref] PreviewExportOptions SetLayoutName([Const] DOMString layoutName);
     [Ref] PreviewExportOptions SetFallbackAuthor([Const] DOMString id, [Const] DOMString username);
     [Ref] PreviewExportOptions SetAuthenticatedPlayer([Const] DOMString playerId, [Const] DOMString playerUsername, [Const] DOMString playerToken);
@@ -3733,6 +3734,11 @@ interface PreviewExportOptions {
     [Ref] PreviewExportOptions SetElectronRemoteRequirePath([Const] DOMString electronRemoteRequirePath);
     [Ref] PreviewExportOptions SetGDevelopResourceToken([Const] DOMString gdevelopResourceToken);
     [Ref] PreviewExportOptions SetAllowAuthenticationUsingIframeForPreview(boolean enable);
+    [Ref] PreviewExportOptions SetCrashReportUploadLevel([Const] DOMString crashReportUploadLevel);
+    [Ref] PreviewExportOptions SetPreviewContext([Const] DOMString previewContext);
+    [Ref] PreviewExportOptions SetGDevelopVersionWithHash([Const] DOMString gdevelopVersionWithHash);
+    [Ref] PreviewExportOptions SetProjectTemplateSlug([Const] DOMString projectTemplateSlug);
+    [Ref] PreviewExportOptions SetSourceGameId([Const] DOMString sourceGameId);
 };
 
 [Prefix="gdjs::"]

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -2765,6 +2765,7 @@ export class PreviewExportOptions extends EmscriptenObject {
   constructor(project: Project, outputPath: string);
   useWebsocketDebuggerClientWithServerAddress(address: string, port: string): PreviewExportOptions;
   useWindowMessageDebuggerClient(): PreviewExportOptions;
+  useMinimalDebuggerClient(): PreviewExportOptions;
   setLayoutName(layoutName: string): PreviewExportOptions;
   setFallbackAuthor(id: string, username: string): PreviewExportOptions;
   setAuthenticatedPlayer(playerId: string, playerUsername: string, playerToken: string): PreviewExportOptions;
@@ -2778,6 +2779,11 @@ export class PreviewExportOptions extends EmscriptenObject {
   setElectronRemoteRequirePath(electronRemoteRequirePath: string): PreviewExportOptions;
   setGDevelopResourceToken(gdevelopResourceToken: string): PreviewExportOptions;
   setAllowAuthenticationUsingIframeForPreview(enable: boolean): PreviewExportOptions;
+  setCrashReportUploadLevel(crashReportUploadLevel: string): PreviewExportOptions;
+  setPreviewContext(previewContext: string): PreviewExportOptions;
+  setGDevelopVersionWithHash(gdevelopVersionWithHash: string): PreviewExportOptions;
+  setProjectTemplateSlug(projectTemplateSlug: string): PreviewExportOptions;
+  setSourceGameId(sourceGameId: string): PreviewExportOptions;
 }
 
 export class ExportOptions extends EmscriptenObject {

--- a/GDevelop.js/types/gdpreviewexportoptions.js
+++ b/GDevelop.js/types/gdpreviewexportoptions.js
@@ -3,6 +3,7 @@ declare class gdPreviewExportOptions {
   constructor(project: gdProject, outputPath: string): void;
   useWebsocketDebuggerClientWithServerAddress(address: string, port: string): gdPreviewExportOptions;
   useWindowMessageDebuggerClient(): gdPreviewExportOptions;
+  useMinimalDebuggerClient(): gdPreviewExportOptions;
   setLayoutName(layoutName: string): gdPreviewExportOptions;
   setFallbackAuthor(id: string, username: string): gdPreviewExportOptions;
   setAuthenticatedPlayer(playerId: string, playerUsername: string, playerToken: string): gdPreviewExportOptions;
@@ -16,6 +17,11 @@ declare class gdPreviewExportOptions {
   setElectronRemoteRequirePath(electronRemoteRequirePath: string): gdPreviewExportOptions;
   setGDevelopResourceToken(gdevelopResourceToken: string): gdPreviewExportOptions;
   setAllowAuthenticationUsingIframeForPreview(enable: boolean): gdPreviewExportOptions;
+  setCrashReportUploadLevel(crashReportUploadLevel: string): gdPreviewExportOptions;
+  setPreviewContext(previewContext: string): gdPreviewExportOptions;
+  setGDevelopVersionWithHash(gdevelopVersionWithHash: string): gdPreviewExportOptions;
+  setProjectTemplateSlug(projectTemplateSlug: string): gdPreviewExportOptions;
+  setSourceGameId(sourceGameId: string): gdPreviewExportOptions;
   delete(): void;
   ptr: number;
 };

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
@@ -8,7 +8,10 @@ import { timeFunction } from '../../../Utils/TimeFunction';
 import { findGDJS } from '../../../GameEngineFinder/LocalGDJSFinder';
 import LocalNetworkPreviewDialog from './LocalNetworkPreviewDialog';
 import assignIn from 'lodash/assignIn';
-import { type PreviewOptions } from '../../PreviewLauncher.flow';
+import {
+  type PreviewOptions,
+  type PreviewLauncherProps,
+} from '../../PreviewLauncher.flow';
 import SubscriptionChecker, {
   type SubscriptionCheckerInterface,
 } from '../../../Profile/Subscription/SubscriptionChecker';
@@ -17,15 +20,11 @@ import {
   localPreviewDebuggerServer,
 } from './LocalPreviewDebuggerServer';
 import Window from '../../../Utils/Window';
+import { getIDEVersionWithHash } from '../../../Version';
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
 const gd: libGDevelop = global.gd;
-
-type Props = {|
-  getIncludeFileHashs: () => { [string]: number },
-  onExport?: () => void,
-|};
 
 type State = {|
   networkPreviewDialogOpen: boolean,
@@ -47,7 +46,7 @@ type State = {|
 |};
 
 export default class LocalPreviewLauncher extends React.Component<
-  Props,
+  PreviewLauncherProps,
   State
 > {
   canDoNetworkPreview = () => true;
@@ -249,6 +248,17 @@ export default class LocalPreviewLauncher extends React.Component<
             previewExportOptions.setFullLoadingScreen(
               previewOptions.fullLoadingScreen
             );
+            previewExportOptions.setGDevelopVersionWithHash(
+              getIDEVersionWithHash()
+            );
+            previewExportOptions.setCrashReportUploadLevel(
+              this.props.crashReportUploadLevel
+            );
+            previewExportOptions.setPreviewContext(this.props.previewContext);
+            previewExportOptions.setProjectTemplateSlug(
+              project.getTemplateSlug()
+            );
+            previewExportOptions.setSourceGameId(this.props.sourceGameId);
 
             if (previewOptions.fallbackAuthor) {
               previewExportOptions.setFallbackAuthor(

--- a/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
+++ b/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
@@ -22,6 +22,9 @@ export type PreviewOptions = {|
 
 /** The props that PreviewLauncher must support */
 export type PreviewLauncherProps = {|
+  crashReportUploadLevel: string,
+  previewContext: string,
+  sourceGameId: string,
   getIncludeFileHashs: () => { [string]: number },
   onExport: () => void,
 |};

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -228,6 +228,7 @@ export type PreferencesValues = {|
   displaySaveReminder: {| activated: boolean |}, // Store as object in case we need to add options.
   editorStateByProject: { [string]: { editorTabs: EditorTabsPersistedState } },
   fetchPlayerTokenForPreviewAutomatically: boolean,
+  previewCrashReportUploadLevel: string,
 |};
 
 /**
@@ -326,6 +327,7 @@ export type Preferences = {|
     editorState?: {| editorTabs: EditorTabsPersistedState |}
   ) => void,
   setFetchPlayerTokenForPreviewAutomatically: (enabled: boolean) => void,
+  setPreviewCrashReportUploadLevel: (level: string) => void,
 |};
 
 export const initialPreferences = {
@@ -380,6 +382,7 @@ export const initialPreferences = {
     displaySaveReminder: { activated: true },
     editorStateByProject: {},
     fetchPlayerTokenForPreviewAutomatically: true,
+    previewCrashReportUploadLevel: 'exclude-javascript-code-events',
   },
   setLanguage: () => {},
   setThemeName: () => {},
@@ -450,6 +453,7 @@ export const initialPreferences = {
   getEditorStateForProject: projectId => {},
   setEditorStateForProject: (projectId, editorState) => {},
   setFetchPlayerTokenForPreviewAutomatically: (enabled: boolean) => {},
+  setPreviewCrashReportUploadLevel: (level: string) => {},
 };
 
 const PreferencesContext = React.createContext<Preferences>(initialPreferences);

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesDialog.js
@@ -81,6 +81,7 @@ const PreferencesDialog = ({
     setWatchProjectFolderFilesForLocalProjects,
     setDisplaySaveReminder,
     setFetchPlayerTokenForPreviewAutomatically,
+    setPreviewCrashReportUploadLevel,
   } = React.useContext(PreferencesContext);
 
   const initialUse3DEditor = React.useRef<boolean>(values.use3DEditor);
@@ -426,6 +427,18 @@ const PreferencesDialog = ({
             labelPosition="right"
             label={
               <Trans>Automatically open the diagnostic report at preview</Trans>
+            }
+          />
+          <Toggle
+            onToggle={(e, check) =>
+              setPreviewCrashReportUploadLevel(
+                check ? 'exclude-javascript-code-events' : 'none'
+              )
+            }
+            toggled={values.previewCrashReportUploadLevel !== 'none'}
+            labelPosition="right"
+            label={
+              <Trans>Send crash reports during previews to GDevelop</Trans>
             }
           />
           <Toggle

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -196,6 +196,9 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     setFetchPlayerTokenForPreviewAutomatically: this._setFetchPlayerTokenForPreviewAutomatically.bind(
       this
     ),
+    setPreviewCrashReportUploadLevel: this._setPreviewCrashReportUploadLevel.bind(
+      this
+    ),
   };
 
   componentDidMount() {
@@ -992,6 +995,18 @@ export default class PreferencesProvider extends React.Component<Props, State> {
         values: {
           ...state.values,
           fetchPlayerTokenForPreviewAutomatically: newValue,
+        },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _setPreviewCrashReportUploadLevel(newValue: string) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          previewCrashReportUploadLevel: newValue,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3605,6 +3605,13 @@ const MainFrame = (props: Props) => {
       {!!renderPreviewLauncher &&
         renderPreviewLauncher(
           {
+            crashReportUploadLevel:
+              preferences.values.previewCrashReportUploadLevel ||
+              'exclude-javascript-code-events',
+            previewContext: quickCustomizationDialogOpenedFromGameId
+              ? 'preview-quick-customization'
+              : 'preview',
+            sourceGameId: quickCustomizationDialogOpenedFromGameId || '',
             getIncludeFileHashs:
               eventsFunctionsExtensionsContext.getIncludeFileHashs,
             onExport: () => openShareDialog('publish'),


### PR DESCRIPTION
Especially useful to automatically discover crashes and obvious bugs in the game engine without requiring users to create GitHub issues. Exceptions in JS code are not reported to avoid noise.
Can be deactivated in preferences. Not enabled on exported games.