### PR TITLE
chore: Export classes in ResourceLoader for better TypeScript compatibility

### DIFF
--- a/GDJS/Runtime/ResourceLoader.ts
+++ b/GDJS/Runtime/ResourceLoader.ts
@@ -37,7 +37,7 @@ namespace gdjs {
    * and make impossible to finely tune in which order scenes are actually
    * downloaded.
    */
-  class LoadingTask {
+  export class LoadingTask {
     identifier: string;
     private onProgressCallbacks: Array<(count: number, total: number) => void>;
     private onFinishCallbacks: Array<() => void>;
@@ -934,7 +934,7 @@ namespace gdjs {
    * Give `ResourceLoadingQueue` access to private members of `ResourceManager`
    * without exposing them outside.
    */
-  class PrivateResourceManager {
+  export class PrivateResourceManager {
     private resourceLoader: ResourceLoader;
 
     /**
@@ -1003,7 +1003,7 @@ namespace gdjs {
     newTaskState: LoadingTaskState | null
   ) => Set<string>;
 
-  class ResourceLoadingQueue {
+  export class ResourceLoadingQueue {
     private resourceLoader: PrivateResourceManager;
     private name: string;
     /**


### PR DESCRIPTION
Hello,

This PR simply adds exports for the new classes in `ResourceLoader`, which makes it possible to inherit from these classes and extend their functionality.

The main problem is that after compilation to JS, the `gdjs` namespace does not contain these classes, which means they cannot be accessed externally.