### PR TITLE
Update pickAllObjects to use gdja.copyArray

### DIFF
--- a/GDJS/Runtime/events-tools/objecttools.ts
+++ b/GDJS/Runtime/events-tools/objecttools.ts
@@ -362,8 +362,7 @@ namespace gdjs {
           if (objectsLists.items.hasOwnProperty(name)) {
             const allObjects = objectsContext.getObjects(name);
             const objectsList = objectsLists.items[name];
-            objectsList.length = 0;
-            objectsList.push.apply(objectsList, allObjects);
+            gdjs.copyArray(allObjects, objectsList);
           }
         }
         return true;


### PR DESCRIPTION
Replace the `push` hack with `gdjs.copyArray`.
Misusing push like this can cause issues when a large amount of objects are used.

(Untested, quick edit made from my phone)