### PR TITLE
Fix hot-reloading of custom objects

### DIFF
--- a/GDJS/Runtime/debugger-client/hot-reloader.ts
+++ b/GDJS/Runtime/debugger-client/hot-reloader.ts
@@ -738,7 +738,6 @@ namespace gdjs {
           // scene (see `_hotReloadRuntimeInstanceContainer` call from
           // `_hotReloadRuntimeSceneInstances`).
           objects: mergedChildObjectDataList,
-          childrenContent: mergedChildObjectDataList,
         };
         return mergedObjectConfiguration;
       });


### PR DESCRIPTION
I'm confident it was a mistake because `childrenContent` is not an `Array` but an index type. `childrenContent` is not used anywhere else as an `Array`.