### PR TITLE
Add max size on asset card

### DIFF
--- a/newIDE/app/src/AssetStore/AssetCard.js
+++ b/newIDE/app/src/AssetStore/AssetCard.js
@@ -56,7 +56,7 @@ export const AssetCard = ({
         <CheckeredBackground />
         <AssetPreviewImage
           assetShortHeader={assetShortHeader}
-          maxSize={128}
+          maxSize={size}
           loading="lazy"
         />
       </div>


### PR DESCRIPTION
Before:
<img width="334" alt="image" src="https://github.com/user-attachments/assets/ff196655-dadd-4cb7-8bde-fb06ae519f8a" />

With maxSize={size}
<img width="334" alt="image" src="https://github.com/user-attachments/assets/26f775a2-4780-4d42-8a66-0675dfe32fcd" />

Without maxSize
<img width="335" alt="image" src="https://github.com/user-attachments/assets/f25c1fe6-d7ce-4164-976a-ac83e487dd41" />
