### PR TITLE
Fix resource paths containing hash characters

### DIFF
--- a/GDJS/Runtime/ResourceLoader.ts
+++ b/GDJS/Runtime/ResourceLoader.ts
@@ -29,6 +29,19 @@ namespace gdjs {
     );
   };
 
+  const encodeLocalResourceUrl = (url: string): string => {
+    if (
+      url.startsWith('http://') ||
+      url.startsWith('https://') ||
+      url.startsWith('data:') ||
+      url.startsWith('blob:')
+    ) {
+      return url;
+    }
+
+    return encodeURI(url).replace(/#/g, '%23');
+  };
+
   /**
    * A task of pre-loading resources used by a scene.
    *
@@ -617,6 +630,8 @@ namespace gdjs {
      * the resource (this can be for example a token needed to access the resource).
      */
     getFullUrl(url: string) {
+      url = encodeLocalResourceUrl(url);
+
       if (this._runtimeGame.isInGameEdition()) {
         // Avoid adding cache burst to URLs which are assumed to be immutable files,
         // to avoid costly useless requests each time the game is hot-reloaded.

--- a/newIDE/app/src/ResourcesLoader/index.js
+++ b/newIDE/app/src/ResourcesLoader/index.js
@@ -3,6 +3,7 @@ import { addGDevelopResourceTokenIfRequired } from '../Utils/CrossOrigin';
 import optionalRequire from '../Utils/OptionalRequire';
 const electron = optionalRequire('electron');
 const path = optionalRequire('path');
+const nodeUrl = optionalRequire('url');
 
 class UrlsCache {
   projectCache: { [number]: { [string]: string } } = {};
@@ -132,15 +133,17 @@ export default class ResourcesLoader {
       // Support local filesystem with Electron
       const file = project.getProjectFile();
       const projectPath = path.dirname(file);
-      const resourceAbsolutePath = path
-        .resolve(projectPath, urlOrFilename)
-        .replace(/\\/g, '/');
+      const resourceAbsolutePath = path.resolve(projectPath, urlOrFilename);
+      const resourceUrl = nodeUrl
+        ? nodeUrl.pathToFileURL(resourceAbsolutePath).href
+        : 'file://' +
+          resourceAbsolutePath.replace(/\\/g, '/').replace(/#/g, '%23');
 
       console.info('Caching resolved local filename:', resourceAbsolutePath);
       return this._cache.cacheLocalFileUrl(
         project,
         urlOrFilename,
-        'file://' + resourceAbsolutePath,
+        resourceUrl,
         !!disableCacheBurst
       );
     }

--- a/newIDE/app/src/ResourcesLoader/index.spec.js
+++ b/newIDE/app/src/ResourcesLoader/index.spec.js
@@ -1,0 +1,34 @@
+// @flow
+import ResourcesLoader from './index';
+
+jest.mock('../Utils/OptionalRequire');
+
+describe('ResourcesLoader', () => {
+  let dateNowSpy;
+
+  beforeEach(() => {
+    ResourcesLoader.burstAllUrlsCache();
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1234);
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+  });
+
+  test('encodes hash characters in local file URLs before adding cache parameters', () => {
+    const project: any = {
+      ptr: 1,
+      getProjectFile: () => '/project/Game Jam #1/game.json',
+    };
+
+    const resolvedUrl = ResourcesLoader.getFullUrl(
+      project,
+      'Parts/hero #1.png',
+      {}
+    );
+
+    expect(resolvedUrl).toBe(
+      'file:///project/Game%20Jam%20%231/Parts/hero%20%231.png?cache=1234'
+    );
+  });
+});

--- a/newIDE/app/src/Utils/__mocks__/OptionalRequire.js
+++ b/newIDE/app/src/Utils/__mocks__/OptionalRequire.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import nodeUrl from 'url';
 
 const mockElectron = {
   ipcRenderer: {
@@ -44,6 +45,9 @@ const mockOptionalRequire = jest.fn(
     }
     if (moduleName === 'path') {
       return path;
+    }
+    if (moduleName === 'url') {
+      return nodeUrl;
     }
     if (moduleName === 'os') {
       return mockOs;


### PR DESCRIPTION
## Summary
- Build Electron local file URLs with Node `pathToFileURL`, so `#`, spaces, and non-ASCII path characters are encoded before `<img>`/Pixi see them.
- Encode local/exported runtime resource URLs before adding cache-busting or token query parameters, so `#` is not interpreted as a fragment in exported games or in-game preview.

Fixes #4015.

## Checks
- `git diff --check`
- `npx --yes prettier@1.15.3 --list-different newIDE/app/src/ResourcesLoader/index.js`
- `npx --yes prettier@3.4.2 --list-different GDJS/Runtime/ResourceLoader.ts`
- Targeted Node check for `Game Jam #1/Parts/hero.png` -> `Game%20Jam%20%231/Parts/hero.png` and `pathToFileURL` output for local paths with `#`.