### PR TITLE
chore(flow): bump flow-bin to 0.170.0

### DIFF
--- a/newIDE/app/.flowconfig
+++ b/newIDE/app/.flowconfig
@@ -27,3 +27,4 @@
 [options]
 module.ignore_non_literal_requires=true
 sharedmemory.hash_table_pow=22
+types_first=false

--- a/newIDE/app/flow-typed/npm/libGD.js-for-tests-only.js
+++ b/newIDE/app/flow-typed/npm/libGD.js-for-tests-only.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare module 'libGD.js-for-tests-only' {
+  declare module.exports: any;
+}

--- a/newIDE/app/package-lock.json
+++ b/newIDE/app/package-lock.json
@@ -88,7 +88,7 @@
         "babel-loader": "8.1.0",
         "chokidar": "4.0.3",
         "concurrently": "9.2.1",
-        "flow-bin": "0.131.0",
+        "flow-bin": "0.170.0",
         "flow-coverage-report": "^0.4.0",
         "folder-hash": "^3.0.0",
         "iso-639-1": "^3.1.2",
@@ -16565,7 +16565,7 @@
       }
     },
     "node_modules/flow-bin": {
-      "version": "0.131.0",
+      "version": "0.170.0",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/newIDE/app/package.json
+++ b/newIDE/app/package.json
@@ -24,7 +24,7 @@
     "babel-loader": "8.1.0",
     "chokidar": "4.0.3",
     "concurrently": "9.2.1",
-    "flow-bin": "0.131.0",
+    "flow-bin": "0.170.0",
     "flow-coverage-report": "^0.4.0",
     "folder-hash": "^3.0.0",
     "iso-639-1": "^3.1.2",


### PR DESCRIPTION
## Summary
- upgrade the newIDE Flow tooling to flow-bin 0.170.0 and keep classic mode enabled
- add a Flow stub for libGD.js-for-tests-only so the type checker recognizes the test helper

## Testing
- npm run flow

------
https://chatgpt.com/codex/tasks/task_b_690789b50fa08327b0556fe96083fe3d