### PR TITLE
[Top-down movement] Turn back at least as fast as it decelerate

### DIFF
--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -34,6 +34,7 @@ void TopDownMovementBehavior::InitializeContent(
   behaviorContent.SetAttribute("viewpoint", "TopDown");
   behaviorContent.SetAttribute("customIsometryAngle", 30);
   behaviorContent.SetAttribute("movementAngleOffset", 0);
+  behaviorContent.SetAttribute("useLegacyTurnBack", false);
 }
 
 std::map<gd::String, gd::PropertyDescriptor>
@@ -93,6 +94,15 @@ TopDownMovementBehavior::GetProperties(
       .SetValue(behaviorContent.GetBoolAttribute("ignoreDefaultControls")
                     ? "false"
                     : "true")
+      .SetType("Boolean");
+  properties["UseLegacyTurnBack"]
+      .SetLabel(_("Only use acceleration to turn back "
+                  "(deprecated — best left unchecked)"))
+      .SetGroup(_("Deprecated options"))
+      .SetDeprecated()
+      .SetValue(behaviorContent.GetBoolAttribute("useLegacyTurnBack", true)
+                    ? "true"
+                    : "false")
       .SetType("Boolean");
 
   gd::String viewpoint = behaviorContent.GetStringAttribute("viewpoint");
@@ -155,6 +165,9 @@ bool TopDownMovementBehavior::UpdateProperty(
   if (name == "RotateObject") {
     behaviorContent.SetAttribute("rotateObject", (value != "0"));
     return true;
+  }
+  if (name == "UseLegacyTurnBack") {
+    behaviorContent.SetAttribute("useLegacyTurnBack", (value == "1"));
   }
   if (name == "Viewpoint") {
     // Fix the offset angle when switching between top-down and isometry

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -35,6 +35,7 @@ void TopDownMovementBehavior::InitializeContent(
   behaviorContent.SetAttribute("customIsometryAngle", 30);
   behaviorContent.SetAttribute("movementAngleOffset", 0);
   behaviorContent.SetAttribute("useLegacyTurnBack", false);
+  behaviorContent.SetAttribute("movementMode", "Sharp turn with smooth turn back");
 }
 
 std::map<gd::String, gd::PropertyDescriptor>
@@ -147,6 +148,21 @@ TopDownMovementBehavior::GetProperties(
           "Usually 0, unless you choose an *Isometry* viewpoint in which case "
           "-45 is recommended."));
 
+  gd::String movementMode = behaviorContent.GetStringAttribute("movementMode");
+  gd::String movementModeStr = _("Sharp turn with smooth turn back");
+  if (movementMode == "Sharp turn")
+    movementModeStr = _("Sharp turn");
+  else if (movementMode == "Smooth turn")
+    movementModeStr = _("Smooth turn");
+
+  properties["MovementMode"]
+      .SetLabel(_("Mode"))
+      .SetValue(movementModeStr)
+      .SetType("Choice")
+      .AddExtraInfo(_("Sharp turn with smooth turn back"))
+      .AddExtraInfo(_("Sharp turn"))
+      .AddExtraInfo(_("Smooth turn"));
+
   return properties;
 }
 
@@ -197,6 +213,14 @@ bool TopDownMovementBehavior::UpdateProperty(
   }
   if (name == "MovementAngleOffset") {
     behaviorContent.SetAttribute("movementAngleOffset", value.To<float>());
+  }
+  if (name == "MovementMode") {
+    if (value == _("Sharp turn"))
+      behaviorContent.SetAttribute("movementMode", "Sharp turn");
+    else if (value == _("Smooth turn"))
+      behaviorContent.SetAttribute("movementMode", "Smooth turn");
+    else
+      behaviorContent.SetAttribute("movementMode", "Sharp turn with smooth turn back");
   }
 
   if (value.To<float>() < 0) return false;

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -553,8 +553,9 @@ namespace gdjs {
             this._xVelocity * this._xVelocity +
             this._yVelocity * this._yVelocity;
           if (squaredSpeed > this._maxSpeed * this._maxSpeed) {
-            this._xVelocity = this._maxSpeed * cos;
-            this._yVelocity = this._maxSpeed * sin;
+            const ratio = this._maxSpeed / Math.sqrt(squaredSpeed);
+            this._xVelocity *= ratio;
+            this._yVelocity *= ratio;
           }
         } else {
           let currentSpeed = Math.hypot(this._xVelocity, this._yVelocity);

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -554,7 +554,7 @@ namespace gdjs {
             const dotProduct = this._xVelocity * cos + this._yVelocity * sin;
             if (dotProduct < 0) {
               // The object is turning back.
-              // Keep negative part of velocity projected on the new direction.
+              // Keep the negative velocity projected on the new direction.
               currentSpeed = dotProduct;
             }
           }

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -548,15 +548,6 @@ namespace gdjs {
             this._deceleration,
             timeDelta
           );
-
-          const squaredSpeed =
-            this._xVelocity * this._xVelocity +
-            this._yVelocity * this._yVelocity;
-          if (squaredSpeed > this._maxSpeed * this._maxSpeed) {
-            const ratio = this._maxSpeed / Math.sqrt(squaredSpeed);
-            this._xVelocity *= ratio;
-            this._yVelocity *= ratio;
-          }
         } else {
           let currentSpeed = Math.hypot(this._xVelocity, this._yVelocity);
           if (this._movementMode === MovementMode.SharpTurnWithSmoothTurnBack) {
@@ -578,6 +569,15 @@ namespace gdjs {
           this._xVelocity = speed * cos;
           this._yVelocity = speed * sin;
         }
+      }
+
+      const squaredSpeed =
+        this._xVelocity * this._xVelocity +
+        this._yVelocity * this._yVelocity;
+      if (squaredSpeed > this._maxSpeed * this._maxSpeed) {
+        const ratio = this._maxSpeed / Math.sqrt(squaredSpeed);
+        this._xVelocity *= ratio;
+        this._yVelocity *= ratio;
       }
 
       // No acceleration for angular speed for now.

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -527,46 +527,27 @@ namespace gdjs {
         const targetedSpeedX = targetedSpeed * cos;
         const targetedSpeedY = targetedSpeed * sin;
 
+        const getAcceleratedSpeed = this._useLegacyTurnBack
+          ? TopDownMovementRuntimeBehavior.getLegacyAcceleratedSpeed
+          : TopDownMovementRuntimeBehavior.getAcceleratedSpeed;
+
         if (this._movementMode === MovementMode.SmoothTurn) {
-          if (this._useLegacyTurnBack) {
-            this._xVelocity =
-              TopDownMovementRuntimeBehavior.getLegacyAcceleratedSpeed(
-                this._xVelocity,
-                targetedSpeedX,
-                this._maxSpeed,
-                this._acceleration,
-                this._deceleration,
-                timeDelta
-              );
-            this._yVelocity =
-              TopDownMovementRuntimeBehavior.getLegacyAcceleratedSpeed(
-                this._yVelocity,
-                targetedSpeedY,
-                this._maxSpeed,
-                this._acceleration,
-                this._deceleration,
-                timeDelta
-              );
-          } else {
-            this._xVelocity =
-              TopDownMovementRuntimeBehavior.getAcceleratedSpeed(
-                this._xVelocity,
-                targetedSpeedX,
-                this._maxSpeed,
-                this._acceleration,
-                this._deceleration,
-                timeDelta
-              );
-            this._yVelocity =
-              TopDownMovementRuntimeBehavior.getAcceleratedSpeed(
-                this._yVelocity,
-                targetedSpeedY,
-                this._maxSpeed,
-                this._acceleration,
-                this._deceleration,
-                timeDelta
-              );
-          }
+          this._xVelocity = getAcceleratedSpeed(
+            this._xVelocity,
+            targetedSpeedX,
+            this._maxSpeed,
+            this._acceleration,
+            this._deceleration,
+            timeDelta
+          );
+          this._yVelocity = getAcceleratedSpeed(
+            this._yVelocity,
+            targetedSpeedY,
+            this._maxSpeed,
+            this._acceleration,
+            this._deceleration,
+            timeDelta
+          );
 
           const squaredSpeed =
             this._xVelocity * this._xVelocity +
@@ -580,18 +561,19 @@ namespace gdjs {
           if (this._movementMode === MovementMode.SharpTurnWithSmoothTurnBack) {
             const dotProduct = this._xVelocity * cos + this._yVelocity * sin;
             if (dotProduct < 0) {
+              // The object is turning back.
+              // Keep negative part of velocity projected on the new direction.
               currentSpeed = dotProduct;
             }
           }
-          const speed =
-            TopDownMovementRuntimeBehavior.getLegacyAcceleratedSpeed(
-              currentSpeed,
-              targetedSpeed,
-              this._maxSpeed,
-              this._acceleration,
-              this._deceleration,
-              timeDelta
-            );
+          const speed = getAcceleratedSpeed(
+            currentSpeed,
+            targetedSpeed,
+            this._maxSpeed,
+            this._acceleration,
+            this._deceleration,
+            timeDelta
+          );
           this._xVelocity = speed * cos;
           this._yVelocity = speed * sin;
         }

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -471,48 +471,31 @@ namespace gdjs {
       let cos = 1;
       let sin = 0;
 
+      let isMoving = false;
+      let targetedSpeed = 0;
       // Update the speed of the object:
       if (direction !== -1) {
+        isMoving = true;
         directionInRad =
           ((direction + this._movementAngleOffset / 45) * Math.PI) / 4.0;
         directionInDeg = direction * 45 + this._movementAngleOffset;
-        // This makes the trigo resilient to rounding errors on directionInRad.
-        cos = Math.cos(directionInRad);
-        sin = Math.sin(directionInRad);
-        if (cos === -1 || cos === 1) {
-          sin = 0;
-        }
-        if (sin === -1 || sin === 1) {
-          cos = 0;
-        }
-        this._xVelocity += this._acceleration * timeDelta * cos;
-        this._yVelocity += this._acceleration * timeDelta * sin;
+        targetedSpeed = this._maxSpeed;
       } else if (this._stickForce !== 0) {
+        isMoving = true;
         if (!this._allowDiagonals) {
           this._stickAngle = 90 * Math.floor((this._stickAngle + 45) / 90);
         }
         directionInDeg = this._stickAngle + this._movementAngleOffset;
         directionInRad = (directionInDeg * Math.PI) / 180;
-        const norm = this._acceleration * timeDelta * this._stickForce;
-        // This makes the trigo resilient to rounding errors on directionInRad.
-        cos = Math.cos(directionInRad);
-        sin = Math.sin(directionInRad);
-        if (cos === -1 || cos === 1) {
-          sin = 0;
-        }
-        if (sin === -1 || sin === 1) {
-          cos = 0;
-        }
-        this._xVelocity += norm * cos;
-        this._yVelocity += norm * sin;
+        targetedSpeed = this._maxSpeed * this._stickForce;
 
         this._wasStickUsed = true;
-        this._stickForce = 0;
       } else if (this._yVelocity !== 0 || this._xVelocity !== 0) {
+        isMoving = true;
         directionInRad = Math.atan2(this._yVelocity, this._xVelocity);
         directionInDeg = (directionInRad * 180.0) / Math.PI;
-        const xVelocityWasPositive = this._xVelocity >= 0;
-        const yVelocityWasPositive = this._yVelocity >= 0;
+      }
+      if (isMoving) {
         // This makes the trigo resilient to rounding errors on directionInRad.
         cos = Math.cos(directionInRad);
         sin = Math.sin(directionInRad);
@@ -522,20 +505,32 @@ namespace gdjs {
         if (sin === -1 || sin === 1) {
           cos = 0;
         }
-        this._xVelocity -= this._deceleration * timeDelta * cos;
-        this._yVelocity -= this._deceleration * timeDelta * sin;
-        if (this._xVelocity > 0 !== xVelocityWasPositive) {
-          this._xVelocity = 0;
+        const targetedSpeedX = targetedSpeed * cos;
+        const targetedSpeedY = targetedSpeed * sin;
+
+        this._xVelocity = TopDownMovementRuntimeBehavior.getAcceleratedSpeed(
+          this._xVelocity,
+          targetedSpeedX,
+          this._maxSpeed,
+          this._acceleration,
+          this._deceleration,
+          timeDelta
+        );
+        this._yVelocity = TopDownMovementRuntimeBehavior.getAcceleratedSpeed(
+          this._yVelocity,
+          targetedSpeedY,
+          this._maxSpeed,
+          this._acceleration,
+          this._deceleration,
+          timeDelta
+        );
+
+        const squaredSpeed =
+          this._xVelocity * this._xVelocity + this._yVelocity * this._yVelocity;
+        if (squaredSpeed > this._maxSpeed * this._maxSpeed) {
+          this._xVelocity = this._maxSpeed * cos;
+          this._yVelocity = this._maxSpeed * sin;
         }
-        if (this._yVelocity > 0 !== yVelocityWasPositive) {
-          this._yVelocity = 0;
-        }
-      }
-      const squaredSpeed =
-        this._xVelocity * this._xVelocity + this._yVelocity * this._yVelocity;
-      if (squaredSpeed > this._maxSpeed * this._maxSpeed) {
-        this._xVelocity = this._maxSpeed * cos;
-        this._yVelocity = this._maxSpeed * sin;
       }
 
       // No acceleration for angular speed for now.
@@ -589,7 +584,67 @@ namespace gdjs {
         this._rightKey = false;
         this._upKey = false;
         this._downKey = false;
+        this._stickForce = 0;
       }
+    }
+
+    private static getAcceleratedSpeed(
+      currentSpeed: float,
+      targetedSpeed: float,
+      speedMax: float,
+      acceleration: float,
+      deceleration: float,
+      timeDelta: float
+    ): float {
+      let newSpeed = currentSpeed;
+      const turningBackAcceleration = Math.max(acceleration, deceleration);
+      if (targetedSpeed < 0) {
+        if (currentSpeed <= targetedSpeed) {
+          // Reduce the speed to match the stick force.
+          newSpeed = Math.min(
+            targetedSpeed,
+            currentSpeed + turningBackAcceleration * timeDelta
+          );
+        } else if (currentSpeed <= 0) {
+          // Accelerate
+          newSpeed -= Math.max(-speedMax, acceleration * timeDelta);
+        } else {
+          // Turn back at least as fast as it would stop.
+          newSpeed = Math.max(
+            targetedSpeed,
+            currentSpeed - turningBackAcceleration * timeDelta
+          );
+        }
+      } else if (targetedSpeed > 0) {
+        if (currentSpeed >= targetedSpeed) {
+          // Reduce the speed to match the stick force.
+          newSpeed = Math.max(
+            targetedSpeed,
+            currentSpeed - turningBackAcceleration * timeDelta
+          );
+        } else if (currentSpeed >= 0) {
+          // Accelerate
+          newSpeed = Math.min(
+            speedMax,
+            currentSpeed + acceleration * timeDelta
+          );
+        } else {
+          // Turn back at least as fast as it would stop.
+          newSpeed = Math.min(
+            targetedSpeed,
+            currentSpeed + turningBackAcceleration * timeDelta
+          );
+        }
+      } else {
+        // Decelerate and stop.
+        if (currentSpeed < 0) {
+          newSpeed = Math.min(currentSpeed + deceleration * timeDelta, 0);
+        }
+        if (currentSpeed > 0) {
+          newSpeed = Math.max(currentSpeed - deceleration * timeDelta, 0);
+        }
+      }
+      return newSpeed;
     }
 
     simulateControl(input: string) {

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.ts
@@ -572,8 +572,7 @@ namespace gdjs {
       }
 
       const squaredSpeed =
-        this._xVelocity * this._xVelocity +
-        this._yVelocity * this._yVelocity;
+        this._xVelocity * this._xVelocity + this._yVelocity * this._yVelocity;
       if (squaredSpeed > this._maxSpeed * this._maxSpeed) {
         const ratio = this._maxSpeed / Math.sqrt(squaredSpeed);
         this._xVelocity *= ratio;


### PR DESCRIPTION
### Changes
- Add a new property that allows to choose between 3 modes
  - "Sharp turn with smooth turn back" which is what you are used to
  - "Sharp turn" which is more responsive
  - "Smooth turn" which keeps inertia
- Turn back at least as fast as it decelerate
  - You need to go in advanced and deprecated sections and uncheck the property to enable this in existing projects.
- Make analog stick controls more responsive