### PR TITLE
Add line height property for text objects

### DIFF
--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -442,6 +442,26 @@ module.exports = {
       .getCodeExtraInformation()
       .setFunctionName(`setFontFamily`);
 
+    object
+      .addExpressionAndConditionAndAction(
+        'number',
+        'LineHeight',
+        _('Line height'),
+        _('the line height in pixels (0 for default)'),
+        _('the line height'),
+        '',
+        'res/conditions/characterSize24.png'
+      )
+      .addParameter('object', 'BBText', 'BBText', false)
+      .useStandardParameters(
+        'number',
+        gd.ParameterOptions.makeNewOptions().setDescription(
+          _('Line height in pixels (0 for default)')
+        )
+      )
+      .setFunctionName('setLineHeight')
+      .setGetter('getLineHeight');
+
     const actions = object.getAllActions();
     const conditions = object.getAllConditions();
     const expressions = object.getAllExpressions();

--- a/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
@@ -32,6 +32,7 @@ namespace gdjs {
           wordWrap: runtimeObject._wrapping,
           wordWrapWidth: runtimeObject._wrappingWidth,
           align: runtimeObject._textAlign as PIXI.TextStyleAlign | undefined,
+          lineHeight: runtimeObject._lineHeight > 0 ? runtimeObject._lineHeight : undefined,
         },
       });
       instanceContainer
@@ -76,6 +77,13 @@ namespace gdjs {
         this._object._color[1],
         this._object._color[2]
       );
+      this._pixiObject.dirty = true;
+    }
+
+    updateLineHeight(): void {
+      //@ts-ignore Private member usage.
+      this._pixiObject.textStyles.default.lineHeight = 
+        this._object._lineHeight > 0 ? this._object._lineHeight : undefined;
       this._pixiObject.dirty = true;
     }
 

--- a/Extensions/BBText/bbtextruntimeobject.ts
+++ b/Extensions/BBText/bbtextruntimeobject.ts
@@ -20,6 +20,8 @@ namespace gdjs {
       /** Alignment of the text: "left", "center" or "right" */
       align: 'left' | 'center' | 'right';
       verticalTextAlignment: 'top' | 'center' | 'bottom';
+      /** Line height for multiline text */
+      lineHeight: float;
     };
   };
   export type BBTextObjectData = ObjectData & BBTextObjectDataType;
@@ -35,6 +37,7 @@ namespace gdjs {
     align: string;
     vta: string;
     hidden: boolean;
+    lh: float;
   };
 
   export type BBTextObjectNetworkSyncData = ObjectNetworkSyncData &
@@ -61,6 +64,7 @@ namespace gdjs {
 
     _textAlign: string;
     _verticalTextAlignment: string;
+    _lineHeight: float;
 
     _renderer: gdjs.BBTextRuntimeObjectRenderer;
 
@@ -88,6 +92,7 @@ namespace gdjs {
       this._verticalTextAlignment =
         objectData.content.verticalTextAlignment || 'top';
       this.hidden = !objectData.content.visible;
+      this._lineHeight = objectData.content.lineHeight || 0;
 
       this._renderer = new gdjs.BBTextRuntimeObjectRenderer(
         this,
@@ -142,6 +147,10 @@ namespace gdjs {
           newObjectData.content.verticalTextAlignment
         );
       }
+      if (oldObjectData.content.lineHeight !== newObjectData.content.lineHeight) {
+        this.setLineHeight(newObjectData.content.lineHeight || 0);
+      }
+
       return true;
     }
 
@@ -158,6 +167,7 @@ namespace gdjs {
         align: this._textAlign,
         vta: this._verticalTextAlignment,
         hidden: this.hidden,
+        lh: this._lineHeight,
       };
     }
 
