### PR TITLE
Remove flagging the game as mobile on every build

### DIFF
--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -1158,8 +1158,6 @@ void Project::SerializeTo(SerializerElement& element) const {
 
   extensionProperties.SerializeTo(propElement.AddChild("extensionProperties"));
   
-  playableDevicesElement.AddChild("").SetStringValue("mobile");
-
   SerializerElement& platformsElement = propElement.AddChild("platforms");
   platformsElement.ConsiderAsArrayOf("platform");
   for (std::size_t i = 0; i < platforms.size(); ++i) {


### PR DESCRIPTION
This is done just above with a condition.
Looks like atypoe from this PR: https://github.com/4ian/GDevelop/commit/3846a1553be4fa41f8084cad0aba0f709e28b2a7#diff-2957ef0a080da73e83c7c2cc9df413a627a73ec3cdb9e3da3faad6b230fcf3b4