### PR TITLE
Deprecate internal actions and conditions to set and compare property values

### DIFF
--- a/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/AdvancedExtension.cpp
@@ -141,7 +141,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
                     "res/function32.png")
       .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .SetRelevantForFunctionEventsOnly()
-      .MarkAsAdvanced();
+      .MarkAsAdvanced()
+      .SetHidden();
 
   extension
       .AddExpression(
@@ -177,7 +178,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
       .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .UseStandardRelationalOperatorParameters(
           "number", gd::ParameterOptions::MakeNewOptions())
-      .SetRelevantForFunctionEventsOnly();
+      .SetRelevantForFunctionEventsOnly()
+      .SetHidden();
 
   extension
       .AddCondition(
@@ -191,7 +193,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsAdvancedExtension(
       .AddParameter("functionParameterName", _("Parameter name"), "number,string,boolean")
       .UseStandardRelationalOperatorParameters(
           "string", gd::ParameterOptions::MakeNewOptions())
-      .SetRelevantForFunctionEventsOnly();
+      .SetRelevantForFunctionEventsOnly()
+      .SetHidden();
 }
 
 }  // namespace gd

--- a/Core/GDCore/IDE/PropertyFunctionGenerator.h
+++ b/Core/GDCore/IDE/PropertyFunctionGenerator.h
@@ -3,8 +3,7 @@
  * Copyright 2008-2022 Florian Rival (Florian.Rival@gmail.com). All rights
  * reserved. This project is released under the MIT License.
  */
-#ifndef GDCORE_PROPERTYFUNCTIONGENERATOR_H
-#define GDCORE_PROPERTYFUNCTIONGENERATOR_H
+#pragma once
 
 namespace gd {
 class String;
@@ -73,5 +72,3 @@ class GD_CORE_API PropertyFunctionGenerator {
 };
 
 }  // namespace gd
-
-#endif  // GDCORE_PROPERTYFUNCTIONGENERATOR_H

--- a/Core/tests/PropertyFunctionGenerator.cpp
+++ b/Core/tests/PropertyFunctionGenerator.cpp
@@ -116,14 +116,11 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(setterEvent.GetConditions().size() == 0);
       REQUIRE(setterEvent.GetActions().size() == 1);
       auto &setterAction = setterEvent.GetActions().at(0);
-      REQUIRE(
-          setterAction.GetType() ==
-          "MyEventsExtension::MyEventsBasedBehavior::SetPropertyMovementAngle");
-      REQUIRE(setterAction.GetParametersCount() == 4);
-      REQUIRE(setterAction.GetParameter(0).GetPlainString() == "Object");
-      REQUIRE(setterAction.GetParameter(1).GetPlainString() == "Behavior");
-      REQUIRE(setterAction.GetParameter(2).GetPlainString() == "=");
-      REQUIRE(setterAction.GetParameter(3).GetPlainString() == "Value");
+      REQUIRE(setterAction.GetType() == "SetNumberVariable");
+      REQUIRE(setterAction.GetParametersCount() == 3);
+      REQUIRE(setterAction.GetParameter(0).GetPlainString() == "MovementAngle");
+      REQUIRE(setterAction.GetParameter(1).GetPlainString() == "=");
+      REQUIRE(setterAction.GetParameter(2).GetPlainString() == "Value");
     }
   }
 
@@ -206,12 +203,12 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(getterEvent.GetActions().size() == 1);
 
       auto &getterCondition = getterEvent.GetConditions().at(0);
-      REQUIRE(getterCondition.GetType() ==
-              "MyEventsExtension::MyEventsBasedBehavior::PropertyRotate");
+      REQUIRE(getterCondition.GetType() == "BooleanVariable");
       REQUIRE(!getterCondition.IsInverted());
-      REQUIRE(getterCondition.GetParametersCount() == 2);
-      REQUIRE(getterCondition.GetParameter(0).GetPlainString() == "Object");
-      REQUIRE(getterCondition.GetParameter(1).GetPlainString() == "Behavior");
+      REQUIRE(getterCondition.GetParametersCount() == 3);
+      REQUIRE(getterCondition.GetParameter(0).GetPlainString() == "Rotate");
+      REQUIRE(getterCondition.GetParameter(1).GetPlainString() == "True");
+      REQUIRE(getterCondition.GetParameter(2).GetPlainString() == "");
 
       auto &getterAction = getterEvent.GetActions().at(0);
       REQUIRE(getterAction.GetType() == "SetReturnBoolean");
