### PR TITLE
Fix the checker background in collisions and point editor, also in resource editor.

### DIFF
--- a/newIDE/app/src/ResourcesList/CheckeredBackground.js
+++ b/newIDE/app/src/ResourcesList/CheckeredBackground.js
@@ -26,7 +26,6 @@ const CheckeredBackground = () => {
     left: 0,
     width: '100%',
     height: '100%',
-    zIndex: -1,
 
     // Apply a theme-defined CSS filter on static checkered background
     background: 'url("res/transparentback.png") repeat',


### PR DESCRIPTION
Close https://github.com/4ian/GDevelop/issues/6927

The z order -1 is not useful as the component is already behind the one that display the images.
This z order -1 has been added in the PR for the Quick Customization. But it also works without.


![image](https://github.com/user-attachments/assets/0844f84e-6b69-4535-8295-ef1aa4bc719e)
