### PR TITLE
Adaptive tabs according to screen width

### DIFF
--- a/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
@@ -82,10 +82,15 @@ export function DraggableEditorTabs({
         return editors.map((editorTab, id) => {
           const isCurrentTab = getCurrentTabIndex(editorTabs) === id;
 
-          // Maximum width of a tab is the width so that all tabs can fit it.
-          // The home tab is special because it's just an icon.
-          const maxWidth =
-            (containerWidth - homeTabApproximateWidth) / (editors.length - 1);
+          // Maximum width of a tab is the width so that all tabs can fit it,
+          // unless on a small screen, where we want to avoid compressing tabs too much
+          // (and encourage scrolling instead).
+          const minimumMaxWidth = windowSize === 'small' ? 100 : 0;
+          const maxWidth = Math.max(
+            minimumMaxWidth,
+            // The home tab is special because it's just an icon.
+            (containerWidth - homeTabApproximateWidth) / (editors.length - 1)
+          );
 
           return (
             <DraggableClosableTab

--- a/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
+++ b/newIDE/app/src/MainFrame/EditorTabs/DraggableEditorTabs.js
@@ -17,6 +17,8 @@ import {
   type ClosableTabProps,
 } from '../../UI/ClosableTabs';
 import { useResponsiveWindowSize } from '../../UI/Responsive/ResponsiveWindowMeasurer';
+import useOnResize from '../../Utils/UseOnResize';
+import useForceUpdate from '../../Utils/UseForceUpdate';
 
 const DragSourceAndDropTarget = makeDragSourceAndDropTarget<EditorTab>(
   'draggable-closable-tab'
@@ -36,6 +38,8 @@ type DraggableEditorTabsProps = {|
 const getTabId = (editorTab: EditorTab) =>
   `tab-${editorTab.key.replace(/\s/g, '-')}`;
 
+const homeTabApproximateWidth = 35;
+
 export function DraggableEditorTabs({
   hideLabels,
   editorTabs,
@@ -47,6 +51,9 @@ export function DraggableEditorTabs({
   onDropTab,
 }: DraggableEditorTabsProps) {
   let draggedTabIndex: ?number = null;
+
+  // Ensure the component is re-rendered when the window is resized.
+  useOnResize(useForceUpdate());
   const { windowSize } = useResponsiveWindowSize();
 
   const currentTab = getCurrentTab(editorTabs);
@@ -68,39 +75,52 @@ export function DraggableEditorTabs({
   );
 
   return (
-    <ClosableTabs hideLabels={hideLabels}>
-      {getEditors(editorTabs).map((editorTab, id) => {
-        const isCurrentTab = getCurrentTabIndex(editorTabs) === id;
-        return (
-          <DraggableClosableTab
-            index={id}
-            label={editorTab.label}
-            icon={editorTab.icon}
-            renderCustomIcon={editorTab.renderCustomIcon}
-            key={editorTab.key}
-            id={getTabId(editorTab)}
-            data={editorTab.tabOptions ? editorTab.tabOptions.data : undefined}
-            active={isCurrentTab}
-            onClick={() => onClickTab(id)}
-            onClose={() => onCloseTab(editorTab)}
-            onCloseOthers={() => onCloseOtherTabs(editorTab)}
-            onCloseAll={onCloseAll}
-            onActivated={() => onTabActivated(editorTab)}
-            closable={editorTab.closable}
-            onBeginDrag={() => {
-              draggedTabIndex = id;
-              return editorTab;
-            }}
-            onDrop={toHoveredIndex => {
-              if (typeof draggedTabIndex === 'number') {
-                onDropTab(draggedTabIndex, id);
-                draggedTabIndex = null;
+    <ClosableTabs
+      hideLabels={hideLabels}
+      renderTabs={({ containerWidth }) => {
+        const editors = getEditors(editorTabs);
+        return editors.map((editorTab, id) => {
+          const isCurrentTab = getCurrentTabIndex(editorTabs) === id;
+
+          // Maximum width of a tab is the width so that all tabs can fit it.
+          // The home tab is special because it's just an icon.
+          const maxWidth =
+            (containerWidth - homeTabApproximateWidth) / (editors.length - 1);
+
+          return (
+            <DraggableClosableTab
+              index={id}
+              label={editorTab.label}
+              icon={editorTab.icon}
+              renderCustomIcon={editorTab.renderCustomIcon}
+              key={editorTab.key}
+              id={getTabId(editorTab)}
+              data={
+                editorTab.tabOptions ? editorTab.tabOptions.data : undefined
               }
-            }}
-          />
-        );
-      })}
-    </ClosableTabs>
+              active={isCurrentTab}
+              onClick={() => onClickTab(id)}
+              onClose={() => onCloseTab(editorTab)}
+              onCloseOthers={() => onCloseOtherTabs(editorTab)}
+              onCloseAll={onCloseAll}
+              onActivated={() => onTabActivated(editorTab)}
+              closable={editorTab.closable}
+              onBeginDrag={() => {
+                draggedTabIndex = id;
+                return editorTab;
+              }}
+              onDrop={toHoveredIndex => {
+                if (typeof draggedTabIndex === 'number') {
+                  onDropTab(draggedTabIndex, id);
+                  draggedTabIndex = null;
+                }
+              }}
+              maxWidth={maxWidth}
+            />
+          );
+        });
+      }}
+    />
   );
 }
 
@@ -127,6 +147,7 @@ export function DraggableClosableTab({
   onActivated,
   onBeginDrag,
   onDrop,
+  maxWidth,
 }: DraggableClosableTabProps) {
   return (
     <ScreenTypeMeasurer>
@@ -165,6 +186,7 @@ export function DraggableClosableTab({
                   closable={closable}
                   onClick={onClick}
                   onActivated={onActivated}
+                  maxWidth={maxWidth}
                   key={id}
                 />
                 {isOver && <ColumnDropIndicator />}

--- a/newIDE/app/src/MainFrame/TabsTitlebar.js
+++ b/newIDE/app/src/MainFrame/TabsTitlebar.js
@@ -9,6 +9,8 @@ import {
   TitleBarRightSafeMargins,
 } from '../UI/TitleBarSafeMargins';
 
+const DRAGGABLE_PART_CLASS_NAME = 'title-bar-draggable-part';
+
 type Props = {|
   children: React.Node,
   toggleProjectManager: () => void,
@@ -49,6 +51,7 @@ export default function TabsTitlebar({
         size="small"
         // Even if not in the toolbar, keep this ID for backward compatibility for tutorials.
         id="main-toolbar-project-manager-button"
+        className={DRAGGABLE_PART_CLASS_NAME}
         style={styles.menuIcon}
         color="default"
         onClick={toggleProjectManager}
@@ -56,7 +59,7 @@ export default function TabsTitlebar({
         <MenuIcon />
       </IconButton>
       {children}
-      <TitleBarRightSafeMargins rightSideAdditionalOffsetToGiveSpaceToDrag />
+      <TitleBarRightSafeMargins />
     </div>
   );
 }

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -19,7 +19,6 @@ const styles = {
     flex: 1,
   },
   tabLabel: {
-    maxWidth: 360,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -76,13 +75,14 @@ export class TabContentContainer extends React.Component<TabContentContainerProp
 
 type ClosableTabsProps = {|
   hideLabels?: boolean,
-  children: React.Node,
+  renderTabs: ({| containerWidth: number |}) => React.Node,
 |};
 
-export const ClosableTabs = ({ hideLabels, children }: ClosableTabsProps) => {
+export const ClosableTabs = ({ hideLabels, renderTabs }: ClosableTabsProps) => {
   const containerRef = React.useRef<?HTMLDivElement>(null);
   const tabItemContainerStyle = {
     maxWidth: '100%', // Tabs should take all width
+    flex: 1,
     display: hideLabels ? 'none' : 'flex',
     flexWrap: 'nowrap', // Single line of tab...
     overflowX: 'overlay', // ...scroll horizontally if needed
@@ -97,6 +97,10 @@ export const ClosableTabs = ({ hideLabels, children }: ClosableTabsProps) => {
     }
   }, []);
 
+  const containerWidth = containerRef.current
+    ? containerRef.current.clientWidth
+    : null;
+
   return (
     <div
       ref={containerRef}
@@ -104,7 +108,7 @@ export const ClosableTabs = ({ hideLabels, children }: ClosableTabsProps) => {
       style={tabItemContainerStyle}
       onWheel={onScroll}
     >
-      {children}
+      {containerWidth !== null ? renderTabs({ containerWidth }) : null}
     </div>
   );
 };
@@ -122,6 +126,7 @@ export type ClosableTabProps = {|
   onCloseAll: () => void,
   onClick: () => void,
   onActivated: () => void,
+  maxWidth: number,
 |};
 
 export function ClosableTab({
@@ -137,6 +142,7 @@ export function ClosableTab({
   closable,
   onClick,
   onActivated,
+  maxWidth,
 }: ClosableTabProps) {
   React.useEffect(
     () => {
@@ -189,6 +195,14 @@ export function ClosableTab({
       : active
       ? 0.022
       : 0.224;
+
+  const labelMaxWidth = Math.max(
+    0.1, // No negative max-width, which would actually not enforce any max width.
+    (maxWidth || 320) -
+    20 /* Close button */ -
+    32 /* Icon */ -
+      9 /* Extra margins */
+  );
 
   return (
     <React.Fragment>
@@ -244,7 +258,17 @@ export function ClosableTab({
                 {renderCustomIcon ? renderCustomIcon(brightness) : icon}
               </span>
             ) : null}
-            {label && <span style={styles.tabLabel}>{label}</span>}
+            {label && (
+              <span
+                style={{
+                  ...styles.tabLabel,
+                  maxWidth: labelMaxWidth,
+                }}
+                title={label}
+              >
+                {label}
+              </span>
+            )}
           </span>
         </ButtonBase>
         {closable && (

--- a/newIDE/app/src/UI/ClosableTabs.js
+++ b/newIDE/app/src/UI/ClosableTabs.js
@@ -8,6 +8,8 @@ import { useLongTouch } from '../Utils/UseLongTouch';
 import GDevelopThemeContext from './Theme/GDevelopThemeContext';
 import { dataObjectToProps, type HTMLDataset } from '../Utils/HTMLDataset';
 import Cross from './CustomSvgIcons/Cross';
+import useForceUpdate from '../Utils/UseForceUpdate';
+import useOnResize from '../Utils/UseOnResize';
 
 const styles = {
   tabContentContainer: {
@@ -79,6 +81,7 @@ type ClosableTabsProps = {|
 |};
 
 export const ClosableTabs = ({ hideLabels, renderTabs }: ClosableTabsProps) => {
+  const forceUpdate = useForceUpdate();
   const containerRef = React.useRef<?HTMLDivElement>(null);
   const tabItemContainerStyle = {
     maxWidth: '100%', // Tabs should take all width
@@ -100,6 +103,14 @@ export const ClosableTabs = ({ hideLabels, renderTabs }: ClosableTabsProps) => {
   const containerWidth = containerRef.current
     ? containerRef.current.clientWidth
     : null;
+
+  React.useLayoutEffect(
+    () => {
+      // Force a re-render the first time after we know the container width.
+      forceUpdate();
+    },
+    [forceUpdate]
+  );
 
   return (
     <div

--- a/newIDE/app/src/UI/IconButton.js
+++ b/newIDE/app/src/UI/IconButton.js
@@ -36,6 +36,7 @@ type Props = {|
   edge?: 'start' | 'end' | false,
   id?: string,
 
+  className?: string,
   style?: {|
     padding?: number | string,
     width?: number,

--- a/newIDE/app/src/UI/TitleBarSafeMargins.js
+++ b/newIDE/app/src/UI/TitleBarSafeMargins.js
@@ -14,7 +14,7 @@ const titleBarStyles = {
     alignSelf: 'stretch',
     flexShrink: 0,
   },
-  rightSideArea: { alignSelf: 'stretch', flex: 1 },
+  rightSideArea: { alignSelf: 'stretch', flexShrink: 0 },
 };
 
 export const TitleBarLeftSafeMargins = ({
@@ -69,10 +69,8 @@ export const TitleBarLeftSafeMargins = ({
 
 export const TitleBarRightSafeMargins = ({
   backgroundColor,
-  rightSideAdditionalOffsetToGiveSpaceToDrag,
 }: {|
   backgroundColor?: string,
-  rightSideAdditionalOffsetToGiveSpaceToDrag?: boolean,
 |}) => {
   // An installed PWA can have window controls displayed as overlay. If supported,
   // we set up a listener to detect any change and force a refresh that will read
@@ -95,9 +93,6 @@ export const TitleBarRightSafeMargins = ({
     }
   }
 
-  const draggableMinWidth =
-    rightSideOffset + (rightSideAdditionalOffsetToGiveSpaceToDrag ? 30 : 0);
-
   // Always display this draggable area, as it will take the whole available space
   // in the title bar.
   return (
@@ -105,7 +100,7 @@ export const TitleBarRightSafeMargins = ({
       className={DRAGGABLE_PART_CLASS_NAME}
       style={{
         ...titleBarStyles.rightSideArea,
-        minWidth: draggableMinWidth,
+        minWidth: rightSideOffset,
         backgroundColor: backgroundColor || 'transparent',
       }}
     />

--- a/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
+++ b/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
@@ -8,7 +8,7 @@ import {
 } from '../../UI/ClosableTabs';
 import ValueStateHolder from '../ValueStateHolder';
 import FixedHeightFlexContainer from '../FixedHeightFlexContainer';
-import { Column } from '../../UI/Grid';
+import { Column, Line } from '../../UI/Grid';
 import DragAndDropContextProvider from '../../UI/DragAndDrop/DragAndDropContextProvider';
 import ObjectsList from '../../ObjectsList';
 import GDevelopJsInitializerDecorator, {
@@ -30,48 +30,50 @@ export const ThreeTabs = () => (
     render={(value, onChange) => (
       <FixedHeightFlexContainer height={400}>
         <Column expand>
-          <ClosableTabs
-            renderTabs={({ containerWidth }) => (
-              <>
-                <ClosableTab
-                  onActivated={action('Tab 1 activated')}
-                  closable={false}
-                  active={value === 0}
-                  onClick={() => onChange(0)}
-                  label={null}
-                  icon={<Home />}
-                  onClose={action('Close tab 1')}
-                  onCloseAll={action('Close all')}
-                  onCloseOthers={action('Close others')}
-                  maxWidth={300}
-                />
-                <ClosableTab
-                  onActivated={action('Tab 2 activated')}
-                  closable
-                  active={value === 1}
-                  onClick={() => onChange(1)}
-                  label="Tab 2"
-                  icon={null}
-                  onClose={action('Close tab 2')}
-                  onCloseAll={action('Close all')}
-                  onCloseOthers={action('Close others')}
-                  maxWidth={300}
-                />
-                <ClosableTab
-                  onActivated={action('Tab 3 activated')}
-                  closable
-                  active={value === 2}
-                  onClick={() => onChange(2)}
-                  label="Tab 3 with a long label"
-                  icon={null}
-                  onClose={action('Close tab 3')}
-                  onCloseAll={action('Close all')}
-                  onCloseOthers={action('Close others')}
-                  maxWidth={300}
-                />
-              </>
-            )}
-          />
+          <Line noMargin>
+            <ClosableTabs
+              renderTabs={({ containerWidth }) => (
+                <>
+                  <ClosableTab
+                    onActivated={action('Tab 1 activated')}
+                    closable={false}
+                    active={value === 0}
+                    onClick={() => onChange(0)}
+                    label={null}
+                    icon={<Home />}
+                    onClose={action('Close tab 1')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                  <ClosableTab
+                    onActivated={action('Tab 2 activated')}
+                    closable
+                    active={value === 1}
+                    onClick={() => onChange(1)}
+                    label="Tab 2"
+                    icon={null}
+                    onClose={action('Close tab 2')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                  <ClosableTab
+                    onActivated={action('Tab 3 activated')}
+                    closable
+                    active={value === 2}
+                    onClick={() => onChange(2)}
+                    label="Tab 3 with a long label"
+                    icon={null}
+                    onClose={action('Close tab 3')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                </>
+              )}
+            />
+          </Line>
           {
             <TabContentContainer active={value === 0}>
               <div
@@ -111,60 +113,62 @@ export const LongLabels = () => (
     render={(value, onChange) => (
       <FixedHeightFlexContainer height={400}>
         <Column expand>
-          <ClosableTabs
-            renderTabs={({ containerWidth }) => (
-              <>
-                <ClosableTab
-                  onActivated={action('Tab 1 activated')}
-                  closable
-                  active={value === 0}
-                  label="Tab 1 with a very very long label"
-                  icon={null}
-                  onClose={action('Close tab 1')}
-                  onCloseAll={action('Close all')}
-                  onCloseOthers={action('Close others')}
-                  onClick={() => onChange(0)}
-                  maxWidth={300}
-                />
-                <ClosableTab
-                  onActivated={action('Tab 2 activated')}
-                  closable
-                  active={value === 1}
-                  onClick={() => onChange(1)}
-                  label="Small 2"
-                  icon={null}
-                  onClose={action('Close tab 2')}
-                  onCloseAll={action('Close all')}
-                  onCloseOthers={action('Close others')}
-                  maxWidth={300}
-                />
-                <ClosableTab
-                  onActivated={action('Tab 3 activated')}
-                  closable
-                  active={value === 2}
-                  onClick={() => onChange(2)}
-                  label="Tab 3 with a very very loooooooooooooooooooooooooooooooooooooooooong label"
-                  icon={null}
-                  onClose={action('Close tab 3')}
-                  onCloseAll={action('Close all')}
-                  onCloseOthers={action('Close others')}
-                  maxWidth={300}
-                />
-                <ClosableTab
-                  onActivated={action('Tab 4 activated')}
-                  closable
-                  active={value === 3}
-                  onClick={() => onChange(3)}
-                  label="Small 4"
-                  icon={null}
-                  onClose={action('Close tab 4')}
-                  onCloseAll={action('Close all')}
-                  onCloseOthers={action('Close others')}
-                  maxWidth={300}
-                />
-              </>
-            )}
-          />
+          <Line noMargin>
+            <ClosableTabs
+              renderTabs={({ containerWidth }) => (
+                <>
+                  <ClosableTab
+                    onActivated={action('Tab 1 activated')}
+                    closable
+                    active={value === 0}
+                    label="Tab 1 with a very very long label"
+                    icon={null}
+                    onClose={action('Close tab 1')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    onClick={() => onChange(0)}
+                    maxWidth={300}
+                  />
+                  <ClosableTab
+                    onActivated={action('Tab 2 activated')}
+                    closable
+                    active={value === 1}
+                    onClick={() => onChange(1)}
+                    label="Small 2"
+                    icon={null}
+                    onClose={action('Close tab 2')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                  <ClosableTab
+                    onActivated={action('Tab 3 activated')}
+                    closable
+                    active={value === 2}
+                    onClick={() => onChange(2)}
+                    label="Tab 3 with a very very loooooooooooooooooooooooooooooooooooooooooong label"
+                    icon={null}
+                    onClose={action('Close tab 3')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                  <ClosableTab
+                    onActivated={action('Tab 4 activated')}
+                    closable
+                    active={value === 3}
+                    onClick={() => onChange(3)}
+                    label="Small 4"
+                    icon={null}
+                    onClose={action('Close tab 4')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                </>
+              )}
+            />
+          </Line>
           {
             <TabContentContainer active={value === 0}>
               <div
@@ -223,9 +227,9 @@ export const WithObjectsList = () => (
       <DragAndDropContextProvider>
         <FixedHeightFlexContainer height={400}>
           <Column expand>
-            <ClosableTabs
-              renderTabs={({ containerWidth }) => (
-                <>
+            <Line noMargin>
+              <ClosableTabs
+                renderTabs={({ containerWidth }) => [
                   <ClosableTab
                     onActivated={action('Tab 1 activated')}
                     closable
@@ -237,7 +241,7 @@ export const WithObjectsList = () => (
                     onCloseAll={action('Close all')}
                     onCloseOthers={action('Close others')}
                     maxWidth={300}
-                  />
+                  />,
                   <ClosableTab
                     onActivated={action('Tab 2 activated')}
                     closable
@@ -249,7 +253,7 @@ export const WithObjectsList = () => (
                     onCloseAll={action('Close all')}
                     onCloseOthers={action('Close others')}
                     maxWidth={300}
-                  />
+                  />,
                   <ClosableTab
                     onActivated={action('Tab 3 activated')}
                     closable
@@ -261,10 +265,10 @@ export const WithObjectsList = () => (
                     onCloseAll={action('Close all')}
                     onCloseOthers={action('Close others')}
                     maxWidth={300}
-                  />
-                </>
-              )}
-            />
+                  />,
+                ]}
+              />
+            </Line>
             {
               <TabContentContainer active={value === 0}>
                 <div

--- a/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
+++ b/newIDE/app/src/stories/componentStories/ClosableTabs.stories.js
@@ -30,41 +30,48 @@ export const ThreeTabs = () => (
     render={(value, onChange) => (
       <FixedHeightFlexContainer height={400}>
         <Column expand>
-          <ClosableTabs>
-            <ClosableTab
-              onActivated={action('Tab 1 activated')}
-              closable={false}
-              active={value === 0}
-              onClick={() => onChange(0)}
-              label={null}
-              icon={<Home />}
-              onClose={action('Close tab 1')}
-              onCloseAll={action('Close all')}
-              onCloseOthers={action('Close others')}
-            />
-            <ClosableTab
-              onActivated={action('Tab 2 activated')}
-              closable
-              active={value === 1}
-              onClick={() => onChange(1)}
-              label="Tab 2"
-              icon={null}
-              onClose={action('Close tab 2')}
-              onCloseAll={action('Close all')}
-              onCloseOthers={action('Close others')}
-            />
-            <ClosableTab
-              onActivated={action('Tab 3 activated')}
-              closable
-              active={value === 2}
-              onClick={() => onChange(2)}
-              label="Tab 3 with a long label"
-              icon={null}
-              onClose={action('Close tab 3')}
-              onCloseAll={action('Close all')}
-              onCloseOthers={action('Close others')}
-            />
-          </ClosableTabs>
+          <ClosableTabs
+            renderTabs={({ containerWidth }) => (
+              <>
+                <ClosableTab
+                  onActivated={action('Tab 1 activated')}
+                  closable={false}
+                  active={value === 0}
+                  onClick={() => onChange(0)}
+                  label={null}
+                  icon={<Home />}
+                  onClose={action('Close tab 1')}
+                  onCloseAll={action('Close all')}
+                  onCloseOthers={action('Close others')}
+                  maxWidth={300}
+                />
+                <ClosableTab
+                  onActivated={action('Tab 2 activated')}
+                  closable
+                  active={value === 1}
+                  onClick={() => onChange(1)}
+                  label="Tab 2"
+                  icon={null}
+                  onClose={action('Close tab 2')}
+                  onCloseAll={action('Close all')}
+                  onCloseOthers={action('Close others')}
+                  maxWidth={300}
+                />
+                <ClosableTab
+                  onActivated={action('Tab 3 activated')}
+                  closable
+                  active={value === 2}
+                  onClick={() => onChange(2)}
+                  label="Tab 3 with a long label"
+                  icon={null}
+                  onClose={action('Close tab 3')}
+                  onCloseAll={action('Close all')}
+                  onCloseOthers={action('Close others')}
+                  maxWidth={300}
+                />
+              </>
+            )}
+          />
           {
             <TabContentContainer active={value === 0}>
               <div
@@ -104,52 +111,60 @@ export const LongLabels = () => (
     render={(value, onChange) => (
       <FixedHeightFlexContainer height={400}>
         <Column expand>
-          <ClosableTabs>
-            <ClosableTab
-              onActivated={action('Tab 1 activated')}
-              closable
-              active={value === 0}
-              label="Tab 1 with a very very long label"
-              icon={null}
-              onClose={action('Close tab 1')}
-              onCloseAll={action('Close all')}
-              onCloseOthers={action('Close others')}
-              onClick={() => onChange(0)}
-            />
-            <ClosableTab
-              onActivated={action('Tab 2 activated')}
-              closable
-              active={value === 1}
-              onClick={() => onChange(1)}
-              label="Small 2"
-              icon={null}
-              onClose={action('Close tab 2')}
-              onCloseAll={action('Close all')}
-              onCloseOthers={action('Close others')}
-            />
-            <ClosableTab
-              onActivated={action('Tab 3 activated')}
-              closable
-              active={value === 2}
-              onClick={() => onChange(2)}
-              label="Tab 3 with a very very loooooooooooooooooooooooooooooooooooooooooong label"
-              icon={null}
-              onClose={action('Close tab 3')}
-              onCloseAll={action('Close all')}
-              onCloseOthers={action('Close others')}
-            />
-            <ClosableTab
-              onActivated={action('Tab 4 activated')}
-              closable
-              active={value === 3}
-              onClick={() => onChange(3)}
-              label="Small 4"
-              icon={null}
-              onClose={action('Close tab 4')}
-              onCloseAll={action('Close all')}
-              onCloseOthers={action('Close others')}
-            />
-          </ClosableTabs>
+          <ClosableTabs
+            renderTabs={({ containerWidth }) => (
+              <>
+                <ClosableTab
+                  onActivated={action('Tab 1 activated')}
+                  closable
+                  active={value === 0}
+                  label="Tab 1 with a very very long label"
+                  icon={null}
+                  onClose={action('Close tab 1')}
+                  onCloseAll={action('Close all')}
+                  onCloseOthers={action('Close others')}
+                  onClick={() => onChange(0)}
+                  maxWidth={300}
+                />
+                <ClosableTab
+                  onActivated={action('Tab 2 activated')}
+                  closable
+                  active={value === 1}
+                  onClick={() => onChange(1)}
+                  label="Small 2"
+                  icon={null}
+                  onClose={action('Close tab 2')}
+                  onCloseAll={action('Close all')}
+                  onCloseOthers={action('Close others')}
+                  maxWidth={300}
+                />
+                <ClosableTab
+                  onActivated={action('Tab 3 activated')}
+                  closable
+                  active={value === 2}
+                  onClick={() => onChange(2)}
+                  label="Tab 3 with a very very loooooooooooooooooooooooooooooooooooooooooong label"
+                  icon={null}
+                  onClose={action('Close tab 3')}
+                  onCloseAll={action('Close all')}
+                  onCloseOthers={action('Close others')}
+                  maxWidth={300}
+                />
+                <ClosableTab
+                  onActivated={action('Tab 4 activated')}
+                  closable
+                  active={value === 3}
+                  onClick={() => onChange(3)}
+                  label="Small 4"
+                  icon={null}
+                  onClose={action('Close tab 4')}
+                  onCloseAll={action('Close all')}
+                  onCloseOthers={action('Close others')}
+                  maxWidth={300}
+                />
+              </>
+            )}
+          />
           {
             <TabContentContainer active={value === 0}>
               <div
@@ -208,41 +223,48 @@ export const WithObjectsList = () => (
       <DragAndDropContextProvider>
         <FixedHeightFlexContainer height={400}>
           <Column expand>
-            <ClosableTabs>
-              <ClosableTab
-                onActivated={action('Tab 1 activated')}
-                closable
-                active={value === 0}
-                label="Tab 1"
-                icon={null}
-                onClick={() => onChange(0)}
-                onClose={action('Close tab 1')}
-                onCloseAll={action('Close all')}
-                onCloseOthers={action('Close others')}
-              />
-              <ClosableTab
-                onActivated={action('Tab 2 activated')}
-                closable
-                active={value === 1}
-                label="Tab 2"
-                icon={null}
-                onClick={() => onChange(1)}
-                onClose={action('Close tab 2')}
-                onCloseAll={action('Close all')}
-                onCloseOthers={action('Close others')}
-              />
-              <ClosableTab
-                onActivated={action('Tab 3 activated')}
-                closable
-                active={value === 2}
-                label="Tab 3"
-                icon={null}
-                onClick={() => onChange(2)}
-                onClose={action('Close tab 3')}
-                onCloseAll={action('Close all')}
-                onCloseOthers={action('Close others')}
-              />
-            </ClosableTabs>
+            <ClosableTabs
+              renderTabs={({ containerWidth }) => (
+                <>
+                  <ClosableTab
+                    onActivated={action('Tab 1 activated')}
+                    closable
+                    active={value === 0}
+                    label="Tab 1"
+                    icon={null}
+                    onClick={() => onChange(0)}
+                    onClose={action('Close tab 1')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                  <ClosableTab
+                    onActivated={action('Tab 2 activated')}
+                    closable
+                    active={value === 1}
+                    label="Tab 2"
+                    icon={null}
+                    onClick={() => onChange(1)}
+                    onClose={action('Close tab 2')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                  <ClosableTab
+                    onActivated={action('Tab 3 activated')}
+                    closable
+                    active={value === 2}
+                    label="Tab 3"
+                    icon={null}
+                    onClick={() => onChange(2)}
+                    onClose={action('Close tab 3')}
+                    onCloseAll={action('Close all')}
+                    onCloseOthers={action('Close others')}
+                    maxWidth={300}
+                  />
+                </>
+              )}
+            />
             {
               <TabContentContainer active={value === 0}>
                 <div


### PR DESCRIPTION
Medium:
<img width="741" alt="image" src="https://github.com/user-attachments/assets/ca997f89-31e2-41a3-a6e5-297ba116de11" />
<img width="728" alt="image" src="https://github.com/user-attachments/assets/1459ee5d-f547-4a49-b7ce-7846897cbbcb" />
<img width="724" alt="image" src="https://github.com/user-attachments/assets/4a5adceb-8ab6-48f4-9b9b-313730377f14" />

Still allow scroll if too many tabs to fit:
<img width="676" alt="image" src="https://github.com/user-attachments/assets/a90599ee-dbfa-4219-927b-55e71ff28bac" />


Large:
<img width="1844" alt="image" src="https://github.com/user-attachments/assets/c4586d0b-5c0d-4dc1-a111-ef683ce1c17c" />
<img width="1841" alt="image" src="https://github.com/user-attachments/assets/24a7dcab-96b6-4ca7-a848-f1913eed3775" />

Small screens never go too low (and rely on scroll):
<img width="401" alt="image" src="https://github.com/user-attachments/assets/c07bd709-37bd-4e34-9253-fbb8e45f0b8a" />
<img width="407" alt="image" src="https://github.com/user-attachments/assets/b62a6f07-6162-45f6-a4f9-8ea887f49d78" />

