### PR TITLE
Fix custom objects being destroyed too soon

### DIFF
--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -256,6 +256,11 @@ namespace gdjs {
       this._instanceContainer.onDestroyFromScene(this._runtimeScene);
     }
 
+    override onDestroyed(): void {
+      this._instanceContainer._destroy();
+      super.onDestroyed();
+    }
+
     override update(parent: gdjs.RuntimeInstanceContainer): void {
       this._instanceContainer._updateObjectsPreEvents();
 
@@ -276,6 +281,8 @@ namespace gdjs {
 
     /**
      * This method is called when the preview is being hot-reloaded.
+     *
+     * Custom objects implements this method with code generated from events.
      */
     onHotReloading(parent: gdjs.RuntimeInstanceContainer) {}
 
@@ -284,6 +291,8 @@ namespace gdjs {
 
     /**
      * This method is called each tick after events are done.
+     *
+     * Custom objects implements this method with code generated from events.
      * @param parent The instanceContainer owning the object
      */
     doStepPostEvents(parent: gdjs.RuntimeInstanceContainer) {}
@@ -291,6 +300,8 @@ namespace gdjs {
     /**
      * This method is called when the object is being removed from its parent
      * container and is about to be destroyed/reused later.
+     *
+     * Custom objects implements this method with code generated from events.
      */
     onDestroy(parent: gdjs.RuntimeInstanceContainer) {}
 

--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -282,7 +282,7 @@ namespace gdjs {
     /**
      * This method is called when the preview is being hot-reloaded.
      *
-     * Custom objects implements this method with code generated from events.
+     * Custom objects implement this method with code generated from events.
      */
     onHotReloading(parent: gdjs.RuntimeInstanceContainer) {}
 
@@ -292,7 +292,7 @@ namespace gdjs {
     /**
      * This method is called each tick after events are done.
      *
-     * Custom objects implements this method with code generated from events.
+     * Custom objects implement this method with code generated from events.
      * @param parent The instanceContainer owning the object
      */
     doStepPostEvents(parent: gdjs.RuntimeInstanceContainer) {}
@@ -301,7 +301,7 @@ namespace gdjs {
      * This method is called when the object is being removed from its parent
      * container and is about to be destroyed/reused later.
      *
-     * Custom objects implements this method with code generated from events.
+     * Custom objects implement this method with code generated from events.
      */
     onDestroy(parent: gdjs.RuntimeInstanceContainer) {}
 

--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -253,7 +253,7 @@ namespace gdjs {
       // Let behaviors do something before the object is destroyed.
       super.onDeletedFromScene();
       // Destroy the children.
-      this._instanceContainer.onDestroyFromScene(this._runtimeScene);
+      this._instanceContainer.onDeletedFromScene(this._runtimeScene);
     }
 
     override onDestroyed(): void {

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -190,22 +190,21 @@ namespace gdjs {
       if (!this._isLoaded) {
         return;
       }
-
       // Notify the objects they are being destroyed
       const allInstancesList = this.getAdhocListOfAllInstances();
       for (let i = 0, len = allInstancesList.length; i < len; ++i) {
         const object = allInstancesList[i];
         object.onDeletedFromScene();
-        // The object can free all its resource directly...
-        object.onDestroyed();
       }
-      // ...as its container cache `_instancesRemoved` is also destroy.
-      this._destroy();
-
       this._isLoaded = false;
     }
 
     _destroy() {
+      const allInstancesList = this.getAdhocListOfAllInstances();
+      for (let i = 0, len = allInstancesList.length; i < len; ++i) {
+        const object = allInstancesList[i];
+        object.onDestroyed();
+      }
       // It should not be necessary to reset these variables, but this help
       // ensuring that all memory related to the container is released immediately.
       super._destroy();

--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -71,7 +71,7 @@ namespace gdjs {
       eventsBasedObjectVariantData: EventsBasedObjectVariantData
     ) {
       if (this._isLoaded) {
-        this.onDestroyFromScene(this._parent);
+        this.onDeletedFromScene(this._parent);
       }
 
       const isForcedToOverrideEventsBasedObjectChildrenConfiguration =
@@ -186,7 +186,7 @@ namespace gdjs {
      *
      * @param instanceContainer The container owning the object.
      */
-    onDestroyFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
+    onDeletedFromScene(instanceContainer: gdjs.RuntimeInstanceContainer): void {
       if (!this._isLoaded) {
         return;
       }
@@ -199,7 +199,7 @@ namespace gdjs {
       this._isLoaded = false;
     }
 
-    _destroy() {
+    override _destroy() {
       const allInstancesList = this.getAdhocListOfAllInstances();
       for (let i = 0, len = allInstancesList.length; i < len; ++i) {
         const object = allInstancesList[i];

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -292,7 +292,7 @@ namespace gdjs {
 
     /**
      * Called to reset the object to its default state. This is used for objects that are
-     * "recycled": they are dismissed (at which point `onDestroyFromScene` is called) but still
+     * "recycled": they are dismissed (at which point `onDeletedFromScene` is called) but still
      * stored in a cache to be reused next time an object must be created. At this point,
      * `reinitialize` will be called. The object must then work as if it was a newly constructed
      * object.
@@ -596,7 +596,7 @@ namespace gdjs {
     /**
      * Remove an object from a scene.
      *
-     * Do not change/redefine this method. Instead, redefine the onDestroyFromScene method.
+     * Do not change/redefine this method. Instead, redefine the onDeletedFromScene method.
      */
     deleteFromScene(): void {
       if (this._livingOnScene) {
@@ -619,7 +619,7 @@ namespace gdjs {
      * can still be used by events.
      *
      * If you redefine this function, **make sure to call the original method**
-     * (`RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);`).
+     * (`RuntimeObject.prototype.onDeletedFromScene.call(this, runtimeScene);`).
      */
     onDeletedFromScene(): void {
       const theLayer = this._runtimeScene.getLayer(this.layer);

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -614,8 +614,11 @@ namespace gdjs {
     }
 
     /**
-     * Called when the object is destroyed (because it is removed from a scene or the scene
-     * is being unloaded). If you redefine this function, **make sure to call the original method**
+     * Called when the object is deleted (because it is removed from a scene or
+     * the scene is being unloaded). The object is not actually destroyed and
+     * can still be used by events.
+     *
+     * If you redefine this function, **make sure to call the original method**
      * (`RuntimeObject.prototype.onDestroyFromScene.call(this, runtimeScene);`).
      */
     onDeletedFromScene(): void {
@@ -635,6 +638,10 @@ namespace gdjs {
       this.clearEffects();
     }
 
+    /**
+     * Called on deleted objects after all events has been executed for the
+     * current frame and the object can be safely destroyed.
+     */
     onDestroyed(): void {}
 
     /**

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -619,7 +619,7 @@ namespace gdjs {
      * can still be used by events.
      *
      * If you redefine this function, **make sure to call the original method**
-     * (`RuntimeObject.prototype.onDeletedFromScene.call(this, runtimeScene);`).
+     * (`super.onDeletedFromScene();`).
      */
     onDeletedFromScene(): void {
       const theLayer = this._runtimeScene.getLayer(this.layer);

--- a/GDJS/Runtime/runtimescene.ts
+++ b/GDJS/Runtime/runtimescene.ts
@@ -308,7 +308,7 @@ namespace gdjs {
       this.onGameResolutionResized();
     }
 
-    _destroy() {
+    override _destroy() {
       // It should not be necessary to reset these variables, but this help
       // ensuring that all memory related to the RuntimeScene is released immediately.
       super._destroy();

--- a/GDJS/scripts/codemod-file-to-ts.js
+++ b/GDJS/scripts/codemod-file-to-ts.js
@@ -225,7 +225,7 @@ const identifyClassNames = (code) => {
     .replace(/(  hide\w*\(.*\))(: any)? {/g, '$1: void {')
     .replace(/(  reset\w*\(.*\))(: any)? {/g, '$1: void {')
     .replace(/(  deleteFromScene\w*\(.*\))(: any)? {/g, '$1: void {')
-    .replace(/(  onDestroyFromScene\w*\(.*\))(: any)? {/g, '$1: void {')
+    .replace(/(  onDeletedFromScene\w*\(.*\))(: any)? {/g, '$1: void {')
     .replace(/(  enable\w*\(.*\))(: any)? {/g, '$1: void {')
     // Members:
     .replace(/(\w*): any = (\d)/g, '$1: number = $2')

--- a/GDevelop.js/TestUtils/GDJSMocks.js
+++ b/GDevelop.js/TestUtils/GDJSMocks.js
@@ -475,7 +475,7 @@ class RuntimeObject {
   }
 
   /** @param {RuntimeScene} runtimeScene */
-  onDestroyFromScene(runtimeScene) {
+  onDeletedFromScene(runtimeScene) {
     // Note: these mocks don't support behaviors nor layers or effects.
 
     this.destroyCallbacks.forEach((c) => c());
@@ -789,7 +789,7 @@ class RuntimeScene {
     }
 
     //Notify the object it was removed from the scene
-    obj.onDestroyFromScene(this);
+    obj.onDeletedFromScene(this);
   }
 
   getObjects(objectName) {


### PR DESCRIPTION
It avoids this log:
```
RuntimeScene.getObjects: No instances called "MyChildObject"! Adding it.
```