### PR TITLE
Display a placeholder when the spine resource is invalid

### DIFF
--- a/newIDE/app/src/ObjectsRendering/PixiResourcesLoader.js
+++ b/newIDE/app/src/ObjectsRendering/PixiResourcesLoader.js
@@ -754,17 +754,8 @@ export default class PixiResourcesLoader {
     const promise = spineDataPromises[spineName];
     if (promise) return promise;
 
-    if (!spineName) {
-      // Nothing is even tried to be loaded.
-      return {
-        skeleton: null,
-        loadingError: null,
-        loadingErrorReason: null,
-      };
-    }
-
     const resourceManager = project.getResourcesManager();
-    if (spineName.length === 0 || !resourceManager.hasResource(spineName)) {
+    if (!spineName || !resourceManager.hasResource(spineName)) {
       return {
         skeleton: null,
         loadingError: null,


### PR DESCRIPTION
It also avoids to systematically log an error for each instance.