@@ -192,6 +202,9 @@ namespace gdjs {
       }
       if (this._verticalTextAlignment !== undefined) {
         this.setVerticalTextAlignment(networkSyncData.vta);
+      }
+      if (networkSyncData.lh !== undefined) {
+        this.setLineHeight(networkSyncData.lh);
       }
       if (this.hidden !== undefined) {
         this.hide(networkSyncData.hidden);
@@ -305,6 +318,23 @@ namespace gdjs {
      */
     getVerticalTextAlignment(): string {
       return this._verticalTextAlignment;
+    }
+
+    /**
+     * Get the line height of the text object.
+     * @return the line height
+     */
+    getLineHeight(): float {
+      return this._lineHeight;
+    }
+
+    /**
+     * Set the line height of the text object.
+     * @param lineHeight the line height
+     */
+    setLineHeight(lineHeight: float): void {
+      this._lineHeight = lineHeight;
+      this._renderer.updateLineHeight();
     }
 
     override setX(x: float): void {

--- a/Extensions/BitmapText/JsExtension.js
+++ b/Extensions/BitmapText/JsExtension.js
@@ -413,6 +413,26 @@ module.exports = {
       .setFunctionName('setWrappingWidth')
       .setGetter('getWrappingWidth');
 
+    object
+      .addExpressionAndConditionAndAction(
+        'number',
+        'LineHeight',
+        _('Line height'),
+        _('the line height in pixels (0 for default)'),
+        _('the line height'),
+        '',
+        'res/conditions/characterSize24.png'
+      )
+      .addParameter('object', _('Bitmap text'), 'BitmapTextObject', false)
+      .useStandardParameters(
+        'number',
+        gd.ParameterOptions.makeNewOptions().setDescription(
+          _('Line height in pixels (0 for default)')
+        )
+      )
+      .setFunctionName('setLineHeight')
+      .setGetter('getLineHeight');
+
     return extension;
   },
 

--- a/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
@@ -145,6 +145,12 @@ namespace gdjs {
       this.updatePosition();
     }
 
+    updateLineHeight(): void {
+      // Note: PIXI.BitmapText doesn't have native lineHeight support
+      // We'll need to handle this in updatePosition for multiline text
+      this.updatePosition();
+    }
+
     updatePosition(): void {
       if (this._object.isWrapping() && this.getWidth() !== 0) {
         const alignmentX =

--- a/Extensions/BitmapText/bitmaptextruntimeobject.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject.ts
@@ -20,6 +20,8 @@ namespace gdjs {
       /** Alignment of the text. */
       align: 'left' | 'center' | 'right';
       verticalTextAlignment: 'top' | 'center' | 'bottom';
+      /** Line height for multiline text. */
+      lineHeight: float;
     };
   };
   export type BitmapTextObjectData = ObjectData & BitmapTextObjectDataType;
@@ -66,6 +68,7 @@ namespace gdjs {
     _wrappingWidth: float;
     _textAlign: string;
     _verticalTextAlignment: string;
+    _lineHeight: float;
 
     _renderer: gdjs.BitmapTextRuntimeObjectPixiRenderer;
 
@@ -92,6 +95,7 @@ namespace gdjs {
       this._textAlign = objectData.content.align;
       this._verticalTextAlignment =
         objectData.content.verticalTextAlignment || 'top';
+      this._lineHeight = objectData.content.lineHeight || 0;
 
       this._renderer = new gdjs.BitmapTextRuntimeObjectRenderer(
         this,
@@ -151,6 +155,9 @@ namespace gdjs {
           newObjectData.content.verticalTextAlignment
         );
       }
+      if (oldObjectData.content.lineHeight !== newObjectData.content.lineHeight) {
+        this.setLineHeight(newObjectData.content.lineHeight);
+      }
 
       return true;
     }
@@ -168,6 +175,7 @@ namespace gdjs {
         wwidth: this._wrappingWidth,
         align: this._textAlign,
         vta: this._verticalTextAlignment,
+        lh: this._lineHeight,
       };
     }
 
@@ -205,6 +213,9 @@ namespace gdjs {
       }
       if (this._verticalTextAlignment !== undefined) {
         this.setVerticalTextAlignment(networkSyncData.vta);
+      }
+      if (this._lineHeight !== undefined) {
+        this.setLineHeight(networkSyncData.lh);
       }
     }
 
@@ -352,6 +363,15 @@ namespace gdjs {
      */
     getVerticalTextAlignment(): string {
       return this._verticalTextAlignment;
+    }
+
+    setLineHeight(lineHeight: float): void {
+      this._lineHeight = lineHeight;
+      this._renderer.updateLineHeight();
+    }
+
+    getLineHeight(): float {
+      return this._lineHeight;
     }
 
     override setX(x: float): void {

--- a/Extensions/TextObject/Extension.cpp
+++ b/Extensions/TextObject/Extension.cpp
@@ -449,6 +449,17 @@ void DeclareTextObjectExtension(gd::PlatformExtension& extension) {
       .AddParameter("object", _("Object"), "Text")
       .UseStandardParameters("number", gd::ParameterOptions::MakeNewOptions());
 
+  obj.AddExpressionAndConditionAndAction("number",
+                                         "LineHeight",
+                                         _("Line height"),
+                                         _("the line height of a text object"),
+                                         _("the line height"),
+                                         "",
+                                         "res/conditions/characterSize24.png")
+      .AddParameter("object", _("Object"), "Text")
+      .UseStandardParameters("number", gd::ParameterOptions::MakeNewOptions()
+          .SetDescription(_("Line height in pixels (0 for default)")));
+
   // Support for deprecated "Size" actions/conditions:
   obj.AddDuplicatedAction("Size", "Text::SetFontSize").SetHidden();
   obj.AddDuplicatedCondition("Size", "Text::FontSize").SetHidden();

--- a/Extensions/TextObject/JsExtension.cpp
+++ b/Extensions/TextObject/JsExtension.cpp
@@ -38,6 +38,14 @@ class TextObjectJsExtension : public gd::PlatformExtension {
     GetAllExpressionsForObject("TextObject::Text")["FontSize"]
         .SetFunctionName("getCharacterSize");
 
+    GetAllActionsForObject("TextObject::Text")["TextObject::Text::SetLineHeight"]
+        .SetFunctionName("setLineHeight")
+        .SetGetter("getLineHeight");
+    GetAllConditionsForObject("TextObject::Text")["TextObject::Text::LineHeight"]
+        .SetFunctionName("getLineHeight");
+    GetAllExpressionsForObject("TextObject::Text")["LineHeight"]
+        .SetFunctionName("getLineHeight");
+
     GetAllActionsForObject("TextObject::Text")["TextObject::Font"]
         .SetFunctionName("setFontName");
 

--- a/Extensions/TextObject/TextObject.cpp
+++ b/Extensions/TextObject/TextObject.cpp
@@ -36,7 +36,8 @@ TextObject::TextObject()
       shadowOpacity(127),
       shadowAngle(90),
       shadowDistance(4),
-      shadowBlurRadius(2) {}
+      shadowBlurRadius(2),
+      lineHeight(0) {}
 
 TextObject::~TextObject() {};
 
@@ -110,6 +111,10 @@ bool TextObject::UpdateProperty(const gd::String& propertyName,
     shadowBlurRadius = newValue.To<double>();
     return true;
   }
+  if (propertyName == "lineHeight") {
+    lineHeight = newValue.To<double>();
+    return true;
+  }
 
   return false;
 }
@@ -134,6 +139,15 @@ std::map<gd::String, gd::PropertyDescriptor> TextObject::GetProperties() const {
       .SetType("resource")
       .AddExtraInfo("font")
       .SetLabel(_("Font"))
+      .SetGroup(_("Font"))
+      .SetQuickCustomizationVisibility(gd::QuickCustomization::Hidden);
+
+  objectProperties["lineHeight"]
+      .SetValue(gd::String::From(lineHeight))
+      .SetType("number")
+      .SetLabel(_("Line height"))
+      .SetDescription(_("Space between lines in pixels (0 for default)"))
+      .SetMeasurementUnit(gd::MeasurementUnit::GetPixel())
       .SetGroup(_("Font"))
       .SetQuickCustomizationVisibility(gd::QuickCustomization::Hidden);
 
@@ -304,6 +318,8 @@ void TextObject::DoUnserializeFrom(gd::Project& project,
     SetShadowAngle(content.GetIntAttribute("shadowAngle", 90));
     SetShadowDistance(content.GetIntAttribute("shadowDistance", 4));
     SetShadowBlurRadius(content.GetIntAttribute("shadowBlurRadius", 2));
+    
+    SetLineHeight(content.GetDoubleAttribute("lineHeight", 0));
   }
 }
 
@@ -356,6 +372,8 @@ void TextObject::DoSerializeTo(gd::SerializerElement& element) const {
   content.SetAttribute("shadowAngle", shadowAngle);
   content.SetAttribute("shadowDistance", shadowDistance);
   content.SetAttribute("shadowBlurRadius", shadowBlurRadius);
+  
+  content.SetAttribute("lineHeight", lineHeight);
 }
 
 void TextObject::ExposeResources(gd::ArbitraryResourceWorker& worker) {

--- a/Extensions/TextObject/TextObject.h
+++ b/Extensions/TextObject/TextObject.h
@@ -113,6 +113,9 @@ class GD_EXTENSION_API TextObject : public gd::ObjectConfiguration {
   void SetShadowBlurRadius(double value) { shadowBlurRadius = value; };
   double GetShadowBlurRadius() const { return shadowBlurRadius; };
 
+  void SetLineHeight(double value) { lineHeight = value; };
+  double GetLineHeight() const { return lineHeight; };
+
  private:
   virtual void DoUnserializeFrom(gd::Project& project,
                                  const gd::SerializerElement& element) override;
@@ -137,4 +140,6 @@ class GD_EXTENSION_API TextObject : public gd::ObjectConfiguration {
   double shadowAngle;
   double shadowDistance;
   double shadowBlurRadius;
+  
+  double lineHeight;
 };

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -87,6 +87,14 @@ namespace gdjs {
         : 0;
       style.padding = Math.ceil(this._object._padding + extraPaddingForShadow);
 
+      // Set line height
+      if (this._object._lineHeight > 0) {
+        style.lineHeight = this._object._lineHeight;
+      } else {
+        // @ts-ignore - Remove lineHeight if it's 0 or not set
+        delete style.lineHeight;
+      }
+
       // Prevent spikey outlines by adding a miter limit
       style.miterLimit = 3;
       this.updatePosition();

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -34,6 +34,7 @@ namespace gdjs {
       shadowDistance: float;
       shadowAngle: float;
       shadowBlurRadius: float;
+      lineHeight: float;
     };
   };
 
@@ -62,6 +63,7 @@ namespace gdjs {
     sha: float;
     shb: float;
     pad: integer;
+    lh: float;
   };
 
   export type TextObjectNetworkSyncData = ObjectNetworkSyncData &
@@ -104,6 +106,7 @@ namespace gdjs {
     _padding: integer = 5;
     _str: string;
     _renderer: gdjs.TextRuntimeObjectRenderer;
+    _lineHeight: float = 0;
 
     // We can store the scale as nothing else can change it.
     _scaleX: number = 1;
@@ -139,6 +142,8 @@ namespace gdjs {
       this._shadowDistance = content.shadowDistance;
       this._shadowBlur = content.shadowBlurRadius;
       this._shadowAngle = content.shadowAngle;
+
+      this._lineHeight = content.lineHeight || 0;
 
       this._renderer = new gdjs.TextRuntimeObjectRenderer(
         this,
@@ -211,6 +216,9 @@ namespace gdjs {
       if (oldContent.shadowBlurRadius !== newContent.shadowBlurRadius) {
         this.setShadowBlurRadius(newContent.shadowBlurRadius);
       }
+      if (oldContent.lineHeight !== newContent.lineHeight) {
+        this.setLineHeight(newContent.lineHeight || 0);
+      }
       return true;
     }
 
@@ -239,6 +247,7 @@ namespace gdjs {
         sha: this._shadowAngle,
         shb: this._shadowBlur,
         pad: this._padding,
+        lh: this._lineHeight,
       };
     }
 
@@ -314,6 +323,9 @@ namespace gdjs {
       }
       if (networkSyncData.pad !== undefined) {
         this.setPadding(networkSyncData.pad);
+      }
+      if (networkSyncData.lh !== undefined) {
+        this.setLineHeight(networkSyncData.lh);
       }
     }
 
@@ -927,6 +939,23 @@ namespace gdjs {
      */
     setPadding(value: float): void {
       this._padding = value;
+      this._renderer.updateStyle();
+    }
+
+    /**
+     * Get the line height of the text object.
+     * @return the line height
+     */
+    getLineHeight(): number {
+      return this._lineHeight;
+    }
+
+    /**
+     * Set the line height of the text object.
+     * @param value the line height
+     */
+    setLineHeight(value: float): void {
+      this._lineHeight = value;
       this._renderer.updateStyle();
     }
   }

--- a/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
+++ b/newIDE/app/src/ObjectEditor/Editors/TextEditor.js
@@ -125,6 +125,28 @@ export default class TextEditor extends React.Component<EditorProps, void> {
             />
           </Line>
           <LineStackLayout noMargin alignItems="center">
+            <MiniToolbarText firstChild>
+              <Trans>Line height:</Trans>
+            </MiniToolbarText>
+            <SemiControlledTextField
+              commitOnBlur
+              id="text-object-line-height"
+              type="number"
+              margin="none"
+              style={styles.sizeTextField}
+              value={textObjectConfiguration.getLineHeight()}
+              onChange={value => {
+                textObjectConfiguration.setLineHeight(
+                  parseInt(value, 10) || 0
+                );
+                this.forceUpdate();
+              }}
+            />
+            <MiniToolbarText>
+              <Trans>pixels (0 for default)</Trans>
+            </MiniToolbarText>
+          </LineStackLayout>
+          <LineStackLayout noMargin alignItems="center">
             <ButtonGroup size="small">
               <Button
                 variant={textAlignment === 'left' ? 'contained' : 'outlined'}

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -32,6 +32,8 @@ export default class RenderedTextInstance extends RenderedInstance {
   _shadowColor = '0;0;0';
   _shadowOpacity = 127;
   _shadowBlurRadius = 2;
+  
+  _lineHeight = 0;
 
   constructor(
     project: gdProject,
@@ -112,6 +114,7 @@ export default class RenderedTextInstance extends RenderedInstance {
       textObjectConfiguration.getShadowOpacity() !== this._shadowOpacity ||
       textObjectConfiguration.getShadowBlurRadius() !==
         this._shadowBlurRadius ||
+      textObjectConfiguration.getLineHeight() !== this._lineHeight ||
       this._instance.hasCustomSize() !== this._wrapping ||
       (this.getCustomWidth() !== this._wrappingWidth && this._wrapping)
     ) {
@@ -132,6 +135,8 @@ export default class RenderedTextInstance extends RenderedInstance {
       this._shadowColor = textObjectConfiguration.getShadowColor();
       this._shadowOpacity = textObjectConfiguration.getShadowOpacity();
       this._shadowBlurRadius = textObjectConfiguration.getShadowBlurRadius();
+
+      this._lineHeight = textObjectConfiguration.getLineHeight();
 
       this._wrapping = this._instance.hasCustomSize();
       this._wrappingWidth = this.getCustomWidth();
@@ -187,6 +192,13 @@ export default class RenderedTextInstance extends RenderedInstance {
         ? style.dropShadowDistance + style.dropShadowBlur
         : 0;
       style.padding = Math.ceil(extraPaddingForShadow);
+
+      // Set line height if specified (0 means use default)
+      if (this._lineHeight > 0) {
+        style.lineHeight = this._lineHeight;
+      } else {
+        delete style.lineHeight;
+      }
 
       // Manually ask the PIXI object to re-render as we changed a style property
       // see http://www.html5gamedevs.com/topic/16924-change-text-style-post-render/


### PR DESCRIPTION
Add a `lineHeight` property to Text, BitmapText, and BBText objects to control the vertical spacing of multiline text.

---
<a href="https://cursor.com/background-agent?bcId=bc-ceb57503-ab3c-49fb-b2fc-d8a5b6db2a2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ceb57503-ab3c-49fb-b2fc-d8a5b6db2a2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

