### PR TITLE
Switch GDJS browser tests to Vitest

### DIFF
--- a/GDJS/tests/README.md
+++ b/GDJS/tests/README.md
@@ -12,9 +12,8 @@ npm install
 Then launch tests:
 
 ```bash
-npm run test:watch # This will use Chrome Headless
+npm run test:watch          # Runs tests in a headless browser using Vitest
 npm run test-benchmark:watch # This will also run benchmarks
-npm run test:firefox:watch # To run tests using Firefox
 ```
 
 > ⚠️ If you're working on GDJS or extensions, make sure to have the development version of GDevelop running so that changes in GDJS or extension files are rebuilt (or run `npm run build` in `GDJS/`, but better run GDevelop so that any changes are watched).
@@ -23,7 +22,7 @@ npm run test:firefox:watch # To run tests using Firefox
 
 ### Unit tests
 
-Tests are launched using Chrome. You need Chrome installed to run them. You can change the browser by modifying the package.json "test" command and install the appropriate karma package.
+Tests are launched using [Vitest](https://vitest.dev/) in a headless browser. You can change the browser by editing the `vitest.config.js` file.
 
 Tests are located in the **tests** folder for the game engine, or directly in the folder of the tested extensions.
 

--- a/GDJS/tests/benchmarks/force.js
+++ b/GDJS/tests/benchmarks/force.js
@@ -1,6 +1,6 @@
 describe('gdjs.Force', function() {
-	it('benchmark setting angle and length', function(){
-		this.timeout(20000);
+        it('benchmark setting angle and length', function(){
+                vi.setTimeout(20000);
         var layer = new gdjs.Force();
         
         const benchmarkSuite = makeBenchmarkSuite();

--- a/GDJS/tests/benchmarks/layer.js
+++ b/GDJS/tests/benchmarks/layer.js
@@ -5,7 +5,7 @@ describe('gdjs.Layer', function() {
   var runtimeScene = new gdjs.RuntimeScene(runtimeGame);
 
   it('benchmark convertCoords and convertInverseCoords', function() {
-    this.timeout(30000);
+    vi.setTimeout(30000);
     var layer = new gdjs.Layer(
       { name: 'My layer',
         visibility: true,

--- a/GDJS/tests/benchmarks/polygon.js
+++ b/GDJS/tests/benchmarks/polygon.js
@@ -1,6 +1,6 @@
 describe('gdjs.Polygon', function() {
   it('benchmark gdjs.Polygon.collisionTest between two polygons', function() {
-    this.timeout(20000);
+    vi.setTimeout(20000);
     var rect1 = gdjs.Polygon.createRectangle(32, 40);
     var rect2 = gdjs.Polygon.createRectangle(32, 40);
     var rect3 = gdjs.Polygon.createRectangle(32, 40);

--- a/GDJS/tests/benchmarks/runtimeobject.js
+++ b/GDJS/tests/benchmarks/runtimeobject.js
@@ -1,8 +1,8 @@
 describe('gdjs.RuntimeObject', function() {
     const runtimeScene = new gdjs.RuntimeScene(null);
     
-	it('benchmark getAABB of rotated vs non rotated objects', function(){
-    this.timeout(20000);
+        it('benchmark getAABB of rotated vs non rotated objects', function(){
+    vi.setTimeout(20000);
 		var object = new gdjs.RuntimeObject(runtimeScene, {name: "obj1", type: "", behaviors: [], effects: []});
 		object.getWidth = function() { return 10; };
 		object.getHeight = function() { return 20; };
@@ -25,8 +25,8 @@ describe('gdjs.RuntimeObject', function() {
         console.log(benchmarkSuite.run());
 	});
 
-	it('benchmark getAABB of rotated vs non rotated objects, with non default center', function(){
-    this.timeout(20000);
+        it('benchmark getAABB of rotated vs non rotated objects, with non default center', function(){
+    vi.setTimeout(20000);
 		var object = new gdjs.RuntimeObject(runtimeScene, {name: "obj1", type: "", behaviors: [], effects: []});
 		object.getWidth = function() { return 10; };
 		object.getHeight = function() { return 20; };

--- a/GDJS/tests/benchmarks/spriteruntimeobject.js
+++ b/GDJS/tests/benchmarks/spriteruntimeobject.js
@@ -65,7 +65,7 @@ describe('gdjs.SpriteRuntimeObject', function () {
     });
 
   it('benchmark getAABB of rotated vs non rotated sprite, with custom hitboxes, origin and center', function () {
-    this.timeout(20000);
+    vi.setTimeout(20000);
     const object = makeSpriteRuntimeObjectWithCustomHitBox(runtimeScene);
 
     const benchmarkSuite = makeBenchmarkSuite({

--- a/GDJS/tests/benchmarks/variablescontainer.js
+++ b/GDJS/tests/benchmarks/variablescontainer.js
@@ -1,6 +1,6 @@
 describe('gdjs.VariablesContainer', function() {
   it('benchmark get', function() {
-    this.timeout(20000);
+    vi.setTimeout(20000);
     var container = new gdjs.VariablesContainer();
 
     const benchmarkSuite = makeBenchmarkSuite();

--- a/GDJS/tests/package.json
+++ b/GDJS/tests/package.json
@@ -5,16 +5,10 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "test": "karma start --browsers ChromeHeadless --single-run",
-    "test:watch": "karma start --browsers ChromeHeadless",
-    "test-benchmark": "karma start --browsers ChromeHeadless --single-run --enableBenchmarks",
-    "test-benchmark:watch": "karma start --browsers ChromeHeadless --enableBenchmarks",
-    "test:firefox": "karma start --browsers Firefox --single-run",
-    "test:firefox:watch": "karma start --browsers Firefox",
-    "test:chrome": "karma start --browsers Chrome --single-run",
-    "test:chrome:watch": "karma start --browsers Chrome",
-    "test:edge": "karma start --browsers EdgeHeadless --single-run",
-    "test:edge:watch": "karma start --browsers EdgeHeadless"
+    "test": "vitest run --browser",
+    "test:watch": "vitest --browser",
+    "test-benchmark": "vitest run --browser",
+    "test-benchmark:watch": "vitest --browser"
   },
   "keywords": [
     "HTML5",
@@ -30,12 +24,9 @@
     "mocha": "^1.21.4"
   },
   "devDependencies": {
-    "@chiragrupani/karma-chromium-edge-launcher": "2.1.1",
-    "karma": "^1.7.1",
-    "karma-chrome-launcher": "^2.2.0",
-    "karma-firefox-launcher": "^1.1.0",
-    "karma-mocha": "^1.3.0",
-    "karma-sinon": "^1.0.5",
+    "vitest": "^0.34.0",
+    "vite": "^4.4.9",
+    "@vitest/browser": "^0.34.0",
     "sinon": "^15.0.1"
   }
 }

--- a/GDJS/tests/tests/asynctasks.js
+++ b/GDJS/tests/tests/asynctasks.js
@@ -27,7 +27,7 @@
     const runtimeScene = new gdjs.RuntimeScene(runtimeGame);
     const asyncTasksManager = runtimeScene.getAsyncTasksManager();
 
-    this.beforeEach(() => asyncTasksManager.clearTasks());
+    beforeEach(() => asyncTasksManager.clearTasks());
 
     it('should call a resolved callback', function () {
       const cb = createMockCallback();

--- a/GDJS/tests/vitest.config.js
+++ b/GDJS/tests/vitest.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      name: 'chrome',
+      headless: true,
+    },
+    setupFiles: [
+      './vitest.setup.js',
+      './tests-utils/init.js',
+      './tests-utils/init.pixiruntimegamewithassets.js',
+      './tests-utils/init.pixiruntimegame.js',
+      './tests-utils/MockedCustomObject.js',
+    ],
+    include: ['tests/**/*.js', 'benchmarks/**/*.js', '../Extensions/**/tests/**/*.js'],
+  },
+});

--- a/GDJS/tests/vitest.setup.js
+++ b/GDJS/tests/vitest.setup.js
@@ -1,0 +1,9 @@
+import expect from 'expect.js';
+import sinon from 'sinon';
+
+// Expose expect.js and sinon globally like Karma used to do.
+// Vitest provides its own expect, but tests rely on expect.js syntax.
+// eslint-disable-next-line no-undef
+global.expect = expect;
+// eslint-disable-next-line no-undef
+global.sinon = sinon;


### PR DESCRIPTION
## Summary
- replace Karma with Vitest for GDJS tests
- update benchmarks to use `vi.setTimeout`
- fix `beforeEach` usage
- document how to run tests with Vitest
- add Vitest config and setup files

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863f31a67348327b10a19312f4d6caa