### PR TITLE
Fix tint action of Sprite not handling floating point color component

### DIFF
--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject-pixi-renderer.ts
@@ -389,26 +389,15 @@ namespace gdjs {
       this.updatePosition();
     }
 
-    setColor(rgbColor): void {
-      const colors = rgbColor.split(';');
-      if (colors.length < 3) {
-        return;
-      }
-      this._centerSprite.tint = gdjs.rgbToHexNumber(
-        parseInt(colors[0], 10),
-        parseInt(colors[1], 10),
-        parseInt(colors[2], 10)
-      );
+    setColor(rgbOrHexColor: string): void {
+      const tint = gdjs.rgbOrHexStringToNumber(rgbOrHexColor);
+      this._centerSprite.tint = tint;
       for (
         let borderCounter = 0;
         borderCounter < this._borderSprites.length;
         borderCounter++
       ) {
-        this._borderSprites[borderCounter].tint = gdjs.rgbToHexNumber(
-          parseInt(colors[0], 10),
-          parseInt(colors[1], 10),
-          parseInt(colors[2], 10)
-        );
+        this._borderSprites[borderCounter].tint = tint;
       }
       this._spritesContainer.cacheAsBitmap = false;
     }
@@ -416,11 +405,11 @@ namespace gdjs {
     getColor() {
       const rgb = new PIXI.Color(this._centerSprite.tint).toRgbArray();
       return (
-        Math.floor(rgb[0] * 255) +
+        Math.round(rgb[0] * 255) +
         ';' +
-        Math.floor(rgb[1] * 255) +
+        Math.round(rgb[1] * 255) +
         ';' +
-        Math.floor(rgb[2] * 255)
+        Math.round(rgb[2] * 255)
       );
     }
 

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -602,16 +602,10 @@ namespace gdjs {
 
     /**
      * Change the text color.
-     * @param colorString color as a "R;G;B" string, for example: "255;0;0"
+     * @param rgbOrHexColor color as a "R;G;B" string, for example: "255;0;0"
      */
-    setColor(colorString: string): void {
-      const color = colorString.split(';');
-      if (color.length < 3) {
-        return;
-      }
-      this._color[0] = parseInt(color[0], 10);
-      this._color[1] = parseInt(color[1], 10);
-      this._color[2] = parseInt(color[2], 10);
+    setColor(rgbOrHexColor: string): void {
+      this._color = gdjs.rgbOrHexToRGBColor(rgbOrHexColor);
       this._useGradient = false;
       this._renderer.updateStyle();
     }
@@ -720,18 +714,12 @@ namespace gdjs {
 
     /**
      * Set the outline for the text object.
-     * @param str color as a "R;G;B" string, for example: "255;0;0"
+     * @param rgbOrHexColor color as a "R;G;B" string, for example: "255;0;0"
      * @param thickness thickness of the outline (0 = disabled)
      * @deprecated Prefer independent setters.
      */
-    setOutline(str: string, thickness: number): void {
-      const color = str.split(';');
-      if (color.length < 3) {
-        return;
-      }
-      this._outlineColor[0] = parseInt(color[0], 10);
-      this._outlineColor[1] = parseInt(color[1], 10);
-      this._outlineColor[2] = parseInt(color[2], 10);
+    setOutline(rgbOrHexColor: string, thickness: number): void {
+      this._outlineColor = gdjs.rgbOrHexToRGBColor(rgbOrHexColor);
       this._outlineThickness = thickness;
       this._renderer.updateStyle();
     }
@@ -773,25 +761,19 @@ namespace gdjs {
 
     /**
      * Set the shadow for the text object.
-     * @param str color as a "R;G;B" string, for example: "255;0;0"
+     * @param rgbOrHexColor color as a "R;G;B" string, for example: "255;0;0"
      * @param distance distance between the shadow and the text, in pixels.
      * @param blur amount of shadow blur, in pixels.
      * @param angle shadow offset direction, in degrees.
      * @deprecated Prefer independent setters.
      */
     setShadow(
-      str: string,
+      rgbOrHexColor: string,
       distance: number,
       blur: integer,
       angle: float
     ): void {
-      const color = str.split(';');
-      if (color.length < 3) {
-        return;
-      }
-      this._shadowColor[0] = parseInt(color[0], 10);
-      this._shadowColor[1] = parseInt(color[1], 10);
-      this._shadowColor[2] = parseInt(color[2], 10);
+      this._shadowColor = gdjs.rgbOrHexToRGBColor(rgbOrHexColor);
       this._shadowDistance = distance;
       this._shadowBlur = blur;
       this._shadowAngle = angle;
@@ -904,38 +886,18 @@ namespace gdjs {
       strThirdColor: string,
       strFourthColor: string
     ): void {
-      const colorFirst = strFirstColor.split(';');
-      const colorSecond = strSecondColor.split(';');
-      const colorThird = strThirdColor.split(';');
-      const colorFourth = strFourthColor.split(';');
       this._gradient = [];
-      if (colorFirst.length == 3) {
-        this._gradient.push([
-          parseInt(colorFirst[0], 10),
-          parseInt(colorFirst[1], 10),
-          parseInt(colorFirst[2], 10),
-        ]);
+      if (strFirstColor) {
+        this._gradient.push(gdjs.rgbOrHexToRGBColor(strFirstColor));
       }
-      if (colorSecond.length == 3) {
-        this._gradient.push([
-          parseInt(colorSecond[0], 10),
-          parseInt(colorSecond[1], 10),
-          parseInt(colorSecond[2], 10),
-        ]);
+      if (strSecondColor) {
+        this._gradient.push(gdjs.rgbOrHexToRGBColor(strSecondColor));
       }
-      if (colorThird.length == 3) {
-        this._gradient.push([
-          parseInt(colorThird[0], 10),
-          parseInt(colorThird[1], 10),
-          parseInt(colorThird[2], 10),
-        ]);
+      if (strThirdColor) {
+        this._gradient.push(gdjs.rgbOrHexToRGBColor(strThirdColor));
       }
-      if (colorFourth.length == 3) {
-        this._gradient.push([
-          parseInt(colorFourth[0], 10),
-          parseInt(colorFourth[1], 10),
-          parseInt(colorFourth[2], 10),
-        ]);
+      if (strFourthColor) {
+        this._gradient.push(gdjs.rgbOrHexToRGBColor(strFourthColor));
       }
       this._gradientType = strGradientType;
       this._useGradient = this._gradient.length > 1 ? true : false;

--- a/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
+++ b/Extensions/TiledSpriteObject/tiledspriteruntimeobject-pixi-renderer.ts
@@ -92,28 +92,18 @@ namespace gdjs {
         -this._object._yOffset % this._tiledSprite.texture.height;
     }
 
-    setColor(rgbColor: string): void {
-      const colors = rgbColor.split(';');
-      if (colors.length < 3) {
-        return;
-      }
-      this._tiledSprite.tint =
-        '0x' +
-        gdjs.rgbToHex(
-          parseInt(colors[0], 10),
-          parseInt(colors[1], 10),
-          parseInt(colors[2], 10)
-        );
+    setColor(rgbOrHexColor: string): void {
+      this._tiledSprite.tint = gdjs.rgbOrHexStringToNumber(rgbOrHexColor);
     }
 
     getColor() {
       const rgb = new PIXI.Color(this._tiledSprite.tint).toRgbArray();
       return (
-        Math.floor(rgb[0] * 255) +
+        Math.round(rgb[0] * 255) +
         ';' +
-        Math.floor(rgb[1] * 255) +
+        Math.round(rgb[1] * 255) +
         ';' +
-        Math.floor(rgb[2] * 255)
+        Math.round(rgb[2] * 255)
       );
     }
 

--- a/Extensions/TweenBehavior/tweenruntimebehavior.ts
+++ b/Extensions/TweenBehavior/tweenruntimebehavior.ts
@@ -1326,11 +1326,11 @@ namespace gdjs {
             lightness
           );
           owner.setColor(
-            Math.floor(rgbFromHslColor[0]) +
+            Math.round(rgbFromHslColor[0]) +
               ';' +
-              Math.floor(rgbFromHslColor[1]) +
+              Math.round(rgbFromHslColor[1]) +
               ';' +
-              Math.floor(rgbFromHslColor[2])
+              Math.round(rgbFromHslColor[2])
           );
         };
       } else {
@@ -1439,12 +1439,11 @@ namespace gdjs {
       if (!isColorable(this.owner)) return;
       const owner = this.owner;
 
-      const rgbFromColor: string[] = owner.getColor().split(';');
-      if (rgbFromColor.length < 3) return;
+      const rgbFromColor = gdjs.rgbOrHexToRGBColor(owner.getColor());
       const hslFromColor = gdjs.evtTools.tween.rgbToHsl(
-        parseFloat(rgbFromColor[0]),
-        parseFloat(rgbFromColor[1]),
-        parseFloat(rgbFromColor[2])
+        rgbFromColor[0],
+        rgbFromColor[1],
+        rgbFromColor[2]
       );
 
       const toH = animateHue ? toHue : hslFromColor[0];
@@ -1474,11 +1473,11 @@ namespace gdjs {
           );
 
           owner.setColor(
-            Math.floor(rgbFromHslColor[0]) +
+            Math.round(rgbFromHslColor[0]) +
               ';' +
-              Math.floor(rgbFromHslColor[1]) +
+              Math.round(rgbFromHslColor[1]) +
               ';' +
-              Math.floor(rgbFromHslColor[2])
+              Math.round(rgbFromHslColor[2])
           );
         },
 

--- a/GDJS/Runtime/events-tools/cameratools.ts
+++ b/GDJS/Runtime/events-tools/cameratools.ts
@@ -462,12 +462,12 @@ namespace gdjs {
       /**
        * @param instanceContainer the container owning the layer
        * @param layerName The lighting layer with the ambient color.
-       * @param rgbColor The color, in RGB format ("128;200;255").
+       * @param rgbOrHexColor The color, in RGB format ("128;200;255").
        */
       export const setLayerAmbientLightColor = function (
         instanceContainer: gdjs.RuntimeInstanceContainer,
         layerName: string,
-        rgbColor: string
+        rgbOrHexColor: string
       ) {
         if (
           !instanceContainer.hasLayer(layerName) ||
@@ -475,17 +475,10 @@ namespace gdjs {
         ) {
           return;
         }
-        const colors = rgbColor.split(';');
-        if (colors.length < 3) {
-          return;
-        }
+        const color = gdjs.rgbOrHexToRGBColor(rgbOrHexColor);
         return instanceContainer
           .getLayer(layerName)
-          .setClearColor(
-            parseInt(colors[0], 10),
-            parseInt(colors[1], 10),
-            parseInt(colors[2], 10)
-          );
+          .setClearColor(color[0], color[1], color[2]);
       };
     }
   }

--- a/GDJS/Runtime/events-tools/runtimescenetools.ts
+++ b/GDJS/Runtime/events-tools/runtimescenetools.ts
@@ -24,19 +24,12 @@ namespace gdjs {
 
       export const setBackgroundColor = function (
         runtimeScene: gdjs.RuntimeScene,
-        rgbColor: string
+        rgbOrHexColor: string
       ) {
-        const colors = rgbColor.split(';');
-        if (colors.length < 3) {
-          return;
-        }
+        const color = gdjs.rgbOrHexToRGBColor(rgbOrHexColor);
         runtimeScene
           .getScene()
-          .setBackgroundColor(
-            parseInt(colors[0]),
-            parseInt(colors[1]),
-            parseInt(colors[2])
-          );
+          .setBackgroundColor(color[0], color[1], color[2]);
       };
 
       export const getElapsedTimeInSeconds = function (

--- a/GDJS/Runtime/gd.ts
+++ b/GDJS/Runtime/gd.ts
@@ -105,6 +105,7 @@ namespace gdjs {
   export const rgbOrHexToRGBColor = function (
     value: string
   ): [number, number, number] {
+    // TODO Add a `result` parameter to allow to reuse the returned array.
     const rgbColor = extractRGBString(value);
     if (rgbColor) {
       const splitValue = rgbColor.split(';');
@@ -145,11 +146,11 @@ namespace gdjs {
    * @param b Blue
    */
   export const rgbToHexNumber = function (
-    r: integer,
-    g: integer,
-    b: integer
+    r: float,
+    g: float,
+    b: float
   ): integer {
-    return (r << 16) + (g << 8) + b;
+    return (Math.round(r) << 16) + (Math.round(g) << 8) + Math.round(b);
   };
 
   /**

--- a/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/spriteruntimeobject-pixi-renderer.ts
@@ -140,18 +140,18 @@ namespace gdjs {
       this._sprite.visible = !this._object.hidden;
     }
 
-    setColor(rgbOrHexColor): void {
+    setColor(rgbOrHexColor: string): void {
       this._sprite.tint = gdjs.rgbOrHexStringToNumber(rgbOrHexColor);
     }
 
     getColor() {
       const rgb = new PIXI.Color(this._sprite.tint).toRgbArray();
       return (
-        Math.floor(rgb[0] * 255) +
+        Math.round(rgb[0] * 255) +
         ';' +
-        Math.floor(rgb[1] * 255) +
+        Math.round(rgb[1] * 255) +
         ';' +
-        Math.floor(rgb[2] * 255)
+        Math.round(rgb[2] * 255)
       );
     }
 


### PR DESCRIPTION
### Side effect
**Context**
- when a color parameter value has an invalid syntax

**Before**
- actions didn't do anything

**After**
- actions set it to black

I think it's easier to debug for users because at least it does something.