### PR TITLE
Add tooltip in game analytics

### DIFF
--- a/newIDE/app/src/GameDashboard/GameAnalyticsCharts.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsCharts.js
@@ -57,18 +57,18 @@ const CustomTooltip = ({
   payload,
   label,
   customStyle,
-  labelType,
+  labelSuffix,
 }: {|
   payload: ?Array<any>,
   label: string,
   customStyle: Object,
-  labelType: ?string,
+  labelSuffix: ?string,
 |}) =>
   payload ? (
     <Paper style={customStyle} background="light">
       <ColumnStackLayout>
         <Text size="sub-title" noMargin>
-          {label} {labelType ? labelType : ''}
+          {label} {labelSuffix ? labelSuffix : ''}
         </Text>
         {payload.length > 0 &&
           payload.map(
@@ -300,7 +300,7 @@ export const PlayersRepartitionPerDurationChart = ({
             CustomTooltip({
               ...props,
               customStyle: styles.tooltipContent,
-              labelType: i18n._(t`minutes`),
+              labelSuffix: i18n._(t`minutes`),
             })
           }
         />

--- a/newIDE/app/src/GameDashboard/GameAnalyticsCharts.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsCharts.js
@@ -57,16 +57,18 @@ const CustomTooltip = ({
   payload,
   label,
   customStyle,
+  labelType,
 }: {|
   payload: ?Array<any>,
   label: string,
   customStyle: Object,
+  labelType: ?string,
 |}) =>
   payload ? (
     <Paper style={customStyle} background="light">
       <ColumnStackLayout>
         <Text size="sub-title" noMargin>
-          {label}
+          {label} {labelType ? labelType : ''}
         </Text>
         {payload.length > 0 &&
           payload.map(
@@ -167,7 +169,7 @@ export const BounceRateChart = ({
       <LineChart data={chartData.overTime} margin={chartMargins}>
         <RechartsLine
           name={i18n._(t`Bounce rate`)}
-          unit="%"
+          unit={' %'}
           formatter={minutesFormatter}
           type="monotone"
           dataKey="bounceRatePercent"
@@ -185,6 +187,7 @@ export const BounceRateChart = ({
           style={styles.tickLabel}
         />
         <YAxis
+          unit={' %'}
           dataKey="bounceRatePercent"
           stroke={gdevelopTheme.chart.textColor}
           style={styles.tickLabel}
@@ -234,6 +237,7 @@ export const MeanPlayTimeChart = ({
           style={styles.tickLabel}
         />
         <YAxis
+          unit={` ` + i18n._(t`min`)}
           dataKey="meanPlayedDurationInMinutes"
           stroke={gdevelopTheme.chart.textColor}
           style={styles.tickLabel}
@@ -272,6 +276,7 @@ export const PlayersRepartitionPerDurationChart = ({
           yAxisId={0}
         />
         <XAxis
+          unit={` ` + i18n._(t`min`)}
           name={i18n._(t`Played time`)}
           dataKey="duration"
           type="number"
@@ -295,6 +300,7 @@ export const PlayersRepartitionPerDurationChart = ({
             CustomTooltip({
               ...props,
               customStyle: styles.tooltipContent,
+              labelType: i18n._(t`minutes`),
             })
           }
         />

--- a/newIDE/app/src/GameDashboard/GameAnalyticsCharts.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsCharts.js
@@ -169,7 +169,7 @@ export const BounceRateChart = ({
       <LineChart data={chartData.overTime} margin={chartMargins}>
         <RechartsLine
           name={i18n._(t`Bounce rate`)}
-          unit={' %'}
+          unit={'%'}
           formatter={minutesFormatter}
           type="monotone"
           dataKey="bounceRatePercent"
@@ -187,7 +187,7 @@ export const BounceRateChart = ({
           style={styles.tickLabel}
         />
         <YAxis
-          unit={' %'}
+          unit={'%'}
           dataKey="bounceRatePercent"
           stroke={gdevelopTheme.chart.textColor}
           style={styles.tickLabel}
@@ -326,7 +326,7 @@ export const PlayersDurationPerDayChart = ({
           type="monotone"
           dataKey="over60sPlayersPercent"
           formatter={percentFormatter}
-          unit={' %'}
+          unit={'%'}
           stroke={gdevelopTheme.chart.dataColor1}
           fill={gdevelopTheme.chart.dataColor1}
           fillOpacity={0.15}
@@ -337,7 +337,7 @@ export const PlayersDurationPerDayChart = ({
           type="monotone"
           dataKey="over180sPlayersPercent"
           formatter={percentFormatter}
-          unit={' %'}
+          unit={'%'}
           stroke={gdevelopTheme.chart.dataColor1}
           fill={gdevelopTheme.chart.dataColor1}
           fillOpacity={0.15}
@@ -348,7 +348,7 @@ export const PlayersDurationPerDayChart = ({
           type="monotone"
           dataKey="over300sPlayersPercent"
           formatter={percentFormatter}
-          unit={' %'}
+          unit={'%'}
           stroke={gdevelopTheme.chart.dataColor1}
           fill={gdevelopTheme.chart.dataColor1}
           fillOpacity={0.15}
@@ -359,7 +359,7 @@ export const PlayersDurationPerDayChart = ({
           type="monotone"
           dataKey="over600sPlayersPercent"
           formatter={percentFormatter}
-          unit={' %'}
+          unit={'%'}
           stroke={gdevelopTheme.chart.dataColor1}
           fill={gdevelopTheme.chart.dataColor1}
           fillOpacity={0.15}
@@ -370,7 +370,7 @@ export const PlayersDurationPerDayChart = ({
           type="monotone"
           dataKey="over900sPlayersPercent"
           formatter={percentFormatter}
-          unit={' %'}
+          unit={'%'}
           stroke={gdevelopTheme.chart.dataColor1}
           fill={gdevelopTheme.chart.dataColor1}
           fillOpacity={0.15}
@@ -389,7 +389,7 @@ export const PlayersDurationPerDayChart = ({
           dataKey="over60sPlayersPercent"
           stroke={gdevelopTheme.chart.textColor}
           style={styles.tickLabel}
-          unit={' %'}
+          unit={'%'}
         />
         <Tooltip
           content={props =>

--- a/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
@@ -3,6 +3,9 @@ import * as React from 'react';
 import { Trans, t } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import Grid from '@material-ui/core/Grid';
+import Tooltip from '@material-ui/core/Tooltip';
+import classNames from 'classnames';
+import { icon } from 'classnames';
 import { formatISO, subDays } from 'date-fns';
 import { Column, Line } from '../UI/Grid';
 import {
@@ -21,6 +24,7 @@ import PlaceholderError from '../UI/PlaceholderError';
 import SelectField from '../UI/SelectField';
 import SelectOption from '../UI/SelectOption';
 import PlaceholderLoader from '../UI/PlaceholderLoader';
+import InfoIcon from '../UI/CustomSvgIcons/CircledInfo';
 import { buildChartData, daysShownForYear } from './GameAnalyticsEvaluator';
 import {
   BounceRateChart,
@@ -232,6 +236,22 @@ export const GameAnalyticsPanel = ({
                       }{' '}
                       minutes
                     </Trans>
+                    <Tooltip
+                      title={
+                        <Column noMargin>
+                          <Text size="body">
+                            <Trans>
+                              Players who engage with a game for at least X
+                              minutes. This information is crucial for
+                              understanding player retention and game
+                              performance.
+                            </Trans>
+                          </Text>
+                        </Column>
+                      }
+                    >
+                      <InfoIcon />
+                    </Tooltip>
                   </Text>
                   <PlayersDurationPerDayChart
                     chartData={chartData}

--- a/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
@@ -188,9 +188,10 @@ export const GameAnalyticsPanel = ({
                       title={
                         <Text>
                           <Trans>
-                            Percentage of people who leave before 60 seconds.
-                            The smaller the number, the better — it means more
-                            people are interested and stay longer.
+                            Percentage of people who leave before 60 seconds
+                            including loading screens. The smaller the number,
+                            the better — it means more people are interested and
+                            stay longer.
                           </Trans>
                         </Text>
                       }

--- a/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
@@ -145,6 +145,7 @@ export const GameAnalyticsPanel = ({
                   <Text size="block-title" align="center">
                     <Trans>{chartData.overview.playersCount} sessions</Trans>
                     <Tooltip
+                      style={{ verticalAlign: 'bottom' }}
                       title={
                         <Text>
                           <Trans>
@@ -185,6 +186,7 @@ export const GameAnalyticsPanel = ({
                       rate
                     </Trans>
                     <Tooltip
+                      style={{ verticalAlign: 'bottom' }}
                       title={
                         <Text>
                           <Trans>
@@ -216,6 +218,7 @@ export const GameAnalyticsPanel = ({
                       minutes per player
                     </Trans>
                     <Tooltip
+                      style={{ verticalAlign: 'bottom' }}
                       title={
                         <Text>
                           <Trans>
@@ -250,6 +253,7 @@ export const GameAnalyticsPanel = ({
                       minutes
                     </Trans>
                     <Tooltip
+                      style={{ verticalAlign: 'bottom' }}
                       title={
                         <Text>
                           <Trans>
@@ -287,6 +291,7 @@ export const GameAnalyticsPanel = ({
                       minutes
                     </Trans>
                     <Tooltip
+                      style={{ verticalAlign: 'bottom' }}
                       title={
                         <Text>
                           <Trans>

--- a/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
@@ -191,9 +191,7 @@ export const GameAnalyticsPanel = ({
                         <Text>
                           <Trans>
                             Percentage of people who leave before 60 seconds
-                            including loading screens. The smaller the number,
-                            the better — it means more people are interested and
-                            stay longer.
+                            including loading screens.
                           </Trans>
                         </Text>
                       }

--- a/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
@@ -148,9 +148,9 @@ export const GameAnalyticsPanel = ({
                       title={
                         <Text>
                           <Trans>
-                            Number of people who launched the game. A viewer is
-                            a single visitor, and a player is a visitor after 60
-                            seconds of activity in the game.
+                            Number of people who launched the game. Viewers are
+                            considered players when they stayed at least 60
+                            seconds including loading screens.
                           </Trans>
                         </Text>
                       }

--- a/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
+++ b/newIDE/app/src/GameDashboard/GameAnalyticsPanel.js
@@ -4,8 +4,6 @@ import { Trans, t } from '@lingui/macro';
 import { I18n } from '@lingui/react';
 import Grid from '@material-ui/core/Grid';
 import Tooltip from '@material-ui/core/Tooltip';
-import classNames from 'classnames';
-import { icon } from 'classnames';
 import { formatISO, subDays } from 'date-fns';
 import { Column, Line } from '../UI/Grid';
 import {
@@ -146,6 +144,19 @@ export const GameAnalyticsPanel = ({
                 <Column noMargin alignItems="center" expand>
                   <Text size="block-title" align="center">
                     <Trans>{chartData.overview.playersCount} sessions</Trans>
+                    <Tooltip
+                      title={
+                        <Text>
+                          <Trans>
+                            Number of people who launched the game. A viewer is
+                            a single visitor, and a player is a visitor after 60
+                            seconds of activity in the game.
+                          </Trans>
+                        </Text>
+                      }
+                    >
+                      <InfoIcon />
+                    </Tooltip>
                   </Text>
                   <SessionsChart
                     chartData={chartData}
@@ -173,6 +184,19 @@ export const GameAnalyticsPanel = ({
                       {Math.round(chartData.overview.bounceRatePercent)}% bounce
                       rate
                     </Trans>
+                    <Tooltip
+                      title={
+                        <Text>
+                          <Trans>
+                            Percentage of people who leave before 60 seconds.
+                            The smaller the number, the better — it means more
+                            people are interested and stay longer.
+                          </Trans>
+                        </Text>
+                      }
+                    >
+                      <InfoIcon />
+                    </Tooltip>
                   </Text>
                   <BounceRateChart
                     chartData={chartData}
@@ -190,6 +214,17 @@ export const GameAnalyticsPanel = ({
                       )}{' '}
                       minutes per player
                     </Trans>
+                    <Tooltip
+                      title={
+                        <Text>
+                          <Trans>
+                            Is the average time a player spends in the game.
+                          </Trans>
+                        </Text>
+                      }
+                    >
+                      <InfoIcon />
+                    </Tooltip>
                   </Text>
                   <MeanPlayTimeChart
                     chartData={chartData}
@@ -213,6 +248,20 @@ export const GameAnalyticsPanel = ({
                       }{' '}
                       minutes
                     </Trans>
+                    <Tooltip
+                      title={
+                        <Text>
+                          <Trans>
+                            Average of players still active after 15 minutes.
+                            This graph shows how long players stay in the game
+                            after X minutes. It helps to see if the players quit
+                            quickly or keep playing for a while.
+                          </Trans>
+                        </Text>
+                      }
+                    >
+                      <InfoIcon />
+                    </Tooltip>
                   </Text>
                   <PlayersRepartitionPerDurationChart
                     chartData={chartData}
@@ -238,16 +287,16 @@ export const GameAnalyticsPanel = ({
                     </Trans>
                     <Tooltip
                       title={
-                        <Column noMargin>
-                          <Text size="body">
-                            <Trans>
-                              Players who engage with a game for at least X
-                              minutes. This information is crucial for
-                              understanding player retention and game
-                              performance.
-                            </Trans>
-                          </Text>
-                        </Column>
+                        <Text>
+                          <Trans>
+                            Shows how long players stay in the game over time.
+                            The percentages are showing people playing for more
+                            than 3, 5, 10, and 15 minutes based on the best day.
+                            A higher value means better player retention on the
+                            day. This helps you understand when players are most
+                            engaged — and when they drop off quickly.
+                          </Trans>
+                        </Text>
                       }
                     >
                       <InfoIcon />

--- a/newIDE/app/src/GameDashboard/Widgets/AnalyticsWidget.js
+++ b/newIDE/app/src/GameDashboard/Widgets/AnalyticsWidget.js
@@ -119,7 +119,7 @@ const AnalyticsWidget = ({ game, onSeeAll, gameMetrics, gameUrl }: Props) => {
               ) : (
                 <Column expand noMargin>
                   <Line alignItems="center" justifyContent="space-between">
-                    <Text size="block-title" noMargin>
+                    <Text size="sub-title" noMargin>
                       <Trans>Sessions</Trans>
                     </Text>
                     <RaisedButton


### PR DESCRIPTION
Add more details on the game analytics.

- Add on the x-axis "min" suffix on the penultimate graph
- Add "minutes" on the tooltip of the  penultimate graph
- Add ? icon tooltip for each graph with a description of the title, and how read the graph, and what it's for based on `GameAnalyticsEvaluator.js`
- Add percentage unit on y-axis on graphs

[The wiki is wrong ](https://wiki.gdevelop.io/gdevelop5/interface/games-dashboard/game-analytics/#interpreting-game-analytics)as it details more descriptions than there are graphs in the engine, I'll fix the wiki with the changes from this PR once merged.

![image](https://github.com/user-attachments/assets/8f3831f6-a19a-45c1-b998-4617411cd8e7)
![image](https://github.com/user-attachments/assets/6a408f43-57e4-41c7-97bd-6fb125e60e29)
![image](https://github.com/user-attachments/assets/c5758f35-6dd9-4b4a-9b6f-0a1f9e912bd8)
![image](https://github.com/user-attachments/assets/c70eea5f-f2ee-4741-acc9-ad9c251e1823)
![image](https://github.com/user-attachments/assets/31d5520a-5b62-4f62-899c-eb8eb2a5a9b3)



After / Before
![image](https://github.com/user-attachments/assets/6deb36d3-0a42-4705-8043-3c207248d9bb)
