### PR TITLE
Fix a crash when searching instructions after extension are re-generated

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -117,7 +117,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 _("Change the position of the center of _PARAM0_: _PARAM1_ "
                   "_PARAM2_ (x "
                   "axis), _PARAM3_ _PARAM4_ (y axis)"),
-                _("Position/Center"),
+                _("Position ❯ Center"),
                 "res/actions/position24_black.png",
                 "res/actions/position_black.png")
       .AddParameter("object", _("Object"))
@@ -133,7 +133,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Center X position"),
          _("the X position of the center of rotation"),
          _("the X position of the center"),
-         _("Position/Center"),
+         _("Position ❯ Center"),
          "res/actions/position24_black.png")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -144,7 +144,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Center Y position"),
          _("the Y position of the center of rotation"),
          _("the Y position of the center"),
-         _("Position/Center"),
+         _("Position ❯ Center"),
          "res/actions/position24_black.png")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -155,7 +155,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                                 _("the bounding box (the area encapsulating "
                                   "the object) left position"),
                                 _("the bounding box left position"),
-                                _("Position/Bounding Box"),
+                                _("Position ❯ Bounding Box"),
                                 "res/conditions/bounding-box-left_black.svg")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -166,7 +166,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Bounding box top position"),
          _("the bounding box (the area encapsulating the object) top position"),
          _("the bounding box top position"),
-         _("Position/Bounding Box"),
+         _("Position ❯ Bounding Box"),
          "res/conditions/bounding-box-top_black.svg")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -177,7 +177,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                                 _("the bounding box (the area encapsulating "
                                   "the object) right position"),
                                 _("the bounding box right position"),
-                                _("Position/Bounding Box"),
+                                _("Position ❯ Bounding Box"),
                                 "res/conditions/bounding-box-right_black.svg")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -188,7 +188,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                                 _("the bounding box (the area encapsulating "
                                   "the object) bottom position"),
                                 _("the bounding box bottom position"),
-                                _("Position/Bounding Box"),
+                                _("Position ❯ Bounding Box"),
                                 "res/conditions/bounding-box-bottom_black.svg")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -199,7 +199,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                                 _("the bounding box (the area encapsulating "
                                   "the object) center X position"),
                                 _("the bounding box center X position"),
-                                _("Position/Bounding Box"),
+                                _("Position ❯ Bounding Box"),
                                 "res/conditions/bounding-box-center_black.svg")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -210,7 +210,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                                 _("the bounding box (the area encapsulating "
                                   "the object) center Y position"),
                                 _("the bounding box center Y position"),
-                                _("Position/Bounding Box"),
+                                _("Position ❯ Bounding Box"),
                                 "res/conditions/bounding-box-center_black.svg")
       .AddParameter("object", _("Object"))
       .UseStandardParameters("number", ParameterOptions::MakeNewOptions());
@@ -574,7 +574,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                    _("Check if the specified child of the object "
                      "structure variable exists."),
                    _("Child _PARAM2_ of variable _PARAM1_ of _PARAM0_ exists"),
-                   _("Variables/Arrays and structures"),
+                   _("Variables ❯ Arrays and structures"),
                    "res/conditions/var24.png",
                    "res/conditions/var.png")
       .AddParameter("object", _("Object"))
@@ -587,7 +587,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 _("Remove a child"),
                 _("Remove a child from an object structure variable."),
                 _("Remove child _PARAM2_ from variable _PARAM1_ of _PARAM0_"),
-                _("Variables/Arrays and structures"),
+                _("Variables ❯ Arrays and structures"),
                 "res/actions/var24.png",
                 "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -601,7 +601,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 _("Remove all the children from the object array or structure "
                   "variable."),
                 _("Clear children from variable _PARAM1_ of _PARAM0_"),
