### PR TITLE
perf(collision): add spatial hash grid for broad-phase collision culling

### DIFF
--- a/GDJS/Runtime/events-tools/objecttools.ts
+++ b/GDJS/Runtime/events-tools/objecttools.ts
@@ -218,6 +218,19 @@ namespace gdjs {
         arr.length = finalSize;
       };
 
+      /**
+       * Minimum total-object count before switching from brute-force
+       * (twoListsTest) to spatial-hash-accelerated collision testing.
+       */
+      const _SPATIAL_HASH_MIN_OBJECTS = 32;
+
+      /** Reusable spatial hash grid — avoids re-allocation each frame. */
+      let _collisionGrid: gdjs.SpatialHashGrid<gdjs.RuntimeObject> | null =
+        null;
+
+      /** Reusable array for spatial hash query results. */
+      const _spatialQueryResult: gdjs.RuntimeObject[] = [];
+
       export const hitBoxesCollisionTest = function (
         objectsLists1: ObjectsLists,
         objectsLists2: ObjectsLists,
@@ -225,13 +238,177 @@ namespace gdjs {
         instanceContainer: gdjs.RuntimeInstanceContainer,
         ignoreTouchingEdges: boolean
       ) {
-        return gdjs.evtTools.object.twoListsTest(
-          gdjs.RuntimeObject.collisionTest,
-          objectsLists1,
-          objectsLists2,
-          inverted,
-          ignoreTouchingEdges
+        // Flatten ObjectsLists into flat arrays-of-arrays.
+        const objects1Lists = gdjs.staticArray(
+          gdjs.evtTools.object.hitBoxesCollisionTest
         );
+        objectsLists1.values(objects1Lists);
+        const objects2Lists = gdjs.staticArray2(
+          gdjs.evtTools.object.hitBoxesCollisionTest
+        );
+        objectsLists2.values(objects2Lists);
+
+        // Count total objects in each side.
+        let totalObj1 = 0;
+        let totalObj2 = 0;
+        for (let i = 0, len = objects1Lists.length; i < len; ++i)
+          totalObj1 += objects1Lists[i].length;
+        for (let i = 0, len = objects2Lists.length; i < len; ++i)
+          totalObj2 += objects2Lists[i].length;
+
+        // For small lists the overhead of building a grid isn't worthwhile.
+        if (totalObj1 + totalObj2 < _SPATIAL_HASH_MIN_OBJECTS) {
+          return gdjs.evtTools.object.twoListsTest(
+            gdjs.RuntimeObject.collisionTest,
+            objectsLists1,
+            objectsLists2,
+            inverted,
+            ignoreTouchingEdges
+          );
+        }
+
+        // ── Spatial-hash accelerated path ──────────────────────────────
+        let isTrue = false;
+
+        // 1. Reset pick flags on all objects.
+        for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
+          const arr = objects1Lists[i];
+          for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+            arr[k].pick = false;
+          }
+        }
+        for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
+          const arr = objects2Lists[i];
+          for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+            arr[k].pick = false;
+          }
+        }
+
+        // 2. Determine cell size: 2× the average object dimension of list2.
+        //    This gives ~1–4 objects per cell on average.
+        let totalDim = 0;
+        for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
+          const arr = objects2Lists[i];
+          for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+            const w = arr[k].getWidth();
+            const h = arr[k].getHeight();
+            totalDim += w > h ? w : h;
+          }
+        }
+        const avgDim = totalObj2 > 0 ? totalDim / totalObj2 : 64;
+        const cellSize = avgDim * 2 > 32 ? avgDim * 2 : 32;
+
+        // 3. Build (or reconfigure) the grid.
+        if (!_collisionGrid) {
+          _collisionGrid = new gdjs.SpatialHashGrid<gdjs.RuntimeObject>(
+            cellSize
+          );
+        } else {
+          _collisionGrid.clear();
+          if (
+            _collisionGrid.getCellSize() < cellSize - 0.01 ||
+            _collisionGrid.getCellSize() > cellSize + 0.01
+          ) {
+            _collisionGrid.setCellSize(cellSize);
+          }
+        }
+
+        // 4. Insert every list-2 object by its AABB.
+        for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
+          const arr = objects2Lists[i];
+          for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+            const obj = arr[k];
+            const aabb = obj.getAABB();
+            _collisionGrid.insert(
+              obj,
+              aabb.min[0],
+              aabb.min[1],
+              aabb.max[0],
+              aabb.max[1]
+            );
+          }
+        }
+
+        // 5. For each list-1 object, query nearby candidates and test.
+        for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
+          const arr1 = objects1Lists[i];
+          for (let k = 0, lenk = arr1.length; k < lenk; ++k) {
+            const obj1 = arr1[k];
+            let atLeastOneObject = false;
+
+            // Query the grid with obj1's AABB.
+            const aabb1 = obj1.getAABB();
+            _spatialQueryResult.length = 0;
+            _collisionGrid.queryToArray(
+              aabb1.min[0],
+              aabb1.min[1],
+              aabb1.max[0],
+              aabb1.max[1],
+              _spatialQueryResult
+            );
+
+            for (let l = 0, lenl = _spatialQueryResult.length; l < lenl; ++l) {
+              const obj2 = _spatialQueryResult[l];
+
+              // Skip if both already picked (same optimisation as twoListsTest).
+              if (obj1.pick && obj2.pick) {
+                continue;
+              }
+              // Never test an object against itself.
+              if (obj1.id === obj2.id) {
+                continue;
+              }
+
+              if (
+                gdjs.RuntimeObject.collisionTest(
+                  obj1,
+                  obj2,
+                  ignoreTouchingEdges
+                )
+              ) {
+                if (!inverted) {
+                  isTrue = true;
+                  obj1.pick = true;
+                  obj2.pick = true;
+                }
+                atLeastOneObject = true;
+              }
+            }
+
+            if (!atLeastOneObject && inverted) {
+              isTrue = true;
+              obj1.pick = true;
+            }
+          }
+        }
+
+        // 6. Trim objects that were not picked.
+        for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
+          const arr = objects1Lists[i];
+          let finalSize = 0;
+          for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+            if (arr[k].pick) {
+              arr[finalSize] = arr[k];
+              finalSize++;
+            }
+          }
+          arr.length = finalSize;
+        }
+        if (!inverted) {
+          for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
+            const arr = objects2Lists[i];
+            let finalSize = 0;
+            for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+              if (arr[k].pick) {
+                arr[finalSize] = arr[k];
+                finalSize++;
+              }
+            }
+            arr.length = finalSize;
+          }
+        }
+
+        return isTrue;
       };
 
       export const _distanceBetweenObjects = function (obj1, obj2, distance) {

--- a/GDJS/Runtime/events-tools/objecttools.ts
+++ b/GDJS/Runtime/events-tools/objecttools.ts
@@ -225,26 +225,53 @@ namespace gdjs {
       const _SPATIAL_HASH_MIN_OBJECTS = 32;
 
       /** Reusable spatial hash grid — avoids re-allocation each frame. */
-      let _collisionGrid: gdjs.SpatialHashGrid<gdjs.RuntimeObject> | null =
+      let _spatialHashGrid: gdjs.SpatialHashGrid<gdjs.RuntimeObject> | null =
         null;
 
       /** Reusable array for spatial hash query results. */
       const _spatialQueryResult: gdjs.RuntimeObject[] = [];
 
-      export const hitBoxesCollisionTest = function (
+      /**
+       * An improved version of {@link twoListsTest} that uses a spatial hash
+       * grid when the total object count exceeds {@link _SPATIAL_HASH_MIN_OBJECTS}.
+       *
+       * For small lists the behaviour is identical to `twoListsTest` (brute-force
+       * O(N×M) all-pairs).  For large lists the spatial hash reduces this to
+       * ~O(N+M) by only testing nearby pairs.
+       *
+       * **Self-collision note:** When `objectsLists1` and `objectsLists2`
+       * refer to the same list (e.g. "Enemies collide with Enemies"), every
+       * pair (A, B) will be considered from both directions (A vs B *and*
+       * B vs A).  The `pick` flag short-circuits the second test when
+       * `!inverted`, because both objects are already marked as picked.
+       * In the `inverted` path the `atLeastOneObject` flag is tracked
+       * per-obj1, which mirrors the existing semantics of `twoListsTest`.
+       *
+       * @param predicate The collision/distance/etc. test to run on each pair.
+       * @param objectsLists1 First set of object lists.
+       * @param objectsLists2 Second set of object lists.
+       * @param inverted When true, only list-1 objects are filtered (picks
+       *   objects that do *not* satisfy the predicate against any list-2 object).
+       * @param extraArg Extra argument forwarded to `predicate` (avoids closures).
+       */
+      export const twoListsTestWithSpatialHashing = function (
+        predicate: (
+          object1: gdjs.RuntimeObject,
+          object2: gdjs.RuntimeObject,
+          extraArg: any
+        ) => boolean,
         objectsLists1: ObjectsLists,
         objectsLists2: ObjectsLists,
         inverted: boolean,
-        instanceContainer: gdjs.RuntimeInstanceContainer,
-        ignoreTouchingEdges: boolean
+        extraArg: any
       ) {
         // 1. Flatten ObjectsLists into arrays-of-arrays (done once for all paths).
         const objects1Lists = gdjs.staticArray(
-          gdjs.evtTools.object.hitBoxesCollisionTest
+          gdjs.evtTools.object.twoListsTestWithSpatialHashing
         );
         objectsLists1.values(objects1Lists);
         const objects2Lists = gdjs.staticArray2(
-          gdjs.evtTools.object.hitBoxesCollisionTest
+          gdjs.evtTools.object.twoListsTestWithSpatialHashing
         );
         objectsLists2.values(objects2Lists);
 
@@ -275,7 +302,7 @@ namespace gdjs {
         if (totalObj1 + totalObj2 < _SPATIAL_HASH_MIN_OBJECTS) {
           // ── Brute-force path ─────────────────────────────────────────
           // Same O(N×M) all-pairs test as twoListsTest, inlined here to
-          // use the already-flattened arrays and avoid double-flatten.
+          // use the already-flattened arrays and avoid a double-flatten.
           for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
             const arr1 = objects1Lists[i];
             for (let k = 0, lenk = arr1.length; k < lenk; ++k) {
@@ -288,11 +315,7 @@ namespace gdjs {
                   }
                   if (
                     arr1[k].id !== arr2[l].id &&
-                    gdjs.RuntimeObject.collisionTest(
-                      arr1[k],
-                      arr2[l],
-                      ignoreTouchingEdges
-                    )
+                    predicate(arr1[k], arr2[l], extraArg)
                   ) {
                     if (!inverted) {
                       isTrue = true;
@@ -327,17 +350,17 @@ namespace gdjs {
           const cellSize = avgDim * 2 > 32 ? avgDim * 2 : 32;
 
           // Build (or reconfigure) the grid.
-          if (!_collisionGrid) {
-            _collisionGrid = new gdjs.SpatialHashGrid<gdjs.RuntimeObject>(
+          if (!_spatialHashGrid) {
+            _spatialHashGrid = new gdjs.SpatialHashGrid<gdjs.RuntimeObject>(
               cellSize
             );
           } else {
-            _collisionGrid.clear();
+            _spatialHashGrid.clear();
             if (
-              _collisionGrid.getCellSize() < cellSize - 0.01 ||
-              _collisionGrid.getCellSize() > cellSize + 0.01
+              _spatialHashGrid.getCellSize() < cellSize - 0.01 ||
+              _spatialHashGrid.getCellSize() > cellSize + 0.01
             ) {
-              _collisionGrid.setCellSize(cellSize);
+              _spatialHashGrid.setCellSize(cellSize);
             }
           }
 
@@ -347,7 +370,7 @@ namespace gdjs {
             for (let k = 0, lenk = arr.length; k < lenk; ++k) {
               const obj = arr[k];
               const aabb = obj.getAABB();
-              _collisionGrid.insert(
+              _spatialHashGrid.insert(
                 obj,
                 aabb.min[0],
                 aabb.min[1],
@@ -367,7 +390,7 @@ namespace gdjs {
               // Query the grid with obj1's AABB.
               const aabb1 = obj1.getAABB();
               _spatialQueryResult.length = 0;
-              _collisionGrid.queryToArray(
+              _spatialHashGrid.queryToArray(
                 aabb1.min[0],
                 aabb1.min[1],
                 aabb1.max[0],
@@ -391,13 +414,7 @@ namespace gdjs {
                   continue;
                 }
 
-                if (
-                  gdjs.RuntimeObject.collisionTest(
-                    obj1,
-                    obj2,
-                    ignoreTouchingEdges
-                  )
-                ) {
+                if (predicate(obj1, obj2, extraArg)) {
                   if (!inverted) {
                     isTrue = true;
                     obj1.pick = true;
@@ -442,6 +459,22 @@ namespace gdjs {
         }
 
         return isTrue;
+      };
+
+      export const hitBoxesCollisionTest = function (
+        objectsLists1: ObjectsLists,
+        objectsLists2: ObjectsLists,
+        inverted: boolean,
+        instanceContainer: gdjs.RuntimeInstanceContainer,
+        ignoreTouchingEdges: boolean
+      ) {
+        return gdjs.evtTools.object.twoListsTestWithSpatialHashing(
+          gdjs.RuntimeObject.collisionTest,
+          objectsLists1,
+          objectsLists2,
+          inverted,
+          ignoreTouchingEdges
+        );
       };
 
       export const _distanceBetweenObjects = function (obj1, obj2, distance) {

--- a/GDJS/Runtime/events-tools/objecttools.ts
+++ b/GDJS/Runtime/events-tools/objecttools.ts
@@ -219,8 +219,8 @@ namespace gdjs {
       };
 
       /**
-       * Minimum total-object count before switching from brute-force
-       * (twoListsTest) to spatial-hash-accelerated collision testing.
+       * Minimum total-object count (list1 + list2) before switching from
+       * brute-force to spatial-hash-accelerated collision.
        */
       const _SPATIAL_HASH_MIN_OBJECTS = 32;
 
@@ -238,7 +238,7 @@ namespace gdjs {
         instanceContainer: gdjs.RuntimeInstanceContainer,
         ignoreTouchingEdges: boolean
       ) {
-        // Flatten ObjectsLists into flat arrays-of-arrays.
+        // 1. Flatten ObjectsLists into arrays-of-arrays (done once for all paths).
         const objects1Lists = gdjs.staticArray(
           gdjs.evtTools.object.hitBoxesCollisionTest
         );
@@ -248,7 +248,7 @@ namespace gdjs {
         );
         objectsLists2.values(objects2Lists);
 
-        // Count total objects in each side.
+        // Count total objects.
         let totalObj1 = 0;
         let totalObj2 = 0;
         for (let i = 0, len = objects1Lists.length; i < len; ++i)
@@ -256,21 +256,7 @@ namespace gdjs {
         for (let i = 0, len = objects2Lists.length; i < len; ++i)
           totalObj2 += objects2Lists[i].length;
 
-        // For small lists the overhead of building a grid isn't worthwhile.
-        if (totalObj1 + totalObj2 < _SPATIAL_HASH_MIN_OBJECTS) {
-          return gdjs.evtTools.object.twoListsTest(
-            gdjs.RuntimeObject.collisionTest,
-            objectsLists1,
-            objectsLists2,
-            inverted,
-            ignoreTouchingEdges
-          );
-        }
-
-        // ── Spatial-hash accelerated path ──────────────────────────────
-        let isTrue = false;
-
-        // 1. Reset pick flags on all objects.
+        // 2. Reset pick flags on all objects (shared by both paths).
         for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
           const arr = objects1Lists[i];
           for (let k = 0, lenk = arr.length; k < lenk; ++k) {
@@ -284,105 +270,152 @@ namespace gdjs {
           }
         }
 
-        // 2. Determine cell size: 2× the average object dimension of list2.
-        //    This gives ~1–4 objects per cell on average.
-        let totalDim = 0;
-        for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
-          const arr = objects2Lists[i];
-          for (let k = 0, lenk = arr.length; k < lenk; ++k) {
-            const w = arr[k].getWidth();
-            const h = arr[k].getHeight();
-            totalDim += w > h ? w : h;
-          }
-        }
-        const avgDim = totalObj2 > 0 ? totalDim / totalObj2 : 64;
-        const cellSize = avgDim * 2 > 32 ? avgDim * 2 : 32;
+        let isTrue = false;
 
-        // 3. Build (or reconfigure) the grid.
-        if (!_collisionGrid) {
-          _collisionGrid = new gdjs.SpatialHashGrid<gdjs.RuntimeObject>(
-            cellSize
-          );
-        } else {
-          _collisionGrid.clear();
-          if (
-            _collisionGrid.getCellSize() < cellSize - 0.01 ||
-            _collisionGrid.getCellSize() > cellSize + 0.01
-          ) {
-            _collisionGrid.setCellSize(cellSize);
-          }
-        }
-
-        // 4. Insert every list-2 object by its AABB.
-        for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
-          const arr = objects2Lists[i];
-          for (let k = 0, lenk = arr.length; k < lenk; ++k) {
-            const obj = arr[k];
-            const aabb = obj.getAABB();
-            _collisionGrid.insert(
-              obj,
-              aabb.min[0],
-              aabb.min[1],
-              aabb.max[0],
-              aabb.max[1]
-            );
-          }
-        }
-
-        // 5. For each list-1 object, query nearby candidates and test.
-        for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
-          const arr1 = objects1Lists[i];
-          for (let k = 0, lenk = arr1.length; k < lenk; ++k) {
-            const obj1 = arr1[k];
-            let atLeastOneObject = false;
-
-            // Query the grid with obj1's AABB.
-            const aabb1 = obj1.getAABB();
-            _spatialQueryResult.length = 0;
-            _collisionGrid.queryToArray(
-              aabb1.min[0],
-              aabb1.min[1],
-              aabb1.max[0],
-              aabb1.max[1],
-              _spatialQueryResult
-            );
-
-            for (let l = 0, lenl = _spatialQueryResult.length; l < lenl; ++l) {
-              const obj2 = _spatialQueryResult[l];
-
-              // Skip if both already picked (same optimisation as twoListsTest).
-              if (obj1.pick && obj2.pick) {
-                continue;
-              }
-              // Never test an object against itself.
-              if (obj1.id === obj2.id) {
-                continue;
-              }
-
-              if (
-                gdjs.RuntimeObject.collisionTest(
-                  obj1,
-                  obj2,
-                  ignoreTouchingEdges
-                )
-              ) {
-                if (!inverted) {
-                  isTrue = true;
-                  obj1.pick = true;
-                  obj2.pick = true;
+        if (totalObj1 + totalObj2 < _SPATIAL_HASH_MIN_OBJECTS) {
+          // ── Brute-force path ─────────────────────────────────────────
+          // Same O(N×M) all-pairs test as twoListsTest, inlined here to
+          // use the already-flattened arrays and avoid double-flatten.
+          for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
+            const arr1 = objects1Lists[i];
+            for (let k = 0, lenk = arr1.length; k < lenk; ++k) {
+              let atLeastOneObject = false;
+              for (let j = 0, lenj = objects2Lists.length; j < lenj; ++j) {
+                const arr2 = objects2Lists[j];
+                for (let l = 0, lenl = arr2.length; l < lenl; ++l) {
+                  if (arr1[k].pick && arr2[l].pick) {
+                    continue;
+                  }
+                  if (
+                    arr1[k].id !== arr2[l].id &&
+                    gdjs.RuntimeObject.collisionTest(
+                      arr1[k],
+                      arr2[l],
+                      ignoreTouchingEdges
+                    )
+                  ) {
+                    if (!inverted) {
+                      isTrue = true;
+                      arr1[k].pick = true;
+                      arr2[l].pick = true;
+                    }
+                    atLeastOneObject = true;
+                  }
                 }
-                atLeastOneObject = true;
+              }
+              if (!atLeastOneObject && inverted) {
+                isTrue = true;
+                arr1[k].pick = true;
               }
             }
+          }
+        } else {
+          // ── Spatial-hash accelerated path ─────────────────────────────
 
-            if (!atLeastOneObject && inverted) {
-              isTrue = true;
-              obj1.pick = true;
+          // Determine cell size: 2× the average object dimension of list2.
+          // This gives ~1–4 objects per cell on average.
+          let totalDim = 0;
+          for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
+            const arr = objects2Lists[i];
+            for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+              const w = arr[k].getWidth();
+              const h = arr[k].getHeight();
+              totalDim += w > h ? w : h;
+            }
+          }
+          const avgDim = totalObj2 > 0 ? totalDim / totalObj2 : 64;
+          const cellSize = avgDim * 2 > 32 ? avgDim * 2 : 32;
+
+          // Build (or reconfigure) the grid.
+          if (!_collisionGrid) {
+            _collisionGrid = new gdjs.SpatialHashGrid<gdjs.RuntimeObject>(
+              cellSize
+            );
+          } else {
+            _collisionGrid.clear();
+            if (
+              _collisionGrid.getCellSize() < cellSize - 0.01 ||
+              _collisionGrid.getCellSize() > cellSize + 0.01
+            ) {
+              _collisionGrid.setCellSize(cellSize);
+            }
+          }
+
+          // Insert every list-2 object by its AABB.
+          for (let i = 0, leni = objects2Lists.length; i < leni; ++i) {
+            const arr = objects2Lists[i];
+            for (let k = 0, lenk = arr.length; k < lenk; ++k) {
+              const obj = arr[k];
+              const aabb = obj.getAABB();
+              _collisionGrid.insert(
+                obj,
+                aabb.min[0],
+                aabb.min[1],
+                aabb.max[0],
+                aabb.max[1]
+              );
+            }
+          }
+
+          // For each list-1 object, query nearby candidates and test.
+          for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
+            const arr1 = objects1Lists[i];
+            for (let k = 0, lenk = arr1.length; k < lenk; ++k) {
+              const obj1 = arr1[k];
+              let atLeastOneObject = false;
+
+              // Query the grid with obj1's AABB.
+              const aabb1 = obj1.getAABB();
+              _spatialQueryResult.length = 0;
+              _collisionGrid.queryToArray(
+                aabb1.min[0],
+                aabb1.min[1],
+                aabb1.max[0],
+                aabb1.max[1],
+                _spatialQueryResult
+              );
+
+              for (
+                let l = 0, lenl = _spatialQueryResult.length;
+                l < lenl;
+                ++l
+              ) {
+                const obj2 = _spatialQueryResult[l];
+
+                // Skip if both already picked (same optimisation as twoListsTest).
+                if (obj1.pick && obj2.pick) {
+                  continue;
+                }
+                // Never test an object against itself.
+                if (obj1.id === obj2.id) {
+                  continue;
+                }
+
+                if (
+                  gdjs.RuntimeObject.collisionTest(
+                    obj1,
+                    obj2,
+                    ignoreTouchingEdges
+                  )
+                ) {
+                  if (!inverted) {
+                    isTrue = true;
+                    obj1.pick = true;
+                    obj2.pick = true;
+                  }
+                  atLeastOneObject = true;
+                }
+              }
+
+              if (!atLeastOneObject && inverted) {
+                isTrue = true;
+                obj1.pick = true;
+              }
             }
           }
         }
 
-        // 6. Trim objects that were not picked.
+        // 3. Trim objects that were not picked (shared by both paths).
         for (let i = 0, leni = objects1Lists.length; i < leni; ++i) {
           const arr = objects1Lists[i];
           let finalSize = 0;

--- a/GDJS/Runtime/spatial-hash-grid.ts
+++ b/GDJS/Runtime/spatial-hash-grid.ts
@@ -1,0 +1,135 @@
+/*
+ * GDevelop JS Platform
+ * Copyright 2013-present Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * This project is released under the MIT License.
+ */
+namespace gdjs {
+  /**
+   * A spatial hash grid for broad-phase collision culling.
+   *
+   * Objects are inserted by their axis-aligned bounding box (AABB) and can
+   * be queried by region to find potential overlapping candidates, avoiding
+   * the O(N×M) cost of testing every pair.
+   *
+   * @category Utils > Geometry
+   */
+  export class SpatialHashGrid<T> {
+    /** Width/height of each grid cell. */
+    private _cellSize: number;
+    /** 1 / cellSize, cached to replace divisions with multiplications. */
+    private _invCellSize: number;
+    /** Map from hashed cell key → array of items in that cell. */
+    private _grid: Map<number, T[]> = new Map();
+    /** Pool of reusable arrays to reduce GC pressure. */
+    private _pooledArrays: T[][] = [];
+
+    constructor(cellSize: number) {
+      this._cellSize = cellSize;
+      this._invCellSize = 1 / cellSize;
+    }
+
+    /** Change the cell size (also clears the grid). */
+    setCellSize(cellSize: number): void {
+      this._cellSize = cellSize;
+      this._invCellSize = 1 / cellSize;
+      this.clear();
+    }
+
+    getCellSize(): number {
+      return this._cellSize;
+    }
+
+    /** Remove all items, returning internal arrays to the pool. */
+    clear(): void {
+      this._grid.forEach((arr) => {
+        arr.length = 0;
+        this._pooledArrays.push(arr);
+      });
+      this._grid.clear();
+    }
+
+    /**
+     * Hash a 2D cell coordinate to a single integer key.
+     * Uses multiplication with large primes + XOR to distribute evenly.
+     */
+    private _hashKey(cellX: number, cellY: number): number {
+      return ((cellX * 92837111) ^ (cellY * 689287499)) | 0;
+    }
+
+    /** Get or create the array for a grid cell. */
+    private _getOrCreateCell(key: number): T[] {
+      let cell = this._grid.get(key);
+      if (!cell) {
+        cell = this._pooledArrays.length > 0 ? this._pooledArrays.pop()! : [];
+        this._grid.set(key, cell);
+      }
+      return cell;
+    }
+
+    /**
+     * Insert an item into every cell its AABB overlaps.
+     *
+     * @param item The item to store.
+     * @param minX Left edge of the item's AABB.
+     * @param minY Top edge of the item's AABB.
+     * @param maxX Right edge of the item's AABB.
+     * @param maxY Bottom edge of the item's AABB.
+     */
+    insert(
+      item: T,
+      minX: number,
+      minY: number,
+      maxX: number,
+      maxY: number
+    ): void {
+      const minCellX = (minX * this._invCellSize) | 0;
+      const minCellY = (minY * this._invCellSize) | 0;
+      // Use Math.floor for max to ensure negative coords round correctly.
+      const maxCellX = Math.floor(maxX * this._invCellSize) | 0;
+      const maxCellY = Math.floor(maxY * this._invCellSize) | 0;
+
+      for (let cx = minCellX; cx <= maxCellX; cx++) {
+        for (let cy = minCellY; cy <= maxCellY; cy++) {
+          this._getOrCreateCell(this._hashKey(cx, cy)).push(item);
+        }
+      }
+    }
+
+    /**
+     * Collect every item stored in cells that overlap the query region.
+     *
+     * **Note:** an item that spans multiple cells may appear more than once
+     * in `result`.  Callers should de-duplicate if needed (the collision
+     * pipeline's `pick` flags already handle this).
+     *
+     * @param minX Left edge of the query region.
+     * @param minY Top edge of the query region.
+     * @param maxX Right edge of the query region.
+     * @param maxY Bottom edge of the query region.
+     * @param result Array to push matches into (NOT cleared by this method).
+     */
+    queryToArray(
+      minX: number,
+      minY: number,
+      maxX: number,
+      maxY: number,
+      result: T[]
+    ): void {
+      const minCellX = (minX * this._invCellSize) | 0;
+      const minCellY = (minY * this._invCellSize) | 0;
+      const maxCellX = Math.floor(maxX * this._invCellSize) | 0;
+      const maxCellY = Math.floor(maxY * this._invCellSize) | 0;
+
+      for (let cx = minCellX; cx <= maxCellX; cx++) {
+        for (let cy = minCellY; cy <= maxCellY; cy++) {
+          const cell = this._grid.get(this._hashKey(cx, cy));
+          if (cell) {
+            for (let i = 0, len = cell.length; i < len; i++) {
+              result.push(cell[i]);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/GDJS/Runtime/spatial-hash-grid.ts
+++ b/GDJS/Runtime/spatial-hash-grid.ts
@@ -11,6 +11,12 @@ namespace gdjs {
    * be queried by region to find potential overlapping candidates, avoiding
    * the O(N×M) cost of testing every pair.
    *
+   * **Important — duplicate results:** An item whose AABB spans multiple
+   * grid cells will be stored in each of those cells.  Consequently,
+   * {@link queryToArray} may return the same item more than once.  Callers
+   * are responsible for de-duplicating results if needed.  The collision
+   * pipeline in `objecttools.ts` handles this implicitly via `pick` flags.
+   *
    * @category Utils > Geometry
    */
   export class SpatialHashGrid<T> {
@@ -49,8 +55,36 @@ namespace gdjs {
     }
 
     /**
+     * Trim the internal array pool to at most `maxSize` entries.
+     *
+     * The pool grows as cells are cleared but is never shrunk automatically.
+     * Call this after a one-time spike (e.g. a scene with many temporary
+     * objects) to release memory that is no longer needed.
+     */
+    trimPool(maxSize: number): void {
+      if (this._pooledArrays.length > maxSize) {
+        this._pooledArrays.length = maxSize;
+      }
+    }
+
+    /**
+     * Convert a world coordinate to a cell index, correctly handling
+     * negative values (where `| 0` truncates toward zero instead of
+     * flooring).
+     */
+    private _toCell(v: number): number {
+      const c = v * this._invCellSize;
+      return c >= 0 ? c | 0 : Math.floor(c);
+    }
+
+    /**
      * Hash a 2D cell coordinate to a single integer key.
      * Uses multiplication with large primes + XOR to distribute evenly.
+     *
+     * Hash collisions are harmless: they only cause extra candidates to be
+     * returned by {@link queryToArray}, but every candidate is still
+     * validated by the full collision predicate, so correctness is
+     * unaffected.
      */
     private _hashKey(cellX: number, cellY: number): number {
       return ((cellX * 92837111) ^ (cellY * 689287499)) | 0;
@@ -82,11 +116,10 @@ namespace gdjs {
       maxX: number,
       maxY: number
     ): void {
-      const minCellX = (minX * this._invCellSize) | 0;
-      const minCellY = (minY * this._invCellSize) | 0;
-      // Use Math.floor for max to ensure negative coords round correctly.
-      const maxCellX = Math.floor(maxX * this._invCellSize) | 0;
-      const maxCellY = Math.floor(maxY * this._invCellSize) | 0;
+      const minCellX = this._toCell(minX);
+      const minCellY = this._toCell(minY);
+      const maxCellX = this._toCell(maxX);
+      const maxCellY = this._toCell(maxY);
 
       for (let cx = minCellX; cx <= maxCellX; cx++) {
         for (let cy = minCellY; cy <= maxCellY; cy++) {
@@ -115,10 +148,10 @@ namespace gdjs {
       maxY: number,
       result: T[]
     ): void {
-      const minCellX = (minX * this._invCellSize) | 0;
-      const minCellY = (minY * this._invCellSize) | 0;
-      const maxCellX = Math.floor(maxX * this._invCellSize) | 0;
-      const maxCellY = Math.floor(maxY * this._invCellSize) | 0;
+      const minCellX = this._toCell(minX);
+      const minCellY = this._toCell(minY);
+      const maxCellX = this._toCell(maxX);
+      const maxCellY = this._toCell(maxY);
 
       for (let cx = minCellX; cx <= maxCellX; cx++) {
         for (let cy = minCellY; cy <= maxCellY; cy++) {


### PR DESCRIPTION
Replace O(N×M) brute-force pair enumeration in `hitBoxesCollisionTest` with a **spatial hash grid** that only tests nearby object pairs, dramatically reducing collision detection cost for scenes with many objects.

## Problem

The existing `hitBoxesCollisionTest` delegates to `twoListsTest`, which tests **every** object in list 1 against **every** object in list 2 — O(N×M) complexity. At N=1000 objects this takes ~43ms per collision check, exceeding the entire 16.7ms frame budget at 60fps.

## Solution

- **New file: `GDJS/Runtime/spatial-hash-grid.ts`** — A generic `SpatialHashGrid<T>` class that maps items by their AABB into fixed-size grid cells. Uses hash-based cell keys (prime multiplication + XOR) and pools internal arrays to minimize GC pressure.

- **Modified: `GDJS/Runtime/events-tools/objecttools.ts`** — `hitBoxesCollisionTest` now builds a spatial hash grid when total object count ≥ 32, inserting list-2 objects by AABB and querying only nearby candidates for each list-1 object. Falls back to the original `twoListsTest` for small lists where grid overhead is not worthwhile.

### Key design decisions:
- **Adaptive cell size:** 2× average object dimension (minimum 32px) — keeps ~1–4 objects per cell
- **Threshold of 32 objects:** Below this, brute-force is faster than grid construction overhead
- **Grid is reused across frames** (module-level singleton) — only cleared and potentially resized, never reallocated
- **Same pick/trim semantics** as original `twoListsTest` — behavioral parity preserved

## Benchmark Results

| N objects | Brute-force (mean) | Spatial Hash (mean) | Speedup |
|-----------|-------------------|--------------------|---------| 
| 50        | 0.097ms           | 0.021ms            | **4.7×**  |
| 100       | 0.414ms           | 0.048ms            | **8.6×**  |
| 250       | 2.696ms           | 0.224ms            | **12.0×** |
| 500       | 11.05ms           | 0.800ms            | **13.8×** |
| 1000      | 43.29ms           | 3.417ms            | **12.7×** |

At N=1000, collision detection drops from **~43ms** (2.6× over frame budget) to **~3.4ms** (well within budget).

Scaling also improves: brute-force N=1000 is 442× slower than N=50; spatial hash N=1000 is only 167× slower than N=50.

## Benchmark Code

The benchmark suite used to produce these results is available as `benchmarks.patch` in the repo root. Apply and run with:
\`\`\`bash
git apply benchmarks.patch
cd benchmarks && npm install && npx vitest bench --run
\`\`\`

## Testing

- Baseline verified by stashing optimization and re-running benchmarks (numbers matched saved baseline within normal variance)
- Optimization verified across multiple runs with consistent 5–14× speedup
- Small-list fallback ensures no regression for scenes with few objects

[benchmarks.patch](https://github.com/user-attachments/files/25352720/benchmarks.patch)
