### PR TITLE
Add dispose method to Runtimegame

### DIFF
--- a/Extensions/Spine/managers/pixi-spine-atlas-manager.ts
+++ b/Extensions/Spine/managers/pixi-spine-atlas-manager.ts
@@ -194,5 +194,12 @@ namespace gdjs {
         ? resource
         : null;
     }
+    /**
+     * Clear cache of loaded spine atlases.
+     */
+    dispose(): void {
+      this._loadedSpineAtlases.clear();
+      this._loadingSpineAtlases.clear();
+    }
   }
 }

--- a/Extensions/Spine/managers/pixi-spine-atlas-manager.ts
+++ b/Extensions/Spine/managers/pixi-spine-atlas-manager.ts
@@ -195,7 +195,8 @@ namespace gdjs {
         : null;
     }
     /**
-     * Clear cache of loaded spine atlases.
+     * To be called when the game is disposed.
+     * Clear the Spine Atlases loaded in this manager.
      */
     dispose(): void {
       this._loadedSpineAtlases.clear();

--- a/Extensions/Spine/managers/pixi-spine-manager.ts
+++ b/Extensions/Spine/managers/pixi-spine-manager.ts
@@ -117,7 +117,8 @@ namespace gdjs {
     }
 
     /**
-     * Clear cache of loaded spine skeleton data.
+     * To be called when the game is disposed.
+     * Clear the Spine skeleton data loaded in this manager.
      */
     dispose(): void {
       this._loadedSpines.clear();

--- a/Extensions/Spine/managers/pixi-spine-manager.ts
+++ b/Extensions/Spine/managers/pixi-spine-manager.ts
@@ -115,5 +115,12 @@ namespace gdjs {
         ? resource
         : null;
     }
+
+    /**
+     * Clear cache of loaded spine skeleton data.
+     */
+    dispose(): void {
+      this._loadedSpines.clear();
+    }
   }
 }

--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -144,8 +144,9 @@ namespace gdjs {
       );
     }
 
-    /*
-     * Clear cache of loaded three models and downloaded array buffers.
+    /**
+     * To be called when the game is disposed.
+     * Clear the models, resources loaded and destroy 3D models loaders in this manager.
      */
     dispose(): void {
       this._loadedThreeModels.clear();

--- a/GDJS/Runtime/Model3DManager.ts
+++ b/GDJS/Runtime/Model3DManager.ts
@@ -143,5 +143,24 @@ namespace gdjs {
         this._loadedThreeModels.getFromName(resourceName) || this._invalidModel
       );
     }
+
+    /*
+     * Clear cache of loaded three models and downloaded array buffers.
+     */
+    dispose(): void {
+      this._loadedThreeModels.clear();
+      this._downloadedArrayBuffers.clear();
+      this._loader = null;
+      this._dracoLoader = null;
+
+      if (this._invalidModel) {
+        this._invalidModel.cameras = [];
+        this._invalidModel.animations = [];
+        this._invalidModel.scenes = [];
+        this._invalidModel.userData = {};
+        this._invalidModel.asset = {};
+        this._invalidModel.scene.clear();
+      }
+    }
   }
 }

--- a/GDJS/Runtime/ResourceLoader.ts
+++ b/GDJS/Runtime/ResourceLoader.ts
@@ -454,8 +454,9 @@ namespace gdjs {
       });
     }
 
-    /*
-     * Dispose all resource managers.
+    /**
+     * To be called when the game is disposed.
+     * Dispose all the resource managers.
      */
     dispose(): void {
       for (const resourceManager of this._resourceManagersMap.values()) {

--- a/GDJS/Runtime/ResourceLoader.ts
+++ b/GDJS/Runtime/ResourceLoader.ts
@@ -454,6 +454,15 @@ namespace gdjs {
       });
     }
 
