### PR TITLE
Fix potential crashes in events function edition

### DIFF
--- a/Core/GDCore/Extensions/Metadata/ParameterMetadataTools.cpp
+++ b/Core/GDCore/Extensions/Metadata/ParameterMetadataTools.cpp
@@ -6,6 +6,8 @@
 #include "ParameterMetadataTools.h"
 
 #include "GDCore/Events/Expression.h"
+#include "GDCore/Events/Parsers/ExpressionParser2.h"
+#include "GDCore/Events/Parsers/ExpressionParser2NodePrinter.h"
 #include "GDCore/Project/Object.h"
 #include "GDCore/Project/ObjectsContainer.h"
 #include "GDCore/Project/ObjectsContainersList.h"
@@ -13,8 +15,6 @@
 #include "GDCore/Project/Project.h"
 #include "GDCore/String.h"
 #include "InstructionMetadata.h"
-#include "GDCore/Events/Parsers/ExpressionParser2.h"
-#include "GDCore/Events/Parsers/ExpressionParser2NodePrinter.h"
 
 namespace gd {
 const ParameterMetadata ParameterMetadataTools::badParameterMetadata;
@@ -23,7 +23,10 @@ void ParameterMetadataTools::ParametersToObjectsContainer(
     const gd::Project& project,
     const ParameterMetadataContainer& parameters,
     gd::ObjectsContainer& outputObjectsContainer) {
-  outputObjectsContainer.GetObjects().clear();
+  // Keep track of all objects and their behaviors names, so we can remove
+  // those who are in the container but not in the parameters anymore.
+  std::set<gd::String> allObjectNames;
+  std::map<gd::String, std::set<gd::String>> allObjectBehaviorNames;
 
   gd::String lastObjectName;
   for (std::size_t i = 0; i < parameters.GetParametersCount(); ++i) {
@@ -31,31 +34,84 @@ void ParameterMetadataTools::ParametersToObjectsContainer(
     if (parameter.GetName().empty()) continue;
 
     if (gd::ParameterMetadata::IsObject(parameter.GetType())) {
-      outputObjectsContainer.InsertNewObject(
-          project,
-          parameter.GetExtraInfo(),
-          parameter.GetName(),
-          outputObjectsContainer.GetObjectsCount());
+      const gd::String& objectName = parameter.GetName();
+      const gd::String& objectType = parameter.GetExtraInfo();
+      allObjectNames.insert(objectName);
+
+      // Check if we can keep the existing object.
+      if (outputObjectsContainer.HasObjectNamed(objectName)) {
+        const gd::Object& object = outputObjectsContainer.GetObject(objectName);
+
+        if (object.GetType() != objectType) {
+          // Object type has changed, remove it so it is re-created.
+          outputObjectsContainer.RemoveObject(objectName);
+        }
+      }
+
+      if (outputObjectsContainer.HasObjectNamed(objectName)) {
+        // Keep the existing object - behaviors will be added or removed later.
+      } else {
+        outputObjectsContainer.InsertNewObject(
+            project,
+            parameter.GetExtraInfo(),
+            objectName,
+            outputObjectsContainer.GetObjectsCount());
+      }
 
       // Memorize the last object name. By convention, parameters that require
       // an object (mainly, "objectvar" and "behavior") should be placed after
       // the object in the list of parameters (if possible, just after).
       // Search "lastObjectName" in the codebase for other place where this
       // convention is enforced.
-      lastObjectName = parameter.GetName();
+      lastObjectName = objectName;
     } else if (gd::ParameterMetadata::IsBehavior(parameter.GetType())) {
       if (!lastObjectName.empty()) {
         if (outputObjectsContainer.HasObjectNamed(lastObjectName)) {
-          const gd::Object& object =
-              outputObjectsContainer.GetObject(lastObjectName);
-          gd::String behaviorName = parameter.GetName();
+          const gd::String& behaviorName = parameter.GetName();
+          const gd::String& behaviorType = parameter.GetExtraInfo();
+
+          gd::Object& object = outputObjectsContainer.GetObject(lastObjectName);
+          allObjectBehaviorNames[lastObjectName].insert(behaviorName);
+
+          // Check if we can keep the existing behavior.
+          if (object.HasBehaviorNamed(behaviorName)) {
+            if (object.GetBehavior(behaviorName).GetTypeName() !=
+                behaviorType) {
+              // Behavior type has changed, remove it so it is re-created.
+              object.RemoveBehavior(behaviorName);
+            }
+          }
 
           if (!object.HasBehaviorNamed(behaviorName)) {
-            outputObjectsContainer.GetObject(lastObjectName)
-                .AddNewBehavior(
-                    project, parameter.GetExtraInfo(), behaviorName);
+            object.AddNewBehavior(
+                project, parameter.GetExtraInfo(), behaviorName);
           }
         }
+      }
+    }
+  }
+
+  // Remove objects that are not in the parameters anymore.
+  std::set<gd::String> objectNamesInContainer =
+      outputObjectsContainer.GetAllObjectNames();
+  for (const auto& objectName : objectNamesInContainer) {
+    if (allObjectNames.find(objectName) == allObjectNames.end()) {
+      outputObjectsContainer.RemoveObject(objectName);
+    }
+  }
+
+  // Remove behaviors of objects that are not in the parameters anymore.
+  for (const auto& objectName : allObjectNames) {
+    if (!outputObjectsContainer.HasObjectNamed(objectName)) {
+      // Should not happen.
+      continue;
+    }
+
+    auto& object = outputObjectsContainer.GetObject(objectName);
+    for (const auto& behaviorName : object.GetAllBehaviorNames()) {
+      const auto& allBehaviorNames = allObjectBehaviorNames[objectName];
+      if (allBehaviorNames.find(behaviorName) == allBehaviorNames.end()) {
+        object.RemoveBehavior(behaviorName);
       }
     }
   }

--- a/Core/GDCore/IDE/EventsFunctionTools.cpp
+++ b/Core/GDCore/IDE/EventsFunctionTools.cpp
@@ -24,15 +24,16 @@ void EventsFunctionTools::FreeEventsFunctionToObjectsContainer(
     const gd::EventsFunction& eventsFunction,
     gd::ObjectsContainer& outputObjectsContainer) {
   // Functions scope for objects is defined according
-  // to parameters
-  outputObjectsContainer.GetObjects().clear();
-  outputObjectsContainer.GetObjectGroups().Clear();
-
+  // to parameters.
   auto &parameters = eventsFunction.GetParametersForEvents(functionContainer);
   gd::ParameterMetadataTools::ParametersToObjectsContainer(
       project,
       parameters,
       outputObjectsContainer);
+
+  // TODO: in theory we should ensure stability of the groups across calls
+  // to this function. BUT groups in functions should probably have never been
+  // supported, so we're phasing this out in the UI.
   outputObjectsContainer.GetObjectGroups() = eventsFunction.GetObjectGroups();
 }
 

--- a/Core/GDCore/Project/ObjectGroup.h
+++ b/Core/GDCore/Project/ObjectGroup.h
@@ -20,8 +20,8 @@ namespace gd {
 /**
  * \brief Represents an object group.
  *
- * Objects groups do not really contains objects : They are just used in events,
- * so as to create events which can be applied to several objects.
+ * Objects groups do not really contains objects: they are just used in events,
+ * to create events which can be applied to several objects.
  *
  * \ingroup PlatformDefinition
  */

--- a/Core/GDCore/Project/ObjectsContainer.cpp
+++ b/Core/GDCore/Project/ObjectsContainer.cpp
@@ -205,6 +205,14 @@ void ObjectsContainer::MoveObjectFolderOrObjectToAnotherContainerInFolder(
       objectFolderOrObject, newParentFolder, newPosition);
 }
 
+std::set<gd::String> ObjectsContainer::GetAllObjectNames() const {
+  std::set<gd::String> names;
+  for (const auto& object : initialObjects) {
+    names.insert(object->GetName());
+  }
+  return names;
+}
+
 std::vector<const ObjectFolderOrObject*>
 ObjectsContainer::GetAllObjectFolderOrObjects() const {
   std::vector<const ObjectFolderOrObject*> results;

--- a/Core/GDCore/Project/ObjectsContainer.h
+++ b/Core/GDCore/Project/ObjectsContainer.h
@@ -7,6 +7,7 @@
 #define GDCORE_OBJECTSCONTAINER_H
 #include <memory>
 #include <vector>
+#include <set>
 #include "GDCore/String.h"
 #include "GDCore/Project/ObjectGroupsContainer.h"
 #include "GDCore/Project/ObjectFolderOrObject.h"
@@ -40,7 +41,7 @@ class GD_CORE_API ObjectsContainer {
    */
   ObjectsContainer();
   virtual ~ObjectsContainer();
-  
+
   ObjectsContainer(const ObjectsContainer&);
   ObjectsContainer& operator=(const ObjectsContainer& rhs);
 
@@ -168,6 +169,8 @@ class GD_CORE_API ObjectsContainer {
   const std::vector<std::unique_ptr<gd::Object> >& GetObjects() const {
     return initialObjects;
   }
+
+  std::set<gd::String> GetAllObjectNames() const;
   ///@}
 
   /**

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/index.js
@@ -152,6 +152,9 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
       eventsFunctionsExtension,
     } = this.props;
 
+    const hasLegacyFunctionObjectGroups =
+      eventsFunction.getObjectGroups().count() > 0;
+
     return (
       <Column expand useFullHeight noOverflowParent>
         <Line>
@@ -168,11 +171,13 @@ export default class EventsFunctionConfigurationEditor extends React.Component<
                   value: ('parameters': TabNames),
                   label: <Trans>Parameters</Trans>,
                 },
-                {
-                  value: ('groups': TabNames),
-                  label: <Trans>Object groups</Trans>,
-                },
-              ]}
+                hasLegacyFunctionObjectGroups
+                  ? {
+                      value: ('groups': TabNames),
+                      label: <Trans>Object groups</Trans>,
+                    }
+                  : null,
+              ].filter(Boolean)}
             />
           </Column>
         </Line>


### PR DESCRIPTION
Due to the instruction selectors using objects that were not stable in memory (each render of `InstructionOrObjectSelector` would re-create them in memory and would lead callbacks to access deleted objects)