### PR TITLE
Fix "i.find is not a function" TypeError by using Array.isArray checks

### DIFF
--- a/newIDE/app/src/AiGeneration/AiRequestContext.js
+++ b/newIDE/app/src/AiGeneration/AiRequestContext.js
@@ -378,7 +378,9 @@ export const useAiRequestHistory = (
             .map(
               // $FlowFixMe[cannot-resolve-name]
               (message: AiRequestUserMessage) => {
-                const userRequest = message.content.find(
+                const content = message.content;
+                if (!Array.isArray(content)) return '';
+                const userRequest = content.find(
                   item => item.type === 'user_request'
                 );
                 return userRequest ? userRequest.text : '';

--- a/newIDE/app/src/AssetStore/AssetsList.js
+++ b/newIDE/app/src/AssetStore/AssetsList.js
@@ -630,7 +630,7 @@ const AssetsList: React.ComponentType<{
 
     const publicAssetPackAuthors: ?Array<Author> = React.useMemo(
       () =>
-        openedAssetPack && authors && openedAssetPack.authors
+        openedAssetPack && Array.isArray(authors) && openedAssetPack.authors
           ? openedAssetPack.authors
               .map(author => {
                 return authors.find(({ name }) => name === author.name);
@@ -642,7 +642,7 @@ const AssetsList: React.ComponentType<{
 
     const publicAssetPackLicenses: ?Array<License> = React.useMemo(
       () =>
-        openedAssetPack && licenses && openedAssetPack.licenses
+        openedAssetPack && Array.isArray(licenses) && openedAssetPack.licenses
           ? openedAssetPack.licenses
               .map(license => {
                 return licenses.find(({ name }) => name === license.name);

--- a/newIDE/app/src/ProjectCreation/NewProjectSetupDialog.js
+++ b/newIDE/app/src/ProjectCreation/NewProjectSetupDialog.js
@@ -320,7 +320,7 @@ const NewProjectSetupDialog = ({
   }[] = React.useMemo(
     () => {
       if (
-        !exampleShortHeaders ||
+        !Array.isArray(exampleShortHeaders) ||
         !selectedExampleShortHeader ||
         !selectedExampleShortHeader.linkedExampleShortHeaders
       )

--- a/newIDE/app/src/QuickCustomization/QuickCustomizationGameTiles.js
+++ b/newIDE/app/src/QuickCustomization/QuickCustomizationGameTiles.js
@@ -54,7 +54,9 @@ export const QuickCustomizationGameTiles = ({
 
   const displayedExampleShortHeaders = React.useMemo(
     () => {
-      const allQuickCustomizationExampleShortHeaders = exampleShortHeaders
+      const allQuickCustomizationExampleShortHeaders = Array.isArray(
+        exampleShortHeaders
+      )
         ? quickCustomizationRecommendation.list
             .map(({ type, exampleSlug, thumbnailTitleByLocale }) => {
               if (type !== 'example') {


### PR DESCRIPTION
The crash occurred in QuickCustomizationGameTiles where .find() was called
on exampleShortHeaders inside a .map() callback within a useMemo. A simple
truthy check allowed non-array values (e.g. from unexpected API responses)
to pass through, causing the TypeError. Replace truthy checks with
Array.isArray() guards in all similar patterns across the codebase.

https://claude.ai/code/session_01RBuGkQEBACvBuixfUDyUdR