### PR TITLE
Incapsulate logic of getting file url in Sound manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 .Spotlight-V100
 .Trashes
 Thumbs.db
+/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,3 @@
 .Spotlight-V100
 .Trashes
 Thumbs.db
-/build/*

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -511,10 +511,10 @@ namespace gdjs {
      * @param resource
      * @param isMusic
      */
-    private _preloadAudioFile = (
+    private _preloadAudioFile (
       resource: ResourceData,
       isMusic: boolean
-    ): Promise<number> => {
+    ): Promise<number>  {
       const file = resource.file;
       return new Promise((resolve, reject) => {
         const container = isMusic ? this._loadedMusics : this._loadedSounds;

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -511,10 +511,10 @@ namespace gdjs {
      * @param resource
      * @param isMusic
      */
-    private _preloadAudioFile (
+    private _preloadAudioFile(
       resource: ResourceData,
       isMusic: boolean
-    ): Promise<number>  {
+    ): Promise<number> {
       const file = resource.file;
       return new Promise((resolve, reject) => {
         const container = isMusic ? this._loadedMusics : this._loadedSounds;
@@ -525,9 +525,8 @@ namespace gdjs {
             onloaderror: (soundId: number, error?: string) => reject(error),
             html5: isMusic,
             xhr: {
-              withCredentials: this._resourceLoader.checkIfCredentialsRequired(
-                file
-              ),
+              withCredentials:
+                this._resourceLoader.checkIfCredentialsRequired(file),
             },
             // Cache the sound with no volume. This avoids a bug where it plays at full volume
             // for a split second before setting its correct volume.
@@ -535,7 +534,7 @@ namespace gdjs {
           })
         );
       });
-    };
+    }
 
     /**
      * Store the sound in the specified array, put it at the first index that
@@ -588,9 +587,10 @@ namespace gdjs {
               src: this._getSoundUrlsFromResource(resource),
               html5: isMusic,
               xhr: {
-                withCredentials: this._resourceLoader.checkIfCredentialsRequired(
-                  resource.file
-                ),
+                withCredentials:
+                  this._resourceLoader.checkIfCredentialsRequired(
+                    resource.file
+                  ),
               },
               // Cache the sound with no volume. This avoids a bug where it plays at full volume
               // for a split second before setting its correct volume.
@@ -627,9 +627,10 @@ namespace gdjs {
               src: this._getSoundUrlsFromResource(resource),
               html5: isMusic,
               xhr: {
-                withCredentials: this._resourceLoader.checkIfCredentialsRequired(
-                  resource.file
-                ),
+                withCredentials:
+                  this._resourceLoader.checkIfCredentialsRequired(
+                    resource.file
+                  ),
               },
               // Cache the sound with no volume. This avoids a bug where it plays at full volume
               // for a split second before setting its correct volume.
@@ -903,9 +904,8 @@ namespace gdjs {
           const file = resource.file;
           await new Promise((resolve, reject) => {
             const sound = new XMLHttpRequest();
-            sound.withCredentials = this._resourceLoader.checkIfCredentialsRequired(
-              file
-            );
+            sound.withCredentials =
+              this._resourceLoader.checkIfCredentialsRequired(file);
             sound.addEventListener('load', resolve);
             sound.addEventListener('error', (_) =>
               reject('XHR error: ' + file)

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -582,7 +582,6 @@ namespace gdjs {
 
       let howl = cacheContainer.get(resource);
       if (!howl) {
-        const fileName = resource ? resource.file : soundName;
         howl = new Howl(
           Object.assign(
             {
@@ -590,7 +589,7 @@ namespace gdjs {
               html5: isMusic,
               xhr: {
                 withCredentials: this._resourceLoader.checkIfCredentialsRequired(
-                  fileName
+                  resource.file
                 ),
               },
               // Cache the sound with no volume. This avoids a bug where it plays at full volume

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -9,6 +9,14 @@ namespace gdjs {
 
   const resourceKinds: Array<ResourceKind> = ['audio'];
 
+  const HowlParameters: HowlOptions = {
+    preload: true,
+    onplayerror: (_, error) =>
+      logger.error("Can't play an audio file: " + error),
+    onloaderror: (_, error) =>
+      logger.error('Error while loading an audio file: ' + error),
+  };
+
   /**
    * Ensure the volume is between 0 and 1.
    */
@@ -447,14 +455,6 @@ namespace gdjs {
       return resourceKinds;
     }
 
-    static HowlParameters: HowlOptions = {
-      preload: true,
-      onplayerror: (_, error) =>
-        logger.error("Can't play an audio file: " + error),
-      onloaderror: (_, error) =>
-        logger.error('Error while loading an audio file: ' + error),
-    };
-
     /**
      * Ensure rate is in a range valid for Howler.js
      * @return The clamped rate
@@ -519,7 +519,7 @@ namespace gdjs {
       return new Promise((resolve, reject) => {
         const container = isMusic ? this._loadedMusics : this._loadedSounds;
         container[file] = new Howl(
-          Object.assign({}, HowlerSoundManager.HowlParameters, {
+          Object.assign({}, HowlParameters, {
             src: this._getSoundUrlsFromResource(resource),
             onload: resolve,
             onloaderror: (soundId: number, error?: string) => reject(error),
@@ -597,7 +597,7 @@ namespace gdjs {
               // for a split second before setting its correct volume.
               volume: 0,
             },
-            HowlerSoundManager.HowlParameters
+            HowlParameters
           )
         );
         cacheContainer.set(resource, howl);
@@ -636,7 +636,7 @@ namespace gdjs {
               // for a split second before setting its correct volume.
               volume: 0,
             },
-            HowlerSoundManager.HowlParameters
+            HowlParameters
           )
         )
       );


### PR DESCRIPTION
This PR is intended for a minor refactoring of the howler-sound-manager.

- Two private methods, _getSoundUrlsFromResource and _getDefaultSoundUrl, have been created to handle the    formation of src.
- In the loadResource method, the preloadAudioFile function was being created each time, despite not using any data from the closure. The preloadAudioFile function has been extracted as a private method.

	
This minor refactoring can help extend the functionality of the class by inheriting from SoundManager without the need to override much of its implementation.