### PR TITLE
Fix rendered custom objects with an overriding of children configuration in the editor

### DIFF
--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -105,7 +105,14 @@ namespace gdjs {
         return;
       }
 
-      let usedVariantData: EventsBasedObjectVariantData = eventsBasedObjectData;
+      if (!eventsBasedObjectData.defaultVariant) {
+        eventsBasedObjectData.defaultVariant = {
+          ...eventsBasedObjectData,
+          name: '',
+        };
+      }
+      let usedVariantData: EventsBasedObjectVariantData =
+        eventsBasedObjectData.defaultVariant;
       if (customObjectData.variant) {
         for (
           let variantIndex = 0;

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -80,7 +80,11 @@ namespace gdjs {
         ++i
       ) {
         const childObjectData = eventsBasedObjectVariantData.objects[i];
-        if (customObjectData.childrenContent) {
+        // The children configuration override only applies to the default variant.
+        if (
+          customObjectData.childrenContent &&
+          !eventsBasedObjectVariantData.name
+        ) {
           this.registerObject({
             ...childObjectData,
             // The custom object overrides its events-based object configuration.

--- a/GDJS/Runtime/types/project-data.d.ts
+++ b/GDJS/Runtime/types/project-data.d.ts
@@ -212,6 +212,9 @@ declare interface EventsBasedObjectData
   name: string;
   isInnerAreaFollowingParentSize: boolean;
   variants: Array<EventsBasedObjectVariantData>;
+  /** Added at runtime to have the default variant with an empty name instead
+   * of the events-based object name. */
+  defaultVariant?: EventsBasedObjectVariantData;
 }
 
 declare interface EventsBasedObjectVariantData extends InstanceContainerData {

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedCustomObjectInstance.js
@@ -195,20 +195,29 @@ export default class RenderedCustomObjectInstance extends Rendered3DInstance
     let renderedInstance = this.renderedInstances.get(instance.ptr);
     if (!renderedInstance) {
       // No renderer associated yet, the instance must have been just created!...
+
+      const customObjectConfiguration = gd.asCustomObjectConfiguration(
+        this._associatedObjectConfiguration
+      );
+
       let childObjectConfiguration = null;
       const variant = this.getVariant();
       if (variant) {
         const childObjects = variant.getObjects();
         if (childObjects.hasObjectNamed(instance.getObjectName())) {
           const childObject = childObjects.getObject(instance.getObjectName());
-          childObjectConfiguration = childObject.getConfiguration();
+          childObjectConfiguration =
+            this.eventBasedObject &&
+            customObjectConfiguration.isMarkedAsOverridingEventsBasedObjectChildrenConfiguration() &&
+            variant === this.eventBasedObject.getDefaultVariant()
+              ? customObjectConfiguration.getChildObjectConfiguration(
+                  instance.getObjectName()
+                )
+              : childObject.getConfiguration();
         }
       }
       // Apply property mapping rules on the child instance.
       const childPropertyOverridings = new Map<string, string>();
-      const customObjectConfiguration = gd.asCustomObjectConfiguration(
-        this._associatedObjectConfiguration
-      );
       const customObjectProperties = customObjectConfiguration.getProperties();
       for (const propertyMappingRule of this._propertyMappingRules) {
         if (propertyMappingRule.targetChild !== instance.getObjectName()) {


### PR DESCRIPTION
- Fix children overriding to only apply to the default variant at runtime