### PR TITLE
Fix used extension check false positive from usused object or behavior events

### DIFF
--- a/Core/GDCore/IDE/Events/UsedExtensionsFinder.cpp
+++ b/Core/GDCore/IDE/Events/UsedExtensionsFinder.cpp
@@ -207,9 +207,9 @@ void UsedExtensionsFinder::OnVisitFunctionCallNode(FunctionCallNode& node) {
   }
 
   // Unused event-based objects or events-based behaviors may use object and
-  // behavior instructions that should not be detected as extension usage.
+  // behavior expressions that should not be detected as extension usage.
   // The extension of actually used objects and behaviors will be detected on
-  // scene objects. This is why object or behavior instructions usually don't
+  // scene objects. This is why object or behavior expressions usually don't
   // have any import.
   if (!metadata.GetMetadata().GetIncludeFiles().empty()) {
     result.AddUsedExtension(metadata.GetExtension());

--- a/Core/GDCore/IDE/Events/UsedExtensionsFinder.cpp
+++ b/Core/GDCore/IDE/Events/UsedExtensionsFinder.cpp
@@ -69,9 +69,16 @@ bool UsedExtensionsFinder::DoVisitInstruction(gd::Instruction& instruction,
                         project.GetCurrentPlatform(), instruction.GetType())
                   : gd::MetadataProvider::GetExtensionAndActionMetadata(
                         project.GetCurrentPlatform(), instruction.GetType());
-  result.AddUsedExtension(metadata.GetExtension());
-  for (auto&& includeFile : metadata.GetMetadata().GetIncludeFiles()) {
-    result.AddUsedIncludeFiles(includeFile);
+  // Unused event-based objects or events-based behaviors may use object and
+  // behavior instructions that should not be detected as extension usage.
+  // The extension of actually used objects and behaviors will be detected on
+  // scene objects. This is why object or behavior instructions usually don't
+  // have any import.
+  if (!metadata.GetMetadata().GetIncludeFiles().empty()) {
+    result.AddUsedExtension(metadata.GetExtension());
+    for (auto &&includeFile : metadata.GetMetadata().GetIncludeFiles()) {
+      result.AddUsedIncludeFiles(includeFile);
+    }
   }
 
   gd::ParameterMetadataTools::IterateOverParameters(
@@ -199,9 +206,16 @@ void UsedExtensionsFinder::OnVisitFunctionCallNode(FunctionCallNode& node) {
       return;
   }
 
-  result.AddUsedExtension(metadata.GetExtension());
-  for (auto&& includeFile : metadata.GetMetadata().GetIncludeFiles()) {
-    result.AddUsedIncludeFiles(includeFile);
+  // Unused event-based objects or events-based behaviors may use object and
+  // behavior instructions that should not be detected as extension usage.
+  // The extension of actually used objects and behaviors will be detected on
+  // scene objects. This is why object or behavior instructions usually don't
+  // have any import.
+  if (!metadata.GetMetadata().GetIncludeFiles().empty()) {
+    result.AddUsedExtension(metadata.GetExtension());
+    for (auto &&includeFile : metadata.GetMetadata().GetIncludeFiles()) {
+      result.AddUsedIncludeFiles(includeFile);
+    }
   }
 };
 


### PR DESCRIPTION
- Some extensions have control behaviors for several built-in movement behavior but most examples only use one of them.
- All built-in movement behaviors were added to the list of used extension in the example pages.
- It was detected by the example repository CI that check the Platformer example metadata:
  https://app.circleci.com/pipelines/github/GDevelopApp/GDevelop-examples/2454/workflows/44f09388-b5f0-4b48-ad5d-c317b8dfa99e/jobs/7384
- For instance the top-down RPG example is wrongly tagged as using the 3D Physics behavior, the Platformer behavior...
  https://gdevelop.io/game-example/free/top-down-rpg

Blocks:
- https://github.com/GDevelopApp/GDevelop-examples/pull/752
