### PR TITLE
Fix tooltip on light theme

### DIFF
--- a/newIDE/app/src/PropertiesEditor/MeasurementUnitDocumentation.js
+++ b/newIDE/app/src/PropertiesEditor/MeasurementUnitDocumentation.js
@@ -18,7 +18,7 @@ type Props = {|
   elementsWithWords: string,
 |};
 
-export default function MeasurementUnitDocumentation({
+export default function sMeasurementUnitDocumentation({
   label,
   description,
   elementsWithWords,

--- a/newIDE/app/src/UI/Theme/CreateTheme.js
+++ b/newIDE/app/src/UI/Theme/CreateTheme.js
@@ -319,6 +319,13 @@ export function getMuiOverrides({
       tooltip: {
         backgroundColor: tooltipBackgroundColor,
         color: tooltipTextColor,
+        // Ensure Typography (Text component) inside tooltips uses the tooltip text color,
+        // instead of using the theme's textPrimary which can be invisible on the tooltip background.
+        // We use an attribute selector because in development mode MUI v4 appends a numeric
+        // counter to class names (e.g. "MuiTypography-root-78"), which breaks a plain class selector.
+        '& [class*="MuiTypography-root"]': {
+          color: tooltipTextColor,
+        },
         // Ensure chips inside tooltips have good contrast
         '& .MuiChip-root': {
           color: tooltipTextColor,


### PR DESCRIPTION
Before:
<img width="499" height="375" alt="image" src="https://github.com/user-attachments/assets/2b315c8f-3234-496a-9dc0-e657f7660069" />


<img width="635" height="244" alt="image" src="https://github.com/user-attachments/assets/7c6ea173-cba1-421b-b7b0-1f1c9ee22979" />