@@ -257,19 +254,19 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(setterNoEvent.GetActions().size() == 1);
 
       auto &setterNoCondition = setterNoEvent.GetConditions().at(0);
-      REQUIRE(setterNoCondition.GetType() == "GetArgumentAsBoolean");
-      REQUIRE(setterNoCondition.IsInverted());
-      REQUIRE(setterNoCondition.GetParametersCount() == 1);
-      REQUIRE(setterNoCondition.GetParameter(0).GetPlainString() ==
-              "\"Value\"");
+      REQUIRE(setterNoCondition.GetType() == "BooleanVariable");
+      REQUIRE(!setterNoCondition.IsInverted());
+      REQUIRE(setterNoCondition.GetParametersCount() == 3);
+      REQUIRE(setterNoCondition.GetParameter(0).GetPlainString() == "Value");
+      REQUIRE(setterNoCondition.GetParameter(1).GetPlainString() == "False");
+      REQUIRE(setterNoCondition.GetParameter(2).GetPlainString() == "");
 
       auto &setterNoAction = setterNoEvent.GetActions().at(0);
-      REQUIRE(setterNoAction.GetType() ==
-              "MyEventsExtension::MyEventsBasedBehavior::SetPropertyRotate");
+      REQUIRE(setterNoAction.GetType() == "SetBooleanVariable");
       REQUIRE(setterNoAction.GetParametersCount() == 3);
-      REQUIRE(setterNoAction.GetParameter(0).GetPlainString() == "Object");
-      REQUIRE(setterNoAction.GetParameter(1).GetPlainString() == "Behavior");
-      REQUIRE(setterNoAction.GetParameter(2).GetPlainString() == "no");
+      REQUIRE(setterNoAction.GetParameter(0).GetPlainString() == "Rotate");
+      REQUIRE(setterNoAction.GetParameter(1).GetPlainString() == "False");
+      REQUIRE(setterNoAction.GetParameter(2).GetPlainString() == "");
 
       auto &setterYesEvent =
           dynamic_cast<gd::StandardEvent &>(setter.GetEvents().GetEvent(1));
@@ -277,19 +274,19 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(setterYesEvent.GetActions().size() == 1);
 
       auto &setterYesCondition = setterYesEvent.GetConditions().at(0);
-      REQUIRE(setterYesCondition.GetType() == "GetArgumentAsBoolean");
+      REQUIRE(setterYesCondition.GetType() == "BooleanVariable");
       REQUIRE(!setterYesCondition.IsInverted());
-      REQUIRE(setterYesCondition.GetParametersCount() == 1);
-      REQUIRE(setterYesCondition.GetParameter(0).GetPlainString() ==
-              "\"Value\"");
+      REQUIRE(setterYesCondition.GetParametersCount() == 3);
+      REQUIRE(setterYesCondition.GetParameter(0).GetPlainString() == "Value");
+      REQUIRE(setterYesCondition.GetParameter(1).GetPlainString() == "True");
+      REQUIRE(setterYesCondition.GetParameter(2).GetPlainString() == "");
 
       auto &setterYesAction = setterYesEvent.GetActions().at(0);
-      REQUIRE(setterYesAction.GetType() ==
-              "MyEventsExtension::MyEventsBasedBehavior::SetPropertyRotate");
+      REQUIRE(setterYesAction.GetType() == "SetBooleanVariable");
       REQUIRE(setterYesAction.GetParametersCount() == 3);
-      REQUIRE(setterYesAction.GetParameter(0).GetPlainString() == "Object");
-      REQUIRE(setterYesAction.GetParameter(1).GetPlainString() == "Behavior");
-      REQUIRE(setterYesAction.GetParameter(2).GetPlainString() == "yes");
+      REQUIRE(setterYesAction.GetParameter(0).GetPlainString() == "Rotate");
+      REQUIRE(setterYesAction.GetParameter(1).GetPlainString() == "True");
+      REQUIRE(setterYesAction.GetParameter(2).GetPlainString() == "");
     }
   }
   SECTION("Can generate functions for a number property in an object") {
@@ -366,11 +363,9 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(setterEvent.GetConditions().size() == 0);
       REQUIRE(setterEvent.GetActions().size() == 1);
       auto &setterAction = setterEvent.GetActions().at(0);
-      REQUIRE(
-          setterAction.GetType() ==
-          "MyEventsExtension::MyEventsBasedObject::SetPropertyMovementAngle");
+      REQUIRE(setterAction.GetType() == "SetNumberVariable");
       REQUIRE(setterAction.GetParametersCount() == 3);
-      REQUIRE(setterAction.GetParameter(0).GetPlainString() == "Object");
+      REQUIRE(setterAction.GetParameter(0).GetPlainString() == "MovementAngle");
       REQUIRE(setterAction.GetParameter(1).GetPlainString() == "=");
       REQUIRE(setterAction.GetParameter(2).GetPlainString() == "Value");
     }
