### PR TITLE
Fix toggle "update game page" sometimes not being visible when publishing to gd.games

### DIFF
--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineWebExportFlow.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineWebExport/OnlineWebExportFlow.js
@@ -29,19 +29,16 @@ const OnlineWebExportFlow = ({
 }: OnlineWebExportFlowProps) => {
   const {
     game,
-    builds,
+    gameBuilds,
     refreshGame,
     setGame,
     gameAvailabilityError,
   } = gameAndBuildsManager;
   const isGameOwnedByCurrentUser =
     !gameAvailabilityError || gameAvailabilityError !== 'not-owned';
-  const hasGameExistingWebBuilds =
-    game && builds
-      ? !!builds.filter(
-          build => build.gameId === game.id && build.type === 'web-build'
-        ).length
-      : false;
+  const hasGameExistingWebBuilds = gameBuilds
+    ? !!gameBuilds.filter(build => build.type === 'web-build').length
+    : false;
   const isPublishedOnGdGames = !!game && !!game.publicWebBuildId;
 
   const [

--- a/newIDE/app/src/ExportAndShare/ShareDialog/ExportLauncher.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/ExportLauncher.js
@@ -204,7 +204,7 @@ export default class ExportLauncher extends Component<Props, State> {
           setTimeout(() => {
             this.setState({ build });
             authenticatedUser.onRefreshLimits();
-            this.props.gameAndBuildsManager.refreshBuilds();
+            this.props.gameAndBuildsManager.refreshGameBuilds();
           }, 3000);
         }
       },
@@ -347,7 +347,7 @@ export default class ExportLauncher extends Component<Props, State> {
         // When the build is started, update the game because the build may be linked to it.
         this.props.gameAndBuildsManager.refreshGame();
         // Also refresh the builds list, as the new build will be considered as a pending build.
-        this.props.gameAndBuildsManager.refreshBuilds();
+        this.props.gameAndBuildsManager.refreshGameBuilds();
       }
       setStep('done');
       this.setState({
@@ -416,11 +416,11 @@ export default class ExportLauncher extends Component<Props, State> {
     );
 
     const hasBuildsCurrentlyRunning = () => {
-      if (!gameAndBuildsManager.builds) return false;
+      if (!gameAndBuildsManager.gameBuilds) return false;
 
       // We check pending builds that are not more than 10 minutes old,
       // to avoid counting builds that may be stuck.
-      return !!gameAndBuildsManager.builds.filter(
+      return !!gameAndBuildsManager.gameBuilds.filter(
         build =>
           build.status === 'pending' &&
           build.type === exportPipeline.onlineBuildType &&

--- a/newIDE/app/src/Utils/UseGameAndBuildsManager.js
+++ b/newIDE/app/src/Utils/UseGameAndBuildsManager.js
@@ -48,8 +48,8 @@ export type GameManager = {|
 
 export type GameAndBuildsManager = {|
   ...GameManager,
-  builds: ?Array<Build>,
-  refreshBuilds: () => Promise<void>,
+  gameBuilds: ?Array<Build>,
+  refreshGameBuilds: () => Promise<void>,
 |};
 
 type Props = {|
@@ -244,14 +244,20 @@ export const useGameAndBuildsManager = ({
     onGameRegistered,
   });
 
-  const [builds, setBuilds] = React.useState<?Array<Build>>(null);
-  const refreshBuilds = React.useCallback(
+  const { game } = gameManager;
+
+  const [gameBuilds, setGameBuilds] = React.useState<?Array<Build>>(null);
+  const refreshGameBuilds = React.useCallback(
     async () => {
-      if (!profile) return;
+      if (!profile || !game) return;
 
       try {
-        const userBuilds = await getBuilds(getAuthorizationHeader, profile.id);
-        setBuilds(userBuilds);
+        const gameBuilds = await getBuilds(
+          getAuthorizationHeader,
+          profile.id,
+          game.id
+        );
+        setGameBuilds(gameBuilds);
       } catch (error) {
         console.error('Error while loading builds:', error);
         showAlert({
@@ -260,23 +266,23 @@ export const useGameAndBuildsManager = ({
         });
       }
     },
-    [profile, getAuthorizationHeader, showAlert]
+    [profile, getAuthorizationHeader, showAlert, game]
   );
 
   React.useEffect(
     () => {
-      refreshBuilds();
+      refreshGameBuilds();
     },
-    [refreshBuilds]
+    [refreshGameBuilds]
   );
 
   const gameAndBuildsManager: GameAndBuildsManager = React.useMemo(
     () => ({
       ...gameManager,
-      builds,
-      refreshBuilds,
+      gameBuilds,
+      refreshGameBuilds,
     }),
-    [gameManager, refreshBuilds, builds]
+    [gameManager, refreshGameBuilds, gameBuilds]
   );
 
   return gameAndBuildsManager;

--- a/newIDE/app/src/fixtures/GDevelopServicesTestData/FakeGameAndBuildsManager.js
+++ b/newIDE/app/src/fixtures/GDevelopServicesTestData/FakeGameAndBuildsManager.js
@@ -14,8 +14,8 @@ export const fakeEmptyGameAndBuildsManager: GameAndBuildsManager = {
   setGame: () => {},
   refreshGame: async () => {},
   gameAvailabilityError: null,
-  builds: null,
-  refreshBuilds: async () => {},
+  gameBuilds: null,
+  refreshGameBuilds: async () => {},
   registerGameIfNeeded: async () => {},
 };
 
@@ -24,14 +24,14 @@ export const fakeGameAndBuildsManager: GameAndBuildsManager = {
   setGame: () => {},
   refreshGame: async () => {},
   gameAvailabilityError: null,
-  builds: [
+  gameBuilds: [
     pendingCordovaBuild,
     pendingElectronBuild,
     completeCordovaBuild,
     completeElectronBuild,
     completeWebBuild,
   ],
-  refreshBuilds: async () => {},
+  refreshGameBuilds: async () => {},
   registerGameIfNeeded: async () => {},
 };
 
@@ -40,8 +40,8 @@ export const fakeNotOwnedGameAndBuildsManager: GameAndBuildsManager = {
   setGame: () => {},
   refreshGame: async () => {},
   gameAvailabilityError: 'not-owned',
-  builds: null,
-  refreshBuilds: async () => {},
+  gameBuilds: null,
+  refreshGameBuilds: async () => {},
   registerGameIfNeeded: async () => {},
 };
 
@@ -50,7 +50,7 @@ export const fakeUnexpectedErrorGameAndBuildsManager: GameAndBuildsManager = {
   setGame: () => {},
   refreshGame: async () => {},
   gameAvailabilityError: 'unexpected',
-  builds: null,
-  refreshBuilds: async () => {},
+  gameBuilds: null,
+  refreshGameBuilds: async () => {},
   registerGameIfNeeded: async () => {},
 };


### PR DESCRIPTION
This could happen when the last build was too old, and the interface considered the game as new.
Updated logic to return all the builds of the game, instead of a subset of all the builds of the user