### PR TITLE
Add gdcore-tools hook

### DIFF
--- a/.github/workflows/gdcore-tools-hook.yml
+++ b/.github/workflows/gdcore-tools-hook.yml
@@ -1,4 +1,4 @@
-# This worflow notifies arrthuro555's gdcore-tools repository when a new release is published.
+# This worflow notifies arthuro555's gdcore-tools repository when a new release is published.
 #
 # This is used to allow gdcore-tools, a library to use GDCore outside of GDevelop,
 # to attempt to automatically build, test, and publish a release for the new

--- a/.github/workflows/gdcore-tools-hook.yml
+++ b/.github/workflows/gdcore-tools-hook.yml
@@ -1,0 +1,22 @@
+# This worflow notifies arrthuro555's gdcore-tools repository when a new release is published.
+#
+# This is used to allow gdcore-tools, a library to use GDCore outside of GDevelop,
+# to attempt to automatically build, test, and publish a release for the new
+# GDevelop version.
+name: Trigger gdcore-tools pipeline
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch-event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GDCORE_TOOLS_PAT }}
+          repository: arthuro555/gdcore-tools
+          event-type: gdevelop-release
+          client-payload: '{"release": ${{ toJson(github.event.release) }}}'


### PR DESCRIPTION
This dispatches an event to gdcore-tools when a new GDevelop release is published, allowing it to automatically build and publish.