### PR TITLE
Improve the top of the instance/object properties panel.

### DIFF
--- a/newIDE/app/src/ObjectEditor/CompactObjectPropertiesEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/CompactObjectPropertiesEditor/index.js
@@ -405,7 +405,16 @@ export const CompactObjectPropertiesEditor = ({
                   <Object2d style={styles.icon} />
                 )}
                 <Text size="body" noMargin>
-                  <Trans>{objectMetadata.getFullName()}</Trans>
+                  <Trans>{objectMetadata.getFullName()} - </Trans>
+                </Text>
+                <Text
+                  allowSelection
+                  displayInlineAsSpan
+                  noMargin
+                  size="body"
+                  noMargin
+                >
+                  {object.getName()}
                 </Text>
                 {helpLink && (
                   <IconButton
@@ -419,11 +428,6 @@ export const CompactObjectPropertiesEditor = ({
                 )}
               </LineStackLayout>
             </LineStackLayout>
-            <CompactTextField
-              value={object.getName()}
-              onChange={() => {}}
-              disabled
-            />
           </ColumnStackLayout>
           <TopLevelCollapsibleSection
             title={<Trans>Properties</Trans>}


### PR DESCRIPTION
Make the top of the panel consistent accross instance and object, the text of the object is still selectable, and its easier to read the type is that an instance or which kind of object.

### This PR
![improved](https://github.com/user-attachments/assets/1a7b4274-ab38-40a2-bfb2-daecb53e6d33)

### Currently
![before](https://github.com/user-attachments/assets/ab4ccba1-a641-4d09-8062-86f3ad27fe0f)
