### PR TITLE
Add "Create new folder" menu item inside "Move to folder" menu

### DIFF
--- a/newIDE/app/src/ObjectsList/ObjectFolderTreeViewItemContent.js
+++ b/newIDE/app/src/ObjectsList/ObjectFolderTreeViewItemContent.js
@@ -234,24 +234,38 @@ export class ObjectFolderTreeViewItemContent implements TreeViewItemContent {
       },
       {
         label: i18n._('Move to folder'),
-        submenu: filteredFolderAndPathsInContainer.map(({ folder, path }) => ({
-          label: path,
-          enabled: folder !== this.objectFolder.getParent(),
-          click: () => {
-            if (folder === this.objectFolder.getParent()) return;
-            this.objectFolder
-              .getParent()
-              .moveObjectFolderOrObjectToAnotherFolder(
-                this.objectFolder,
-                folder,
-                0
-              );
-            onMovedObjectFolderOrObjectToAnotherFolderInSameContainer({
-              objectFolderOrObject: folder,
-              global: this._isGlobal,
-            });
+        submenu: [
+          ...filteredFolderAndPathsInContainer.map(({ folder, path }) => ({
+            label: path,
+            enabled: folder !== this.objectFolder.getParent(),
+            click: () => {
+              if (folder === this.objectFolder.getParent()) return;
+              this.objectFolder
+                .getParent()
+                .moveObjectFolderOrObjectToAnotherFolder(
+                  this.objectFolder,
+                  folder,
+                  0
+                );
+              onMovedObjectFolderOrObjectToAnotherFolderInSameContainer({
+                objectFolderOrObject: folder,
+                global: this._isGlobal,
+              });
+            },
+          })),
+
+          { type: 'separator' },
+          {
+            label: i18n._(t`Create new folder...`),
+            click: () =>
+              addFolder([
+                {
+                  objectFolderOrObject: this.objectFolder.getParent(),
+                  global: this._isGlobal,
+                },
+              ]),
           },
-        })),
+        ],
       },
       ...renderQuickCustomizationMenuItems({
         i18n,

--- a/newIDE/app/src/ObjectsList/ObjectTreeViewItemContent.js
+++ b/newIDE/app/src/ObjectsList/ObjectTreeViewItemContent.js
@@ -79,6 +79,7 @@ export type ObjectTreeViewItemProps = {|
   selectObjectFolderOrObjectWithContext: (
     objectFolderOrObjectWithContext: ?ObjectFolderOrObjectWithContext
   ) => void,
+  addFolder: (items: Array<ObjectFolderOrObjectWithContext>) => void,
   forceUpdateList: () => void,
   forceUpdate: () => void,
 |};
@@ -280,6 +281,7 @@ export class ObjectTreeViewItemContent implements TreeViewItemContent {
       setAsGlobalObject,
       onOpenEventBasedObjectEditor,
       selectObjectFolderOrObjectWithContext,
+      addFolder,
     } = this.props;
 
     const container = this._isGlobal
@@ -390,19 +392,36 @@ export class ObjectTreeViewItemContent implements TreeViewItemContent {
       },
       {
         label: i18n._('Move to folder'),
-        submenu: folderAndPathsInContainer.map(({ folder, path }) => ({
-          label: path,
-          enabled: folder !== this.object.getParent(),
-          click: () => {
-            this.object
-              .getParent()
-              .moveObjectFolderOrObjectToAnotherFolder(this.object, folder, 0);
-            onMovedObjectFolderOrObjectToAnotherFolderInSameContainer({
-              objectFolderOrObject: folder,
-              global: this._isGlobal,
-            });
+        submenu: [
+          ...folderAndPathsInContainer.map(({ folder, path }) => ({
+            label: path,
+            enabled: folder !== this.object.getParent(),
+            click: () => {
+              this.object
+                .getParent()
+                .moveObjectFolderOrObjectToAnotherFolder(
+                  this.object,
+                  folder,
+                  0
+                );
+              onMovedObjectFolderOrObjectToAnotherFolderInSameContainer({
+                objectFolderOrObject: folder,
+                global: this._isGlobal,
+              });
+            },
+          })),
+          { type: 'separator' },
+          {
+            label: i18n._(t`Create new folder...`),
+            click: () =>
+              addFolder([
+                {
+                  objectFolderOrObject: this.object.getParent(),
+                  global: this._isGlobal,
+                },
+              ]),
           },
-        })),
+        ],
       },
       { type: 'separator' },
       {

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -947,6 +947,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         getThumbnail,
         showDeleteConfirmation,
         selectObjectFolderOrObjectWithContext,
+        addFolder,
         forceUpdateList,
         forceUpdate,
       }),
@@ -972,6 +973,7 @@ const ObjectsList = React.forwardRef<Props, ObjectsListInterface>(
         getThumbnail,
         showDeleteConfirmation,
         selectObjectFolderOrObjectWithContext,
+        addFolder,
         forceUpdateList,
         forceUpdate,
       ]


### PR DESCRIPTION
Add a menu item to create a new folder inside the "Move to folder" menu, both for objects and for existing folders:


Manual tests:
- [x] Works on global folder/objects
- [x] Works on objects context menu
  <img width="560" alt="image" src="https://github.com/user-attachments/assets/0fd57159-00ee-4841-8d8e-47b50ba036d5">
- [x] Works on folder context menu
  <img width="575" alt="image" src="https://github.com/user-attachments/assets/d462e376-6b41-4528-84a2-6d367d67ea35">