### PR TITLE
fix(admob): upgrade to patched GDevelop forks for Cordova iOS 8 compat

### DIFF
--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -61,7 +61,7 @@ module.exports = {
       .setName('AdMob Cordova plugin')
       .setDependencyType('cordova')
       .setExportName('gdevelop-cordova-admob-plus')
-      .setVersion('2.0.0-alpha.21')
+      .setVersion('2.0.0-alpha.24')
       .setExtraSetting(
         'APP_ID_ANDROID',
         new gd.PropertyDescriptor('AdMobAppIdAndroid').setType(

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -61,7 +61,7 @@ module.exports = {
       .setName('AdMob Cordova plugin')
       .setDependencyType('cordova')
       .setExportName('gdevelop-cordova-admob-plus')
-      .setVersion('2.0.0-alpha.20')
+      .setVersion('2.0.0-alpha.21')
       .setExtraSetting(
         'APP_ID_ANDROID',
         new gd.PropertyDescriptor('AdMobAppIdAndroid').setType(

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -61,7 +61,7 @@ module.exports = {
       .setName('AdMob Cordova plugin')
       .setDependencyType('cordova')
       .setExportName('gdevelop-cordova-admob-plus')
-      .setVersion('2.0.0-alpha.19')
+      .setVersion('2.0.0-alpha.20')
       .setExtraSetting(
         'APP_ID_ANDROID',
         new gd.PropertyDescriptor('AdMobAppIdAndroid').setType(

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -40,7 +40,7 @@ module.exports = {
       .addDependency()
       .setName('Consent Cordova plugin')
       .setDependencyType('cordova')
-      .setExportName('cordova-plugin-consent')
+      .setExportName('gdevelop-cordova-plugin-consent')
       .setVersion('3.0.0-alpha.9')
       .onlyIfOtherDependencyIsExported('AdMob Cordova plugin');
 
@@ -60,8 +60,8 @@ module.exports = {
       .addDependency()
       .setName('AdMob Cordova plugin')
       .setDependencyType('cordova')
-      .setExportName('admob-plus-cordova')
-      .setVersion('2.0.0-alpha.18')
+      .setExportName('gdevelop-cordova-admob-plus')
+      .setVersion('2.0.0-alpha.19')
       .setExtraSetting(
         'APP_ID_ANDROID',
         new gd.PropertyDescriptor('AdMobAppIdAndroid').setType(

--- a/Extensions/AdMob/JsExtension.js
+++ b/Extensions/AdMob/JsExtension.js
@@ -41,7 +41,7 @@ module.exports = {
       .setName('Consent Cordova plugin')
       .setDependencyType('cordova')
       .setExportName('gdevelop-cordova-plugin-consent')
-      .setVersion('3.0.0-alpha.9')
+      .setVersion('3.0.0-alpha.9.patch.1')
       .onlyIfOtherDependencyIsExported('AdMob Cordova plugin');
 
     extension
@@ -61,7 +61,7 @@ module.exports = {
       .setName('AdMob Cordova plugin')
       .setDependencyType('cordova')
       .setExportName('gdevelop-cordova-admob-plus')
-      .setVersion('2.0.0-alpha.24')
+      .setVersion('2.0.0-alpha.19.patch.1')
       .setExtraSetting(
         'APP_ID_ANDROID',
         new gd.PropertyDescriptor('AdMobAppIdAndroid').setType(

--- a/newIDE/app/src/ExportAndShare/ExportPipeline.flow.js
+++ b/newIDE/app/src/ExportAndShare/ExportPipeline.flow.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { type I18n as I18nType } from '@lingui/core';
 import { type Build, type BuildType } from '../Utils/GDevelopServices/Build';
 import { type AuthenticatedUser } from '../Profile/AuthenticatedUserContext';
 import { type BuildStep } from './Builds/BuildStepsProgress';
@@ -11,6 +12,7 @@ export type ExportPipelineContext<ExportState> = {|
   project: gdProject,
   exportState: ExportState,
   updateStepProgress: (count: number, total: number) => void,
+  i18n: I18nType,
 |};
 
 export type HeaderProps<ExportState> = {|

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalCordovaExport.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalCordovaExport.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -131,9 +131,17 @@ export const localCordovaExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       urlFiles: localFileSystem.getAllUrlFilesIn(context.exportState.outputDir),

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalElectronExport.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalElectronExport.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -131,9 +131,17 @@ export const localElectronExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       urlFiles: localFileSystem.getAllUrlFilesIn(context.exportState.outputDir),

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalFacebookInstantGamesExport.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalFacebookInstantGamesExport.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -153,9 +153,17 @@ export const localFacebookInstantGamesExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       temporaryOutputDir,

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalHTML5Export.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalHTML5Export.js
@@ -1,5 +1,5 @@
 // @flow
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 
 import React from 'react';
 import RaisedButton from '../../UI/RaisedButton';
@@ -133,9 +133,17 @@ export const localHTML5ExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       urlFiles: localFileSystem.getAllUrlFilesIn(context.exportState.outputDir),

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineCordovaExport.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineCordovaExport.js
@@ -1,4 +1,5 @@
 // @flow
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import assignIn from 'lodash/assignIn';
 import {
@@ -129,9 +130,17 @@ export const localOnlineCordovaExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       temporaryOutputDir,

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineCordovaIosExport.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineCordovaIosExport.js
@@ -1,4 +1,5 @@
 // @flow
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import assignIn from 'lodash/assignIn';
 import {
@@ -128,9 +129,17 @@ export const localOnlineCordovaIosExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       temporaryOutputDir,

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineElectronExport.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineElectronExport.js
@@ -1,4 +1,5 @@
 // @flow
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import assignIn from 'lodash/assignIn';
 import {
@@ -125,9 +126,17 @@ export const localOnlineElectronExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       temporaryOutputDir,

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineWebExport.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalOnlineWebExport.js
@@ -1,4 +1,5 @@
 // @flow
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import assignIn from 'lodash/assignIn';
 import {
@@ -116,9 +117,17 @@ export const localOnlineWebExportPipeline: ExportPipeline<
         fallbackAuthor.username
       );
     }
-    exporter.exportWholePixiProject(exportOptions);
+    const exportSucceeded = exporter.exportWholePixiProject(exportOptions);
     exportOptions.delete();
     exporter.delete();
+
+    if (!exportSucceeded) {
+      throw new Error(
+        context.i18n._(
+          t`Export failed. Check that the output folder is accessible and that you have the necessary permissions.`
+        )
+      );
+    }
 
     return {
       temporaryOutputDir,

--- a/newIDE/app/src/ExportAndShare/ShareDialog/ExportLauncher.js
+++ b/newIDE/app/src/ExportAndShare/ShareDialog/ExportLauncher.js
@@ -272,6 +272,7 @@ export default class ExportLauncher extends Component<Props, State> {
         project,
         updateStepProgress: this._updateStepProgress,
         exportState: this.state.exportState,
+        i18n,
       };
 
       if (
@@ -443,7 +444,7 @@ export default class ExportLauncher extends Component<Props, State> {
       return exportPipeline.canLaunchBuild(exportState, errored, exportStep);
     };
 
-    const isExporting = !!exportStep && exportStep !== 'done';
+    const isExporting = !!exportStep && exportStep !== 'done' && !errored;
     const isBuildRunning = !!build && build.status === 'pending';
     const isExportingOrWaitingForBuild = isExporting || isBuildRunning;
     const isExportAndBuildCompleteOrErrored =


### PR DESCRIPTION
Switch admob-plus-cordova -> gdevelop-cordova-admob-plus@2.0.0-alpha.19 and cordova-plugin-consent -> gdevelop-cordova-plugin-consent@3.0.0-alpha.9, fixing CDVPluginResult optional/enum breaking changes from Cordova iOS 8.