### PR TITLE
Fix pointer events being triggered on tileset scrollbar area

### DIFF
--- a/newIDE/app/src/InstancesEditor/TileSetVisualizer.js
+++ b/newIDE/app/src/InstancesEditor/TileSetVisualizer.js
@@ -136,6 +136,19 @@ const getImageCoordinatesFromPointerEvent = (
   }
 
   const bounds = divContainer.getBoundingClientRect();
+
+  // Ignore pointer events on the scrollbar area. getBoundingClientRect includes
+  // scrollbars, but clientWidth/clientHeight exclude them, so any click beyond
+  // clientWidth or clientHeight is on a scrollbar, not on the tile content.
+  const relativeX = event.clientX - bounds.left;
+  const relativeY = event.clientY - bounds.top;
+  if (
+    relativeX >= divContainer.clientWidth ||
+    relativeY >= divContainer.clientHeight
+  ) {
+    return;
+  }
+
   const mouseXWithoutScrollLeft = event.clientX - bounds.left + 1;
   const mouseX = mouseXWithoutScrollLeft + divContainer.scrollLeft;
   const mouseY = event.clientY - bounds.top + 1;


### PR DESCRIPTION
Fix #8316

## Summary
Fixed an issue where pointer events on the TileSet visualizer were being processed even when clicking on the scrollbar area, causing unintended tile selections or interactions.

## Key Changes
- Added bounds checking to ignore pointer events that occur on scrollbar areas
- Calculates relative pointer position and compares against `clientWidth` and `clientHeight` (which exclude scrollbars) to detect scrollbar clicks
- Returns early from `getImageCoordinatesFromPointerEvent` when a scrollbar click is detected, preventing further processing

## Implementation Details
The fix leverages the difference between `getBoundingClientRect()` (which includes scrollbars) and `clientWidth`/`clientHeight` (which exclude them). Any click beyond these client dimensions is guaranteed to be on a scrollbar rather than the actual tile content, allowing us to safely ignore those events.

https://claude.ai/code/session_01Xp5ZVJAfz23Gz38WyjTbFL