### PR TITLE
Improve tooltip background color for all themes

### DIFF
--- a/newIDE/app/src/UI/Theme/BlueDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/BlueDarkTheme/theme.json
@@ -489,6 +489,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#494952",
+          "comment": "Lighter background for good contrast in dark theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#FAFAFA",
+          "comment": "Light text for good contrast"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#FF5E3B"

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -22,6 +22,8 @@ export function getMuiOverrides({
   snackbarBackgroundColor,
   snackbarBorderColor,
   textDefaultColor,
+  tooltipBackgroundColor,
+  tooltipTextColor,
 }: {|
   tabTextColor: string,
   tabSelectedTextColor: string,
@@ -37,6 +39,8 @@ export function getMuiOverrides({
   snackbarBackgroundColor: string,
   snackbarBorderColor: string,
   textDefaultColor: string,
+  tooltipBackgroundColor: string,
+  tooltipTextColor: string,
 |}): any {
   return {
     MuiTypography: {
@@ -309,6 +313,23 @@ export function getMuiOverrides({
       },
       message: {
         color: textDefaultColor,
+      },
+    },
+    MuiTooltip: {
+      tooltip: {
+        backgroundColor: tooltipBackgroundColor,
+        color: tooltipTextColor,
+        // Ensure chips inside tooltips have good contrast
+        '& .MuiChip-root': {
+          color: tooltipTextColor,
+        },
+        '& .MuiChip-outlined': {
+          borderColor: tooltipTextColor,
+          color: tooltipTextColor,
+        },
+        '& .MuiChip-icon': {
+          color: tooltipTextColor,
+        },
       },
     },
   };
@@ -721,6 +742,8 @@ export function createGdevelopTheme({
         snackbarBackgroundColor: styles['ThemeSnackbarBackgroundColor'],
         snackbarBorderColor: styles['ThemeSnackbarBorderColor'],
         textDefaultColor: styles['ThemeTextDefaultColor'],
+        tooltipBackgroundColor: styles['ThemeTooltipBackgroundColor'],
+        tooltipTextColor: styles['ThemeTooltipTextColor'],
       }),
     },
   };

--- a/newIDE/app/src/UI/Theme/DeepBlueTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DeepBlueTheme/theme.json
@@ -375,6 +375,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#30363d",
+          "comment": "Lighter background for good contrast in dark theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#c9d1d9",
+          "comment": "Light text for good contrast"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#f85149"

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -541,6 +541,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#494952",
+          "comment": "Lighter background for good contrast in dark theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#FAFAFA",
+          "comment": "Light text for good contrast"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#FF5E3B"

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -539,6 +539,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#1D1D26",
+          "comment": "Dark background for good contrast in light theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#FAFAFA",
+          "comment": "Light text for good contrast against dark background"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#F03F18"

--- a/newIDE/app/src/UI/Theme/NordTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/NordTheme/theme.json
@@ -480,6 +480,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#4C566A",
+          "comment": "Lighter background for good contrast in dark theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#ECEFF4",
+          "comment": "Light text for good contrast"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#FF5E3B"

--- a/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/OneDarkTheme/theme.json
@@ -485,6 +485,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#3E4452",
+          "comment": "Lighter background for good contrast in dark theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#FAFAFA",
+          "comment": "Light text for good contrast"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#FF5E3B"

--- a/newIDE/app/src/UI/Theme/RosePineTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/RosePineTheme/theme.json
@@ -481,6 +481,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#403D52",
+          "comment": "Lighter background for good contrast in dark theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#E0DEF4",
+          "comment": "Light text for good contrast"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#FF5E3B"

--- a/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/SolarizedDarkTheme/theme.json
@@ -482,6 +482,20 @@
         }
       }
     },
+    "tooltip": {
+      "background": {
+        "color": {
+          "value": "#073642",
+          "comment": "Lighter background for good contrast in dark theme"
+        }
+      },
+      "text": {
+        "color": {
+          "value": "#FDF6E3",
+          "comment": "Light text for good contrast"
+        }
+      }
+    },
     "notification": {
       "badge-color": {
         "value": "#FF5E3B"


### PR DESCRIPTION
Before:
<img width="583" height="343" alt="Capture d’écran 2026-02-16 à 18 36 59" src="https://github.com/user-attachments/assets/da94aa24-8037-44a9-94d9-aa1787fddacc" />

After:
<img width="760" height="496" alt="Capture d’écran 2026-02-16 à 18 37 18" src="https://github.com/user-attachments/assets/7e2bba45-92c6-48c5-9e5b-6a743f603f29" />
