### PR TITLE
Fix memory corruption when events in extensions had errors

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/DiagnosticReport.h
+++ b/Core/GDCore/Events/CodeGeneration/DiagnosticReport.h
@@ -14,10 +14,10 @@
 namespace gd {
 
 /**
- * \brief 
+ * \brief
  */
 class GD_CORE_API ProjectDiagnostic {
-public:
+ public:
   enum ErrorType {
     UndeclaredVariable,
     MissingBehavior,
@@ -25,12 +25,17 @@ public:
     MismatchedObjectType,
   };
 
-  ProjectDiagnostic(ErrorType type_, const gd::String &message_,
+  ProjectDiagnostic(ErrorType type_,
+                    const gd::String &message_,
                     const gd::String &actualValue_,
-                    const gd::String &expectedValue_, const gd::String &objectName_ = "")
-      : type(type_), message(message_), actualValue(actualValue_), expectedValue(expectedValue_),
-        objectName(objectName_){};
-  virtual ~ProjectDiagnostic(){};
+                    const gd::String &expectedValue_,
+                    const gd::String &objectName_ = "")
+      : type(type_),
+        message(message_),
+        actualValue(actualValue_),
+        expectedValue(expectedValue_),
+        objectName(objectName_) {};
+  virtual ~ProjectDiagnostic() {};
 
   ErrorType GetType() const { return type; };
   const gd::String &GetMessage() const { return message; }
@@ -38,7 +43,7 @@ public:
   const gd::String &GetActualValue() const { return actualValue; }
   const gd::String &GetExpectedValue() const { return expectedValue; }
 
-private:
+ private:
   ErrorType type;
   gd::String message;
   gd::String objectName;
@@ -47,12 +52,12 @@ private:
 };
 
 /**
- * \brief 
+ * \brief
  */
 class GD_CORE_API DiagnosticReport {
-public:
-  DiagnosticReport(){};
-  virtual ~DiagnosticReport(){};
+ public:
+  DiagnosticReport() {};
+  virtual ~DiagnosticReport() {};
 
   void Add(const gd::ProjectDiagnostic &projectDiagnostic) {
     projectDiagnostics.push_back(
@@ -67,32 +72,39 @@ public:
 
   const gd::String &GetSceneName() const { return sceneName; }
 
-  void SetSceneName(const gd::String &sceneName_) {
-    sceneName = sceneName_;
+  void SetSceneName(const gd::String &sceneName_) { sceneName = sceneName_; }
+
+  void LogAllDiagnostics() {
+    for (auto &diagnostic : projectDiagnostics) {
+      std::cout << diagnostic->GetMessage()
+                << "(object: " << diagnostic->GetObjectName()
+                << ", actual value: " << diagnostic->GetActualValue()
+                << ", expected value: " << diagnostic->GetExpectedValue() << ")"
+                << std::endl;
+    }
   }
 
-private:
+ private:
   std::vector<std::unique_ptr<gd::ProjectDiagnostic>> projectDiagnostics;
   gd::String sceneName;
 };
 
 /**
- * \brief 
+ * \brief
  */
 class GD_CORE_API WholeProjectDiagnosticReport {
-public:
-  WholeProjectDiagnosticReport(){};
-  virtual ~WholeProjectDiagnosticReport(){};
+ public:
+  WholeProjectDiagnosticReport() {};
+  virtual ~WholeProjectDiagnosticReport() {};
 
   const DiagnosticReport &Get(std::size_t index) const {
     return *diagnosticReports[index].get();
   };
 
-  void Clear() {
-    diagnosticReports.clear();
-  };
+  void Clear() { diagnosticReports.clear(); };
 
-  DiagnosticReport& AddNewDiagnosticReportForScene(const gd::String &sceneName) {
+  DiagnosticReport &AddNewDiagnosticReportForScene(
+      const gd::String &sceneName) {
     auto diagnosticReport = gd::make_unique<gd::DiagnosticReport>();
     diagnosticReport->SetSceneName(sceneName);
     diagnosticReports.push_back(std::move(diagnosticReport));
@@ -102,7 +114,7 @@ public:
   std::size_t Count() const { return diagnosticReports.size(); };
 
   bool HasAnyIssue() {
-    for (auto& diagnosticReport : diagnosticReports) {
+    for (auto &diagnosticReport : diagnosticReports) {
       if (diagnosticReport->Count() > 0) {
         return true;
       }
@@ -110,8 +122,8 @@ public:
     return false;
   }
 
-private:
+ private:
   std::vector<std::unique_ptr<gd::DiagnosticReport>> diagnosticReports;
 };
 
-} // namespace gd
+}  // namespace gd

--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -345,14 +345,14 @@ gd::String EventsCodeGenerator::GenerateConditionCode(
         gd::ProjectDiagnostic projectDiagnostic(
             gd::ProjectDiagnostic::ErrorType::UnknownObject, "",
             objectInParameter, "");
-        diagnosticReport->Add(projectDiagnostic);
+        if (diagnosticReport) diagnosticReport->Add(projectDiagnostic);
         return "/* Unknown object - skipped. */";
       } else if (!expectedObjectType.empty() &&
                  actualObjectType != expectedObjectType) {
         gd::ProjectDiagnostic projectDiagnostic(
             gd::ProjectDiagnostic::ErrorType::MismatchedObjectType, "",
             actualObjectType, expectedObjectType, objectInParameter);
-        diagnosticReport->Add(projectDiagnostic);
+        if (diagnosticReport) diagnosticReport->Add(projectDiagnostic);
         return "/* Mismatched object type - skipped. */";
       }
     }
@@ -509,7 +509,7 @@ void EventsCodeGenerator::CheckBehaviorParameters(
             gd::ProjectDiagnostic projectDiagnostic(
                 gd::ProjectDiagnostic::ErrorType::MissingBehavior, "",
                 actualBehaviorType, expectedBehaviorType, lastObjectName);
-            diagnosticReport->Add(projectDiagnostic);
+            if (diagnosticReport) diagnosticReport->Add(projectDiagnostic);
           }
         }
       });
@@ -567,14 +567,14 @@ gd::String EventsCodeGenerator::GenerateActionCode(
         gd::ProjectDiagnostic projectDiagnostic(
             gd::ProjectDiagnostic::ErrorType::UnknownObject, "",
             objectInParameter, "");
-        diagnosticReport->Add(projectDiagnostic);
+        if (diagnosticReport) diagnosticReport->Add(projectDiagnostic);
         return "/* Unknown object - skipped. */";
       } else if (!expectedObjectType.empty() &&
                  actualObjectType != expectedObjectType) {
         gd::ProjectDiagnostic projectDiagnostic(
             gd::ProjectDiagnostic::ErrorType::MismatchedObjectType, "",
             actualObjectType, expectedObjectType, objectInParameter);
-        diagnosticReport->Add(projectDiagnostic);
+        if (diagnosticReport) diagnosticReport->Add(projectDiagnostic);
         return "/* Mismatched object type - skipped. */";
       }
     }


### PR DESCRIPTION
This was probably the cause of some weird crashes when working with extensions.