### PR TITLE
fix(instances-editor): persist selected layer across sessions

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesEditorSettings.js
+++ b/newIDE/app/src/InstancesEditor/InstancesEditorSettings.js
@@ -20,6 +20,9 @@ export type InstancesEditorSettings = {|
 
   /** Is the window mask shown? */
   windowMask: boolean,
+
+  /** The name of the layer selected to place instances on. */
+  selectedLayer: string,
 |};
 
 export const getRecommendedInitialZoomFactor = (
@@ -54,6 +57,7 @@ export const prepareInstancesEditorSettings = (
       0.01
     ),
     windowMask: object.windowMask || false,
+    selectedLayer: object.selectedLayer || '',
   };
 };
 

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -208,6 +208,8 @@ export default class SceneEditor extends React.Component<Props, State> {
     super(props);
 
     this.instancesSelection = new InstancesSelection();
+
+    const initialInstancesEditorSettings = props.getInitialInstancesEditorSettings();
     this.state = {
       setupGridOpen: false,
       scenePropertiesDialogOpen: false,
@@ -226,7 +228,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       extractAsExternalLayoutDialogOpen: false,
       extractAsCustomObjectDialogOpen: false,
 
-      instancesEditorSettings: props.getInitialInstancesEditorSettings(),
+      instancesEditorSettings: initialInstancesEditorSettings,
       history: getHistoryInitialState(props.initialInstances, {
         historyMaxSize: 50,
       }),
@@ -242,7 +244,7 @@ export default class SceneEditor extends React.Component<Props, State> {
       tileMapTileSelection: null,
 
       selectedObjectFolderOrObjectsWithContext: [],
-      selectedLayer: BASE_LAYER_NAME,
+      selectedLayer: initialInstancesEditorSettings.selectedLayer || BASE_LAYER_NAME,
       invisibleLayerOnWhichInstancesHaveJustBeenAdded: null,
 
       lastSelectionType: 'instance',
@@ -2044,7 +2046,13 @@ export default class SceneEditor extends React.Component<Props, State> {
                 onLayerRenamed={this._onLayerRenamed}
                 onRemoveLayer={this._onRemoveLayer}
                 onSelectLayer={(layer: string) =>
-                  this.setState({ selectedLayer: layer })
+                  this.setState({
+                    selectedLayer: layer,
+                    instancesEditorSettings: {
+                      ...this.state.instancesEditorSettings,
+                      selectedLayer: layer,
+                    },
+                  })
                 }
                 tileMapTileSelection={this.state.tileMapTileSelection}
                 onSelectTileMapTile={this.onSelectTileMapTile}


### PR DESCRIPTION

# 🎉 Hacktoberfest 2025 Contribution — Fix: Remember Last Selected Layer in Instances Editor

## 🧩 Summary
Fixes #7699  this PR fixes[#7699 ](https://github.com/4ian/GDevelop/issues/7699), where the **Instances Editor** layer selection would always reset to the **Base Layer** upon restarting GDevelop.  
With this update, the editor now remembers the **last selected layer** across sessions for a smoother workflow.

---

## 🛠️ Changes Made

### 1. `newIDE/app/src/InstancesEditor/InstancesEditorSettings.js`
- Added a new property `selectedLayer` to the `InstancesEditorSettings` type to store the user’s last selected layer.
- Updated the `prepareInstancesEditorSettings` function to load and persist the `selectedLayer` value from the project data.

### 2. `newIDE/app/src/SceneEditor/index.js`
- Updated the `SceneEditor` constructor to initialize state using the `selectedLayer` value from `InstancesEditorSettings`.
- Modified the `onSelectLayer` function to:
  - Update the selected layer in the component’s local state.
  - Persist this change to the `instancesEditorSettings` for session-to-session retention.

---

## ✅ Result
- The previously selected layer now **persists after restarting GDevelop**.  
- Prevents accidental sprite placement on locked Base Layers.  
- Enhances usability when working with multi-layered scenes.

---

## 🧪 Steps to Verify
1. Open a project containing multiple layers.  
2. Select any layer other than the Base Layer (e.g., `UI`).  
3. Save and close GDevelop.  
4. Reopen the project — the previously selected layer should remain active.

---

## 🏷️ Hacktoberfest
This PR is part of **Hacktoberfest 2025** 🎉  
If accepted, please add the **`hacktoberfest-accepted`** label when merging.  

Thank you for maintaining and supporting this awesome open-source project! 🙌
