### PR TITLE
Fix tilemap new weird behaviors

### DIFF
--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -630,7 +630,12 @@ const defineSimpleTileMap = function (extension, _, gd) {
 
     objectProperties.set(
       'columnCount',
-      new gd.PropertyDescriptor((objectContent.columnCount || 4).toString())
+      new gd.PropertyDescriptor(
+        (typeof objectContent.columnCount === 'undefined'
+          ? 4
+          : objectContent.columnCount
+        ).toString()
+      )
         .setType('number')
         .setLabel(_('Columns'))
         .setDescription(_('Number of columns.'))
@@ -638,7 +643,12 @@ const defineSimpleTileMap = function (extension, _, gd) {
     );
     objectProperties.set(
       'rowCount',
-      new gd.PropertyDescriptor((objectContent.rowCount || 4).toString())
+      new gd.PropertyDescriptor(
+        (typeof objectContent.rowCount === 'undefined'
+          ? 4
+          : objectContent.rowCount
+        ).toString()
+      )
         .setType('number')
         .setLabel(_('Rows'))
         .setDescription(_('Number of rows.'))
@@ -646,7 +656,12 @@ const defineSimpleTileMap = function (extension, _, gd) {
     );
     objectProperties.set(
       'tileSize',
-      new gd.PropertyDescriptor((objectContent.tileSize || 8).toString())
+      new gd.PropertyDescriptor(
+        (typeof objectContent.tileSize === 'undefined'
+          ? 8
+          : objectContent.tileSize
+        ).toString()
+      )
         .setType('number')
         .setLabel(_('Tile size'))
         .setDescription(_('Tile size in pixels.'))

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -830,7 +830,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       'TileIdAtPosition',
       _('Tile (at position)'),
       _('the id of the tile at the scene coordinates'),
-      _('the tile id at scene coordinates _PARAM3_ ; _PARAM4_'),
+      _('the tile id at scene coordinates _PARAM3_ ; _PARAM4_ of _PARAM0_'),
       '',
       'JsPlatform/Extensions/tile_map.svg'
     )
@@ -847,7 +847,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile vertically (at position)'),
       _('Flip tile vertically at scene coordinates.'),
       _(
-        'Flip tile vertically at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
+        'Flip tile vertically at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
       ),
       _('Effects'),
       'res/actions/flipY24.png',
@@ -866,7 +866,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile horizontally (at position)'),
       _('Flip tile horizontally at scene coordinates.'),
       _(
-        'Flip tile horizontally at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
+        'Flip tile horizontally at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -918,7 +918,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile vertically (on the grid)'),
       _('Flip tile vertically at grid coordinates.'),
       _(
-        'Flip tile vertically at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
+        'Flip tile vertically at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
       ),
       _('Effects'),
       'res/actions/flipY24.png',
@@ -937,7 +937,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile horizontally (on the grid)'),
       _('Flip tile horizontally at grid coordinates.'),
       _(
-        'Flip tile horizontally at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
+        'Flip tile horizontally at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -955,7 +955,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       'RemoveTileAtGridCoordinates',
       _('Remove tile (on the grid)'),
       _('Remove the tile at the grid coordinates.'),
-      _('Remove tile at grid coordinates _PARAM1_ ; _PARAM2_'),
+      _('Remove tile at grid coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_'),
       '',
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
@@ -972,7 +972,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped horizontally (at position)'),
       _('Check if tile at scene coordinates is flipped horizontally.'),
       _(
-        'The tile at scene coordinates _PARAM1_ ; _PARAM2_ is flipped horizontally'
+        'The tile at scene coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped horizontally'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -990,7 +990,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped vertically (at position)'),
       _('Check if tile at scene coordinates is flipped vertically.'),
       _(
-        'The tile at scene coordinates _PARAM1_ ; _PARAM2_ is flipped vertically'
+        'The tile at scene coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped vertically'
       ),
       _('Effects'),
       'res/actions/flipY24.png',
@@ -1008,7 +1008,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped horizontally (on the grid)'),
       _('Check if tile at grid coordinates is flipped horizontally.'),
       _(
-        'The tile at grid coordinates _PARAM1_ ; _PARAM2_ is flipped horizontally'
+        'The tile at grid coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped horizontally'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -1026,7 +1026,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped vertically (on the grid)'),
       _('Check if tile at grid coordinates is flipped vertically.'),
       _(
-        'The tile at grid coordinates _PARAM1_ ; _PARAM2_ is flipped vertically'
+        'The tile at grid coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped vertically'
       ),
       _('Effects'),
       'res/actions/flipY24.png',

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -2338,7 +2338,9 @@ module.exports = {
           ? this._editableTileMap.isEmpty()
           : false;
         let objectToChange;
-        if (isTileMapEmpty || !atlasImageResourceName) {
+        if (this.errorPixiObject) {
+          objectToChange = this.errorPixiObject;
+        } else if (isTileMapEmpty || !atlasImageResourceName) {
           this.tileMapPixiObject.visible = false;
           this._placeholderPixiObject.visible = true;
           this._placeholderTextPixiObject.text = !atlasImageResourceName

--- a/Extensions/TileMap/JsExtension.js
+++ b/Extensions/TileMap/JsExtension.js
@@ -750,7 +750,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
     .addExpression(
       'TilesetColumnCount',
       _('Tileset column count'),
-      _('Get the number of column in the tileset.'),
+      _('Get the number of columns in the tileset.'),
       '',
       'JsPlatform/Extensions/tile_map.svg'
     )
@@ -761,7 +761,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
     .addExpression(
       'TilesetRowCount',
       _('Tileset row count'),
-      _('Get the number of row in the tileset.'),
+      _('Get the number of rows in the tileset.'),
       '',
       'JsPlatform/Extensions/tile_map.svg'
     )
@@ -830,7 +830,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       'TileIdAtPosition',
       _('Tile (at position)'),
       _('the id of the tile at the scene coordinates'),
-      _('the tile id at scene coordinates _PARAM3_ ; _PARAM4_ of _PARAM0_'),
+      _('the tile id in _PARAM0_ at scene coordinates _PARAM3_ ; _PARAM4_'),
       '',
       'JsPlatform/Extensions/tile_map.svg'
     )
@@ -847,7 +847,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile vertically (at position)'),
       _('Flip tile vertically at scene coordinates.'),
       _(
-        'Flip tile vertically at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
+        'Flip tile vertically in _PARAM0_ at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
       ),
       _('Effects'),
       'res/actions/flipY24.png',
@@ -866,7 +866,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile horizontally (at position)'),
       _('Flip tile horizontally at scene coordinates.'),
       _(
-        'Flip tile horizontally at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
+        'Flip tile horizontally in _PARAM0_ at scene coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -884,7 +884,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       'RemoveTileAtPosition',
       _('Remove tile (at position)'),
       _('Remove the tile at the scene coordinates.'),
-      _('Remove tile at scene coordinates _PARAM1_ ; _PARAM2_'),
+      _('Remove tile in _PARAM0_ at scene coordinates _PARAM1_ ; _PARAM2_'),
       '',
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
@@ -918,7 +918,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile vertically (on the grid)'),
       _('Flip tile vertically at grid coordinates.'),
       _(
-        'Flip tile vertically at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
+        'Flip tile vertically in _PARAM0_ at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
       ),
       _('Effects'),
       'res/actions/flipY24.png',
@@ -937,7 +937,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Flip tile horizontally (on the grid)'),
       _('Flip tile horizontally at grid coordinates.'),
       _(
-        'Flip tile horizontally at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_ of _PARAM0_'
+        'Flip tile horizontally in _PARAM0_ at grid coordinates _PARAM1_ ; _PARAM2_: _PARAM3_'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -955,7 +955,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       'RemoveTileAtGridCoordinates',
       _('Remove tile (on the grid)'),
       _('Remove the tile at the grid coordinates.'),
-      _('Remove tile at grid coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_'),
+      _('Remove tile in _PARAM0_ at grid coordinates _PARAM1_ ; _PARAM2_'),
       '',
       'JsPlatform/Extensions/tile_map.svg',
       'JsPlatform/Extensions/tile_map.svg'
@@ -972,7 +972,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped horizontally (at position)'),
       _('Check if tile at scene coordinates is flipped horizontally.'),
       _(
-        'The tile at scene coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped horizontally'
+        'The tile in _PARAM0_ at scene coordinates _PARAM1_ ; _PARAM2_ is flipped horizontally'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -990,7 +990,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped vertically (at position)'),
       _('Check if tile at scene coordinates is flipped vertically.'),
       _(
-        'The tile at scene coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped vertically'
+        'The tile in _PARAM0_ at scene coordinates _PARAM1_ ; _PARAM2_ is flipped vertically'
       ),
       _('Effects'),
       'res/actions/flipY24.png',
@@ -1008,7 +1008,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped horizontally (on the grid)'),
       _('Check if tile at grid coordinates is flipped horizontally.'),
       _(
-        'The tile at grid coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped horizontally'
+        'The tile in _PARAM0_ at grid coordinates _PARAM1_ ; _PARAM2_ is flipped horizontally'
       ),
       _('Effects'),
       'res/actions/flipX24.png',
@@ -1026,7 +1026,7 @@ const defineSimpleTileMap = function (extension, _, gd) {
       _('Tile flipped vertically (on the grid)'),
       _('Check if tile at grid coordinates is flipped vertically.'),
       _(
-        'The tile at grid coordinates _PARAM1_ ; _PARAM2_ of _PARAM0_ is flipped vertically'
+        'The tile in _PARAM0_ at grid coordinates _PARAM1_ ; _PARAM2_ is flipped vertically'
       ),
       _('Effects'),
       'res/actions/flipY24.png',

--- a/Extensions/TileMap/simpletilemapruntimeobject.ts
+++ b/Extensions/TileMap/simpletilemapruntimeobject.ts
@@ -218,6 +218,12 @@ namespace gdjs {
       tileMapLoadingCallback: (tileMap: TileMapHelper.EditableTileMap) => void
     ): void {
       if (!this._initialTileMapAsJsObject) return;
+      if (this._columnCount <= 0 || this._rowCount <= 0) {
+        console.error(
+          `Tilemap object ${this.name} is not configured properly.`
+        );
+        return;
+      }
 
       this._tileMapManager.getOrLoadSimpleTileMap(
         this._initialTileMapAsJsObject,

--- a/newIDE/app/src/CompactPropertiesEditor/index.js
+++ b/newIDE/app/src/CompactPropertiesEditor/index.js
@@ -618,6 +618,7 @@ const CompactPropertiesEditor = ({
         compactSelectField = (
           <CompactSelectField
             value={getFieldValue({ instances, field })}
+            key={field.name}
             id={field.name}
             onChange={(newValue: string) => {
               instances.forEach(i => setValue(i, parseFloat(newValue) || 0));
@@ -640,6 +641,7 @@ const CompactPropertiesEditor = ({
               field,
               defaultValue: '(Multiple values)',
             })}
+            key={field.name}
             id={field.name}
             onChange={(newValue: string) => {
               instances.forEach(i => setValue(i, newValue || ''));

--- a/newIDE/app/src/InstancesEditor/SelectedInstances.js
+++ b/newIDE/app/src/InstancesEditor/SelectedInstances.js
@@ -18,6 +18,7 @@ import KeyboardShortcuts from '../UI/KeyboardShortcuts';
 type Props = {|
   instancesSelection: InstancesSelection,
   instanceMeasurer: InstanceMeasurer,
+  shouldDisplayHandles: () => boolean,
   onResize: (
     deltaX: number,
     deltaY: number,
@@ -72,6 +73,7 @@ const resizeGrabbingIconNames = {
 export default class SelectedInstances {
   instancesSelection: InstancesSelection;
   instanceMeasurer: InstanceMeasurer;
+  shouldDisplayHandles: () => boolean;
   onResize: (
     deltaX: number,
     deltaY: number,
@@ -105,6 +107,7 @@ export default class SelectedInstances {
   constructor({
     instancesSelection,
     instanceMeasurer,
+    shouldDisplayHandles,
     onResize,
     onResizeEnd,
     onRotate,
@@ -118,6 +121,7 @@ export default class SelectedInstances {
   }: Props) {
     this.instanceMeasurer = instanceMeasurer;
     this.onResize = onResize;
+    this.shouldDisplayHandles = shouldDisplayHandles;
     this.onResizeEnd = onResizeEnd;
     this.onRotate = onRotate;
     this.onRotateEnd = onRotateEnd;
@@ -303,6 +307,7 @@ export default class SelectedInstances {
       buttonPadding,
       hitAreaPadding,
     } = getButtonSizes(this._screenType);
+    const displayHandle = this.shouldDisplayHandles();
     const selection = this.instancesSelection.getSelectedInstances();
     let x1 = 0;
     let y1 = 0;
@@ -368,7 +373,8 @@ export default class SelectedInstances {
 
     // If there are no unlocked instances, hide the resize buttons.
     const show =
-      selection.filter(instance => !instance.isLocked()).length !== 0;
+      selection.filter(instance => !instance.isLocked()).length !== 0 &&
+      displayHandle;
 
     // Position the resize buttons.
     for (const grabbingLocation of resizeGrabbingLocationValues) {

--- a/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
+++ b/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
@@ -367,12 +367,16 @@ class TileMapPaintingPreview {
     sprite.width = spriteWidth;
     sprite.height = spriteHeight;
 
-    const allXCoordinates = spritesCoordinatesInTileMapGrid.map(({ x }) => x);
-    const allYCoordinates = spritesCoordinatesInTileMapGrid.map(({ y }) => y);
-    const minX = Math.min(...allXCoordinates);
-    const maxX = Math.max(...allXCoordinates);
-    const minY = Math.min(...allYCoordinates);
-    const maxY = Math.max(...allYCoordinates);
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const { x, y } of spritesCoordinatesInTileMapGrid) {
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+    }
 
     this.tileMapToSceneTransformation.transform(
       [minX * tileSize, minY * tileSize],

--- a/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
+++ b/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
@@ -134,45 +134,53 @@ export const getTilesGridCoordinatesFromPointerSceneCoordinates = ({
     });
   }
   if (coordinates.length === 2) {
-    const topLeftCornerCoordinatesInTileMap = [0, 0];
-    const bottomRightCornerCoordinatesInTileMap = [0, 0];
-
+    const firstPointCoordinatesInTileMap = [0, 0];
     sceneToTileMapTransformation.transform(
-      [
-        Math.min(coordinates[0].x, coordinates[1].x),
-        Math.min(coordinates[0].y, coordinates[1].y),
-      ],
-      topLeftCornerCoordinatesInTileMap
+      [coordinates[0].x, coordinates[0].y],
+      firstPointCoordinatesInTileMap
     );
-    topLeftCornerCoordinatesInTileMap[0] = Math.floor(
-      topLeftCornerCoordinatesInTileMap[0] / tileSize
-    );
-    topLeftCornerCoordinatesInTileMap[1] = Math.floor(
-      topLeftCornerCoordinatesInTileMap[1] / tileSize
-    );
-
+    const secondPointCoordinatesInTileMap = [0, 0];
     sceneToTileMapTransformation.transform(
-      [
-        Math.max(coordinates[0].x, coordinates[1].x),
-        Math.max(coordinates[0].y, coordinates[1].y),
-      ],
-      bottomRightCornerCoordinatesInTileMap
+      [coordinates[1].x, coordinates[1].y],
+      secondPointCoordinatesInTileMap
     );
-    bottomRightCornerCoordinatesInTileMap[0] = Math.floor(
-      bottomRightCornerCoordinatesInTileMap[0] / tileSize
-    );
-    bottomRightCornerCoordinatesInTileMap[1] = Math.floor(
-      bottomRightCornerCoordinatesInTileMap[1] / tileSize
-    );
+    const topLeftCornerCoordinatesInTileMap = [
+      Math.min(
+        firstPointCoordinatesInTileMap[0],
+        secondPointCoordinatesInTileMap[0]
+      ),
+      Math.min(
+        firstPointCoordinatesInTileMap[1],
+        secondPointCoordinatesInTileMap[1]
+      ),
+    ];
+    const bottomRightCornerCoordinatesInTileMap = [
+      Math.max(
+        firstPointCoordinatesInTileMap[0],
+        secondPointCoordinatesInTileMap[0]
+      ),
+      Math.max(
+        firstPointCoordinatesInTileMap[1],
+        secondPointCoordinatesInTileMap[1]
+      ),
+    ];
+    const topLeftCornerCoordinatesInTileMapGrid = [
+      Math.floor(topLeftCornerCoordinatesInTileMap[0] / tileSize),
+      Math.floor(topLeftCornerCoordinatesInTileMap[1] / tileSize),
+    ];
+    const bottomRightCornerCoordinatesInTileMapGrid = [
+      Math.floor(bottomRightCornerCoordinatesInTileMap[0] / tileSize),
+      Math.floor(bottomRightCornerCoordinatesInTileMap[1] / tileSize),
+    ];
 
     for (
-      let columnIndex = topLeftCornerCoordinatesInTileMap[0];
-      columnIndex <= bottomRightCornerCoordinatesInTileMap[0];
+      let columnIndex = topLeftCornerCoordinatesInTileMapGrid[0];
+      columnIndex <= bottomRightCornerCoordinatesInTileMapGrid[0];
       columnIndex++
     ) {
       for (
-        let rowIndex = topLeftCornerCoordinatesInTileMap[1];
-        rowIndex <= bottomRightCornerCoordinatesInTileMap[1];
+        let rowIndex = topLeftCornerCoordinatesInTileMapGrid[1];
+        rowIndex <= bottomRightCornerCoordinatesInTileMapGrid[1];
         rowIndex++
       ) {
         tilesCoordinatesInTileMapGrid.push({ x: columnIndex, y: rowIndex });

--- a/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
+++ b/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
@@ -25,14 +25,16 @@ export const updateSceneToTileMapTransformation = (
     scaleY = 1;
   if (instance.hasCustomSize()) {
     const editableTileMap = renderedInstance.getEditableTileMap();
-    if (!editableTileMap) {
+    if (editableTileMap) {
+      scaleX = instance.getCustomWidth() / editableTileMap.getWidth();
+      scaleY = instance.getCustomHeight() / editableTileMap.getHeight();
+    } else {
       console.error(
-        `Could not find the editable tile map for instance of object ${instance.getObjectName()}.`
+        `Could not find the editable tile map for instance of object ${instance.getObjectName()}. Make sure the tile map object is correctly configured.`
       );
-      return;
+      // Do not early return on error to make the preview still working to not give
+      // a sense of something broken.
     }
-    scaleX = instance.getCustomWidth() / editableTileMap.getWidth();
-    scaleY = instance.getCustomHeight() / editableTileMap.getHeight();
   }
   const absScaleX = Math.abs(scaleX);
   const absScaleY = Math.abs(scaleY);

--- a/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
+++ b/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
@@ -345,7 +345,7 @@ class TileMapPaintingPreview {
     spritesCoordinatesInTileMapGrid.forEach(({ x, y }) => {
       let sprite;
 
-      if (tileMapTileSelection.kind === 'single' || isBadlyConfigured) {
+      if (tileMapTileSelection.kind === 'single') {
         // TODO: Find a way not to regenerate the sprites on each render.
         sprite = new PIXI.Sprite(texture);
         if (tileMapTileSelection.flipHorizontally) {
@@ -355,6 +355,7 @@ class TileMapPaintingPreview {
           sprite.scale.y *= -1;
         }
       } else {
+        // If the tileset is badly configured, use tiled sprite with the invalid texture.
         sprite = new PIXI.TilingSprite(texture, 2, 2);
         sprite.tileScale.x = this.viewPosition.toCanvasScale(scaleX);
         sprite.tileScale.y = this.viewPosition.toCanvasScale(scaleY);

--- a/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
+++ b/newIDE/app/src/InstancesEditor/TileMapPaintingPreview.js
@@ -77,7 +77,7 @@ export const getTileSet = (object: gdObject) => {
   return { rowCount, columnCount, tileSize, atlasImage };
 };
 
-const isTileSetBadlyConfigured = ({
+export const isTileSetBadlyConfigured = ({
   rowCount,
   columnCount,
   tileSize,

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -505,6 +505,7 @@ export default class InstancesEditor extends Component<Props, State> {
     });
     this.selectedInstances = new SelectedInstances({
       instancesSelection: this.props.instancesSelection,
+      shouldDisplayHandles: this.shouldDisplayClickableHandles,
       onResize: this._onResize,
       onResizeEnd: this._onResizeEnd,
       onRotate: this._onRotate,
@@ -732,6 +733,8 @@ export default class InstancesEditor extends Component<Props, State> {
     if (this.props.tileMapTileSelection) return { color: 0xfff, alpha: 0 };
     return { color: isLocked ? 0xbc5753 : 0x6868e8, alpha: 1 };
   };
+
+  shouldDisplayClickableHandles = () => !this.props.tileMapTileSelection;
 
   getZoomFactor = () => {
     return this.props.instancesEditorSettings.zoomFactor;

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -45,6 +45,7 @@ import Background from './Background';
 import TileMapPaintingPreview, {
   getTileSet,
   getTilesGridCoordinatesFromPointerSceneCoordinates,
+  isTileSetBadlyConfigured,
   updateSceneToTileMapTransformation,
 } from './TileMapPaintingPreview';
 import {
@@ -825,6 +826,12 @@ export default class InstancesEditor extends Component<Props, State> {
       const tileSet = getTileSet(object);
       if (!tileSet.atlasImage) {
         console.warn('Trying to paint on a tilemap without an atlas image.');
+        return;
+      }
+      if (isTileSetBadlyConfigured(tileSet)) {
+        console.warn(
+          'Trying to paint on a tilemap with a badly configured tileset.'
+        );
         return;
       }
       const tileMapGridCoordinates = getTilesGridCoordinatesFromPointerSceneCoordinates(

--- a/newIDE/app/src/ObjectEditor/Editors/SimpleTileMapEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SimpleTileMapEditor.js
@@ -67,12 +67,13 @@ const SimpleTileMapEditor = ({
       |},
       tileSize: number
     ) => {
-      const newRowCount = dimensions.height / tileSize;
-      const newColumnCount = dimensions.width / tileSize;
+      const newRowCount = Math.floor(dimensions.height / tileSize);
+      const newColumnCount = Math.floor(dimensions.width / tileSize);
 
       if (rowCount === newRowCount && columnCount === newColumnCount) {
         return;
       }
+      setError(null);
       objectConfiguration.updateProperty('rowCount', newRowCount.toString());
       objectConfiguration.updateProperty(
         'columnCount',
@@ -92,7 +93,6 @@ const SimpleTileMapEditor = ({
       if (!value) {
         return;
       }
-      setError(null);
       objectConfiguration.updateProperty('tileSize', value.toString());
       if (loadedAtlasImageDimensions) {
         recomputeTileSet(loadedAtlasImageDimensions, value);
@@ -140,17 +140,11 @@ const SimpleTileMapEditor = ({
   React.useEffect(
     () => {
       if (!loadedAtlasImageDimensions) return;
-      const _rowCount = loadedAtlasImageDimensions.height / tileSize;
-      const _columnCount = loadedAtlasImageDimensions.width / tileSize;
-      if (!Number.isInteger(_rowCount) || !Number.isInteger(_columnCount)) {
-        setError(
-          <Trans>
-            The new atlas image size is not compatible with the tile size.
-          </Trans>
-        );
+      if (rowCount <= 0 || columnCount <= 0) {
+        setError(<Trans>The atlas image is smaller than the tile size.</Trans>);
       }
     },
-    [tileSize, loadedAtlasImageDimensions]
+    [rowCount, columnCount, loadedAtlasImageDimensions]
   );
 
   const onAtlasImageLoaded = React.useCallback(

--- a/newIDE/app/src/ObjectEditor/Editors/SimpleTileMapEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SimpleTileMapEditor.js
@@ -131,6 +131,7 @@ const SimpleTileMapEditor = ({
   const onChangeAtlasImage = React.useCallback(
     () => {
       if (onObjectUpdated) onObjectUpdated();
+      setError(null);
       onSizeUpdated();
       forceUpdate();
     },


### PR DESCRIPTION
- Improve performance display when painting using a PIXI.TilingSprite
- Fix painting when tilemap is rotated
- Allow atlas size to be something else than a tile size multiple and ignore last column and row
- Display error message only when the the tile size is greater than the atlas image
- Do not crash preview if tilemap badly configured
- Add object name in actions and conditions