### PR TITLE
Compute project path dynamically from file metadata

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -199,7 +199,10 @@ import { QuickCustomizationDialog } from '../QuickCustomization/QuickCustomizati
 import { type ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import useGamesList from '../GameDashboard/UseGamesList';
 import useCapturesManager from './UseCapturesManager';
-import { readProjectSettings } from '../Utils/ProjectSettingsReader';
+import {
+  readProjectSettings,
+  getProjectDirectory,
+} from '../Utils/ProjectSettingsReader';
 import { type ToolbarButtonConfig } from './CustomToolbarButton';
 import { applyProjectPreferences } from '../Utils/ApplyProjectPreferences';
 import {
@@ -314,7 +317,6 @@ export type State = {|
   saveToStorageProviderDialogOpen: boolean,
   gdjsDevelopmentWatcherEnabled: boolean,
   toolbarButtons: Array<ToolbarButtonConfig>,
-  projectPath: ?string,
 |};
 
 const initialPreviewState: PreviewState = {
@@ -393,7 +395,6 @@ const MainFrame = (props: Props) => {
       saveToStorageProviderDialogOpen: false,
       gdjsDevelopmentWatcherEnabled: false,
       toolbarButtons: [],
-      projectPath: null,
     }: State)
   );
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
@@ -1002,7 +1003,6 @@ const MainFrame = (props: Props) => {
         currentFileMetadata: null,
         editorTabs: closeProjectTabs(state.editorTabs, currentProject),
         toolbarButtons: [],
-        projectPath: null,
       }));
 
       // Delete the project from memory. All references to it have been dropped previously
@@ -1115,7 +1115,6 @@ const MainFrame = (props: Props) => {
             setState(currentState => ({
               ...currentState,
               toolbarButtons: rawSettings.toolbarButtons || [],
-              projectPath: rawSettings.projectPath,
             }));
           }
         } catch (error) {
@@ -4872,7 +4871,9 @@ const MainFrame = (props: Props) => {
     onRestartInGameEditor,
     showRestartInGameEditorAfterErrorButton,
     toolbarButtons: state.toolbarButtons,
-    projectPath: state.projectPath,
+    projectPath: currentFileMetadata
+      ? getProjectDirectory(currentFileMetadata.fileIdentifier)
+      : null,
   };
 
   const hasEditorsInLeftPane = hasEditorsInPane(state.editorTabs, 'left');

--- a/newIDE/app/src/Utils/ProjectSettingsReader.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.js
@@ -11,7 +11,6 @@ const path = optionalRequire('path');
 export type ParsedProjectSettings = {
   preferences?: { [string]: boolean | string | number },
   toolbarButtons?: Array<ToolbarButtonConfig>,
-  projectPath: string,
 };
 
 const SETTINGS_FILE_NAME = 'gdevelop-settings.yaml';
@@ -19,7 +18,7 @@ const SETTINGS_FILE_NAME = 'gdevelop-settings.yaml';
 // Only allow safe characters in npm script names to prevent command injection
 const SAFE_SCRIPT_NAME_PATTERN = /^[a-zA-Z0-9_:-]+$/;
 
-const getProjectDirectory = (projectFilePath: string): string | null => {
+export const getProjectDirectory = (projectFilePath: string): string | null => {
   if (!path) return null;
   return path.dirname(projectFilePath);
 };
@@ -133,7 +132,7 @@ export const readProjectSettings = async (
       } preferences, ${toolbarButtons.length} buttons`
     );
 
-    const result: ParsedProjectSettings = { projectPath: projectDirectory };
+    const result: ParsedProjectSettings = {};
     if (Object.keys(preferences).length > 0) {
       result.preferences = preferences;
     }


### PR DESCRIPTION
## Summary
Refactored project path handling to compute it dynamically from the current file metadata instead of storing it as state. This eliminates redundant state management and ensures the project path is always derived from the authoritative source.

## Key Changes
- Removed `projectPath` from MainFrame state type and initialization
- Removed `projectPath` assignment when loading project settings
- Removed `projectPath` reset when closing projects
- Exported `getProjectDirectory` utility function from ProjectSettingsReader
- Updated MainFrame to compute `projectPath` on-the-fly from `currentFileMetadata.fileIdentifier` when passing props to child components
- Removed `projectPath` from ParsedProjectSettings type definition

## Implementation Details
- The project path is now computed as a derived value: `currentFileMetadata ? getProjectDirectory(currentFileMetadata.fileIdentifier) : null`
- This approach ensures the project path is always consistent with the current file metadata without requiring separate state synchronization
- The `getProjectDirectory` function is now exported and reusable across the codebase

https://claude.ai/code/session_01QVDNxqCvYd9nT9jqarueqn