### PR TITLE
Fix grid snapping when instances are pasted

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -1,5 +1,5 @@
 // @flow
-import { roundPosition } from '../Utils/GridHelpers';
+import { roundPositionsToGrid } from '../Utils/GridHelpers';
 import { unserializeFromJSObject } from '../Utils/Serializer';
 import { type InstancesEditorSettings } from './InstancesEditorSettings';
 const gd: libGDevelop = global.gd;
@@ -8,29 +8,6 @@ type Props = {|
   instances: gdInitialInstancesContainer,
   instancesEditorSettings: InstancesEditorSettings,
 |};
-
-const roundPositionsToGrid = (
-  pos: [number, number],
-  instancesEditorSettings: InstancesEditorSettings
-): [number, number] => {
-  const newPos = pos;
-
-  if (instancesEditorSettings.grid && instancesEditorSettings.snap) {
-    roundPosition(
-      newPos,
-      instancesEditorSettings.gridWidth,
-      instancesEditorSettings.gridHeight,
-      instancesEditorSettings.gridOffsetX,
-      instancesEditorSettings.gridOffsetY,
-      instancesEditorSettings.gridType
-    );
-  } else {
-    newPos[0] = Math.round(newPos[0]);
-    newPos[1] = Math.round(newPos[1]);
-  }
-
-  return newPos;
-};
 
 /**
  * Allow to add instances on the scene. Supports "temporary" instances,
@@ -56,14 +33,12 @@ export default class InstancesAdder {
     position,
     copyReferential,
     serializedInstances,
-    preventSnapToGrid = false,
     addInstancesInTheForeground = false,
     doesObjectExistInContext,
   }: {|
     position: [number, number],
     copyReferential: [number, number],
     serializedInstances: Array<Object>,
-    preventSnapToGrid?: boolean,
     addInstancesInTheForeground?: boolean,
     doesObjectExistInContext: string => boolean,
   |}): Array<gdInitialInstance> => {
@@ -78,18 +53,8 @@ export default class InstancesAdder {
         const instance = new gd.InitialInstance();
         unserializeFromJSObject(instance, serializedInstance);
         if (!doesObjectExistInContext(instance.getObjectName())) return null;
-        const desiredPosition = [
-          instance.getX() - copyReferential[0] + position[0],
-          instance.getY() - copyReferential[1] + position[1],
-        ];
-        const newPos = preventSnapToGrid
-          ? desiredPosition
-          : roundPositionsToGrid(
-              desiredPosition,
-              this._instancesEditorSettings
-            );
-        instance.setX(newPos[0]);
-        instance.setY(newPos[1]);
+        instance.setX(instance.getX() - copyReferential[0] + position[0]);
+        instance.setY(instance.getY() - copyReferential[1] + position[1]);
         if (addInstancesInTheForeground) {
           if (
             addedInstancesLowestZOrder === null ||

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -770,11 +770,14 @@ export default class InstancesEditor extends Component<Props, State> {
     position: [number, number],
     copyReferential: [number, number],
     serializedInstances: Array<Object>,
-    preventSnapToGrid?: boolean,
     addInstancesInTheForeground?: boolean,
     doesObjectExistInContext: string => boolean,
   |}): Array<gdInitialInstance> => {
     return this._instancesAdder.addSerializedInstances(options);
+  };
+
+  snapSelection = (instances: gdInitialInstance[]) => {
+    this.instancesMover.snapSelection(instances);
   };
 
   /**

--- a/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
+++ b/newIDE/app/src/SceneEditor/EditorsDisplay.flow.js
@@ -173,9 +173,9 @@ export type SceneEditorsDisplayInterface = {|
       position: [number, number],
       copyReferential: [number, number],
       serializedInstances: Array<Object>,
-      preventSnapToGrid?: boolean,
       addInstancesInTheForeground?: boolean,
       doesObjectExistInContext: string => boolean,
     |}) => Array<gdInitialInstance>,
+    snapSelection: (instances: gdInitialInstance[]) => void,
   |},
 |};

--- a/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/MosaicEditorsDisplay/index.js
@@ -229,6 +229,7 @@ const MosaicEditorsDisplay = React.forwardRef<
         addSerializedInstances: editor
           ? editor.addSerializedInstances
           : () => [],
+        snapSelection: editor ? editor.snapSelection : noop,
       },
     };
   });

--- a/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
+++ b/newIDE/app/src/SceneEditor/SwipeableDrawerEditorsDisplay/index.js
@@ -222,6 +222,7 @@ const SwipeableDrawerEditorsDisplay = React.forwardRef<
         addSerializedInstances: editor
           ? editor.addSerializedInstances
           : () => [],
+        snapSelection: editor ? editor.snapSelection : noop,
       },
     };
   });

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -1654,7 +1654,6 @@ export default class SceneEditor extends React.Component<Props, State> {
         position: [0, 0],
         copyReferential: [-2 * MOVEMENT_BIG_DELTA, -2 * MOVEMENT_BIG_DELTA],
         serializedInstances: serializedSelection,
-        preventSnapToGrid: true,
         doesObjectExistInContext:
           // Instance duplication can only be done in the same scene, so no need to check
           () => true,
@@ -1709,6 +1708,7 @@ export default class SceneEditor extends React.Component<Props, State> {
             .hasObjectNamed(objectName),
       }
     );
+    editorDisplay.instancesHandlers.snapSelection(newInstances);
 
     this._onInstancesAdded(newInstances);
     this.instancesSelection.clearSelection();

--- a/newIDE/app/src/Utils/GridHelpers.js
+++ b/newIDE/app/src/Utils/GridHelpers.js
@@ -1,5 +1,37 @@
 // @flow
 
+import { type InstancesEditorSettings } from '../InstancesEditor/InstancesEditorSettings';
+
+export const roundPositionsToGrid = (
+  pos: [number, number],
+  instancesEditorSettings: InstancesEditorSettings,
+  noGridSnap?: boolean = false
+): [number, number] => {
+  const newPos = pos;
+
+  if (
+    instancesEditorSettings.grid &&
+    instancesEditorSettings.snap &&
+    !noGridSnap
+  ) {
+    roundPosition(
+      newPos,
+      instancesEditorSettings.gridWidth,
+      instancesEditorSettings.gridHeight,
+      instancesEditorSettings.gridOffsetX,
+      instancesEditorSettings.gridOffsetY,
+      instancesEditorSettings.gridType
+    );
+  } else {
+    // Without a grid, the position is still rounded to the nearest pixel.
+    // The size of the instance (or selection of instances) might not be round,
+    // so the magnet corner is still relevant.
+    newPos[0] = Math.round(newPos[0]);
+    newPos[1] = Math.round(newPos[1]);
+  }
+  return newPos;
+};
+
 export const roundPosition = (
   pos: [number, number],
   gridWidth: number,


### PR DESCRIPTION
Instances were rounded from their positions (instead of their AABB) and one by one which means they could move differently.
`addSerializedInstances` no longer handles the snapping, so it will make it easier to reuse it somewhere else.