### PR TITLE
Add theme toggle to homepage

### DIFF
--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageHeader.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/HomePageHeader.js
@@ -18,7 +18,10 @@ import SaveProjectIcon from '../../SaveProjectIcon';
 import Mobile from '../../../UI/CustomSvgIcons/Mobile';
 import Desktop from '../../../UI/CustomSvgIcons/Desktop';
 import HistoryIcon from '../../../UI/CustomSvgIcons/History';
+import SunIcon from '../../../UI/CustomSvgIcons/Sun';
+import Brightness3Icon from '@material-ui/icons/Brightness3';
 import AuthenticatedUserContext from '../../../Profile/AuthenticatedUserContext';
+import PreferencesContext from '../../Preferences/PreferencesContext';
 const electron = optionalRequire('electron');
 
 type Props = {|
@@ -40,6 +43,18 @@ export const HomePageHeader = ({
 }: Props) => {
   const { isMobile } = useResponsiveWindowSize();
   const { profile } = React.useContext(AuthenticatedUserContext);
+  const preferences = React.useContext(PreferencesContext);
+  const isDarkTheme = preferences.values.themeName.includes('Dark');
+
+  const toggleTheme = React.useCallback(
+    () => {
+      const newTheme = isDarkTheme
+        ? 'GDevelop default Light'
+        : 'GDevelop default Dark';
+      preferences.setThemeName(newTheme);
+    },
+    [isDarkTheme, preferences]
+  );
 
   return (
     <I18n>
@@ -96,6 +111,21 @@ export const HomePageHeader = ({
                 ))}
               <UserChip onOpenProfile={onOpenProfile} />
               {profile && <NotificationChip />}
+              <IconButton
+                size="small"
+                id="homepage-theme-toggle-button"
+                onClick={toggleTheme}
+                tooltip={
+                  isDarkTheme ? t`Switch to light mode` : t`Switch to dark mode`
+                }
+                color="default"
+              >
+                {isDarkTheme ? (
+                  <SunIcon style={{ fontSize: 20 }} />
+                ) : (
+                  <Brightness3Icon style={{ fontSize: 20 }} />
+                )}
+              </IconButton>
               {isMobile ? (
                 <IconButton size="small" onClick={onOpenLanguageDialog}>
                   <TranslateIcon fontSize="small" />


### PR DESCRIPTION
Adds a theme toggle button to the homepage header that allows users to easily switch between light and dark modes.

## Changes
- Added sun/moon icon button in the homepage header (next to language selector)
- Sun icon appears in dark mode (click to switch to light)
- Moon icon appears in light mode (click to switch to dark)
- Seamlessly integrates with existing theme system

## Preview

<img width="500" alt="Theme toggle button on homepage" src="https://github.com/user-attachments/assets/d13e4772-588b-4757-8968-1a8c996834de" />

*Theme toggle button location in the homepage header*

---

**Feature**: One-click theme switching on homepage  
**Files modified**: 1 (`HomePageHeader.js`)

---

## Note about previous PR

Apologies for my last PR I encountered an issue during development and realized my changes didn't work as intended. I didn't include screenshots of the functionality because I couldn't get it working properly. I attempted to fix it but decided it would take too much time to resolve correctly. This PR is a fresh, working implementation.