### PR TITLE
Fix GDJS test resource paths

### DIFF
--- a/Extensions/TileMap/tests/tilemapcollisionmaskruntimeobject.spec.js
+++ b/Extensions/TileMap/tests/tilemapcollisionmaskruntimeobject.spec.js
@@ -5,21 +5,24 @@ describe('gdjs.TileMapCollisionMaskRuntimeObject', function () {
       resources: {
         resources: [
           {
-            file: 'base/tests-utils/simple-tiled-map/SmallTiledMap.json',
+            file:
+              'base/GDJS/tests/tests-utils/simple-tiled-map/SmallTiledMap.json',
             kind: 'json',
             metadata: '',
             name: 'SmallTiledMap.json',
             userAdded: true,
           },
           {
-            file: 'base/tests-utils/simple-tiled-map/FlippingTiledMap.json',
+            file:
+              'base/GDJS/tests/tests-utils/simple-tiled-map/FlippingTiledMap.json',
             kind: 'json',
             metadata: '',
             name: 'FlippingTiledMap.json',
             userAdded: true,
           },
           {
-            file: 'base/tests-utils/simple-tiled-map/MiniTiledSet.json',
+            file:
+              'base/GDJS/tests/tests-utils/simple-tiled-map/MiniTiledSet.json',
             kind: 'json',
             metadata: '',
             name: 'MiniTiledSet.json',

--- a/GDJS/tests/karma.conf.js
+++ b/GDJS/tests/karma.conf.js
@@ -151,8 +151,8 @@ module.exports = function (config) {
       './newIDE/app/resources/GDJS/Runtime/Extensions/TileMap/helper/TileMapHelper.js',
       './newIDE/app/resources/GDJS/Runtime/Extensions/TileMap/pako/dist/pako.min.js',
       './newIDE/app/resources/GDJS/Runtime/Extensions/Spine/pixi-spine/pixi-spine.js',
-      './newIDE/app/resources/GDJS/Runtime/Extensions/Spine/managers/spineruntimeobject.js',
-      './newIDE/app/resources/GDJS/Runtime/Extensions/Spine/managers/spineruntimeobject-pixi-renderer.js',
+      './newIDE/app/resources/GDJS/Runtime/Extensions/Spine/spineruntimeobject.js',
+      './newIDE/app/resources/GDJS/Runtime/Extensions/Spine/spineruntimeobject-pixi-renderer.js',
       './newIDE/app/resources/GDJS/Runtime/Extensions/Spine/managers/*.js',
 
       // Test extensions:

--- a/GDJS/tests/tests-utils/init.pixiruntimegamewithassets.js
+++ b/GDJS/tests/tests-utils/init.pixiruntimegamewithassets.js
@@ -86,7 +86,7 @@ gdjs.getPixiRuntimeGameWithAssets = () => {
           kind: 'image',
           name: 'base/tests-utils/assets/64x64.jpg',
           metadata: '',
-          file: 'base/tests-utils/assets/64x64.jpg',
+          file: 'base/GDJS/tests/tests-utils/assets/64x64.jpg',
           userAdded: true,
         },
       ],


### PR DESCRIPTION
It seems that this redirection no longer works.
```
    proxies: {
      '/base/tests-utils/': '/base/GDJS/tests/tests-utils/',
    },
```