### PR TITLE
feat: Select All in event list

### DIFF
--- a/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
+++ b/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
@@ -200,6 +200,7 @@ export type AskAiEditorInterface = {|
   onObjectGroupsModifiedOutsideEditor: (
     changes: ObjectGroupsOutsideEditorChanges
   ) => void,
+  selectAllEvents: () => void,
   startOrOpenChat: (
     ?{|
       aiRequestId: string | null,
@@ -966,6 +967,7 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
         onInstancesModifiedOutsideEditor: noop,
         onObjectsModifiedOutsideEditor: noop,
         onObjectGroupsModifiedOutsideEditor: noop,
+        selectAllEvents: noop,
         startOrOpenChat: onStartOrOpenChat,
         notifyChangesToInGameEditor: setEditorHotReloadNeeded,
         switchInGameEditorIfNoHotReloadIsNeeded: noop,

--- a/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
+++ b/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
@@ -200,7 +200,7 @@ export type AskAiEditorInterface = {|
   onObjectGroupsModifiedOutsideEditor: (
     changes: ObjectGroupsOutsideEditorChanges
   ) => void,
-  selectAllEvents: () => void,
+  selectAllInsideEditor: () => void,
   startOrOpenChat: (
     ?{|
       aiRequestId: string | null,
@@ -967,7 +967,7 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
         onInstancesModifiedOutsideEditor: noop,
         onObjectsModifiedOutsideEditor: noop,
         onObjectGroupsModifiedOutsideEditor: noop,
-        selectAllEvents: noop,
+        selectAllInsideEditor: noop,
         startOrOpenChat: onStartOrOpenChat,
         notifyChangesToInGameEditor: setEditorHotReloadNeeded,
         switchInGameEditorIfNoHotReloadIsNeeded: noop,

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -306,6 +306,12 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     }
   };
 
+  selectAllEvents = () => {
+    if (this.editor) {
+      this.editor.selectAllEvents();
+    }
+  };
+
   selectEventsFunctionByName = (
     functionName: string,
     behaviorName: ?string,

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -581,7 +581,9 @@ const EventsTree: React.ComponentType<{
   const eventPtrToRowIndex = React.useRef<{ [key: string]: number }>({});
   const getEventRow = React.useCallback(
     (searchedEvent: gdBaseEvent) => {
-      return eventPtrToRowIndex.current['' + searchedEvent.ptr] || -1;
+      const key = '' + searchedEvent.ptr;
+      const rowIndex = eventPtrToRowIndex.current[key];
+      return rowIndex === undefined ? -1 : rowIndex;
     },
     [eventPtrToRowIndex]
   );

--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -293,7 +293,18 @@ export const selectEvent = (
   multiSelection: boolean = false
 ): SelectionState => {
   const event = eventContext.event;
-  if (isEventSelected(selection, event)) return selection;
+  const alreadySelected = isEventSelected(selection, event);
+
+  if (multiSelection && alreadySelected) {
+    return {
+      ...selection,
+      selectedEvents: selection.selectedEvents.filter(
+        selectedEventContext => selectedEventContext.event.ptr !== event.ptr
+      ),
+    };
+  }
+
+  if (alreadySelected) return selection;
 
   const existingSelection = multiSelection ? selection : clearSelection();
   return {

--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -302,6 +302,15 @@ export const selectEvent = (
   };
 };
 
+export const selectAllTopLevelEvents = (
+  eventContexts: Array<EventContext>
+): SelectionState => {
+  return {
+    ...clearSelection(),
+    selectedEvents: eventContexts,
+  };
+};
+
 export const selectInstruction = (
   eventContext: EventContext,
   selection: SelectionState,

--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -313,7 +313,7 @@ export const selectEvent = (
   };
 };
 
-export const selectAllTopLevelEvents = (
+export const selectEvents = (
   eventContexts: Array<EventContext>
 ): SelectionState => {
   return {

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -287,8 +287,9 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       onCut: () => this.cutSelection(),
       onPaste: () => this.pasteEventsOrInstructions(),
       onSelectAll: () => this.selectAllEvents(),
+      onDeselectAll: () => this.deselectAll(),
       onSearch: () => this._toggleSearchPanel(),
-      onEscape: () => this._closeSearchPanel(),
+      onEscape: () => this._handleEscape(),
       onUndo: () => this.undo(),
       onRedo: () => this.redo(),
       onZoomIn: (event: KeyboardEvent) => this.onZoomEvent('IN')(event),
@@ -816,6 +817,12 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
         click: () => this.deleteSelection(),
         accelerator: 'Delete',
       },
+      {
+        label: i18n._(t`Deselect All`),
+        click: () => this.deselectAll(),
+        accelerator: 'CmdOrCtrl+Shift+A',
+        visible: hasSomethingSelected(this.state.selection),
+      },
       hasSelectedAtLeastOneCondition(this.state.selection)
         ? {
             label: i18n._(t`Invert Condition`),
@@ -1007,6 +1014,21 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     );
   };
 
+  deselectAll = () => {
+    if (!hasSomethingSelected(this.state.selection)) return;
+    this.setState({ selection: clearSelection() }, () => this.updateToolbar());
+  };
+
+  _handleEscape = () => {
+    if (this.state.showSearchPanel) {
+      this._closeSearchPanel();
+      return;
+    }
+    if (hasSomethingSelected(this.state.selection)) {
+      this.deselectAll();
+    }
+  };
+
   collapseAll = () => {
     if (this._eventsTree) this._eventsTree.foldAll();
   };
@@ -1049,6 +1071,12 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       label: i18n._(t`Select All`),
       click: () => this.selectAllEvents(),
       accelerator: 'CmdOrCtrl+A',
+    },
+    {
+      label: i18n._(t`Deselect All`),
+      click: () => this.deselectAll(),
+      accelerator: 'CmdOrCtrl+Shift+A',
+      visible: hasSomethingSelected(this.state.selection),
     },
     {
       label: i18n._(t`Toggle Disabled`),

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -42,7 +42,7 @@ import {
   type VariableDeclarationContext,
   getInitialSelection,
   selectEvent,
-  selectAllTopLevelEvents,
+  selectEvents,
   selectInstruction,
   hasSomethingSelected,
   hasEventSelected,
@@ -1009,7 +1009,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     }
     const eventContexts = eventsTree.getEventContextAtRowIndexes(rowIndexes);
 
-    this.setState({ selection: selectAllTopLevelEvents(eventContexts) }, () =>
+    this.setState({ selection: selectEvents(eventContexts) }, () =>
       this.updateToolbar()
     );
   };

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -42,6 +42,7 @@ import {
   type VariableDeclarationContext,
   getInitialSelection,
   selectEvent,
+  selectAllTopLevelEvents,
   selectInstruction,
   hasSomethingSelected,
   hasEventSelected,
@@ -285,6 +286,7 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       onCopy: () => this.copySelection(),
       onCut: () => this.cutSelection(),
       onPaste: () => this.pasteEventsOrInstructions(),
+      onSelectAll: () => this.selectAllEvents(),
       onSearch: () => this._toggleSearchPanel(),
       onEscape: () => this._closeSearchPanel(),
       onUndo: () => this.undo(),
@@ -988,6 +990,23 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
     );
   };
 
+  selectAllEvents = () => {
+    const eventsTree = this._eventsTree;
+    if (!eventsTree) return;
+
+    const { events } = this.props;
+    const rowIndexes: Array<number> = [];
+    for (let i = 0; i < events.getEventsCount(); i++) {
+      const rowIndex = eventsTree.getEventRow(events.getEventAt(i));
+      if (rowIndex !== -1) rowIndexes.push(rowIndex);
+    }
+    const eventContexts = eventsTree.getEventContextAtRowIndexes(rowIndexes);
+
+    this.setState({ selection: selectAllTopLevelEvents(eventContexts) }, () =>
+      this.updateToolbar()
+    );
+  };
+
   collapseAll = () => {
     if (this._eventsTree) this._eventsTree.foldAll();
   };
@@ -1025,6 +1044,11 @@ export class EventsSheetComponentWithoutHandle extends React.Component<
       label: i18n._(t`Delete`),
       click: () => this.deleteSelection(),
       accelerator: 'Delete',
+    },
+    {
+      label: i18n._(t`Select All`),
+      click: () => this.selectAllEvents(),
+      accelerator: 'CmdOrCtrl+A',
     },
     {
       label: i18n._(t`Toggle Disabled`),
@@ -2832,6 +2856,7 @@ export type EventsSheetInterface = {|
     searchFilters?: SearchFilterParams
   ) => void,
   clearGlobalSearchResults: () => void,
+  selectAllEvents: () => void,
 |};
 
 // EventsSheet is a wrapper so that the component can use multiple
@@ -2845,6 +2870,7 @@ const EventsSheet = (props, ref) => {
     scrollToEventPath,
     setGlobalSearchResults,
     clearGlobalSearchResults,
+    selectAllEvents,
   }));
 
   const {
@@ -2883,6 +2909,9 @@ const EventsSheet = (props, ref) => {
   };
   const clearGlobalSearchResults = () => {
     if (component.current) component.current.clearGlobalSearchResults();
+  };
+  const selectAllEvents = () => {
+    if (component.current) component.current.selectAllEvents();
   };
 
   const authenticatedUser = React.useContext(AuthenticatedUserContext);

--- a/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
@@ -80,6 +80,10 @@ export class DebuggerEditorContainer extends React.Component<
     // No thing to be done.
   }
 
+  selectAllEvents() {
+    // No thing to be done.
+  }
+
   notifyChangesToInGameEditor(hotReloadSteps: HotReloadSteps) {
     setEditorHotReloadNeeded(hotReloadSteps);
   }

--- a/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/DebuggerEditorContainer.js
@@ -80,7 +80,7 @@ export class DebuggerEditorContainer extends React.Component<
     // No thing to be done.
   }
 
-  selectAllEvents() {
+  selectAllInsideEditor() {
     // No thing to be done.
   }
 

--- a/newIDE/app/src/MainFrame/EditorContainers/EventsEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/EventsEditorContainer.js
@@ -89,7 +89,7 @@ export class EventsEditorContainer extends React.Component<RenderEditorContainer
     if (this.editor) this.editor.clearGlobalSearchResults();
   }
 
-  selectAllEvents() {
+  selectAllInsideEditor() {
     if (this.editor) this.editor.selectAllEvents();
   }
 

--- a/newIDE/app/src/MainFrame/EditorContainers/EventsEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/EventsEditorContainer.js
@@ -89,6 +89,10 @@ export class EventsEditorContainer extends React.Component<RenderEditorContainer
     if (this.editor) this.editor.clearGlobalSearchResults();
   }
 
+  selectAllEvents() {
+    if (this.editor) this.editor.selectAllEvents();
+  }
+
   forceUpdateEditor() {
     // No updates to be done.
   }

--- a/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
@@ -78,7 +78,7 @@ export class EventsFunctionsExtensionEditorContainer extends React.Component<Ren
     }
   }
 
-  selectAllEvents() {
+  selectAllInsideEditor() {
     if (this.editor) {
       this.editor.selectAllEvents();
     }

--- a/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/EventsFunctionsExtensionEditorContainer.js
@@ -78,6 +78,12 @@ export class EventsFunctionsExtensionEditorContainer extends React.Component<Ren
     }
   }
 
+  selectAllEvents() {
+    if (this.editor) {
+      this.editor.selectAllEvents();
+    }
+  }
+
   forceUpdateEditor() {
     // No updates to be done.
   }

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
@@ -120,7 +120,7 @@ export class ExternalEventsEditorContainer extends React.Component<
     if (this.editor) this.editor.clearGlobalSearchResults();
   }
 
