### PR TITLE
Adjusting Event sheet colors-P2

### DIFF
--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -763,7 +763,7 @@
     "instruction-parameter": {
       "base": {
         "color": {
-          "value": "#9AA5CE"
+          "value": "#8BED1C"
         }
       },
       "number": {
@@ -778,7 +778,7 @@
       },
       "behavior": {
         "color": {
-          "value": "#8BED1C"
+          "value": "#9AA5CE"
         }
       },
       "operator": {
@@ -793,7 +793,7 @@
       },
       "error": {
         "color": {
-          "value": "#281603"
+          "value": "#FF8569"
         },
         "background-color": {
           "value": "#FF8569"

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -793,15 +793,15 @@
       },
       "error": {
         "color": {
-          "value": "#FF8569"
+          "value": "#281603"
         },
         "background-color": {
-          "value": "#FF856944"
+          "value": "#FF8569"
         }
       },
       "warning": {
         "color": {
-          "value": "#FFBC57"
+          "value": "#FB9600"
         }
       }
     },

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -763,45 +763,45 @@
     "instruction-parameter": {
       "base": {
         "color": {
-          "value": "#98C379"
+          "value": "#B2BCD7"
         }
       },
       "number": {
         "color": {
-          "value": "#E5C07B"
+          "value": "#95C6FF"
         }
       },
       "object": {
         "color": {
-          "value": "#C678DD"
+          "value": "#C9B6FC"
         }
       },
       "behavior": {
         "color": {
-          "value": "#E09563"
+          "value": "#42F0AE"
         }
       },
       "operator": {
         "color": {
-          "value": "#B77CFF"
+          "value": "#FF85ED"
         }
       },
       "var": {
         "color": {
-          "value": "#56B6C2"
+          "value": "#CBE500"
         }
       },
       "error": {
         "color": {
-          "value": "#E06C75"
+          "value": "#FF8569"
         },
         "background-color": {
-          "value": "#E06C7544"
+          "value": "#FF856944"
         }
       },
       "warning": {
         "color": {
-          "value": "#E5C07B"
+          "value": "#FFBC57"
         }
       }
     },

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -763,22 +763,22 @@
     "instruction-parameter": {
       "base": {
         "color": {
-          "value": "#B2BCD7"
+          "value": "#9AA5CE"
         }
       },
       "number": {
         "color": {
-          "value": "#95C6FF"
+          "value": "#8AD6FF"
         }
       },
       "object": {
         "color": {
-          "value": "#C9B6FC"
+          "value": "#A483FF"
         }
       },
       "behavior": {
         "color": {
-          "value": "#42F0AE"
+          "value": "#8BED1C"
         }
       },
       "operator": {
@@ -788,7 +788,7 @@
       },
       "var": {
         "color": {
-          "value": "#CBE500"
+          "value": "#E2E225"
         }
       },
       "error": {

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -710,7 +710,7 @@
     },
     "conditions": {
       "background-color": {
-        "value": "#3E4452"
+        "value": "#25252E"
       },
       "border-color": {
         "value": "#3E4452"
@@ -740,7 +740,7 @@
     },
     "actions": {
       "background-color": {
-        "value": "#282C34"
+        "value": "#1D1D26"
       },
       "color": {
         "value": "#D6DEEC"

--- a/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultDarkTheme/theme.json
@@ -793,10 +793,10 @@
       },
       "error": {
         "color": {
-          "value": "#FF8569"
+          "value": "#FE6C46"
         },
         "background-color": {
-          "value": "#FF8569"
+          "value": "#FE6C46"
         }
       },
       "warning": {

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -761,32 +761,32 @@
     "instruction-parameter": {
       "base": {
         "color": {
-          "value": "#687085"
+          "value": "#5D689B"
         }
       },
       "number": {
         "color": {
-          "value": "#006DEE"
+          "value": "#046ACA"
         }
       },
       "object": {
         "color": {
-          "value": "#7046EC"
+          "value": "#7742F8"
         }
       },
       "behavior": {
         "color": {
-          "value": "#00AB6A"
+          "value": "#027C2A"
         }
       },
       "operator": {
         "color": {
-          "value": "#FF1ADD"
+          "value": "#C112A8"
         }
       },
       "var": {
         "color": {
-          "value": "#CC9200"
+          "value": "#7D6925"
         }
       },
       "error": {

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -761,7 +761,7 @@
     "instruction-parameter": {
       "base": {
         "color": {
-          "value": "#5D689B"
+          "value": "#027C2A"
         }
       },
       "number": {
@@ -776,7 +776,7 @@
       },
       "behavior": {
         "color": {
-          "value": "#027C2A"
+          "value": "#5D689B"
         }
       },
       "operator": {
@@ -791,7 +791,7 @@
       },
       "error": {
         "color": {
-          "value": "#281603"
+          "value": "#F03F18"
         },
         "background-color": {
           "value": "#F03F18"

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -708,7 +708,7 @@
     },
     "conditions": {
       "background-color": {
-        "value": "#f1f2f2"
+        "value": "#EBEBED"
       },
       "border-color": {
         "value": "#e2e2e2"
@@ -738,7 +738,7 @@
     },
     "actions": {
       "background-color": {
-        "value": "#FFFFFF"
+        "value": "#FAFAFA"
       },
       "color": {
         "value": "black"

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -791,15 +791,15 @@
       },
       "error": {
         "color": {
-          "value": "#FF8569"
+          "value": "#281603"
         },
         "background-color": {
-          "value": "#FF856944"
+          "value": "#F03F18"
         }
       },
       "warning": {
         "color": {
-          "value": "#FFBC57"
+          "value": "#D24700"
         }
       }
     },

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -761,45 +761,45 @@
     "instruction-parameter": {
       "base": {
         "color": {
-          "value": "rgb(78, 78, 78)"
+          "value": "#687085"
         }
       },
       "number": {
         "color": {
-          "value": "rgb(27, 143, 1)"
+          "value": "#006DEE"
         }
       },
       "object": {
         "color": {
-          "value": "#3c4698"
+          "value": "#7046EC"
         }
       },
       "behavior": {
         "color": {
-          "value": "rgb(119, 119, 119)"
+          "value": "#00AB6A"
         }
       },
       "operator": {
         "color": {
-          "value": "rgb(55, 131, 211)"
+          "value": "#FF1ADD"
         }
       },
       "var": {
         "color": {
-          "value": "rgb(131, 55, 162)"
+          "value": "#CC9200"
         }
       },
       "error": {
         "color": {
-          "value": "#E06C75"
+          "value": "#FF8569"
         },
         "background-color": {
-          "value": "#E06C7544"
+          "value": "#FF856944"
         }
       },
       "warning": {
         "color": {
-          "value": "#E5C07B"
+          "value": "#FFBC57"
         }
       }
     },

--- a/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
+++ b/newIDE/app/src/UI/Theme/DefaultLightTheme/theme.json
@@ -791,7 +791,7 @@
       },
       "error": {
         "color": {
-          "value": "#F03F18"
+          "value": "#C92906"
         },
         "background-color": {
           "value": "#F03F18"


### PR DESCRIPTION
Updating colors from [Palette No.1](https://github.com/4ian/GDevelop/pull/8495) to match the [minimum accessibility standards of AA for text](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html):

- Used GDevelop's offcial Gray as background
- Updated colors to hit at least the minimum value of contrast for small text (less than 18px).
- Same standards applied to Dark and Light
- Colors are equivalent across color Tokens (blue in dark is also blue in light, and so on.

----------------
**Notes:**

- Some [VSCode palette themes](https://vscodethemes.com/?sort=installs) where explored after observation on PR 8495
- Got color examples from palettes that could be GDevelop compatible
- Ran colors against AA contrast checkers
- Corrected colors to be at least AA (good readability for text smaller to 18px)
- Only kept swatches that matched the minimum of AA.