### PR TITLE
Fix tentatively crash in popped-out window when a theme is missing a color

### DIFF
--- a/newIDE/app/src/Utils/Window.js
+++ b/newIDE/app/src/Utils/Window.js
@@ -125,6 +125,13 @@ export default class Window {
   static setWindowBackgroundColor(newColor: string, targetDocument?: Document) {
     const doc = targetDocument || document;
 
+    if (!newColor) {
+      // Be defensive against themes missing a color (for instance, a
+      // newly added variable that an older or custom theme doesn't define):
+      // skip the update rather than crashing.
+      return;
+    }
+
     if (documentBackgroundColors.get(doc) === newColor) {
       // Avoid potentially expensive DOM query/modification if no changes needed.
       return;


### PR DESCRIPTION
Window.setWindowBackgroundColor was crashing with "Cannot read properties of undefined (reading 'replace')" when called with an undefined color. Unsure why it happens but now skip the update instead of crashing.

Fix #8517