### PR TITLE
Fix panel sprite rendering when its size is smaller than margins

### DIFF
--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
@@ -116,20 +116,24 @@ namespace gdjs {
 
     _updateLocalPositions() {
       const obj = this._object;
-      this._centerSprite.position.x = obj._lBorder;
-      this._centerSprite.position.y = obj._tBorder;
+      const leftBorder = this._borderSprites[3].width;
+      const topBorder = this._borderSprites[3].height;
+      const rightBorder = this._borderSprites[7].width;
+      const bottomBorder = this._borderSprites[7].height;
+
+      this._centerSprite.position.x = leftBorder;
+      this._centerSprite.position.y = topBorder;
 
       //Right
-      this._borderSprites[0].position.x = obj._width - obj._rBorder;
-      this._borderSprites[0].position.y = obj._tBorder;
+      this._borderSprites[0].position.x = obj._width - rightBorder;
+      this._borderSprites[0].position.y = topBorder;
 
       //Top-right
-      this._borderSprites[1].position.x =
-        obj._width - this._borderSprites[1].width;
+      this._borderSprites[1].position.x = obj._width - rightBorder;
       this._borderSprites[1].position.y = 0;
 
       //Top
-      this._borderSprites[2].position.x = obj._lBorder;
+      this._borderSprites[2].position.x = leftBorder;
       this._borderSprites[2].position.y = 0;
 
       //Top-Left
@@ -138,26 +142,24 @@ namespace gdjs {
 
       //Left
       this._borderSprites[4].position.x = 0;
-      this._borderSprites[4].position.y = obj._tBorder;
+      this._borderSprites[4].position.y = topBorder;
 
       //Bottom-Left
       this._borderSprites[5].position.x = 0;
-      this._borderSprites[5].position.y =
-        obj._height - this._borderSprites[5].height;
+      this._borderSprites[5].position.y = obj._height - bottomBorder;
 
       //Bottom
-      this._borderSprites[6].position.x = obj._lBorder;
-      this._borderSprites[6].position.y = obj._height - obj._bBorder;
+      this._borderSprites[6].position.x = leftBorder;
+      this._borderSprites[6].position.y = obj._height - bottomBorder;
 
       //Bottom-Right
-      this._borderSprites[7].position.x =
-        obj._width - this._borderSprites[7].width;
-      this._borderSprites[7].position.y =
-        obj._height - this._borderSprites[7].height;
+      this._borderSprites[7].position.x = obj._width - rightBorder;
+      this._borderSprites[7].position.y = obj._height - bottomBorder;
     }
 
     _updateSpritesAndTexturesSize() {
       const obj = this._object;
+
       this._centerSprite.width = Math.max(
         obj._width - obj._rBorder - obj._lBorder,
         0
@@ -167,33 +169,65 @@ namespace gdjs {
         0
       );
 
+      let leftMargin = obj._lBorder;
+      let rightMargin = obj._rBorder;
+      if (this._centerSprite.width === 0 && obj._lBorder + obj._rBorder > 0) {
+        leftMargin =
+          (obj._width * obj._lBorder) / (obj._lBorder + obj._rBorder);
+        rightMargin = obj._width - leftMargin;
+      }
+      let topMargin = obj._tBorder;
+      let bottomMargin = obj._bBorder;
+      if (this._centerSprite.height === 0 && obj._tBorder + obj._bBorder > 0) {
+        topMargin =
+          (obj._height * obj._tBorder) / (obj._tBorder + obj._bBorder);
+        bottomMargin = obj._height - topMargin;
+      }
+
       //Right
-      this._borderSprites[0].width = obj._rBorder;
+      this._borderSprites[0].width = rightMargin;
       this._borderSprites[0].height = Math.max(
-        obj._height - obj._tBorder - obj._bBorder,
+        obj._height - topMargin - bottomMargin,
         0
       );
 
       //Top
-      this._borderSprites[2].height = obj._tBorder;
+      this._borderSprites[2].height = topMargin;
       this._borderSprites[2].width = Math.max(
-        obj._width - obj._rBorder - obj._lBorder,
+        obj._width - rightMargin - leftMargin,
         0
       );
 
       //Left
-      this._borderSprites[4].width = obj._lBorder;
+      this._borderSprites[4].width = leftMargin;
       this._borderSprites[4].height = Math.max(
-        obj._height - obj._tBorder - obj._bBorder,
+        obj._height - topMargin - bottomMargin,
         0
       );
 
       //Bottom
-      this._borderSprites[6].height = obj._bBorder;
+      this._borderSprites[6].height = bottomMargin;
       this._borderSprites[6].width = Math.max(
-        obj._width - obj._rBorder - obj._lBorder,
+        obj._width - rightMargin - leftMargin,
         0
       );
+
+      //Top-right
+      this._borderSprites[1].width = rightMargin;
+      this._borderSprites[1].height = topMargin;
+
+      //Top-Left
+      this._borderSprites[3].width = leftMargin;
+      this._borderSprites[3].height = topMargin;
+
+      //Bottom-Left
+      this._borderSprites[5].width = leftMargin;
+      this._borderSprites[5].height = bottomMargin;
+
+      //Bottom-Right
+      this._borderSprites[7].width = rightMargin;
+      this._borderSprites[7].height = bottomMargin;
+
       this._wasRendered = true;
       this._spritesContainer.cacheAsBitmap = false;
     }

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedPanelSpriteInstance.js
@@ -156,25 +156,24 @@ export default class RenderedPanelSpriteInstance extends RenderedInstance {
   }
 
   _updateLocalPositions() {
-    const panelSprite = gd.asPanelSpriteConfiguration(
-      this._associatedObjectConfiguration
-    );
+    const leftBorder = this._borderSprites[3].width;
+    const topBorder = this._borderSprites[3].height;
+    const rightBorder = this._width - this._borderSprites[7].width;
+    const bottomBorder = this._height - this._borderSprites[7].height;
 
-    this._centerSprite.position.x = panelSprite.getLeftMargin();
-    this._centerSprite.position.y = panelSprite.getTopMargin();
+    this._centerSprite.position.x = leftBorder;
+    this._centerSprite.position.y = topBorder;
 
     //Right
-    this._borderSprites[0].position.x =
-      this._width - panelSprite.getRightMargin();
-    this._borderSprites[0].position.y = panelSprite.getTopMargin();
+    this._borderSprites[0].position.x = rightBorder;
+    this._borderSprites[0].position.y = topBorder;
 
     //Top-right
-    this._borderSprites[1].position.x =
-      this._width - this._borderSprites[1].width;
+    this._borderSprites[1].position.x = rightBorder;
     this._borderSprites[1].position.y = 0;
 
     //Top
-    this._borderSprites[2].position.x = panelSprite.getLeftMargin();
+    this._borderSprites[2].position.x = leftBorder;
     this._borderSprites[2].position.y = 0;
 
     //Top-Left
@@ -183,23 +182,19 @@ export default class RenderedPanelSpriteInstance extends RenderedInstance {
 
     //Left
     this._borderSprites[4].position.x = 0;
-    this._borderSprites[4].position.y = panelSprite.getTopMargin();
+    this._borderSprites[4].position.y = topBorder;
 
     //Bottom-Left
     this._borderSprites[5].position.x = 0;
-    this._borderSprites[5].position.y =
-      this._height - this._borderSprites[5].height;
+    this._borderSprites[5].position.y = bottomBorder;
 
     //Bottom
-    this._borderSprites[6].position.x = panelSprite.getLeftMargin();
-    this._borderSprites[6].position.y =
-      this._height - panelSprite.getBottomMargin();
+    this._borderSprites[6].position.x = leftBorder;
+    this._borderSprites[6].position.y = bottomBorder;
 
     //Bottom-Right
-    this._borderSprites[7].position.x =
-      this._width - this._borderSprites[7].width;
-    this._borderSprites[7].position.y =
-      this._height - this._borderSprites[7].height;
+    this._borderSprites[7].position.x = rightBorder;
+    this._borderSprites[7].position.y = bottomBorder;
   }
 
   _updateSpritesAndTexturesSize() {
@@ -215,33 +210,62 @@ export default class RenderedPanelSpriteInstance extends RenderedInstance {
       0
     );
 
+    let leftMargin = panelSprite.getLeftMargin();
+    let rightMargin = panelSprite.getRightMargin();
+    if (this._centerSprite.width === 0 && leftMargin + rightMargin > 0) {
+      leftMargin = (this._width * leftMargin) / (leftMargin + rightMargin);
+      rightMargin = this._width - leftMargin;
+    }
+    let topMargin = panelSprite.getTopMargin();
+    let bottomMargin = panelSprite.getBottomMargin();
+    if (this._centerSprite.height === 0 && topMargin + bottomMargin > 0) {
+      topMargin = (this._height * topMargin) / (topMargin + bottomMargin);
+      bottomMargin = this._height - topMargin;
+    }
+
     //Right
-    this._borderSprites[0].width = panelSprite.getRightMargin();
+    this._borderSprites[0].width = rightMargin;
     this._borderSprites[0].height = Math.max(
-      this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
+      this._height - topMargin - bottomMargin,
       0
     );
 
     //Top
-    this._borderSprites[2].height = panelSprite.getTopMargin();
+    this._borderSprites[2].height = topMargin;
     this._borderSprites[2].width = Math.max(
-      this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
+      this._width - rightMargin - leftMargin,
       0
     );
 
     //Left
-    this._borderSprites[4].width = panelSprite.getLeftMargin();
+    this._borderSprites[4].width = leftMargin;
     this._borderSprites[4].height = Math.max(
-      this._height - panelSprite.getTopMargin() - panelSprite.getBottomMargin(),
+      this._height - topMargin - bottomMargin,
       0
     );
 
     //Bottom
-    this._borderSprites[6].height = panelSprite.getBottomMargin();
+    this._borderSprites[6].height = bottomMargin;
     this._borderSprites[6].width = Math.max(
-      this._width - panelSprite.getRightMargin() - panelSprite.getLeftMargin(),
+      this._width - rightMargin - leftMargin,
       0
     );
+
+    //Top-right
+    this._borderSprites[1].width = rightMargin;
+    this._borderSprites[1].height = topMargin;
+
+    //Top-Left
+    this._borderSprites[3].width = leftMargin;
+    this._borderSprites[3].height = topMargin;
+
+    //Bottom-Left
+    this._borderSprites[5].width = leftMargin;
+    this._borderSprites[5].height = bottomMargin;
+
+    //Bottom-Right
+    this._borderSprites[7].width = rightMargin;
+    this._borderSprites[7].height = bottomMargin;
 
     this._pixiObject.cacheAsBitmap = false;
   }


### PR DESCRIPTION
The border are resized instead of going past each other. This is especially important for resource bars.
Ideally, borders should be cropped instead of resized (it may depend what we do though), but the artifacts are less noticeable now.

![image](https://github.com/user-attachments/assets/d86927cd-60c1-4b64-9019-05455552c7cc)
