### PR TITLE
Fix SearchBar dropping characters when typing quickly

### DIFF
--- a/newIDE/app/src/UI/SearchBar.js
+++ b/newIDE/app/src/UI/SearchBar.js
@@ -110,8 +110,20 @@ const SearchBar: React.ComponentType<{
 
     const textField = React.useRef<?TextFieldInterface>(null);
 
+    // Track the last value we reported to the parent via onChange,
+    // so we can distinguish parent echoing our value back from
+    // an external parent-driven change.
+    const lastValueReportedToParent = React.useRef<string>(parentValue);
+
     const nonEmpty = !!value && value.length > 0;
-    const debouncedOnChange = useDebounce(onChange ? onChange : noop, 250);
+    const onChangeTrackingRef = React.useCallback(
+      (newValue: string) => {
+        lastValueReportedToParent.current = newValue;
+        if (onChange) onChange(newValue);
+      },
+      [onChange]
+    );
+    const debouncedOnChange = useDebounce(onChangeTrackingRef, 250);
 
     const changeValueDebounced = React.useCallback(
       (newValue: string) => {
@@ -124,6 +136,7 @@ const SearchBar: React.ComponentType<{
     const changeValueImmediately = React.useCallback(
       (newValue: string) => {
         setValue(newValue);
+        lastValueReportedToParent.current = newValue;
         onChange && onChange(newValue);
       },
       [onChange, setValue]
@@ -131,9 +144,15 @@ const SearchBar: React.ComponentType<{
 
     React.useEffect(
       () => {
-        // The value given by the parent has priority: if it changes,
-        // the search bar must display it.
-        setValue(parentValue);
+        // Only sync from parent if the value was changed externally,
+        // not just echoed back from our own debounced onChange callback.
+        // This prevents a race condition where the parent echoes back a
+        // stale debounced value and overwrites characters the user has
+        // typed since then (e.g. typing "qui" fast would become "qi").
+        if (parentValue !== lastValueReportedToParent.current) {
+          setValue(parentValue);
+        }
+        lastValueReportedToParent.current = parentValue;
       },
       [parentValue]
     );


### PR DESCRIPTION
## Summary

- **Fixes a race condition** in the SearchBar component where typing quickly would drop characters (e.g. typing "qui" fast would result in "qi")
- The root cause: the SearchBar debounces `onChange` notifications to the parent (250ms), but a `useEffect` that syncs `parentValue` back to local state couldn't distinguish between the parent echoing back a stale debounced value vs. an external value change — so the echo would overwrite characters typed after the debounce fired
- **Fix:** track the last value reported to the parent via a ref, and only sync from `parentValue` when it differs from what was last reported

## Reproduction

1. Open any dialog with a SearchBar (e.g. add action/condition)
2. Type "q", wait ~0.1s, then type "ui" quickly
3. **Before fix:** input shows "qi" (the "u" is lost)
4. **After fix:** input correctly shows "qui"

## Test plan

- [ ] Type quickly in SearchBar fields (action search, event search, asset store, etc.) and verify no characters are dropped
- [ ] Verify that clearing the search bar still works (cancel button)
- [ ] Verify that selecting an autocomplete tag still clears the input
- [ ] Verify that parent-driven value changes (e.g. programmatic reset) still update the input correctly

https://claude.ai/code/session_01HEAdMX4AjUbrtVdxhoe33w