### PR TITLE
feat: SpineRuntimeObject: Disable updateHitboxes to avoid unnecessary recomputation

### DIFF
--- a/Extensions/Spine/spineruntimeobject.ts
+++ b/Extensions/Spine/spineruntimeobject.ts
@@ -73,6 +73,7 @@ namespace gdjs {
       );
       this.setAnimationIndex(0);
       this._renderer.updateAnimation(0);
+      this.hitBoxes.length = 0;
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
@@ -181,6 +182,9 @@ namespace gdjs {
       ) {
         this.setAnimationElapsedTime(syncData.anet);
       }
+    }
+
+    updateHitBoxes(): void {
     }
 
     extraInitializationFromInitialInstance(

--- a/Extensions/Spine/spineruntimeobject.ts
+++ b/Extensions/Spine/spineruntimeobject.ts
@@ -53,6 +53,8 @@ namespace gdjs {
 
     readonly spineResourceName: string;
 
+    static isHitBoxesUpdateDisabled = false;
+
     /**
      * @param instanceContainer The container the object belongs to.
      * @param objectData The object data used to initialize the object
@@ -73,7 +75,10 @@ namespace gdjs {
       );
       this.setAnimationIndex(0);
       this._renderer.updateAnimation(0);
-      this.hitBoxes.length = 0;
+
+      if (SpineRuntimeObject.isHitBoxesUpdateDisabled) {
+          this.hitBoxes.length = 0;
+      }
 
       // *ALWAYS* call `this.onCreated()` at the very end of your object constructor.
       this.onCreated();
@@ -185,6 +190,11 @@ namespace gdjs {
     }
 
     updateHitBoxes(): void {
+        if (SpineRuntimeObject.isHitBoxesUpdateDisabled) {
+            return;
+        }
+
+        super.updateHitBoxes();
     }
 
     extraInitializationFromInitialInstance(


### PR DESCRIPTION
## Summary
This PR disables hitbox updates for `SpineRuntimeObject` by making `updateHitBoxes()` a no-op and leaving `hitBoxes` empty. Continuously invalidating and recomputing hitboxes provided no benefit and added per-frame overhead.

## Context & motivation
- Spine animations update every frame, which previously triggered `invalidateHitboxes()` often.
- Making `updateHitBoxes()` a no-op removes wasted work and reduces CPU usage in scenes with multiple Spine animations.

## What’s changed
- `Extensions/Spine/spineruntimeobject.ts`: `updateHitBoxes()` is now intentionally empty; `hitBoxes` remains empty for Spine objects. Other calls to `invalidateHitboxes()` remain but will not trigger any heavy recomputation for Spine.