+    /*
+     * Dispose all resource managers.
+     */
+    dispose(): void {
+      for (const resourceManager of this._resourceManagersMap.values()) {
+        resourceManager.dispose();
+      }
+    }
+
     /**
      * Put a given scene at the end of the queue.
      *

--- a/GDJS/Runtime/ResourceManager.ts
+++ b/GDJS/Runtime/ResourceManager.ts
@@ -31,7 +31,8 @@ namespace gdjs {
     getResourceKinds(): Array<ResourceKind>;
 
     /**
-     * Dispose the manager, free all resources.
+     * Should clear all resources, data, loaders stored by this manager.
+     * Using the manager after calling this method is undefined behavior.
      */
     dispose(): void;
   }

--- a/GDJS/Runtime/ResourceManager.ts
+++ b/GDJS/Runtime/ResourceManager.ts
@@ -29,5 +29,7 @@ namespace gdjs {
      * Return the kind of resources handled by this manager.
      */
     getResourceKinds(): Array<ResourceKind>;
+
+    dispose(): void;
   }
 }

--- a/GDJS/Runtime/ResourceManager.ts
+++ b/GDJS/Runtime/ResourceManager.ts
@@ -30,6 +30,9 @@ namespace gdjs {
      */
     getResourceKinds(): Array<ResourceKind>;
 
+    /**
+     * Dispose the manager, free all resources.
+     */
     dispose(): void;
   }
 }

--- a/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
+++ b/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
@@ -198,7 +198,8 @@ namespace gdjs {
       }
     }
 
-    /*
+    /**
+     * To be called when the game is disposed.
      * Clear caches of loaded font families.
      */
     dispose(): void {

--- a/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
+++ b/GDJS/Runtime/fontfaceobserver-font-manager/fontfaceobserver-font-manager.ts
@@ -197,6 +197,14 @@ namespace gdjs {
         );
       }
     }
+
+    /*
+     * Clear caches of loaded font families.
+     */
+    dispose(): void {
+      this._loadedFontFamily.clear();
+      this._loadedFontFamilySet.clear();
+    }
   }
 
   //Register the class to let the engine use it.

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -869,7 +869,8 @@ namespace gdjs {
       }
     }
 
-    /*
+    /**
+     * To be called when the game is disposed.
      * Unloads all audio from memory, clear Howl cache and stop all audio.
      */
     dispose(): void {

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -868,6 +868,13 @@ namespace gdjs {
         }
       }
     }
+
+    /*
+     * Unloads all audio from memory, clear Howl cache and stop all audio.
+     */
+    dispose(): void {
+      this.unloadAll();
+    }
   }
 
   // Register the class to let the engine use it.

--- a/GDJS/Runtime/jsonmanager.ts
+++ b/GDJS/Runtime/jsonmanager.ts
@@ -200,5 +200,13 @@ namespace gdjs {
     getLoadedJson(resourceName: string): Object | null {
       return this._loadedJsons.getFromName(resourceName) || null;
     }
+
+    /*
+     * Clear cache of loaded jsons.
+     */
+    dispose(): void {
+      this._loadedJsons.clear();
+      this._callbacks.clear();
+    }
   }
 }

--- a/GDJS/Runtime/jsonmanager.ts
+++ b/GDJS/Runtime/jsonmanager.ts
@@ -201,8 +201,9 @@ namespace gdjs {
       return this._loadedJsons.getFromName(resourceName) || null;
     }
 
-    /*
-     * Clear cache of loaded jsons.
+    /**
+     * To be called when the game is disposed.
+     * Clear the JSONs loaded in this manager.
      */
     dispose(): void {
       this._loadedJsons.clear();

--- a/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
@@ -291,6 +291,7 @@ namespace gdjs {
     }
 
     /**
+     * To be called when the game is disposed.
      * Uninstall all the fonts from memory and clear cache of loaded fonts.
      */
     dispose(): void {

--- a/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
@@ -289,6 +289,23 @@ namespace gdjs {
         );
       }
     }
