### PR TITLE
Fix layers hot-reload in the 3D editor

### DIFF
--- a/GDJS/Runtime/InGameEditor/InGameEditor.tsx
+++ b/GDJS/Runtime/InGameEditor/InGameEditor.tsx
@@ -790,6 +790,7 @@ namespace gdjs {
     private _editedInstanceContainer: gdjs.RuntimeInstanceContainer | null =
       null;
     private _editedInstanceDataList: InstanceData[] = [];
+    private _editedLayerDataList: LayerData[] = [];
     private _selectedLayerName: string = '';
     private _innerArea: AABB3D | null = null;
     private _threeInnerArea: THREE.Object3D | null = null;
@@ -1019,6 +1020,10 @@ namespace gdjs {
       return this._editedInstanceDataList;
     }
 
+    getEditedLayerDataList(): LayerData[] {
+      return this._editedLayerDataList;
+    }
+
     getEditedInstanceContainer(): gdjs.RuntimeInstanceContainer | null {
       return this._editedInstanceContainer;
     }
@@ -1085,6 +1090,7 @@ namespace gdjs {
         .map((object) => object.persistentUuid)
         .filter(Boolean) as Array<string>;
 
+      let editedLayerDataList: Array<LayerData> = [];
       let editedInstanceDataList: Array<InstanceData> = [];
       if (eventsBasedObjectType) {
         const eventsBasedObjectVariantData =
@@ -1093,6 +1099,7 @@ namespace gdjs {
             eventsBasedObjectVariantName || ''
           );
         if (eventsBasedObjectVariantData) {
+          editedLayerDataList = eventsBasedObjectVariantData.layers;
           editedInstanceDataList = eventsBasedObjectVariantData.instances;
           await this._runtimeGame._resourcesLoader.loadResources(
             eventsBasedObjectVariantData.usedResources.map(
@@ -1154,6 +1161,9 @@ namespace gdjs {
         }
         this._currentScene = newScene;
         this._editedInstanceContainer = newScene;
+        if (sceneAndExtensionsData) {
+          editedLayerDataList = sceneAndExtensionsData.sceneData.layers;
+        }
         if (externalLayoutName) {
           const externalLayoutData =
             this._runtimeGame.getExternalLayoutData(externalLayoutName);
@@ -1171,6 +1181,7 @@ namespace gdjs {
         console.warn('eventsBasedObjectType or sceneName must be set.');
       }
       this._editedInstanceDataList = editedInstanceDataList;
+      this._editedLayerDataList = editedLayerDataList;
       this._editorId = editorId || '';
       if (editorCamera3D) {
         this.restoreCameraState(editorCamera3D);

--- a/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
+++ b/GDJS/Runtime/debugger-client/abstract-debugger-client.ts
@@ -304,6 +304,7 @@ namespace gdjs {
           if (inGameEditor) {
             const editedInstanceContainer =
               inGameEditor.getEditedInstanceContainer();
+            const editedLayerDataList = inGameEditor.getEditedLayerDataList();
             if (editedInstanceContainer) {
               inGameEditor.onLayersDataChange(
                 data.payload.layers,
@@ -311,6 +312,7 @@ namespace gdjs {
               );
               that._hotReloader.hotReloadRuntimeSceneLayers(
                 data.payload.layers,
+                editedLayerDataList,
                 editedInstanceContainer
               );
               // Apply `areEffectsHidden` to all the layers of the project data.

--- a/GDJS/Runtime/debugger-client/hot-reloader.ts
+++ b/GDJS/Runtime/debugger-client/hot-reloader.ts
@@ -1323,27 +1323,16 @@ namespace gdjs {
 
     hotReloadRuntimeSceneLayers(
       newLayers: LayerData[],
+      oldLayers: LayerData[],
       runtimeInstanceContainer: gdjs.RuntimeInstanceContainer
     ): void {
-      const layerNames = [];
-      runtimeInstanceContainer.getAllLayerNames(layerNames);
-      const oldLayers = layerNames.map((layerName) =>
-        runtimeInstanceContainer.hasLayer(layerName)
-          ? runtimeInstanceContainer.getLayer(layerName)._initialLayerData
-          : null
-      );
       this._hotReloadRuntimeSceneLayers(
         oldLayers.filter(Boolean) as LayerData[],
         newLayers,
         runtimeInstanceContainer
       );
       // Update the GameData
-      for (let index = 0; index < newLayers.length; index++) {
-        const oldLayer = oldLayers[index];
-        if (oldLayer) {
-          HotReloader.assignOrDelete(oldLayer, newLayers[index]);
-        }
-      }
+      gdjs.copyArray(newLayers, oldLayers);
     }
 
     _hotReloadRuntimeSceneLayers(


### PR DESCRIPTION
### Context
- `_hotReloadRuntimeLayer` already re-asigns `gdjs.RuntimeLayer._initialLayerData`.
- Instances from `initialLayerData` are no longer matching the one in `ProjectData` after calling `_hotReloadRuntimeSceneLayers` which is fine for a full hot-reload since the new `ProjectData` replace the old one.

### Actual
- Copying the `LayerData` instance content was useless.

### Expected
- The new `LayerData` instances must be copied back in the `ProjectData` array.