### PR TITLE
Fix a case where neither the variant nor the children is shown in the object editor

### DIFF
--- a/newIDE/app/src/ObjectEditor/Editors/CustomObjectPropertiesEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/Editors/CustomObjectPropertiesEditor/index.js
@@ -401,10 +401,11 @@ const CustomObjectPropertiesEditor = (props: Props) => {
                       </ColumnStackLayout>
                     </>
                   )}
-                  {!getVariantName(
+                  {(!getVariantName(
                     eventBasedObject,
                     customObjectConfiguration
-                  ) &&
+                  ) ||
+                    customObjectConfiguration.isForcedToOverrideEventsBasedObjectChildrenConfiguration()) &&
                     (eventBasedObject &&
                       (!customObjectConfiguration.isForcedToOverrideEventsBasedObjectChildrenConfiguration() &&
                       !customObjectConfiguration.isMarkedAsOverridingEventsBasedObjectChildrenConfiguration() ? (


### PR DESCRIPTION
This can happens if someone selected a variant and:
- decide to roll back to an old extension release
- or removed all the instances of the default variant for some reason