### PR TITLE
Sanitize the .fnt before loading in PixiJS

### DIFF
--- a/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-bitmapfont-manager.ts
@@ -280,7 +280,7 @@ namespace gdjs {
         );
         const fontDataRaw = await response.text();
 
-        // Sanitize : remove the lines staring with #
+        // Sanitize: remove lines starting with # (acting as comments)
         const sanitizedFontData = fontDataRaw
           .split('\n')
           .filter((line) => !line.trim().startsWith('#'))


### PR DESCRIPTION
This PR aim to sanitize the .fnt file, because a new header has been added in every .fnt generated with the common BitmapFont generator at http://snowb.org/

So this PR sanitize the raw text by removing the lines starting by # before to give the text to load in PixiJS.

Original report: https://forum.gdevelop.io/t/parse-fnt-files-text-to-ignore-and-empty-lines/72334
