### PR TITLE
Fix effect default values for old projects

### DIFF
--- a/Core/GDCore/Project/Effect.cpp
+++ b/Core/GDCore/Project/Effect.cpp
@@ -8,6 +8,8 @@
 #include "GDCore/Serialization/SerializerElement.h"
 
 namespace gd {
+  
+gd::String Effect::badStringParameterValue;
 
 void Effect::SerializeTo(SerializerElement& element) const {
   element.SetAttribute("name", GetName());

--- a/Core/GDCore/Project/Effect.h
+++ b/Core/GDCore/Project/Effect.h
@@ -34,39 +34,42 @@ class GD_CORE_API Effect {
   void SetFolded(bool fold = true) { folded = fold; }
   bool IsFolded() const { return folded; }
 
-  void SetDoubleParameter(const gd::String& name, double value) {
+  void SetDoubleParameter(const gd::String &name, double value) {
     doubleParameters[name] = value;
   }
 
-  double GetDoubleParameter(const gd::String& name) {
-    return doubleParameters[name];
+  double GetDoubleParameter(const gd::String &name) const {
+    auto itr = doubleParameters.find(name);
+    return itr == doubleParameters.end() ? 0 : itr->second;
   }
 
-  bool HasDoubleParameter(const gd::String& name) {
+  bool HasDoubleParameter(const gd::String &name) const {
     return doubleParameters.find(name) != doubleParameters.end();
   }
 
-  void SetStringParameter(const gd::String& name, const gd::String& value) {
+  void SetStringParameter(const gd::String &name, const gd::String &value) {
     stringParameters[name] = value;
   }
 
-  const gd::String& GetStringParameter(const gd::String& name) {
-    return stringParameters[name];
+  const gd::String &GetStringParameter(const gd::String &name) const {
+    auto itr = stringParameters.find(name);
+    return itr == stringParameters.end() ? badStringParameterValue : itr->second;
   }
 
-  bool HasStringParameter(const gd::String& name) {
+  bool HasStringParameter(const gd::String &name) const {
     return stringParameters.find(name) != stringParameters.end();
   }
 
-  void SetBooleanParameter(const gd::String& name, bool value) {
+  void SetBooleanParameter(const gd::String &name, bool value) {
     booleanParameters[name] = value;
   }
 
-  bool GetBooleanParameter(const gd::String& name) {
-    return booleanParameters[name];
+  bool GetBooleanParameter(const gd::String &name) const {
+    auto itr = booleanParameters.find(name);
+    return itr == booleanParameters.end() ? false : itr->second;
   }
 
-  bool HasBooleanParameter(const gd::String& name) {
+  bool HasBooleanParameter(const gd::String &name) const {
     return booleanParameters.find(name) != booleanParameters.end();
   }
 
@@ -105,6 +108,9 @@ class GD_CORE_API Effect {
   std::map<gd::String, double> doubleParameters; ///< Values of parameters being doubles, keyed by names.
   std::map<gd::String, gd::String> stringParameters; ///< Values of parameters being strings, keyed by names.
   std::map<gd::String, bool> booleanParameters; ///< Values of parameters being booleans, keyed by names.
+
+  static gd::String badStringParameterValue;  ///< Empty string returned by
+                                              ///< GeStringParameter
 };
 
 }  // namespace gd

--- a/newIDE/app/src/EffectsList/EnumerateEffects.js
+++ b/newIDE/app/src/EffectsList/EnumerateEffects.js
@@ -75,7 +75,7 @@ export const enumerateEffectsMetadata = (
                   getValue: (effect: gdEffect) =>
                     effect.hasBooleanParameter(parameterName)
                       ? effect.getBooleanParameter(parameterName)
-                      : defaultValue === '1',
+                      : defaultValue === 'true',
                   setValue: (effect: gdEffect, newValue: boolean) =>
                     effect.setBooleanParameter(parameterName, newValue),
                   getLabel,

--- a/newIDE/app/src/EffectsList/index.js
+++ b/newIDE/app/src/EffectsList/index.js
@@ -211,6 +211,15 @@ const Effect = React.forwardRef(
         return advancedPropertiesSchema.some((field: Field) => {
           const name = field.valueType ? field.name : null;
           if (!name) return false;
+          if (
+            field.valueType === 'number'
+              ? !effect.hasDoubleParameter(name)
+              : field.valueType === 'boolean'
+              ? !effect.hasBooleanParameter(name)
+              : !effect.hasStringParameter(name)
+          ) {
+            return false;
+          }
 
           const current =
             field.valueType === 'number'


### PR DESCRIPTION
I forgot the map `[]` operator is actually a get or set.
Effects property getters are now `const` which will avoid any strange side effects.