### PR TITLE
Fix images pixelated because of border

### DIFF
--- a/newIDE/app/src/AssetStore/ShopTiles.js
+++ b/newIDE/app/src/AssetStore/ShopTiles.js
@@ -39,7 +39,7 @@ const styles = {
   previewImage: {
     width: '100%',
     display: 'block',
-    objectFit: 'cover',
+    objectFit: 'contain',
     borderRadius: 8,
     border: '1px solid lightgrey',
     boxSizing: 'border-box', // Take border in account for sizing to avoid cumulative layout shift.

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/LearnSection/EducationCurriculumLesson.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/LearnSection/EducationCurriculumLesson.js
@@ -30,7 +30,7 @@ const styles = {
   container: { maxWidth: 850 },
   thumbnail: {
     display: 'block', // Display as a block to prevent cumulative layout shift.
-    objectFit: 'cover',
+    objectFit: 'contain',
     verticalAlign: 'middle',
     borderRadius: 8,
     width: '100%',

--- a/newIDE/app/src/UI/ImageTileGrid.js
+++ b/newIDE/app/src/UI/ImageTileGrid.js
@@ -46,7 +46,7 @@ const styles = {
   },
   thumbnailImageWithDescription: {
     display: 'block', // Display as a block to prevent cumulative layout shift.
-    objectFit: 'cover',
+    objectFit: 'contain',
     verticalAlign: 'middle',
     width: '100%',
     borderRadius: 8,


### PR DESCRIPTION
having an objectFit 'cover' with a border makes the image slightly shrunk, which makes it looks pixelated:

Before: 
<img width="1024" height="251" alt="image" src="https://github.com/user-attachments/assets/c6286f76-e30b-43ac-ac8f-04766ad93fe5" />

After:
<img width="1014" height="236" alt="image" src="https://github.com/user-attachments/assets/08e91d35-6062-41c9-8fcc-d816ac3a2fdc" />
 