-  selectAllEvents() {
+  selectAllInsideEditor() {
     if (this.editor) this.editor.selectAllEvents();
   }
 

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
@@ -120,6 +120,10 @@ export class ExternalEventsEditorContainer extends React.Component<
     if (this.editor) this.editor.clearGlobalSearchResults();
   }
 
+  selectAllEvents() {
+    if (this.editor) this.editor.selectAllEvents();
+  }
+
   forceUpdateEditor() {
     // No updates to be done.
   }

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
@@ -219,6 +219,10 @@ export class ExternalLayoutEditorContainer extends React.Component<
     // No thing to be done.
   }
 
+  selectAllEvents() {
+    // No thing to be done.
+  }
+
   onInstancesModifiedOutsideEditor(changes: InstancesOutsideEditorChanges) {
     if (changes.scene !== this.getLayout()) {
       return;

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalLayoutEditorContainer.js
@@ -219,7 +219,7 @@ export class ExternalLayoutEditorContainer extends React.Component<
     // No thing to be done.
   }
 
-  selectAllEvents() {
+  selectAllInsideEditor() {
     // No thing to be done.
   }
 

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -217,6 +217,7 @@ export type HomePageEditorInterface = {|
   onObjectGroupsModifiedOutsideEditor: (
     changes: ObjectGroupsOutsideEditorChanges
   ) => void,
+  selectAllEvents: () => void,
 |};
 
 export const HomePage: React.ComponentType<Props> = React.memo<Props>(
@@ -560,6 +561,7 @@ export const HomePage: React.ComponentType<Props> = React.memo<Props>(
         onInstancesModifiedOutsideEditor: noop,
         onObjectsModifiedOutsideEditor: noop,
         onObjectGroupsModifiedOutsideEditor: noop,
+        selectAllEvents: noop,
       }));
 
       // As the homepage is never unmounted, we need to ensure the games platform

--- a/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/HomePage/index.js
@@ -217,7 +217,7 @@ export type HomePageEditorInterface = {|
   onObjectGroupsModifiedOutsideEditor: (
     changes: ObjectGroupsOutsideEditorChanges
   ) => void,
-  selectAllEvents: () => void,
+  selectAllInsideEditor: () => void,
 |};
 
 export const HomePage: React.ComponentType<Props> = React.memo<Props>(
@@ -561,7 +561,7 @@ export const HomePage: React.ComponentType<Props> = React.memo<Props>(
         onInstancesModifiedOutsideEditor: noop,
         onObjectsModifiedOutsideEditor: noop,
         onObjectGroupsModifiedOutsideEditor: noop,
-        selectAllEvents: noop,
+        selectAllInsideEditor: noop,
       }));
 
       // As the homepage is never unmounted, we need to ensure the games platform

