### PR TITLE
Replace the "add folder" button by a drop-down menu action

### DIFF
--- a/Core/GDCore/Project/ObjectsContainersList.h
+++ b/Core/GDCore/Project/ObjectsContainersList.h
@@ -192,6 +192,11 @@ class GD_CORE_API ObjectsContainersList {
 
   /**
    * \brief Return a the objects container at position \a index.
+   *
+   * The returned `ObjectsContainer` may contain cloned objects (see
+   * `ProjectScopedContainers::MakeNewProjectScopedContainersForEventsBasedObject`)
+   * or "fake" objects used by events like parameters. They must not be used to
+   * edit the objects.
    */
   const gd::ObjectsContainer &GetObjectsContainer(std::size_t index) const;
 

--- a/Core/GDCore/Project/ProjectScopedContainers.cpp
+++ b/Core/GDCore/Project/ProjectScopedContainers.cpp
@@ -109,8 +109,14 @@ ProjectScopedContainers::MakeNewProjectScopedContainersForEventsBasedObject(
     const gd::EventsBasedObject &eventsBasedObject,
     gd::ObjectsContainer &outputObjectsContainer) {
 
+  // Making copies of the object can lead to memory issues when UI components
+  // keep the copy in their state.
   outputObjectsContainer.GetObjects().clear();
   outputObjectsContainer.GetObjectGroups().Clear();
+  // This object named "Object" represents the parent and is used by events.
+  // TODO Use a dedicated ObjectsContainer with only this "Object" and check in
+  // the codebase that this container is not assumed as a
+  // "globalObjectsContainer".
   outputObjectsContainer.InsertNewObject(
       project,
       gd::PlatformExtension::GetObjectFullType(

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrObjectSelector.js
@@ -173,6 +173,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
       this._scrollView.current.scrollTo(this._selectedItem.current);
     }
 
+    // The objects must never be kept in a state as they may be temporary copies.
     const objectsContainersList = this.props.projectScopedContainersAccessor
       .get()
       .getObjectsContainersList();
@@ -298,6 +299,7 @@ export default class InstructionOrObjectSelector extends React.PureComponent<
       onClickMore,
     } = this.props;
 
+    // The objects must never be kept in a state as they may be temporary copies.
     const objectsContainersList = projectScopedContainersAccessor
       .get()
       .getObjectsContainersList();

--- a/newIDE/app/src/ExpressionAutocompletion/index.js
+++ b/newIDE/app/src/ExpressionAutocompletion/index.js
@@ -265,6 +265,7 @@ const getAutocompletionsForText = function(
     .get()
     .getObjectsContainersList();
 
+  // The objects must never be kept in a state as they may be temporary copies.
   if (objectsContainersList.getObjectsContainersCount() === 0) {
     throw new Error(
       'Called getAutocompletionsForText without any object container.'

--- a/newIDE/app/src/ObjectsList/EnumerateObjects.js
+++ b/newIDE/app/src/ObjectsList/EnumerateObjects.js
@@ -212,6 +212,7 @@ export const enumerateObjectsAndGroups = (
   objectType: ?string = undefined,
   requiredBehaviorTypes?: Array<string> = []
 ) => {
+  // The objects must never be kept in a state as they may be temporary copies.
   if (objectsContainersList.getObjectsContainersCount() === 0) {
     console.error(
       'Called enumerateObjectsAndGroups without any object container.'

--- a/newIDE/app/src/ObjectsList/ObjectFolderTreeViewItemContent.js
+++ b/newIDE/app/src/ObjectsList/ObjectFolderTreeViewItemContent.js
@@ -20,6 +20,24 @@ import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
 import type { ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import { type HTMLDataset } from '../Utils/HTMLDataset';
 
+export const expandAllSubfolders = (
+  objectFolder: gdObjectFolderOrObject,
+  isGlobal: boolean,
+  expandFolders: (
+    objectFolderOrObjectWithContexts: Array<ObjectFolderOrObjectWithContext>
+  ) => void
+) => {
+  const subFolders = enumerateFoldersInFolder(objectFolder).map(
+    folderAndPath => folderAndPath.folder
+  );
+  expandFolders(
+    [objectFolder, ...subFolders].map(folder => ({
+      objectFolderOrObject: folder,
+      global: isGlobal,
+    }))
+  );
+};
+
 export type ObjectFolderTreeViewItemCallbacks = {|
   onObjectPasted?: gdObject => void,
   onRenameObjectFolderOrObjectWithContextFinish: (
@@ -262,17 +280,8 @@ export class ObjectFolderTreeViewItemContent implements TreeViewItemContent {
       { type: 'separator' },
       {
         label: i18n._(t`Expand all sub folders`),
-        click: () => {
-          const subFolders = enumerateFoldersInFolder(this.objectFolder).map(
-            folderAndPath => folderAndPath.folder
-          );
-          expandFolders(
-            [this.objectFolder, ...subFolders].map(folder => ({
-              objectFolderOrObject: folder,
-              global: this._isGlobal,
-            }))
-          );
-        },
+        click: () =>
+          expandAllSubfolders(this.objectFolder, this._isGlobal, expandFolders),
       },
     ];
   }

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -1524,8 +1524,8 @@ const arePropsEqual = (prevProps: Props, nextProps: Props): boolean =>
   prevProps.selectedObjectFolderOrObjectsWithContext ===
     nextProps.selectedObjectFolderOrObjectsWithContext &&
   prevProps.project === nextProps.project &&
-  prevProps.projectScopedContainersAccessor ===
-    nextProps.projectScopedContainersAccessor;
+  prevProps.globalObjectsContainer === nextProps.globalObjectsContainer &&
+  prevProps.objectsContainer === nextProps.objectsContainer;
 
 const MemoizedObjectsList = React.memo<Props, ObjectsListInterface>(
   ObjectsList,

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -394,7 +394,13 @@ type Props = {|
   layout: ?gdLayout,
   eventsBasedObject: gdEventsBasedObject | null,
   initialInstances?: gdInitialInstancesContainer,
+  // The objects retried from ProjectScopedContainers must never be kept in a
+  // state as they may be temporary copies.
+  // It also contains "fake" objects like "Object" for the parent of custom objects.
+  // It's useful to check if an object name is taken, but not to edit ObjectsContainer.
+  // Also see `ProjectScopedContainers::MakeNewProjectScopedContainersForEventsBasedObject`.
   projectScopedContainersAccessor: ProjectScopedContainersAccessor,
+  // These 2 containers always contains the "real" objects.
   globalObjectsContainer: gdObjectsContainer | null,
   objectsContainer: gdObjectsContainer,
   onSelectAllInstancesOfObjectInLayout?: string => void,
@@ -1394,11 +1400,11 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
     return (
       <Background maxWidth>
         <LineStackLayout>
-          <Column expand noMargin>
+          <Column expand>
             <SearchBar
               value={searchText}
               onRequestSearch={() => {}}
-              onChange={text => setSearchText(text)}
+              onChange={setSearchText}
               placeholder={t`Search objects`}
             />
           </Column>

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -395,6 +395,8 @@ type Props = {|
   eventsBasedObject: gdEventsBasedObject | null,
   initialInstances?: gdInitialInstancesContainer,
   projectScopedContainersAccessor: ProjectScopedContainersAccessor,
+  globalObjectsContainer: gdObjectsContainer | null,
+  objectsContainer: gdObjectsContainer,
   onSelectAllInstancesOfObjectInLayout?: string => void,
   resourceManagementProps: ResourceManagementProps,
   onDeleteObjects: (
@@ -442,6 +444,8 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
       eventsBasedObject,
       initialInstances,
       projectScopedContainersAccessor,
+      globalObjectsContainer,
+      objectsContainer,
       resourceManagementProps,
       onSelectAllInstancesOfObjectInLayout,
       onDeleteObjects,
@@ -467,25 +471,6 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
     }: Props,
     ref
   ) => {
-    // TODO Handle any number of object containers.
-    const objectsContainersList = projectScopedContainersAccessor
-      .get()
-      .getObjectsContainersList();
-
-    if (objectsContainersList.getObjectsContainersCount() === 0) {
-      throw new Error('Used ObjectsList without any object container.');
-    }
-    if (objectsContainersList.getObjectsContainersCount() > 2) {
-      console.error('Used ObjectsList with more than 2 object containers.');
-    }
-    const globalObjectsContainer =
-      objectsContainersList.getObjectsContainersCount() > 1
-        ? objectsContainersList.getObjectsContainer(0)
-        : null;
-    const objectsContainer = objectsContainersList.getObjectsContainer(
-      objectsContainersList.getObjectsContainersCount() - 1
-    );
-
     const { currentlyRunningInAppTutorial } = React.useContext(
       InAppTutorialContext
     );

--- a/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
@@ -378,6 +378,8 @@ const MosaicEditorsDisplay = React.forwardRef<
               layout={layout}
               eventsBasedObject={eventsBasedObject}
               projectScopedContainersAccessor={projectScopedContainersAccessor}
+              globalObjectsContainer={globalObjectsContainer}
+              objectsContainer={objectsContainer}
               initialInstances={initialInstances}
               onSelectAllInstancesOfObjectInLayout={
                 props.onSelectAllInstancesOfObjectInLayout

--- a/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
@@ -310,6 +310,8 @@ const SwipeableDrawerEditorsDisplay = React.forwardRef<
                       projectScopedContainersAccessor={
                         projectScopedContainersAccessor
                       }
+                      globalObjectsContainer={globalObjectsContainer}
+                      objectsContainer={objectsContainer}
                       layout={layout}
                       eventsBasedObject={eventsBasedObject}
                       initialInstances={initialInstances}

--- a/newIDE/app/src/UI/TreeView/TreeViewRow.js
+++ b/newIDE/app/src/UI/TreeView/TreeViewRow.js
@@ -176,10 +176,10 @@ const TreeViewRow = <Item: ItemBaseAttributes>(props: Props<Item>) => {
 
   const selectAndOpenContextMenu = React.useCallback(
     (event: MouseEvent) => {
-      onClickItem(event);
+      if (!node.item.isRoot) onClickItem(event);
       openContextMenu(event);
     },
-    [onClickItem, openContextMenu]
+    [node, onClickItem, openContextMenu]
   );
 
   const setIsStayingOver = React.useCallback(

--- a/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
+++ b/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
@@ -267,6 +267,8 @@ export const WithObjectsList = () => (
                   projectScopedContainersAccessor={
                     testProject.testSceneProjectScopedContainersAccessor
                   }
+                  globalObjectsContainer={testProject.project.getObjects()}
+                  objectsContainer={testProject.testLayout.getObjects()}
                   resourceManagementProps={fakeResourceManagementProps}
                   onEditObject={action('On edit object')}
                   onOpenEventBasedObjectEditor={action('On edit children')}

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/ObjectsList.stories.js
@@ -31,6 +31,8 @@ export const Default = () => (
         projectScopedContainersAccessor={
           testProject.testSceneProjectScopedContainersAccessor
         }
+        globalObjectsContainer={testProject.project.getObjects()}
+        objectsContainer={testProject.testLayout.getObjects()}
         resourceManagementProps={fakeResourceManagementProps}
         onEditObject={action('On edit object')}
         onOpenEventBasedObjectEditor={action('On edit children')}
@@ -65,6 +67,8 @@ export const WithSerializedObjectView = () => (
           projectScopedContainersAccessor={
             testProject.testSceneProjectScopedContainersAccessor
           }
+          globalObjectsContainer={testProject.project.getObjects()}
+          objectsContainer={testProject.testLayout.getObjects()}
           resourceManagementProps={fakeResourceManagementProps}
           onEditObject={action('On edit object')}
           onOpenEventBasedObjectEditor={action('On edit children')}


### PR DESCRIPTION
### Changes
- Remove the "add folder" button
- Add drop-down menu action for titles to
  - Add a folder
  - Expand all folders at once
- Fix the collapsing of root items when opening the menu