### PR TITLE
Apply disabled text styling to Else events

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/ElseEvent.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/ElseEvent.js
@@ -9,6 +9,7 @@ import {
   executableEventContainer,
   invalidElse,
   elseTextContainer,
+  disabledText,
 } from '../ClassNames';
 import { type EventRendererProps } from './EventRenderer';
 import ConditionsActionsColumns from '../ConditionsActionsColumns';
@@ -57,7 +58,11 @@ export default class ElseEvent extends React.Component<EventRendererProps, *> {
               )
             }
           >
-            <span>
+            <span
+              className={classNames({
+                [disabledText]: this.props.disabled,
+              })}
+            >
               {elseEvent.getConditions().size() > 0 ? (
                 <Trans>Else if</Trans>
               ) : (


### PR DESCRIPTION
## Summary
Updated the ElseEvent renderer to apply the `disabledText` CSS class when an event is disabled, ensuring consistent visual styling across the events sheet.

## Changes
- Imported the `disabledText` class name from ClassNames
- Applied conditional `disabledText` class to the Else event span element based on the `disabled` prop
- Used `classNames` utility to conditionally apply the styling

## Implementation Details
The `disabledText` class is now conditionally applied to the Else event text when `this.props.disabled` is true, providing visual feedback to users that the event is disabled. This maintains consistency with how other event types handle disabled state styling.

https://claude.ai/code/session_01HSJwSA2BtjRuB59A7XtRMg