### PR TITLE
Factor expression validator warnings

### DIFF
--- a/Core/GDCore/IDE/Events/ExpressionValidator.cpp
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.cpp
@@ -298,13 +298,11 @@ ExpressionValidator::Type ExpressionValidator::ValidateFunction(
   // Check if the expression is deprecated
   if (metadata.IsDeprecated()) {
     gd::String deprecationMessage = metadata.GetDeprecationMessage();
-    auto diagnostic = gd::make_unique<ExpressionParserError>(
+    RaiseWarning(
         gd::ExpressionParserError::ErrorType::DeprecatedExpression,
         _("This expression is deprecated.") +
             (deprecationMessage.empty() ? "" : " " + deprecationMessage),
         function.location);
-    deprecationWarnings.push_back(diagnostic.get());
-    supplementalErrors.push_back(std::move(diagnostic));
   }
 
   // Validate the type of the function

--- a/Core/GDCore/IDE/Events/ExpressionValidator.h
+++ b/Core/GDCore/IDE/Events/ExpressionValidator.h
@@ -488,6 +488,20 @@ private:
     supplementalErrors.push_back(std::move(diagnostic));
   }
 
+  void RaiseWarning(gd::ExpressionParserError::ErrorType type,
+                    const gd::String &message,
+                    const ExpressionParserLocation &location,
+                    const gd::String &actualValue = "",
+                    const gd::String &objectName = "") {
+    auto diagnostic = gd::make_unique<ExpressionParserError>(
+        type, message, location, actualValue, objectName);
+    deprecationWarnings.push_back(diagnostic.get());
+    // Warnings found by the validator are not holden by the AST nodes.
+    // They must be owned by the validator to keep living while warnings are
+    // handled by the caller.
+    supplementalErrors.push_back(std::move(diagnostic));
+  }
+
   void RaiseUnknownIdentifierError(const gd::String &message,
                                    const ExpressionParserLocation &location) {
     RaiseError(gd::ExpressionParserError::ErrorType::UnknownIdentifier, message,


### PR DESCRIPTION
Small refactoring: add `ExpressionValidator::RaiseWarning` to avoid forgetting push_back in the future and making it cleaner for the reader.
