### PR TITLE
Close previews and unregister in-game editor

### DIFF
--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserPreview/BrowserPreviewDebuggerServer.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserPreview/BrowserPreviewDebuggerServer.js
@@ -165,6 +165,39 @@ class BrowserPreviewDebuggerServer {
   registerEmbeddedGameFrame(window: WindowProxy) {
     embbededGameFrameWindow = window;
   }
+  closeAllPreviews() {
+    // Close all preview windows
+    for (const id in existingPreviewWindows) {
+      const previewWindow = existingPreviewWindows[id];
+      try {
+        if (previewWindow && !previewWindow.closed) {
+          previewWindow.close();
+        }
+      } catch (error) {
+        console.warn('Failed to close preview window:', error);
+      }
+    }
+
+    // Clear all preview windows and embedded game frame
+    Object.keys(existingPreviewWindows).forEach(id => {
+      delete existingPreviewWindows[id];
+    });
+    embbededGameFrameWindow = null;
+
+    // Stop the polling if no windows remain
+    if (windowClosedPollingIntervalId !== null) {
+      clearInterval(windowClosedPollingIntervalId);
+      windowClosedPollingIntervalId = null;
+    }
+
+    // Notify callbacks that all connections are closed
+    callbacksList.forEach(({ onConnectionClosed }) => {
+      onConnectionClosed({
+        id: 'all',
+        debuggerIds: getExistingDebuggerIds(),
+      });
+    });
+  }
 }
 export const browserPreviewDebuggerServer: PreviewDebuggerServer = new BrowserPreviewDebuggerServer();
 

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/LocalPreviewDebuggerServer.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/LocalPreviewDebuggerServer.js
@@ -195,6 +195,18 @@ class LocalPreviewDebuggerServer {
     // Nothing to do, the local preview debugger server communicates
     // with the embedded game frame through WebSocket, like other preview windows.
   }
+  closeAllPreviews() {
+    if (!ipcRenderer) return;
+
+    // Request the main process to close all preview windows
+    ipcRenderer.send('preview-close-all');
+
+    // Request the main process to close all debugger connections
+    ipcRenderer.send('debugger-close-all-connections');
+
+    // Clear the debugger IDs list
+    debuggerIds.length = 0;
+  }
 }
 
 export const localPreviewDebuggerServer: PreviewDebuggerServer = new LocalPreviewDebuggerServer();

