### PR TITLE
Guard against null project references in AI generation components

### DIFF
--- a/newIDE/app/src/AiGeneration/AiRequestChat/ChatMessages.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/ChatMessages.js
@@ -48,6 +48,7 @@ import CheckCircle from '@material-ui/icons/CheckCircle';
 import Link from '../../UI/Link';
 import { type FileMetadata } from '../../ProjectsStorage';
 import UnsavedChangesContext from '../../MainFrame/UnsavedChangesContext';
+import { exceptionallyGuardAgainstNullPtr } from '../../Utils/IsNullPtr';
 import { OrchestratorPlan } from './OrchestratorPlan';
 import { type FunctionCallItem, type RenderItem } from './Utils';
 
@@ -135,7 +136,8 @@ export const ChatMessages: React.ComponentType<Props> = React.memo<Props>(
     editorFunctionCallResults,
     onProcessFunctionCalls,
     editorCallbacks,
-    project,
+
+    project: nullableProject,
     fileMetadata,
     onUserRequestTextChange,
     shouldBeWorkingIfNotPaused,
@@ -151,6 +153,7 @@ export const ChatMessages: React.ComponentType<Props> = React.memo<Props>(
     forkingState,
     onRestore,
   }: Props) {
+    const project = exceptionallyGuardAgainstNullPtr(nullableProject);
     const theme = React.useContext(GDevelopThemeContext);
     const isLightTheme = theme.palette.type === 'light';
     const {

--- a/newIDE/app/src/AiGeneration/AiRequestChat/index.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import useStableValue from '../../Utils/useStableValue';
+import { exceptionallyGuardAgainstNullPtr } from '../../Utils/IsNullPtr';
 import type { I18n as I18nType } from '@lingui/core';
 import { ColumnStackLayout, LineStackLayout } from '../../UI/Layout';
 import Text from '../../UI/Text';
@@ -378,7 +379,7 @@ export const AiRequestChat: React.ComponentType<{
   (
     {
       aiConfigurationPresetsWithAvailability,
-      project,
+      project: nullableProject,
       fileMetadata,
       aiRequest,
       isSending,
@@ -407,6 +408,7 @@ export const AiRequestChat: React.ComponentType<{
     }: Props,
     ref
   ) => {
+    const project = exceptionallyGuardAgainstNullPtr(nullableProject);
     const {
       aiRequestHistory: { handleNavigateHistory, resetNavigation },
     } = React.useContext(AiRequestContext);

--- a/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
+++ b/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { type I18n as I18nType } from '@lingui/core';
+import { exceptionallyGuardAgainstNullPtr } from '../Utils/IsNullPtr';
 import { I18n } from '@lingui/react';
 import {
   type RenderEditorContainerPropsWithRef,
@@ -222,7 +223,7 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
       {
         isActive,
         setToolbar,
-        project,
+        project: nullableProject,
         resourceManagementProps,
         fileMetadata,
         storageProvider,
@@ -246,6 +247,8 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
       }: Props,
       ref
     ) => {
+      const project = exceptionallyGuardAgainstNullPtr(nullableProject);
+
       const onCreateProject = React.useCallback(
         async ({
           name,


### PR DESCRIPTION
## Summary
This PR adds null pointer guards to three AI generation components that receive a project prop, ensuring type safety and preventing potential runtime errors when the project reference is unexpectedly null.

## Key Changes
- Added imports of `exceptionallyGuardAgainstNullPtr` utility to three files:
  - `ChatMessages.js`
  - `AskAiEditorContainer.js`
  - `AiRequestChat/index.js`

- Renamed the `project` prop parameter to `nullableProject` in component destructuring to clearly indicate it may be null

- Added null pointer guard calls at the start of each component's implementation to safely extract the non-null project reference:
  ```javascript
  const project = exceptionallyGuardAgainstNullPtr(nullableProject);
  ```

## Implementation Details
The changes follow a consistent pattern across all three components:
1. The prop is renamed during destructuring to signal its nullable nature
2. The guard function is called immediately in the component body
3. The resulting `project` variable is used throughout the component logic

This approach maintains type safety while allowing the components to handle cases where a null project might be passed, either by throwing an error or handling it gracefully depending on the guard function's implementation.

https://claude.ai/code/session_01EcSgkFHhaXQBQU5sqEenWu