--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -63,7 +63,7 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
     // No thing to be done.
   }
 
-  selectAllEvents() {
+  selectAllInsideEditor() {
     // No thing to be done.
   }
 

--- a/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ResourcesEditorContainer.js
@@ -63,6 +63,10 @@ export class ResourcesEditorContainer extends React.Component<RenderEditorContai
     // No thing to be done.
   }
 
+  selectAllEvents() {
+    // No thing to be done.
+  }
+
   notifyChangesToInGameEditor(hotReloadSteps: HotReloadSteps) {
     setEditorHotReloadNeeded(hotReloadSteps);
   }

--- a/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
@@ -161,7 +161,7 @@ export class SceneEditorContainer extends React.Component<RenderEditorContainerP
     // No thing to be done.
   }
 
-  selectAllEvents() {
+  selectAllInsideEditor() {
     // No thing to be done.
   }
 

--- a/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/SceneEditorContainer.js
@@ -161,6 +161,10 @@ export class SceneEditorContainer extends React.Component<RenderEditorContainerP
     // No thing to be done.
   }
 
+  selectAllEvents() {
+    // No thing to be done.
+  }
+
   onInstancesModifiedOutsideEditor(changes: InstancesOutsideEditorChanges) {
     if (changes.scene !== this.getLayout()) {
       return;

--- a/newIDE/app/src/MainFrame/ElectronMainMenu.js
+++ b/newIDE/app/src/MainFrame/ElectronMainMenu.js
@@ -230,6 +230,11 @@ const ElectronMainMenu = ({
     shouldApply: isFocusedOnMainWindow,
   });
   useIPCEventListener({
+    ipcEvent: 'main-menu-select-all',
+    callback: callbacks.onSelectAll,
+    shouldApply: isFocusedOnMainWindow,
+  });
+  useIPCEventListener({
     ipcEvent: 'update-status',
     callback: callbacks.setElectronUpdateStatus,
     shouldApply: true, // Keep logic around app update even if on preview window

--- a/newIDE/app/src/MainFrame/MainMenu.js
+++ b/newIDE/app/src/MainFrame/MainMenu.js
@@ -51,6 +51,7 @@ export type MainMenuCallbacks = {|
   onOpenLanguage: (open?: boolean) => void,
   onOpenProfile: (open?: boolean) => void,
   onOpenAskAi: () => void,
+  onSelectAll: () => void,
   setElectronUpdateStatus: ElectronUpdateStatus => void,
 |};
 
@@ -79,6 +80,7 @@ export type MainMenuEvent =
   | 'main-menu-open-language'
   | 'main-menu-open-profile'
   | 'main-menu-open-ask-ai'
+  | 'main-menu-select-all'
   | 'update-status';
 
 const getMainMenuEventCallback = (
@@ -105,6 +107,7 @@ const getMainMenuEventCallback = (
     'main-menu-open-language': callbacks.onOpenLanguage,
     'main-menu-open-profile': callbacks.onOpenProfile,
     'main-menu-open-ask-ai': callbacks.onOpenAskAi,
+    'main-menu-select-all': callbacks.onSelectAll,
     'update-status': callbacks.setElectronUpdateStatus,
   };
 
@@ -215,7 +218,11 @@ export const buildMainMenuDeclarativeTemplate = ({
       { label: i18n._(t`Paste`), role: 'paste' },
       { label: i18n._(t`Paste and Match Style`), role: 'pasteandmatchstyle' },
       { label: i18n._(t`Delete`), role: 'delete' },
-      { label: i18n._(t`Select All`), role: 'selectall' },
+      {
+        label: i18n._(t`Select All`),
+        accelerator: 'CmdOrCtrl+A',
+        onClickSendEvent: 'main-menu-select-all',
+      },
     ],
   };
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3482,6 +3482,22 @@ const MainFrame = (props: Props): React.MixedElement => {
     [state.editorTabs]
   );
 
+  const selectAllEventsInActiveEditors = React.useCallback(
+    () => {
+      for (const paneIdentifier in state.editorTabs.panes) {
+        const currentTab = getCurrentTabForPane(
+          state.editorTabs,
+          paneIdentifier
+        );
+        const editorRef = currentTab ? currentTab.editorRef : null;
+        if (editorRef) {
+          editorRef.selectAllEvents();
+        }
+      }
+    },
+    [state.editorTabs]
+  );
+
   const _onProjectItemModified = () => {
     triggerUnsavedChanges();
     forceUpdate();
@@ -5025,6 +5041,7 @@ const MainFrame = (props: Props): React.MixedElement => {
     onOpenLanguage: () => openLanguageDialog(true),
     onOpenProfile: onOpenProfileDialog,
     onOpenAskAi: openAskAi,
+    onSelectAll: selectAllEventsInActiveEditors,
     setElectronUpdateStatus: setElectronUpdateStatus,
   };
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -3482,7 +3482,7 @@ const MainFrame = (props: Props): React.MixedElement => {
     [state.editorTabs]
   );
 
-  const selectAllEventsInActiveEditors = React.useCallback(
+  const selectAllInActiveEditors = React.useCallback(
     () => {
       for (const paneIdentifier in state.editorTabs.panes) {
         const currentTab = getCurrentTabForPane(
@@ -3491,7 +3491,7 @@ const MainFrame = (props: Props): React.MixedElement => {
         );
         const editorRef = currentTab ? currentTab.editorRef : null;
         if (editorRef) {
-          editorRef.selectAllEvents();
+          editorRef.selectAllInsideEditor();
         }
       }
     },
@@ -5041,7 +5041,7 @@ const MainFrame = (props: Props): React.MixedElement => {
     onOpenLanguage: () => openLanguageDialog(true),
     onOpenProfile: onOpenProfileDialog,
     onOpenAskAi: openAskAi,
-    onSelectAll: selectAllEventsInActiveEditors,
+    onSelectAll: selectAllInActiveEditors,
     setElectronUpdateStatus: setElectronUpdateStatus,
   };
 

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -50,6 +50,7 @@ type ShortcutCallbacks = {|
   onShift2?: () => void | Promise<void>,
   onShift3?: () => void | Promise<void>,
   onSelectAll?: () => void | Promise<void>,
+  onDeselectAll?: () => void | Promise<void>,
   onToggleGrabbingTool?: (isEnabled: boolean) => void | Promise<void>,
   onRename?: () => void | Promise<void>,
 |};
@@ -261,6 +262,7 @@ export default class KeyboardShortcuts {
       onPaste,
       onDuplicate,
       onSelectAll,
+      onDeselectAll,
       onUndo,
       onRedo,
       onSearch,
@@ -312,7 +314,20 @@ export default class KeyboardShortcuts {
       evt.preventDefault();
       onDuplicate();
     }
-    if (onSelectAll && this._isControlOrCmdPressed() && evt.which === A_KEY) {
+    if (
+      onDeselectAll &&
+      this._isControlOrCmdPressed() &&
+      evt.shiftKey &&
+      evt.which === A_KEY
+    ) {
+      evt.preventDefault();
+      onDeselectAll();
+    } else if (
+      onSelectAll &&
+      this._isControlOrCmdPressed() &&
+      !evt.shiftKey &&
+      evt.which === A_KEY
+    ) {
       evt.preventDefault();
       onSelectAll();
     }

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -14,6 +14,7 @@ const MINUS_KEY = 189;
 const SPACE_KEY = 32;
 const NUMPAD_ADD = 107;
 const NUMPAD_SUBTRACT = 109;
+const A_KEY = 65;
 const C_KEY = 67;
 const D_KEY = 68;
 const F_KEY = 70;
@@ -48,6 +49,7 @@ type ShortcutCallbacks = {|
   onShift1?: () => void | Promise<void>,
   onShift2?: () => void | Promise<void>,
   onShift3?: () => void | Promise<void>,
+  onSelectAll?: () => void | Promise<void>,
   onToggleGrabbingTool?: (isEnabled: boolean) => void | Promise<void>,
   onRename?: () => void | Promise<void>,
 |};
@@ -258,6 +260,7 @@ export default class KeyboardShortcuts {
       onCut,
       onPaste,
       onDuplicate,
+      onSelectAll,
       onUndo,
       onRedo,
       onSearch,
@@ -308,6 +311,10 @@ export default class KeyboardShortcuts {
     if (onDuplicate && this._isControlOrCmdPressed() && evt.which === D_KEY) {
       evt.preventDefault();
       onDuplicate();
+    }
+    if (onSelectAll && this._isControlOrCmdPressed() && evt.which === A_KEY) {
+      evt.preventDefault();
+      onSelectAll();
     }
     if (
       (onUndo || onRedo) &&


### PR DESCRIPTION
# Multi-selection improvements for the Events Sheet

## Summary

This PR adds **Select All / Deselect All** functionality to the Events Sheet and improves the existing multi-selection UX with a proper toggle behavior. It also includes a small bugfix in `EventsTree.getEventRow` that was silently affecting the very first event in the tree.

## What's new

### Select All
Selects all top-level events in the current Events Sheet (extension events, scene events, external events). Sub-events are not added to the selection — they are implicitly included via their parents, matching the existing behavior of operations like Cut / Copy / Move into Group.

Available via:
- Keyboard shortcut **`Ctrl/Cmd + A`**
- Right-click on any event → **"Select All"**
- Electron menu **`Edit > Select All`**

### Deselect All
Clears the current selection (events, instructions, instruction lists). Works whenever there is at least one selected item.

Available via:
- Keyboard shortcut **`Ctrl/Cmd + Shift + A`**
- **`Escape`** key (extended logic: closes search panel first, otherwise clears selection)
- Right-click on any event or instruction → **"Deselect All"** (visible only when something is selected)

### Shift+Click toggle
Shift-clicking an already-selected event now **removes it from the selection**, matching the standard behavior of macOS Finder, VS Code, Figma, Sketch and other modern apps with multi-select. Plain click behavior is unchanged.

### Bugfix: first event row index
`EventsTree.getEventRow` had a classic JS pitfall (`0 || -1 === -1`) that caused the topmost event to be reported as "not found". This silently broke a few features for the first event in the tree:
- Scrolling to it from global search / AI navigation
- Scrolling after creating a new event when it became the first one
- Correct undo/redo position tracking

Now fixed.

## How to use

- **Select all top-level events** — press `Ctrl/Cmd + A`, or right-click an event → "Select All", or use the Electron menu `Edit > Select All`.
- **Deselect everything** — press `Ctrl/Cmd + Shift + A` or `Esc`, or right-click an event/instruction → "Deselect All".
- **Add one event to the current selection** — `Shift + Click` on an unselected event.
- **Remove one event from the current selection** — `Shift + Click` on an already-selected event (toggle).

The Electron `Edit > Select All` menu item is now properly wired to the active Events Sheet (previously it relied on the native `selectall` role and did nothing useful for events).