### PR TITLE
Fix TextInput displayed position when inside a custom object whose layer is moved

### DIFF
--- a/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
+++ b/GDJS/Runtime/CustomRuntimeObjectInstanceContainer.ts
@@ -382,11 +382,9 @@ namespace gdjs {
     ): FloatPoint {
       const position = result || [0, 0];
       this._customObject.applyObjectTransformation(sceneX, sceneY, position);
-      return this._parent.convertInverseCoords(
-        position[0],
-        position[1],
-        position
-      );
+      return this._parent
+        .getLayer(this._customObject.getLayer())
+        .convertInverseCoords(position[0], position[1], 0, position);
     }
 
     /**


### PR DESCRIPTION
It aligns with `convertCoords` implementation.

Fixes https://github.com/4ian/GDevelop/issues/7690