### PR TITLE
Close previews and unregister in-game editor

### DIFF
--- a/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
+++ b/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
@@ -435,6 +435,13 @@ export const EmbeddedGameFrame = ({
     const hasSomethingLoaded = !!previewIndexHtmlLocation;
     if (previewDebuggerServer && iframe && hasSomethingLoaded)
       previewDebuggerServer.registerEmbeddedGameFrame(iframe.contentWindow);
+    return () => {
+      if (previewDebuggerServer) {
+        // Ensure the embedded game frame is unregistered when the component unmounts
+        // or when the debugger server instance changes.
+        previewDebuggerServer.unregisterEmbeddedGameFrame();
+      }
+    };
   });
 
   const [isDraggedItem3D, setDraggedItem3D] = React.useState(false);

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/LocalPreviewDebuggerServer.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/LocalPreviewDebuggerServer.js
@@ -195,6 +195,27 @@ class LocalPreviewDebuggerServer {
     // Nothing to do, the local preview debugger server communicates
     // with the embedded game frame through WebSocket, like other preview windows.
   }
+  unregisterEmbeddedGameFrame() {
+    // Nothing to do: the embedded game frame uses WebSocket like other previews.
+  }
+  closeAndClearAllConnections() {
+    // Ask the main process to close all preview windows (best-effort)
+    // and clear local debugger ids.
+    if (ipcRenderer) {
+      try {
+        ipcRenderer.invoke('preview-close-all');
+      } catch (e) {}
+    }
+    // Clear debugger ids and notify callbacks of closures.
+    while (debuggerIds.length) {
+      const id = debuggerIds.pop();
+      if (id != null) {
+        callbacksList.forEach(({ onConnectionClosed }) =>
+          onConnectionClosed({ id, debuggerIds })
+        );
+      }
+    }
+  }
 }
 
 export const localPreviewDebuggerServer: PreviewDebuggerServer = new LocalPreviewDebuggerServer();

--- a/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
+++ b/newIDE/app/src/ExportAndShare/PreviewLauncher.flow.js
@@ -136,6 +136,16 @@ export interface PreviewDebuggerServer {
   sendMessageWithResponse(message: Object): Promise<Object>;
   registerCallbacks(callbacks: PreviewDebuggerServerCallbacks): () => void;
   registerEmbeddedGameFrame(window: WindowProxy): void;
+  /**
+   * Ensure any reference to the EmbeddedGameFrame is cleared.
+   * Implementations should also notify connection closed callbacks if needed.
+   */
+  unregisterEmbeddedGameFrame(): void;
+  /**
+   * Close all previews (windows/frames) and clear any existing debugger connections.
+   * Implementations should best-effort close windows/sockets and MUST clear debugger ids.
+   */
+  closeAndClearAllConnections(): void;
 }
 
 /** The logs returned by the game hot-reloader. */

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -871,6 +871,19 @@ const MainFrame = (props: Props) => {
       const currentProject = currentProjectRef.current;
       if (!currentProject) return;
 
+      // Ensure all previews are closed and debugger connections cleared.
+      try {
+        const previewLauncher = _previewLauncher.current;
+        if (previewLauncher && previewLauncher.getPreviewDebuggerServer) {
+          const previewDebuggerServer = previewLauncher.getPreviewDebuggerServer();
+          if (previewDebuggerServer && previewDebuggerServer.closeAndClearAllConnections) {
+            previewDebuggerServer.closeAndClearAllConnections();
+          }
+        }
+      } catch (e) {
+        console.warn('Error while closing previews on project close:', e);
+      }
+
       // Close the editors related to this project.
       await setState(state => ({
         ...state,

--- a/newIDE/electron-app/app/PreviewWindow.js
+++ b/newIDE/electron-app/app/PreviewWindow.js
@@ -88,7 +88,18 @@ const closePreviewWindow = windowId => {
   if (previewWindow) previewWindow.close();
 };
 
+const closeAllPreviewWindows = () => {
+  // Close all windows best-effort and clear the array.
+  previewWindows.forEach(window => {
+    try {
+      if (window && !window.isDestroyed()) window.close();
+    } catch (e) {}
+  });
+  previewWindows = [];
+};
+
 module.exports = {
   openPreviewWindow,
   closePreviewWindow,
+  closeAllPreviewWindows,
 };

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -12,7 +12,11 @@ const autoUpdater = require('electron-updater').autoUpdater;
 const log = require('electron-log');
 const { uploadLocalFile } = require('./LocalFileUploader');
 const { serveFolder, stopServer } = require('./ServeFolder');
-const { startDebuggerServer, sendMessage } = require('./DebuggerServer');
+const {
+  startDebuggerServer,
+  sendMessage,
+  closeAllConnections: closeAllDebuggerConnections,
+} = require('./DebuggerServer');
 const {
   buildElectronMenuFromDeclarativeTemplate,
   buildPlaceholderMainMenu,
@@ -26,7 +30,11 @@ const {
   downloadLocalFile,
   saveLocalFileFromArrayBuffer,
 } = require('./LocalFileDownloader');
-const { openPreviewWindow, closePreviewWindow } = require('./PreviewWindow');
+const {
+  openPreviewWindow,
+  closePreviewWindow,
+  closeAllPreviewWindows,
+} = require('./PreviewWindow');
 const {
   setupLocalGDJSDevelopmentWatcher,
   closeLocalGDJSDevelopmentWatcher,
@@ -188,6 +196,12 @@ app.on('ready', function() {
   });
   ipcMain.handle('preview-close', async (event, options) => {
     return closePreviewWindow(options.windowId);
+  });
+  ipcMain.handle('preview-close-all', async (event, options) => {
+    closeAllPreviewWindows();
+    try {
+      closeAllDebuggerConnections();
+    } catch (e) {}
   });
 
   // Piskel image editor


### PR DESCRIPTION
Close all previews and unregister the in-game editor when a project is closed to prevent stale debugger connections and incorrect hot reloads.

Previously, when closing a project and opening a new one, the `EmbeddedGameFrame` and other preview windows/connections were not always properly unregistered or closed. This caused the debugger server to retain references to the old project, leading to hot reloads being incorrectly applied to the wrong game or previews showing content from a previous project. This change ensures a clean state for each new project.

---
<a href="https://cursor.com/background-agent?bcId=bc-16795066-31c8-4e93-9a92-eaf3b92fb12e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16795066-31c8-4e93-9a92-eaf3b92fb12e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