@@ -454,11 +449,12 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(getterEvent.GetActions().size() == 1);
 
       auto &getterCondition = getterEvent.GetConditions().at(0);
-      REQUIRE(getterCondition.GetType() ==
-              "MyEventsExtension::MyEventsBasedObject::PropertyRotate");
+      REQUIRE(getterCondition.GetType() == "BooleanVariable");
       REQUIRE(!getterCondition.IsInverted());
-      REQUIRE(getterCondition.GetParametersCount() == 1);
-      REQUIRE(getterCondition.GetParameter(0).GetPlainString() == "Object");
+      REQUIRE(getterCondition.GetParametersCount() == 3);
+      REQUIRE(getterCondition.GetParameter(0).GetPlainString() == "Rotate");
+      REQUIRE(getterCondition.GetParameter(1).GetPlainString() == "True");
+      REQUIRE(getterCondition.GetParameter(2).GetPlainString() == "");
 
       auto &getterAction = getterEvent.GetActions().at(0);
       REQUIRE(getterAction.GetType() == "SetReturnBoolean");
@@ -500,18 +496,19 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(setterNoEvent.GetActions().size() == 1);
 
       auto &setterNoCondition = setterNoEvent.GetConditions().at(0);
-      REQUIRE(setterNoCondition.GetType() == "GetArgumentAsBoolean");
-      REQUIRE(setterNoCondition.IsInverted());
-      REQUIRE(setterNoCondition.GetParametersCount() == 1);
-      REQUIRE(setterNoCondition.GetParameter(0).GetPlainString() ==
-              "\"Value\"");
+      REQUIRE(setterNoCondition.GetType() == "BooleanVariable");
+      REQUIRE(!setterNoCondition.IsInverted());
+      REQUIRE(setterNoCondition.GetParametersCount() == 3);
+      REQUIRE(setterNoCondition.GetParameter(0).GetPlainString() == "Value");
+      REQUIRE(setterNoCondition.GetParameter(1).GetPlainString() == "False");
+      REQUIRE(setterNoCondition.GetParameter(2).GetPlainString() == "");
 
       auto &setterNoAction = setterNoEvent.GetActions().at(0);
-      REQUIRE(setterNoAction.GetType() ==
-              "MyEventsExtension::MyEventsBasedObject::SetPropertyRotate");
-      REQUIRE(setterNoAction.GetParametersCount() == 2);
-      REQUIRE(setterNoAction.GetParameter(0).GetPlainString() == "Object");
-      REQUIRE(setterNoAction.GetParameter(1).GetPlainString() == "no");
+      REQUIRE(setterNoAction.GetType() == "SetBooleanVariable");
+      REQUIRE(setterNoAction.GetParametersCount() == 3);
+      REQUIRE(setterNoAction.GetParameter(0).GetPlainString() == "Rotate");
+      REQUIRE(setterNoAction.GetParameter(1).GetPlainString() == "False");
+      REQUIRE(setterNoAction.GetParameter(2).GetPlainString() == "");
 
       auto &setterYesEvent =
           dynamic_cast<gd::StandardEvent &>(setter.GetEvents().GetEvent(1));
@@ -519,18 +516,19 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(setterYesEvent.GetActions().size() == 1);
 
       auto &setterYesCondition = setterYesEvent.GetConditions().at(0);
-      REQUIRE(setterYesCondition.GetType() == "GetArgumentAsBoolean");
+      REQUIRE(setterYesCondition.GetType() == "BooleanVariable");
       REQUIRE(!setterYesCondition.IsInverted());
-      REQUIRE(setterYesCondition.GetParametersCount() == 1);
-      REQUIRE(setterYesCondition.GetParameter(0).GetPlainString() ==
-              "\"Value\"");
+      REQUIRE(setterYesCondition.GetParametersCount() == 3);
+      REQUIRE(setterYesCondition.GetParameter(0).GetPlainString() == "Value");
+      REQUIRE(setterYesCondition.GetParameter(1).GetPlainString() == "True");
+      REQUIRE(setterYesCondition.GetParameter(2).GetPlainString() == "");
 
       auto &setterYesAction = setterYesEvent.GetActions().at(0);
