### PR TITLE
[3D character] Allow to set higher speed than the maximum speed

### DIFF
--- a/Extensions/Physics3DBehavior/JsExtension.js
+++ b/Extensions/Physics3DBehavior/JsExtension.js
@@ -2237,7 +2237,7 @@ module.exports = {
         .setGetter('getSidewaysSpeedMax');
 
       aut
-        .addExpressionAndCondition(
+        .addExpressionAndConditionAndAction(
           'number',
           'CurrentFallSpeed',
           _('Current falling speed'),
@@ -2257,34 +2257,11 @@ module.exports = {
           )
         )
         .markAsAdvanced()
-        .setFunctionName('getCurrentFallSpeed');
-
-      aut
-        .addScopedAction(
-          'SetCurrentFallSpeed',
-          _('Current falling speed'),
-          _(
-            "Change the current falling speed of the object. This action doesn't have any effect when the character is not falling or is in the first phase of a jump."
-          ),
-          _('the current falling speed'),
-          _('Character state'),
-          'JsPlatform/Extensions/physics_character3d.svg',
-          'JsPlatform/Extensions/physics_character3d.svg'
-        )
-        .addParameter('object', _('Object'), '', false)
-        .addParameter('behavior', _('Behavior'), 'PhysicsCharacter3D')
-        .useStandardOperatorParameters(
-          'number',
-          gd.ParameterOptions.makeNewOptions().setDescription(
-            _('Speed (in pixels per second)')
-          )
-        )
-        .markAsAdvanced()
         .setFunctionName('setCurrentFallSpeed')
         .setGetter('getCurrentFallSpeed');
 
       aut
-        .addExpressionAndCondition(
+        .addExpressionAndConditionAndAction(
           'number',
           'CurrentJumpSpeed',
           _('Current jump speed'),
@@ -2304,7 +2281,8 @@ module.exports = {
           )
         )
         .markAsAdvanced()
-        .setFunctionName('getCurrentJumpSpeed');
+        .setFunctionName('setCurrentJumpSpeed')
+        .setGetter('getCurrentJumpSpeed');
 
       aut
         .addExpressionAndConditionAndAction(

--- a/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
@@ -597,7 +597,7 @@ namespace gdjs {
           );
         } else if (currentSpeed <= 0) {
           // Accelerate
-          newSpeed -= acceleration * timeDelta;
+          newSpeed -= Math.max(-speedMax, acceleration * timeDelta);
         } else {
           // Turn back at least as fast as it would stop.
           newSpeed = Math.max(
@@ -614,7 +614,10 @@ namespace gdjs {
           );
         } else if (currentSpeed >= 0) {
           // Accelerate
-          newSpeed += acceleration * timeDelta;
+          newSpeed = Math.min(
+            speedMax,
+            currentSpeed + acceleration * timeDelta
+          );
         } else {
           // Turn back at least as fast as it would stop.
           newSpeed = Math.min(
@@ -631,7 +634,7 @@ namespace gdjs {
           newSpeed = Math.max(currentSpeed - deceleration * timeDelta, 0);
         }
       }
-      return gdjs.evtTools.common.clamp(newSpeed, -speedMax, speedMax);
+      return newSpeed;
     }
 
     private updateGroundVelocity(
@@ -991,11 +994,7 @@ namespace gdjs {
      * @param currentForwardSpeed The current speed.
      */
     setCurrentForwardSpeed(currentForwardSpeed: float): void {
-      this._currentForwardSpeed = gdjs.evtTools.common.clamp(
-        currentForwardSpeed,
-        -this._forwardSpeedMax,
-        this._forwardSpeedMax
-      );
+      this._currentForwardSpeed = currentForwardSpeed;
     }
 
     /**
@@ -1011,11 +1010,7 @@ namespace gdjs {
      * @param currentSidewaysSpeed The current speed.
      */
     setCurrentSidewaysSpeed(currentSidewaysSpeed: float): void {
-      this._currentSidewaysSpeed = gdjs.evtTools.common.clamp(
-        currentSidewaysSpeed,
-        -this._sidewaysSpeedMax,
-        this._sidewaysSpeedMax
-      );
+      this._currentSidewaysSpeed = currentSidewaysSpeed;
     }
 
     /**
@@ -1029,17 +1024,13 @@ namespace gdjs {
 
     /**
      * Set the current fall speed.
-     *
-     * When the character is not in the falling state this method has no effect.
      */
     setCurrentFallSpeed(currentFallSpeed: float) {
-      if (this.isFalling()) {
-        this._currentFallSpeed = gdjs.evtTools.common.clamp(
-          currentFallSpeed,
-          0,
-          this._maxFallingSpeed
-        );
-      }
+      this._currentFallSpeed = gdjs.evtTools.common.clamp(
+        currentFallSpeed,
+        0,
+        this._maxFallingSpeed
+      );
     }
 
     /**
@@ -1048,6 +1039,13 @@ namespace gdjs {
      */
     getCurrentJumpSpeed(): float {
       return this._currentJumpSpeed;
+    }
+
+    /**
+     * Set the current jump speed.
+     */
+    setCurrentJumpSpeed(currentJumpSpeed: float) {
+      this._currentJumpSpeed = Math.max(0, currentJumpSpeed);
     }
 
     /**


### PR DESCRIPTION
### Changes
- The actions allow to set a speed that is greater than the maximum speed.
  - The speed is then decelerated to reach the targeted speed (which can't be over the maximum speed).
  - It allows to do speed bursts easily.