### PR TITLE
Scope mock data mocking to specific stories

### DIFF
--- a/newIDE/app/.storybook/main.js
+++ b/newIDE/app/.storybook/main.js
@@ -18,6 +18,5 @@ module.exports = {
       },
     },
     '@storybook/preset-create-react-app',
-    'storybook-addon-mock',
   ],
 };

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import withMock from 'storybook-addon-mock';
 
 import paperDecorator from '../../../PaperDecorator';
 import { AssetDetails } from '../../../../AssetStore/AssetDetails';
@@ -15,7 +16,7 @@ import { AssetStoreNavigatorStateProvider } from '../../../../AssetStore/AssetSt
 export default {
   title: 'AssetStore/AssetStore/AssetDetails',
   component: AssetDetails,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const Wrapper = ({ children }: {| children: React.Node |}) => {

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetPackInstallDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetPackInstallDialog.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 
 import paperDecorator from '../../../PaperDecorator';
 import AssetPackInstallDialog from '../../../../AssetStore/AssetPackInstallDialog';
@@ -23,7 +24,7 @@ import { AssetStoreNavigatorStateProvider } from '../../../../AssetStore/AssetSt
 export default {
   title: 'AssetStore/AssetStore/AssetPackInstallDialog',
   component: AssetPackInstallDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const mockApiDataForPublicAssets = [

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 import paperDecorator from '../../../PaperDecorator';
 import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
 import { AssetStoreStateProvider } from '../../../../AssetStore/AssetStoreContext';
@@ -15,7 +16,7 @@ import { AssetStoreNavigatorStateProvider } from '../../../../AssetStore/AssetSt
 export default {
   title: 'AssetStore/AssetStore',
   component: AssetStore,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionInstallDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionInstallDialog.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 
 import paperDecorator from '../../../PaperDecorator';
 import { testProject } from '../../../GDevelopJsInitializerDecorator';
@@ -20,7 +21,7 @@ import {
 export default {
   title: 'AssetStore/ExtensionStore/ExtensionInstallDialog',
   component: ExtensionInstallDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionStore.stories.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { I18n } from '@lingui/react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 
 import paperDecorator from '../../../PaperDecorator';
 import { ExtensionStore } from '../../../../AssetStore/ExtensionStore';
@@ -18,7 +19,7 @@ import PreferencesContext, {
 export default {
   title: 'AssetStore/ExtensionStore',
   component: ExtensionStore,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionsSearchDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionsSearchDialog.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 
 import paperDecorator from '../../../PaperDecorator';
 import ExtensionsSearchDialog from '../../../../AssetStore/ExtensionStore/ExtensionsSearchDialog';
@@ -14,7 +15,7 @@ import { fakeExtensionsRegistry } from '../../../../fixtures/GDevelopServicesTes
 export default {
   title: 'AssetStore/ExtensionStore/ExtensionSearchDialog',
   component: ExtensionsSearchDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/GameRegistration.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameRegistration.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import withMock from 'storybook-addon-mock';
 
 import paperDecorator from '../PaperDecorator';
 
@@ -17,7 +18,7 @@ import { GDevelopGameApi } from '../../Utils/GDevelopServices/ApiConfigs';
 export default {
   title: 'GameDashboard/GameRegistration',
   component: GameRegistration,
-  decorators: [paperDecorator, GDevelopJsInitializerDecorator],
+  decorators: [paperDecorator, GDevelopJsInitializerDecorator, withMock],
 };
 
 export const NoProjectLoaded = () => (

--- a/newIDE/app/src/stories/componentStories/HomePage/HomePage.stories.js
+++ b/newIDE/app/src/stories/componentStories/HomePage/HomePage.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 import { HomePage } from '../../../MainFrame/EditorContainers/HomePage';
 import GDevelopJsInitializerDecorator, {
   testProject,
@@ -161,7 +162,7 @@ const WrappedHomePage = ({
 export default {
   title: 'HomePage',
   component: WrappedHomePage,
-  decorators: [GDevelopJsInitializerDecorator, inAppTutorialDecorator],
+  decorators: [GDevelopJsInitializerDecorator, inAppTutorialDecorator, withMock],
 };
 
 export const BuildSectionLoading = () => (

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/NewBehaviorDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/NewBehaviorDialog.stories.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 import { I18n } from '@lingui/react';
+import withMock from 'storybook-addon-mock';
 
 // Keep first as it creates the `global.gd` object:
 import { testProject } from '../../GDevelopJsInitializerDecorator';
@@ -20,6 +21,7 @@ import PreferencesContext, {
 export default {
   title: 'ObjectEditor/NewBehaviorDialog',
   component: NewBehaviorDialog,
+  decorators: [withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/ProjectCreation/ProjectGeneratingDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/ProjectCreation/ProjectGeneratingDialog.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 
 import paperDecorator from '../../PaperDecorator';
 import ProjectGeneratingDialog from '../../../ProjectCreation/ProjectGeneratingDialog';
@@ -12,7 +13,7 @@ import { fakeSilverAuthenticatedUser } from '../../../fixtures/GDevelopServicesT
 export default {
   title: 'Project Creation/ProjectGeneratingDialog',
   component: ProjectGeneratingDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 export const Generating = () => {

--- a/newIDE/app/src/stories/componentStories/Share/OnlineGameLink.stories.js
+++ b/newIDE/app/src/stories/componentStories/Share/OnlineGameLink.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
+import withMock from 'storybook-addon-mock';
 import paperDecorator from '../../PaperDecorator';
 
 import { OnlineGameLink } from '../../../ExportAndShare/GenericExporters/OnlineWebExport';
@@ -16,7 +17,7 @@ import { GDevelopGameApi } from '../../../Utils/GDevelopServices/ApiConfigs';
 export default {
   title: 'Share/OnlineGameLink',
   component: OnlineGameLink,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
   parameters: {
     mockData: [
       {

--- a/newIDE/app/src/stories/componentStories/Share/ShareDialog/InviteHome.stories.js
+++ b/newIDE/app/src/stories/componentStories/Share/ShareDialog/InviteHome.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import withMock from 'storybook-addon-mock';
 import paperDecorator from '../../../PaperDecorator';
 
 import InviteHome from '../../../../ExportAndShare/ShareDialog/InviteHome';
@@ -42,7 +43,7 @@ const notOwnedProjectId = 'not-owned-project-id';
 export default {
   title: 'Share/InviteHome',
   component: InviteHome,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 export const NotLoggedInOrOffline = () => {


### PR DESCRIPTION
Remove global Storybook XHR mocking and apply `withMock` decorator only to stories that declare mock data.

---
<a href="https://cursor.com/background-agent?bcId=bc-d847885d-2017-4e4d-bfb2-3e1fbbc2b17e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d847885d-2017-4e4d-bfb2-3e1fbbc2b17e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