-      REQUIRE(setterYesAction.GetType() ==
-              "MyEventsExtension::MyEventsBasedObject::SetPropertyRotate");
-      REQUIRE(setterYesAction.GetParametersCount() == 2);
-      REQUIRE(setterYesAction.GetParameter(0).GetPlainString() == "Object");
-      REQUIRE(setterYesAction.GetParameter(1).GetPlainString() == "yes");
+      REQUIRE(setterYesAction.GetType() == "SetBooleanVariable");
+      REQUIRE(setterYesAction.GetParametersCount() == 3);
+      REQUIRE(setterYesAction.GetParameter(0).GetPlainString() == "Rotate");
+      REQUIRE(setterYesAction.GetParameter(1).GetPlainString() == "True");
+      REQUIRE(setterYesAction.GetParameter(2).GetPlainString() == "");
     }
   }
 
@@ -588,9 +586,11 @@ TEST_CASE("PropertyFunctionGenerator", "[common]") {
       REQUIRE(setterEvent.GetConditions().size() == 0);
       REQUIRE(setterEvent.GetActions().size() == 1);
       auto &setterAction = setterEvent.GetActions().at(0);
-      REQUIRE(setterAction.GetType() ==
-              "MyEventsExtension::MyEventsBasedBehavior::"
-              "SetSharedPropertyMovementAngle");
+      REQUIRE(setterAction.GetType() == "SetNumberVariable");
+      REQUIRE(setterAction.GetParametersCount() == 3);
+      REQUIRE(setterAction.GetParameter(0).GetPlainString() == "MovementAngle");
+      REQUIRE(setterAction.GetParameter(1).GetPlainString() == "=");
+      REQUIRE(setterAction.GetParameter(2).GetPlainString() == "Value");
     }
   }
 

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
@@ -1041,7 +1041,8 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
     const int valueParameterIndex,
     std::function<gd::AbstractFunctionMetadata &(
         gd::AbstractFunctionMetadata &instructionOrExpression)>
-        addObjectAndBehaviorParameters) {
+        addObjectAndBehaviorParameters,
+    bool isSharedProperty) {
   auto &propertyType = property.GetType();
 
   auto group = (eventsBasedEntity.GetFullName() || eventsBasedEntity.GetName())
@@ -1057,7 +1058,10 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
         group,
         GetExtensionIconUrl(extension), GetExtensionIconUrl(extension));
     addObjectAndBehaviorParameters(conditionMetadata);
-    conditionMetadata.SetFunctionName(getterName).SetHidden();
+    conditionMetadata.SetFunctionName(getterName);
+    if (!isSharedProperty) {
+      conditionMetadata.SetHidden();
+    }
 
     auto &setterActionMetadata = entityMetadata.AddScopedAction(
         actionName, propertyLabel,
@@ -1074,7 +1078,10 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
     addObjectAndBehaviorParameters(setterActionMetadata);
     setterActionMetadata
         .AddParameter("yesorno", _("New value to set"), "", false)
-        .SetFunctionName(setterName).SetHidden();
+        .SetFunctionName(setterName);
+    if (!isSharedProperty) {
+      setterActionMetadata.SetHidden();
+    }
 
     auto &toggleActionMetadata = entityMetadata.AddScopedAction(
         toggleActionName, _("Toggle") + " " + propertyLabel,
@@ -1087,7 +1094,10 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
         group,
         GetExtensionIconUrl(extension), GetExtensionIconUrl(extension));
     addObjectAndBehaviorParameters(toggleActionMetadata);
-    toggleActionMetadata.SetFunctionName(toggleFunctionName).SetHidden();
+    toggleActionMetadata.SetFunctionName(toggleFunctionName);
+    if (!isSharedProperty) {
+      toggleActionMetadata.SetHidden();
+    }
   } else {
     auto typeExtraInfo = GetStringifiedExtraInfo(property);
     auto parameterOptions = gd::ParameterOptions::MakeNewOptions();
@@ -1110,8 +1120,10 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
             gd::ValueTypeMetadata::ConvertPropertyTypeToValueType(propertyType),
             parameterOptions)
         .SetFunctionName(setterName)
-        .SetGetter(getterName)
-        .SetHidden();
+        .SetGetter(getterName);
+    if (!isSharedProperty) {
+      propertyInstructionMetadata.SetHidden();
+    }
   }
 }
 
