### PR TITLE
[Experimental, WIP] Scene editor 

### DIFF
--- a/Core/GDCore/Project/PropertyDescriptor.cpp
+++ b/Core/GDCore/Project/PropertyDescriptor.cpp
@@ -51,7 +51,9 @@ void PropertyDescriptor::UnserializeFrom(const SerializerElement& element) {
   currentValue = element.GetChild("value").GetStringValue();
   type = element.GetChild("type").GetStringValue();
   if (type == "Number") {
-    gd::String unitName = element.GetChild("unit").GetStringValue();
+    gd::String unitName = element.HasChild("unit")
+                              ? element.GetChild("unit").GetStringValue()
+                              : "";
     measurementUnit =
         gd::MeasurementUnit::HasDefaultMeasurementUnitNamed(unitName)
             ? measurementUnit =

--- a/GDJS/GDJS/IDE/ExporterHelper.cpp
+++ b/GDJS/GDJS/IDE/ExporterHelper.cpp
@@ -240,6 +240,9 @@ bool ExporterHelper::ExportProjectForPixiPreview(
   if (options.isDevelopmentEnvironment) {
     runtimeGameOptions.AddChild("environment").SetStringValue("dev");
   }
+  if (options.isInGameEdition) {
+    runtimeGameOptions.AddChild("isInGameEdition").SetBoolValue(true);
+  }
   if (!options.gdevelopResourceToken.empty()) {
     runtimeGameOptions.AddChild("gdevelopResourceToken")
         .SetStringValue(options.gdevelopResourceToken);

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -170,6 +170,14 @@ struct PreviewExportOptions {
   }
 
   /**
+   * \brief Set if the export is made for being edited in the editor.
+   */
+  PreviewExportOptions &SetIsInGameEdition(bool enable) {
+    isInGameEdition = enable;
+    return *this;
+  }
+
+  /**
    * \brief If set to a non zero value, the exported script URLs will have an
    * extra search parameter added (with the given value) to ensure browser cache
    * is bypassed when they are loaded.
@@ -291,6 +299,7 @@ struct PreviewExportOptions {
   bool projectDataOnlyExport;
   bool fullLoadingScreen;
   bool isDevelopmentEnvironment;
+  bool isInGameEdition;
   unsigned int nonRuntimeScriptsCacheBurst;
   gd::String electronRemoteRequirePath;
   gd::String gdevelopResourceToken;

--- a/GDJS/GDJS/IDE/ExporterHelper.h
+++ b/GDJS/GDJS/IDE/ExporterHelper.h
@@ -45,6 +45,7 @@ struct PreviewExportOptions {
         projectDataOnlyExport(false),
         fullLoadingScreen(false),
         isDevelopmentEnvironment(false),
+        isInGameEdition(false),
         nonRuntimeScriptsCacheBurst(0),
         fallbackAuthorId(""),
         fallbackAuthorUsername(""),

--- a/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
@@ -263,15 +263,24 @@ namespace gdjs {
       } else if (data.command === 'hotReload') {
         that._hotReloader.hotReload().then((logs) => {
           that.sendHotReloaderLogs(logs);
+          // TODO: if fatal error, should probably reload. The editor should handle this
+          // as it knows the current scene to show.
         });
-      } else if (data.command === 'requestSceneChange') {
+      } else if (data.command === 'requestSceneReplace') {
         const sceneName = data.sceneName || null;
         if (!sceneName) {
-          logger.warn('No scene name specified, requestSceneChange aborted');
+          logger.warn('No scene name specified, requestSceneReplace aborted');
+          return;
+        }
+
+        const currentScene = runtimeGame.getSceneStack().getCurrentScene();
+        if (currentScene && currentScene.getName() === sceneName) {
           return;
         }
 
         runtimeGame.getSceneStack().replace(sceneName, true);
+        // TODO: if fatal error, should probably reload. The editor should handle this
+        // as it knows the current scene to show.
       } else if (data.command === 'updateInstances') {
         // TODO: do an update/partial hot reload of the instances
       } else {

--- a/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
@@ -264,6 +264,8 @@ namespace gdjs {
         that._hotReloader.hotReload().then((logs) => {
           that.sendHotReloaderLogs(logs);
         });
+      } else if (data.command === 'updateInstances') {
+        // TODO: do an update/partial hot reload of the instances
       } else {
         logger.info(
           'Unknown command "' + data.command + '" received by the debugger.'
@@ -563,6 +565,15 @@ namespace gdjs {
         circularSafeStringify({
           command: 'game.resumed',
           payload: null,
+        })
+      );
+    }
+
+    sendInstancesUpdated(runtimeObjects: gdjs.RuntimeObject[]): void {
+      this._sendMessage(
+        circularSafeStringify({
+          command: 'instances.updated',
+          payload: 'TODO',
         })
       );
     }

--- a/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
@@ -264,6 +264,14 @@ namespace gdjs {
         that._hotReloader.hotReload().then((logs) => {
           that.sendHotReloaderLogs(logs);
         });
+      } else if (data.command === 'requestSceneChange') {
+        const sceneName = data.sceneName || null;
+        if (!sceneName) {
+          logger.warn('No scene name specified, requestSceneChange aborted');
+          return;
+        }
+
+        runtimeGame.getSceneStack().replace(sceneName, true);
       } else if (data.command === 'updateInstances') {
         // TODO: do an update/partial hot reload of the instances
       } else {

--- a/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
@@ -245,6 +245,8 @@ namespace gdjs {
         that.sendRuntimeGameDump();
       } else if (data.command === 'refresh') {
         that.sendRuntimeGameDump();
+      } else if (data.command === 'getStatus') {
+        that.sendRuntimeGameStatus();
       } else if (data.command === 'set') {
         that.set(data.path, data.newValue);
       } else if (data.command === 'call') {
@@ -267,6 +269,8 @@ namespace gdjs {
           // as it knows the current scene to show.
         });
       } else if (data.command === 'requestSceneReplace') {
+        if (!this._runtimegame.isInGameEdition()) return;
+
         const sceneName = data.sceneName || null;
         if (!sceneName) {
           logger.warn('No scene name specified, requestSceneReplace aborted');
@@ -451,6 +455,18 @@ namespace gdjs {
       logger.log('Calling', path, 'with', args);
       object[path[currentIndex]].apply(object, args);
       return true;
+    }
+
+    sendRuntimeGameStatus(): void {
+      this._sendMessage(
+        circularSafeStringify({
+          command: 'status',
+          payload: {
+            isPaused: this._runtimegame.isPaused(),
+            isInGameEdition: this._runtimegame.isInGameEdition(),
+          },
+        })
+      );
     }
 
     /**

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -45,8 +45,12 @@ namespace gdjs {
   export type RuntimeGameOptions = {
     /** if true, force fullscreen. */
     forceFullscreen?: boolean;
+
     /** if true, game is run as a preview launched from an editor. */
     isPreview?: boolean;
+    /** if true, game is run for being edited from the editor. */
+    isInGameEdition?: boolean;
+
     /** The name of the external layout to create in the scene at position 0;0. */
     injectExternalLayout?: string;
     /** Script files, used for hot-reloading. */

--- a/GDJS/Runtime/runtimegame.ts
+++ b/GDJS/Runtime/runtimegame.ts
@@ -1299,6 +1299,14 @@ namespace gdjs {
     }
 
     /**
+     * Check if the game loop is paused, for debugging/edition purposes.
+     * @returns true if the current game is paused
+     */
+    isPaused(): boolean {
+      return this._paused;
+    }
+
+    /**
      * Check if the game should call GDevelop development APIs or not.
      *
      * Unless you are contributing to GDevelop, avoid using this.

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -358,7 +358,7 @@ namespace gdjs {
     }
 
     /**
-     * Step and render the scene.
+     * Step (execute the game logic) and render the scene.
      * @param elapsedTime In milliseconds
      * @return true if the game loop should continue, false if a scene change/push/pop
      * or a game stop was requested.
@@ -418,6 +418,23 @@ namespace gdjs {
       if (this._profiler) {
         this._profiler.end('callbacks and extensions (post-events)');
       }
+
+      this.render();
+
+      this._isJustResumed = false;
+      if (this._profiler) {
+        this._profiler.end('render');
+      }
+      if (this._profiler) {
+        this._profiler.endFrame();
+      }
+      return !!this.getRequestedChange();
+    }
+
+    /**
+     * Render the scene (but do not execute the game logic).
+     */
+    render() {
       if (this._profiler) {
         this._profiler.begin('objects (pre-render, effects update)');
       }
@@ -447,21 +464,6 @@ namespace gdjs {
         );
       }
 
-      this._isJustResumed = false;
-      this.render();
-      if (this._profiler) {
-        this._profiler.end('render');
-      }
-      if (this._profiler) {
-        this._profiler.endFrame();
-      }
-      return !!this.getRequestedChange();
-    }
-
-    /**
-     * Render the PIXI container associated to the runtimeScene.
-     */
-    render() {
       this._renderer.render();
     }
 

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -3843,6 +3843,7 @@ interface PreviewExportOptions {
     [Ref] PreviewExportOptions SetNativeMobileApp(boolean enable);
     [Ref] PreviewExportOptions SetFullLoadingScreen(boolean enable);
     [Ref] PreviewExportOptions SetIsDevelopmentEnvironment(boolean enable);
+    [Ref] PreviewExportOptions SetIsInGameEdition(boolean enable);
     [Ref] PreviewExportOptions SetNonRuntimeScriptsCacheBurst(unsigned long value);
     [Ref] PreviewExportOptions SetElectronRemoteRequirePath([Const] DOMString electronRemoteRequirePath);
     [Ref] PreviewExportOptions SetGDevelopResourceToken([Const] DOMString gdevelopResourceToken);

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -2850,6 +2850,7 @@ export class PreviewExportOptions extends EmscriptenObject {
   setNativeMobileApp(enable: boolean): PreviewExportOptions;
   setFullLoadingScreen(enable: boolean): PreviewExportOptions;
   setIsDevelopmentEnvironment(enable: boolean): PreviewExportOptions;
+  setIsInGameEdition(enable: boolean): PreviewExportOptions;
   setNonRuntimeScriptsCacheBurst(value: number): PreviewExportOptions;
   setElectronRemoteRequirePath(electronRemoteRequirePath: string): PreviewExportOptions;
   setGDevelopResourceToken(gdevelopResourceToken: string): PreviewExportOptions;

--- a/GDevelop.js/types/gdpreviewexportoptions.js
+++ b/GDevelop.js/types/gdpreviewexportoptions.js
@@ -13,6 +13,7 @@ declare class gdPreviewExportOptions {
   setNativeMobileApp(enable: boolean): gdPreviewExportOptions;
   setFullLoadingScreen(enable: boolean): gdPreviewExportOptions;
   setIsDevelopmentEnvironment(enable: boolean): gdPreviewExportOptions;
+  setIsInGameEdition(enable: boolean): gdPreviewExportOptions;
   setNonRuntimeScriptsCacheBurst(value: number): gdPreviewExportOptions;
   setElectronRemoteRequirePath(electronRemoteRequirePath: string): gdPreviewExportOptions;
   setGDevelopResourceToken(gdevelopResourceToken: string): gdPreviewExportOptions;

--- a/newIDE/app/src/CommandPalette/CommandManager.js
+++ b/newIDE/app/src/CommandPalette/CommandManager.js
@@ -51,18 +51,19 @@ export default class CommandManager implements CommandManagerInterface {
   }
 
   registerCommand = (commandName: CommandName, command: Command) => {
-    if (this._commands[commandName])
-      return console.warn(
-        `Tried to register command ${commandName}, but it is already registered.`
-      );
+    if (this._commands[commandName]) return;
+    // if (this._commands[commandName])
+    //   return console.warn(
+    //     `Tried to register command ${commandName}, but it is already registered.`
+    //   );
     this._commands[commandName] = command;
   };
 
   deregisterCommand = (commandName: CommandName) => {
-    if (!this._commands[commandName])
-      return console.warn(
-        `Tried to deregister command ${commandName}, but it is not registered.`
-      );
+    // if (!this._commands[commandName])
+    //   return console.warn(
+    //     `Tried to deregister command ${commandName}, but it is not registered.`
+    //   );
     delete this._commands[commandName];
   };
 

--- a/newIDE/app/src/Debugger/index.js
+++ b/newIDE/app/src/Debugger/index.js
@@ -219,6 +219,11 @@ export default class Debugger extends React.Component<Props, State> {
     this.setState({
       unregisterDebuggerServerCallbacks: unregisterCallbacks,
     });
+
+    // Fetch the status of each debugger client.
+    previewDebuggerServer.getExistingDebuggerIds().forEach(debuggerId => {
+      previewDebuggerServer.sendMessage(debuggerId, { command: 'getStatus' });
+    });
   };
 
   _handleMessage = (id: DebuggerId, data: any) => {
@@ -229,6 +234,13 @@ export default class Debugger extends React.Component<Props, State> {
           [id]: data.payload,
         },
       });
+    } else if (data.command === 'status') {
+      this.setState(
+        state => ({
+          gameIsPaused: { ...state.gameIsPaused, [id]: !!data.payload.isPaused },
+        }),
+        () => this.updateToolbar()
+      );
     } else if (data.command === 'profiler.output') {
       this.setState({
         profilerOutputs: {
@@ -276,26 +288,14 @@ export default class Debugger extends React.Component<Props, State> {
     const { previewDebuggerServer } = this.props;
     previewDebuggerServer.sendMessage(id, { command: 'play' });
 
-    // TODO: state should be set by the game (game.paused, game.resumed)
-    // this.setState(
-    //   state => ({
-    //     gameIsPaused: { ...state.gameIsPaused, [id]: false },
-    //   }),
-    //   () => this.updateToolbar()
-    // );
+    // Pause status is transmitted by the game (using `game.paused`, `game.resumed` or `status`).
   };
 
   _pause = (id: DebuggerId) => {
     const { previewDebuggerServer } = this.props;
     previewDebuggerServer.sendMessage(id, { command: 'pause' });
 
-    // TODO: state should be set by the game (game.paused, game.resumed)
-    // this.setState(
-    //   state => ({
-    //     gameIsPaused: { ...state.gameIsPaused, [id]: true },
-    //   }),
-    //   () => this.updateToolbar()
-    // );
+    // Pause status is transmitted by the game (using `game.paused`, `game.resumed` or `status`).
   };
 
   _refresh = (id: DebuggerId) => {

--- a/newIDE/app/src/Debugger/index.js
+++ b/newIDE/app/src/Debugger/index.js
@@ -276,24 +276,26 @@ export default class Debugger extends React.Component<Props, State> {
     const { previewDebuggerServer } = this.props;
     previewDebuggerServer.sendMessage(id, { command: 'play' });
 
-    this.setState(
-      state => ({
-        gameIsPaused: { ...state.gameIsPaused, [id]: false },
-      }),
-      () => this.updateToolbar()
-    );
+    // TODO: state should be set by the game (game.paused, game.resumed)
+    // this.setState(
+    //   state => ({
+    //     gameIsPaused: { ...state.gameIsPaused, [id]: false },
+    //   }),
+    //   () => this.updateToolbar()
+    // );
   };
 
   _pause = (id: DebuggerId) => {
     const { previewDebuggerServer } = this.props;
     previewDebuggerServer.sendMessage(id, { command: 'pause' });
 
-    this.setState(
-      state => ({
-        gameIsPaused: { ...state.gameIsPaused, [id]: true },
-      }),
-      () => this.updateToolbar()
-    );
+    // TODO: state should be set by the game (game.paused, game.resumed)
+    // this.setState(
+    //   state => ({
+    //     gameIsPaused: { ...state.gameIsPaused, [id]: true },
+    //   }),
+    //   () => this.updateToolbar()
+    // );
   };
 
   _refresh = (id: DebuggerId) => {

--- a/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
+++ b/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from 'react';
+
+type SwitchToPreviewOptions = {|
+  previewIndexHtmlLocation: string,
+|};
+
+type SwitchToSceneEditionOptions = {|
+  sceneName: string,
+|};
+
+let onSwitchToPreview: null | (SwitchToPreviewOptions => void) = null;
+let onSwitchToSceneEdition: null | (SwitchToSceneEditionOptions => void) = null;
+
+export const switchToPreview = ({
+  previewIndexHtmlLocation,
+}: SwitchToPreviewOptions) => {
+  if (!onSwitchToPreview) throw new Error('No EmbeddedGameFrame registered.');
+  onSwitchToPreview({ previewIndexHtmlLocation });
+};
+
+export const switchToSceneEdition = ({
+  sceneName,
+}: SwitchToSceneEditionOptions) => {
+  if (!onSwitchToSceneEdition) throw new Error('No EmbeddedGameFrame registered.');
+  onSwitchToSceneEdition({ sceneName });
+};
+
+export const EmbeddedGameFrame = () => {
+  const [
+    previewIndexHtmlLocation,
+    setPreviewIndexHtmlLocation,
+  ] = React.useState<string>('');
+  const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+  // TODO: display a loader when the preview is being loaded.
+
+  React.useEffect(() => {
+    // TODO: use a real context for this?
+    onSwitchToPreview = (options: SwitchToPreviewOptions) => {
+      setPreviewIndexHtmlLocation(options.previewIndexHtmlLocation);
+      if (iframeRef.current) {
+        iframeRef.current.contentWindow.focus();
+      }
+    };
+    onSwitchToSceneEdition = (options: SwitchToSceneEditionOptions) => {
+      console.log("TODO: switch to scene edition", options);
+    };
+  }, []);
+
+  return (
+    <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
+      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <iframe
+          ref={iframeRef}
+          title="Game Preview"
+          src={previewIndexHtmlLocation}
+          tabIndex={-1}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            border: 'none',
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
+++ b/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { type PreviewDebuggerServer } from '../ExportAndShare/PreviewLauncher.flow';
 
 type SwitchToPreviewOptions = {|
   previewIndexHtmlLocation: string,
@@ -22,11 +23,16 @@ export const switchToPreview = ({
 export const switchToSceneEdition = ({
   sceneName,
 }: SwitchToSceneEditionOptions) => {
-  if (!onSwitchToSceneEdition) throw new Error('No EmbeddedGameFrame registered.');
+  if (!onSwitchToSceneEdition)
+    throw new Error('No EmbeddedGameFrame registered.');
   onSwitchToSceneEdition({ sceneName });
 };
 
-export const EmbeddedGameFrame = () => {
+type Props = {|
+  previewDebuggerServer: PreviewDebuggerServer | null,
+|};
+
+export const EmbeddedGameFrame = ({ previewDebuggerServer }: Props) => {
   const [
     previewIndexHtmlLocation,
     setPreviewIndexHtmlLocation,
@@ -43,9 +49,17 @@ export const EmbeddedGameFrame = () => {
       }
     };
     onSwitchToSceneEdition = (options: SwitchToSceneEditionOptions) => {
-      console.log("TODO: switch to scene edition", options);
+      if (!previewDebuggerServer) return;
+
+      console.log('TODO: switch to scene edition', options);
+      previewDebuggerServer.getExistingDebuggerIds().forEach(debuggerId => {
+        previewDebuggerServer.sendMessage(debuggerId, {
+          command: 'requestSceneChange',
+          sceneName: options.sceneName,
+        });
+      });
     };
-  }, []);
+  }, [previewDebuggerServer]);
 
   return (
     <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>

--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserS3PreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserS3PreviewLauncher/index.js
@@ -20,7 +20,7 @@ import { displayBlackLoadingScreenOrThrow } from '../../../Utils/BrowserExternal
 import { getGDevelopResourceJwtToken } from '../../../Utils/GDevelopServices/Project';
 import { isNativeMobileApp } from '../../../Utils/Platform';
 import { getIDEVersionWithHash } from '../../../Version';
-import { switchToPreview } from '../../../EmbeddedGame/EmbeddedGameFrame';
+import { attachToPreview } from '../../../EmbeddedGame/EmbeddedGameFrame';
 const gd: libGDevelop = global.gd;
 
 type State = {|
@@ -159,6 +159,7 @@ export default class BrowserS3PreviewLauncher extends React.Component<
       );
       previewExportOptions.setLayoutName(layout.getName());
       previewExportOptions.setIsDevelopmentEnvironment(Window.isDev());
+      previewExportOptions.setIsInGameEdition(previewOptions.isForInGameEdition);
       if (externalLayout) {
         previewExportOptions.setExternalLayoutName(externalLayout.getName());
       }
@@ -221,9 +222,11 @@ export default class BrowserS3PreviewLauncher extends React.Component<
       // Upload any file that must be exported for the preview.
       await browserS3FileSystem.uploadPendingObjects();
 
-      switchToPreview({
-        previewIndexHtmlLocation: outputDir + '/index.html',
-      });
+      if (previewOptions.isForInGameEdition) {
+        attachToPreview({
+          previewIndexHtmlLocation: outputDir + '/index.html',
+        });
+      }
 
       // Change the HTML file displayed by the preview window so that it starts loading
       // the game.

--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserS3PreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserS3PreviewLauncher/index.js
@@ -20,6 +20,7 @@ import { displayBlackLoadingScreenOrThrow } from '../../../Utils/BrowserExternal
 import { getGDevelopResourceJwtToken } from '../../../Utils/GDevelopServices/Project';
 import { isNativeMobileApp } from '../../../Utils/Platform';
 import { getIDEVersionWithHash } from '../../../Version';
+import { switchToPreview } from '../../../EmbeddedGame/EmbeddedGameFrame';
 const gd: libGDevelop = global.gd;
 
 type State = {|
@@ -219,6 +220,10 @@ export default class BrowserS3PreviewLauncher extends React.Component<
 
       // Upload any file that must be exported for the preview.
       await browserS3FileSystem.uploadPendingObjects();
+
+      switchToPreview({
+        previewIndexHtmlLocation: outputDir + '/index.html',
+      });
 
       // Change the HTML file displayed by the preview window so that it starts loading
       // the game.

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
@@ -22,6 +22,7 @@ import {
 } from './LocalPreviewDebuggerServer';
 import Window from '../../../Utils/Window';
 import { getIDEVersionWithHash } from '../../../Version';
+import { switchToPreview } from '../../../EmbeddedGame/EmbeddedGameFrame';
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
@@ -327,6 +328,9 @@ export default class LocalPreviewLauncher extends React.Component<
                 hotReloadsCount: state.hotReloadsCount + 1,
               }));
             } else {
+              switchToPreview({
+                previewIndexHtmlLocation: `file://${outputDir}/index.html`,
+              });
               this._openPreviewWindow(project, outputDir, previewOptions);
             }
           },

--- a/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
+++ b/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
@@ -15,6 +15,7 @@ export type LaunchPreviewOptions = {
   fullLoadingScreen?: boolean,
   forceDiagnosticReport?: boolean,
   numberOfWindows?: number,
+  isForInGameEdition?: {forcedSceneName: string},
   launchCaptureOptions?: LaunchCaptureOptions,
 };
 export type CaptureOptions = {|
@@ -40,6 +41,7 @@ export type PreviewOptions = {|
     playerToken: string,
   },
   numberOfWindows: number,
+  isForInGameEdition: boolean,
   getIsMenuBarHiddenInPreview: () => boolean,
   getIsAlwaysOnTopInPreview: () => boolean,
   captureOptions: CaptureOptions,

--- a/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/EditorTabsHandler.js
@@ -48,6 +48,8 @@ export type EditorTab = {|
   extraEditorProps: ?EditorContainerExtraProps,
   /** If set to false, the tab can't be closed. */
   closable: boolean,
+  /** If set to true, `pointer-events: none` is applied to the tab content. */
+  removePointerEvents: boolean,
 |};
 
 export type EditorTabsState = {|
@@ -91,6 +93,7 @@ export type EditorOpeningOptions = {|
   extraEditorProps?: EditorContainerExtraProps,
   dontFocusTab?: boolean,
   closable?: boolean,
+  removePointerEvents?: boolean,
 |};
 
 export const getEditorTabMetadata = (
@@ -138,6 +141,7 @@ export const openEditorTab = (
     key,
     extraEditorProps,
     dontFocusTab,
+    removePointerEvents,
     closable,
   }: EditorOpeningOptions
 ): EditorTabsState => {
@@ -163,6 +167,7 @@ export const openEditorTab = (
     extraEditorProps,
     editorRef: null,
     closable: typeof closable === 'undefined' ? true : !!closable,
+    removePointerEvents: !!removePointerEvents,
   };
 
   return {

--- a/newIDE/app/src/MainFrame/PreviewState.js
+++ b/newIDE/app/src/MainFrame/PreviewState.js
@@ -21,27 +21,34 @@ export type PreviewState = {|
   overridenPreviewExternalLayoutName: ?string,
 |};
 
+type DebuggerStatus = {|
+  isPaused: boolean,
+  isInGameEdition: boolean,
+|};
+
 type PreviewDebuggerServerWatcherResults = {|
-  previewDebuggerIds: Array<DebuggerId>,
+  hasNonEditionPreviewsRunning: boolean,
   hotReloadLogs: Array<HotReloaderLog>,
   clearHotReloadLogs: () => void,
 |};
 
 /**
- * Return the ids of the debuggers being run, watching for changes (new
+ * Return the status of the debuggers being run, watching for changes (new
  * debugger launched or existing one closed).
  */
 export const usePreviewDebuggerServerWatcher = (
   previewDebuggerServer: ?PreviewDebuggerServer
 ): PreviewDebuggerServerWatcherResults => {
-  const [debuggerIds, setDebuggerIds] = React.useState<Array<DebuggerId>>([]);
+  const [debuggerStatus, setDebuggerStatus] = React.useState<{
+    [DebuggerId]: DebuggerStatus,
+  }>({});
   const [hotReloadLogs, setHotReloadLogs] = React.useState<
     Array<HotReloaderLog>
   >([]);
   React.useEffect(
     () => {
       if (!previewDebuggerServer) {
-        setDebuggerIds([]);
+        setDebuggerStatus({});
         return;
       }
 
@@ -50,10 +57,24 @@ export const usePreviewDebuggerServerWatcher = (
           // Nothing to do.
         },
         onConnectionClosed: ({ id, debuggerIds }) => {
-          setDebuggerIds([...debuggerIds]);
+          // Remove the debugger status.
+          setDebuggerStatus(debuggerStatus => {
+            const {
+              [id]: closedDebuggerStatus,
+              ...otherDebuggerStatus
+            } = debuggerStatus;
+            console.info(
+              `Connection closed with preview #${id}. Last status was:`,
+              closedDebuggerStatus
+            );
+
+            return otherDebuggerStatus;
+          });
         },
         onConnectionOpened: ({ id, debuggerIds }) => {
-          setDebuggerIds([...debuggerIds]);
+          // Ask the new debugger client for its status (but don't assume anything
+          // at this stage).
+          previewDebuggerServer.sendMessage(id, { command: 'getStatus' });
         },
         onConnectionErrored: ({ id }) => {
           // Nothing to do (onConnectionClosed is called if necessary).
@@ -64,6 +85,14 @@ export const usePreviewDebuggerServerWatcher = (
         onHandleParsedMessage: ({ id, parsedMessage }) => {
           if (parsedMessage.command === 'hotReloader.logs') {
             setHotReloadLogs(parsedMessage.payload);
+          } else if (parsedMessage.command === 'status') {
+            setDebuggerStatus(debuggerStatus => ({
+              ...debuggerStatus,
+              [id]: {
+                isPaused: !!parsedMessage.payload.isPaused,
+                isInGameEdition: !!parsedMessage.payload.isInGameEdition,
+              },
+            }));
           }
         },
       });
@@ -77,5 +106,9 @@ export const usePreviewDebuggerServerWatcher = (
     setHotReloadLogs,
   ]);
 
-  return { previewDebuggerIds: debuggerIds, hotReloadLogs, clearHotReloadLogs };
+  const hasNonEditionPreviewsRunning = Object.keys(debuggerStatus).some(
+    key => !debuggerStatus[+key].isInGameEdition
+  );
+
+  return { hasNonEditionPreviewsRunning, hotReloadLogs, clearHotReloadLogs };
 };

--- a/newIDE/app/src/MainFrame/TabsTitlebar.js
+++ b/newIDE/app/src/MainFrame/TabsTitlebar.js
@@ -19,7 +19,12 @@ type Props = {|
 const DRAGGABLE_PART_CLASS_NAME = 'title-bar-draggable-part';
 
 const styles = {
-  container: { display: 'flex', flexShrink: 0, alignItems: 'flex-end' },
+  container: {
+    display: 'flex',
+    flexShrink: 0,
+    alignItems: 'flex-end',
+    position: 'relative',
+  },
   leftSideArea: { alignSelf: 'stretch', flexShrink: 0 },
   rightSideArea: { alignSelf: 'stretch', flex: 1 },
   menuIcon: { marginLeft: 4, marginRight: 4 },

--- a/newIDE/app/src/MainFrame/Toolbar/PreviewAndShareButtons.js
+++ b/newIDE/app/src/MainFrame/Toolbar/PreviewAndShareButtons.js
@@ -87,21 +87,21 @@ const PreviewAndShareButtons = React.memo<PreviewAndShareButtonsProps>(
                 click: async () => {
                   await onPreviewWithoutHotReload({ numberOfWindows: 2 });
                 },
-                enabled: isPreviewEnabled && !hasPreviewsRunning,
+                enabled: isPreviewEnabled,
               },
               {
                 label: i18n._(t`3 previews in 3 windows`),
                 click: async () => {
                   onPreviewWithoutHotReload({ numberOfWindows: 3 });
                 },
-                enabled: isPreviewEnabled && !hasPreviewsRunning,
+                enabled: isPreviewEnabled,
               },
               {
                 label: i18n._(t`4 previews in 4 windows`),
                 click: async () => {
                   onPreviewWithoutHotReload({ numberOfWindows: 4 });
                 },
-                enabled: isPreviewEnabled && !hasPreviewsRunning,
+                enabled: isPreviewEnabled,
               },
             ],
           },

--- a/newIDE/app/src/MainFrame/Toolbar/PreviewAndShareButtons.js
+++ b/newIDE/app/src/MainFrame/Toolbar/PreviewAndShareButtons.js
@@ -185,7 +185,9 @@ const PreviewAndShareButtons = React.memo<PreviewAndShareButtonsProps>(
       <LineStackLayout noMargin>
         <FlatButtonWithSplitMenu
           primary
-          onClick={onHotReloadPreview}
+          onClick={
+            hasPreviewsRunning ? onHotReloadPreview : onPreviewWithoutHotReload
+          }
           disabled={!isPreviewEnabled}
           icon={hasPreviewsRunning ? <UpdateIcon /> : <PreviewIcon />}
           label={

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -410,11 +410,10 @@ const MainFrame = (props: Props) => {
     _previewLauncher.current &&
     _previewLauncher.current.getPreviewDebuggerServer();
   const {
-    previewDebuggerIds,
+    hasNonEditionPreviewsRunning,
     hotReloadLogs,
     clearHotReloadLogs,
   } = usePreviewDebuggerServerWatcher(previewDebuggerServer);
-  const hasPreviewsRunning = !!previewDebuggerIds.length;
   const {
     ensureInteractionHappened,
     renderOpenConfirmDialog,
@@ -1818,7 +1817,7 @@ const MainFrame = (props: Props) => {
 
   const hotReloadPreviewButtonProps: HotReloadPreviewButtonProps = React.useMemo(
     () => ({
-      hasPreviewsRunning,
+      hasPreviewsRunning: hasNonEditionPreviewsRunning,
       launchProjectWithLoadingScreenPreview: () =>
         launchPreview({ fullLoadingScreen: true }),
       launchProjectDataOnlyPreview: () =>
@@ -1826,7 +1825,7 @@ const MainFrame = (props: Props) => {
       launchProjectCodeAndDataPreview: () =>
         launchPreview({ hotReload: true, projectDataOnlyExport: false }),
     }),
-    [hasPreviewsRunning, launchPreview]
+    [hasNonEditionPreviewsRunning, launchPreview]
   );
 
   const getEditorsTabStateWithScene = React.useCallback(
@@ -3503,7 +3502,7 @@ const MainFrame = (props: Props) => {
     previewEnabled:
       !!state.currentProject && state.currentProject.getLayoutsCount() > 0,
     onOpenProjectManager: toggleProjectManager,
-    hasPreviewsRunning,
+    hasPreviewsRunning: hasNonEditionPreviewsRunning,
     allowNetworkPreview:
       !!_previewLauncher.current &&
       _previewLauncher.current.canDoNetworkPreview(),
@@ -3729,7 +3728,7 @@ const MainFrame = (props: Props) => {
           !checkedOutVersionStatus && !cloudProjectRecoveryOpenedVersionId
         }
         onOpenDebugger={launchDebuggerAndPreview}
-        hasPreviewsRunning={hasPreviewsRunning}
+        hasPreviewsRunning={hasNonEditionPreviewsRunning}
         onPreviewWithoutHotReload={launchNewPreview}
         onNetworkPreview={launchNetworkPreview}
         onHotReloadPreview={launchHotReloadPreview}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3577,7 +3577,7 @@ const MainFrame = (props: Props) => {
         'main-frame' /* The root styling, done in CSS to read some CSS variables. */
       }
     >
-      <EmbeddedGameFrame />
+      <EmbeddedGameFrame previewDebuggerServer={previewDebuggerServer} />
       {!!renderMainMenu &&
         renderMainMenu(
           { ...buildMainMenuProps, isApplicationTopLevelMenu: true },

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -200,6 +200,7 @@ import { type ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import useGamesList from '../GameDashboard/UseGamesList';
 import useCapturesManager from './UseCapturesManager';
 import useHomepageWitchForRouting from './UseHomepageWitchForRouting';
+import { EmbeddedGameFrame } from '../EmbeddedGame/EmbeddedGameFrame';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -620,6 +621,11 @@ const MainFrame = (props: Props) => {
           <ExtensionIcon />
         ) : null;
 
+
+      // Scene editors can have an embedded game, so they redefine manually
+      // which components can have clicks/touches.
+      const removePointerEvents = kind === 'layout';
+
       const closable = kind !== 'start page';
       const extraEditorProps =
         kind === 'start page'
@@ -637,6 +643,7 @@ const MainFrame = (props: Props) => {
             )
           : null,
         closable,
+        removePointerEvents,
         label,
         projectItemName: name,
         tabOptions,
@@ -3570,6 +3577,7 @@ const MainFrame = (props: Props) => {
         'main-frame' /* The root styling, done in CSS to read some CSS variables. */
       }
     >
+      <EmbeddedGameFrame />
       {!!renderMainMenu &&
         renderMainMenu(
           { ...buildMainMenuProps, isApplicationTopLevelMenu: true },
@@ -3706,7 +3714,11 @@ const MainFrame = (props: Props) => {
           const errorBoundaryProps = getEditorErrorBoundaryProps(editorTab.key);
 
           return (
-            <TabContentContainer key={editorTab.key} active={isCurrentTab}>
+            <TabContentContainer
+              key={editorTab.key}
+              active={isCurrentTab}
+              removePointerEvents={editorTab.removePointerEvents}
+            >
               <CommandsContextScopedProvider active={isCurrentTab}>
                 <ErrorBoundary
                   componentTitle={errorBoundaryProps.componentTitle}

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/CollisionMasksEditor/index.js
@@ -307,7 +307,7 @@ const CollisionMasksEditor = ({
   if (!animations.getAnimationsCount()) return null;
   const resourceName = sprite ? sprite.getImageName() : '';
 
-  const editors: { [string]: Editor } = {
+  const editors: { [string]: Editor | null } = {
     preview: {
       type: 'primary',
       noTitleBar: true,

--- a/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/SpriteEditor/PointsEditor/index.js
@@ -205,7 +205,7 @@ const PointsEditor = ({
   if (!animations.getAnimationsCount()) return null;
   const resourceName = sprite ? sprite.getImageName() : '';
 
-  const editors: { [string]: Editor } = {
+  const editors: { [string]: Editor | null } = {
     preview: {
       type: 'primary',
       noTitleBar: true,

--- a/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
+++ b/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
@@ -21,6 +21,7 @@ import { ProjectScopedContainersAccessor } from '../InstructionOrExpression/Even
 import { type TileMapTileSelection } from '../InstancesEditor/TileSetVisualizer';
 
 export type SceneEditorsDisplayProps = {|
+  gameEditorMode: 'embedded-game' | 'instances-editor',
   project: gdProject,
   layout: gdLayout | null,
   eventsFunctionsExtension: gdEventsFunctionsExtension | null,

--- a/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
@@ -82,6 +82,7 @@ const MosaicEditorsDisplay = React.forwardRef<
   SceneEditorsDisplayInterface
 >((props, ref) => {
   const {
+    gameEditorMode,
     project,
     resourceManagementProps,
     layout,
@@ -323,7 +324,7 @@ const MosaicEditorsDisplay = React.forwardRef<
         />
       ),
     },
-    'instances-editor': {
+    'instances-editor': gameEditorMode === 'embedded-game' ? null : {
       type: 'primary',
       noTitleBar: true,
       noSoftKeyboardAvoidance: true,
@@ -448,6 +449,7 @@ const MosaicEditorsDisplay = React.forwardRef<
       ),
     },
   };
+
   return (
     <EditorMosaic
       editors={editors}

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -249,6 +249,11 @@ export default class SceneEditor extends React.Component<Props, State> {
     this.resourceExternallyChangedCallbackId = registerOnResourceExternallyChangedCallback(
       this.onResourceExternallyChanged.bind(this)
     );
+    if (this.props.isActive) {
+      if (this.props.layout && this.state.gameEditorMode === 'embedded-game') {
+        switchToSceneEdition({ sceneName: this.props.layout.getName() });
+      }
+    }
   }
   componentWillUnmount() {
     unregisterOnResourceExternallyChangedCallback(

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -80,6 +80,7 @@ import { unserializeFromJSObject } from '../Utils/Serializer';
 import { ProjectScopedContainersAccessor } from '../InstructionOrExpression/EventsScope';
 import { type TileMapTileSelection } from '../InstancesEditor/TileSetVisualizer';
 import { extractAsCustomObject } from './CustomObjectExtractor/CustomObjectExtractor';
+import { switchToSceneEdition } from '../EmbeddedGame/EmbeddedGameFrame';
 
 const gd: libGDevelop = global.gd;
 
@@ -141,6 +142,7 @@ type Props = {|
 |};
 
 type State = {|
+  gameEditorMode: 'embedded-game' | 'instances-editor',
   setupGridOpen: boolean,
   scenePropertiesDialogOpen: boolean,
   layersListOpen: boolean,
@@ -196,6 +198,7 @@ export default class SceneEditor extends React.Component<Props, State> {
 
     this.instancesSelection = new InstancesSelection();
     this.state = {
+      gameEditorMode: 'embedded-game',
       setupGridOpen: false,
       scenePropertiesDialogOpen: false,
       layersListOpen: false,
@@ -395,6 +398,10 @@ export default class SceneEditor extends React.Component<Props, State> {
           selectedObjectFolderOrObjectsWithContext
         ),
       }));
+
+      if (this.props.layout && this.state.gameEditorMode === 'embedded-game') {
+        switchToSceneEdition({ sceneName: this.props.layout.getName() });
+      }
     }
   }
 
@@ -1955,6 +1962,7 @@ export default class SceneEditor extends React.Component<Props, State> {
               />
               <EditorsDisplay
                 ref={ref => (this.editorDisplay = ref)}
+                gameEditorMode={this.state.gameEditorMode}
                 project={project}
                 layout={layout}
                 eventsFunctionsExtension={eventsFunctionsExtension}

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -45,6 +45,7 @@ const styles = {
 
 type TabContentContainerProps = {|
   active: boolean,
+  removePointerEvents?: boolean,
   children: React.Node,
 |};
 
@@ -69,6 +70,7 @@ export class TabContentContainer extends React.Component<TabContentContainerProp
         style={{
           ...styles.tabContentContainer,
           ...(active ? undefined : { display: 'none' }),
+          pointerEvents: this.props.removePointerEvents ? 'none' : undefined,
         }}
       >
         {children}

--- a/newIDE/app/src/UI/EditorMosaic/index.js
+++ b/newIDE/app/src/UI/EditorMosaic/index.js
@@ -252,7 +252,7 @@ export type EditorMosaicInterface = {|
 type Props = {|
   initialNodes: EditorMosaicNode,
   editors: {
-    [string]: Editor,
+    [string]: Editor | null,
   },
   limitToOneSecondaryEditor?: boolean,
   onOpenedEditorsChanged?: () => void,
@@ -300,7 +300,8 @@ const EditorMosaic = React.forwardRef<Props, EditorMosaicInterface>(
         if (limitToOneSecondaryEditor && editor.type === 'secondary') {
           // Replace the existing secondary editor, if any.
           const secondaryEditorName = openedEditorNames.find(
-            editorName => editors[editorName].type === 'secondary'
+            editorName =>
+              editors[editorName] && editors[editorName].type === 'secondary'
           );
           if (secondaryEditorName) {
             setMosaicNode(
@@ -408,12 +409,16 @@ const EditorMosaic = React.forwardRef<Props, EditorMosaicInterface>(
               // Move the entire mosaic up when the soft keyboard is open:
               'avoid-soft-keyboard': true,
             })}
+            style={{ position: 'relative', width: '100%', height: '100%' }}
             renderTile={(editorName: string, path: string) => {
               const editor = editors[editorName];
-              if (!editor) {
+              if (editor === undefined) {
                 console.error(
                   'Trying to render un unknown editor: ' + editorName
                 );
+                return null;
+              }
+              if (editor === null) {
                 return null;
               }
 

--- a/newIDE/app/src/UI/EditorMosaic/style.css
+++ b/newIDE/app/src/UI/EditorMosaic/style.css
@@ -7,10 +7,10 @@
 }
 
 .mosaic-gd-theme.mosaic .mosaic-root {
-  left: 0;
+  /* left: 0;
   right: 0;
   top: 0;
-  bottom: 0;
+  bottom: 0; */
 }
 
 .mosaic-gd-theme .mosaic-window {

--- a/newIDE/app/src/UI/LoaderModal.js
+++ b/newIDE/app/src/UI/LoaderModal.js
@@ -28,14 +28,15 @@ type Props = {|
   progress?: ?number,
 |};
 
-const transitionDuration = { enter: 0, exit: 150 };
+const transitionDuration = { enter: 400 };
 
 const LoaderModal = ({ progress, message, show }: Props) => {
   const isInfinite = progress === null || progress === undefined;
+  if (!show) return null;
   return (
     <I18n>
       {({ i18n }) => (
-        <Dialog open={show} transitionDuration={transitionDuration}>
+        <Dialog open transitionDuration={transitionDuration}>
           <DialogContent style={styles.dialogContent}>
             <div
               style={{

--- a/newIDE/app/src/UI/Theme/Global/Mosaic.css
+++ b/newIDE/app/src/UI/Theme/Global/Mosaic.css
@@ -1,6 +1,11 @@
 /* Mosaic layout */
 .mosaic-gd-theme.mosaic {
-  background-color: var(--mosaic-layout-background-color) !important;
+  /* background-color: var(--mosaic-layout-background-color) !important; */
+  background-color: transparent !important;
+}
+
+.mosaic-drop-target .drop-target-container {
+  pointer-events: all;
 }
 
 /* Mosaic window and tile */
@@ -25,6 +30,14 @@
 .mosaic-gd-theme.mosaic-blueprint-theme .mosaic-window .mosaic-window-toolbar.draggable:hover,
 .mosaic-gd-theme.mosaic.mosaic-blueprint-theme .mosaic-preview .mosaic-window-toolbar.draggable:hover {
   background: var(--mosaic-toolbar-background-color) !important;
+}
+
+.mosaic-gd-theme .mosaic-window {
+  pointer-events: all;
+}
+
+.mosaic-gd-theme .mosaic-split {
+  pointer-events: all;
 }
 
 .mosaic-gd-theme .mosaic-split.-column {

--- a/newIDE/app/src/UI/Toolbar.js
+++ b/newIDE/app/src/UI/Toolbar.js
@@ -17,6 +17,7 @@ const styles = {
     overflowY: 'hidden',
     paddingLeft: 8,
     paddingRight: 8,
+    position: 'relative',
   },
 };
 


### PR DESCRIPTION
- Add an "EmbeddedGameFrame" that displays a preview. This preview is in "game edition" mode, which for now does nothing apart from pausing the game and rendering the initial state of objects.
  - This is a working preview so it can actually be played using the debugger.
  - This works as a single iframe that is never moved at the background of the editor. Not moving it is important so that it stays loaded.
- When the scene tab is changed in the editor, the editor is asking the "preview" to change scene (all previews, but only the "in game edition" previews follow the request).
  - Other previews can be run as usual. 

TODO:
- Reset/reload the embedded game frame if the game hot reloading failed.
- Create a context for switching the scene and attaching the game frame?
- Add an option to go back to the old editor (make this "editor" an opt-in choice)
- Probably anything related to actual edition in another PR.

Some things could already be backported in smaller PRs:
- Reworked debugger client/server to add a "status" to know if the game is paused or not. This fixes a bug where the Debugger tab would show something as run when it is paused.
- Refactored `prepareExporter` method outside of a class.
- async/await-ified hot reloading function.
- async/await-ified launchPreview function in editor.
- allow RuntimeScene `render()` method to run objects/layer pre-render methods.
