### PR TITLE
Fix crash when WebGL context creation fails in InstancesEditor

### DIFF
--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -204,7 +204,7 @@ export default class InstancesEditor extends Component<Props, State> {
   componentDidMount() {
     // Initialize the PIXI renderer, if possible
     if (this.canvasArea && !this.pixiRenderer) {
-      this._initializeCanvasAndRenderer();
+      this._safelyInitializeCanvasAndRenderer();
     }
   }
 
@@ -213,7 +213,7 @@ export default class InstancesEditor extends Component<Props, State> {
     // This can happen if canvasArea was not rendered
     // just after the mount (depends on react-dnd versions?).
     if (this.canvasArea && !this.pixiRenderer) {
-      this._initializeCanvasAndRenderer();
+      this._safelyInitializeCanvasAndRenderer();
     }
 
     // Track previous tool before picker is activated
@@ -231,6 +231,20 @@ export default class InstancesEditor extends Component<Props, State> {
     } else if (!isPickerActive && wasPickerActive) {
       // Picker just deactivated, clear the stored previous tool
       this._previousToolBeforePicker = null;
+    }
+  }
+
+  _safelyInitializeCanvasAndRenderer() {
+    try {
+      this._initializeCanvasAndRenderer();
+    } catch (error) {
+      console.error(
+        'Exception caught while initializing the canvas and renderer:',
+        error
+      );
+      this.setState({
+        renderingError: { error, uniqueErrorId: generateUUID() },
+      });
     }
   }
 


### PR DESCRIPTION
When WebGL context creation fails (e.g. due to too many active contexts,
GPU memory exhaustion, or driver issues), _initializeCanvasAndRenderer
threw an uncaught error that crashed the component. Now the initialization
is wrapped in a try-catch that gracefully sets renderingError state,
showing the existing ErrorFallbackComponent instead of crashing.

https://claude.ai/code/session_01JwKHjegi8K2MRWWYQ4b95T