@@ -1187,7 +1199,7 @@ void MetadataDeclarationHelper::
         extension, behaviorMetadata, eventsBasedBehavior, *property,
         propertyLabel, expressionName, conditionName, actionName,
         toggleActionName, setterName, getterName, toggleFunctionName, 2,
-        addObjectAndBehaviorParameters);
+        addObjectAndBehaviorParameters, false);
   }
 
   for (auto &property :
@@ -1219,7 +1231,7 @@ void MetadataDeclarationHelper::
         extension, behaviorMetadata, eventsBasedBehavior, *property,
         propertyLabel, expressionName, conditionName, actionName,
         toggleActionName, setterName, getterName, toggleFunctionName, 2,
-        addObjectAndBehaviorParameters);
+        addObjectAndBehaviorParameters, true);
   }
 }
 
@@ -1275,7 +1287,7 @@ void MetadataDeclarationHelper::
     DeclarePropertyInstructionAndExpression(
         extension, objectMetadata, eventsBasedObject, *property, propertyLabel,
         expressionName, conditionName, actionName, toggleActionName, setterName,
-        getterName, toggleFunctionName, 1, addObjectParameter);
+        getterName, toggleFunctionName, 1, addObjectParameter, false);
   }
 }
 

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.cpp
@@ -1057,7 +1057,7 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
         group,
         GetExtensionIconUrl(extension), GetExtensionIconUrl(extension));
     addObjectAndBehaviorParameters(conditionMetadata);
-    conditionMetadata.SetFunctionName(getterName);
+    conditionMetadata.SetFunctionName(getterName).SetHidden();
 
     auto &setterActionMetadata = entityMetadata.AddScopedAction(
         actionName, propertyLabel,
@@ -1074,7 +1074,7 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
     addObjectAndBehaviorParameters(setterActionMetadata);
     setterActionMetadata
         .AddParameter("yesorno", _("New value to set"), "", false)
-        .SetFunctionName(setterName);
+        .SetFunctionName(setterName).SetHidden();
 
     auto &toggleActionMetadata = entityMetadata.AddScopedAction(
         toggleActionName, _("Toggle") + " " + propertyLabel,
@@ -1087,7 +1087,7 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
         group,
         GetExtensionIconUrl(extension), GetExtensionIconUrl(extension));
     addObjectAndBehaviorParameters(toggleActionMetadata);
-    toggleActionMetadata.SetFunctionName(toggleFunctionName);
+    toggleActionMetadata.SetFunctionName(toggleFunctionName).SetHidden();
   } else {
     auto typeExtraInfo = GetStringifiedExtraInfo(property);
     auto parameterOptions = gd::ParameterOptions::MakeNewOptions();
@@ -1110,7 +1110,8 @@ void MetadataDeclarationHelper::DeclarePropertyInstructionAndExpression(
             gd::ValueTypeMetadata::ConvertPropertyTypeToValueType(propertyType),
             parameterOptions)
         .SetFunctionName(setterName)
-        .SetGetter(getterName);
+        .SetGetter(getterName)
+        .SetHidden();
   }
 }
 

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.h
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.h
@@ -149,7 +149,8 @@ private:
       const int valueParameterIndex,
       std::function<gd::AbstractFunctionMetadata &(
           gd::AbstractFunctionMetadata &instructionOrExpression)>
-          addObjectAndBehaviorParameters);
+          addObjectAndBehaviorParameters,
+      bool isSharedProperty);
 
   /**
    * Declare the instructions (actions/conditions) and expressions for the

--- a/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.h
+++ b/GDJS/GDJS/Events/CodeGeneration/MetadataDeclarationHelper.h
@@ -133,6 +133,10 @@ private:
       gd::PlatformExtension &extension,
       const gd::EventsFunctionsExtension &eventsFunctionsExtension);
 
+  /**
+   * @brief Declare deprecated instructions to access properties.
+   * Variable instructions are now used instead of this.
+   */
   static void DeclarePropertyInstructionAndExpression(
       gd::PlatformExtension &extension,
       gd::InstructionOrExpressionContainerMetadata &entityMetadata,

--- a/GDevelop.js/__tests__/MetadataDeclarationHelper.js
+++ b/GDevelop.js/__tests__/MetadataDeclarationHelper.js
@@ -838,8 +838,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Change the property value for Value of _PARAM0_: _PARAM2_ _PARAM3_'
     );
