### PR TITLE
Fix color crashes in Preview

### DIFF
--- a/Extensions/3D/AmbientLight.ts
+++ b/Extensions/3D/AmbientLight.ts
@@ -73,9 +73,7 @@ namespace gdjs {
           }
           updateStringParameter(parameterName: string, value: string): void {
             if (parameterName === 'color') {
-              this.light.color.setHex(
-                gdjs.rgbOrHexStringToNumber(value)
-              );
+              this.light.color.setHex(gdjs.rgbOrHexStringToNumber(value));
             }
           }
           updateColorParameter(parameterName: string, value: number): void {

--- a/Extensions/3D/AmbientLight.ts
+++ b/Extensions/3D/AmbientLight.ts
@@ -74,7 +74,7 @@ namespace gdjs {
           updateStringParameter(parameterName: string, value: string): void {
             if (parameterName === 'color') {
               this.light.color.setHex(
-                gdjs.PixiFiltersTools.rgbOrHexToHexNumber(value)
+                gdjs.rgbOrHexStringToNumber(value)
               );
             }
           }

--- a/Extensions/3D/DirectionalLight.ts
+++ b/Extensions/3D/DirectionalLight.ts
@@ -94,7 +94,7 @@ namespace gdjs {
           updateStringParameter(parameterName: string, value: string): void {
             if (parameterName === 'color') {
               this.light.color = new THREE.Color(
-                gdjs.PixiFiltersTools.rgbOrHexToHexNumber(value)
+                gdjs.rgbOrHexStringToNumber(value)
               );
             }
             if (parameterName === 'top') {

--- a/Extensions/3D/ExponentialFog.ts
+++ b/Extensions/3D/ExponentialFog.ts
@@ -71,7 +71,7 @@ namespace gdjs {
           updateStringParameter(parameterName: string, value: string): void {
             if (parameterName === 'color') {
               this.fog.color = new THREE.Color(
-                gdjs.PixiFiltersTools.rgbOrHexToHexNumber(value)
+                gdjs.rgbOrHexStringToNumber(value)
               );
             }
           }

--- a/Extensions/3D/HemisphereLight.ts
+++ b/Extensions/3D/HemisphereLight.ts
@@ -95,12 +95,12 @@ namespace gdjs {
           updateStringParameter(parameterName: string, value: string): void {
             if (parameterName === 'skyColor') {
               this.light.color = new THREE.Color(
-                gdjs.PixiFiltersTools.rgbOrHexToHexNumber(value)
+                gdjs.rgbOrHexStringToNumber(value)
               );
             }
             if (parameterName === 'groundColor') {
               this.light.groundColor = new THREE.Color(
-                gdjs.PixiFiltersTools.rgbOrHexToHexNumber(value)
+                gdjs.rgbOrHexStringToNumber(value)
               );
             }
             if (parameterName === 'top') {

--- a/Extensions/3D/LinearFog.ts
+++ b/Extensions/3D/LinearFog.ts
@@ -76,7 +76,7 @@ namespace gdjs {
           updateStringParameter(parameterName: string, value: string): void {
             if (parameterName === 'color') {
               this.fog.color = new THREE.Color(
-                gdjs.PixiFiltersTools.rgbOrHexToHexNumber(value)
+                gdjs.rgbOrHexStringToNumber(value)
               );
             }
           }

--- a/Extensions/Effects/bevel-pixi-filter.ts
+++ b/Extensions/Effects/bevel-pixi-filter.ts
@@ -67,14 +67,10 @@ namespace gdjs {
         const bevelFilter = (filter as unknown) as PIXI.filters.BevelFilter &
           BevelFilterExtra;
         if (parameterName === 'lightColor') {
-          bevelFilter.lightColor = gdjs.rgbOrHexStringToNumber(
-            value
-          );
+          bevelFilter.lightColor = gdjs.rgbOrHexStringToNumber(value);
         }
         if (parameterName === 'shadowColor') {
-          bevelFilter.shadowColor = gdjs.rgbOrHexStringToNumber(
-            value
-          );
+          bevelFilter.shadowColor = gdjs.rgbOrHexStringToNumber(value);
         }
       }
       updateColorParameter(

--- a/Extensions/Effects/bevel-pixi-filter.ts
+++ b/Extensions/Effects/bevel-pixi-filter.ts
@@ -67,12 +67,12 @@ namespace gdjs {
         const bevelFilter = (filter as unknown) as PIXI.filters.BevelFilter &
           BevelFilterExtra;
         if (parameterName === 'lightColor') {
-          bevelFilter.lightColor = gdjs.PixiFiltersTools.rgbOrHexToHexNumber(
+          bevelFilter.lightColor = gdjs.rgbOrHexStringToNumber(
             value
           );
         }
         if (parameterName === 'shadowColor') {
-          bevelFilter.shadowColor = gdjs.PixiFiltersTools.rgbOrHexToHexNumber(
+          bevelFilter.shadowColor = gdjs.rgbOrHexStringToNumber(
             value
           );
         }

--- a/Extensions/Effects/color-replace-pixi-filter.ts
+++ b/Extensions/Effects/color-replace-pixi-filter.ts
@@ -45,11 +45,11 @@ namespace gdjs {
         const colorReplaceFilter = (filter as unknown) as PIXI.filters.ColorReplaceFilter &
           ColorReplaceFilterExtra;
         if (parameterName === 'originalColor') {
-          colorReplaceFilter.originalColor = gdjs.PixiFiltersTools.rgbOrHexToHexNumber(
+          colorReplaceFilter.originalColor = gdjs.rgbOrHexStringToNumber(
             value
           );
         } else if (parameterName === 'newColor') {
-          colorReplaceFilter.newColor = gdjs.PixiFiltersTools.rgbOrHexToHexNumber(
+          colorReplaceFilter.newColor = gdjs.rgbOrHexStringToNumber(
             value
           );
         }

--- a/Extensions/Effects/color-replace-pixi-filter.ts
+++ b/Extensions/Effects/color-replace-pixi-filter.ts
@@ -45,13 +45,9 @@ namespace gdjs {
         const colorReplaceFilter = (filter as unknown) as PIXI.filters.ColorReplaceFilter &
           ColorReplaceFilterExtra;
         if (parameterName === 'originalColor') {
-          colorReplaceFilter.originalColor = gdjs.rgbOrHexStringToNumber(
-            value
-          );
+          colorReplaceFilter.originalColor = gdjs.rgbOrHexStringToNumber(value);
         } else if (parameterName === 'newColor') {
-          colorReplaceFilter.newColor = gdjs.rgbOrHexStringToNumber(
-            value
-          );
+          colorReplaceFilter.newColor = gdjs.rgbOrHexStringToNumber(value);
         }
       }
       updateColorParameter(

--- a/Extensions/Effects/drop-shadow-pixi-filter.ts
+++ b/Extensions/Effects/drop-shadow-pixi-filter.ts
@@ -66,7 +66,7 @@ namespace gdjs {
       ) {
         const dropShadowFilter = (filter as unknown) as PIXI.filters.DropShadowFilter;
         if (parameterName === 'color') {
-          dropShadowFilter.color = gdjs.PixiFiltersTools.rgbOrHexToHexNumber(
+          dropShadowFilter.color = gdjs.rgbOrHexStringToNumber(
             value
           );
         }

--- a/Extensions/Effects/drop-shadow-pixi-filter.ts
+++ b/Extensions/Effects/drop-shadow-pixi-filter.ts
@@ -66,9 +66,7 @@ namespace gdjs {
       ) {
         const dropShadowFilter = (filter as unknown) as PIXI.filters.DropShadowFilter;
         if (parameterName === 'color') {
-          dropShadowFilter.color = gdjs.rgbOrHexStringToNumber(
-            value
-          );
+          dropShadowFilter.color = gdjs.rgbOrHexStringToNumber(value);
         }
       }
       updateColorParameter(

--- a/Extensions/Effects/glow-pixi-filter.ts
+++ b/Extensions/Effects/glow-pixi-filter.ts
@@ -53,7 +53,7 @@ namespace gdjs {
         const glowFilter = (filter as unknown) as PIXI.filters.GlowFilter &
           GlowFilterExtra;
         if (parameterName === 'color') {
-          glowFilter.color = gdjs.PixiFiltersTools.rgbOrHexToHexNumber(value);
+          glowFilter.color = gdjs.rgbOrHexStringToNumber(value);
         }
       }
       updateColorParameter(

--- a/Extensions/Effects/outline-pixi-filter.ts
+++ b/Extensions/Effects/outline-pixi-filter.ts
@@ -41,9 +41,7 @@ namespace gdjs {
       ) {
         const outlineFilter = (filter as unknown) as PIXI.filters.OutlineFilter;
         if (parameterName === 'color') {
-          outlineFilter.color = gdjs.rgbOrHexStringToNumber(
-            value
-          );
+          outlineFilter.color = gdjs.rgbOrHexStringToNumber(value);
         }
       }
       updateColorParameter(

--- a/Extensions/Effects/outline-pixi-filter.ts
+++ b/Extensions/Effects/outline-pixi-filter.ts
@@ -41,7 +41,7 @@ namespace gdjs {
       ) {
         const outlineFilter = (filter as unknown) as PIXI.filters.OutlineFilter;
         if (parameterName === 'color') {
-          outlineFilter.color = gdjs.PixiFiltersTools.rgbOrHexToHexNumber(
+          outlineFilter.color = gdjs.rgbOrHexStringToNumber(
             value
           );
         }

--- a/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-filters-tools.ts
@@ -52,22 +52,6 @@ namespace gdjs {
       _filterCreators[filterName] = filterCreator;
     };
 
-    /**
-     * Convert a string RGB color ("rrr;ggg;bbb") or a hex string (#rrggbb) to a hex number.
-     * @param value The color as a RGB string or hex string
-     */
-    export const rgbOrHexToHexNumber = function (value: string): number {
-      const splitValue = value.split(';');
-      if (splitValue.length === 3) {
-        return gdjs.rgbToHexNumber(
-          parseInt(splitValue[0], 10),
-          parseInt(splitValue[1], 10),
-          parseInt(splitValue[2], 10)
-        );
-      }
-      return parseInt(value.replace('#', '0x'), 16);
-    };
-
     /** A wrapper allowing to create an effect. */
     export interface FilterCreator {
       /** Function to call to create the filter */

--- a/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
@@ -142,16 +142,8 @@ namespace gdjs {
       this._sprite.visible = !this._object.hidden;
     }
 
-    setColor(rgbColor): void {
-      const colors = rgbColor.split(';');
-      if (colors.length < 3) {
-        return;
-      }
-      this._sprite.tint = gdjs.rgbToHexNumber(
-        parseInt(colors[0], 10),
-        parseInt(colors[1], 10),
-        parseInt(colors[2], 10)
-      );
+    setColor(rgbOrHexColor): void {
+      this._sprite.tint = gdjs.rgbOrHexStringToNumber(rgbOrHexColor);
     }
 
     getColor() {

--- a/GDJS/Runtime/spriteruntimeobject.ts
+++ b/GDJS/Runtime/spriteruntimeobject.ts
@@ -759,10 +759,10 @@ namespace gdjs {
     /**
      * Change the tint of the sprite object.
      *
-     * @param rgbColor The color, in RGB format ("128;200;255").
+     * @param rgbOrHexColor The color as a string, in RGB format ("128;200;255") or Hex format.
      */
-    setColor(rgbColor: string): void {
-      this._renderer.setColor(rgbColor);
+    setColor(rgbOrHexColor: string): void {
+      this._renderer.setColor(rgbOrHexColor);
     }
 
     /**

--- a/GDJS/tests/tests/colors.js
+++ b/GDJS/tests/tests/colors.js
@@ -1,0 +1,55 @@
+describe('gdjs', function () {
+  it('should define gdjs', function () {
+    expect(gdjs).to.be.ok();
+  });
+
+  describe('Color conversion', function () {
+    describe('Hex strings to RGB components', () => {
+      it('should convert hex strings', function () {
+        expect(gdjs.hexToRGBColor('#FFFFfF')).to.eql([255, 255, 255]);
+        expect(gdjs.hexToRGBColor('#000000')).to.eql([0, 0, 0]);
+        expect(gdjs.hexToRGBColor('#1245F5')).to.eql([18, 69, 245]);
+      });
+      it('should convert hex strings without hashtag', function () {
+        expect(gdjs.hexToRGBColor('FFFFfF')).to.eql([255, 255, 255]);
+        expect(gdjs.hexToRGBColor('000000')).to.eql([0, 0, 0]);
+        expect(gdjs.hexToRGBColor('1245F5')).to.eql([18, 69, 245]);
+      });
+      it('should convert shorthand hex strings', function () {
+        expect(gdjs.shorthandHexToRGBColor('#FfF')).to.eql([255, 255, 255]);
+        expect(gdjs.shorthandHexToRGBColor('#000')).to.eql([0, 0, 0]);
+        expect(gdjs.shorthandHexToRGBColor('#F3a')).to.eql([255, 51, 170]);
+      });
+      it('should convert shorthand hex strings without hashtag', function () {
+        expect(gdjs.shorthandHexToRGBColor('FFF')).to.eql([255, 255, 255]);
+        expect(gdjs.shorthandHexToRGBColor('000')).to.eql([0, 0, 0]);
+        expect(gdjs.shorthandHexToRGBColor('F3a')).to.eql([255, 51, 170]);
+      });
+    });
+    describe.only('RGB strings to RGB components', () => {
+      it('should convert rgb strings', function () {
+        expect(gdjs.rgbOrHexToRGBColor('0;0;0')).to.eql([0, 0, 0]);
+        expect(gdjs.rgbOrHexToRGBColor('255;255;255')).to.eql([255, 255, 255]);
+        expect(gdjs.rgbOrHexToRGBColor('120;12;6')).to.eql([120, 12, 6]);
+      });
+      it('should max rgb values', function () {
+        expect(gdjs.rgbOrHexToRGBColor('255;255;300')).to.eql([255, 255, 255]);
+        expect(gdjs.rgbOrHexToRGBColor('999;12;6')).to.eql([255, 12, 6]);
+      });
+      it('should cut rgb values if string too long', function () {
+        expect(gdjs.rgbOrHexToRGBColor('255;255;200456')).to.eql([
+          255,
+          255,
+          200,
+        ]);
+      });
+      it('should return components for black if unrecognized input', function () {
+        expect(gdjs.rgbOrHexToRGBColor('NaN')).to.eql([0, 0, 0]);
+        expect(gdjs.rgbOrHexToRGBColor('19819830803')).to.eql([0, 0, 0]);
+        expect(gdjs.rgbOrHexToRGBColor('Infinity')).to.eql([0, 0, 0]);
+        expect(gdjs.rgbOrHexToRGBColor('-4564')).to.eql([0, 0, 0]);
+        expect(gdjs.rgbOrHexToRGBColor('9999;12;6')).to.eql([0, 0, 0]);
+      });
+    });
+  });
+});

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -296,6 +296,7 @@ const Effect = React.forwardRef(
                         </BackgroundText>
                       </Line>
                       <PropertiesEditor
+                        keyPrefix={effect.getEffectType()}
                         instances={[effect]}
                         schema={effectMetadata.parametersSchema}
                         project={project}

--- a/newIDE/app/src/PropertiesEditor/index.js
+++ b/newIDE/app/src/PropertiesEditor/index.js
@@ -141,6 +141,7 @@ type Props = {|
   instances: Instances,
   schema: Schema,
   mode?: 'column' | 'row',
+  keyPrefix?: string,
 
   // If set, render the "extra" description content from fields
   // (see getExtraDescription).
@@ -250,6 +251,7 @@ const PropertiesEditor = ({
   unsavedChanges,
   project,
   resourceManagementProps,
+  keyPrefix,
 }: Props) => {
   const forceUpdate = useForceUpdate();
 
@@ -309,7 +311,7 @@ const PropertiesEditor = ({
                 </React.Fragment>
               )
             }
-            key={field.name}
+            key={`${keyPrefix || ''}-${field.name}`}
             id={field.name}
             checked={getFieldValue({ instances, field })}
             onCheck={(event, newValue) => {
@@ -325,7 +327,7 @@ const PropertiesEditor = ({
         return (
           <SemiControlledTextField
             value={getFieldValue({ instances, field })}
-            key={field.name}
+            key={`${keyPrefix || ''}-${field.name}`}
             id={field.name}
             floatingLabelText={getFieldLabel({ instances, field })}
             floatingLabelFixed
@@ -355,7 +357,7 @@ const PropertiesEditor = ({
       } else if (field.valueType === 'color') {
         const { setValue } = field;
         return (
-          <Column key={field.name} expand noMargin>
+          <Column key={`${keyPrefix || ''}-${field.name}`} expand noMargin>
             <ColorField
               id={field.name}
               floatingLabelText={getFieldLabel({ instances, field })}
@@ -376,7 +378,7 @@ const PropertiesEditor = ({
         const { setValue } = field;
         return (
           <SemiControlledTextField
-            key={field.name}
+            key={`${keyPrefix || ''}-${field.name}`}
             id={field.name}
             onChange={text => {
               instances.forEach(i => setValue(i, text || ''));
@@ -398,7 +400,7 @@ const PropertiesEditor = ({
         } = field;
         return (
           <TextFieldWithButtonLayout
-            key={field.name}
+            key={`${keyPrefix || ''}-${field.name}`}
             renderTextField={() => (
               <SemiControlledTextField
                 value={getFieldValue({
@@ -444,7 +446,7 @@ const PropertiesEditor = ({
         );
       }
     },
-    [instances, getFieldDescription, _onInstancesModified]
+    [instances, getFieldDescription, _onInstancesModified, keyPrefix]
   );
 
   const renderSelectField = React.useCallback(
@@ -470,7 +472,7 @@ const PropertiesEditor = ({
         return (
           <SelectField
             value={getFieldValue({ instances, field })}
-            key={field.name}
+            key={`${keyPrefix || ''}-${field.name}`}
             id={field.name}
             floatingLabelText={getFieldLabel({ instances, field })}
             helperMarkdownText={getFieldDescription(field)}
@@ -493,7 +495,7 @@ const PropertiesEditor = ({
               field,
               defaultValue: '(Multiple values)',
             })}
-            key={field.name}
+            key={`${keyPrefix || ''}-${field.name}`}
             id={field.name}
             floatingLabelText={getFieldLabel({ instances, field })}
             helperMarkdownText={getFieldDescription(field)}
@@ -509,7 +511,7 @@ const PropertiesEditor = ({
         );
       }
     },
-    [instances, _onInstancesModified, getFieldDescription]
+    [instances, _onInstancesModified, getFieldDescription, keyPrefix]
   );
 
   const renderButton = React.useCallback(
@@ -552,7 +554,7 @@ const PropertiesEditor = ({
     const { setValue } = field;
     return (
       <ResourceSelectorWithThumbnail
-        key={field.name}
+        key={`${keyPrefix || ''}-${field.name}`}
         project={project}
         resourceManagementProps={resourceManagementProps}
         resourceKind={field.resourceKind}
@@ -633,7 +635,9 @@ const PropertiesEditor = ({
       } else if (field.children) {
         if (field.type === 'row') {
           const contentView = (
-            <UnsavedChangesContext.Consumer key={field.name}>
+            <UnsavedChangesContext.Consumer
+              key={`${keyPrefix || ''}-${field.name}`}
+            >
               {unsavedChanges => (
                 <PropertiesEditor
                   project={project}
@@ -659,9 +663,11 @@ const PropertiesEditor = ({
         }
 
         return (
-          <div key={field.name}>
+          <div key={`${keyPrefix || ''}-${field.name}`}>
             <Subheader>{field.name}</Subheader>
-            <UnsavedChangesContext.Consumer key={field.name}>
+            <UnsavedChangesContext.Consumer
+              key={`${keyPrefix || ''}-${field.name}`}
+            >
               {unsavedChanges => (
                 <PropertiesEditor
                   project={project}


### PR DESCRIPTION
- Make color parsing from string more robust
- Allow use of hex strings and shorthand hex strings in color fields
- Remove UI glitch when switching effect type and both effects have parameters with identical names