### PR TITLE
Try catch sound resuming when app is focused back again

### DIFF
--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -419,10 +419,25 @@ namespace gdjs {
         document.addEventListener(
           'resume',
           function () {
-            for (let i = 0; i < that._pausedSounds.length; i++) {
-              const sound = that._pausedSounds[i];
-              if (!sound.stopped()) {
-                sound.play();
+            try {
+              for (let i = 0; i < that._pausedSounds.length; i++) {
+                const sound = that._pausedSounds[i];
+                if (!sound.stopped()) {
+                  sound.play();
+                }
+              }
+            } catch (error) {
+              if (
+                error.message &&
+                typeof error.message === 'string' &&
+                error.message.startsWith('Maximum call stack size exceeded')
+              ) {
+                console.warn(
+                  'An error occurred when resuming paused sounds while the game was in background:',
+                  error
+                );
+              } else {
+                throw error;
               }
             }
             that._pausedSounds.length = 0;


### PR DESCRIPTION
To prevent crashes in the preview.

See Howler.js issue https://github.com/goldfire/howler.js/issues/1202