### PR TITLE
Add custom default Group and Comment colors

### DIFF
--- a/newIDE/app/src/CommandPalette/CommandsList.js
+++ b/newIDE/app/src/CommandPalette/CommandsList.js
@@ -69,7 +69,8 @@ export type CommandName =
   | 'SEARCH_EVENTS'
   | 'OPEN_EXTENSION_SETTINGS'
   | 'OPEN_PROFILE'
-  | 'OPEN_MEMORY_TRACKER_REGISTRY';
+  | 'OPEN_MEMORY_TRACKER_REGISTRY'
+  | 'OPEN_EVENT_DEFAULT_COLORS_DIALOG';
 
 export const commandAreas = {
   GENERAL: (t`General`: any),
@@ -184,6 +185,10 @@ const commandsList: { [CommandName]: CommandMetadata } = {
   OPEN_PROJECT_PROPERTIES: {
     area: 'PROJECT',
     displayText: t`Open project properties`,
+  },
+  OPEN_EVENT_DEFAULT_COLORS_DIALOG: {
+    area: 'PROJECT',
+    displayText: t`Group and Comment default colors`,
   },
   OPEN_PROJECT_LOADING_SCREEN: {
     area: 'PROJECT',

--- a/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
+++ b/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
@@ -15,6 +15,9 @@ import {
 } from '../Utils/ColorTransformer';
 import { MiniToolbarText } from '../UI/MiniToolbar';
 import GDevelopThemeContext from '../UI/Theme/GDevelopThemeContext';
+import { ColumnStackLayout, LineStackLayout } from '../UI/Layout';
+import Paper from '../UI/Paper';
+import Text from '../UI/Text';
 
 const EXTENSION_NAME = 'EventDefaultColors';
 const PROP_GROUP_BG = 'groupBg';
@@ -30,7 +33,6 @@ const styles = {
     marginTop: 20,
     padding: 10,
     borderRadius: 8,
-    border: '1px solid rgba(255, 255, 255, 0.1)',
   },
   previewEvent: {
     padding: 10,
@@ -134,8 +136,8 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props): React.Node => {
       onRequestClose={onClose}
       onApply={onApply}
     >
-      <Column noMargin>
-        <Line alignItems="center">
+      <ColumnStackLayout noMargin>
+        <LineStackLayout alignItems="center">
           <MiniToolbarText>
             <Trans>Group background:</Trans>
           </MiniToolbarText>
@@ -145,8 +147,8 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props): React.Node => {
             onChangeComplete={color => setGroupColor(color.rgb)}
             disableAlpha
           />
-        </Line>
-        <Line alignItems="center">
+        </LineStackLayout>
+        <LineStackLayout alignItems="center">
           <MiniToolbarText>
             <Trans>Comment background:</Trans>
           </MiniToolbarText>
@@ -165,17 +167,16 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props): React.Node => {
             onChangeComplete={color => setCommentTextColor(color.rgb)}
             disableAlpha
           />
-        </Line>
-        <div
-          style={{
-            ...styles.previewContainer,
-            backgroundColor: gdevelopTheme.dialog.backgroundColor,
-          }}
+        </LineStackLayout>
+        <Paper
+          background="dark"
+          variant="outlined"
+          style={styles.previewContainer}
         >
-          <Column noMargin>
-            <MiniToolbarText>
+          <ColumnStackLayout noMargin>
+            <Text size="block-title">
               <Trans>Preview (newly created events):</Trans>
-            </MiniToolbarText>
+            </Text>
             <div
               style={{
                 ...styles.previewEvent,
@@ -200,9 +201,9 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props): React.Node => {
                 </Trans>
               </span>
             </div>
-          </Column>
-        </div>
-      </Column>
+          </ColumnStackLayout>
+        </Paper>
+      </ColumnStackLayout>
     </Dialog>
   );
 };

--- a/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
+++ b/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
@@ -1,0 +1,215 @@
+// @flow
+import { Trans } from '@lingui/macro';
+
+import * as React from 'react';
+import Dialog, { DialogPrimaryButton } from '../UI/Dialog';
+import FlatButton from '../UI/FlatButton';
+import { Line, Column } from '../UI/Grid';
+import ColorPicker from '../UI/ColorField/ColorPicker';
+import { type RGBColor, rgbToHex } from '../Utils/ColorTransformer';
+import { MiniToolbarText } from '../UI/MiniToolbar';
+
+const EXTENSION_NAME = 'EventDefaultColors';
+const PROP_GROUP_BG = 'groupBg';
+const PROP_COMMENT_BG = 'commentBg';
+const PROP_COMMENT_TEXT = 'commentText';
+
+const rgbToString = (color: RGBColor) => `${color.r};${color.g};${color.b}`;
+const stringToRgb = (str: string, defaultColor: RGBColor): RGBColor => {
+  if (!str) return defaultColor;
+  const parts = str.split(';').map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) return defaultColor;
+  return { r: parts[0], g: parts[1], b: parts[2] };
+};
+
+const styles = {
+  colorPicker: {
+    width: 90,
+    marginRight: 10,
+  },
+  previewContainer: {
+    marginTop: 20,
+    padding: 10,
+    borderRadius: 8,
+    border: '1px solid #ccc',
+    backgroundColor: '#fff',
+    color: '#000',
+  },
+  previewEvent: {
+    padding: 10,
+    marginBottom: 5,
+    borderRadius: 4,
+    fontSize: 14,
+    fontFamily: 'sans-serif',
+    display: 'flex',
+    alignItems: 'center',
+    minHeight: '2.5em',
+  },
+  groupTitle: {
+    fontSize: '1.3em',
+    fontWeight: 'normal',
+  },
+  commentText: {
+    fontStyle: 'italic',
+    whiteSpace: 'pre-wrap',
+  },
+};
+
+type Props = {|
+  project: gdProject,
+  onClose: () => void,
+|};
+
+const EventDefaultColorsDialog = ({ project, onClose }: Props) => {
+  const extensionProperties = project.getExtensionProperties();
+
+  const [groupColor, setGroupColor] = React.useState<RGBColor>(
+    stringToRgb(extensionProperties.getValue(EXTENSION_NAME, PROP_GROUP_BG), {
+      r: 74,
+      g: 176,
+      b: 228,
+    })
+  );
+  const [commentBgColor, setCommentBgColor] = React.useState<RGBColor>(
+    stringToRgb(extensionProperties.getValue(EXTENSION_NAME, PROP_COMMENT_BG), {
+      r: 255,
+      g: 230,
+      b: 109,
+    })
+  );
+  const [commentTextColor, setCommentTextColor] = React.useState<RGBColor>(
+    stringToRgb(
+      extensionProperties.getValue(EXTENSION_NAME, PROP_COMMENT_TEXT),
+      {
+        r: 0,
+        g: 0,
+        b: 0,
+      }
+    )
+  );
+
+  const onApply = () => {
+    extensionProperties.setValue(
+      EXTENSION_NAME,
+      PROP_GROUP_BG,
+      rgbToString(groupColor)
+    );
+    extensionProperties.setValue(
+      EXTENSION_NAME,
+      PROP_COMMENT_BG,
+      rgbToString(commentBgColor)
+    );
+    extensionProperties.setValue(
+      EXTENSION_NAME,
+      PROP_COMMENT_TEXT,
+      rgbToString(commentTextColor)
+    );
+    onClose();
+  };
+
+  const groupTextColorHex =
+    (groupColor.r + groupColor.g + groupColor.b) / 3 > 200
+      ? '#000000'
+      : '#ffffff';
+  const groupBgColorHex = `#${rgbToHex(
+    groupColor.r,
+    groupColor.g,
+    groupColor.b
+  )}`;
+  const commentBgColorHex = `#${rgbToHex(
+    commentBgColor.r,
+    commentBgColor.g,
+    commentBgColor.b
+  )}`;
+  const commentTextColorHex = `#${rgbToHex(
+    commentTextColor.r,
+    commentTextColor.g,
+    commentTextColor.b
+  )}`;
+
+  return (
+    <Dialog
+      title={<Trans>Group and Comment default colors</Trans>}
+      open
+      maxWidth="sm"
+      actions={[
+        <FlatButton
+          key="cancel"
+          label={<Trans>Cancel</Trans>}
+          onClick={onClose}
+        />,
+        <DialogPrimaryButton
+          key="apply"
+          label={<Trans>Apply</Trans>}
+          onClick={onApply}
+        />,
+      ]}
+      onRequestClose={onClose}
+    >
+      <Column noMargin>
+        <Line alignItems="center">
+          <MiniToolbarText>
+            <Trans>Group background:</Trans>
+          </MiniToolbarText>
+          <ColorPicker
+            style={styles.colorPicker}
+            color={groupColor}
+            onChangeComplete={color => setGroupColor(color.rgb)}
+            disableAlpha
+          />
+        </Line>
+        <Line alignItems="center">
+          <MiniToolbarText>
+            <Trans>Comment background:</Trans>
+          </MiniToolbarText>
+          <ColorPicker
+            style={styles.colorPicker}
+            color={commentBgColor}
+            onChangeComplete={color => setCommentBgColor(color.rgb)}
+            disableAlpha
+          />
+          <MiniToolbarText>
+            <Trans>Comment text:</Trans>
+          </MiniToolbarText>
+          <ColorPicker
+            style={styles.colorPicker}
+            color={commentTextColor}
+            onChangeComplete={color => setCommentTextColor(color.rgb)}
+            disableAlpha
+          />
+        </Line>
+        <Column noMargin style={styles.previewContainer}>
+          <MiniToolbarText>
+            <Trans>Preview (newly created events):</Trans>
+          </MiniToolbarText>
+          <div
+            style={{
+              ...styles.previewEvent,
+              backgroundColor: groupBgColorHex,
+              color: groupTextColorHex,
+            }}
+          >
+            <span style={styles.groupTitle}>
+              <Trans>Example Group</Trans>
+            </span>
+          </div>
+          <div
+            style={{
+              ...styles.previewEvent,
+              backgroundColor: commentBgColorHex,
+              color: commentTextColorHex,
+            }}
+          >
+            <span style={styles.commentText}>
+              <Trans>
+                This is a comment event with your chosen default colors.
+              </Trans>
+            </span>
+          </div>
+        </Column>
+      </Column>
+    </Dialog>
+  );
+};
+
+export default EventDefaultColorsDialog;

--- a/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
+++ b/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
@@ -14,6 +14,7 @@ import {
   isLightRgbColor,
 } from '../Utils/ColorTransformer';
 import { MiniToolbarText } from '../UI/MiniToolbar';
+import GDevelopThemeContext from '../UI/Theme/GDevelopThemeContext';
 
 const EXTENSION_NAME = 'EventDefaultColors';
 const PROP_GROUP_BG = 'groupBg';
@@ -29,9 +30,7 @@ const styles = {
     marginTop: 20,
     padding: 10,
     borderRadius: 8,
-    border: '1px solid #ccc',
-    backgroundColor: '#fff',
-    color: '#000',
+    border: '1px solid rgba(255, 255, 255, 0.1)',
   },
   previewEvent: {
     padding: 10,
@@ -58,7 +57,7 @@ type Props = {|
   onClose: () => void,
 |};
 
-const EventDefaultColorsDialog = ({ project, onClose }: Props) => {
+const EventDefaultColorsDialog = ({ project, onClose }: Props): React.Node => {
   const extensionProperties = project.getExtensionProperties();
 
   const [groupColor, setGroupColor] = React.useState<RGBColor>(
@@ -96,6 +95,8 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props) => {
     onClose();
   };
 
+  const gdevelopTheme = React.useContext(GDevelopThemeContext);
+
   const groupTextColorHex = isLightRgbColor(groupColor) ? '#000000' : '#ffffff';
   const groupBgColorHex = `#${rgbToHex(
     groupColor.r,
@@ -131,6 +132,7 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props) => {
         />,
       ]}
       onRequestClose={onClose}
+      onApply={onApply}
     >
       <Column noMargin>
         <Line alignItems="center">
@@ -164,35 +166,42 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props) => {
             disableAlpha
           />
         </Line>
-        <Column noMargin style={styles.previewContainer}>
-          <MiniToolbarText>
-            <Trans>Preview (newly created events):</Trans>
-          </MiniToolbarText>
-          <div
-            style={{
-              ...styles.previewEvent,
-              backgroundColor: groupBgColorHex,
-              color: groupTextColorHex,
-            }}
-          >
-            <span style={styles.groupTitle}>
-              <Trans>Example Group</Trans>
-            </span>
-          </div>
-          <div
-            style={{
-              ...styles.previewEvent,
-              backgroundColor: commentBgColorHex,
-              color: commentTextColorHex,
-            }}
-          >
-            <span style={styles.commentText}>
-              <Trans>
-                This is a comment event with your chosen default colors.
-              </Trans>
-            </span>
-          </div>
-        </Column>
+        <div
+          style={{
+            ...styles.previewContainer,
+            backgroundColor: gdevelopTheme.dialog.backgroundColor,
+          }}
+        >
+          <Column noMargin>
+            <MiniToolbarText>
+              <Trans>Preview (newly created events):</Trans>
+            </MiniToolbarText>
+            <div
+              style={{
+                ...styles.previewEvent,
+                backgroundColor: groupBgColorHex,
+                color: groupTextColorHex,
+              }}
+            >
+              <span style={styles.groupTitle}>
+                <Trans>Example Group</Trans>
+              </span>
+            </div>
+            <div
+              style={{
+                ...styles.previewEvent,
+                backgroundColor: commentBgColorHex,
+                color: commentTextColorHex,
+              }}
+            >
+              <span style={styles.commentText}>
+                <Trans>
+                  This is a comment event with your chosen default colors.
+                </Trans>
+              </span>
+            </div>
+          </Column>
+        </div>
       </Column>
     </Dialog>
   );

--- a/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
+++ b/newIDE/app/src/EventsSheet/EventDefaultColorsDialog.js
@@ -6,21 +6,19 @@ import Dialog, { DialogPrimaryButton } from '../UI/Dialog';
 import FlatButton from '../UI/FlatButton';
 import { Line, Column } from '../UI/Grid';
 import ColorPicker from '../UI/ColorField/ColorPicker';
-import { type RGBColor, rgbToHex } from '../Utils/ColorTransformer';
+import {
+  type RGBColor,
+  rgbToHex,
+  rgbColorToRGBString,
+  rgbStringAndAlphaToRGBColor,
+  isLightRgbColor,
+} from '../Utils/ColorTransformer';
 import { MiniToolbarText } from '../UI/MiniToolbar';
 
 const EXTENSION_NAME = 'EventDefaultColors';
 const PROP_GROUP_BG = 'groupBg';
 const PROP_COMMENT_BG = 'commentBg';
 const PROP_COMMENT_TEXT = 'commentText';
-
-const rgbToString = (color: RGBColor) => `${color.r};${color.g};${color.b}`;
-const stringToRgb = (str: string, defaultColor: RGBColor): RGBColor => {
-  if (!str) return defaultColor;
-  const parts = str.split(';').map(Number);
-  if (parts.length !== 3 || parts.some(isNaN)) return defaultColor;
-  return { r: parts[0], g: parts[1], b: parts[2] };
-};
 
 const styles = {
   colorPicker: {
@@ -64,53 +62,41 @@ const EventDefaultColorsDialog = ({ project, onClose }: Props) => {
   const extensionProperties = project.getExtensionProperties();
 
   const [groupColor, setGroupColor] = React.useState<RGBColor>(
-    stringToRgb(extensionProperties.getValue(EXTENSION_NAME, PROP_GROUP_BG), {
-      r: 74,
-      g: 176,
-      b: 228,
-    })
+    rgbStringAndAlphaToRGBColor(
+      extensionProperties.getValue(EXTENSION_NAME, PROP_GROUP_BG)
+    ) || { r: 74, g: 176, b: 228 }
   );
   const [commentBgColor, setCommentBgColor] = React.useState<RGBColor>(
-    stringToRgb(extensionProperties.getValue(EXTENSION_NAME, PROP_COMMENT_BG), {
-      r: 255,
-      g: 230,
-      b: 109,
-    })
+    rgbStringAndAlphaToRGBColor(
+      extensionProperties.getValue(EXTENSION_NAME, PROP_COMMENT_BG)
+    ) || { r: 255, g: 230, b: 109 }
   );
   const [commentTextColor, setCommentTextColor] = React.useState<RGBColor>(
-    stringToRgb(
-      extensionProperties.getValue(EXTENSION_NAME, PROP_COMMENT_TEXT),
-      {
-        r: 0,
-        g: 0,
-        b: 0,
-      }
-    )
+    rgbStringAndAlphaToRGBColor(
+      extensionProperties.getValue(EXTENSION_NAME, PROP_COMMENT_TEXT)
+    ) || { r: 0, g: 0, b: 0 }
   );
 
   const onApply = () => {
     extensionProperties.setValue(
       EXTENSION_NAME,
       PROP_GROUP_BG,
-      rgbToString(groupColor)
+      rgbColorToRGBString(groupColor)
     );
     extensionProperties.setValue(
       EXTENSION_NAME,
       PROP_COMMENT_BG,
-      rgbToString(commentBgColor)
+      rgbColorToRGBString(commentBgColor)
     );
     extensionProperties.setValue(
       EXTENSION_NAME,
       PROP_COMMENT_TEXT,
-      rgbToString(commentTextColor)
+      rgbColorToRGBString(commentTextColor)
     );
     onClose();
   };
 
-  const groupTextColorHex =
-    (groupColor.r + groupColor.g + groupColor.b) / 3 > 200
-      ? '#000000'
-      : '#ffffff';
+  const groupTextColorHex = isLightRgbColor(groupColor) ? '#000000' : '#ffffff';
   const groupBgColorHex = `#${rgbToHex(
     groupColor.r,
     groupColor.g,

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -720,6 +720,35 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       insertion.indexInList + 1
     );
 
+    const extensionProperties = project.getExtensionProperties();
+    const stringToRgb = (str: string, defaultColor: Object): Object => {
+      if (!str) return defaultColor;
+      const parts = str.split(';').map(Number);
+      if (parts.length !== 3 || parts.some(isNaN)) return defaultColor;
+      return { r: parts[0], g: parts[1], b: parts[2] };
+    };
+
+    if (type === 'BuiltinCommonInstructions::Group') {
+      const groupEvent = gd.asGroupEvent(newEvent);
+      const color = stringToRgb(
+        extensionProperties.getValue('EventDefaultColors', 'groupBg'),
+        { r: 74, g: 176, b: 228 }
+      );
+      groupEvent.setBackgroundColor(color.r, color.g, color.b);
+    } else if (type === 'BuiltinCommonInstructions::Comment') {
+      const commentEvent = gd.asCommentEvent(newEvent);
+      const bgColor = stringToRgb(
+        extensionProperties.getValue('EventDefaultColors', 'commentBg'),
+        { r: 255, g: 230, b: 109 }
+      );
+      const textColor = stringToRgb(
+        extensionProperties.getValue('EventDefaultColors', 'commentText'),
+        { r: 0, g: 0, b: 0 }
+      );
+      commentEvent.setBackgroundColor(bgColor.r, bgColor.g, bgColor.b);
+      commentEvent.setTextColor(textColor.r, textColor.g, textColor.b);
+    }
+
     const eventsTree = this._eventsTree;
     if (eventsTree) {
       eventsTree.forceEventsUpdate(() => {

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -128,6 +128,7 @@ import { useHighlightedAiGeneratedEvent } from './UseHighlightedAiGeneratedEvent
 import { findEventByPath } from '../Utils/EventsValidationScanner';
 import type { SearchFilterParams } from '../Utils/Search';
 import type { InitialSearchFilterParams } from './SearchPanel';
+import { rgbStringAndAlphaToRGBColor } from '../Utils/ColorTransformer';
 
 const gd: libGDevelop = global.gd;
 
@@ -721,30 +722,21 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     );
 
     const extensionProperties = project.getExtensionProperties();
-    const stringToRgb = (str: string, defaultColor: Object): Object => {
-      if (!str) return defaultColor;
-      const parts = str.split(';').map(Number);
-      if (parts.length !== 3 || parts.some(isNaN)) return defaultColor;
-      return { r: parts[0], g: parts[1], b: parts[2] };
-    };
 
     if (type === 'BuiltinCommonInstructions::Group') {
       const groupEvent = gd.asGroupEvent(newEvent);
-      const color = stringToRgb(
-        extensionProperties.getValue('EventDefaultColors', 'groupBg'),
-        { r: 74, g: 176, b: 228 }
-      );
+      const color = rgbStringAndAlphaToRGBColor(
+        extensionProperties.getValue('EventDefaultColors', 'groupBg')
+      ) || { r: 74, g: 176, b: 228 };
       groupEvent.setBackgroundColor(color.r, color.g, color.b);
     } else if (type === 'BuiltinCommonInstructions::Comment') {
       const commentEvent = gd.asCommentEvent(newEvent);
-      const bgColor = stringToRgb(
-        extensionProperties.getValue('EventDefaultColors', 'commentBg'),
-        { r: 255, g: 230, b: 109 }
-      );
-      const textColor = stringToRgb(
-        extensionProperties.getValue('EventDefaultColors', 'commentText'),
-        { r: 0, g: 0, b: 0 }
-      );
+      const bgColor = rgbStringAndAlphaToRGBColor(
+        extensionProperties.getValue('EventDefaultColors', 'commentBg')
+      ) || { r: 255, g: 230, b: 109 };
+      const textColor = rgbStringAndAlphaToRGBColor(
+        extensionProperties.getValue('EventDefaultColors', 'commentText')
+      ) || { r: 0, g: 0, b: 0 };
       commentEvent.setBackgroundColor(bgColor.r, bgColor.g, bgColor.b);
       commentEvent.setTextColor(textColor.r, textColor.g, textColor.b);
     }

--- a/newIDE/app/src/MainFrame/MainFrameCommands.js
+++ b/newIDE/app/src/MainFrame/MainFrameCommands.js
@@ -70,6 +70,7 @@ type CommandHandlers = {|
   onRestartInGameEditor: (reason: string) => void,
   onOpenGlobalSearch: () => void,
   onOpenMemoryTrackerRegistry: () => void,
+  onOpenEventDefaultColorsDialog: () => void,
 |};
 
 const useMainFrameCommands = (handlers: CommandHandlers) => {
@@ -181,6 +182,10 @@ const useMainFrameCommands = (handlers: CommandHandlers) => {
 
   useCommand('OPEN_MEMORY_TRACKER_REGISTRY', true, {
     handler: handlers.onOpenMemoryTrackerRegistry,
+  });
+
+  useCommand('OPEN_EVENT_DEFAULT_COLORS_DIALOG', !!handlers.project, {
+    handler: handlers.onOpenEventDefaultColorsDialog,
   });
 
   useCommandWithOptions('OPEN_LAYOUT', !!handlers.project, {

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -241,6 +241,7 @@ import StandaloneDialog from './StandAloneDialog';
 import { useInGameEditorSettings } from '../EmbeddedGame/InGameEditorSettings';
 import { ProjectScopedContainersAccessor } from '../InstructionOrExpression/EventsScope';
 import { useAutomatedRegularInGameEditorRestart } from '../EmbeddedGame/UseAutomatedRegularInGameEditorRestart';
+import EventDefaultColorsDialog from '../EventsSheet/EventDefaultColorsDialog';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -466,6 +467,10 @@ const MainFrame = (props: Props): React.MixedElement => {
   const [
     memoryTrackerRegistryDialogOpen,
     setMemoryTrackedRegistryDialogOpen,
+  ] = React.useState<boolean>(false);
+  const [
+    eventDefaultColorsDialogOpen,
+    setEventDefaultColorsDialogOpen,
   ] = React.useState<boolean>(false);
 
   /**
@@ -4867,6 +4872,7 @@ const MainFrame = (props: Props): React.MixedElement => {
     onRestartInGameEditor,
     onOpenGlobalSearch: openGlobalSearch,
     onOpenMemoryTrackerRegistry: () => setMemoryTrackedRegistryDialogOpen(true),
+    onOpenEventDefaultColorsDialog: () => setEventDefaultColorsDialogOpen(true),
   });
 
   const resourceManagementProps: ResourceManagementProps = React.useMemo(
@@ -5605,6 +5611,12 @@ const MainFrame = (props: Props): React.MixedElement => {
       {memoryTrackerRegistryDialogOpen && (
         <MemoryTrackedRegistryDialog
           onClose={() => setMemoryTrackedRegistryDialogOpen(false)}
+        />
+      )}
+      {eventDefaultColorsDialogOpen && currentProject && (
+        <EventDefaultColorsDialog
+          project={currentProject}
+          onClose={() => setEventDefaultColorsDialogOpen(false)}
         />
       )}
       <CustomDragLayer />


### PR DESCRIPTION
This feature adds a new section in the command palette for users to set default custom colors for newly created groups and comments in the event sheet for a specific project.

The motivation for this feature is that users wanting to have consistent custom colors in their groups and comments need to manually change the color of each group/comment as they create them. This feature can save a lot of time for users that want unique colors in their event sheets as they no longer will need to edit each group or comment one-by-one as they are created.

I opted to use the command palette for this feature to not pollute the project settings menu. 

Color for groups do not have editable text option as text color is already calculated depending on its color.

<img width="676" height="351" alt="image" src="https://github.com/user-attachments/assets/2fa92f9f-02ec-4dce-99de-bd301caa718f" />

<img width="686" height="513" alt="image" src="https://github.com/user-attachments/assets/28a0f96a-71ae-4cf0-86ff-b7ff1fdd04ec" />

<img width="1846" height="414" alt="image" src="https://github.com/user-attachments/assets/6ab4b8b9-3db2-468a-835a-bce489e6df64" />