-                _("Variables/Arrays and structures"),
+                _("Variables ❯ Arrays and structures"),
                 "res/actions/var24.png",
                 "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -811,7 +811,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add text variable"),
          _("Adds a text (string) to the end of an object array variable."),
          _("Add value _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var24.png",
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -825,7 +825,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 _("Add variable array value"),
                 _("Adds a number to the end of an object array variable."),
                 _("Add value _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-                _("Variables/Arrays and structures"),
+                _("Variables ❯ Arrays and structures"),
                 "res/actions/var24.png",
                 "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -840,7 +840,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add boolean variable"),
          _("Adds a boolean to the end of an object array variable."),
          _("Add value _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var24.png",
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -856,7 +856,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add existing variable"),
          _("Adds an existing variable to the end of an object array variable."),
          _("Add variable _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var24.png",
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -874,7 +874,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add existing variable"),
          _("Adds an existing variable to the end of an object array variable."),
          _("Add variable _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var24.png",
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -891,7 +891,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add text variable"),
          _("Adds a text (string) to the end of an object array variable."),
          _("Add text _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var24.png",
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -905,7 +905,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
                 _("Add number variable"),
                 _("Adds a number to the end of an object array variable."),
                 _("Add number _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-                _("Variables/Arrays and structures"),
+                _("Variables ❯ Arrays and structures"),
                 "res/actions/var24.png",
                 "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -920,7 +920,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Add boolean variable"),
          _("Adds a boolean to the end of an object array variable."),
          _("Add boolean _PARAM2_ to array variable _PARAM1_ of _PARAM0_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var24.png",
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -937,7 +937,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
            "variable."),
          _("Remove variable at index _PARAM2_ from array variable _PARAM1_ of "
            "_PARAM0_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var24.png",
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
@@ -951,7 +951,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Number of children"),
          _("Compare the number of children in an object array variable."),
          _("The number of children in the array variable _PARAM1_"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/conditions/var24.png",
          "res/conditions/var.png")
       .AddParameter("object", _("Object"))
@@ -966,7 +966,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("First text child"),
          _("Get the value of the first element of an object array variable, if "
            "it is a text (string) variable."),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Array variable"))
@@ -977,7 +977,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("First number child"),
          _("Get the value of the first element of an object array variable, if "
            "it is a number variable."),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Array variable"))
@@ -988,7 +988,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Last text child"),
          _("Get the value of the last element of an object array variable, if "
            "it is a text (string) variable."),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Array variable"))
@@ -999,7 +999,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          _("Last number child"),
          _("Get the value of the last element of an object array variable, if "
            "it is a number variable."),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Array variable"))
@@ -1408,7 +1408,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
          "VariableChildCount",
          _("Number of children"),
          _("Number of children in an object array or structure variable"),
-         _("Variables/Arrays and structures"),
+         _("Variables ❯ Arrays and structures"),
          "res/actions/var.png")
       .AddParameter("object", _("Object"))
       .AddParameter("objectvar", _("Array or structure variable"))

--- a/Core/GDCore/Extensions/Builtin/VariablesExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/VariablesExtension.cpp
@@ -283,7 +283,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     _("Number variable"),
                     _("Compare the number value of a scene variable."),
                     _("The number of scene variable _PARAM0_"),
-                    _("External variables/Scene variables"),
+                    _("External variables ❯ Scene variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -296,7 +296,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     _("Text variable"),
                     _("Compare the text (string) of a scene variable."),
                     _("The text of scene variable _PARAM0_"),
-                    _("External variables/Scene variables"),
+                    _("External variables ❯ Scene variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -310,7 +310,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Boolean variable"),
           _("Compare the boolean value of a scene variable."),
           _("The boolean value of scene variable _PARAM0_ is _PARAM1_"),
-          _("External variables/Scene variables"),
+          _("External variables ❯ Scene variables"),
           "res/conditions/var24.png",
           "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -324,7 +324,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     _("Check if the specified child of the scene structure "
                       "variable exists."),
                     _("Child _PARAM1_ of scene variable _PARAM0_ exists"),
-                    _("External variables/Scene variables/Arrays and structures"),
+                    _("External variables ❯ Scene variables ❯ Arrays and structures"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -339,7 +339,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     _("Check if the specified child of the global structure "
                       "variable exists."),
                     _("Child _PARAM1_ of global variable _PARAM0_ exists"),
-                    _("External variables/Global variables/Arrays and structures"),
+                    _("External variables ❯ Global variables ❯ Arrays and structures"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -353,7 +353,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     "Variable defined",
                     "Test if the scene variable exists.",
                     "Scene variable _PARAM0_ is defined",
-                    _("External variables/Scene variables"),
+                    _("External variables ❯ Scene variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddCodeOnlyParameter("currentScene", "")
@@ -365,7 +365,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     _("Number variable"),
                     _("Compare the number value of a global variable."),
                     _("the global variable _PARAM0_"),
-                    _("External variables/Global variables"),
+                    _("External variables ❯ Global variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -379,7 +379,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     _("Text variable"),
                     _("Compare the text (string) of a global variable."),
                     _("the text of the global variable _PARAM0_"),
-                    _("External variables/Global variables"),
+                    _("External variables ❯ Global variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -394,7 +394,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Boolean variable"),
           _("Compare the boolean value of a global variable."),
           _("The boolean value of global variable _PARAM0_ is _PARAM1_"),
-          _("External variables/Global variables"),
+          _("External variables ❯ Global variables"),
           "res/conditions/var24.png",
           "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -407,7 +407,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                     "Variable defined",
                     "Test if a global variable exists.",
                     "Global variable _PARAM0_ is defined",
-                    _("External variables/Global variables"),
+                    _("External variables ❯ Global variables"),
                     "res/conditions/var24.png",
                     "res/conditions/var.png")
       .AddCodeOnlyParameter("currentScene", "")
@@ -420,7 +420,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Change number variable"),
                  _("Modify the number value of a scene variable."),
                  _("the scene variable _PARAM0_"),
-                 _("External variables/Scene variables"),
+                 _("External variables ❯ Scene variables"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -433,7 +433,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Change text variable"),
                  _("Modify the text (string) of a scene variable."),
                  _("the text of scene variable _PARAM0_"),
-                 _("External variables/Scene variables"),
+                 _("External variables ❯ Scene variables"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -447,7 +447,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Change boolean variable"),
           _("Modify the boolean value of a scene variable."),
           _("Set the boolean value of scene variable _PARAM0_ to _PARAM1_"),
-          _("External variables/Scene variables"),
+          _("External variables ❯ Scene variables"),
           "res/conditions/var24.png",
           "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -461,7 +461,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                      _("If it was true, it will become false, and if it was "
                        "false it will become true."),
                  _("Toggle the boolean value of scene variable _PARAM0_"),
-                 _("External variables/Scene variables"),
+                 _("External variables ❯ Scene variables"),
                  "res/conditions/var24.png",
                  "res/conditions/var.png")
       .AddParameter("scenevar", _("Variable"))
@@ -472,7 +472,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Change number variable"),
                  _("Modify the number value of a global variable."),
                  _("the global variable _PARAM0_"),
-                 _("External variables/Global variables"),
+                 _("External variables ❯ Global variables"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -486,7 +486,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Change text variable"),
                  _("Modify the text (string) of a global variable."),
                  _("the text of global variable _PARAM0_"),
-                 _("External variables/Global variables"),
+                 _("External variables ❯ Global variables"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -501,7 +501,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Change boolean variable"),
           _("Modify the boolean value of a global variable."),
           _("Set the boolean value of global variable _PARAM0_ to _PARAM1_"),
-          _("External variables/Global variables"),
+          _("External variables ❯ Global variables"),
           "res/conditions/var24.png",
           "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -515,7 +515,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                      _("If it was true, it will become false, and if it was "
                        "false it will become true."),
                  _("Toggle the boolean value of global variable _PARAM0_"),
-                 _("External variables/Global variables"),
+                 _("External variables ❯ Global variables"),
                  "res/conditions/var24.png",
                  "res/conditions/var.png")
       .AddParameter("globalvar", _("Variable"))
@@ -527,7 +527,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Remove a child"),
           _("Remove a child from a scene structure variable."),
           _("Remove child _PARAM1_ from scene structure variable _PARAM0_"),
-          _("External variables/Scene variables/Arrays and structures"),
+          _("External variables ❯ Scene variables ❯ Arrays and structures"),
           "res/actions/var24.png",
           "res/actions/var.png")
       .AddParameter("scenevar", _("Structure variable"))
@@ -542,7 +542,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Remove a child"),
           _("Remove a child from a global structure variable."),
           _("Remove child _PARAM1_ from global structure variable _PARAM0_"),
-          _("External variables/Global variables/Arrays and structures"),
+          _("External variables ❯ Global variables ❯ Arrays and structures"),
           "res/actions/var24.png",
           "res/actions/var.png")
       .AddParameter("globalvar", _("Structure variable"))
@@ -557,7 +557,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Remove all the children from the scene structure or array "
                    "variable."),
                  _("Clear children from scene variable _PARAM0_"),
-                 _("External variables/Scene variables/Arrays and structures"),
+                 _("External variables ❯ Scene variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Structure or array variable"))
@@ -571,7 +571,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Remove all the children from the global structure or array "
                    "variable."),
                  _("Clear children from global variable _PARAM0_"),
-                 _("External variables/Global variables/Arrays and structures"),
+                 _("External variables ❯ Global variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("globalvar", _("Structure or array variable"))
@@ -585,7 +585,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Adds an existing variable at the end of a scene array "
                    "variable."),
                  _("Add variable _PARAM1_ to array variable _PARAM0_"),
-                 _("External variables/Scene variables/Arrays and structures"),
+                 _("External variables ❯ Scene variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
@@ -603,7 +603,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Add text variable"),
           _("Adds a text (string) at the end of a scene array variable."),
           _("Add text _PARAM1_ to array variable _PARAM0_"),
-          _("External variables/Scene variables/Arrays and structures"),
+          _("External variables ❯ Scene variables ❯ Arrays and structures"),
           "res/actions/var24.png",
           "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
@@ -617,7 +617,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Add number variable"),
                  _("Adds a number at the end of a scene array variable."),
                  _("Add number _PARAM1_ to array variable _PARAM0_"),
-                 _("External variables/Scene variables/Arrays and structures"),
+                 _("External variables ❯ Scene variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
@@ -631,7 +631,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Add boolean variable"),
                  _("Adds a boolean at the end of a scene array variable."),
                  _("Add boolean _PARAM1_ to array variable _PARAM0_"),
-                 _("External variables/Scene variables/Arrays and structures"),
+                 _("External variables ❯ Scene variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
@@ -647,7 +647,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                    "variable."),
                  _("Remove variable at index _PARAM1_ from scene array "
                    "variable _PARAM0_"),
-                 _("External variables/Scene variables/Arrays and structures"),
+                 _("External variables ❯ Scene variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
@@ -662,7 +662,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Number of children"),
           _("Compare the number of children in a scene array variable."),
           _("The number of children in the array variable _PARAM0_"),
-          _("External variables/Scene variables/Arrays and structures"),
+          _("External variables ❯ Scene variables ❯ Arrays and structures"),
           "res/conditions/var24.png",
           "res/conditions/var.png")
       .AddParameter("scenevar", _("Array variable"))
@@ -678,7 +678,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("First text child"),
           _("Get the value of the first element of a scene array variable, if "
             "it is a text (string)."),
-          _("External variables/Scene variables/Arrays and structures"),
+          _("External variables ❯ Scene variables ❯ Arrays and structures"),
           "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -690,7 +690,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("First number child"),
           _("Get the value of the first element of a scene array variable, if "
             "it is a number."),
-          _("External variables/Scene variables/Arrays and structures"),
+          _("External variables ❯ Scene variables ❯ Arrays and structures"),
           "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -702,7 +702,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Last text child"),
           _("Get the value of the last element of a scene array variable, if "
             "it is a text (string)."),
-          _("External variables/Scene variables/Arrays and structures"),
+          _("External variables ❯ Scene variables ❯ Arrays and structures"),
           "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -714,7 +714,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Last number child"),
           _("Get the value of the last element of a scene array variable, if "
             "it is a number."),
-          _("External variables/Scene variables/Arrays and structures"),
+          _("External variables ❯ Scene variables ❯ Arrays and structures"),
           "res/actions/var.png")
       .AddParameter("scenevar", _("Array variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -726,7 +726,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Add existing variable"),
           _("Adds an existing variable at the end of a global array variable."),
           _("Add variable _PARAM1_ to array variable _PARAM0_"),
-          _("External variables/Global variables/Arrays and structures"),
+          _("External variables ❯ Global variables ❯ Arrays and structures"),
           "res/actions/var24.png",
           "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
@@ -745,7 +745,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                    "array variable."),
                  _("Remove variable at index _PARAM1_ from global array "
                    "variable _PARAM0_"),
-                 _("External variables/Global variables/Arrays and structures"),
+                 _("External variables ❯ Global variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
@@ -760,7 +760,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Add text variable"),
           _("Adds a text (string) at the end of a global array variable."),
           _("Add text _PARAM1_ to array variable _PARAM0_"),
-          _("External variables/Global variables/Arrays and structures"),
+          _("External variables ❯ Global variables ❯ Arrays and structures"),
           "res/actions/var24.png",
           "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
@@ -774,7 +774,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Add number variable"),
                  _("Adds a number at the end of a global array variable."),
                  _("Add number _PARAM1_ to array variable _PARAM0_"),
-                 _("External variables/Global variables/Arrays and structures"),
+                 _("External variables ❯ Global variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
@@ -788,7 +788,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                  _("Add boolean variable"),
                  _("Adds a boolean at the end of a global array variable."),
                  _("Add boolean _PARAM1_ to array variable _PARAM0_"),
-                 _("External variables/Global variables/Arrays and structures"),
+                 _("External variables ❯ Global variables ❯ Arrays and structures"),
                  "res/actions/var24.png",
                  "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
@@ -803,7 +803,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Number of children"),
           _("Compare the number of children in a global array variable."),
           _("The number of children of the array variable _PARAM0_"),
-          _("External variables/Global variables/Arrays and structures"),
+          _("External variables ❯ Global variables ❯ Arrays and structures"),
           "res/conditions/var24.png",
           "res/conditions/var.png")
       .AddParameter("globalvar", _("Array variable"))
@@ -818,7 +818,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                         _("First text child"),
                         _("Value of the first element of a global array "
                           "variable, if it is a text (string) variable."),
-                        _("External variables/Global variables/Arrays and structures"),
+                        _("External variables ❯ Global variables ❯ Arrays and structures"),
                         "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -829,7 +829,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                      _("First number child"),
                      _("Value of the first element of a global array "
                        "variable, if it is a number variable"),
-                     _("External variables/Global variables/Arrays and structures"),
+                     _("External variables ❯ Global variables ❯ Arrays and structures"),
                      "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -841,7 +841,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Last text child"),
           _("Value of the last element of a global array variable, if "
             "it is a text (string) variable."),
-          _("External variables/Global variables/Arrays and structures"),
+          _("External variables ❯ Global variables ❯ Arrays and structures"),
           "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -853,7 +853,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
           _("Last number child"),
           _("Value of the last element of a global array variable, if "
             "it is a number variable"),
-          _("External variables/Global variables/Arrays and structures"),
+          _("External variables ❯ Global variables ❯ Arrays and structures"),
           "res/actions/var.png")
       .AddParameter("globalvar", _("Array variable"))
       .SetRelevantForFunctionEventsOnly();
@@ -863,7 +863,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
                      _("Number of children"),
                      _("Number of children in a global array or "
                        "structure variable"),
-                     _("External variables/Global variables/Arrays and structures"),
+                     _("External variables ❯ Global variables ❯ Arrays and structures"),
                      "res/actions/var.png")
       .AddParameter("globalvar", _("Array or structure variable"))
       .SetHelpPath("/all-features/variables/structures-and-arrays/")
