### PR TITLE
Fix #7429: Prevent stuck keys when game window loses focus

### DIFF
--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.ts
@@ -676,6 +676,11 @@ namespace gdjs {
         manager.onKeyReleased(e.keyCode, e.location);
       };
 
+      // Prevent "stuck" keys when the game loses focus
+      window.addEventListener('blur', () => {
+        manager.clearAllPressedKeys();
+      });
+
       // Mouse:
 
       // Converts HTML mouse button to InputManager mouse button.


### PR DESCRIPTION
# Summary

Fixes a bug where keyboard inputs could become stuck when the user unfocus the window.

# Changes

Ensures keys pressed are properly handled when the editor loses focus.

Cleans up event listeners to avoid lingering state when switching scenes.

# Motivation

The issue led to confusing and frustrating user experience when keys (like arrow keys or shortcuts) would appear stuck after interacting with other windows or tabs. This fix restores reliable keyboard behavior.

# Demo


https://github.com/user-attachments/assets/29a4721c-1a92-4536-a391-f41b30a4f59f

