### PR TITLE
Add point attachment rotation and scale expression for spine

### DIFF
--- a/Extensions/Spine/JsExtension.js
+++ b/Extensions/Spine/JsExtension.js
@@ -109,56 +109,106 @@ module.exports = {
     object
       .addExpressionAndCondition(
         'number',
-        'PointAttachmentScaleX',
-        _('Point attachment scale X position'),
-        _('x position of spine point attachment scale'),
-        _('x position of spine _PARAM1_ point attachment for _PARAM2_ slot'),
+        'PointAttachmentScaleXWorld',
+        _('Point attachment scale world X position'),
+        _('world x position of spine point attachment scale'),
+        _('world x position of spine _PARAM1_ point attachment for _PARAM2_ slot'),
         _('Animations and images'),
         'JsPlatform/Extensions/spine.svg'
       )
       .addParameter('object', _('Spine'), 'SpineObject')
       .addParameter('string', _('Attachment name'))
       .addParameter('string', _('Slot name (use "" if names are the same)'))
-      .addParameter('expression', _('World scaleX? (0=no, 1=yes)'), '', true)
-      .setDefaultValue('0')
       .useStandardParameters('number', gd.ParameterOptions.makeNewOptions())
-      .setFunctionName('getPointAttachmentScaleX');
+      .setFunctionName('getPointAttachmentScaleXWorld');
 
     object
       .addExpressionAndCondition(
         'number',
-        'PointAttachmentScaleY',
-        _('Point attachment scale Y position'),
-        _('y position of spine point attachment scale'),
-        _('y position of spine _PARAM1_ point attachment for _PARAM2_ slot'),
+        'PointAttachmentScaleXLocal',
+        _('Point attachment scale local X position'),
+        _('local x position of spine point attachment scale'),
+        _('local x position of spine _PARAM1_ point attachment for _PARAM2_ slot'),
         _('Animations and images'),
         'JsPlatform/Extensions/spine.svg'
       )
       .addParameter('object', _('Spine'), 'SpineObject')
       .addParameter('string', _('Attachment name'))
       .addParameter('string', _('Slot name (use "" if names are the same)'))
-      .addParameter('expression', _('World scaleY? (0=no, 1=yes)'), '', true)
-      .setDefaultValue('0')
       .useStandardParameters('number', gd.ParameterOptions.makeNewOptions())
-      .setFunctionName('getPointAttachmentScaleY');
+      .setFunctionName('getPointAttachmentScaleXLocal');
 
     object
       .addExpressionAndCondition(
         'number',
-        'PointAttachmentRotation',
-        _('Point attachment rotation'),
-        _('rotation of spine point attachment'),
-        _('rotation of spine _PARAM1_ point attachment for _PARAM2_ slot'),
+        'PointAttachmentScaleYWorld',
+        _('Point attachment scale world Y position'),
+        _('world y position of spine point attachment scale'),
+        _(
+          'world y position of spine _PARAM1_ point attachment for _PARAM2_ slot'
+        ),
         _('Animations and images'),
         'JsPlatform/Extensions/spine.svg'
       )
       .addParameter('object', _('Spine'), 'SpineObject')
       .addParameter('string', _('Attachment name'))
       .addParameter('string', _('Slot name (use "" if names are the same)'))
-      .addParameter('expression', _('World rotation? (0=no, 1=yes)'), '', true)
-      .setDefaultValue('0')
       .useStandardParameters('number', gd.ParameterOptions.makeNewOptions())
-      .setFunctionName('getPointAttachmentRotation');
+      .setFunctionName('getPointAttachmentScaleYWorld');
+
+    object
+      .addExpressionAndCondition(
+        'number',
+        'PointAttachmentScaleYLocal',
+        _('Point attachment scale local Y position'),
+        _('local y position of spine point attachment scale'),
+        _(
+          'local y position of spine _PARAM1_ point attachment for _PARAM2_ slot'
+        ),
+        _('Animations and images'),
+        'JsPlatform/Extensions/spine.svg'
+      )
+      .addParameter('object', _('Spine'), 'SpineObject')
+      .addParameter('string', _('Attachment name'))
+      .addParameter('string', _('Slot name (use "" if names are the same)'))
+      .useStandardParameters('number', gd.ParameterOptions.makeNewOptions())
+      .setFunctionName('getPointAttachmentScaleYLocal');
+
+    object
+      .addExpressionAndCondition(
+        'number',
+        'PointAttachmentRotationWorld',
+        _('Point attachment world rotation'),
+        _('world rotation of spine point attachment'),
+        _(
+          'world rotation of spine _PARAM1_ point attachment for _PARAM2_ slot'
+        ),
+        _('Animations and images'),
+        'JsPlatform/Extensions/spine.svg'
+      )
+      .addParameter('object', _('Spine'), 'SpineObject')
+      .addParameter('string', _('Attachment name'))
+      .addParameter('string', _('Slot name (use "" if names are the same)'))
+      .useStandardParameters('number', gd.ParameterOptions.makeNewOptions())
+      .setFunctionName('getPointAttachmentRotationWorld');
+
+    object
+      .addExpressionAndCondition(
+        'number',
+        'PointAttachmentRotationLocal',
+        _('Point attachment local rotation'),
+        _('local rotation of spine point attachment'),
+        _(
+          'local rotation of spine _PARAM1_ point attachment for _PARAM2_ slot'
+        ),
+        _('Animations and images'),
+        'JsPlatform/Extensions/spine.svg'
+      )
+      .addParameter('object', _('Spine'), 'SpineObject')
+      .addParameter('string', _('Attachment name'))
+      .addParameter('string', _('Slot name (use "" if names are the same)'))
+      .useStandardParameters('number', gd.ParameterOptions.makeNewOptions())
+      .setFunctionName('getPointAttachmentRotationLocal');
 
     return extension;
   },

