### PR TITLE
Scope Storybook XHR mocks to stories with mock data

### DIFF
--- a/newIDE/app/.storybook/main.js
+++ b/newIDE/app/.storybook/main.js
@@ -18,6 +18,5 @@ module.exports = {
       },
     },
     '@storybook/preset-create-react-app',
-    'storybook-addon-mock',
   ],
 };

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetDetails.stories.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 import paperDecorator from '../../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 import { AssetDetails } from '../../../../AssetStore/AssetDetails';
 import {
   fakeAssetShortHeader1,
@@ -15,7 +16,7 @@ import { AssetStoreNavigatorStateProvider } from '../../../../AssetStore/AssetSt
 export default {
   title: 'AssetStore/AssetStore/AssetDetails',
   component: AssetDetails,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const Wrapper = ({ children }: {| children: React.Node |}) => {

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetPackInstallDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetPackInstallDialog.stories.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import paperDecorator from '../../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 import AssetPackInstallDialog from '../../../../AssetStore/AssetPackInstallDialog';
 import {
   fakeAsset1,
@@ -23,7 +24,7 @@ import { AssetStoreNavigatorStateProvider } from '../../../../AssetStore/AssetSt
 export default {
   title: 'AssetStore/AssetStore/AssetPackInstallDialog',
   component: AssetPackInstallDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const mockApiDataForPublicAssets = [

--- a/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/AssetStore/AssetStore.stories.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 import paperDecorator from '../../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
 import { AssetStoreStateProvider } from '../../../../AssetStore/AssetStoreContext';
 import { AssetStore } from '../../../../AssetStore';
@@ -15,7 +16,7 @@ import { AssetStoreNavigatorStateProvider } from '../../../../AssetStore/AssetSt
 export default {
   title: 'AssetStore/AssetStore',
   component: AssetStore,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionInstallDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionInstallDialog.stories.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import paperDecorator from '../../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 import { testProject } from '../../../GDevelopJsInitializerDecorator';
 
 import ExtensionInstallDialog from '../../../../AssetStore/ExtensionStore/ExtensionInstallDialog';
@@ -20,7 +21,7 @@ import {
 export default {
   title: 'AssetStore/ExtensionStore/ExtensionInstallDialog',
   component: ExtensionInstallDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionStore.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionStore.stories.js
@@ -4,6 +4,7 @@ import { I18n } from '@lingui/react';
 import { action } from '@storybook/addon-actions';
 
 import paperDecorator from '../../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 import { ExtensionStore } from '../../../../AssetStore/ExtensionStore';
 import FixedHeightFlexContainer from '../../../FixedHeightFlexContainer';
 import { ExtensionStoreStateProvider } from '../../../../AssetStore/ExtensionStore/ExtensionStoreContext';
@@ -18,7 +19,7 @@ import PreferencesContext, {
 export default {
   title: 'AssetStore/ExtensionStore',
   component: ExtensionStore,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionsSearchDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/AssetStore/ExtensionStore/ExtensionsSearchDialog.stories.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import paperDecorator from '../../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 import ExtensionsSearchDialog from '../../../../AssetStore/ExtensionStore/ExtensionsSearchDialog';
 import { I18n } from '@lingui/react';
 import EventsFunctionsExtensionsProvider from '../../../../EventsFunctionsExtensionsLoader/EventsFunctionsExtensionsProvider';
@@ -14,7 +15,7 @@ import { fakeExtensionsRegistry } from '../../../../fixtures/GDevelopServicesTes
 export default {
   title: 'AssetStore/ExtensionStore/ExtensionSearchDialog',
   component: ExtensionsSearchDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/GameRegistration.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameRegistration.stories.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 import paperDecorator from '../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 
 import { GameRegistration } from '../../GameDashboard/GameRegistration';
 import GDevelopJsInitializerDecorator, {
@@ -17,7 +18,7 @@ import { GDevelopGameApi } from '../../Utils/GDevelopServices/ApiConfigs';
 export default {
   title: 'GameDashboard/GameRegistration',
   component: GameRegistration,
-  decorators: [paperDecorator, GDevelopJsInitializerDecorator],
+  decorators: [paperDecorator, GDevelopJsInitializerDecorator, withMock],
 };
 
 export const NoProjectLoaded = () => (

--- a/newIDE/app/src/stories/componentStories/HomePage/HomePage.stories.js
+++ b/newIDE/app/src/stories/componentStories/HomePage/HomePage.stories.js
@@ -27,6 +27,7 @@ import { GDevelopAssetApi } from '../../../Utils/GDevelopServices/ApiConfigs';
 import fakeResourceManagementProps from '../../FakeResourceManagement';
 import inAppTutorialDecorator from '../../InAppTutorialDecorator';
 import { useResponsiveWindowSize } from '../../../UI/Responsive/ResponsiveWindowMeasurer';
+import withMock from 'storybook-addon-mock';
 
 const apiDataServerSideError = {
   mockData: [
@@ -161,7 +162,7 @@ const WrappedHomePage = ({
 export default {
   title: 'HomePage',
   component: WrappedHomePage,
-  decorators: [GDevelopJsInitializerDecorator, inAppTutorialDecorator],
+  decorators: [GDevelopJsInitializerDecorator, inAppTutorialDecorator, withMock],
 };
 
 export const BuildSectionLoading = () => (

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/NewBehaviorDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/NewBehaviorDialog.stories.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 import { I18n } from '@lingui/react';
+import withMock from 'storybook-addon-mock';
 
 // Keep first as it creates the `global.gd` object:
 import { testProject } from '../../GDevelopJsInitializerDecorator';
@@ -20,6 +21,7 @@ import PreferencesContext, {
 export default {
   title: 'ObjectEditor/NewBehaviorDialog',
   component: NewBehaviorDialog,
+  decorators: [withMock],
 };
 
 const apiDataServerSideError = {

--- a/newIDE/app/src/stories/componentStories/ProjectCreation/ProjectGeneratingDialog.stories.js
+++ b/newIDE/app/src/stories/componentStories/ProjectCreation/ProjectGeneratingDialog.stories.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import paperDecorator from '../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 import ProjectGeneratingDialog from '../../../ProjectCreation/ProjectGeneratingDialog';
 import UrlStorageProvider from '../../../ProjectsStorage/UrlStorageProvider';
 import { GDevelopGenerationApi } from '../../../Utils/GDevelopServices/ApiConfigs';
@@ -12,7 +13,7 @@ import { fakeSilverAuthenticatedUser } from '../../../fixtures/GDevelopServicesT
 export default {
   title: 'Project Creation/ProjectGeneratingDialog',
   component: ProjectGeneratingDialog,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 export const Generating = () => {

--- a/newIDE/app/src/stories/componentStories/Share/OnlineGameLink.stories.js
+++ b/newIDE/app/src/stories/componentStories/Share/OnlineGameLink.stories.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 import paperDecorator from '../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 
 import { OnlineGameLink } from '../../../ExportAndShare/GenericExporters/OnlineWebExport';
 import {
@@ -16,7 +17,7 @@ import { GDevelopGameApi } from '../../../Utils/GDevelopServices/ApiConfigs';
 export default {
   title: 'Share/OnlineGameLink',
   component: OnlineGameLink,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
   parameters: {
     mockData: [
       {

--- a/newIDE/app/src/stories/componentStories/Share/ShareDialog/InviteHome.stories.js
+++ b/newIDE/app/src/stories/componentStories/Share/ShareDialog/InviteHome.stories.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import paperDecorator from '../../../PaperDecorator';
+import withMock from 'storybook-addon-mock';
 
 import InviteHome from '../../../../ExportAndShare/ShareDialog/InviteHome';
 import {
@@ -42,7 +43,7 @@ const notOwnedProjectId = 'not-owned-project-id';
 export default {
   title: 'Share/InviteHome',
   component: InviteHome,
-  decorators: [paperDecorator],
+  decorators: [paperDecorator, withMock],
 };
 
 export const NotLoggedInOrOffline = () => {


### PR DESCRIPTION
## Summary
- remove global `storybook-addon-mock` from Storybook config
- import and register `withMock` only in stories defining `mockData`

## Testing
- `CI=true npm test` *(fails: Cannot find module 'libGD.js-for-tests-only' from 'src/setupTests.js')*

------
https://chatgpt.com/codex/tasks/task_b_68aca00d456c8327b3a4623555d81de3