### PR TITLE
Fix multiplayer synchronization of 3D custom object positions

### DIFF
--- a/Extensions/3D/A_RuntimeObject3D.ts
+++ b/Extensions/3D/A_RuntimeObject3D.ts
@@ -5,8 +5,6 @@ namespace gdjs {
   type Object3DNetworkSyncDataType = {
     // z is position on the Z axis, different from zo, which is Z order
     z: number;
-    w: number;
-    h: number;
     d: number;
     rx: number;
     ry: number;
@@ -116,8 +114,6 @@ namespace gdjs {
       return {
         ...super.getNetworkSyncData(),
         z: this.getZ(),
-        w: this.getWidth(),
-        h: this.getHeight(),
         d: this.getDepth(),
         rx: this.getRotationX(),
         ry: this.getRotationY(),
@@ -130,8 +126,6 @@ namespace gdjs {
     updateFromNetworkSyncData(networkSyncData: Object3DNetworkSyncData) {
       super.updateFromNetworkSyncData(networkSyncData);
       if (networkSyncData.z !== undefined) this.setZ(networkSyncData.z);
-      if (networkSyncData.w !== undefined) this.setWidth(networkSyncData.w);
-      if (networkSyncData.h !== undefined) this.setHeight(networkSyncData.h);
       if (networkSyncData.d !== undefined) this.setDepth(networkSyncData.d);
       if (networkSyncData.rx !== undefined)
         this.setRotationX(networkSyncData.rx);

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -1,4 +1,12 @@
 namespace gdjs {
+  type CustomObject3DNetworkSyncDataType = CustomObjectNetworkSyncDataType & {
+    z: float;
+    d: float;
+    rx: float;
+    ry: float;
+    ifz: boolean;
+  };
+
   /**
    * Base class for 3D custom objects.
    */
@@ -77,39 +85,28 @@ namespace gdjs {
       }
     }
 
-    override getNetworkSyncData(): Object3DNetworkSyncData {
+    getNetworkSyncData(): CustomObject3DNetworkSyncDataType {
       return {
         ...super.getNetworkSyncData(),
         z: this.getZ(),
-        w: this.getWidth(),
-        h: this.getHeight(),
         d: this.getDepth(),
         rx: this.getRotationX(),
         ry: this.getRotationY(),
-        flipX: this.isFlippedX(),
-        flipY: this.isFlippedY(),
-        flipZ: this.isFlippedZ(),
+        ifz: this.isFlippedZ(),
       };
     }
 
-    override updateFromNetworkSyncData(
-      networkSyncData: Object3DNetworkSyncData
-    ) {
+    updateFromNetworkSyncData(
+      networkSyncData: CustomObject3DNetworkSyncDataType
+    ): void {
       super.updateFromNetworkSyncData(networkSyncData);
       if (networkSyncData.z !== undefined) this.setZ(networkSyncData.z);
-      if (networkSyncData.w !== undefined) this.setWidth(networkSyncData.w);
-      if (networkSyncData.h !== undefined) this.setHeight(networkSyncData.h);
       if (networkSyncData.d !== undefined) this.setDepth(networkSyncData.d);
       if (networkSyncData.rx !== undefined)
         this.setRotationX(networkSyncData.rx);
       if (networkSyncData.ry !== undefined)
         this.setRotationY(networkSyncData.ry);
-      if (networkSyncData.flipX !== undefined)
-        this.flipX(networkSyncData.flipX);
-      if (networkSyncData.flipY !== undefined)
-        this.flipY(networkSyncData.flipY);
-      if (networkSyncData.flipZ !== undefined)
-        this.flipZ(networkSyncData.flipZ);
+      if (networkSyncData.ifz !== undefined) this.flipZ(networkSyncData.ifz);
     }
 
     /**

--- a/Extensions/3D/CustomRuntimeObject3D.ts
+++ b/Extensions/3D/CustomRuntimeObject3D.ts
@@ -77,6 +77,41 @@ namespace gdjs {
       }
     }
 
+    override getNetworkSyncData(): Object3DNetworkSyncData {
+      return {
+        ...super.getNetworkSyncData(),
+        z: this.getZ(),
+        w: this.getWidth(),
+        h: this.getHeight(),
+        d: this.getDepth(),
+        rx: this.getRotationX(),
+        ry: this.getRotationY(),
+        flipX: this.isFlippedX(),
+        flipY: this.isFlippedY(),
+        flipZ: this.isFlippedZ(),
+      };
+    }
+
+    override updateFromNetworkSyncData(
+      networkSyncData: Object3DNetworkSyncData
+    ) {
+      super.updateFromNetworkSyncData(networkSyncData);
+      if (networkSyncData.z !== undefined) this.setZ(networkSyncData.z);
+      if (networkSyncData.w !== undefined) this.setWidth(networkSyncData.w);
+      if (networkSyncData.h !== undefined) this.setHeight(networkSyncData.h);
+      if (networkSyncData.d !== undefined) this.setDepth(networkSyncData.d);
+      if (networkSyncData.rx !== undefined)
+        this.setRotationX(networkSyncData.rx);
+      if (networkSyncData.ry !== undefined)
+        this.setRotationY(networkSyncData.ry);
+      if (networkSyncData.flipX !== undefined)
+        this.flipX(networkSyncData.flipX);
+      if (networkSyncData.flipY !== undefined)
+        this.flipY(networkSyncData.flipY);
+      if (networkSyncData.flipZ !== undefined)
+        this.flipZ(networkSyncData.flipZ);
+    }
+
     /**
      * Set the object position on the Z axis.
      */

--- a/Extensions/Multiplayer/multiplayerobjectruntimebehavior.ts
+++ b/Extensions/Multiplayer/multiplayerobjectruntimebehavior.ts
@@ -293,6 +293,8 @@ namespace gdjs {
           x: objectNetworkSyncData.x,
           y: objectNetworkSyncData.y,
           z: objectNetworkSyncData.z,
+          w: objectNetworkSyncData.w,
+          h: objectNetworkSyncData.h,
           zo: objectNetworkSyncData.zo,
           a: objectNetworkSyncData.a,
           hid: objectNetworkSyncData.hid,
@@ -369,6 +371,9 @@ namespace gdjs {
         this._lastSentBasicObjectSyncData = {
           x: objectNetworkSyncData.x,
           y: objectNetworkSyncData.y,
+          z: objectNetworkSyncData.z,
+          w: objectNetworkSyncData.w,
+          h: objectNetworkSyncData.h,
           zo: objectNetworkSyncData.zo,
           a: objectNetworkSyncData.a,
           hid: objectNetworkSyncData.hid,

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.ts
@@ -25,8 +25,6 @@ namespace gdjs {
   export type PanelSpriteObjectData = ObjectData & PanelSpriteObjectDataType;
 
   export type PanelSpriteNetworkSyncDataType = {
-    wid: number;
-    hei: number;
     op: number;
     color: string;
   };
@@ -124,8 +122,6 @@ namespace gdjs {
     getNetworkSyncData(): PanelSpriteNetworkSyncData {
       return {
         ...super.getNetworkSyncData(),
-        wid: this.getWidth(),
-        hei: this.getHeight(),
         op: this.getOpacity(),
         color: this.getColor(),
       };
@@ -138,12 +134,6 @@ namespace gdjs {
 
       // Texture is not synchronized, see if this is asked or not.
 
-      if (networkSyncData.wid !== undefined) {
-        this.setWidth(networkSyncData.wid);
-      }
-      if (networkSyncData.hei !== undefined) {
-        this.setHeight(networkSyncData.hei);
-      }
       if (networkSyncData.op !== undefined) {
         this.setOpacity(networkSyncData.op);
       }

--- a/Extensions/Spine/spineruntimeobject.ts
+++ b/Extensions/Spine/spineruntimeobject.ts
@@ -14,8 +14,6 @@ namespace gdjs {
 
   export type SpineNetworkSyncDataType = {
     opa: float;
-    wid: float;
-    hei: float;
     scaX: float;
     scaY: float;
     flipX: boolean;
@@ -117,8 +115,6 @@ namespace gdjs {
       return {
         ...super.getNetworkSyncData(),
         opa: this._opacity,
-        wid: this.getWidth(),
-        hei: this.getHeight(),
         scaX: this.getScaleX(),
         scaY: this.getScaleY(),
         flipX: this.isFlippedX(),
@@ -136,12 +132,6 @@ namespace gdjs {
 
       if (syncData.opa !== undefined && syncData.opa !== this._opacity) {
         this.setOpacity(syncData.opa);
-      }
-      if (syncData.wid !== undefined && syncData.wid !== this.getWidth()) {
-        this.setWidth(syncData.wid);
-      }
-      if (syncData.hei !== undefined && syncData.hei !== this.getHeight()) {
-        this.setHeight(syncData.hei);
       }
       if (syncData.scaX !== undefined && syncData.scaX !== this.getScaleX()) {
         this.setScaleX(syncData.scaX);

--- a/Extensions/TextInput/textinputruntimeobject.ts
+++ b/Extensions/TextInput/textinputruntimeobject.ts
@@ -64,8 +64,6 @@ namespace gdjs {
 
   export type TextInputNetworkSyncDataType = {
     opa: float;
-    wid: float;
-    hei: float;
     txt: string;
     frn: string;
     fs: number;
@@ -260,8 +258,6 @@ namespace gdjs {
       return {
         ...super.getNetworkSyncData(),
         opa: this.getOpacity(),
-        wid: this.getWidth(),
-        hei: this.getHeight(),
         txt: this.getText(),
         frn: this.getFontResourceName(),
         fs: this.getFontSize(),
@@ -282,8 +278,6 @@ namespace gdjs {
       super.updateFromNetworkSyncData(syncData);
 
       if (syncData.opa !== undefined) this.setOpacity(syncData.opa);
-      if (syncData.wid !== undefined) this.setWidth(syncData.wid);
-      if (syncData.hei !== undefined) this.setHeight(syncData.hei);
       if (syncData.txt !== undefined) this.setText(syncData.txt);
       if (syncData.frn !== undefined) this.setFontResourceName(syncData.frn);
       if (syncData.fs !== undefined) this.setFontSize(syncData.fs);

--- a/Extensions/TileMap/simpletilemapruntimeobject.ts
+++ b/Extensions/TileMap/simpletilemapruntimeobject.ts
@@ -17,8 +17,6 @@ namespace gdjs {
   export type SimpleTileMapNetworkSyncDataType = {
     op: number;
     ai: string;
-    wid: number;
-    hei: number;
     // TODO: Support tilemap synchronization. Find an efficient way to send tiles changes.
   };
 
@@ -170,8 +168,6 @@ namespace gdjs {
         ...super.getNetworkSyncData(),
         op: this._opacity,
         ai: this._atlasImage,
-        wid: this.getWidth(),
-        hei: this.getHeight(),
       };
     }
 
@@ -185,18 +181,6 @@ namespace gdjs {
         networkSyncData.op !== this._opacity
       ) {
         this.setOpacity(networkSyncData.op);
-      }
-      if (
-        networkSyncData.wid !== undefined &&
-        networkSyncData.wid !== this.getWidth()
-      ) {
-        this.setWidth(networkSyncData.wid);
-      }
-      if (
-        networkSyncData.hei !== undefined &&
-        networkSyncData.hei !== this.getHeight()
-      ) {
-        this.setHeight(networkSyncData.hei);
       }
       if (networkSyncData.ai !== undefined) {
         // TODO: support changing the atlas texture

--- a/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
+++ b/Extensions/TileMap/tilemapcollisionmaskruntimeobject.ts
@@ -26,8 +26,6 @@ namespace gdjs {
     os: float;
     fo: float;
     oo: float;
-    wid: float;
-    hei: float;
   };
 
   export type TilemapCollisionMaskNetworkSyncData = ObjectNetworkSyncData &
@@ -202,8 +200,6 @@ namespace gdjs {
         os: this.getOutlineSize(),
         fo: this.getFillOpacity(),
         oo: this.getOutlineOpacity(),
-        wid: this.getWidth(),
-        hei: this.getHeight(),
       };
     }
 
@@ -235,12 +231,6 @@ namespace gdjs {
       }
       if (networkSyncData.oo !== undefined) {
         this.setOutlineOpacity(networkSyncData.oo);
-      }
-      if (networkSyncData.wid !== undefined) {
-        this.setWidth(networkSyncData.wid);
-      }
-      if (networkSyncData.hei !== undefined) {
-        this.setHeight(networkSyncData.hei);
       }
     }
 

--- a/Extensions/TileMap/tilemapruntimeobject.ts
+++ b/Extensions/TileMap/tilemapruntimeobject.ts
@@ -25,8 +25,6 @@ namespace gdjs {
     lai: number;
     lei: number;
     asps: number;
-    wid: number;
-    hei: number;
   };
 
   export type TilemapNetworkSyncData = ObjectNetworkSyncData &
@@ -158,8 +156,6 @@ namespace gdjs {
         lai: this._layerIndex,
         lei: this._levelIndex,
         asps: this._animationSpeedScale,
-        wid: this.getWidth(),
-        hei: this.getHeight(),
       };
     }
 
@@ -189,12 +185,6 @@ namespace gdjs {
       }
       if (networkSyncData.asps !== undefined) {
         this.setAnimationSpeedScale(networkSyncData.asps);
-      }
-      if (networkSyncData.wid !== undefined) {
-        this.setWidth(networkSyncData.wid);
-      }
-      if (networkSyncData.hei !== undefined) {
-        this.setHeight(networkSyncData.hei);
       }
     }
 

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject.ts
@@ -15,8 +15,6 @@ namespace gdjs {
   export type TiledSpriteObjectData = ObjectData & TiledSpriteObjectDataType;
 
   export type TiledSpriteNetworkSyncDataType = {
-    wid: number;
-    hei: number;
     xo: number;
     yo: number;
     op: number;
@@ -83,8 +81,6 @@ namespace gdjs {
     getNetworkSyncData(): TiledSpriteNetworkSyncData {
       return {
         ...super.getNetworkSyncData(),
-        wid: this.getWidth(),
-        hei: this.getHeight(),
         xo: this.getXOffset(),
         yo: this.getYOffset(),
         op: this.getOpacity(),
@@ -99,12 +95,6 @@ namespace gdjs {
 
       // Texture is not synchronized, see if this is asked or not.
 
-      if (networkSyncData.wid !== undefined) {
-        this.setWidth(networkSyncData.wid);
-      }
-      if (networkSyncData.hei !== undefined) {
-        this.setHeight(networkSyncData.hei);
-      }
       if (networkSyncData.xo !== undefined) {
         this.setXOffset(networkSyncData.xo);
       }

--- a/Extensions/Video/videoruntimeobject.ts
+++ b/Extensions/Video/videoruntimeobject.ts
@@ -18,8 +18,6 @@ namespace gdjs {
 
   export type VideoNetworkSyncDataType = {
     op: float;
-    wid: float;
-    hei: float;
     // We don't sync volume, as it's probably a user setting?
     pla: boolean;
     loop: boolean;
@@ -105,8 +103,6 @@ namespace gdjs {
       return {
         ...super.getNetworkSyncData(),
         op: this._opacity,
-        wid: this.getWidth(),
-        hei: this.getHeight(),
         pla: this.isPlayed(),
         loop: this.isLooped(),
         ct: this.getCurrentTime(),
@@ -119,12 +115,6 @@ namespace gdjs {
 
       if (this._opacity !== undefined && this._opacity && syncData.op) {
         this.setOpacity(syncData.op);
-      }
-      if (this.getWidth() !== undefined && this.getWidth() !== syncData.wid) {
-        this.setWidth(syncData.wid);
-      }
-      if (this.getHeight() !== undefined && this.getHeight() !== syncData.hei) {
-        this.setHeight(syncData.hei);
       }
       if (syncData.pla !== undefined && this.isPlayed() !== syncData.pla) {
         syncData.pla ? this.play() : this.pause();

--- a/GDJS/Runtime/CustomRuntimeObject.ts
+++ b/GDJS/Runtime/CustomRuntimeObject.ts
@@ -17,6 +17,11 @@ namespace gdjs {
     isInnerAreaFollowingParentSize: boolean;
   };
 
+  export type CustomObjectNetworkSyncDataType = ObjectNetworkSyncData & {
+    ifx: boolean;
+    ify: boolean;
+  };
+
   /**
    * An object that contains other object.
    *
@@ -214,6 +219,26 @@ namespace gdjs {
         }
       }
       return true;
+    }
+
+    getNetworkSyncData(): CustomObjectNetworkSyncDataType {
+      return {
+        ...super.getNetworkSyncData(),
+        ifx: this.isFlippedX(),
+        ify: this.isFlippedY(),
+      };
+    }
+
+    updateFromNetworkSyncData(
+      networkSyncData: CustomObjectNetworkSyncDataType
+    ) {
+      super.updateFromNetworkSyncData(networkSyncData);
+      if (networkSyncData.ifx !== undefined) {
+        this.flipX(networkSyncData.ifx);
+      }
+      if (networkSyncData.ify !== undefined) {
+        this.flipY(networkSyncData.ify);
+      }
     }
 
     override extraInitializationFromInitialInstance(

--- a/GDJS/Runtime/runtimeobject.ts
+++ b/GDJS/Runtime/runtimeobject.ts
@@ -484,6 +484,8 @@ namespace gdjs {
       return {
         x: this.x,
         y: this.y,
+        w: this.getWidth(),
+        h: this.getHeight(),
         zo: this.zOrder,
         a: this.angle,
         hid: this.hidden,
@@ -511,6 +513,12 @@ namespace gdjs {
       }
       if (networkSyncData.y !== undefined) {
         this.setY(networkSyncData.y);
+      }
+      if (networkSyncData.w !== undefined) {
+        this.setWidth(networkSyncData.w);
+      }
+      if (networkSyncData.h !== undefined) {
+        this.setHeight(networkSyncData.h);
       }
       if (networkSyncData.zo !== undefined) {
         this.setZOrder(networkSyncData.zo);

--- a/GDJS/Runtime/types/project-data.d.ts
+++ b/GDJS/Runtime/types/project-data.d.ts
@@ -52,6 +52,10 @@ declare type BasicObjectNetworkSyncData = {
   y: number;
   /** The position of the instance on the Z axis. Defined only for 3D games */
   z?: number;
+  /** The width of the instance */
+  w: number;
+  /** The height of the instance */
+  h: number;
   /** Z order of the instance */
   zo: number;
   /** The angle of the instance. */


### PR DESCRIPTION
`CustomRuntimeObject3D` doesn't extend `RuntimeObject3D`. This change is a copy-paste from `RuntimeObject3D` implementation.