### PR TITLE
Fix unwanted hitboxes on tilemap when tiles are flipped

### DIFF
--- a/Extensions/TileMap/collision/TransformedTileMap.ts
+++ b/Extensions/TileMap/collision/TransformedTileMap.ts
@@ -752,13 +752,9 @@ namespace gdjs {
         // It avoids small objects to be pushed side way into a wall when they
         // should be pop out of the wall.
 
-        let applyFlippingTransformations = true;
-
         const hasFullHitBox =
           definitionHitboxes.length === 1 && definition.hasFullHitBox(tag);
         if (hasFullHitBox) {
-          // The hit box is full so it is invariant when flipping it.
-          applyFlippingTransformations = false;
           const isLeftFull = this._hasNeighborFullHitBox(-1, 0);
           const isRightFull = this._hasNeighborFullHitBox(1, 0);
           const isTopFull = this._hasNeighborFullHitBox(0, -1);
@@ -843,11 +839,14 @@ namespace gdjs {
         // TODO: If the tile contains hitboxes that are both extended and not full,
         // this code should be adapted so that the transformation considers the
         // actual width and height of the hitbox (and not the tile).
+        // At the moment, extended hitboxes can only be full and since flipping
+        // transformations don't change a full hitbox, those transformations
+        // are not applied.
 
         const tileTransformation =
           TransformedCollisionTile.workingTransformation;
         tileTransformation.setToTranslation(width * this.x, height * this.y);
-        if (applyFlippingTransformations) {
+        if (!hasFullHitBox) {
           if (this.layer.isFlippedHorizontally(this.x, this.y)) {
             tileTransformation.flipX(width / 2);
           }

--- a/Extensions/TileMap/collision/TransformedTileMap.ts
+++ b/Extensions/TileMap/collision/TransformedTileMap.ts
@@ -752,9 +752,13 @@ namespace gdjs {
         // It avoids small objects to be pushed side way into a wall when they
         // should be pop out of the wall.
 
+        let applyFlippingTransformations = true;
+
         const hasFullHitBox =
           definitionHitboxes.length === 1 && definition.hasFullHitBox(tag);
         if (hasFullHitBox) {
+          // The hit box is full so it is invariant when flipping it.
+          applyFlippingTransformations = false;
           const isLeftFull = this._hasNeighborFullHitBox(-1, 0);
           const isRightFull = this._hasNeighborFullHitBox(1, 0);
           const isTopFull = this._hasNeighborFullHitBox(0, -1);
@@ -834,19 +838,26 @@ namespace gdjs {
         }
 
         // Transform the hit boxes.
+        // First compute the affine transformation relative to the tile.
+        // Then the transformation is applied to each polygon in the hitboxes.
+        // TODO: If the tile contains hitboxes that are both extended and not full,
+        // this code should be adapted so that the transformation considers the
+        // actual width and height of the hitbox (and not the tile).
 
         const tileTransformation =
           TransformedCollisionTile.workingTransformation;
         tileTransformation.setToTranslation(width * this.x, height * this.y);
-        if (this.layer.isFlippedHorizontally(this.x, this.y)) {
-          tileTransformation.flipX(width / 2);
-        }
-        if (this.layer.isFlippedVertically(this.x, this.y)) {
-          tileTransformation.flipY(height / 2);
-        }
-        if (this.layer.isFlippedDiagonally(this.x, this.y)) {
-          tileTransformation.flipX(width / 2);
-          tileTransformation.rotateAround(Math.PI / 2, width / 2, height / 2);
+        if (applyFlippingTransformations) {
+          if (this.layer.isFlippedHorizontally(this.x, this.y)) {
+            tileTransformation.flipX(width / 2);
+          }
+          if (this.layer.isFlippedVertically(this.x, this.y)) {
+            tileTransformation.flipY(height / 2);
+          }
+          if (this.layer.isFlippedDiagonally(this.x, this.y)) {
+            tileTransformation.flipX(width / 2);
+            tileTransformation.rotateAround(Math.PI / 2, width / 2, height / 2);
+          }
         }
         tileTransformation.preConcatenate(tileMap.getTransformation());
         for (


### PR DESCRIPTION
Do not apply flipping transformation on tile collision mask if it is full

Example with a tilemap for which tiles have been flipped both ways:

Before fix:

<img width="237" alt="image" src="https://github.com/user-attachments/assets/8f3c656d-1039-45d0-8158-3394ed8ff179">


After fix:

<img width="262" alt="image" src="https://github.com/user-attachments/assets/7075d717-d32d-466b-bc35-1250ffcb8a51">
