### PR TITLE
Fix renaming objects on mobile weird behaviors

### DIFF
--- a/newIDE/app/src/UI/TreeView/TreeViewRow.js
+++ b/newIDE/app/src/UI/TreeView/TreeViewRow.js
@@ -100,6 +100,7 @@ const SemiControlledRowInput = ({
         }}
         onClick={stopPropagation}
         onDoubleClick={stopPropagation}
+        onContextMenu={stopPropagation}
         onBlur={() => {
           onEndRenaming(value);
         }}
@@ -172,7 +173,10 @@ const TreeViewRow = <Item: ItemBaseAttributes>(props: Props<Item>) => {
     [onContextMenu, index, node.item]
   );
 
-  const longTouchForContextMenuProps = useLongTouch(openContextMenu, {
+  const {
+    isPressingRef: isLongTouchPressingRef,
+    ...longTouchForContextMenuProps
+  } = useLongTouch(openContextMenu, {
     delay: DELAY_BEFORE_OPENING_CONTEXT_MENU_ON_MOBILE,
   });
 
@@ -302,7 +306,10 @@ const TreeViewRow = <Item: ItemBaseAttributes>(props: Props<Item>) => {
           !node.item.isRoot &&
           !node.item.isPlaceholder &&
           // Prevent dragging of item whose name is edited, allowing to select text with click and drag on text.
-          renamedItemId !== node.id
+          renamedItemId !== node.id &&
+          // Prevent drag from starting during a long-press (which opens the context menu on mobile).
+          // When the user moves their finger, useLongTouch cancels, clearing isPressingRef, re-enabling drag.
+          !isLongTouchPressingRef.current
         }
         canDrop={canDrop ? () => canDrop(node.item, whereToDrop) : () => true}
         drop={() => {
@@ -363,6 +370,8 @@ const TreeViewRow = <Item: ItemBaseAttributes>(props: Props<Item>) => {
           canDrop,
         }) => {
           setIsStayingOver(isOver, canDrop);
+
+          const isRenaming = renamedItemId === node.id;
 
           let itemRow = (
             <div
@@ -460,11 +469,13 @@ const TreeViewRow = <Item: ItemBaseAttributes>(props: Props<Item>) => {
                   onEditItem ? () => onEditItem(node.item) : undefined
                 }
                 onContextMenu={
-                  shouldSelectUponContextMenuOpening
+                  isRenaming
+                    ? undefined
+                    : shouldSelectUponContextMenuOpening
                     ? selectAndOpenContextMenu
                     : openContextMenu
                 }
-                {...longTouchForContextMenuProps}
+                {...(isRenaming ? {} : longTouchForContextMenuProps)}
               >
                 {itemRow}
                 {(node.rightComponent ||

--- a/newIDE/app/src/Utils/UseLongTouch.js
+++ b/newIDE/app/src/Utils/UseLongTouch.js
@@ -53,13 +53,16 @@ export const useLongTouch = (
   onTouchEnd: () => void,
   onTouchMove: (event: TouchEvent) => void,
   onTouchStart: (event: TouchEvent) => void,
+  isPressingRef: {| current: boolean |},
 } => {
   const timeout = React.useRef<?TimeoutID>(null);
   const context = options && options.context ? options.context : null;
   const delay = options && options.delay ? options.delay : defaultDelay;
   const currentClientCoordinates = React.useRef<?ClientCoordinates>(null);
+  const isPressingRef = React.useRef<boolean>(false);
   const clear = React.useCallback(
     () => {
+      isPressingRef.current = false;
       if (context) delete contextLocks[context];
       timeout.current && clearTimeout(timeout.current);
     },
@@ -108,7 +111,9 @@ export const useLongTouch = (
 
       const clientCoordinates = getClientXY(event);
       currentClientCoordinates.current = clientCoordinates;
+      isPressingRef.current = true;
       timeout.current = setTimeout(() => {
+        isPressingRef.current = false;
         callback(clientCoordinates);
       }, delay);
     },
@@ -144,5 +149,6 @@ export const useLongTouch = (
     onTouchStart: start,
     onTouchMove: onMove,
     onTouchEnd: clear,
+    isPressingRef,
   };
 };


### PR DESCRIPTION
https://forum.gdevelop.io/t/cant-rename-objects-on-mobile/75634

Bugs:
- starting a rename was showing the image of the element dragged
- could not press on the input to select it

Before:

https://github.com/user-attachments/assets/858cf066-2794-4ccd-b32a-09fec8a13beb

After:

https://github.com/user-attachments/assets/da1d6484-19cd-47cc-8916-b11d20d29fbe

