### PR TITLE
Forbid camera zoom to be set to 0

### DIFF
--- a/Extensions/TweenBehavior/tests/LayoutTween.spec.js
+++ b/Extensions/TweenBehavior/tests/LayoutTween.spec.js
@@ -347,17 +347,21 @@ describe('gdjs.TweenRuntimeBehavior', () => {
     // Check that there is no NaN.
     for (let i = 0; i < 11; i++) {
       runtimeScene.renderAndStep(1000 / 60);
-      expect(camera.getCameraZoom(runtimeScene, '', 0)).to.be(0);
+      // The tween tries to set the camera zoom to 0, but it has no effect
+      // because it doesn't make sense.
+      expect(camera.getCameraZoom(runtimeScene, '', 0)).to.be(1);
     }
   });
 
   it('can tween a layer camera zoom from 0', () => {
+    // The zoom stays at 1 because 0 doesn't make sense.
     camera.setCameraZoom(runtimeScene, 0, '', 0);
+    // Here, it actually tweens from 1 to 1.
     tween.tweenCameraZoom2(runtimeScene, 'MyTween', 1, '', 'linear', 0.25);
     // A camera zoom of 0 doesn't make sense.
     // Check that there is no NaN.
     for (let i = 0; i < 11; i++) {
-      expect(camera.getCameraZoom(runtimeScene, '', 0)).to.be(0);
+      expect(camera.getCameraZoom(runtimeScene, '', 0)).to.be(1);
       runtimeScene.renderAndStep(1000 / 60);
     }
     expect(camera.getCameraZoom(runtimeScene, '', 0)).to.be(1);

--- a/GDJS/Runtime/layer.ts
+++ b/GDJS/Runtime/layer.ts
@@ -9,6 +9,7 @@ namespace gdjs {
    */
   export class Layer extends gdjs.RuntimeLayer {
     _cameraRotation: float = 0;
+    /** The camera zoom factor strictly greater than 0. */
     _zoomFactor: float = 1;
     _cameraX: float;
     _cameraY: float;
@@ -166,6 +167,9 @@ namespace gdjs {
      * @param cameraId The camera number. Currently ignored.
      */
     override setCameraZoom(newZoom: float, cameraId?: integer): void {
+      if (newZoom <= 0) {
+        return;
+      }
       this._zoomFactor = newZoom;
       this._isCameraZDirty = true;
       this._renderer.updatePosition();
@@ -283,8 +287,8 @@ namespace gdjs {
 
       x -= this.getRuntimeScene()._cachedGameResolutionWidth / 2;
       y -= this.getRuntimeScene()._cachedGameResolutionHeight / 2;
-      x /= Math.abs(this._zoomFactor);
-      y /= Math.abs(this._zoomFactor);
+      x /= this._zoomFactor;
+      y /= this._zoomFactor;
 
       // Only compute angle and cos/sin once (allow heavy optimization from JS engines).
       const angleInRadians = (this._cameraRotation / 180) * Math.PI;
@@ -320,8 +324,8 @@ namespace gdjs {
     ): FloatPoint {
       x -= this._runtimeScene.getViewportOriginX();
       y -= this._runtimeScene.getViewportOriginY();
-      x /= Math.abs(this._zoomFactor);
-      y /= Math.abs(this._zoomFactor);
+      x /= this._zoomFactor;
+      y /= this._zoomFactor;
 
       // Only compute angle and cos/sin once (allow heavy optimization from JS engines).
       const angleInRadians = (this._cameraRotation / 180) * Math.PI;
@@ -367,8 +371,8 @@ namespace gdjs {
       const sinValue = Math.sin(-angleInRadians);
       x = cosValue * x - sinValue * y;
       y = sinValue * tmp + cosValue * y;
-      x *= Math.abs(this._zoomFactor);
-      y *= Math.abs(this._zoomFactor);
+      x *= this._zoomFactor;
+      y *= this._zoomFactor;
       position[0] = x + this.getRuntimeScene()._cachedGameResolutionWidth / 2;
       position[1] = y + this.getRuntimeScene()._cachedGameResolutionHeight / 2;
 
@@ -404,8 +408,8 @@ namespace gdjs {
       const sinValue = Math.sin(-angleInRadians);
       x = cosValue * x - sinValue * y;
       y = sinValue * tmp + cosValue * y;
-      x *= Math.abs(this._zoomFactor);
-      y *= Math.abs(this._zoomFactor);
+      x *= this._zoomFactor;
+      y *= this._zoomFactor;
       x += this._runtimeScene.getViewportOriginX();
       y += this._runtimeScene.getViewportOriginY();
 


### PR DESCRIPTION
Setting the camera zoom to 0 was making `CursorX()` and  `CursorX()` return `NaN`.