### PR TITLE
Allow to tween 3D boxes tint color

### DIFF
--- a/Extensions/3D/Cube3DRuntimeObject.ts
+++ b/Extensions/3D/Cube3DRuntimeObject.ts
@@ -45,7 +45,7 @@ namespace gdjs {
     trfb: integer;
     frn: [string, string, string, string, string, string];
     mt: number;
-    tint: number;
+    tint: string;
   };
 
   type Cube3DObjectNetworkSyncData = Object3DNetworkSyncData &
@@ -72,7 +72,8 @@ namespace gdjs {
     ];
     _materialType: gdjs.Cube3DRuntimeObject.MaterialType =
       gdjs.Cube3DRuntimeObject.MaterialType.Basic;
-    _tint: number;
+    _tint: string;
+
     constructor(
       instanceContainer: gdjs.RuntimeInstanceContainer,
       objectData: Cube3DObjectData
@@ -119,9 +120,7 @@ namespace gdjs {
         objectData.content.bottomFaceResourceName,
       ];
 
-      this._tint = gdjs.rgbOrHexStringToNumber(
-        objectData.content.tint || '255;255;255'
-      );
+      this._tint = objectData.content.tint || '255;255;255';
 
       this._materialType = this._convertMaterialType(
         objectData.content.materialType
@@ -212,11 +211,17 @@ namespace gdjs {
       this._faceResourceNames[faceIndex] = resourceName;
       this._renderer.updateFace(faceIndex);
     }
-    setTint(tint: string): void {
-      const tintInHex = gdjs.rgbOrHexStringToNumber(tint);
-      if (tintInHex === this._tint) return;
-      this._tint = tintInHex;
+
+    setColor(tint: string): void {
+      if (this._tint === tint) {
+        return;
+      }
+      this._tint = tint;
       this._renderer.updateTint();
+    }
+
+    getColor(): string {
+      return this._tint;
     }
 
     /** @internal */
@@ -303,7 +308,7 @@ namespace gdjs {
         );
       }
       if (oldObjectData.content.tint !== newObjectData.content.tint) {
-        this.setTint(newObjectData.content.tint);
+        this.setColor(newObjectData.content.tint);
       }
 
       if (

--- a/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
+++ b/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
@@ -92,11 +92,12 @@ namespace gdjs {
       this.updateRotation();
       this.updateTint();
     }
+
     updateTint() {
       const tints: number[] = [];
 
       const normalizedTint = gdjs
-        .hexNumberToRGBArray(this._cube3DRuntimeObject._tint)
+        .rgbOrHexToRGBColor(this._cube3DRuntimeObject.getColor())
         .map((component) => component / 255);
 
       for (

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -1593,17 +1593,17 @@ module.exports = {
     object
       .addScopedAction(
         'SetTint',
-        _('Tint'),
+        _('Tint color'),
         _('Change the tint of the cube.'),
         _('Change the tint of _PARAM0_ to _PARAM1_'),
-        _('Tint'),
+        _('Effects'),
         'res/actions/color24.png',
         'res/actions/color.png'
       )
       .addParameter('object', _('3D Cube'), 'Cube3DObject', false)
       .addParameter('color', _('Tint'), '', false)
       .getCodeExtraInformation()
-      .setFunctionName('setTint');
+      .setFunctionName('setColor');
 
     extension
       .addExpressionAndConditionAndAction(


### PR DESCRIPTION
The tween behavior relies on the interface: `setColor` and `getColor`.