### PR TITLE
Scope mock data mocking to specific stories

### DIFF
--- a/newIDE/app/.storybook/main.js
+++ b/newIDE/app/.storybook/main.js
@@ -18,6 +18,5 @@ module.exports = {
       },
     },
     '@storybook/preset-create-react-app',
-    'storybook-addon-mock',
   ],
 };


### PR DESCRIPTION
Remove global `storybook-addon-mock` activation to scope XHR mocking only to stories that declare mock data.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d68d4e5-cdad-4a59-b982-b792e910d26e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d68d4e5-cdad-4a59-b982-b792e910d26e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

