### PR TITLE
[3D physics character] Fix a 1-frame delay on the "is falling" condition

### DIFF
--- a/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
@@ -1224,7 +1224,7 @@ namespace gdjs {
      * @returns Returns true if it is falling and false if not.
      */
     isFallingWithoutJumping(): boolean {
-      return !this.isOnFloor() && this._currentJumpSpeed === 0;
+      return !this.isOnFloor() && !this.isJumping();
     }
 
     /**
@@ -1241,7 +1241,8 @@ namespace gdjs {
      */
     isFalling(): boolean {
       return (
-        !this.isOnFloor() && this._currentJumpSpeed < this._currentFallSpeed
+        !this.isOnFloor() ||
+        (this.isJumping() && this._currentFallSpeed > this._currentJumpSpeed)
       );
     }
 


### PR DESCRIPTION
This is what causes a bug in the coyote time behavior.
It now works like the 2D platformer character.