### PR TITLE
Fix issues when reworking a quick customization project

### DIFF
--- a/newIDE/app/src/ExportAndShare/ShareDialog/ExportLauncher.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/ExportLauncher.js
@@ -58,7 +58,7 @@ type Props = {|
   uiMode?: 'minimal',
 
   onExportLaunched?: () => void,
-  onExportSucceeded?: () => void,
+  onExportSucceeded?: ({ build: ?Build }) => Promise<void>,
   onExportErrored?: () => void,
 |};
 
@@ -354,7 +354,8 @@ export default class ExportLauncher extends Component<Props, State> {
         compressionOutput,
         doneFooterOpen: true,
       });
-      if (this.props.onExportSucceeded) this.props.onExportSucceeded();
+      if (this.props.onExportSucceeded)
+        this.props.onExportSucceeded({ build: this.state.build });
     } catch (error) {
       console.error('An error happened during export:', error);
       if (!this.state.errored) {

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/MaxProjectCountAlertMessage.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/BuildSection/MaxProjectCountAlertMessage.js
@@ -8,6 +8,7 @@ import AlertMessage from '../../../../UI/AlertMessage';
 import { Line, Column } from '../../../../UI/Grid';
 import { type Limits } from '../../../../Utils/GDevelopServices/Usage';
 import { type AuthenticatedUser } from '../../../../Profile/AuthenticatedUserContext';
+import Gold from '../../../../Profile/Subscription/Icons/Gold';
 
 type Props = {|
   onUpgrade: () => void,
@@ -45,6 +46,14 @@ export const MaxProjectCountAlertMessage = ({
       <Column noMargin expand>
         <AlertMessage
           kind="warning"
+          renderLeftIcon={() => (
+            <Gold
+              style={{
+                width: 48,
+                height: 48,
+              }}
+            />
+          )}
           renderRightButton={
             canMaximumCountBeIncreased
               ? () => (

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3970,18 +3970,27 @@ const MainFrame = (props: Props) => {
             }
           }}
           onlineWebExporter={quickPublishOnlineWebExporter}
+          isRequiredToSaveAsNewCloudProject={() => {
+            const storageProvider = getStorageProvider();
+            return storageProvider.internalName !== 'Cloud';
+          }}
           onSaveProject={async () => {
             // Automatically try to save project to the cloud.
             const storageProvider = getStorageProvider();
+            if (storageProvider.internalName === 'Cloud') {
+              saveProject();
+              return;
+            }
+
             if (
-              !['Empty', 'UrlStorageProvider', 'Cloud'].includes(
+              !['Empty', 'UrlStorageProvider'].includes(
                 storageProvider.internalName
               )
             ) {
               console.error(
                 `Unexpected storage provider ${
                   storageProvider.internalName
-                } when saving project from quick customization dialog. Saving anyway.`
+                } when saving project from quick customization dialog. Saving anyway as a new cloud project.`
               );
             }
 

--- a/newIDE/app/src/ProjectsStorage/SaveToStorageProviderDialog.js
+++ b/newIDE/app/src/ProjectsStorage/SaveToStorageProviderDialog.js
@@ -9,7 +9,10 @@ import { List } from '../UI/List';
 import StorageProviderListItem from './StorageProviderListItem';
 import { type StorageProvider } from '.';
 import AuthenticatedUserContext from '../Profile/AuthenticatedUserContext';
-import { MaxProjectCountAlertMessage } from '../MainFrame/EditorContainers/HomePage/BuildSection/MaxProjectCountAlertMessage';
+import {
+  checkIfHasTooManyCloudProjects,
+  MaxProjectCountAlertMessage,
+} from '../MainFrame/EditorContainers/HomePage/BuildSection/MaxProjectCountAlertMessage';
 import { SubscriptionSuggestionContext } from '../Profile/Subscription/SubscriptionSuggestionContext';
 
 type Props = {|
@@ -31,12 +34,9 @@ const SaveToStorageProviderDialog = ({
   const { profile, limits, cloudProjects } = authenticatedUser;
 
   const isLoadingCloudProjects = !!profile && !cloudProjects;
-  const isCloudProjectsMaximumReached =
-    !!limits &&
-    !!cloudProjects &&
-    limits.capabilities.cloudProjects.maximumCount > 0 &&
-    cloudProjects.filter(cloudProject => !cloudProject.deletedAt).length >=
-      limits.capabilities.cloudProjects.maximumCount;
+  const isCloudProjectsMaximumReached = checkIfHasTooManyCloudProjects(
+    authenticatedUser
+  );
 
   return (
     <Dialog

--- a/newIDE/app/src/QuickCustomization/QuickCustomizationDialog.js
+++ b/newIDE/app/src/QuickCustomization/QuickCustomizationDialog.js
@@ -21,6 +21,12 @@ type Props = {|
   onlineWebExporter: Exporter,
   onSaveProject: () => Promise<void>,
   isSavingProject: boolean,
+  /**
+   * Should return true if the project will be saved as a new cloud project,
+   * false otherwise (i.e: if the project is *already saved* as a cloud project,
+   * and so there are no risks, notably, to get beyond the limit of cloud projects).
+   */
+  isRequiredToSaveAsNewCloudProject: () => boolean,
   canClose: boolean,
   sourceGameId: string,
 |};
@@ -33,6 +39,7 @@ export const QuickCustomizationDialog = ({
   onlineWebExporter,
   onSaveProject,
   isSavingProject,
+  isRequiredToSaveAsNewCloudProject,
   canClose,
   sourceGameId,
 }: Props) => {
@@ -66,6 +73,7 @@ export const QuickCustomizationDialog = ({
     onlineWebExporter,
     onSaveProject,
     isSavingProject,
+    isRequiredToSaveAsNewCloudProject,
     onClose,
     onContinueQuickCustomization,
     onTryAnotherGame,

--- a/newIDE/app/src/QuickCustomization/index.js
+++ b/newIDE/app/src/QuickCustomization/index.js
@@ -144,6 +144,7 @@ type Props = {|
   onlineWebExporter: Exporter,
   onSaveProject: () => Promise<void>,
   isSavingProject: boolean,
+  isRequiredToSaveAsNewCloudProject: () => boolean,
   onClose: () => Promise<void>,
   onContinueQuickCustomization: () => void,
   onTryAnotherGame: () => void,
@@ -158,6 +159,7 @@ export const renderQuickCustomization = ({
   onlineWebExporter,
   onSaveProject,
   isSavingProject,
+  isRequiredToSaveAsNewCloudProject,
   onClose,
   onContinueQuickCustomization,
   onTryAnotherGame,
@@ -191,6 +193,9 @@ export const renderQuickCustomization = ({
             }
             onSaveProject={onSaveProject}
             isSavingProject={isSavingProject}
+            isRequiredToSaveAsNewCloudProject={
+              isRequiredToSaveAsNewCloudProject
+            }
             onClose={onClose}
             onContinueQuickCustomization={onContinueQuickCustomization}
             onTryAnotherGame={onTryAnotherGame}


### PR DESCRIPTION
* Don't save the project multiple times if already saved as a cloud project (avoid duplicates and warning about maximum number of cloud projects reached),
* When the game is exported a second time, the game page is now properly updated.
  * Ensure that an instant build link is shown in the case the game is not owned/registered (highlight unlikely, but could happen) (covered by a story).
* Rework the banner to display a gold icon rather than a scary warning:
  <img width="1013" alt="image" src="https://github.com/user-attachments/assets/aa6f5cf2-f23e-4d56-a233-35b2452226ff">
