### PR TITLE
Fix typo in GuidedLessons.js

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/InAppTutorials/GuidedLessons.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/InAppTutorials/GuidedLessons.js
@@ -139,7 +139,7 @@ const GuidedLessons = ({ selectInAppTutorial, lessonsIds }: Props) => {
       id: CAMERA_PARALLAX_IN_APP_TUTORIAL_ID,
       title: t`Background and cameras`,
       shortDescription: t`Follow a character with scrolling background.`,
-      description: t`Follow this Castlevania-type chraracter with the camera, while the background scrolls.`,
+      description: t`Follow this Castlevania-type character with the camera, while the background scrolls.`,
       durationInMinutes: 2,
       renderImage: props => <Parallax {...props} />,
     },


### PR DESCRIPTION
Fix this
<img width="370" alt="image" src="https://github.com/user-attachments/assets/42d26bb7-5f28-42ad-8cb0-a0e6a0f541ad" />