--- a/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
+++ b/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
@@ -136,6 +136,7 @@ export interface PreviewDebuggerServer {
   sendMessageWithResponse(message: Object): Promise<Object>;
   registerCallbacks(callbacks: PreviewDebuggerServerCallbacks): () => void;
   registerEmbeddedGameFrame(window: WindowProxy): void;
+  closeAllPreviews(): void;
 }
 
 /** The logs returned by the game hot-reloader. */

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -864,6 +864,16 @@ const MainFrame = (props: Props) => {
       // - Add a dirty flag system to refresh on demand.
       setIsProjectClosedSoAvoidReloadingExtensions(true);
 
+      // Close all previews and unregister the embedded game frame
+      const previewLauncher = _previewLauncher.current;
+      if (previewLauncher && previewLauncher.getPreviewDebuggerServer) {
+        const debuggerServer = previewLauncher.getPreviewDebuggerServer();
+        if (debuggerServer && debuggerServer.closeAllPreviews) {
+          console.info('Closing all previews and unregistering embedded game frame...');
+          debuggerServer.closeAllPreviews();
+        }
+      }
+
       // While not strictly necessary, use `currentProjectRef` to be 100%
       // sure to have the latest project (avoid risking any stale variable to an old
       // `currentProject` from the state in case someone kept an old reference to `closeProject`

--- a/newIDE/electron-app/app/DebuggerServer.js
+++ b/newIDE/electron-app/app/DebuggerServer.js
@@ -24,6 +24,22 @@ const getServerAddress = wsServer => ({
  * Debugger logic is made inside Debugger (in newIDE) or gdjs.AbstractDebuggerClient
  * (in GDJS).
  */
+const closeAllConnections = () => {
+  // Close all active WebSocket connections
+  for (const id in webSockets) {
+    if (webSockets[id]) {
+      try {
+        log.info(`Closing debugger connection with id "${id}".`);
+        webSockets[id].close();
+      } catch (error) {
+        log.error(`Error closing debugger connection with id "${id}":`, error);
+      }
+      webSockets[id] = null;
+    }
+  }
+  webSockets = {};
+};
+
 module.exports = {
   startDebuggerServer: options => {
     if (wsServer) {
@@ -78,6 +94,7 @@ module.exports = {
     );
   },
   closeServer,
+  closeAllConnections,
   sendMessage: ({ id, message }, cb) => {
     if (!webSockets[id]) return cb(`Debugger connection with id "${id}" does not exist`);
 

--- a/newIDE/electron-app/app/PreviewWindow.js
+++ b/newIDE/electron-app/app/PreviewWindow.js
@@ -88,7 +88,23 @@ const closePreviewWindow = windowId => {
   if (previewWindow) previewWindow.close();
 };
 
+const closeAllPreviewWindows = () => {
+  // Close all preview windows
+  previewWindows.forEach(previewWindow => {
+    try {
+      if (previewWindow && !previewWindow.isDestroyed()) {
+        previewWindow.close();
+      }
+    } catch (error) {
+      console.error('Error closing preview window:', error);
+    }
+  });
+  // Clear the array
+  previewWindows = [];
+};
+
 module.exports = {
   openPreviewWindow,
   closePreviewWindow,
+  closeAllPreviewWindows,
 };

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -12,7 +12,7 @@ const autoUpdater = require('electron-updater').autoUpdater;
 const log = require('electron-log');
 const { uploadLocalFile } = require('./LocalFileUploader');
 const { serveFolder, stopServer } = require('./ServeFolder');
-const { startDebuggerServer, sendMessage } = require('./DebuggerServer');
+const { startDebuggerServer, sendMessage, closeAllConnections } = require('./DebuggerServer');
 const {
   buildElectronMenuFromDeclarativeTemplate,
   buildPlaceholderMainMenu,
@@ -26,7 +26,7 @@ const {
   downloadLocalFile,
   saveLocalFileFromArrayBuffer,
 } = require('./LocalFileDownloader');
-const { openPreviewWindow, closePreviewWindow } = require('./PreviewWindow');
+const { openPreviewWindow, closePreviewWindow, closeAllPreviewWindows } = require('./PreviewWindow');
 const {
   setupLocalGDJSDevelopmentWatcher,
   closeLocalGDJSDevelopmentWatcher,
@@ -188,6 +188,10 @@ app.on('ready', function() {
   });
   ipcMain.handle('preview-close', async (event, options) => {
     return closePreviewWindow(options.windowId);
+  });
+  ipcMain.on('preview-close-all', () => {
+    log.info('Closing all preview windows');
+    closeAllPreviewWindows();
   });
 
   // Piskel image editor
@@ -360,6 +364,10 @@ app.on('ready', function() {
     sendMessage(message, err =>
       event.sender.send('debugger-send-message-done', err)
     );
+  });
+  ipcMain.on('debugger-close-all-connections', () => {
+    log.info('Closing all debugger connections');
+    closeAllConnections();
   });
 
   ipcMain.on('updates-check-and-download', event => {


### PR DESCRIPTION
Close all previews and unregister the in-game-editor when a project is closed.

This fixes an issue where the in-game-editor or other previews could remain linked to a previously opened project, leading to incorrect hot reloads or the editor being stuck on the old game. This ensures a clean state and proper preview/editor behavior when switching projects.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8e28559-1f51-4143-8416-8de1647873d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8e28559-1f51-4143-8416-8de1647873d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

