### PR TITLE
Add body type selector actions for Physics2 and Physics3D behaviors

### DIFF
--- a/Extensions/Physics2Behavior/JsExtension.js
+++ b/Extensions/Physics2Behavior/JsExtension.js
@@ -795,6 +795,27 @@ module.exports = {
       .setFunctionName('setKinematic');
 
     aut
+      .addAction(
+        'SetBodyType',
+        _('Set body type'),
+        _('Set the body type of an object.'),
+        _('Set the body type of _PARAM0_ to _PARAM2_'),
+        _('Dynamics'),
+        'res/physics32.png',
+        'res/physics32.png'
+      )
+      .addParameter('object', _('Object'), '', false)
+      .addParameter('behavior', _('Behavior'), 'Physics2Behavior')
+      .addParameter(
+        'stringWithSelector',
+        _('Body type'),
+        '["Static", "Dynamic", "Kinematic"]',
+        false
+      )
+      .getCodeExtraInformation()
+      .setFunctionName('setBodyType');
+
+    aut
       .addCondition(
         'IsBullet',
         _('Is treated as a bullet'),

--- a/Extensions/Physics2Behavior/physics2runtimebehavior.ts
+++ b/Extensions/Physics2Behavior/physics2runtimebehavior.ts
@@ -1139,6 +1139,21 @@ namespace gdjs {
       return this.bodyType === 'Kinematic';
     }
 
+    setBodyType(bodyType: string): void {
+      switch (bodyType) {
+        case 'Static':
+          this.setStatic();
+          break;
+        case 'Kinematic':
+          this.setKinematic();
+          break;
+        case 'Dynamic':
+        default:
+          this.setDynamic();
+          break;
+      }
+    }
+
     setKinematic(): void {
       // Check if there is no modification
       if (this.bodyType === 'Kinematic') {

--- a/Extensions/Physics3DBehavior/JsExtension.js
+++ b/Extensions/Physics3DBehavior/JsExtension.js
@@ -822,6 +822,27 @@ module.exports = {
         .setFunctionName('isKinematic');
 
       aut
+        .addScopedAction(
+          'SetBodyType',
+          _('Set body type'),
+          _('Set the body type of an object.'),
+          _('Set the body type of _PARAM0_ to _PARAM2_'),
+          _('Dynamics'),
+          'JsPlatform/Extensions/physics3d.svg',
+          'JsPlatform/Extensions/physics3d.svg'
+        )
+        .addParameter('object', _('Object'), '', false)
+        .addParameter('behavior', _('Behavior'), 'Physics3DBehavior')
+        .addParameter(
+          'stringWithSelector',
+          _('Body type'),
+          '["Static", "Dynamic", "Kinematic"]',
+          false
+        )
+        .getCodeExtraInformation()
+        .setFunctionName('setBodyType');
+
+      aut
         .addScopedCondition(
           'IsBullet',
           _('Is treated as a bullet'),

--- a/Extensions/Physics3DBehavior/Physics3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/Physics3DRuntimeBehavior.ts
@@ -1153,6 +1153,52 @@ namespace gdjs {
       return this.bodyType === 'Kinematic';
     }
 
+    setBodyType(bodyType: string): void {
+      if (
+        bodyType !== 'Static' &&
+        bodyType !== 'Dynamic' &&
+        bodyType !== 'Kinematic'
+      ) {
+        return;
+      }
+
+      if (this.bodyType === bodyType) {
+        return;
+      }
+
+      this.bodyType = bodyType;
+
+      if (this._body === null) {
+        if (!this._createBody()) return;
+      }
+
+      if (this._body === null) {
+        return;
+      }
+      const body = this._body!;
+      const bodyInterface = this._sharedData.bodyInterface;
+      let motionType: Jolt.EMotionType;
+      switch (this.bodyType) {
+        case 'Static':
+          motionType = Jolt.EMotionType_Static;
+          break;
+        case 'Kinematic':
+          motionType = Jolt.EMotionType_Kinematic;
+          break;
+        case 'Dynamic':
+        default:
+          motionType = Jolt.EMotionType_Dynamic;
+          break;
+      }
+
+      bodyInterface.SetMotionType(
+        body.GetID(),
+        motionType,
+        Jolt.EActivation_Activate
+      );
+      bodyInterface.SetObjectLayer(body.GetID(), this.getBodyLayer());
+    }
+
     isBullet(): boolean {
       return this.bullet;
     }


### PR DESCRIPTION
## Summary
- add SetBodyType actions with string selector options to Physics2 and Physics3D extensions
- implement runtime behavior helpers to switch body types based on the selected value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd44ec367883279dfc153c8f8cd844