### PR TITLE
Fix exception 't.bind is not a function' when a resource has an empty file

### DIFF
--- a/GDJS/Runtime/ResourceLoader.ts
+++ b/GDJS/Runtime/ResourceLoader.ts
@@ -246,6 +246,13 @@ namespace gdjs {
 
       this._resources.clear();
       for (const resourceData of resourceDataArray) {
+        if (!resourceData.file) {
+          // Empty string or missing `file` field: not a valid resource, let's entirely ignore it.
+          // Otherwise, this can confuse some loaders that will consider an empty string different
+          // than a file that happen not to fail to load.
+          continue;
+        }
+
         this._resources.set(resourceData.name, resourceData);
       }
     }


### PR DESCRIPTION
Avoid crash at loading if used as background:
<img width="755" alt="image" src="https://github.com/user-attachments/assets/7166b1df-0825-480e-8b9f-a5ef6abc76f6">

Avoid also an exception when loading resources if used by an object.