### PR TITLE
Fix a crash in the new behavior dialog

### DIFF
--- a/Core/GDCore/Extensions/Metadata/BehaviorMetadata.cpp
+++ b/Core/GDCore/Extensions/Metadata/BehaviorMetadata.cpp
@@ -441,12 +441,18 @@ std::map<gd::String, gd::PropertyDescriptor> BehaviorMetadata::GetSharedProperti
 
 const std::vector<gd::String>& BehaviorMetadata::GetRequiredBehaviorTypes() const {
   requiredBehaviors.clear();
-  for (auto& property : Get().GetProperties()) {
+  if (!instance) {
+    return requiredBehaviors;
+  }
+  for (auto& property : instance->GetProperties()) {
     const String& propertyName = property.first;
     const gd::PropertyDescriptor& propertyDescriptor = property.second;
 
     if (propertyDescriptor.GetType() == "Behavior") {
-      requiredBehaviors.push_back(propertyDescriptor.GetExtraInfo()[0]);
+      const auto& extraInfos = propertyDescriptor.GetExtraInfo();
+      if (extraInfos.size() > 0) {
+        requiredBehaviors.push_back(extraInfos[0]);
+      }
     }
   }
   return requiredBehaviors;


### PR DESCRIPTION
- The crash happens when the extensions didn't load as expected.