### PR TITLE
Spacing nit-fixing

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/BottomButtons.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/BottomButtons.js
@@ -96,7 +96,7 @@ export default function BottomButtons({
                               : addButtonTooltipLabelMouse
                           )}
                         >
-                          <Trans>Add a new event</Trans>
+                          + <Trans>Add a new event</Trans>
                         </button>
                       }
                       // $FlowFixMe[incompatible-type]
@@ -107,7 +107,7 @@ export default function BottomButtons({
                     <ElementWithMenu
                       element={
                         <button style={styles.addButton} className="add-link">
-                          <Trans>Add...</Trans>
+                          + <Trans>Add...</Trans>
                         </button>
                       }
                       // $FlowFixMe[incompatible-type]

--- a/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
@@ -278,7 +278,7 @@ export default function InstructionsList({
                     }
                     title={i18n._(addButtonTooltipLabel)}
                   >
-                    {addButtonLabel || addButtonDefaultLabel}
+                    + {addButtonLabel || addButtonDefaultLabel}
                   </button>
                   {canPaste && (
                     <span style={styles.pasteButtonContainer}>

--- a/newIDE/app/src/EventsSheet/EventsTree/style.css
+++ b/newIDE/app/src/EventsSheet/EventsTree/style.css
@@ -161,13 +161,13 @@
  * Links to add a condition or an action
  */
 .gd-events-sheet .add-link {
-    background:none!important;
-    color:inherit;
-    border:none;
-    padding:0!important;
+    background: none !important;
+    color: inherit;
+    border: none;
+    padding: 2px 6px !important;
     font: inherit;
     cursor: pointer;
-    opacity: 0.6;
+    opacity: 0.65;
 
     /** Ensure the links are not growing outside of their parents on small screens. */
     text-align: left;
@@ -175,7 +175,7 @@
     overflow-wrap: break-word;
 }
 .gd-events-sheet .add-link:hover {
-    opacity: 0.9;
+    opacity: 1;
 }
 
 /**


### PR DESCRIPTION
Changing a couple of factors to improve readability and reduce errors:
- Adding a "+" before buttons to add elements to the events (following app's conventions in other screens to improve recognition)
- Adjusting button padding to visually separate it from instruction text (better distinguishing them from instructions text blocks)
- Adding spacing to the Instruction List blocks to add a little more "visual air" to the rhythm of the sheet (helping the eye quickly identify where the "add" button would sit).