### PR TITLE
Initialize project from example

### DIFF
--- a/newIDE/app/src/EditorFunctions/index.js
+++ b/newIDE/app/src/EditorFunctions/index.js
@@ -3461,6 +3461,27 @@ const addOrEditVariable: EditorFunction = {
   },
 };
 
+const initializeProject: EditorFunction = {
+  renderForEditor: ({ args }) => {
+    const name = extractRequiredString(args, 'name');
+    const slug = extractRequiredString(args, 'slug');
+
+    return {
+      text: (
+        <Trans>
+          Initialize a new project "{name}" from example "{slug}".
+        </Trans>
+      ),
+    };
+  },
+  // The actual project creation is handled by the Ask AI editor container,
+  // which can process this command even if no project is currently open.
+  // Returning a generic success here ensures graceful handling if invoked.
+  launchFunction: async () => {
+    return makeGenericSuccess('Project initialization requested.');
+  },
+};
+
 export const editorFunctions: { [string]: EditorFunction } = {
   create_object: createObject,
   inspect_object_properties: inspectObjectProperties,
@@ -3479,4 +3500,5 @@ export const editorFunctions: { [string]: EditorFunction } = {
   inspect_scene_properties_layers_effects: inspectScenePropertiesLayersEffects,
   change_scene_properties_layers_effects: changeScenePropertiesLayersEffects,
   add_or_edit_variable: addOrEditVariable,
+  initialize_project: initializeProject,
 };


### PR DESCRIPTION
Add `initialize_project` AI command to allow the AI to create a new project from an example directly, even when no project is open, and remove the old AI project creation dialog.

The previous AI flow for creating a project involved a user dialog. This change streamlines the process by enabling the AI to directly specify an example and project name, making the project initialization more autonomous and integrated with AI commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4d007fd-4851-43e3-acbb-6ea69b2ca8bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4d007fd-4851-43e3-acbb-6ea69b2ca8bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

