### PR TITLE
Fix handling of instance/locked variables

### DIFF
--- a/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/index.js
@@ -17,7 +17,6 @@ import ScrollView, { type ScrollViewInterface } from '../../UI/ScrollView';
 import EventsRootVariablesFinder from '../../Utils/EventsRootVariablesFinder';
 import VariablesList, {
   type HistoryHandler,
-  type VariablesListInterface,
 } from '../../VariablesList/VariablesList';
 import ShareExternal from '../../UI/CustomSvgIcons/ShareExternal';
 import useForceUpdate from '../../Utils/UseForceUpdate';
@@ -30,7 +29,6 @@ import { ProjectScopedContainersAccessor } from '../../InstructionOrExpression/E
 import TileSetVisualizer, {
   type TileMapTileSelection,
 } from '../TileSetVisualizer';
-import Add from '../../UI/CustomSvgIcons/Add';
 import {
   TopLevelCollapsibleSection,
   CollapsibleSubPanel,
@@ -125,7 +123,6 @@ type Props = {|
   historyHandler?: HistoryHandler,
   tileMapTileSelection: ?TileMapTileSelection,
   onSelectTileMapTile: (?TileMapTileSelection) => void,
-  isVariableListLocked: boolean,
   canOverrideBehaviorProperties: boolean,
 |};
 
@@ -147,12 +144,10 @@ export const CompactInstancePropertiesEditor = ({
   projectScopedContainersAccessor,
   tileMapTileSelection,
   onSelectTileMapTile,
-  isVariableListLocked,
   canOverrideBehaviorProperties,
 }: Props): null | React.Node => {
   const forceUpdate = useForceUpdate();
   const instance = instances[0];
-  const variablesListRef = React.useRef<?VariablesListInterface>(null);
 
   const scrollViewRef = React.useRef<?ScrollViewInterface>(null);
   /**
@@ -480,23 +475,10 @@ export const CompactInstancePropertiesEditor = ({
                     >
                       <ShareExternal style={styles.icon} />
                     </IconButton>
-                    {isVariableListLocked ? null : (
-                      <IconButton
-                        size="small"
-                        onClick={
-                          variablesListRef.current
-                            ? variablesListRef.current.addVariable
-                            : undefined
-                        }
-                      >
-                        <Add style={styles.icon} />
-                      </IconButton>
-                    )}
                   </Line>
                 </Line>
               </Column>
               <VariablesList
-                ref={variablesListRef}
                 projectScopedContainersAccessor={
                   projectScopedContainersAccessor
                 }
@@ -520,7 +502,7 @@ export const CompactInstancePropertiesEditor = ({
                 compactEmptyPlaceholderText={
                   <Trans>There are no variables on this instance.</Trans>
                 }
-                isListLocked={isVariableListLocked}
+                isListLocked={true}
               />
             </>
           ) : null}

--- a/newIDE/app/src/SceneEditor/InstanceOrObjectPropertiesEditorContainer.js
+++ b/newIDE/app/src/SceneEditor/InstanceOrObjectPropertiesEditorContainer.js
@@ -170,7 +170,6 @@ export const InstanceOrObjectPropertiesEditorContainer: React.ComponentType<{
             tileMapTileSelection={tileMapTileSelection}
             onSelectTileMapTile={onSelectTileMapTile}
             historyHandler={historyHandler}
-            isVariableListLocked={isVariableListLocked}
             layout={layout}
             objectsContainer={objectsContainer}
             globalObjectsContainer={globalObjectsContainer}

--- a/newIDE/app/src/stories/componentStories/LayoutEditor/CompactInstancePropertiesEditor.stories.js
+++ b/newIDE/app/src/stories/componentStories/LayoutEditor/CompactInstancePropertiesEditor.stories.js
@@ -42,7 +42,6 @@ export const InstanceSprite2d = (): React.Node => (
             )}
             tileMapTileSelection={null}
             onSelectTileMapTile={() => {}}
-            isVariableListLocked={false}
             canOverrideBehaviorProperties={true}
             resourceManagementProps={fakeResourceManagementProps}
           />
@@ -75,7 +74,6 @@ export const InstanceCube3d = (): React.Node => (
             )}
             tileMapTileSelection={null}
             onSelectTileMapTile={() => {}}
-            isVariableListLocked={false}
             canOverrideBehaviorProperties={true}
             resourceManagementProps={fakeResourceManagementProps}
           />
@@ -108,7 +106,6 @@ export const InstanceTextInput = (): React.Node => (
             )}
             tileMapTileSelection={null}
             onSelectTileMapTile={() => {}}
-            isVariableListLocked={false}
             canOverrideBehaviorProperties={true}
             resourceManagementProps={fakeResourceManagementProps}
           />


### PR DESCRIPTION
- Can't add an instance variable (removed + button). Instance variables are ONLY overriding existing object variables.
- Can now paste/delete a child of structure/array of a variable that is re-defined in instances variables. Previously it was not possible to paste a copied variable in a instance variable that was a structure/array