### PR TITLE
Fix null reference error in Material-UI ButtonBase ripple effect

### DIFF
--- a/newIDE/app/patches/@material-ui+core+4.11.0.patch
+++ b/newIDE/app/patches/@material-ui+core+4.11.0.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@material-ui/core/ButtonBase/ButtonBase.js b/node_modules/@material-ui/core/ButtonBase/ButtonBase.js
+index 94b4ac5..d5a1177 100644
+--- a/node_modules/@material-ui/core/ButtonBase/ButtonBase.js
++++ b/node_modules/@material-ui/core/ButtonBase/ButtonBase.js
+@@ -157,7 +157,7 @@ var ButtonBase = /*#__PURE__*/React.forwardRef(function ButtonBase(props, ref) {
+     };
+   }, []);
+   React.useEffect(function () {
+-    if (focusVisible && focusRipple && !disableRipple) {
++    if (focusVisible && focusRipple && !disableRipple && rippleRef.current) {
+       rippleRef.current.pulsate();
+     }
+   }, [disableRipple, focusRipple, focusVisible]);
+diff --git a/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js b/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js
+index e340afe..f37af18 100644
+--- a/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js
++++ b/node_modules/@material-ui/core/esm/ButtonBase/ButtonBase.js
+@@ -134,7 +134,7 @@ var ButtonBase = /*#__PURE__*/React.forwardRef(function ButtonBase(props, ref) {
+     };
+   }, []);
+   React.useEffect(function () {
+-    if (focusVisible && focusRipple && !disableRipple) {
++    if (focusVisible && focusRipple && !disableRipple && rippleRef.current) {
+       rippleRef.current.pulsate();
+     }
+   }, [disableRipple, focusRipple, focusVisible]);


### PR DESCRIPTION
## Summary
Add a null check for `rippleRef.current` before calling the `pulsate()` method in Material-UI's ButtonBase component to prevent runtime errors when the ripple reference is not yet initialized.

## Changes
- Added `rippleRef.current` existence check in the focus ripple effect condition
- Applied the fix to both the CommonJS and ESM versions of ButtonBase.js
- The condition now reads: `if (focusVisible && focusRipple && !disableRipple && rippleRef.current)` instead of `if (focusVisible && focusRipple && !disableRipple)`

## Details
This patch prevents a potential null reference exception that could occur when the focus ripple effect attempts to pulsate before the ripple component has been fully mounted and its ref initialized. This is a defensive programming fix that ensures the ripple element exists before attempting to call methods on it.

https://claude.ai/code/session_01RrEFbmatZn6TW12EgY7VMm