-    // It is deprecated, variable instructions are used instead.
-    expect(action.isHidden()).toBe(true);
+    // Shared properties can't be used in variable instructions yet.
+    expect(action.isHidden()).toBe(false);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(4);
@@ -863,8 +863,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'The property value for Value of _PARAM0_ _PARAM2_ _PARAM3_'
     );
-    // It is deprecated, variable instructions are used instead.
-    expect(condition.isHidden()).toBe(true);
+    // Shared properties can't be used in variable instructions yet.
+    expect(condition.isHidden()).toBe(false);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(4);
@@ -939,8 +939,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Set property value for Value of _PARAM0_ to _PARAM2_'
     );
-    // It is deprecated, variable instructions are used instead.
-    expect(action.isHidden()).toBe(true);
+    // Shared properties can't be used in variable instructions yet.
+    expect(action.isHidden()).toBe(false);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(3);
@@ -962,8 +962,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'Property Value of _PARAM0_ is true'
     );
-    // It is deprecated, variable instructions are used instead.
-    expect(condition.isHidden()).toBe(true);
+    // Shared properties can't be used in variable instructions yet.
+    expect(condition.isHidden()).toBe(false);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(2);

--- a/GDevelop.js/__tests__/MetadataDeclarationHelper.js
+++ b/GDevelop.js/__tests__/MetadataDeclarationHelper.js
@@ -579,7 +579,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Change the property value for Value of _PARAM0_: _PARAM2_ _PARAM3_'
     );
-    expect(action.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(action.isHidden()).toBe(true);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(4);
@@ -603,7 +604,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'The property value for Value of _PARAM0_ _PARAM2_ _PARAM3_'
     );
-    expect(condition.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(condition.isHidden()).toBe(true);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(4);
@@ -757,7 +759,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Set property value for Value of _PARAM0_ to _PARAM2_'
     );
-    expect(action.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(action.isHidden()).toBe(true);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(3);
@@ -779,7 +782,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'Property Value of _PARAM0_ is true'
     );
-    expect(condition.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(condition.isHidden()).toBe(true);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(2);
@@ -834,7 +838,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Change the property value for Value of _PARAM0_: _PARAM2_ _PARAM3_'
     );
-    expect(action.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(action.isHidden()).toBe(true);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(4);
@@ -858,7 +863,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'The property value for Value of _PARAM0_ _PARAM2_ _PARAM3_'
     );
-    expect(condition.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(condition.isHidden()).toBe(true);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(4);
@@ -933,7 +939,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Set property value for Value of _PARAM0_ to _PARAM2_'
     );
-    expect(action.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(action.isHidden()).toBe(true);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(3);
@@ -955,7 +962,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'Property Value of _PARAM0_ is true'
     );
-    expect(condition.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(condition.isHidden()).toBe(true);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(2);
@@ -1444,7 +1452,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Change the property value for Value of _PARAM0_: _PARAM1_ _PARAM2_'
     );
-    expect(action.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(action.isHidden()).toBe(true);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(3);
@@ -1467,7 +1476,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'The property value for Value of _PARAM0_ _PARAM1_ _PARAM2_'
     );
-    expect(condition.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(condition.isHidden()).toBe(true);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(3);
@@ -1538,7 +1548,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(action.getSentence()).toBe(
       'Set property value for Value of _PARAM0_ to _PARAM1_'
     );
-    expect(action.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(action.isHidden()).toBe(true);
     expect(action.isPrivate()).toBe(true);
 
     expect(action.getParametersCount()).toBe(2);
@@ -1559,7 +1570,8 @@ describe('MetadataDeclarationHelper', () => {
     expect(condition.getSentence()).toBe(
       'Property Value of _PARAM0_ is true'
     );
-    expect(condition.isHidden()).toBe(false);
+    // It is deprecated, variable instructions are used instead.
+    expect(condition.isHidden()).toBe(true);
     expect(condition.isPrivate()).toBe(true);
 
     expect(condition.getParametersCount()).toBe(1);


### PR DESCRIPTION
- Also deprecate conditions to compare parameter values
- The action and condition to set and compare variables must be used instead
- Generated getter and setter now use the new system

These instruction were kept as a workaround in case of issue in the code generation of variable instructions. 20 migrated extensions has been tested on 4 examples.
- https://github.com/GDevelopApp/GDevelop-extensions/pull/1535
- https://github.com/GDevelopApp/GDevelop-extensions/pull/1538
- https://github.com/GDevelopApp/GDevelop-extensions/pull/1539
- https://github.com/GDevelopApp/GDevelop-extensions/pull/1544