### PR TITLE
Initialize project from example

### DIFF
--- a/newIDE/app/src/EditorFunctions/index.js
+++ b/newIDE/app/src/EditorFunctions/index.js
@@ -123,6 +123,10 @@ export type EditorCallbacks = {|
         | 'none',
     |}
   ) => void,
+  onCreateProjectFromExample?: (
+    exampleName: string,
+    exampleSlug: string
+  ) => Promise<void>,
 |};
 
 export type SceneEventsOutsideEditorChanges = {|
@@ -3461,6 +3465,45 @@ const addOrEditVariable: EditorFunction = {
   },
 };
 
+const initializeProject: EditorFunction = {
+  renderForEditor: ({ project, args, editorCallbacks, shouldShowDetails }) => {
+    const name = SafeExtractor.extractStringProperty(args, 'name');
+    const exampleSlug = SafeExtractor.extractStringProperty(args, 'example_slug');
+
+    if (!name && !exampleSlug) {
+      return {
+        text: <Trans>Initialize project (missing required arguments)</Trans>,
+      };
+    }
+
+    return {
+      text: (
+        <Trans>
+          Initialize project{name && ` "${name}"`}
+          {exampleSlug && ` from example "${exampleSlug}"`}
+        </Trans>
+      ),
+    };
+  },
+  launchFunction: async ({ project, args }) => {
+    const name = extractRequiredString(args, 'name');
+    const exampleSlug = extractRequiredString(args, 'example_slug');
+
+    // This function requires special handling in the AskAiEditorContainer
+    // because project initialization needs to be done through the MainFrame callbacks
+    return {
+      success: true,
+      message: `Project initialization requested: name="${name}", example_slug="${exampleSlug}"`,
+      // Signal that this needs special handling
+      _requiresProjectInitialization: true,
+      _projectInitializationData: {
+        name,
+        exampleSlug,
+      },
+    };
+  },
+};
+
 export const editorFunctions: { [string]: EditorFunction } = {
   create_object: createObject,
   inspect_object_properties: inspectObjectProperties,
@@ -3479,4 +3522,5 @@ export const editorFunctions: { [string]: EditorFunction } = {
   inspect_scene_properties_layers_effects: inspectScenePropertiesLayersEffects,
   change_scene_properties_layers_effects: changeScenePropertiesLayersEffects,
   add_or_edit_variable: addOrEditVariable,
+  initialize_project: initializeProject,
 };

--- a/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/BaseEditor.js
@@ -47,6 +47,7 @@ export type RenderEditorContainerProps = {|
   project: ?gdProject,
   fileMetadata: ?FileMetadata,
   storageProvider: StorageProvider,
+  getStorageProvider: () => StorageProvider,
   setToolbar: (?React.Node) => void,
   setGamesPlatformFrameShown: ({| shown: boolean, isMobile: boolean |}) => void,
 

--- a/newIDE/app/src/MainFrame/EditorTabsPane.js
+++ b/newIDE/app/src/MainFrame/EditorTabsPane.js
@@ -578,6 +578,7 @@ const EditorTabsPane = React.forwardRef<Props, {||}>((props, ref) => {
                       project: currentProject,
                       fileMetadata: currentFileMetadata,
                       storageProvider: getStorageProvider(),
+                      getStorageProvider,
                       ref: editorRef => (editorTab.editorRef = editorRef),
                       setToolbar: editorToolbar =>
                         setEditorToolbar(editorToolbar, isCurrentTab),

--- a/test_initialize_project.md
+++ b/test_initialize_project.md
@@ -1,0 +1,55 @@
+# Test Initialize Project Command
+
+## Summary of Changes
+
+### 1. Added `initialize_project` function to EditorFunctions/index.js
+- Takes `name` and `example_slug` as arguments
+- Returns a special response that signals project initialization is needed
+
+### 2. Updated EditorCallbacks type
+- Added optional `onCreateProjectFromExample` callback
+
+### 3. Modified EditorFunctionCallRunner
+- Handles the special case when `_requiresProjectInitialization` is true
+- Calls the `onCreateProjectFromExample` callback with the project name and example slug
+
+### 4. Updated AskAiEditorContainer
+- Removed automatic project creation when no project is open
+- Added implementation of `onCreateProjectFromExample` callback that:
+  - Fetches all examples to find the one matching the slug
+  - Creates appropriate project setup
+  - Calls the main `onCreateProjectFromExample` from props
+- Shows an alert if agent mode is used without a project
+
+### 5. Updated BaseEditor and EditorTabsPane
+- Added `getStorageProvider` to props type
+- Passed through to editor containers
+
+## How it Works
+
+1. AI sends `initialize_project` command with project name and example slug
+2. The command is processed by EditorFunctionCallRunner
+3. Special handling detects the initialization request
+4. Calls the callback to create project from example
+5. The callback in AskAiEditorContainer:
+   - Finds the example by slug
+   - Sets up project configuration
+   - Triggers actual project creation through MainFrame
+
+## Testing Instructions
+
+To test this implementation:
+
+1. Open GDevelop without any project
+2. Use AI chat/agent mode
+3. AI should be able to use the `initialize_project` command
+4. Command should create a new project based on the specified example
+
+## Example AI Command
+
+```json
+{
+  "name": "initialize_project",
+  "arguments": "{\"name\": \"My Platformer Game\", \"example_slug\": \"geometry-monster\"}"
+}
+```


### PR DESCRIPTION
Implement `initialize_project` AI command to allow AI to create projects from examples, centralizing project creation logic and removing the automatic project creation dialog from the AI editor.

---
<a href="https://cursor.com/background-agent?bcId=bc-88555160-70d4-4842-b1b0-d0c2552bd33e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88555160-70d4-4842-b1b0-d0c2552bd33e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

