### PR TITLE
Fix inline fields prefilling to = after opening a relational operator

### DIFF
--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -2629,6 +2629,13 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
                   </ErrorBoundary>
                 )}
                 <InlineParameterEditor
+                  // Remount when switching parameters so stale local state can't
+                  // bleed into the next parameter via React 18 batched renders.
+                  key={`${
+                    this.state.editedParameter.instruction
+                      ? this.state.editedParameter.instruction.ptr
+                      : 'none'
+                  }-${this.state.editedParameter.parameterIndex}`}
                   open={this.state.inlineEditing}
                   anchorEl={this.state.inlineEditingAnchorEl}
                   onRequestClose={() => {


### PR DESCRIPTION
This was likely due to React 18 batching setState and an effect from a field being applied on another field

Before:

https://github.com/user-attachments/assets/a58044fe-8b36-4794-b831-4dbb6313c19f

After:

https://github.com/user-attachments/assets/c3ac3fcc-01c8-4c39-8235-db6f5644578d


