### PR TITLE
Move local editor settings to a sidecar file

### DIFF
--- a/newIDE/app/scripts/import-libGD.js
+++ b/newIDE/app/scripts/import-libGD.js
@@ -66,17 +66,28 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
     return branch;
   };
 
+  const getHashFromGitRef = gitRef => {
+    const hashShellString = shell.exec(`git rev-parse "${gitRef}"`, {
+      silent: true,
+    });
+    const hash = (hashShellString.stdout || 'unknown-hash').trim();
+
+    if (hashShellString.stderr || hashShellString.code) {
+      shell.echo(`⚠️ Can't find the hash of the associated commit.`);
+      return null;
+    }
+
+    return hash;
+  };
+
   // Try to download libGD.js from a specific commit on the current branch
   const downloadCommitLibGdJs = (branch, gitRef) =>
     new Promise((resolve, reject) => {
       shell.echo(`ℹ️ Trying to download libGD.js for ${gitRef}.`);
 
-      var hashShellString = shell.exec(`git rev-parse "${gitRef}"`, {
-        silent: true,
-      });
-      const hash = (hashShellString.stdout || 'unknown-hash').trim();
+      const hash = getHashFromGitRef(gitRef);
       const branch = getBranchFromGitRef(gitRef);
-      if (hashShellString.stderr || hashShellString.code || !branch) {
+      if (!hash || !branch) {
         shell.echo(
           `⚠️ Can't find the hash or branch of the associated commit.`
         );
@@ -87,6 +98,25 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
       resolve(
         downloadLibGdJs(
           `https://s3.amazonaws.com/gdevelop-gdevelop.js/${branch}/commit/${hash}`
+        )
+      );
+    });
+
+  const downloadMasterCommitLibGdJs = gitRef =>
+    new Promise((resolve, reject) => {
+      shell.echo(
+        `ℹ️ Trying to download libGD.js for ${gitRef} from master.`
+      );
+
+      const hash = getHashFromGitRef(gitRef);
+      if (!hash) {
+        reject();
+        return;
+      }
+
+      resolve(
+        downloadLibGdJs(
+          `https://s3.amazonaws.com/gdevelop-gdevelop.js/master/commit/${hash}`
         )
       );
     });
@@ -151,10 +181,14 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
   };
 
   const branch = getBranchFromGitRef('HEAD');
+  const downloadCommitLibGdJsWithMasterFallback = gitRef =>
+    downloadCommitLibGdJs(branch, gitRef).catch(() =>
+      downloadMasterCommitLibGdJs(gitRef)
+    );
 
   // Try to download the latest libGD.js, fallback to previous or master ones
   // if not found (including different parents, for handling of merge commits).
-  downloadCommitLibGdJs(branch, 'HEAD').then(onLibGdJsDownloaded, () => {
+  downloadCommitLibGdJsWithMasterFallback('HEAD').then(onLibGdJsDownloaded, () => {
     // Force the exact version of GDevelop.js to be downloaded for AppVeyor - because
     // this means we build the app and we don't want to risk mismatch (Core C++ not up to date
     // with the IDE JavaScript).
@@ -168,9 +202,9 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
       shell.exit(1);
     }
 
-    downloadCommitLibGdJs(branch, 'HEAD~1').then(onLibGdJsDownloaded, () =>
-      downloadCommitLibGdJs(branch, 'HEAD~2').then(onLibGdJsDownloaded, () =>
-        downloadCommitLibGdJs(branch, 'HEAD~3').then(onLibGdJsDownloaded, () =>
+    downloadCommitLibGdJsWithMasterFallback('HEAD~1').then(onLibGdJsDownloaded, () =>
+      downloadCommitLibGdJsWithMasterFallback('HEAD~2').then(onLibGdJsDownloaded, () =>
+        downloadCommitLibGdJsWithMasterFallback('HEAD~3').then(onLibGdJsDownloaded, () =>
           downloadBranchLatestLibGdJs(branch).then(onLibGdJsDownloaded, () =>
             downloadBranchLatestLibGdJs('master').then(
               onLibGdJsDownloaded,

--- a/newIDE/app/scripts/import-libGD.js
+++ b/newIDE/app/scripts/import-libGD.js
@@ -80,8 +80,8 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
     return hash;
   };
 
-  // Try to download libGD.js from a specific commit on the current branch
-  const downloadCommitLibGdJs = (branch, gitRef) =>
+  // Try to download libGD.js from a specific commit on the inferred branch.
+  const downloadCommitLibGdJs = gitRef =>
     new Promise((resolve, reject) => {
       shell.echo(`ℹ️ Trying to download libGD.js for ${gitRef}.`);
 
@@ -182,51 +182,54 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
 
   const branch = getBranchFromGitRef('HEAD');
   const downloadCommitLibGdJsWithMasterFallback = gitRef =>
-    downloadCommitLibGdJs(branch, gitRef).catch(() =>
+    downloadCommitLibGdJs(gitRef).catch(() =>
       downloadMasterCommitLibGdJs(gitRef)
+    );
+  const tryDownloadInOrder = downloaders =>
+    downloaders.reduce(
+      (previousDownload, download) => previousDownload.catch(() => download()),
+      Promise.reject()
     );
 
   // Try to download the latest libGD.js, fallback to previous or master ones
   // if not found (including different parents, for handling of merge commits).
-  downloadCommitLibGdJsWithMasterFallback('HEAD').then(onLibGdJsDownloaded, () => {
-    // Force the exact version of GDevelop.js to be downloaded for AppVeyor - because
-    // this means we build the app and we don't want to risk mismatch (Core C++ not up to date
-    // with the IDE JavaScript).
-    if (process.env.APPVEYOR || process.env.REQUIRES_EXACT_LIBGD_JS_VERSION) {
-      shell.echo(
-        `❌ Can't download the exact required version of libGD.js - check it was built by CircleCI before running this CI.`
-      );
-      shell.echo(
-        `ℹ️ See the pipeline on https://app.circleci.com/pipelines/github/4ian/GDevelop.`
-      );
-      shell.exit(1);
-    }
+  downloadCommitLibGdJsWithMasterFallback('HEAD').then(
+    onLibGdJsDownloaded,
+    () => {
+      // Force the exact version of GDevelop.js to be downloaded for AppVeyor - because
+      // this means we build the app and we don't want to risk mismatch (Core C++ not up to date
+      // with the IDE JavaScript).
+      if (process.env.APPVEYOR || process.env.REQUIRES_EXACT_LIBGD_JS_VERSION) {
+        shell.echo(
+          `❌ Can't download the exact required version of libGD.js - check it was built by CircleCI before running this CI.`
+        );
+        shell.echo(
+          `ℹ️ See the pipeline on https://app.circleci.com/pipelines/github/4ian/GDevelop.`
+        );
+        shell.exit(1);
+      }
 
-    downloadCommitLibGdJsWithMasterFallback('HEAD~1').then(onLibGdJsDownloaded, () =>
-      downloadCommitLibGdJsWithMasterFallback('HEAD~2').then(onLibGdJsDownloaded, () =>
-        downloadCommitLibGdJsWithMasterFallback('HEAD~3').then(onLibGdJsDownloaded, () =>
-          downloadBranchLatestLibGdJs(branch).then(onLibGdJsDownloaded, () =>
-            downloadBranchLatestLibGdJs('master').then(
-              onLibGdJsDownloaded,
-              () => {
-                if (alreadyHasLibGdJs) {
-                  shell.echo(
-                    `ℹ️ Can't download any version of libGD.js, assuming you can go ahead with the existing one.`
-                  );
-                  shell.exit(0);
-                  return;
-                } else {
-                  shell.echo(
-                    `❌ Can't download any version of libGD.js, please check your internet connection.`
-                  );
-                  shell.exit(1);
-                  return;
-                }
-              }
-            )
-          )
-        )
-      )
-    );
-  });
+      tryDownloadInOrder([
+        () => downloadCommitLibGdJsWithMasterFallback('HEAD~1'),
+        () => downloadCommitLibGdJsWithMasterFallback('HEAD~2'),
+        () => downloadCommitLibGdJsWithMasterFallback('HEAD~3'),
+        () => downloadBranchLatestLibGdJs(branch),
+        () => downloadBranchLatestLibGdJs('master'),
+      ]).then(onLibGdJsDownloaded, () => {
+        if (alreadyHasLibGdJs) {
+          shell.echo(
+            `ℹ️ Can't download any version of libGD.js, assuming you can go ahead with the existing one.`
+          );
+          shell.exit(0);
+          return;
+        } else {
+          shell.echo(
+            `❌ Can't download any version of libGD.js, please check your internet connection.`
+          );
+          shell.exit(1);
+          return;
+        }
+      });
+    }
+  );
 }

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
@@ -4,7 +4,7 @@ import optionalRequire from '../../Utils/OptionalRequire';
 const path = optionalRequire('path');
 
 export const editorSettingsDirectoryName = '.gdevelop';
-export const editorSettingsFileName = 'editor-settings.json';
+export const editorSettingsFileSuffix = '.editor-settings.json';
 
 export type ProjectEditorSettings = {|
   layoutSettings: { [layoutName: string]: Object },
@@ -14,17 +14,15 @@ export type ProjectEditorSettings = {|
   },
 |};
 
-export const getProjectEditorSettingsFilePath = (
-  projectPath: string
-): string => {
+export const getProjectEditorSettingsFilePath = (filePath: string): string => {
   if (!path) {
     throw new Error('Filesystem paths are not supported.');
   }
 
   return path.join(
-    projectPath,
+    path.dirname(filePath),
     editorSettingsDirectoryName,
-    editorSettingsFileName
+    path.basename(filePath, path.extname(filePath)) + editorSettingsFileSuffix
   );
 };
 
@@ -35,7 +33,7 @@ const makeProjectEditorSettings = (): ProjectEditorSettings => ({
 });
 
 const hasOwn = (object: Object, propertyName: string): boolean =>
-  Object.keys(object).indexOf(propertyName) !== -1;
+  Object.prototype.hasOwnProperty.call(object, propertyName);
 
 const isEmpty = (object: Object): boolean => Object.keys(object).length === 0;
 
@@ -70,8 +68,9 @@ export const extractProjectEditorSettings = (
         typeof externalLayout.name === 'string' &&
         hasOwn(externalLayout, 'editionSettings')
       ) {
-        projectEditorSettings.externalLayoutSettings[externalLayout.name] =
-          externalLayout.editionSettings;
+        projectEditorSettings.externalLayoutSettings[
+          externalLayout.name
+        ] = externalLayout.editionSettings;
         delete externalLayout.editionSettings;
       }
     });
@@ -88,7 +87,10 @@ export const extractProjectEditorSettings = (
       }
 
       extension.eventsBasedObjects.forEach(eventsBasedObject => {
-        if (!eventsBasedObject || typeof eventsBasedObject.name !== 'string') {
+        if (
+          !eventsBasedObject ||
+          typeof eventsBasedObject.name !== 'string'
+        ) {
           return;
         }
 
@@ -168,7 +170,9 @@ export const applyProjectEditorSettings = (
     });
   }
 
-  const { eventsBasedObjectVariantSettings } = projectEditorSettings;
+  const {
+    eventsBasedObjectVariantSettings,
+  } = projectEditorSettings;
   if (
     eventsBasedObjectVariantSettings &&
     Array.isArray(serializedProjectObject.eventsFunctionsExtensions)
@@ -183,7 +187,10 @@ export const applyProjectEditorSettings = (
       }
 
       extension.eventsBasedObjects.forEach(eventsBasedObject => {
-        if (!eventsBasedObject || typeof eventsBasedObject.name !== 'string') {
+        if (
+          !eventsBasedObject ||
+          typeof eventsBasedObject.name !== 'string'
+        ) {
           return;
         }
 

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
@@ -1,0 +1,219 @@
+// @flow
+import optionalRequire from '../../Utils/OptionalRequire';
+
+const path = optionalRequire('path');
+
+export const editorSettingsDirectoryName = '.gdevelop';
+export const editorSettingsFileName = 'editor-settings.json';
+
+export type ProjectEditorSettings = {|
+  layoutSettings: { [layoutName: string]: Object },
+  externalLayoutSettings: { [externalLayoutName: string]: Object },
+  eventsBasedObjectVariantSettings: {
+    [variantIdentifier: string]: Object,
+  },
+|};
+
+export const getProjectEditorSettingsFilePath = (
+  projectPath: string
+): string => {
+  if (!path) {
+    throw new Error('Filesystem paths are not supported.');
+  }
+
+  return path.join(
+    projectPath,
+    editorSettingsDirectoryName,
+    editorSettingsFileName
+  );
+};
+
+const makeProjectEditorSettings = (): ProjectEditorSettings => ({
+  layoutSettings: {},
+  externalLayoutSettings: {},
+  eventsBasedObjectVariantSettings: {},
+});
+
+const hasOwn = (object: Object, propertyName: string): boolean =>
+  Object.prototype.hasOwnProperty.call(object, propertyName);
+
+const isEmpty = (object: Object): boolean => Object.keys(object).length === 0;
+
+const makeVariantIdentifier = (
+  extensionName: string,
+  objectName: string,
+  variantName: string
+): string => `${extensionName}::${objectName}::${variantName}`;
+
+export const extractProjectEditorSettings = (
+  serializedProjectObject: Object
+): ?ProjectEditorSettings => {
+  const projectEditorSettings = makeProjectEditorSettings();
+
+  if (Array.isArray(serializedProjectObject.layouts)) {
+    serializedProjectObject.layouts.forEach(layout => {
+      if (
+        layout &&
+        typeof layout.name === 'string' &&
+        hasOwn(layout, 'uiSettings')
+      ) {
+        projectEditorSettings.layoutSettings[layout.name] = layout.uiSettings;
+        delete layout.uiSettings;
+      }
+    });
+  }
+
+  if (Array.isArray(serializedProjectObject.externalLayouts)) {
+    serializedProjectObject.externalLayouts.forEach(externalLayout => {
+      if (
+        externalLayout &&
+        typeof externalLayout.name === 'string' &&
+        hasOwn(externalLayout, 'editionSettings')
+      ) {
+        projectEditorSettings.externalLayoutSettings[
+          externalLayout.name
+        ] = externalLayout.editionSettings;
+        delete externalLayout.editionSettings;
+      }
+    });
+  }
+
+  if (Array.isArray(serializedProjectObject.eventsFunctionsExtensions)) {
+    serializedProjectObject.eventsFunctionsExtensions.forEach(extension => {
+      if (
+        !extension ||
+        typeof extension.name !== 'string' ||
+        !Array.isArray(extension.eventsBasedObjects)
+      ) {
+        return;
+      }
+
+      extension.eventsBasedObjects.forEach(eventsBasedObject => {
+        if (!eventsBasedObject || typeof eventsBasedObject.name !== 'string') {
+          return;
+        }
+
+        if (hasOwn(eventsBasedObject, 'editionSettings')) {
+          projectEditorSettings.eventsBasedObjectVariantSettings[
+            makeVariantIdentifier(extension.name, eventsBasedObject.name, '')
+          ] = eventsBasedObject.editionSettings;
+          delete eventsBasedObject.editionSettings;
+        }
+
+        if (Array.isArray(eventsBasedObject.variants)) {
+          eventsBasedObject.variants.forEach(variant => {
+            if (
+              variant &&
+              typeof variant.name === 'string' &&
+              hasOwn(variant, 'editionSettings')
+            ) {
+              projectEditorSettings.eventsBasedObjectVariantSettings[
+                makeVariantIdentifier(
+                  extension.name,
+                  eventsBasedObject.name,
+                  variant.name
+                )
+              ] = variant.editionSettings;
+              delete variant.editionSettings;
+            }
+          });
+        }
+      });
+    });
+  }
+
+  if (
+    isEmpty(projectEditorSettings.layoutSettings) &&
+    isEmpty(projectEditorSettings.externalLayoutSettings) &&
+    isEmpty(projectEditorSettings.eventsBasedObjectVariantSettings)
+  ) {
+    return null;
+  }
+
+  return projectEditorSettings;
+};
+
+export const applyProjectEditorSettings = (
+  serializedProjectObject: Object,
+  projectEditorSettings: ?ProjectEditorSettings
+) => {
+  if (!projectEditorSettings) return;
+
+  const { layoutSettings } = projectEditorSettings;
+  if (layoutSettings && Array.isArray(serializedProjectObject.layouts)) {
+    serializedProjectObject.layouts.forEach(layout => {
+      if (
+        layout &&
+        typeof layout.name === 'string' &&
+        layoutSettings[layout.name]
+      ) {
+        layout.uiSettings = layoutSettings[layout.name];
+      }
+    });
+  }
+
+  const { externalLayoutSettings } = projectEditorSettings;
+  if (
+    externalLayoutSettings &&
+    Array.isArray(serializedProjectObject.externalLayouts)
+  ) {
+    serializedProjectObject.externalLayouts.forEach(externalLayout => {
+      if (
+        externalLayout &&
+        typeof externalLayout.name === 'string' &&
+        externalLayoutSettings[externalLayout.name]
+      ) {
+        externalLayout.editionSettings =
+          externalLayoutSettings[externalLayout.name];
+      }
+    });
+  }
+
+  const { eventsBasedObjectVariantSettings } = projectEditorSettings;
+  if (
+    eventsBasedObjectVariantSettings &&
+    Array.isArray(serializedProjectObject.eventsFunctionsExtensions)
+  ) {
+    serializedProjectObject.eventsFunctionsExtensions.forEach(extension => {
+      if (
+        !extension ||
+        typeof extension.name !== 'string' ||
+        !Array.isArray(extension.eventsBasedObjects)
+      ) {
+        return;
+      }
+
+      extension.eventsBasedObjects.forEach(eventsBasedObject => {
+        if (!eventsBasedObject || typeof eventsBasedObject.name !== 'string') {
+          return;
+        }
+
+        const defaultVariantSettings =
+          eventsBasedObjectVariantSettings[
+            makeVariantIdentifier(extension.name, eventsBasedObject.name, '')
+          ];
+        if (defaultVariantSettings) {
+          eventsBasedObject.editionSettings = defaultVariantSettings;
+        }
+
+        if (Array.isArray(eventsBasedObject.variants)) {
+          eventsBasedObject.variants.forEach(variant => {
+            if (!variant || typeof variant.name !== 'string') return;
+
+            const variantSettings =
+              eventsBasedObjectVariantSettings[
+                makeVariantIdentifier(
+                  extension.name,
+                  eventsBasedObject.name,
+                  variant.name
+                )
+              ];
+            if (variantSettings) {
+              variant.editionSettings = variantSettings;
+            }
+          });
+        }
+      });
+    });
+  }
+};

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
@@ -68,9 +68,8 @@ export const extractProjectEditorSettings = (
         typeof externalLayout.name === 'string' &&
         hasOwn(externalLayout, 'editionSettings')
       ) {
-        projectEditorSettings.externalLayoutSettings[
-          externalLayout.name
-        ] = externalLayout.editionSettings;
+        projectEditorSettings.externalLayoutSettings[externalLayout.name] =
+          externalLayout.editionSettings;
         delete externalLayout.editionSettings;
       }
     });

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
@@ -86,10 +86,7 @@ export const extractProjectEditorSettings = (
       }
 
       extension.eventsBasedObjects.forEach(eventsBasedObject => {
-        if (
-          !eventsBasedObject ||
-          typeof eventsBasedObject.name !== 'string'
-        ) {
+        if (!eventsBasedObject || typeof eventsBasedObject.name !== 'string') {
           return;
         }
 
@@ -184,10 +181,7 @@ export const applyProjectEditorSettings = (
       }
 
       extension.eventsBasedObjects.forEach(eventsBasedObject => {
-        if (
-          !eventsBasedObject ||
-          typeof eventsBasedObject.name !== 'string'
-        ) {
+        if (!eventsBasedObject || typeof eventsBasedObject.name !== 'string') {
           return;
         }
 

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
@@ -33,7 +33,7 @@ const makeProjectEditorSettings = (): ProjectEditorSettings => ({
 });
 
 const hasOwn = (object: Object, propertyName: string): boolean =>
-  Object.prototype.hasOwnProperty.call(object, propertyName);
+  Object.keys(object).indexOf(propertyName) !== -1;
 
 const isEmpty = (object: Object): boolean => Object.keys(object).length === 0;
 
@@ -170,9 +170,7 @@ export const applyProjectEditorSettings = (
     });
   }
 
-  const {
-    eventsBasedObjectVariantSettings,
-  } = projectEditorSettings;
+  const { eventsBasedObjectVariantSettings } = projectEditorSettings;
   if (
     eventsBasedObjectVariantSettings &&
     Array.isArray(serializedProjectObject.eventsFunctionsExtensions)

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.js
@@ -35,7 +35,7 @@ const makeProjectEditorSettings = (): ProjectEditorSettings => ({
 });
 
 const hasOwn = (object: Object, propertyName: string): boolean =>
-  Object.prototype.hasOwnProperty.call(object, propertyName);
+  Object.keys(object).indexOf(propertyName) !== -1;
 
 const isEmpty = (object: Object): boolean => Object.keys(object).length === 0;
 
@@ -70,9 +70,8 @@ export const extractProjectEditorSettings = (
         typeof externalLayout.name === 'string' &&
         hasOwn(externalLayout, 'editionSettings')
       ) {
-        projectEditorSettings.externalLayoutSettings[
-          externalLayout.name
-        ] = externalLayout.editionSettings;
+        projectEditorSettings.externalLayoutSettings[externalLayout.name] =
+          externalLayout.editionSettings;
         delete externalLayout.editionSettings;
       }
     });

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
@@ -9,9 +9,7 @@ import path from 'path';
 
 describe('LocalEditorSettingsStorage', () => {
   it('stores settings separately for projects in the same folder', () => {
-    expect(
-      getProjectEditorSettingsFilePath('C:/Projects/game.json')
-    ).toBe(
+    expect(getProjectEditorSettingsFilePath('C:/Projects/game.json')).toBe(
       path.join('C:/Projects', '.gdevelop', 'game.editor-settings.json')
     );
     expect(

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
@@ -1,0 +1,123 @@
+// @flow
+import {
+  applyProjectEditorSettings,
+  extractProjectEditorSettings,
+} from './LocalEditorSettingsStorage';
+
+describe('LocalEditorSettingsStorage', () => {
+  it('extracts editor settings from project content and applies them back', () => {
+    const serializedProjectObject: any = {
+      layouts: [
+        {
+          name: 'Level 1',
+          uiSettings: {
+            grid: true,
+            zoomFactor: 0.5,
+          },
+        },
+        {
+          name: 'Level 2',
+        },
+      ],
+      externalLayouts: [
+        {
+          name: 'HUD',
+          editionSettings: {
+            windowMask: true,
+          },
+        },
+      ],
+      eventsFunctionsExtensions: [
+        {
+          name: 'Inventory',
+          eventsBasedObjects: [
+            {
+              name: 'Slot',
+              editionSettings: {
+                selectedLayer: 'Base',
+              },
+              variants: [
+                {
+                  name: 'Large',
+                  editionSettings: {
+                    gridWidth: 64,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const editorSettings = extractProjectEditorSettings(
+      serializedProjectObject
+    );
+
+    expect(editorSettings).toEqual({
+      layoutSettings: {
+        'Level 1': {
+          grid: true,
+          zoomFactor: 0.5,
+        },
+      },
+      externalLayoutSettings: {
+        HUD: {
+          windowMask: true,
+        },
+      },
+      eventsBasedObjectVariantSettings: {
+        'Inventory::Slot::': {
+          selectedLayer: 'Base',
+        },
+        'Inventory::Slot::Large': {
+          gridWidth: 64,
+        },
+      },
+    });
+    expect(serializedProjectObject.layouts[0].uiSettings).toBeUndefined();
+    expect(
+      serializedProjectObject.externalLayouts[0].editionSettings
+    ).toBeUndefined();
+    expect(
+      serializedProjectObject.eventsFunctionsExtensions[0].eventsBasedObjects[0]
+        .editionSettings
+    ).toBeUndefined();
+    expect(
+      serializedProjectObject.eventsFunctionsExtensions[0].eventsBasedObjects[0]
+        .variants[0].editionSettings
+    ).toBeUndefined();
+
+    applyProjectEditorSettings(serializedProjectObject, editorSettings);
+
+    expect(serializedProjectObject.layouts[0].uiSettings).toEqual({
+      grid: true,
+      zoomFactor: 0.5,
+    });
+    expect(serializedProjectObject.externalLayouts[0].editionSettings).toEqual({
+      windowMask: true,
+    });
+    expect(
+      serializedProjectObject.eventsFunctionsExtensions[0].eventsBasedObjects[0]
+        .editionSettings
+    ).toEqual({
+      selectedLayer: 'Base',
+    });
+    expect(
+      serializedProjectObject.eventsFunctionsExtensions[0].eventsBasedObjects[0]
+        .variants[0].editionSettings
+    ).toEqual({
+      gridWidth: 64,
+    });
+  });
+
+  it('returns null when there are no editor settings to extract', () => {
+    expect(
+      extractProjectEditorSettings({
+        layouts: [{ name: 'Level 1' }],
+        externalLayouts: [],
+        eventsFunctionsExtensions: [],
+      })
+    ).toBe(null);
+  });
+});

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
@@ -12,9 +12,7 @@ describe('LocalEditorSettingsStorage', () => {
     expect(getProjectEditorSettingsFilePath('C:/Projects/game.json')).toBe(
       path.join('C:/Projects', '.gdevelop', 'game.editor-settings.json')
     );
-    expect(
-      getProjectEditorSettingsFilePath('C:/Projects/prototype.json')
-    ).toBe(
+    expect(getProjectEditorSettingsFilePath('C:/Projects/prototype.json')).toBe(
       path.join('C:/Projects', '.gdevelop', 'prototype.editor-settings.json')
     );
   });

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalEditorSettingsStorage.spec.js
@@ -2,9 +2,25 @@
 import {
   applyProjectEditorSettings,
   extractProjectEditorSettings,
+  getProjectEditorSettingsFilePath,
 } from './LocalEditorSettingsStorage';
+// $FlowFixMe[cannot-resolve-module]
+import path from 'path';
 
 describe('LocalEditorSettingsStorage', () => {
+  it('stores settings separately for projects in the same folder', () => {
+    expect(
+      getProjectEditorSettingsFilePath('C:/Projects/game.json')
+    ).toBe(
+      path.join('C:/Projects', '.gdevelop', 'game.editor-settings.json')
+    );
+    expect(
+      getProjectEditorSettingsFilePath('C:/Projects/prototype.json')
+    ).toBe(
+      path.join('C:/Projects', '.gdevelop', 'prototype.editor-settings.json')
+    );
+  });
+
   it('extracts editor settings from project content and applies them back', () => {
     const serializedProjectObject: any = {
       layouts: [

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectOpener.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectOpener.js
@@ -39,21 +39,25 @@ export const onOpen = (
       // of large game files.
       maxUnsplitDepth: 3,
     })
-      .then(() =>
-        readJSONFile(getProjectEditorSettingsFilePath(projectPath))
+      .then(() => {
+        const projectEditorSettingsFilePath = getProjectEditorSettingsFilePath(
+          projectPath
+        );
+        if (!fs.existsSync(projectEditorSettingsFilePath)) {
+          return;
+        }
+
+        return readJSONFile(projectEditorSettingsFilePath)
           .then(projectEditorSettings => {
             applyProjectEditorSettings(object, projectEditorSettings);
           })
           .catch(error => {
-            if (error && error.code === 'ENOENT') {
-              return;
-            }
             console.warn(
               'Unable to read project editor settings. Opening the project without them.',
               error
             );
-          })
-      )
+          });
+      })
       .then(() => {
         return { content: object };
       });

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectOpener.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectOpener.js
@@ -3,6 +3,10 @@ import optionalRequire from '../../Utils/OptionalRequire';
 import { type FileMetadata } from '../index';
 import { unsplit } from '../../Utils/ObjectSplitter';
 import { openFilePicker, readJSONFile } from '../../Utils/FileSystem';
+import {
+  applyProjectEditorSettings,
+  getProjectEditorSettingsFilePath,
+} from './LocalEditorSettingsStorage';
 const fs = optionalRequire('fs');
 const path = optionalRequire('path');
 
@@ -34,9 +38,25 @@ export const onOpen = (
       // to be un-splitted, but not the content of these properties), to avoid very slow processing
       // of large game files.
       maxUnsplitDepth: 3,
-    }).then(() => {
-      return { content: object };
-    });
+    })
+      .then(() =>
+        readJSONFile(getProjectEditorSettingsFilePath(projectPath))
+          .then(projectEditorSettings => {
+            applyProjectEditorSettings(object, projectEditorSettings);
+          })
+          .catch(error => {
+            if (error && error.code === 'ENOENT') {
+              return;
+            }
+            console.warn(
+              'Unable to read project editor settings. Opening the project without them.',
+              error
+            );
+          })
+      )
+      .then(() => {
+        return { content: object };
+      });
   });
 };
 

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectOpener.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectOpener.js
@@ -39,25 +39,21 @@ export const onOpen = (
       // of large game files.
       maxUnsplitDepth: 3,
     })
-      .then(() => {
-        const projectEditorSettingsFilePath = getProjectEditorSettingsFilePath(
-          projectPath
-        );
-        if (!fs.existsSync(projectEditorSettingsFilePath)) {
-          return;
-        }
-
-        return readJSONFile(projectEditorSettingsFilePath)
+      .then(() =>
+        readJSONFile(getProjectEditorSettingsFilePath(filePath))
           .then(projectEditorSettings => {
             applyProjectEditorSettings(object, projectEditorSettings);
           })
           .catch(error => {
+            if (error && error.code === 'ENOENT') {
+              return;
+            }
             console.warn(
               'Unable to read project editor settings. Opening the project without them.',
               error
             );
-          });
-      })
+          })
+      )
       .then(() => {
         return { content: object };
       });

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -19,6 +19,10 @@ import {
   splitPaths,
   getSlugifiedUniqueNameFromProperty,
 } from '../../Utils/ObjectSplitter';
+import {
+  extractProjectEditorSettings,
+  getProjectEditorSettingsFilePath,
+} from './LocalEditorSettingsStorage';
 import type { MessageDescriptor } from '../../Utils/i18n/MessageDescriptor.flow';
 import LocalFolderPicker from '../../UI/LocalFolderPicker';
 import SaveAsOptionsDialog from '../SaveAsOptionsDialog';
@@ -131,7 +135,19 @@ const writeProjectFiles = async ({
   } else {
     serializedProjectObject = serializeToJSObject(project);
   }
+  const projectEditorSettings = extractProjectEditorSettings(
+    serializedProjectObject
+  );
   const serializeEndTime = Date.now();
+
+  if (projectEditorSettings) {
+    await writeAndCheckFormattedJSONFile(
+      projectEditorSettings,
+      getProjectEditorSettingsFilePath(projectPath)
+    );
+  } else {
+    await fs.remove(getProjectEditorSettingsFilePath(projectPath));
+  }
 
   if (project.isFolderProject()) {
     const partialObjects = split(serializedProjectObject, {

--- a/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
+++ b/newIDE/app/src/ProjectsStorage/LocalFileStorageProvider/LocalProjectWriter.js
@@ -143,10 +143,10 @@ const writeProjectFiles = async ({
   if (projectEditorSettings) {
     await writeAndCheckFormattedJSONFile(
       projectEditorSettings,
-      getProjectEditorSettingsFilePath(projectPath)
+      getProjectEditorSettingsFilePath(filePath)
     );
   } else {
-    await fs.remove(getProjectEditorSettingsFilePath(projectPath));
+    await fs.remove(getProjectEditorSettingsFilePath(filePath));
   }
 
   if (project.isFolderProject()) {


### PR DESCRIPTION
Addresses #1983.

## Summary
- Persist local editor UI settings in per-project sidecars under `.gdevelop/<project-name>.editor-settings.json` instead of writing them into the project JSON.
- Restore sidecar settings when opening local projects, while keeping existing embedded settings working when no sidecar exists.
- Remove stale sidecar settings when a project no longer has editor settings to persist.
- Keep sidecars distinct when multiple project files live in the same folder.
- Add coverage for sidecar paths plus extracting/applying layout, external layout, and custom object variant editor settings.
- Make the pre-built `libGD.js` downloader try matching `master/commit/<hash>` builds before `master/latest`, so detached PR CI does not pick an incompatible generated file.

## Notes
- The sidecars are intentionally local/user-specific, so teams can gitignore `.gdevelop/` to avoid collaboration conflicts.
- I kept this scoped to the local file storage path where the Git conflict problem happens.
- Missing sidecar files are ignored via `ENOENT`, so normal local projects do not emit a warning before one has been created.

## Verification
- Semaphore `Fast tests (not building GDevelop.js - can have false negatives)`: passed on the latest commit.
- Semaphore Flow: passed with `No errors!` on the earlier run before the CI-only fallback update.
- Semaphore `newIDE auto-formatting` and `newIDE linting`: passed on the latest commit.
- Not run locally: this Codex environment does not have the repository dependency setup needed for the full GDevelop test suite.