### PR TITLE
Fix hemisphere light orientation when the top is set on Z+

### DIFF
--- a/Extensions/3D/DirectionalLight.ts
+++ b/Extensions/3D/DirectionalLight.ts
@@ -18,19 +18,18 @@ namespace gdjs {
           return new gdjs.PixiFiltersTools.EmptyFilter();
         }
         return new (class implements gdjs.PixiFiltersTools.Filter {
-          private _light: THREE.DirectionalLight;
-          private _isEnabled: boolean = false;
-          private _top: string = 'Y-';
+          private _top: string = 'Z+';
           private _elevation: float = 45;
           private _rotation: float = 0;
-
-          private _shadowMapDirty = true;
           private _shadowMapSize: float = 1024;
           private _minimumShadowBias: float = 0;
-
-          private _shadowCameraDirty = true;
           private _distanceFromCamera: float = 1500;
           private _frustumSize: float = 4000;
+
+          private _isEnabled: boolean = false;
+          private _light: THREE.DirectionalLight;
+          private _shadowMapDirty = true;
+          private _shadowCameraDirty = true;
           private _shadowCameraHelper: THREE.CameraHelper | null;
 
           constructor() {

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -1916,11 +1916,11 @@ module.exports = {
         .setType('number');
       properties
         .getOrCreate('top')
-        .setValue('Y-')
+        .setValue('Z+')
         .setLabel(_('3D world top'))
         .setType('choice')
-        .addExtraInfo('Y-')
         .addExtraInfo('Z+')
+        .addExtraInfo('Y-')
         .setGroup(_('Orientation'));
       properties
         .getOrCreate('elevation')
@@ -1974,6 +1974,7 @@ module.exports = {
         .setValue('1500')
         .setLabel(_("Distance from layer's camera"))
         .setType('number')
+        .setGroup(_('Shadows'))
         .setAdvanced(true);
     }
     {
@@ -2006,11 +2007,11 @@ module.exports = {
         .setType('number');
       properties
         .getOrCreate('top')
-        .setValue('Y-')
+        .setValue('Z+')
         .setLabel(_('3D world top'))
         .setType('choice')
-        .addExtraInfo('Y-')
         .addExtraInfo('Z+')
+        .addExtraInfo('Y-')
         .setGroup(_('Orientation'));
       properties
         .getOrCreate('elevation')

--- a/newIDE/app/src/ProjectCreation/CreateProject.js
+++ b/newIDE/app/src/ProjectCreation/CreateProject.js
@@ -46,7 +46,7 @@ export const addDefaultLightToLayer = (layer: gdLayer): void => {
 
   const ambientLight = layer
     .getEffects()
-    .insertNewEffect('3D Ambient Light', 0);
+    .insertNewEffect('3D Ambient Hemisphere Light', 0);
   ambientLight.setEffectType('Scene3D::HemisphereLight');
   ambientLight.setStringParameter('skyColor', '255;255;255');
   ambientLight.setStringParameter('groundColor', '127;127;127');

--- a/newIDE/app/src/ProjectCreation/CreateProject.js
+++ b/newIDE/app/src/ProjectCreation/CreateProject.js
@@ -46,10 +46,14 @@ export const addDefaultLightToLayer = (layer: gdLayer): void => {
 
   const ambientLight = layer
     .getEffects()
-    .insertNewEffect('3D Ammbient Light', 0);
-  ambientLight.setEffectType('Scene3D::AmbientLight');
-  ambientLight.setStringParameter('color', '255;255;255');
-  ambientLight.setDoubleParameter('intensity', 0.25);
+    .insertNewEffect('3D Ambient Light', 0);
+  ambientLight.setEffectType('Scene3D::HemisphereLight');
+  ambientLight.setStringParameter('skyColor', '255;255;255');
+  ambientLight.setStringParameter('groundColor', '127;127;127');
+  ambientLight.setDoubleParameter('intensity', 0.33);
+  ambientLight.setStringParameter('top', 'Z+');
+  ambientLight.setDoubleParameter('elevation', 40);
+  ambientLight.setDoubleParameter('rotation', 300);
 };
 
 export const addDefaultLightToAllLayers = (layout: gdLayout): void => {


### PR DESCRIPTION
The 2 rotations where not applied in the right order.

Also
- Use an hemisphere light instead of ambient light by default to avoid plain colors without any depth into the shadows
- Use Z+ as the default top