### PR TITLE
Fix extraction to custom object sometimes using an already used name

### DIFF
--- a/newIDE/app/src/SceneEditor/CustomObjectExtractor/CustomObjectExtractor.js
+++ b/newIDE/app/src/SceneEditor/CustomObjectExtractor/CustomObjectExtractor.js
@@ -124,15 +124,28 @@ export const extractAsCustomObject = ({
     extensionName,
     eventsBasedObjectName
   );
+  const customObjectNameInScene = newNameGenerator(
+    eventsBasedObjectName,
+    tentativeNewName => {
+      if (globalObjects && globalObjects.hasObjectNamed(tentativeNewName)) {
+        return true;
+      }
+      if (sceneObjects.hasObjectNamed(tentativeNewName)) {
+        return true;
+      }
+
+      return false;
+    }
+  );
   sceneObjects.insertNewObject(
     project,
     customObjectType,
-    eventsBasedObjectName,
+    customObjectNameInScene,
     0
   );
 
   const customObjectInstance = initialInstances.insertNewInitialInstance();
-  customObjectInstance.setObjectName(eventsBasedObjectName);
+  customObjectInstance.setObjectName(customObjectNameInScene);
   customObjectInstance.setX(selectionAABB.left);
   customObjectInstance.setY(selectionAABB.top);
   customObjectInstance.setZ(selectionAABB.zMin);


### PR DESCRIPTION
After an extraction of a custom object called "Title": 
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c4b5096c-aa42-497d-b9fc-02dfc6e1f1ea">
