### PR TITLE
Fix description sentence PhysicsCharacter3D behavior

### DIFF
--- a/Extensions/Physics3DBehavior/JsExtension.js
+++ b/Extensions/Physics3DBehavior/JsExtension.js
@@ -2569,7 +2569,7 @@ module.exports = {
           'CurrentFallSpeed',
           _('Current falling speed'),
           _(
-            'Compare the current falling speed of the object. Its value is always positive.'
+            'the current falling speed of the object. Its value is always positive.'
           ),
           _('the current falling speed'),
           _('Character state'),
@@ -2593,7 +2593,7 @@ module.exports = {
           'CurrentJumpSpeed',
           _('Current jump speed'),
           _(
-            'Compare the current jump speed of the object. Its value is always positive.'
+            'the current jump speed of the object. Its value is always positive.'
           ),
           _('the current jump speed'),
           _('Character state'),


### PR DESCRIPTION
Remove the **Compare** extra word in these sentences:

<img width="1233" height="526" alt="image" src="https://github.com/user-attachments/assets/4640bba9-fe1a-4d0e-83e6-0c6430a5e42f" />

<img width="555" height="94" alt="image" src="https://github.com/user-attachments/assets/9a922d5a-d8d7-4421-992f-e85396ccd0ad" />


