### PR TITLE
Close previews and unregister in-game editor

### DIFF
--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserPreview/BrowserPreviewDebuggerServer.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserPreview/BrowserPreviewDebuggerServer.js
@@ -165,6 +165,43 @@ class BrowserPreviewDebuggerServer {
   registerEmbeddedGameFrame(window: WindowProxy) {
     embbededGameFrameWindow = window;
   }
+  unregisterEmbeddedGameFrame() {
+    embbededGameFrameWindow = null;
+  }
+  closeAllPreviews() {
+    // Close all preview windows
+    for (const id in existingPreviewWindows) {
+      const previewWindow = existingPreviewWindows[id];
+      try {
+        if (!previewWindow.closed) {
+          previewWindow.close();
+        }
+      } catch (error) {
+        // Ignore errors when closing windows
+        console.warn('Error closing preview window:', error);
+      }
+    }
+    // Clear all preview windows and embedded game frame
+    existingPreviewWindows = {};
+    embbededGameFrameWindow = null;
+    
+    // Notify callbacks about closed connections
+    const allDebuggerIds = getExistingDebuggerIds();
+    allDebuggerIds.forEach(id => {
+      callbacksList.forEach(({ onConnectionClosed }) =>
+        onConnectionClosed({
+          id,
+          debuggerIds: [],
+        })
+      );
+    });
+    
+    // Clear polling interval if it's running
+    if (windowClosedPollingIntervalId !== null) {
+      clearInterval(windowClosedPollingIntervalId);
+      windowClosedPollingIntervalId = null;
+    }
+  }
 }
 export const browserPreviewDebuggerServer: PreviewDebuggerServer = new BrowserPreviewDebuggerServer();
 

--- a/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
+++ b/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
@@ -136,6 +136,8 @@ export interface PreviewDebuggerServer {
   sendMessageWithResponse(message: Object): Promise<Object>;
   registerCallbacks(callbacks: PreviewDebuggerServerCallbacks): () => void;
   registerEmbeddedGameFrame(window: WindowProxy): void;
+  unregisterEmbeddedGameFrame(): void;
+  closeAllPreviews(): void;
 }
 
 /** The logs returned by the game hot-reloader. */

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -871,6 +871,17 @@ const MainFrame = (props: Props) => {
       const currentProject = currentProjectRef.current;
       if (!currentProject) return;
 
+      // Close all previews and clear debugger connections
+      console.info('Closing all previews and clearing debugger connections...');
+      const previewLauncher = _previewLauncher.current;
+      if (previewLauncher) {
+        const debuggerServer = previewLauncher.getPreviewDebuggerServer();
+        if (debuggerServer) {
+          debuggerServer.closeAllPreviews();
+          debuggerServer.unregisterEmbeddedGameFrame();
+        }
+      }
+
       // Close the editors related to this project.
       await setState(state => ({
         ...state,

--- a/newIDE/electron-app/app/DebuggerServer.js
+++ b/newIDE/electron-app/app/DebuggerServer.js
@@ -8,6 +8,26 @@ let webSockets = {};
 let nextDebuggerId = 0;
 
 const closeServer = () => {
+  // Close all websocket connections
+  for (const id in webSockets) {
+    if (webSockets[id]) {
+      try {
+        webSockets[id].close();
+      } catch (error) {
+        log.warn(`Error closing websocket connection ${id}:`, error);
+      }
+    }
+  }
+  
+  // Close the server
+  if (wsServer) {
+    try {
+      wsServer.close();
+    } catch (error) {
+      log.warn('Error closing websocket server:', error);
+    }
+  }
+  
   wsServer = null;
   webSockets = {};
 };

--- a/newIDE/electron-app/app/PreviewWindow.js
+++ b/newIDE/electron-app/app/PreviewWindow.js
@@ -88,7 +88,20 @@ const closePreviewWindow = windowId => {
   if (previewWindow) previewWindow.close();
 };
 
+const closeAllPreviewWindows = () => {
+  previewWindows.forEach(previewWindow => {
+    try {
+      previewWindow.close();
+    } catch (error) {
+      // Ignore errors when closing windows
+      console.warn('Error closing preview window:', error);
+    }
+  });
+  previewWindows = [];
+};
+
 module.exports = {
   openPreviewWindow,
   closePreviewWindow,
+  closeAllPreviewWindows,
 };

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -26,7 +26,7 @@ const {
   downloadLocalFile,
   saveLocalFileFromArrayBuffer,
 } = require('./LocalFileDownloader');
-const { openPreviewWindow, closePreviewWindow } = require('./PreviewWindow');
+const { openPreviewWindow, closePreviewWindow, closeAllPreviewWindows } = require('./PreviewWindow');
 const {
   setupLocalGDJSDevelopmentWatcher,
   closeLocalGDJSDevelopmentWatcher,
@@ -188,6 +188,9 @@ app.on('ready', function() {
   });
   ipcMain.handle('preview-close', async (event, options) => {
     return closePreviewWindow(options.windowId);
+  });
+  ipcMain.handle('preview-close-all', async (event) => {
+    return closeAllPreviewWindows();
   });
 
   // Piskel image editor


### PR DESCRIPTION
Close all previews and unregister the in-game-editor when a project is closed to prevent stale previews from affecting new projects.

Previously, when a project was closed and a new one opened, existing previews (including the in-game-editor) were not properly terminated or unregistered. This led to scenarios where the debugger server would still see active debugger IDs from the old project, causing hot reloads to be attempted on the wrong game or preventing new previews from launching correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-88663171-fdcd-4ca6-b608-016d3229a6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88663171-fdcd-4ca6-b608-016d3229a6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

