### PR TITLE
Guard against dead variables container in compact object/instance editors

### DIFF
--- a/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/CompactInstancePropertiesEditor/index.js
@@ -43,6 +43,7 @@ import { type ResourceManagementProps } from '../../ResourcesList/ResourceSource
 import { usePersistedScrollPosition } from '../../Utils/UsePersistedScrollPosition';
 import EmptyMessage from '../../UI/EmptyMessage';
 import CompactBehaviorsEditorService from '../../ObjectEditor/CompactObjectPropertiesEditor/CompactBehaviorsEditorService';
+import { exceptionallyGuardAgainstDeadObject } from '../../Utils/IsNullPtr';
 
 const gd: libGDevelop = global.gd;
 
@@ -158,6 +159,9 @@ export const CompactInstancePropertiesEditor = ({
    * obviously plus instance-wise variables with same name).
    */
   const shouldDisplayVariablesList = instances.length === 1;
+  const variablesContainer = shouldDisplayVariablesList
+    ? exceptionallyGuardAgainstDeadObject(instance.getVariables())
+    : null;
 
   // $FlowFixMe[missing-local-annot]
   const onScrollY = React.useCallback(deltaY => {
@@ -491,7 +495,7 @@ export const CompactInstancePropertiesEditor = ({
               )}
             />
           ) : null}
-          {object && shouldDisplayVariablesList ? (
+          {object && shouldDisplayVariablesList && variablesContainer ? (
             <>
               <Separator />
               <Column>
@@ -517,7 +521,7 @@ export const CompactInstancePropertiesEditor = ({
                 }
                 directlyStoreValueChangesWhileEditing
                 inheritedVariablesContainer={object.getVariables()}
-                variablesContainer={instance.getVariables()}
+                variablesContainer={variablesContainer}
                 areObjectVariables
                 size="compact"
                 onComputeAllVariableNames={() =>

--- a/newIDE/app/src/ObjectEditor/CompactObjectPropertiesEditor/index.js
+++ b/newIDE/app/src/ObjectEditor/CompactObjectPropertiesEditor/index.js
@@ -60,6 +60,7 @@ import { CompactEffectsListEditor } from '../../LayersList/CompactLayerPropertie
 import { CompactPropertiesEditorByVisibility } from '../../CompactPropertiesEditor/CompactPropertiesEditorByVisibility';
 import propertiesMapToSchema from '../../PropertiesEditor/PropertiesMapToSchema';
 import { useForceRecompute } from '../../Utils/UseForceUpdate';
+import { exceptionallyGuardAgainstDeadObject } from '../../Utils/IsNullPtr';
 
 const gd: libGDevelop = global.gd;
 
@@ -289,6 +290,9 @@ export const CompactObjectPropertiesEditor = ({
   const { showDeleteConfirmation } = useAlertDialog();
   const variablesListRef = React.useRef<?VariablesListInterface>(null);
   const object = objects[0];
+  const variablesContainer = exceptionallyGuardAgainstDeadObject(
+    object.getVariables()
+  );
   const objectConfiguration = object.getConfiguration();
 
   // Don't use a memo for this because metadata from custom objects are built
@@ -815,65 +819,67 @@ export const CompactObjectPropertiesEditor = ({
               </ColumnStackLayout>
             )}
           />
-          <TopLevelCollapsibleSection
-            title={<Trans>Object Variables</Trans>}
-            isFolded={isVariablesFolded}
-            toggleFolded={() => setIsVariablesFolded(!isVariablesFolded)}
-            onOpenFullEditor={() => onEditObject(object, 'variables')}
-            onAdd={
-              isVariableListLocked
-                ? null
-                : () => {
-                    if (variablesListRef.current) {
-                      variablesListRef.current.addVariable();
-                    }
-                    setIsVariablesFolded(false);
-                  }
-            }
-            renderContentAsHiddenWhenFolded={
-              true /* Allows to keep a ref to the variables list for add button to work. */
-            }
-            noContentMargin
-            renderContent={() => (
-              <VariablesList
-                ref={variablesListRef}
-                projectScopedContainersAccessor={
-                  projectScopedContainersAccessor
-                }
-                directlyStoreValueChangesWhileEditing
-                variablesContainer={object.getVariables()}
-                areObjectVariables
-                size="compact"
-                onComputeAllVariableNames={() =>
-                  object && layout
-                    ? EventsRootVariablesFinder.findAllObjectVariables(
-                        project.getCurrentPlatform(),
-                        project,
-                        layout,
-                        object.getName()
-                      )
-                    : []
-                }
-                historyHandler={historyHandler}
-                toolbarIconStyle={styles.icon}
-                compactEmptyPlaceholderText={
-                  <Trans>
-                    There are no{' '}
-                    <Link
-                      href={objectVariablesHelpLink}
-                      onClick={() =>
-                        Window.openExternalURL(objectVariablesHelpLink)
+          {variablesContainer && (
+            <TopLevelCollapsibleSection
+              title={<Trans>Object Variables</Trans>}
+              isFolded={isVariablesFolded}
+              toggleFolded={() => setIsVariablesFolded(!isVariablesFolded)}
+              onOpenFullEditor={() => onEditObject(object, 'variables')}
+              onAdd={
+                isVariableListLocked
+                  ? null
+                  : () => {
+                      if (variablesListRef.current) {
+                        variablesListRef.current.addVariable();
                       }
-                    >
-                      variables
-                    </Link>{' '}
-                    on this object.
-                  </Trans>
-                }
-                isListLocked={isVariableListLocked}
-              />
-            )}
-          />
+                      setIsVariablesFolded(false);
+                    }
+              }
+              renderContentAsHiddenWhenFolded={
+                true /* Allows to keep a ref to the variables list for add button to work. */
+              }
+              noContentMargin
+              renderContent={() => (
+                <VariablesList
+                  ref={variablesListRef}
+                  projectScopedContainersAccessor={
+                    projectScopedContainersAccessor
+                  }
+                  directlyStoreValueChangesWhileEditing
+                  variablesContainer={variablesContainer}
+                  areObjectVariables
+                  size="compact"
+                  onComputeAllVariableNames={() =>
+                    object && layout
+                      ? EventsRootVariablesFinder.findAllObjectVariables(
+                          project.getCurrentPlatform(),
+                          project,
+                          layout,
+                          object.getName()
+                        )
+                      : []
+                  }
+                  historyHandler={historyHandler}
+                  toolbarIconStyle={styles.icon}
+                  compactEmptyPlaceholderText={
+                    <Trans>
+                      There are no{' '}
+                      <Link
+                        href={objectVariablesHelpLink}
+                        onClick={() =>
+                          Window.openExternalURL(objectVariablesHelpLink)
+                        }
+                      >
+                        variables
+                      </Link>{' '}
+                      on this object.
+                    </Trans>
+                  }
+                  isListLocked={isVariableListLocked}
+                />
+              )}
+            />
+          )}
           {objectMetadata &&
             objectMetadata.hasDefaultBehavior(
               'EffectCapability::EffectBehavior'


### PR DESCRIPTION
### Motivation
- Prevent crashes when accessing variables of objects or instances that may have become invalid by guarding against dead pointers returned by `object.getVariables()` or `instance.getVariables()`.
- Ensure the variables list UI only renders when a valid variables container is available to avoid undefined behavior in the compact editors.

### Description
- Import `exceptionallyGuardAgainstDeadObject` from `../../Utils/IsNullPtr` and use it to sanitize `object.getVariables()` and `instance.getVariables()` into `variablesContainer` before use.
- Use `variablesContainer` instead of direct calls to `getVariables()` when rendering `VariablesList` and when handling the object variables `TopLevelCollapsibleSection` to conditionally render that section only when the container is valid.
- Keep the variables list ref and add behavior intact while preventing usage of a potentially dead object pointer.

### Testing
- Ran the project's test suite with `yarn test`, and all tests passed.
- Ran the linter with `yarn lint`, and no linting errors were reported.
- Performed a development build with `yarn build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d17c8b415083278837ab5c92a70804)