### PR TITLE
Fix "Never reached character" error during GDevelop.js build

### DIFF
--- a/GDevelop.js/scripts/generate-dts.mjs
+++ b/GDevelop.js/scripts/generate-dts.mjs
@@ -262,6 +262,7 @@ for (const [
       attributes.push(
         `${attributeName}${optionalReturn ? '?' : ''}: ${returnType};`
       );
+      Parser.skipWhitespaces();
       continue;
     }
 


### PR DESCRIPTION
Fixes:  #7168

During the final phase of the GDevelop.js build, the generateTSTypes task is executed. This task generates the type.d.ts file from the interfaces defined in the Bindings.idl file.
If the last element of an interface is an attribute, the parser expects a type token in the next iteration, which is invalid in this context.
To handle this, after processing an attribute, we now consume any whitespace characters to ensure we reach the end of the interface definition, which correctly terminates the parsing process.

The issue occurred during the parsing of the Vector2f interface, which looks like this:

```
interface Vector2f {
    void Vector2f();

    attribute float x;
    attribute float y;
};
```