@@ -883,7 +883,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
       .AddExpression("Variable",
                      _("Number variable"),
                      _("Number value of a scene variable"),
-                     _("External variables/Scene variables"),
+                     _("External variables ❯ Scene variables"),
                      "res/actions/var.png")
       .AddParameter("scenevar", _("Variable"))
       .SetRelevantForFunctionEventsOnly();
@@ -892,7 +892,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
       .AddStrExpression("VariableString",
                         _("Text variable"),
                         _("Text of a scene variable"),
-                        _("External variables/Scene variables"),
+                        _("External variables ❯ Scene variables"),
                         "res/actions/var.png")
       .AddParameter("scenevar", _("Variable"))
       .SetRelevantForFunctionEventsOnly();
@@ -901,7 +901,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
       .AddExpression("GlobalVariable",
                      _("Number variable"),
                      _("Number value of a global variable"),
-                     _("External variables/Global variables"),
+                     _("External variables ❯ Global variables"),
                      "res/actions/var.png")
       .AddParameter("globalvar", _("Name of the global variable"))
       .SetRelevantForFunctionEventsOnly();
@@ -910,7 +910,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsVariablesExtension(
       .AddStrExpression("GlobalVariableString",
                         _("Text variable"),
                         _("Text of a global variable"),
-                        _("External variables/Global variables"),
+                        _("External variables ❯ Global variables"),
                         "res/actions/var.png")
       .AddParameter("globalvar", _("Variable"))
       .SetRelevantForFunctionEventsOnly();

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -69,7 +69,7 @@ module.exports = {
           _('Center Z position'),
           _('the Z position of the center of rotation'),
           _('the Z position of the center'),
-          _('Position/Center'),
+          _('Position ❯ Center'),
           'res/conditions/3d_box.svg'
         )
         .addParameter('object', _('3D object'), '', false)

--- a/Extensions/Firebase/JsExtension.js
+++ b/Extensions/Firebase/JsExtension.js
@@ -422,7 +422,7 @@ module.exports = {
         _('Is the user email address verified'),
         _('Checks if the email address of the user got verified.'),
         _('The email of the user is verified'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -440,7 +440,7 @@ module.exports = {
         'GetUserEmail',
         _('User email address'),
         _('Return the user email address.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -457,7 +457,7 @@ module.exports = {
         'GetAccountCreationTime',
         _('Accounts creation time'),
         _('Return the accounts creation time.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -474,7 +474,7 @@ module.exports = {
         'GetLastLoginTime',
         _('User last login time'),
         _('Return the user last login time.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -491,7 +491,7 @@ module.exports = {
         'GetUserDisplayName',
         _('User display name'),
         _('Return the user display name.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -508,7 +508,7 @@ module.exports = {
         'GetPhoneNumber',
         _('User phone number'),
         _('Return the user phone number.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -528,7 +528,7 @@ module.exports = {
           'Return the user Unique IDentifier. Use that to link data to an ' +
             'user instead of the name or email.'
         ),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -545,7 +545,7 @@ module.exports = {
         'GetTenantID',
         _('User tenant ID'),
         _('Return the user tenant ID. For advanced usage only.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -562,7 +562,7 @@ module.exports = {
         'GetRefreshToken',
         _('User refresh token'),
         _('Return the user refresh token. For advanced usage only.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -579,7 +579,7 @@ module.exports = {
         'GetPhotoURL',
         _('Profile picture URL'),
         _('Gets an URL to the user profile picture.'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png'
       )
       .getCodeExtraInformation()
@@ -597,7 +597,7 @@ module.exports = {
         _('Send a password reset email'),
         _('Send a password reset link per email.'),
         _('Send a password reset email'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -619,7 +619,7 @@ module.exports = {
         _('Send a verification email'),
         _('Send a link per email to verify the user email.'),
         _('Send a verification email'),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -638,7 +638,7 @@ module.exports = {
         _('Display name'),
         _('Sets the user display name.'),
         _("Set the user's display name to _PARAM0_"),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -658,7 +658,7 @@ module.exports = {
         _('Profile picture'),
         _('Change the user profile picture URL to a new one.'),
         _("Change the user's profile picture URL to _PARAM0_"),
-        _('Authentication/User Management'),
+        _('Authentication ❯ User Management'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -684,7 +684,7 @@ module.exports = {
         _(
           "Change the user's email to _PARAM0_ and store result in _PARAM4_ (send verification email: _PARAM3_)"
         ),
-        _('Authentication/User Management/Advanced'),
+        _('Authentication ❯ User Management ❯ Advanced'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -725,7 +725,7 @@ module.exports = {
         _(
           "Change the user's email to _PARAM0_ and store result in _PARAM2_ (send verification email: _PARAM1_)"
         ),
-        _('Authentication/User Management/Advanced'),
+        _('Authentication ❯ User Management ❯ Advanced'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -764,7 +764,7 @@ module.exports = {
           'Change the user password to _PARAM2_ and store result in ' +
             '_PARAM4_ (send verification email: _PARAM3_)'
         ),
-        _('Authentication/User Management/Advanced'),
+        _('Authentication ❯ User Management ❯ Advanced'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -806,7 +806,7 @@ module.exports = {
           'Change the user password to _PARAM0_ and store result in ' +
             '_PARAM2_ (send verification email: _PARAM1_)'
         ),
-        _('Authentication/User Management/Advanced'),
+        _('Authentication ❯ User Management ❯ Advanced'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -842,7 +842,7 @@ module.exports = {
             'Deletes the user account.'
         ),
         _('Delete the user account and store result in _PARAM2_'),
-        _('Authentication/User Management/Advanced'),
+        _('Authentication ❯ User Management ❯ Advanced'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )
@@ -873,7 +873,7 @@ module.exports = {
             'This is the same as "Delete the user account" but reauthenticates via an external provider.'
         ),
         _('Delete the user account and store result in _PARAM0_'),
-        _('Authentication/User Management/Advanced'),
+        _('Authentication ❯ User Management ❯ Advanced'),
         'JsPlatform/Extensions/firebase.png',
         'JsPlatform/Extensions/firebase.png'
       )

--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -2076,7 +2076,7 @@ module.exports = {
           'Add a distance joint between two objects. The length is converted to meters using the world scale on X. The frequency and damping ratio are related to the joint speed of oscillation and how fast it stops.'
         ),
         _('Add a distance joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Distance'),
+        _('Joints ❯ Distance'),
         'JsPlatform/Extensions/distance_joint24.png',
         'JsPlatform/Extensions/distance_joint16.png'
       )
@@ -2130,7 +2130,7 @@ module.exports = {
         _('Distance joint length'),
         _('Modify a distance joint length.'),
         _('the length for distance joint _PARAM2_'),
-        _('Joints/Distance'),
+        _('Joints ❯ Distance'),
         'JsPlatform/Extensions/distance_joint24.png',
         'JsPlatform/Extensions/distance_joint16.png'
       )
@@ -2150,7 +2150,7 @@ module.exports = {
         'DistanceJointLength',
         _('Distance joint length'),
         _('Distance joint length'),
-        _('Joints/Distance'),
+        _('Joints ❯ Distance'),
         'JsPlatform/Extensions/distance_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2165,7 +2165,7 @@ module.exports = {
         _('Distance joint frequency'),
         _('Modify a distance joint frequency.'),
         _('the frequency for distance joint _PARAM2_'),
-        _('Joints/Distance'),
+        _('Joints ❯ Distance'),
         'JsPlatform/Extensions/distance_joint24.png',
         'JsPlatform/Extensions/distance_joint16.png'
       )
@@ -2185,7 +2185,7 @@ module.exports = {
         'DistanceJointFrequency',
         _('Distance joint frequency'),
         _('Distance joint frequency'),
-        _('Joints/Distance'),
+        _('Joints ❯ Distance'),
         'JsPlatform/Extensions/distance_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2200,7 +2200,7 @@ module.exports = {
         _('Distance joint damping ratio'),
         _('Modify a distance joint damping ratio.'),
         _('the damping ratio for distance joint _PARAM2_'),
-        _('Joints/Distance'),
+        _('Joints ❯ Distance'),
         'JsPlatform/Extensions/distance_joint24.png',
         'JsPlatform/Extensions/distance_joint16.png'
       )
@@ -2220,7 +2220,7 @@ module.exports = {
         'DistanceJointDampingRatio',
         _('Distance joint damping ratio'),
         _('Distance joint damping ratio'),
-        _('Joints/Distance'),
+        _('Joints ❯ Distance'),
         'JsPlatform/Extensions/distance_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2238,7 +2238,7 @@ module.exports = {
           'Add a revolute joint to an object at a fixed point. The object is attached as the second object in the joint, so you can use this for gear joints.'
         ),
         _('Add a revolute joint to _PARAM0_ at _PARAM2_;_PARAM3_'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2287,7 +2287,7 @@ module.exports = {
           'Add a revolute joint between two objects. The reference angle determines what is considered as the base angle at the initial state.'
         ),
         _('Add a revolute joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2343,7 +2343,7 @@ module.exports = {
         'RevoluteJointReferenceAngle',
         _('Revolute joint reference angle'),
         _('Revolute joint reference angle'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2357,7 +2357,7 @@ module.exports = {
         'RevoluteJointAngle',
         _('Revolute joint current angle'),
         _('Revolute joint current angle'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2371,7 +2371,7 @@ module.exports = {
         'RevoluteJointSpeed',
         _('Revolute joint angular speed'),
         _('Revolute joint angular speed'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2386,7 +2386,7 @@ module.exports = {
         _('Revolute joint limits enabled'),
         _('Check if a revolute joint limits are enabled.'),
         _('Limits for revolute joint _PARAM2_ are enabled'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2402,7 +2402,7 @@ module.exports = {
         _('Enable revolute joint limits'),
         _('Enable or disable a revolute joint angle limits.'),
         _('Enable limits for revolute joint _PARAM2_: _PARAM3_'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2419,7 +2419,7 @@ module.exports = {
         _('Revolute joint limits'),
         _('Modify a revolute joint angle limits.'),
         _('Set the limits to _PARAM3_;_PARAM4_ for revolute joint _PARAM2_'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2436,7 +2436,7 @@ module.exports = {
         'RevoluteJointMinAngle',
         _('Revolute joint minimum angle'),
         _('Revolute joint minimum angle'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2450,7 +2450,7 @@ module.exports = {
         'RevoluteJointMaxAngle',
         _('Revolute joint maximum angle'),
         _('Revolute joint maximum angle'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2465,7 +2465,7 @@ module.exports = {
         _('Revolute joint motor enabled'),
         _('Check if a revolute joint motor is enabled.'),
         _('Motor of revolute joint _PARAM2_ is enabled'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2481,7 +2481,7 @@ module.exports = {
         _('Enable revolute joint motor'),
         _('Enable or disable a revolute joint motor.'),
         _('Enable motor for revolute joint _PARAM2_: _PARAM3_'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2498,7 +2498,7 @@ module.exports = {
         _('Revolute joint motor speed'),
         _('Modify a revolute joint motor speed.'),
         _('the motor speed for revolute joint _PARAM2_'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2518,7 +2518,7 @@ module.exports = {
         'RevoluteJointMotorSpeed',
         _('Revolute joint motor speed'),
         _('Revolute joint motor speed'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2533,7 +2533,7 @@ module.exports = {
         _('Revolute joint max motor torque'),
         _('Modify a revolute joint maximum motor torque.'),
         _('the maximum motor torque for revolute joint _PARAM2_'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint24.png',
         'JsPlatform/Extensions/revolute_joint16.png'
       )
@@ -2553,7 +2553,7 @@ module.exports = {
         'RevoluteJointMaxMotorTorque',
         _('Revolute joint max motor torque'),
         _('Revolute joint maximum motor torque'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2567,7 +2567,7 @@ module.exports = {
         'RevoluteJointMotorTorque',
         _('Revolute joint motor torque'),
         _('Revolute joint motor torque'),
-        _('Joints/Revolute'),
+        _('Joints ❯ Revolute'),
         'JsPlatform/Extensions/revolute_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2585,7 +2585,7 @@ module.exports = {
           'Add a prismatic joint between two objects. The translation limits are converted to meters using the world scale on X.'
         ),
         _('Add a prismatic joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2647,7 +2647,7 @@ module.exports = {
         'PrismaticJointAxisAngle',
         _('Prismatic joint axis angle'),
         _('Prismatic joint axis angle'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2661,7 +2661,7 @@ module.exports = {
         'PrismaticJointReferenceAngle',
         _('Prismatic joint reference angle'),
         _('Prismatic joint reference angle'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2675,7 +2675,7 @@ module.exports = {
         'PrismaticJointTranslation',
         _('Prismatic joint current translation'),
         _('Prismatic joint current translation'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2689,7 +2689,7 @@ module.exports = {
         'PrismaticJointSpeed',
         _('Prismatic joint current speed'),
         _('Prismatic joint speed'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2704,7 +2704,7 @@ module.exports = {
         _('Prismatic joint limits enabled'),
         _('Check if a prismatic joint limits are enabled.'),
         _('Limits for prismatic joint _PARAM2_ are enabled'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2720,7 +2720,7 @@ module.exports = {
         _('Enable prismatic joint limits'),
         _('Enable or disable a prismatic joint limits.'),
         _('Enable limits for prismatic joint _PARAM2_: _PARAM3_'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2737,7 +2737,7 @@ module.exports = {
         _('Prismatic joint limits'),
         _('Modify a prismatic joint limits.'),
         _('Set the limits to _PARAM3_;_PARAM4_ for prismatic joint _PARAM2_'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2754,7 +2754,7 @@ module.exports = {
         'PrismaticJointMinTranslation',
         _('Prismatic joint minimum translation'),
         _('Prismatic joint minimum translation'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2768,7 +2768,7 @@ module.exports = {
         'PrismaticJointMaxTranslation',
         _('Prismatic joint maximum translation'),
         _('Prismatic joint maximum translation'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2783,7 +2783,7 @@ module.exports = {
         _('Prismatic joint motor enabled'),
         _('Check if a prismatic joint motor is enabled.'),
         _('Motor for prismatic joint _PARAM2_ is enabled'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2799,7 +2799,7 @@ module.exports = {
         _('Enable prismatic joint motor'),
         _('Enable or disable a prismatic joint motor.'),
         _('Enable motor for prismatic joint _PARAM2_: _PARAM3_'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2816,7 +2816,7 @@ module.exports = {
         _('Prismatic joint motor speed'),
         _('Modify a prismatic joint motor speed.'),
         _('the motor force for prismatic joint _PARAM2_'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2836,7 +2836,7 @@ module.exports = {
         'PrismaticJointMotorSpeed',
         _('Prismatic joint motor speed'),
         _('Prismatic joint motor speed'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2851,7 +2851,7 @@ module.exports = {
         _('Prismatic joint max motor force'),
         _('Modify a prismatic joint maximum motor force.'),
         _('the maximum motor force for prismatic joint _PARAM2_'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint24.png',
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
@@ -2871,7 +2871,7 @@ module.exports = {
         'PrismaticJointMaxMotorForce',
         _('Prismatic joint max motor force'),
         _('Prismatic joint maximum motor force'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2885,7 +2885,7 @@ module.exports = {
         'PrismaticJointMotorForce',
         _('Prismatic joint motor force'),
         _('Prismatic joint motor force'),
-        _('Joints/Prismatic'),
+        _('Joints ❯ Prismatic'),
         'JsPlatform/Extensions/prismatic_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2903,7 +2903,7 @@ module.exports = {
           'Add a pulley joint between two objects. Lengths are converted to meters using the world scale on X.'
         ),
         _('Add a pulley joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint24.png',
         'JsPlatform/Extensions/pulley_joint16.png'
       )
@@ -2962,7 +2962,7 @@ module.exports = {
         'PulleyJointFirstGroundAnchorX',
         _('Pulley joint first ground anchor X'),
         _('Pulley joint first ground anchor X'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2976,7 +2976,7 @@ module.exports = {
         'PulleyJointFirstGroundAnchorY',
         _('Pulley joint first ground anchor Y'),
         _('Pulley joint first ground anchor Y'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -2990,7 +2990,7 @@ module.exports = {
         'PulleyJointSecondGroundAnchorX',
         _('Pulley joint second ground anchor X'),
         _('Pulley joint second ground anchor X'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3004,7 +3004,7 @@ module.exports = {
         'PulleyJointSecondGroundAnchorY',
         _('Pulley joint second ground anchor Y'),
         _('Pulley joint second ground anchor Y'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3018,7 +3018,7 @@ module.exports = {
         'PulleyJointFirstLength',
         _('Pulley joint first length'),
         _('Pulley joint first length'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3032,7 +3032,7 @@ module.exports = {
         'PulleyJointSecondLength',
         _('Pulley joint second length'),
         _('Pulley joint second length'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3046,7 +3046,7 @@ module.exports = {
         'PulleyJointRatio',
         _('Pulley joint ratio'),
         _('Pulley joint ratio'),
-        _('Joints/Pulley'),
+        _('Joints ❯ Pulley'),
         'JsPlatform/Extensions/pulley_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3064,7 +3064,7 @@ module.exports = {
           'Add a gear joint between two joints. Attention: Gear joints require the joints to be revolute or prismatic, and both of them to be attached to a static body as first object.'
         ),
         _('Add a gear joint between joints _PARAM2_ and _PARAM3_'),
-        _('Joints/Gear'),
+        _('Joints ❯ Gear'),
         'JsPlatform/Extensions/gear_joint24.png',
         'JsPlatform/Extensions/gear_joint16.png'
       )
@@ -3095,7 +3095,7 @@ module.exports = {
         'GearJointFirstJoint',
         _('Gear joint first joint'),
         _('Gear joint first joint'),
-        _('Joints/Gear'),
+        _('Joints ❯ Gear'),
         'JsPlatform/Extensions/gear_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3109,7 +3109,7 @@ module.exports = {
         'GearJointSecondJoint',
         _('Gear joint second joint'),
         _('Gear joint second joint'),
-        _('Joints/Gear'),
+        _('Joints ❯ Gear'),
         'JsPlatform/Extensions/gear_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3124,7 +3124,7 @@ module.exports = {
         _('Gear joint ratio'),
         _('Modify a Gear joint ratio.'),
         _('the ratio for gear joint _PARAM2_'),
-        _('Joints/Gear'),
+        _('Joints ❯ Gear'),
         'JsPlatform/Extensions/gear_joint24.png',
         'JsPlatform/Extensions/gear_joint16.png'
       )
@@ -3144,7 +3144,7 @@ module.exports = {
         'GearJointRatio',
         _('Gear joint ratio'),
         _('Gear joint ratio'),
-        _('Joints/Gear'),
+        _('Joints ❯ Gear'),
         'JsPlatform/Extensions/gear_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3162,7 +3162,7 @@ module.exports = {
           'Add a mouse joint to an object (makes the object move towards a specific point).'
         ),
         _('Add a mouse joint to _PARAM0_'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
       )
@@ -3208,7 +3208,7 @@ module.exports = {
         _(
           'Set the target position of mouse joint _PARAM2_ of _PARAM0_ to _PARAM3_;_PARAM4_'
         ),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
       )
@@ -3225,7 +3225,7 @@ module.exports = {
         'MouseJointTargetX',
         _('Mouse joint target X'),
         _('Mouse joint target X'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3239,7 +3239,7 @@ module.exports = {
         'MouseJointTargetY',
         _('Mouse joint target Y'),
         _('Mouse joint target Y'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3254,7 +3254,7 @@ module.exports = {
         _('Mouse joint max force'),
         _('Set a mouse joint maximum force.'),
         _('the maximum force for mouse joint _PARAM2_'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
       )
@@ -3274,7 +3274,7 @@ module.exports = {
         'MouseJointMaxForce',
         _('Mouse joint max force'),
         _('Mouse joint maximum force'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3289,7 +3289,7 @@ module.exports = {
         _('Mouse joint frequency'),
         _('Set a mouse joint frequency.'),
         _('the frequency for mouse joint _PARAM2_'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
       )
@@ -3309,7 +3309,7 @@ module.exports = {
         'MouseJointFrequency',
         _('Mouse joint frequency'),
         _('Mouse joint frequency'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3324,7 +3324,7 @@ module.exports = {
         _('Mouse joint damping ratio'),
         _('Set a mouse joint damping ratio.'),
         _('the damping ratio for mouse joint _PARAM2_'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint24.png',
         'JsPlatform/Extensions/mouse_joint16.png'
       )
@@ -3344,7 +3344,7 @@ module.exports = {
         'MouseJointDampingRatio',
         _('Mouse joint damping ratio'),
         _('Mouse joint damping ratio'),
-        _('Joints/Mouse'),
+        _('Joints ❯ Mouse'),
         'JsPlatform/Extensions/mouse_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3362,7 +3362,7 @@ module.exports = {
           'Add a wheel joint between two objects. Higher frequencies means higher suspensions. Damping determines oscillations, critical damping of 1 means no oscillations.'
         ),
         _('Add a wheel joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
       )
@@ -3420,7 +3420,7 @@ module.exports = {
         'WheelJointAxisAngle',
         _('Wheel joint axis angle'),
         _('Wheel joint axis angle'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3434,7 +3434,7 @@ module.exports = {
         'WheelJointTranslation',
         _('Wheel joint current translation'),
         _('Wheel joint current translation'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3448,7 +3448,7 @@ module.exports = {
         'WheelJointSpeed',
         _('Wheel joint current speed'),
         _('Wheel joint speed'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3463,7 +3463,7 @@ module.exports = {
         _('Wheel joint motor enabled'),
         _('Check if a wheel joint motor is enabled.'),
         _('Motor for wheel joint _PARAM2_ is enabled'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
       )
@@ -3479,7 +3479,7 @@ module.exports = {
         _('Enable wheel joint motor'),
         _('Enable or disable a wheel joint motor.'),
         _('Enable motor for wheel joint _PARAM2_: _PARAM3_'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
       )
@@ -3496,7 +3496,7 @@ module.exports = {
         _('Wheel joint motor speed'),
         _('Modify a wheel joint motor speed.'),
         _('the motor speed for wheel joint _PARAM2_'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
       )
@@ -3516,7 +3516,7 @@ module.exports = {
         'WheelJointMotorSpeed',
         _('Wheel joint motor speed'),
         _('Wheel joint motor speed'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3531,7 +3531,7 @@ module.exports = {
         _('Wheel joint max motor torque'),
         _('Modify a wheel joint maximum motor torque.'),
         _('the maximum motor torque for wheel joint _PARAM2_'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
       )
@@ -3551,7 +3551,7 @@ module.exports = {
         'WheelJointMaxMotorTorque',
         _('Wheel joint max motor torque'),
         _('Wheel joint maximum motor torque'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3565,7 +3565,7 @@ module.exports = {
         'WheelJointMotorTorque',
         _('Wheel joint motor torque'),
         _('Wheel joint motor torque'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3580,7 +3580,7 @@ module.exports = {
         _('Wheel joint frequency'),
         _('Modify a wheel joint frequency.'),
         _('the frequency for wheel joint _PARAM2_'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
       )
@@ -3600,7 +3600,7 @@ module.exports = {
         'WheelJointFrequency',
         _('Wheel joint frequency'),
         _('Wheel joint frequency'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3615,7 +3615,7 @@ module.exports = {
         _('Wheel joint damping ratio'),
         _('Modify a wheel joint damping ratio.'),
         _('the damping ratio for wheel joint _PARAM2_'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint24.png',
         'JsPlatform/Extensions/wheel_joint16.png'
       )
@@ -3635,7 +3635,7 @@ module.exports = {
         'WheelJointDampingRatio',
         _('Wheel joint damping ratio'),
         _('Wheel joint damping ratio'),
-        _('Joints/Wheel'),
+        _('Joints ❯ Wheel'),
         'JsPlatform/Extensions/wheel_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3651,7 +3651,7 @@ module.exports = {
         _('Add weld joint'),
         _('Add a weld joint between two objects.'),
         _('Add a weld joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Weld'),
+        _('Joints ❯ Weld'),
         'JsPlatform/Extensions/weld_joint24.png',
         'JsPlatform/Extensions/weld_joint16.png'
       )
@@ -3699,7 +3699,7 @@ module.exports = {
         'WeldJointReferenceAngle',
         _('Weld joint reference angle'),
         _('Weld joint reference angle'),
-        _('Joints/Weld'),
+        _('Joints ❯ Weld'),
         'JsPlatform/Extensions/weld_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3714,7 +3714,7 @@ module.exports = {
         _('Weld joint frequency'),
         _('Modify a weld joint frequency.'),
         _('the frequency for weld joint _PARAM2_'),
-        _('Joints/Weld'),
+        _('Joints ❯ Weld'),
         'JsPlatform/Extensions/weld_joint24.png',
         'JsPlatform/Extensions/weld_joint16.png'
       )
@@ -3734,7 +3734,7 @@ module.exports = {
         'WeldJointFrequency',
         _('Weld joint frequency'),
         _('Weld joint frequency'),
-        _('Joints/Weld'),
+        _('Joints ❯ Weld'),
         'JsPlatform/Extensions/weld_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3749,7 +3749,7 @@ module.exports = {
         _('Weld joint damping ratio'),
         _('Modify a weld joint damping ratio.'),
         _('the damping ratio for weld joint _PARAM2_'),
-        _('Joints/Weld'),
+        _('Joints ❯ Weld'),
         'JsPlatform/Extensions/weld_joint24.png',
         'JsPlatform/Extensions/weld_joint16.png'
       )
@@ -3769,7 +3769,7 @@ module.exports = {
         'WeldJointDampingRatio',
         _('Weld joint damping ratio'),
         _('Weld joint damping ratio'),
-        _('Joints/Weld'),
+        _('Joints ❯ Weld'),
         'JsPlatform/Extensions/weld_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3787,7 +3787,7 @@ module.exports = {
           'Add a rope joint between two objects. The maximum length is converted to meters using the world scale on X.'
         ),
         _('Add a rope joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Rope'),
+        _('Joints ❯ Rope'),
         'JsPlatform/Extensions/rope_joint24.png',
         'JsPlatform/Extensions/rope_joint16.png'
       )
@@ -3827,7 +3827,7 @@ module.exports = {
         _('Rope joint max length'),
         _('Modify a rope joint maximum length.'),
         _('the maximum length for rope joint _PARAM2_'),
-        _('Joints/Rope'),
+        _('Joints ❯ Rope'),
         'JsPlatform/Extensions/rope_joint24.png',
         'JsPlatform/Extensions/rope_joint16.png'
       )
@@ -3847,7 +3847,7 @@ module.exports = {
         'RopeJointMaxLength',
         _('Rope joint max length'),
         _('Rope joint maximum length'),
-        _('Joints/Rope'),
+        _('Joints ❯ Rope'),
         'JsPlatform/Extensions/rope_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3863,7 +3863,7 @@ module.exports = {
         _('Add friction joint'),
         _('Add a friction joint between two objects.'),
         _('Add a friction joint between _PARAM0_ and _PARAM4_'),
-        _('Joints/Friction'),
+        _('Joints ❯ Friction'),
         'JsPlatform/Extensions/friction_joint24.png',
         'JsPlatform/Extensions/friction_joint16.png'
       )
@@ -3898,7 +3898,7 @@ module.exports = {
         _('Friction joint max force'),
         _('Modify a friction joint maximum force.'),
         _('the maximum force for friction joint _PARAM2_'),
-        _('Joints/Friction'),
+        _('Joints ❯ Friction'),
         'JsPlatform/Extensions/friction_joint24.png',
         'JsPlatform/Extensions/friction_joint16.png'
       )
@@ -3918,7 +3918,7 @@ module.exports = {
         'FrictionJointMaxForce',
         _('Friction joint max force'),
         _('Friction joint maximum force'),
-        _('Joints/Friction'),
+        _('Joints ❯ Friction'),
         'JsPlatform/Extensions/friction_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3933,7 +3933,7 @@ module.exports = {
         _('Friction joint max torque'),
         _('Modify a friction joint maximum torque.'),
         _('the maximum torque for friction joint _PARAM2_'),
-        _('Joints/Friction'),
+        _('Joints ❯ Friction'),
         'JsPlatform/Extensions/friction_joint24.png',
         'JsPlatform/Extensions/friction_joint16.png'
       )
@@ -3953,7 +3953,7 @@ module.exports = {
         'FrictionJointMaxTorque',
         _('Friction joint max torque'),
         _('Friction joint maximum torque'),
-        _('Joints/Friction'),
+        _('Joints ❯ Friction'),
         'JsPlatform/Extensions/friction_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -3971,7 +3971,7 @@ module.exports = {
           'Add a motor joint between two objects. The position and angle offsets are relative to the first object.'
         ),
         _('Add a motor joint between _PARAM0_ and _PARAM2_'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
       )
@@ -4007,7 +4007,7 @@ module.exports = {
         _('Motor joint offset'),
         _('Modify a motor joint offset.'),
         _('Set offset to _PARAM3_;_PARAM4_ for motor joint _PARAM2_'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
       )
@@ -4024,7 +4024,7 @@ module.exports = {
         'MotorJointOffsetX',
         _('Motor joint offset X'),
         _('Motor joint offset X'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -4038,7 +4038,7 @@ module.exports = {
         'MotorJointOffsetY',
         _('Motor joint offset Y'),
         _('Motor joint offset Y'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -4053,7 +4053,7 @@ module.exports = {
         _('Motor joint angular offset'),
         _('Modify a motor joint angular offset.'),
         _('the angular offset for motor joint _PARAM2_'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
       )
@@ -4073,7 +4073,7 @@ module.exports = {
         'MotorJointAngularOffset',
         _('Motor joint angular offset'),
         _('Motor joint angular offset'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -4088,7 +4088,7 @@ module.exports = {
         _('Motor joint max force'),
         _('Modify a motor joint maximum force.'),
         _('the maximum force for motor joint _PARAM2_'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
       )
@@ -4108,7 +4108,7 @@ module.exports = {
         'MotorJointMaxForce',
         _('Motor joint max force'),
         _('Motor joint maximum force'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -4123,7 +4123,7 @@ module.exports = {
         _('Motor joint max torque'),
         _('Modify a motor joint maximum torque.'),
         _('the maximum torque for motor joint _PARAM2_'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
       )
@@ -4143,7 +4143,7 @@ module.exports = {
         'MotorJointMaxTorque',
         _('Motor joint max torque'),
         _('Motor joint maximum torque'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)
@@ -4158,7 +4158,7 @@ module.exports = {
         _('Motor joint correction factor'),
         _('Modify a motor joint correction factor.'),
         _('the correction factor for motor joint _PARAM2_'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint24.png',
         'JsPlatform/Extensions/motor_joint16.png'
       )
@@ -4178,7 +4178,7 @@ module.exports = {
         'MotorJointCorrectionFactor',
         _('Motor joint correction factor'),
         _('Motor joint correction factor'),
-        _('Joints/Motor'),
+        _('Joints ❯ Motor'),
         'JsPlatform/Extensions/motor_joint16.png'
       )
       .addParameter('object', _('Object'), '', false)

--- a/Extensions/Steamworks/JsExtension.js
+++ b/Extensions/Steamworks/JsExtension.js
@@ -341,7 +341,7 @@ module.exports = {
         _('Leave current lobby'),
         _('Marks the player as having left the current lobby.'),
         _('Leave the current lobby'),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg',
         'JsPlatform/Extensions/steam.svg'
       )
@@ -357,7 +357,7 @@ module.exports = {
           'Opens the steam invitation dialogue to let the player invite their Steam friends to the current lobby. Only works if the player is currently in a lobby.'
         ),
         _('Open lobby invitation dialogue'),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg',
         'JsPlatform/Extensions/steam.svg'
       )
@@ -377,7 +377,7 @@ module.exports = {
         _(
           'Set current lobby attribute _PARAM0_ to _PARAM1_ (store result in _PARAM2_)'
         ),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg',
         'JsPlatform/Extensions/steam.svg'
       )
@@ -402,7 +402,7 @@ module.exports = {
         _('Set the lobby joinability'),
         _('Sets whether other users can join the current lobby or not.'),
         _('Make current lobby joinable: _PARAM0_ (store result in _PARAM1_)'),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg',
         'JsPlatform/Extensions/steam.svg'
       )
@@ -421,7 +421,7 @@ module.exports = {
         _("Get the lobby's members"),
         _('Gets the Steam ID of all players in the current lobby.'),
         _('Store the array of all players in _PARAM0_'),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg',
         'JsPlatform/Extensions/steam.svg'
       )
@@ -463,7 +463,7 @@ module.exports = {
         _(
           'The ID of the current lobby, useful for letting other players join it.'
         ),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg'
       )
       .getCodeExtraInformation()
@@ -475,7 +475,7 @@ module.exports = {
         'CurrentLobbyAttribute',
         _('Attribute of the lobby'),
         _("Obtains the value of one of the current lobby's attributes."),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg'
       )
       .addParameter(
@@ -493,7 +493,7 @@ module.exports = {
         'CurrentLobbyMemberCount',
         _('Member count of the lobby'),
         _("Obtains the current lobby's member count."),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg'
       )
       .getCodeExtraInformation()
@@ -505,7 +505,7 @@ module.exports = {
         'CurrentLobbyMemberLimit',
         _('Member limit of the lobby'),
         _("Obtains the current lobby's maximum member limit."),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg'
       )
       .getCodeExtraInformation()
@@ -517,7 +517,7 @@ module.exports = {
         'CurrentLobbyOwner',
         _('Owner of the lobby'),
         _('Obtains the Steam ID of the user that owns the current lobby.'),
-        _('Matchmaking/Current lobby'),
+        _('Matchmaking ❯ Current lobby'),
         'JsPlatform/Extensions/steam.svg'
       )
       .getCodeExtraInformation()
@@ -1200,7 +1200,7 @@ module.exports = {
         _(
           'The amount of data that has been downloaded by Steam for a currrently downloading item so far.'
         ),
-        _('Workshop/Download'),
+        _('Workshop ❯ Download'),
         'JsPlatform/Extensions/steam.svg'
       )
       .addParameter(
@@ -1220,7 +1220,7 @@ module.exports = {
         _(
           'The amount of data that needs to be downloaded in total by Steam for a currrently downloading item.'
         ),
-        _('Workshop/Download'),
+        _('Workshop ❯ Download'),
         'JsPlatform/Extensions/steam.svg'
       )
       .addParameter(

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionTreeViewItems.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionOrExpressionTreeViewItems.js
@@ -192,9 +192,10 @@ export class InstructionTreeViewItemContent implements TreeViewItemContent {
     return {
       instructionType: this.instructionMetadata.type.replace(/:/g, '-'),
       object: this.instructionMetadata.scope.objectMetadata
-        ? this.instructionMetadata.scope.objectMetadata
-            .getName()
-            .replace(/:/g, '-') + '-'
+        ? this.instructionMetadata.scope.objectMetadata.name.replace(
+            /:/g,
+            '-'
+          ) + '-'
         : undefined,
     };
   }

--- a/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/Keys.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/SelectorListItems/Keys.js
@@ -28,7 +28,7 @@ export const getInstructionListItemKey = (
 ) =>
   `instruction-key-${instruction.fullGroupName}${
     instruction.scope.objectMetadata
-      ? '-' + instruction.scope.objectMetadata.getName()
+      ? '-' + instruction.scope.objectMetadata.name
       : ''
   }-${instruction.type}`;
 
@@ -52,8 +52,9 @@ export const getInstructionOrExpressionIdentifier = (
 ): string =>
   `instruction-or-expression-${
     instructionOrExpressionMetadata.scope.objectMetadata
-      ? instructionOrExpressionMetadata.scope.objectMetadata
-          .getName()
-          .replace(/:/g, '-') + '-'
+      ? instructionOrExpressionMetadata.scope.objectMetadata.name.replace(
+          /:/g,
+          '-'
+        ) + '-'
       : ''
   }${instructionOrExpressionMetadata.type.replace(/:/g, '-')}`;

--- a/newIDE/app/src/EventsSheet/InstructionEditor/TreeViewItems.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/TreeViewItems.js
@@ -306,9 +306,10 @@ export class InstructionTreeViewItemContent implements TreeViewItemContent {
     return {
       instructionType: this.instructionMetadata.type.replace(/:/g, '-'),
       object: this.instructionMetadata.scope.objectMetadata
-        ? this.instructionMetadata.scope.objectMetadata
-            .getName()
-            .replace(/:/g, '-') + '-'
+        ? this.instructionMetadata.scope.objectMetadata.name.replace(
+            /:/g,
+            '-'
+          ) + '-'
         : undefined,
     };
   }

--- a/newIDE/app/src/InstructionOrExpression/CreateTree.js
+++ b/newIDE/app/src/InstructionOrExpression/CreateTree.js
@@ -10,7 +10,7 @@ import {
 } from './EnumeratedInstructionOrExpressionMetadata';
 import { getInstructionType } from '../EventsSheet/InstructionEditor/SelectorListItems/Keys';
 
-const GROUP_DELIMITER = '/';
+const GROUP_DELIMITER = ' ❯ ';
 const getSortedFreeInstructionsTopLevelGroups = (i18n: I18nType) => [
   i18n._(t`General`),
   i18n._(t`Input`),

--- a/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.js
@@ -9,7 +9,7 @@ import flatten from 'lodash/flatten';
 import { getExtensionPrefix } from './EnumerateInstructions';
 const gd: libGDevelop = global.gd;
 
-const GROUP_DELIMITER = '/';
+const GROUP_DELIMITER = ' ❯ ';
 
 const shouldOnlyBeNumberType = (type: string) => type === 'number';
 
@@ -66,7 +66,7 @@ export const enumerateFreeExpressions = (
     mapVector(allExtensions, extension => {
       const prefix = getExtensionPrefix(extension, i18n);
       const scope = {
-        extension,
+        extension: { name: extension.getName() },
         objectMetadata: undefined,
         behaviorMetadata: undefined,
       };
@@ -100,7 +100,13 @@ export const enumerateObjectExpressions = (
   );
   const extension = extensionAndObjectMetadata.getExtension();
   const objectMetadata = extensionAndObjectMetadata.getMetadata();
-  const scope = { extension, objectMetadata };
+  const scope = {
+    extension: { name: extension.getName() },
+    objectMetadata: {
+      name: objectMetadata.getName(),
+      isPrivate: objectMetadata.isPrivate(),
+    },
+  };
 
   let objectsExpressions = [
     ...(shouldOnlyBeNumberType(type)
@@ -156,7 +162,13 @@ export const enumerateBehaviorExpressions = (
   );
   const extension = extensionAndBehaviorMetadata.getExtension();
   const behaviorMetadata = extensionAndBehaviorMetadata.getMetadata();
-  const scope = { extension, behaviorMetadata };
+  const scope = {
+    extension: { name: extension.getName() },
+    behaviorMetadata: {
+      name: behaviorMetadata.getName(),
+      isPrivate: behaviorMetadata.isPrivate(),
+    },
+  };
 
   return [
     ...(shouldOnlyBeNumberType(type)
@@ -192,7 +204,13 @@ export const enumerateAllExpressions = (
     //Objects expressions:
     mapVector(extension.getExtensionObjectsTypes(), objectType => {
       const objectMetadata = extension.getObjectMetadata(objectType);
-      const scope = { extension, objectMetadata };
+      const scope = {
+        extension: { name: extension.getName() },
+        objectMetadata: {
+          name: objectMetadata.getName(),
+          isPrivate: objectMetadata.isPrivate(),
+        },
+      };
 
       if (!shouldOnlyBeNumberType(type))
         objectsExpressions.push.apply(
@@ -216,7 +234,13 @@ export const enumerateAllExpressions = (
     //Behaviors expressions:
     mapVector(extension.getBehaviorsTypes(), behaviorType => {
       const behaviorMetadata = extension.getBehaviorMetadata(behaviorType);
-      const scope = { extension, behaviorMetadata };
+      const scope = {
+        extension: { name: extension.getName() },
+        behaviorMetadata: {
+          name: behaviorMetadata.getName(),
+          isPrivate: behaviorMetadata.isPrivate(),
+        },
+      };
 
       if (!shouldOnlyBeNumberType(type))
         behaviorsExpressions.push.apply(

--- a/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateExpressions.spec.js
@@ -229,7 +229,7 @@ describe('EnumerateExpressions', () => {
       'Timers and time': {
         Time: {
           displayedName: 'Current time',
-          fullGroupName: 'General/Timers and time',
+          fullGroupName: 'General ❯ Timers and time',
           iconFilename: 'res/actions/time.png',
           isPrivate: false,
           name: 'Time',
@@ -251,7 +251,7 @@ describe('EnumerateExpressions', () => {
       Angle: {
         Angle: {
           displayedName: 'Angle',
-          fullGroupName: 'General/Objects/Angle',
+          fullGroupName: 'General ❯ Objects ❯ Angle',
           iconFilename: 'res/actions/direction_black.png',
           isPrivate: false,
           name: 'Angle',
@@ -270,7 +270,7 @@ describe('EnumerateExpressions', () => {
       Position: {
         PointX: {
           displayedName: 'X position of a point',
-          fullGroupName: 'General/Sprite/Position',
+          fullGroupName: 'General ❯ Sprite ❯ Position',
           iconFilename: 'res/actions/position_black.png',
           isPrivate: false,
           name: 'PointX',
@@ -292,7 +292,8 @@ describe('EnumerateExpressions', () => {
       'Platformer configuration': {
         MaxSpeed: {
           displayedName: 'Maximum horizontal speed',
-          fullGroupName: 'Movement/Platform behavior/Platformer configuration',
+          fullGroupName:
+            'Movement ❯ Platform behavior ❯ Platformer configuration',
           iconFilename: 'CppPlatform/Extensions/platformerobjecticon.png',
           isPrivate: false,
           name: 'MaxSpeed',

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.js
@@ -8,7 +8,7 @@ import { translateExtensionCategory } from '../Utils/Extension/ExtensionCategori
 
 const gd: libGDevelop = global.gd;
 
-const GROUP_DELIMITER = '/';
+const GROUP_DELIMITER = ' ❯ ';
 
 const freeInstructionsToKeep = {
   BuiltinObject: [
@@ -360,7 +360,7 @@ export const enumerateAllInstructions = (
       prefix,
       isCondition ? extension.getAllConditions() : extension.getAllActions(),
       {
-        extension,
+        extension: { name: extension.getName() },
         objectMetadata: undefined,
         behaviorMetadata: undefined,
       },
@@ -372,7 +372,13 @@ export const enumerateAllInstructions = (
     for (let j = 0; j < allObjectsTypes.size(); ++j) {
       const objectType = allObjectsTypes.at(j);
       const objectMetadata = extension.getObjectMetadata(objectType);
-      const scope = { extension, objectMetadata };
+      const scope = {
+        extension: { name: extension.getName() },
+        objectMetadata: {
+          name: objectMetadata.getName(),
+          isPrivate: objectMetadata.isPrivate(),
+        },
+      };
       allInstructions = [
         ...allInstructions,
         ...enumerateExtensionInstructions(
@@ -390,7 +396,13 @@ export const enumerateAllInstructions = (
     for (let j = 0; j < allBehaviorsTypes.size(); ++j) {
       const behaviorType = allBehaviorsTypes.at(j);
       const behaviorMetadata = extension.getBehaviorMetadata(behaviorType);
-      const scope = { extension, behaviorMetadata };
+      const scope = {
+        extension: { name: extension.getName() },
+        behaviorMetadata: {
+          name: behaviorMetadata.getName(),
+          isPrivate: behaviorMetadata.isPrivate(),
+        },
+      };
 
       allInstructions = [
         ...allInstructions,
@@ -468,7 +480,13 @@ export const enumerateObjectAndBehaviorsInstructions = (
   );
   const extension = extensionAndObjectMetadata.getExtension();
   const objectMetadata = extensionAndObjectMetadata.getMetadata();
-  const scope = { extension, objectMetadata };
+  const scope = {
+    extension: { name: extension.getName() },
+    objectMetadata: {
+      name: objectMetadata.getName(),
+      isPrivate: objectMetadata.isPrivate(),
+    },
+  };
   const prefix = '';
 
   // Free instructions
@@ -490,7 +508,13 @@ export const enumerateObjectAndBehaviorsInstructions = (
     .getAllPlatformExtensions();
   for (let i = 0; i < allExtensions.size(); ++i) {
     const extension = allExtensions.at(i);
-    const scope = { extension, objectMetadata };
+    const scope = {
+      extension: { name: extension.getName() },
+      objectMetadata: {
+        name: objectMetadata.getName(),
+        isPrivate: objectMetadata.isPrivate(),
+      },
+    };
 
     allInstructions = [
       ...allInstructions,
@@ -538,7 +562,13 @@ export const enumerateObjectAndBehaviorsInstructions = (
     // eslint-disable-next-line
     behaviorTypes.forEach(behaviorType => {
       const behaviorMetadata = extension.getBehaviorMetadata(behaviorType);
-      const scope = { extension, behaviorMetadata };
+      const scope = {
+        extension: { name: extension.getName() },
+        behaviorMetadata: {
+          name: behaviorMetadata.getName(),
+          isPrivate: behaviorMetadata.isPrivate(),
+        },
+      };
 
       // Free functions can require a behavior even if this behavior is from
       // another extension.
@@ -613,7 +643,7 @@ export const enumerateFreeInstructions = (
         isCondition,
         extension,
         {
-          extension,
+          extension: { name: extension.getName() },
           objectMetadata: undefined,
           behaviorMetadata: undefined,
         },

--- a/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumerateInstructions.spec.js
@@ -32,7 +32,8 @@ describe('EnumerateInstructions', () => {
     ).toEqual(
       expect.objectContaining({
         displayedName: 'Animation finished',
-        fullGroupName: 'General/Animatable capability/Animations and images',
+        fullGroupName:
+          'General ❯ Animatable capability ❯ Animations and images',
         type: 'AnimatableCapability::AnimatableBehavior::HasAnimationEnded',
       })
     );
@@ -41,7 +42,7 @@ describe('EnumerateInstructions', () => {
     ).toEqual(
       expect.objectContaining({
         displayedName: 'Current frame',
-        fullGroupName: 'General/Sprite/Animations and images',
+        fullGroupName: 'General ❯ Sprite ❯ Animations and images',
         type: 'Sprite',
       })
     );
@@ -52,7 +53,7 @@ describe('EnumerateInstructions', () => {
     ).toEqual(
       expect.objectContaining({
         displayedName: 'Trigger once while true',
-        fullGroupName: 'Advanced/Events and control flow',
+        fullGroupName: 'Advanced ❯ Events and control flow',
         type: 'BuiltinCommonInstructions::Once',
       })
     );
@@ -61,7 +62,7 @@ describe('EnumerateInstructions', () => {
     ).toEqual(
       expect.objectContaining({
         displayedName: 'The cursor/touch is on an object',
-        fullGroupName: 'General/Objects/Mouse and touch',
+        fullGroupName: 'General ❯ Objects ❯ Mouse and touch',
         type: 'SourisSurObjet',
       })
     );
@@ -79,12 +80,12 @@ describe('EnumerateInstructions', () => {
       expect.arrayContaining([
         expect.objectContaining({
           displayedName: 'Start (or reset) a scene timer',
-          fullGroupName: 'General/Timers and time',
+          fullGroupName: 'General ❯ Timers and time',
           type: 'ResetTimer',
         }),
         expect.objectContaining({
           displayedName: 'Rotate',
-          fullGroupName: 'General/Objects/Angle',
+          fullGroupName: 'General ❯ Objects ❯ Angle',
           type: 'Rotate',
         }),
       ])
@@ -101,7 +102,7 @@ describe('EnumerateInstructions', () => {
         'Events and control flow': {
           'BuiltinCommonInstructions::Once': {
             displayedName: 'Trigger once while true',
-            fullGroupName: 'Advanced/Events and control flow',
+            fullGroupName: 'Advanced ❯ Events and control flow',
             type: 'BuiltinCommonInstructions::Once',
           },
         },
@@ -110,7 +111,7 @@ describe('EnumerateInstructions', () => {
         'Sounds and music': {
           GlobalVolume: {
             displayedName: 'Global volume',
-            fullGroupName: 'Audio/Sounds and music',
+            fullGroupName: 'Audio ❯ Sounds and music',
             type: 'GlobalVolume',
           },
         },

--- a/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.spec.js
+++ b/newIDE/app/src/InstructionOrExpression/EnumeratedInstructionOrExpressionMetadata.spec.js
@@ -26,7 +26,7 @@ describe('EnumeratedInstructionOrExpressionMetadata', () => {
       expect.not.arrayContaining([
         expect.objectContaining({
           displayedName: 'Set number return value',
-          fullGroupName: 'Advanced/Event functions',
+          fullGroupName: 'Advanced ❯ Event functions',
           type: 'SetReturnNumber',
         }),
       ])
@@ -55,7 +55,7 @@ describe('EnumeratedInstructionOrExpressionMetadata', () => {
       expect.arrayContaining([
         expect.objectContaining({
           displayedName: 'Set number return value',
-          fullGroupName: 'Advanced/Event functions',
+          fullGroupName: 'Advanced ❯ Event functions',
           type: 'SetReturnNumber',
         }),
       ])

--- a/newIDE/app/src/fixtures/TestExpressionAutocompletions.js
+++ b/newIDE/app/src/fixtures/TestExpressionAutocompletions.js
@@ -32,7 +32,11 @@ const makeFakeEnumeratedExpressionMetadata = (
     parameterIndex =>
       expressionMetadata.getParameters().getParameterAt(parameterIndex)
   ),
-  scope: { extension },
+  scope: {
+    extension: {
+      name: extension.getName(),
+    },
+  },
   isPrivate: false,
   isRelevantForLayoutEvents: true,
   isRelevantForFunctionEvents: true,


### PR DESCRIPTION
Fix risk of crash because reading ObjectMetadata or BehaviorMetadata that are C++ objects that could have been destroyed if extensions have finished being re-generated in the meantime.
Instead, store needed information only when the instructions are enumerated, so we don't risk accessing invalid C++ objects when a search is done.

Also update separator when showing results in UI: 
<img width="545" alt="image" src="https://github.com/user-attachments/assets/ef26970f-64d7-4949-b2a7-1dc79d01a8ae" />
<img width="534" alt="image" src="https://github.com/user-attachments/assets/c49a3841-ace7-42d2-998c-f5e9f1ed08e8" />
