### PR TITLE
Fix a crash when using the "Fixed rotation" action on a 3D character

### DIFF
--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -818,7 +818,7 @@ module.exports = {
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('yesorno', _('Treat as bullet?'), '', false)
+      .addParameter('yesorno', _('Treat as bullet'), '', false)
       .setDefaultValue('false')
       .getCodeExtraInformation()
       .setFunctionName('setBullet');
@@ -852,7 +852,7 @@ module.exports = {
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('yesorno', _('Fixed rotation?'), '', false)
+      .addParameter('yesorno', _('Fixed rotation'), '', false)
       .setDefaultValue('false')
       .getCodeExtraInformation()
       .setFunctionName('setFixedRotation');
@@ -886,7 +886,7 @@ module.exports = {
       )
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
-      .addParameter('yesorno', _('Can sleep?'), '', false)
+      .addParameter('yesorno', _('Can sleep'), '', false)
       .setDefaultValue('true')
       .getCodeExtraInformation()
       .setFunctionName('setSleepingAllowed');
@@ -1296,7 +1296,7 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Layer (1 - 16)'))
-      .addParameter('yesorno', _('Enable?'), '', false)
+      .addParameter('yesorno', _('Enable'), '', false)
       .setDefaultValue('true')
       .getCodeExtraInformation()
       .setFunctionName('enableLayer');
@@ -1332,7 +1332,7 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Mask (1 - 16)'))
-      .addParameter('yesorno', _('Enable?'), '', false)
+      .addParameter('yesorno', _('Enable'), '', false)
       .setDefaultValue('true')
       .getCodeExtraInformation()
       .setFunctionName('enableMask');
@@ -2409,7 +2409,7 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('yesorno', _('Enable?'))
+      .addParameter('yesorno', _('Enable'))
       .getCodeExtraInformation()
       .setFunctionName('enableRevoluteJointLimits');
 
@@ -2488,7 +2488,7 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('yesorno', _('Enable?'))
+      .addParameter('yesorno', _('Enable'))
       .getCodeExtraInformation()
       .setFunctionName('enableRevoluteJointMotor');
 
@@ -2727,7 +2727,7 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('yesorno', _('Enable?'))
+      .addParameter('yesorno', _('Enable'))
       .getCodeExtraInformation()
       .setFunctionName('enablePrismaticJointLimits');
 
@@ -2806,7 +2806,7 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('yesorno', _('Enable?'))
+      .addParameter('yesorno', _('Enable'))
       .getCodeExtraInformation()
       .setFunctionName('enablePrismaticJointMotor');
 
@@ -3486,7 +3486,7 @@ module.exports = {
       .addParameter('object', _('Object'), '', false)
       .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
       .addParameter('expression', _('Joint ID'))
-      .addParameter('yesorno', _('Enable?'))
+      .addParameter('yesorno', _('Enable'))
       .getCodeExtraInformation()
       .setFunctionName('enableWheelJointMotor');
 

--- a/Extensions/Physics3DBehavior/JsExtension.js
+++ b/Extensions/Physics3DBehavior/JsExtension.js
@@ -274,7 +274,7 @@ module.exports = {
           .setLabel('Fixed Rotation')
           .setDescription(
             _(
-              "If enabled, the object won't rotate and will stay at the same angle. Useful for characters for example."
+              "If enabled, the object won't rotate and will stay at the same angle."
             )
           )
           .setGroup(_('Movement'));
@@ -845,7 +845,7 @@ module.exports = {
         )
         .addParameter('object', _('Object'), '', false)
         .addParameter('behavior', _('Behavior'), 'Physics3DBehavior')
-        .addParameter('yesorno', _('Treat as bullet?'), '', false)
+        .addParameter('yesorno', _('Treat as bullet'), '', false)
         .setDefaultValue('false')
         .getCodeExtraInformation()
         .setFunctionName('setBullet');
@@ -870,7 +870,7 @@ module.exports = {
           'SetFixedRotation',
           _('Fixed rotation'),
           _(
-            "Enable or disable an object fixed rotation. If enabled the object won't be able to rotate."
+            "Enable or disable an object fixed rotation. If enabled the object won't be able to rotate. This action has no effect on characters."
           ),
           _('Set _PARAM0_ fixed rotation: _PARAM2_'),
           _('Dynamics'),
@@ -879,7 +879,7 @@ module.exports = {
         )
         .addParameter('object', _('Object'), '', false)
         .addParameter('behavior', _('Behavior'), 'Physics3DBehavior')
-        .addParameter('yesorno', _('Fixed rotation?'), '', false)
+        .addParameter('yesorno', _('Fixed rotation'), '', false)
         .setDefaultValue('false')
         .getCodeExtraInformation()
         .setFunctionName('setFixedRotation');
@@ -1054,7 +1054,7 @@ module.exports = {
         .addParameter('object', _('Object'), '', false)
         .addParameter('behavior', _('Behavior'), 'Physics3DBehavior')
         .addParameter('expression', _('Layer (1 - 8)'))
-        .addParameter('yesorno', _('Enable?'), '', false)
+        .addParameter('yesorno', _('Enable'), '', false)
         .setDefaultValue('true')
         .getCodeExtraInformation()
         .setFunctionName('enableLayer');
@@ -1090,7 +1090,7 @@ module.exports = {
         .addParameter('object', _('Object'), '', false)
         .addParameter('behavior', _('Behavior'), 'Physics3DBehavior')
         .addParameter('expression', _('Mask (1 - 8)'))
-        .addParameter('yesorno', _('Enable?'), '', false)
+        .addParameter('yesorno', _('Enable'), '', false)
         .setDefaultValue('true')
         .getCodeExtraInformation()
         .setFunctionName('enableMask');

--- a/Extensions/Physics3DBehavior/Physics3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/Physics3DRuntimeBehavior.ts
@@ -927,9 +927,7 @@ namespace gdjs {
       const angularVelocityY = angularVelocity.GetY();
       const angularVelocityZ = angularVelocity.GetZ();
 
-      let bodyID = this._body.GetID();
-      bodyInterface.RemoveBody(bodyID);
-      bodyInterface.DestroyBody(bodyID);
+      this.bodyUpdater.destroyBody();
       this._contactsEndedThisFrame.length = 0;
       this._contactsStartedThisFrame.length = 0;
       this._currentContacts.length = 0;
@@ -938,7 +936,7 @@ namespace gdjs {
       if (!this._body) {
         return;
       }
-      bodyID = this._body.GetID();
+      const bodyID = this._body.GetID();
       bodyInterface.SetLinearVelocity(
         bodyID,
         this.getVec3(linearVelocityX, linearVelocityY, linearVelocityZ)


### PR DESCRIPTION
The crash was caused by the old character not being removed and still using a destroyed body.