### PR TITLE
Update behaviors shared data when objects are created or duplicated

### DIFF
--- a/newIDE/app/src/EditorFunctions/index.js
+++ b/newIDE/app/src/EditorFunctions/index.js
@@ -790,6 +790,14 @@ const createOrReplaceObject: EditorFunction = {
             `Unable to search and install object (${message}).`
           );
         } else if (status === 'asset-installed') {
+          // Update behaviors shared data for the scene where the object was created.
+          // Assets from the store can come with behaviors that have shared data.
+          if (target_object_scope === 'global') {
+            gd.WholeProjectRefactorer.updateBehaviorsSharedData(project);
+          } else {
+            layout.updateBehaviorsSharedData(project);
+          }
+
           // /!\ Tell the editor that some objects have potentially been modified (and even removed).
           // This will force the objects panel to refresh.
           onObjectsModifiedOutsideEditor({
@@ -1012,6 +1020,13 @@ const createOrReplaceObject: EditorFunction = {
         project
       );
       newObject.setName(targetObjectName); // Unserialization has overwritten the name.
+
+      // Update behaviors shared data for the scene where the object was duplicated.
+      if (target_object_scope === 'global') {
+        gd.WholeProjectRefactorer.updateBehaviorsSharedData(project);
+      } else {
+        layout.updateBehaviorsSharedData(project);
+      }
 
       // /!\ Tell the editor that some objects have potentially been modified (and even removed).
       // This will force the objects panel to refresh.


### PR DESCRIPTION
## Summary
This PR ensures that behaviors' shared data is properly updated whenever objects are created from store assets or duplicated within a scene or globally.

## Key Changes
- Added `updateBehaviorsSharedData` calls after asset installation in the `createOrReplaceObject` function
- Added `updateBehaviorsSharedData` calls after object duplication
- Both changes respect the object scope (global vs scene-specific) by calling the appropriate update method:
  - `gd.WholeProjectRefactorer.updateBehaviorsSharedData(project)` for global objects
  - `layout.updateBehaviorsSharedData(project)` for scene-specific objects

## Implementation Details
The updates are placed immediately after object creation/duplication and before the `onObjectsModifiedOutsideEditor` notification, ensuring that shared data is synchronized before the editor is notified of changes. This is particularly important for store assets that may come with behaviors containing shared data that needs to be properly initialized.

https://claude.ai/code/session_01P7NonNjWuvryhaWvipb7nJ