### PR TITLE
Refactor property choices to use internal identifiers

### DIFF
--- a/Extensions/AnchorBehavior/AnchorBehavior.cpp
+++ b/Extensions/AnchorBehavior/AnchorBehavior.cpp
@@ -26,30 +26,30 @@ void AnchorBehavior::InitializeContent(gd::SerializerElement& content) {
 }
 
 namespace {
-gd::String GetAnchorAsString(AnchorBehavior::HorizontalAnchor anchor) {
+gd::String GetHorizontalAnchorAsString(AnchorBehavior::HorizontalAnchor anchor) {
   if (anchor == AnchorBehavior::ANCHOR_HORIZONTAL_WINDOW_LEFT)
-    return _("Window left");
+    return "WindowLeft";
   else if (anchor == AnchorBehavior::ANCHOR_HORIZONTAL_WINDOW_RIGHT)
-    return _("Window right");
+    return "WindowRight";
   else if (anchor == AnchorBehavior::ANCHOR_HORIZONTAL_PROPORTIONAL)
-    return _("Proportional");
+    return "Proportional";
   else if (anchor == AnchorBehavior::ANCHOR_HORIZONTAL_WINDOW_CENTER)
-    return _("Window center");
+    return "WindowCenter";
   else
-    return _("No anchor");
+    return "None";
 }
 
-gd::String GetAnchorAsString(AnchorBehavior::VerticalAnchor anchor) {
+gd::String GetVerticalAnchorAsString(AnchorBehavior::VerticalAnchor anchor) {
   if (anchor == AnchorBehavior::ANCHOR_VERTICAL_WINDOW_TOP)
-    return _("Window top");
+    return "WindowTop";
   else if (anchor == AnchorBehavior::ANCHOR_VERTICAL_WINDOW_BOTTOM)
-    return _("Window bottom");
+    return "WindowBottom";
   else if (anchor == AnchorBehavior::ANCHOR_VERTICAL_PROPORTIONAL)
-    return _("Proportional");
+    return "Proportional";
   else if (anchor == AnchorBehavior::ANCHOR_VERTICAL_WINDOW_CENTER)
-    return _("Window center");
+    return "WindowCenter";
   else
-    return _("No anchor");
+    return "None";
 }
 }  // namespace
 
@@ -67,50 +67,50 @@ std::map<gd::String, gd::PropertyDescriptor> AnchorBehavior::GetProperties(
                         "window size when the object is created."));
 
   properties["leftEdgeAnchor"]
-      .SetValue(GetAnchorAsString(static_cast<HorizontalAnchor>(
+      .SetValue(GetHorizontalAnchorAsString(static_cast<HorizontalAnchor>(
           behaviorContent.GetIntAttribute("leftEdgeAnchor"))))
       .SetType("Choice")
-      .AddExtraInfo(_("No anchor"))
-      .AddExtraInfo(_("Window left"))
-      .AddExtraInfo(_("Window center"))
-      .AddExtraInfo(_("Window right"))
-      .AddExtraInfo(_("Proportional"))
+      .AddChoice("None", _("No anchor"))
+      .AddChoice("WindowLeft", _("Window left"))
+      .AddChoice("WindowCenter", _("Window center"))
+      .AddChoice("WindowRight", _("Window right"))
+      .AddChoice("Proportional", _("Proportional"))
       .SetLabel(_("Left edge"))
       .SetDescription(_("Anchor the left edge of the object on X axis."));
 
   properties["rightEdgeAnchor"]
-      .SetValue(GetAnchorAsString(static_cast<HorizontalAnchor>(
+      .SetValue(GetHorizontalAnchorAsString(static_cast<HorizontalAnchor>(
           behaviorContent.GetIntAttribute("rightEdgeAnchor"))))
       .SetType("Choice")
-      .AddExtraInfo(_("No anchor"))
-      .AddExtraInfo(_("Window left"))
-      .AddExtraInfo(_("Window center"))
-      .AddExtraInfo(_("Window right"))
-      .AddExtraInfo(_("Proportional"))
+      .AddChoice("None", _("No anchor"))
+      .AddChoice("WindowLeft", _("Window left"))
+      .AddChoice("WindowCenter", _("Window center"))
+      .AddChoice("WindowRight", _("Window right"))
+      .AddChoice("Proportional", _("Proportional"))
       .SetLabel(_("Right edge"))
       .SetDescription(_("Anchor the right edge of the object on X axis."));
 
   properties["topEdgeAnchor"]
-      .SetValue(GetAnchorAsString(static_cast<VerticalAnchor>(
+      .SetValue(GetVerticalAnchorAsString(static_cast<VerticalAnchor>(
           behaviorContent.GetIntAttribute("topEdgeAnchor"))))
       .SetType("Choice")
-      .AddExtraInfo(_("No anchor"))
-      .AddExtraInfo(_("Window top"))
-      .AddExtraInfo(_("Window center"))
-      .AddExtraInfo(_("Window bottom"))
-      .AddExtraInfo(_("Proportional"))
+      .AddChoice("None", _("No anchor"))
+      .AddChoice("WindowTop", _("Window top"))
+      .AddChoice("WindowCenter", _("Window center"))
+      .AddChoice("WindowBottom", _("Window bottom"))
+      .AddChoice("Proportional", _("Proportional"))
       .SetLabel(_("Top edge"))
       .SetDescription(_("Anchor the top edge of the object on Y axis."));
 
   properties["bottomEdgeAnchor"]
-      .SetValue(GetAnchorAsString(static_cast<VerticalAnchor>(
+      .SetValue(GetVerticalAnchorAsString(static_cast<VerticalAnchor>(
           behaviorContent.GetIntAttribute("bottomEdgeAnchor"))))
       .SetType("Choice")
-      .AddExtraInfo(_("No anchor"))
-      .AddExtraInfo(_("Window top"))
-      .AddExtraInfo(_("Window center"))
-      .AddExtraInfo(_("Window bottom"))
-      .AddExtraInfo(_("Proportional"))
+      .AddChoice("None", _("No anchor"))
+      .AddChoice("WindowTop", _("Window top"))
+      .AddChoice("WindowCenter", _("Window center"))
+      .AddChoice("WindowBottom", _("Window bottom"))
+      .AddChoice("Proportional", _("Proportional"))
       .SetLabel(_("Bottom edge"))
       .SetDescription(_("Anchor the bottom edge of the object on Y axis."));
 
@@ -132,13 +132,14 @@ std::map<gd::String, gd::PropertyDescriptor> AnchorBehavior::GetProperties(
 namespace {
 AnchorBehavior::HorizontalAnchor GetHorizontalAnchorFromString(
     const gd::String& value) {
-  if (value == _("Window left"))
+  auto normalizedValue = value.LowerCase();
+  if (normalizedValue == "windowleft")
     return AnchorBehavior::ANCHOR_HORIZONTAL_WINDOW_LEFT;
-  else if (value == _("Window right"))
+  else if (normalizedValue == "windowright")
     return AnchorBehavior::ANCHOR_HORIZONTAL_WINDOW_RIGHT;
-  else if (value == _("Proportional"))
+  else if (normalizedValue == "proportional")
     return AnchorBehavior::ANCHOR_HORIZONTAL_PROPORTIONAL;
-  else if (value == _("Window center"))
+  else if (normalizedValue == "windowcenter")
     return AnchorBehavior::ANCHOR_HORIZONTAL_WINDOW_CENTER;
   else
     return AnchorBehavior::ANCHOR_HORIZONTAL_NONE;
@@ -146,13 +147,14 @@ AnchorBehavior::HorizontalAnchor GetHorizontalAnchorFromString(
 
 AnchorBehavior::VerticalAnchor GetVerticalAnchorFromString(
     const gd::String& value) {
-  if (value == _("Window top"))
+  auto normalizedValue = value.LowerCase();
+  if (normalizedValue == "windowtop")
     return AnchorBehavior::ANCHOR_VERTICAL_WINDOW_TOP;
-  else if (value == _("Window bottom"))
+  else if (normalizedValue == "windowbottom")
     return AnchorBehavior::ANCHOR_VERTICAL_WINDOW_BOTTOM;
-  else if (value == _("Proportional"))
+  else if (normalizedValue == "proportional")
     return AnchorBehavior::ANCHOR_VERTICAL_PROPORTIONAL;
-  else if (value == _("Window center"))
+  else if (normalizedValue == "windowcenter")
     return AnchorBehavior::ANCHOR_VERTICAL_WINDOW_CENTER;
   else
     return AnchorBehavior::ANCHOR_VERTICAL_NONE;

--- a/Extensions/PlatformBehavior/PlatformBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformBehavior.cpp
@@ -30,19 +30,14 @@ std::map<gd::String, gd::PropertyDescriptor> PlatformBehavior::GetProperties(
   std::map<gd::String, gd::PropertyDescriptor> properties;
 
   gd::String platformType = behaviorContent.GetStringAttribute("platformType");
-  gd::String platformTypeStr = _("Platform");
-  if (platformType == "Ladder")
-    platformTypeStr = _("Ladder");
-  else if (platformType == "Jumpthru")
-    platformTypeStr = _("Jumpthru platform");
 
   properties["PlatformType"]
       .SetLabel(_("Type"))
-      .SetValue(platformTypeStr)
+      .SetValue(platformType.empty() ? "NormalPlatform" : platformType)
       .SetType("Choice")
-      .AddExtraInfo(_("Platform"))
-      .AddExtraInfo(_("Jumpthru platform"))
-      .AddExtraInfo(_("Ladder"));
+      .AddChoice("NormalPlatform", _("Platform"))
+      .AddChoice("Jumpthru", _("Jumpthru platform"))
+      .AddChoice("Ladder", _("Ladder"));
   properties["CanBeGrabbed"]
       .SetLabel(_("Ledges can be grabbed"))
       .SetGroup(_("Ledge"))
@@ -65,9 +60,10 @@ bool PlatformBehavior::UpdateProperty(gd::SerializerElement& behaviorContent,
   if (name == "CanBeGrabbed")
     behaviorContent.SetAttribute("canBeGrabbed", (value == "1"));
   else if (name == "PlatformType") {
-    if (value == _("Jumpthru platform"))
+    auto normalizedValue = value.LowerCase();
+    if (normalizedValue == "jumpthru")
       behaviorContent.SetAttribute("platformType", "Jumpthru");
-    else if (value == _("Ladder"))
+    else if (normalizedValue == "ladder")
       behaviorContent.SetAttribute("platformType", "Ladder");
     else
       behaviorContent.SetAttribute("platformType", "NormalPlatform");

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -107,25 +107,16 @@ TopDownMovementBehavior::GetProperties(
       .SetType("Boolean");
 
   gd::String viewpoint = behaviorContent.GetStringAttribute("viewpoint");
-  gd::String viewpointStr = _("Top-Down");
-  if (viewpoint == "TopDown")
-    viewpointStr = _("Top-Down");
-  else if (viewpoint == "PixelIsometry")
-    viewpointStr = _("Isometry 2:1 (26.565°)");
-  else if (viewpoint == "TrueIsometry")
-    viewpointStr = _("True Isometry (30°)");
-  else if (viewpoint == "CustomIsometry")
-    viewpointStr = _("Custom Isometry");
   properties["Viewpoint"]
       .SetLabel(_("Viewpoint"))
       .SetGroup(_("Viewpoint"))
       .SetAdvanced()
-      .SetValue(viewpointStr)
+      .SetValue(viewpoint.empty() ? "TopDown" : viewpoint)
       .SetType("Choice")
-      .AddExtraInfo(_("Top-Down"))
-      .AddExtraInfo(_("Isometry 2:1 (26.565°)"))
-      .AddExtraInfo(_("True Isometry (30°)"))
-      .AddExtraInfo(_("Custom Isometry"));
+      .AddChoice("TopDown", _("Top-Down"))
+      .AddChoice("PixelIsometry", _("Isometry 2:1 (26.565°)"))
+      .AddChoice("TrueIsometry", _("True Isometry (30°)"))
+      .AddChoice("CustomIsometry", _("Custom Isometry"));
   properties["CustomIsometryAngle"]
       .SetLabel(_("Custom isometry angle (between 1deg and 44deg)"))
       .SetGroup(_("Viewpoint"))
@@ -171,26 +162,27 @@ bool TopDownMovementBehavior::UpdateProperty(
     behaviorContent.SetAttribute("useLegacyTurnBack", (value == "1"));
   }
   if (name == "Viewpoint") {
+    auto normalizedValue = value.LowerCase();
     // Fix the offset angle when switching between top-down and isometry
     const gd::String& oldValue =
         behaviorContent.GetStringAttribute("viewpoint", "TopDown", "");
-    if (value == _("Top-Down") && oldValue != "TopDown") {
+    if (normalizedValue == "topdown" && oldValue != "TopDown") {
       behaviorContent.SetAttribute(
           "movementAngleOffset",
           behaviorContent.GetDoubleAttribute("movementAngleOffset", 0, "") +
               45);
-    } else if (value != _("Top-Down") && oldValue == "TopDown") {
+    } else if (normalizedValue != "topdown" && oldValue == "TopDown") {
       behaviorContent.SetAttribute(
           "movementAngleOffset",
           behaviorContent.GetDoubleAttribute("movementAngleOffset", 45, "") -
               45);
     }
 
-    if (value == _("Isometry 2:1 (26.565°)"))
+    if (normalizedValue == "pixelisometry")
       behaviorContent.SetAttribute("viewpoint", "PixelIsometry");
-    else if (value == _("True Isometry (30°)"))
+    else if (normalizedValue == "trueisometry")
       behaviorContent.SetAttribute("viewpoint", "TrueIsometry");
-    else if (value == _("Custom Isometry"))
+    else if (normalizedValue == "customisometry")
       behaviorContent.SetAttribute("viewpoint", "CustomIsometry");
     else
       behaviorContent.SetAttribute("viewpoint", "TopDown");


### PR DESCRIPTION
## Summary
This PR refactors how property choices are handled in behavior extensions by separating internal identifiers from user-facing display names. Instead of using localized strings for both storage and display, the code now uses consistent internal identifiers (e.g., "WindowLeft", "Jumpthru") while keeping localized strings only for UI labels.

## Key Changes

- **AnchorBehavior**: 
  - Split `GetAnchorAsString()` into `GetHorizontalAnchorAsString()` and `GetVerticalAnchorAsString()`
  - Changed return values from localized strings to internal identifiers ("WindowLeft", "WindowRight", "WindowCenter", "Proportional", "None")
  - Updated `AddExtraInfo()` calls to `AddChoice()` with internal identifier as first parameter
  - Modified parsing functions to normalize input values to lowercase before comparison

- **PlatformBehavior**:
  - Replaced localized string mapping logic with direct use of internal identifiers
  - Changed choice options to use "NormalPlatform", "Jumpthru", "Ladder" as identifiers
  - Updated `UpdateProperty()` to normalize and compare against lowercase identifiers

- **TopDownMovementBehavior**:
  - Removed intermediate string mapping for viewpoint types
  - Changed to use internal identifiers: "TopDown", "PixelIsometry", "TrueIsometry", "CustomIsometry"
  - Updated `AddExtraInfo()` calls to `AddChoice()` pattern
  - Modified property update logic to use normalized lowercase comparisons

## Implementation Details

- All parsing functions now normalize input values using `.LowerCase()` before comparison to handle case-insensitive matching
- Internal identifiers are stored in properties and used for serialization
- Localized strings are preserved exclusively for UI display via `_()` macro in `AddChoice()` calls
- This approach improves consistency and makes the code more maintainable by separating concerns between data storage and presentation

https://claude.ai/code/session_01V46Au1iTmUJgA4mN7MiJL8