+
+    /**
+     * Uninstall all the fonts from memory and clear cache of loaded fonts.
+     */
+    dispose(): void {
+      for (const bitmapFontInstallKey in this._pixiBitmapFontsInUse) {
+        PIXI.BitmapFont.uninstall(bitmapFontInstallKey);
+      }
+
+      for (const bitmapFontInstallKey of this._pixiBitmapFontsToUninstall) {
+        PIXI.BitmapFont.uninstall(bitmapFontInstallKey);
+      }
+
+      this._pixiBitmapFontsInUse = {};
+      this._pixiBitmapFontsToUninstall.length = 0;
+      this._loadedFontsData.clear();
+    }
   }
 
   // Register the class to let the engine use it.

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -463,6 +463,54 @@ namespace gdjs {
       }
       return particleTexture;
     }
+
+    /*
+     * Clear caches of loaded textures and materials.
+     */
+    dispose(): void {
+      this._loadedTextures.clear();
+
+      const threeTextures: THREE.Texture[] = [];
+      this._loadedThreeTextures.values(threeTextures);
+      this._loadedThreeTextures.clear();
+      for (const threeTexture of threeTextures) {
+        threeTexture.dispose();
+      }
+
+      const threeMaterials: THREE.Material[] = [];
+      this._loadedThreeMaterials.values(threeMaterials);
+      this._loadedThreeMaterials.clear();
+      for (const threeMaterial of threeMaterials) {
+        threeMaterial.dispose();
+      }
+
+      for (const pixiTexture of this._diskTextures.values()) {
+        if (pixiTexture.destroyed) {
+          continue;
+        }
+
+        pixiTexture.destroy();
+      }
+      this._diskTextures.clear();
+
+      for (const pixiTexture of this._rectangleTextures.values()) {
+        if (pixiTexture.destroyed) {
+          continue;
+        }
+
+        pixiTexture.destroy();
+      }
+      this._rectangleTextures.clear();
+
+      for (const pixiTexture of this._scaledTextures.values()) {
+        if (pixiTexture.destroyed) {
+          continue;
+        }
+
+        pixiTexture.destroy();
+      }
+      this._scaledTextures.clear();
+    }
   }
 
   //Register the class to let the engine use it.

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -464,7 +464,8 @@ namespace gdjs {
       return particleTexture;
     }
 
-    /*
+    /**
+     * To be called when the game is disposed.
      * Clear caches of loaded textures and materials.
      */
     dispose(): void {

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -850,6 +850,10 @@ namespace gdjs {
       requestAnimationFrame(gameLoop);
     }
 
+    stopGameLoop(): void {
+      cancelAnimationFrame(this._nextFrameId);
+    }
+
     getPIXIRenderer() {
       return this._pixiRenderer;
     }
@@ -923,6 +927,18 @@ namespace gdjs {
         }
       }
       // HTML5 games on mobile/browsers don't have a way to close their window/page.
