### PR TITLE
Add ability to enter custom skin string in 'Set skin' action for spine

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/ObjectSkinNameField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ObjectSkinNameField.js
@@ -46,9 +46,8 @@ export default (React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
 
     const [skinNames, setSkinNames] = React.useState<Array<string>>([]);
     const [isExpressionField, setIsExpressionField] = React.useState<boolean>(
-      true
+      false
     );
-    const canAutocomplete = skinNames.length > 0;
 
     const objectName = getLastObjectParameterValue({
       instructionMetadata,
@@ -104,13 +103,6 @@ export default (React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         };
       },
       [project, objectName, globalObjectsContainer, objectsContainer]
-    );
-
-    React.useEffect(
-      () => {
-        setIsExpressionField(!canAutocomplete);
-      },
-      [canAutocomplete]
     );
 
     const switchFieldType = () => {
@@ -184,27 +176,25 @@ export default (React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
           )
         }
         renderButton={style =>
-          canAutocomplete ? (
-            isExpressionField ? (
-              <FlatButton
-                id="switch-expression-select"
-                leftIcon={<TypeCursorSelect />}
-                style={style}
-                primary
-                label={<Trans>Select</Trans>}
-                onClick={switchFieldType}
-              />
-            ) : (
-              <RaisedButton
-                id="switch-expression-select"
-                icon={<Functions />}
-                style={style}
-                primary
-                label={<Trans>Use an expression</Trans>}
-                onClick={switchFieldType}
-              />
-            )
-          ) : null
+          isExpressionField ? (
+            <FlatButton
+              id="switch-expression-select"
+              leftIcon={<TypeCursorSelect />}
+              style={style}
+              primary
+              label={<Trans>Select</Trans>}
+              onClick={switchFieldType}
+            />
+          ) : (
+            <RaisedButton
+              id="switch-expression-select"
+              icon={<Functions />}
+              style={style}
+              primary
+              label={<Trans>Use an expression</Trans>}
+              onClick={switchFieldType}
+            />
+          )
         }
       />
     );


### PR DESCRIPTION
Hi. Let me provide this PR. This change will allow to set skins for group of Spine objects (skin names should be identical for different spine files in this case). Also it is very useful in general to be able to set skin using variable, which is not possible now without large unnecessary group of events with 1 condition for each possible skin.
 