### PR TITLE
Make Events Sheet more robust against changes in events made outside of the tab

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/EventHeightsCache.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/EventHeightsCache.js
@@ -1,55 +1,22 @@
 // @flow
 
-type WatchedComponent = {
-  +onHeightsChanged: Function => void,
-};
+type OnHeightChangedCallback = (cb?: () => void) => void;
 
 /**
- * Store the height of events and notify a component whenever
- * heights have changed.
- * Needed for EventsTree as we need to tell it when heights have changed
- * so it can recompute the internal row heights of the react-virtualized List.
+ * Store the height of events.
+ * Needed for EventsTree as we need to tell the react-virtualized List
+ * the size of each event - which we only know after the event has been rendered.
  */
 export default class EventHeightsCache {
   eventHeights = {};
   updateTimeoutId: ?TimeoutID = null;
-  component: ?WatchedComponent = null;
+  onHeightsChanged: OnHeightChangedCallback;
 
-  constructor(component: WatchedComponent) {
-    this.component = component;
-  }
-
-  _notifyComponent() {
-    if (this.updateTimeoutId) {
-      return; // An update is already scheduled.
-    }
-
-    // Notify the component, on the next tick, that heights have changed
-    this.updateTimeoutId = setTimeout(() => {
-      if (this.component) {
-        this.component.onHeightsChanged(() => (this.updateTimeoutId = null));
-      } else {
-        this.updateTimeoutId = null;
-      }
-    }, 0);
+  constructor(onHeightsChanged: OnHeightChangedCallback) {
+    this.onHeightsChanged = onHeightsChanged;
   }
 
   setEventHeight(event: gdBaseEvent, height: number) {
-    if (height === 0) {
-      // Don't store the new height because it's 0, meaning a new rendering later
-      // will then render the proper height. In the meantime, we don't want to
-      // store this empty rendering BUT we still need to notify the parent that
-      // an update is needed.
-      this._notifyComponent();
-      return;
-    }
-
-    const cachedHeight = this.eventHeights[event.ptr];
-    if (cachedHeight === undefined || cachedHeight !== height) {
-      // Notify the parent component that a height changed.
-      this._notifyComponent();
-    }
-
     this.eventHeights[event.ptr] = height;
   }
 

--- a/newIDE/app/src/EventsSheet/EventsTree/EventHeightsCache.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/EventHeightsCache.js
@@ -1,7 +1,5 @@
 // @flow
 
-type OnHeightChangedCallback = (cb?: () => void) => void;
-
 /**
  * Store the height of events.
  * Needed for EventsTree as we need to tell the react-virtualized List
@@ -10,11 +8,6 @@ type OnHeightChangedCallback = (cb?: () => void) => void;
 export default class EventHeightsCache {
   eventHeights = {};
   updateTimeoutId: ?TimeoutID = null;
-  onHeightsChanged: OnHeightChangedCallback;
-
-  constructor(onHeightsChanged: OnHeightChangedCallback) {
-    this.onHeightsChanged = onHeightsChanged;
-  }
 
   setEventHeight(event: gdBaseEvent, height: number) {
     this.eventHeights[event.ptr] = height;

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/CommentEvent.js
@@ -70,6 +70,9 @@ export default class CommentEvent extends React.Component<
         if (this._textField) {
           this._textField.focus({ caretPosition: 'end' });
         }
+        // Wait for the change to be applied on the DOM before calling onUpdate,
+        // so that the height of the event is updated.
+        this.props.onUpdate();
       }
     );
   };
@@ -78,8 +81,11 @@ export default class CommentEvent extends React.Component<
     const commentEvent = gd.asCommentEvent(this.props.event);
     commentEvent.setComment(text);
 
-    this.props.onUpdate();
-    this.forceUpdate();
+    this.forceUpdate(() => {
+      // Wait for the change to be applied on the DOM before calling onUpdate,
+      // so that the height of the event is updated.
+      this.props.onUpdate();
+    });
   };
 
   endEditing = () => {

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -1,7 +1,6 @@
 // @flow
 import { Trans } from '@lingui/macro';
-import React, { Component, type Node } from 'react';
-import findIndex from 'lodash/findIndex';
+import * as React from 'react';
 import {
   SortableTreeWithoutDndContext,
   getFlatDataFromTree,
@@ -9,7 +8,7 @@ import {
 } from 'react-sortable-tree';
 import { type ConnectDragSource } from 'react-dnd';
 import { mapFor } from '../../Utils/MapFor';
-import { getInitialSelection, isEventSelected } from '../SelectionHandler';
+import { isEventSelected } from '../SelectionHandler';
 import EventsRenderingService from './EventsRenderingService';
 import EventHeightsCache from './EventHeightsCache';
 import classNames from 'classnames';
@@ -124,7 +123,7 @@ type EventsContainerProps = {|
   onEventContextMenu: (x: number, y: number) => void,
   onOpenExternalEvents: string => void,
   onOpenLayout: string => void,
-  renderObjectThumbnail: string => Node,
+  renderObjectThumbnail: string => React.Node,
 
   screenType: ScreenType,
   eventsSheetWidth: number,
@@ -157,13 +156,17 @@ const EventContainer = (props: EventsContainerProps) => {
   } = props;
   const forceUpdate = useForceUpdate();
   const containerRef = React.useRef<?HTMLDivElement>(null);
-  const height = containerRef.current ? containerRef.current.offsetHeight : 0;
-  React.useEffect(
-    () => {
-      eventsHeightsCache.setEventHeight(event, height);
-    },
-    [event, eventsHeightsCache, height]
-  );
+
+  // At EACH rendering, update the cache with the current height of the event.
+  React.useLayoutEffect(() => {
+    const height = containerRef.current ? containerRef.current.offsetHeight : 0;
+    if (height === 0) {
+      // An empty height means that the event is hidden, when navigating outside of the events sheet tab for example.
+      // Don't store the height in this case.
+      return;
+    }
+    eventsHeightsCache.setEventHeight(event, height);
+  });
 
   const _onEventContextMenu = React.useCallback(
     (domEvent: MouseEvent) => {
@@ -345,11 +348,23 @@ type EventsTreeProps = {|
   tutorials: ?Array<Tutorial>,
 |};
 
+export type EventsTreeInterface = {|
+  forceEventsUpdate: (cb?: () => void) => void,
+  foldAll: () => void,
+  unfoldToLevel: (level: number) => void,
+  getEventContextAtRowIndexes: (
+    rowIndexes: Array<number>
+  ) => Array<EventContext>,
+  scrollToRow: (row: number) => void,
+  getEventRow: (event: gdBaseEvent) => number,
+  unfoldForEvent: (event: gdBaseEvent) => void,
+|};
+
 // A node displayed by the SortableTree. Almost always represents an
 // event, except for the buttons at the bottom of the sheet and the tutorial.
 export type SortableTreeNode = {|
   // Necessary attributes for react-sortable-tree.
-  title: (node: {| node: SortableTreeNode |}) => Node,
+  title: (node: {| node: SortableTreeNode |}) => React.Node,
   children: Array<any>,
   expanded: boolean,
 
@@ -370,193 +385,463 @@ export type SortableTreeNode = {|
   fixedHeight?: ?number,
 |};
 
-type State = {|
-  treeData: Array<any>,
-  flatData: Array<gdBaseEvent>,
-  draggedNode: ?SortableTreeNode,
-  isScrolledTop: boolean,
-  isScrolledBottom: boolean,
-|};
-
 const getNodeKey = ({ treeIndex }) => treeIndex;
 
 /**
  * Display a tree of event. Builtin on react-sortable-tree so that event
  * can be drag'n'dropped and events rows are virtualized.
  */
-export default class ThemableEventsTree extends Component<
-  EventsTreeProps,
-  State
-> {
-  static defaultProps = {
-    selection: getInitialSelection(),
-  };
-  _list: ?any;
-  eventsHeightsCache: EventHeightsCache;
-  DragSourceAndDropTarget = makeDragSourceAndDropTarget<SortableTreeNode>(
-    eventsSheetEventsDnDType
-  );
-  DropTarget = makeDropTarget<SortableTreeNode>(eventsSheetEventsDnDType);
-  temporaryUnfoldedNodes: Array<SortableTreeNode>;
-  _hoverTimerId: ?TimeoutID;
+const EventsTree = React.forwardRef<EventsTreeProps, EventsTreeInterface>(
+  (props, ref) => {
+    const forceUpdate = useForceUpdate();
 
-  constructor(props: EventsTreeProps) {
-    super(props);
-    this.temporaryUnfoldedNodes = [];
-    this.eventsHeightsCache = new EventHeightsCache(this);
-    this.state = {
-      ...this._eventsToTreeData(
-        props.projectScopedContainersAccessor,
-        props.events
-      ),
-      draggedNode: null,
-      isScrolledTop: true,
-      isScrolledBottom: false,
-    };
-  }
+    const _list = React.useRef<?any>(null);
 
-  componentDidMount() {
-    this.onHeightsChanged();
-  }
+    const DragSourceAndDropTarget = React.useMemo(
+      () =>
+        makeDragSourceAndDropTarget<SortableTreeNode>(eventsSheetEventsDnDType),
+      []
+    );
+    const DropTarget = React.useMemo(
+      () => makeDropTarget<SortableTreeNode>(eventsSheetEventsDnDType),
+      []
+    );
+    const temporaryUnfoldedNodes = React.useRef<Array<SortableTreeNode>>([]);
+    const _hoverTimerId = React.useRef<?TimeoutID>(null);
 
-  componentDidUpdate(prevProps: EventsTreeProps) {
-    const {
-      values: { hiddenTutorialHints },
-    } = this.props.preferences;
-    const {
-      values: { hiddenTutorialHints: previousHiddenTutorialHints },
-    } = prevProps.preferences;
-    if (
-      hiddenTutorialHints['intro-event-system'] !==
-      previousHiddenTutorialHints['intro-event-system']
-    ) {
-      this.setState({
-        ...this.state,
-        treeData: this.state.treeData.filter(
-          data => data.key !== 'eventstree-tutorial-node'
-        ),
-      });
-    }
-  }
+    const [draggedNode, setDraggedNode] = React.useState(null);
+    const [isScrolledTop, setIsScrolledTop] = React.useState(true);
+    const [isScrolledBottom, setIsScrolledBottom] = React.useState(false);
 
-  componentWillUnmount() {
-    this._hoverTimerId && clearTimeout(this._hoverTimerId);
-  }
+    // TODO: ensure this is not needed anymore.
+    // componentDidUpdate(prevProps: EventsTreeProps) {
+    // const {
+    //   values: { hiddenTutorialHints },
+    // } = props.preferences;
+    // const {
+    //   values: { hiddenTutorialHints: previousHiddenTutorialHints },
+    // } = prevProps.preferences;
+    // if (
+    //   hiddenTutorialHints['intro-event-system'] !==
+    //   previousHiddenTutorialHints['intro-event-system']
+    // ) {
+    //   this.setState({
+    //     ...this.state,
+    //     treeData: this.state.treeData.filter(
+    //       data => data.key !== 'eventstree-tutorial-node'
+    //     ),
+    //   });
+    // }
+    // }
 
-  /**
-   * Should be called whenever an event height has changed
-   */
-  onHeightsChanged(cb: ?() => void) {
-    this.forceUpdate(() => {
-      if (this._list && this._list.wrappedInstance.current) {
-        this._list.wrappedInstance.current.recomputeRowHeights();
-      }
-      if (cb) cb();
-    });
-  }
+    // This is the data that will be displayed by the tree - reconstructed at each render
+    // (because events could have changed, some could have been deleted, so we can't keep
+    // any reference to them).
+    // Array is created now, so can be referenced by callbacks, and filled later.
+    const treeDataRoot = React.useRef<Array<SortableTreeNode>>([]);
 
-  /**
-   * Should be called whenever events changed (new event...)
-   * from outside this component.
-   */
-  forceEventsUpdate(cb: ?() => void) {
-    this.setState(
-      this._eventsToTreeData(
-        this.props.projectScopedContainersAccessor,
-        this.props.events
-      ),
-      () => {
-        if (this._list && this._list.wrappedInstance.current) {
-          this._list.wrappedInstance.current.recomputeRowHeights();
+    React.useEffect(() => {
+      return () => {
+        if (_hoverTimerId.current) clearTimeout(_hoverTimerId.current);
+      };
+    }, []);
+
+    /**
+     * Should be called whenever an event height has changed
+     */
+    const onHeightsChanged = React.useCallback(
+      (cb: ?() => void) => {
+        if (_list.current && _list.current.wrappedInstance.current) {
+          _list.current.wrappedInstance.current.recomputeRowHeights();
         }
-        if (cb) cb();
-      }
+        forceUpdate();
+
+        // Use a timeout so that the callback is called after the events
+        // have been re-rendered.
+        setTimeout(() => {
+          if (cb) cb();
+        });
+      },
+      [forceUpdate]
     );
-  }
+    const forceEventsUpdate = onHeightsChanged;
 
-  scrollToRow(row: number) {
-    if (row !== -1) {
-      const currentList = this._list;
-      if (currentList) {
-        const listWrapper = currentList.wrappedInstance.current;
-        listWrapper && listWrapper.scrollToRow(row);
-      }
-    }
-  }
-
-  /**
-   * Unfold events so that the given one is visible
-   */
-  unfoldForEvent(event: gdBaseEvent) {
-    gd.EventsListUnfolder.unfoldWhenContaining(this.props.events, event);
-    this.forceEventsUpdate();
-  }
-
-  foldAll() {
-    gd.EventsListUnfolder.foldAll(this.props.events);
-    this.forceEventsUpdate();
-  }
-
-  unfoldToLevel(level: number) {
-    gd.EventsListUnfolder.unfoldToLevel(this.props.events, level);
-    this.forceEventsUpdate();
-  }
-
-  getEventRow(searchedEvent: gdBaseEvent) {
-    // TODO: flatData could be replaced by a hashmap of events to row index
-    return findIndex(
-      this.state.flatData,
-      event => event.ptr === searchedEvent.ptr
+    const eventsHeightsCache = React.useMemo(
+      () => new EventHeightsCache(onHeightsChanged),
+      [onHeightsChanged]
     );
-  }
 
-  getEventContextAtRowIndexes(rowIndexes: Array<number>): Array<EventContext> {
-    // We use flatDataTree instead of this.state.flatData because we need the events contexts too.
-    const flatDataTree: Array<{ node: SortableTreeNode }> = getFlatDataFromTree(
-      {
-        treeData: this.state.treeData,
-        getNodeKey,
-        ignoreCollapsed: true,
-      }
+    React.useEffect(() => {
+      onHeightsChanged();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const scrollToRow = React.useCallback((row: number) => {
+      if (row === -1) return;
+      if (!_list.current) return;
+      if (!_list.current.wrappedInstance.current) return;
+      _list.current.wrappedInstance.current.scrollToRow(row);
+    }, []);
+
+    /**
+     * Unfold events so that the given one is visible
+     */
+    const unfoldForEvent = React.useCallback(
+      (event: gdBaseEvent) => {
+        gd.EventsListUnfolder.unfoldWhenContaining(props.events, event);
+        forceEventsUpdate();
+      },
+      [forceEventsUpdate, props.events]
     );
-    return rowIndexes
-      .map(rowIndex => {
-        if (!flatDataTree[rowIndex]) return null;
-        const {
-          node: {
-            event,
-            eventsList,
-            indexInList,
-            projectScopedContainersAccessor,
-          },
-        } = flatDataTree[rowIndex];
-        return event
-          ? { event, eventsList, indexInList, projectScopedContainersAccessor }
-          : null;
-      })
-      .filter(Boolean);
-  }
 
-  _eventsToTreeData = (
-    parentProjectScopedContainersAccessor: ProjectScopedContainersAccessor,
-    eventsList: gdEventsList,
-    flatData: Array<gdBaseEvent> = [],
-    depth: number = 0,
-    parentDisabled: boolean = false,
-    parentAbsolutePath: Array<number> = [],
-    parentRelativePath: ?Array<number> = null
-  ) => {
-    const treeData = mapFor<SortableTreeNode>(
-      0,
-      eventsList.getEventsCount(),
-      i => {
+    const foldAll = React.useCallback(
+      () => {
+        gd.EventsListUnfolder.foldAll(props.events);
+        forceEventsUpdate();
+      },
+      [forceEventsUpdate, props.events]
+    );
+
+    const unfoldToLevel = React.useCallback(
+      (level: number) => {
+        gd.EventsListUnfolder.unfoldToLevel(props.events, level);
+        forceEventsUpdate();
+      },
+      [forceEventsUpdate, props.events]
+    );
+
+    const tutorial = React.useMemo(
+      () =>
+        getTutorial(props.preferences, props.tutorials, 'intro-event-system'),
+      [props.preferences, props.tutorials]
+    );
+
+    const _canDrag = React.useCallback((node: ?SortableTreeNode) => {
+      return !!node && !!node.event;
+    }, []);
+
+    const _canDrop = React.useCallback((hoveredNode: SortableTreeNode) => {
+      return true;
+    }, []);
+
+    const _restoreFoldedNodes = React.useCallback(
+      () => {
+        temporaryUnfoldedNodes.current.forEach(
+          node => node.event && node.event.setFolded(true)
+        );
+
+        temporaryUnfoldedNodes.current = [];
+        forceEventsUpdate();
+      },
+      [forceEventsUpdate]
+    );
+
+    const _onEndDrag = React.useCallback(
+      () => {
+        // This method is always called at the end of the drag, regardless of whether
+        // an event was actually dropped. It is also already called in `_onDrop` to update
+        // the event list and compute history. So if draggedNode is null, we want to avoid
+        // recomputing the event list.
+        if (draggedNode) {
+          setDraggedNode(null);
+          _restoreFoldedNodes();
+          forceEventsUpdate();
+        }
+      },
+      [draggedNode, _restoreFoldedNodes, forceEventsUpdate]
+    );
+
+    const eventPtrToRowIndex = React.useRef<{ [key: string]: number }>({});
+    const getEventRow = React.useCallback(
+      (searchedEvent: gdBaseEvent) => {
+        return eventPtrToRowIndex.current['' + searchedEvent.ptr] || -1;
+      },
+      [eventPtrToRowIndex]
+    );
+
+    const temporaryUnfoldNode = React.useCallback(
+      (isOverLazy: boolean, node: SortableTreeNode) => {
+        const { event } = node;
+        if (!event) return;
+
+        const isNodeTemporaryUnfolded = temporaryUnfoldedNodes.current.some(
+          foldedNode => node.key === foldedNode.key
+        );
+        if (isOverLazy) {
+          if (!_hoverTimerId.current && !node.expanded) {
+            if (!isNodeTemporaryUnfolded) {
+              _hoverTimerId.current = window.setTimeout(() => {
+                // $FlowFixMe - Per the condition above, we are confident that node.event is not null.
+                event.setFolded(false);
+                temporaryUnfoldedNodes.current.push(node);
+                forceEventsUpdate();
+              }, 1000);
+            }
+          }
+        } else {
+          if (_hoverTimerId.current) window.clearTimeout(_hoverTimerId.current);
+          _hoverTimerId.current = null;
+        }
+      },
+      [forceEventsUpdate]
+    );
+
+    const _getRowHeight = ({ node }: {| node: ?SortableTreeNode |}) => {
+      if (!node) {
+        return 0;
+      }
+      if (!node.event) {
+        return node.fixedHeight || 0;
+      }
+
+      return eventsHeightsCache.getEventHeight(node.event);
+    };
+
+    const {
+      project,
+      globalObjectsContainer,
+      objectsContainer,
+      showObjectThumbnails,
+    } = props;
+    const renderObjectThumbnail = React.useCallback(
+      (objectName: string) => {
+        if (!showObjectThumbnails) return null;
+
+        const object = getObjectByName(
+          globalObjectsContainer,
+          objectsContainer,
+          objectName
+        );
+        if (!object) return null;
+
+        return (
+          <CorsAwareImage
+            className={classNames({
+              [icon]: true,
+            })}
+            alt=""
+            src={getThumbnail(project, object.getConfiguration())}
+          />
+        );
+      },
+      [project, globalObjectsContainer, objectsContainer, showObjectThumbnails]
+    );
+
+    const { onEventMoved } = props;
+    const _onDrop = React.useCallback(
+      (
+        moveFunction: MoveFunctionArguments => void,
+        currentNode: SortableTreeNode
+      ) => {
+        if (!draggedNode) return;
+
+        moveFunction({
+          node: draggedNode,
+          targetNode: currentNode,
+        });
+        const { nodePath, event } = draggedNode;
+        _onEndDrag();
+        if (!event) {
+          console.warn('EventsSheet: No event found in dragged node.');
+          return;
+        }
+        const newRowIndex = getEventRow(event);
+        onEventMoved(nodePath[nodePath.length - 1], newRowIndex);
+      },
+      [draggedNode, _onEndDrag, onEventMoved, getEventRow]
+    );
+
+    const _renderEvent = ({ node }: {| node: SortableTreeNode |}) => {
+      const { event, depth, disabled } = node;
+      if (!event) return null;
+
+      const isDragged =
+        !!draggedNode &&
+        (isDescendant(draggedNode, node) || node.key === draggedNode.key);
+      return (
+        <DragSourceAndDropTarget
+          beginDrag={() => {
+            setDraggedNode(node);
+            return node;
+          }}
+          canDrag={() => _canDrag(node)}
+          canDrop={() => _canDrop(node)}
+          // Drop operations are handled by DropContainers.
+          drop={() => {
+            return;
+          }}
+          endDrag={_onEndDrag}
+        >
+          {({ connectDragSource, connectDropTarget, isOverLazy }) => {
+            temporaryUnfoldNode(isOverLazy, node);
+
+            const eventContext = {
+              eventsList: node.eventsList,
+              event: event,
+              indexInList: node.indexInList,
+              projectScopedContainersAccessor:
+                node.projectScopedContainersAccessor,
+            };
+
+            const dropTarget = (
+              <div
+                style={{
+                  opacity: isDragged ? 0.5 : 1,
+                  ...getEventContainerStyle(props.windowSize),
+                }}
+                {...dataObjectToProps({ rowIndex: node.rowIndex.toString() })}
+              >
+                <EventContainer
+                  project={props.project}
+                  scope={props.scope}
+                  globalObjectsContainer={props.globalObjectsContainer}
+                  objectsContainer={props.objectsContainer}
+                  projectScopedContainersAccessor={
+                    node.projectScopedContainersAccessor
+                  }
+                  event={event}
+                  key={event.ptr}
+                  eventsHeightsCache={eventsHeightsCache}
+                  selection={props.selection}
+                  leftIndentWidth={
+                    depth *
+                    (getIndentWidth(props.windowSize) * props.indentScale)
+                  }
+                  onAddNewInstruction={instructionsListContext =>
+                    props.onAddNewInstruction(
+                      eventContext,
+                      instructionsListContext
+                    )
+                  }
+                  onPasteInstructions={instructionsListContext =>
+                    props.onPasteInstructions(
+                      eventContext,
+                      instructionsListContext
+                    )
+                  }
+                  onMoveToInstruction={instructionContext =>
+                    props.onMoveToInstruction(eventContext, instructionContext)
+                  }
+                  onMoveToInstructionsList={instructionContext =>
+                    props.onMoveToInstructionsList(
+                      eventContext,
+                      instructionContext
+                    )
+                  }
+                  onInstructionClick={instructionContext =>
+                    props.onInstructionClick(eventContext, instructionContext)
+                  }
+                  onInstructionDoubleClick={instructionContext =>
+                    props.onInstructionDoubleClick(
+                      eventContext,
+                      instructionContext
+                    )
+                  }
+                  onParameterClick={parameterContext =>
+                    props.onParameterClick(eventContext, parameterContext)
+                  }
+                  onVariableDeclarationClick={variableDeclarationContext =>
+                    props.onVariableDeclarationClick(
+                      eventContext,
+                      variableDeclarationContext
+                    )
+                  }
+                  onVariableDeclarationDoubleClick={variableDeclarationContext =>
+                    props.onVariableDeclarationDoubleClick(
+                      eventContext,
+                      variableDeclarationContext
+                    )
+                  }
+                  onEventClick={() =>
+                    props.onEventClick({
+                      eventsList: node.eventsList,
+                      event: event,
+                      indexInList: node.indexInList,
+                      projectScopedContainersAccessor:
+                        node.projectScopedContainersAccessor,
+                    })
+                  }
+                  onEndEditingEvent={() => props.onEndEditingEvent(event)}
+                  onEventContextMenu={(x, y) =>
+                    props.onEventContextMenu(x, y, {
+                      eventsList: node.eventsList,
+                      event: event,
+                      indexInList: node.indexInList,
+                      projectScopedContainersAccessor:
+                        node.projectScopedContainersAccessor,
+                    })
+                  }
+                  onInstructionContextMenu={(...args) =>
+                    props.onInstructionContextMenu(eventContext, ...args)
+                  }
+                  onAddInstructionContextMenu={(...args) =>
+                    props.onAddInstructionContextMenu(eventContext, ...args)
+                  }
+                  onOpenExternalEvents={props.onOpenExternalEvents}
+                  onOpenLayout={(name: string) => {
+                    props.onOpenLayout(name);
+                  }}
+                  disabled={
+                    disabled /* Use node.disabled (not event.disabled) as it is true if a parent event is disabled*/
+                  }
+                  renderObjectThumbnail={renderObjectThumbnail}
+                  screenType={props.screenType}
+                  eventsSheetWidth={props.eventsSheetWidth}
+                  eventsSheetHeight={props.eventsSheetHeight}
+                  connectDragSource={connectDragSource}
+                  windowSize={props.windowSize}
+                  idPrefix={`event-${node.relativeNodePath.join('-')}`}
+                />
+                {draggedNode && (
+                  <DropContainer
+                    node={node}
+                    draggedNode={draggedNode}
+                    draggedNodeHeight={_getRowHeight({
+                      node: draggedNode,
+                    })}
+                    DnDComponent={DropTarget}
+                    onDrop={_onDrop}
+                    activateTargets={!isDragged && !!draggedNode}
+                    windowSize={props.windowSize}
+                    indentScale={props.indentScale}
+                    getNodeAtPath={path =>
+                      getNodeAtPath({
+                        path,
+                        treeData: treeDataRoot.current,
+                        getNodeKey,
+                      }).node
+                    }
+                  />
+                )}
+              </div>
+            );
+
+            return isDragged ? dropTarget : connectDropTarget(dropTarget);
+          }}
+        </DragSourceAndDropTarget>
+      );
+    };
+
+    // TODO: consider moving this to a standalone function.
+    const buildEventsTreeData = (
+      treeData: Array<SortableTreeNode>,
+      parentProjectScopedContainersAccessor: ProjectScopedContainersAccessor,
+      eventsList: gdEventsList,
+      flattenedList: Array<gdBaseEvent> = [],
+      depth: number = 0,
+      parentDisabled: boolean = false,
+      parentAbsolutePath: Array<number> = [],
+      parentRelativePath: ?Array<number> = null
+    ) => {
+      treeData.length = 0;
+      mapFor(0, eventsList.getEventsCount(), i => {
         const event = eventsList.getEventAt(i);
-        flatData.push(event);
+        flattenedList.push(event);
 
         const disabled = parentDisabled || event.isDisabled();
-        const absoluteIndex = flatData.length - 1;
+        const absoluteIndex = flattenedList.length - 1;
         const currentAbsolutePath = parentAbsolutePath.concat(
-          flatData.length - 1
+          flattenedList.length - 1
         );
         const currentRelativePath = [...(parentRelativePath || []), i];
         const projectScopedContainersAccessor = event.canHaveVariables()
@@ -565,8 +850,24 @@ export default class ThemableEventsTree extends Component<
             )
           : parentProjectScopedContainersAccessor;
 
-        return {
-          title: this._renderEvent,
+        eventPtrToRowIndex.current['' + event.ptr] = absoluteIndex;
+
+        const childrenTreeData = [];
+        buildEventsTreeData(
+          childrenTreeData,
+          projectScopedContainersAccessor,
+          event.getSubEvents(),
+          // flattenedList is a flat representation of events, one for each line.
+          // Hence it should not contain the folded events.
+          !event.isFolded() ? flattenedList : [],
+          depth + 1,
+          disabled,
+          currentAbsolutePath,
+          currentRelativePath
+        );
+
+        treeData.push({
+          title: _renderEvent,
           event,
           eventsList,
           indexInList: i,
@@ -575,429 +876,205 @@ export default class ThemableEventsTree extends Component<
           disabled,
           depth,
           key: event.ptr, //TODO: useless?
-          children: this._eventsToTreeData(
-            projectScopedContainersAccessor,
-            event.getSubEvents(),
-            // flatData is a flat representation of events, one for each line.
-            // Hence it should not contain the folded events.
-            !event.isFolded() ? flatData : [],
-            depth + 1,
-            disabled,
-            currentAbsolutePath,
-            currentRelativePath
-          ).treeData,
+          children: childrenTreeData,
           nodePath: currentAbsolutePath,
           relativeNodePath: currentRelativePath,
           projectScopedContainersAccessor,
-        };
-      }
-    );
-    const tutorial = getTutorial(
-      this.props.preferences,
-      this.props.tutorials,
-      'intro-event-system'
-    );
-
-    // Add the bottom buttons if we're at the root
-    const extraNodes = [
-      depth === 0
-        ? {
-            title: () => (
-              <BottomButtons
-                onAddEvent={(eventType: string) =>
-                  this.props.onAddNewEvent(eventType, this.props.events)
-                }
-                DnDComponent={this.DropTarget}
-                draggedNode={this.state.draggedNode}
-                rootEventsList={eventsList}
-              />
-            ),
-            event: null,
-            indexInList: eventsList.getEventsCount(),
-            disabled: false,
-            depth: 0,
-            fixedHeight: 40,
-            children: [],
-          }
-        : null,
-      depth === 0 && eventsList.getEventsCount() !== 0 && tutorial
-        ? {
-            title: () => (
-              <Line justifyContent="center">
-                <TutorialMessage tutorial={tutorial} />
-              </Line>
-            ),
-            event: null,
-            indexInList: eventsList.getEventsCount() + 1,
-            disabled: false,
-            depth: 0,
-            fixedHeight: 150,
-            children: [],
-            key: 'eventstree-tutorial-node',
-          }
-        : null,
-      depth === 0 && eventsList.getEventsCount() === 0
-        ? {
-            title: () => (
-              <EmptyPlaceholder
-                title={<Trans>Add your first event</Trans>}
-                description={<Trans>Events define the rules of a game.</Trans>}
-                actionLabel={<Trans>Add an event</Trans>}
-                helpPagePath="/events"
-                tutorialId="intro-event-system"
-                actionButtonId="add-event-button"
-                onAction={() =>
-                  this.props.onAddNewEvent(
-                    'BuiltinCommonInstructions::Standard',
-                    this.props.events
-                  )
-                }
-              />
-            ),
-            event: null,
-            indexInList: eventsList.getEventsCount() + 1,
-            disabled: false,
-            depth: 0,
-            fixedHeight: 300,
-            children: [],
-          }
-        : null,
-    ].filter(Boolean);
-
-    return {
-      // $FlowFixMe - We are confident treeData and extraNodes are both arrays of SortableTreeNode
-      treeData: extraNodes.length ? treeData.concat(extraNodes) : treeData,
-      flatData,
-    };
-  };
-
-  _canDrag = (node: ?SortableTreeNode) => {
-    return !!node && !!node.event;
-  };
-
-  _canDrop = (hoveredNode: SortableTreeNode) => {
-    return true;
-  };
-
-  _onDrop = (
-    moveFunction: MoveFunctionArguments => void,
-    currentNode: SortableTreeNode
-  ) => {
-    const draggedNode = this.state.draggedNode;
-    if (draggedNode) {
-      moveFunction({
-        node: draggedNode,
-        targetNode: currentNode,
+        });
       });
-      const { nodePath, event } = draggedNode;
-      this._onEndDrag();
-      if (!event) {
-        console.warn('EventsSheet: No event found in dragged node.');
-        return;
-      }
-      const newRowIndex = this.getEventRow(event);
-      this.props.onEventMoved(nodePath[nodePath.length - 1], newRowIndex);
-    }
-  };
 
-  _onVisibilityToggle = ({ node }: {| node: SortableTreeNode |}) => {
-    const { event } = node;
-    if (!event) return;
-
-    event.setFolded(!event.isFolded());
-    this.forceEventsUpdate();
-  };
-
-  _renderObjectThumbnail = (objectName: string) => {
-    const {
-      project,
-      globalObjectsContainer,
-      objectsContainer,
-      showObjectThumbnails,
-    } = this.props;
-    if (!showObjectThumbnails) return null;
-
-    const object = getObjectByName(
-      globalObjectsContainer,
-      objectsContainer,
-      objectName
-    );
-    if (!object) return null;
-
-    return (
-      <CorsAwareImage
-        className={classNames({
-          [icon]: true,
-        })}
-        alt=""
-        src={getThumbnail(project, object.getConfiguration())}
-      />
-    );
-  };
-
-  _temporaryUnfoldNode = (isOverLazy: boolean, node: SortableTreeNode) => {
-    const { event } = node;
-    if (!event) return;
-
-    const isNodeTemporaryUnfolded = this.temporaryUnfoldedNodes.some(
-      foldedNode => node.key === foldedNode.key
-    );
-    if (isOverLazy) {
-      if (!this._hoverTimerId && !node.expanded) {
-        if (!isNodeTemporaryUnfolded) {
-          this._hoverTimerId = window.setTimeout(() => {
-            // $FlowFixMe - Per the condition above, we are confident that node.event is not null.
-            event.setFolded(false);
-            this.temporaryUnfoldedNodes.push(node);
-            this.forceEventsUpdate();
-          }, 1000);
-        }
-      }
-    } else {
-      window.clearTimeout(this._hoverTimerId);
-      this._hoverTimerId = null;
-    }
-  };
-
-  _restoreFoldedNodes = () => {
-    this.temporaryUnfoldedNodes.forEach(
-      node => node.event && node.event.setFolded(true)
-    );
-
-    this.temporaryUnfoldedNodes = [];
-    this.forceEventsUpdate();
-  };
-
-  _getRowHeight = ({ node }: {| node: ?SortableTreeNode |}) => {
-    if (!node) return 0;
-    if (!node.event) return node.fixedHeight || 0;
-
-    return this.eventsHeightsCache.getEventHeight(node.event);
-  };
-
-  _onEndDrag = () => {
-    // This method is always called at the end of the drag, regardless of whether
-    // an event was actually dropped. It is also already called in `_onDrop` to update
-    // the event list and compute history. So if draggedNode is null, we want to avoid
-    // recomputing the event list.
-    if (this.state.draggedNode) {
-      this.setState({ draggedNode: null });
-      this._restoreFoldedNodes();
-      this.forceEventsUpdate();
-    }
-  };
-
-  _renderEvent = ({ node }: {| node: SortableTreeNode |}) => {
-    const { event, depth, disabled } = node;
-    if (!event) return null;
-    const { DragSourceAndDropTarget, DropTarget } = this;
-    const isDragged =
-      !!this.state.draggedNode &&
-      (isDescendant(this.state.draggedNode, node) ||
-        node.key === this.state.draggedNode.key);
-    return (
-      <DragSourceAndDropTarget
-        beginDrag={() => {
-          this.setState({ draggedNode: node });
-          return node;
-        }}
-        canDrag={() => this._canDrag(node)}
-        canDrop={() => this._canDrop(node)}
-        // Drop operations are handled by DropContainers.
-        drop={() => {
-          return;
-        }}
-        endDrag={this._onEndDrag}
-      >
-        {({ connectDragSource, connectDropTarget, isOverLazy }) => {
-          this._temporaryUnfoldNode(isOverLazy, node);
-
-          const eventContext = {
-            eventsList: node.eventsList,
-            event: event,
-            indexInList: node.indexInList,
-            projectScopedContainersAccessor:
-              node.projectScopedContainersAccessor,
-          };
-
-          const dropTarget = (
-            <div
-              style={{
-                opacity: isDragged ? 0.5 : 1,
-                ...getEventContainerStyle(this.props.windowSize),
-              }}
-              {...dataObjectToProps({ rowIndex: node.rowIndex.toString() })}
-            >
-              <EventContainer
-                project={this.props.project}
-                scope={this.props.scope}
-                globalObjectsContainer={this.props.globalObjectsContainer}
-                objectsContainer={this.props.objectsContainer}
-                projectScopedContainersAccessor={
-                  node.projectScopedContainersAccessor
-                }
-                event={event}
-                key={event.ptr}
-                eventsHeightsCache={this.eventsHeightsCache}
-                selection={this.props.selection}
-                leftIndentWidth={
-                  depth *
-                  (getIndentWidth(this.props.windowSize) *
-                    this.props.indentScale)
-                }
-                onAddNewInstruction={instructionsListContext =>
-                  this.props.onAddNewInstruction(
-                    eventContext,
-                    instructionsListContext
-                  )
-                }
-                onPasteInstructions={instructionsListContext =>
-                  this.props.onPasteInstructions(
-                    eventContext,
-                    instructionsListContext
-                  )
-                }
-                onMoveToInstruction={instructionContext =>
-                  this.props.onMoveToInstruction(
-                    eventContext,
-                    instructionContext
-                  )
-                }
-                onMoveToInstructionsList={instructionContext =>
-                  this.props.onMoveToInstructionsList(
-                    eventContext,
-                    instructionContext
-                  )
-                }
-                onInstructionClick={instructionContext =>
-                  this.props.onInstructionClick(
-                    eventContext,
-                    instructionContext
-                  )
-                }
-                onInstructionDoubleClick={instructionContext =>
-                  this.props.onInstructionDoubleClick(
-                    eventContext,
-                    instructionContext
-                  )
-                }
-                onParameterClick={parameterContext =>
-                  this.props.onParameterClick(eventContext, parameterContext)
-                }
-                onVariableDeclarationClick={variableDeclarationContext =>
-                  this.props.onVariableDeclarationClick(
-                    eventContext,
-                    variableDeclarationContext
-                  )
-                }
-                onVariableDeclarationDoubleClick={variableDeclarationContext =>
-                  this.props.onVariableDeclarationDoubleClick(
-                    eventContext,
-                    variableDeclarationContext
-                  )
-                }
-                onEventClick={() =>
-                  this.props.onEventClick({
-                    eventsList: node.eventsList,
-                    event: event,
-                    indexInList: node.indexInList,
-                    projectScopedContainersAccessor:
-                      node.projectScopedContainersAccessor,
-                  })
-                }
-                onEndEditingEvent={() => this.props.onEndEditingEvent(event)}
-                onEventContextMenu={(x, y) =>
-                  this.props.onEventContextMenu(x, y, {
-                    eventsList: node.eventsList,
-                    event: event,
-                    indexInList: node.indexInList,
-                    projectScopedContainersAccessor:
-                      node.projectScopedContainersAccessor,
-                  })
-                }
-                onInstructionContextMenu={(...args) =>
-                  this.props.onInstructionContextMenu(eventContext, ...args)
-                }
-                onAddInstructionContextMenu={(...args) =>
-                  this.props.onAddInstructionContextMenu(eventContext, ...args)
-                }
-                onOpenExternalEvents={this.props.onOpenExternalEvents}
-                onOpenLayout={(name: string) => {
-                  this.props.onOpenLayout(name);
-                }}
-                disabled={
-                  disabled /* Use node.disabled (not event.disabled) as it is true if a parent event is disabled*/
-                }
-                renderObjectThumbnail={this._renderObjectThumbnail}
-                screenType={this.props.screenType}
-                eventsSheetWidth={this.props.eventsSheetWidth}
-                eventsSheetHeight={this.props.eventsSheetHeight}
-                connectDragSource={connectDragSource}
-                windowSize={this.props.windowSize}
-                idPrefix={`event-${node.relativeNodePath.join('-')}`}
-              />
-              {this.state.draggedNode && (
-                <DropContainer
-                  node={node}
-                  draggedNode={this.state.draggedNode}
-                  draggedNodeHeight={this._getRowHeight({
-                    node: this.state.draggedNode,
-                  })}
+      // Add the bottom buttons if we're at the root
+      const extraNodes: Array<SortableTreeNode> = [
+        depth === 0
+          ? {
+              title: () => (
+                <BottomButtons
+                  onAddEvent={(eventType: string) =>
+                    props.onAddNewEvent(eventType, props.events)
+                  }
                   DnDComponent={DropTarget}
-                  onDrop={this._onDrop}
-                  activateTargets={!isDragged && !!this.state.draggedNode}
-                  windowSize={this.props.windowSize}
-                  indentScale={this.props.indentScale}
-                  getNodeAtPath={path =>
-                    getNodeAtPath({
-                      path,
-                      treeData: this.state.treeData,
-                      getNodeKey,
-                    }).node
+                  draggedNode={draggedNode}
+                  rootEventsList={eventsList}
+                />
+              ),
+              event: null,
+              indexInList: eventsList.getEventsCount(),
+              disabled: false,
+              depth: 0,
+              fixedHeight: 40,
+              children: [],
+              eventsList,
+              rowIndex: flattenedList.length,
+              projectScopedContainersAccessor: parentProjectScopedContainersAccessor,
+              key: 'bottom-buttons',
+              // Unused, but still provided to make typing happy:
+              expanded: false,
+              nodePath: [flattenedList.length + 0],
+              relativeNodePath: [flattenedList.length + 0],
+            }
+          : null,
+        depth === 0 && eventsList.getEventsCount() !== 0 && tutorial
+          ? {
+              title: () => (
+                <Line justifyContent="center">
+                  <TutorialMessage tutorial={tutorial} />
+                </Line>
+              ),
+              event: null,
+              indexInList: eventsList.getEventsCount() + 1,
+              disabled: false,
+              depth: 0,
+              fixedHeight: 150,
+              children: [],
+              eventsList,
+              rowIndex: flattenedList.length + 1,
+              projectScopedContainersAccessor: parentProjectScopedContainersAccessor,
+              key: 'eventstree-tutorial-node',
+              // Unused, but still provided to make typing happy:
+              expanded: false,
+              nodePath: [flattenedList.length + 1],
+              relativeNodePath: [flattenedList.length + 1],
+            }
+          : null,
+        depth === 0 && eventsList.getEventsCount() === 0
+          ? {
+              title: () => (
+                <EmptyPlaceholder
+                  title={<Trans>Add your first event</Trans>}
+                  description={
+                    <Trans>Events define the rules of a game.</Trans>
+                  }
+                  actionLabel={<Trans>Add an event</Trans>}
+                  helpPagePath="/events"
+                  tutorialId="intro-event-system"
+                  actionButtonId="add-event-button"
+                  onAction={() =>
+                    props.onAddNewEvent(
+                      'BuiltinCommonInstructions::Standard',
+                      props.events
+                    )
                   }
                 />
-              )}
-            </div>
-          );
+              ),
+              event: null,
+              indexInList: eventsList.getEventsCount() + 1,
+              disabled: false,
+              depth: 0,
+              fixedHeight: 300,
+              children: [],
+              eventsList,
+              rowIndex: flattenedList.length + 2,
+              projectScopedContainersAccessor: parentProjectScopedContainersAccessor,
+              key: 'empty-state',
+              // Unused, but still provided to make typing happy:
+              expanded: false,
+              nodePath: [flattenedList.length + 2],
+              relativeNodePath: [flattenedList.length + 2],
+            }
+          : null,
+      ].filter(Boolean);
 
-          return isDragged ? dropTarget : connectDropTarget(dropTarget);
-        }}
-      </DragSourceAndDropTarget>
+      treeData.push(...extraNodes);
+    };
+
+    const getEventContextAtRowIndexes = (
+      rowIndexes: Array<number>
+    ): Array<EventContext> => {
+      // We use flatDataTree instead of treeDataRoot because we need the events contexts too.
+      const flatDataTree: Array<{
+        node: SortableTreeNode,
+      }> = getFlatDataFromTree({
+        treeData: treeDataRoot.current,
+        getNodeKey,
+        ignoreCollapsed: true,
+      });
+      return rowIndexes
+        .map(rowIndex => {
+          if (!flatDataTree[rowIndex]) return null;
+          const {
+            node: {
+              event,
+              eventsList,
+              indexInList,
+              projectScopedContainersAccessor,
+            },
+          } = flatDataTree[rowIndex];
+          return event
+            ? {
+                event,
+                eventsList,
+                indexInList,
+                projectScopedContainersAccessor,
+              }
+            : null;
+        })
+        .filter(Boolean);
+    };
+
+    React.useImperativeHandle(ref, () => ({
+      forceEventsUpdate,
+      foldAll,
+      unfoldToLevel,
+      getEventContextAtRowIndexes,
+      scrollToRow,
+      getEventRow,
+      unfoldForEvent,
+    }));
+
+    const _onVisibilityToggle = React.useCallback(
+      ({ node }: {| node: SortableTreeNode |}) => {
+        const { event } = node;
+        if (!event) return;
+
+        event.setFolded(!event.isFolded());
+        forceEventsUpdate();
+      },
+      [forceEventsUpdate]
     );
-  };
 
-  _isNodeHighlighted = ({
-    node,
-    searchQuery,
-  }: {
-    node: SortableTreeNode,
-    searchQuery: ?Array<gdBaseEvent>,
-  }) => {
-    const searchResults = searchQuery;
-    if (!searchResults) return false;
-    const { event } = node;
-    if (!event) return false;
+    const _isNodeHighlighted = React.useCallback(
+      ({
+        node,
+        searchQuery,
+      }: {
+        node: SortableTreeNode,
+        searchQuery: ?Array<gdBaseEvent>,
+      }) => {
+        const searchResults = searchQuery;
+        if (!searchResults) return false;
+        const { event } = node;
+        if (!event) return false;
 
-    return searchResults.find(highlightedEvent =>
-      gd.compare(highlightedEvent, event)
+        return searchResults.find(highlightedEvent =>
+          gd.compare(highlightedEvent, event)
+        );
+      },
+      []
     );
-  };
 
-  _scrollUp = () => {
-    this._list && this._list.container.scrollBy({ top: -5 });
-  };
+    const _scrollUp = React.useCallback(() => {
+      _list.current && _list.current.container.scrollBy({ top: -5 });
+    }, []);
 
-  _scrollDown = () => {
-    this._list && this._list.container.scrollBy({ top: 5 });
-  };
+    const _scrollDown = React.useCallback(() => {
+      _list.current && _list.current.container.scrollBy({ top: 5 });
+    }, []);
 
-  render() {
-    // react-sortable-tree does the rendering by transforming treeData
-    // into a flat array, the result being memoized. This hack forces
-    // a re-rendering of events, by discarding the memoized flat array
-    // (otherwise, no re-rendering would be done).
-    const treeData = this.state.treeData ? [...this.state.treeData] : null;
-    const zoomLevel = this.props.fontSize || 14;
+    const zoomLevel = props.fontSize || 14;
+
+    buildEventsTreeData(
+      treeDataRoot.current,
+      props.projectScopedContainersAccessor,
+      props.events
+    );
+
+    React.useLayoutEffect(() => {
+      // Recompute the row heights of the tree at each render, because there
+      // is no guarantee that events heights have not changed (resizing, change in event...).
+      if (_list.current && _list.current.wrappedInstance.current) {
+        _list.current.wrappedInstance.current.recomputeRowHeights();
+      }
+    });
 
     return (
       <div
@@ -1015,50 +1092,48 @@ export default class ThemableEventsTree extends Component<
       >
         {/* Disable for touchscreen because the dragged DOM node gets deleted, the */}
         {/* touch events are lost and the dnd does not drop anymore (hypothesis). */}
-        {this.props.screenType !== 'touch' && (
+        {props.screenType !== 'touch' && (
           <>
             <AutoScroll
-              DnDComponent={this.DropTarget}
+              DnDComponent={DropTarget}
               direction="top"
-              activateTargets={
-                !!this.state.draggedNode && !this.state.isScrolledTop
-              }
-              onHover={this._scrollUp}
+              activateTargets={!!draggedNode && !isScrolledTop}
+              onHover={_scrollUp}
             />
             <AutoScroll
-              DnDComponent={this.DropTarget}
+              DnDComponent={DropTarget}
               direction="bottom"
-              activateTargets={
-                !!this.state.draggedNode && !this.state.isScrolledBottom
-              }
-              onHover={this._scrollDown}
+              activateTargets={!!draggedNode && !isScrolledBottom}
+              onHover={_scrollDown}
             />
           </>
         )}
         <SortableTree
-          treeData={treeData}
+          treeData={
+            // Pass a new array each time, otherwise the tree will not re-render.
+            [...treeDataRoot.current]
+          }
           scaffoldBlockPxWidth={
-            getIndentWidth(this.props.windowSize) * this.props.indentScale
+            getIndentWidth(props.windowSize) * props.indentScale
           }
           onChange={noop}
-          onVisibilityToggle={this._onVisibilityToggle}
+          onVisibilityToggle={_onVisibilityToggle}
           canDrag={false}
-          rowHeight={this._getRowHeight}
-          searchMethod={this._isNodeHighlighted}
-          searchQuery={this.props.searchResults}
-          searchFocusOffset={this.props.searchFocusOffset}
-          className={
-            this.props.searchResults ? eventsTreeWithSearchResults : ''
-          }
+          rowHeight={_getRowHeight}
+          searchMethod={_isNodeHighlighted}
+          searchQuery={props.searchResults}
+          searchFocusOffset={props.searchFocusOffset}
+          className={props.searchResults ? eventsTreeWithSearchResults : ''}
           reactVirtualizedListProps={{
-            ref: list => (this._list = list),
+            ref: list => {
+              _list.current = list;
+            },
             onScroll: event => {
-              this.props.onScroll && this.props.onScroll();
-              this.setState({
-                isScrolledTop: event.scrollTop === 0,
-                isScrolledBottom:
-                  event.clientHeight + event.scrollTop >= event.scrollHeight,
-              });
+              props.onScroll && props.onScroll();
+              setIsScrolledTop(event.scrollTop === 0);
+              setIsScrolledBottom(
+                event.clientHeight + event.scrollTop >= event.scrollHeight
+              );
             },
             scrollToAlignment: 'center',
           }}
@@ -1070,4 +1145,6 @@ export default class ThemableEventsTree extends Component<
       </div>
     );
   }
-}
+);
+
+export default EventsTree;

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -406,6 +406,7 @@ const EventsTree = React.forwardRef<EventsTreeProps, EventsTreeInterface>(
     const forceUpdate = useForceUpdate();
 
     const _list = React.useRef<?any>(null);
+    const eventsHeightsCache = React.useMemo(() => new EventHeightsCache(), []);
 
     const DragSourceAndDropTarget = React.useMemo(
       () =>
@@ -454,11 +455,6 @@ const EventsTree = React.forwardRef<EventsTreeProps, EventsTreeInterface>(
       [forceUpdate]
     );
     const forceEventsUpdate = onHeightsChanged;
-
-    const eventsHeightsCache = React.useMemo(
-      () => new EventHeightsCache(onHeightsChanged),
-      [onHeightsChanged]
-    );
 
     React.useEffect(() => {
       onHeightsChanged();
@@ -813,7 +809,6 @@ const EventsTree = React.forwardRef<EventsTreeProps, EventsTreeInterface>(
       );
     };
 
-    // TODO: consider moving this to a standalone function.
     const buildEventsTreeData = (
       treeData: Array<SortableTreeNode>,
       parentProjectScopedContainersAccessor: ProjectScopedContainersAccessor,
@@ -1053,6 +1048,9 @@ const EventsTree = React.forwardRef<EventsTreeProps, EventsTreeInterface>(
 
     const zoomLevel = props.fontSize || 14;
 
+    // Update treeDataRoot with the events tree. Done at each render as events
+    // could change at any time, so we can't keep stale data
+    // (we would risk pointing to deleted events in memory).
     buildEventsTreeData(
       treeDataRoot.current,
       props.projectScopedContainersAccessor,

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -4,7 +4,7 @@ import { I18n } from '@lingui/react';
 import { type I18n as I18nType } from '@lingui/core';
 
 import * as React from 'react';
-import EventsTree from './EventsTree';
+import EventsTree, { type EventsTreeInterface } from './EventsTree';
 import { getInstructionMetadata } from './InstructionEditor/InstructionEditor';
 import InstructionEditorDialog from './InstructionEditor/InstructionEditorDialog';
 import InstructionEditorMenu from './InstructionEditor/InstructionEditorMenu';
@@ -232,7 +232,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
   ComponentProps,
   State
 > {
-  _eventsTree: ?EventsTree;
+  _eventsTree: ?EventsTreeInterface;
   _eventSearcher: ?EventsSearcher;
   _searchPanel: ?SearchPanelInterface;
   _containerDiv = React.createRef<HTMLDivElement>();
@@ -558,16 +558,16 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       insertion.indexInList + 1
     );
 
-    const currentTree = this._eventsTree;
-    if (currentTree) {
-      currentTree.forceEventsUpdate(() => {
+    const eventsTree = this._eventsTree;
+    if (eventsTree) {
+      eventsTree.forceEventsUpdate(() => {
         const positions = this._getChangedEventRows([newEvent]);
         this._saveChangesToHistory(
           'ADD',
           { positionsBeforeAction: positions, positionAfterAction: positions },
           () => {
             if (!context && !selectedEventContext) {
-              currentTree.scrollToRow(currentTree.getEventRow(newEvent));
+              eventsTree.scrollToRow(eventsTree.getEventRow(newEvent));
             }
           }
         );
@@ -580,7 +580,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
           (type === 'BuiltinCommonInstructions::Comment' ||
             type === 'BuiltinCommonInstructions::Group')
         ) {
-          const rowIndex = currentTree.getEventRow(newEvent);
+          const rowIndex = eventsTree.getEventRow(newEvent);
           const clickableElement = document.querySelector(
             `[data-row-index="${rowIndex}"] [data-editable-text="true"]`
           );
@@ -1372,9 +1372,9 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
   };
 
   _getChangedEventRows = (events: Array<gdBaseEvent>) => {
-    const currentTree = this._eventsTree;
-    if (currentTree) {
-      return events.map(event => currentTree.getEventRow(event));
+    const eventsTree = this._eventsTree;
+    if (eventsTree) {
+      return events.map(event => eventsTree.getEventRow(event));
     }
     return [];
   };
@@ -1484,10 +1484,11 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       // If it is a ADD or EDIT, then the element will be present, so we can select them.
       // If it is a DELETE, then they will not be present, so we can't select them.
       let newSelection: SelectionState = getInitialSelection();
+      let eventContexts: Array<EventContext> = [];
       if (type === 'DELETE') {
         newSelection = clearSelection();
       } else {
-        const eventContexts = eventsTree.getEventContextAtRowIndexes(
+        eventContexts = eventsTree.getEventContextAtRowIndexes(
           positions.positionAfterAction
         );
         newSelection = selectEventsAfterHistoryChange(eventContexts);

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -1484,11 +1484,10 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       // If it is a ADD or EDIT, then the element will be present, so we can select them.
       // If it is a DELETE, then they will not be present, so we can't select them.
       let newSelection: SelectionState = getInitialSelection();
-      let eventContexts: Array<EventContext> = [];
       if (type === 'DELETE') {
         newSelection = clearSelection();
       } else {
-        eventContexts = eventsTree.getEventContextAtRowIndexes(
+        const eventContexts = eventsTree.getEventContextAtRowIndexes(
           positions.positionAfterAction
         );
         newSelection = selectEventsAfterHistoryChange(eventContexts);

--- a/newIDE/app/src/fixtures/TestProject.js
+++ b/newIDE/app/src/fixtures/TestProject.js
@@ -20,6 +20,7 @@ export type TestProject = {|
   spriteObjectWithoutBehaviors: gdObject,
   testSpriteObjectInstance: gdInitialInstance,
   testLayout: gdLayout,
+  testProjectScopedContainersAccessor: ProjectScopedContainersAccessor,
   testSceneProjectScopedContainersAccessor: ProjectScopedContainersAccessor,
   group1: gdObjectGroup,
   group2: gdObjectGroup,
@@ -902,6 +903,12 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
     'whatever-this-is-not-recognised'
   );
 
+  const testProjectScopedContainersAccessor = new ProjectScopedContainersAccessor(
+    {
+      project,
+    }
+  );
+
   const testSceneProjectScopedContainersAccessor = new ProjectScopedContainersAccessor(
     {
       project,
@@ -942,6 +949,7 @@ export const makeTestProject = (gd /*: libGDevelop */) /*: TestProject */ => {
     spriteObjectWithBehaviors,
     spriteObjectWithoutBehaviors,
     testLayout,
+    testProjectScopedContainersAccessor,
     testSceneProjectScopedContainersAccessor,
     group1,
     group2,

--- a/newIDE/app/src/stories/componentStories/EventsSheet/EventsTree.stories.js
+++ b/newIDE/app/src/stories/componentStories/EventsSheet/EventsTree.stories.js
@@ -42,6 +42,9 @@ export const DefaultMediumScreenScopeInLayout = () => (
             project: testProject.project,
             layout: testProject.testLayout,
           }}
+          projectScopedContainersAccessor={
+            testProject.testSceneProjectScopedContainersAccessor
+          }
           globalObjectsContainer={testProject.project.getObjects()}
           objectsContainer={testProject.testLayout.getObjects()}
           selection={getInitialSelection()}
@@ -53,6 +56,10 @@ export const DefaultMediumScreenScopeInLayout = () => (
           onInstructionDoubleClick={action('instruction double click')}
           onInstructionContextMenu={action('instruction context menu')}
           onAddInstructionContextMenu={action('instruction list context menu')}
+          onVariableDeclarationDoubleClick={action(
+            'onVariableDeclarationDoubleClick'
+          )}
+          onVariableDeclarationClick={action('onVariableDeclarationClick')}
           onParameterClick={action('parameter click')}
           onEventClick={action('event click')}
           onEventContextMenu={action('event context menu')}
@@ -66,6 +73,8 @@ export const DefaultMediumScreenScopeInLayout = () => (
           screenType={'normal'}
           windowSize={'medium'}
           eventsSheetHeight={500}
+          eventsSheetWidth={500}
+          indentScale={1}
           preferences={initialPreferences}
           tutorials={eventsTreeTutorials}
           onEndEditingEvent={action('end editing event')}
@@ -86,6 +95,9 @@ export const DefaultSmallScreenScopeInLayout = () => (
             project: testProject.project,
             layout: testProject.testLayout,
           }}
+          projectScopedContainersAccessor={
+            testProject.testSceneProjectScopedContainersAccessor
+          }
           globalObjectsContainer={testProject.project.getObjects()}
           objectsContainer={testProject.testLayout.getObjects()}
           selection={getInitialSelection()}
@@ -97,6 +109,10 @@ export const DefaultSmallScreenScopeInLayout = () => (
           onInstructionDoubleClick={action('instruction double click')}
           onInstructionContextMenu={action('instruction context menu')}
           onAddInstructionContextMenu={action('instruction list context menu')}
+          onVariableDeclarationDoubleClick={action(
+            'onVariableDeclarationDoubleClick'
+          )}
+          onVariableDeclarationClick={action('onVariableDeclarationClick')}
           onParameterClick={action('parameter click')}
           onEventClick={action('event click')}
           onEventContextMenu={action('event context menu')}
@@ -110,6 +126,8 @@ export const DefaultSmallScreenScopeInLayout = () => (
           screenType={'normal'}
           windowSize={'small'}
           eventsSheetHeight={500}
+          eventsSheetWidth={500}
+          indentScale={1}
           preferences={initialPreferences}
           tutorials={eventsTreeTutorials}
           onEndEditingEvent={action('end editing event')}
@@ -127,6 +145,9 @@ export const DefaultMediumScreenScopeNotInLayout = () => (
           events={testProject.testLayout.getEvents()}
           project={testProject.project}
           scope={{ project: testProject.project }}
+          projectScopedContainersAccessor={
+            testProject.testProjectScopedContainersAccessor
+          }
           globalObjectsContainer={testProject.project.getObjects()}
           objectsContainer={testProject.testLayout.getObjects()}
           selection={getInitialSelection()}
@@ -138,6 +159,10 @@ export const DefaultMediumScreenScopeNotInLayout = () => (
           onInstructionDoubleClick={action('instruction double click')}
           onInstructionContextMenu={action('instruction context menu')}
           onAddInstructionContextMenu={action('instruction list context menu')}
+          onVariableDeclarationDoubleClick={action(
+            'onVariableDeclarationDoubleClick'
+          )}
+          onVariableDeclarationClick={action('onVariableDeclarationClick')}
           onParameterClick={action('parameter click')}
           onEventClick={action('event click')}
           onEventContextMenu={action('event context menu')}
@@ -151,6 +176,8 @@ export const DefaultMediumScreenScopeNotInLayout = () => (
           screenType={'normal'}
           windowSize={'medium'}
           eventsSheetHeight={500}
+          eventsSheetWidth={500}
+          indentScale={1}
           preferences={initialPreferences}
           tutorials={eventsTreeTutorials}
           onEndEditingEvent={action('end editing event')}
@@ -171,6 +198,9 @@ export const EmptySmallScreenScopeInALayout = () => (
             project: testProject.project,
             layout: testProject.testLayout,
           }}
+          projectScopedContainersAccessor={
+            testProject.testSceneProjectScopedContainersAccessor
+          }
           globalObjectsContainer={testProject.project.getObjects()}
           objectsContainer={testProject.testLayout.getObjects()}
           selection={getInitialSelection()}
@@ -182,6 +212,10 @@ export const EmptySmallScreenScopeInALayout = () => (
           onInstructionDoubleClick={action('instruction double click')}
           onInstructionContextMenu={action('instruction context menu')}
           onAddInstructionContextMenu={action('instruction list context menu')}
+          onVariableDeclarationDoubleClick={action(
+            'onVariableDeclarationDoubleClick'
+          )}
+          onVariableDeclarationClick={action('onVariableDeclarationClick')}
           onParameterClick={action('parameter click')}
           onEventClick={action('event click')}
           onEventContextMenu={action('event context menu')}
@@ -195,6 +229,8 @@ export const EmptySmallScreenScopeInALayout = () => (
           screenType={'normal'}
           windowSize={'small'}
           eventsSheetHeight={500}
+          eventsSheetWidth={500}
+          indentScale={1}
           preferences={initialPreferences}
           tutorials={eventsTreeTutorials}
           onEndEditingEvent={action('end editing event')}


### PR DESCRIPTION
- Move to a functional component (and ensure no use-after-free when undo/redo)
- Ensure at each render events read are the latest existing in memory (no use-after-free if events were changed)
- Fix comment height update