+    }
+
+    /**
+     * Dispose PixiRenderer, ThreeRenderer and remove canvas from DOM.
+     */
+    dispose() {
+      this._pixiRenderer?.destroy(true);
+      this._threeRenderer?.dispose();
+      this._pixiRenderer = null;
+      this._threeRenderer = null;
+      this._gameCanvas = null;
+      this._domElementsContainer = null;
     }
 
     /**

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -44,6 +44,8 @@ namespace gdjs {
 
     _nextFrameId: integer = 0;
 
+    _wasDisposed: boolean = false;
+
     /**
      * @param game The game that is being rendered
      * @param forceFullscreen If fullscreen should be always activated
@@ -62,6 +64,8 @@ namespace gdjs {
      *
      */
     createStandardCanvas(parentElement: HTMLElement) {
+      this._throwIfDisposed();
+
       let gameCanvas: HTMLCanvasElement;
       if (typeof THREE !== 'undefined') {
         gameCanvas = document.createElement('canvas');
@@ -336,6 +340,7 @@ namespace gdjs {
      * Change the margin that must be preserved around the game canvas.
      */
     setMargins(top, right, bottom, left): void {
+      this._throwIfDisposed();
       if (
         this._marginTop === top &&
         this._marginRight === right &&
@@ -357,6 +362,7 @@ namespace gdjs {
      * @param height The new height, in pixels.
      */
     setWindowSize(width: float, height: float): void {
+      this._throwIfDisposed();
       const remote = this.getElectronRemote();
       if (remote) {
         const browserWindow = remote.getCurrentWindow();
@@ -379,6 +385,7 @@ namespace gdjs {
      * Center the window on screen.
      */
     centerWindow() {
+      this._throwIfDisposed();
       const remote = this.getElectronRemote();
       if (remote) {
         const browserWindow = remote.getCurrentWindow();
@@ -398,6 +405,7 @@ namespace gdjs {
      * De/activate fullscreen for the game.
      */
     setFullScreen(enable): void {
+      this._throwIfDisposed();
       if (this._forceFullscreen) {
         return;
       }
@@ -521,6 +529,7 @@ namespace gdjs {
       window: Window,
       document: Document
     ) {
+      this._throwIfDisposed();
       const canvas = this._gameCanvas;
       if (!canvas) return;
 
@@ -833,6 +842,7 @@ namespace gdjs {
     }
 
     startGameLoop(fn) {
+      this._throwIfDisposed();
       let oldTime = 0;
       const gameLoop = (time: float) => {
         // Schedule the next frame now to be sure it's called as soon
@@ -939,6 +949,7 @@ namespace gdjs {
       this._threeRenderer = null;
       this._gameCanvas = null;
       this._domElementsContainer = null;
+      this._wasDisposed = true;
     }
 
     /**
@@ -996,6 +1007,12 @@ namespace gdjs {
 
     getGame() {
       return this._game;
+    }
+
+    private _throwIfDisposed(): void {
+      if (this._wasDisposed) {
+        throw 'The RuntimeGameRenderer has been disposed and should not be used anymore.';
+      }
     }
   }
 

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -954,6 +954,17 @@ namespace gdjs {
       }
     }
 
+    /*
+     * Stop game loop, unload all scenes, dispose renderer and resources.
+     */
+    dispose(): void {
+      this._renderer.stopGameLoop();
+      this._sceneStack.dispose();
+      this._renderer.dispose();
+      this._resourcesLoader.dispose();
+      logger.info('Runtimegame is disposed');
+    }
+
     /**
      * Set if the session should be registered.
      */

--- a/GDJS/Runtime/scenestack.ts
+++ b/GDJS/Runtime/scenestack.ts
@@ -354,5 +354,16 @@ namespace gdjs {
 
       return hasMadeChangeToStack;
     }
+
+    /*
+     * Unload all the scenes and clear the stack.
+     */
+    dispose(): void {
+      for (const item of this._stack) {
+        item.unloadScene();
+      }
+
+      this._stack.length = 0;
+    }
   }
 }


### PR DESCRIPTION
# Summary
This PR adds a new dispose functionality to the RuntimeGame class, which serves as an entry point for memory cleanup. The RuntimeGame.dispose method calls dispose on all relevant managers and resources, enabling the complete unloading of the game from memory when needed.

# Changes
- **RuntimeGame.dispose()**: New method that acts as the main entry point for memory cleanup. It:
  - Stops the game loop.
  - Disposes of all scenes in the SceneStack.
  - Clears resources through ResourceLoader.
  - Releases graphics resources in the renderer.
- **Other classes** (dispose methods): The following classes now have dispose methods that clear cached resources:
  - **Spine Atlas and Spine Manager**: Clears spine atlases and skeleton data.
  - **Model3DManager**: Clears 3D models, array buffers, and resets loaders.
  - **Font, Sound, JSON, BitmapFont, and Image Managers**: Clear their respective caches (fonts, audio, JSON data, textures, etc.).
  - **Renderer and SceneStack**: Remove all graphical resources and clear the scene stack.

# Impact
Though unused at present, this new dispose functionality in RuntimeGame allows for efficient memory cleanup when the game is no longer needed