### PR TITLE
Fix modifier key state when focus moves to child elements

### DIFF
--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -2033,7 +2033,19 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
               onKeyDown={this._keyboardShortcuts.onKeyDown}
               onKeyUp={this._keyboardShortcuts.onKeyUp}
               onDragOver={this._keyboardShortcuts.onDragOver}
-              onBlur={this._keyboardShortcuts.resetModifiers}
+              onBlur={event => {
+                // Only reset modifiers if focus is moving outside the container.
+                // When focus moves to a child (e.g., an instruction with tabIndex),
+                // we must keep modifier state so that Shift+click multi-selection works.
+                if (
+                  !event.currentTarget.contains(
+                    // $FlowFixMe - relatedTarget might not be a Node in Flow's definition.
+                    event.relatedTarget
+                  )
+                ) {
+                  this._keyboardShortcuts.resetModifiers();
+                }
+              }}
               ref={this._containerDiv}
               tabIndex={0}
             >


### PR DESCRIPTION
## Summary
Fixed an issue where modifier keys (Shift, Ctrl, etc.) were being reset when focus moved to child elements within the EventsSheet container, breaking multi-selection functionality like Shift+click.

## Changes
- Modified the `onBlur` handler in EventsSheet to only reset modifier state when focus moves completely outside the container
- Added a check using `event.currentTarget.contains(event.relatedTarget)` to distinguish between focus leaving the container vs. moving to a child element
- This preserves modifier key state for interactions with child elements (e.g., instructions with `tabIndex`) while still properly cleaning up when focus leaves entirely

## Implementation Details
- The fix uses the `relatedTarget` property of the blur event to determine where focus is moving to
- A Flow comment was added to suppress a type error since `relatedTarget` may not be strictly typed as a Node in Flow's definitions
- This maintains the original behavior of resetting modifiers when appropriate while fixing the regression for internal focus changes

https://claude.ai/code/session_01Yc41KFGEN4FBpM7pRjQkXL