### PR TITLE
Fix Basic Material not preserving material names from GLB models

### DIFF
--- a/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
+++ b/Extensions/3D/Model3DRuntimeObject3DRenderer.ts
@@ -32,6 +32,7 @@ namespace gdjs {
     material: THREE.Material
   ): THREE.MeshBasicMaterial => {
     const basicMaterial = new THREE.MeshBasicMaterial();
+    basicMaterial.name = material.name;
     //@ts-ignore
     if (material.color) {
       //@ts-ignore


### PR DESCRIPTION
When converting materials to MeshBasicMaterial, the original material
name was not being copied over, causing all materials to appear unnamed.
This made it impossible to target specific materials by name at runtime.

https://claude.ai/code/session_01QSWYumP9jppg32jnLqDwqR