### PR TITLE
Fix crash when pinching in image preview on mobile

### DIFF
--- a/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
+++ b/newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js
@@ -308,21 +308,17 @@ const ImagePreview = ({
             y: touch2clientY - containerRect.top,
           }
         );
-        if (previousDoubleTouchInfo.current) {
+        const previousTouchInfo = previousDoubleTouchInfo.current;
+        if (previousTouchInfo) {
           setZoomState(zoomState => ({
             ...zoomState,
             xOffset:
-              zoomState.xOffset +
-              (newCenter[0] - previousDoubleTouchInfo.current.center[0]),
+              zoomState.xOffset + (newCenter[0] - previousTouchInfo.center[0]),
             yOffset:
-              zoomState.yOffset +
-              (newCenter[1] - previousDoubleTouchInfo.current.center[1]),
+              zoomState.yOffset + (newCenter[1] - previousTouchInfo.center[1]),
           }));
 
-          zoomAroundPointBy(
-            newDistance / previousDoubleTouchInfo.current.distance,
-            newCenter
-          );
+          zoomAroundPointBy(newDistance / previousTouchInfo.distance, newCenter);
         }
         previousDoubleTouchInfo.current = {
           distance: newDistance,


### PR DESCRIPTION
### Motivation
- Users could hit `TypeError: Cannot read properties of null (reading 'center')` while pinch-zooming in the image resource preview because `previousDoubleTouchInfo.current` could become `null` between the guard check and later uses.

### Description
- Snapshot `previousDoubleTouchInfo.current` into a local `previousTouchInfo` variable in `newIDE/app/src/ResourcesList/ResourcePreview/ImagePreview.js` before using it. 
- Use `previousTouchInfo.center` and `previousTouchInfo.distance` consistently for pan and zoom calculations to avoid dereferencing a ref that may have been nulled. 
- Preserve existing gesture behavior while removing the race that caused the null access.

### Testing
- Committed the change with `git commit` (succeeded). 
- Attempted to run `yarn --cwd newIDE/app eslint src/ResourcesList/ResourcePreview/ImagePreview.js`, but the lint run failed due to missing workspace dependencies in this environment and requires running `yarn install` to proceed. 
- Verified the file diff to confirm the null-check fix was applied and the code changes are correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b27a8c07648327992fed6501594aa4)