### PR TITLE
updated the instance list icons

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesList/index.js
+++ b/newIDE/app/src/InstancesEditor/InstancesList/index.js
@@ -18,6 +18,8 @@ import { toFixedWithoutTrailingZeros } from '../../Utils/Mathematics';
 import ErrorBoundary from '../../UI/ErrorBoundary';
 import useForceUpdate from '../../Utils/UseForceUpdate';
 import { Column, Line } from '../../UI/Grid';
+import LayersIcon from '../../UI/CustomSvgIcons/Layers';
+import RotateZ from '../../UI/CustomSvgIcons/RotateZ';
 const gd = global.gd;
 
 const minimumWidths = {
@@ -149,36 +151,39 @@ class InstancesList extends Component<Props, State> {
     }
   };
 
-  _renderLockCell = ({
-    rowData: { instance },
-  }: {
-    rowData: RenderedRowInfo,
-  }) => {
-    return (
-      <IconButton
-        size="small"
-        onClick={() => {
-          if (instance.isSealed()) {
-            instance.setSealed(false);
-            instance.setLocked(false);
-            return;
-          }
-          if (instance.isLocked()) {
-            instance.setSealed(true);
-            return;
-          }
-          instance.setLocked(true);
-        }}
-      >
-        {instance.isLocked() && instance.isSealed() ? (
-          <RemoveCircle />
-        ) : instance.isLocked() ? (
-          <Lock />
-        ) : (
-          <LockOpen />
-        )}
-      </IconButton>
-    );
+_renderLockCell = ({
+  rowData: { instance },
+}: {
+  rowData: RenderedRowInfo,
+}) => {
+  return (
+    <IconButton
+      size="small"
+      style={{
+        opacity: instance.isLocked() ? 1 : 0.4, 
+      }}
+      onClick={() => {
+        if (instance.isSealed()) {
+          instance.setSealed(false);
+          instance.setLocked(false);
+          return;
+        }
+        if (instance.isLocked()) {
+          instance.setSealed(true);
+          return;
+        }
+        instance.setLocked(true);
+      }}
+    >
+      {instance.isLocked() && instance.isSealed() ? (
+        <RemoveCircle />
+      ) : instance.isLocked() ? (
+        <Lock />
+      ) : (
+        <LockOpen />
+      )}
+    </IconButton>
+  );
   };
 
   _selectFirstInstance = () => {
@@ -291,16 +296,7 @@ class InstancesList extends Component<Props, State> {
                       width={Math.max(width * 0.35, minimumWidths.objectName)}
                       className={'tableColumn'}
                     />
-                    <RVColumn
-                      label=""
-                      dataKey="locked"
-                      width={Math.max(
-                        width * 0.05,
-                        minimumWidths.numberProperty
-                      )}
-                      className={'tableColumn'}
-                      cellRenderer={this._renderLockCell}
-                    />
+                   
                     <RVColumn
                       label={<Trans>X</Trans>}
                       dataKey="x"
@@ -320,21 +316,6 @@ class InstancesList extends Component<Props, State> {
                       className={'tableColumn'}
                     />
                     <RVColumn
-                      label={<Trans>Angle</Trans>}
-                      dataKey="angle"
-                      width={Math.max(
-                        width * 0.1,
-                        minimumWidths.numberProperty
-                      )}
-                      className={'tableColumn'}
-                    />
-                    <RVColumn
-                      label={<Trans>Layer</Trans>}
-                      dataKey="layer"
-                      width={Math.max(width * 0.2, minimumWidths.layerName)}
-                      className={'tableColumn'}
-                    />
-                    <RVColumn
                       label={<Trans>Z Order</Trans>}
                       dataKey="zOrder"
                       width={Math.max(
@@ -343,7 +324,32 @@ class InstancesList extends Component<Props, State> {
                       )}
                       className={'tableColumn'}
                     />
-                  </RVTable>
+                     <RVColumn
+                      label={<Trans><RotateZ></RotateZ></Trans>}
+                      dataKey="angle"
+                      width={Math.max(
+                        width * 0.1,
+                        minimumWidths.numberProperty
+                      )}
+                      className={'tableColumn'}
+                    />
+                    <RVColumn
+                      label={<Trans><LayersIcon></LayersIcon></Trans>}
+                      dataKey="layer"
+                      width={Math.max(width * 0.1, minimumWidths.layerName)}
+                      className={'tableColumn'}
+                    />
+                     <RVColumn
+                      label=""
+                      dataKey="locked"
+                      width={Math.max(
+                        width * 0.05,
+                        minimumWidths.numberProperty
+                      )}
+                      className={'tableColumn'}
+                      cellRenderer={this._renderLockCell}
+                    />
+                  </RVTable>  
                 )}
               </AutoSizer>
             </div>


### PR DESCRIPTION
Fixes #6755 

Before : (Hard to distinguish which are the locked or unlocked instances on the instance list)
![Screenshot 2024-11-29 101923](https://github.com/user-attachments/assets/41fdb642-11f8-4004-9131-228b2f4b4a5e)

After this PR : (easy to distinguish which are the locked or unlocked instances on the instance list)
![Screenshot 2024-11-29 101608](https://github.com/user-attachments/assets/c56c420e-746c-4c78-9c50-c626529052b5)

