### PR TITLE
fix: encode '#' in local file paths to fix preview (#4015)

### DIFF
--- a/newIDE/app/src/ResourcesLoader/index.js
+++ b/newIDE/app/src/ResourcesLoader/index.js
@@ -134,7 +134,8 @@ export default class ResourcesLoader {
       const projectPath = path.dirname(file);
       const resourceAbsolutePath = path
         .resolve(projectPath, urlOrFilename)
-        .replace(/\\/g, '/');
+        .replace(/\\/g, '/')
+        .replace(/#/g, '%23');
 
       console.info('Caching resolved local filename:', resourceAbsolutePath);
       return this._cache.cacheLocalFileUrl(


### PR DESCRIPTION
## Summary
Fixes #4015 — File paths containing `#` break preview in the scene editor and resource tab.

## Problem
When a local file path contains a `#` character (e.g., `Weekend Jam #1/Parts/hero.png`), the browser interprets everything after `#` as a URL fragment identifier. This causes `<img>` tags to fail loading the resource.

## Solution
Added `.replace(/#/g, '%23')` to the local file path resolution in `ResourcesLoader/index.js`. This encodes the `#` character to `%23` in the resolved absolute path before it's used as a file URL.

This is a minimal, targeted fix that:
- Only affects local filesystem paths (Electron environment)
- Doesn't modify `CorsAwareImage.js` or other components
- Handles all occurrences of `#` in the path
- Preserves existing path resolution logic

## Testing
- Tested with file paths containing `#` (e.g., `E:\Projects\Game Jam #1\Parts\hero.png`)
- Verified preview works correctly in scene editor
- Verified resource tab displays the image
- Confirmed no regression with normal paths (without `#`)
