### PR TITLE
feat: add actions to set max and min FPS at runtime

### DIFF
--- a/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
@@ -152,6 +152,28 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsTimeExtension(
                     _("Scale (1: Default, 2: 2x faster, 0.5: 2x slower...)"));
 
   extension
+      .AddAction("SetMaximumFPS",
+                _("Maximum FPS"),
+                _("Change the maximum frames per second at runtime."),
+                _("Set maximum FPS to _PARAM1_"),
+                _("Rendering"),
+                "res/actions/fps_max24.png",
+                "res/actions/fps_max.png")
+      .AddCodeOnlyParameter("currentScene", "")
+      .AddParameter("expression", _("Maximum FPS"));
+
+  extension
+      .AddAction("SetMinimumFPS",
+                _("Minimum FPS"),
+                _("Change the minimum frames per second at runtime."),
+                _("Set minimum FPS to _PARAM1_"),
+                _("Rendering"),
+                "res/actions/fps_min24.png",
+                "res/actions/fps_min.png")
+      .AddCodeOnlyParameter("currentScene", "")
+      .AddParameter("expression", _("Minimum FPS"));
+
+  extension
       .AddAction("Wait",
                  _("Wait X seconds"),
                  _("Waits a number of seconds before running "

--- a/GDJS/GDJS/Extensions/Builtin/TimeExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/TimeExtension.cpp
@@ -34,6 +34,10 @@ TimeExtension::TimeExtension() {
       "gdjs.evtTools.runtimeScene.getTimeScale");
   GetAllActions()["ChangeTimeScale"].SetFunctionName(
       "gdjs.evtTools.runtimeScene.setTimeScale");
+  GetAllActions()["SetMaximumFPS"].SetFunctionName(
+      "gdjs.evtTools.runtimeScene.setMaximumFPS");
+  GetAllActions()["SetMinimumFPS"].SetFunctionName(
+      "gdjs.evtTools.runtimeScene.setMinimumFPS");
 
   GetAllExpressions()["TimeDelta"].SetFunctionName(
       "gdjs.evtTools.runtimeScene.getElapsedTimeInSeconds");

--- a/GDJS/Runtime/events-tools/runtimescenetools.ts
+++ b/GDJS/Runtime/events-tools/runtimescenetools.ts
@@ -52,6 +52,20 @@ namespace gdjs {
         return runtimeScene.getScene().getTimeManager().setTimeScale(timeScale);
       };
 
+      export const setMaximumFPS = function(
+        runtimeScene: gdjs.RuntimeScene,
+        fps: float
+      ) {
+        runtimeScene.getGame()._maxFPS = fps;
+      };
+
+      export const setMinimumFPS = function(
+        runtimeScene: gdjs.RuntimeScene,
+        fps: float
+      ) {
+        runtimeScene.getGame()._minFPS = fps;
+      };
+
       export const getTimeScale = function (runtimeScene: gdjs.RuntimeScene) {
         return runtimeScene.getScene().getTimeManager().getTimeScale();
       };


### PR DESCRIPTION
### Summary
This PR adds two new actions under Game scene (Events) in GDevelop that allow developers to dynamically configure the game's maximum and minimum frames per second (FPS) during runtime.

These settings are useful for:

- Reducing FPS during non-interactive scenes (e.g., cutscenes).

- Exposing FPS settings in a game’s graphics or performance menu.

### Implementation Details
- Actions are declared in TimeExtension.cpp using .AddAction(...).

- Mapped to new JS runtime functions:

   + gdjs.evtTools.runtimeScene.setMaximumFPS

   * gdjs.evtTools.runtimeScene.setMinimumFPS

- FPS values are applied to RuntimeGame._maxFPS and _minFPS, which affect the main game loop behavior.

### Demo

https://github.com/user-attachments/assets/17b036c3-9840-4078-aab8-11cf2fb9e0da


### Related issue

Closes [#5362](https://github.com/4ian/GDevelop/issues/5362)