### PR TITLE
Extract playback sound logic in separate methods

### DIFF
--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -443,13 +443,13 @@ namespace gdjs {
         }
       } catch (error) {
         if (
-            error.message &&
-            typeof error.message === 'string' &&
-            error.message.startsWith('Maximum call stack size exceeded')
+          error.message &&
+          typeof error.message === 'string' &&
+          error.message.startsWith('Maximum call stack size exceeded')
         ) {
           console.warn(
-              'An error occurred when resuming paused sounds while the game was in background:',
-              error
+            'An error occurred when resuming paused sounds while the game was in background:',
+            error
           );
         } else {
           throw error;


### PR DESCRIPTION
The logic for pause/play sounds was moved into separate methods. This was done to allow pausing and resuming sounds externally at the right moment. 