### PR TITLE
Forbid to edit variants from the store without duplicating them first

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/CustomObjectPropertiesEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/CustomObjectPropertiesEditor/index.js
@@ -79,7 +79,7 @@ const getVariantName = (
     ? customObjectConfiguration.getVariantName()
     : '';
 
-const getVariant = (
+export const getVariant = (
   eventBasedObject: gdEventsBasedObject,
   customObjectConfiguration: gdCustomObjectConfiguration
 ): gdEventsBasedObjectVariant => {

--- a/newIDE/app/src/ObjectsList/ObjectTreeViewItemContent.js
+++ b/newIDE/app/src/ObjectsList/ObjectTreeViewItemContent.js
@@ -19,6 +19,7 @@ import {
 import { type ObjectEditorTab } from '../ObjectEditor/ObjectEditorDialog';
 import type { ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import { type HTMLDataset } from '../Utils/HTMLDataset';
+import { getVariant } from '../ObjectEditor/Editors/CustomObjectPropertiesEditor';
 
 const gd: libGDevelop = global.gd;
 
@@ -370,6 +371,11 @@ export class ObjectTreeViewItemContent implements TreeViewItemContent {
       project.hasEventsBasedObject(object.getType())
         ? {
             label: i18n._(t`Edit children`),
+            enabled:
+              getVariant(
+                project.getEventsBasedObject(object.getType()),
+                gd.asCustomObjectConfiguration(object.getConfiguration())
+              ).getAssetStoreAssetId() === '',
             click: () => {
               const customObjectConfiguration = gd.asCustomObjectConfiguration(
                 object.getConfiguration()

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -80,6 +80,7 @@ import { unserializeFromJSObject } from '../Utils/Serializer';
 import { ProjectScopedContainersAccessor } from '../InstructionOrExpression/EventsScope';
 import { type TileMapTileSelection } from '../InstancesEditor/TileSetVisualizer';
 import { extractAsCustomObject } from './CustomObjectExtractor/CustomObjectExtractor';
+import { getVariant } from '../ObjectEditor/Editors/CustomObjectPropertiesEditor';
 
 const gd: libGDevelop = global.gd;
 
@@ -1576,6 +1577,11 @@ export default class SceneEditor extends React.Component<Props, State> {
         object && project.hasEventsBasedObject(object.getType())
           ? {
               label: i18n._(t`Edit children`),
+              enabled:
+                getVariant(
+                  project.getEventsBasedObject(object.getType()),
+                  gd.asCustomObjectConfiguration(object.getConfiguration())
+                ).getAssetStoreAssetId() === '',
               click: () => {
                 const customObjectConfiguration = gd.asCustomObjectConfiguration(
                   object.getConfiguration()


### PR DESCRIPTION
I wonder if a dialog should be shown instead with a message like "Variants from the store can't be edited directly. Do you want to duplicate it?".