### PR TITLE
Fix Android build and player authentication sometimes not working

### DIFF
--- a/Extensions/Leaderboards/JsExtension.js
+++ b/Extensions/Leaderboards/JsExtension.js
@@ -31,6 +31,12 @@ module.exports = {
       .setIcon('JsPlatform/Extensions/leaderboard.svg');
 
     extension
+      .addDependency()
+      .setName('Safari View Controller Cordova plugin')
+      .setDependencyType('cordova')
+      .setExportName('@gdevelop/cordova-plugin-safariviewcontroller');
+
+    extension
       .addAction(
         'SavePlayerScore',
         _('Save player score'),

--- a/Extensions/Multiplayer/JsExtension.js
+++ b/Extensions/Multiplayer/JsExtension.js
@@ -32,6 +32,12 @@ module.exports = {
       .setIcon('JsPlatform/Extensions/multiplayer.svg');
 
     extension
+      .addDependency()
+      .setName('Safari View Controller Cordova plugin')
+      .setDependencyType('cordova')
+      .setExportName('@gdevelop/cordova-plugin-safariviewcontroller');
+
+    extension
       .addStrExpression(
         'CurrentLobbyID',
         _('Current lobby ID'),

--- a/Extensions/PlayerAuthentication/JsExtension.js
+++ b/Extensions/PlayerAuthentication/JsExtension.js
@@ -35,7 +35,7 @@ module.exports = {
       .addDependency()
       .setName('Safari View Controller Cordova plugin')
       .setDependencyType('cordova')
-      .setExportName('cordova-plugin-safariviewcontroller');
+      .setExportName('@gdevelop/cordova-plugin-safariviewcontroller');
 
     extension
       .addAction(

--- a/Extensions/PlayerAuthentication/playerauthenticationtools.ts
+++ b/Extensions/PlayerAuthentication/playerauthenticationtools.ts
@@ -834,34 +834,51 @@ namespace gdjs {
             authWindowOptions,
           });
 
+          if (typeof SafariViewController === 'undefined') {
+            logger.error(
+              'Cordova plugin SafariViewController is not installed.'
+            );
+            resolve('errored');
+            return;
+          }
+
           SafariViewController.isAvailable(function (available: boolean) {
-            if (available) {
-              SafariViewController.show(
-                {
-                  url: targetUrl,
-                  hidden: false,
-                  animated: true,
-                  transition: 'slide',
-                  enterReaderModeIfAvailable: false,
-                  barColor: '#000000',
-                  tintColor: '#ffffff',
-                  controlTintColor: '#ffffff',
-                },
-                function (result: any) {
-                  // Other events are `opened` and `loaded`.
-                  if (result.event === 'closed') {
-                    resolve('dismissed');
-                  }
-                },
-                function (error: any) {
-                  logger.log('Error opening webview: ' + JSON.stringify(error));
-                  resolve('errored');
-                }
+            if (!available) {
+              logger.error(
+                'Cordova plugin SafariViewController is installed but not available'
               );
-            } else {
-              logger.error('Plugin SafariViewController is not available');
               resolve('errored');
+              return;
             }
+
+            logger.info(
+              'Opening authentication window for Cordova with SafariViewController.'
+            );
+            SafariViewController.show(
+              {
+                url: targetUrl,
+                hidden: false,
+                animated: true,
+                transition: 'slide',
+                enterReaderModeIfAvailable: false,
+                barColor: '#000000',
+                tintColor: '#ffffff',
+                controlTintColor: '#ffffff',
+              },
+              function (result: any) {
+                // Other events are `opened` and `loaded`.
+                if (result.event === 'closed') {
+                  resolve('dismissed');
+                }
+              },
+              function (error: any) {
+                logger.log(
+                  'Error opening authentication window: ' +
+                    JSON.stringify(error)
+                );
+                resolve('errored');
+              }
+            );
           });
         }
       );


### PR DESCRIPTION
- Player authentication window could not open if no action/condition related to player authentication was used
- Fix Android build by using an updated dependency for opening the authentication window