### PR TITLE
Catch callback functions of Firebase preventing JS crash

### DIFF
--- a/Extensions/Firebase/B_firebasetools/C_firebasetools.ts
+++ b/Extensions/Firebase/B_firebasetools/C_firebasetools.ts
@@ -30,7 +30,13 @@ namespace gdjs {
         if (typeof firebaseConfig !== 'object') return;
         if (firebase.apps.length !== 0) await firebase.app().delete();
         firebase.initializeApp(firebaseConfig);
-        for (let func of onAppCreated) func();
+        for (let func of onAppCreated) {
+          try {
+            func();
+          } catch (e) {
+            logger.error('An error occurred while running a callback: ' + e);
+          }
+        }
       };
 
       gdjs.registerFirstRuntimeSceneLoadedCallback(_setupFirebase);


### PR DESCRIPTION
This happens for instance when an API key entered is wrong