### PR TITLE
Extract instruction name parsing into reusable utility method

### DIFF
--- a/Core/GDCore/Extensions/PlatformExtension.cpp
+++ b/Core/GDCore/Extensions/PlatformExtension.cpp
@@ -840,6 +840,19 @@ gd::String PlatformExtension::GetObjectNameFromFullObjectType(
   return type.substr(separatorIndex + 2);
 }
 
+gd::String PlatformExtension::GetInstructionNameFromFullType(
+    const gd::String& type) {
+  const auto separatorPosition =
+      type.rfind(PlatformExtension::GetNamespaceSeparator());
+  if (separatorPosition == gd::String::npos) {
+    return type;
+  }
+  if (separatorPosition + 2 >= type.size()) {
+    return type;
+  }
+  return type.substr(separatorPosition + 2);
+}
+
 PlatformExtension::PlatformExtension()
     : deprecated(false), category("General") {}
 

--- a/Core/GDCore/Extensions/PlatformExtension.h
+++ b/Core/GDCore/Extensions/PlatformExtension.h
@@ -711,6 +711,15 @@ static gd::String GetVariantFullType(const gd::String& extensionName,
 
   static gd::String GetObjectNameFromFullObjectType(const gd::String& type);
 
+  /**
+   * \brief Get the instruction name from a full type
+   * (e.g. "MyExtension::DoSomething" -> "DoSomething").
+   *
+   * If no namespace separator is found or the name after the separator is
+   * empty, the full type is returned as-is.
+   */
+  static gd::String GetInstructionNameFromFullType(const gd::String& type);
+
  private:
   /**
    * Set the namespace (the string all actions/conditions/expressions start

--- a/Core/GDCore/IDE/Events/EventsRefactorer.cpp
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.cpp
@@ -16,6 +16,7 @@
 #include "GDCore/Extensions/Metadata/ExpressionMetadata.h"
 #include "GDCore/Extensions/Metadata/MetadataProvider.h"
 #include "GDCore/Extensions/Platform.h"
+#include "GDCore/Extensions/PlatformExtension.h"
 #include "GDCore/IDE/Events/ExpressionValidator.h"
 #include "GDCore/IDE/Events/InstructionSentenceFormatter.h"
 #include "GDCore/Project/ObjectsContainer.h"
@@ -945,12 +946,9 @@ bool EventsRefactorer::SearchStringInFormattedText(const gd::Platform& platform,
   if (foundPosition != gd::String::npos) return true;
 
   if (inInstructionNames) {
-    const gd::String& instructionType = instruction.GetType();
-    size_t lastSeparator = instructionType.find_last_of("::");
     gd::String instructionName =
-        lastSeparator != gd::String::npos
-            ? instructionType.substr(lastSeparator + 1)
-            : instructionType;
+        PlatformExtension::GetInstructionNameFromFullType(
+            instruction.GetType());
     size_t nameFoundPosition =
         matchCase ? instructionName.find(search)
                   : instructionName.FindCaseInsensitive(search);


### PR DESCRIPTION
## Summary
This PR refactors instruction name extraction logic by creating a new reusable utility method `GetInstructionNameFromFullType()` in `PlatformExtension` and updates existing code to use it.

## Key Changes
- Added `PlatformExtension::GetInstructionNameFromFullType()` static method that extracts the instruction name from a fully-qualified type string (e.g., "MyExtension::DoSomething" → "DoSomething")
- The method handles edge cases where no namespace separator is found or the name after the separator is empty by returning the full type as-is
- Refactored `EventsRefactorer::SearchStringInFormattedText()` to use the new utility method instead of duplicating the parsing logic inline
- Added necessary include for `PlatformExtension.h` in `EventsRefactorer.cpp`

## Implementation Details
- The new method uses `rfind()` to locate the namespace separator from the right, consistent with the existing `GetObjectNameFromFullObjectType()` pattern
- Includes proper bounds checking to ensure the extracted substring is valid
- Centralizes this common parsing operation to reduce code duplication and improve maintainability

https://claude.ai/code/session_01AckTxyKwTAFCPKMW2kdFdP