### PR TITLE
Add Ctrl/Cmd+K as secondary shortcut for command palette

### DIFF
--- a/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
+++ b/newIDE/app/src/KeyboardShortcuts/DefaultShortcuts.js
@@ -62,4 +62,13 @@ const defaultShortcuts: ShortcutMap = {
   OPEN_EXTENSION_SETTINGS: '',
 };
 
+/**
+ * Secondary (alternative) shortcuts for commands.
+ * These are not user-customizable and provide additional
+ * key bindings for commonly used commands.
+ */
+export const defaultSecondaryShortcuts: ShortcutMap = {
+  OPEN_COMMAND_PALETTE: 'CmdOrCtrl+KeyK',
+};
+
 export default defaultShortcuts;

--- a/newIDE/app/src/KeyboardShortcuts/ShortcutsList.js
+++ b/newIDE/app/src/KeyboardShortcuts/ShortcutsList.js
@@ -10,7 +10,9 @@ import DismissableAlertMessage from '../UI/DismissableAlertMessage';
 import { type ShortcutMap } from './DefaultShortcuts';
 import { getShortcutDisplayName } from './index';
 import Window from '../Utils/Window';
-import defaultShortcuts from '../KeyboardShortcuts/DefaultShortcuts';
+import defaultShortcuts, {
+  defaultSecondaryShortcuts,
+} from '../KeyboardShortcuts/DefaultShortcuts';
 import ShortcutsListRow from './ShortcutsListRow';
 import commandsList, {
   type CommandName,
@@ -102,6 +104,9 @@ const ShortcutsList = (props: Props): React.Node => {
     props.userShortcutMap['OPEN_COMMAND_PALETTE'] ||
       defaultShortcuts['OPEN_COMMAND_PALETTE']
   );
+  const commandPaletteSecondaryShortcut = getShortcutDisplayName(
+    defaultSecondaryShortcuts['OPEN_COMMAND_PALETTE']
+  );
 
   return (
     <ColumnStackLayout noMargin>
@@ -110,7 +115,8 @@ const ShortcutsList = (props: Props): React.Node => {
         identifier="command-palette-shortcut"
       >
         <Trans>
-          You can open the command palette by pressing {commandPaletteShortcut}.
+          You can open the command palette by pressing {commandPaletteShortcut}{' '}
+          or {commandPaletteSecondaryShortcut}.
         </Trans>
       </DismissableAlertMessage>
       <RaisedButton

--- a/newIDE/app/src/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/KeyboardShortcuts/index.js
@@ -6,7 +6,10 @@ import reservedShortcuts from './ReservedShortcuts';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import commandsList, { type CommandName } from '../CommandPalette/CommandsList';
 import isUserTyping from './IsUserTyping';
-import defaultShortcuts, { type ShortcutMap } from './DefaultShortcuts';
+import defaultShortcuts, {
+  defaultSecondaryShortcuts,
+  type ShortcutMap,
+} from './DefaultShortcuts';
 import { type PreviewDebuggerServer } from '../ExportAndShare/PreviewLauncher.flow';
 import optionalRequire from '../Utils/OptionalRequire';
 import { SafeExtractor } from '../Utils/SafeExtractor';
@@ -264,9 +267,14 @@ export const useKeyboardShortcuts = ({
         if (!shortcutData.isValid) return;
 
         // Get corresponding command, if it exists
-        const commandName = Object.keys(shortcutMap).find(
-          name => shortcutMap[name] === shortcutData.shortcutString
-        );
+        const commandName =
+          Object.keys(shortcutMap).find(
+            name => shortcutMap[name] === shortcutData.shortcutString
+          ) ||
+          Object.keys(defaultSecondaryShortcuts).find(
+            name =>
+              defaultSecondaryShortcuts[name] === shortcutData.shortcutString
+          );
         if (!commandName) return;
 
         // On desktop app, ignore shortcuts that are handled by Electron
@@ -342,9 +350,14 @@ export const useKeyboardShortcuts = ({
           if (!shortcutData.isValid) return;
 
           // Get corresponding command, if it exists
-          const commandName = Object.keys(shortcutMap).find(
-            name => shortcutMap[name] === shortcutData.shortcutString
-          );
+          const commandName =
+            Object.keys(shortcutMap).find(
+              name => shortcutMap[name] === shortcutData.shortcutString
+            ) ||
+            Object.keys(defaultSecondaryShortcuts).find(
+              name =>
+                defaultSecondaryShortcuts[name] === shortcutData.shortcutString
+            );
           if (!commandName) return;
 
           const command = commandsList[commandName];


### PR DESCRIPTION
Add a secondary (non-customizable) keyboard shortcut map that allows Ctrl+K (Cmd+K on Mac) to open the command palette alongside the existing Ctrl+P (Cmd+P) primary shortcut.