### PR TITLE
[3D character] Fix the "is falling" condition from being true when the character is going up

### DIFF
--- a/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
@@ -1274,7 +1274,7 @@ namespace gdjs {
      */
     isFalling(): boolean {
       return (
-        !this.isOnFloor() ||
+        this.isFallingWithoutJumping() ||
         (this.isJumping() && this._currentFallSpeed > this._currentJumpSpeed)
       );
     }


### PR DESCRIPTION
It had the side effect of making the 3D advanced jump extension allow an extra jump