### PR TITLE
NewIDE app flow formatting

### DIFF
--- a/newIDE/app/src/InstancesEditor/ClickInterceptor.js
+++ b/newIDE/app/src/InstancesEditor/ClickInterceptor.js
@@ -174,7 +174,7 @@ class ClickInterceptor {
         const MIN_DISTANCE = 2; // pixels
         const dx = sceneCoordinates[0] - lastPoint.x;
         const dy = sceneCoordinates[1] - lastPoint.y;
-       if (Math.abs(dx) < MIN_DISTANCE && Math.abs(dy) < MIN_DISTANCE) {
+        if (Math.abs(dx) < MIN_DISTANCE && Math.abs(dy) < MIN_DISTANCE) {
           return;
         }
       }

--- a/newIDE/app/src/Utils/TileMap.js
+++ b/newIDE/app/src/Utils/TileMap.js
@@ -19,9 +19,21 @@ export type TileSet = {|
   atlasImage: string,
 |};
 
+type TileMapCoordinate = {| x: number, y: number |};
+
+type FreehandTileMapCacheEntry = {|
+  processedCount: number,
+  tileMap: Map<string, TileMapTilePatch>,
+|};
+
+const freehandTileMapCache: WeakMap<
+  Array<TileMapCoordinate>,
+  FreehandTileMapCacheEntry
+> = new WeakMap();
+
 const areSameCoordinates = (
-  tileA: {| x: number, y: number |},
-  tileB: {| x: number, y: number |}
+  tileA: TileMapCoordinate,
+  tileB: TileMapCoordinate
 ): boolean => tileA.x === tileB.x && tileA.y === tileB.y;
 
 /**
@@ -232,7 +244,7 @@ export const getTilesGridCoordinatesFromPointerSceneCoordinates = ({
   sceneToTileMapTransformation,
 }: {|
   tileMapTileSelection: TileMapTileSelection,
-  coordinates: Array<{| x: number, y: number |}>,
+  coordinates: Array<TileMapCoordinate>,
   tileSize: number,
   sceneToTileMapTransformation: AffineTransformation,
 |}): TileMapTilePatch[] => {
@@ -313,22 +325,18 @@ export const getTilesGridCoordinatesFromPointerSceneCoordinates = ({
     const selectionHeight =
       selectionBottomRightCorner.y - selectionTopLeftCorner.y + 1;
 
-    // Process only coordinates that haven't been processed yet.
-    // We use a cache attached to the coordinates array to track progress.
-    let processedCount = coordinates._processedCount || 0;
+    const cachedEntry = freehandTileMapCache.get(coordinates);
+    let processedCount = 0;
+    let tileMap = new Map<string, TileMapTilePatch>();
 
-    // If the array length decreased, it means the array was reset or reused.
-    // Clear the cache and start fresh.
-    if (processedCount > coordinates.length) {
-      processedCount = 0;
-      coordinates._processedCount = 0;
-      coordinates._cachedTileMap = null;
+    if (cachedEntry) {
+      // If the array length decreased, it means the array was reset or reused.
+      // Clear the cache and start fresh.
+      if (cachedEntry.processedCount <= coordinates.length) {
+        processedCount = cachedEntry.processedCount;
+        tileMap = new Map(cachedEntry.tileMap);
+      }
     }
-
-    // Start with cached result if it exists, otherwise create new map
-    const tileMap = coordinates._cachedTileMap
-      ? new Map(coordinates._cachedTileMap)
-      : new Map<string, TileMapTilePatch>();
 
     // Process only new coordinates since last call
     for (let i = processedCount; i < coordinates.length; i++) {
@@ -366,8 +374,10 @@ export const getTilesGridCoordinatesFromPointerSceneCoordinates = ({
     }
 
     // Update cache for next incremental call
-    coordinates._processedCount = coordinates.length;
-    coordinates._cachedTileMap = tileMap;
+    freehandTileMapCache.set(coordinates, {
+      processedCount: coordinates.length,
+      tileMap,
+    });
 
     return [...tileMap.values()];
   }


### PR DESCRIPTION
Fix `npm run flow` and formatting in `newIDE/app` by refactoring a Flow-unsafe cache and applying Prettier corrections.

The `TileMap.js` change addresses a Flow typing error where `_processedCount` and `_cachedTileMap` properties were being attached directly to a `coordinates` array, which Flow rejects. This was refactored to use a typed `WeakMap` for safe caching.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8f514129-defa-4ff5-8993-337ed8b36eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f514129-defa-4ff5-8993-337ed8b36eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