--- a/Extensions/Spine/spineruntimeobject-pixi-renderer.ts
+++ b/Extensions/Spine/spineruntimeobject-pixi-renderer.ts
@@ -246,7 +246,7 @@ namespace gdjs {
     getPointAttachmentRotation(
       attachmentName: string,
       slotName?: string,
-      isWorld?: number
+      isWorld?: boolean
     ): number {
       if (!slotName) {
         slotName = attachmentName;
@@ -277,7 +277,7 @@ namespace gdjs {
     getPointAttachmentScale(
       attachmentName: string,
       slotName?: string,
-      isWorld?: number
+      isWorld?: boolean
     ): pixi_spine.Vector2 {
       if (!slotName) {
         slotName = attachmentName;
@@ -342,7 +342,6 @@ namespace gdjs {
       slotName: string,
       renderObject: pixi_spine.Spine
     ): { slot: pixi_spine.ISlot; attachment: IPointAttachment } {
-
       const slot = renderObject.skeleton.findSlot(slotName);
       if (!slot) {
         throw new Error(

--- a/Extensions/Spine/spineruntimeobject.ts
+++ b/Extensions/Spine/spineruntimeobject.ts
@@ -534,35 +534,69 @@ namespace gdjs {
         .y;
     }
 
-    getPointAttachmentScaleX(
+    getPointAttachmentScaleXWorld(
       attachmentName: string,
-      slotName?: string,
-      isWorld?: number
-    ): number {
-      return this._renderer.getPointAttachmentScale(attachmentName, slotName, isWorld).x;
-    }
-
-    getPointAttachmentScaleY(
-      attachmentName: string,
-      slotName?: string,
-      isWorld?: number
+      slotName?: string
     ): number {
       return this._renderer.getPointAttachmentScale(
         attachmentName,
         slotName,
-        isWorld
+        true
+      ).x;
+    }
+
+    getPointAttachmentScaleXLocal(
+      attachmentName: string,
+      slotName?: string
+    ): number {
+      return this._renderer.getPointAttachmentScale(
+        attachmentName,
+        slotName,
+        false
+      ).x;
+    }
+
+    getPointAttachmentScaleYWorld(
+      attachmentName: string,
+      slotName?: string
+    ): number {
+      return this._renderer.getPointAttachmentScale(
+        attachmentName,
+        slotName,
+        true
       ).y;
     }
 
-    getPointAttachmentRotation(
+    getPointAttachmentScaleYLocal(
       attachmentName: string,
-      slotName?: string,
-      isWorld?: number
+      slotName?: string
+    ): number {
+      return this._renderer.getPointAttachmentScale(
+        attachmentName,
+        slotName,
+        false
+      ).y;
+    }
+
+    getPointAttachmentRotationWorld(
+      attachmentName: string,
+      slotName?: string
     ): number {
       return this._renderer.getPointAttachmentRotation(
         attachmentName,
         slotName,
-        isWorld
+        true
+      );
+    }
+
+    getPointAttachmentRotationLocal(
+      attachmentName: string,
+      slotName?: string
+    ): number {
+      return this._renderer.getPointAttachmentRotation(
+        attachmentName,
+        slotName,
+        false
       );
     }
 


### PR DESCRIPTION
Hi. For Spine objects, we already have the **PointAttachment (X, Y)** expression, which allows tracking the position of a specific part of a Spine animation.

This PR adds several new expressions in a similar way:

* **PointAttachmentScaleX** and **PointAttachmentScaleY** — allow tracking the scale value of a selected part of a Spine object.
  The expression takes three arguments: **attachment name**, **slot name**, and **isWorld scale value**.
  `0` (default) returns the local scale, `1` returns the world scale.

* **PointAttachmentRotation** — allows tracking the rotation value of a selected part of a Spine object.
  The expression takes three arguments: **attachment name**, **slot name**, and **isWorld rotation value**.
  `0` (default) returns the local rotation, `1` returns the world rotation.

With this, we can track both **scale** and **rotation**, which gives us the ability to attach other game objects to specific parts of a Spine object.
