### PR TITLE
Use a shorter label for the button to toggle parameters in drop-down list

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ExternalLayoutNameField.js
@@ -115,7 +115,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select an external layout</Trans>}
+              label={<Trans>Select</Trans>}
               onClick={switchFieldType}
             />
           ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/KeyboardKeyField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/KeyboardKeyField.js
@@ -256,7 +256,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select a key</Trans>}
+              label={<Trans>Select</Trans>}
               onClick={switchFieldType}
             />
           ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectNameField.js
@@ -142,7 +142,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                 leftIcon={<TypeCursorSelect />}
                 style={style}
                 primary
-                label={<Trans>Select an effect</Trans>}
+                label={<Trans>Select</Trans>}
                 onClick={switchFieldType}
               />
             ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerEffectParameterNameField.js
@@ -170,7 +170,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                 leftIcon={<TypeCursorSelect />}
                 style={style}
                 primary
-                label={<Trans>Select an effect property</Trans>}
+                label={<Trans>Select</Trans>}
                 onClick={switchFieldType}
               />
             ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/LayerField.js
@@ -134,7 +134,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                 leftIcon={<TypeCursorSelect />}
                 style={style}
                 primary
-                label={<Trans>Select a layer</Trans>}
+                label={<Trans>Select</Trans>}
                 onClick={switchFieldType}
               />
             ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/MouseButtonField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/MouseButtonField.js
@@ -141,7 +141,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select a mouse button</Trans>}
+              label={<Trans>Select</Trans>}
               onClick={switchFieldType}
             />
           ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectAnimationNameField.js
@@ -145,7 +145,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                 leftIcon={<TypeCursorSelect />}
                 style={style}
                 primary
-                label={<Trans>Select an animation</Trans>}
+                label={<Trans>Select</Trans>}
                 onClick={switchFieldType}
               />
             ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectNameField.js
@@ -180,7 +180,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                 leftIcon={<TypeCursorSelect />}
                 style={style}
                 primary
-                label={<Trans>Select an effect</Trans>}
+                label={<Trans>Select</Trans>}
                 onClick={switchFieldType}
               />
             ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectEffectParameterNameField.js
@@ -229,7 +229,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
                 leftIcon={<TypeCursorSelect />}
                 style={style}
                 primary
-                label={<Trans>Select an effect property</Trans>}
+                label={<Trans>Select</Trans>}
                 onClick={switchFieldType}
               />
             ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SceneNameField.js
@@ -116,7 +116,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select a scene</Trans>}
+              label={<Trans>Select</Trans>}
               onClick={switchFieldType}
             />
           ) : (

--- a/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/StringWithSelectorField.js
@@ -129,7 +129,7 @@ export default React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
               leftIcon={<TypeCursorSelect />}
               style={style}
               primary
-              label={<Trans>Select a value</Trans>}
+              label={<Trans>Select</Trans>}
               onClick={switchFieldType}
             />
           ) : (


### PR DESCRIPTION
- In expression mode, the "select" button is next to the "expression builder" button which doesn't leave much room for the field

Some users reported issues with an OS upscale of 125%

![image](https://github.com/user-attachments/assets/72140cad-fb28-49f3-83bf-9fc24114b713)
