### PR TITLE
Fix conflict between variable or property and parameter in variable setters

### DIFF
--- a/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/Core/GDCore/Events/CodeGeneration/EventsCodeGenerator.h
@@ -467,7 +467,14 @@ class GD_CORE_API EventsCodeGenerator {
    */
   virtual gd::String GetCodeNamespace() { return ""; };
 
-  enum VariableScope { LAYOUT_VARIABLE = 0, PROJECT_VARIABLE, OBJECT_VARIABLE, ANY_VARIABLE };
+  enum VariableScope {
+    LAYOUT_VARIABLE = 0,
+    PROJECT_VARIABLE,
+    OBJECT_VARIABLE,
+    ANY_VARIABLE,
+    VARIABLE_OR_PROPERTY,
+    VARIABLE_OR_PROPERTY_OR_PARAMETER
+  };
 
   /**
    * Generate a single unique number for the specified instruction.
@@ -579,7 +586,9 @@ protected:
 
     } else if (scope == PROJECT_VARIABLE) {
       return "getProjectVariable(" + variableName + ")";
-    } else if (scope == ANY_VARIABLE) {
+    } else if (scope == ANY_VARIABLE || scope == VARIABLE_OR_PROPERTY ||
+               scope == VARIABLE_OR_PROPERTY_OR_PARAMETER) {
+      // TODO Split the 3 cases to make tests stronger.
       return "getAnyVariable(" + variableName + ")";
     }
 

--- a/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
+++ b/Core/GDCore/Events/CodeGeneration/ExpressionCodeGenerator.cpp
@@ -133,9 +133,12 @@ void ExpressionCodeGenerator::OnVisitVariableNode(VariableNode& node) {
   if (gd::ParameterMetadata::IsExpression("variable", type)) {
     // The node is a variable inside an expression waiting for a *variable* to be returned, not its value.
     EventsCodeGenerator::VariableScope scope =
-        type == "variable" || type == "variableOrProperty" ||
-                type == "variableOrPropertyOrParameter"
+        type == "variable"
             ? gd::EventsCodeGenerator::ANY_VARIABLE
+        : type == "variableOrProperty"
+            ? gd::EventsCodeGenerator::VARIABLE_OR_PROPERTY
+        : type == "variableOrPropertyOrParameter"
+            ? gd::EventsCodeGenerator::VARIABLE_OR_PROPERTY_OR_PARAMETER
         : type == "globalvar" ? gd::EventsCodeGenerator::PROJECT_VARIABLE
         : type == "scenevar"  ? gd::EventsCodeGenerator::LAYOUT_VARIABLE
                               : gd::EventsCodeGenerator::OBJECT_VARIABLE;
@@ -223,9 +226,12 @@ void ExpressionCodeGenerator::OnVisitIdentifierNode(IdentifierNode& node) {
         codeGenerator.GenerateObject(node.identifierName, type, context);
   } else if (gd::ParameterMetadata::IsExpression("variable", type)) {
     EventsCodeGenerator::VariableScope scope =
-        type == "variable" || type == "variableOrProperty" ||
-                type == "variableOrPropertyOrParameter"
+        type == "variable"
             ? gd::EventsCodeGenerator::ANY_VARIABLE
+        : type == "variableOrProperty"
+            ? gd::EventsCodeGenerator::VARIABLE_OR_PROPERTY
+        : type == "variableOrPropertyOrParameter"
+            ? gd::EventsCodeGenerator::VARIABLE_OR_PROPERTY_OR_PARAMETER
         : type == "globalvar" ? gd::EventsCodeGenerator::PROJECT_VARIABLE
         : type == "scenevar"  ? gd::EventsCodeGenerator::LAYOUT_VARIABLE
                               : gd::EventsCodeGenerator::OBJECT_VARIABLE;
@@ -254,7 +260,7 @@ void ExpressionCodeGenerator::OnVisitIdentifierNode(IdentifierNode& node) {
       output += codeGenerator.GenerateVariableValueAs(type);
     }, [&]() {
       output += codeGenerator.GenerateGetVariable(
-          node.identifierName, gd::EventsCodeGenerator::ANY_VARIABLE, context,
+          node.identifierName, gd::EventsCodeGenerator::VARIABLE_OR_PROPERTY_OR_PARAMETER, context,
           "", !node.childIdentifierName.empty());
       if (!node.childIdentifierName.empty()) {
         output += codeGenerator.GenerateVariableAccessor(node.childIdentifierName);

--- a/Core/GDCore/IDE/Events/EventsVariableInstructionTypeSwitcher.cpp
+++ b/Core/GDCore/IDE/Events/EventsVariableInstructionTypeSwitcher.cpp
@@ -75,14 +75,14 @@ bool EventsVariableInstructionTypeSwitcher::DoVisitInstruction(gd::Instruction& 
             variablesContainer =
                 &GetProjectScopedContainers()
                       .GetVariablesContainersList()
-                      .GetVariablesContainerFromVariableNameExcludingParameters(variableName);
+                      .GetVariablesContainerFromVariableOrPropertyName(variableName);
         } else {
           if (GetProjectScopedContainers().GetVariablesContainersList().Has(
                   variableName)) {
             variablesContainer =
                 &GetProjectScopedContainers()
                       .GetVariablesContainersList()
-                      .GetVariablesContainerFromVariableName(variableName);
+                      .GetVariablesContainerFromVariableOrPropertyOrParameterName(variableName);
           }
         }
 

--- a/Core/GDCore/IDE/Events/EventsVariableInstructionTypeSwitcher.cpp
+++ b/Core/GDCore/IDE/Events/EventsVariableInstructionTypeSwitcher.cpp
@@ -71,6 +71,11 @@ bool EventsVariableInstructionTypeSwitcher::DoVisitInstruction(gd::Instruction& 
                     .GetObjectsContainersList()
                     .GetObjectOrGroupVariablesContainer(lastObjectName);
           }
+        } else if (type == "variableOrProperty") {
+            variablesContainer =
+                &GetProjectScopedContainers()
+                      .GetVariablesContainersList()
+                      .GetVariablesContainerFromVariableNameExcludingParameters(variableName);
         } else {
           if (GetProjectScopedContainers().GetVariablesContainersList().Has(
                   variableName)) {

--- a/Core/GDCore/IDE/Events/EventsVariableReplacer.cpp
+++ b/Core/GDCore/IDE/Events/EventsVariableReplacer.cpp
@@ -122,7 +122,7 @@ class GD_CORE_API ExpressionVariableReplacer
         [&]() {
           // This is a variable.
           if (&projectScopedContainers.GetVariablesContainersList()
-                   .GetVariablesContainerFromVariableName(node.name) ==
+                   .GetVariablesContainerFromVariableOrPropertyOrParameterName(node.name) ==
               &targetVariablesContainer) {
             // The node represents a variable, that can come from the target
             // (because the target is in the scope), replace or remove it:
@@ -235,7 +235,7 @@ class GD_CORE_API ExpressionVariableReplacer
         [&]() {
           // This is a variable.
           if (&projectScopedContainers.GetVariablesContainersList()
-                   .GetVariablesContainerFromVariableName(
+                   .GetVariablesContainerFromVariableOrPropertyOrParameterName(
                        node.identifierName) == &targetVariablesContainer) {
             // The node represents a variable, that can come from the target
             // (because the target is in the scope), replace or remove it:

--- a/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionCompletionFinder.h
@@ -1034,7 +1034,7 @@ class GD_CORE_API ExpressionCompletionFinder
           description.SetVariableType(variable.GetType());
           description.SetVariableScope(
               projectScopedContainers.GetVariablesContainersList()
-                  .GetVariablesContainerFromVariableName(variableName)
+                  .GetVariablesContainerFromVariableOrPropertyOrParameterName(variableName)
                   .GetSourceType());
           completions.push_back(description);
 
@@ -1086,7 +1086,7 @@ class GD_CORE_API ExpressionCompletionFinder
           description.SetVariableType(variable.GetType());
           description.SetVariableScope(
               projectScopedContainers.GetVariablesContainersList()
-                  .GetVariablesContainerFromVariableName(variableName)
+                  .GetVariablesContainerFromVariableOrPropertyOrParameterName(variableName)
                   .GetSourceType());
           completions.push_back(description);
 

--- a/Core/GDCore/IDE/Events/ExpressionVariablePathFinder.h
+++ b/Core/GDCore/IDE/Events/ExpressionVariablePathFinder.h
@@ -215,7 +215,7 @@ class GD_CORE_API ExpressionVariablePathFinder
             if (projectScopedContainers.GetVariablesContainersList().Has(identifier)) {
               variablesContainer =
                   &(projectScopedContainers.GetVariablesContainersList()
-                        .GetVariablesContainerFromVariableName(identifier));
+                        .GetVariablesContainerFromVariableOrPropertyOrParameterName(identifier));
               variableName = identifier;
               if (childIdentifier) {
                 childVariableNames.push_back(*childIdentifier);
@@ -229,7 +229,7 @@ class GD_CORE_API ExpressionVariablePathFinder
                         identifier)) {
               variablesContainer =
                   &(projectScopedContainers.GetVariablesContainersList()
-                        .GetVariablesContainerFromVariableName(identifier));
+                        .GetVariablesContainerFromVariableOrPropertyOrParameterName(identifier));
               variableName = identifier;
               // There is no support for "children" of properties.
             }
@@ -241,7 +241,7 @@ class GD_CORE_API ExpressionVariablePathFinder
                     identifier)) {
               variablesContainer =
                   &(projectScopedContainers.GetVariablesContainersList()
-                        .GetVariablesContainerFromVariableName(identifier));
+                        .GetVariablesContainerFromVariableOrPropertyOrParameterName(identifier));
               variableName = identifier;
               // There is no support for "children" of parameters.
             }

--- a/Core/GDCore/Project/ProjectScopedContainers.h
+++ b/Core/GDCore/Project/ProjectScopedContainers.h
@@ -131,7 +131,7 @@ class ProjectScopedContainers {
       return objectCallback();
     else if (variablesContainersList.Has(name)) {
       const auto &variablesContainer =
-          variablesContainersList.GetVariablesContainerFromVariableName(name);
+          variablesContainersList.GetVariablesContainerFromVariableOrPropertyOrParameterName(name);
       const auto sourceType = variablesContainer.GetSourceType();
       if (sourceType == gd::VariablesContainer::SourceType::Properties) {
         return propertyCallback();

--- a/Core/GDCore/Project/VariablesContainersList.cpp
+++ b/Core/GDCore/Project/VariablesContainersList.cpp
@@ -147,7 +147,7 @@ const Variable& VariablesContainersList::Get(const gd::String& name) const {
 }
 
 const VariablesContainer &
-VariablesContainersList::GetVariablesContainerFromVariableName(
+VariablesContainersList::GetVariablesContainerFromVariableOrPropertyOrParameterName(
     const gd::String &variableName) const {
   for (auto it = variablesContainers.rbegin(); it != variablesContainers.rend();
        ++it) {
@@ -158,7 +158,7 @@ VariablesContainersList::GetVariablesContainerFromVariableName(
 }
 
 const VariablesContainer &VariablesContainersList::
-    GetVariablesContainerFromVariableNameExcludingParameters(
+    GetVariablesContainerFromVariableOrPropertyName(
         const gd::String &variableName) const {
   for (auto it = variablesContainers.rbegin(); it != variablesContainers.rend();
        ++it) {
@@ -171,7 +171,7 @@ const VariablesContainer &VariablesContainersList::
 }
 
 const VariablesContainer &VariablesContainersList::
-    GetVariablesContainerFromVariableNameExcludingParametersAndProperties(
+    GetVariablesContainerFromVariableNameOnly(
         const gd::String &variableName) const {
   for (auto it = variablesContainers.rbegin(); it != variablesContainers.rend();
        ++it) {

--- a/Core/GDCore/Project/VariablesContainersList.cpp
+++ b/Core/GDCore/Project/VariablesContainersList.cpp
@@ -157,6 +157,34 @@ VariablesContainersList::GetVariablesContainerFromVariableName(
   return badVariablesContainer;
 }
 
+const VariablesContainer &VariablesContainersList::
+    GetVariablesContainerFromVariableNameExcludingParameters(
+        const gd::String &variableName) const {
+  for (auto it = variablesContainers.rbegin(); it != variablesContainers.rend();
+       ++it) {
+    if ((*it)->GetSourceType() !=
+            gd::VariablesContainer::SourceType::Parameters &&
+        (*it)->Has(variableName))
+      return **it;
+  }
+  return badVariablesContainer;
+}
+
+const VariablesContainer &VariablesContainersList::
+    GetVariablesContainerFromVariableNameExcludingParametersAndProperties(
+        const gd::String &variableName) const {
+  for (auto it = variablesContainers.rbegin(); it != variablesContainers.rend();
+       ++it) {
+    if ((*it)->GetSourceType() !=
+            gd::VariablesContainer::SourceType::Parameters &&
+        (*it)->GetSourceType() !=
+            gd::VariablesContainer::SourceType::Properties &&
+        (*it)->Has(variableName))
+      return **it;
+  }
+  return badVariablesContainer;
+}
+
 std::size_t
 VariablesContainersList::GetVariablesContainerPositionFromVariableName(
     const gd::String &variableName) const {

--- a/Core/GDCore/Project/VariablesContainersList.h
+++ b/Core/GDCore/Project/VariablesContainersList.h
@@ -115,10 +115,22 @@ public:
   }
 
   /**
-   * Get the variables container for a given variable.
+   * Get the variables container for a given variable or property or parameter.
    */
   const VariablesContainer &
   GetVariablesContainerFromVariableName(const gd::String &variableName) const;
+
+  /**
+   * Get the variables container for a given variable or property.
+   */
+  const VariablesContainer &
+  GetVariablesContainerFromVariableNameExcludingParameters(const gd::String &variableName) const;
+
+  /**
+   * Get the variables container for a given variable.
+   */
+  const VariablesContainer &
+  GetVariablesContainerFromVariableNameExcludingParametersAndProperties(const gd::String &variableName) const;
 
   /**
    * Get the variables container index for a given variable.

--- a/Core/GDCore/Project/VariablesContainersList.h
+++ b/Core/GDCore/Project/VariablesContainersList.h
@@ -118,19 +118,19 @@ public:
    * Get the variables container for a given variable or property or parameter.
    */
   const VariablesContainer &
-  GetVariablesContainerFromVariableName(const gd::String &variableName) const;
+  GetVariablesContainerFromVariableOrPropertyOrParameterName(const gd::String &variableName) const;
 
   /**
    * Get the variables container for a given variable or property.
    */
   const VariablesContainer &
-  GetVariablesContainerFromVariableNameExcludingParameters(const gd::String &variableName) const;
+  GetVariablesContainerFromVariableOrPropertyName(const gd::String &variableName) const;
 
   /**
    * Get the variables container for a given variable.
    */
   const VariablesContainer &
-  GetVariablesContainerFromVariableNameExcludingParametersAndProperties(const gd::String &variableName) const;
+  GetVariablesContainerFromVariableNameOnly(const gd::String &variableName) const;
 
   /**
    * Get the variables container index for a given variable.

--- a/Core/tests/WholeProjectRefactorer-ApplyRefactoringForVariablesContainer.cpp
+++ b/Core/tests/WholeProjectRefactorer-ApplyRefactoringForVariablesContainer.cpp
@@ -1540,7 +1540,7 @@ TEST_CASE("WholeProjectRefactorer::ApplyRefactoringForVariablesContainer",
   auto projectScopedContainers =
     gd::ProjectScopedContainers::MakeNewProjectScopedContainersForProjectAndLayout(project, scene);
     REQUIRE(&projectScopedContainers.GetVariablesContainersList()
-                   .GetVariablesContainerFromVariableName("MyVariable") == &scene.GetVariables());
+                   .GetVariablesContainerFromVariableOrPropertyOrParameterName("MyVariable") == &scene.GetVariables());
 
     // Do the changes and launch the refactoring.
     scene.GetVariables().ResetPersistentUuid();

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -1369,14 +1369,14 @@ gd::String EventsCodeGenerator::GenerateGetVariable(
         GetProjectScopedContainers().GetVariablesContainersList();
     const auto &variablesContainer =
         scope == VARIABLE_OR_PROPERTY_OR_PARAMETER
-            ? variablesContainersList.GetVariablesContainerFromVariableName(
+            ? variablesContainersList.GetVariablesContainerFromVariableOrPropertyOrParameterName(
                   variableName)
         : scope == VARIABLE_OR_PROPERTY
             ? variablesContainersList
-                  .GetVariablesContainerFromVariableNameExcludingParameters(
+                  .GetVariablesContainerFromVariableOrPropertyName(
                       variableName)
             : variablesContainersList
-                  .GetVariablesContainerFromVariableNameExcludingParametersAndProperties(
+                  .GetVariablesContainerFromVariableNameOnly(
                       variableName);
     const auto sourceType = variablesContainer.GetSourceType();
     if (sourceType == gd::VariablesContainer::SourceType::Scene) {

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -1363,12 +1363,21 @@ gd::String EventsCodeGenerator::GenerateGetVariable(
     bool hasChild) {
   gd::String output;
   const gd::VariablesContainer* variables = NULL;
-  if (scope == ANY_VARIABLE) {
+  if (scope == ANY_VARIABLE || scope == VARIABLE_OR_PROPERTY ||
+      scope == VARIABLE_OR_PROPERTY_OR_PARAMETER) {
     const auto variablesContainersList =
         GetProjectScopedContainers().GetVariablesContainersList();
-    const auto& variablesContainer =
-        variablesContainersList.GetVariablesContainerFromVariableName(
-            variableName);
+    const auto &variablesContainer =
+        scope == VARIABLE_OR_PROPERTY_OR_PARAMETER
+            ? variablesContainersList.GetVariablesContainerFromVariableName(
+                  variableName)
+        : scope == VARIABLE_OR_PROPERTY
+            ? variablesContainersList
+                  .GetVariablesContainerFromVariableNameExcludingParameters(
+                      variableName)
+            : variablesContainersList
+                  .GetVariablesContainerFromVariableNameExcludingParametersAndProperties(
+                      variableName);
     const auto sourceType = variablesContainer.GetSourceType();
     if (sourceType == gd::VariablesContainer::SourceType::Scene) {
       variables = &variablesContainer;

--- a/GDJS/GDJS/Extensions/Builtin/VariablesExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/VariablesExtension.cpp
@@ -181,7 +181,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableName(
+            variablesContainersList.GetVariablesContainerFromVariableNameExcludingParameters(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType == gd::VariablesContainer::SourceType::Properties) {
@@ -244,7 +244,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableName(
+            variablesContainersList.GetVariablesContainerFromVariableNameExcludingParameters(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType == gd::VariablesContainer::SourceType::Properties) {
@@ -304,7 +304,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableName(
+            variablesContainersList.GetVariablesContainerFromVariableNameExcludingParameters(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType == gd::VariablesContainer::SourceType::Properties) {

--- a/GDJS/GDJS/Extensions/Builtin/VariablesExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/VariablesExtension.cpp
@@ -44,7 +44,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableName(
+            variablesContainersList.GetVariablesContainerFromVariableOrPropertyOrParameterName(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType != gd::VariablesContainer::SourceType::Properties &&
@@ -75,7 +75,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableName(
+            variablesContainersList.GetVariablesContainerFromVariableOrPropertyOrParameterName(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType != gd::VariablesContainer::SourceType::Properties &&
@@ -107,7 +107,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableName(
+            variablesContainersList.GetVariablesContainerFromVariableOrPropertyOrParameterName(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType != gd::VariablesContainer::SourceType::Properties &&
@@ -181,7 +181,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableNameExcludingParameters(
+            variablesContainersList.GetVariablesContainerFromVariableOrPropertyName(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType == gd::VariablesContainer::SourceType::Properties) {
@@ -244,7 +244,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableNameExcludingParameters(
+            variablesContainersList.GetVariablesContainerFromVariableOrPropertyName(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType == gd::VariablesContainer::SourceType::Properties) {
@@ -304,7 +304,7 @@ VariablesExtension::VariablesExtension() {
         const auto variablesContainersList =
             codeGenerator.GetProjectScopedContainers().GetVariablesContainersList();
         const auto& variablesContainer =
-            variablesContainersList.GetVariablesContainerFromVariableNameExcludingParameters(
+            variablesContainersList.GetVariablesContainerFromVariableOrPropertyName(
                 variableName);
         const auto sourceType = variablesContainer.GetSourceType();
         if (sourceType == gd::VariablesContainer::SourceType::Properties) {

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -341,9 +341,9 @@ interface VariablesContainer {
 interface VariablesContainersList {
   boolean Has([Const] DOMString name);
   [Const, Ref] Variable Get([Const] DOMString name);
-  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableName([Const] DOMString variableName);
-  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableNameExcludingParameters([Const] DOMString variableName);
-  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableNameExcludingParametersAndProperties([Const] DOMString variableName);
+  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableOrPropertyOrParameterName([Const] DOMString variableName);
+  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableOrPropertyName([Const] DOMString variableName);
+  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableNameOnly([Const] DOMString variableName);
 
   [Const, Ref] VariablesContainer GetVariablesContainer(unsigned long index);
   unsigned long GetVariablesContainersCount();

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -342,6 +342,8 @@ interface VariablesContainersList {
   boolean Has([Const] DOMString name);
   [Const, Ref] Variable Get([Const] DOMString name);
   [Const, Ref] VariablesContainer GetVariablesContainerFromVariableName([Const] DOMString variableName);
+  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableNameExcludingParameters([Const] DOMString variableName);
+  [Const, Ref] VariablesContainer GetVariablesContainerFromVariableNameExcludingParametersAndProperties([Const] DOMString variableName);
 
   [Const, Ref] VariablesContainer GetVariablesContainer(unsigned long index);
   unsigned long GetVariablesContainersCount();

--- a/GDevelop.js/__tests__/GDJSBehaviorCodeGenerationIntegrationTests.js
+++ b/GDevelop.js/__tests__/GDJSBehaviorCodeGenerationIntegrationTests.js
@@ -297,6 +297,8 @@ describe('libGD.js - GDJS Behavior Code Generation integration tests', function 
       eventsFunctionsExtension,
       eventsBasedBehavior
     );
+    // Add a parameter with the same name as the property.
+    // It won't be used as SetNumberVariable has a variableOrProperty parameter.
     const eventsFunction = eventsBasedBehavior
       .getEventsFunctions()
       .insertNewEventsFunction('MyFunction', 0);
@@ -319,7 +321,7 @@ describe('libGD.js - GDJS Behavior Code Generation integration tests', function 
     // Check the default value is set.
     expect(behavior._getMyIdentifier()).toBe(123);
 
-    behavior.MyFunction();
+    behavior.MyFunction(222);
     expect(behavior._getMyIdentifier()).toBe(456);
   });
 

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -361,9 +361,9 @@ export class VariablesContainer extends EmscriptenObject {
 export class VariablesContainersList extends EmscriptenObject {
   has(name: string): boolean;
   get(name: string): Variable;
-  getVariablesContainerFromVariableName(variableName: string): VariablesContainer;
-  getVariablesContainerFromVariableNameExcludingParameters(variableName: string): VariablesContainer;
-  getVariablesContainerFromVariableNameExcludingParametersAndProperties(variableName: string): VariablesContainer;
+  getVariablesContainerFromVariableOrPropertyOrParameterName(variableName: string): VariablesContainer;
+  getVariablesContainerFromVariableOrPropertyName(variableName: string): VariablesContainer;
+  getVariablesContainerFromVariableNameOnly(variableName: string): VariablesContainer;
   getVariablesContainer(index: number): VariablesContainer;
   getVariablesContainersCount(): number;
 }

--- a/GDevelop.js/types.d.ts
+++ b/GDevelop.js/types.d.ts
@@ -362,6 +362,8 @@ export class VariablesContainersList extends EmscriptenObject {
   has(name: string): boolean;
   get(name: string): Variable;
   getVariablesContainerFromVariableName(variableName: string): VariablesContainer;
+  getVariablesContainerFromVariableNameExcludingParameters(variableName: string): VariablesContainer;
+  getVariablesContainerFromVariableNameExcludingParametersAndProperties(variableName: string): VariablesContainer;
   getVariablesContainer(index: number): VariablesContainer;
   getVariablesContainersCount(): number;
 }

--- a/GDevelop.js/types/gdvariablescontainerslist.js
+++ b/GDevelop.js/types/gdvariablescontainerslist.js
@@ -2,9 +2,9 @@
 declare class gdVariablesContainersList {
   has(name: string): boolean;
   get(name: string): gdVariable;
-  getVariablesContainerFromVariableName(variableName: string): gdVariablesContainer;
-  getVariablesContainerFromVariableNameExcludingParameters(variableName: string): gdVariablesContainer;
-  getVariablesContainerFromVariableNameExcludingParametersAndProperties(variableName: string): gdVariablesContainer;
+  getVariablesContainerFromVariableOrPropertyOrParameterName(variableName: string): gdVariablesContainer;
+  getVariablesContainerFromVariableOrPropertyName(variableName: string): gdVariablesContainer;
+  getVariablesContainerFromVariableNameOnly(variableName: string): gdVariablesContainer;
   getVariablesContainer(index: number): gdVariablesContainer;
   getVariablesContainersCount(): number;
   delete(): void;

--- a/GDevelop.js/types/gdvariablescontainerslist.js
+++ b/GDevelop.js/types/gdvariablescontainerslist.js
@@ -3,6 +3,8 @@ declare class gdVariablesContainersList {
   has(name: string): boolean;
   get(name: string): gdVariable;
   getVariablesContainerFromVariableName(variableName: string): gdVariablesContainer;
+  getVariablesContainerFromVariableNameExcludingParameters(variableName: string): gdVariablesContainer;
+  getVariablesContainerFromVariableNameExcludingParametersAndProperties(variableName: string): gdVariablesContainer;
   getVariablesContainer(index: number): gdVariablesContainer;
   getVariablesContainersCount(): number;
   delete(): void;

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachChildVariableEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachChildVariableEvent.js
@@ -15,7 +15,7 @@ import {
 import InlinePopover from '../../InlinePopover';
 import AnyVariableField from '../../ParameterFields/AnyVariableField';
 import { getVariableSourceIcon } from '../../ParameterFields/VariableField';
-import { getVariableSourceFromVariableName } from '../../ParameterFields/AnyVariableField';
+import { getVariableSourceFromIdentifier } from '../../ParameterFields/AnyVariableField';
 
 import { type ParameterFieldInterface } from '../../ParameterFields/ParameterFieldCommons';
 import { type EventRendererProps } from './EventRenderer';
@@ -30,7 +30,7 @@ export const getVariableSourceOrSceneIcon = (
   projectScopedContainersAccessor: ProjectScopedContainersAccessor,
   variableName: string
 ) => {
-  const variablesContainerSourceType = getVariableSourceFromVariableName(
+  const variablesContainerSourceType = getVariableSourceFromIdentifier(
     variableName,
     projectScopedContainersAccessor.get()
   );

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachChildVariableEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ForEachChildVariableEvent.js
@@ -14,10 +14,9 @@ import {
 } from '../ClassNames';
 import InlinePopover from '../../InlinePopover';
 import AnyVariableField from '../../ParameterFields/AnyVariableField';
-import {
-  getVariableSourceIcon,
-  getVariablesContainerSourceType,
-} from '../../ParameterFields/VariableField';
+import { getVariableSourceIcon } from '../../ParameterFields/VariableField';
+import { getVariableSourceFromVariableName } from '../../ParameterFields/AnyVariableField';
+
 import { type ParameterFieldInterface } from '../../ParameterFields/ParameterFieldCommons';
 import { type EventRendererProps } from './EventRenderer';
 import ConditionsActionsColumns from '../ConditionsActionsColumns';
@@ -31,9 +30,9 @@ export const getVariableSourceOrSceneIcon = (
   projectScopedContainersAccessor: ProjectScopedContainersAccessor,
   variableName: string
 ) => {
-  const variablesContainerSourceType = getVariablesContainerSourceType(
-    projectScopedContainersAccessor,
-    variableName
+  const variablesContainerSourceType = getVariableSourceFromVariableName(
+    variableName,
+    projectScopedContainersAccessor.get()
   );
   return getVariableSourceIcon(
     variablesContainerSourceType === gd.VariablesContainer.Unknown

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableField.js
@@ -73,18 +73,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       [projectScopedContainersAccessor]
     );
 
-    const getVariableSourceFromVariableName = React.useCallback(
-      variableName =>
-        projectScopedContainersAccessor
-          .get()
-          .getVariablesContainersList()
-          .getVariablesContainerFromVariableNameExcludingParametersAndProperties(
-            variableName
-          )
-          .getSourceType(),
-      [projectScopedContainersAccessor]
-    );
-
     const onVariableEditorApply = React.useCallback(
       (selectedVariableName: string | null) => {
         if (selectedVariableName && selectedVariableName.startsWith(value)) {

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableField.js
@@ -73,6 +73,18 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       [projectScopedContainersAccessor]
     );
 
+    const getVariableSourceFromVariableName = React.useCallback(
+      variableName =>
+        projectScopedContainersAccessor
+          .get()
+          .getVariablesContainersList()
+          .getVariablesContainerFromVariableNameExcludingParametersAndProperties(
+            variableName
+          )
+          .getSourceType(),
+      [projectScopedContainersAccessor]
+    );
+
     const onVariableEditorApply = React.useCallback(
       (selectedVariableName: string | null) => {
         if (selectedVariableName && selectedVariableName.startsWith(value)) {
@@ -121,6 +133,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
+          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
         />
         {editorOpen && (
           <GlobalAndSceneVariablesDialog
@@ -139,5 +152,20 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
+export const getVariableSourceFromVariableName = (
+  variableName: string,
+  projectScopedContainers: gdProjectScopedContainers
+): VariablesContainer_SourceType => {
+  const rootVariableName = getRootVariableName(variableName);
+  const variablesContainersList = projectScopedContainers.getVariablesContainersList();
+  return variablesContainersList.has(rootVariableName)
+    ? variablesContainersList
+        .getVariablesContainerFromVariableNameExcludingParametersAndProperties(
+          rootVariableName
+        )
+        .getSourceType()
+    : gd.VariablesContainer.Unknown;
+};
+
 export const renderInlineAnyVariable = (props: ParameterInlineRendererProps) =>
-  renderVariableWithIcon(props, 'variable');
+  renderVariableWithIcon(props, 'variable', getVariableSourceFromVariableName);

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableField.js
@@ -121,7 +121,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
-          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
+          getVariableSourceFromIdentifier={getVariableSourceFromIdentifier}
         />
         {editorOpen && (
           <GlobalAndSceneVariablesDialog
@@ -140,7 +140,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
-export const getVariableSourceFromVariableName = (
+export const getVariableSourceFromIdentifier = (
   variableName: string,
   projectScopedContainers: gdProjectScopedContainers
 ): VariablesContainer_SourceType => {
@@ -148,12 +148,10 @@ export const getVariableSourceFromVariableName = (
   const variablesContainersList = projectScopedContainers.getVariablesContainersList();
   return variablesContainersList.has(rootVariableName)
     ? variablesContainersList
-        .getVariablesContainerFromVariableNameExcludingParametersAndProperties(
-          rootVariableName
-        )
+        .getVariablesContainerFromVariableNameOnly(rootVariableName)
         .getSourceType()
     : gd.VariablesContainer.Unknown;
 };
 
 export const renderInlineAnyVariable = (props: ParameterInlineRendererProps) =>
-  renderVariableWithIcon(props, 'variable', getVariableSourceFromVariableName);
+  renderVariableWithIcon(props, 'variable', getVariableSourceFromIdentifier);

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyField.js
@@ -71,18 +71,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       [projectScopedContainersAccessor]
     );
 
-    const getVariableSourceFromVariableName = React.useCallback(
-      variableName =>
-        projectScopedContainersAccessor
-          .get()
-          .getVariablesContainersList()
-          .getVariablesContainerFromVariableNameExcludingParameters(
-            variableName
-          )
-          .getSourceType(),
-      [projectScopedContainersAccessor]
-    );
-
     const onVariableEditorApply = React.useCallback(
       (selectedVariableName: string | null) => {
         if (selectedVariableName && selectedVariableName.startsWith(value)) {

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyField.js
@@ -71,6 +71,18 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       [projectScopedContainersAccessor]
     );
 
+    const getVariableSourceFromVariableName = React.useCallback(
+      variableName =>
+        projectScopedContainersAccessor
+          .get()
+          .getVariablesContainersList()
+          .getVariablesContainerFromVariableNameExcludingParameters(
+            variableName
+          )
+          .getSourceType(),
+      [projectScopedContainersAccessor]
+    );
+
     const onVariableEditorApply = React.useCallback(
       (selectedVariableName: string | null) => {
         if (selectedVariableName && selectedVariableName.startsWith(value)) {
@@ -119,6 +131,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
+          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
         />
         {editorOpen && (
           <GlobalAndSceneVariablesDialog
@@ -137,6 +150,22 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
+export const getVariableSourceFromVariableName = (
+  variableName: string,
+  projectScopedContainers: gdProjectScopedContainers
+): VariablesContainer_SourceType => {
+  const rootVariableName = getRootVariableName(variableName);
+  const variablesContainersList = projectScopedContainers.getVariablesContainersList();
+  return variablesContainersList.has(rootVariableName)
+    ? variablesContainersList
+        .getVariablesContainerFromVariableNameExcludingParameters(
+          rootVariableName
+        )
+        .getSourceType()
+    : gd.VariablesContainer.Unknown;
+};
+
 export const renderInlineAnyVariableOrProperty = (
   props: ParameterInlineRendererProps
-) => renderVariableWithIcon(props, 'variable');
+) =>
+  renderVariableWithIcon(props, 'variable', getVariableSourceFromVariableName);

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyField.js
@@ -119,7 +119,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
-          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
+          getVariableSourceFromIdentifier={getVariableSourceFromIdentifier}
         />
         {editorOpen && (
           <GlobalAndSceneVariablesDialog
@@ -138,7 +138,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
-export const getVariableSourceFromVariableName = (
+export const getVariableSourceFromIdentifier = (
   variableName: string,
   projectScopedContainers: gdProjectScopedContainers
 ): VariablesContainer_SourceType => {
@@ -146,14 +146,11 @@ export const getVariableSourceFromVariableName = (
   const variablesContainersList = projectScopedContainers.getVariablesContainersList();
   return variablesContainersList.has(rootVariableName)
     ? variablesContainersList
-        .getVariablesContainerFromVariableNameExcludingParameters(
-          rootVariableName
-        )
+        .getVariablesContainerFromVariableOrPropertyName(rootVariableName)
         .getSourceType()
     : gd.VariablesContainer.Unknown;
 };
 
 export const renderInlineAnyVariableOrProperty = (
   props: ParameterInlineRendererProps
-) =>
-  renderVariableWithIcon(props, 'variable', getVariableSourceFromVariableName);
+) => renderVariableWithIcon(props, 'variable', getVariableSourceFromIdentifier);

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyOrParameterField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyOrParameterField.js
@@ -16,6 +16,8 @@ import {
 import { enumerateVariablesOrPropertiesOrParametersOfContainersList } from './EnumerateVariables';
 import { mapFor } from '../../Utils/MapFor';
 
+const gd: libGDevelop = global.gd;
+
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function AnyVariableField(props: ParameterFieldProps, ref) {
     const field = React.useRef<?VariableFieldInterface>(null);
@@ -62,6 +64,16 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           }
         );
       },
+      [projectScopedContainersAccessor]
+    );
+
+    const getVariableSourceFromVariableName = React.useCallback(
+      variableName =>
+        projectScopedContainersAccessor
+          .get()
+          .getVariablesContainersList()
+          .getVariablesContainerFromVariableName(variableName)
+          .getSourceType(),
       [projectScopedContainersAccessor]
     );
 
@@ -113,6 +125,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
+          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
         />
         {editorOpen && (
           <GlobalAndSceneVariablesDialog
@@ -131,6 +144,20 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
+export const getVariableSourceFromVariableName = (
+  variableName: string,
+  projectScopedContainers: gdProjectScopedContainers
+): VariablesContainer_SourceType => {
+  const rootVariableName = getRootVariableName(variableName);
+  const variablesContainersList = projectScopedContainers.getVariablesContainersList();
+  return variablesContainersList.has(rootVariableName)
+    ? variablesContainersList
+        .getVariablesContainerFromVariableName(rootVariableName)
+        .getSourceType()
+    : gd.VariablesContainer.Unknown;
+};
+
 export const renderInlineAnyVariableOrPropertyOrParameter = (
   props: ParameterInlineRendererProps
-) => renderVariableWithIcon(props, 'variable');
+) =>
+  renderVariableWithIcon(props, 'variable', getVariableSourceFromVariableName);

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyOrParameterField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyOrParameterField.js
@@ -67,16 +67,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       [projectScopedContainersAccessor]
     );
 
-    const getVariableSourceFromVariableName = React.useCallback(
-      variableName =>
-        projectScopedContainersAccessor
-          .get()
-          .getVariablesContainersList()
-          .getVariablesContainerFromVariableName(variableName)
-          .getSourceType(),
-      [projectScopedContainersAccessor]
-    );
-
     const onVariableEditorApply = React.useCallback(
       (selectedVariableName: string | null) => {
         if (selectedVariableName && selectedVariableName.startsWith(value)) {

--- a/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyOrParameterField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/AnyVariableOrPropertyOrParameterField.js
@@ -115,7 +115,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
-          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
+          getVariableSourceFromIdentifier={getVariableSourceFromIdentifier}
         />
         {editorOpen && (
           <GlobalAndSceneVariablesDialog
@@ -134,7 +134,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
-export const getVariableSourceFromVariableName = (
+export const getVariableSourceFromIdentifier = (
   variableName: string,
   projectScopedContainers: gdProjectScopedContainers
 ): VariablesContainer_SourceType => {
@@ -142,12 +142,13 @@ export const getVariableSourceFromVariableName = (
   const variablesContainersList = projectScopedContainers.getVariablesContainersList();
   return variablesContainersList.has(rootVariableName)
     ? variablesContainersList
-        .getVariablesContainerFromVariableName(rootVariableName)
+        .getVariablesContainerFromVariableOrPropertyOrParameterName(
+          rootVariableName
+        )
         .getSourceType()
     : gd.VariablesContainer.Unknown;
 };
 
 export const renderInlineAnyVariableOrPropertyOrParameter = (
   props: ParameterInlineRendererProps
-) =>
-  renderVariableWithIcon(props, 'variable', getVariableSourceFromVariableName);
+) => renderVariableWithIcon(props, 'variable', getVariableSourceFromIdentifier);

--- a/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
@@ -44,7 +44,9 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         const variablesContainer = variablesContainers.find(
           variablesContainer => variablesContainer.has(variableName)
         );
-        return variablesContainer ? variablesContainer.getSourceType() : null;
+        return variablesContainer
+          ? variablesContainer.getSourceType()
+          : gd.VariablesContainer.Unknown;
       },
       [variablesContainers]
     );

--- a/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
@@ -39,18 +39,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       [project]
     );
 
-    const getVariableSourceFromVariableName = React.useCallback(
-      variableName => {
-        const variablesContainer = variablesContainers.find(
-          variablesContainer => variablesContainer.has(variableName)
-        );
-        return variablesContainer
-          ? variablesContainer.getSourceType()
-          : gd.VariablesContainer.Unknown;
-      },
-      [variablesContainers]
-    );
-
     const enumerateGlobaleVariables = React.useCallback(
       () => {
         return project ? enumerateVariables(project.getVariables()) : [];
@@ -76,7 +64,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           objectsContainer={props.objectsContainer}
           projectScopedContainersAccessor={projectScopedContainersAccessor}
           scope={scope}
-          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
+          getVariableSourceFromIdentifier={getVariableSourceFromIdentifier}
         />
         {editorOpen && project && (
           <GlobalVariablesDialog
@@ -104,7 +92,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
-const getVariableSourceFromVariableName = (
+const getVariableSourceFromIdentifier = (
   variableName: string,
   projectScopedContainers: gdProjectScopedContainers
 ): VariablesContainer_SourceType => gd.VariablesContainer.Global;
@@ -115,5 +103,5 @@ export const renderInlineGlobalVariable = (
   renderVariableWithIcon(
     props,
     'global variable',
-    getVariableSourceFromVariableName
+    getVariableSourceFromIdentifier
   );

--- a/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/GlobalVariableField.js
@@ -13,7 +13,8 @@ import {
   type FieldFocusFunction,
 } from './ParameterFieldCommons';
 import { enumerateVariables } from './EnumerateVariables';
-import GlobalVariableIcon from '../../UI/CustomSvgIcons/GlobalVariable';
+
+const gd: libGDevelop = global.gd;
 
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function GlobalVariableField(props: ParameterFieldProps, ref) {
@@ -36,6 +37,16 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         return project ? [project.getVariables()] : [];
       },
       [project]
+    );
+
+    const getVariableSourceFromVariableName = React.useCallback(
+      variableName => {
+        const variablesContainer = variablesContainers.find(
+          variablesContainer => variablesContainer.has(variableName)
+        );
+        return variablesContainer ? variablesContainer.getSourceType() : null;
+      },
+      [variablesContainers]
     );
 
     const enumerateGlobaleVariables = React.useCallback(
@@ -63,6 +74,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           objectsContainer={props.objectsContainer}
           projectScopedContainersAccessor={projectScopedContainersAccessor}
           scope={scope}
+          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
         />
         {editorOpen && project && (
           <GlobalVariablesDialog
@@ -90,6 +102,16 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
+const getVariableSourceFromVariableName = (
+  variableName: string,
+  projectScopedContainers: gdProjectScopedContainers
+): VariablesContainer_SourceType => gd.VariablesContainer.Global;
+
 export const renderInlineGlobalVariable = (
   props: ParameterInlineRendererProps
-) => renderVariableWithIcon(props, 'global variable', GlobalVariableIcon);
+) =>
+  renderVariableWithIcon(
+    props,
+    'global variable',
+    getVariableSourceFromVariableName
+  );

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
@@ -139,7 +139,9 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         const variablesContainer = variablesContainers.find(
           variablesContainer => variablesContainer.has(variableName)
         );
-        return variablesContainer ? variablesContainer.getSourceType() : null;
+        return variablesContainer
+          ? variablesContainer.getSourceType()
+          : gd.VariablesContainer.Unknown;
       },
       [variablesContainers]
     );

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
@@ -134,18 +134,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       ]
     );
 
-    const getVariableSourceFromVariableName = React.useCallback(
-      variableName => {
-        const variablesContainer = variablesContainers.find(
-          variablesContainer => variablesContainer.has(variableName)
-        );
-        return variablesContainer
-          ? variablesContainer.getSourceType()
-          : gd.VariablesContainer.Unknown;
-      },
-      [variablesContainers]
-    );
-
     const enumerateObjectVariables = React.useCallback(
       () =>
         variablesContainers.length > 0
@@ -216,7 +204,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
-          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
+          getVariableSourceFromIdentifier={getVariableSourceFromIdentifier}
         />
         {editorOpen &&
           project &&
@@ -260,8 +248,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
-const getVariableSourceFromVariableName = (
-  variableName: string,
+const getVariableSourceFromIdentifier = (
+  identifier: string,
   projectScopedContainers: gdProjectScopedContainers
 ): VariablesContainer_SourceType => gd.VariablesContainer.Object;
 
@@ -271,5 +259,5 @@ export const renderInlineObjectVariable = (
   renderVariableWithIcon(
     props,
     'object variable',
-    getVariableSourceFromVariableName
+    getVariableSourceFromIdentifier
   );

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectVariableField.js
@@ -16,7 +16,6 @@ import {
 import { getLastObjectParameterValue } from './ParameterMetadataTools';
 import getObjectByName from '../../Utils/GetObjectByName';
 import getObjectGroupByName from '../../Utils/GetObjectGroupByName';
-import ObjectVariableIcon from '../../UI/CustomSvgIcons/ObjectVariable';
 import { enumerateVariables } from './EnumerateVariables';
 import { intersectionBy } from 'lodash';
 import EventsRootVariablesFinder from '../../Utils/EventsRootVariablesFinder';
@@ -135,6 +134,16 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       ]
     );
 
+    const getVariableSourceFromVariableName = React.useCallback(
+      variableName => {
+        const variablesContainer = variablesContainers.find(
+          variablesContainer => variablesContainer.has(variableName)
+        );
+        return variablesContainer ? variablesContainer.getSourceType() : null;
+      },
+      [variablesContainers]
+    );
+
     const enumerateObjectVariables = React.useCallback(
       () =>
         variablesContainers.length > 0
@@ -205,6 +214,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               : undefined
           }
           onInstructionTypeChanged={onInstructionTypeChanged}
+          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
         />
         {editorOpen &&
           project &&
@@ -248,6 +258,16 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
+const getVariableSourceFromVariableName = (
+  variableName: string,
+  projectScopedContainers: gdProjectScopedContainers
+): VariablesContainer_SourceType => gd.VariablesContainer.Object;
+
 export const renderInlineObjectVariable = (
   props: ParameterInlineRendererProps
-) => renderVariableWithIcon(props, 'object variable', ObjectVariableIcon);
+) =>
+  renderVariableWithIcon(
+    props,
+    'object variable',
+    getVariableSourceFromVariableName
+  );

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
@@ -56,7 +56,9 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         const variablesContainer = variablesContainers.find(
           variablesContainer => variablesContainer.has(variableName)
         );
-        return variablesContainer ? variablesContainer.getSourceType() : null;
+        return variablesContainer
+          ? variablesContainer.getSourceType()
+          : gd.VariablesContainer.Unknown;
       },
       [variablesContainers]
     );

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
@@ -51,18 +51,6 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
       [eventsFunctionsExtension, layout]
     );
 
-    const getVariableSourceFromVariableName = React.useCallback(
-      variableName => {
-        const variablesContainer = variablesContainers.find(
-          variablesContainer => variablesContainer.has(variableName)
-        );
-        return variablesContainer
-          ? variablesContainer.getSourceType()
-          : gd.VariablesContainer.Unknown;
-      },
-      [variablesContainers]
-    );
-
     const enumerateSceneVariables = React.useCallback(
       () => {
         return layout
@@ -108,7 +96,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               ? `parameter-${props.parameterIndex}-scene-variable-field`
               : undefined
           }
-          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
+          getVariableSourceFromIdentifier={getVariableSourceFromIdentifier}
         />
         {editorOpen && layout && project && (
           <SceneVariablesDialog
@@ -142,8 +130,8 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
-const getVariableSourceFromVariableName = (
-  variableName: string,
+const getVariableSourceFromIdentifier = (
+  identifier: string,
   projectScopedContainers: gdProjectScopedContainers
 ): VariablesContainer_SourceType => gd.VariablesContainer.Scene;
 
@@ -153,5 +141,5 @@ export const renderInlineSceneVariable = (
   renderVariableWithIcon(
     props,
     'scene variable',
-    getVariableSourceFromVariableName
+    getVariableSourceFromIdentifier
   );

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneVariableField.js
@@ -13,8 +13,9 @@ import {
   type FieldFocusFunction,
 } from './ParameterFieldCommons';
 import { enumerateVariables } from './EnumerateVariables';
-import SceneVariableIcon from '../../UI/CustomSvgIcons/SceneVariable';
 import GlobalAndSceneVariablesDialog from '../../VariablesList/GlobalAndSceneVariablesDialog';
+
+const gd: libGDevelop = global.gd;
 
 export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function SceneVariableField(props: ParameterFieldProps, ref) {
@@ -48,6 +49,16 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           : [];
       },
       [eventsFunctionsExtension, layout]
+    );
+
+    const getVariableSourceFromVariableName = React.useCallback(
+      variableName => {
+        const variablesContainer = variablesContainers.find(
+          variablesContainer => variablesContainer.has(variableName)
+        );
+        return variablesContainer ? variablesContainer.getSourceType() : null;
+      },
+      [variablesContainers]
     );
 
     const enumerateSceneVariables = React.useCallback(
@@ -95,6 +106,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               ? `parameter-${props.parameterIndex}-scene-variable-field`
               : undefined
           }
+          getVariableSourceFromVariableName={getVariableSourceFromVariableName}
         />
         {editorOpen && layout && project && (
           <SceneVariablesDialog
@@ -128,6 +140,16 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   }
 );
 
+const getVariableSourceFromVariableName = (
+  variableName: string,
+  projectScopedContainers: gdProjectScopedContainers
+): VariablesContainer_SourceType => gd.VariablesContainer.Scene;
+
 export const renderInlineSceneVariable = (
   props: ParameterInlineRendererProps
-) => renderVariableWithIcon(props, 'scene variable', SceneVariableIcon);
+) =>
+  renderVariableWithIcon(
+    props,
+    'scene variable',
+    getVariableSourceFromVariableName
+  );

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -55,8 +55,9 @@ type Props = {
   isObjectVariable: boolean,
   variablesContainers: Array<gdVariablesContainer>,
   getVariableSourceFromVariableName: (
-    variableRootName: string
-  ) => VariablesContainer_SourceType | null,
+    variableRootName: string,
+    projectScopedContainers: gdProjectScopedContainers
+  ) => VariablesContainer_SourceType,
   enumerateVariables: () => Array<EnumeratedVariable>,
   forceDeclaration?: boolean,
   onOpenDialog: (VariableDialogOpeningProps => void) | null,
@@ -102,7 +103,8 @@ export const quicklyAnalyzeVariableName = (
   name: string,
   variablesContainers?: Array<gdVariablesContainer>,
   getVariableSourceFromVariableName?: (
-    variableRootName: string
+    variableRootName: string,
+    projectScopedContainers: gdProjectScopedContainers
   ) => VariablesContainer_SourceType | null,
   projectScopedContainersAccessor?: ProjectScopedContainersAccessor,
   isObjectVariable: boolean = false
@@ -159,7 +161,10 @@ export const quicklyAnalyzeVariableName = (
     name.length !== rootVariableName.length &&
     getVariableSourceFromVariableName
   ) {
-    const variableSource = getVariableSourceFromVariableName(rootVariableName);
+    const variableSource = getVariableSourceFromVariableName(
+      rootVariableName,
+      projectScopedContainers
+    );
 
     if (variableSource === gd.VariablesContainer.Parameters) {
       return VariableNameQuickAnalyzeResults.PARAMETER_WITH_CHILD;

--- a/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/VariableField.js
@@ -54,8 +54,8 @@ type Props = {
   ...ParameterFieldProps,
   isObjectVariable: boolean,
   variablesContainers: Array<gdVariablesContainer>,
-  getVariableSourceFromVariableName: (
-    variableRootName: string,
+  getVariableSourceFromIdentifier: (
+    identifier: string,
     projectScopedContainers: gdProjectScopedContainers
   ) => VariablesContainer_SourceType,
   enumerateVariables: () => Array<EnumeratedVariable>,
@@ -102,8 +102,8 @@ export const getRootVariableName = (name: string): string => {
 export const quicklyAnalyzeVariableName = (
   name: string,
   variablesContainers?: Array<gdVariablesContainer>,
-  getVariableSourceFromVariableName?: (
-    variableRootName: string,
+  getVariableSourceFromIdentifier?: (
+    identifier: string,
     projectScopedContainers: gdProjectScopedContainers
   ) => VariablesContainer_SourceType | null,
   projectScopedContainersAccessor?: ProjectScopedContainersAccessor,
@@ -159,9 +159,9 @@ export const quicklyAnalyzeVariableName = (
 
   if (
     name.length !== rootVariableName.length &&
-    getVariableSourceFromVariableName
+    getVariableSourceFromIdentifier
   ) {
-    const variableSource = getVariableSourceFromVariableName(
+    const variableSource = getVariableSourceFromIdentifier(
       rootVariableName,
       projectScopedContainers
     );
@@ -236,7 +236,7 @@ export default React.forwardRef<Props, VariableFieldInterface>(
       id,
       onInstructionTypeChanged,
       isObjectVariable,
-      getVariableSourceFromVariableName,
+      getVariableSourceFromIdentifier,
     } = props;
 
     const field = React.useRef<?SemiControlledAutoCompleteInterface>(null);
@@ -328,7 +328,7 @@ export default React.forwardRef<Props, VariableFieldInterface>(
     const quicklyAnalysisResult = quicklyAnalyzeVariableName(
       value,
       variablesContainers,
-      getVariableSourceFromVariableName,
+      getVariableSourceFromIdentifier,
       projectScopedContainersAccessor,
       isObjectVariable
     );
@@ -514,7 +514,7 @@ export const renderVariableWithIcon = (
     projectScopedContainersAccessor,
   }: ParameterInlineRendererProps,
   tooltip: string,
-  getVariableSourceFromVariableName: (
+  getVariableSourceFromIdentifier: (
     variableName: string,
     projectScopedContainers: gdProjectScopedContainers
   ) => VariablesContainer_SourceType
@@ -523,7 +523,7 @@ export const renderVariableWithIcon = (
     return <MissingParameterValue />;
   }
   const VariableIcon = getVariableSourceIcon(
-    getVariableSourceFromVariableName(
+    getVariableSourceFromIdentifier(
       value,
       projectScopedContainersAccessor.get()
     )


### PR DESCRIPTION
### Context
- An identifier in a "Set variable value" action matches an extension scene variable and a parameter at the same time

### Actual
- A parameter getter is generated as if it where a variable and it crashes at preview
- The event sheet displays a parameter icon for the variable field

### Expected
- A scene variable getter is generated (as parameter can't be used in actions)
- The event sheet displays an extension scene variable icon for the variable field


Note that, in both cases, a non-fatal error will appear in the event sheet for the conflict with the parameter (the error message is not displayed anywhere because the `VariableField` don't display `ExpressionValidator` errors)

